### PR TITLE
bun:sqlite: close the sqlite3 handle when Database open fails

### DIFF
--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1780,7 +1780,12 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
     int statusCode = sqlite3_open_v2(path.utf8().data(), &db, openFlags, nullptr);
 
     if (statusCode != SQLITE_OK) {
-        throwException(lexicalGlobalObject, scope, createSQLiteError(lexicalGlobalObject, db));
+        // sqlite3_open_v2 usually writes a handle to *ppDb even on failure; the
+        // caller must sqlite3_close() it. Build the error first so errmsg/errno
+        // are read from the handle, then release it.
+        JSValue error = createSQLiteError(lexicalGlobalObject, db);
+        sqlite3_close(db);
+        throwException(lexicalGlobalObject, scope, error);
         return {};
     }
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2,7 +2,17 @@ import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir, tempDirWithFiles } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isASAN,
+  isDebug,
+  isMacOS,
+  isMacOSVersionAtLeast,
+  isWindows,
+  tempDir,
+  tempDirWithFiles,
+} from "harness";
 import { tmpdir } from "os";
 import path from "path";
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2,7 +2,7 @@ import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isMacOSVersionAtLeast, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isMacOSVersionAtLeast, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -2189,7 +2189,8 @@ it("exec/run with an embedded NUL byte in the SQL string does not hang", async (
 });
 
 it("new Database() does not leak the sqlite3 handle when open fails", async () => {
-  const badPath = path.join(tmpdir(), `bun-sqlite-nonexistent-${Date.now()}-${process.pid}`, "x.sqlite");
+  using dir = tempDir("sqlite-open-fail", {});
+  const badPath = path.join(String(dir), "nonexistent", "x.sqlite");
 
   // The failed open must still surface the real SQLite error code after the
   // handle has been released.

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2216,8 +2216,7 @@ it("new Database() does not leak the sqlite3 handle when open fails", async () =
     cmd: [bunExe(), "-e", src],
     env: {
       ...bunEnv,
-      ASAN_OPTIONS:
-        "detect_leaks=1:symbolize=0:quarantine_size_mb=0:allow_user_segv_handler=1:disable_coredump=0",
+      ASAN_OPTIONS: "detect_leaks=1:symbolize=0:quarantine_size_mb=0:allow_user_segv_handler=1:disable_coredump=0",
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2,7 +2,7 @@ import { spawnSync } from "bun";
 import { constants, Database, SQLiteError } from "bun:sqlite";
 import { describe, expect, it } from "bun:test";
 import { existsSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isMacOS, isMacOSVersionAtLeast, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isMacOSVersionAtLeast, isWindows, tempDirWithFiles } from "harness";
 import { tmpdir } from "os";
 import path from "path";
 
@@ -2186,4 +2186,55 @@ it("exec/run with an embedded NUL byte in the SQL string does not hang", async (
     signalCode: null,
     exitCode: 0,
   });
+});
+
+it("new Database() does not leak the sqlite3 handle when open fails", async () => {
+  const badPath = path.join(tmpdir(), `bun-sqlite-nonexistent-${Date.now()}-${process.pid}`, "x.sqlite");
+
+  // The failed open must still surface the real SQLite error code after the
+  // handle has been released.
+  expect(() => new Database(badPath)).toThrow(expect.objectContaining({ code: "SQLITE_CANTOPEN" }));
+
+  // sqlite3_open_v2 writes a handle to *ppDb even when it returns an error,
+  // and that handle must be sqlite3_close()'d by the caller. Before the fix
+  // the SQLITE_CANTOPEN branch threw without closing it, so every failed open
+  // leaked the connection object (~3.5 KB each). ASAN's quarantine holds freed
+  // allocations in RSS, so the signal is LSAN's leak byte total on ASAN builds
+  // and RSS growth on release builds.
+  const iters = 2000;
+  const src = `
+    import { Database } from "bun:sqlite";
+    const step = () => { try { new Database(${JSON.stringify(badPath)}); } catch {} };
+    for (let i = 0; i < 200; i++) step();
+    Bun.gc(true);
+    const start = process.memoryUsage.rss();
+    for (let i = 0; i < ${iters}; i++) step();
+    Bun.gc(true);
+    console.log(((process.memoryUsage.rss() - start) / 1024 / 1024).toFixed(1));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: {
+      ...bunEnv,
+      ASAN_OPTIONS:
+        "detect_leaks=1:symbolize=0:quarantine_size_mb=0:allow_user_segv_handler=1:disable_coredump=0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const growthMB = parseFloat(stdout.trim());
+  expect(Number.isFinite(growthMB)).toBe(true);
+
+  const lsan = stderr.match(/SUMMARY: AddressSanitizer: (\d+) byte\(s\) leaked/);
+  if (lsan) {
+    // Unfixed: ~2.8 MB in ~16000 allocations. Fixed: a single ~124 byte
+    // startup allocation unrelated to sqlite.
+    expect(Number(lsan[1])).toBeLessThan(100_000);
+  } else if (!isASAN && !isDebug) {
+    // Unfixed: ~7 MB over 2000 iterations. Fixed: allocator noise.
+    expect(growthMB).toBeLessThan(4);
+    expect(exitCode).toBe(0);
+  }
 });

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -2195,12 +2195,9 @@ it("new Database() does not leak the sqlite3 handle when open fails", async () =
   // handle has been released.
   expect(() => new Database(badPath)).toThrow(expect.objectContaining({ code: "SQLITE_CANTOPEN" }));
 
-  // sqlite3_open_v2 writes a handle to *ppDb even when it returns an error,
-  // and that handle must be sqlite3_close()'d by the caller. Before the fix
-  // the SQLITE_CANTOPEN branch threw without closing it, so every failed open
-  // leaked the connection object (~3.5 KB each). ASAN's quarantine holds freed
-  // allocations in RSS, so the signal is LSAN's leak byte total on ASAN builds
-  // and RSS growth on release builds.
+  // sqlite3_open_v2 returns a handle that must be sqlite3_close()'d even on
+  // failure; previously it leaked (~3.5 KB/attempt). ASAN's quarantine hides
+  // this in RSS, so assert on LSAN bytes there and on RSS for release builds.
   const iters = 2000;
   const src = `
     import { Database } from "bun:sqlite";

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -112,8 +112,6 @@ leak:WebCore::JSReadableStreamDefaultControllerPrototype::finishCreation
 leak:create_ssl_context_from_bun_options
 # test/js/node/test/parallel/test-inspector-enabled.js
 leak:jsc.Debugger.startJSDebuggerThread
-# test/js/sql/sqlite-sql.test.ts
-leak:WebCore::jsSQLStatementOpenStatementFunction
 # test/js/web/atomics.test.ts — RunLoop::dispatchAfter's DispatchTimer captures
 # a Ref to itself in m_function; the cycle only breaks when fired(). If stop()
 # is called before firing (WaiterListManager::clearTimer on notify/unregister),


### PR DESCRIPTION
### What

`new Database(path)` leaked the underlying `sqlite3*` handle whenever `sqlite3_open_v2` returned an error (`SQLITE_CANTOPEN` for a nonexistent directory, `SQLITE_PERM`, `SQLITE_READONLY`, ...). A retry loop or health check against a missing or permission-denied path grew RSS without bound.

### Repro

```js
import { Database } from "bun:sqlite";
for (let i = 0; i < 20000; i++) {
  try { new Database("/nonexistent/dir/x.sqlite"); } catch {}
}
Bun.gc(true);
// RSS before fix: +69 MB (release), LSAN: 2.8 MB leaked over 2000 iters
// RSS after fix: flat, LSAN: 0 per-iteration leaks
```

### Cause

Per the SQLite docs, `sqlite3_open_v2` writes a connection handle to `*ppDb` even on failure, and the caller must release it with `sqlite3_close()`. `jsSQLStatementOpenStatementFunction` in `src/jsc/bindings/sqlite/JSSQLStatement.cpp` threw the `SQLiteError` and returned without closing that handle. The deserialize path a few lines up already handled this correctly.

### Fix

Build the `SQLiteError` from the handle first (so `errmsg`/`errno` are captured), then `sqlite3_close(db)`, then throw.

Also removed the now-dead `leak:WebCore::jsSQLStatementOpenStatementFunction` entry from `test/leaksan.supp`, which had been added to mask this exact leak for `test/js/sql/sqlite-sql.test.ts`.

### Verification

LeakSanitizer on the debug build, 2000 failed opens:

| build | LSAN summary |
| --- | --- |
| before | `2848124 byte(s) leaked in 16001 allocation(s)` rooted at `sqlite3_open_v2` -> `openDatabase` |
| after | `124 byte(s) leaked in 1 allocation(s)` (unrelated one-off sourcemap allocation) |

The new test spawns a child with `ASAN_OPTIONS=detect_leaks=1:symbolize=0` and asserts the LSAN byte total stays under 100 KB on ASAN builds, and RSS growth stays under 4 MB on release builds. It also asserts the thrown error still carries `code: "SQLITE_CANTOPEN"`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->