### PR TITLE
Bun.serve: skip 100 Continue when Content-Length exceeds maxRequestBodySize

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -799,6 +799,11 @@ public:
         return std::move(*this);
     }
 
+    TemplatedApp &&setMaxRequestBodySize(uint64_t maxRequestBodySize) {
+        httpContext->getSocketContextData()->maxRequestBodySize = maxRequestBodySize;
+        return std::move(*this);
+    }
+
     TemplatedApp &&setMaxHTTPHeaderSize(uint64_t maxHeaderSize) {
         httpContext->getSocketContextData()->maxHeaderSize = maxHeaderSize;
         return std::move(*this);

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -645,6 +645,7 @@ struct Http2Context {
     void *parent = nullptr;
     HttpFlags *parentFlags = nullptr;
     uint64_t *parentMaxHeaderSize = nullptr;
+    uint64_t *parentMaxRequestBodySize = nullptr;
     void (*notifyParentClosed)(void *parent, us_socket_t *s, bool filteredOpen, bool filteredAccept) = nullptr;
     void (*detachFromParent)(void *parent, Http2Context *ctx) = nullptr;
     /* Seconds without traffic in either direction before a connection is
@@ -698,6 +699,7 @@ struct Http2Context {
         parent = data;
         parentFlags = &data->flags;
         parentMaxHeaderSize = &data->maxHeaderSize;
+        parentMaxRequestBodySize = &data->maxRequestBodySize;
         data->http2Context = this;
         data->allowHttp1 = allowHttp1;
         detachFromParent = [](void *p, Http2Context *ctx) { ctx->detach((HttpContextData<SSL> *) p); };
@@ -727,6 +729,7 @@ struct Http2Context {
         parent = nullptr;
         parentFlags = nullptr;
         parentMaxHeaderSize = nullptr;
+        parentMaxRequestBodySize = nullptr;
         notifyParentClosed = nullptr;
         detachFromParent = nullptr;
     }
@@ -1726,7 +1729,12 @@ inline bool Http2Connection::handleHeaderBlock(uint32_t streamId, uint8_t flags,
 inline bool Http2Connection::dispatchRequest(Http2Response *stream, const us_quic_header_t *headers, unsigned count) {
     Http2Request req(headers, count);
     if (!(ctx->parentFlags && ctx->parentFlags->usingCustomExpectHandler) && req.getHeader("expect") == "100-continue") {
-        stream->writeContinue();
+        /* Same gate as HttpContext: no 100 for a content-length the handler
+         * will 413 from the head alone (RFC 9110 10.1.1). */
+        if (stream->declaredContentLength < 0 || !ctx->parentMaxRequestBodySize
+            || (uint64_t) stream->declaredContentLength <= *ctx->parentMaxRequestBodySize) {
+            stream->writeContinue();
+        }
     }
     ctx->dispatchDepth++;
     ctx->router.getUserData() = {stream, &req};

--- a/packages/bun-uws/src/Http3App.h
+++ b/packages/bun-uws/src/Http3App.h
@@ -53,6 +53,9 @@ struct H3App {
     void clearRoutes() {
         http3Context->getContextData()->router = decltype(http3Context->getContextData()->router){};
     }
+    void setMaxRequestBodySize(uint64_t maxRequestBodySize) {
+        http3Context->getContextData()->maxRequestBodySize = maxRequestBodySize;
+    }
     /* GOAWAY + drain. The engine itself is torn down in the destructor. */
     void close() { http3Context->shutdown(); }
     bool addServerNameWithOptions(const char *hostname, SocketContextOptions options) {

--- a/packages/bun-uws/src/Http3Context.h
+++ b/packages/bun-uws/src/Http3Context.h
@@ -7,6 +7,7 @@
 #include "Http3Request.h"
 #include "Http3Response.h"
 #include "Http3ResponseData.h"
+#include "HttpParser.h"
 
 namespace uWS {
 
@@ -35,7 +36,16 @@ struct Http3Context {
             rd->reset();
 
             Http3Request req(s);
-            if (req.getHeader("expect") == "100-continue") res->writeContinue();
+            if (req.getHeader("expect") == "100-continue") {
+                /* RFC 9110 10.1.1: a Content-Length over the configured limit
+                 * is a 413 from the head alone; skip the 100 so the handler
+                 * can answer the final status directly. */
+                std::string_view cl = req.getHeader("content-length");
+                uint64_t len = cl.length() ? HttpParser::toUnsignedInteger(cl) : 0;
+                if (len == UINT64_MAX || len <= cd->maxRequestBodySize) {
+                    res->writeContinue();
+                }
+            }
             cd->router.getUserData() = {res, &req};
             if (!cd->router.route(req.getMethod(), req.getUrl())) {
                 res->writeStatus("404 Not Found")->end();

--- a/packages/bun-uws/src/Http3ContextData.h
+++ b/packages/bun-uws/src/Http3ContextData.h
@@ -14,6 +14,9 @@ struct Http3ContextData {
         Http3Request *httpRequest;
     };
     HttpRouter<RouterData> router;
+    /* Gate for the auto 100-continue; mirrors HttpContextData. UINT64_MAX =
+     * unlimited; 0 is a real limit. */
+    uint64_t maxRequestBodySize = UINT64_MAX;
 };
 
 }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -1027,7 +1027,23 @@ public:
                 /* Middleware? Automatically respond to expectations */
                 std::string_view expect = user.httpRequest->getHeader("expect");
                 if (expect.length() && expect == "100-continue") {
-                    user.httpResponse->writeContinue();
+                    /* RFC 9110 10.1.1: answer the final status instead of 100
+                     * when the outcome is already known. A Content-Length over
+                     * the configured limit is rejected from the head alone, so
+                     * inviting the upload first wastes the body transfer. */
+                    bool overLimit = false;
+                    if (uint64_t limit = httpContextData->maxRequestBodySize) {
+                        std::string_view cl = user.httpRequest->getHeader("content-length");
+                        uint64_t len = cl.length() ? 0 : UINT64_MAX;
+                        for (char c : cl) {
+                            if (c < '0' || c > '9') { len = UINT64_MAX; break; }
+                            len = len * 10 + (uint64_t)(c - '0');
+                        }
+                        overLimit = len != UINT64_MAX && len > limit;
+                    }
+                    if (!overLimit) {
+                        user.httpResponse->writeContinue();
+                    }
                 }
             }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -1030,17 +1030,9 @@ public:
                     /* RFC 9110 10.1.1: a Content-Length over the configured
                      * limit is a 413 from the head alone; skip the 100 so the
                      * handler can answer the final status directly. */
-                    bool overLimit = false;
-                    if (uint64_t limit = httpContextData->maxRequestBodySize) {
-                        std::string_view cl = user.httpRequest->getHeader("content-length");
-                        uint64_t len = cl.length() ? 0 : UINT64_MAX;
-                        for (char c : cl) {
-                            if (c < '0' || c > '9') { len = UINT64_MAX; break; }
-                            len = len * 10 + (uint64_t)(c - '0');
-                        }
-                        overLimit = len != UINT64_MAX && len > limit;
-                    }
-                    if (!overLimit) {
+                    std::string_view cl = user.httpRequest->getHeader("content-length");
+                    uint64_t len = cl.length() ? HttpParser::toUnsignedInteger(cl) : 0;
+                    if (len == UINT64_MAX || len <= httpContextData->maxRequestBodySize) {
                         user.httpResponse->writeContinue();
                     }
                 }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -1027,10 +1027,9 @@ public:
                 /* Middleware? Automatically respond to expectations */
                 std::string_view expect = user.httpRequest->getHeader("expect");
                 if (expect.length() && expect == "100-continue") {
-                    /* RFC 9110 10.1.1: answer the final status instead of 100
-                     * when the outcome is already known. A Content-Length over
-                     * the configured limit is rejected from the head alone, so
-                     * inviting the upload first wastes the body transfer. */
+                    /* RFC 9110 10.1.1: a Content-Length over the configured
+                     * limit is a 413 from the head alone; skip the 100 so the
+                     * handler can answer the final status directly. */
                     bool overLimit = false;
                     if (uint64_t limit = httpContextData->maxRequestBodySize) {
                         std::string_view cl = user.httpRequest->getHeader("content-length");

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -88,6 +88,10 @@ private:
     OnClientErrorCallback onClientError = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
+    /* Gate for the auto 100-continue: when non-zero, an Expect: 100-continue
+     * request whose Content-Length already exceeds this is not sent 100. The
+     * handler's own size check still produces the 413. */
+    uint64_t maxRequestBodySize = 0;
 
     /* HTTP/2: set by Http2Context::attach(). A connection that negotiated h2
      * (ALPN) or opened with the prior-knowledge preface is handed over via

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -88,10 +88,10 @@ private:
     OnClientErrorCallback onClientError = nullptr;
 
     uint64_t maxHeaderSize = 0; // 0 means no limit
-    /* Gate for the auto 100-continue: when non-zero, an Expect: 100-continue
-     * request whose Content-Length already exceeds this is not sent 100. The
-     * handler's own size check still produces the 413. */
-    uint64_t maxRequestBodySize = 0;
+    /* Gate for the auto 100-continue: an Expect: 100-continue request whose
+     * Content-Length exceeds this is not sent 100 (the handler still produces
+     * the 413). UINT64_MAX = unlimited; 0 is a real limit (reject any body). */
+    uint64_t maxRequestBodySize = UINT64_MAX;
 
     /* HTTP/2: set by Http2Context::attach(). A connection that negotiated h2
      * (ALPN) or opened with the prior-knowledge preface is handed over via

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -619,6 +619,7 @@ struct HttpResponseData;
          * personality so a client cannot stream unbounded extension bytes. */
         static const uint64_t MAX_CHUNK_EXTENSION_SIZE = 16 * 1024;
 
+    public:
         /* Returns UINT64_MAX on error. Maximum 999999999 is allowed. */
         static uint64_t toUnsignedInteger(std::string_view str) {
             /* We assume at least 64-bit integer giving us safely 999999999999999999 (18 number of 9s) */
@@ -636,6 +637,7 @@ struct HttpResponseData;
             }
             return unsignedIntegerValue;
         }
+    private:
 
         static inline uint64_t hasLess(uint64_t x, uint64_t n) {
             return (((x)-~0ULL/255*(n))&~(x)&~0ULL/255*128);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3048,9 +3048,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         } else {
             // Bun.serve: tell uWS the body-size limit so its auto 100-continue
             // is skipped for an over-limit Content-Length (RFC 9110 10.1.1);
-            // `prepare_js_request_context` answers 413 from the head alone.
+            // `prepare_js_request_context*` answers 413 from the head alone.
             let limit = this_ref.config.max_request_body_size as u64;
             bun_opaque::opaque_deref_mut(app).set_max_request_body_size(limit);
+            if Self::HAS_H3 {
+                if let Some(h3_app) = this_ref.h3_app {
+                    bun_opaque::opaque_deref_mut(h3_app).set_max_request_body_size(limit);
+                }
+            }
         }
 
         // the listen_* trampolines re-derive `&mut *this` synchronously

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3046,9 +3046,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // borrow is live — `&mut` scoped to this call.
             unsafe { (*this).set_using_custom_expect_handler(true) };
         } else {
-            // Bun.serve: tell uWS the body-size limit so its auto 100-continue
-            // is skipped for an over-limit Content-Length (RFC 9110 10.1.1);
-            // `prepare_js_request_context*` answers 413 from the head alone.
+            // Lets uWS skip its auto 100-continue for an over-limit Content-Length.
             let limit = this_ref.config.max_request_body_size as u64;
             bun_opaque::opaque_deref_mut(app).set_max_request_body_size(limit);
             if Self::HAS_H3 {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3045,6 +3045,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // SAFETY: `this` is the live boxed server from `init()`; no other
             // borrow is live — `&mut` scoped to this call.
             unsafe { (*this).set_using_custom_expect_handler(true) };
+        } else {
+            // Bun.serve: tell uWS the body-size limit so its auto 100-continue
+            // is skipped for an over-limit Content-Length (RFC 9110 10.1.1);
+            // `prepare_js_request_context` answers 413 from the head alone.
+            let limit = this_ref.config.max_request_body_size as u64;
+            bun_opaque::opaque_deref_mut(app).set_max_request_body_size(limit);
         }
 
         // the listen_* trampolines re-derive `&mut *this` synchronously

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -150,6 +150,10 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_set_max_http_header_size(Self::SSL_FLAG, self.as_raw(), max_header_size)
     }
 
+    pub fn set_max_request_body_size(&mut self, max_request_body_size: u64) {
+        c::uws_app_set_max_request_body_size(Self::SSL_FLAG, self.as_raw(), max_request_body_size)
+    }
+
     pub fn clear_routes(&mut self) {
         c::uws_app_clear_routes(Self::SSL_FLAG, self.as_raw())
     }
@@ -547,6 +551,11 @@ pub mod c {
             ssl: i32,
             app: &mut uws_app_t,
             max_header_size: u64,
+        );
+        pub(crate) safe fn uws_app_set_max_request_body_size(
+            ssl: i32,
+            app: &mut uws_app_t,
+            max_request_body_size: u64,
         );
         pub(crate) fn uws_app_get(
             ssl: i32,

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -421,6 +421,9 @@ impl App {
     pub fn clear_routes(&mut self) {
         c::uws_h3_app_clear_routes(self)
     }
+    pub fn set_max_request_body_size(&mut self, max_request_body_size: u64) {
+        c::uws_h3_app_set_max_request_body_size(self, max_request_body_size)
+    }
 
     fn route<UD, H>(which: RouteKind, this: &mut App, pattern: &[u8], ud: *mut UD, _handler: H)
     where
@@ -596,6 +599,10 @@ mod c {
         pub(super) fn uws_h3_app_destroy(app: *mut App);
         pub(super) safe fn uws_h3_app_close(app: &mut App);
         pub(super) safe fn uws_h3_app_clear_routes(app: &mut App);
+        pub(super) safe fn uws_h3_app_set_max_request_body_size(
+            app: &mut App,
+            max_request_body_size: u64,
+        );
         pub(super) fn uws_h3_app_add_server_name(
             app: *mut App,
             hostname: *const c_char,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -507,6 +507,15 @@ extern "C"
       uwsApp->setMaxHTTPHeaderSize(max_header_size);
     }
   }
+  void uws_app_set_max_request_body_size(int ssl, uws_app_t *app, uint64_t max_request_body_size) {
+    if (ssl) {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->setMaxRequestBodySize(max_request_body_size);
+    } else {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->setMaxRequestBodySize(max_request_body_size);
+    }
+  }
   void uws_app_set_flags(int ssl, uws_app_t *app, bool require_host_header, bool use_strict_method_validation, uint8_t lenient_http_flags, bool http_allow_half_open) {
     if (ssl) {
       uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;

--- a/src/uws_sys/libuwsockets_h3.cpp
+++ b/src/uws_sys/libuwsockets_h3.cpp
@@ -52,6 +52,10 @@ uws_h3_app_t* uws_h3_create_app(struct us_bun_socket_context_options_t options, 
 void uws_h3_app_destroy(uws_h3_app_t* app) { delete (H3App*)app; }
 void uws_h3_app_close(uws_h3_app_t* app) { ((H3App*)app)->close(); }
 void uws_h3_app_clear_routes(uws_h3_app_t* app) { ((H3App*)app)->clearRoutes(); }
+void uws_h3_app_set_max_request_body_size(uws_h3_app_t* app, uint64_t max_request_body_size)
+{
+    ((H3App*)app)->setMaxRequestBodySize(max_request_body_size);
+}
 
 bool uws_h3_app_add_server_name(uws_h3_app_t* app, const char* hostname,
     struct us_bun_socket_context_options_t options)

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -410,4 +410,57 @@ describe("Bun.serve http2 lifecycle", () => {
     proc.stdin.end();
     await proc.exited;
   });
+
+  test("expect: 100-continue gets the final 413, not 100, for an over-limit content-length", async () => {
+    using dir = tempDir("serve-http2-expect", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const server = Bun.serve({
+          port: 0, http2: true, maxRequestBodySize: 100,
+          async fetch(req) { return new Response("len:" + (await req.arrayBuffer()).byteLength); },
+        });
+        console.log(server.port);
+        process.stdin.on("end", () => process.exit(0)); process.stdin.resume();`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const reader = proc.stdout.getReader();
+    let line = "";
+    while (!line.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("server exited before printing its port");
+      line += new TextDecoder().decode(value);
+    }
+    const port = Number(line.trim());
+    const firstStatus = async (contentLength: number, body?: Buffer) => {
+      const raw = await RawH2.connect(port, false);
+      await raw.waitFor(f => f.type === T.SETTINGS);
+      raw.headers(
+        1,
+        [...baseHeaders("/", "POST"), ["expect", "100-continue"], ["content-length", String(contentLength)]],
+        F.END_HEADERS,
+      );
+      const first = await raw.waitFor(f => f.type === T.HEADERS && f.streamId === 1);
+      const statuses = [decodeStatus(first.payload)];
+      if (body) {
+        raw.write(frame(T.DATA, F.END_STREAM, 1, body));
+        const final = await raw.waitFor(f => f.type === T.HEADERS && f.streamId === 1 && f !== first);
+        statuses.push(decodeStatus(final.payload));
+      }
+      raw.close();
+      return statuses;
+    };
+    // Over limit: the head alone decides the 413, so no 100 Continue first.
+    expect(await firstStatus(500)).toEqual([413]);
+    // Under limit: 100 Continue, then the real response once the body arrives.
+    expect(await firstStatus(10, Buffer.alloc(10, "x"))).toEqual([100, 200]);
+    proc.stdin.end();
+    await proc.exited;
+  });
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2632,6 +2632,71 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
   }
 });
 
+it("should not send 100 Continue for an over-limit Content-Length with Expect: 100-continue", async () => {
+  // RFC 9110 10.1.1: a server MUST either send 100 Continue and read, or send
+  // a final status. When Content-Length already exceeds maxRequestBodySize the
+  // 413 is decided from the request head alone, so inviting the upload with
+  // 100 Continue first wastes the body transfer for a known rejection.
+  using server = Bun.serve({
+    port: 0,
+    maxRequestBodySize: 100,
+    async fetch(req) {
+      return new Response("len:" + (await req.text()).length);
+    },
+  });
+
+  const probe = (contentLength: number, sendExpect: boolean, body: string = "") =>
+    new Promise<string[]>((resolve, reject) => {
+      let buf = "";
+      let sentBody = body.length === 0;
+      Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        socket: {
+          open(s) {
+            s.write(
+              "POST / HTTP/1.1\r\n" +
+                "Host: x\r\n" +
+                (sendExpect ? "Expect: 100-continue\r\n" : "") +
+                "Content-Length: " +
+                contentLength +
+                "\r\n\r\n",
+            );
+            if (!sendExpect && body) {
+              s.write(body);
+              sentBody = true;
+            }
+          },
+          data(s, d) {
+            buf += d.toString();
+            if (sendExpect && !sentBody && buf.includes("100 Continue")) {
+              sentBody = true;
+              s.write(body);
+            }
+            // A final (non-1xx) status ends the exchange for our purposes.
+            if (/HTTP\/1\.1 [2-5]\d\d/.test(buf)) {
+              s.end();
+            }
+          },
+          close() {
+            resolve(buf.match(/HTTP\/1\.1 \d+ [^\r\n]*/g) || []);
+          },
+          error: reject,
+        },
+      });
+    });
+
+  // Over limit with Expect: the client asked permission; answer 413 directly.
+  expect(await probe(500, true)).toEqual(["HTTP/1.1 413 Request Entity Too Large"]);
+  // Over limit without Expect: unchanged baseline.
+  expect(await probe(500, false)).toEqual(["HTTP/1.1 413 Request Entity Too Large"]);
+  // Under limit with Expect: still get 100 Continue, then the final response.
+  expect(await probe(50, true, Buffer.alloc(50, "x").toString())).toEqual([
+    "HTTP/1.1 100 Continue",
+    "HTTP/1.1 200 OK",
+  ]);
+});
+
 it("should support promise returned from error", async () => {
   const { promise, resolve } = Promise.withResolvers<string>();
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2691,10 +2691,7 @@ it("should not send 100 Continue for an over-limit Content-Length with Expect: 1
   // Over limit without Expect: unchanged baseline.
   expect(await probe(500, false)).toEqual(["HTTP/1.1 413 Request Entity Too Large"]);
   // Under limit with Expect: still get 100 Continue, then the final response.
-  expect(await probe(50, true, Buffer.alloc(50, "x").toString())).toEqual([
-    "HTTP/1.1 100 Continue",
-    "HTTP/1.1 200 OK",
-  ]);
+  expect(await probe(50, true, Buffer.alloc(50, "x").toString())).toEqual(["HTTP/1.1 100 Continue", "HTTP/1.1 200 OK"]);
 });
 
 it("should support promise returned from error", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2633,10 +2633,9 @@ it("should response with HTTP 413 when request body is larger than maxRequestBod
 });
 
 it("should not send 100 Continue for an over-limit Content-Length with Expect: 100-continue", async () => {
-  // RFC 9110 10.1.1: a server MUST either send 100 Continue and read, or send
-  // a final status. When Content-Length already exceeds maxRequestBodySize the
-  // 413 is decided from the request head alone, so inviting the upload with
-  // 100 Continue first wastes the body transfer for a known rejection.
+  // RFC 9110 10.1.1: answer the final status instead of 100 when it is already
+  // known. Content-Length > maxRequestBodySize is a 413 from the head alone,
+  // so a 100 Continue first invites an upload that will be rejected.
   using server = Bun.serve({
     port: 0,
     maxRequestBodySize: 100,


### PR DESCRIPTION
### Problem
- An `Expect: 100-continue` request whose `Content-Length` is already over `maxRequestBodySize` gets `HTTP/1.1 100 Continue` followed by `413 Request Entity Too Large` in the same write. The same head without `Expect` is 413'd at once, so the decision is known up front. The client that asked permission first is the one told to upload a body it will be rejected for.
- Cause: uWS auto-sends `100 Continue` before it calls the route handler (`packages/bun-uws/src/HttpContext.h`, router lambda in `onHttp`). The size check that writes the 413 runs inside the handler (`prepare_js_request_context`, `src/runtime/server/mod.rs`). The H2 (`Http2Context.h` `dispatchRequest`) and H3 (`Http3Context.h` `on_stream_headers`) paths have the same ordering.

### Fix
- Add `maxRequestBodySize` to `HttpContextData` (default `UINT64_MAX`, so 0 stays a real limit) and gate the auto `100 Continue` on `Content-Length <= limit`. The handler still produces the 413. Requests with no or invalid `Content-Length` still get `100 Continue`.
- Same gate on H3 (`Http3ContextData`) and H2. H2 reads the parent `HttpContextData` limit through a pointer, the way it already mirrors `maxHeaderSize`, and compares the already-parsed `declaredContentLength`.
- `Bun.serve` sets the limit at listen time for non-node:http servers. `node:http` is unchanged: it opts out of the auto-continue via `usingCustomExpectHandler` and emits `checkContinue`.
- Verified: `test/js/bun/http/serve.test.ts` ("should not send 100 Continue for an over-limit Content-Length", fails on stock bun) and `test/js/bun/http/serve-http2-lifecycle.test.ts` ("expect: 100-continue gets the final 413", fails on stock bun). Also ran `serve-http2.test.ts`, `serve-http3.test.ts`, the node `test-http-expect-continue*` tests, and `test-http-7480-should-emit-continue-event.ts`.

### Background
- `Expect: 100-continue` (RFC 9110 10.1.1) lets a client send only the request head and wait for the server to say "go ahead" (`100 Continue`) or answer with a final status before the body is uploaded. A server that already knows the final status should send it instead of 100.
- In uWS the router wraps every route handler in a lambda that handles `Expect` itself unless `usingCustomExpectHandler` is set. `Bun.serve` relies on that auto-continue. `node:http` sets the flag and handles `Expect` in JS.
- `maxRequestBodySize` is enforced in two places: up front against `Content-Length` (the 413 this PR is about), and while streaming for bodies without a length. Only the first is decidable from the head, so only it gates the 100.

<details><summary>Notes</summary>

Repro (raw TCP against `Bun.serve({ port: 0, maxRequestBodySize: 100, fetch })`):

```
POST / HTTP/1.1
Host: x
Expect: 100-continue
Content-Length: 500
```

Before: `["HTTP/1.1 100 Continue","HTTP/1.1 413 Request Entity Too Large"]`
After: `["HTTP/1.1 413 Request Entity Too Large"]`
Under the limit (`Content-Length: 50` + `Expect`): still `100 Continue`, then `200 OK`.

`HttpParser::toUnsignedInteger` was made public so the H1/H3 gates reuse the parser's own Content-Length parse instead of a copy.

A GET/HEAD/OPTIONS/TRACE with `Expect: 100-continue` and an over-limit `Content-Length` no longer gets a 100 even though the handler does not size-check those methods. That request is itself a client-side spec violation, the final status is unchanged, and the server may always answer the final status directly, so the gate stays method-agnostic rather than duplicating the method list from `Method.rs` into C++.

Self-reviewed: 5 review concerns raised (0-as-limit semantics, helper reuse, H3 sibling, H2 sibling, comment length), 5 addressed; 1 (method gate) declined with the reasoning above.

Rebased onto main after the HTTP/2 server landed; conflicts were mechanical (`is_node_http_server` rename, `uws_app_set_flags` signature, removed `uws_h3_get_native_handle`).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->