### PR TITLE
Implement --max-old-space-size to bound the JS heap

### DIFF
--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -73,6 +73,12 @@ bun run <file or script>
   Use less memory, but run garbage collection more often
 </ParamField>
 
+<ParamField path="--max-old-space-size" type="number">
+  Set the maximum JavaScript heap size in megabytes, for Node.js compatibility. The process aborts with Node's
+  "JavaScript heap out of memory" fatal error when a full GC cannot keep the heap under the limit.
+  <code>--max_old_space_size</code> is accepted as an alias. 0 means no limit
+</ParamField>
+
 <ParamField path="--expose-gc" type="boolean">
   Expose <code>gc()</code> on the global object. Has no effect on <code>Bun.gc()</code>
 </ParamField>
@@ -259,12 +265,6 @@ bun run <file or script>
 
 <ParamField path="--max-http-header-size" type="number" default="16384">
   Set the maximum size of HTTP headers in bytes. Default is 16KiB
-</ParamField>
-
-<ParamField path="--max-old-space-size" type="number">
-  Set the maximum JavaScript heap size in megabytes, for Node.js compatibility. The process aborts with Node's
-  "JavaScript heap out of memory" fatal error when a full GC cannot keep the heap under the limit.
-  <code>--max_old_space_size</code> is accepted as an alias. 0 means no limit
 </ParamField>
 
 <ParamField path="--dns-result-order" type="string" default="verbatim">

--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -261,6 +261,12 @@ bun run <file or script>
   Set the maximum size of HTTP headers in bytes. Default is 16KiB
 </ParamField>
 
