### PR TITLE
fetch: report OpenSSL reason (ERR_SSL_*) for non-certificate TLS handshake failures

### DIFF
--- a/src/http/HTTPCertError.rs
+++ b/src/http/HTTPCertError.rs
@@ -20,6 +20,65 @@ impl Default for HTTPCertError {
     }
 }
 
+/// Owned copy of the uSockets handshake-failure sentinel (`error_no < 0`):
+/// `-71`/"EPROTO" for a fatal TLS protocol error (`ssl_dispatch_parked_reason`,
+/// `reason` is the `ERR_error_string_n` output) or `-46`/"ECONNRESET" for a
+/// mid-handshake close (`ssl_trigger_handshake_econnreset`), both in
+/// packages/bun-usockets/src/crypto/openssl.c. The `reason` pointer is a stack
+/// buffer in the EPROTO case, so an owned copy is required to outlive
+/// `on_handshake`. Carried on `HTTPClientResult` so `fetch()` can report the
+/// OpenSSL reason (e.g. `WRONG_VERSION_NUMBER`) instead of a certificate
+/// verification error.
+#[derive(Clone, Default)]
+pub struct TLSHandshakeError {
+    pub code: Box<[u8]>,
+    pub reason: Box<[u8]>,
+}
+
+impl TLSHandshakeError {
+    /// Capture the code/reason from a handshake-failure sentinel. Only call
+    /// when `error_no < 0`; X509 verify errors use [`HTTPCertError`].
+    pub fn from_verify_error(ssl_error: &bun_uws::us_bun_verify_error_t) -> Self {
+        Self {
+            code: Box::from(ssl_error.code_bytes()),
+            reason: Box::from(ssl_error.reason_bytes()),
+        }
+    }
+
+    /// Node-style error code for the JS `Error.code` property: for an EPROTO
+    /// sentinel whose `reason` carries an OpenSSL reason string, derive
+    /// `ERR_SSL_<REASON>` the way Node's `ThrowCryptoError` does; otherwise
+    /// fall back to the sentinel's own code (`EPROTO`/`ECONNRESET`). The
+    /// `reason` may be either the full `ERR_error_string_n` line
+    /// (`error:<hex>:<lib>:<func>:<REASON>`, direct path via
+    /// `ssl_dispatch_parked_reason`) or the bare `ERR_reason_error_string`
+    /// output (`<REASON>` only, inner-TLS path via `SSLWrapper`); both reduce
+    /// to the last `:`-separated segment, which BoringSSL emits upper-snake.
+    pub fn node_error_code(&self) -> Box<[u8]> {
+        if &*self.code == b"EPROTO" {
+            let reason = self
+                .reason
+                .rsplit(|&b| b == b':')
+                .next()
+                .unwrap_or(&self.reason);
+            if !reason.is_empty()
+                && reason
+                    .iter()
+                    .all(|&b| b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'_')
+            {
+                let mut code = Vec::with_capacity(8 + reason.len());
+                code.extend_from_slice(b"ERR_SSL_");
+                code.extend_from_slice(reason);
+                return code.into_boxed_slice();
+            }
+        }
+        if self.code.is_empty() {
+            return Box::from(&b"EPROTO"[..]);
+        }
+        self.code.clone()
+    }
+}
+
 impl HTTPCertError {
     /// Build from the uSockets verify-error struct delivered to `on_handshake`.
     ///

--- a/src/http/HTTPCertError.rs
+++ b/src/http/HTTPCertError.rs
@@ -66,8 +66,9 @@ impl TLSHandshakeError {
                     .iter()
                     .all(|&b| b.is_ascii_uppercase() || b.is_ascii_digit() || b == b'_')
             {
-                let mut code = Vec::with_capacity(8 + reason.len());
-                code.extend_from_slice(b"ERR_SSL_");
+                const PREFIX: &[u8] = b"ERR_SSL_";
+                let mut code = Vec::with_capacity(PREFIX.len() + reason.len());
+                code.extend_from_slice(PREFIX);
                 code.extend_from_slice(reason);
                 return code.into_boxed_slice();
             }

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1187,10 +1187,18 @@ impl<const SSL: bool> Handler<SSL> {
                 // if we are here is because server rejected us, and the error_no is the cause of this
                 // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
                 if client.flags.did_have_handshaking_error {
-                    client.close_and_fail::<SSL>(
-                        get_cert_error_from_no(handshake_error.error_no),
-                        socket,
-                    );
+                    // A negative `error_no` is one of the uSockets handshake
+                    // sentinels (-71 EPROTO / -46 ECONNRESET), not an
+                    // `X509_V_ERR_*` code. Capture the OpenSSL reason so the
+                    // JS side can report it instead of a certificate error.
+                    let err = if handshake_error.error_no < 0 {
+                        client.state.tls_handshake_error =
+                            Some(crate::TLSHandshakeError::from_verify_error(&ssl_error));
+                        crate::Error::TLSHandshakeFailed
+                    } else {
+                        get_cert_error_from_no(handshake_error.error_no)
+                    };
+                    client.close_and_fail::<SSL>(err, socket);
                     return;
                 }
                 // if handshake_success it self is false, this means that the connection was rejected

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -53,6 +53,10 @@ pub struct InternalState<'a> {
     /// the post-redirect target). Captured on the HTTP thread at the failure
     /// so the JS side never dereferences the client's borrowed URL buffers.
     pub dns_hostname: Option<Box<[u8]>>,
+    /// Owned copy of the uSockets handshake-failure sentinel when `fail` is
+    /// `TLSHandshakeFailed`. Carries the OpenSSL reason string so the JS
+    /// side can report Node's `ERR_SSL_*` code instead of a generic failure.
+    pub tls_handshake_error: Option<crate::TLSHandshakeError>,
     pub request_stage: HTTPStage,
     pub response_stage: HTTPStage,
     pub certificate_info: Option<CertificateInfo>,
@@ -140,6 +144,7 @@ impl Default for InternalState<'_> {
             fail: None,
             dns_error: 0,
             dns_hostname: None,
+            tls_handshake_error: None,
             request_stage: HTTPStage::Pending,
             response_stage: HTTPStage::Pending,
             certificate_info: None,

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -378,10 +378,10 @@ fn on_handshake(
     this.state.request_stage = HTTPStage::ProxyHeaders;
     this.state.request_sent_len = 0;
     let handshake_error = HTTPCertError::from_verify_error(ssl_error);
+    // handshake completed but we may have ssl errors
+    this.flags.did_have_handshaking_error = handshake_error.error_no != 0;
     if handshake_success {
         scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake success");
-        // handshake completed but we may have ssl errors
-        this.flags.did_have_handshaking_error = handshake_error.error_no != 0;
         if this.flags.reject_unauthorized {
             // only reject the connection if reject_unauthorized == true
             if this.flags.did_have_handshaking_error {
@@ -455,8 +455,18 @@ fn on_handshake(
         scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake failed");
         // if we are here is because server rejected us, and the error_no is the cause of this
         // if we set reject_unauthorized == false this means the server requires custom CA aka NODE_EXTRA_CA_CERTS
-        if this.flags.did_have_handshaking_error && handshake_error.error_no != 0 {
-            let err = crate::get_cert_error_from_no(handshake_error.error_no);
+        if this.flags.did_have_handshaking_error {
+            // A negative `error_no` is one of the uSockets handshake sentinels
+            // (-71 EPROTO / -46 ECONNRESET), not an `X509_V_ERR_*` code.
+            // Capture the OpenSSL reason so the JS side can report it instead
+            // of a certificate error.
+            let err = if handshake_error.error_no < 0 {
+                this.state.tls_handshake_error =
+                    Some(crate::TLSHandshakeError::from_verify_error(&ssl_error));
+                crate::Error::TLSHandshakeFailed
+            } else {
+                crate::get_cert_error_from_no(handshake_error.error_no)
+            };
             // SAFETY: `this` dead (NLL); reenter via raw ptr.
             ProxyTunnel::close_from_callback(proxy_nn, err);
             return;

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     DNSResolveFailed,
     #[error("ConnectionRefused")]
     ConnectionRefused,
+    #[error("TLSHandshakeFailed")]
+    TLSHandshakeFailed,
     #[error("TooManyRedirects")]
     TooManyRedirects,
     #[error("HTTP3Unsupported")]
@@ -282,6 +284,7 @@ impl Error {
             Self::ConnectionClosed => "ConnectionClosed",
             Self::DNSResolveFailed => "DNSResolveFailed",
             Self::ConnectionRefused => "ConnectionRefused",
+            Self::TLSHandshakeFailed => "TLSHandshakeFailed",
             Self::TooManyRedirects => "TooManyRedirects",
             Self::HTTP3Unsupported => "HTTP3Unsupported",
             Self::ResponseHeadersTooLarge => "ResponseHeadersTooLarge",

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -54,7 +54,7 @@ pub use certificate_info::CertificateInfo;
 pub use decompressor::Decompressor;
 pub use header_builder::HeaderBuilder;
 pub use headers::{Headers, HeadersExt};
-pub use http_cert_error::HTTPCertError;
+pub use http_cert_error::{HTTPCertError, TLSHandshakeError};
 pub use http_context::{HTTPContext, HTTPSocket};
 pub use http_request_body::HTTPRequestBody;
 pub use http_thread::HttpThread as HTTPThread;
@@ -439,6 +439,10 @@ pub struct HTTPClientResult<'a> {
     /// JS side never dereferences the client's borrowed URL buffers, which
     /// the HTTP thread frees after the result callback returns.
     pub dns_hostname: Option<Box<[u8]>>,
+    /// Owned copy of the uSockets handshake-failure sentinel when `fail` is
+    /// `TLSHandshakeFailed`; carries the OpenSSL reason so the JS side can
+    /// report Node's `ERR_SSL_*` code instead of a certificate error.
+    pub tls_handshake_error: Option<TLSHandshakeError>,
 
     /// Owns the response metadata aka headers, url and status code
     pub metadata: Option<HTTPResponseMetadata>,
@@ -501,6 +505,7 @@ impl<'a> HTTPClientResult<'a> {
             fail: self.fail,
             dns_error: self.dns_error,
             dns_hostname: self.dns_hostname,
+            tls_handshake_error: self.tls_handshake_error,
             metadata: self.metadata,
             body_size: self.body_size,
             certificate_info: self.certificate_info,
@@ -4229,6 +4234,7 @@ impl<'a> HTTPClient<'a> {
             fail,
             dns_error,
             dns_hostname,
+            tls_handshake_error,
             metadata,
             body_size,
             certificate_info,
@@ -4242,6 +4248,7 @@ impl<'a> HTTPClient<'a> {
                 r.fail,
                 r.dns_error,
                 r.dns_hostname,
+                r.tls_handshake_error,
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
@@ -4385,6 +4392,7 @@ impl<'a> HTTPClient<'a> {
             fail,
             dns_error,
             dns_hostname,
+            tls_handshake_error,
             metadata,
             body_size,
             certificate_info,
@@ -4430,6 +4438,7 @@ impl<'a> HTTPClient<'a> {
             fail,
             dns_error,
             dns_hostname,
+            tls_handshake_error,
             metadata,
             body_size,
             certificate_info,
@@ -4443,6 +4452,7 @@ impl<'a> HTTPClient<'a> {
                 r.fail,
                 r.dns_error,
                 r.dns_hostname,
+                r.tls_handshake_error,
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
@@ -4472,6 +4482,7 @@ impl<'a> HTTPClient<'a> {
             fail,
             dns_error,
             dns_hostname,
+            tls_handshake_error,
             metadata,
             body_size,
             certificate_info,
@@ -4647,6 +4658,7 @@ impl<'a> HTTPClient<'a> {
                     fail: self.state.fail,
                     dns_error: self.state.dns_error,
                     dns_hostname: self.state.dns_hostname.take(),
+                    tls_handshake_error: self.state.tls_handshake_error.take(),
                     has_more: self.state.fail.is_none() && !self.state.is_done(),
                     body_size,
                     certificate_info: None,
@@ -4664,6 +4676,7 @@ impl<'a> HTTPClient<'a> {
             fail: self.state.fail,
             dns_error: self.state.dns_error,
             dns_hostname: self.state.dns_hostname.take(),
+            tls_handshake_error: self.state.tls_handshake_error.take(),
             // check if we are reporting cert errors, do not have a fail state and we are not done
             has_more: certificate_info.is_some()
                 || (self.state.fail.is_none() && !self.state.is_done()),

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1326,6 +1326,31 @@ impl FetchTasklet {
             }
         }
 
+        // A TLS handshake that failed for a non-certificate reason (server
+        // sent a fatal alert, peer isn't speaking TLS at all, or the socket
+        // closed mid-handshake). The HTTP thread captured the OpenSSL reason
+        // so the error reports Node's `ERR_SSL_*` / `ECONNRESET` identity
+        // instead of a certificate verification error.
+        if fail == http::Error::TLSHandshakeFailed {
+            let tls_err = self.result.tls_handshake_error.take().unwrap_or_default();
+            let code = tls_err.node_error_code();
+            let message = if tls_err.reason.is_empty() {
+                BunString::static_("TLS handshake failed")
+            } else {
+                BunString::clone_utf8(&tls_err.reason)
+            };
+            return BodyValueError::SystemError(jsc::SystemError {
+                errno: 0,
+                code: BunString::clone_utf8(&code),
+                message,
+                path,
+                syscall: BunString::EMPTY,
+                hostname: BunString::EMPTY,
+                fd: core::ffi::c_int::MIN,
+                dest: BunString::EMPTY,
+            });
+        }
+
         let code = if fail == http::Error::ConnectionClosed {
             BunString::static_("ECONNRESET")
         } else {

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -156,14 +156,15 @@ pub mod ssl_wrapper {
     mod boring_sys {
         pub(super) use bun_boringssl::c::{
             BIO_ctrl_pending, BIO_free, BIO_new, BIO_read, BIO_s_mem, BIO_set_mem_eof_return,
-            BIO_write, ERR_clear_error, SSL, SSL_CTX, SSL_CTX_free, SSL_CTX_get_verify_mode,
-            SSL_ERROR_SSL, SSL_ERROR_SYSCALL, SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE,
-            SSL_ERROR_WANT_WRITE, SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_NONE,
-            SSL_VERIFY_PEER, SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio,
-            SSL_get_shutdown, SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read,
-            SSL_renegotiate, SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state,
-            SSL_set_renegotiate_mode, SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown,
-            SSL_write, X509_STORE, X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
+            BIO_write, ERR_clear_error, ERR_peek_last_error, ERR_reason_error_string, SSL, SSL_CTX,
+            SSL_CTX_free, SSL_CTX_get_verify_mode, SSL_ERROR_SSL, SSL_ERROR_SYSCALL,
+            SSL_ERROR_WANT_READ, SSL_ERROR_WANT_RENEGOTIATE, SSL_ERROR_WANT_WRITE,
+            SSL_ERROR_ZERO_RETURN, SSL_RECEIVED_SHUTDOWN, SSL_VERIFY_NONE, SSL_VERIFY_PEER,
+            SSL_do_handshake, SSL_free, SSL_get_error, SSL_get_rbio, SSL_get_shutdown,
+            SSL_get_wbio, SSL_is_init_finished, SSL_new, SSL_pending, SSL_read, SSL_renegotiate,
+            SSL_set_accept_state, SSL_set_bio, SSL_set_connect_state, SSL_set_renegotiate_mode,
+            SSL_set_verify, SSL_set0_verify_cert_store, SSL_shutdown, SSL_write, X509_STORE,
+            X509_STORE_CTX, ssl_renegotiate_explicit, ssl_renegotiate_never,
         };
     }
 
@@ -899,6 +900,15 @@ pub mod ssl_wrapper {
             if result <= 0 {
                 // SAFETY: ssl is still valid.
                 let err = unsafe { boring_sys::SSL_get_error(ssl.as_ptr(), result) };
+                // Capture the protocol-level reason (WRONG_VERSION_NUMBER,
+                // fatal alert, ...) before draining the queue so the handshake
+                // callback can report it. Mirrors `ssl_park_fatal_reason` in
+                // openssl.c.
+                let ssl_queue_err = if err == boring_sys::SSL_ERROR_SSL {
+                    boring_sys::ERR_peek_last_error()
+                } else {
+                    0
+                };
                 boring_sys::ERR_clear_error();
                 if err == boring_sys::SSL_ERROR_ZERO_RETURN {
                     // Remotely-Initiated Shutdown
@@ -920,7 +930,18 @@ pub mod ssl_wrapper {
                     Self::r(this)
                         .flags
                         .set_handshake_state(HandshakeState::HandshakeCompleted);
-                    let verify = Self::r(this).get_verify_error();
+                    let verify = if ssl_queue_err != 0 {
+                        // Same shape `ssl_dispatch_parked_reason` (openssl.c)
+                        // uses for a fatal handshake error; `reason` points
+                        // into BoringSSL's static error-string table.
+                        us_bun_verify_error_t {
+                            error_no: -71,
+                            code: c"EPROTO".as_ptr(),
+                            reason: boring_sys::ERR_reason_error_string(ssl_queue_err),
+                        }
+                    } else {
+                        Self::r(this).get_verify_error()
+                    };
                     Self::r(this).trigger_handshake_callback(false, verify);
 
                     if Self::r(this).flags.fatal_error() {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -712,8 +712,6 @@ describe.concurrent("fetch-tls", () => {
     // alert before any certificate verification runs.
     const alpn = tls.createServer({ ...CERT_LOCALHOST_IP, ALPNProtocols: ["bun-bogus-alpn"] }, () => {});
     alpn.on("tlsClientError", () => {});
-    alpn.listen(0, "127.0.0.1");
-    await once(alpn, "listening");
 
     // Plain TCP server behind an https:// URL: the ClientHello is answered
     // with bytes that are not a TLS record (WRONG_VERSION_NUMBER).
@@ -721,8 +719,6 @@ describe.concurrent("fetch-tls", () => {
       s.on("error", () => {});
       s.end("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
     });
-    plain.listen(0, "127.0.0.1");
-    await once(plain, "listening");
 
     // CONNECT proxy that opens the tunnel and then feeds non-TLS bytes into
     // it: the inner TLS handshake (SSLWrapper) must report the same identity
@@ -739,10 +735,15 @@ describe.concurrent("fetch-tls", () => {
         }
       });
     });
-    proxy.listen(0, "127.0.0.1");
-    await once(proxy, "listening");
 
     try {
+      alpn.listen(0, "127.0.0.1");
+      await once(alpn, "listening");
+      plain.listen(0, "127.0.0.1");
+      await once(plain, "listening");
+      proxy.listen(0, "127.0.0.1");
+      await once(proxy, "listening");
+
       const alpnPort = (alpn.address() as net.AddressInfo).port;
       const plainPort = (plain.address() as net.AddressInfo).port;
       const proxyPort = (proxy.address() as net.AddressInfo).port;

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { once } from "node:events";
+import net from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -696,6 +698,109 @@ describe.concurrent("fetch-tls", () => {
       const stderr = await proc.stderr.text();
       expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
       expect(stderr).toContain("ignoring extra certs");
+    }
+  });
+
+  // A TLS handshake that fails for a reason unrelated to certificate
+  // verification (the server aborts the handshake with a fatal ALPN alert, or
+  // the peer isn't speaking TLS at all) must surface the OpenSSL reason, not
+  // a certificate verification error. With rejectUnauthorized:false a
+  // certificate error is impossible by construction.
+  it("reports the OpenSSL reason for non-certificate TLS handshake failures", async () => {
+    // TLS server that only offers an ALPN protocol fetch() never advertises,
+    // so BoringSSL aborts the handshake with a fatal no_application_protocol
+    // alert before any certificate verification runs.
+    const alpn = tls.createServer({ ...CERT_LOCALHOST_IP, ALPNProtocols: ["bun-bogus-alpn"] }, () => {});
+    alpn.on("tlsClientError", () => {});
+    alpn.listen(0, "127.0.0.1");
+    await once(alpn, "listening");
+
+    // Plain TCP server behind an https:// URL: the ClientHello is answered
+    // with bytes that are not a TLS record (WRONG_VERSION_NUMBER).
+    const plain = net.createServer(s => {
+      s.on("error", () => {});
+      s.end("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
+    });
+    plain.listen(0, "127.0.0.1");
+    await once(plain, "listening");
+
+    // CONNECT proxy that opens the tunnel and then feeds non-TLS bytes into
+    // it: the inner TLS handshake (SSLWrapper) must report the same identity
+    // as the direct path.
+    const proxy = net.createServer(cs => {
+      cs.on("error", () => {});
+      let buf = "";
+      cs.on("data", d => {
+        buf += d;
+        if (buf.includes("\r\n\r\n") && buf.startsWith("CONNECT")) {
+          cs.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          cs.write(Buffer.alloc(480, "GARBAGE NOT TLS "));
+          buf = "";
+        }
+      });
+    });
+    proxy.listen(0, "127.0.0.1");
+    await once(proxy, "listening");
+
+    try {
+      const alpnPort = (alpn.address() as net.AddressInfo).port;
+      const plainPort = (plain.address() as net.AddressInfo).port;
+      const proxyPort = (proxy.address() as net.AddressInfo).port;
+
+      // Run the probes in a subprocess with proxy-bypass env cleared so the
+      // explicit `proxy:` option is honored for loopback targets regardless of
+      // the ambient environment.
+      const fixture = `
+        const probe = async (url, opts) => {
+          try { await fetch(url, { ...opts, tls: { rejectUnauthorized: false } }); return { code: "RESOLVED" }; }
+          catch (e) { return { code: e?.code ?? "NO_CODE", message: String(e?.message ?? "") }; }
+        };
+        const [alpnMismatch, plainBehindHttps, tunnelGarbage] = await Promise.all([
+          probe("https://127.0.0.1:${alpnPort}/"),
+          probe("https://127.0.0.1:${plainPort}/"),
+          probe("https://127.0.0.1:1/x", { proxy: "http://127.0.0.1:${proxyPort}" }),
+        ]);
+        console.log(JSON.stringify({ alpnMismatch, plainBehindHttps, tunnelGarbage }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: {
+          ...bunEnv,
+          NO_PROXY: undefined,
+          no_proxy: undefined,
+          HTTP_PROXY: undefined,
+          http_proxy: undefined,
+          HTTPS_PROXY: undefined,
+          https_proxy: undefined,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const result = JSON.parse(stdout.trim() || "null");
+      // None of these can be a certificate verification error.
+      expect({ result, stderr }).toEqual({
+        result: {
+          alpnMismatch: {
+            code: expect.stringMatching(/^ERR_SSL_/),
+            message: expect.stringMatching(/NO_APPLICATION_PROTOCOL/i),
+          },
+          plainBehindHttps: {
+            code: "ERR_SSL_WRONG_VERSION_NUMBER",
+            message: expect.stringMatching(/WRONG_VERSION_NUMBER/i),
+          },
+          tunnelGarbage: {
+            code: "ERR_SSL_WRONG_VERSION_NUMBER",
+            message: expect.stringMatching(/WRONG_VERSION_NUMBER/i),
+          },
+        },
+        stderr: expect.any(String),
+      });
+      expect(exitCode).toBe(0);
+    } finally {
+      alpn.close();
+      plain.close();
+      proxy.close();
     }
   });
 });


### PR DESCRIPTION
Non-certificate TLS handshake failures in `fetch()` were being reported as `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`, even with `tls: { rejectUnauthorized: false }` where a certificate error is impossible by construction. This sends operators hunting through CA stores when the actual fault is an ALPN mismatch, a non-TLS peer behind an `https://` URL, or a mid-handshake connection close. Node reports the same scenarios with the OpenSSL reason (`ERR_SSL_WRONG_VERSION_NUMBER`, `ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL`, ...).

### Reproduction

```js
import tls from "node:tls"; import net from "node:net";
const alpn = tls.createServer({ cert, key, ALPNProtocols: ["h2"] }, () => {});
alpn.on("tlsClientError", () => {});
const plain = net.createServer(s => s.end("HTTP/1.1 400 Bad Request\r\n\r\n"));
// ... listen both on port 0 ...
for (const [name, url] of [["alpn-mismatch", `https://127.0.0.1:${pa}/`],
                           ["plaintext-server", `https://127.0.0.1:${pb}/`]]) {
  try { await fetch(url, { tls: { rejectUnauthorized: false } }); }
  catch (e) { console.log(name, "->", e.code, "|", e.message); }
}
```

Before:
```
alpn-mismatch -> UNKNOWN_CERTIFICATE_VERIFICATION_ERROR | unknown certificate verification error
plaintext-server -> UNKNOWN_CERTIFICATE_VERIFICATION_ERROR | unknown certificate verification error
```

After:
```
alpn-mismatch -> ERR_SSL_TLSV1_ALERT_NO_APPLICATION_PROTOCOL | error:10000460:SSL routines:OPENSSL_internal:TLSV1_ALERT_NO_APPLICATION_PROTOCOL
plaintext-server -> ERR_SSL_WRONG_VERSION_NUMBER | error:100000f7:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER
```

### Cause

uSockets already dispatches these failures with a non-X509 sentinel: `ssl_dispatch_parked_reason` in `packages/bun-usockets/src/crypto/openssl.c` sends `{error_no: -71, code: "EPROTO", reason: ERR_error_string_n(...)}` for a fatal protocol error, and `ssl_trigger_handshake_econnreset` sends `{error_no: -46, code: "ECONNRESET"}` for a mid-handshake close. The HTTP client's handshake-failure branch in `HTTPContext::on_handshake` and `ProxyTunnel::on_handshake` fed the negative `error_no` into `get_cert_error_from_no`, whose `X509_V_ERR_*` lookup table maps any unknown value to `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`.

The proxy-tunnel inner-TLS path had two additional defects: `SSLWrapper::update_handshake_state` cleared the BoringSSL error queue before the handshake callback fired, discarding the reason; and `ProxyTunnel::on_handshake` only set `did_have_handshaking_error` inside its success branch, so a failed inner handshake always fell through to `ConnectionRefused`.

### Fix

- `src/http/HTTPCertError.rs`: new `TLSHandshakeError` struct that captures an owned copy of the sentinel's `code`/`reason` (the EPROTO `reason` is a stack buffer in uSockets, so an owned copy is required to outlive `on_handshake`), and `node_error_code()` which derives `ERR_SSL_<REASON>` from the last `:`-separated segment of the OpenSSL error string, matching Node's `ThrowCryptoError`.
- `src/http/HTTPContext.rs`, `src/http/ProxyTunnel.rs`: in the handshake-failure branch, a negative `error_no` (`X509_V_ERR_*` values are all non-negative) records a `TLSHandshakeError` on the client state and fails with the new `Error::TLSHandshakeFailed` instead of routing through the X509 lookup. `ProxyTunnel::on_handshake` now hoists `did_have_handshaking_error` before branching on success, matching `HTTPContext`.
- `src/uws/lib.rs`: `SSLWrapper::update_handshake_state` peeks `ERR_peek_last_error()` before clearing the queue on `SSL_ERROR_SSL` and dispatches the same `-71`/EPROTO shape uSockets does, with `reason` from BoringSSL's static `ERR_reason_error_string` table. Mirrors `ssl_park_fatal_reason`/`ssl_dispatch_parked_reason` in `openssl.c`.
- `src/http/{error.rs, InternalState.rs, lib.rs}`: add the `TLSHandshakeFailed` variant and plumb `tls_handshake_error` through `InternalState` and `HTTPClientResult` (same side-channel shape as `dns_hostname`).
- `src/runtime/webcore/fetch/FetchTasklet.rs`: when `fail == TLSHandshakeFailed`, report `code = node_error_code()` and `message = reason`.

### Testing

New test in `test/js/web/fetch/fetch.tls.test.ts` stands up three hostile peers (a TLS server offering only an ALPN protocol fetch never advertises, a plain TCP server behind `https://`, and a CONNECT proxy that feeds garbage into the tunnel) and asserts each rejects with `code: /^ERR_SSL_/` and a message carrying the OpenSSL reason; none may surface a certificate verification error. Fails on the unfixed build with exactly the `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR` / `ConnectionRefused` mislabels above.

Supersedes #34182 and subsumes #31950: those map the sentinel to a generic `ERR_TLS_HANDSHAKE_FAILED` or `EPROTO` code without the OpenSSL reason. This PR carries the reason through to a Node-compatible `ERR_SSL_*` code.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (a944c97c9)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1137.39ms]
(pass) fetch-tls > fetch with valid tls should not throw [1730.26ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1856.31ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [272.87ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2043.65ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1972.84ms]
(pass) fetch-tls > fetch with self-sign tls should throw [85.14ms]
(pass) fetch-tls > fetch with invalid tls should throw [78.95ms]
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [143.29ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [637.00ms]
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b2b8aa2bc)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls should not throw [1532.43ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [1552.12ms]
(pass) fetch-tls > checkServerIdentity approval still transmits the request and round-trips the response [37.86ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [45.78ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1557.67ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers (with AbortSignal) [49.14ms]
(pass) fetch-tls > fetch should use NODE_EXTRA_CA_CERTS [41.83ms]
(pass) fetch-tls > checkServerIdentity rejection prevents the request from being transmitted [47.97ms]
(pass) fetch-tls > fetch with invalid tls + rejectUnauthorized: false should not throw [45.87ms]
(pass) fetch-tls > fetch with self-sign certificate tls + rejectUnauthorized: false should not throw [46.63ms]
(pass) fetch-tls > fetch should respect rejectUnauthorized e
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.0 (a944c97c9)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1139.16ms]
(pass) fetch-tls > fetch with valid tls should not throw [1739.70ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [113.32ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2058.75ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1971.53ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [2056.23ms]
(pass) fetch-tls > fetch with self-sign tls should throw [151.97ms]
(pass) fetch-tls > fetch with invalid tls should throw [145.73ms]
(pass) fetch-tls > fetch with checkServerIdentity failing should throw [126.52ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [602.50m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 806ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_uws v0.0.0 (/workspace/bun/src/uws)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/HTTPCertError.rs                 |  60 +++++++++++++++++
 src/http/HTTPContext.rs                   |  16 +++--
 src/http/InternalState.rs                 |   5 ++
 src/http/ProxyTunnel.rs                   |  18 +++--
 src/http/error.rs                         |   3 +
 src/http/lib.rs                           |  15 ++++-
 src/runtime/webcore/fetch/FetchTasklet.rs |  25 +++++++
 src/uws/lib.rs                            |  39 ++++++++---
 test/js/web/fetch/fetch.tls.test.ts       | 106 ++++++++++++++++++++++++++++++
 9 files changed, 269 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/HTTPCertError.rs                      2      4      0
src/http/HTTPContext.rs                        1      1      0
src/http/InternalState.rs                      2      2      0
src/http/ProxyTunnel.rs                        2      2      0
src/http/error.rs                              3      2      0
src/http/lib.rs                                7      8      0
src/runtime/webcore/fetch/FetchTasklet.rs      3      1      0
src/uws/lib.rs                                 2      3      0
test/js/web/fetch/fetch.tls.test.ts            2      3      0
```

</details>

<!-- robobun:evidence:end -->