### PR TITLE
Atomics.waitAsync: keep the event loop alive once notify schedules the resolve task

### DIFF
--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -80,6 +80,14 @@ void JSCTaskScheduler::onScheduleWorkSoon(WebCore::JSVMClientData* clientData, R
             Bun__eventLoop__incrementRefConcurrently(clientData->bunVM, -1);
         return;
     }
+    // An AtSomePoint ticket (Atomics.waitAsync) sat in m_pendingTicketsOther
+    // without an event-loop ref while dormant. The work is now imminent, so
+    // promote it; otherwise the queued concurrent task is invisible to
+    // is_event_loop_alive() and the loop can exit before draining it.
+    if (auto pending = scheduler.m_pendingTicketsOther.take(ticket)) {
+        Bun__eventLoop__incrementRefConcurrently(clientData->bunVM, 1);
+        scheduler.m_pendingTicketsKeepingEventLoopAlive.add(pending.releaseNonNull());
+    }
     auto* job = new JSCDeferredWorkTask(WTF::move(ticket), WTF::move(task));
     Bun__queueJSCDeferredWorkTaskConcurrently(clientData->bunVM, job);
 }

--- a/test/js/web/atomics.test.ts
+++ b/test/js/web/atomics.test.ts
@@ -184,9 +184,11 @@ describe("Atomics", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("notify=5\nresolved:w0:ok,w1:ok,w2:ok,w3:ok,w4:ok\n");
-      expect(exitCode).toBe(0);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "notify=5\nresolved:w0:ok,w1:ok,w2:ok,w3:ok,w4:ok\n",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
     });
 
     test("waitAsync alone does not keep the event loop alive", async () => {
@@ -203,9 +205,11 @@ describe("Atomics", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("exit\n");
-      expect(exitCode).toBe(0);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "exit\n",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
     });
   });
 