+<ParamField path="--max-old-space-size" type="number">
+  Set the maximum JavaScript heap size in megabytes, for Node.js compatibility. The process aborts with Node's
+  "JavaScript heap out of memory" fatal error when a full GC cannot keep the heap under the limit.
+  <code>--max_old_space_size</code> is accepted as an alias. 0 means no limit
+</ParamField>
+
 <ParamField path="--dns-result-order" type="string" default="verbatim">
   Set the default order of DNS lookup results. Valid orders: <code>verbatim</code> (default), <code>ipv4first</code>,{" "}
   <code>ipv6first</code>

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -809,6 +809,7 @@ export function buildAllowedNodeEnvironmentFlags() {
     "--inspect-brk",
     "--inspect-port",
     "--max-http-header-size",
+    "--max-old-space-size",
     "--no-addons",
     "--no-deprecation",
     "--no-warnings",

--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -5,10 +5,8 @@ const { hideFromStack, throwNotImplemented } = require("internal/shared");
 const { validateString, validateOneOf } = require("internal/validators");
 const { isDataView, isAnyArrayBuffer } = require("node:util/types");
 const jsc: typeof import("bun:jsc") = require("bun:jsc");
-const { isStringOneByteRepresentation, startGCProfiler, stopGCProfiler, discardGCProfiler } = $cpp(
-  "NodeV8.cpp",
-  "Bun::createNodeV8Binding",
-);
+const { isStringOneByteRepresentation, startGCProfiler, stopGCProfiler, discardGCProfiler, maxOldSpaceSizeBytes } =
+  $cpp("NodeV8.cpp", "Bun::createNodeV8Binding");
 
 const DateNow = Date.now;
 const FunctionPrototypeCall = Function.prototype.call;
@@ -168,34 +166,6 @@ function totalmem() {
   return totalmem_;
 }
 
-let maxOldSpaceSize_ = -1;
-
-// --max-old-space-size is enforced (the process aborts when a full GC cannot
-// keep the heap under it), so report it like V8 does. Last occurrence wins.
-function maxOldSpaceSizeBytes() {
-  if (maxOldSpaceSize_ === -1) {
-    let megabytes = 0;
-    const execArgv = process.execArgv;
-    for (let i = 0; i < execArgv.length; i++) {
-      const arg = execArgv[i];
-      let value: string | undefined;
-      if (arg.startsWith("--max-old-space-size=") || arg.startsWith("--max_old_space_size=")) {
-        value = arg.slice("--max-old-space-size=".length);
-      } else if (arg === "--max-old-space-size" || arg === "--max_old_space_size") {
-        value = execArgv[i + 1];
-      }
-      if (value !== undefined) {
-        // 0 is a valid value meaning "no limit", so it must reset an
-        // earlier positive value like the native parser does.
-        const parsed = Number.parseInt(value, 10);
-        if (parsed >= 0) megabytes = parsed;
-      }
-    }
-    maxOldSpaceSize_ = megabytes * 1024 * 1024;
-  }
-  return maxOldSpaceSize_;
-}
-
 function getHeapStatistics() {
   const stats = jsc.heapStats();
   const memory = jsc.memoryUsage();
@@ -212,7 +182,9 @@ function getHeapStatistics() {
     total_available_size: totalmem() - stats.heapSize,
     used_heap_size: stats.heapSize,
     total_allocated_bytes: stats.heapCapacity,
-    heap_size_limit: maxOldSpaceSizeBytes() || Math.min(memory.peak * 10, totalmem()),
+    // --max-old-space-size is enforced (the process aborts when a full GC
+    // cannot keep the heap under it), so report it like V8 does.
+    heap_size_limit: maxOldSpaceSizeBytes || Math.min(memory.peak * 10, totalmem()),
     malloced_memory: stats.heapSize,
     peak_malloced_memory: memory.peak,
 

--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -168,6 +168,34 @@ function totalmem() {
   return totalmem_;
 }
 
+let maxOldSpaceSize_ = -1;
+
+// --max-old-space-size is enforced (the process aborts when a full GC cannot
+// keep the heap under it), so report it like V8 does. Last occurrence wins.
+function maxOldSpaceSizeBytes() {
+  if (maxOldSpaceSize_ === -1) {
+    let megabytes = 0;
+    const execArgv = process.execArgv;
+    for (let i = 0; i < execArgv.length; i++) {
+      const arg = execArgv[i];
+      let value: string | undefined;
+      if (arg.startsWith("--max-old-space-size=") || arg.startsWith("--max_old_space_size=")) {
+        value = arg.slice("--max-old-space-size=".length);
+      } else if (arg === "--max-old-space-size" || arg === "--max_old_space_size") {
+        value = execArgv[i + 1];
+      }
+      if (value !== undefined) {
+        // 0 is a valid value meaning "no limit", so it must reset an
+        // earlier positive value like the native parser does.
+        const parsed = Number.parseInt(value, 10);
+        if (parsed >= 0) megabytes = parsed;
+      }
+    }
+    maxOldSpaceSize_ = megabytes * 1024 * 1024;
+  }
+  return maxOldSpaceSize_;
+}
+
 function getHeapStatistics() {
   const stats = jsc.heapStats();
   const memory = jsc.memoryUsage();
@@ -184,7 +212,7 @@ function getHeapStatistics() {
     total_available_size: totalmem() - stats.heapSize,
     used_heap_size: stats.heapSize,
     total_allocated_bytes: stats.heapCapacity,
-    heap_size_limit: Math.min(memory.peak * 10, totalmem()),
+    heap_size_limit: maxOldSpaceSizeBytes() || Math.min(memory.peak * 10, totalmem()),
     malloced_memory: stats.heapSize,
     peak_malloced_memory: memory.peak,
 

--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -24,11 +24,62 @@
 
 #include "JSDOMWrapper.h"
 #include <JavaScriptCore/DeferredWorkTimer.h>
+#include <JavaScriptCore/HeapObserver.h>
 #include "NodeVM.h"
 #include "../../runtime/bake/BakeGlobalObject.h"
 #include "napi_handle_scope.h"
 #include "NativePromiseContext.h"
 #include "StrongRootBlock.h"
+
+#if OS(WINDOWS)
+#include <stdlib.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace Bun {
+
+// Enforces `--max-old-space-size`: when a full GC cannot keep the live heap
+// under the limit, fail fast with Node's fatal OOM message and exit code
+// instead of letting the process grow until the OS kills it.
+class HeapSizeLimitObserver final : public JSC::HeapObserver {
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(HeapSizeLimitObserver);
+
+public:
+    HeapSizeLimitObserver(JSC::Heap& heap, size_t limit)
+        : m_heap(heap)
+        , m_limit(limit)
+    {
+    }
+
+    void willGarbageCollect() final {}
+
+    // May run on the collector thread; only reads heap counters and exits.
+    void didGarbageCollect(JSC::CollectionScope scope) final
+    {
+        if (scope != JSC::CollectionScope::Full)
+            return;
+        size_t sizeAfterGC = m_heap.sizeAfterLastFullCollection();
+        if (sizeAfterGC <= m_limit) [[likely]]
+            return;
+        fprintf(stderr,
+            "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory\n"
+            "(heap size %zu MB exceeded the limit of %zu MB set by --max-old-space-size)\n",
+            sizeAfterGC / (1024 * 1024), m_limit / (1024 * 1024));
+        fflush(stderr);
+        // Node exits with 134 (128 + SIGABRT) here; _exit keeps it
+        // deterministic and safe from any thread.
+        _exit(134);
+    }
+
+    JSC::Heap& heap() { return m_heap; }
+
+private:
+    JSC::Heap& m_heap;
+    size_t m_limit;
+};
+
+} // namespace Bun
 
 namespace WebCore {
 using namespace JSC;
@@ -95,8 +146,18 @@ void JSVMClientData::JSHeapDataDeleter::operator()(JSHeapData* heapData) const
         delete heapData;
 }
 
+void JSVMClientData::enforceMaxOldSpaceSize(VM& vm, size_t limitBytes)
+{
+    ASSERT(!m_heapSizeLimitObserver);
+    m_heapSizeLimitObserver = makeUnique<Bun::HeapSizeLimitObserver>(vm.heap, limitBytes);
+    vm.heap.addObserver(m_heapSizeLimitObserver.get());
+}
+
 JSVMClientData::~JSVMClientData()
 {
+    if (m_heapSizeLimitObserver)
+        m_heapSizeLimitObserver->heap().removeObserver(m_heapSizeLimitObserver.get());
+
     while (!m_clients.isEmpty()) {
         auto* client = &*m_clients.begin();
         client->remove();

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -78,6 +78,7 @@ class GlobalObject;
 
 namespace Bun {
 class StrongRootBlock;
+class HeapSizeLimitObserver;
 
 // JSC measures the live size of the heap at the end of each collection, but only
 // publishes it per scope: an eden collection updates
@@ -214,6 +215,9 @@ public:
     // `worker` is the WorkerMessagingProxy this VM is being created for, or null on the main thread.
     static void create(JSC::VM*, void* bunVM, WorkerMessagingProxy* worker);
 
+    // Registers the --max-old-space-size observer with this VM's heap.
+    void enforceMaxOldSpaceSize(JSC::VM&, size_t limitBytes);
+
     JSHeapData& heapData() { return *m_heapData; }
     BunBuiltinNames& builtinNames() { return m_builtinNames; }
     JSBuiltinFunctions& builtinFunctions() { return *m_builtinFunctions; }
@@ -324,6 +328,11 @@ private:
     SentinelLinkedList<JSVMClientDataClient, BasicRawSentinelNode<JSVMClientDataClient>> m_clients;
     bool m_isWorkerVM { false };
     bool m_isNodeWorkerVM { false };
+
+    // Enforces --max-old-space-size. Registered with the heap by
+    // enforceMaxOldSpaceSize() (main thread VM only), unregistered in
+    // ~JSVMClientData (which ~VM runs while `heap` is alive).
+    std::unique_ptr<Bun::HeapSizeLimitObserver> m_heapSizeLimitObserver;
 
 public:
     // upstream's `&vm != commonVMOrNull()`

--- a/src/jsc/bindings/NodeV8.cpp
+++ b/src/jsc/bindings/NodeV8.cpp
@@ -13,6 +13,8 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <wtf/StdLibExtras.h>
 
+extern "C" size_t Bun__Node__MaxOldSpaceSizeBytes;
+
 namespace Bun {
 
 using namespace JSC;
@@ -102,6 +104,9 @@ JSC::JSObject* createNodeV8Binding(JSC::JSGlobalObject* globalObject)
     object->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "startGCProfiler"_s), 0, functionStartGCProfiler, ImplementationVisibility::Public, JSC::NoIntrinsic, 0);
     object->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "stopGCProfiler"_s), 1, functionStopGCProfiler, ImplementationVisibility::Public, JSC::NoIntrinsic, 0);
     object->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "discardGCProfiler"_s), 1, functionDiscardGCProfiler, ImplementationVisibility::Public, JSC::NoIntrinsic, 0);
+    // The enforced --max-old-space-size limit in bytes (0 = no limit), read
+    // from the parsed CLI value rather than the mutable process.execArgv.
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "maxOldSpaceSizeBytes"_s), JSC::jsNumber(static_cast<double>(Bun__Node__MaxOldSpaceSizeBytes)), 0);
     return object;
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -280,6 +280,8 @@ extern "C" long Bun__crashHandlerFromJSCFrame(void*, void*, void*, void*);
 // bun_icu_default_locale.cpp
 extern "C" void Bun__ensureICUDefaultLocale();
 
