### PR TITLE
shell: don't consume the next word as a file target for `2>&1` / `1>&2`

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -799,8 +799,8 @@ impl Builtin {
                 }
             }
             None if redirect.duplicate_out() => {
-                // `2>&1` (stderr=true,dup_out=true) → stderr := stdout
-                // `1>&2` (stdout=true,dup_out=true) → stdout := stderr
+                // `2>&1` (stdout=true,dup_out=true) → stderr := stdout
+                // `1>&2` (stderr=true,dup_out=true) → stdout := stderr
                 let me = Self::of_mut(interp, cmd);
                 if redirect.stdout() {
                     me.stderr = me.stdout.dup_ref();

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -586,8 +586,8 @@ pub mod ast {
             const STDOUT        = 1 << 1;
             const STDERR        = 1 << 2;
             const APPEND        = 1 << 3;
-            /// 1>&2 === stdout=true and duplicate_out=true
-            /// 2>&1 === stderr=true and duplicate_out=true
+            /// 2>&1 === stdout=true and duplicate_out=true
+            /// 1>&2 === stderr=true and duplicate_out=true
             const DUPLICATE_OUT = 1 << 4;
         }
     }

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1571,10 +1571,26 @@ impl<'bump> Parser<'bump> {
 
         let mut name_and_args = bun_alloc::ArenaVec::new_in(self.alloc);
         name_and_args.push(name);
-        while let Some(arg) = self.parse_atom()? {
-            name_and_args.push(arg);
+        let mut parsed_redirect = ParsedRedirect::default();
+        let mut has_redirect = false;
+        loop {
+            if let Some(arg) = self.parse_atom()? {
+                name_and_args.push(arg);
+                continue;
+            }
+            if self.check(TokenTag::Redirect) {
+                if has_redirect {
+                    self.add_error(format_args!(
+                        "Multiple redirects are not supported yet. Please open a GitHub issue."
+                    ))?;
+                    return Err(ParseError::Unsupported.into());
+                }
+                parsed_redirect = self.parse_redirect()?;
+                has_redirect = true;
+                continue;
+            }
+            break;
         }
-        let parsed_redirect = self.parse_redirect()?;
 
         Ok(ast::CmdOrAssigns::Cmd(ast::Cmd {
             assigns: assigns.into_bump_slice(),
@@ -1596,6 +1612,11 @@ impl<'bump> Parser<'bump> {
         };
         let redirect_file: Option<ast::Redirect<'bump>> = 'redirect_file: {
             if has_redirect {
+                // `2>&1` / `1>&2` are complete on their own; the next word is an
+                // argument of the command, not a file operand.
+                if redirect.duplicate_out() {
+                    break 'redirect_file None;
+                }
                 if self.r#match(TokenTag::JSObjRef) {
                     let Token::JSObjRef(obj_ref) = self.prev() else {
                         unreachable!()
@@ -1606,9 +1627,6 @@ impl<'bump> Parser<'bump> {
                 let file = match self.parse_atom()? {
                     Some(f) => f,
                     None => {
-                        if redirect.duplicate_out() {
-                            break 'redirect_file None;
-                        }
                         self.add_error(format_args!("Redirection with no file"))?;
                         return Err(ParseError::Expected.into());
                     }

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -23,6 +23,25 @@ describe("IOWriter file output redirection", () => {
       .runAsTest("zero-length write should trigger onIOWriterChunk callback");
   });
 
+  describe("fd-dup redirect followed by a word", () => {
+    // `2>&1` has no file operand, so `b` must stay an argument of echo.
+    TestBuilder.command`echo a 2>&1 b`
+      .ensureTempDir()
+      .exitCode(0)
+      .stdout("a b\n")
+      .stderr("")
+      .doesNotExist("b")
+      .runAsTest("2>&1 does not consume the next word as a file");
+
+    TestBuilder.command`echo a 1>&2 b`
+      .ensureTempDir()
+      .exitCode(0)
+      .stdout("")
+      .stderr("a b\n")
+      .doesNotExist("b")
+      .runAsTest("1>&2 does not consume the next word as a file");
+  });
+
   describe("drainBufferedData edge cases", () => {
     TestBuilder.command`echo -n ${"x".repeat(1024 * 10)} > large.txt`
       .exitCode(0)

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -1091,5 +1091,9 @@ describe("parse shell invalid input", () => {
     await TestBuilder.command`echo (echo foo && echo hi)`.error("Unexpected token: `(`").run();
 
     await TestBuilder.command`echo foo >`.error("Redirection with no file").run();
+
+    await TestBuilder.command`echo a 2>&1 b > f`
+      .error("Multiple redirects are not supported yet. Please open a GitHub issue.")
+      .run();
   });
 });

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -59,6 +59,31 @@ describe("parse shell", () => {
     expect(result).toEqual(expected);
   });
 
+  test("fd-dup redirect does not consume the next word", () => {
+    // `2>&1` / `1>&2` are complete redirects; the following word is an
+    // argument of the command (bash: `echo a 2>&1 b` prints "a b").
+    const cmd = {
+      assigns: [],
+      name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "a" } }, { simple: { Text: "b" } }],
+      redirect: redirect({ stdout: true, duplicate_out: true }),
+      redirect_file: null,
+    };
+    expect(JSON.parse(parse`echo a 2>&1 b`)).toEqual({ stmts: [{ exprs: [{ cmd }] }] });
+
+    const cmd2 = {
+      assigns: [],
+      name_and_args: [{ simple: { Text: "echo" } }, { simple: { Text: "a" } }, { simple: { Text: "b" } }],
+      redirect: redirect({ stderr: true, duplicate_out: true }),
+      redirect_file: null,
+    };
+    expect(JSON.parse(parse`echo a 1>&2 b`)).toEqual({ stmts: [{ exprs: [{ cmd: cmd2 }] }] });
+
+    // With the trailing word absent the redirect still stands on its own.
+    expect(JSON.parse(parse`echo a 2>&1`)).toEqual({
+      stmts: [{ exprs: [{ cmd: { ...cmd, name_and_args: cmd.name_and_args.slice(0, 2) } }] }],
+    });
+  });
+
   test("single atom", () => {
     expect(JSON.parse(parse`ls`)).toEqual({
       stmts: [


### PR DESCRIPTION
## Repro

```js
import { $ } from "bun";
await $`${{ raw: "echo a 2>&1 b" }}`.quiet();
// bash : prints "a b" to stdout
// bun  : writes "a\n" into a file named `b`
```

`1>&2` had the mirrored problem: `echo a 1>&2 b` created an empty file `b` and wrote `a` to stdout instead of writing `a b` to stderr.

## Cause

`parse_redirect` in `src/shell_parser/parse.rs` unconditionally read a file operand after consuming a `Redirect` token. The `duplicate_out()` check was only reached when `parse_atom()` returned `None` (i.e. the redirect was the last token of the command), so for `echo a 2>&1 b` it grabbed `b` and stored it as `redirect_file`.

## Fix

Check `redirect.duplicate_out()` before attempting to parse an operand; fd-dup redirects carry their target fd in the token itself and never take a file.

`parse_simple_cmd` also now interleaves argument and redirect parsing, so the `b` that follows the dup stays in `name_and_args` instead of starting a new statement. That loop is the same shape as #34901 (which fixes the `> file` variant of the same interleaving problem), so whichever lands first the other is a trivial merge; the `parse_redirect` change here is the new piece.

A second redirect after the dup (e.g. `echo a 2>&1 b > f`) now reports the existing "Multiple redirects are not supported yet" parse error, which previously surfaced as the less helpful `expected a command or assignment but got: "Redirect"`.

## Verification

- `test/js/bun/shell/parse.test.ts`: `echo a 2>&1 b` and `echo a 1>&2 b` parse as one command with `name_and_args: [echo, a, b]` and `redirect_file: null`; bare `echo a 2>&1` is unchanged.
- `test/js/bun/shell/file-io.test.ts`: both forms print `a b` to the expected stream and no file `b` is created.

Both fail on the released binary (parse sees `redirect_file: b`; behavioral sees empty stdout and a file on disk). Full `parse.test.ts`, `lex.test.ts`, `file-io.test.ts`, and `bunshell.test.ts` (414 tests) pass on this branch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/file-io.test.ts test/js/bun/shell/parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b6ee4df4d)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [83.91ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [9.72ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [6.96ms]
207 | 
208 |     async doChecks(stdout: Buffer, stderr: Buffer, exitCode: number): Promise<void> {
209 |       const tempdir = this.tempdir || "NO_TEMP_DIR";
210 |       if (this.expected_stdout !== undefined) {
211 |         if (typeof this.expected_stdout === "string") {
212 |           expect(stdout.toString()).toEqual(this.expect
... (truncated)

release without fix: 5 failed, 4 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [1.51ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [0.22ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [0.20ms]
207 | 
208 |     async doChecks(stdout: Buffer, stderr: Buffer, exitCode: number): Promise<void> {
209 |       const tempdir = this.tempdir || "NO_TEMP_DIR";
210 |       if (this.expected_stdout !== undefined) {
211 |         if (typeof this.expected_stdout === "string") {
212 |           expect(stdout.toString()).toEqual(this.expected_stdout.replaceAll("$TEMP_DIR", tempdir));
                                          ^
error: expect(received).toEqual(expected)

- "a b
- "
+ ""

- Expected  - 2
+ Received  + 1

      at doChecks (/workspace/bun/test/js/bun/shell/test_builder.ts:212:37)
      at run (/workspace/bun/test/js/bun/shell/test_builder.ts:251:20)
      at async <anonymous> (/workspace/bun/test/js/bun/shell/test_builder.ts:297:24)
(fail) IOWriter file output redirec
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/file-io.test.ts test/js/bun/shell/parse.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (b6ee4df4d)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [59.26ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [8.00ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [6.39ms]
a b
(pass) IOWriter file output redirection > fd-dup redirect followed by a word > 2>&1 does not consume the next word as a file [9.82ms]
a b
(pass) IOWriter file output redirection > fd-dup redirect followed by a word > 1>&2 does not consume the next word as a file [14.79ms]
(pass) IOWriter file output redirection > drainBufferedDat
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b6ee4df4d4
  features     (none)

22 deps, 106 codegen, 1169 objects in 939ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [34.00ms]
[2/1232] gen ErrorCode+*.h
[3/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[5/1232] gen .bind.ts → GeneratedBindings.cpp
[6/1232] fetch zlib
[zlib] up to date
[7/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to d
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/Builtin.rs      |  4 ++--
 src/shell_parser/parse.rs         | 34 ++++++++++++++++++++++++++--------
 test/js/bun/shell/file-io.test.ts | 19 +++++++++++++++++++
 test/js/bun/shell/parse.test.ts   | 29 +++++++++++++++++++++++++++++
 4 files changed, 76 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/shell/Builtin.rs           1      1      0
src/shell_parser/parse.rs              8      3      0
test/js/bun/shell/file-io.test.ts      1      1      0
test/js/bun/shell/parse.test.ts        1      2      0
```

</details>

**root cause** · written by the author bot

The shell parser's `parse_redirect` unconditionally called `parse_atom()` to read a file operand after any redirect token, so for fd-duplication forms like `2>&1` that take no operand, the following word was wrongly consumed as the redirect target instead of remaining a command argument. The fix checks `redirect.duplicate_out()` immediately after extracting the redirect flags and returns early with no file operand, leaving subsequent words to be parsed as arguments. It also reports the existing "multiple redirects are not supported" error when a dup redirect appears alongside another redire…

<!-- robobun:evidence:end -->