### PR TITLE
js_parser: keep anonymous `export default function` anonymous so `.name` is "default"

### DIFF
--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -581,10 +581,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 match s2_data {
                     StmtData::SFunction(mut func_ref) => {
                         let func: &mut S::Function = &mut *func_ref;
-                        // Leave `func.func.name` unset when the source had none so the
-                        // engine assigns `.name = "default"` (ES2015 SetFunctionName).
-                        // React Fast Refresh needs a binding for `$RefreshReg$`, so
-                        // inject the generated name only on that dev-only path.
+                        // Leave anonymous so SetFunctionName assigns `.name = "default"`;
+                        // React Fast Refresh injects a name for its `$RefreshReg$` binding.
                         let name: &'a [u8] = if let Some(func_loc) = func.func.name {
                             p.load_name_from_ref(func_loc.ref_)
                         } else {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -583,9 +583,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let func: &mut S::Function = &mut *func_ref;
                         // Leave `func.func.name` unset when the source had none so the
                         // engine assigns `.name = "default"` (ES2015 SetFunctionName).
+                        // React Fast Refresh needs a binding for `$RefreshReg$`, so
+                        // inject the generated name only on that dev-only path.
                         let name: &'a [u8] = if let Some(func_loc) = func.func.name {
                             p.load_name_from_ref(func_loc.ref_)
                         } else {
+                            if p.options.features.react_fast_refresh {
+                                func.func.name = Some(data.default_name);
+                            }
                             js_ast::ClauseItem::DEFAULT_ALIAS
                         };
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -581,10 +581,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 match s2_data {
                     StmtData::SFunction(mut func_ref) => {
                         let func: &mut S::Function = &mut *func_ref;
+                        // Leave `func.func.name` unset when the source had none so the
+                        // engine assigns `.name = "default"` (ES2015 SetFunctionName).
                         let name: &'a [u8] = if let Some(func_loc) = func.func.name {
                             p.load_name_from_ref(func_loc.ref_)
                         } else {
-                            func.func.name = Some(data.default_name);
                             js_ast::ClauseItem::DEFAULT_ALIAS
                         };
 

--- a/test/bundler/transpiler/export-default-name.test.ts
+++ b/test/bundler/transpiler/export-default-name.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("anonymous export default .name", () => {
+  test.concurrent.each([
+    ["function", "export default function () {}"],
+    ["async function", "export default async function () {}"],
+    ["function*", "export default function* () {}"],
+    ["async function*", "export default async function* () {}"],
+    ["class", "export default class {}"],
+    ["arrow", "export default () => 1;"],
+  ])("%s: .name is 'default'", async (_label, decl) => {
+    using dir = tempDir("export-default-name", {
+      "mod.mjs": `${decl}\nimport self from "./mod.mjs";\nconsole.log(JSON.stringify(self.name));\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "mod.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '"default"\n', stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent("named function keeps its own name", async () => {
+    using dir = tempDir("export-default-named", {
+      "mod.mjs": `export default function Foo() {}\nimport self from "./mod.mjs";\nconsole.log(JSON.stringify(self.name));\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "mod.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '"Foo"\n', stderr: "", exitCode: 0 });
+  });
+});

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -1,6 +1,47 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
+describe("anonymous export default .name", () => {
+  test.concurrent.each([
+    ["function", "export default function () {}"],
+    ["async function", "export default async function () {}"],
+    ["function*", "export default function* () {}"],
+    ["async function*", "export default async function* () {}"],
+    ["class", "export default class {}"],
+    ["arrow", "export default () => 1;"],
+  ])("%s: .name is 'default'", async (_label, decl) => {
+    using dir = tempDir("export-default-name", {
+      "mod.mjs": `${decl}\nimport self from "./mod.mjs";\nconsole.log(JSON.stringify(self.name));\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "mod.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('"default"\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("named function keeps its own name", async () => {
+    using dir = tempDir("export-default-named", {
+      "mod.mjs": `export default function Foo() {}\nimport self from "./mod.mjs";\nconsole.log(JSON.stringify(self.name));\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "mod.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('"Foo"\n');
+    expect(exitCode).toBe(0);
+  });
+});
+
 test("use strict causes CommonJS", () => {
   const { stdout, exitCode } = Bun.spawnSync({
     cmd: [bunExe(), require.resolve("./use-strict-fixture.js")],

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -20,9 +20,7 @@ describe("anonymous export default .name", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe('"default"\n');
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '"default"\n', stderr: "", exitCode: 0 });
   });
 
   test.concurrent("named function keeps its own name", async () => {
@@ -36,9 +34,7 @@ describe("anonymous export default .name", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe('"Foo"\n');
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '"Foo"\n', stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -1,43 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-describe("anonymous export default .name", () => {
-  test.concurrent.each([
-    ["function", "export default function () {}"],
-    ["async function", "export default async function () {}"],
-    ["function*", "export default function* () {}"],
-    ["async function*", "export default async function* () {}"],
-    ["class", "export default class {}"],
-    ["arrow", "export default () => 1;"],
-  ])("%s: .name is 'default'", async (_label, decl) => {
-    using dir = tempDir("export-default-name", {
-      "mod.mjs": `${decl}\nimport self from "./mod.mjs";\nconsole.log(JSON.stringify(self.name));\n`,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "mod.mjs"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '"default"\n', stderr: "", exitCode: 0 });
-  });
-
-  test.concurrent("named function keeps its own name", async () => {
-    using dir = tempDir("export-default-named", {
-      "mod.mjs": `export default function Foo() {}\nimport self from "./mod.mjs";\nconsole.log(JSON.stringify(self.name));\n`,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "mod.mjs"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: '"Foo"\n', stderr: "", exitCode: 0 });
-  });
-});
-
 test("use strict causes CommonJS", () => {
   const { stdout, exitCode } = Bun.spawnSync({
     cmd: [bunExe(), require.resolve("./use-strict-fixture.js")],

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -45,8 +45,6 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
   });
 
   test("bundled output uses a valid identifier for the generated default name", async () => {
-    // `--no-bundle` now keeps the function anonymous, so check the bundled output
-    // where convertStmtsForChunk still assigns the generated `_1_default` name.
     using dir = tempDir("issue-31401-bundle", {
       "1.ts": `export default function () {}\n`,
       "entry.ts": `import f from "./1.ts"; console.log(typeof f);\n`,

--- a/test/regression/issue/31401.test.ts
+++ b/test/regression/issue/31401.test.ts
@@ -44,13 +44,16 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
     expect(exitCode).toBe(0);
   });
 
-  test("transpile-only output uses a valid identifier for the generated default name", async () => {
-    using dir = tempDir("issue-31401-transpile", {
+  test("bundled output uses a valid identifier for the generated default name", async () => {
+    // `--no-bundle` now keeps the function anonymous, so check the bundled output
+    // where convertStmtsForChunk still assigns the generated `_1_default` name.
+    using dir = tempDir("issue-31401-bundle", {
       "1.ts": `export default function () {}\n`,
+      "entry.ts": `import f from "./1.ts"; console.log(typeof f);\n`,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--no-bundle", join(String(dir), "1.ts")],
+      cmd: [bunExe(), "build", join(String(dir), "entry.ts")],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",
@@ -60,7 +63,7 @@ describe.concurrent("issue 31401: anonymous default export from digit-named modu
 
     expect(stderr).not.toContain("No identifiers allowed directly after numeric literal");
     // Must be a valid identifier: the leading digit gets an underscore prefix.
-    expect(normalizeBunSnapshot(stdout)).toContain("export default function _1_default() {}");
+    expect(normalizeBunSnapshot(stdout)).toContain("function _1_default() {}");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## What

`export default function () {}` (and its `async`/generator variants) produced a function whose observable `.name` was `"<basename>_default"` instead of the spec-required `"default"`. Node prints `"default"`.

```js
// mod.mjs
export default function () {}
import self from './mod.mjs';
console.log(JSON.stringify(self.name));
// node mod.mjs -> "default"
// bun  mod.mjs -> "mod_default"   (before)
```

`export default class {}` and `export default () => 1` were already correct at runtime.

## Why

The visit pass wrote the generated default-export binding symbol (`<basename>_default`, created by `create_default_name`) into `func.func.name` when the source had no name, so the printer emitted `export default function mod_default() {}`. Per ES2015 15.2.3.11, an anonymous default-exported function declaration receives its name via `SetFunctionName(F, "default")` at evaluation time, which only happens when the emitted declaration stays anonymous.

The class path only injects `data.default_name` into `class_name` when decorator lowering needs a concrete binding; this change brings the function path in line. The assignment is kept under `react_fast_refresh` because that dev-only transform emits a `$RefreshReg$(default_name_ref, ...)` call that needs a concrete binding, and `ConvertESMExportsForHmr` relies on `func.name` to produce one. `react_fast_refresh` is only set on bundler/bake paths, never on the runtime transpiler, so `bun run` / `--no-bundle` output stays anonymous. `data.default_name` is still recorded via `record_on_exit!()`, and the bundler's `convertStmtsForChunk` assigns the name itself when stripping exports.

This is observable via `.name`-keyed dispatch/telemetry and leaked the source file's basename.

## Verification

New tests in `test/bundler/transpiler/export-default-name.test.ts` cover `function`, `async function`, `function*`, `async function*`, `class`, arrow, and a named function (regression guard). The four function cases fail on main with `"mod_default"` and pass with this change. `test/bake/dev/react-spa.test.ts` (React Fast Refresh with anonymous default components) passes. `test/regression/issue/31401.test.ts` was updated to check the `_1_default` identifier in bundled output, where `convertStmtsForChunk` still emits it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/export-default-name.test.ts "test/regression/issue/31401.test.ts"
bun test v1.4.0 (259c30df9)

test/regression/issue/31401.test.ts:
(pass) issue 31401: anonymous default export from digit-named module > bundled output uses a valid identifier for the generated default name [277.90ms]
(pass) issue 31401: anonymous default export from digit-named module > run a digit-named module with an anonymous default function [452.77ms]
(pass) issue 31401: anonymous default export from digit-named module > import a digit-named module with an anonymous default function [445.81ms]

test/bundler/transpiler/export-default-name.test.ts:
18 |       env: bunEnv,
19 |       cwd: String(dir),
20 |       stderr: "pipe",
21 |     });
22 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
23 |     expect({ stdout, stderr, exitCode }).toEqual({ stdout: '"default"\n', stderr: "", exitCode: 0 });
                                              ^
error: expect(received).toEqual(expe
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (88e8b7a84)

test/regression/issue/31401.test.ts:
(pass) issue 31401: anonymous default export from digit-named module > bundled output uses a valid identifier for the generated default name [5.23ms]
(pass) issue 31401: anonymous default export from digit-named module > run a digit-named module with an anonymous default function [13.05ms]
(pass) issue 31401: anonymous default export from digit-named module > import a digit-named module with an anonymous default function [12.24ms]

test/bundler/transpiler/export-default-name.test.ts:
(pass) anonymous export default .name > function: .name is 'default' [14.26ms]
(pass) anonymous export default .name > function*: .name is 'default' [12.98ms]
(pass) anonymous export default .name > async function: .name is 'default' [13.52ms]
(pass) anonymous export default .name > async function*: .name is 'default' [12.47ms]
(pass) anonymous export default .name > class: .name is 'default' [11.96ms]
(pass) anonymous export default .name > arrow: .name is 'default' [11.46ms]
(pass) anonymous export default .name > named function keeps its own name [11.50ms]

 10 pass
 0 fail
 2 snapshots, 16 expect() calls
Ran 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/export-default-name.test.ts "test/regression/issue/31401.test.ts"
bun test v1.4.0 (259c30df9)

test/regression/issue/31401.test.ts:
(pass) issue 31401: anonymous default export from digit-named module > bundled output uses a valid identifier for the generated default name [377.54ms]
(pass) issue 31401: anonymous default export from digit-named module > run a digit-named module with an anonymous default function [477.34ms]
(pass) issue 31401: anonymous default export from digit-named module > import a digit-named module with an anonymous default function [607.24ms]

test/bundler/transpiler/export-default-name.test.ts:
(pass) anonymous export default .name > function*: .name is 'default' [512.83ms]
(pass) anonymous export default .name > function: .name is 'default' [747.25ms]
(pass) anonymous export default .name > class: .name is 'default' [864.17ms]
(pass) anonymous export default .name > async function: .name is 'default' [921.52ms]
(pass) anonymous export default .name > async function*: .name is 'default' [1
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 727ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_collections v0.0.0 (/workspace/bun/src/collections)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/visit_stmt.rs                  |  6 +++-
 .../bundler/transpiler/export-default-name.test.ts | 39 ++++++++++++++++++++++
 test/regression/issue/31401.test.ts                |  9 ++---
 3 files changed, 49 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/js_parser/visit/visit_stmt.rs                        4      4      0
test/bundler/transpiler/export-default-name.test.ts      0      1      0
test/regression/issue/31401.test.ts                      1      4      0
```

</details>

<!-- robobun:evidence:end -->