### PR TITLE
node:crypto: sign and verify with sha512-224 and sha512-256

### DIFF
--- a/patches/boringssl/sha512t-sign.patch
+++ b/patches/boringssl/sha512t-sign.patch
@@ -1,17 +1,6 @@
 --- a/crypto/fipsmodule/rsa/rsa.cc.inc
 +++ b/crypto/fipsmodule/rsa/rsa.cc.inc
-@@ -413,6 +413,10 @@
-   uint8_t bytes[19];
- };
- 
-+// BoringSSL ships EVP_sha512_224 but only defines SHA512_256_DIGEST_LENGTH in
-+// <openssl/sha2.h>.
-+#define SHA512_224_DIGEST_LENGTH 28
-+
- // kPKCS1SigPrefixes contains the ASN.1 prefixes for PKCS#1 signatures with
- // different hash functions.
- static const struct pkcs1_sig_prefix kPKCS1SigPrefixes[] = {
-@@ -458,6 +462,22 @@
+@@ -458,6 +458,22 @@
          {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
           0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40},
      },

--- a/patches/boringssl/sha512t-sign.patch
+++ b/patches/boringssl/sha512t-sign.patch
@@ -1,0 +1,52 @@
+--- a/crypto/fipsmodule/rsa/rsa.cc.inc
++++ b/crypto/fipsmodule/rsa/rsa.cc.inc
+@@ -413,6 +413,10 @@
+   uint8_t bytes[19];
+ };
+ 
++// BoringSSL ships EVP_sha512_224 but only defines SHA512_256_DIGEST_LENGTH in
++// <openssl/sha2.h>.
++#define SHA512_224_DIGEST_LENGTH 28
++
+ // kPKCS1SigPrefixes contains the ASN.1 prefixes for PKCS#1 signatures with
+ // different hash functions.
+ static const struct pkcs1_sig_prefix kPKCS1SigPrefixes[] = {
+@@ -458,6 +462,22 @@
+         {0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
+          0x04, 0x02, 0x03, 0x05, 0x00, 0x04, 0x40},
+     },
++    // id-sha512-224 / id-sha512-256 (NIST CSOR 2.16.840.1.101.3.4.2.{5,6}) with
++    // the NULL parameters RFC 8017 specifies for PKCS#1 v1.5.
++    {
++        NID_sha512_224,
++        SHA512_224_DIGEST_LENGTH,
++        19,
++        {0x30, 0x2d, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
++         0x04, 0x02, 0x05, 0x05, 0x00, 0x04, 0x1c},
++    },
++    {
++        NID_sha512_256,
++        SHA512_256_DIGEST_LENGTH,
++        19,
++        {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03,
++         0x04, 0x02, 0x06, 0x05, 0x00, 0x04, 0x20},
++    },
+     {
+         NID_undef,
+         0,
+--- a/crypto/evp/p_ec.cc
++++ b/crypto/evp/p_ec.cc
+@@ -428,9 +428,12 @@
+     case EVP_PKEY_CTRL_MD: {
+       const EVP_MD *md = reinterpret_cast<const EVP_MD *>(p2);
+       int md_type = EVP_MD_type(md);
++      // pkey_ec_sign/pkey_ec_verify hand the digest straight to ECDSA_sign and
++      // never read dctx->md, so the truncated SHA-512 variants only need this gate.
+       if (md_type != NID_sha1 && md_type != NID_sha224 &&
+           md_type != NID_sha256 && md_type != NID_sha384 &&
+-          md_type != NID_sha512) {
++          md_type != NID_sha512 && md_type != NID_sha512_224 &&
++          md_type != NID_sha512_256) {
+         OPENSSL_PUT_ERROR(EVP, EVP_R_INVALID_DIGEST_TYPE);
+         return 0;
+       }

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -40,10 +40,9 @@ export const boringssl: Dependency = {
   // on Mach-O/COFF the hooks compile to static nullptr and OPENSSL_malloc goes
   // straight to libc. Declare them as plain externs so lib.rs binds everywhere.
   //
-  // sha512t-sign: BoringSSL exposes EVP_sha512_224/256 but leaves NID_sha512_224/256
-  // out of kPKCS1SigPrefixes and pkey_ec_ctrl's whitelist, so EVP_DigestSign with an
-  // RSA PKCS#1 v1.5 or EC key rejects a digest BoringSSL itself computes. Drop once
-  // the fork carries the change and BORINGSSL_COMMIT moves.
+  // sha512t-sign: BoringSSL ships EVP_sha512_224/256 but omits NID_sha512_224/256 from
+  // kPKCS1SigPrefixes and pkey_ec_ctrl, so RSA PKCS#1 v1.5 and EC sign/verify reject
+  // them. Drop once the fork carries the change and BORINGSSL_COMMIT moves.
   patches: ["patches/boringssl/require-memory-hooks.patch", "patches/boringssl/sha512t-sign.patch"],
 
   build: cfg => {

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -39,7 +39,12 @@ export const boringssl: Dependency = {
   // Upstream mem.cc gates OPENSSL_memory_* weak-symbol overrides on __ELF__;
   // on Mach-O/COFF the hooks compile to static nullptr and OPENSSL_malloc goes
   // straight to libc. Declare them as plain externs so lib.rs binds everywhere.
-  patches: ["patches/boringssl/require-memory-hooks.patch"],
+  //
+  // sha512t-sign: BoringSSL exposes EVP_sha512_224/256 but leaves NID_sha512_224/256
+  // out of kPKCS1SigPrefixes and pkey_ec_ctrl's whitelist, so EVP_DigestSign with an
+  // RSA PKCS#1 v1.5 or EC key rejects a digest BoringSSL itself computes. Drop once
+  // the fork carries the change and BORINGSSL_COMMIT moves.
+  patches: ["patches/boringssl/require-memory-hooks.patch", "patches/boringssl/sha512t-sign.patch"],
 
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1969,6 +1969,12 @@ const EVP_MD* getDigestByName(const WTF::StringView name)
         if (WTF::equalIgnoringASCIICase(bits, "512"_s)) {
             return EVP_sha512();
         }
+        if (WTF::equalIgnoringASCIICase(bits, "512/224"_s)) {
+            return EVP_sha512_224();
+        }
+        if (WTF::equalIgnoringASCIICase(bits, "512/256"_s)) {
+            return EVP_sha512_256();
+        }
     }
 
     if (WTF::startsWithIgnoringASCIICase(name, "sha"_s)) {

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -114,3 +114,97 @@ describe("crypto.verify", () => {
     expect(verified).toBe(true);
   });
 });
+
+describe("SHA-512/224 and SHA-512/256 sign/verify", () => {
+  const digests = ["sha512-224", "sha512-256"];
+  const message = Buffer.from("sha512/t truncated digest conformance");
+  const fixture = (name: string) => readFileSync(`${__dirname}/fixtures/${name}`, "utf8");
+
+  const rsaPrivate = fixture("rsa_private_2048.pem");
+  const rsaPublic = fixture("rsa_public_2048.pem");
+  const ecPrivate = fixture("ec_p256_private.pem");
+  const ecPublic = fixture("ec_p256_public.pem");
+
+  // Signatures produced by Node.js (OpenSSL) over `message` with the fixtures
+  // above. RSA PKCS#1 v1.5 is deterministic, so these pin the exact DigestInfo
+  // encoding rather than just proving we can verify what we sign.
+  const rsaPkcs1: Record<string, string> = {
+    "sha512-224":
+      "psEUABh24pmkwPp4prxY2T0QzxpunNaOnfadI/WBRkQzP15tQcKh1bV1ZGeGo4YmmyfMdib/QhFbadd2FSdsqS5LJKcnZlj9gb3kTHgu6YyiQiLyeq9z0SWz4pdkKc1iq7KAa5TMIgak7b6SqVMI5iA+x80Bi2Xh9qAGE0IZuIuRWEnVNQYEZK9ORau8lNxn9Ib7DwdKcCsLS626H+cxm8YHu3QcVT4YV5mPZ+E6WhtNV0Ff1r7myMoXFefrDsDyPVSED0bGrKBbbawR1Y8s+I0c+YAaGVLlO2ZSFdbqAC+VkeNEy1lxNFrNKavf9UM6s6Ml85yRcnaa1Kwue3BTjw==",
+    "sha512-256":
+      "CnZSfkxxTlGqykoCLNolJpRi0pHmEQ0JV6YgtEB/weA/zB4RWK6D3s6ZJ9+Xo10ld0DmMpTBG61Nck6qm8MevsWdePR0Ldj/jHSEnvEyS6K4RhOjAfXxqbAWdoh04JEaz6v72LSLFqEAs4siJcaKFZ/d9HPTVXgkSD2wOjlDAvKgu+5UMh/5FxXJAXPhr5K1YdU/Uie2lbQ5VwzRJq8dG9afT0UgpTyUdr9XGuPr09HRrflsedSElarsGorUa1O1V1l7L8Btj29shDX0NBTl5niA7SwnzeAawW3dfakRPeDGqn/we94kyK8vw71oCpVySg/PLQNt6ArUBN23Zcbs1A==",
+  };
+
+  // PSS and ECDSA are randomized, so these only exercise the verify path.
+  const rsaPss: Record<string, string> = {
+    "sha512-224":
+      "HYlsKCnKIZIoaQ2mqS5+eTdypx2ypQlOV+qfJYWT/8350FpqFO5fugLTT6ap68AeAVwSTJayTwwjb6uelIMnJsHLAmeaFwFnA34lrhv5CMhzgThxoN/hLlo7PmTItXOHzATEqSuWOlCT8JmcCYTRkXWNmPCvRPO6b4cFiB1w1XD99l8sb90FBOEuNjnVL872O0pdFcA87Z6wdXpVMIn2OmD+KwvR3c8f+Yck6vo9QwXpiKNaEuwdRhQV++ZvxfI5XHqHT+lkBToXgRGuHJda9wLvzvdJ+HoGpqIigglNLPXaOyLqDbK4KIBjchzNf77az9DqtADGKtetQikru4DILQ==",
+    "sha512-256":
+      "InLtCNTKfBkPlVKGdzOVeSeloObt0E1+03AfxZ5EvIH8XBmT8nJhuDBJoA/02ndpJCQmEPuGOYhDm5f8ZOjwwfkTGGhAG2D77k9xvVzrPeJYkZsff13/2LwwgI36P7/TXjBgCNsUly0Y9WkuM1JVg/rSDUsrw+YDCfocP3My8AkgxCfE7fLQQW+Jb0rjFgyaRUz6wItzB/+aXjKpJl1oWZj8GDjZToWTThumHLIn4sm/MFOXyoCuLv59qiPApYD14uvTckA98TkeeBOT9upehNt5GGLjeRJNK8n2jjWtscKBya5tZ01JwFppXjwqE/X832yuHoc6YcLtHBEARp82Dw==",
+  };
+
+  const ecdsa: Record<string, string> = {
+    "sha512-224": "MEUCIQCicz3JtMf0wDnpIH21Ux9roA+zcG8cqdKCvL3Qe/PprQIgK7waBH2z/G5+TrEsZ+zuov+C52V6WpH5WlbjaM5SU5A=",
+    "sha512-256": "MEQCICjmdz59MesS8BnyG0pzPeRZ70BApipq99pTGmguTwA1AiBGhRw1PBYI6fO09gN1aAkdwfFjo+6Jma/b8LizYA8F8A==",
+  };
+
+  describe.each(digests)("%s", digest => {
+    test("crypto.sign() and createSign() reproduce OpenSSL's RSA PKCS#1 v1.5 bytes", () => {
+      expect({
+        oneShot: crypto.sign(digest, message, rsaPrivate).toString("base64"),
+        streaming: crypto.createSign(digest).update(message).sign(rsaPrivate, "base64"),
+      }).toEqual({ oneShot: rsaPkcs1[digest], streaming: rsaPkcs1[digest] });
+    });
+
+    test("crypto.verify() accepts OpenSSL's signatures", () => {
+      expect({
+        pkcs1: crypto.verify(digest, message, rsaPublic, Buffer.from(rsaPkcs1[digest], "base64")),
+        pss: crypto.verify(
+          digest,
+          message,
+          { key: rsaPublic, padding: crypto.constants.RSA_PKCS1_PSS_PADDING },
+          Buffer.from(rsaPss[digest], "base64"),
+        ),
+        ecdsa: crypto.verify(digest, message, ecPublic, Buffer.from(ecdsa[digest], "base64")),
+      }).toEqual({ pkcs1: true, pss: true, ecdsa: true });
+    });
+
+    test("createVerify() accepts OpenSSL's signatures", () => {
+      expect({
+        pkcs1: crypto.createVerify(digest).update(message).verify(rsaPublic, rsaPkcs1[digest], "base64"),
+        ecdsa: crypto.createVerify(digest).update(message).verify(ecPublic, ecdsa[digest], "base64"),
+      }).toEqual({ pkcs1: true, ecdsa: true });
+    });
+
+    test("ECDSA signatures round-trip", () => {
+      const oneShot = crypto.sign(digest, message, ecPrivate);
+      const streaming = crypto.createSign(digest).update(message).sign(ecPrivate);
+      expect({
+        oneShot: crypto.verify(digest, message, ecPublic, oneShot),
+        streaming: crypto.createVerify(digest).update(message).verify(ecPublic, streaming),
+      }).toEqual({ oneShot: true, streaming: true });
+    });
+
+    test("the RSA-SHA512/<t> alias resolves", () => {
+      const alias = digest === "sha512-224" ? "RSA-SHA512/224" : "RSA-SHA512/256";
+      expect({
+        sign: crypto.sign(alias, message, rsaPrivate).toString("base64"),
+        verify: crypto.verify(alias, message, rsaPublic, Buffer.from(rsaPkcs1[digest], "base64")),
+      }).toEqual({ sign: rsaPkcs1[digest], verify: true });
+    });
+
+    test("tampered and mismatched signatures are rejected", () => {
+      const tamperedRsa = Buffer.from(rsaPkcs1[digest], "base64");
+      tamperedRsa[tamperedRsa.length - 1] ^= 1;
+      const tamperedEcdsa = Buffer.from(ecdsa[digest], "base64");
+      tamperedEcdsa[tamperedEcdsa.length - 1] ^= 1;
+
+      expect({
+        tamperedRsa: crypto.verify(digest, message, rsaPublic, tamperedRsa),
+        tamperedEcdsa: crypto.verify(digest, message, ecPublic, tamperedEcdsa),
+        wrongMessage: crypto.verify(digest, Buffer.from("other"), rsaPublic, Buffer.from(rsaPkcs1[digest], "base64")),
+        wrongDigest: crypto.verify("sha256", message, rsaPublic, Buffer.from(rsaPkcs1[digest], "base64")),
+      }).toEqual({ tamperedRsa: false, tamperedEcdsa: false, wrongMessage: false, wrongDigest: false });
+    });
+  });
+});

--- a/test/js/node/crypto/crypto-oneshot.test.ts
+++ b/test/js/node/crypto/crypto-oneshot.test.ts
@@ -185,6 +185,18 @@ describe("SHA-512/224 and SHA-512/256 sign/verify", () => {
       }).toEqual({ oneShot: true, streaming: true });
     });
 
+    test("RSA-PSS signatures round-trip", () => {
+      const padding = crypto.constants.RSA_PKCS1_PSS_PADDING;
+      const oneShot = crypto.sign(digest, message, { key: rsaPrivate, padding });
+      const streaming = crypto.createSign(digest).update(message).sign({ key: rsaPrivate, padding });
+      expect({
+        oneShotVerify: crypto.verify(digest, message, { key: rsaPublic, padding }, oneShot),
+        streamingVerify: crypto.createVerify(digest).update(message).verify({ key: rsaPublic, padding }, streaming),
+        // PSS output is randomized, so the two signatures must differ.
+        randomized: !oneShot.equals(streaming),
+      }).toEqual({ oneShotVerify: true, streamingVerify: true, randomized: true });
+    });
+
     test("the RSA-SHA512/<t> alias resolves", () => {
       const alias = digest === "sha512-224" ? "RSA-SHA512/224" : "RSA-SHA512/256";
       expect({

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -270,8 +270,6 @@ describe("createHash", () => {
     "rsa-sha3-256",
     "rsa-sha3-384",
     "rsa-sha3-512",
-    "rsa-sha512/224",
-    "rsa-sha512/256",
     "rsa-sm3",
     "sha1withrsaencryption",
     "sha224withrsaencryption",


### PR DESCRIPTION
## What does this PR do?

`crypto.getHashes()` lists `sha512-224` and `sha512-256` and `createHash`/`createHmac` compute them correctly, but every signing entry point rejected them. Node.js signs and verifies both with RSA and EC keys.

```js
import crypto from "node:crypto";
const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
crypto.sign("sha512-256", Buffer.from("hello"), privateKey);
// Before: Error: error:0e00009d:RSA routines:OPENSSL_internal:UNKNOWN_ALGORITHM_TYPE
// After:  <Buffer ...> (256 bytes, matches Node byte-for-byte)
```

Before this change:
- RSA `crypto.sign()` threw `ERR_OSSL_UNKNOWN_ALGORITHM_TYPE`
- EC `crypto.sign()` threw `ERR_OSSL_INVALID_DIGEST_TYPE`
- `createSign(alg).sign()` threw a code-less `TypeError: Failed to create signature`
- RSA `crypto.verify()` / `createVerify().verify()` returned `false` for every signature instead of throwing
- The `RSA-SHA512/224` and `RSA-SHA512/256` aliases threw `ERR_CRYPTO_INVALID_DIGEST`

## Root cause

BoringSSL exposes `EVP_sha512_224` / `EVP_sha512_256` and recognises the names in `EVP_get_digestbyname`, so Bun's digest lookup already succeeds. The rejection comes from inside BoringSSL:

- `kPKCS1SigPrefixes` in `crypto/fipsmodule/rsa/rsa.cc.inc` has no entries for `NID_sha512_224`/`NID_sha512_256`, so `RSA_sign`/`RSA_verify` raise `RSA_R_UNKNOWN_ALGORITHM_TYPE` for PKCS#1 v1.5 padding. `EVP_DigestVerify` maps that to a plain `0`, which Bun returns as `false`.
- `pkey_ec_ctrl`'s `EVP_PKEY_CTRL_MD` whitelist in `crypto/evp/p_ec.cc` only admits sha1/224/256/384/512, so `EVP_DigestSignInit` with an EC key raises `EVP_R_INVALID_DIGEST_TYPE`.

RSA-PSS already worked because `RSA_sign_pss_mgf1` never consults the PKCS#1 prefix table.

## Fix

`patches/boringssl/sha512t-sign.patch` adds both NIDs to the two tables, with the `id-sha512-224` / `id-sha512-256` DigestInfo prefixes from RFC 8017 (NIST CSOR OIDs 2.16.840.1.101.3.4.2.5 and .6, NULL parameters). The prefixes were verified byte-exact against what Node/OpenSSL emit by raw-RSA-decrypting a Node signature.

`ncrypto.cpp` `getDigestByName` gains the `RSA-SHA512/224` and `RSA-SHA512/256` aliases so the OpenSSL long names Node advertises resolve (BoringSSL's `nid_to_digest_mapping` only carries `RSA-SHA1` through `RSA-SHA512`).

## How did you verify your code works?

`test/js/node/crypto/crypto-oneshot.test.ts` adds coverage for both digests across one-shot/streaming sign and verify, with RSA PKCS#1 v1.5, RSA-PSS, and ECDSA. The PKCS#1 fixtures are deterministic signatures generated by Node, so the tests also pin byte-exact interop with OpenSSL rather than only proving self-consistency.

This is the third member of the advertised-but-unsignable digest census after #33518 (`sha3-*`) and #34348 (`ripemd160`/`md4` silent-false verify). Whichever of #33518 and this PR merges second will need a trivial rebase of the shared `p_ec.cc` whitelist and `kPKCS1SigPrefixes` hunks.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto-oneshot.test.ts test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (7444609df)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.03ms]
(pass) crypto.randomInt should return a number [2.25ms]
(pass) crypto.randomInt with no arguments [3.50ms]
(pass) crypto.randomInt with one argument [2.32ms]
(pass) crypto.randomInt with a callback [35.84ms]
(pass) createHash > rsa-md5 - "Hello World" [7.89ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.25ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.15ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.98ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.37ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.17ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.77ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.81ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.86ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.97ms]
(pass) createHash > rsa-sh
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a2949b9eb)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.26ms]
(pass) crypto.randomInt should return a number [0.06ms]
(pass) crypto.randomInt with no arguments [0.90ms]
(pass) crypto.randomInt with one argument [0.03ms]
(pass) crypto.randomInt with a callback [0.55ms]
(pass) createHash > rsa-md5 - "Hello World" [1.53ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.06ms]
(pass) createHash > rsa-ripemd160 - "Hello World"
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 - "Hello World" [0.08ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha1-2 - "Hello World"
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.03ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rsa-sha3-256 - "Hello World"

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/crypto/crypto-oneshot.test.ts test/js/node/crypto/node-crypto.test.js
bun test v1.4.0 (7444609df)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.16ms]
(pass) crypto.randomInt should return a number [2.24ms]
(pass) crypto.randomInt with no arguments [3.54ms]
(pass) crypto.randomInt with one argument [2.73ms]
(pass) crypto.randomInt with a callback [39.08ms]
(pass) createHash > rsa-md5 - "Hello World" [7.93ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.13ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.14ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.94ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.11ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.20ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.81ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.82ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.88ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.99ms]
(pass) createHash > rsa-sh
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 656ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
patches/boringssl/sha512t-sign.patch       |  41 +++++++++++
 scripts/build/deps/boringssl.ts            |   6 +-
 src/jsc/bindings/ncrypto.cpp               |   6 ++
 test/js/node/crypto/crypto-oneshot.test.ts | 106 +++++++++++++++++++++++++++++
 test/js/node/crypto/node-crypto.test.js    |   2 -
 5 files changed, 158 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
patches/boringssl/sha512t-sign.patch            0      3      0
scripts/build/deps/boringssl.ts                 1      2      0
src/jsc/bindings/ncrypto.cpp                    1      1      0
test/js/node/crypto/crypto-oneshot.test.ts      2      2      0
test/js/node/crypto/node-crypto.test.js         1      1      0
```

</details>

<!-- robobun:evidence:end -->