### PR TITLE
bun:ffi: free the TinyCC state when cc() throws

### DIFF
--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -633,6 +633,11 @@ impl CompileC {
                 return Err(crate::Error::DeferredErrors);
             }
         };
+        // errdefer state.destroy(): every Err return below must free the TCC state.
+        let state_guard = scopeguard::guard(state_ptr, |p| {
+            // SAFETY: `p` came from `TCC::State::init` above and has not been destroyed.
+            unsafe { TCC::State::destroy(p.as_ptr()) };
+        });
         // SAFETY: `state_ptr` was just returned non-null by `TCC::State::init`;
         // we hold the only reference for the rest of this function.
         let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
@@ -873,7 +878,7 @@ impl CompileC {
         self.error_check()
             .map_err(|_| crate::Error::DeferredErrors)?;
 
-        Ok(state_ptr)
+        Ok(scopeguard::ScopeGuard::into_inner(state_guard))
     }
 }
 

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1,7 +1,7 @@
 import { cc, CString, JSCallback, ptr, type FFIFunction, type Library } from "bun:ffi";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { promises as fs } from "fs";
-import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 // TODO: we need to install build-essential and Apple SDK in CI.
@@ -91,6 +91,55 @@ describe.skipIf(isASAN)("given an add(a, b) function", () => {
     }).toThrow(/"subtract" is missing/);
   });
 }); // </given add(a, b) function>
+
+// A cc() that throws must still free its TinyCC state. The missing-symbol path
+// exercises the worst case: the source compiles and relocates (JIT pages mmap'd)
+// before the throw, so the leaked state is large and the RSS signal is clear.
+it("does not leak the TinyCC state when cc() throws", async () => {
+  using dir = tempDir("bun-ffi-cc-leak", {
+    "good.c": "int f() { return 42; }\n",
+    "fixture.js": /* js */ `
+      import { cc } from "bun:ffi";
+      import path from "path";
+
+      const source = path.join(import.meta.dir, "good.c");
+      const step = () => {
+        try {
+          cc({ source, symbols: { nosuchsym_xyz: { args: [], returns: "int" } } }).close();
+        } catch {}
+      };
+
+      for (let i = 0; i < 100; i++) step();
+      Bun.gc(true);
+      const start = process.memoryUsage.rss();
+      for (let i = 0; i < 800; i++) step();
+      Bun.gc(true);
+      const end = process.memoryUsage.rss();
+      console.log(JSON.stringify({ deltaMB: (end - start) / 1048576 }));
+    `,
+  });
+
+  // Shrink the ASAN quarantine so RSS reflects what is actually retained,
+  // not freed-but-quarantined TCC blocks.
+  const asanOptions = [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=1"].filter(Boolean).join(":");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: { ...bunEnv, ASAN_OPTIONS: asanOptions },
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: normalizeBunSnapshot(stdout), stderr, exitCode }).toMatchObject({
+    stdout: expect.stringMatching(/^\{"deltaMB":/),
+    exitCode: 0,
+  });
+  const { deltaMB } = JSON.parse(stdout);
+  // 800 leaked states ≈ 23-33 MB depending on build; the bound sits well
+  // below that and above allocator jitter.
+  expect(deltaMB).toBeLessThan(isASAN || isDebug ? 15 : 10);
+});
 
 describe("given a source file with syntax errors", () => {
   const source = /* c */ `


### PR DESCRIPTION
## What

`CompileC::compile()` in `src/runtime/ffi/ffi_body.rs` creates a `TCC::State` via `TCC::State::init()` and then has about a dozen error-return paths (include/library-path failures, the deferred-error branches after `error_check`, the compile-error branch, relocate failure, and the missing-symbol throw) that return without destroying it. The caller only wraps the state in a destroy-guard on the `Ok` path, so every `cc()` that throws leaks its entire TinyCC compile state. The missing-symbol path is the worst case: the source compiles and relocates (mmapping JIT pages) before the lookup fails, so each throw leaks ~38 KB.

## Repro

```js
import { cc } from "bun:ffi";
import { writeFileSync } from "node:fs";
writeFileSync("/tmp/good.c", "int f() { return 42; }\n");
const rss = () => (process.memoryUsage.rss() / 1048576).toFixed(1);
for (let i = 0; i < 100; i++) try { cc({ source: "/tmp/good.c", symbols: { nope: { args: [], returns: "int" } } }); } catch {}
Bun.gc(true); const start = rss();
for (let i = 0; i < 2000; i++) try { cc({ source: "/tmp/good.c", symbols: { nope: { args: [], returns: "int" } } }); } catch {}
Bun.gc(true); console.log(`start=${start}MB end=${rss()}MB`);
```

Before: `start=44.5MB end=122.5MB` (+78 MB over 2000 iters, ~39 KB/call).
After: flat. LSan reports zero per-iteration leaks.

## Fix

Guard the freshly created state with `scopeguard` immediately after `TCC::State::init` succeeds so any `Err` return runs `tcc_delete`, and disarm via `ScopeGuard::into_inner` on `Ok`. This is the same errdefer pattern `TCC::State::init` uses internally and `Function::compile` already uses for its per-symbol trampoline state.

## Verification

New test in `test/js/bun/ffi/cc.test.ts` runs 800 throwing `cc()` calls in a subprocess and asserts RSS growth stays under 10 MB (15 MB for debug/ASAN). Without the fix the subprocess grows by ~23-34 MB depending on build. The test sets `quarantine_size_mb=1` in the child's `ASAN_OPTIONS` so RSS reflects what is actually retained rather than freed-but-quarantined blocks.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->