### PR TITLE
bun:sqlite: keep empty-name columns; gate row-returning on sqlite3_column_count

### DIFF
--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -2230,7 +2230,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionAll, (JSC::JSGlob
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    size_t columnCount = castedThis->columnNames->size();
+    int columnCount = sqlite3_column_count(stmt);
     JSValue result = jsUndefined();
     if (status == SQLITE_ROW) {
         // this is a count from UPDATE or another query like that
@@ -2384,7 +2384,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
         }
     }
 
-    size_t columnCount = castedThis->columnNames->size();
+    size_t columnCount = sqlite3_column_count(stmt);
     JSValue result = jsNull();
     if (status == SQLITE_ROW) {
         // this is a count from UPDATE or another query like that
@@ -2393,15 +2393,13 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows, (JSC::JSGlo
                 status = sqlite3_step(stmt);
             }
 
-            result = jsNumber(sqlite3_column_count(stmt));
+            result = jsNumber(0);
 
         } else {
 
             JSC::JSArray* resultArray = JSC::constructEmptyArray(lexicalGlobalObject, static_cast<ArrayAllocationProfile*>(nullptr), 0);
             RETURN_IF_EXCEPTION(scope, {});
             {
-                size_t columnCount = sqlite3_column_count(stmt);
-
                 do {
                     JSC::JSArray* row = constructResultRow(vm, lexicalGlobalObject, castedThis, columnCount);
                     if (!row || scope.exception()) [[unlikely]] {
@@ -2473,7 +2471,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
         }
     }
 
-    size_t columnCount = castedThis->columnNames->size();
+    size_t columnCount = sqlite3_column_count(stmt);
     JSValue result = jsNull();
     if (status == SQLITE_ROW) {
         // this is a count from UPDATE or another query like that
@@ -2482,15 +2480,13 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows, (JSC::JS
                 status = sqlite3_step(stmt);
             }
 
-            result = jsNumber(sqlite3_column_count(stmt));
+            result = jsNumber(0);
 
         } else {
 
             JSC::JSArray* resultArray = JSC::constructEmptyArray(lexicalGlobalObject, nullptr, 0);
             RETURN_IF_EXCEPTION(scope, {});
             {
-                size_t columnCount = sqlite3_column_count(stmt);
-
                 do {
                     JSC::JSArray* row = constructResultRowRaw(vm, lexicalGlobalObject, castedThis, columnCount);
                     if (!row || scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -759,17 +759,14 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
             }
 
             size_t len = strlen(name);
-            if (len == 0) {
-                anyHoles = true;
-                break;
-            }
 
             // When joining multiple tables, the same column names can appear multiple times
             // columnNames de-dupes property names internally
             // We can't have two properties with the same name, so we use validColumns to track this.
             auto preCount = columnNames->size();
-            columnNames->add(
-                Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len })));
+            columnNames->add(len == 0
+                    ? vm.propertyNames->emptyIdentifier
+                    : Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len })));
             auto curCount = columnNames->size();
 
             if (preCount != curCount) {
@@ -815,14 +812,11 @@ static void initializeColumnNames(JSC::JSGlobalObject* lexicalGlobalObject, JSSQ
     for (int i = count - 1; i >= 0; i--) {
         const char* name = sqlite3_column_name(stmt, i);
 
-        if (name == nullptr)
-            break;
+        size_t len = name != nullptr ? strlen(name) : 0;
 
-        size_t len = strlen(name);
-        if (len == 0)
-            break;
-
-        const auto key = Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len }));
+        const auto key = len == 0
+            ? vm.propertyNames->emptyIdentifier
+            : Identifier::fromString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len }));
 
         JSC::JSValue primitive = JSC::jsUndefined();
         auto decl = sqlite3_column_decltype(stmt, i);
