### PR TITLE
shell: keep words after a redirection as arguments of the same command

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1612,6 +1612,11 @@ impl<'bump> Parser<'bump> {
         };
         let redirect_file: Option<ast::Redirect<'bump>> = 'redirect_file: {
             if has_redirect {
+                // `n>&m` is complete on its own and takes no file operand; the
+                // following word (if any) belongs to the enclosing command.
+                if redirect.duplicate_out() {
+                    break 'redirect_file None;
+                }
                 if self.r#match(TokenTag::JSObjRef) {
                     let Token::JSObjRef(obj_ref) = self.prev() else {
                         unreachable!()
@@ -1622,9 +1627,6 @@ impl<'bump> Parser<'bump> {
                 let file = match self.parse_atom()? {
                     Some(f) => f,
                     None => {
-                        if redirect.duplicate_out() {
-                            break 'redirect_file None;
-                        }
                         self.add_error(format_args!("Redirection with no file"))?;
                         return Err(ParseError::Expected.into());
                     }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1571,10 +1571,26 @@ impl<'bump> Parser<'bump> {
 
         let mut name_and_args = bun_alloc::ArenaVec::new_in(self.alloc);
         name_and_args.push(name);
-        while let Some(arg) = self.parse_atom()? {
-            name_and_args.push(arg);
+        let mut parsed_redirect = ParsedRedirect::default();
+        let mut has_redirect = false;
+        loop {
+            if let Some(arg) = self.parse_atom()? {
+                name_and_args.push(arg);
+                continue;
+            }
+            if self.check(TokenTag::Redirect) {
+                if has_redirect {
+                    self.add_error(format_args!(
+                        "Multiple redirects are not supported yet. Please open a GitHub issue."
+                    ))?;
+                    return Err(ParseError::Unsupported.into());
+                }
+                parsed_redirect = self.parse_redirect()?;
+                has_redirect = true;
+                continue;
+            }
+            break;
         }
-        let parsed_redirect = self.parse_redirect()?;
 
         Ok(ast::CmdOrAssigns::Cmd(ast::Cmd {
             assigns: assigns.into_bump_slice(),

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -23,6 +23,38 @@ describe("IOWriter file output redirection", () => {
       .runAsTest("zero-length write should trigger onIOWriterChunk callback");
   });
 
+  describe("redirection between arguments", () => {
+    // POSIX allows a redirection anywhere among a simple command's words; words
+    // after the redirect target belong to the same command, not a new one.
+    TestBuilder.command`echo x > log rm cache`
+      .ensureTempDir()
+      .file("cache", "precious")
+      .exitCode(0)
+      .fileEquals("log", "x rm cache\n")
+      .fileEquals("cache", "precious")
+      .runAsTest("words after > file stay as arguments (do not run as a command)");
+
+    TestBuilder.command`printf '[%s]' A > o B`
+      .ensureTempDir()
+      .exitCode(0)
+      .stderr("")
+      .fileEquals("o", "[A][B]")
+      .runAsTest("printf argument after > file is passed to printf");
+
+    TestBuilder.command`cat < f0 f1`
+      .ensureTempDir()
+      .file("f0", "a0\na1\n")
+      .file("f1", "b0\n")
+      .exitCode(0)
+      .stdout("b0\n")
+      .stderr("")
+      .runAsTest("word after < file is a file operand, not a new command");
+
+    TestBuilder.command`echo a > f1 b > f2`
+      .error("Multiple redirects are not supported yet. Please open a GitHub issue.")
+      .runAsTest("second redirect after intervening words is rejected at parse time");
+  });
+
   describe("drainBufferedData edge cases", () => {
     TestBuilder.command`echo -n ${"x".repeat(1024 * 10)} > large.txt`
       .exitCode(0)

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -50,6 +50,20 @@ describe("IOWriter file output redirection", () => {
       .stderr("")
       .runAsTest("word after < file is a file operand, not a new command");
 
+    TestBuilder.command`echo A 2>&1 B C`
+      .ensureTempDir()
+      .exitCode(0)
+      .stdout("A B C\n")
+      .stderr("")
+      .runAsTest("words after 2>&1 stay as arguments (fd-dup takes no file operand)");
+
+    TestBuilder.command`echo A 1>&2 B`
+      .ensureTempDir()
+      .exitCode(0)
+      .stdout("")
+      .stderr("A B\n")
+      .runAsTest("words after 1>&2 stay as arguments");
+
     TestBuilder.command`echo a > f1 b > f2`
       .error("Multiple redirects are not supported yet. Please open a GitHub issue.")
       .runAsTest("second redirect after intervening words is rejected at parse time");

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -59,6 +59,31 @@ describe("parse shell", () => {
     expect(result).toEqual(expected);
   });
 
+  test("redirect between arguments", () => {
+    // POSIX lets a redirection appear anywhere among a simple command's words.
+    // `echo x > log rm cache` must parse as one command with four words.
+    const cmd = {
+      assigns: [],
+      name_and_args: [
+        { simple: { Text: "echo" } },
+        { simple: { Text: "x" } },
+        { simple: { Text: "rm" } },
+        { simple: { Text: "cache" } },
+      ],
+      redirect: redirect({ stdout: true }),
+      redirect_file: { atom: { simple: { Text: "log" } } },
+    };
+    expect(JSON.parse(parse`echo x > log rm cache`)).toEqual({ stmts: [{ exprs: [{ cmd }] }] });
+
+    const catCmd = {
+      assigns: [],
+      name_and_args: [{ simple: { Text: "cat" } }, { simple: { Text: "f1" } }],
+      redirect: redirect({ stdin: true }),
+      redirect_file: { atom: { simple: { Text: "f0" } } },
+    };
+    expect(JSON.parse(parse`cat < f0 f1`)).toEqual({ stmts: [{ exprs: [{ cmd: catCmd }] }] });
+  });
+
   test("single atom", () => {
     expect(JSON.parse(parse`ls`)).toEqual({
       stmts: [

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -82,6 +82,20 @@ describe("parse shell", () => {
       redirect_file: { atom: { simple: { Text: "f0" } } },
     };
     expect(JSON.parse(parse`cat < f0 f1`)).toEqual({ stmts: [{ exprs: [{ cmd: catCmd }] }] });
+
+    // `n>&m` takes no file operand, so the following word stays in argv.
+    const dupCmd = {
+      assigns: [],
+      name_and_args: [
+        { simple: { Text: "echo" } },
+        { simple: { Text: "A" } },
+        { simple: { Text: "B" } },
+        { simple: { Text: "C" } },
+      ],
+      redirect: redirect({ stdout: true, duplicate_out: true }),
+      redirect_file: null,
+    };
+    expect(JSON.parse(parse`echo A 2>&1 B C`)).toEqual({ stmts: [{ exprs: [{ cmd: dupCmd }] }] });
   });
 
   test("single atom", () => {


### PR DESCRIPTION
## What

In Bun Shell, a redirection terminated the simple command it appeared in. Every word after the redirect target was parsed as a **new command** and executed.

```js
import { $ } from "bun";
await $`echo precious > cache`.quiet();
await $`${{ raw: "echo x > log rm cache" }}`.quiet();
//            ^^^^^^^^^^^^^^^^^^^^^^^^^^
// bash: writes "x rm cache" to log; cache survives
// bun : writes "x"          to log; then RUNS `rm cache`
```

```js
await $`${{ raw: "cat < f0 f1" }}`.quiet();
// bash: "b0\n"  (f1 is a file operand; cat reads it and ignores stdin)
// bun : "a0\na1\n" + stderr "bun: command not found: f1"
```

POSIX allows redirections anywhere among a simple command's words, so `echo x > log rm cache` is `echo x rm cache` with stdout redirected to `log`.

## Cause

`parse_simple_cmd` collected arguments until `parse_atom()` returned `None`, called `parse_redirect()` once, and returned. `parse_atom()` returns `None` on a `Redirect` token, so the argument loop ended at the first redirection. Back in `parse_stmt`, the remaining words were not a statement terminator, so it called `parse_expr()` again and produced a second command.

## Fix

`parse_simple_cmd` now interleaves argument and redirect parsing in a single loop: when `parse_atom()` yields `None` on a `Redirect` token, the redirect is consumed and argument collection continues. The AST still carries a single redirect per command, so a second redirect (including `echo a > f1 b > f2`, which previously ran `b > f2` as a command) is now reported as the existing "Multiple redirects are not supported yet" parse error.

## Tests

- `test/js/bun/shell/parse.test.ts`: AST shape for `echo x > log rm cache` and `cat < f0 f1` (one command, all words in `name_and_args`).
- `test/js/bun/shell/file-io.test.ts`: behavioral coverage for `>`, `<`, and `printf` with a redirect mid-command, plus the multi-redirect error.

Verified fail-before with `USE_SYSTEM_BUN=1` and pass-after with the debug build; `bunshell.test.ts` (414 tests) and the full `parse.test.ts`/`lex.test.ts`/`file-io.test.ts` suites pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/file-io.test.ts test/js/bun/shell/parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5cdecf6ca)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [57.70ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [7.41ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [6.13ms]
228 |       } else if (typeof this.expected_exit_code === "function") this.expected_exit_code(exitCode);
229 | 
230 |       for (const [filename, expected_raw] of Object.entries(this.file_equals)) {
231 |         const expected = typeof expected_raw === "string" ? expected_raw : await expected_raw();
232 |         const actual = awai
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (781213480)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [5.61ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [0.28ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [0.16ms]
(pass) IOWriter file output redirection > redirection between arguments > words after > file stay as arguments (do not run as a command) [0.22ms]
(pass) IOWriter file output redirection > redirection between arguments > printf argument after > file is passed to printf [1.33ms]
b0
(pass) IOWriter file output redirection > redirection between arguments > word after < file is a file operand, not a new command [1.14ms]
A B C
(pass) IOWriter file output redirection > redirection between arguments > words after 2>&1 stay as arguments (fd-dup takes no file operand) [0.08ms]
A B
(pass) IOWriter file output redirection > redirection between arguments > words after 1>&2 stay as arguments [0.07ms]
(pass) IOWriter file output redirection > redirection between arguments > second redirec
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/file-io.test.ts test/js/bun/shell/parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5cdecf6ca)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [58.99ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [19.68ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [7.60ms]
(pass) IOWriter file output redirection > redirection between arguments > words after > file stay as arguments (do not run as a command) [13.46ms]
(pass) IOWriter file output redirection > redirection between arguments > printf argument after > file is passed to printf [9.40ms]
b0
(pass) IOWriter file output redirection > redirectio
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 716ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/shell_parser/parse.rs         | 30 ++++++++++++++++++++-----
 test/js/bun/shell/file-io.test.ts | 46 +++++++++++++++++++++++++++++++++++++++
 test/js/bun/shell/parse.test.ts   | 39 +++++++++++++++++++++++++++++++++
 3 files changed, 109 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/shell_parser/parse.rs              7      2      0
test/js/bun/shell/file-io.test.ts      2      2      0
test/js/bun/shell/parse.test.ts        2      3      0
```

</details>

<!-- robobun:evidence:end -->