### PR TITLE
inspect: stop at a foreign realm's Object.prototype; print [Getter] for array index accessors

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4444,7 +4444,7 @@ pub mod formatter {
                 let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
                 let mut empty_start: Option<u32> = None;
                 'first: {
-                    let element = value.get_direct_index(self.global_this, 0);
+                    let element = value.get_own_index_for_inspect(self.global_this, 0);
 
                     let tag = Tag::get_advanced(element, self.global_this, tag_opts)?;
 
@@ -4484,7 +4484,7 @@ pub mod formatter {
                 let mut nonempty_count: u32 = 1;
 
                 while (i as u64) < len {
-                    let element = value.get_direct_index(self.global_this, i);
+                    let element = value.get_own_index_for_inspect(self.global_this, i);
                     if element.is_empty() {
                         if empty_start.is_none() {
                             empty_start = Some(i);

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2595,10 +2595,9 @@ impl JSValue {
         }
         JSC__JSValue__getDirectIndex(self, global, i)
     }
-    /// Read the `i`th indexed own property for console.log/`Bun.inspect`: an
-    /// own indexed accessor is returned as its `GetterSetter` cell (the printer
-    /// renders `[Getter]`) instead of being called, and any exception from the
-    /// lookup is swallowed. Holes return the empty value.
+    /// `i`th indexed own property for `Bun.inspect`: accessors come back as the
+    /// `GetterSetter` cell (printer renders `[Getter]`) instead of being called,
+    /// exceptions are swallowed, and holes return the empty value.
     pub fn get_own_index_for_inspect(self, global: &JSGlobalObject, i: u32) -> JSValue {
         unsafe extern "C" {
             safe fn JSC__JSValue__getOwnIndexForInspect(

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2582,8 +2582,8 @@ impl JSValue {
         }
         JSBuffer__isBuffer(global, self)
     }
-    /// `JSValue.getDirectIndex` — read the `i`th indexed
-    /// own-property slot directly (no prototype walk, no getters). Returns
+    /// `JSValue.getDirectIndex` — read the `i`th indexed own property
+    /// (no prototype walk). Own indexed accessors **are** invoked. Returns
     /// the empty value for holes.
     pub fn get_direct_index(self, global: &JSGlobalObject, i: u32) -> JSValue {
         unsafe extern "C" {
@@ -2594,6 +2594,20 @@ impl JSValue {
             ) -> JSValue;
         }
         JSC__JSValue__getDirectIndex(self, global, i)
+    }
+    /// Read the `i`th indexed own property for console.log/`Bun.inspect`: an
+    /// own indexed accessor is returned as its `GetterSetter` cell (the printer
+    /// renders `[Getter]`) instead of being called, and any exception from the
+    /// lookup is swallowed. Holes return the empty value.
+    pub fn get_own_index_for_inspect(self, global: &JSGlobalObject, i: u32) -> JSValue {
+        unsafe extern "C" {
+            safe fn JSC__JSValue__getOwnIndexForInspect(
+                this: JSValue,
+                global: &JSGlobalObject,
+                i: u32,
+            ) -> JSValue;
+        }
+        JSC__JSValue__getOwnIndexForInspect(self, global, i)
     }
     /// Smallest own present index of a `JSArray` that is `>= start`, or
     /// `None` when every index from `start` to the end of the array is a

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2881,10 +2881,9 @@ JSC::EncodedJSValue JSC__JSValue__getDirectIndex(JSC::EncodedJSValue jsValue, JS
     return JSC::JSValue::encode(object->getDirectIndex(arg1, arg3));
 }
 
-// Like getDirectIndex, but for console.log/inspect: an own indexed accessor is
-// returned as its GetterSetter cell (so the printer renders "[Getter]") instead
-// of being invoked, and any exception is swallowed rather than escaping the
-// inspect walk. Holes return the empty value.
+// getDirectIndex for console.log/inspect: own indexed accessors come back as
+// their GetterSetter cell (printer renders "[Getter]") instead of being called,
+// exceptions are swallowed, and holes return the empty value.
 extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnIndexForInspect(JSC::EncodedJSValue encodedValue, JSC::JSGlobalObject* globalObject, uint32_t i)
 {
     JSC::JSObject* object = JSC::JSValue::decode(encodedValue).getObject();
@@ -2898,7 +2897,10 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnIndexForInspect(JSC::EncodedJ
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::PropertySlot slot(object, JSC::PropertySlot::InternalMethodType::Get);
     bool has = object->methodTable()->getOwnPropertySlotByIndex(object, globalObject, i, slot);
-    CLEAR_IF_EXCEPTION(scope);
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
     if (!has)
         return JSC::JSValue::encode(JSC::JSValue());
     if (slot.isAccessor())
@@ -5129,10 +5131,9 @@ static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC:
     size_t prototypeCount = 0;
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    // The prototype walk ends at a realm's Object.prototype / Function.prototype.
-    // A `node:vm` object's chain ends at a *different* realm's prototypes, so a
-    // pointer-identity check against this realm's intrinsics would walk through
-    // them and enumerate `toString`/`hasOwnProperty`/... as if they were own.
+    // End the walk at any realm's Object.prototype / Function.prototype; an
+    // identity check against *this* realm's intrinsics would walk through a
+    // `node:vm` object's foreign-realm prototype and list its methods as own.
     auto isTerminalPrototype = [&](JSC::JSValue proto) -> bool {
         JSC::JSObject* protoObject = proto.getObject();
         if (!protoObject)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2894,7 +2894,7 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnIndexForInspect(JSC::EncodedJ
         return JSC::JSValue::encode(quick);
 
     auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::PropertySlot slot(object, JSC::PropertySlot::InternalMethodType::Get);
     bool has = object->methodTable()->getOwnPropertySlotByIndex(object, globalObject, i, slot);
     if (scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -95,6 +95,7 @@
 #include "wtf/GregorianDateTime.h"
 
 #include "JavaScriptCore/FunctionPrototype.h"
+#include "JavaScriptCore/ObjectPrototype.h"
 #include "JSFetchHeaders.h"
 #include "FetchHeaders.h"
 #include "DOMURL.h"
@@ -2880,6 +2881,36 @@ JSC::EncodedJSValue JSC__JSValue__getDirectIndex(JSC::EncodedJSValue jsValue, JS
     return JSC::JSValue::encode(object->getDirectIndex(arg1, arg3));
 }
 
+// Like getDirectIndex, but for console.log/inspect: an own indexed accessor is
+// returned as its GetterSetter cell (so the printer renders "[Getter]") instead
+// of being invoked, and any exception is swallowed rather than escaping the
+// inspect walk. Holes return the empty value.
+extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnIndexForInspect(JSC::EncodedJSValue encodedValue, JSC::JSGlobalObject* globalObject, uint32_t i)
+{
+    JSC::JSObject* object = JSC::JSValue::decode(encodedValue).getObject();
+    if (!object) [[unlikely]]
+        return JSC::JSValue::encode(JSC::JSValue());
+
+    if (JSC::JSValue quick = object->tryGetIndexQuickly(i))
+        return JSC::JSValue::encode(quick);
+
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::PropertySlot slot(object, JSC::PropertySlot::InternalMethodType::Get);
+    bool has = object->methodTable()->getOwnPropertySlotByIndex(object, globalObject, i, slot);
+    CLEAR_IF_EXCEPTION(scope);
+    if (!has)
+        return JSC::JSValue::encode(JSC::JSValue());
+    if (slot.isAccessor())
+        return JSC::JSValue::encode(slot.getterSetter());
+    JSC::JSValue result = slot.getValue(globalObject, i);
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    }
+    return JSC::JSValue::encode(result ? result : JSC::JSValue());
+}
+
 JSC::EncodedJSValue JSC__JSObject__getDirect(JSC::JSObject* arg0, JSC::JSGlobalObject* arg1,
     const ZigString* arg2)
 {
@@ -5098,6 +5129,21 @@ static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC:
     size_t prototypeCount = 0;
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+    // The prototype walk ends at a realm's Object.prototype / Function.prototype.
+    // A `node:vm` object's chain ends at a *different* realm's prototypes, so a
+    // pointer-identity check against this realm's intrinsics would walk through
+    // them and enumerate `toString`/`hasOwnProperty`/... as if they were own.
+    auto isTerminalPrototype = [&](JSC::JSValue proto) -> bool {
+        JSC::JSObject* protoObject = proto.getObject();
+        if (!protoObject)
+            return true;
+        if (protoObject->inherits<JSC::ObjectPrototype>() || protoObject->inherits<JSC::FunctionPrototype>())
+            return true;
+        if (protoObject->inherits<JSGlobalProxy>())
+            return uncheckedDowncast<JSGlobalProxy>(protoObject)->target() != globalObject;
+        return false;
+    };
+
     JSC::Structure* structure = object->structure();
     bool fast = !nonIndexedOnly && canPerformFastPropertyEnumerationForIterationBun(structure);
     JSValue prototypeObject = value;
@@ -5107,7 +5153,7 @@ static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC:
             fast = false;
 
             if (JSValue proto = object->getPrototype(globalObject)) {
-                if ((structure = proto.structureOrNull())) {
+                if (!isTerminalPrototype(proto) && (structure = proto.structureOrNull())) {
                     prototypeObject = proto;
                     fast = canPerformFastPropertyEnumerationForIterationBun(structure);
                     prototypeCount = 1;
@@ -5184,7 +5230,7 @@ restart:
             if (prototypeCount++ < 5) {
 
                 if (JSValue proto = prototypeObject.getPrototype(globalObject)) {
-                    if (!(proto == globalObject->objectPrototype() || proto == globalObject->functionPrototype() || (proto.inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(proto)->target() != globalObject))) {
+                    if (!isTerminalPrototype(proto)) {
                         if ((structure = proto.structureOrNull())) {
                             prototypeObject = proto;
                             fast = canPerformFastPropertyEnumerationForIterationBun(structure);
@@ -5205,7 +5251,7 @@ restart:
 
         JSObject* iterating = prototypeObject.getObject();
 
-        while (iterating && !(iterating == globalObject->objectPrototype() || iterating == globalObject->functionPrototype() || (iterating->inherits<JSGlobalProxy>() && uncheckedDowncast<JSGlobalProxy>(iterating)->target() != globalObject)) && prototypeCount++ < 5) {
+        while (iterating && !isTerminalPrototype(iterating) && prototypeCount++ < 5) {
             if constexpr (nonIndexedOnly) {
                 iterating->getOwnNonIndexPropertyNames(globalObject, properties, DontEnumPropertiesMode::Include);
             } else {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
+import vm from "node:vm";
 import { join } from "path";
 import util from "util";
-import vm from "node:vm";
 it("prototype", () => {
   const prototypes = [
     Request.prototype,

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -849,6 +849,27 @@ describe("array with own indexed accessor", () => {
     expect(Bun.inspect(arr)).toBe("[ 1, [Getter/Setter], 3 ]");
   });
 
+  it("prints [Getter] for an accessor at index 0", () => {
+    const arr = [1, 2, 3];
+    let called = false;
+    Object.defineProperty(arr, 0, {
+      get() {
+        called = true;
+        throw new Error("boom");
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    expect(Bun.inspect(arr)).toBe("[\n  [Getter], 2, 3\n]");
+    expect(called).toBe(false);
+  });
+
+  it("prints [Setter] for a setter-only indexed accessor", () => {
+    const arr = [1, 2, 3];
+    Object.defineProperty(arr, 1, { set(v) {}, enumerable: true, configurable: true });
+    expect(Bun.inspect(arr)).toBe("[ 1, [Setter], 3 ]");
+  });
+
   it("console.log does not throw when an indexed getter throws", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -860,9 +860,10 @@ describe("array with own indexed accessor", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toContain("[Getter]");
-    expect(stdout).toContain("after");
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "[ 1, [Getter], 3 ]\nafter\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tmpdirSync } from "harness";
 import { join } from "path";
 import util from "util";
+import vm from "node:vm";
 it("prototype", () => {
   const prototypes = [
     Request.prototype,
@@ -802,4 +803,66 @@ it("CustomEvent", () => {
       BUBBLING_PHASE: 3,
     }"
   `);
+});
+
+describe("node:vm cross-realm objects", () => {
+  it("does not print the foreign realm's Object.prototype methods as own props", () => {
+    const out = Bun.inspect(vm.runInNewContext("({a:1})"));
+    expect(out).not.toContain("hasOwnProperty");
+    expect(out).not.toContain("toString");
+    expect(out).toBe("{\n  a: 1,\n}");
+  });
+
+  it("handles empty objects and arrays from another realm", () => {
+    expect(Bun.inspect(vm.runInNewContext("({})"))).toBe("{}");
+    expect(Bun.inspect(vm.runInNewContext("[1, 2, 3]"))).toBe("[ 1, 2, 3 ]");
+    expect(Bun.inspect(vm.runInNewContext("(function foo(){})"))).toBe("[Function: foo]");
+  });
+
+  it("still walks a user-defined class's prototype from another realm", () => {
+    const obj = vm.runInNewContext("class C { m() {} } new C()");
+    const out = Bun.inspect(obj);
+    expect(out).toContain("m: [Function: m]");
+    expect(out).not.toContain("hasOwnProperty");
+  });
+});
+
+describe("array with own indexed accessor", () => {
+  it("prints [Getter] instead of invoking a throwing getter", () => {
+    const arr = [1, 2, 3];
+    let called = false;
+    Object.defineProperty(arr, 1, {
+      get() {
+        called = true;
+        throw new Error("index getter invoked");
+      },
+      enumerable: true,
+      configurable: true,
+    });
+    expect(Bun.inspect(arr)).toBe("[ 1, [Getter], 3 ]");
+    expect(called).toBe(false);
+  });
+
+  it("prints [Getter/Setter] for an accessor with both", () => {
+    const arr = [1, 2, 3];
+    Object.defineProperty(arr, 1, { get() {}, set(v) {}, enumerable: true, configurable: true });
+    expect(Bun.inspect(arr)).toBe("[ 1, [Getter/Setter], 3 ]");
+  });
+
+  it("console.log does not throw when an indexed getter throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const a=[1,2,3];Object.defineProperty(a,1,{get(){throw new Error("boom")},enumerable:true});console.log(a);console.log("after");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("[Getter]");
+    expect(stdout).toContain("after");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
Two console.log/Bun.inspect defects, both in the property walker.

## Repro

```js
import vm from "node:vm";
console.log(vm.runInNewContext("({a:1})"));
// bun:  { a: 1, toString: ..., hasOwnProperty: ..., __defineGetter__: ..., ... }
// node: { a: 1 }

const arr = [1, 2, 3];
Object.defineProperty(arr, 1, { get() { throw new Error("boom"); }, enumerable: true });
console.log(arr);
// bun:  "[ 1, " then the getter's error throws out of console.log
// node: [ 1, [Getter], 3 ]
```

## Cause

`forEachPropertyImpl` walks the prototype chain to show class members and ends that walk on `proto == globalObject->objectPrototype()` / `functionPrototype()`. That is an identity compare against the *calling* realm's intrinsics; a `node:vm` object's chain ends at a different realm's `Object.prototype`, so the walk continued through it and listed `toString` / `hasOwnProperty` / `__defineGetter__` / ... as if they were own.

`print_array` read each element through `JSObject::getDirectIndex`, which ends in `slot.getValue(...)` and so invokes an own indexed accessor. A throwing getter escaped `console.log`, and a non-throwing one ran user side effects from a debug print.

## Fix

Factor the terminator into an `isTerminalPrototype` helper that matches any realm's `Object.prototype` / `Function.prototype` via `inherits<ObjectPrototype>()` / `inherits<FunctionPrototype>()` (plus the existing `JSGlobalProxy` case), and use it at all three walk sites: the fast-path empty-object hop, the fast-path `anyHits` continue, and the slow-path `while` loop.

Add `JSC__JSValue__getOwnIndexForInspect`: an own indexed accessor returns its `GetterSetter` cell (the existing `Tag::GetterSetter` path renders `[Getter]` / `[Getter/Setter]`) instead of being called, and any lookup exception is swallowed; holes stay empty. `print_array` reads elements through it.

## Verification

New tests in `test/js/bun/util/inspect.test.js`: cross-realm `{a:1}` / `{}` / `[1,2,3]` / `function` print the same as Node, a cross-realm class instance still shows its own prototype's method, and an array with a throwing index getter prints `[ 1, [Getter], 3 ]` without invoking the getter.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2042a8f8a)

test/js/bun/util/inspect.test.js:
(pass) prototype [294.51ms]
(pass) getters [5.54ms]
(pass) setters [4.17ms]
(pass) getter/setters [2.20ms]
(pass) Timeout [4.85ms]
(pass) when prototype defines the same property, don't print the same property twice [2.23ms]
(pass) Blob inspect [8.67ms]
(pass) utf16 property name [60.95ms]
(pass) latin1 [4.25ms]
(pass) Request object [2.55ms]
(pass) MessageEvent [1.85ms]
(pass) MessageEvent with no data set [1.79ms]
(pass) MessageEvent with deleted data [2.45ms]
(pass) TypedArray prints [96.68ms]
(pass) BigIntArray [31.85ms]
(pass) Float32Array 42.68000030517578 [4.27ms]
(pass) Float32Array 42.68 [3.94ms]
(pass) Float64Array 42.68000030517578 [1.48ms]
(pass) Float64Array 42.68 [1.37ms]
(p
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (925695f51)

test/js/bun/util/inspect.test.js:
(pass) prototype [3.42ms]
(pass) getters [0.10ms]
(pass) setters [0.06ms]
(pass) getter/setters [0.03ms]
(pass) Timeout [0.09ms]
(pass) when prototype defines the same property, don't print the same property twice [0.05ms]
(pass) Blob inspect [0.25ms]
(pass) utf16 property name [1.10ms]
(pass) latin1 [0.05ms]
(pass) Request object [0.04ms]
(pass) MessageEvent [0.03ms]
(pass) MessageEvent with no data set [0.01ms]
(pass) MessageEvent with deleted data [0.03ms]
(pass) TypedArray prints [0.97ms]
(pass) BigIntArray [0.36ms]
(pass) Float32Array 42.68000030517578 [0.10ms]
(pass) Float32Array 42.68 [0.08ms]
(pass) Float64Array 42.68000030517578 [0.01ms]
(pass) Float64Array 42.68 [0.02ms]
(pass) jsx with two elements [0.54ms]
(pass) jsx with anon component [0.04ms]
(pass) jsx with fragment [0.09ms]
(pass) inspect [0.68ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [0.03ms]
(pass) latin1 supplemental > latin1 (input) "cbä" [ "cbä" ]
(pass) latin1 supplemental > latin1 (input) "cäb" [ "cäb" ]
(pass) latin1 supplemental > latin1 (input) "äbc äbc" [ "äbc äbc" ]
(pass) latin1 suppl
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (2042a8f8a)

test/js/bun/util/inspect.test.js:
(pass) prototype [297.66ms]
(pass) getters [5.39ms]
(pass) setters [3.87ms]
(pass) getter/setters [2.22ms]
(pass) Timeout [4.82ms]
(pass) when prototype defines the same property, don't print the same property twice [2.15ms]
(pass) Blob inspect [10.20ms]
(pass) utf16 property name [63.42ms]
(pass) latin1 [4.38ms]
(pass) Request object [2.70ms]
(pass) MessageEvent [1.90ms]
(pass) MessageEvent with no data set [1.79ms]
(pass) MessageEvent with deleted data [2.51ms]
(pass) TypedArray prints [98.79ms]
(pass) BigIntArray [33.77ms]
(pass) Float32Array 42.68000030517578 [4.32ms]
(pass) Float32Array 42.68 [4.13ms]
(pass) Float64Array 42.68000030517578 [1.72ms]
(pass) Float64Array 42.68 [1.35ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 699ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 245 extern-C blocks audited
[3/22] gen JS modules (bundle-modules)
Preprocess modules (8173ms)
Bundle modules (31ms)
Postprocesss modules (148ms)
Bundle Functions (783ms)
Generate Code (100ms)

[9.25s] Bundled "src/js" for production
  2042 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rus
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs         |  4 +-
 src/jsc/JSValue.rs               | 17 +++++++-
 src/jsc/bindings/bindings.cpp    | 53 +++++++++++++++++++++++--
 test/js/bun/util/inspect.test.js | 85 ++++++++++++++++++++++++++++++++++++++++
 4 files changed, 152 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/jsc/ConsoleObject.rs              3      2      0
src/jsc/JSValue.rs                    2      2      0
src/jsc/bindings/bindings.cpp         6     11      0
test/js/bun/util/inspect.test.js      4      6      0
```

</details>

<!-- robobun:evidence:end -->