--- a/test/js/web/atomics.test.ts
+++ b/test/js/web/atomics.test.ts
@@ -183,11 +183,7 @@ describe("Atomics", () => {
         env: bunEnv,
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(stdout).toBe("notify=5\nresolved:w0:ok,w1:ok,w2:ok,w3:ok,w4:ok\n");
       expect(exitCode).toBe(0);
@@ -206,11 +202,7 @@ describe("Atomics", () => {
         env: bunEnv,
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(stdout).toBe("exit\n");
       expect(exitCode).toBe(0);

--- a/test/js/web/atomics.test.ts
+++ b/test/js/web/atomics.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("Atomics", () => {
   describe("basic operations", () => {
@@ -158,6 +159,61 @@ describe("Atomics", () => {
       } else {
         expect(typeof result.value).toBe("string");
       }
+    });
+
+    test("waitAsync promises resolve when notify is the last live handle", async () => {
+      // The notify() inside the setTimeout callback is the last thing keeping the
+      // event loop alive. The waiter resolutions it schedules must still run
+      // before the process exits (Node.js behaviour).
+      const src = `
+        const ia = new Int32Array(new SharedArrayBuffer(4));
+        const got = [];
+        for (let i = 0; i < 5; i++)
+          Atomics.waitAsync(ia, 0, 0, 60000).value.then(v => {
+            got.push("w" + i + ":" + v);
+            if (got.length === 5) console.log("resolved:" + got.join(","));
+          });
+        setTimeout(() => console.log("notify=" + Atomics.notify(ia, 0)), 40);
+        process.on("exit", () => {
+          if (got.length !== 5) console.log("exit-with-unsettled:" + got.length);
+        });
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("notify=5\nresolved:w0:ok,w1:ok,w2:ok,w3:ok,w4:ok\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("waitAsync alone does not keep the event loop alive", async () => {
+      // Matches Node.js: a pending waitAsync with no other live handle lets the
+      // process exit. Only a delivered notify should extend the loop.
+      const src = `
+        const ia = new Int32Array(new SharedArrayBuffer(4));
+        Atomics.waitAsync(ia, 0, 0, 60000).value.then(v => console.log("settled:" + v));
+        process.on("exit", () => console.log("exit"));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("exit\n");
+      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
### Repro

```js
const ia = new Int32Array(new SharedArrayBuffer(4));
const got = [];
for (let i = 0; i < 5; i++)
  Atomics.waitAsync(ia, 0, 0, 3000).value.then(v => {
    got.push("w" + i + ":" + v);
    if (got.length === 5) console.log("resolved:", got.join(","));
  });
setTimeout(() => console.log("notify count =", Atomics.notify(ia, 0)), 40);
process.on("exit", () => {
  if (got.length !== 5) console.log("only " + got.length + "/5 settled before exit");
});
```

Node prints `notify count = 5` then `resolved: w0:ok,w1:ok,w2:ok,w3:ok,w4:ok`. Bun prints `notify count = 5` then `only 0/5 settled before exit`.

### Cause

`Atomics.waitAsync` registers its `DeferredWorkTimer` ticket as `WorkType::AtSomePoint`, so `JSCTaskScheduler::onAddPendingWork` stores it in `m_pendingTicketsOther` without taking an event-loop ref. That is correct while the waiter is dormant: a pending `waitAsync` alone must not keep the process alive.

When `Atomics.notify` wakes the waiter, `WaiterListManager::notifyWaiterImpl` calls `scheduleWorkSoon` on that ticket. `JSCTaskScheduler::onScheduleWorkSoon` enqueues a `ConcurrentTask` to run the promise resolution but leaves the ticket in `m_pendingTicketsOther`. `VirtualMachine::is_event_loop_alive()` counts the uws active handles, `EventLoop::tasks`, and `EventLoop::concurrent_ref`, but not the `concurrent_tasks` queue itself. In the repro the `notify` runs inside the callback of the last live handle, so when control returns to the `while vm.is_event_loop_alive()` loop in `run_command.rs` every input is zero and the process exits with the five resolution tasks still sitting in `concurrent_tasks`.

### Fix

In `JSCTaskScheduler::onScheduleWorkSoon`, when the ticket is found in `m_pendingTicketsOther`, move it to `m_pendingTicketsKeepingEventLoopAlive` and take an event-loop ref via `Bun__eventLoop__incrementRefConcurrently(+1)`. The work is imminent at this point, so the ticket now has the same lifetime accounting as an `ImminentlyScheduled` one. `runPendingWork` already decrements the ref when it takes the ticket from the keep-alive set, and `Bun__deleteDeferredWorkTask` does the same via `dropPendingTicketLocked`, so the balance is unchanged for tickets that started as `ImminentlyScheduled`. Tickets that were cancelled before scheduling (`Waiter::cancelAndClear` calls `cancelPendingWork` then `scheduleWorkSoon` with a no-op) are absent from both sets and take the existing no-ref path.

A pending `waitAsync` with no `notify` still does not keep the loop alive; a second test asserts that.

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/web/atomics.test.ts -t "waitAsync promises resolve"
(fail) Atomics > synchronization > waitAsync promises resolve when notify is the last live handle
  "notify=5
- resolved:w0:ok,w1:ok,w2:ok,w3:ok,w4:ok
+ exit-with-unsettled:0
  "

$ bun bd test test/js/web/atomics.test.ts
 30 pass
 0 fail
```

`test/js/web/timers/timer-heap-race.test.ts` and `test/regression/issue/atomics-waitasync-wtftimer-uaf.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/atomics.test.ts
bun test v1.4.0 (bd1eeb0fb)

test/js/web/atomics.test.ts:
(pass) Atomics > basic operations > store and load [4.66ms]
(pass) Atomics > basic operations > add [3.03ms]
(pass) Atomics > basic operations > sub [3.31ms]
(pass) Atomics > basic operations > exchange [2.38ms]
(pass) Atomics > basic operations > compareExchange [2.96ms]
(pass) Atomics > bitwise operations > and [2.33ms]
(pass) Atomics > bitwise operations > or [2.36ms]
(pass) Atomics > bitwise operations > xor [2.12ms]
(pass) Atomics > utility functions > isLockFree [2.98ms]
(pass) Atomics > utility functions > pause [2.43ms]
(pass) Atomics > synchronization > wait with timeout [12.34ms]
(pass) Atomics > synchronization > wait with non-matching value [1.89ms]
(pass) Atomics > synchronization > notify [2.04ms]
(pass) Atomics > synchronization > waitAsync with timeout [3.34ms]
182 |         cmd: [bunExe(), "-e", src],
183 |         env: bunEnv,
184 |         stderr: "pipe",
185 |       });
186 |       const [stdout, stderr, exitCode] = await Promise.a
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (93755644c)

test/js/web/atomics.test.ts:
(pass) Atomics > basic operations > store and load [0.09ms]
(pass) Atomics > basic operations > add [0.04ms]
(pass) Atomics > basic operations > sub [0.03ms]
(pass) Atomics > basic operations > exchange [0.02ms]
(pass) Atomics > basic operations > compareExchange [0.03ms]
(pass) Atomics > bitwise operations > and [0.02ms]
(pass) Atomics > bitwise operations > or [0.02ms]
(pass) Atomics > bitwise operations > xor [0.02ms]
(pass) Atomics > utility functions > isLockFree [0.03ms]
(pass) Atomics > utility functions > pause [0.03ms]
(pass) Atomics > synchronization > wait with timeout [10.13ms]
(pass) Atomics > synchronization > wait with non-matching value [0.11ms]
(pass) Atomics > synchronization > notify [0.03ms]
(pass) Atomics > synchronization > waitAsync with timeout [0.07ms]
(pass) Atomics > synchronization > waitAsync promises resolve when notify is the last live handle [52.38ms]
(pass) Atomics > synchronization > waitAsync alone does not keep the event loop alive [11.85ms]
(pass) Atomics > different TypedArray types > Int8Array [0.08ms]
(pass) Atomics > different TypedArray types > Int16Array [0.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/atomics.test.ts
bun test v1.4.0 (bd1eeb0fb)

test/js/web/atomics.test.ts:
(pass) Atomics > basic operations > store and load [4.80ms]
(pass) Atomics > basic operations > add [3.01ms]
(pass) Atomics > basic operations > sub [3.29ms]
(pass) Atomics > basic operations > exchange [2.41ms]
(pass) Atomics > basic operations > compareExchange [3.24ms]
(pass) Atomics > bitwise operations > and [2.36ms]
(pass) Atomics > bitwise operations > or [2.33ms]
(pass) Atomics > bitwise operations > xor [2.05ms]
(pass) Atomics > utility functions > isLockFree [3.00ms]
(pass) Atomics > utility functions > pause [2.27ms]
(pass) Atomics > synchronization > wait with timeout [12.37ms]
(pass) Atomics > synchronization > wait with non-matching value [1.93ms]
(pass) Atomics > synchronization > notify [1.99ms]
(pass) Atomics > synchronization > waitAsync with timeout [3.30ms]
(pass) Atomics > synchronization > waitAsync promises resolve when notify is the last live handle [474.35ms]
(pass) Atomics > synchronization > waitAsync alone does not keep the
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 630ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCTaskScheduler.cpp |  8 ++++++
 test/js/web/atomics.test.ts           | 52 +++++++++++++++++++++++++++++++++++
 2 files changed, 60 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/JSCTaskScheduler.cpp      1      1      0
test/js/web/atomics.test.ts                2      5      0
```

</details>

<!-- robobun:evidence:end -->