### PR TITLE
watcher, usockets: close fds on error paths that previously leaked them

### DIFF
--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -398,7 +398,12 @@ struct us_socket_t *us_socket_pair(struct us_socket_group_t *group, unsigned cha
         return 0;
     }
 
-    return us_socket_from_fd(group, kind, NULL, socket_ext_size, fds[0], 0);
+    struct us_socket_t *s = us_socket_from_fd(group, kind, NULL, socket_ext_size, fds[0], 0);
+    if (!s) {
+        bsd_close_socket(fds[0]);
+        bsd_close_socket(fds[1]);
+    }
+    return s;
 #endif
 }
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -617,9 +617,15 @@ impl Watcher {
                 ZStr::from_buf(&buf[..], trailing_slash.len())
             };
 
-            self.platform
-                .watch_dir(path)
-                .map_err(|e| e.with_path(file_path))?
+            match self.platform.watch_dir(path) {
+                Ok(idx) => idx,
+                Err(e) => {
+                    if !stored_fd.is_valid() {
+                        let _ = bun_sys::close(fd);
+                    }
+                    return Err(e.with_path(file_path));
+                }
+            }
         };
 
         self.watchlist.append_assume_capacity(WatchItem {

--- a/test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts
+++ b/test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts
@@ -86,6 +86,7 @@ async function runAndCount(env: Record<string, string | undefined>): Promise<num
     stdout: "pipe",
     stderr: "pipe",
   });
+  const stderrP = proc.stderr.text();
   let line: string | undefined;
   for await (const l of forEachLine(proc.stdout)) {
     if (l.startsWith("DIR_FDS=")) {
@@ -95,10 +96,7 @@ async function runAndCount(env: Record<string, string | undefined>): Promise<num
   }
   proc.kill("SIGKILL");
   await proc.exited;
-  if (!line) {
-    const stderr = await proc.stderr.text();
-    throw new Error(`child produced no DIR_FDS line; stderr:\n${stderr}`);
-  }
+  if (!line) throw new Error(`child produced no DIR_FDS line; stderr:\n${await stderrP}`);
   return Number(line.slice("DIR_FDS=".length));
 }
 

