### PR TITLE
fetch: reject truncated compressed bodies on close-delimited responses

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -241,6 +241,29 @@ impl<'a> InternalState<'a> {
         self.flags.received_last_chunk
     }
 
+    /// True when a socket close during `in_progress` completes the body rather
+    /// than failing it: chunked decoder already in the trailers state, or a
+    /// close-delimited response (no Content-Length, no Transfer-Encoding).
+    pub fn is_body_complete_on_close(&self) -> bool {
+        if self.is_chunked_encoding() {
+            // 4 = CHUNKED_IN_TRAILERS_LINE_HEAD, 5 = CHUNKED_IN_TRAILERS_LINE_MIDDLE
+            return matches!(self.chunked_decoder._state, 4 | 5);
+        }
+        self.content_length.is_none() && self.response_stage == HTTPStage::Body
+    }
+
+    /// Mark the body complete and drive `process_body_buffer` one last time
+    /// with `is_final_chunk = true` so a compressed stream that never reached
+    /// stream-end is rejected. Call from every site that flips
+    /// `received_last_chunk` on an end-of-body signal that arrives with no
+    /// accompanying body bytes (h1 FIN, proxy-tunnel close, h2/h3 END_STREAM).
+    /// No-op for complete, empty, or uncompressed bodies.
+    pub fn finalize_body_on_eof(&mut self) -> Result<(), Error> {
+        self.flags.received_last_chunk = true;
+        let buffer_snap = core::mem::take(&mut self.get_body_buffer().list);
+        self.process_body_buffer(buffer_snap, true).map(drop)
+    }
+
     pub fn decompress_bytes(
         &mut self,
         buffer: &[u8],

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -541,42 +541,15 @@ fn on_close(ctx: *mut HTTPClient) {
         && this.state.stage != Stage::Fail
         && !this.state.flags.is_redirect_pending;
     let mut fail_err: Option<crate::Error> = None;
-    if in_progress {
-        if this.state.is_chunked_encoding() {
-            // 4 = CHUNKED_IN_TRAILERS_LINE_HEAD, 5 = CHUNKED_IN_TRAILERS_LINE_MIDDLE
-            // (`phr_chunked_decoder._state` is a raw `c_char`.)
-            match this.state.chunked_decoder._state {
-                4 | 5 => {
-                    this.state.flags.received_last_chunk = true;
-                    let buffer_snap = core::mem::take(&mut this.state.get_body_buffer().list);
-                    match this.state.process_body_buffer(buffer_snap, true) {
-                        Ok(_) => {
-                            // `this` dead (NLL); reborrow via `client_from_ctx` inside.
-                            progress_update_for_proxy_socket(ctx, proxy_nn);
-                            // Drop our temporary ref asynchronously to avoid freeing within callback
-                            crate::http_thread().schedule_proxy_deref(proxy_ptr);
-                            return;
-                        }
-                        Err(e) => fail_err = Some(e),
-                    }
-                }
-                _ => {}
+    if in_progress && this.state.is_body_complete_on_close() {
+        match this.state.finalize_body_on_eof() {
+            Ok(()) => {
+                // `this` dead (NLL); reborrow via `client_from_ctx` inside.
+                progress_update_for_proxy_socket(ctx, proxy_nn);
+                crate::http_thread().schedule_proxy_deref(proxy_ptr);
+                return;
             }
-        } else if this.state.content_length.is_none()
-            && this.state.response_stage == HTTPStage::Body
-        {
-            this.state.flags.received_last_chunk = true;
-            let buffer_snap = core::mem::take(&mut this.state.get_body_buffer().list);
-            match this.state.process_body_buffer(buffer_snap, true) {
-                Ok(_) => {
-                    // `this` dead (NLL); reborrow via `client_from_ctx` inside.
-                    progress_update_for_proxy_socket(ctx, proxy_nn);
-                    // Balance the ref we took asynchronously
-                    crate::http_thread().schedule_proxy_deref(proxy_ptr);
-                    return;
-                }
-                Err(e) => fail_err = Some(e),
-            }
+            Err(e) => fail_err = Some(e),
         }
     }
 

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -547,6 +547,12 @@ fn on_close(ctx: *mut HTTPClient) {
             match this.state.chunked_decoder._state {
                 4 | 5 => {
                     this.state.flags.received_last_chunk = true;
+                    let buffer_snap = core::mem::take(&mut this.state.get_body_buffer().list);
+                    if let Err(err) = this.state.process_body_buffer(buffer_snap, true) {
+                        this.fail(err);
+                        crate::http_thread().schedule_proxy_deref(proxy_ptr);
+                        return;
+                    }
                     // `this` dead (NLL); reborrow via `client_from_ctx` inside.
                     progress_update_for_proxy_socket(ctx, proxy_nn);
                     // Drop our temporary ref asynchronously to avoid freeing within callback
@@ -559,6 +565,12 @@ fn on_close(ctx: *mut HTTPClient) {
             && this.state.response_stage == HTTPStage::Body
         {
             this.state.flags.received_last_chunk = true;
+            let buffer_snap = core::mem::take(&mut this.state.get_body_buffer().list);
+            if let Err(err) = this.state.process_body_buffer(buffer_snap, true) {
+                this.fail(err);
+                crate::http_thread().schedule_proxy_deref(proxy_ptr);
+                return;
+            }
             // `this` dead (NLL); reborrow via `client_from_ctx` inside.
             progress_update_for_proxy_socket(ctx, proxy_nn);
             // Balance the ref we took asynchronously

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -540,6 +540,7 @@ fn on_close(ctx: *mut HTTPClient) {
     let in_progress = this.state.stage != Stage::Done
         && this.state.stage != Stage::Fail
         && !this.state.flags.is_redirect_pending;
+    let mut fail_err: Option<crate::Error> = None;
     if in_progress {
         if this.state.is_chunked_encoding() {
             // 4 = CHUNKED_IN_TRAILERS_LINE_HEAD, 5 = CHUNKED_IN_TRAILERS_LINE_MIDDLE
@@ -548,16 +549,16 @@ fn on_close(ctx: *mut HTTPClient) {
                 4 | 5 => {
                     this.state.flags.received_last_chunk = true;
                     let buffer_snap = core::mem::take(&mut this.state.get_body_buffer().list);
-                    if let Err(err) = this.state.process_body_buffer(buffer_snap, true) {
-                        this.fail(err);
-                        crate::http_thread().schedule_proxy_deref(proxy_ptr);
-                        return;
+                    match this.state.process_body_buffer(buffer_snap, true) {
+                        Ok(_) => {
+                            // `this` dead (NLL); reborrow via `client_from_ctx` inside.
+                            progress_update_for_proxy_socket(ctx, proxy_nn);
+                            // Drop our temporary ref asynchronously to avoid freeing within callback
+                            crate::http_thread().schedule_proxy_deref(proxy_ptr);
+                            return;
+                        }
+                        Err(e) => fail_err = Some(e),
                     }
-                    // `this` dead (NLL); reborrow via `client_from_ctx` inside.
-                    progress_update_for_proxy_socket(ctx, proxy_nn);
-                    // Drop our temporary ref asynchronously to avoid freeing within callback
-                    crate::http_thread().schedule_proxy_deref(proxy_ptr);
-                    return;
                 }
                 _ => {}
             }
@@ -566,21 +567,23 @@ fn on_close(ctx: *mut HTTPClient) {
         {
             this.state.flags.received_last_chunk = true;
             let buffer_snap = core::mem::take(&mut this.state.get_body_buffer().list);
-            if let Err(err) = this.state.process_body_buffer(buffer_snap, true) {
-                this.fail(err);
-                crate::http_thread().schedule_proxy_deref(proxy_ptr);
-                return;
+            match this.state.process_body_buffer(buffer_snap, true) {
+                Ok(_) => {
+                    // `this` dead (NLL); reborrow via `client_from_ctx` inside.
+                    progress_update_for_proxy_socket(ctx, proxy_nn);
+                    // Balance the ref we took asynchronously
+                    crate::http_thread().schedule_proxy_deref(proxy_ptr);
+                    return;
+                }
+                Err(e) => fail_err = Some(e),
             }
-            // `this` dead (NLL); reborrow via `client_from_ctx` inside.
-            progress_update_for_proxy_socket(ctx, proxy_nn);
-            // Balance the ref we took asynchronously
-            crate::http_thread().schedule_proxy_deref(proxy_ptr);
-            return;
         }
     }
 
-    // Otherwise, treat as failure.
-    let err = ProxyTunnel::shutdown_err_of(proxy_nn).get();
+    // Otherwise, treat as failure. `close_and_fail` de-tags the outer socket
+    // before `fail()` frees the AsyncHTTP that embeds `self` (the uSockets ext
+    // still points here until then).
+    let err = fail_err.unwrap_or_else(|| ProxyTunnel::shutdown_err_of(proxy_nn).get());
     match ProxyTunnel::socket_of(proxy_nn) {
         &Socket::Ssl(socket) => {
             this.close_and_fail::<true>(err, socket);
@@ -588,7 +591,11 @@ fn on_close(ctx: *mut HTTPClient) {
         &Socket::Tcp(socket) => {
             this.close_and_fail::<false>(err, socket);
         }
-        Socket::None => {}
+        Socket::None => {
+            if fail_err.is_some() {
+                this.fail(err);
+            }
+        }
     }
     ProxyTunnel::set_socket(proxy_nn, Socket::None);
     // Deref after returning to the event loop to avoid lifetime hazards.

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -1110,6 +1110,14 @@ impl ClientSession {
             stream.client = None;
             client.h2 = None;
             client.state.flags.received_last_chunk = true;
+            // END_STREAM arrived with no accompanying DATA bytes; drive the
+            // decompressor one last time so a truncated compressed stream
+            // with no content-length is rejected instead of resolved short.
+            let buffer_snap = core::mem::take(&mut client.state.get_body_buffer().list);
+            if let Err(err) = client.state.process_body_buffer(buffer_snap, true) {
+                client.h2_fail(err);
+                return true;
+            }
             return self.finish_stream(stream, client);
         }
 

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -1109,12 +1109,7 @@ impl ClientSession {
         if stream.remote_closed() {
             stream.client = None;
             client.h2 = None;
-            client.state.flags.received_last_chunk = true;
-            // END_STREAM arrived with no accompanying DATA bytes; drive the
-            // decompressor one last time so a truncated compressed stream
-            // with no content-length is rejected instead of resolved short.
-            let buffer_snap = core::mem::take(&mut client.state.get_body_buffer().list);
-            if let Err(err) = client.state.process_body_buffer(buffer_snap, true) {
+            if let Err(err) = client.state.finalize_body_on_eof() {
                 client.h2_fail(err);
                 return true;
             }

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -373,12 +373,7 @@ impl ClientSession {
             self.detach(stream);
             // SAFETY: re-derive — detach() invalidated the prior Unique tag.
             let client = client_mut(client_ptr);
-            client.state.flags.received_last_chunk = true;
-            // Stream ended with no accompanying body bytes; drive the
-            // decompressor one last time so a truncated compressed stream
-            // with no content-length is rejected instead of resolved short.
-            let buffer_snap = core::mem::take(&mut client.state.get_body_buffer().list);
-            if let Err(err) = client.state.process_body_buffer(buffer_snap, true) {
+            if let Err(err) = client.state.finalize_body_on_eof() {
                 return client.fail_from_h2(err);
             }
             return finish(client);

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -374,6 +374,13 @@ impl ClientSession {
             // SAFETY: re-derive — detach() invalidated the prior Unique tag.
             let client = client_mut(client_ptr);
             client.state.flags.received_last_chunk = true;
+            // Stream ended with no accompanying body bytes; drive the
+            // decompressor one last time so a truncated compressed stream
+            // with no content-length is rejected instead of resolved short.
+            let buffer_snap = core::mem::take(&mut client.state.get_body_buffer().list);
+            if let Err(err) = client.state.process_body_buffer(buffer_snap, true) {
+                return client.fail_from_h2(err);
+            }
             return finish(client);
         }
     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2084,45 +2084,14 @@ impl<'a> HTTPClient<'a> {
             self.do_redirect::<IS_SSL>(ctx, socket);
             return;
         }
-        if in_progress {
-            if self.state.is_chunked_encoding() {
-                // Match the spec exactly: only the two trailer states mean
-                // "all chunks consumed"; CHUNKED_IN_CHUNK_SIZE/EXT/CRLF mean
-                // the body was truncated mid-stream and must fail.
-                // 4 = CHUNKED_IN_TRAILERS_LINE_HEAD, 5 = CHUNKED_IN_TRAILERS_LINE_MIDDLE
-                if matches!(self.state.chunked_decoder._state, 4 | 5) {
-                    // ignore failure if we are in the middle of trailer headers, since we processed all the chunks and trailers are ignored
-                    self.state.flags.received_last_chunk = true;
-                    // Drive the body buffer one last time as final so the
-                    // decompressor's end-of-stream check runs (and any bytes
-                    // buffered during -2 are flushed to body_out_str).
-                    let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-                    if let Err(err) = self.state.process_body_buffer(buffer_snap, true) {
-                        self.fail(err);
-                        return;
-                    }
-                    let ctx = self.get_ssl_ctx::<IS_SSL>();
-                    self.progress_update::<IS_SSL>(ctx, socket);
-                    return;
-                }
-                // here we are in the middle of a chunk so ECONNRESET is expected
-            } else if self.state.content_length.is_none()
-                && self.state.response_stage == ResponseStage::Body
-            {
-                // no content length informed so we are done here
-                self.state.flags.received_last_chunk = true;
-                // Close-delimited bodies were decompressed per packet with
-                // is_final_chunk=false; drive a final empty chunk so a
-                // truncated compressed stream is rejected, not resolved short.
-                let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-                if let Err(err) = self.state.process_body_buffer(buffer_snap, true) {
-                    self.fail(err);
-                    return;
-                }
-                let ctx = self.get_ssl_ctx::<IS_SSL>();
-                self.progress_update::<IS_SSL>(ctx, socket);
+        if in_progress && self.state.is_body_complete_on_close() {
+            if let Err(err) = self.state.finalize_body_on_eof() {
+                self.fail(err);
                 return;
             }
+            let ctx = self.get_ssl_ctx::<IS_SSL>();
+            self.progress_update::<IS_SSL>(ctx, socket);
+            return;
         }
 
         // `in_progress` also keeps a client whose final result was already

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2093,6 +2093,14 @@ impl<'a> HTTPClient<'a> {
                 if matches!(self.state.chunked_decoder._state, 4 | 5) {
                     // ignore failure if we are in the middle of trailer headers, since we processed all the chunks and trailers are ignored
                     self.state.flags.received_last_chunk = true;
+                    // Drive the body buffer one last time as final so the
+                    // decompressor's end-of-stream check runs (and any bytes
+                    // buffered during -2 are flushed to body_out_str).
+                    let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
+                    if let Err(err) = self.state.process_body_buffer(buffer_snap, true) {
+                        self.fail(err);
+                        return;
+                    }
                     let ctx = self.get_ssl_ctx::<IS_SSL>();
                     self.progress_update::<IS_SSL>(ctx, socket);
                     return;
@@ -2103,6 +2111,15 @@ impl<'a> HTTPClient<'a> {
             {
                 // no content length informed so we are done here
                 self.state.flags.received_last_chunk = true;
+                // Close-delimited bodies were decompressed per packet with
+                // is_final_chunk=false; drive a final empty chunk so a
+                // truncated compressed stream is rejected instead of
+                // resolving with a short body.
+                let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
+                if let Err(err) = self.state.process_body_buffer(buffer_snap, true) {
+                    self.fail(err);
+                    return;
+                }
                 let ctx = self.get_ssl_ctx::<IS_SSL>();
                 self.progress_update::<IS_SSL>(ctx, socket);
                 return;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2113,8 +2113,7 @@ impl<'a> HTTPClient<'a> {
                 self.state.flags.received_last_chunk = true;
                 // Close-delimited bodies were decompressed per packet with
                 // is_final_chunk=false; drive a final empty chunk so a
-                // truncated compressed stream is rejected instead of
-                // resolving with a short body.
+                // truncated compressed stream is rejected, not resolved short.
                 let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
                 if let Err(err) = self.state.process_body_buffer(buffer_snap, true) {
                     self.fail(err);

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -538,6 +538,108 @@ describe("corrupt compressed responses", () => {
     }
   });
 
+  // A close-delimited body (no Content-Length, no Transfer-Encoding) is the
+  // framing where mid-stream truncation is most likely (origin/proxy dying on
+  // a `Connection: close` response). The decompressor's end-of-stream check
+  // must run on FIN, same as it already does for the framed variants above.
+  describe("close-delimited (FIN) framing", () => {
+    const FULL = 50000;
+    const plain = Buffer.alloc(FULL, "A");
+    const truncate = (b: Buffer) => b.subarray(0, b.length >> 1);
+    const codecs: Record<string, [Buffer, string]> = {
+      gzip: [truncate(gzipSync(plain)), "ZlibError"],
+      deflate: [truncate(deflateSync(plain)), "ZlibError"],
+      br: [truncate(brotliCompressSync(plain)), "BrotliDecompressionError"],
+      zstd: [truncate(zstdCompressSync(plain)), "ZstdDecompressionError"],
+    };
+
+    for (const [encoding, [half, errorCode]] of Object.entries(codecs)) {
+      it(`${encoding}: truncated stream rejects the body read`, async () => {
+        const srv = createNetServer(sock => {
+          sock.on("error", () => {});
+          sock.once("data", () => {
+            sock.write(`HTTP/1.1 200 OK\r\nContent-Encoding: ${encoding}\r\nConnection: close\r\n\r\n`);
+            sock.end(half);
+          });
+        });
+        const port = await listen(srv);
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/`);
+          expect(res.status).toBe(200);
+          const bodyErr = await res.arrayBuffer().then(
+            ab => ({ resolved: ab.byteLength }),
+            e => e,
+          );
+          expect(bodyErr).toBeInstanceOf(Error);
+          expect((bodyErr as { code?: string }).code).toBe(errorCode);
+
+          const res2 = await fetch(`http://127.0.0.1:${port}/`);
+          const reader = res2.body!.getReader();
+          let streamErr: unknown = null;
+          try {
+            while (!(await reader.read()).done) {}
+          } catch (e) {
+            streamErr = e;
+          }
+          expect(streamErr).toBeInstanceOf(Error);
+          expect((streamErr as { code?: string }).code).toBe(errorCode);
+        } finally {
+          srv.close();
+        }
+      });
+    }
+
+    // Regression guard: a complete stream under close-delimited framing must
+    // still resolve with the full body.
+    for (const [encoding, compress] of [
+      ["gzip", gzipSync],
+      ["deflate", deflateSync],
+      ["br", brotliCompressSync],
+      ["zstd", zstdCompressSync],
+    ] as const) {
+      it(`${encoding}: complete stream resolves with the full body`, async () => {
+        const body = compress(plain);
+        const srv = createNetServer(sock => {
+          sock.on("error", () => {});
+          sock.once("data", () => {
+            sock.write(`HTTP/1.1 200 OK\r\nContent-Encoding: ${encoding}\r\nConnection: close\r\n\r\n`);
+            sock.end(body);
+          });
+        });
+        const port = await listen(srv);
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/`);
+          const buf = Buffer.from(await res.arrayBuffer());
+          expect({ status: res.status, len: buf.length, ok: buf.equals(plain) }).toEqual({
+            status: 200,
+            len: FULL,
+            ok: true,
+          });
+        } finally {
+          srv.close();
+        }
+      });
+    }
+
+    it("identity: uncompressed close-delimited body is delivered intact", async () => {
+      const body = Buffer.alloc(4096, "x");
+      const srv = createNetServer(sock => {
+        sock.on("error", () => {});
+        sock.once("data", () => {
+          sock.write("HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n");
+          sock.end(body);
+        });
+      });
+      const port = await listen(srv);
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/`);
+        expect(Buffer.from(await res.arrayBuffer()).equals(body)).toBe(true);
+      } finally {
+        srv.close();
+      }
+    });
+  });
+
   it("redirect loop with a non-empty body rejects with TooManyRedirects", async () => {
     // Real-world 302s carry an HTML body, which routes the intermediate
     // head through clone_metadata(); hitting the redirect limit must still
@@ -793,6 +895,7 @@ describe("empty compressed responses", () => {
   for (const [name, write] of Object.entries({
     "chunked": `HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n`,
     "content-length-0": `HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 0\r\n\r\n`,
+    "close-delimited": `HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nConnection: close\r\n\r\n`,
   })) {
     it(`empty gzip body via ${name} resolves as empty`, async () => {
       // end() rather than write(): FIN the connection after the response so

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -538,10 +538,6 @@ describe("corrupt compressed responses", () => {
     }
   });
 
-  // A close-delimited body (no Content-Length, no Transfer-Encoding) is the
-  // framing where mid-stream truncation is most likely (origin/proxy dying on
-  // a `Connection: close` response). The decompressor's end-of-stream check
-  // must run on FIN, same as it already does for the framed variants above.
   describe("close-delimited (FIN) framing", () => {
     const FULL = 50000;
     const plain = Buffer.alloc(FULL, "A");
@@ -589,8 +585,6 @@ describe("corrupt compressed responses", () => {
       });
     }
 
-    // Regression guard: a complete stream under close-delimited framing must
-    // still resolve with the full body.
     for (const [encoding, compress] of [
       ["gzip", gzipSync],
       ["deflate", deflateSync],


### PR DESCRIPTION
### What does this PR do?

A close-delimited response (no Content-Length, no Transfer-Encoding; body ends at socket FIN) carrying a truncated gzip/deflate/br/zstd stream was resolving with a silently short body. The same truncated bytes under Content-Length or complete chunked framing already rejected with `ZlibError` / `BrotliDecompressionError` / `ZstdDecompressionError`.

```js
import net from "node:net"; import zlib from "node:zlib";
const gz = zlib.gzipSync(Buffer.alloc(50000, "A")), half = gz.subarray(0, gz.length >> 1);
const srv = net.createServer(s => {
  s.once("data", () => {
    s.write("HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nConnection: close\r\n\r\n");
    s.end(half);
  });
});
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const b = await (await fetch(`http://127.0.0.1:${srv.address().port}/`)).arrayBuffer();
console.log("len", b.byteLength); // before: 16514 (silently short); after: throws ZlibError
```

`HTTPClient::on_close` (and its `ProxyTunnel` mirror) handled close-delimited completion by setting `received_last_chunk = true` and jumping straight to `progress_update`. Unlike the chunked-done and Content-Length paths, it never drove `process_body_buffer` one last time with `is_final_chunk = true`, so `InflateDecoder::decompress` was never called with `is_done = true` and its `BufError` end-of-stream check never ran. Whatever had been decompressed per packet so far was returned as a successful body.

This PR issues the final `process_body_buffer(.., true)` call before `progress_update` at every site that flips `received_last_chunk` on an end-of-stream signal that arrives with no accompanying body bytes; on error, fail the request. For a complete compressed stream this is a no-op (the decoder is already in `State::End`); for an empty body it short-circuits at the existing `total_body_received == 0` guard.

Sites touched:
- `HTTPClient::on_close`: close-delimited branch and the adjacent chunked-trailers-then-FIN branch
- `ProxyTunnel::on_close`: same two branches (error path falls through to the existing `close_and_fail` dispatch so the outer socket is de-tagged before `fail()`)
- `h2_client::ClientSession::deliver_stream`: empty-buffer + END_STREAM branch (split-read / trailers case)
- `h3_client::ClientSession::deliver`: empty-buffer + `done` branch

### How did you verify your code works?

`test/js/web/fetch/fetch-gzip.test.ts` gains a close-delimited block covering gzip/deflate/br/zstd truncation (rejects), complete-stream (resolves full body), identity (delivered intact), and empty-body (resolves empty). On main the four truncated cases resolve with short bodies (gzip: 16514/50000); with this change they reject with the same error codes as the framed variants.

- `bun bd test test/js/web/fetch/fetch-gzip.test.ts`: 70 pass / 0 fail
- `bun bd test test/js/bun/http/proxy.test.ts`: 58 pass / 0 fail
- `bun bd test test/js/web/fetch/fetch-http2-client.test.ts`: 62 pass / 0 fail
- `bun bd test test/js/web/fetch/fetch-http3-client.test.ts`: 52 pass / 0 fail

The h2/h3 sibling sites are covered by the existing client suites for non-regression; dedicated truncated-stream tests for h2/h3 would need a custom origin that can place END_STREAM on a separate frame from the last DATA bytes and are left for a follow-up.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-gzip.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/181] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/181] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/181] gen cpp.rs (cppbind)
[4/181] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 240 extern-C blocks audited
[5/181] gen JS modules (bundle-modules)
Preprocess modules (7737ms)
Bundle modules (34ms)
Postprocesss modules (119ms)
Bundle Functions (970ms)
Generate Code (12ms)

[8.89s] Bundled "src/js" for development
  2210 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[5/181] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[123/181] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-15.cpp.
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (81e28cf4c)

test/js/web/fetch/fetch-gzip.test.ts:

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:31:3)
 HTTP/1.1 GET http://localhost:39211/
 Connection: keep-alive
 User-Agent: Bun/1.4.0
 Accept: */*
 Host: localhost:39211
 Accept-Encoding: gzip, deflate, br, zstd

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at fetch (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:22:7)
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Wed, 22 Jul 2026 06:57:33 GMT
< Content-Length: 16139


      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:34:3)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:37:3)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:40:5)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:41:43)

      at gcTick (/workspace/bun/test/harness.t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-gzip.test.ts
bun test v1.4.0 (464b68b0b)

test/js/web/fetch/fetch-gzip.test.ts:

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:31:3)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:17:63)
 HTTP/1.1 GET http://localhost:33307/
 Connection: keep-alive
 User-Agent: Bun/1.4.0-debug
 Accept: */*
 Host: localhost:33307
 Accept-Encoding: gzip, deflate, br, zstd

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at fetch (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:22:7)
< 200 OK
< Content-Encoding: gzip
< Content-Type: text/html; charset=utf-8
< Date: Wed, 22 Jul 2026 06:58:40 GMT
< Content-Length: 16139


      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:34:3)

      at gcTick (/workspace/bun/test/harness.ts:316:20)
      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-gzip.test.ts:37:3)

      at gcTick 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 647ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/139] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/139] gen cpp.rs (cppbind)
[3/139] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/139] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[5/139] gen JS modules (bundle-modules)
Preprocess modules (7562ms)
Bundle modules (54ms)
Postprocesss modules (200ms)
Bundle Functions (751ms)
Generate Code (105ms)

[8.69s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[5/139] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/InternalState.rs            | 23 +++++++++
 src/http/ProxyTunnel.rs              | 44 +++++++---------
 src/http/h2_client/ClientSession.rs  |  5 +-
 src/http/h3_client/ClientSession.rs  |  4 +-
 src/http/lib.rs                      | 27 +++-------
 test/js/web/fetch/fetch-gzip.test.ts | 97 ++++++++++++++++++++++++++++++++++++
 6 files changed, 151 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/http/InternalState.rs                 3      1      0
src/http/ProxyTunnel.rs                   3      3      0
src/http/h2_client/ClientSession.rs       2      2      0
src/http/h3_client/ClientSession.rs       2      2      0
src/http/lib.rs                           8      4      0
test/js/web/fetch/fetch-gzip.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->