+extern "C" size_t Bun__Node__MaxOldSpaceSizeBytes;
+
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode, bool oneShotStartup, bool shortLivedGlobals)
 {
     static std::once_flag jsc_init_flag;
@@ -334,6 +336,11 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             // BUN_JSC_useWarmUpMarkedBlocks=1 re-enables it.
             JSC::Options::useWarmUpMarkedBlocks() = false;
 #endif
+            // --max-old-space-size: size the GC heuristics to the requested
+            // cap so collection ramps up before the limit is reached, like V8.
+            // A BUN_JSC_forceRAMSize env override below still wins.
+            if (size_t heapLimit = Bun__Node__MaxOldSpaceSizeBytes)
+                JSC::Options::forceRAMSize() = heapLimit;
             JSC::dangerouslyOverrideJSCBytecodeCacheVersion(getWebKitBytecodeCacheVersion());
 
 #ifdef BUN_DEBUG
@@ -456,9 +463,9 @@ void Zig::GlobalObject::resetOnEachMicrotaskTick()
 
 extern "C" size_t Bun__reported_memory_size;
 
-// executionContextId: -1 for main thread
+// executionContextId: 1 for the main thread (see VirtualMachine::init)
 // executionContextId: maxInt32 for macros
-// executionContextId: >-1 for workers
+// executionContextId: >1 for workers
 extern "C" bool Bun__hasStandaloneModuleGraph();
 
 extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, int32_t executionContextId, bool miniMode, bool evalMode, void* worker_ptr)
