### PR TITLE
HTMLRewriter: throw on deeply nested :not()/:host() selectors instead of crashing

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -358,6 +358,12 @@ impl HTMLRewriter {
         listener: JSValue,
     ) -> JsResult<JSValue> {
         let selector_source = selector_name.to_string();
+        if selector_nesting_too_deep(selector_source.as_bytes()) {
+            return Err(global.throw_value(create_lolhtml_error(
+                global,
+                &"Selector nesting is too deep.",
+            )));
+        }
         let selector = match selector_source.parse::<lol_html::Selector>() {
             Ok(s) => s,
             Err(e) => return Err(global.throw_value(create_lolhtml_error(global, &e))),
@@ -1414,6 +1420,46 @@ impl ElementHandler {
 #[derive(Default, Clone, Copy)]
 pub struct ContentOptions {
     pub html: bool,
+}
+
+// ──────────────────────── selector pre-validation ────────────────────────
+
+const MAX_SELECTOR_NESTING_DEPTH: usize = 128;
+
+/// lol-html's selector parser (servo `selectors`) recurses natively on
+/// `:not(...)` and `:host(...)`; a few thousand levels overflows the stack.
+/// Bound paren depth before parsing so `.on()` throws instead of crashing.
+fn selector_nesting_too_deep(selector: &[u8]) -> bool {
+    if !bun_core::strings::contains_char(selector, b'(') {
+        return false;
+    }
+    let mut depth: usize = 0;
+    let mut i = 0;
+    while let Some(&b) = selector.get(i) {
+        i += 1;
+        match b {
+            b'\\' => i += 1,
+            quote @ (b'"' | b'\'') => {
+                while let Some(&b) = selector.get(i) {
+                    i += 1;
+                    match b {
+                        b'\\' => i += 1,
+                        b if b == quote => break,
+                        _ => {}
+                    }
+                }
+            }
+            b'(' => {
+                depth += 1;
+                if depth > MAX_SELECTOR_NESTING_DEPTH {
+                    return true;
+                }
+            }
+            b')' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    false
 }
 
 // ────────────────────────── error helpers ────────────────────────────────

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -681,6 +681,47 @@ describe("HTMLRewriter", () => {
       "<div><h1><span>1</span></h1><span>2</span><b>3</b></div>",
       "<div><h1><span>1</span></h1><span>new</span><b>3</b></div>",
     );
+  });
+
+  it("rejects deeply nested :not()/:host() selectors without crashing", async () => {
+    // The servo selector parser recurses natively on :not()/:host(); without
+    // a depth guard this overflows the stack during .on(). Run in a child so
+    // a regression shows up as SIGSEGV instead of killing the test runner.
+    const src = `
+      for (const name of ["not", "host"]) {
+        const N = 8000;
+        const sel = (":" + name + "(").repeat(N) + "span" + Buffer.alloc(N, ")").toString();
+        try {
+          new HTMLRewriter().on(sel, { element() {} });
+          console.log(name + " accepted");
+        } catch (e) {
+          console.log(name + " threw: " + e.message);
+        }
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim().split("\n")).toEqual([
+      "not threw: Selector nesting is too deep.",
+      "host threw: Selector nesting is too deep.",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("caps selector nesting at 128 but accepts shallower nesting", () => {
+    const nest = (name, n) => (":" + name + "(").repeat(n) + "span" + Buffer.alloc(n, ")").toString();
+    expect(() => new HTMLRewriter().on(nest("not", 129), { element() {} })).toThrow("Selector nesting is too deep.");
+    expect(() => new HTMLRewriter().on(nest("host", 129), { element() {} })).toThrow("Selector nesting is too deep.");
+    // Parentheses inside an attribute-value string must not count toward depth.
+    expect(() => new HTMLRewriter().on('[data-x="' + Buffer.alloc(200, "(").toString() + '"]', { element() {} })).not.toThrow();
+    // Single-level :not() continues to work.
+    expect(() => new HTMLRewriter().on(":not(span)", { element() {} })).not.toThrow();
   });
 
   it("supports deleting innerContent", async () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -718,10 +718,17 @@ describe("HTMLRewriter", () => {
     const nest = (name, n) => (":" + name + "(").repeat(n) + "span" + Buffer.alloc(n, ")").toString();
     expect(() => new HTMLRewriter().on(nest("not", 129), { element() {} })).toThrow("Selector nesting is too deep.");
     expect(() => new HTMLRewriter().on(nest("host", 129), { element() {} })).toThrow("Selector nesting is too deep.");
+    // Exactly at the limit the depth guard lets the selector through to lol-html.
+    expect(() => new HTMLRewriter().on(nest("not", 128), { element() {} })).not.toThrow();
+    expect(() => new HTMLRewriter().on(nest("host", 128), { element() {} })).toThrow(
+      "Unsupported pseudo-class or pseudo-element in selector.",
+    );
     // Parentheses inside an attribute-value string must not count toward depth.
     expect(() =>
       new HTMLRewriter().on('[data-x="' + Buffer.alloc(200, "(").toString() + '"]', { element() {} }),
     ).not.toThrow();
+    // Escaped parentheses must not count toward depth either.
+    expect(() => new HTMLRewriter().on("a" + Buffer.alloc(400, "\\(").toString(), { element() {} })).not.toThrow();
     // Single-level :not() continues to work.
     expect(() => new HTMLRewriter().on(":not(span)", { element() {} })).not.toThrow();
   });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -719,7 +719,9 @@ describe("HTMLRewriter", () => {
     expect(() => new HTMLRewriter().on(nest("not", 129), { element() {} })).toThrow("Selector nesting is too deep.");
     expect(() => new HTMLRewriter().on(nest("host", 129), { element() {} })).toThrow("Selector nesting is too deep.");
     // Parentheses inside an attribute-value string must not count toward depth.
-    expect(() => new HTMLRewriter().on('[data-x="' + Buffer.alloc(200, "(").toString() + '"]', { element() {} })).not.toThrow();
+    expect(() =>
+      new HTMLRewriter().on('[data-x="' + Buffer.alloc(200, "(").toString() + '"]', { element() {} }),
+    ).not.toThrow();
     // Single-level :not() continues to work.
     expect(() => new HTMLRewriter().on(":not(span)", { element() {} })).not.toThrow();
   });


### PR DESCRIPTION
### Repro

```js
const N = 8000;
const sel = ":not(".repeat(N) + "span" + ")".repeat(N);
new HTMLRewriter().on(sel, { element() {} });
// SIGSEGV (exit 139), deterministic, before any HTML is touched
```

1000/3000/4000 levels are fine; ~6000+ overflows the stack. `:host(...)` nested the same way crashes identically.

### Cause

`lol_html::Selector::from_str` calls into the servo `selectors` crate's `SelectorList::parse`, which parses `:not(...)` and `:host(...)` arguments by recursive descent (`parse_negation` / `parse_inner_compound_selector` -> `parse_selector`). There is no depth counter. The other functional pseudo-classes (`:is`, `:where`, `:has`, `:slotted`, `:part`) are gated on `Parser` trait hooks that lol-html leaves at the default `false`, so those two are the only unconditional recursion paths.

`vendor/lolhtml` is fetched from upstream at build time (not committed), and `selectors` is a crates.io dependency, so neither can be patched in-tree.

### Fix

Pre-scan the selector string in `HTMLRewriter::on_` for parenthesis nesting depth before handing it to `lol_html::Selector::parse`. The scan is string- and escape-aware so parentheses inside attribute values (`[data-x="((("]`) and escaped parens (`\(`) do not count. Selectors with no `(` skip the scan entirely.

Depth is capped at 128, which is well above any real selector and well below the observed crash threshold, and throws `HTMLRewriterError: Selector nesting is too deep.` at `.on()` time.

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter.test.js -t "nested|nesting"
 0 pass / 2 fail    (child process exits 139; depth-129 .on() does not throw)

$ bun bd test test/js/workerd/html-rewriter.test.js
 71 pass / 2 todo / 0 fail
```

Separately, shallow nested `:not(:not(span))` currently parses but matches every element (lol-html's selector VM only handles one negation level and falls through to `Unmatchable` on the inner one). That is a pre-existing behavior not changed here.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (37c39cf5e)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [9.41ms]
(pass) HTMLRewriter > error inside element handler [5.99ms]
(pass) HTMLRewriter > error inside element handler (string) [4.62ms]
(pass) HTMLRewriter > fast async error inside element handler [20.56ms]
(pass) HTMLRewriter > slow async error inside element handler [16.49ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [112.69ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [14.62ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [333.21ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the t
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (37c39cf5e)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [0.39ms]
(pass) HTMLRewriter > error inside element handler [0.14ms]
(pass) HTMLRewriter > error inside element handler (string) [0.04ms]
(pass) HTMLRewriter > fast async error inside element handler [11.37ms]
(pass) HTMLRewriter > slow async error inside element handler [2.87ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [11.09ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [0.20ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [8.74ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the transformed response rejects [1.94ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .arrayBuffer() on the transformed response rejects [1.64ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .body on the transformed response is an errored stream [1.62ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > a read already pending on .body when the upstream f
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (37c39cf5e)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [9.39ms]
(pass) HTMLRewriter > error inside element handler [6.43ms]
(pass) HTMLRewriter > error inside element handler (string) [4.82ms]
(pass) HTMLRewriter > fast async error inside element handler [20.98ms]
(pass) HTMLRewriter > slow async error inside element handler [16.86ms]
(pass) HTMLRewriter > HTMLRewriter: async replacement [111.77ms]
(pass) HTMLRewriter > HTMLRewriter handles Symbol invalid type error [10.19ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > control: .text() on the untransformed response rejects [329.79ms]
(pass) HTMLRewriter > transform rejects when the upstream body fails > .text() on the t
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 731ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/html_rewriter.rs      | 46 +++++++++++++++++++++++++++++++
 test/js/workerd/html-rewriter.test.js | 52 ++++++++++++++++++++++++++++++++++-
 2 files changed, 97 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/api/html_rewriter.rs           2      2      0
test/js/workerd/html-rewriter.test.js      4      4      0
```

</details>

<!-- robobun:evidence:end -->