@@ -2633,29 +2627,19 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnNames, (JSGlobalObject * lexical
     JSSQLStatement* castedThis = dynamicDowncast<JSSQLStatement>(JSValue::decode(thisValue));
     auto scope = DECLARE_THROW_SCOPE(vm);
     CHECK_THIS
+    CHECK_PREPARED
 
-    if (!castedThis->hasExecuted || castedThis->need_update()) {
-        initializeColumnNames(lexicalGlobalObject, castedThis);
-        RETURN_IF_EXCEPTION(scope, {});
-    }
-    JSC::JSArray* array;
-    auto* columnNames = castedThis->columnNames.get();
-    if (columnNames->size() > 0) {
-        if (castedThis->_prototype) {
-            array = ownPropertyKeys(lexicalGlobalObject, castedThis->_prototype.get(), PropertyNameMode::Strings, DontEnumPropertiesMode::Exclude);
-            RETURN_IF_EXCEPTION(scope, {});
-        } else {
-            array = JSC::constructEmptyArray(lexicalGlobalObject, static_cast<ArrayAllocationProfile*>(nullptr), columnNames->size());
-            RETURN_IF_EXCEPTION(scope, {});
-            unsigned int i = 0;
-            for (const auto& column : *columnNames) {
-                auto* string = jsString(vm, column.string());
-                RETURN_IF_EXCEPTION(scope, {});
-                array->putDirectIndex(lexicalGlobalObject, i++, string);
-            }
-        }
-    } else {
-        array = JSC::constructEmptyArray(lexicalGlobalObject, static_cast<ArrayAllocationProfile*>(nullptr), 0);
+    auto* stmt = castedThis->stmt;
+    int count = sqlite3_column_count(stmt);
+    JSC::JSArray* array = JSC::constructEmptyArray(lexicalGlobalObject, static_cast<ArrayAllocationProfile*>(nullptr), count);
+    RETURN_IF_EXCEPTION(scope, {});
+    for (int i = 0; i < count; i++) {
+        const char* name = sqlite3_column_name(stmt, i);
+        size_t len = name != nullptr ? strlen(name) : 0;
+        auto* string = len == 0
+            ? jsEmptyString(vm)
+            : JSC::jsString(vm, WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(name), len }));
+        array->putDirectIndex(lexicalGlobalObject, i, string);
         RETURN_IF_EXCEPTION(scope, {});
     }
     return JSC::JSValue::encode(array);

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1391,49 +1391,46 @@ it("issue#6597 with many columns", () => {
 
 describe("empty and duplicate column names", () => {
   it('an empty alias (AS "") keeps its column and all preceding columns', () => {
-    const db = new Database(":memory:");
-    const stmt = db.prepare('select 1 as a, 2 as "", 3 as b');
+    using db = new Database(":memory:");
+    using stmt = db.prepare('select 1 as a, 2 as "", 3 as b');
     expect(stmt.get()).toEqual({ a: 1, "": 2, b: 3 });
     expect(stmt.all()).toEqual([{ a: 1, "": 2, b: 3 }]);
     expect([...stmt.iterate()]).toEqual([{ a: 1, "": 2, b: 3 }]);
     expect(stmt.values()).toEqual([[1, 2, 3]]);
     expect(stmt.columnNames).toEqual(["a", "", "b"]);
-    db.close();
   });
 
   it("a trailing empty alias does not wipe the whole row", () => {
-    const db = new Database(":memory:");
-    const stmt = db.prepare('select 10 as first_col, 20 as second_col, 30 as ""');
+    using db = new Database(":memory:");
+    using stmt = db.prepare('select 10 as first_col, 20 as second_col, 30 as ""');
     expect(stmt.get()).toEqual({ first_col: 10, second_col: 20, "": 30 });
     expect(stmt.columnNames).toEqual(["first_col", "second_col", ""]);
-    db.close();
   });
 
   it("multiple empty aliases: last value wins on the row object, columnNames keeps all", () => {
-    const db = new Database(":memory:");
-    const stmt = db.prepare('select 1 as "", 2 as x, 3 as ""');
+    using db = new Database(":memory:");
+    using stmt = db.prepare('select 1 as "", 2 as x, 3 as ""');
     expect(stmt.get()).toEqual({ "": 3, x: 2 });
     expect(stmt.columnNames).toEqual(["", "x", ""]);
     expect(stmt.values()).toEqual([[1, 2, 3]]);
-    db.close();
   });
 
-  it("columnNames preserves duplicates and order, matching columnTypes / values()", () => {
-    const db = new Database(":memory:");
-    const stmt = db.prepare("select 1 as a, 2 as b, 3 as a");
+  it("columnNames preserves duplicates and order, matching columnTypes / declaredTypes / values()", () => {
+    using db = new Database(":memory:");
+    using stmt = db.prepare("select 1 as a, 2 as b, 3 as a");
     // row object: last duplicate wins (better-sqlite3/node:sqlite semantics)
     expect(stmt.get()).toEqual({ a: 3, b: 2 });
     expect(stmt.columnNames).toEqual(["a", "b", "a"]);
     expect(stmt.columnNames.length).toBe(stmt.columnTypes.length);
+    expect(stmt.columnNames.length).toBe(stmt.declaredTypes.length);
     expect(stmt.columnNames.length).toBe(stmt.values()[0].length);
-    db.close();
   });
 
   it("columnNames preserves all columns on the >64-column slow path with an empty alias", () => {
-    const db = new Database(":memory:");
+    using db = new Database(":memory:");
     const cols = Array.from({ length: 70 }, (_, i) => `${i} as c${i}`);
     cols[3] = `999 as ""`;
-    const stmt = db.prepare(`select ${cols.join(", ")}`);
+    using stmt = db.prepare(`select ${cols.join(", ")}`);
     const row = stmt.get();
     const names = stmt.columnNames;
     expect(names.length).toBe(70);
@@ -1444,14 +1441,13 @@ describe("empty and duplicate column names", () => {
     expect(row[""]).toBe(999);
     expect(row.c69).toBe(69);
     expect(Object.keys(row).length).toBe(70);
-    db.close();
   });
 
   it("columnNames preserves duplicates on the >64-column slow path", () => {
-    const db = new Database(":memory:");
+    using db = new Database(":memory:");
     const cols = Array.from({ length: 70 }, (_, i) => `${i} as c${i}`);
     cols[50] = `777 as c0`;
-    const stmt = db.prepare(`select ${cols.join(", ")}`);
+    using stmt = db.prepare(`select ${cols.join(", ")}`);
     const names = stmt.columnNames;
     expect(names.length).toBe(70);
     expect(names[0]).toBe("c0");
@@ -1460,7 +1456,6 @@ describe("empty and duplicate column names", () => {
     expect(row.c0).toBe(777);
     expect(row.c49).toBe(49);
     expect(row.c51).toBe(51);
-    db.close();
   });
 });
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1389,6 +1389,81 @@ it("issue#6597 with many columns", () => {
   db.close();
 });
 
+describe("empty and duplicate column names", () => {
+  it('an empty alias (AS "") keeps its column and all preceding columns', () => {
+    const db = new Database(":memory:");
+    const stmt = db.prepare('select 1 as a, 2 as "", 3 as b');
+    expect(stmt.get()).toEqual({ a: 1, "": 2, b: 3 });
+    expect(stmt.all()).toEqual([{ a: 1, "": 2, b: 3 }]);
+    expect([...stmt.iterate()]).toEqual([{ a: 1, "": 2, b: 3 }]);
+    expect(stmt.values()).toEqual([[1, 2, 3]]);
+    expect(stmt.columnNames).toEqual(["a", "", "b"]);
+    db.close();
+  });
+
+  it("a trailing empty alias does not wipe the whole row", () => {
+    const db = new Database(":memory:");
+    const stmt = db.prepare('select 10 as first_col, 20 as second_col, 30 as ""');
+    expect(stmt.get()).toEqual({ first_col: 10, second_col: 20, "": 30 });
+    expect(stmt.columnNames).toEqual(["first_col", "second_col", ""]);
+    db.close();
+  });
+
+  it("multiple empty aliases: last value wins on the row object, columnNames keeps all", () => {
+    const db = new Database(":memory:");
+    const stmt = db.prepare('select 1 as "", 2 as x, 3 as ""');
+    expect(stmt.get()).toEqual({ "": 3, x: 2 });
+    expect(stmt.columnNames).toEqual(["", "x", ""]);
+    expect(stmt.values()).toEqual([[1, 2, 3]]);
+    db.close();
+  });
+
+  it("columnNames preserves duplicates and order, matching columnTypes / values()", () => {
+    const db = new Database(":memory:");
+    const stmt = db.prepare("select 1 as a, 2 as b, 3 as a");
+    // row object: last duplicate wins (better-sqlite3/node:sqlite semantics)
+    expect(stmt.get()).toEqual({ a: 3, b: 2 });
+    expect(stmt.columnNames).toEqual(["a", "b", "a"]);
+    expect(stmt.columnNames.length).toBe(stmt.columnTypes.length);
+    expect(stmt.columnNames.length).toBe(stmt.values()[0].length);
+    db.close();
+  });
+
+  it("columnNames preserves all columns on the >64-column slow path with an empty alias", () => {
+    const db = new Database(":memory:");
+    const cols = Array.from({ length: 70 }, (_, i) => `${i} as c${i}`);
+    cols[3] = `999 as ""`;
+    const stmt = db.prepare(`select ${cols.join(", ")}`);
+    const row = stmt.get();
+    const names = stmt.columnNames;
+    expect(names.length).toBe(70);
+    expect(names[0]).toBe("c0");
+    expect(names[3]).toBe("");
+    expect(names[69]).toBe("c69");
+    expect(row.c0).toBe(0);
+    expect(row[""]).toBe(999);
+    expect(row.c69).toBe(69);
+    expect(Object.keys(row).length).toBe(70);
+    db.close();
+  });
+
+  it("columnNames preserves duplicates on the >64-column slow path", () => {
+    const db = new Database(":memory:");
+    const cols = Array.from({ length: 70 }, (_, i) => `${i} as c${i}`);
+    cols[50] = `777 as c0`;
+    const stmt = db.prepare(`select ${cols.join(", ")}`);
+    const names = stmt.columnNames;
+    expect(names.length).toBe(70);
+    expect(names[0]).toBe("c0");
+    expect(names[50]).toBe("c0");
+    const row = stmt.get();
+    expect(row.c0).toBe(777);
+    expect(row.c49).toBe(49);
+    expect(row.c51).toBe(51);
+    db.close();
+  });
+});
+
 it("issue#7147", () => {
   const db = new Database(":memory:");
   db.exec("CREATE TABLE foos (foo_id INTEGER NOT NULL PRIMARY KEY, foo_a TEXT, foo_b TEXT)");

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1407,6 +1407,44 @@ describe("empty and duplicate column names", () => {
     expect(stmt.columnNames).toEqual(["first_col", "second_col", ""]);
   });
 
+  it('a trailing AS "" SELECT is still row-returning (all/values/raw return arrays, not a number)', () => {
+    using db = new Database(":memory:");
+    db.run("create table t(v)");
+    db.run("insert into t values ('r1'),('r2')");
+    using stmt = db.prepare('select v as name, 1 as "" from t');
+
+    // Previously: .all() returned the stale sqlite3_changes() count (a number),
+    // .values()/.raw() returned the column count, and .get() returned {}.
+    expect(stmt.all()).toEqual([
+      { name: "r1", "": 1 },
+      { name: "r2", "": 1 },
+    ]);
+    expect(stmt.values()).toEqual([
+      ["r1", 1],
+      ["r2", 1],
+    ]);
+    expect(Array.isArray(stmt.raw())).toBe(true);
+    expect(stmt.get()).toEqual({ name: "r1", "": 1 });
+    expect([...stmt.iterate()]).toEqual([
+      { name: "r1", "": 1 },
+      { name: "r2", "": 1 },
+    ]);
+    expect(stmt.columnNames).toEqual(["name", ""]);
+
+    using lone = db.prepare('select 9 as ""');
+    expect(lone.all()).toEqual([{ "": 9 }]);
+    expect(lone.values()).toEqual([[9]]);
+  });
+
+  it('a trailing AS "" SELECT with zero rows returns [], not null', () => {
+    using db = new Database(":memory:");
+    db.run("create table t(v)");
+    using stmt = db.prepare('select v as name, 1 as "" from t');
+    expect(stmt.all()).toEqual([]);
+    expect(stmt.values()).toEqual([]);
+    expect(stmt.raw()).toEqual([]);
+  });
+
   it("multiple empty aliases: last value wins on the row object, columnNames keeps all", () => {
     using db = new Database(":memory:");
     using stmt = db.prepare('select 1 as "", 2 as x, 3 as ""');


### PR DESCRIPTION
### Reproduction

```js
import { Database } from "bun:sqlite";
const db = new Database(":memory:");

// (A) an empty alias drops itself and every preceding column
db.prepare('select 1 as a, 2 as "", 3 as b').get();
// bun:  { b: 3 }           node:sqlite / better-sqlite3: { a: 1, "": 2, b: 3 }

// (B) a trailing empty alias makes .all()/.values()/.raw() return a number
db.run("create table t(v)"); db.run("insert into t values ('r1'),('r2')");
db.prepare('select v as name, 1 as "" from t').all();
// bun:  2   (a stale sqlite3_changes() count, not an array)
// .values()/.raw() return 2 (the column count); .get() returns {}

// (C) columnNames is de-duped and reordered
const s = db.prepare("select 1 as a, 2 as b, 3 as a");
s.columnNames;            // bun: ["b","a"]   node:sqlite: ["a","b","a"]
[s.columnNames.length, s.columnTypes.length, s.values()[0].length]; // 2 3 3
```

`.values()` returns all the data in (A), so that face is silent column loss. (B) is worse: `stmt.all().length` is `undefined` and `for (const r of stmt.all())` throws.

### Cause

`initializeColumnNames` in `src/jsc/bindings/sqlite/JSSQLStatement.cpp` walks the result columns in reverse and adds each name to a de-duplicating `PropertyNameArrayBuilder`, then reverses the vector at the end.

- When it hits an empty name (`AS ""`), both the fast path and the slow path `break` out of the loop. Because iteration is in reverse, that drops the empty-name column and every column before it. With a trailing `""` the loop bails on the first step and leaves `columnNames` empty.
- `all()`, `values()` and `raw()` branch on `castedThis->columnNames->size() == 0` to decide "this was an UPDATE, return the changes/column count". With an empty `columnNames`, a row-returning SELECT falls into that branch and hands back a bare number.
- The `columnNames` getter returns that same de-duplicated property-name vector, so with duplicate column names it comes back shorter than `columnTypes` / `declaredTypes` / `values()[0]` and in a different order.

### Fix

- Treat an empty column name as an ordinary property name (`""` is a valid object key) in both the fast and slow paths instead of breaking out of the loop. Repeated empty names de-dup like any other duplicate, so the last one wins on the row object.
- Source `columnCount` in `all()`/`values()`/`raw()` from `sqlite3_column_count(stmt)` instead of `columnNames->size()`, so the row-vs-changes decision does not depend on the name scan at all.
- Build the `columnNames` getter directly from `sqlite3_column_name` for each `i` in `[0, sqlite3_column_count(stmt))`, so its length always matches the column count and duplicates and order are preserved. This matches `node:sqlite` and `better-sqlite3` and lines up with `columnTypes` / `declaredTypes` / `values()`.

One behavior note: `stmt.columnNames` after `stmt.finalize()` now throws `"Statement has finalized"`, matching `columnTypes` / `declaredTypes` / `paramsCount` / `columnsCount` which already did. Previously it returned the cached (and, per this bug, wrong) de-duplicated array. Reading `columnNames` after `db.close()` is unchanged, since `close()` does not null the underlying `sqlite3_stmt*`.

### Verification

New `describe("empty and duplicate column names")` block in `test/js/bun/sqlite/sqlite.test.js` covers all three faces on the fast path and the >64-column slow path. All eight cases fail on `USE_SYSTEM_BUN=1` and pass on `bun bd`; the full `sqlite.test.js` (98) and `node-sqlite.test.ts` (115) suites are green.
