### PR TITLE
yaml: own the property-name anchor string so it survives GC during stringify

### DIFF
--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -133,7 +133,10 @@ impl AnchorAlias {
                 ValueOrigin::Root => AnchorAliasName::Root,
                 ValueOrigin::ArrayItem => AnchorAliasName::ArrayItem(0),
                 ValueOrigin::PropValue(prop_name) => AnchorAliasName::PropValue {
-                    prop_name,
+                    // `prop_name` is borrowed from `JSPropertyIterator::next()` and may be
+                    // freed once that iterator drops and user getters trigger GC; own a ref
+                    // so it survives until the emitting pass reads it back.
+                    prop_name: OwnedString::new(prop_name.dupe_ref()),
                     counter: 0,
                 },
             },
@@ -146,7 +149,7 @@ pub(crate) enum AnchorAliasName {
     Root,
     ArrayItem(usize),
     PropValue {
-        prop_name: BunString,
+        prop_name: OwnedString,
         // added after the name
         counter: usize,
     },
@@ -408,7 +411,7 @@ impl Stringifier {
                         self.builder.append_latin1(b"value");
                         self.builder.append_usize(*counter);
                     } else {
-                        self.builder.append_string(*prop_name);
+                        self.builder.append_string(prop_name.get());
                         if *counter != 0 {
                             self.builder.append_usize(*counter);
                         }

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -3090,6 +3090,52 @@ config:
         expect(reparsed).toEqual(value);
         expect(reparsed["\\u{10FFFF}a"]).toBe(reparsed.b);
       });
+
+      test("anchor name survives GC when user getters run between the anchor pass and emission", async () => {
+        // The Proxy's ownKeys yields a property name nothing else references once its iterator
+        // drops; the `zero`/`second` getters allocate and force GC so the stored anchor name's
+        // StringImpl is freed and recycled before the emit pass dereferences it.
+        const src = `
+          let bad = 0;
+          for (let r = 0; r < 3; r++) {
+            let n = 0;
+            const shared = { v: 1 };
+            const churn = () => {
+              const j = [];
+              for (let i = 0; i < 2000; i++) j.push(Math.random().toString(36).padEnd(18, "K"));
+              Bun.gc(true);
+            };
+            const p = new Proxy({}, {
+              ownKeys() { return ["dynamic" + (n++) + Math.random().toString(36).slice(2)]; },
+              getOwnPropertyDescriptor() { return { value: shared, enumerable: true, configurable: true }; },
+              get() { return shared; },
+            });
+            const o = {};
+            Object.defineProperty(o, "zero", { enumerable: true, get() { churn(); return 0; } });
+            o.first = p;
+            Object.defineProperty(o, "second", { enumerable: true, get() { churn(); return shared; } });
+            o.third = shared;
+            const s = Bun.YAML.stringify(o);
+            let parsed;
+            try { parsed = Bun.YAML.parse(s); } catch (e) { bad++; console.error("round " + r + ": " + e.message + " in: " + s); continue; }
+            const inner = Object.values(parsed.first)[0];
+            if (!(parsed.second === inner && parsed.third === inner && inner.v === 1)) {
+              bad++;
+              console.error("round " + r + ": structure mismatch in: " + s);
+            }
+          }
+          if (bad) { console.log("FAIL:" + bad + "/3"); process.exitCode = 1; }
+          else console.log("OK");
+        `;
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", src],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+      });
     });
 
     // Edge cases and error handling


### PR DESCRIPTION
## Repro

```js
const shared = { v: 1 };
const churn = () => {
  const j = [];
  for (let i = 0; i < 2000; i++) j.push(Math.random().toString(36).padEnd(18, "K"));
  Bun.gc(true);
};
const p = new Proxy({}, {
  ownKeys() { return ["dynamic" + Math.random().toString(36).slice(2)]; },
  getOwnPropertyDescriptor() { return { value: shared, enumerable: true, configurable: true }; },
  get() { return shared; },
});
const o = {};
Object.defineProperty(o, "zero", { enumerable: true, get() { churn(); return 0; } });
o.first = p;
Object.defineProperty(o, "second", { enumerable: true, get() { churn(); return shared; } });
o.third = shared;
console.log(Bun.YAML.stringify(o));
// {zero: 0,first: {dynamic1...: &dynamic0... {v: 1}},second: *0.fg2pilul614KKKKK,third: *0.fg2pilul614KKKKK}
Bun.YAML.parse(Bun.YAML.stringify(o));
// SyntaxError: YAML Parse error: Unresolved alias
```

The emitted alias `*0.fg2pilul614KKKKK` is the getter's own allocation noise, not the anchor name; `Bun.YAML.parse` rejects the output with "Unresolved alias". Distinct from #34855 (self-referential alias resolution).

## Cause

`find_anchors_and_aliases` records the property name a shared value was first seen under so it can be reused as the anchor name:

```rust
// src/runtime/api/YAMLObject.rs
*object_entry.value_ptr = AnchorAlias::init(origin);  // origin = ValueOrigin::PropValue(prop_name)
```

`prop_name` is the `bun.String` returned by `JSPropertyIterator::next()`, which wraps the iterator's `PropertyNameArray` entry without bumping its refcount (`Bun::toString(prop.impl())` in `JSPropertyIterator.cpp`). Once that inner iterator drops and a later user getter allocates and forces GC, the `StringImpl` backing the stored name is freed and its cell reused by an unrelated string. The emission pass then dereferences it at `can_use_prop_name_as_anchor` / `append_string`, leaking the recycled bytes into the anchor/alias. ASAN stays quiet because the cell is live (recycled), not poisoned.

## Fix

Store the name as an `OwnedString` (`dupe_ref()` on the borrowed `bun.String`) so the anchor table holds a +1 ref for the lifetime of the `Stringifier`.

## Verification

New test in `test/js/bun/yaml/yaml.test.ts` spawns a subprocess that runs three rounds of the repro and asserts every `Bun.YAML.stringify` output round-trips with correct object identity.

- `bun bd test test/js/bun/yaml/yaml.test.ts`: 626 pass / 21 todo / 0 fail (new test included).
- `bun bd test test/js/bun/yaml/yaml-test-suite.test.ts test/js/bun/yaml/yaml-block-scalar-matrix.test.ts`: 1486 pass / 0 fail.
- New test without the src/ change: fails on both debug+ASAN (20/20 fresh processes) and the canary release build (50/50), printing the churn bytes in the failure diff.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 21 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (315992f38)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.11ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.29ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.30ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [2.09ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.33ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.35ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.27ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.10ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.90ms]
(pass) Bun.YAML > parse > input types > parses fro
... (truncated)

release without fix: 21 skipped
bun test v1.4.0-canary.1 (e3f273bee)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [2.19ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.06ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [1.55ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [1.15ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.10ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [1.19ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.09ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Blob [1.27ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 21 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (315992f38)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.01ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.16ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.22ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [2.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.18ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.27ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.21ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [2.99ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.84ms]
(pass) Bun.YAML > parse > input types > parses fro
... (truncated)

release with fix: 21 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 768ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/22] gen JS modules (bundle-modules)
Preprocess modules (7540ms)
Bundle modules (32ms)
Postprocesss modules (195ms)
Bundle Functions (674ms)
Generate Code (105ms)

[8.56s] Bundled "src/js" for production
  2042 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rus
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/YAMLObject.rs |  9 ++++++---
 test/js/bun/yaml/yaml.test.ts | 46 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 52 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/runtime/api/YAMLObject.rs      4      2      0
test/js/bun/yaml/yaml.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->