### PR TITLE
MessagePort: drain a started port even with no 'message' listener

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -240,9 +240,11 @@ function injectFakeEmitter(Class) {
   function removeAllListeners(type) {
     const map = registryFor(this, false);
     if (!map) return this;
+    let removedMessage = false;
     const removeType = t => {
       const byListener = map.get(t);
       if (byListener) {
+        if (t === "message" && byListener.size > 0) removedMessage = true;
         for (const w of byListener.values()) this.removeEventListener(t, w);
         map.delete(t);
       }
@@ -254,6 +256,11 @@ function injectFakeEmitter(Class) {
     } else {
       removeType(type);
     }
+    // Node's NodeEventTarget.removeAllListeners never fires [kRemoveListener], so a
+    // MessagePort stays receiving. The per-wrapper removeEventListener above stopped
+    // it; restore with start(). Guarded by this.start so non-MessagePort targets
+    // (Worker) are unaffected.
+    if (removedMessage && typeof this.start === "function") this.start();
     return this;
   }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -541,7 +541,10 @@ bool MessagePort::removeEventListener(const AtomString& eventType, EventListener
         m_hasMessageEventListener = false;
         // Node stops the port when the last 'message' listener goes away; further
         // messages buffer for receiveMessageOnPort until start() (or a new listener).
-        m_started = false;
+        // A removeEventListener for a callback that was never registered is a no-op
+        // (`result` is false) and must not stop an explicitly-start()ed port.
+        if (result)
+            m_started = false;
     }
     if (!hasEventListeners(eventNames().closeEvent))
         m_hasCloseEventListener.store(false, std::memory_order_release);

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -517,6 +517,12 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
 
 bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)
 {
+    // Node only fires [kNewListener] (and so start()) when the add actually lands;
+    // an already-aborted signal or a duplicate both return false here and must not
+    // start the port. Mirrors the `result` gate in removeEventListener below.
+    auto result = EventTarget::addEventListener(eventType, WTF::move(listener), options);
+    if (!result)
+        return false;
     if (eventType == eventNames().messageEvent) {
         m_hasMessageEventListener = true;
         // start() re-attaches each time, so a listener added after a pause
@@ -531,7 +537,7 @@ bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListene
                 m_pipe->registerCloseContext(m_side, context->identifier(), ThreadSafeWeakPtr<MessagePort> { *this });
         }
     }
-    return EventTarget::addEventListener(eventType, WTF::move(listener), options);
+    return result;
 }
 
 bool MessagePort::removeEventListener(const AtomString& eventType, EventListener& listener, const EventListenerOptions& options)

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -282,7 +282,7 @@ void MessagePort::peerClosed()
     // Deliver whatever the peer sent before it closed, then fire 'close'. Node orders
     // them that way, and registerCloseContext()'s retroactive notify can land before any
     // drain is scheduled -- e.g. on('close') registered before on('message').
