### PR TITLE
fetch: response.body.cancel() on an unread body aborts the transfer

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -735,6 +735,40 @@ JSPromise* nativeSourceCancel(JSGlobalObject* globalObject, JSReadableStreamDefa
     RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
 }
 
+JSPromise* cancelPendingNativeSource(JSGlobalObject* globalObject, JSReadableStream* stream, JSValue reason)
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    ASSERT(stream->m_bunMode == BunStreamMode::NativePending);
+    ASSERT(stream->m_controllerKind == ControllerKind::None);
+    stream->m_bunMode = BunStreamMode::Default;
+    JSObject* handle = stream->nativeHandleDetached() ? nullptr : stream->m_nativePtr.get().getObject();
+    if (!handle)
+        RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+    JSValue thrown;
+    {
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        MarkedArgumentBuffer updateRefArgs;
+        updateRefArgs.append(jsBoolean(false));
+        ASSERT(!updateRefArgs.hasOverflowed());
+        invokeMethod(vm, globalObject, handle, builtinNames(vm).updateRefPublicName(), updateRefArgs);
+        if (!catchScope.exception()) {
+            MarkedArgumentBuffer cancelArgs;
+            cancelArgs.append(reason);
+            ASSERT(!cancelArgs.hasOverflowed());
+            invokeMethod(vm, globalObject, handle, builtinNames(vm).cancelPublicName(), cancelArgs);
+        }
+        if (catchScope.exception()) [[unlikely]] {
+            thrown = takeAbruptCompletion(globalObject, catchScope);
+            if (thrown.isEmpty())
+                return nullptr;
+        }
+    }
+    if (!thrown.isEmpty())
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    RELEASE_AND_RETURN(scope, promiseFulfilledWith(globalObject, JSC::jsUndefined()));
+}
+
 // The [bound-convention] onDrain body: a dead consumer drops the chunk.
 static void nativeSourceOnDrain(JSGlobalObject* globalObject, JSNativeStreamSourceAdapter* adapter, JSValue chunk)
 {

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -321,6 +321,22 @@ static JSValue invokeMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject*
     RELEASE_AND_RETURN(scope, call(globalObject, method, getCallData(method), object, args));
 }
 
