### PR TITLE
bun:sqlite: report direct changes in run().changes, not the total_changes delta

### DIFF
--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1500,7 +1500,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
     bool strict = internalFlagsValue.isInt32() && (internalFlagsValue.asInt32() & kStrictFlag) != 0;
     bool safeIntegers = internalFlagsValue.isInt32() && (internalFlagsValue.asInt32() & kSafeIntegersFlag) != 0;
 
-    const int total_changes_before = sqlite3_total_changes(db);
+    sqlite3_int64 changes = 0;
 
     while (sqlStringHead && sqlStringHead < end) {
         if (isSkippedInSQLiteQuery(*sqlStringHead)) [[unlikely]] {
@@ -1556,9 +1556,18 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
             didSetBindings = true;
         }
 
+        const int total_changes_before = sqlite3_total_changes(db);
+
         do {
             rc = sqlite3_step(sql.stmt);
         } while (rc == SQLITE_ROW);
+
+        // sqlite3_changes64() is only updated by INSERT/UPDATE/DELETE; gate on
+        // total_changes so a SELECT or DDL statement doesn't re-add the previous
+        // statement's count.
+        if (sqlite3_total_changes(db) != total_changes_before) {
+            changes += sqlite3_changes64(db);
+        }
 
         didExecuteAny = true;
         sqlStringHead = tail;
@@ -1575,9 +1584,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
     }
 
     if (auto* diff = dynamicDowncast<JSC::InternalFieldTuple>(diffValue)) {
-        const int total_changes_after = sqlite3_total_changes(db);
         int64_t last_insert_rowid = sqlite3_last_insert_rowid(db);
-        diff->putInternalField(vm, 0, JSC::jsNumber(total_changes_after - total_changes_before));
+        diff->putInternalField(vm, 0, JSC::jsNumber(static_cast<double>(changes)));
         if (safeIntegers) {
             auto* bigInt = JSBigInt::createFrom(lexicalGlobalObject, last_insert_rowid);
             RETURN_IF_EXCEPTION(scope, {});
@@ -2565,8 +2573,6 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
         return {};
     }
 
-    int total_changes_before = sqlite3_total_changes(castedThis->version_db->db);
-
     int status = sqlite3_step(stmt);
     if (!sqlite3_stmt_readonly(stmt)) {
         castedThis->version_db->version++;
@@ -2592,9 +2598,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRun, (JSC::JSGlob
 
     if (auto* diff = dynamicDowncast<JSC::InternalFieldTuple>(diffValue)) {
         auto* db = castedThis->version_db->db;
-        const int total_changes_after = sqlite3_total_changes(db);
         int64_t last_insert_rowid = sqlite3_last_insert_rowid(db);
-        diff->putInternalField(vm, 0, JSC::jsNumber(total_changes_after - total_changes_before));
+        diff->putInternalField(vm, 0, JSC::jsNumber(static_cast<double>(sqlite3_changes64(db))));
         if (castedThis->useBigInt64) {
             JSValue lastRowIdBigInt = JSBigInt::createFrom(lexicalGlobalObject, last_insert_rowid);
             RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -374,7 +374,9 @@ it("creates", () => {
     ]),
   );
   expect(stmt2.run()).toStrictEqual({
-    changes: 0,
+    // sqlite3_changes() of the most recently completed INSERT/UPDATE/DELETE,
+    // matching better-sqlite3 and node:sqlite.
+    changes: 1,
     lastInsertRowid: 3,
   });
 
@@ -1493,6 +1495,33 @@ it("reports changes in Statement#run", () => {
   expect(db.run(sql).changes).toBe(2);
   expect(db.prepare(sql).run().changes).toBe(2);
   expect(db.query(sql).run().changes).toBe(2);
+});
+
+it("run().changes reports direct changes only (not trigger or foreign-key cascade rows)", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE p(x); CREATE TABLE log(y);");
+  db.exec(
+    "CREATE TRIGGER tp AFTER INSERT ON p BEGIN INSERT INTO log VALUES (new.x); INSERT INTO log VALUES (new.x * 2); END;",
+  );
+
+  // Statement#run: one direct row, two trigger rows
+  expect(db.prepare("INSERT INTO p VALUES (5)").run().changes).toBe(1);
+  expect(db.prepare("INSERT INTO p VALUES (?),(?)").run(6, 7).changes).toBe(2);
+
+  // Database#run
+  expect(db.run("INSERT INTO p VALUES (8)").changes).toBe(1);
+  // multi-statement: direct changes summed across statements, trigger rows excluded
+  expect(db.run("INSERT INTO p VALUES (9); INSERT INTO p VALUES (10),(11); SELECT * FROM p;").changes).toBe(3);
+
+  // ON DELETE CASCADE
+  db.exec("PRAGMA foreign_keys = ON; CREATE TABLE par(id INTEGER PRIMARY KEY);");
+  db.exec("CREATE TABLE ch(id INTEGER PRIMARY KEY, pid REFERENCES par(id) ON DELETE CASCADE);");
+  db.exec("INSERT INTO par VALUES (1); INSERT INTO ch VALUES (10,1),(11,1),(12,1);");
+  expect(db.prepare("DELETE FROM par WHERE id = 1").run().changes).toBe(1);
+
+  // sanity: trigger + cascade actually fired
+  expect(db.prepare("SELECT count(*) AS c FROM log").get()).toEqual({ c: 14 });
+  expect(db.prepare("SELECT count(*) AS c FROM ch").get()).toEqual({ c: 0 });
 });
 
 it("#13082", async () => {


### PR DESCRIPTION
## What

`Statement#run().changes` and `Database#run().changes` were computed as the `sqlite3_total_changes()` delta around the statement, so every row a trigger writes and every child row an `ON DELETE CASCADE` removes was added to the count. The standard optimistic-concurrency check `if (res.changes !== 1) throw` miscounts on any schema with triggers or cascades.

## Repro

```js
import { Database } from "bun:sqlite";
const db = new Database(":memory:");
db.exec("create table p(x); create table log(y);");
db.exec("create trigger tp after insert on p begin insert into log values (new.x); insert into log values (new.x*2); end;");
console.log(db.prepare("insert into p values (5)").run().changes);        // before: 3   after: 1
console.log(db.prepare("insert into p values (?),(?)").run(6,7).changes); // before: 6   after: 2
db.exec("pragma foreign_keys=on; create table par(id integer primary key);");
db.exec("create table ch(id integer primary key, pid references par(id) on delete cascade);");
db.exec("insert into par values (1); insert into ch values (10,1),(11,1),(12,1);");
console.log(db.prepare("delete from par where id=1").run().changes);      // before: 4   after: 1
```

## Fix

- `Statement#run()`: read `sqlite3_changes64()` after stepping, same as `better-sqlite3`, `node:sqlite` (including Bun's own implementation in `NodeSqlite.cpp`), and Python `sqlite3`.
- `Database#run()` (multi-statement): sum `sqlite3_changes64()` per statement, gated on `sqlite3_total_changes()` movement so a `SELECT` or DDL statement doesn't re-add the previous statement's count.

## Behavior change

`Statement#run()` on a read-only statement (e.g. `SELECT`) now returns the direct-change count from the most recently completed `INSERT`/`UPDATE`/`DELETE` on the connection, rather than `0`. This matches `better-sqlite3` and `node:sqlite`; `.run()` is documented for statements that do not return rows. One existing test assertion was updated accordingly.

## Verification

- New test fails on `main` (received `3`, expected `1`) and passes with this change.
- `bun bd test test/js/bun/sqlite/`: 101 pass
- `bun bd test test/js/node/sqlite/`: 115 pass, 4 skip

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->