### PR TITLE
fetch: accept HTTP/1.1 responses with more than 256 header fields

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -27,7 +27,6 @@ pub struct InternalState<'a> {
 
     pub transfer_encoding: Encoding,
     pub encoding: Encoding,
-    pub content_encoding_i: u8,
     pub chunked_decoder: bun_picohttp::phr_chunked_decoder,
     pub decompressor: Decompressor,
     pub stage: Stage,
@@ -65,7 +64,6 @@ pub struct InternalState<'a> {
 pub struct InternalStateFlags {
     pub allow_keepalive: bool,
     pub received_last_chunk: bool,
-    pub did_set_content_encoding: bool,
     pub is_redirect_pending: bool,
     pub is_libdeflate_fast_path_disabled: bool,
     pub resend_request_body_on_redirect: bool,
@@ -98,7 +96,6 @@ impl InternalStateFlags {
         Self {
             allow_keepalive: true,
             received_last_chunk: false,
-            did_set_content_encoding: false,
             is_redirect_pending: false,
             is_libdeflate_fast_path_disabled: false,
             resend_request_body_on_redirect: false,
@@ -126,7 +123,6 @@ impl Default for InternalState<'_> {
             flags: InternalStateFlags::new(),
             transfer_encoding: Encoding::Identity,
             encoding: Encoding::Identity,
-            content_encoding_i: u8::MAX,
             chunked_decoder: bun_picohttp::phr_chunked_decoder::default(),
             decompressor: Decompressor::None,
             stage: Stage::Pending,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3867,19 +3867,8 @@ impl<'a> HTTPClient<'a> {
             }
         };
         // handle_response_metadata may mutate `response`; mirror it back so
-        // clone_metadata() sees the up-to-date headers regardless of the
-        // content-encoding branch below.
+        // clone_metadata() sees the up-to-date headers.
         self.state.pending_response = Some(response);
-
-        if (self.state.content_encoding_i as usize) < response.headers.list.len()
-            && !self.state.flags.did_set_content_encoding
-        {
-            // if it compressed with this header, it is no longer because we will decompress it
-            self.state.flags.did_set_content_encoding = true;
-            self.state.content_encoding_i = u8::MAX;
-            // we need to reset the pending response because we removed a header
-            self.state.pending_response = Some(response);
-        }
 
         if should_continue == ShouldContinue::Finished {
             if self.state.flags.is_redirect_pending {
@@ -5037,7 +5026,7 @@ impl<'a> HTTPClient<'a> {
         let mut location: &[u8] = b"";
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
-        for (header_i, header) in response.headers.list.iter().enumerate() {
+        for header in response.headers.list.iter() {
             match hash_header_name(header.name()) {
                 h if h == hash_header_const(b"Content-Length") => {
                     // RFC 9110 section 9.3.6: a client MUST ignore
@@ -5089,18 +5078,14 @@ impl<'a> HTTPClient<'a> {
                             || strings::eql_case_insensitive_ascii_check_length(value, b"x-gzip")
                         {
                             self.state.encoding = Encoding::Gzip;
-                            self.state.content_encoding_i = header_i as u8;
                         } else if strings::eql_case_insensitive_ascii_check_length(
                             value, b"deflate",
                         ) {
                             self.state.encoding = Encoding::Deflate;
-                            self.state.content_encoding_i = header_i as u8;
                         } else if strings::eql_case_insensitive_ascii_check_length(value, b"br") {
                             self.state.encoding = Encoding::Brotli;
-                            self.state.content_encoding_i = header_i as u8;
                         } else if strings::eql_case_insensitive_ascii_check_length(value, b"zstd") {
                             self.state.encoding = Encoding::Zstd;
-                            self.state.content_encoding_i = header_i as u8;
                         }
                     }
                 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1048,8 +1048,16 @@ static SHARED_REQUEST_HEADERS_BUF: bun_core::RacyCell<[picohttp::Header; MAX_REQ
     bun_core::RacyCell::new([picohttp::Header::ZERO; MAX_REQUEST_HEADERS]);
 
 // this doesn't need to be stack memory because it is immediately cloned after use
-static SHARED_RESPONSE_HEADERS_BUF: bun_core::RacyCell<[picohttp::Header; 256]> =
-    bun_core::RacyCell::new([picohttp::Header::ZERO; 256]);
+const MAX_RESPONSE_HEADERS_INLINE: usize = 256;
+static SHARED_RESPONSE_HEADERS_BUF: bun_core::RacyCell<
+    [picohttp::Header; MAX_RESPONSE_HEADERS_INLINE],
+> = bun_core::RacyCell::new([picohttp::Header::ZERO; MAX_RESPONSE_HEADERS_INLINE]);
+
+// Spillover for responses with more than MAX_RESPONSE_HEADERS_INLINE header
+// fields. Sized on demand to the line count of the response buffer, so the
+// 1 MB byte cap (MAX_RESPONSE_HEADER_BUFFER) bounds the allocation.
+static SHARED_RESPONSE_HEADERS_OVERFLOW: bun_core::RacyCell<Vec<picohttp::Header>> =
+    bun_core::RacyCell::new(Vec::new());
 
 // the first packet for Transfer-Encoding: chunked
 // is usually pretty small or sometimes even just a length
@@ -1072,9 +1080,15 @@ mod scratch {
         unsafe { &mut *SHARED_REQUEST_HEADERS_BUF.get() }
     }
     #[inline]
-    pub(super) fn response_headers() -> &'static mut [picohttp::Header; 256] {
+    pub(super) fn response_headers() -> &'static mut [picohttp::Header; MAX_RESPONSE_HEADERS_INLINE]
+    {
         // SAFETY: see module-level INVARIANT.
         unsafe { &mut *SHARED_RESPONSE_HEADERS_BUF.get() }
+    }
+    #[inline]
+    pub(super) fn response_headers_overflow() -> &'static mut Vec<picohttp::Header> {
+        // SAFETY: see module-level INVARIANT.
+        unsafe { &mut *SHARED_RESPONSE_HEADERS_OVERFLOW.get() }
     }
     #[inline]
     pub(super) fn single_packet_small_buffer() -> &'static mut [u8; 16 * 1024] {
@@ -3729,12 +3743,29 @@ impl<'a> HTTPClient<'a> {
                 return;
             }
 
-            let shared_resp = scratch::response_headers();
-            let response = match picohttp::Response::parse_parts(
+            let mut parse_result = picohttp::Response::parse_parts(
                 to_read!(),
-                shared_resp,
+                scratch::response_headers(),
                 Some(&mut amount_read),
+            );
+            if matches!(
+                parse_result,
+                Err(picohttp::ParseResponseError::TooManyHeaders)
             ) {
+                // More than MAX_RESPONSE_HEADERS_INLINE fields. Size the
+                // overflow scratch to the line count (a strict upper bound on
+                // the field count) and reparse. The 1 MB byte cap below
+                // remains the only hard limit on the response header block.
+                let overflow = scratch::response_headers_overflow();
+                let needed = bun_core::strings::count_char(to_read!(), b'\n');
+                overflow.resize(needed, picohttp::Header::ZERO);
+                parse_result = picohttp::Response::parse_parts(
+                    to_read!(),
+                    overflow.as_mut_slice(),
+                    Some(&mut amount_read),
+                );
+            }
+            let response = match parse_result {
                 Ok(r) => r,
                 Err(picohttp::ParseResponseError::ShortRead) => {
                     // `MAX_HTTP_HEADER_SIZE` (default 16 KB) is the *server*/

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1054,8 +1054,8 @@ static SHARED_RESPONSE_HEADERS_BUF: bun_core::RacyCell<
 > = bun_core::RacyCell::new([picohttp::Header::ZERO; MAX_RESPONSE_HEADERS_INLINE]);
 
 // Spillover for responses with more than MAX_RESPONSE_HEADERS_INLINE header
-// fields. Sized on demand to the line count of the response buffer, so the
-// 1 MB byte cap (MAX_RESPONSE_HEADER_BUFFER) bounds the allocation.
+// fields. Sized on demand to the header-block line count, so the 1 MB byte
+// cap (MAX_RESPONSE_HEADER_BUFFER) on the header block bounds the slot count.
 static SHARED_RESPONSE_HEADERS_OVERFLOW: bun_core::RacyCell<Vec<picohttp::Header>> =
     bun_core::RacyCell::new(Vec::new());
 
@@ -3753,11 +3753,16 @@ impl<'a> HTTPClient<'a> {
                 Err(picohttp::ParseResponseError::TooManyHeaders)
             ) {
                 // More than MAX_RESPONSE_HEADERS_INLINE fields. Size the
-                // overflow scratch to the line count (a strict upper bound on
-                // the field count) and reparse. The 1 MB byte cap below
-                // remains the only hard limit on the response header block.
+                // overflow scratch to the header-block line count (a strict
+                // upper bound on the field count) and reparse. Count only up
+                // to the terminating CRLF CRLF when present so a newline-dense
+                // body in the same read doesn't inflate the slot count.
+                let buf = to_read!();
+                let header_end = bun_core::strings::index_of(buf, b"\r\n\r\n")
+                    .map(|i| i + 4)
+                    .unwrap_or(buf.len());
+                let needed = bun_core::strings::count_char(&buf[..header_end], b'\n');
                 let overflow = scratch::response_headers_overflow();
-                let needed = bun_core::strings::count_char(to_read!(), b'\n');
                 overflow.resize(needed, picohttp::Header::ZERO);
                 parse_result = picohttp::Response::parse_parts(
                     to_read!(),
@@ -3798,8 +3803,12 @@ impl<'a> HTTPClient<'a> {
             };
 
             // we save the successful parsed response
-            // SAFETY: response borrows SHARED_RESPONSE_HEADERS_BUF / response_message_buffer,
-            // both of which outlive this fn; widen to 'static for storage.
+            // SAFETY: `response` borrows SHARED_RESPONSE_HEADERS_BUF (fixed
+            // static) or SHARED_RESPONSE_HEADERS_OVERFLOW (Vec; buffer moves on
+            // resize) plus response_message_buffer / incoming_data. The erased
+            // borrow is overwritten with `Response::default()` at the top of
+            // each loop iteration before the next resize/append, and
+            // `clone_metadata()` deep-copies before this fn returns.
             // Rebind `response` to the detached `'static` copy so it no longer
             // borrows `to_read` (lets the `to_read` reassignment below pass
             // borrowck — `RawSlice::slice` ties output to `&to_read`).

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -927,7 +927,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         let response = match picohttp::Response::parse(body, &mut me.headers_buf) {
             Ok(r) => r,
-            Err(picohttp::ParseResponseError::MalformedHttpResponse) => {
+            Err(
+                picohttp::ParseResponseError::MalformedHttpResponse
+                | picohttp::ParseResponseError::TooManyHeaders,
+            ) => {
                 // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
                 unsafe { Self::terminate(this.as_ptr(), ErrorCode::InvalidResponse) };
                 return;
@@ -986,7 +989,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // Parse the response to find the end of headers
         let response = match picohttp::Response::parse(body, &mut me.headers_buf) {
             Ok(r) => r,
-            Err(picohttp::ParseResponseError::MalformedHttpResponse) => {
+            Err(
+                picohttp::ParseResponseError::MalformedHttpResponse
+                | picohttp::ParseResponseError::TooManyHeaders,
+            ) => {
                 // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
                 unsafe { Self::terminate(this.as_ptr(), ErrorCode::InvalidResponse) };
                 return;
@@ -1227,7 +1233,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
 
         let response = match picohttp::Response::parse(body, &mut me.headers_buf) {
             Ok(r) => r,
-            Err(picohttp::ParseResponseError::MalformedHttpResponse) => {
+            Err(
+                picohttp::ParseResponseError::MalformedHttpResponse
+                | picohttp::ParseResponseError::TooManyHeaders,
+            ) => {
                 // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
                 unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
                 return;

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -518,6 +518,11 @@ impl fmt::Display for StatusCodeFormatter {
 pub enum ParseResponseError {
     #[strum(serialize = "Malformed_HTTP_Response")]
     MalformedHttpResponse,
+    /// picohttpparser filled every slot in the caller's `[Header]` scratch
+    /// before finding the terminating CRLF. The response may be valid; the
+    /// caller can retry with a larger buffer.
+    #[strum(serialize = "Response_Headers_Too_Large")]
+    TooManyHeaders,
     ShortRead,
 }
 bun_core::impl_tag_error!(ParseResponseError);
@@ -618,6 +623,14 @@ impl<'a> Response<'a> {
 
         match rc {
             -1 => {
+                // picohttpparser returns -1 both for genuinely invalid input
+                // and when `num_headers` reaches `max_headers` before the
+                // terminating CRLF. In the overflow case `num_headers` is
+                // written back equal to the input capacity; every other -1
+                // path leaves it strictly below.
+                if !src.is_empty() && num_headers == src.len() {
+                    return Err(ParseResponseError::TooManyHeaders);
+                }
                 bun_core::debug!("Malformed HTTP response:\n{}", BStr::new(buf));
                 Err(ParseResponseError::MalformedHttpResponse)
             }

--- a/test/js/bun/http/fetch-header-count-limit.test.ts
+++ b/test/js/bun/http/fetch-header-count-limit.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import { createServer } from "node:net";
 
@@ -104,4 +104,52 @@ test("default headers preserved when user headers overflow the buffer", async ()
   expect(headerNames).toContain("host");
   expect(headerNames).toContain("user-agent");
   expect(headerNames).toContain("accept");
+});
+
+// The response header field count is bounded only by the 1 MB byte cap on
+// the header block; there is no fixed slot count. Node/undici behave the
+// same way (llhttp caps bytes, not fields).
+describe("fetch accepts responses with more than 256 header fields", () => {
+  async function serveNHeaders(n: number) {
+    const server = createServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        let head = "HTTP/1.1 200 OK\r\n";
+        for (let i = 0; i < n; i++) head += `X-H-${i}: v${i}\r\n`;
+        socket.end(head + "Content-Length: 2\r\nConnection: close\r\n\r\nok");
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    return server;
+  }
+
+  test.concurrent.each([200, 255, 300, 1000])("%i header fields", async n => {
+    await using server = await serveNHeaders(n);
+    const { port } = server.address() as import("node:net").AddressInfo;
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+    // Spot-check the first field, the last field, and Content-Length so the
+    // whole header block was delivered without truncation.
+    expect(res.headers.get("x-h-0")).toBe("v0");
+    expect(res.headers.get(`x-h-${n - 1}`)).toBe(`v${n - 1}`);
+    expect(res.headers.get("content-length")).toBe("2");
+  });
+
+  test.concurrent("genuinely malformed response still rejects with Malformed_HTTP_Response", async () => {
+    await using server = createServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => socket.end("HTTP/1.1 200 OK\r\nbad header line\r\n\r\n"));
+    }).listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    let code: string | undefined;
+    try {
+      await fetch(`http://127.0.0.1:${port}/`);
+    } catch (e: any) {
+      code = e.code ?? e.name;
+    }
+    expect(code).toBe("Malformed_HTTP_Response");
+  });
 });

--- a/test/js/bun/http/fetch-header-count-limit.test.ts
+++ b/test/js/bun/http/fetch-header-count-limit.test.ts
@@ -137,6 +137,26 @@ describe("fetch accepts responses with more than 256 header fields", () => {
     expect(res.headers.get("content-length")).toBe("2");
   });
 
+  test.concurrent("newline-dense body in the same write as a >256-field header block", async () => {
+    // The overflow scratch is sized from the header-block line count, not the
+    // body, so a body full of LFs must not affect parsing.
+    const body = Buffer.alloc(8192, "\n").toString();
+    await using server = createServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        let head = "HTTP/1.1 200 OK\r\n";
+        for (let i = 0; i < 300; i++) head += `X-H-${i}: v${i}\r\n`;
+        socket.end(head + `Content-Length: ${body.length}\r\nConnection: close\r\n\r\n` + body);
+      });
+    }).listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(body);
+    expect(res.headers.get("x-h-299")).toBe("v299");
+  });
+
   test.concurrent("genuinely malformed response still rejects with Malformed_HTTP_Response", async () => {
     await using server = createServer(socket => {
       socket.on("error", () => {});


### PR DESCRIPTION
## Repro

```js
import net from "node:net";
const srv = net.createServer(s => {
  s.once("data", () => {
    let h = "HTTP/1.1 200 OK\r\n";
    for (let i = 0; i < 300; i++) h += `X-H-${i}: v${i}\r\n`;
    s.end(h + "Content-Length: 2\r\n\r\nok");
  });
});
srv.listen(0, "127.0.0.1", async () => {
  const res = await fetch(`http://127.0.0.1:${srv.address().port}/`);
  console.log(res.status, await res.text());
  srv.close();
});
```

```
bun:  error: Malformed_HTTP_Response
node: 200 ok
```

255 fields resolve, 256 and up are rejected as malformed even though the bytes are valid HTTP/1.1. A single 1 MB header value is accepted, so this is a field-count cap, not a byte guard. curl, Node/undici, and bun's own `node:http.get` all accept 1000+ fields. This hits real origins that send many `Set-Cookie` lines or per-item cache/rate-limit/debug headers.

## Cause

picohttpparser returns `-1` both for genuinely invalid input and when `num_headers` reaches `max_headers` before the terminating CRLF; `picohttp::Response::parse_parts` mapped every `-1` to `ParseResponseError::MalformedHttpResponse`. The HTTP client passes a fixed `[picohttp::Header; 256]` scratch (`SHARED_RESPONSE_HEADERS_BUF`), so the 257th field fills it and the response is rejected with a misleading error.

## Fix

* `parse_parts` distinguishes the overflow case (on `-1` picohttpparser writes `num_headers == max_headers` only when the array filled; every other `-1` path leaves it strictly below) and returns a new `ParseResponseError::TooManyHeaders`.
* `handle_on_data_headers` retries into an HTTP-thread scratch `Vec<picohttp::Header>` sized to the `\n` count of the received bytes (a strict upper bound on the field count). The existing 1 MB byte cap (`MAX_RESPONSE_HEADER_BUFFER`) stays as the only hard limit on the header block, which matches llhttp's byte-only bound in Node.
* The WebSocket upgrade client's three match arms treat `TooManyHeaders` the same as `MalformedHttpResponse` (a 101 handshake with >128 fields is still rejected, just via the existing `InvalidResponse` code rather than a compile break).

The common case (≤256 fields) is unchanged: one parse into the fixed array, no allocation, no line-count scan.

## Verification

New `describe` in `test/js/bun/http/fetch-header-count-limit.test.ts` covers 200/255/300/1000 response header fields plus a genuinely malformed response that must still reject with `Malformed_HTTP_Response`.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/http/fetch-header-count-limit.test.ts
 5 pass
 3 fail   (255, 300, 1000: "Malformed_HTTP_Response")

$ bun bd test test/js/bun/http/fetch-header-count-limit.test.ts
 8 pass
 0 fail
```

`fetch-redirect.test.ts`, `headers.test.ts`, `fetch_headers.test.js`, and `client-fetch.test.ts` (151 tests) pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/fetch-header-count-limit.test.ts
bun test v1.4.0 (6b2fb977d)

test/js/bun/http/fetch-header-count-limit.test.ts:
(pass) fetch with many headers does not crash [1516.95ms]
(pass) fetch with exactly 250 custom headers sends all of them [832.39ms]
(pass) default headers preserved when user headers overflow the buffer [917.63ms]
DEBUG: Malformed HTTP response:
HTTP/1.1 200 OK
X-H-0: v0
X-H-1: v1
X-H-2: v2
X-H-3: v3
X-H-4: v4
X-H-5: v5
X-H-6: v6
X-H-7: v7
X-H-8: v8
X-H-9: v9
X-H-10: v10
X-H-11: v11
X-H-12: v12
X-H-13: v13
X-H-14: v14
X-H-15: v15
X-H-16: v16
X-H-17: v17
X-H-18: v18
X-H-19: v19
X-H-20: v20
X-H-21: v21
X-H-22: v22
X-H-23: v23
X-H-24: v24
X-H-25: v25
X-H-26: v26
X-H-27: v27
X-H-28: v28
X-H-29: v29
X-H-30: v30
X-H-31: v31
X-H-32: v32
X-H-33: v33
X-H-34: v34
X-H-35: v35
X-H-36: v36
X-H-37: v37
X-H-38: v38
X-H-39: v39
X-H-40: v40
X-H-41: v41
X-H-42: v42
X-H-43: v43
X-H-44: v44
X-H-45: v45
X-H-46: v46
X-H-47: v47
X-H-48: v48
X-H-49: v49
X-H-50: v50
X-H-51: v51
X-
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bc809505c)

test/js/bun/http/fetch-header-count-limit.test.ts:
(pass) fetch with many headers does not crash [19.40ms]
(pass) fetch with exactly 250 custom headers sends all of them [4.11ms]
(pass) default headers preserved when user headers overflow the buffer [2.71ms]
(pass) fetch accepts responses with more than 256 header fields > 200 header fields [2.88ms]
(pass) fetch accepts responses with more than 256 header fields > 255 header fields [3.69ms]
(pass) fetch accepts responses with more than 256 header fields > 300 header fields [3.64ms]
(pass) fetch accepts responses with more than 256 header fields > 1000 header fields [8.07ms]
(pass) fetch accepts responses with more than 256 header fields > newline-dense body in the same write as a >256-field header block [8.05ms]
(pass) fetch accepts responses with more than 256 header fields > genuinely malformed response still rejects with Malformed_HTTP_Response [7.78ms]

 9 pass
 0 fail
 32 expect() calls
Ran 9 tests across 1 file. [196.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/fetch-header-count-limit.test.ts
bun test v1.4.0 (6b2fb977d)

test/js/bun/http/fetch-header-count-limit.test.ts:
(pass) fetch with many headers does not crash [2203.48ms]
(pass) fetch with exactly 250 custom headers sends all of them [1244.16ms]
(pass) default headers preserved when user headers overflow the buffer [1334.03ms]
(pass) fetch accepts responses with more than 256 header fields > 200 header fields [7704.14ms]
(pass) fetch accepts responses with more than 256 header fields > 255 header fields [7697.93ms]
(pass) fetch accepts responses with more than 256 header fields > 300 header fields [7693.71ms]
(pass) fetch accepts responses with more than 256 header fields > 1000 header fields [7688.88ms]
(pass) fetch accepts responses with more than 256 header fields > newline-dense body in the same write as a >256-field header block [7684.75ms]
DEBUG: Malformed HTTP response:
HTTP/1.1 200 OK
bad header line


(pass) fetch accepts responses with more than 256 header fields > genuinely malformed response still reject
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 720ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/InternalState.rs                          |  4 --
 src/http/lib.rs                                    | 75 ++++++++++++++--------
 .../websocket_client/WebSocketUpgradeClient.rs     | 15 ++++-
 src/picohttp/lib.rs                                | 13 ++++
 test/js/bun/http/fetch-header-count-limit.test.ts  | 70 +++++++++++++++++++-
 5 files changed, 144 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/http/InternalState.rs                                    3      4      0
src/http/lib.rs                                             14     13      0
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs      1      3      0
src/picohttp/lib.rs                                          2      2      0
test/js/bun/http/fetch-header-count-limit.test.ts            2      6      0
```

</details>

<!-- robobun:evidence:end -->