--- a/test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts
+++ b/test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts
@@ -1,0 +1,123 @@
+// An LD_PRELOAD shim makes inotify_add_watch fail with ENOSPC for directory
+// watches (IN_ONLYDIR in the mask), simulating fs.inotify.max_user_watches
+// exhaustion. Under --watch, every imported file's parent directory is opened
+// via open() and then passed to inotify_add_watch; if the add fails the fd
+// must be closed, not leaked.
+//
+// The test compares the count of open directory fds between a baseline run
+// (inotify succeeds, the watchlist intentionally holds the fd) and a shimmed
+// run (inotify fails). With the fix, the shimmed run holds DIR_COUNT fewer
+// directory fds because the fd is closed on the error path. Without the fix,
+// the shimmed run holds the same number of fds as the baseline because the
+// fd is leaked instead of being closed.
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, forEachLine, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+const DIR_COUNT = 20;
+
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdint.h>
+#include <sys/inotify.h>
+
+static int (*real)(int, const char *, uint32_t);
+
+int inotify_add_watch(int fd, const char *path, uint32_t mask) {
+    if (!real) real = (int (*)(int, const char *, uint32_t)) dlsym(RTLD_NEXT, "inotify_add_watch");
+    if (mask & IN_ONLYDIR) {
+        errno = ENOSPC;
+        return -1;
+    }
+    return real(fd, path, mask);
+}
+`;
+
+function makeEntry(n: number) {
+  let s = "";
+  for (let i = 0; i < n; i++) s += `import "./d${i}/m.ts";\n`;
+  s += `import { readdirSync, readlinkSync } from "node:fs";\n`;
+  s += `let count = 0;\n`;
+  s += `for (const name of readdirSync("/proc/self/fd")) {\n`;
+  s += `  try {\n`;
+  s += `    const target = readlinkSync("/proc/self/fd/" + name);\n`;
+  s += `    if (/\\/d\\d+$/.test(target)) count++;\n`;
+  s += `  } catch {}\n`;
+  s += `}\n`;
+  s += `console.log("DIR_FDS=" + count);\n`;
+  s += `setInterval(() => {}, 1 << 30);\n`;
+  return s;
+}
+
+let shimPath: string;
+let dir: ReturnType<typeof tempDir> | undefined;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  const files: Record<string, string> = {
+    "shim.c": SHIM_C,
+    "entry.ts": makeEntry(DIR_COUNT),
+  };
+  for (let i = 0; i < DIR_COUNT; i++) files[`d${i}/m.ts`] = `export const x = ${i};\n`;
+  dir = tempDir("inotify-fail-leak", files);
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+async function runAndCount(env: Record<string, string | undefined>): Promise<number> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--watch", "entry.ts"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  let line: string | undefined;
+  for await (const l of forEachLine(proc.stdout)) {
+    if (l.startsWith("DIR_FDS=")) {
+      line = l;
+      break;
+    }
+  }
+  proc.kill("SIGKILL");
+  await proc.exited;
+  if (!line) {
+    const stderr = await proc.stderr.text();
+    throw new Error(`child produced no DIR_FDS line; stderr:\n${stderr}`);
+  }
+  return Number(line.slice("DIR_FDS=".length));
+}
+
+test.skipIf(!isLinux || !cc)(
+  "--watch closes the directory fd when inotify_add_watch fails with ENOSPC",
+  async () => {
+    const existing = bunEnv.LD_PRELOAD;
+    const shimEnv = { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath };
+
+    const [baseline, failing] = await Promise.all([runAndCount(bunEnv), runAndCount(shimEnv)]);
+
+    // When inotify succeeds the watchlist holds one dir fd per directory; when
+    // inotify fails that fd must be closed, so the failing run should hold
+    // DIR_COUNT fewer directory fds than the baseline. Without the fix the fd
+    // is leaked and the two counts are equal.
+    expect({ baseline, failing, released: baseline - failing }).toEqual({
+      baseline: expect.any(Number),
+      failing: expect.any(Number),
+      released: DIR_COUNT,
+    });
+  },
+);

--- a/test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts
+++ b/test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts
@@ -102,22 +102,19 @@ async function runAndCount(env: Record<string, string | undefined>): Promise<num
   return Number(line.slice("DIR_FDS=".length));
 }
 
-test.skipIf(!isLinux || !cc)(
-  "--watch closes the directory fd when inotify_add_watch fails with ENOSPC",
-  async () => {
-    const existing = bunEnv.LD_PRELOAD;
-    const shimEnv = { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath };
+test.skipIf(!isLinux || !cc)("--watch closes the directory fd when inotify_add_watch fails with ENOSPC", async () => {
+  const existing = bunEnv.LD_PRELOAD;
+  const shimEnv = { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath };
 
-    const [baseline, failing] = await Promise.all([runAndCount(bunEnv), runAndCount(shimEnv)]);
+  const [baseline, failing] = await Promise.all([runAndCount(bunEnv), runAndCount(shimEnv)]);
 
-    // When inotify succeeds the watchlist holds one dir fd per directory; when
-    // inotify fails that fd must be closed, so the failing run should hold
-    // DIR_COUNT fewer directory fds than the baseline. Without the fix the fd
-    // is leaked and the two counts are equal.
-    expect({ baseline, failing, released: baseline - failing }).toEqual({
-      baseline: expect.any(Number),
-      failing: expect.any(Number),
-      released: DIR_COUNT,
-    });
-  },
-);
+  // When inotify succeeds the watchlist holds one dir fd per directory; when
+  // inotify fails that fd must be closed, so the failing run should hold
+  // DIR_COUNT fewer directory fds than the baseline. Without the fix the fd
+  // is leaked and the two counts are equal.
+  expect({ baseline, failing, released: baseline - failing }).toEqual({
+    baseline: expect.any(Number),
+    failing: expect.any(Number),
+    released: DIR_COUNT,
+  });
+});


### PR DESCRIPTION
Two acquire-then-early-return fd leaks found in static pattern audit #12 (error-path resource leaks).

## `Watcher.rs` `append_directory_assume_capacity`

When `stored_fd` is invalid the function opens the directory itself via `bun_sys::open_a()`. On Linux it then calls `self.platform.watch_dir(path)?`, and if `inotify_add_watch` fails (ENOSPC once `fs.inotify.max_user_watches` is exhausted, or ENOENT if the directory is removed between the open and the add) the `?` propagated the error without closing the fd we just opened.

Under `--watch` / `--hot` on a project large enough to exhaust `max_user_watches`, this leaks one directory fd per failing directory and creeps toward EMFILE.

Fix: close the fd on the `Err` arm when (and only when) we opened it. A caller-supplied `stored_fd` is still the caller's to manage; the one caller that passes a valid fd already has a scopeguard around it.

## `us_socket_pair` in `packages/bun-usockets/src/socket.c`

`socketpair()` creates two fds, then `us_socket_from_fd` is called on `fds[0]`. On failure (`us_poll_start_rc` / `epoll_ctl ADD` returns an error) that path does `us_poll_free` and returns NULL, but `us_poll_free` only frees the poll struct, it does not close the fd. `fds[1]` was never wrapped at all. Both ends leak.

Fix: close both fds before returning NULL.

## Testing

`test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts` covers the watcher leak on Linux with an LD_PRELOAD shim that makes `inotify_add_watch` return ENOSPC for directory watches (`IN_ONLYDIR` in the mask). It runs `bun --watch` over an entry that imports from 20 subdirectories and counts open fds in `/proc/self/fd` that resolve to those subdirectories.

Before this change the failing run holds the same number of directory fds as a baseline run where inotify succeeds (`released: 0`), because the leaked fd looks the same as the intentionally held watchlist fd. After, the failing run holds exactly `DIR_COUNT` fewer (`released: 20`).

`us_socket_pair` has no live callers; the failure path also requires `epoll_ctl ADD` to fail, so that one is not separately tested. `test/cli/watch/watch.test.ts`, `test/cli/hot/hot.test.ts` and `test/js/bun/net/socket.test.ts` are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/inotify-add-watch-fail-fd-leak.test.ts

<!-- robobun:evidence:end -->