### PR TITLE
Guard the console and test-runner formatters against native stack overflow on deeply nested values

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2189,16 +2189,6 @@ unsafe extern "C" {
     #[cfg(windows)]
     safe fn clock_gettime_monotonic(sec: &mut i64, nsec: &mut i64);
 }
-impl Default for StackCheck {
-    /// `cached_stack_end` defaults to `0`, so
-    /// `is_safe_to_recurse()` always reports true; use `init()` for a real bound.
-    #[inline]
-    fn default() -> Self {
-        Self {
-            cached_stack_end: 0,
-        }
-    }
-}
 impl StackCheck {
     #[inline]
     pub fn configure_thread() {

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2191,7 +2191,7 @@ unsafe extern "C" {
 }
 impl Default for StackCheck {
     /// `cached_stack_end` defaults to `0`, so
-    /// `is_safe_to_recurse()` always reports true until `init`/`update`.
+    /// `is_safe_to_recurse()` always reports true; use `init()` for a real bound.
     #[inline]
     fn default() -> Self {
         Self {
@@ -2209,10 +2209,6 @@ impl StackCheck {
         Self {
             cached_stack_end: Bun__StackCheck__getMaxStack() as usize,
         }
-    }
-    #[inline]
-    pub fn update(&mut self) {
-        self.cached_stack_end = Bun__StackCheck__getMaxStack() as usize;
     }
     /// Is there enough stack space to safely recurse?
     /// Threshold: `> 256K` on Windows, `> 128K` elsewhere.

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5617,7 +5617,6 @@ pub mod formatter {
             value: JSValue,
             writer: &mut dyn bun_io::Write,
         ) -> JsResult<()> {
-            self.stack_check.update();
             let one = [value];
             self.remaining_values = bun_ptr::RawSlice::new(&one);
             let global = self.global_this;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1598,12 +1598,7 @@ pub mod formatter {
         pub ordered_properties: bool,
         pub(crate) custom_formatted_object: CustomFormattedObject,
         pub(crate) disable_inspect_custom: bool,
-        /// Seated by `new()`. `StackCheck::default()` has no stack bound and
-        /// would let a deep enough value recurse until the native stack
-        /// overflows.
         pub(crate) stack_check: StackCheck,
-        /// On an exhausted stack, throw a `RangeError` instead of silently
-        /// truncating the output.
         pub(crate) can_throw_stack_overflow: bool,
         pub(crate) error_display_level: ErrorDisplayLevel,
         /// If `ArrayBuffer`-like objects contain ASCII text, the buffer is

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -667,7 +667,6 @@ impl<'a> TablePrinter<'a> {
                 f.single_line = true;
                 f.max_depth = 5;
                 f.can_throw_stack_overflow = true;
-                f.stack_check = StackCheck::init();
                 f
             },
             values_col_width: None,
@@ -1338,7 +1337,6 @@ pub fn format2(
         fmt.max_depth = options.max_depth;
         fmt.single_line = options.single_line;
         fmt.indent = u32::from(options.default_indent);
-        fmt.stack_check = StackCheck::init();
         fmt.can_throw_stack_overflow = true;
         fmt.error_display_level = options.error_display_level;
         let tag = formatter::Tag::get(vals[0], global)?;
@@ -1401,7 +1399,6 @@ pub fn format2(
     fmt.max_depth = options.max_depth;
     fmt.single_line = options.single_line;
     fmt.indent = u32::from(options.default_indent);
-    fmt.stack_check = StackCheck::init();
     fmt.can_throw_stack_overflow = true;
     fmt.error_display_level = options.error_display_level;
     let mut tag: formatter::TagResult;
@@ -1631,10 +1628,9 @@ pub mod formatter {
                 ordered_properties: false,
                 custom_formatted_object: CustomFormattedObject::default(),
                 disable_inspect_custom: false,
-                // `StackCheck::default()` has `cached_stack_end = 0` ⇒ the
-                // check always passes; callers that want a real bound
-                // overwrite with `StackCheck::init()` explicitly.
-                stack_check: StackCheck::default(),
+                // `print_as_prelude` is the only recursion guard on the array
+                // path, so seat a live bound here (one thread-local read).
+                stack_check: StackCheck::init(),
                 can_throw_stack_overflow: false,
                 error_display_level: ErrorDisplayLevel::Full,
                 format_buffer_as_text: false,
@@ -5848,7 +5844,6 @@ pub(crate) extern "C" fn Bun__ConsoleObject__timeLog(
     fmt.max_depth = bun_options_types::context::try_get()
         .and_then(|ctx| ctx.runtime_options.console_depth)
         .unwrap_or(DEFAULT_CONSOLE_LOG_DEPTH);
-    fmt.stack_check = StackCheck::init();
     fmt.can_throw_stack_overflow = true;
     let console = vm_console(global);
     // SAFETY: see [`vm_console`] — points at the live boxed `ConsoleObject` for

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1598,7 +1598,12 @@ pub mod formatter {
         pub ordered_properties: bool,
         pub(crate) custom_formatted_object: CustomFormattedObject,
         pub(crate) disable_inspect_custom: bool,
+        /// Seated by `new()`. `StackCheck::default()` has no stack bound and
+        /// would let a deep enough value recurse until the native stack
+        /// overflows.
         pub(crate) stack_check: StackCheck,
+        /// On an exhausted stack, throw a `RangeError` instead of silently
+        /// truncating the output.
         pub(crate) can_throw_stack_overflow: bool,
         pub(crate) error_display_level: ErrorDisplayLevel,
         /// If `ArrayBuffer`-like objects contain ASCII text, the buffer is

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1628,8 +1628,6 @@ pub mod formatter {
                 ordered_properties: false,
                 custom_formatted_object: CustomFormattedObject::default(),
                 disable_inspect_custom: false,
-                // `print_as_prelude` is the only recursion guard on the array
-                // path, so seat a live bound here (one thread-local read).
                 stack_check: StackCheck::init(),
                 can_throw_stack_overflow: false,
                 error_display_level: ErrorDisplayLevel::Full,
@@ -3215,16 +3213,15 @@ pub mod formatter {
             if self.global_this.has_exception() {
                 return Err(jsc::JsError::Thrown);
             }
-            if !can_circ {
-                return Ok(true);
-            }
-
             if !self.stack_check.is_safe_to_recurse() {
                 self.failed = true;
                 if self.can_throw_stack_overflow {
                     return Err(self.global_this.throw_stack_overflow());
                 }
                 return Ok(false);
+            }
+            if !can_circ {
+                return Ok(true);
             }
 
             if self.map_node.is_none() {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2633,7 +2633,6 @@ impl JSValue {
         formatter: &'a mut crate::console_object::Formatter<'b>,
     ) -> crate::console_object::formatter::ZigFormatter<'a, 'b> {
         formatter.remaining_values = bun_ptr::RawSlice::EMPTY;
-        formatter.stack_check.update();
         crate::console_object::formatter::ZigFormatter::new(formatter, self)
     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4919,7 +4919,6 @@ impl VirtualMachine {
         allow_side_effects: bool,
     ) {
         let mut formatter = crate::console_object::Formatter::new(self.global());
-        formatter.stack_check = bun_core::StackCheck::init();
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         self.print_errorlike_object(
             exception.value(),
@@ -6010,7 +6009,6 @@ impl VirtualMachine {
         allow_ansi_color: bool,
     ) -> crate::CrateResult<()> {
         let mut default_formatter = crate::console_object::Formatter::new(self.global());
-        default_formatter.stack_check = bun_core::StackCheck::init();
         let f = formatter.unwrap_or(&mut default_formatter);
         self.print_error_instance_body(
             zig_exception,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4919,6 +4919,7 @@ impl VirtualMachine {
         allow_side_effects: bool,
     ) {
         let mut formatter = crate::console_object::Formatter::new(self.global());
+        formatter.stack_check = bun_core::StackCheck::init();
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         self.print_errorlike_object(
             exception.value(),
@@ -6009,6 +6010,7 @@ impl VirtualMachine {
         allow_ansi_color: bool,
     ) -> crate::CrateResult<()> {
         let mut default_formatter = crate::console_object::Formatter::new(self.global());
+        default_formatter.stack_check = bun_core::StackCheck::init();
         let f = formatter.unwrap_or(&mut default_formatter);
         self.print_error_instance_body(
             zig_exception,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6045,8 +6045,7 @@ impl VirtualMachine {
         // re-check here with an extra `MAX_PATH_BYTES * 3` of slack on Windows
         // to cover the transpiler's nested path buffers — same parity-level
         // protection the Object path gets from C++ `forEachProperty`'s
-        // `vm.isSafeToRecurse()`. The formatter's `stack_check` was seated by
-        // the caller (`format2` / `Bun.inspect`).
+        // `vm.isSafeToRecurse()`.
         let extra_headroom: usize = if cfg!(windows) {
             // 3× PathBuffer ≈ 288 KB — empirically enough for the
             // `remap_zig_exception` → `transpile_source_code` chain on the

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1263,6 +1263,7 @@ fn print_exception(
         vm_ref.print_exception(exception, exception_list, writer, true);
     } else {
         let mut formatter = bun_jsc::console_object::Formatter::new(global);
+        formatter.stack_check = bun_core::StackCheck::init();
         // `Formatter::new` already
         // defaults `error_display_level` to `Full` (ConsoleObject.rs:1176).
         let colors = bun_core::Output::enable_ansi_colors_stderr();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1263,7 +1263,6 @@ fn print_exception(
         vm_ref.print_exception(exception, exception_list, writer, true);
     } else {
         let mut formatter = bun_jsc::console_object::Formatter::new(global);
-        formatter.stack_check = bun_core::StackCheck::init();
         // `Formatter::new` already
         // defaults `error_display_level` to `Full` (ConsoleObject.rs:1176).
         let colors = bun_core::Output::enable_ansi_colors_stderr();

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -28,6 +28,7 @@ impl<'a> DiffFormatter<'a> {
             add_newline: false,
             flush: false,
             quote_strings: true,
+            can_throw_stack_overflow: false,
         };
         let mut received_buf: Vec<u8> = Vec::new();
         JestPrettyFormat::format(

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -226,6 +226,7 @@ pub mod expect {
                 add_newline: false,
                 flush: false,
                 quote_strings: true,
+                can_throw_stack_overflow: true,
             };
             JestPrettyFormat::format(
                 MessageLevel::Debug,

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -101,8 +101,6 @@ pub struct FormatOptions {
     pub(crate) add_newline: bool,
     pub flush: bool,
     pub(crate) quote_strings: bool,
-    /// Fail with the stack overflow error instead of returning the truncated
-    /// output of a value deeper than the native stack allows.
     pub(crate) can_throw_stack_overflow: bool,
 }
 
@@ -323,8 +321,6 @@ pub struct Formatter<'a> {
     pub(crate) estimated_line_length: usize,
     pub(crate) always_newline_scope: bool,
     stack_check: StackCheck,
-    /// `stack_check` cut the walk short (and set `failed`, which makes the
-    /// rest of the walk unwind without printing).
     hit_stack_limit: bool,
 }
 
@@ -345,9 +341,7 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    /// Thrown once the walk has unwound rather than where the limit was hit,
-    /// so it does not depend on the C++ property/entry walks in between (whose
-    /// callbacks cannot return an error) carrying a pending exception back out.
+    /// Deferred to here because the C++ property walks drop exceptions thrown from their callbacks.
     fn finish(&self, options: FormatOptions) -> JsResult<()> {
         if self.hit_stack_limit && options.can_throw_stack_overflow {
             return Err(self.global_this.throw_stack_overflow());

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -322,8 +322,6 @@ pub struct Formatter<'a> {
     pub(crate) estimated_line_length: usize,
     pub(crate) always_newline_scope: bool,
     stack_check: StackCheck,
-    /// Snapshot serialization sets this so a too-deep value fails the test
-    /// rather than storing a truncated snapshot; diff output leaves it off.
     can_throw_stack_overflow: bool,
 }
 

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2642,11 +2642,7 @@ impl bun_jsc::ConsoleFormatter for Formatter<'_> {
     }
 }
 
-/// Maps the wider `console_object::Tag` onto this file's `Tag`. Only the
-/// variants the `write_format` hooks and the asymmetric matchers actually emit
-/// are reachable (Boolean / Double / Object / Array / Private / String); the
-/// rest collapse onto `Object` so any future caller still renders something
-/// useful.
+/// Variants this file has no arm for collapse onto `Object`.
 impl From<bun_jsc::FormatTag> for Tag {
     fn from(tag: bun_jsc::FormatTag) -> Self {
         use bun_jsc::FormatTag as Ft;
@@ -2700,11 +2696,7 @@ pub trait AsymmetricMatcherFormatter {
     fn amf_quote_strings(&mut self) -> &mut bool;
     /// `printAs(tag, …)` routed through the formatter's own runtime
     /// dispatcher. Only `Object` / `String` / `Array` are reached.
-    ///
-    /// Generic over the writer so that the caller's writer goes down as is. A
-    /// matcher nested in a matcher re-enters this for every level, and a
-    /// writer adapter added per level would stack up into one frame per level
-    /// inside every single write, below the stack check in `print_as`.
+    /// Generic rather than `dyn` so nested matchers do not stack one writer adapter per level.
     fn amf_print_as<W: bun_io::Write, const C: bool>(
         &mut self,
         tag: bun_jsc::FormatTag,

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -101,7 +101,6 @@ pub struct FormatOptions {
     pub(crate) add_newline: bool,
     pub flush: bool,
     pub(crate) quote_strings: bool,
-    /// Seats `Formatter::can_throw_stack_overflow`.
     pub(crate) can_throw_stack_overflow: bool,
 }
 
@@ -323,10 +322,8 @@ pub struct Formatter<'a> {
     pub(crate) estimated_line_length: usize,
     pub(crate) always_newline_scope: bool,
     stack_check: StackCheck,
-    /// On an exhausted stack, throw a `RangeError` instead of silently
-    /// truncating the output. Set for snapshot serialization, where a
-    /// truncated result would be stored as if it were complete; left off for
-    /// diff output, which is only diagnostic.
+    /// Snapshot serialization sets this so a too-deep value fails the test
+    /// rather than storing a truncated snapshot; diff output leaves it off.
     can_throw_stack_overflow: bool,
 }
 
@@ -1053,8 +1050,6 @@ impl<'a> Formatter<'a> {
         if self.failed {
             return Ok(());
         }
-        // Ahead of the circular-reference bookkeeping below, which only some
-        // of the tags that recurse into child values take part in.
         if !self.stack_check.is_safe_to_recurse() {
             self.failed = true;
             if self.can_throw_stack_overflow {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -101,6 +101,8 @@ pub struct FormatOptions {
     pub(crate) add_newline: bool,
     pub flush: bool,
     pub(crate) quote_strings: bool,
+    /// Fail with the stack overflow error instead of returning the truncated
+    /// output of a value deeper than the native stack allows.
     pub(crate) can_throw_stack_overflow: bool,
 }
 
@@ -147,7 +149,6 @@ impl JestPrettyFormat {
         if len == 1 {
             fmt = Formatter::new(global);
             fmt.quote_strings = options.quote_strings;
-            fmt.can_throw_stack_overflow = options.can_throw_stack_overflow;
             let tag = Tag::get(vals[0], global)?;
 
             if tag.tag == Tag::String {
@@ -186,7 +187,7 @@ impl JestPrettyFormat {
             }
 
             let _ = writer.flush();
-            return Ok(());
+            return fmt.finish(options);
         }
 
         // The flush must fire on every exit including `?` propagation from
@@ -194,7 +195,6 @@ impl JestPrettyFormat {
         fmt = Formatter::new(global);
         fmt.remaining_values = &vals[..len][1..];
         fmt.quote_strings = options.quote_strings;
-        fmt.can_throw_stack_overflow = options.can_throw_stack_overflow;
 
         let result: JsResult<()> = (|| {
             let mut this_value: JSValue = vals[0];
@@ -258,7 +258,8 @@ impl JestPrettyFormat {
         }
 
         // map_node release handled by `impl Drop for Formatter`.
-        result
+        result?;
+        fmt.finish(options)
     }
 }
 
@@ -322,7 +323,9 @@ pub struct Formatter<'a> {
     pub(crate) estimated_line_length: usize,
     pub(crate) always_newline_scope: bool,
     stack_check: StackCheck,
-    can_throw_stack_overflow: bool,
+    /// `stack_check` cut the walk short (and set `failed`, which makes the
+    /// rest of the walk unwind without printing).
+    hit_stack_limit: bool,
 }
 
 impl<'a> Formatter<'a> {
@@ -338,8 +341,18 @@ impl<'a> Formatter<'a> {
             estimated_line_length: 0,
             always_newline_scope: false,
             stack_check: StackCheck::init(),
-            can_throw_stack_overflow: false,
+            hit_stack_limit: false,
         }
+    }
+
+    /// Thrown once the walk has unwound rather than where the limit was hit,
+    /// so it does not depend on the C++ property/entry walks in between (whose
+    /// callbacks cannot return an error) carrying a pending exception back out.
+    fn finish(&self, options: FormatOptions) -> JsResult<()> {
+        if self.hit_stack_limit && options.can_throw_stack_overflow {
+            return Err(self.global_this.throw_stack_overflow());
+        }
+        Ok(())
     }
 
     pub(crate) fn good_time_for_a_new_line(&mut self) -> bool {
@@ -1050,9 +1063,7 @@ impl<'a> Formatter<'a> {
         }
         if !self.stack_check.is_safe_to_recurse() {
             self.failed = true;
-            if self.can_throw_stack_overflow {
-                return Err(self.global_this.throw_stack_overflow());
-            }
+            self.hit_stack_limit = true;
             return Ok(());
         }
         // reshaped for borrowck — `WrappedWriter` borrows both writer_

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2,7 +2,7 @@ use crate::test_runner::expect::JSValueTestExt;
 use core::ffi::c_void;
 
 use bun_collections::HashMap;
-use bun_core::fmt as bun_fmt;
+use bun_core::{fmt as bun_fmt, StackCheck};
 use bun_jsc::{
     self as jsc, ComptimeStringMapExt as _, JSGlobalObject, JSObject,
     JSPropertyIterator, JSType, JSValue, JsError, JsResult, VM,
@@ -318,6 +318,7 @@ pub struct Formatter<'a> {
     pub(crate) failed: bool,
     pub(crate) estimated_line_length: usize,
     pub(crate) always_newline_scope: bool,
+    pub(crate) stack_check: StackCheck,
 }
 
 impl<'a> Formatter<'a> {
@@ -332,6 +333,7 @@ impl<'a> Formatter<'a> {
             failed: false,
             estimated_line_length: 0,
             always_newline_scope: false,
+            stack_check: StackCheck::init(),
         }
     }
 
@@ -1039,6 +1041,10 @@ impl<'a> Formatter<'a> {
         js_type: JSType,
     ) -> JsResult<()> {
         if self.failed {
+            return Ok(());
+        }
+        if !self.stack_check.is_safe_to_recurse() {
+            self.failed = true;
             return Ok(());
         }
         // reshaped for borrowck — `WrappedWriter` borrows both writer_

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -101,6 +101,8 @@ pub struct FormatOptions {
     pub(crate) add_newline: bool,
     pub flush: bool,
     pub(crate) quote_strings: bool,
+    /// Seats `Formatter::can_throw_stack_overflow`.
+    pub(crate) can_throw_stack_overflow: bool,
 }
 
 impl JestPrettyFormat {
@@ -146,6 +148,7 @@ impl JestPrettyFormat {
         if len == 1 {
             fmt = Formatter::new(global);
             fmt.quote_strings = options.quote_strings;
+            fmt.can_throw_stack_overflow = options.can_throw_stack_overflow;
             let tag = Tag::get(vals[0], global)?;
 
             if tag.tag == Tag::String {
@@ -192,6 +195,7 @@ impl JestPrettyFormat {
         fmt = Formatter::new(global);
         fmt.remaining_values = &vals[..len][1..];
         fmt.quote_strings = options.quote_strings;
+        fmt.can_throw_stack_overflow = options.can_throw_stack_overflow;
 
         let result: JsResult<()> = (|| {
             let mut this_value: JSValue = vals[0];
@@ -318,7 +322,12 @@ pub struct Formatter<'a> {
     pub(crate) failed: bool,
     pub(crate) estimated_line_length: usize,
     pub(crate) always_newline_scope: bool,
-    pub(crate) stack_check: StackCheck,
+    stack_check: StackCheck,
+    /// On an exhausted stack, throw a `RangeError` instead of silently
+    /// truncating the output. Set for snapshot serialization, where a
+    /// truncated result would be stored as if it were complete; left off for
+    /// diff output, which is only diagnostic.
+    can_throw_stack_overflow: bool,
 }
 
 impl<'a> Formatter<'a> {
@@ -334,6 +343,7 @@ impl<'a> Formatter<'a> {
             estimated_line_length: 0,
             always_newline_scope: false,
             stack_check: StackCheck::init(),
+            can_throw_stack_overflow: false,
         }
     }
 
@@ -1043,8 +1053,13 @@ impl<'a> Formatter<'a> {
         if self.failed {
             return Ok(());
         }
+        // Ahead of the circular-reference bookkeeping below, which only some
+        // of the tags that recurse into child values take part in.
         if !self.stack_check.is_safe_to_recurse() {
             self.failed = true;
+            if self.can_throw_stack_overflow {
+                return Err(self.global_this.throw_stack_overflow());
+            }
             return Ok(());
         }
         // reshaped for borrowck — `WrappedWriter` borrows both writer_

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2602,8 +2602,7 @@ impl<'a> Formatter<'a> {
 /// for nested values. The trait is the layering seam — it lives in `bun_jsc`,
 /// the webcore types call through it generically, and this file supplies the
 /// test-runner-specific dispatch. Mirrors the `bun_jsc::console_object`
-/// `Formatter` impl (`src/jsc/lib.rs`) one-for-one, mapping the
-/// `bun_jsc::FormatTag` enum onto this file's smaller `Tag` set.
+/// `Formatter` impl (`src/jsc/lib.rs`) one-for-one.
 impl bun_jsc::ConsoleFormatter for Formatter<'_> {
     #[inline]
     fn global_this(&self) -> &JSGlobalObject { self.global_this }
@@ -2632,12 +2631,26 @@ impl bun_jsc::ConsoleFormatter for Formatter<'_> {
         value: JSValue,
         cell: JSType,
     ) -> JsResult<()> {
+        let mut sink = bun_io::FmtAdapter::new(writer);
+        let global = self.global_this;
+        self.format::<_, ENABLE_ANSI_COLORS>(
+            TagResult { tag: tag.into(), cell },
+            &mut sink,
+            value,
+            global,
+        )
+    }
+}
+
+/// Maps the wider `console_object::Tag` onto this file's `Tag`. Only the
+/// variants the `write_format` hooks and the asymmetric matchers actually emit
+/// are reachable (Boolean / Double / Object / Array / Private / String); the
+/// rest collapse onto `Object` so any future caller still renders something
+/// useful.
+impl From<bun_jsc::FormatTag> for Tag {
+    fn from(tag: bun_jsc::FormatTag) -> Self {
         use bun_jsc::FormatTag as Ft;
-        // Map the wider `console_object::Tag` onto this file's `Tag`. Only the
-        // variants the `write_format` hooks actually emit are reachable
-        // (Boolean / Double / Object / Private / String); the rest collapse
-        // onto `Object` so any future caller still renders something useful.
-        let local = match tag {
+        match tag {
             Ft::StringPossiblyFormatted => Tag::StringPossiblyFormatted,
             Ft::String => Tag::String,
             Ft::Undefined => Tag::Undefined,
@@ -2671,15 +2684,7 @@ impl bun_jsc::ConsoleFormatter for Formatter<'_> {
             | Ft::CustomGetterSetter
             | Ft::Proxy
             | Ft::RevokedProxy => Tag::Object,
-        };
-        let mut sink = bun_io::FmtAdapter::new(writer);
-        let global = self.global_this;
-        self.format::<_, ENABLE_ANSI_COLORS>(
-            TagResult { tag: local, cell },
-            &mut sink,
-            value,
-            global,
-        )
+        }
     }
 }
 
@@ -2695,10 +2700,15 @@ pub trait AsymmetricMatcherFormatter {
     fn amf_quote_strings(&mut self) -> &mut bool;
     /// `printAs(tag, …)` routed through the formatter's own runtime
     /// dispatcher. Only `Object` / `String` / `Array` are reached.
-    fn amf_print_as<const C: bool>(
+    ///
+    /// Generic over the writer so that the caller's writer goes down as is. A
+    /// matcher nested in a matcher re-enters this for every level, and a
+    /// writer adapter added per level would stack up into one frame per level
+    /// inside every single write, below the stack check in `print_as`.
+    fn amf_print_as<W: bun_io::Write, const C: bool>(
         &mut self,
         tag: bun_jsc::FormatTag,
-        w: &mut dyn bun_io::Write,
+        w: &mut W,
         v: JSValue,
         cell: JSType,
     ) -> JsResult<()>;
@@ -2711,18 +2721,15 @@ impl AsymmetricMatcherFormatter for Formatter<'_> {
     fn amf_global_this(&self) -> &JSGlobalObject { self.global_this }
     #[inline]
     fn amf_quote_strings(&mut self) -> &mut bool { &mut self.quote_strings }
-    fn amf_print_as<const C: bool>(
+    fn amf_print_as<W: bun_io::Write, const C: bool>(
         &mut self,
         tag: bun_jsc::FormatTag,
-        w: &mut dyn bun_io::Write,
+        w: &mut W,
         v: JSValue,
         cell: JSType,
     ) -> JsResult<()> {
-        // Reuse the `ConsoleFormatter` bridge above (FormatTag → local `Tag`
-        // mapping + `format` dispatch). `AsFmt` adapts `dyn bun_io::Write` →
-        // `core::fmt::Write` for the trait method's signature.
-        let mut bridge = AsFmt::new(w);
-        <Self as bun_jsc::ConsoleFormatter>::print_as::<_, C>(self, tag, &mut bridge, v, cell)
+        let global = self.global_this;
+        self.format::<W, C>(TagResult { tag: tag.into(), cell }, w, v, global)
     }
 }
 
@@ -2733,10 +2740,10 @@ impl AsymmetricMatcherFormatter for bun_jsc::console_object::Formatter<'_> {
     fn amf_global_this(&self) -> &JSGlobalObject { self.global_this }
     #[inline]
     fn amf_quote_strings(&mut self) -> &mut bool { &mut self.quote_strings }
-    fn amf_print_as<const C: bool>(
+    fn amf_print_as<W: bun_io::Write, const C: bool>(
         &mut self,
         tag: bun_jsc::FormatTag,
-        w: &mut dyn bun_io::Write,
+        w: &mut W,
         v: JSValue,
         cell: JSType,
     ) -> JsResult<()> {
@@ -2868,7 +2875,7 @@ impl JestPrettyFormat {
                 this.amf_add_for_new_line(b"ObjectContaining ".len());
                 writer.write_all(b"ObjectContaining ");
             }
-            this.amf_print_as::<ENABLE_ANSI_COLORS>(
+            this.amf_print_as::<_, ENABLE_ANSI_COLORS>(
                 bun_jsc::FormatTag::Object, &mut *writer.ctx, object_value, JSType::Object,
             )?;
         } else if let Some(matcher) = value.as_class_ref::<expect::ExpectStringContaining>() {
@@ -2887,7 +2894,7 @@ impl JestPrettyFormat {
                 this.amf_add_for_new_line(b"StringContaining ".len());
                 writer.write_all(b"StringContaining ");
             }
-            this.amf_print_as::<ENABLE_ANSI_COLORS>(
+            this.amf_print_as::<_, ENABLE_ANSI_COLORS>(
                 bun_jsc::FormatTag::String, &mut *writer.ctx, substring_value, JSType::String,
             )?;
         } else if let Some(matcher) = value.as_class_ref::<expect::ExpectStringMatching>() {
@@ -2910,7 +2917,7 @@ impl JestPrettyFormat {
             if test_value.is_reg_exp() {
                 *this.amf_quote_strings() = false;
             }
-            this.amf_print_as::<ENABLE_ANSI_COLORS>(
+            this.amf_print_as::<_, ENABLE_ANSI_COLORS>(
                 bun_jsc::FormatTag::String, &mut *writer.ctx, test_value, JSType::String,
             )?;
             *this.amf_quote_strings() = original_quote_strings;
@@ -2942,7 +2949,7 @@ impl JestPrettyFormat {
                 this.amf_add_for_new_line(matcher_name.length() + 1);
                 writer.print(format_args!("{}", matcher_name));
                 writer.write_all(b" ");
-                this.amf_print_as::<ENABLE_ANSI_COLORS>(
+                this.amf_print_as::<_, ENABLE_ANSI_COLORS>(
                     bun_jsc::FormatTag::Array, &mut *writer.ctx, args_value, JSType::Array,
                 )?;
             }

--- a/test/js/bun/test/pretty-format-overflow.test.ts
+++ b/test/js/bun/test/pretty-format-overflow.test.ts
@@ -50,4 +50,27 @@ test("deep nesting", () => {
     // Verify it actually formatted and showed the diff (not just crashed)
     expect(stderr).toContain("expect(received).toEqual(expected)");
   }, 30000);
+
+  test.concurrent("deeply nested array via toEqual", async () => {
+    await using dir = tempDir("pretty-format-stack", {
+      "deep.test.ts": `
+        import { test, expect } from "bun:test";
+        test("deep", () => {
+          let a: unknown = [];
+          for (let i = 0; i < 50000; i++) a = [a];
+          expect(a).toEqual([]);
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "deep.test.ts"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+    expect(proc.signalCode).toBeNull();
+    expect(proc.exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/test/pretty-format-overflow.test.ts
+++ b/test/js/bun/test/pretty-format-overflow.test.ts
@@ -66,7 +66,10 @@ describe.concurrent("pretty_format on a value deeper than the native stack", () 
   const depth = 100_000;
   const shapes = {
     array: `let v = []; for (let i = 0; i < ${depth}; i++) v = [v];`,
-    object: `let v = {}; for (let i = 0; i < ${depth}; i++) v = { k: v };`,
+    // The second key matters for the snapshot cases below: the property walk formats "k" and then
+    // goes on to "x", and it does not carry an exception thrown while formatting "k" back out, so
+    // refusing the snapshot must not rely on one.
+    object: `let v = {}; for (let i = 0; i < ${depth}; i++) v = { k: v, x: 1 };`,
     // React elements are formatted by their own arm (Tag::JSX), not the object one.
     "React element": `
       let v = "x";
@@ -111,21 +114,25 @@ describe.concurrent("pretty_format on a value deeper than the native stack", () 
     });
   }
 
-  test("toMatchSnapshot on a deep object throws instead of writing a truncated snapshot", async () => {
+  // The formatter throws the stack overflow RangeError; the snapshot matchers currently report it
+  // as "Failed to pretty format value" (#37334 changes them to rethrow the error itself).
+  const formattingFailed = /Maximum call stack size exceeded|Failed to pretty format value/;
+
+  test("toMatchSnapshot on a deep object fails instead of writing a truncated snapshot", async () => {
     const { stderr, exitCode, snapshotFileWritten } = await runDeepTest(
       `${shapes.object}\nexpect(v).toMatchSnapshot();`,
     );
-    expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+    expect(stderr).toMatch(formattingFailed);
     expect(stderr).toContain("1 fail");
     expect(snapshotFileWritten).toBe(false);
     expect(exitCode).toBe(1);
   });
 
-  test("toMatchInlineSnapshot on a deep object throws instead of writing a truncated snapshot", async () => {
+  test("toMatchInlineSnapshot on a deep object fails instead of writing a truncated snapshot", async () => {
     const { stderr, exitCode, testFileRewritten } = await runDeepTest(
       `${shapes.object}\nexpect(v).toMatchInlineSnapshot();`,
     );
-    expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+    expect(stderr).toMatch(formattingFailed);
     expect(stderr).toContain("1 fail");
     expect(testFileRewritten).toBe(false);
     expect(exitCode).toBe(1);

--- a/test/js/bun/test/pretty-format-overflow.test.ts
+++ b/test/js/bun/test/pretty-format-overflow.test.ts
@@ -4,6 +4,8 @@
 
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 describe("pretty_format should handle deeply nested objects without crashing", () => {
   test("deeply nested object with many properties", async () => {
@@ -50,27 +52,82 @@ test("deep nesting", () => {
     // Verify it actually formatted and showed the diff (not just crashed)
     expect(stderr).toContain("expect(received).toEqual(expected)");
   }, 30000);
+});
 
-  test.concurrent("deeply nested array via toEqual", async () => {
-    await using dir = tempDir("pretty-format-stack", {
-      "deep.test.ts": `
-        import { test, expect } from "bun:test";
-        test("deep", () => {
-          let a: unknown = [];
-          for (let i = 0; i < 50000; i++) a = [a];
-          expect(a).toEqual([]);
-        });
-      `,
-    });
+// Formatting a value nested deeper than the native stack can hold used to recurse until the
+// process died with SIGSEGV, taking the whole `bun test` run down with it. The formatter now stops
+// before that point: a failure diff shows what was rendered, and a snapshot refuses to serialize
+// the value (a truncated snapshot would be stored as if it were complete). Each case runs in a
+// subprocess so a regression fails the test instead of the runner.
+describe.concurrent("pretty_format on a value deeper than the native stack", () => {
+  // Several times deeper than the native stack holds for any of these shapes on any platform
+  // (a release build gets through about 23k array levels or 5k object levels on Linux's 8 MB main
+  // thread stack; macOS and Windows builds get an 18 MB stack, debug builds have far larger frames).
+  const depth = 100_000;
+  const shapes = {
+    array: `let v = []; for (let i = 0; i < ${depth}; i++) v = [v];`,
+    object: `let v = {}; for (let i = 0; i < ${depth}; i++) v = { k: v };`,
+    // React elements are formatted by their own arm (Tag::JSX), not the object one.
+    "React element": `
+      let v = "x";
+      for (let i = 0; i < ${depth}; i++) {
+        v = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: { children: v } };
+      }`,
+  };
+
+  async function runDeepTest(body: string) {
+    const source = `
+      import { test, expect } from "bun:test";
+      test("deep", () => {
+        ${body}
+      });
+    `;
+    using dir = tempDir("pretty-format-deep", { "deep.test.ts": source });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "deep.test.ts"],
-      env: bunEnv,
-      cwd: dir,
+      // Snapshot writing is disabled under CI=1 (which bunEnv sets); allow it so that "no snapshot
+      // was written" below is the formatter's doing.
+      env: { ...bunEnv, CI: "false" },
+      cwd: String(dir),
       stdout: "ignore",
-      stderr: "ignore",
+      stderr: "pipe",
     });
-    await proc.exited;
-    expect(proc.signalCode).toBeNull();
-    expect(proc.exitCode).toBe(1);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return {
+      stderr,
+      exitCode,
+      snapshotFileWritten: existsSync(join(String(dir), "__snapshots__", "deep.test.ts.snap")),
+      testFileRewritten: readFileSync(join(String(dir), "deep.test.ts"), "utf8") !== source,
+    };
+  }
+
+  for (const [name, build] of Object.entries(shapes)) {
+    test(`failing toEqual on a deep ${name} still prints a diff`, async () => {
+      const { stderr, exitCode } = await runDeepTest(`${build}\nexpect(v).toEqual(1);`);
+      expect(stderr).toContain("expect(received).toEqual(expected)");
+      expect(stderr).toContain("+ Received");
+      expect(stderr).toContain("1 fail");
+      expect(exitCode).toBe(1);
+    });
+  }
+
+  test("toMatchSnapshot on a deep object throws instead of writing a truncated snapshot", async () => {
+    const { stderr, exitCode, snapshotFileWritten } = await runDeepTest(
+      `${shapes.object}\nexpect(v).toMatchSnapshot();`,
+    );
+    expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+    expect(stderr).toContain("1 fail");
+    expect(snapshotFileWritten).toBe(false);
+    expect(exitCode).toBe(1);
+  });
+
+  test("toMatchInlineSnapshot on a deep object throws instead of writing a truncated snapshot", async () => {
+    const { stderr, exitCode, testFileRewritten } = await runDeepTest(
+      `${shapes.object}\nexpect(v).toMatchInlineSnapshot();`,
+    );
+    expect(stderr).toContain("RangeError: Maximum call stack size exceeded");
+    expect(stderr).toContain("1 fail");
+    expect(testFileRewritten).toBe(false);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/test/pretty-format-overflow.test.ts
+++ b/test/js/bun/test/pretty-format-overflow.test.ts
@@ -115,6 +115,21 @@ describe.concurrent("pretty_format and the native stack limit", () => {
     });
   }
 
+  // Asymmetric matchers are rendered through a separate entry point that used to wrap the writer
+  // once per level, so every write from deep inside the chain went through one extra frame per
+  // level below the stack check, and a release build still crashed after the check was added.
+  test("failing toEqual against a deep expect.objectContaining chain still prints a diff", async () => {
+    const { stderr, exitCode } = await runDeepTest(`
+      let v = expect.objectContaining({ leaf: 1 });
+      for (let i = 0; i < 50_000; i++) v = expect.objectContaining({ k: v });
+      expect({ k: 2 }).toEqual(v);
+    `);
+    expect(stderr).toContain("expect(received).toEqual(expected)");
+    expect(stderr).toContain('"k": ObjectContaining {');
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
   // The formatter throws the stack overflow RangeError; the snapshot matchers currently report it
   // as "Failed to pretty format value" (#37334 changes them to rethrow the error itself).
   const formattingFailed = /Maximum call stack size exceeded|Failed to pretty format value/;

--- a/test/js/bun/test/pretty-format-overflow.test.ts
+++ b/test/js/bun/test/pretty-format-overflow.test.ts
@@ -59,7 +59,7 @@ test("deep nesting", () => {
 // before that point: a failure diff shows what was rendered, and a snapshot refuses to serialize
 // the value (a truncated snapshot would be stored as if it were complete). Each case runs in a
 // subprocess so a regression fails the test instead of the runner.
-describe.concurrent("pretty_format on a value deeper than the native stack", () => {
+describe.concurrent("pretty_format and the native stack limit", () => {
   // Several times deeper than the native stack holds for any of these shapes on any platform
   // (a release build gets through about 23k array levels or 5k object levels on Linux's 8 MB main
   // thread stack; macOS and Windows builds get an 18 MB stack, debug builds have far larger frames).
@@ -96,10 +96,11 @@ describe.concurrent("pretty_format on a value deeper than the native stack", () 
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const snapshotFile = join(String(dir), "__snapshots__", "deep.test.ts.snap");
     return {
       stderr,
       exitCode,
-      snapshotFileWritten: existsSync(join(String(dir), "__snapshots__", "deep.test.ts.snap")),
+      snapshot: existsSync(snapshotFile) ? readFileSync(snapshotFile, "utf8") : null,
       testFileRewritten: readFileSync(join(String(dir), "deep.test.ts"), "utf8") !== source,
     };
   }
@@ -119,12 +120,10 @@ describe.concurrent("pretty_format on a value deeper than the native stack", () 
   const formattingFailed = /Maximum call stack size exceeded|Failed to pretty format value/;
 
   test("toMatchSnapshot on a deep object fails instead of writing a truncated snapshot", async () => {
-    const { stderr, exitCode, snapshotFileWritten } = await runDeepTest(
-      `${shapes.object}\nexpect(v).toMatchSnapshot();`,
-    );
+    const { stderr, exitCode, snapshot } = await runDeepTest(`${shapes.object}\nexpect(v).toMatchSnapshot();`);
     expect(stderr).toMatch(formattingFailed);
     expect(stderr).toContain("1 fail");
-    expect(snapshotFileWritten).toBe(false);
+    expect(snapshot).toBeNull();
     expect(exitCode).toBe(1);
   });
 
@@ -135,6 +134,23 @@ describe.concurrent("pretty_format on a value deeper than the native stack", () 
     expect(stderr).toMatch(formattingFailed);
     expect(stderr).toContain("1 fail");
     expect(testFileRewritten).toBe(false);
+    expect(exitCode).toBe(1);
+  });
+
+  // The limit has to stay well clear of depths in everyday use. A debug build with ASAN, the build
+  // with the largest frames, gets through about 500 object levels before the guard fires (a release
+  // build about ten times that), so this value has to come out in full both as a snapshot and in a
+  // diff, leaf included.
+  test("a 256-deep object is still serialized in full", async () => {
+    const { stderr, exitCode, snapshot } = await runDeepTest(`
+      let v = "floor-leaf";
+      for (let i = 0; i < 256; i++) v = { k: v, x: 1 };
+      expect(v).toMatchSnapshot();
+      expect(v).toEqual(1);
+    `);
+    expect(snapshot).toContain('"floor-leaf"');
+    expect(stderr).toContain('"floor-leaf"');
+    expect(stderr).toContain("1 fail");
     expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -127,7 +127,7 @@ describe.each([
   ["array", "[a]", "throw a;"],
   ["array", "[a]", "Promise.reject(a);"],
   ["Proxy", "new Proxy(a,{})", "throw a;"],
-])("%s / %s", (_, wrap, stmt) => {
+])("%s / %s / %s", (_, wrap, stmt) => {
   test.concurrent("native error printer survives a deeply nested thrown value", async () => {
     const src = `
       let a = {};

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -128,21 +128,16 @@ describe.each(["throw a;", "Promise.reject(a);"])("%s", stmt => {
     const src = `
       let a = [];
       for (let i = 0; i < 50000; i++) a = [a];
-      try { console.log(a); } catch (e) { console.error("control:" + e.constructor.name); }
       ${stmt}
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", src],
-      env: { ...bunEnv, NO_COLOR: "1" },
+      env: bunEnv,
       stdout: "ignore",
-      stderr: "pipe",
+      stderr: "ignore",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    const lines = stderr.trimEnd().split("\n");
-
-    expect(lines[0]).toBe("control:RangeError");
+    await proc.exited;
     expect(proc.signalCode).toBeNull();
-    expect(lines.at(-1)).toMatch(/^Bun v\S+ \(.+\)$/);
-    expect(exitCode).toBe(1);
+    expect(proc.exitCode).toBe(1);
   });
 });

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -123,9 +123,6 @@ test("native error printer handles lone surrogates in message and stack frame na
   expect(exitCode).toBe(1);
 });
 
-// The uncaught-exception printer constructs its own Formatter. Before this fix
-// it left `stack_check` at the always-passes default, so formatting a deeply
-// nested non-Error value recursed until the native stack overflowed (SIGSEGV).
 describe.each(["throw a;", "Promise.reject(a);"])("%s", stmt => {
   test.concurrent("native error printer survives a deeply nested thrown value", async () => {
     const src = `
@@ -141,11 +138,11 @@ describe.each(["throw a;", "Promise.reject(a);"])("%s", stmt => {
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const lines = stderr.trimEnd().split("\n");
 
-    // console.log of the same value is guarded (throws RangeError); the
-    // uncaught-exception printer must be at least as safe.
-    expect(stderr).toContain("control:RangeError");
+    expect(lines[0]).toBe("control:RangeError");
     expect(proc.signalCode).toBeNull();
+    expect(lines.at(-1)).toMatch(/^Bun v\S+ \(.+\)$/);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -123,11 +123,15 @@ test("native error printer handles lone surrogates in message and stack frame na
   expect(exitCode).toBe(1);
 });
 
-describe.each(["throw a;", "Promise.reject(a);"])("%s", stmt => {
+describe.each([
+  ["array", "[a]", "throw a;"],
+  ["array", "[a]", "Promise.reject(a);"],
+  ["Proxy", "new Proxy(a,{})", "throw a;"],
+])("%s / %s", (_, wrap, stmt) => {
   test.concurrent("native error printer survives a deeply nested thrown value", async () => {
     const src = `
-      let a = [];
-      for (let i = 0; i < 50000; i++) a = [a];
+      let a = {};
+      for (let i = 0; i < 50000; i++) a = ${wrap};
       ${stmt}
     `;
     await using proc = Bun.spawn({

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
@@ -121,4 +121,31 @@ test("native error printer handles lone surrogates in message and stack frame na
   // Printer must not have crashed: normal uncaught-error exit (1), no signal.
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(1);
+});
+
+// The uncaught-exception printer constructs its own Formatter. Before this fix
+// it left `stack_check` at the always-passes default, so formatting a deeply
+// nested non-Error value recursed until the native stack overflowed (SIGSEGV).
+describe.each(["throw a;", "Promise.reject(a);"])("%s", stmt => {
+  test.concurrent("native error printer survives a deeply nested thrown value", async () => {
+    const src = `
+      let a = [];
+      for (let i = 0; i < 50000; i++) a = [a];
+      try { console.log(a); } catch (e) { console.error("control:" + e.constructor.name); }
+      ${stmt}
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // console.log of the same value is guarded (throws RangeError); the
+    // uncaught-exception printer must be at least as safe.
+    expect(stderr).toContain("control:RangeError");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -123,21 +123,30 @@ test("native error printer handles lone surrogates in message and stack frame na
   expect(exitCode).toBe(1);
 });
 
-describe.each([
-  ["array", "[a]", "throw a;"],
-  ["array", "[a]", "Promise.reject(a);"],
-  ["Proxy", "new Proxy(a,{})", "throw a;"],
-])("%s / %s / %s", (_, wrap, stmt) => {
-  test.concurrent("native error printer survives a deeply nested thrown value", async () => {
-    const src = `
-      let a = {};
-      for (let i = 0; i < 50000; i++) a = ${wrap};
-      ${stmt}
-    `;
+// The uncaught exception printer used to recurse into a deeply nested value
+// until the native stack overflowed and the process died with SIGSEGV. Each
+// shape recurses through a different path: arrays through the value formatter,
+// a Proxy through its target (a tag the formatter does not track for circular
+// references), error.cause through the error printer itself.
+describe("native error printer survives a deeply nested uncaught value", () => {
+  const cases: [name: string, src: string][] = [
+    ["throw array", "let a = []; for (let i = 0; i < 50000; i++) a = [a]; throw a;"],
+    ["reject with array", "let a = []; for (let i = 0; i < 50000; i++) a = [a]; Promise.reject(a);"],
+    ["throw Proxy chain", "let a = {}; for (let i = 0; i < 50000; i++) a = new Proxy(a, {}); throw a;"],
+    [
+      "throw error.cause chain",
+      "let e = new Error('root'); for (let i = 0; i < 10000; i++) e = new Error('wrap', { cause: e }); throw e;",
+    ],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_, src) => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", src],
       env: bunEnv,
       stdout: "ignore",
+      // Everything that fits on the stack is still printed. For the array that
+      // is hundreds of megabytes of indentation on a release build, so don't
+      // pipe it; the assertion is that the printer gave up instead of crashing.
       stderr: "ignore",
     });
     await proc.exited;

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -129,13 +129,22 @@ test("native error printer handles lone surrogates in message and stack frame na
 // a Proxy through its target (a tag the formatter does not track for circular
 // references), error.cause through the error printer itself.
 describe("native error printer survives a deeply nested uncaught value", () => {
+  // Depths are sized so that an unfixed printer overflows on every platform,
+  // including the 18 MB main thread stack of the macOS and Windows builds (Linux
+  // has 8 MB): a release build spends at least about 175 bytes of stack per
+  // array or Proxy level, so 18 MB holds at most about 105k of them, and
+  // several KB per error level. A fixed printer stops at the stack limit, so
+  // the depth does not change how much it prints.
   const cases: [name: string, src: string][] = [
-    ["throw array", "let a = []; for (let i = 0; i < 50000; i++) a = [a]; throw a;"],
-    ["reject with array", "let a = []; for (let i = 0; i < 50000; i++) a = [a]; Promise.reject(a);"],
-    ["throw Proxy chain", "let a = {}; for (let i = 0; i < 50000; i++) a = new Proxy(a, {}); throw a;"],
+    ["throw array", "let a = []; for (let i = 0; i < 150_000; i++) a = [a]; throw a;"],
+    ["reject with array", "let a = []; for (let i = 0; i < 150_000; i++) a = [a]; Promise.reject(a);"],
+    [
+      "throw Proxy chain",
+      "const handler = {}; let a = {}; for (let i = 0; i < 150_000; i++) a = new Proxy(a, handler); throw a;",
+    ],
     [
       "throw error.cause chain",
-      "let e = new Error('root'); for (let i = 0; i < 10000; i++) e = new Error('wrap', { cause: e }); throw e;",
+      "let e = new Error('root'); for (let i = 0; i < 10_000; i++) e = new Error('wrap', { cause: e }); throw e;",
     ],
   ];
 

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import stripAnsi from "strip-ansi";
 
 describe("Bun.inspect", () => {
@@ -137,6 +138,36 @@ describe("Bun.inspect", () => {
     expect(() => Bun.inspect(object, { depth: Infinity })).toThrowErrorMatchingInlineSnapshot(
       `"Maximum call stack size exceeded."`,
     );
+  });
+
+  // React elements are not tracked for circular references, and the stack check used to be
+  // skipped together with that tracking, so unlike the object and Error chains above this chain
+  // overflowed the native stack and killed the process (at any `depth`: element props are not
+  // depth limited). Nesting through a prop rather than `children` keeps the rendering one line, so
+  // the levels that do get rendered before the limit stay small. Run in a subprocess so a
+  // regression fails this test instead of taking the test runner down.
+  it("stack overflow is thrown when it should be for React element chains", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `let v = "leaf";
+         for (let i = 0; i < 100_000; i++) {
+           v = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: { x: v } };
+         }
+         try {
+           Bun.inspect(v);
+           console.log("returned");
+         } catch (e) {
+           console.log(e.name + ": " + e.message);
+         }`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("RangeError: Maximum call stack size exceeded.\n");
+    expect(exitCode).toBe(0);
   });
 
   it("depth = 0", () => {


### PR DESCRIPTION
Throwing or rejecting a deeply nested non-Error value (a 50k-deep array, Proxy chain, or error.cause chain) SIGSEGVs the process instead of printing the error and exiting 1. The same values SIGSEGV `bun test` when the diff or snapshot formatter renders them.

### Repro

```js
let a = [];
for (let i = 0; i < 50000; i++) a = [a];
throw a;   // or Promise.reject(a); or expect(a).toEqual(1) / toMatchSnapshot() in a test
```

```
[
  [
    [
...
Segmentation fault (exit 139)
```

3/3 on 1.4.0 and ASAN main. Node prints a truncated `[ [ [ [Array] ] ] ]` and exits 1.

### Cause

- `console_object::Formatter::new()` left `stack_check` at `StackCheck::default()`, whose `cached_stack_end` is 0 so `is_safe_to_recurse()` always returns true. `format2` / `Bun.inspect` overwrote it with `StackCheck::init()`, but ~40 other callers (including `VirtualMachine::print_exception`) did not, so the `print_as_prelude` guard never fired for them and `print_array` (no `max_depth` clamp) recursed until the native stack overflowed.
- `print_as_prelude` also returned early at `!can_circ` before the stack check, so `Tag::Proxy` (not in `can_have_circular_references()`) bypassed the guard even where `stack_check` was seated.
- `test_runner::pretty_format::Formatter` (the `toEqual` diff and `toMatchSnapshot` serializer) is a separate struct with no stack guard at all.

### Fix

- `console_object::Formatter::new()` seats `stack_check = StackCheck::init()` itself (one cached thread-local read; on an unconfigured thread it yields 0, same as the old default). The per-call-site re-seats in ConsoleObject.rs, `JSValue::to_fmt`, and `Formatter::format_value` are removed. `StackCheck::update` and the `Default` impl (the unbounded value this bug came from) have no users left and are removed.
- `print_as_prelude` checks `is_safe_to_recurse()` before the `!can_circ` early-return so every recursive tag is covered.
- `pretty_format::Formatter` gains `stack_check` (seated in `new()`) and a guard at the top of `print_as` that sets `failed` (unwinding the walk) and `hit_stack_limit`. `JestPrettyFormat::format` then consults a new `FormatOptions::can_throw_stack_overflow` once the walk has unwound:
  - diff output (`toEqual` failures) leaves it off, so a truncated diff is still printed;
  - snapshot serialization (`toMatchSnapshot`, `toMatchInlineSnapshot`) turns it on, so a value too deep to serialize fails the test instead of a truncated serialization being written to the `.snap` / test file and compared on later runs.
  
  The throw is deferred to the end of `format` rather than raised where the limit is hit because `JSC__JSValue__forEachPropertyOrdered` drops an exception thrown from its callback when further properties follow; a leaf-level throw only reached the matcher for arrays and single-key objects (verified: with the leaf-level version, a two-key object still wrote a truncated snapshot).
- The asymmetric-matcher bridge (`amf_print_as`, used when a diff renders `expect.objectContaining(...)` and friends) took a `&mut dyn Write` and wrapped it in two adapters per nesting level, so a write issued N matchers deep passed through 2N adapter frames below the stack check and a ~5k-deep `objectContaining` chain still overflowed on release. It is now generic over the writer and calls `format` directly; the `FormatTag` mapping it shared with the `write_format` bridge becomes a `From` impl.
- The uncaught-exception printer keeps `can_throw_stack_overflow` off: it truncates and exits 1.

Since #37334 the snapshot matchers rethrow the formatter's own error, so the failure surfaces as `RangeError: Maximum call stack size exceeded`. This PR does not touch `expect.rs`.

### Verification

`test/js/bun/util/reportError.test.ts`: `throw` / `Promise.reject` of a 150k-deep array, a 150k-deep Proxy chain, and a 10k-deep error.cause chain each exit 1 with no signal (depths are sized so an unfixed printer also overflows the 18 MB main-thread stacks of the macOS and Windows builds, not only Linux's 8 MB) (stderr is not piped: the console formatter writes ~K^2 bytes of indentation before the guard fires on release builds).

`test/js/node/util/bun-inspect.test.ts`: `Bun.inspect` of a 100k-deep React element chain throws `RangeError` in-process instead of crashing (the throwing branch of the `print_as_prelude` reorder; elements, like Proxies, are not tracked for circular references).

`test/js/bun/test/pretty-format-overflow.test.ts`: failing `toEqual` on a 100k-deep array / two-key object / React element chain, and against a 50k-deep `expect.objectContaining` chain, still prints a diff and `1 fail`; `toMatchSnapshot` and `toMatchInlineSnapshot` on the 100k-deep two-key object fail and write nothing (`pretty_format` caps indentation at 32 levels, so its piped output is ~3 MB on release). A 256-deep object is asserted to still serialize in full, as a floor on where the guard may fire (measured at ~500 object levels on a debug+ASAN build and ~10x that on release, before main raised the ASAN stack reserve from 128 KB to 512 KB and moved to LLVM 23).

With `src/` at the merge-base the 11 new overflow cases fail (plus, on a debug+ASAN build of current main, the pre-existing 500-deep `toEqual` case in the same file, which this change also covers) (SIGSEGV, or the child dies before printing) and with the fix all 32 tests in the three files pass, including the snapshot path under `BUN_JSC_validateExceptionChecks=1`. Re-verified locally after each rebase onto main, up to 5a24ce6c33. The current head (677370570b) additionally merges main, including its `StackCheck` threshold change and the LLVM 23 / Rust nightly upgrade. The merge left this PR's hunks intact and the net diff unchanged. On that head, CI build 116586 ran all three files on the x64-asan lane (shards 14, 7, 9) with the new toolchain: 8/8, 6/6 and 18/18 pass, which includes the 256-deep floor case. That lane is an optimized ASAN build. A debug+ASAN build (`bun bd`), where frames are largest and where the ~500-level figure above was taken, has not been re-measured on the new toolchain. At the old per-level cost the larger reserve still leaves about 475 levels against the 256 floor. Earlier, the second rebase resolved conflicts with #37334 and the `DiffFormatter::new` refactor by taking main's `expect.rs` / `diff_format.rs` and re-adding the one `FormatOptions` field. `bun-inspect.test.ts`, `inspect.test.js`, `console/`, `snapshot-tests/`, `jest-each` / `describe` (exercise `format_value`), and `expect.test.js` pass unchanged.

### Related open PRs

- #34885 (closed into this one): its `pretty_format` guard and test matrix are folded in here.
- #29709 guards the same JSX/Proxy recursion with a local check; the `print_as_prelude` reorder here covers it, and the two touch the same hunk.
- #36602 seats `stack_check` locally in `print_exception`; redundant once `Formatter::new()` seats it.
- #35288 adds a depth cap on entries and cause chains; independent of the stack guard, but adjacent in `ConsoleObject.rs`.
- #39565 changes how the C++ property walk handles an exception thrown while a failure message is formatted (the behaviour the deferred throw here sidesteps) and touches `diff_format.rs`, where this PR adds one field.
- #37334 (merged) made the snapshot matchers rethrow the formatter's error; the tests here accept that message (and the older wrapper text).

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 4 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/pretty-format-overflow.test.ts test/js/bun/util/reportError.test.ts test/js/node/util/bun-inspect.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/test/pretty-format-overflow.test.ts:
43 |     });
44 | 
45 |     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
46 | 
47 |     // The test should fail due to assertion mismatch, but should NOT crash
48 |     expect(exitCode).toBe(1);
                          ^
error: expect(received).toBe(expected)

Expected: 1
Received: 139

      at <anonymous> (/workspace/bun/test/js/bun/test/pretty-format-overflow.test.ts:48:22)
(fail) pretty_format should handle deeply nested objects without crashing > deeply nested object with many properties [7187.27ms]
106 |   }
107 | 
108 |   for (const [name, build] of Object.entries(shapes)) {
109 |     test(`failing toEqual on a deep ${name} still prints a diff`, async () => {
110 |       const { stderr, exitCode } = await runDeepTest(`${build}\nexpect(v).toEqual(1);`);
111 |       expect(stderr).toContain("expec
... (truncated)

release without fix: 11 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/test/pretty-format-overflow.test.ts:
(pass) pretty_format should handle deeply nested objects without crashing > deeply nested object with many properties [41.75ms]
(pass) pretty_format and the native stack limit > a 256-deep object is still serialized in full [7.04ms]
106 |   }
107 | 
108 |   for (const [name, build] of Object.entries(shapes)) {
109 |     test(`failing toEqual on a deep ${name} still prints a diff`, async () => {
110 |       const { stderr, exitCode } = await runDeepTest(`${build}\nexpect(v).toEqual(1);`);
111 |       expect(stderr).toContain("expect(received).toEqual(expected)");
                           ^
error: expect(received).toContain(expected)

Expected to contain: "expect(received).toEqual(expected)"
Received: "\ndeep.test.ts:\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/pretty-format-overflow.test.ts:111:22)
(fail) pretty_format and the native stack limit > failing toEqual on a deep object still prints a diff [132.61ms]
106 |   }
107 | 
108 |   for (const [name, build] of Object.entries(shapes)) {
109 |     test(`failing toEqual on a deep ${name} still prints a diff`, async (
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/pretty-format-overflow.test.ts test/js/bun/util/reportError.test.ts test/js/node/util/bun-inspect.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/test/pretty-format-overflow.test.ts:
(pass) pretty_format should handle deeply nested objects without crashing > deeply nested object with many properties [7794.26ms]
(pass) pretty_format and the native stack limit > failing toEqual on a deep array still prints a diff [616.23ms]
(pass) pretty_format and the native stack limit > toMatchSnapshot on a deep object fails instead of writing a truncated snapshot [589.01ms]
(pass) pretty_format and the native stack limit > failing toEqual against a deep expect.objectContaining chain still prints a diff [702.59ms]
(pass) pretty_format and the native stack limit > failing toEqual on a deep object still prints a diff [761.33ms]
(pass) pretty_format and the native stack limit > failing toEqual on a deep React element still prints a diff [840.78ms]
(pass) pretty_format and the native stack limit > a 256-deep object is still serialized in 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5a24ce6c33
  features     baseline

23 deps, 131 codegen, 1172 objects in 781ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [13.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/util.rs                            |  14 ---
 src/jsc/ConsoleObject.rs                        |  17 +---
 src/jsc/JSValue.rs                              |   1 -
 src/jsc/VirtualMachine.rs                       |   3 +-
 src/runtime/test_runner/diff_format.rs          |   1 +
 src/runtime/test_runner/mod.rs                  |   1 +
 src/runtime/test_runner/pretty_format.rs        |  86 ++++++++++-------
 test/js/bun/test/pretty-format-overflow.test.ts | 118 ++++++++++++++++++++++++
 test/js/bun/util/reportError.test.ts            |  43 ++++++++-
 test/js/node/util/bun-inspect.test.ts           |  31 +++++++
 10 files changed, 250 insertions(+), 65 deletions(-)
```

</details>

**gate history** · 11 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/bun_core/util.rs                                 2      2     59
src/jsc/ConsoleObject.rs                            12      8     59
src/jsc/JSValue.rs                                   2      3     59
src/jsc/VirtualMachine.rs                            7      6     59
src/runtime/test_runner/diff_format.rs               1      1     59
src/runtime/test_runner/mod.rs                       0      0     59
src/runtime/test_runner/pretty_format.rs             9      8     60
test/js/bun/test/pretty-format-overflow.test.ts      2      2     38
test/js/bun/util/reportError.test.ts                 5      7     46
test/js/node/util/bun-inspect.test.ts                0      0     14
```

</details>

<!-- robobun:evidence:end -->