@@ -478,8 +485,10 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
         const char* disable_stop_if_necessary_timer = getenv("BUN_DISABLE_STOP_IF_NECESSARY_TIMER");
         // Keep stopIfNecessaryTimer enabled by default when either:
         // - `--smol` is passed
+        // - `--max-old-space-size` is set (the mutator must not outrun the
+        //   collector, or the heap blows through the limit between full GCs)
         // - The machine has less than 4GB of RAM
-        bool shouldDisableStopIfNecessaryTimer = !miniMode;
+        bool shouldDisableStopIfNecessaryTimer = !miniMode && !Bun__Node__MaxOldSpaceSizeBytes;
 
         if (disable_stop_if_necessary_timer) {
             const char value = disable_stop_if_necessary_timer[0];
@@ -505,6 +514,15 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     ASSERT(vmPtr->runLoop().kind() == WTF::RunLoop::Kind::Bun);
 
     WebCore::JSVMClientData::create(&vm, Bun__getVM(), static_cast<WebCore::WorkerMessagingProxy*>(worker_ptr));
+
+    // Only the main thread VM (context id 1, see VirtualMachine::init)
+    // enforces --max-old-space-size. Node terminates an over-limit worker
+    // without killing the process (resourceLimits), so a worker heap OOM
+    // must not _exit the whole process from here.
+    if (executionContextId == 1) {
+        if (size_t heapLimit = Bun__Node__MaxOldSpaceSizeBytes)
+            WebCore::clientData(vm)->enforceMaxOldSpaceSize(vm, heapLimit);
+    }
 
     const auto createGlobalObject = [&]() -> Zig::GlobalObject* {
         if (executionContextId == std::numeric_limits<int32_t>::max() || executionContextId > 1) [[unlikely]] {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -237,6 +237,9 @@ const RUNTIME_PARAMS_: &[ParamType] = &[
         "--insecure-http-parser            Use an insecure HTTP parser that accepts invalid HTTP headers"
     ),
     parse_param!(
+        "--max-old-space-size/--max_old_space_size <INT>     Set the maximum JavaScript heap size in megabytes, for Node.js compatibility"
+    ),
+    parse_param!(
         "--dns-result-order <STR>          Set the default order of DNS lookup results. Valid orders: verbatim (default), ipv4first, ipv6first"
     ),
     parse_param!(
@@ -749,6 +752,12 @@ fn replace_pid_placeholder(name: &[u8]) -> Box<[u8]> {
     out.into_boxed_slice()
 }
 
+/// `--max-old-space-size`, converted to bytes. 0 = no limit. Read from C++ as
+/// a plain `size_t` before VM creation (JSCInitialize / JSVMClientData).
+#[unsafe(no_mangle)]
+pub(crate) static Bun__Node__MaxOldSpaceSizeBytes: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) enum BunCAStore {
@@ -1162,6 +1171,23 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
 
         if args.flag(b"--insecure-http-parser") {
             bun_http::set_insecure_http_parser(true);
+        }
+
+        if let Some(size_str) = args.option(b"--max-old-space-size") {
+            let megabytes = match strings::parse_int::<usize>(size_str, 10) {
+                Ok(v) => v,
+                Err(_) => {
+                    Output::err_generic(
+                        "Invalid value for --max-old-space-size: \"{}\". Must be a positive integer\n",
+                        format_args!("{}", BStr::new(size_str)),
+                    );
+                    Global::exit(1);
+                }
+            };
+            Bun__Node__MaxOldSpaceSizeBytes.store(
+                megabytes.saturating_mul(1024 * 1024),
+                core::sync::atomic::Ordering::Relaxed,
+            );
         }
 
         if let Some(user_agent) = args.option(b"--user-agent") {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1178,7 +1178,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
                 Ok(v) => v,
                 Err(_) => {
                     Output::err_generic(
-                        "Invalid value for --max-old-space-size: \"{}\". Must be a positive integer\n",
+                        "Invalid value for --max-old-space-size: \"{}\". Must be a non-negative integer (0 disables the limit)\n",
                         format_args!("{}", BStr::new(size_str)),
                     );
                     Global::exit(1);

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -299,13 +299,19 @@ mod _impl {
             static MAP: std::sync::LazyLock<bun_collections::StringSet> =
                 std::sync::LazyLock::new(|| {
                     let mut set = bun_collections::StringSet::new();
+                    fn insert_long(set: &mut bun_collections::StringSet, name: &[u8]) {
+                        let mut k = Vec::with_capacity(2 + name.len());
+                        k.extend_from_slice(b"--");
+                        k.extend_from_slice(name);
+                        bun_core::handle_oom(set.insert(&k));
+                    }
                     for param in crate::cli::arguments::AUTO_PARAMS.iter() {
                         if param.takes_value != bun_clap::Values::None {
                             if let Some(name) = param.names.long {
-                                let mut k = Vec::with_capacity(2 + name.len());
-                                k.extend_from_slice(b"--");
-                                k.extend_from_slice(name);
-                                bun_core::handle_oom(set.insert(&k));
+                                insert_long(&mut set, name);
+                            }
+                            for alias in param.names.long_aliases {
+                                insert_long(&mut set, alias);
                             }
                             if let Some(name) = param.names.short {
                                 bun_core::handle_oom(set.insert(&[b'-', name]));

--- a/test/cli/run/max-old-space-size.test.ts
+++ b/test/cli/run/max-old-space-size.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Pushes ~1 MB of live array data per iteration, then reports how far it got.
+const allocateScript = (mb: number) =>
+  `const chunks = [];
+   for (let i = 0; i < ${mb}; i++) chunks.push(new Array(131072).fill(i));
+   console.log("reached " + chunks.length + "MB");`;
+
+test.concurrent.each(["--max-old-space-size", "--max_old_space_size"])(
+  "%s aborts like Node.js when the live heap exceeds the limit",
+  async flag => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), `${flag}=64`, "-e", allocateScript(256)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("JavaScript heap out of memory");
+    expect(stdout).not.toContain("reached");
+    // Node exits with 134 (128 + SIGABRT) on heap OOM
+    expect(exitCode).toBe(134);
+  },
+);
+
+test.concurrent("--max-old-space-size does not abort workloads that fit under the limit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--max-old-space-size=512", "-e", allocateScript(16)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("JavaScript heap out of memory");
+  expect(stdout).toContain("reached 16MB");
+  expect(exitCode).toBe(0);
+});
+
+// Worker bootstrap alone takes ~5s under debug+ASAN (with or without the
+// flag), so this test needs more than the 5s default timeout.
+test.concurrent(
+  "--max-old-space-size does not kill the process when a worker exceeds the limit",
+  async () => {
+    // The limit only aborts for the main thread VM; Node's model for workers is
+    // resourceLimits + a worker-scoped error, never a process-wide abort.
+    using dir = tempDir("max-old-space-size-worker", {
+      "main.js": `
+      const { Worker } = require("node:worker_threads");
+      const worker = new Worker("./worker.js");
+      worker.on("exit", code => console.log("worker exited " + code));
+    `,
+      "worker.js": `
+      const chunks = [];
+      for (let i = 0; i < 96; i++) chunks.push(new Array(131072).fill(i));
+      Bun.gc(true);
+      console.log("worker reached " + chunks.length + "MB");
+    `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--max-old-space-size=64", "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("JavaScript heap out of memory");
+    expect(stdout).toContain("worker reached 96MB");
+    expect(stdout).toContain("worker exited 0");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
+test.concurrent("space-separated value of the underscore alias stays in process.execArgv", async () => {
+  using dir = tempDir("max-old-space-size-execargv", {
+    "main.js": `console.log(JSON.stringify(process.execArgv));`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--max_old_space_size", "256", "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  // The value must be kept with the flag, or children spawned with the default
+  // execArgv (worker_threads, child_process.fork) consume the script as the value.
+  expect(stdout.trim()).toBe('["--max_old_space_size","256"]');
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("v8.getHeapStatistics().heap_size_limit reports the configured limit", async () => {
+  // npm and friends read heap_size_limit to back off before hitting the cap.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--max-old-space-size=256", "-e", "console.log(require('v8').getHeapStatistics().heap_size_limit)"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe(String(256 * 1024 * 1024));
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("--max-old-space-size rejects a non-numeric value", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--max-old-space-size=abc", "-e", "console.log('ran')"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("Invalid value for --max-old-space-size");
+  expect(stdout).not.toContain("ran");
+  expect(exitCode).toBe(1);
+});

--- a/test/cli/run/max-old-space-size.test.ts
+++ b/test/cli/run/max-old-space-size.test.ts
@@ -24,6 +24,19 @@ test.concurrent.each(["--max-old-space-size", "--max_old_space_size"])(
   },
 );
 
+test.concurrent("--max-old-space-size=0 disables the limit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--max-old-space-size=0", "-e", allocateScript(96)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("JavaScript heap out of memory");
+  expect(stdout).toContain("reached 96MB");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("--max-old-space-size does not abort workloads that fit under the limit", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--max-old-space-size=512", "-e", allocateScript(16)],
@@ -92,8 +105,15 @@ test.concurrent("space-separated value of the underscore alias stays in process.
 
 test.concurrent("v8.getHeapStatistics().heap_size_limit reports the configured limit", async () => {
   // npm and friends read heap_size_limit to back off before hitting the cap.
+  // Mutating execArgv first must not change the answer: the limit comes from
+  // the native parsed value, not from re-parsing process.execArgv.
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "--max-old-space-size=256", "-e", "console.log(require('v8').getHeapStatistics().heap_size_limit)"],
+    cmd: [
+      bunExe(),
+      "--max-old-space-size=256",
+      "-e",
+      "process.execArgv = []; console.log(require('v8').getHeapStatistics().heap_size_limit)",
+    ],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",

--- a/test/cli/run/max-old-space-size.test.ts
+++ b/test/cli/run/max-old-space-size.test.ts
@@ -104,6 +104,12 @@ test.concurrent("v8.getHeapStatistics().heap_size_limit reports the configured l
   expect(exitCode).toBe(0);
 });
 
+test("process.allowedNodeEnvironmentFlags includes --max-old-space-size", () => {
+  // has() normalizes _ to -, so one canonical entry covers both spellings.
+  expect(process.allowedNodeEnvironmentFlags.has("--max-old-space-size")).toBe(true);
+  expect(process.allowedNodeEnvironmentFlags.has("--max_old_space_size")).toBe(true);
+});
+
 test.concurrent("--max-old-space-size rejects a non-numeric value", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--max-old-space-size=abc", "-e", "console.log('ran')"],


### PR DESCRIPTION
Fixes #34917

### Problem

`bun --max-old-space-size=256` was silently ignored (any unknown `--flag=value` is skipped when running a script), so there was no way to bound the JS heap. In memory-limited containers this turns into OOM kills (exit 137) for workloads Node completes under its cap:

```sh
# before: prints "reached 600MB", exit 0. Node aborts near 256MB.
bun --max-old-space-size=256 -e 'const a=[];let mb=0;for(;;){a.push(new Array(131072).fill(mb));if(++mb>=600)break};console.log("reached "+mb+"MB")'
```

`BUN_JSC_gcMaxHeapSize` does not help either: in JSC it is a GC-frequency trigger (request a collection when bytes allocated this cycle exceed it), not a cap, and `BUN_JSC_forceRAMSize` only scales growth heuristics.

### Fix

- Parse `--max-old-space-size=N` (megabytes, `--max_old_space_size` also accepted, 0 = no limit) in the runtime CLI and reject non-numeric values like Node does.
- Set `JSC::Options::forceRAMSize()` to the limit before VM creation so every heap-growth heuristic (proportional heap sizing, critical-memory threshold, min heap size) scales to the cap and the GC works hard before reaching it. An explicit `BUN_JSC_forceRAMSize` env var still overrides the heuristic.
- Keep the stop-if-necessary timer enabled (as `--smol` does) so the mutator yields to the collector under pressure.
- Register a `JSC::HeapObserver` on the main thread VM (owned by `JSVMClientData`, removed in its destructor): after every full GC, if the live heap is still over the limit, print Node's fatal message and exit with Node's code:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
(heap size 404 MB exceeded the limit of 256 MB set by --max-old-space-size)
```

Exit code is 134 (128 + SIGABRT), matching Node, via `_exit` so it is deterministic and safe from the collector thread.

### Semantics notes

- The limit covers the whole JSC heap including reported extra memory (e.g. ArrayBuffer backing stores), while V8 accounts those as "external" outside the old-space cap. For the container use case this is the more useful bound.
- Enforcement happens at full-GC granularity, so a fast allocation burst can transiently overshoot before the first full collection sees it. It is not a hard allocation-time cap like V8's; that would need JSC changes.
- The limit bounds the managed JS heap, not total RSS. Bun's RSS per live heap byte runs higher than Node's (committed-but-free JSC pages are released lazily, and the native runtime's share of memory is larger), so container deployments should leave more headroom below the cgroup limit than they would on Node. Enforcing on committed size (Heap::capacity()) instead of live size would be closer to V8's semantics and is a possible follow-up.
- The GC heuristics apply process-wide, but the fatal abort is enforced only on the main thread VM: in Node an over-limit worker is terminated worker-scoped (`resourceLimits` / `ERR_WORKER_OUT_OF_MEMORY`) rather than killing the process, and Bun does not implement `resourceLimits.maxOldGenerationSizeMb` yet, so worker heaps are not capped. A test pins that a worker exceeding the limit does not kill the process.

### Verification

`test/cli/run/max-old-space-size.test.ts`:
- over-limit workload aborts with the Node message and exit 134 (both flag spellings)
- under-limit workload completes normally
- a worker exceeding the limit does not kill the process
- non-numeric value errors out

All fail on the current release (`reached 256MB`, exit 0) and pass with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/max-old-space-size.test.ts
bun test v1.4.1 (65362b53b)

test/cli/run/max-old-space-size.test.ts:
(pass) --max-old-space-size does not abort workloads that fit under the limit [404.81ms]
error: Script not found "256"
 97 |     stdout: "pipe",
 98 |   });
 99 |   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
100 |   // The value must be kept with the flag, or children spawned with the default
101 |   // execArgv (worker_threads, child_process.fork) consume the script as the value.
102 |   expect(stdout.trim()).toBe('["--max_old_space_size","256"]');
                              ^
error: expect(received).toBe(expected)

Expected: "["--max_old_space_size","256"]"
Received: ""

      at <anonymous> (/workspace/bun/test/cli/run/max-old-space-size.test.ts:102:25)
(fail) space-separated value of the underscore alias stays in process.execArgv [159.53ms]
(pass) --max-old-space-size=0 disables the limit [631.89ms]
15 |       env: bunEnv,
16 |       stdout: "pipe",
17 |       stderr: "pipe",
18 |   
... (truncated)

release without fix: 6 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/cli/run/max-old-space-size.test.ts:
error: Script not found "256"
 97 |     stdout: "pipe",
 98 |   });
 99 |   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
100 |   // The value must be kept with the flag, or children spawned with the default
101 |   // execArgv (worker_threads, child_process.fork) consume the script as the value.
102 |   expect(stdout.trim()).toBe('["--max_old_space_size","256"]');
                              ^
error: expect(received).toBe(expected)

Expected: "["--max_old_space_size","256"]"
Received: ""

      at <anonymous> (/workspace/bun/test/cli/run/max-old-space-size.test.ts:102:25)
(fail) space-separated value of the underscore alias stays in process.execArgv [7.08ms]
117 |     env: bunEnv,
118 |     stdout: "pipe",
119 |     stderr: "pipe",
120 |   });
121 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
122 |   expect(stdout.trim()).toBe(String(256 * 1024 * 1024));
                              ^
error: expect(received).toBe(expected)

Expected: "268435456"
Received: "508026880"

      at <anonym
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/max-old-space-size.test.ts
bun test v1.4.1 (65362b53b)

test/cli/run/max-old-space-size.test.ts:
(pass) --max-old-space-size does not abort workloads that fit under the limit [465.59ms]
(pass) --max_old_space_size aborts like Node.js when the live heap exceeds the limit [677.27ms]
(pass) --max-old-space-size aborts like Node.js when the live heap exceeds the limit [790.96ms]
(pass) space-separated value of the underscore alias stays in process.execArgv [462.19ms]
(pass) --max-old-space-size=0 disables the limit [1170.34ms]
(pass) v8.getHeapStatistics().heap_size_limit reports the configured limit [615.50ms]
(pass) --max-old-space-size does not kill the process when a worker exceeds the limit [3401.27ms]
(pass) process.allowedNodeEnvironmentFlags includes --max-old-space-size [16.85ms]
(pass) --max-old-space-size rejects a non-numeric value [197.98ms]

 9 pass
 0 fail
 26 expect() calls
Ran 9 tests across 1 file. [5.88s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2f49ca224e
  features     baseline

23 deps, 131 codegen, 1172 objects in 711ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [14.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [3.00ms]
[4/1244] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 29ms
[5/1244] gen ErrorCode+*.h
[6/1244] gen bindgenv2
[7/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 14ms

  react-refresh.js  4.81 KB  (entry point)

[8/1244] gen .bind.ts → GeneratedBindings.cpp
[9/1244] gen bake.{client,server,error}.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/snippets/cli/run.mdx                 |   6 ++
 src/js/builtins/ProcessObjectInternals.ts |   1 +
 src/js/node/v8.ts                         |  10 +--
 src/jsc/bindings/BunClientData.cpp        |  61 +++++++++++++
 src/jsc/bindings/BunClientData.h          |   9 ++
 src/jsc/bindings/NodeV8.cpp               |   5 ++
 src/jsc/bindings/ZigGlobalObject.cpp      |  24 ++++-
 src/runtime/cli/Arguments.rs              |  26 ++++++
 src/runtime/node/node_process.rs          |  14 ++-
 test/cli/run/max-old-space-size.test.ts   | 144 ++++++++++++++++++++++++++++++
 10 files changed, 288 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 13 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/snippets/cli/run.mdx                      1      1      0
src/js/builtins/ProcessObjectInternals.ts      1      1      0
src/js/node/v8.ts                              4      6      0
src/jsc/bindings/BunClientData.cpp             5      7      0
src/jsc/bindings/BunClientData.h               6      7      0
src/jsc/bindings/NodeV8.cpp                    1      2      0
src/jsc/bindings/ZigGlobalObject.cpp           9      9      0
src/runtime/cli/Arguments.rs                   5      5      0
src/runtime/node/node_process.rs               1      2      0
test/cli/run/max-old-space-size.test.ts        4     15      0
```

</details>

**root cause** · written by the author bot

Bun accepted `--max-old-space-size` for Node compatibility but never wired the value into JavaScriptCore, so the flag was silently ignored and the heap could grow unbounded until the container's OOM killer intervened. The fix parses the flag (both spellings), converts megabytes to bytes, and feeds the value into JSC's heap-growth heuristics via `forceRAMSize` so the collector works harder as the limit approaches. It also installs a heap observer on the main-thread VM that checks live heap size after each full garbage collection and terminates the process with exit code 134, matching Node's …

<!-- robobun:evidence:end -->
