### PR TITLE
shell(exit): propagate last status on no-arg, fix negative/invalid arg codes

### DIFF
--- a/src/runtime/shell/builtin/exit.rs
+++ b/src/runtime/shell/builtin/exit.rs
@@ -19,18 +19,20 @@ impl Exit {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let bltn = Builtin::of(interp, cmd);
         let code: crate::shell::ExitCode = match bltn.args_slice().len() {
-            0 => 0,
+            // POSIX: "the exit status shall be that of the last command
+            // executed, or zero if no command was executed."
+            0 => interp.as_cmd(cmd).base.shell().last_exit_code,
             1 => {
                 let s = bltn.arg_bytes(0);
                 match parse_exit_code(s) {
                     Some(c) => c,
                     None => {
-                        return Self::fail(interp, cmd, b"exit: numeric argument required\n");
+                        return Self::fail(interp, cmd, b"exit: numeric argument required\n", 2);
                     }
                 }
             }
             _ => {
-                return Self::fail(interp, cmd, b"exit: too many arguments\n");
+                return Self::fail(interp, cmd, b"exit: too many arguments\n", 1);
             }
         };
         // Intentional divergence from bash: this completes only the current
@@ -38,9 +40,9 @@ impl Exit {
         Builtin::done(interp, cmd, code)
     }
 
-    fn fail(interp: &Interpreter, cmd: NodeId, msg: &[u8]) -> Yield {
+    fn fail(interp: &Interpreter, cmd: NodeId, msg: &[u8], code: crate::shell::ExitCode) -> Yield {
         Self::state_mut(interp, cmd).state = State::WaitingIo;
-        Builtin::write_failing_error(interp, cmd, msg, 1)
+        Builtin::write_failing_error(interp, cmd, msg, code)
     }
 
     pub(crate) fn on_io_writer_chunk(
@@ -50,11 +52,13 @@ impl Exit {
         _err: Option<bun_sys::SystemError>,
     ) -> Yield {
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(interp, cmd, 1)
+        let code = Builtin::of(interp, cmd).exit_code.unwrap_or(1);
+        Builtin::done(interp, cmd, code)
     }
 }
 
 fn parse_exit_code(s: &[u8]) -> Option<crate::shell::ExitCode> {
-    // %256 is bash semantics — keep wrapper fn.
-    bun_core::fmt::parse_decimal::<u64>(s).map(|n| (n % 256) as crate::shell::ExitCode)
+    // bash semantics: parse as a signed integer and keep the low 8 bits
+    // (`exit -1` → 255, `exit 300` → 44, `exit -300` → 212).
+    bun_core::fmt::parse_decimal::<i64>(s).map(|n| crate::shell::ExitCode::from(n as u8))
 }

--- a/src/runtime/shell/builtin/exit.rs
+++ b/src/runtime/shell/builtin/exit.rs
@@ -18,21 +18,22 @@ enum State {
 impl Exit {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let bltn = Builtin::of(interp, cmd);
-        let code: crate::shell::ExitCode = match bltn.args_slice().len() {
+        let argc = bltn.args_slice().len();
+        let code: crate::shell::ExitCode = if argc == 0 {
             // POSIX: "the exit status shall be that of the last command
             // executed, or zero if no command was executed."
-            0 => interp.as_cmd(cmd).base.shell().last_exit_code,
-            1 => {
-                let s = bltn.arg_bytes(0);
-                match parse_exit_code(s) {
-                    Some(c) => c,
-                    None => {
-                        return Self::fail(interp, cmd, b"exit: numeric argument required\n", 2);
-                    }
+            interp.as_cmd(cmd).base.shell().last_exit_code
+        } else {
+            // bash checks arg[0] before argc: `exit abc def` is "numeric
+            // argument required" (2), not "too many arguments" (1).
+            match parse_exit_code(bltn.arg_bytes(0)) {
+                None => {
+                    return Self::fail(interp, cmd, b"exit: numeric argument required\n", 2);
                 }
-            }
-            _ => {
-                return Self::fail(interp, cmd, b"exit: too many arguments\n", 1);
+                Some(_) if argc > 1 => {
+                    return Self::fail(interp, cmd, b"exit: too many arguments\n", 1);
+                }
+                Some(c) => c,
             }
         };
         // Intentional divergence from bash: this completes only the current

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -588,6 +588,7 @@ impl Interpreter {
                 __cwd: cwd_arr,
                 cwd_fd,
                 async_pids: SmolList::default(),
+                last_exit_code: 0,
             }),
             root_io: JsCell::new(IO {
                 stdin: crate::shell::io::InKind::Fd(stdin_reader),
@@ -1793,6 +1794,10 @@ pub struct ShellExecEnv {
     pub __cwd: Vec<u8>,
     pub cwd_fd: Fd,
     pub async_pids: SmolList<PidT, 4>,
+    /// Exit status of the most recently completed command in this execution
+    /// context (POSIX `$?`). Read by the `exit` builtin when called with no
+    /// argument. Updated by `Stmt::child_done` and `Binary::child_done`.
+    pub last_exit_code: ExitCode,
 }
 
 pub enum Bufio {
@@ -1958,6 +1963,9 @@ impl ShellExecEnv {
             __cwd: self.__cwd.clone(),
             cwd_fd: dupedfd,
             async_pids: SmolList::default(),
+            // Inherited so a subshell/command-substitution sees the parent's
+            // value; writes never propagate back (POSIX behavior).
+            last_exit_code: self.last_exit_code,
         });
         Ok(bun_core::heap::into_raw(duped))
     }

--- a/src/runtime/shell/states/Binary.rs
+++ b/src/runtime/shell/states/Binary.rs
@@ -80,6 +80,7 @@ impl Binary {
         {
             let me = interp.as_binary_mut(this);
             me.currently_executing = None;
+            me.base.shell_mut().last_exit_code = exit_code;
             if me.left.is_none() {
                 me.left = Some(exit_code);
             } else {

--- a/src/runtime/shell/states/Stmt.rs
+++ b/src/runtime/shell/states/Stmt.rs
@@ -78,6 +78,7 @@ impl Stmt {
         {
             let me = interp.as_stmt_mut(this);
             me.last_exit_code = Some(exit_code);
+            me.base.shell_mut().last_exit_code = exit_code;
             me.idx += 1;
             me.currently_executing = None;
         }

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -1,7 +1,7 @@
 import { describe } from "bun:test";
-import { createTestBuilder } from "../test_builder";
+import { bunExe, createTestBuilder } from "../test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
-const BUN = process.argv0;
+const BUN = bunExe();
 
 describe("exit", async () => {
   TestBuilder.command`exit`.exitCode(0).runAsTest("works");
@@ -23,7 +23,9 @@ describe("exit", async () => {
     TestBuilder.command`false; exit`.exitCode(1).runAsTest("false; exit");
     TestBuilder.command`true; exit`.exitCode(0).runAsTest("true; exit");
     TestBuilder.command`false || exit`.exitCode(1).runAsTest("false || exit");
+    TestBuilder.command`true | false; exit`.exitCode(1).runAsTest("pipeline; exit");
     TestBuilder.command`${{ raw: "(exit 42); exit" }}`.exitCode(42).runAsTest("subshell; exit");
+    TestBuilder.command`${{ raw: "false; (exit)" }}`.exitCode(1).runAsTest("inherited by subshell");
     TestBuilder.command`${BUN} -e ${"process.exit(7)"}; exit`.exitCode(7).runAsTest("subprocess; exit");
     TestBuilder.command`${{ raw: "false\nexit" }}`.exitCode(1).runAsTest("across statements");
     TestBuilder.command`false; exit 3`.exitCode(3).runAsTest("explicit arg wins");

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -19,6 +19,9 @@ describe("exit", async () => {
   // prettier-ignore
   TestBuilder.command`exit abc`.exitCode(2).stderr("exit: numeric argument required\n").runAsTest("numeric argument required");
 
+  // prettier-ignore
+  TestBuilder.command`exit abc def`.exitCode(2).stderr("exit: numeric argument required\n").runAsTest("non-numeric first arg checked before argc");
+
   describe("no argument propagates the last command's status", async () => {
     TestBuilder.command`false; exit`.exitCode(1).runAsTest("false; exit");
     TestBuilder.command`true; exit`.exitCode(0).runAsTest("true; exit");

--- a/test/js/bun/shell/commands/exit.test.ts
+++ b/test/js/bun/shell/commands/exit.test.ts
@@ -1,6 +1,7 @@
 import { describe } from "bun:test";
 import { createTestBuilder } from "../test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
+const BUN = process.argv0;
 
 describe("exit", async () => {
   TestBuilder.command`exit`.exitCode(0).runAsTest("works");
@@ -16,5 +17,20 @@ describe("exit", async () => {
   TestBuilder.command`exit 62757836`.exitCode(204).runAsTest("exit code wraps u8");
 
   // prettier-ignore
-  TestBuilder.command`exit abc`.exitCode(1).stderr("exit: numeric argument required\n").runAsTest("numeric argument required");
+  TestBuilder.command`exit abc`.exitCode(2).stderr("exit: numeric argument required\n").runAsTest("numeric argument required");
+
+  describe("no argument propagates the last command's status", async () => {
+    TestBuilder.command`false; exit`.exitCode(1).runAsTest("false; exit");
+    TestBuilder.command`true; exit`.exitCode(0).runAsTest("true; exit");
+    TestBuilder.command`false || exit`.exitCode(1).runAsTest("false || exit");
+    TestBuilder.command`${{ raw: "(exit 42); exit" }}`.exitCode(42).runAsTest("subshell; exit");
+    TestBuilder.command`${BUN} -e ${"process.exit(7)"}; exit`.exitCode(7).runAsTest("subprocess; exit");
+    TestBuilder.command`${{ raw: "false\nexit" }}`.exitCode(1).runAsTest("across statements");
+    TestBuilder.command`false; exit 3`.exitCode(3).runAsTest("explicit arg wins");
+  });
+
+  describe("negative argument wraps mod 256", async () => {
+    TestBuilder.command`exit -1`.exitCode(255).runAsTest("-1");
+    TestBuilder.command`exit -300`.exitCode(212).runAsTest("-300");
+  });
 });

--- a/test/js/bun/shell/exec.test.ts
+++ b/test/js/bun/shell/exec.test.ts
@@ -55,7 +55,7 @@ describe("bun exec", () => {
       ["rm",     1, "rm: illegal option -- -\n", ""],
       ["mv",     1, "mv: illegal option -- -\n", ""],
       ["ls",     1, "ls: illegal option -- -\n", ""],
-      ["exit",   1, "exit: numeric argument required\n", ""],
+      ["exit",   2, "exit: numeric argument required\n", ""],
       ["true",   0, "", ""],
       ["false",  1, "", ""],
       // ["yes",    1, "", ""],


### PR DESCRIPTION
### Problem

```js
import { $ } from "bun";
$.nothrow();
(await $`${{ raw: "false; exit" }}`.quiet()).exitCode;  // bun: 0  bash: 1
(await $`${{ raw: "exit -1" }}`.quiet()).exitCode;       // bun: 1  bash: 255
(await $`${{ raw: "exit abc" }}`.quiet()).exitCode;      // bun: 1  bash: 2
```

POSIX specifies that `exit` with no argument returns the status of the last command executed. Bun returned 0 unconditionally, so the standard `cmd; exit` tail idiom always reported success to `ShellPromise.exitCode`, which is what CI/deploy wrappers branch on.

### Cause

- `exit` with no argument was hardcoded to `0` in `builtin/exit.rs`.
- The argument was parsed as `u64`, so negatives failed to parse and fell into the "numeric argument required" path.
- Both the "numeric argument required" and "too many arguments" errors returned 1; bash returns 2 for the former.

### Fix

- Track the last command's exit status on `ShellExecEnv` (`last_exit_code`), updated by `Stmt::child_done` and `Binary::child_done`. It is inherited when the env is duped for a subshell/command-substitution/pipeline child, so `(exit 7); exit` works and the child never writes back.
- `exit` with no argument reads `last_exit_code` instead of returning 0.
- Parse the argument as `i64` and keep the low 8 bits: `exit -1` → 255, `exit -300` → 212, `exit 300` → 44 (unchanged).
- "numeric argument required" now returns 2; "too many arguments" still returns 1.

### Verification

`test/js/bun/shell/commands/exit.test.ts` gains coverage for all of the above (16 cases, 8 of which fail on the current release). `bunshell.test.ts` (414 tests) and `exec.test.ts` pass unchanged apart from the expected 1→2 update for `exit --help`.

Related: #33274 adds the same `last_exit_code` field on `ShellExecEnv` to implement `$?`; whichever lands first, the other is a trivial merge. #33282 makes `exit` unwind the script, which is orthogonal.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/exit.test.ts test/js/bun/shell/exec.test.ts
bun test v1.4.0 (d8a9367dc)

test/js/bun/shell/exec.test.ts:
hi!
(pass) bun exec > it works [195.71ms]
bun: command not found: sldkfjslkdjflksdjflj
(pass) bun exec > it works on command fail [152.20ms]
Usage: bun exec <script>

Execute a shell script directly from Bun.

Note: If executing this from a shell, make sure to escape the string!

Examples:
  bun exec "echo hi"
  bun exec "echo \"hey friends\"!"
(pass) bun exec > no args prints help text [131.26ms]
hi "there bud"
(pass) bun exec > it works2 [142.10ms]
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (058ab3c9a)

test/js/bun/shell/exec.test.ts:
hi!
(pass) bun exec > it works [4.67ms]
bun: command not found: sldkfjslkdjflksdjflj
(pass) bun exec > it works on command fail [2.35ms]
Usage: bun exec <script>

Execute a shell script directly from Bun.

Note: If executing this from a shell, make sure to escape the string!

Examples:
  bun exec "echo hi"
  bun exec "echo \"hey friends\"!"
(pass) bun exec > no args prints help text [1.51ms]
hi "there bud"
(pass) bun exec > it works2 [1.84ms]
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/exit.test.ts test/js/bun/shell/exec.test.ts
bun test v1.4.0 (d8a9367dc)

test/js/bun/shell/exec.test.ts:
hi!
(pass) bun exec > it works [194.80ms]
bun: command not found: sldkfjslkdjflksdjflj
(pass) bun exec > it works on command fail [145.34ms]
Usage: bun exec <script>

Execute a shell script directly from Bun.

Note: If executing this from a shell, make sure to escape the string!

Examples:
  bun exec "echo hi"
  bun exec "echo \"hey friends\"!"
(pass) bun exec > no args prints help text [110.20ms]
hi "there bud"
(pass) bun exec > it works2 [139.76ms]
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/builtin/exit.rs       | 39 +++++++++++++++++++--------------
 src/runtime/shell/interpreter.rs        |  8 +++++++
 src/runtime/shell/states/Binary.rs      |  1 +
 src/runtime/shell/states/Stmt.rs        |  1 +
 test/js/bun/shell/commands/exit.test.ts | 25 +++++++++++++++++++--
 test/js/bun/shell/exec.test.ts          |  2 +-
 6 files changed, 56 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/shell/builtin/exit.rs            2      2      0
src/runtime/shell/interpreter.rs             6      3      0
src/runtime/shell/states/Binary.rs           1      1      0
src/runtime/shell/states/Stmt.rs             1      1      0
test/js/bun/shell/commands/exit.test.ts      2      6      0
test/js/bun/shell/exec.test.ts               1      1      0
```

</details>

<!-- robobun:evidence:end -->