+// The native-handle cancel protocol shared by nativeSourceCancel / cancelPendingNativeSource.
+static void invokeNativeHandleCancel(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* handle, JSValue reason)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    MarkedArgumentBuffer updateRefArgs;
+    updateRefArgs.append(jsBoolean(false));
+    ASSERT(!updateRefArgs.hasOverflowed());
+    invokeMethod(vm, globalObject, handle, builtinNames(vm).updateRefPublicName(), updateRefArgs);
+    RETURN_IF_EXCEPTION(scope, );
+    MarkedArgumentBuffer cancelArgs;
+    cancelArgs.append(reason);
+    ASSERT(!cancelArgs.hasOverflowed());
+    scope.release();
+    invokeMethod(vm, globalObject, handle, builtinNames(vm).cancelPublicName(), cancelArgs);
+}
+
 static JSValue wrapWithAsyncContext(JSGlobalObject* globalObject, JSReadableStream* stream, JSValue callable)
 {
     JSValue asyncContext = stream->m_asyncContext.get();
@@ -710,18 +726,8 @@ JSPromise* nativeSourceCancel(JSGlobalObject* globalObject, JSReadableStreamDefa
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         adapter->m_pendingView.clear();
-        if (JSObject* handle = adapter->m_handle.get()) {
-            MarkedArgumentBuffer updateRefArgs;
-            updateRefArgs.append(jsBoolean(false));
-            ASSERT(!updateRefArgs.hasOverflowed());
-            invokeMethod(vm, globalObject, handle, builtinNames(vm).updateRefPublicName(), updateRefArgs);
-            if (!catchScope.exception()) {
-                MarkedArgumentBuffer cancelArgs;
-                cancelArgs.append(reason);
-                ASSERT(!cancelArgs.hasOverflowed());
-                invokeMethod(vm, globalObject, handle, builtinNames(vm).cancelPublicName(), cancelArgs);
-            }
-        }
+        if (JSObject* handle = adapter->m_handle.get())
+            invokeNativeHandleCancel(vm, globalObject, handle, reason);
         if (!catchScope.exception())
             nativeSourceSever(globalObject, adapter);
         if (catchScope.exception()) [[unlikely]] {
@@ -748,16 +754,7 @@ JSPromise* cancelPendingNativeSource(JSGlobalObject* globalObject, JSReadableStr
     JSValue thrown;
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        MarkedArgumentBuffer updateRefArgs;
-        updateRefArgs.append(jsBoolean(false));
-        ASSERT(!updateRefArgs.hasOverflowed());
-        invokeMethod(vm, globalObject, handle, builtinNames(vm).updateRefPublicName(), updateRefArgs);
-        if (!catchScope.exception()) {
-            MarkedArgumentBuffer cancelArgs;
-            cancelArgs.append(reason);
-            ASSERT(!cancelArgs.hasOverflowed());
-            invokeMethod(vm, globalObject, handle, builtinNames(vm).cancelPublicName(), cancelArgs);
-        }
+        invokeNativeHandleCancel(vm, globalObject, handle, reason);
         if (catchScope.exception()) [[unlikely]] {
             thrown = takeAbruptCompletion(globalObject, catchScope);
             if (thrown.isEmpty())

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -412,7 +412,12 @@ JSPromise* readableStreamCancel(JSGlobalObject* globalObject, JSReadableStream* 
     JSPromise* sourceCancelPromise = nullptr;
     switch (stream->m_controllerKind) {
     case ControllerKind::None:
-        sourceCancelPromise = promiseFulfilledWith(globalObject, JSC::jsUndefined());
+        if (stream->m_bunMode == BunStreamMode::NativePending)
+            sourceCancelPromise = cancelPendingNativeSource(globalObject, stream, reason);
+        else {
+            stream->m_bunMode = BunStreamMode::Default;
+            sourceCancelPromise = promiseFulfilledWith(globalObject, JSC::jsUndefined());
+        }
         break;
     case ControllerKind::Default:
         sourceCancelPromise = defaultControllerOf(stream)->cancelSteps(globalObject, reason);

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -504,6 +504,9 @@ void materializeNativeSource(JSC::JSGlobalObject*, JSReadableStream*); // userJS
 JSC::JSValue nativeSourceStart(JSC::JSGlobalObject*, JSReadableStreamDefaultController*); // userJS: no (native handle.start; enqueues the drain value) — BunStreamSource.cpp
 JSC::JSPromise* nativeSourcePull(JSC::JSGlobalObject*, JSReadableStreamDefaultController*); // userJS: no (native handle.pull; its promise's reactions are onNativePull*) — BunStreamSource.cpp
 JSC::JSPromise* nativeSourceCancel(JSC::JSGlobalObject*, JSReadableStreamDefaultController*, JSC::JSValue reason); // userJS: no (native handle.cancel + teardown) — BunStreamSource.cpp
+// readableStreamCancel's ControllerKind::None arm for a still-NativePending stream: calls
+// handle.updateRef(false) + handle.cancel(reason) on m_nativePtr directly, no materialize.
+JSC::JSPromise* cancelPendingNativeSource(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue reason); // userJS: no — BunStreamSource.cpp
 // The JSSink entry point (GlobalObject::assignToStream's body). Returns undefined or
 // a JSPromise (the Signal protocol's value).
 JSC::JSValue assignToStream(JSC::JSGlobalObject*, JSReadableStream*, JSC::JSValue jsSinkController); // userJS: yes — BunStreamSource.cpp

--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -1,5 +1,6 @@
 import { heapStats } from "bun:jsc";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // Test that ReadableStream objects from cancelled fetch responses are properly GC'd.
 //
@@ -137,4 +138,64 @@ test("ReadableStream from fetch should be GC'd after body.cancel()", async () =>
   const leaked = after - baseline;
 
   expect(leaked).toBeLessThanOrEqual(5);
+});
+
+test("response.body.cancel() on a never-read body aborts the underlying fetch", async () => {
+  // fetch() response body streams are lazily materialized on first read. Cancelling
+  // before that first read must still reach the native source and abort the transfer
+  // instead of silently resolving while the client keeps draining the socket.
+  //
+  // Run in a subprocess so the unbounded server stream is cleaned up with the process
+  // and so the client-side RSS growth in the failing case can't OOM the test runner.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let pulls = 0;
+        let aborted = false;
+        const server = Bun.serve({
+          port: 0,
+          fetch(req) {
+            req.signal.addEventListener("abort", () => (aborted = true));
+            return new Response(
+              new ReadableStream(
+                { pull(c) { pulls++; c.enqueue(new Uint8Array(65536)); } },
+                new CountQueuingStrategy({ highWaterMark: 1 }),
+              ),
+            );
+          },
+        });
+        const res = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+        // Let the server start pushing so the client has buffered bytes it never asked for.
+        while (pulls === 0) await Bun.sleep(1);
+        const before = pulls;
+        await res.body.cancel(new Error("nope"));
+        // Poll for quiescence: once cancel has reached the transport, pulls stop growing.
+        // Bail early if pulls run away so the failing case reports instead of timing out.
+        let last = pulls;
+        let stable = 0;
+        while (stable < 5 && pulls - before < 2000) {
+          await Bun.sleep(10);
+          if (pulls === last) stable++;
+          else { stable = 0; last = pulls; }
+        }
+        const after = pulls - before;
+        console.log(JSON.stringify({ after, aborted }));
+        server.stop(true);
+        process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { after, aborted } = JSON.parse(stdout.trim());
+  // When the cancel reaches the fetch tasklet the server sees the abort and pulls stop
+  // within a bounded window. Without the fix the client keeps draining and `after`
+  // grows into the thousands (the poll loop above never stabilizes).
+  expect({ aborted, afterBounded: after < 200 }).toEqual({ aborted: true, afterBounded: true });
+  expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -195,6 +195,10 @@ test("response.body.cancel() on a never-read body aborts the underlying fetch", 
   // When the cancel reaches the fetch tasklet the server sees the abort and pulls stop
   // within a bounded window. Without the fix the client keeps draining and `after`
   // grows into the thousands (the poll loop above never stabilizes).
-  expect({ aborted, afterBounded: after < 200, timedOut }).toEqual({ aborted: true, afterBounded: true, timedOut: false });
+  expect({ aborted, afterBounded: after < 200, timedOut }).toEqual({
+    aborted: true,
+    afterBounded: true,
+    timedOut: false,
+  });
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -189,16 +189,15 @@ test("response.body.cancel() on a never-read body aborts the underlying fetch", 
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const { after, aborted, timedOut } = JSON.parse(stdout.trim());
   // When the cancel reaches the fetch tasklet the server sees the abort and pulls stop
   // within a bounded window. Without the fix the client keeps draining and `after`
   // grows into the thousands (the poll loop above never stabilizes).
-  expect({ aborted, afterBounded: after < 200, timedOut }).toEqual({
+  expect({ aborted, afterBounded: after < 200, timedOut, exitCode }).toEqual({
     aborted: true,
     afterBounded: true,
     timedOut: false,
+    exitCode: 0,
   });
-  expect(exitCode).toBe(0);
 });

--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -141,12 +141,9 @@ test("ReadableStream from fetch should be GC'd after body.cancel()", async () =>
 });
 
 test("response.body.cancel() on a never-read body aborts the underlying fetch", async () => {
-  // fetch() response body streams are lazily materialized on first read. Cancelling
-  // before that first read must still reach the native source and abort the transfer
-  // instead of silently resolving while the client keeps draining the socket.
-  //
-  // Run in a subprocess so the unbounded server stream is cleaned up with the process
-  // and so the client-side RSS growth in the failing case can't OOM the test runner.
+  // Cancelling an unread response body must abort the native transfer, not resolve
+  // while the client keeps draining. Runs in a subprocess so the unbounded stream
+  // and RSS growth in the failing case are contained and cleaned up on exit.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
+++ b/test/js/web/fetch/fetch-stream-cancel-leak.test.ts
@@ -164,21 +164,23 @@ test("response.body.cancel() on a never-read body aborts the underlying fetch", 
           },
         });
         const res = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+        const deadline = performance.now() + 3000;
         // Let the server start pushing so the client has buffered bytes it never asked for.
-        while (pulls === 0) await Bun.sleep(1);
+        while (pulls === 0 && performance.now() < deadline) await Bun.sleep(1);
         const before = pulls;
         await res.body.cancel(new Error("nope"));
         // Poll for quiescence: once cancel has reached the transport, pulls stop growing.
         // Bail early if pulls run away so the failing case reports instead of timing out.
         let last = pulls;
         let stable = 0;
-        while (stable < 5 && pulls - before < 2000) {
+        while (stable < 5 && pulls - before < 2000 && performance.now() < deadline) {
           await Bun.sleep(10);
           if (pulls === last) stable++;
           else { stable = 0; last = pulls; }
         }
         const after = pulls - before;
-        console.log(JSON.stringify({ after, aborted }));
+        const timedOut = performance.now() >= deadline;
+        console.log(JSON.stringify({ after, aborted, timedOut }));
         server.stop(true);
         process.exit(0);
       `,
@@ -189,10 +191,10 @@ test("response.body.cancel() on a never-read body aborts the underlying fetch", 
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const { after, aborted } = JSON.parse(stdout.trim());
+  const { after, aborted, timedOut } = JSON.parse(stdout.trim());
   // When the cancel reaches the fetch tasklet the server sees the abort and pulls stop
   // within a bounded window. Without the fix the client keeps draining and `after`
   // grows into the thousands (the poll loop above never stabilizes).
-  expect({ aborted, afterBounded: after < 200 }).toEqual({ aborted: true, afterBounded: true });
+  expect({ aborted, afterBounded: after < 200, timedOut }).toEqual({ aborted: true, afterBounded: true, timedOut: false });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `response.body.cancel()` on a never-read `fetch()` response body so it actually aborts the HTTP transfer instead of silently resolving while the client keeps draining the socket.

#### Repro

```js
const server = Bun.serve({ port: 0, fetch(req) {
  req.signal.addEventListener("abort", () => sawAbort++);
  return new Response(new ReadableStream({
    pull(c) { pulls++; c.enqueue(new Uint8Array(65536)); },
  }, new CountQueuingStrategy({ highWaterMark: 1 })));
} });
const res = await fetch(`http://127.0.0.1:${server.port}/`);
await res.body.cancel(new Error("nope"));   // never read a byte
```

Before: `serverPulls=+33973 serverSawAbort=0 clientRSS=+3765MB` after 3s and climbing.
After: `serverPulls=+0 serverSawAbort=1 clientRSS=+2MB`.

`res.body.getReader().cancel()` already worked; only the direct `body.cancel()` on a never-read body was broken.

#### Cause

A fetch response body is a lazy `BunStreamMode::NativePending` stream with `ControllerKind::None` until something materializes it. `getReader()` calls `materializeIfNeeded()` first, which installs a `Default` controller whose `cancelSteps` reach `nativeSourceCancel` and the `FetchTasklet::on_stream_cancelled_callback` abort path. `ReadableStream.prototype.cancel` went straight to `readableStreamCancel`, whose `ControllerKind::None` arm returned `promiseFulfilledWith(undefined)` without touching the native handle.

#### Fix

`readableStreamCancel`'s `ControllerKind::None` arm now checks for `NativePending` and calls a new `cancelPendingNativeSource()`, which invokes `handle.updateRef(false)` + `handle.cancel(reason)` on `m_nativePtr` directly (the same calls `nativeSourceCancel` makes for a materialized stream), skipping the `start()`/`drain()`/controller allocation a full materialize would perform. `m_bunMode` is cleared so a subsequent `getReader()` sees an ordinary closed stream.

This also applies to `Blob.stream().cancel()` and `Bun.file(...).stream().cancel()`, which use the same `NativePending` path; those now reach the native source's `cancel` hook as well.

#### Verification

- New test in `test/js/web/fetch/fetch-stream-cancel-leak.test.ts` fails on main (`{aborted: false, afterBounded: false}`) and passes with the fix.
- Existing tests in that file still pass.
- `body-stream.test.ts`, `response.test.ts`, `body.test.ts`, `fetch-abort-stream-body.test.ts`: 9459 pass / 0 fail.
- `streams.test.js`: 157 pass / 2 pre-existing timeouts (unchanged from main).
- `BUN_JSC_validateExceptionChecks=1` clean.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-stream-cancel-leak.test.ts
bun test v1.4.0 (b1cdf7c23)

test/js/web/fetch/fetch-stream-cancel-leak.test.ts:
(pass) ReadableStream from fetch should be GC'd after reader.cancel() [602.61ms]
(pass) ReadableStream from fetch should be GC'd after body.cancel() [575.38ms]
192 |   const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
193 |   const { after, aborted, timedOut } = JSON.parse(stdout.trim());
194 |   // When the cancel reaches the fetch tasklet the server sees the abort and pulls stop
195 |   // within a bounded window. Without the fix the client keeps draining and `after`
196 |   // grows into the thousands (the poll loop above never stabilizes).
197 |   expect({ aborted, afterBounded: after < 200, timedOut, exitCode }).toEqual({
                                                                           ^
error: expect(received).toEqual(expected)

  {
-   "aborted": true,
-   "afterBounded": true,
+   "aborted": false,
+   "afterBounded": false,
    "exitCo
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (729622e37)

test/js/web/fetch/fetch-stream-cancel-leak.test.ts:
(pass) ReadableStream from fetch should be GC'd after reader.cancel() [125.83ms]
(pass) ReadableStream from fetch should be GC'd after body.cancel() [126.01ms]
(pass) response.body.cancel() on a never-read body aborts the underlying fetch [65.31ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [464.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-stream-cancel-leak.test.ts
bun test v1.4.0 (b1cdf7c23)

test/js/web/fetch/fetch-stream-cancel-leak.test.ts:
(pass) ReadableStream from fetch should be GC'd after reader.cancel() [603.28ms]
(pass) ReadableStream from fetch should be GC'd after body.cancel() [583.35ms]
(pass) response.body.cancel() on a never-read body aborts the underlying fetch [518.38ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [3.77s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 627ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/35] cxx obj/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp.o
[2/35] cxx obj/src/jsc/bindings/webcore/streams/JSReadRequest.cpp.o
[3/35] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp.o
[4/35] cxx obj/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp.o
[5/35] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[6/35] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStream.cpp.o
[7/35] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[8/35] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[9/35] cxx obj/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp.o
[10/35] cxx obj/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp.o
[11/35] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp.o
[12/35] cxx obj/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp.o
[13/35] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp.o
[14/35] cxx obj/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../bindings/webcore/streams/BunStreamSource.cpp   | 55 ++++++++++++++-----
 .../webcore/streams/ReadableStreamOperations.cpp   |  7 ++-
 .../bindings/webcore/streams/WebStreamsInternals.h |  3 ++
 test/js/web/fetch/fetch-stream-cancel-leak.test.ts | 63 ++++++++++++++++++++++
 4 files changed, 115 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/streams/BunStreamSource.cpp          4      7      0
…c/bindings/webcore/streams/ReadableStreamOperations.cpp      2      1      0
src/jsc/bindings/webcore/streams/WebStreamsInternals.h        2      1      0
test/js/web/fetch/fetch-stream-cancel-leak.test.ts            5     10      0
```

</details>

<!-- robobun:evidence:end -->