### PR TITLE
node:crypto: accept options object in crypto.hash() for outputEncoding/outputLength

### DIFF
--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -70,7 +70,7 @@ const {
 
 const normalizeEncoding = $newRustFunction("node_util_binding.rs", "normalizeEncoding", 1);
 
-const { validateString } = require("internal/validators");
+const { validateString, validateObject, validateUint32 } = require("internal/validators");
 const { deprecate } = require("internal/util/deprecate");
 
 const kHandle = Symbol("kHandle");
@@ -151,7 +151,30 @@ crypto_exports.createPrivateKey = createPrivateKey;
 var webcrypto = crypto;
 var _subtle = webcrypto.subtle;
 
-crypto_exports.hash = function hash(algorithm, input, outputEncoding = "hex") {
+crypto_exports.hash = function hash(algorithm, input, options) {
+  let outputEncoding;
+  let outputLength;
+
+  if (typeof options === "string") {
+    outputEncoding = options;
+  } else if (options !== undefined) {
+    validateObject(options, "options");
+    outputLength = options.outputLength;
+    outputEncoding = options.outputEncoding;
+  }
+
+  outputEncoding ??= "hex";
+  if (outputEncoding !== "hex") {
+    validateString(outputEncoding, "outputEncoding");
+  }
+
+  if (outputLength !== undefined) {
+    validateUint32(outputLength, "outputLength");
+    const h = new _Hash(algorithm, { outputLength });
+    h.update(h, input);
+    return h.digest(outputEncoding);
+  }
+
   return CryptoHasher.hash(algorithm, input, outputEncoding);
 };
 

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -73,8 +73,6 @@ const normalizeEncoding = $newRustFunction("node_util_binding.rs", "normalizeEnc
 const { validateString, validateObject, validateUint32 } = require("internal/validators");
 const { deprecate } = require("internal/util/deprecate");
 
-const StringPrototypeToLowerCase = String.prototype.toLowerCase;
-
 const kHandle = Symbol("kHandle");
 
 function verifySpkac(spkac, encoding) {
@@ -169,13 +167,10 @@ crypto_exports.hash = function hash(algorithm, input, options) {
   let normalized = outputEncoding;
   if (normalized !== "hex") {
     validateString(outputEncoding, "outputEncoding");
+    // Bun's normalizeEncoding recognizes "buffer" case-insensitively, unlike Node's.
     normalized = normalizeEncoding(outputEncoding);
     if (normalized === undefined) {
-      if (StringPrototypeToLowerCase.$call(outputEncoding) === "buffer") {
-        normalized = "buffer";
-      } else {
-        throw $ERR_INVALID_ARG_VALUE("outputEncoding", outputEncoding);
-      }
+      throw $ERR_INVALID_ARG_VALUE("outputEncoding", outputEncoding);
     }
   }
 

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -73,6 +73,8 @@ const normalizeEncoding = $newRustFunction("node_util_binding.rs", "normalizeEnc
 const { validateString, validateObject, validateUint32 } = require("internal/validators");
 const { deprecate } = require("internal/util/deprecate");
 
+const StringPrototypeToLowerCase = String.prototype.toLowerCase;
+
 const kHandle = Symbol("kHandle");
 
 function verifySpkac(spkac, encoding) {
@@ -169,7 +171,7 @@ crypto_exports.hash = function hash(algorithm, input, options) {
     validateString(outputEncoding, "outputEncoding");
     normalized = normalizeEncoding(outputEncoding);
     if (normalized === undefined) {
-      if (outputEncoding.toLowerCase() === "buffer") {
+      if (StringPrototypeToLowerCase.$call(outputEncoding) === "buffer") {
         normalized = "buffer";
       } else {
         throw $ERR_INVALID_ARG_VALUE("outputEncoding", outputEncoding);

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -70,7 +70,7 @@ const {
 
 const normalizeEncoding = $newRustFunction("node_util_binding.rs", "normalizeEncoding", 1);
 
-const { validateString, validateObject, validateUint32 } = require("internal/validators");
+const { validateString } = require("internal/validators");
 const { deprecate } = require("internal/util/deprecate");
 
 const kHandle = Symbol("kHandle");
@@ -151,37 +151,8 @@ crypto_exports.createPrivateKey = createPrivateKey;
 var webcrypto = crypto;
 var _subtle = webcrypto.subtle;
 
-crypto_exports.hash = function hash(algorithm, input, options) {
-  let outputEncoding;
-  let outputLength;
-
-  if (typeof options === "string") {
-    outputEncoding = options;
-  } else if (options !== undefined) {
-    validateObject(options, "options");
-    outputLength = options.outputLength;
-    outputEncoding = options.outputEncoding;
-  }
-
-  outputEncoding ??= "hex";
-  let normalized = outputEncoding;
-  if (normalized !== "hex") {
-    validateString(outputEncoding, "outputEncoding");
-    // Bun's normalizeEncoding recognizes "buffer" case-insensitively, unlike Node's.
-    normalized = normalizeEncoding(outputEncoding);
-    if (normalized === undefined) {
-      throw $ERR_INVALID_ARG_VALUE("outputEncoding", outputEncoding);
-    }
-  }
-
-  if (outputLength !== undefined) {
-    validateUint32(outputLength, "outputLength");
-    const h = new _Hash(algorithm, { outputLength });
-    h.update(h, input);
-    return h.digest(normalized);
-  }
-
-  return CryptoHasher.hash(algorithm, input, normalized);
+crypto_exports.hash = function hash(algorithm, input, outputEncoding = "hex") {
+  return CryptoHasher.hash(algorithm, input, outputEncoding);
 };
 
 // TODO: move this to zig

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -164,18 +164,27 @@ crypto_exports.hash = function hash(algorithm, input, options) {
   }
 
   outputEncoding ??= "hex";
-  if (outputEncoding !== "hex") {
+  let normalized = outputEncoding;
+  if (normalized !== "hex") {
     validateString(outputEncoding, "outputEncoding");
+    normalized = normalizeEncoding(outputEncoding);
+    if (normalized === undefined) {
+      if (outputEncoding.toLowerCase() === "buffer") {
+        normalized = "buffer";
+      } else {
+        throw $ERR_INVALID_ARG_VALUE("outputEncoding", outputEncoding);
+      }
+    }
   }
 
   if (outputLength !== undefined) {
     validateUint32(outputLength, "outputLength");
     const h = new _Hash(algorithm, { outputLength });
     h.update(h, input);
-    return h.digest(outputEncoding);
+    return h.digest(normalized);
   }
 
-  return CryptoHasher.hash(algorithm, input, outputEncoding);
+  return CryptoHasher.hash(algorithm, input, normalized);
 };
 
 // TODO: move this to zig

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -6,12 +6,13 @@ use bun_boringssl_sys as boring_ssl;
 use bun_core::ZigString;
 use bun_jsc::{
     ArrayBuffer, CallFrame, ErrorCode, JSGlobalObject, JSObject, JSValue, JsCell, JsClass as _,
-    JsError, JsResult,
+    JsError, JsResult, ZigStringSlice,
 };
 
 use crate::crypto::evp::{AlgorithmExt as _, EVP};
 use crate::crypto::{HMAC, create_crypto_error, evp};
 use crate::generated_classes::PropertyName;
+use crate::node::util::validators;
 use crate::node::{BlobOrStringOrBuffer, Encoding, StringOrBuffer};
 use bun_sha_hmac::sha as hashers;
 
@@ -279,7 +280,7 @@ impl CryptoHasher {
             }
         };
 
-        // ?Node.StringOrBuffer (static-method arm: only `undefined` → None)
+        let mut output_length: Option<u32> = None;
         let output: Option<StringOrBuffer> = match next_eat() {
             Some(arg) => match StringOrBuffer::from_js(global, arg)? {
                 Some(v) => Some(v),
@@ -287,15 +288,36 @@ impl CryptoHasher {
                     if arg.is_undefined() {
                         None
                     } else {
-                        return Err(global
-                            .throw_invalid_arguments(format_args!("expected string or buffer")));
+                        validators::validate_object(
+                            global,
+                            arg,
+                            "options",
+                            validators::ValidateObjectOptions::default(),
+                        )?;
+                        if let Some(len) = arg.get(global, "outputLength")? {
+                            output_length = Some(validators::validate_uint32(
+                                global,
+                                len,
+                                "outputLength",
+                                false,
+                            )?);
+                        }
+                        match arg.get(global, "outputEncoding")? {
+                            Some(enc) if !enc.is_null() => {
+                                validators::validate_string(global, enc, "outputEncoding")?;
+                                StringOrBuffer::from_js(global, enc)?
+                            }
+                            _ => Some(StringOrBuffer::EncodedSlice(
+                                ZigStringSlice::from_utf8_never_free(b"hex"),
+                            )),
+                        }
                     }
                 }
             },
             None => None,
         };
 
-        Self::hash_(global, algorithm, &input, output)
+        Self::hash_(global, algorithm, &input, output, output_length)
     }
 
     fn throw_hmac_consumed(global: &JSGlobalObject) -> JsError {
@@ -421,20 +443,40 @@ impl CryptoHasher {
         algorithm: ZigString,
         input: &BlobOrStringOrBuffer,
         output: Option<StringOrBuffer>,
+        output_length: Option<u32>,
     ) -> JsResult<JSValue> {
         let mut evp = match EVP::by_name(&algorithm, global) {
             Some(e) => e,
-            None => match CryptoHasherZig::hash_by_name(global, &algorithm, input, output)? {
-                Some(v) => return Ok(v),
-                None => {
-                    return Err(global.throw_invalid_arguments(format_args!(
-                        "Unsupported algorithm \"{}\"",
-                        algorithm
-                    )));
+            None => {
+                match CryptoHasherZig::hash_by_name(
+                    global,
+                    &algorithm,
+                    input,
+                    output,
+                    output_length,
+                )? {
+                    Some(v) => return Ok(v),
+                    None => {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "Unsupported algorithm \"{}\"",
+                            algorithm
+                        )));
+                    }
                 }
-            },
+            }
         };
         // `defer evp.deinit()` — handled by Drop on `evp`.
+
+        if let Some(len) = output_length {
+            // BoringSSL-backed algorithms are all fixed-length; XOF goes through
+            // CryptoHasherZig above.
+            if u32::from(evp.size()) != len {
+                return Err(global.throw(format_args!(
+                    "Output length {} is invalid for {}, which does not support XOF",
+                    len, algorithm
+                )));
+            }
+        }
 
         if let Some(string_or_buffer) = output {
             if let StringOrBuffer::Buffer(buffer) = &string_or_buffer {
@@ -814,6 +856,7 @@ pub trait ZigHashAlgo: Default + Clone + 'static {
     const ALGORITHM: evp::Algorithm;
     /// Shake128→16, Shake256→32, else the algorithm's digest length.
     const DIGEST_LENGTH: u8;
+    const IS_XOF: bool = false;
     fn init() -> Self {
         Self::default()
     }
@@ -864,6 +907,7 @@ mod zig_crypto_algos {
             impl ZigHashAlgo for $ty {
                 const ALGORITHM: evp::Algorithm = evp::Algorithm::$variant;
                 const DIGEST_LENGTH: u8 = $len;
+                const IS_XOF: bool = true;
                 fn update(&mut self, bytes: &[u8]) {
                     Update::update(self, bytes);
                 }
@@ -904,31 +948,50 @@ impl CryptoHasherZig {
         algorithm: &ZigString,
         input: &BlobOrStringOrBuffer,
         output: Option<StringOrBuffer>,
+        output_length: Option<u32>,
     ) -> JsResult<Option<JSValue>> {
         let name = algorithm.to_slice();
         let Some(algo) = evp::lookup_ignore_case(name.slice()) else {
             return Ok(None);
         };
         macro_rules! arm {
-            ($ty:ty, $g:expr, $alg:expr, $in:expr, $out:expr) => {
+            ($ty:ty, $g:expr, $alg:expr, $in:expr, $out:expr, $len:expr) => {
                 if $alg == <$ty as ZigHashAlgo>::ALGORITHM {
-                    return Ok(Some(Self::hash_by_name_inner::<$ty>($g, $in, $out)?));
+                    return Ok(Some(Self::hash_by_name_inner::<$ty>($g, $in, $out, $len)?));
                 }
             };
         }
-        for_each_zig_algo!(arm, global, algo, input, output);
+        for_each_zig_algo!(arm, global, algo, input, output, output_length);
         Ok(None)
+    }
+
+    fn resolve_output_length<A: ZigHashAlgo>(
+        global: &JSGlobalObject,
+        output_length: Option<u32>,
+    ) -> JsResult<usize> {
+        match output_length {
+            Some(len) if A::IS_XOF => Ok(len as usize),
+            Some(len) if len == u32::from(A::DIGEST_LENGTH) => Ok(len as usize),
+            Some(len) => Err(global.throw(format_args!(
+                "Output length {} is invalid for {}, which does not support XOF",
+                len,
+                bstr::BStr::new(A::ALGORITHM.tag_cstr().to_bytes())
+            ))),
+            None => Ok(A::DIGEST_LENGTH as usize),
+        }
     }
 
     fn hash_by_name_inner<A: ZigHashAlgo>(
         global: &JSGlobalObject,
         input: &BlobOrStringOrBuffer,
         output: Option<StringOrBuffer>,
+        output_length: Option<u32>,
     ) -> JsResult<JSValue> {
+        let len = Self::resolve_output_length::<A>(global, output_length)?;
         if let Some(string_or_buffer) = output {
             if let StringOrBuffer::Buffer(buffer) = &string_or_buffer {
                 let ab = buffer.buffer;
-                return Self::hash_by_name_inner_to_bytes::<A>(global, input, Some(ab));
+                return Self::hash_by_name_inner_to_bytes::<A>(global, input, Some(ab), len);
             }
             let Some(encoding) = Encoding::from(string_or_buffer.slice()) else {
                 return Err(global
@@ -943,18 +1006,19 @@ impl CryptoHasherZig {
             };
 
             if encoding == Encoding::Buffer {
-                return Self::hash_by_name_inner_to_bytes::<A>(global, input, None);
+                return Self::hash_by_name_inner_to_bytes::<A>(global, input, None, len);
             }
 
-            return Self::hash_by_name_inner_to_string::<A>(global, input, encoding);
+            return Self::hash_by_name_inner_to_string::<A>(global, input, encoding, len);
         }
-        Self::hash_by_name_inner_to_bytes::<A>(global, input, None)
+        Self::hash_by_name_inner_to_bytes::<A>(global, input, None, len)
     }
 
     fn hash_by_name_inner_to_string<A: ZigHashAlgo>(
         global: &JSGlobalObject,
         input: &BlobOrStringOrBuffer,
         encoding: Encoding,
+        len: usize,
     ) -> JsResult<JSValue> {
         // `defer input.deinit()` — handled by Drop.
 
@@ -964,23 +1028,29 @@ impl CryptoHasherZig {
             )));
         }
 
+        if len == 0 {
+            return bun_jsc::bun_string_jsc::create_utf8_for_js(global, b"");
+        }
+
         let mut h = A::init();
         h.update(input.slice());
 
-        // Const-generic array length from trait assoc const requires
-        // `feature(generic_const_exprs)` — use a stack buffer of EVP_MAX_MD_SIZE
-        // sliced to A::DIGEST_LENGTH instead.
-        let mut out = [0u8; EVP_MAX_MD_SIZE_USIZE];
-        let len = A::DIGEST_LENGTH as usize;
-        h.final_(&mut out[..len]);
-
-        encoding.encode_with_max_size(global, EVP_MAX_MD_SIZE_USIZE, &out[..len])
+        if len <= EVP_MAX_MD_SIZE_USIZE {
+            let mut out = [0u8; EVP_MAX_MD_SIZE_USIZE];
+            h.final_(&mut out[..len]);
+            encoding.encode_with_max_size(global, EVP_MAX_MD_SIZE_USIZE, &out[..len])
+        } else {
+            let mut out = vec![0u8; len];
+            h.final_(&mut out);
+            encoding.encode_with_size(global, len, &out)
+        }
     }
 
     fn hash_by_name_inner_to_bytes<A: ZigHashAlgo>(
         global: &JSGlobalObject,
         input: &BlobOrStringOrBuffer,
         output: Option<ArrayBuffer>,
+        len: usize,
     ) -> JsResult<JSValue> {
         // `defer input.deinit()` — handled by Drop.
 
@@ -990,14 +1060,20 @@ impl CryptoHasherZig {
             )));
         }
 
+        if len == 0 {
+            return match output {
+                Some(output_buf) => Ok(output_buf.value),
+                None => ArrayBuffer::create_buffer(global, &[]),
+            };
+        }
+
         let mut h = A::init();
-        let digest_length_comptime = A::DIGEST_LENGTH as usize;
 
         if let Some(output_buf) = &output {
-            if output_buf.byte_slice().len() < digest_length_comptime {
+            if output_buf.byte_slice().len() < len {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "TypedArray must be at least {} bytes",
-                    digest_length_comptime
+                    len
                 )));
             }
         }
@@ -1009,15 +1085,18 @@ impl CryptoHasherZig {
             // writable backing store, outliving this frame. Build the `&mut`
             // directly from the raw `*mut u8` field — never via `&[u8].as_ptr()`
             // (Stacked-Borrows UB).
-            let out =
-                unsafe { core::slice::from_raw_parts_mut(output_buf.ptr, digest_length_comptime) };
+            let out = unsafe { core::slice::from_raw_parts_mut(output_buf.ptr, len) };
             h.final_(out);
             Ok(output_buf.value)
-        } else {
+        } else if len <= EVP_MAX_MD_SIZE_USIZE {
             let mut out = [0u8; EVP_MAX_MD_SIZE_USIZE];
-            h.final_(&mut out[..digest_length_comptime]);
+            h.final_(&mut out[..len]);
             // Clone to GC-managed memory
-            ArrayBuffer::create_buffer(global, &out[..digest_length_comptime])
+            ArrayBuffer::create_buffer(global, &out[..len])
+        } else {
+            let mut out = vec![0u8; len].into_boxed_slice();
+            h.final_(&mut out);
+            Ok(JSValue::create_buffer_from_box(global, out))
         }
     }
 

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -255,12 +255,20 @@ impl CryptoHasher {
             string_value.get_zig_string(global)?
         };
 
-        // Parse the output/options argument before decoding `input`: option
-        // getters can run user JS that detaches or resizes the input buffer,
-        // so all user-JS re-entry must happen before the input pointer is
-        // captured.
+        // Reading options-object properties (.get) can run user getters, and
+        // decoding a StringObject input can run [Symbol.toPrimitive]. Both are
+        // user-JS re-entry points that may detach or resize a buffer argument.
+        // Do every such read before any raw pointer is captured: option reads
+        // first, then input decode (captures the input pointer), then finally
+        // wrap the output TypedArray (captures the output pointer) with no
+        // user JS in between.
         let mut output_length: Option<u32> = None;
-        let output: Option<StringOrBuffer> = match arg_at(2) {
+        let mut deferred_output_buffer: Option<JSValue> = None;
+        let mut output: Option<StringOrBuffer> = match arg_at(2) {
+            Some(arg) if arg.js_type().is_array_buffer_like() => {
+                deferred_output_buffer = Some(arg);
+                None
+            }
             Some(arg) => match StringOrBuffer::from_js(global, arg)? {
                 Some(v) => Some(v),
                 None => {
@@ -296,7 +304,6 @@ impl CryptoHasher {
             None => None,
         };
 
-        // Node.BlobOrStringOrBuffer
         let input = {
             let Some(arg) = arg_at(1) else {
                 return Err(
@@ -311,6 +318,10 @@ impl CryptoHasher {
                 }
             }
         };
+
+        if let Some(arg) = deferred_output_buffer {
+            output = StringOrBuffer::from_js(global, arg)?;
+        }
 
         Self::hash_(global, algorithm, &input, output, output_length)
     }

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -243,19 +243,10 @@ impl CryptoHasher {
     /// `(algorithm string, input, optional output buffer/encoding)`.
     pub fn hash(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments();
-        let mut i = 0usize;
-        let mut next_eat = || {
-            if i < arguments.len() {
-                let v = arguments[i];
-                i += 1;
-                Some(v)
-            } else {
-                None
-            }
-        };
+        let arg_at = |i: usize| arguments.get(i).copied();
 
         let algorithm = {
-            let Some(string_value) = next_eat() else {
+            let Some(string_value) = arg_at(0) else {
                 return Err(global.throw_invalid_arguments(format_args!("Missing argument")));
             };
             if string_value.is_undefined_or_null() {
@@ -264,24 +255,12 @@ impl CryptoHasher {
             string_value.get_zig_string(global)?
         };
 
-        // Node.BlobOrStringOrBuffer
-        let input = {
-            let Some(arg) = next_eat() else {
-                return Err(
-                    global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
-                );
-            };
-            match BlobOrStringOrBuffer::from_js(global, arg)? {
-                Some(b) => b,
-                None => {
-                    return Err(global
-                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
-                }
-            }
-        };
-
+        // Parse the output/options argument before decoding `input`: option
+        // getters can run user JS that detaches or resizes the input buffer,
+        // so all user-JS re-entry must happen before the input pointer is
+        // captured.
         let mut output_length: Option<u32> = None;
-        let output: Option<StringOrBuffer> = match next_eat() {
+        let output: Option<StringOrBuffer> = match arg_at(2) {
             Some(arg) => match StringOrBuffer::from_js(global, arg)? {
                 Some(v) => Some(v),
                 None => {
@@ -315,6 +294,22 @@ impl CryptoHasher {
                 }
             },
             None => None,
+        };
+
+        // Node.BlobOrStringOrBuffer
+        let input = {
+            let Some(arg) = arg_at(1) else {
+                return Err(
+                    global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
+                );
+            };
+            match BlobOrStringOrBuffer::from_js(global, arg)? {
+                Some(b) => b,
+                None => {
+                    return Err(global
+                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
+                }
+            }
         };
 
         Self::hash_(global, algorithm, &input, output, output_length)

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -255,13 +255,9 @@ impl CryptoHasher {
             string_value.get_zig_string(global)?
         };
 
-        // Reading options-object properties (.get) can run user getters, and
-        // decoding a StringObject input can run [Symbol.toPrimitive]. Both are
-        // user-JS re-entry points that may detach or resize a buffer argument.
-        // Do every such read before any raw pointer is captured: option reads
-        // first, then input decode (captures the input pointer), then finally
-        // wrap the output TypedArray (captures the output pointer) with no
-        // user JS in between.
+        // Option getters and input ToPrimitive can run user JS that resizes a
+        // buffer argument, so capture raw pointers last: option reads, then
+        // input decode, then the deferred output-TypedArray wrap.
         let mut output_length: Option<u32> = None;
         let mut deferred_output_buffer: Option<JSValue> = None;
         let mut output: Option<StringOrBuffer> = match arg_at(2) {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -755,6 +755,18 @@ impl Encoding {
             .throw()
     }
 
+    /// Thin assertion wrapper over `encode_with_max_size`.
+    #[inline]
+    pub fn encode_with_size(
+        self,
+        global_object: &JSGlobalObject,
+        size: usize,
+        input: &[u8],
+    ) -> JsResult<JSValue> {
+        debug_assert_eq!(input.len(), size);
+        self.encode_with_max_size(global_object, size, input)
+    }
+
     /// `max_size` is a runtime arg (see `encode_with_size`); callers pass
     /// `EVP_MAX_MD_SIZE` etc.
     pub fn encode_with_max_size(

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -376,7 +376,9 @@ pub(crate) fn validate_object(
             ));
         }
 
-        if !value.is_object() && (!options.allow_function() || !value.js_type().is_function()) {
+        if (!value.is_object() || value.is_callable())
+            && (!options.allow_function() || !value.js_type().is_function())
+        {
             return Err(throw_err_invalid_arg_type(
                 global_this,
                 name,

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -340,7 +340,7 @@ pub(crate) fn validate_object(
     options: ValidateObjectOptions,
 ) -> JsResult<()> {
     if !options.allow_nullable() && !options.allow_array() && !options.allow_function() {
-        if value.is_null() || value.js_type().is_array() {
+        if value.is_null() || value.js_type().is_array() || value.is_callable() {
             return Err(throw_err_invalid_arg_type(
                 global_this,
                 name,

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -377,7 +377,7 @@ pub(crate) fn validate_object(
         }
 
         if (!value.is_object() || value.is_callable())
-            && (!options.allow_function() || !value.js_type().is_function())
+            && (!options.allow_function() || !value.is_callable())
         {
             return Err(throw_err_invalid_arg_type(
                 global_this,

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -21,7 +21,7 @@ describe("crypto.hash", () => {
       );
     });
 
-    [null, true, 1, () => {}, {}].forEach(invalid => {
+    [null, true, 1, () => {}, []].forEach(invalid => {
       expect(() => crypto.hash("sha1", "test", invalid)).toThrow(
         expect.objectContaining({
           code: "ERR_INVALID_ARG_TYPE",
@@ -33,6 +33,56 @@ describe("crypto.hash", () => {
       expect.objectContaining({
         code: "ERR_INVALID_ARG_VALUE",
       }),
+    );
+  });
+
+  test("accepts an options object for the third argument", () => {
+    const expectedHex = crypto.createHash("sha256").update("abc").digest("hex");
+    const expectedBase64 = crypto.createHash("sha256").update("abc").digest("base64");
+
+    expect(crypto.hash("sha256", "abc", {})).toBe(expectedHex);
+    expect(crypto.hash("sha256", "abc", { outputEncoding: undefined })).toBe(expectedHex);
+    expect(crypto.hash("sha256", "abc", { outputEncoding: "hex" })).toBe(expectedHex);
+    expect(crypto.hash("sha256", "abc", { outputEncoding: "base64" })).toBe(expectedBase64);
+
+    const buf = crypto.hash("sha256", "abc", { outputEncoding: "buffer" });
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.toString("hex")).toBe(expectedHex);
+
+    expect(() => crypto.hash("sha256", "abc", { outputEncoding: 42 })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+
+  test("options.outputLength controls XOF digest length", () => {
+    for (const [algorithm, length] of [
+      ["shake128", 8],
+      ["shake128", 64],
+      ["shake256", 16],
+    ] as const) {
+      const expected = crypto.createHash(algorithm, { outputLength: length }).update("abc").digest("hex");
+      expect(crypto.hash(algorithm, "abc", { outputLength: length })).toBe(expected);
+      expect(crypto.hash(algorithm, "abc", { outputLength: length, outputEncoding: "hex" })).toBe(expected);
+
+      const buf = crypto.hash(algorithm, Buffer.from("abc"), { outputLength: length, outputEncoding: "buffer" });
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.length).toBe(length);
+      expect(buf.toString("hex")).toBe(expected);
+    }
+
+    expect(crypto.hash("shake128", "abc", { outputLength: 0 })).toBe("");
+
+    expect(crypto.hash("sha256", "abc", { outputLength: 32 })).toBe(
+      crypto.createHash("sha256").update("abc").digest("hex"),
+    );
+
+    for (const invalid of [-1, 1.5, NaN, 2 ** 32]) {
+      expect(() => crypto.hash("shake128", "abc", { outputLength: invalid })).toThrow(
+        expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+      );
+    }
+    expect(() => crypto.hash("shake128", "abc", { outputLength: "8" })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );
   });
   const input = readFileSync(path("utf8_test_text.txt"));

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -85,6 +85,8 @@ describe("crypto.hash", () => {
     expect(crypto.hash("sha256", "abc", { outputLength: 32 })).toBe(
       crypto.createHash("sha256").update("abc").digest("hex"),
     );
+    expect(() => crypto.hash("sha256", "abc", { outputLength: 16 })).toThrow(/does not support XOF/);
+    expect(() => crypto.hash("sha3-256", "abc", { outputLength: 16 })).toThrow(/does not support XOF/);
 
     for (const invalid of [-1, 1.5, NaN, 2 ** 32]) {
       expect(() => crypto.hash("shake128", "abc", { outputLength: invalid })).toThrow(
@@ -94,6 +96,26 @@ describe("crypto.hash", () => {
     expect(() => crypto.hash("shake128", "abc", { outputLength: "8" })).toThrow(
       expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
     );
+  });
+
+  test("option getters cannot invalidate the input buffer mid-call", () => {
+    const ab = new ArrayBuffer(64, { maxByteLength: 64 });
+    const view = new Uint8Array(ab);
+    view.fill(0x61);
+    const expected = crypto.createHash("sha256").update(Buffer.alloc(64, 0x61)).digest("hex");
+    let called = 0;
+    const result = crypto.hash("sha256", view, {
+      get outputLength() {
+        called++;
+        ab.resize(0);
+        return undefined;
+      },
+    });
+    expect(called).toBe(1);
+    // After the getter runs the view is length 0; the hash must reflect that,
+    // not the 64 bytes that existed when the call started.
+    expect(result).toBe(crypto.createHash("sha256").update(Buffer.alloc(0)).digest("hex"));
+    expect(result).not.toBe(expected);
   });
   const input = readFileSync(path("utf8_test_text.txt"));
   [

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -45,9 +45,11 @@ describe("crypto.hash", () => {
     expect(crypto.hash("sha256", "abc", { outputEncoding: "hex" })).toBe(expectedHex);
     expect(crypto.hash("sha256", "abc", { outputEncoding: "base64" })).toBe(expectedBase64);
 
-    const buf = crypto.hash("sha256", "abc", { outputEncoding: "buffer" });
-    expect(Buffer.isBuffer(buf)).toBe(true);
-    expect(buf.toString("hex")).toBe(expectedHex);
+    for (const enc of ["buffer", "Buffer", "BUFFER"]) {
+      const buf = crypto.hash("sha256", "abc", { outputEncoding: enc });
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.toString("hex")).toBe(expectedHex);
+    }
 
     expect(() => crypto.hash("sha256", "abc", { outputEncoding: 42 })).toThrow(
       expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -61,8 +61,10 @@ describe("crypto.hash", () => {
       ["shake256", 16],
     ] as const) {
       const expected = crypto.createHash(algorithm, { outputLength: length }).update("abc").digest("hex");
+      const expectedBase64 = crypto.createHash(algorithm, { outputLength: length }).update("abc").digest("base64");
       expect(crypto.hash(algorithm, "abc", { outputLength: length })).toBe(expected);
       expect(crypto.hash(algorithm, "abc", { outputLength: length, outputEncoding: "hex" })).toBe(expected);
+      expect(crypto.hash(algorithm, "abc", { outputLength: length, outputEncoding: "base64" })).toBe(expectedBase64);
 
       const buf = crypto.hash(algorithm, Buffer.from("abc"), { outputLength: length, outputEncoding: "buffer" });
       expect(Buffer.isBuffer(buf)).toBe(true);

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -72,6 +72,10 @@ describe("crypto.hash", () => {
 
     expect(crypto.hash("shake128", "abc", { outputLength: 0 })).toBe("");
 
+    expect(() => crypto.hash("shake128", "abc", { outputLength: 8, outputEncoding: "not an encoding" })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+    );
+
     expect(crypto.hash("sha256", "abc", { outputLength: 32 })).toBe(
       crypto.createHash("sha256").update("abc").digest("hex"),
     );

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -61,6 +61,7 @@ describe("crypto.hash", () => {
       ["shake128", 8],
       ["shake128", 64],
       ["shake256", 16],
+      ["shake256", 256],
     ] as const) {
       const expected = crypto.createHash(algorithm, { outputLength: length }).update("abc").digest("hex");
       const expectedBase64 = crypto.createHash(algorithm, { outputLength: length }).update("abc").digest("base64");
@@ -75,6 +76,7 @@ describe("crypto.hash", () => {
     }
 
     expect(crypto.hash("shake128", "abc", { outputLength: 0 })).toBe("");
+    expect(crypto.hash("shake128", "abc", { outputLength: 0, outputEncoding: "buffer" })).toEqual(Buffer.alloc(0));
 
     expect(() => crypto.hash("shake128", "abc", { outputLength: 8, outputEncoding: "not an encoding" })).toThrow(
       expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -117,6 +117,26 @@ describe("crypto.hash", () => {
     expect(result).toBe(crypto.createHash("sha256").update(Buffer.alloc(0)).digest("hex"));
     expect(result).not.toBe(expected);
   });
+
+  test("input ToPrimitive cannot invalidate the output buffer mid-call", () => {
+    const outAB = new ArrayBuffer(64, { maxByteLength: 64 });
+    const outView = new Uint8Array(outAB);
+    let called = 0;
+    class Evil extends String {
+      [Symbol.toPrimitive]() {
+        called++;
+        outAB.resize(0);
+        return "abc";
+      }
+    }
+    // The output-buffer form is a Bun extension; the third-argument TypedArray
+    // must not have its backing pointer captured before input coercion runs.
+    expect(() => Bun.CryptoHasher.hash("sha256", new Evil("abc"), outView)).toThrow(
+      /TypedArray must be at least 32 bytes/,
+    );
+    expect(called).toBe(1);
+    expect(outView.byteLength).toBe(0);
+  });
   const input = readFileSync(path("utf8_test_text.txt"));
   [
     "blake2b256",


### PR DESCRIPTION
## What does this PR do?

`crypto.hash(algorithm, data, options)` now accepts the Node.js 24.4+ options-object form of the third argument:

```js
crypto.hash('sha256', 'abc', { outputEncoding: 'base64' })
crypto.hash('shake128', 'abc', { outputLength: 8 })
crypto.hash('shake256', data, { outputLength: 64, outputEncoding: 'buffer' })
```

Previously only the legacy string-encoding form (`crypto.hash('sha256', 'abc', 'base64')`) was accepted; passing an object threw `ERR_INVALID_ARG_TYPE: expected string or buffer`. That made XOF (SHAKE128/256) digests of non-default length unreachable through the one-shot API, and code following the current Node.js docs or silencing Node's DEP0198 (which deprecates SHAKE without `options.outputLength`) failed on Bun.

## Repro

```js
import crypto from 'node:crypto';
console.log(crypto.hash('sha256', 'abc', { outputEncoding: 'base64' }));
// before: TypeError: expected string or buffer
// after:  ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=

console.log(crypto.hash('shake128', 'abc', { outputLength: 8 }));
// before: TypeError: expected string or buffer
// after:  5881092dd818bf5c
```

## How did you verify your code works?

- New tests in `test/js/node/crypto/crypto-oneshot.test.ts` cover `outputEncoding` as an option, `outputLength` for XOF hashes at various lengths (including 0 and >default), non-XOF algorithms with matching `outputLength`, and validation errors (`ERR_INVALID_ARG_TYPE` for bad `options`/`outputEncoding`, `ERR_OUT_OF_RANGE` for bad `outputLength`).
- Fail-before: new tests throw `TypeError: expected string or buffer` on current canary; all 37 pass with the fix.
- `test/js/node/crypto/node-crypto.test.js` (202 tests) and the Node parallel `test-crypto-oneshot-hash.js` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto-oneshot.test.ts
bun test v1.4.0 (184bfea38)

test/js/node/crypto/crypto-oneshot.test.ts:
(pass) crypto.hash > throws for invalid arguments [41.90ms]
38 | 
39 |   test("accepts an options object for the third argument", () => {
40 |     const expectedHex = crypto.createHash("sha256").update("abc").digest("hex");
41 |     const expectedBase64 = crypto.createHash("sha256").update("abc").digest("base64");
42 | 
43 |     expect(crypto.hash("sha256", "abc", {})).toBe(expectedHex);
                       ^
TypeError: expected string or buffer
      at <anonymous> (/workspace/bun/test/js/node/crypto/crypto-oneshot.test.ts:43:19)
(fail) crypto.hash > accepts an options object for the third argument [21.24ms]
63 |       ["shake256", 16],
64 |       ["shake256", 256],
65 |     ] as const) {
66 |       const expected = crypto.createHash(algorithm, { outputLength: length }).update("abc").digest("hex");
67 |       const expectedBase64 = crypto.createHash(algorithm, { outputLength: length }).update("abc").digest("base64");

... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b668b0941)

test/js/node/crypto/crypto-oneshot.test.ts:
(pass) crypto.hash > throws for invalid arguments [1.38ms]
(pass) crypto.hash > accepts an options object for the third argument [0.43ms]
(pass) crypto.hash > options.outputLength controls XOF digest length [3.13ms]
(pass) crypto.hash > option getters cannot invalidate the input buffer mid-call [0.25ms]
(pass) crypto.hash > input ToPrimitive cannot invalidate the output buffer mid-call [0.23ms]
(pass) crypto.hash > output matches crypto.createHash(blake2b256) [0.98ms]
(pass) crypto.hash > output matches crypto.createHash(blake2b512) [0.10ms]
(pass) crypto.hash > output matches crypto.createHash(blake2s256) [0.10ms]
(pass) crypto.hash > output matches crypto.createHash(ripemd160) [0.59ms]
(pass) crypto.hash > output matches crypto.createHash(rmd160) [0.10ms]
(pass) crypto.hash > output matches crypto.createHash(md4) [0.24ms]
(pass) crypto.hash > output matches crypto.createHash(md5) [0.17ms]
(pass) crypto.hash > output matches crypto.createHash(sha1) [0.81ms]
(pass) crypto.hash > output matches crypto.createHash(sha128) [0.05ms]
(pass) crypto.hash > output matches crypto.createHash(sha2
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto-oneshot.test.ts
bun test v1.4.0 (184bfea38)

test/js/node/crypto/crypto-oneshot.test.ts:
(pass) crypto.hash > throws for invalid arguments [25.81ms]
(pass) crypto.hash > accepts an options object for the third argument [17.03ms]
(pass) crypto.hash > options.outputLength controls XOF digest length [40.46ms]
(pass) crypto.hash > option getters cannot invalidate the input buffer mid-call [6.25ms]
(pass) crypto.hash > input ToPrimitive cannot invalidate the output buffer mid-call [10.05ms]
(pass) crypto.hash > output matches crypto.createHash(blake2b256) [7.07ms]
(pass) crypto.hash > output matches crypto.createHash(blake2b512) [4.09ms]
(pass) crypto.hash > output matches crypto.createHash(blake2s256) [6.85ms]
(pass) crypto.hash > output matches crypto.createHash(ripemd160) [3.06ms]
(pass) crypto.hash > output matches crypto.createHash(rmd160) [3.05ms]
(pass) crypto.hash > output matches crypto.createHash(md4) [5.70ms]
(pass) crypto.hash > output matches crypto.createHash(md5) [2.10ms]
(pass) crypto.hash > output
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 805ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/crypto/CryptoHasher.rs         | 203 ++++++++++++++++++++---------
 src/runtime/node/types.rs                  |  12 ++
 src/runtime/node/util/validators.rs        |   6 +-
 test/js/node/crypto/crypto-oneshot.test.ts | 104 ++++++++++++++-
 4 files changed, 261 insertions(+), 64 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/crypto/CryptoHasher.rs             14     17      0
src/runtime/node/types.rs                       7      2      0
src/runtime/node/util/validators.rs             3      3      0
test/js/node/crypto/crypto-oneshot.test.ts      6      9      0
```

</details>

<!-- robobun:evidence:end -->