### PR TITLE
Guard print_errorlike_object against unbounded AggregateError recursion

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4558,6 +4558,7 @@ impl VirtualMachine {
         allow_side_effects: bool,
     ) {
         let mut formatter = crate::console_object::Formatter::new(self.global());
+        formatter.stack_check = bun_core::StackCheck::init();
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         self.print_errorlike_object(
             exception.value(),
@@ -4868,6 +4869,17 @@ impl VirtualMachine {
         // tail instead of via a drop guard (the body has no early-`?` returns
         // once the AggregateError branch is taken).
         let global_ref = self.global();
+
+        // Stack-safety guard for the AggregateError recursion below (`agg_iter`
+        // → `print_errorlike_object`). The `cause` chain is already guarded in
+        // `print_error_instance_js`; this covers the `.errors` chain.
+        if !formatter.stack_check.is_safe_to_recurse() {
+            formatter.failed = true;
+            if formatter.can_throw_stack_overflow {
+                let _ = global_ref.throw_stack_overflow();
+            }
+            return;
+        }
 
         if value.is_aggregate_error(global_ref) {
             // Note: `JSValue::for_each` takes a C-ABI fn

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1194,6 +1194,7 @@ fn print_exception(
         vm_ref.print_exception(exception, exception_list, writer, true);
     } else {
         let mut formatter = bun_jsc::console_object::Formatter::new(global);
+        formatter.stack_check = bun_core::StackCheck::init();
         // `Formatter::new` already
         // defaults `error_display_level` to `Full` (ConsoleObject.rs:1176).
         let colors = bun_core::Output::enable_ansi_colors_stderr();

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import stripAnsi from "strip-ansi";
+import { bunEnv, bunExe } from "harness";
 
 describe("Bun.inspect", () => {
   it("reports error instead of [native code]", () => {
@@ -85,6 +86,38 @@ describe("Bun.inspect", () => {
     expect(() => Bun.inspect(object, { depth: Infinity })).toThrowErrorMatchingInlineSnapshot(
       `"Maximum call stack size exceeded."`,
     );
+  });
+
+  it("stack overflow is thrown when it should be for AggregateError", () => {
+    let e: unknown = new Error("leaf");
+    for (let i = 0; i < 16 * 1024; i++) {
+      e = new AggregateError([e], "agg");
+    }
+
+    expect(() => Bun.inspect(e)).toThrowErrorMatchingInlineSnapshot(`"Maximum call stack size exceeded."`);
+  });
+
+  describe.each(["log", "throw", "reject", "cause"])("printing a deeply nested error via %s", face => {
+    it.concurrent("does not crash", async () => {
+      const src =
+        face === "cause"
+          ? `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) e = new Error("c", { cause: e }); throw e;`
+          : `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) e = new AggregateError([e], "agg");` +
+            {
+              log: ` console.log(e);`,
+              throw: ` throw e;`,
+              reject: ` Promise.reject(e); await 0;`,
+            }[face];
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(proc.signalCode).toBeNull();
+      expect(exitCode).toBe(1);
+    });
   });
 
   it("depth = 0", () => {

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -97,27 +97,23 @@ describe("Bun.inspect", () => {
     expect(() => Bun.inspect(e)).toThrowErrorMatchingInlineSnapshot(`"Maximum call stack size exceeded."`);
   });
 
-  describe.each(["log", "throw", "reject", "cause"])("printing a deeply nested error via %s", face => {
-    it.concurrent("does not crash", async () => {
-      const src =
-        face === "cause"
-          ? `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) e = new Error("c", { cause: e }); throw e;`
-          : `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) e = new AggregateError([e], "agg");` +
-            {
-              log: ` console.log(e);`,
-              throw: ` throw e;`,
-              reject: ` Promise.reject(e); await 0;`,
-            }[face];
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", src],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(proc.signalCode).toBeNull();
-      expect(exitCode).toBe(1);
+  it.concurrent.each([
+    ["log", `e = new AggregateError([e], "agg");`, `console.log(e);`],
+    ["throw", `e = new AggregateError([e], "agg");`, `throw e;`],
+    ["reject", `e = new AggregateError([e], "agg");`, `Promise.reject(e); await 0;`],
+    ["cause", `e = new Error("c", { cause: e });`, `throw e;`],
+  ])("printing a deeply nested error via %s does not crash", async (_, wrap, emit) => {
+    const src = `let e = new Error("leaf"); for (let i = 0; i < 16 * 1024; i++) ${wrap} process.stderr.write("built\\n"); ${emit}`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
     });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr.slice(0, 6)).toBe("built\n");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(1);
   });
 
   it("depth = 0", () => {

--- a/test/js/node/util/bun-inspect.test.ts
+++ b/test/js/node/util/bun-inspect.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import stripAnsi from "strip-ansi";
 import { bunEnv, bunExe } from "harness";
+import stripAnsi from "strip-ansi";
 
 describe("Bun.inspect", () => {
   it("reports error instead of [native code]", () => {


### PR DESCRIPTION
Printing a deeply nested `AggregateError` SIGSEGVs every error-print path: `console.log`, `Bun.inspect`, an uncaught `throw`, and an unhandled `Promise.reject`. Node prints the chain and exits 1.

### Repro

```js
let e = new Error('leaf');
for (let i = 0; i < 5000; i++) e = new AggregateError([e], 'agg' + i);
console.log(e); // Segmentation fault (exit 139), same for Bun.inspect(e) / throw e / Promise.reject(e)
```

3/3 on 1.4.0-canary and ASAN main; ~1000 levels prints fine, ~2000 crashes. The equivalent `cause` chain at the same depth throws a clean `RangeError` from `Bun.inspect`.

### Cause

The AggregateError branch of `VirtualMachine::print_errorlike_object` iterates `.errors` via `JSValue::for_each` -> `agg_iter` -> `print_errorlike_object` with no stack check. The recursion stays inside that branch (each inner error is also an AggregateError) and never reaches the guarded `print_error_instance_js` path until the leaf, so the native stack overflows first.

Separately, `VirtualMachine::print_exception` and the `jsc_hooks::print_exception` entry point both construct a fresh `Formatter` with the default `StackCheck` (`cached_stack_end == 0`, always reports safe), so the existing `cause`-chain guard in `print_error_instance_js` never fires on the uncaught-throw / unhandled-reject paths either. Throwing a 5000-deep `cause` chain also SIGSEGVs today.

### Fix

- `src/jsc/VirtualMachine.rs`: hoist the formatter's `is_safe_to_recurse()` check to the top of `print_errorlike_object`, matching the existing pattern in `print_error_instance_js`. When the limit is hit the formatter throws `RangeError` (for `Bun.inspect` / `console.log`, which opt in via `can_throw_stack_overflow`) or truncates silently (uncaught printer), same as the `cause` chain does today.
- `src/jsc/VirtualMachine.rs`, `src/runtime/jsc_hooks.rs`: seat `formatter.stack_check = StackCheck::init()` at the two `print_exception` entry points so the guard actually fires on the throw/reject paths.

### Verification

New tests in `test/js/node/util/bun-inspect.test.ts` alongside the existing 16K-deep Error/object stack-overflow tests: `Bun.inspect` of a 16K-deep AggregateError throws `RangeError: Maximum call stack size exceeded.`, and spawned subprocesses covering `console.log` / `throw` / `Promise.reject` of a 16K-deep AggregateError plus `throw` of a 16K-deep `cause` chain all exit 1 with no signal.

On the unfixed build the in-process test SIGSEGVs the runner and all four subprocess variants exit 139; with the fix all 17 tests in the file pass.

Related: #34884 seats `StackCheck` inside `Formatter::new()` for the deep non-Error (array/Proxy) throw path; that change does not on its own cover the AggregateError loop here, which never reaches a checked function. Whichever lands second has a trivial rebase of the two seating lines. Also distinct from #31988 (tampered `.errors` property).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/bun-inspect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (383f3bc90)

test/js/node/util/bun-inspect.test.ts:
(pass) Bun.inspect > reports error instead of [native code] [217.29ms]
(pass) Bun.inspect > supports colors: false [5.01ms]
(pass) Bun.inspect > supports colors: true [3.37ms]
(pass) Bun.inspect > supports colors: false, via 2nd arg [1.90ms]
(pass) Bun.inspect > supports colors: true, via 2nd arg [2.05ms]
(pass) Bun.inspect > supports compact [5.10ms]
(pass) Bun.inspect > depth < 0 throws [4.98ms]
(pass) Bun.inspect > depth = Infinity works for Error [104.92ms]
(pass) Bun.inspect > depth = Infinity works for Object [94.32ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for objects [64.47ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for Er
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/util/bun-inspect.test.ts:
(pass) Bun.inspect > reports error instead of [native code] [3.89ms]
(pass) Bun.inspect > supports colors: false [0.18ms]
(pass) Bun.inspect > supports colors: true [0.05ms]
(pass) Bun.inspect > supports colors: false, via 2nd arg [0.02ms]
(pass) Bun.inspect > supports colors: true, via 2nd arg [0.02ms]
(pass) Bun.inspect > supports compact [0.06ms]
(pass) Bun.inspect > depth < 0 throws [0.06ms]
(pass) Bun.inspect > depth = Infinity works for Error [2.32ms]
(pass) Bun.inspect > depth = Infinity works for Object [1.28ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for objects [54.76ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for Error [217.77ms]
/bin/bash: line 1: 49718 Segmentation fault      (core dumped) USE_SYSTEM_BUN=1 bun test --reporter=junit --reporter-outfile=/tmp/mechgate.xml 'test/js/node/util/bun-inspect.test.ts' 2>&1
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/bun-inspect.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (383f3bc90)

test/js/node/util/bun-inspect.test.ts:
(pass) Bun.inspect > reports error instead of [native code] [213.97ms]
(pass) Bun.inspect > supports colors: false [5.32ms]
(pass) Bun.inspect > supports colors: true [3.40ms]
(pass) Bun.inspect > supports colors: false, via 2nd arg [1.90ms]
(pass) Bun.inspect > supports colors: true, via 2nd arg [2.01ms]
(pass) Bun.inspect > supports compact [5.06ms]
(pass) Bun.inspect > depth < 0 throws [4.92ms]
(pass) Bun.inspect > depth = Infinity works for Error [106.48ms]
(pass) Bun.inspect > depth = Infinity works for Object [95.65ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for objects [65.19ms]
(pass) Bun.inspect > stack overflow is thrown when it should be for Er
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     383f3bc904
  features     (none)

22 deps, 106 codegen, 1169 objects in 829ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1232] gen ErrorCode+*.h
[4/1232] gen bindgenv2
[5/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[6/1232] fetch zlib
[zlib] up to date
[7/1232] fetch tinycc
[tinycc] up to date
[8/1232] fetch picohttpparser
[pic
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs             | 12 ++++++++++++
 src/runtime/jsc_hooks.rs              |  1 +
 test/js/node/util/bun-inspect.test.ts | 29 +++++++++++++++++++++++++++++
 3 files changed, 42 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/VirtualMachine.rs                  5      2      0
src/runtime/jsc_hooks.rs                   1      1      0
test/js/node/util/bun-inspect.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->