-    if (m_started && m_hasMessageEventListener)
+    if (m_started)
         flushQueuedMessagesBeforeClose();
     // Fire 'close' (guarded against a double dispatch) and release this side's loop refs
     // so the loop can idle, matching node.

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -146,8 +146,11 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
 
 void MessagePort::start()
 {
-    if (m_started || !isEntangled())
+    if (!isEntangled())
         return;
+    // Node's port state: start() is the sole "receiving" gate. Removing the last
+    // 'message' listener flips m_started back to false (stop()); a later start()
+    // must resume, so this is not a one-shot latch.
     m_started = true;
 
     auto* context = scriptExecutionContext();
@@ -515,14 +518,10 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
 bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)
 {
     if (eventType == eventNames().messageEvent) {
-        start();
         m_hasMessageEventListener = true;
-        // start() no-ops after the first call; re-attach so a listener re-added after a
-        // pause re-schedules the drain for messages buffered meanwhile.
-        if (m_started && isEntangled()) {
-            if (auto* context = scriptExecutionContext())
-                m_pipe->attach(m_side, context->identifier(), ThreadSafeWeakPtr<MessagePort> { *this });
-        }
+        // start() re-attaches each time, so a listener added after a pause
+        // re-schedules the drain for messages buffered meanwhile.
+        start();
     } else if (eventType == eventNames().closeEvent) {
         m_hasCloseEventListener.store(true, std::memory_order_release);
         if (isEntangled()) {
@@ -538,8 +537,12 @@ bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListene
 bool MessagePort::removeEventListener(const AtomString& eventType, EventListener& listener, const EventListenerOptions& options)
 {
     auto result = EventTarget::removeEventListener(eventType, listener, options);
-    if (!hasEventListeners(eventNames().messageEvent))
+    if (eventType == eventNames().messageEvent && !hasEventListeners(eventNames().messageEvent)) {
         m_hasMessageEventListener = false;
+        // Node stops the port when the last 'message' listener goes away; further
+        // messages buffer for receiveMessageOnPort until start() (or a new listener).
+        m_started = false;
+    }
     if (!hasEventListeners(eventNames().closeEvent))
         m_hasCloseEventListener.store(false, std::memory_order_release);
     return result;

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -70,7 +70,6 @@ public:
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
 
     void start();
-    bool hasMessageEventListener() const { return m_hasMessageEventListener; }
     void close();
     // Called on the entangled peer when this side closes: dispatches a
     // 'close' event and releases the event-loop ref so the loop can idle.

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -117,9 +117,10 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
         limit = std::max<size_t>(s.inbox.size(), 1000);
     }
 
-    // All 'message' listeners removed: the port is paused. Leave the inbox buffered
-    // and stop draining; a later addEventListener re-schedules this drain.
-    if (!port->hasMessageEventListener()) {
+    // Paused (removing the last 'message' listener cleared m_started): leave the
+    // inbox buffered. start() re-schedules. A started port with zero listeners
+    // still drains here — node dispatches to no one and the message is dropped.
+    if (!port->started()) {
         Locker locker { s.lock };
         s.state.fetch_and(~uint64_t(DrainScheduled), std::memory_order_acq_rel);
         return;
@@ -170,9 +171,9 @@ void MessagePortPipe::drainAndDispatch(uint8_t side, ScriptExecutionContextIdent
         if (globalObject->drainMicrotasks())
             break; // termination pending
 
-        // Listeners may have been removed mid-drain (port.off()); pause like the
-        // pre-loop check instead of dispatching the rest to zero listeners.
-        if (!port->hasMessageEventListener()) {
+        // The handler may have removed the last 'message' listener (which stops
+        // the port); pause like the pre-loop check and leave the rest buffered.
+        if (!port->started()) {
             Locker locker { s.lock };
             s.state.fetch_and(~uint64_t(DrainScheduled), std::memory_order_acq_rel);
             break;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -257,6 +257,110 @@ test("receiveMessageOnPort works as FIFO", () => {
   }
 }, 9999999);
 
+describe("receiveMessageOnPort interacts with the port's start/stop state like Node", () => {
+  // Node's contract: start() opens the port for delivery (messages are dispatched,
+  // even to zero listeners, and so discarded); removing the last 'message' listener
+  // stops the port again (messages buffer). receiveMessageOnPort only sees what is
+  // still buffered.
+  const tick = () => new Promise<void>(resolve => setImmediate(() => setImmediate(resolve)));
+
+  async function outcome(setup: (p: MessagePort) => void) {
+    const { port1, port2 } = new MessageChannel();
+    try {
+      setup(port2);
+      port1.postMessage("m");
+      await tick();
+      return receiveMessageOnPort(port2);
+    } finally {
+      port1.close();
+      port2.close();
+    }
+  }
+
+  test("start() with no listener discards", async () => {
+    expect(await outcome(p => p.start())).toBe(undefined);
+  });
+
+  test("never started buffers", async () => {
+    expect(await outcome(() => {})).toEqual({ message: "m" });
+  });
+
+  test("addEventListener then removeEventListener (last listener removed) buffers", async () => {
+    expect(
+      await outcome(p => {
+        const h = () => {};
+        p.addEventListener("message", h);
+        p.removeEventListener("message", h);
+      }),
+    ).toEqual({ message: "m" });
+  });
+
+  test("removing the last listener stops the port even after an explicit start()", async () => {
+    expect(
+      await outcome(p => {
+        p.start();
+        const h = () => {};
+        p.addEventListener("message", h);
+        p.removeEventListener("message", h);
+      }),
+    ).toEqual({ message: "m" });
+  });
+
+  test("start() after the last listener was removed resumes delivery (discards)", async () => {
+    expect(
+      await outcome(p => {
+        const h = () => {};
+        p.addEventListener("message", h);
+        p.removeEventListener("message", h);
+        p.start();
+      }),
+    ).toBe(undefined);
+  });
+
+  test("on() then off() buffers", async () => {
+    expect(
+      await outcome(p => {
+        const h = () => {};
+        p.on("message", h);
+        p.off("message", h);
+      }),
+    ).toEqual({ message: "m" });
+  });
+
+  test("on() then off() then start() discards", async () => {
+    expect(
+      await outcome(p => {
+        const h = () => {};
+        p.on("message", h);
+        p.off("message", h);
+        p.start();
+      }),
+    ).toBe(undefined);
+  });
+
+  test("onmessage = fn then onmessage = null buffers", async () => {
+    expect(
+      await outcome(p => {
+        p.onmessage = () => {};
+        p.onmessage = null;
+      }),
+    ).toEqual({ message: "m" });
+  });
+
+  test("a started-but-listenerless port does not grow its queue", async () => {
+    const { port1, port2 } = new MessageChannel();
+    try {
+      port2.start();
+      for (let i = 0; i < 200; i++) port1.postMessage("m" + i);
+      await tick();
+      expect(receiveMessageOnPort(port2)).toBe(undefined);
+    } finally {
+      port1.close();
+      port2.close();
+    }
+  });
+});
+
 test("you can override globalThis.postMessage", async () => {
   const worker = new Worker(new URL("./worker-override-postMessage.js", import.meta.url));
   const message = await new Promise(resolve => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -258,10 +258,6 @@ test("receiveMessageOnPort works as FIFO", () => {
 }, 9999999);
 
 describe("receiveMessageOnPort interacts with the port's start/stop state like Node", () => {
-  // Node's contract: start() opens the port for delivery (messages are dispatched,
-  // even to zero listeners, and so discarded); removing the last 'message' listener
-  // stops the port again (messages buffer). receiveMessageOnPort only sees what is
-  // still buffered.
   const tick = () => new Promise<void>(resolve => setImmediate(() => setImmediate(resolve)));
 
   async function outcome(setup: (p: MessagePort) => void) {
@@ -279,6 +275,15 @@ describe("receiveMessageOnPort interacts with the port's start/stop state like N
 
   test("start() with no listener discards", async () => {
     expect(await outcome(p => p.start())).toBe(undefined);
+  });
+
+  test("start() then removeEventListener of an unregistered listener stays started (discards)", async () => {
+    expect(
+      await outcome(p => {
+        p.start();
+        p.removeEventListener("message", function neverRegistered() {});
+      }),
+    ).toBe(undefined);
   });
 
   test("never started buffers", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -352,6 +352,34 @@ describe("receiveMessageOnPort interacts with the port's start/stop state like N
     ).toEqual({ message: "m" });
   });
 
+  test("removeAllListeners('message') leaves the port receiving (discards)", async () => {
+    expect(
+      await outcome(p => {
+        p.on("message", () => {});
+        p.removeAllListeners("message");
+      }),
+    ).toBe(undefined);
+  });
+
+  test("removeAllListeners() leaves the port receiving (discards)", async () => {
+    expect(
+      await outcome(p => {
+        p.on("message", () => {});
+        p.removeAllListeners();
+      }),
+    ).toBe(undefined);
+  });
+
+  test("addEventListener with an already-aborted signal does not start the port (buffers)", async () => {
+    expect(
+      await outcome(p => {
+        const ac = new AbortController();
+        ac.abort();
+        p.addEventListener("message", () => {}, { signal: ac.signal });
+      }),
+    ).toEqual({ message: "m" });
+  });
+
   test("a started-but-listenerless port does not grow its queue", async () => {
     const { port1, port2 } = new MessageChannel();
     try {


### PR DESCRIPTION
## Repro

```js
const { receiveMessageOnPort, MessageChannel } = require("worker_threads");
const { port1, port2 } = new MessageChannel();
port2.start();            // started, NO listener
port1.postMessage("x");
setTimeout(() => {
  console.log(receiveMessageOnPort(port2));
  // node: undefined            (dispatched to zero listeners, discarded)
  // bun:  { message: 'x' }     (still queued)
  port1.close(); port2.close();
}, 0);
```

A `start()`ed port with no listener kept accumulating messages. Same for `start()` called after the last listener was removed: the port never resumed delivery.

## Cause

Node's `MessagePort` has a single `receiving_messages_` gate: `start()` opens it, removing the last `'message'` listener closes it again (the internal `stop()`), and a later `start()` reopens it. While open, each queued message is dispatched regardless of listener count; while closed, messages buffer for `receiveMessageOnPort()`.

Bun's `drainAndDispatch()` was gating on `hasMessageEventListener()` instead of the started flag, and `start()` was a one-shot latch that early-returned once set. So "started but no listener" buffered indefinitely, and "start() after the last listener was removed" stayed paused.

## Fix

Make `m_started` the gate: `start()` always sets it (no longer latched), `removeEventListener()` clears it when the last `'message'` listener goes, and the drain loop checks `started()` instead of `hasMessageEventListener()`.

## Verification

New `describe` block in `worker_threads.test.ts` covers all nine start/stop/listener permutations against Node's observed behavior. Four cases fail before this change (the three `start()` discards plus the queue-growth check); all nine match Node afterwards. `test/js/web/workers/message-port-pipe.test.ts`, `test/js/web/workers/message-channel.test.ts`, and the `test-worker-message-port*` Node parallel tests continue to pass.

The two adjacent `receiveMessageOnPort` bugs mentioned in the report (falsy payloads, reading after `close()`) already have open PRs: #33357 and #33638.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (73e6b50a0)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1683.54ms]
(pass) all worker_threads module properties are present [24.51ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.72ms]
(pass) all worker_threads worker instance properties are present [151.71ms]
(pass) threadId module and worker property is consistent [195.33ms]
(pass) receiveMessageOnPort works across threads [1620.37ms]
(pass) receiveMessageOnPort works as FIFO [13.26ms]
272 |       port2.close();
273 |     }
274 |   }
275 | 
276 |   test("start() with no listener discards", async () => {
277 |     expect(await outcome(p => p.start())).toBe(undefined);
                                                ^
error: expect(received).toBe(expected)

Expected: undefined
Received: {
  message: "m",
}

      at <anonymous> (/workspace/bun/test/js/node/worker_threads/worker_threads.test.ts:277:43)
(fail) receiveMessageOnP
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (b16d1f917)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [47.25ms]
(pass) all worker_threads module properties are present [1.17ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [1.86ms]
(pass) all worker_threads worker instance properties are present [0.72ms]
(pass) threadId module and worker property is consistent [4.27ms]
(pass) receiveMessageOnPort works across threads [25.10ms]
(pass) receiveMessageOnPort works as FIFO [0.98ms]
(pass) receiveMessageOnPort interacts with the port's start/stop state like Node > start() with no listener discards [0.26ms]
(pass) receiveMessageOnPort interacts with the port's start/stop state like Node > start() then removeEventListener of an unregistered listener stays started (discards) [0.11ms]
(pass) receiveMessageOnPort interacts with the port's start/stop state like Node > never started buffers [0.09ms]
(pass) receiveMessageOnPort interacts with the port's start/stop state like Node > addEventListener then removeEventListener (last listener removed) buffers [0.10ms]
(pass) receiveMessageOnPort interacts with the p
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.0 (73e6b50a0)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1694.18ms]
(pass) all worker_threads module properties are present [24.40ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.81ms]
(pass) all worker_threads worker instance properties are present [158.63ms]
(pass) threadId module and worker property is consistent [193.12ms]
(pass) receiveMessageOnPort works across threads [1654.09ms]
(pass) receiveMessageOnPort works as FIFO [13.54ms]
(pass) receiveMessageOnPort interacts with the port's start/stop state like Node > start() with no listener discards [15.70ms]
(pass) receiveMessageOnPort interacts with the port's start/stop state like Node > start() then removeEventListener of an unregistered listener stays started (discards) [31.01ms]
(pass) receiveMessageOnPort interacts with the port's start/stop state like Node > never started buffers [6.29ms]
(pass) receiveMessageOnPor
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 676ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen cpp.rs (cppbind)
[2/28] gen JS modules (bundle-modules)
Preprocess modules (7257ms)
Bundle modules (34ms)
Postprocesss modules (181ms)
Bundle Functions (797ms)
Generate Code (99ms)

[8.39s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[2/18] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/worker_threads.ts                      |   7 ++
 src/jsc/bindings/webcore/MessagePort.cpp           |  34 +++--
 src/jsc/bindings/webcore/MessagePort.h             |   1 -
 src/jsc/bindings/webcore/MessagePortPipe.cpp       |  13 +-
 test/js/node/worker_threads/worker_threads.test.ts | 137 +++++++++++++++++++++
 5 files changed, 174 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/worker_threads.ts                           3      1      0
src/jsc/bindings/webcore/MessagePort.cpp                4      7      0
src/jsc/bindings/webcore/MessagePort.h                  2      1      0
src/jsc/bindings/webcore/MessagePortPipe.cpp            1      2      0
test/js/node/worker_threads/worker_threads.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->