### PR TITLE
crypto: accept EC SPKI public keys with explicit curve parameters

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -6,6 +6,7 @@
 #include "ncrypto.h"
 #include <openssl/asn1.h>
 #include <openssl/bn.h>
+#include <openssl/bytestring.h>
 #include <openssl/dh.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
@@ -2395,6 +2396,51 @@ EVPKeyPointer::ParseKeyResult TryParsePublicKeyInner(const BIOPointer& bp,
     return EVPKeyPointer::ParseKeyResult(WTF::move(pkey));
 }
 
+// BoringSSL's d2i_PUBKEY rejects EC SPKI with specifiedCurve (explicit) parameters
+// while OpenSSL/Node.js accept them. Reuse EC_KEY_parse_parameters (which BoringSSL
+// already uses for PKCS#8/SEC1 private keys) to map them to a named curve.
+EVP_PKEY* TryParseECSubjectPublicKeyInfo(const unsigned char* der, size_t der_len)
+{
+    MarkPopErrorOnReturn mark_pop_error_on_return;
+
+    CBS cbs, spki, algorithm, oid, key;
+    CBS_init(&cbs, der, der_len);
+    if (!CBS_get_asn1(&cbs, &spki, CBS_ASN1_SEQUENCE) || CBS_len(&cbs) != 0
+        || !CBS_get_asn1(&spki, &algorithm, CBS_ASN1_SEQUENCE)
+        || !CBS_get_asn1(&algorithm, &oid, CBS_ASN1_OBJECT)) {
+        return nullptr;
+    }
+
+    // id-ecPublicKey OBJECT IDENTIFIER ::= { 1.2.840.10045.2.1 }
+    static constexpr uint8_t kIdEcPublicKey[] = { 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01 };
+    if (!CBS_mem_equal(&oid, kIdEcPublicKey, sizeof(kIdEcPublicKey))) {
+        return nullptr;
+    }
+
+    const EC_GROUP* group = EC_KEY_parse_parameters(&algorithm);
+    if (group == nullptr || CBS_len(&algorithm) != 0) {
+        return nullptr;
+    }
+
+    uint8_t padding;
+    if (!CBS_get_asn1(&spki, &key, CBS_ASN1_BITSTRING) || CBS_len(&spki) != 0
+        || !CBS_get_u8(&key, &padding) || padding != 0) {
+        return nullptr;
+    }
+
+    auto eckey = ECKeyPointer::New(group);
+    if (!eckey || !EC_KEY_oct2key(eckey.get(), CBS_data(&key), CBS_len(&key), nullptr)) {
+        return nullptr;
+    }
+
+    auto pkey = EVPKeyPointer::New();
+    if (!pkey || !EVP_PKEY_assign_EC_KEY(pkey.get(), eckey.get())) {
+        return nullptr;
+    }
+    eckey.release();
+    return pkey.release();
+}
+
 constexpr bool IsASN1Sequence(const unsigned char* data,
     size_t size,
     size_t* data_offset,
@@ -2459,8 +2505,15 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePublicKeyPEM(
     if (auto ret = TryParsePublicKeyInner(
             bp,
             "PUBLIC KEY",
-            [](const unsigned char** p, long l) { // NOLINT(runtime/int)
-                return d2i_PUBKEY(nullptr, p, l);
+            [](const unsigned char** p, long l) -> EVP_PKEY* { // NOLINT(runtime/int)
+                const unsigned char* der = *p;
+                if (EVP_PKEY* key = d2i_PUBKEY(nullptr, p, l)) return key;
+                if (EVP_PKEY* key = TryParseECSubjectPublicKeyInfo(der, l)) {
+                    // Discard d2i_PUBKEY's decode error since the fallback succeeded.
+                    ERR_clear_error();
+                    return key;
+                }
+                return nullptr;
             })) {
         return ret;
     }
@@ -2509,8 +2562,14 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePublicKey(
         return EVPKeyPointer::ParseKeyResult(EVPKeyPointer(key));
     }
 
-    if (config.type == PKEncodingType::SPKI && (key = d2i_PUBKEY(nullptr, &start, buffer.len))) {
-        return EVPKeyPointer::ParseKeyResult(EVPKeyPointer(key));
+    if (config.type == PKEncodingType::SPKI) {
+        if ((key = d2i_PUBKEY(nullptr, &start, buffer.len))) {
+            return EVPKeyPointer::ParseKeyResult(EVPKeyPointer(key));
+        }
+        if ((key = TryParseECSubjectPublicKeyInfo(buffer.data, buffer.len))) {
+            ERR_clear_error();
+            return EVPKeyPointer::ParseKeyResult(EVPKeyPointer(key));
+        }
     }
 
     return ParseKeyResult(PKParseError::FAILED);

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -610,6 +610,75 @@ describe("crypto.KeyObjects", () => {
     });
   });
 
+  describe("ec with explicit curve parameters", () => {
+    // P-256 key pair whose PEM encodings use the specifiedCurve (explicit) form of
+    // ECParameters instead of a namedCurve OID. OpenSSL emits this form for
+    // `openssl ec -param_enc explicit`; jsonwebtoken's committed ES256 fixtures
+    // use it. BoringSSL's d2i_PUBKEY rejects the public key but OpenSSL accepts it.
+    const publicPem =
+      "-----BEGIN PUBLIC KEY-----\n" +
+      "MIIBSzCCAQMGByqGSM49AgEwgfcCAQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAA\n" +
+      "AAAAAAAAAAAA////////////////MFsEIP////8AAAABAAAAAAAAAAAAAAAA////\n" +
+      "///////////8BCBaxjXYqjqT57PrvVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwMVAMSd\n" +
+      "NgiG5wSTamZ44ROdJreBn36QBEEEaxfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5\n" +
+      "RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9QIhAP////8AAAAA\n" +
+      "//////////+85vqtpxeehPO5ysL8YyVRAgEBA0IABGrCjldfJzjPCHeMi8LX++ZD\n" +
+      "9NLZxsyXF3HNMrOm9JWKYcV32b4R/4z2MnDKMxLXaQLFHgjYKdLxbBjpeIBkqc0=\n" +
+      "-----END PUBLIC KEY-----\n";
+    const privatePem =
+      "-----BEGIN EC PRIVATE KEY-----\n" +
+      "MIIBaAIBAQQgImAk/YsR1fRVtjTAB4W4JB/71TOst16Bv8muhUb0BZWggfowgfcC\n" +
+      "AQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAAAAAAAAAAAAAA////////////////\n" +
+      "MFsEIP////8AAAABAAAAAAAAAAAAAAAA///////////////8BCBaxjXYqjqT57Pr\n" +
+      "vVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwMVAMSdNgiG5wSTamZ44ROdJreBn36QBEEE\n" +
+      "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54W\n" +
+      "K84zV2sxXs7LtkBoN79R9QIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8\n" +
+      "YyVRAgEBoUQDQgAEasKOV18nOM8Id4yLwtf75kP00tnGzJcXcc0ys6b0lYphxXfZ\n" +
+      "vhH/jPYycMozEtdpAsUeCNgp0vFsGOl4gGSpzQ==\n" +
+      "-----END EC PRIVATE KEY-----\n";
+
+    test("createPublicKey accepts PEM SPKI with explicit parameters", () => {
+      const key = createPublicKey(publicPem);
+      expect({
+        type: key.type,
+        asymmetricKeyType: key.asymmetricKeyType,
+        asymmetricKeyDetails: key.asymmetricKeyDetails,
+      }).toEqual({
+        type: "public",
+        asymmetricKeyType: "ec",
+        asymmetricKeyDetails: { namedCurve: "prime256v1" },
+      });
+      // Re-export should produce a well-formed SPKI that we can parse again.
+      const exported = key.export({ type: "spki", format: "pem" });
+      expect(createPublicKey(exported).asymmetricKeyDetails).toEqual({ namedCurve: "prime256v1" });
+    });
+
+    test("createPublicKey accepts DER SPKI with explicit parameters", () => {
+      const der = Buffer.from(
+        publicPem.replace(/-----(BEGIN|END) PUBLIC KEY-----/g, "").replace(/\s/g, ""),
+        "base64",
+      );
+      const key = createPublicKey({ key: der, format: "der", type: "spki" });
+      expect({
+        asymmetricKeyType: key.asymmetricKeyType,
+        asymmetricKeyDetails: key.asymmetricKeyDetails,
+      }).toEqual({
+        asymmetricKeyType: "ec",
+        asymmetricKeyDetails: { namedCurve: "prime256v1" },
+      });
+    });
+
+    test("sign/verify round-trips with explicit-parameter key pair", () => {
+      const priv = createPrivateKey(privatePem);
+      expect(priv.asymmetricKeyDetails).toEqual({ namedCurve: "prime256v1" });
+      const data = Buffer.from("explicit-params");
+      const sig = sign("sha256", data, priv);
+      expect(verify("sha256", data, publicPem, sig)).toBe(true);
+      expect(verify("sha256", data, createPublicKey(publicPem), sig)).toBe(true);
+      expect(createVerify("sha256").update(data).verify(publicPem, sig)).toBe(true);
+    });
+  });
+
   test("private encrypted should work", async () => {
     // Reading an encrypted key without a passphrase should fail.
     expect(() => createPrivateKey(privateEncryptedPem)).toThrow();

--- a/test/js/node/crypto/crypto.key-objects.test.ts
+++ b/test/js/node/crypto/crypto.key-objects.test.ts
@@ -654,10 +654,7 @@ describe("crypto.KeyObjects", () => {
     });
 
     test("createPublicKey accepts DER SPKI with explicit parameters", () => {
-      const der = Buffer.from(
-        publicPem.replace(/-----(BEGIN|END) PUBLIC KEY-----/g, "").replace(/\s/g, ""),
-        "base64",
-      );
+      const der = Buffer.from(publicPem.replace(/-----(BEGIN|END) PUBLIC KEY-----/g, "").replace(/\s/g, ""), "base64");
       const key = createPublicKey({ key: der, format: "der", type: "spki" });
       expect({
         asymmetricKeyType: key.asymmetricKeyType,


### PR DESCRIPTION
### What does this PR do?

`crypto.createPublicKey()` rejected an EC (prime256v1) SPKI public key whose PEM uses the specifiedCurve (explicit) form of `ECParameters`, throwing a misleading `ERR_OSSL_NO_START_LINE` even though the PEM is well-formed. The matching SEC1 private key with the same explicit parameters imported fine, so Bun accepted one half of the key pair but not the other. `crypto.verify()` with that public PEM failed the same way.

Node.js (OpenSSL) imports both and sign/verify round-trips.

#### Repro

```js
import crypto from "node:crypto";
// P-256 public key with explicit (specifiedCurve) ECParameters
const spki = `-----BEGIN PUBLIC KEY-----
MIIBSzCCAQMGByqGSM49AgEwgfcCAQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAA
AAAAAAAAAAAA////////////////MFsEIP////8AAAABAAAAAAAAAAAAAAAA////
///////////8BCBaxjXYqjqT57PrvVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwMVAMSd
NgiG5wSTamZ44ROdJreBn36QBEEEaxfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5
RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9QIhAP////8AAAAA
//////////+85vqtpxeehPO5ysL8YyVRAgEBA0IABGrCjldfJzjPCHeMi8LX++ZD
9NLZxsyXF3HNMrOm9JWKYcV32b4R/4z2MnDKMxLXaQLFHgjYKdLxbBjpeIBkqc0=
-----END PUBLIC KEY-----`;
crypto.createPublicKey(spki);
```
```
error: error:0900006e:PEM routines:OPENSSL_internal:NO_START_LINE
 code: "ERR_OSSL_NO_START_LINE"
```

Real-world hit: jsonwebtoken 9.0.3's committed ES256 fixture (output of `openssl ec -pubout`) uses this encoding, so its `jwt.verify` tests fail under Bun with `invalid algorithm`.

#### Cause

BoringSSL's `eckey_pub_decode` (reached via `d2i_PUBKEY` / `EVP_parse_public_key`) calls `ec_key_parse_curve_name`, which only accepts a namedCurve OID. Its `eckey_priv_decode` instead calls `ec_key_parse_parameters`, which accepts both namedCurve *and* the explicit specifiedCurve form (matching it to a known named curve). That asymmetry is why the SEC1 private key worked but the SPKI public key did not. OpenSSL accepts both forms in both places.

#### Fix

In `ncrypto.cpp`, when `d2i_PUBKEY` fails on SPKI input, fall back to parsing the `SubjectPublicKeyInfo` directly: match the `id-ecPublicKey` OID, feed the `AlgorithmIdentifier` parameters to BoringSSL's `EC_KEY_parse_parameters` (so explicit parameters are mapped to a named curve the same way the private-key path already does), and build the `EC_KEY` from the BIT STRING via `EC_KEY_oct2key`. Applied to both the PEM and DER SPKI paths.

This is scoped to `node:crypto`; WebCrypto behaviour is unchanged.

### How did you verify your code works?

New tests in `test/js/node/crypto/crypto.key-objects.test.ts` covering PEM SPKI import, DER SPKI import, and sign/verify round-trip with an explicit-parameter key pair. All three fail on main with `ERR_OSSL_NO_START_LINE` / "Failed to read asymmetric key" and pass with the fix. The full `crypto.key-objects.test.ts` suite and upstream `test-crypto-key-objects.js` continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/crypto/crypto.key-objects.test.ts

<!-- robobun:evidence:end -->