### PR TITLE
shell: error on unterminated single/double quote

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -3131,6 +3131,12 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             self.append_char_to_str_pool(char)?;
         }
 
+        match self.chars.state {
+            CharState::Normal => {}
+            CharState::Single => self.add_error(b"Unclosed single quote"),
+            CharState::Double => self.add_error(b"Unclosed double quote"),
+        }
+
         if let Some(subshell_kind) = self.in_subshell {
             match subshell_kind {
                 SubShellKind::Dollar | SubShellKind::Backtick => {

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -2864,6 +2864,9 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             }
                             if self.in_subshell == Some(SubShellKind::Backtick) {
                                 self.break_word_operator()?;
+                                if self.chars.state == CharState::Double {
+                                    self.add_error(b"Unclosed double quote");
+                                }
                                 if let Some(toktag) = self.last_tok_tag() {
                                     if toktag != TokenTag::Delimit {
                                         self.tokens.push(Token::Delimit);

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -727,6 +727,23 @@ describe("lex shell", () => {
       await TestBuilder.command`echo hi &`.error('Background commands "&" are not supported yet.').run();
     });
 
+    describe("Unclosed quote", async () => {
+      TestBuilder.command`${{ raw: `echo "start; touch MARKER; echo cleanup-done` }}`
+        .error("Unclosed double quote")
+        .runAsTest("double quote swallows rest of script");
+      TestBuilder.command`${{ raw: `echo 'start; touch MARKER` }}`
+        .error("Unclosed single quote")
+        .runAsTest("single quote swallows rest of script");
+      TestBuilder.command`${{ raw: `echo hi"` }}`.error("Unclosed double quote").runAsTest("trailing double quote");
+      TestBuilder.command`${{ raw: `echo hi'` }}`.error("Unclosed single quote").runAsTest("trailing single quote");
+      TestBuilder.command`${{ raw: `echo $(echo "hi` }}`
+        .error("Unclosed double quote\nUnclosed command substitution")
+        .runAsTest("inside command substitution");
+      TestBuilder.command`${{ raw: `echo "hi"` }}`.stdout("hi\n").runAsTest("closed double quote ok");
+      TestBuilder.command`${{ raw: `echo 'hi'` }}`.stdout("hi\n").runAsTest("closed single quote ok");
+      TestBuilder.command`echo ${'"'}`.stdout('"\n').runAsTest("interpolated quote is data");
+    });
+
     test("Unclosed subshell", async () => {
       await TestBuilder.command`echo hi && $(echo uh oh`.error("Unclosed command substitution").run();
       await TestBuilder.command`echo hi && $(echo uh oh)`

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -739,6 +739,13 @@ describe("lex shell", () => {
       TestBuilder.command`${{ raw: `echo $(echo "hi` }}`
         .error("Unclosed double quote\nUnclosed command substitution")
         .runAsTest("inside command substitution");
+      TestBuilder.command`${{ raw: 'echo `echo "hi`' }}`
+        .error("Unclosed double quote")
+        .runAsTest("inside backtick substitution");
+      TestBuilder.command`${{ raw: "echo `echo 'hi`" }}`
+        .error("Unclosed single quote\nUnclosed command substitution")
+        .runAsTest("single quote inside backtick substitution");
+      TestBuilder.command`${{ raw: 'echo `echo "hi"`' }}`.stdout("hi\n").runAsTest("closed quote inside backtick ok");
       TestBuilder.command`${{ raw: `echo "hi"` }}`.stdout("hi\n").runAsTest("closed double quote ok");
       TestBuilder.command`${{ raw: `echo 'hi'` }}`.stdout("hi\n").runAsTest("closed single quote ok");
       TestBuilder.command`echo ${'"'}`.stdout('"\n').runAsTest("interpolated quote is data");


### PR DESCRIPTION
## What

The Bun Shell lexer silently accepted an unterminated `"` or `'`. The unclosed quote put the lexer into `Single`/`Double` state and consumed the rest of the script as quoted text, so everything after the opening quote became a single argument to the preceding command. Nothing after it ran, and the script exited 0.

```ts
import { $ } from "bun";
const r = await $`${{ raw: `echo "start; touch MARKER; echo done` }}`.nothrow().quiet();
// before: exitCode 0, stdout "start; touch MARKER; echo done\n", MARKER never created
// bash:   exit 2, "unexpected EOF while looking for matching `\"'", nothing runs
```

Unclosed `$(` / `` ` `` / `(` already raise `Unclosed command substitution` / `Unclosed subshell`; quotes were the only unclosed construct that silently ate the script.

## Fix

At EOF the lexer already checks `in_subshell` to report unclosed command substitution / subshell. This adds the matching check on `chars.state`: if the lexer ends while still in `Single` or `Double`, emit `Unclosed single quote` / `Unclosed double quote`. An unclosed quote inside a command substitution now reports both errors, matching bash.

Interpolated JS values are unaffected: they are escaped and wrapped in balanced quotes before the lexer sees them (covered by the "interpolated quote is data" test).

## Related but not in this PR

- `${VAR}` brace syntax is not parsed at all today (`echo ${FOO}` prints the literal `${FOO}`), so "unterminated `${`" falls out of that rather than a missing EOF check.
- `echo a;; echo b` and a leading/bare `;` are accepted; bash rejects both. Separate parser-layer laxness.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/shell/lex.test.ts -t "Unclosed quote"
5 fail, 3 pass
$ bun bd test test/js/bun/shell/lex.test.ts
38 pass, 0 fail
$ bun bd test test/js/bun/shell/bunshell.test.ts
414 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/lex.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
ninja: Entering directory `/workspace/bun/build/debug'
[1/11] gen cpp.rs (cppbind)
[2/11] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[2/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[3/11] cxx obj/src/jsc/bindings/xxhash3.cpp.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_rust.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang+
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (5760541b4)

test/js/bun/shell/lex.test.ts:
(pass) lex shell > basic [2.15ms]
(pass) lex shell > var edgecase [0.07ms]
(pass) lex shell > vars [0.05ms]
(pass) lex shell > quoted_var [0.05ms]
(pass) lex shell > quoted_edge_case [0.04ms]
(pass) lex shell > quote_multi [0.04ms]
(pass) lex shell > semicolon [0.06ms]
(pass) lex shell > single_quote [0.04ms]
(pass) lex shell > env_vars [0.08ms]
(pass) lex shell > env_vars2 [0.05ms]
(pass) lex shell > env_vars exported [0.04ms]
(pass) lex shell > brace_expansion [0.05ms]
(pass) lex shell > op_and [0.05ms]
(pass) lex shell > op_or [0.04ms]
(pass) lex shell > op_pipe [0.04ms]
(pass) lex shell > op_bg [0.04ms]
(pass) lex shell > op_redirect [0.25ms]
(pass) lex shell > obj_ref [0.98ms]
(pass) lex shell > cmd_sub_dollar [0.07ms]
(pass) lex shell > cmd_sub_dollar_nested [0.06ms]
(pass) lex shell > cmd_sub_edgecase [0.04ms]
(pass) lex shell > cmd_sub_combined_word [0.05ms]
(pass) lex shell > cmd_sub_backtick [0.04ms]
(pass) lex shell > errors > JS object ref in quotes [1.08ms]
(pass) lex shell > errors > Unexpected ')' > lone closing paren [0.09ms]
(pass) lex shell > errors > Unexpected ')' > subshell in 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/lex.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (ef5686791)

test/js/bun/shell/lex.test.ts:
(pass) lex shell > basic [5.18ms]
(pass) lex shell > var edgecase [3.13ms]
(pass) lex shell > vars [3.40ms]
(pass) lex shell > quoted_var [4.13ms]
(pass) lex shell > quoted_edge_case [3.49ms]
(pass) lex shell > quote_multi [3.66ms]
(pass) lex shell > semicolon [5.16ms]
(pass) lex shell > single_quote [3.58ms]
(pass) lex shell > env_vars [5.02ms]
(pass) lex shell > env_vars2 [3.86ms]
(pass) lex shell > env_vars exported [4.49ms]
(pass) lex shell > brace_expansion [4.45ms]
(pass) lex shell > op_and [3.85ms]
(pass) lex shell > op_or [4.22ms]
(pass) lex shell > op_pipe [3.91ms]
(pass) lex shell > op_bg [3.88ms]
(pass) lex shell > op_redirect [23.07ms]
(pass) lex shell > obj_ref [5.99ms]
(pass) lex 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 777ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/10] cxx obj/src/jsc/bindings/xxhash3.cpp.o
[2/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[3/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[4/10] gen cpp.rs (cppbind)
[5/10] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[5/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/shell_parser/parse.rs     |  9 +++++++++
 test/js/bun/shell/lex.test.ts | 24 ++++++++++++++++++++++++
 2 files changed, 33 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/shell_parser/parse.rs          6      2      0
test/js/bun/shell/lex.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->