### PR TITLE
timer: assign epoch on heap insert so AbortSignal.timeout fires in creation order

### DIFF
--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -665,6 +665,17 @@ impl All {
         // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
         let tag = unsafe { (*timer).tag };
         debug_assert!(tag != EventLoopTimerTag::WTFTimer, "use wtf_arm");
+
+        // Bump the global epoch into the per-timer flags so equal-deadline JS
+        // timers (setTimeout/setInterval/AbortSignal.timeout) fire in insertion
+        // order. Before heap insert: `EventLoopTimer::less` reads epoch as tiebreak.
+        // SAFETY: `timer` is live (caller contract).
+        if let Some(flags) = unsafe { js_timer_flags_ptr(timer) } {
+            self.epoch = self.epoch.wrapping_add(1) & ((1u32 << 25) - 1);
+            // SAFETY: `flags` points into the live container recovered above.
+            unsafe { (*flags.as_ptr()).set_epoch(self.epoch) };
+        }
+
         if self.fake_timers.is_active() && tag.allow_fake_timers() {
             // SAFETY: see fn contract
             unsafe {
@@ -829,17 +840,8 @@ impl All {
         timer_ref.next.sec = time.sec;
         timer_ref.next.nsec = time.nsec;
 
-        // Bump the global epoch and write it back
-        // into the per-timer flags so equal-deadline JS timers fire in
-        // refresh order.
-        // SAFETY: `timer` is live (caller contract); `timer_ref`'s last use
-        // is above so the raw `(*timer).tag` read inside is SB-clean.
-        if let Some(flags) = unsafe { js_timer_flags_ptr(timer) } {
-            self.epoch = self.epoch.wrapping_add(1) & ((1u32 << 25) - 1);
-            // SAFETY: `flags` points into the live container recovered above.
-            unsafe { (*flags.as_ptr()).set_epoch(self.epoch) };
-        }
-
+        // `insert` bumps the global epoch and writes it into the per-timer
+        // flags so equal-deadline JS timers fire in refresh order.
         self.insert(timer);
     }
 

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -87,4 +87,32 @@ describe("AbortSignal", () => {
     expect(fmt(ac.reason)).toEqual(fmt(new DOMException("The operation timed out.", "TimeoutError")));
     expect(ac.reason.code).toBe(23);
   });
+
+  // https://wpt.fyi/results/dom/abort/timeout.any.html "AbortSignal timeouts fire in order"
+  test("AbortSignal.timeout with equal deadlines fire in creation order", async () => {
+    const src = `
+      const order = [];
+      const done = Promise.withResolvers();
+      let remaining = 7;
+      const tick = v => { order.push(v); if (--remaining === 0) done.resolve(); };
+      for (let i = 0; i < 6; i++) {
+        const s = AbortSignal.timeout(5);
+        s.onabort = () => tick(i);
+      }
+      // setTimeout with the same delay is a reference: it already fires in
+      // creation order, and these signals should sort alongside it.
+      setTimeout(() => tick("t"), 5);
+      await done.promise;
+      console.log(JSON.stringify(order));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual([0, 1, 2, 3, 4, 5, "t"]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -110,8 +110,7 @@ describe("AbortSignal", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(JSON.parse(stdout.trim())).toEqual([0, 1, 2, 3, 4, 5, "t"]);
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
## What does this PR do?

`AbortSignal.timeout(ms)` signals created with the same deadline were firing their `abort` events in (near-)reverse creation order, while `setTimeout` with the same delay fires in creation order in the same process. Node and browsers fire both in creation order; WPT covers this in `dom/abort/timeout.any.js` ("AbortSignal timeouts fire in order").

### Repro

```js
let a = ""; for (const v of "123456") setTimeout(() => { a += v; }, 5);
let b = ""; for (const v of "123456") { const s = AbortSignal.timeout(5); s.onabort = () => { b += v; }; }
setTimeout(() => console.log({ setTimeout: a, timeoutSignals: b }), 200);
// before: { setTimeout: "123456", timeoutSignals: "654321" }
// after:  { setTimeout: "123456", timeoutSignals: "123456" }
```

### Cause

Equal-deadline JS timers are ordered in the pairing heap by a monotonically increasing `epoch` stored in the timer's `TimerFlags`. `setTimeout`/`setInterval` schedule via `All::update()`, which bumped the global epoch and wrote it into the timer before the heap insert. `AbortSignal.timeout` schedules via `All::insert()` directly (through the `timer_insert` runtime hook), which did **not** bump the epoch, so every signal timer kept the default epoch `0`. With all epochs equal, `EventLoopTimer::less(a, b)` evaluates the tiebreak as `(0 - 0) < U25_MAX/2 == true` for every pair, so each newly inserted node becomes the heap root: LIFO order on pop.

### Fix

Move the epoch bump from `All::update()` into `All::insert()`. `update()` already calls `insert()` as its final step, so the `setTimeout`/`setInterval` path is unchanged (one bump per schedule/refresh, same as before). `AbortSignal.timeout` now gets a fresh epoch on its direct `insert()` call and sorts alongside `setTimeout` in creation order. Non-JS-timer tags (`SubprocessTimeout`, `ValkeyConnectionTimeout`, GC timers, etc.) are unaffected because `js_timer_flags_ptr` returns `None` for them.

### Verification

```sh
bun bd test test/js/web/abort/abort.test.ts
```

New test fails on `main` with `[5, 4, 3, 2, 1, 0, "t"]` and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/abort/abort.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1080b7c6e)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [381.23ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [537.60ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [24.05ms]
(pass) AbortSignal > .signal.reason should be a DOMException [10.05ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [19.48ms]
109 |       cmd: [bunExe(), "-e", src],
110 |       env: bunEnv,
111 |       stderr: "pipe",
112 |     });
113 |     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
114 |     expect(JSON.parse(stdout.trim())).toEqual([0, 1, 2, 3, 4, 5, "t"]);
                                            ^

... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1080b7c6e)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [11.01ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [25.42ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [0.38ms]
(pass) AbortSignal > .signal.reason should be a DOMException [0.12ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [10.33ms]
(pass) AbortSignal > AbortSignal.timeout with equal deadlines fire in creation order [16.58ms]

 6 pass
 0 fail
 14 expect() calls
Ran 6 tests across 1 file. [250.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/abort/abort.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (1080b7c6e)

test/js/web/abort/abort.test.ts:
(pass) AbortSignal > spawn test [382.61ms]
(pass) AbortSignal > AbortSignal.timeout(n) should not freeze the process [523.39ms]
(pass) AbortSignal > AbortSignal.any() should fire abort event [24.56ms]
(pass) AbortSignal > .signal.reason should be a DOMException [10.27ms]
(pass) AbortSignal > .signal.reason should be a DOMException for timeout [19.24ms]
(pass) AbortSignal > AbortSignal.timeout with equal deadlines fire in creation order [444.72ms]

 6 pass
 0 fail
 14 expect() calls
Ran 6 tests across 1 file. [3.48s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 691ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/timer/mod.rs        | 24 +++++++++++++-----------
 test/js/web/abort/abort.test.ts | 27 +++++++++++++++++++++++++++
 2 files changed, 40 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/runtime/timer/mod.rs             5      4      0
test/js/web/abort/abort.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->