### PR TITLE
Bun.serve: throw RangeError for out-of-range port instead of silently clamping

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1166,12 +1166,29 @@ impl ServerConfig {
         }
 
         if let Some(port_) = arg.get_truthy(global, "port")? {
-            let p = u16::try_from(
-                (port_.coerce::<i32>(global)?)
-                    .max(0)
-                    .min(i32::from(u16::MAX)),
-            )
-            .unwrap();
+            let number = port_.to_number(global)?;
+            if !number.is_finite() || number.fract() != 0.0 {
+                return Err(global.throw_range_error(
+                    number,
+                    bun_fmt::OutOfRangeOptions {
+                        field_name: b"options.port",
+                        msg: b"an integer",
+                        ..Default::default()
+                    },
+                ));
+            }
+            if !(0.0..=65535.0).contains(&number) {
+                return Err(global.throw_range_error(
+                    number,
+                    bun_fmt::OutOfRangeOptions {
+                        min: 0,
+                        max: 65535,
+                        field_name: b"options.port",
+                        ..Default::default()
+                    },
+                ));
+            }
+            let p = number as u16;
             if let Address::Tcp { port: tp, .. } = &mut args.address {
                 *tp = p;
             }

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -398,6 +398,61 @@ describe("Bun.serve hostname and port validation", () => {
       });
     }
   });
+
+  describe("invalid port values throw RangeError", () => {
+    const invalidPorts: { port: unknown; received: string }[] = [
+      { port: 65536, received: "65536" },
+      { port: 70000, received: "70000" },
+      { port: 2 ** 32 + 8080, received: "4294975376" },
+      { port: -1, received: "-1" },
+      { port: 1.5, received: "1.5" },
+      { port: "abc", received: "NaN" },
+      { port: NaN, received: "NaN" },
+      { port: Infinity, received: "Infinity" },
+      { port: -Infinity, received: "-Infinity" },
+      { port: "65536", received: "65536" },
+      { port: Number.MAX_SAFE_INTEGER, received: String(Number.MAX_SAFE_INTEGER) },
+    ];
+
+    for (const { port, received } of invalidPorts) {
+      test(`port: ${typeof port === "string" ? JSON.stringify(port) : port}`, () => {
+        let thrown: unknown;
+        try {
+          const server = serve({
+            // @ts-expect-error - Testing invalid port values
+            port,
+            fetch() {
+              return new Response("ok");
+            },
+          });
+          server.stop(true);
+        } catch (e) {
+          thrown = e;
+        }
+        expect(thrown).toBeInstanceOf(RangeError);
+        expect((thrown as RangeError).message).toContain("options.port");
+        expect((thrown as RangeError).message).toContain(received);
+      });
+    }
+
+    test("server.reload() rejects an out-of-range port", () => {
+      using server = serve({
+        port: 0,
+        fetch() {
+          return new Response("ok");
+        },
+      });
+      expect(() =>
+        server.reload({
+          // @ts-expect-error - Testing invalid port values
+          port: 65536,
+          fetch() {
+            return new Response("ok");
+          },
+        }),
+      ).toThrow(RangeError);
+    });
+  });
 });
 
 describe("Bun.serve hostname coercion", () => {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -442,15 +442,21 @@ describe("Bun.serve hostname and port validation", () => {
           return new Response("ok");
         },
       });
-      expect(() =>
+      let thrown: unknown;
+      try {
         server.reload({
           // @ts-expect-error - Testing invalid port values
           port: 65536,
           fetch() {
             return new Response("ok");
           },
-        }),
-      ).toThrow(RangeError);
+        });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(RangeError);
+      expect((thrown as RangeError).message).toContain("options.port");
+      expect((thrown as RangeError).message).toContain("65536");
     });
   });
 });


### PR DESCRIPTION
## What

`Bun.serve({ port })` coerced the port via `ToInt32` and then clamped the result into `[0, 65535]`, so a mistyped port would start a server on the wrong port instead of failing at startup.

```js
for (const p of [65536, 1.5, -1, "abc", 70000, 2 ** 32 + 8080]) {
  try {
    const s = Bun.serve({ port: p, fetch: () => new Response("x") });
    console.log(`port: ${JSON.stringify(p)} -> ARMED on ${s.port}`);
    s.stop(true);
  } catch (e) {
    console.log(`port: ${JSON.stringify(p)} -> THREW: ${e.message}`);
  }
}
```

Before:

```
port: 65536 -> ARMED on 65535
port: 1.5 -> ARMED on 1
port: -1 -> ARMED on 44951
port: "abc" -> ARMED on 46121
port: 70000 -> ARMED on 65535
port: 4294975376 -> ARMED on 65535
```

Every other listener surface (`Bun.listen`, `Bun.udpSocket`, `node:net`, `node:dgram`) already rejects these values with a `RangeError`.

## Fix

`ServerConfig::from_js` now validates the value after `ToNumber` coercion (so numeric strings like `"3000"` continue to work, matching the `port?: string | number` type). NaN, Infinity, non-integers, and values outside `[0, 65535]` throw an `ERR_OUT_OF_RANGE` `RangeError` that names the option and the received value:

```
port: 65536 -> THREW: The value of "options.port" is out of range. It must be >= 0 and <= 65535. Received 65536
port: 1.5 -> THREW: The value of "options.port" is out of range. It must be an integer. Received 1.5
port: -1 -> THREW: The value of "options.port" is out of range. It must be >= 0 and <= 65535. Received -1
port: "abc" -> THREW: The value of "options.port" is out of range. It must be an integer. Received NaN
port: 70000 -> THREW: The value of "options.port" is out of range. It must be >= 0 and <= 65535. Received 70000
port: 4294975376 -> THREW: The value of "options.port" is out of range. It must be >= 0 and <= 65535. Received 4294975376
```

`server.reload()` shares the same config parser and is covered. `null`/`undefined`/`""` still fall through to the env/default port as before.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-args.test.ts

<!-- robobun:evidence:end -->