### PR TITLE
Bun.serve: close WebSockets with 1001 on server.stop() and let stop(true) follow stop(false)

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -414,6 +414,29 @@ public:
         }
     }
 
+    /* Send a close frame to every open WebSocket and fire its close handler.
+     * Unlike close(), this performs the WebSocket closing handshake so peers
+     * observe the given status (e.g. 1001 Going Away) rather than 1006. */
+    TemplatedApp &&endAllWebSockets(int code, std::string_view message = {}) {
+        /* end() fires the close handler synchronously; user JS there can
+         * terminate() a later socket, which rewrites its ->next into the
+         * loop's closed_head and would derail an in-place walk. Snapshot. */
+        std::vector<us_socket_t *> sockets;
+        for (us_socket_group_t *g : webSocketGroups) {
+            for (struct us_socket_t *s = g->head_sockets; s; s = s->next) {
+                sockets.push_back(s);
+            }
+        }
+        for (us_socket_t *s : sockets) {
+            if (!us_socket_is_closed(s)) {
+                /* USERDATA is erased in the handler slots; see the TopicTree
+                 * cast below. end() no-ops on isShuttingDown. */
+                ((WebSocket<SSL, true, int> *) s)->end(code, message);
+            }
+        }
+        return std::move(*this);
+    }
+
     /** Closes all connections connected to this server which are not sending a request or waiting for a response. Does not close the listen socket.
      * With closeWhenIdle set, connections that are busy right now are marked to close as soon as their in-flight work completes (graceful shutdown);
      * upgraded WebSockets and CONNECT/Upgrade tunnels never become idle, so they are left alone either way.

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1700,6 +1700,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // mask the TCP teardown.
             if abrupt && !already_terminated {
                 self.unref();
+                self.end_all_websockets_going_away();
                 if let Some(ws) = self.config.websocket.as_mut() {
                     ws.handler.app = None;
                 }
@@ -1716,6 +1717,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
             return;
         };
+        self.end_all_websockets_going_away();
         if abrupt || self.is_closed() {
             self.unref();
         }
@@ -1746,8 +1748,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
             bun_opaque::opaque_deref_mut(listener).close();
             // Close idle keep-alive connections now and mark busy ones to
-            // close once their in-flight work completes; open websockets are
-            // untouched and drain on their own. Each close reaches
+            // close once their in-flight work completes (open websockets were
+            // ended with 1001 above). Each close reaches
             // `on_connection_filter(-2)` synchronously, so hold the guard so
             // that path cannot form a second `&mut self` under this frame —
             // `stop()` runs `deinit_if_we_can` right after this returns.
@@ -1788,6 +1790,27 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 ws.handler.server = None;
             }
         }
+    }
+
+    /// Send `1001 Going Away` to every open websocket so peers see a clean
+    /// close (not 1006) and the live-socket count drains for the stop promise.
+    fn end_all_websockets_going_away(&mut self) {
+        if !self.has_active_web_sockets() {
+            return;
+        }
+        // node:http `Server#close()` leaves upgraded sockets to the user;
+        // the `ws` shim drains its own `clients` set.
+        if self.config.is_node_http_server {
+            return;
+        }
+        let Some(app) = self.app else { return };
+        // `end()` fires close handlers synchronously; hold (and save/restore)
+        // the re-entrance guard so nested `deinit_if_we_can` / `stop(true)`
+        // early-return instead of running under this frame's `&mut self`.
+        let prev = self.deinit_running.replace(true);
+        // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+        bun_opaque::opaque_deref_mut(app).end_all_websockets(1001, b"Server closed");
+        self.deinit_running.set(prev);
     }
 
     pub(crate) fn stop(&mut self, abrupt: bool) {

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -111,6 +111,23 @@ impl<const SSL: bool> App<SSL> {
         c::uws_app_close_idle(Self::SSL_FLAG, self.as_raw(), i32::from(close_when_idle))
     }
 
+    /// Send a close frame with `code`/`message` to every open WebSocket and
+    /// fire its close handler (the WebSocket closing handshake). Unlike
+    /// [`Self::close`], peers observe `code` rather than an abnormal 1006.
+    pub fn end_all_websockets(&mut self, code: i32, message: &[u8]) {
+        // SAFETY: uWS copies `message` into the close frame before returning,
+        // so the slice only has to live for the duration of the call.
+        unsafe {
+            c::uws_app_end_all_websockets(
+                Self::SSL_FLAG,
+                self.as_raw(),
+                code,
+                message.as_ptr(),
+                message.len(),
+            )
+        }
+    }
+
     pub fn create(opts: &BunSocketContextOptions) -> Option<*mut Self> {
         // SAFETY: FFI call; uws_create_app returns null on failure.
         let app = unsafe { c::uws_create_app(Self::SSL_FLAG, *opts) };
@@ -524,6 +541,13 @@ pub mod c {
             app: &mut uws_app_s,
             close_when_idle: i32,
         ) -> usize;
+        pub(crate) fn uws_app_end_all_websockets(
+            ssl: i32,
+            app: &mut uws_app_s,
+            code: c_int,
+            message: *const u8,
+            length: usize,
+        );
         // safe: `&mut uws_app_s` is ABI-identical to a non-null `*mut`;
         // `handler`/`user_data` are stored opaquely (never dereferenced by the
         // C++ shim itself) — no preconditions on this call.

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -386,6 +386,21 @@ extern "C"
     }
   }
 
+  void uws_app_end_all_websockets(int ssl, uws_app_t *app, int code, const char *message, size_t length)
+  {
+    std::string_view msg = message ? std::string_view(message, length) : std::string_view();
+    if (ssl)
+    {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->endAllWebSockets(code, msg);
+    }
+    else
+    {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->endAllWebSockets(code, msg);
+    }
+  }
+
   void uws_app_set_on_clienterror(int ssl, uws_app_t *app, void (*handler)(void *user_data, int is_ssl, struct us_socket_t *rawSocket, uint8_t errorCode, char *rawPacket, int rawPacketLength), void *user_data)
   {
     if (ssl)

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1224,27 +1224,36 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
     // active_connection_count == 0 and only the has_active_web_sockets() term
     // in get_all_closed_promise's early-return keeps a repeat stop() call from
     // handing back a fresh resolved promise while the first one is pending.
+    // stop() ends websockets that are already open, so the upgrade is held in
+    // fetch() until after the first stop() to get a live ws on a stopped server.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
+          const entered = Promise.withResolvers();
+          const release = Promise.withResolvers();
           const server = Bun.serve({
             port: 0,
             hostname: "127.0.0.1",
-            fetch(req, server) {
+            async fetch(req, server) {
+              entered.resolve();
+              await release.promise;
               if (server.upgrade(req)) return;
               return new Response("no");
             },
             websocket: { open() {}, message() {}, close() {} },
           });
           const ws = new WebSocket("ws://127.0.0.1:" + server.port + "/");
-          await new Promise((resolve, reject) => {
+          const opened = new Promise((resolve, reject) => {
             ws.onopen = resolve;
             ws.onerror = reject;
           });
+          await entered.promise;
           let resolved1 = false, resolved2 = false;
           const p1 = server.stop(false).then(() => { resolved1 = true; });
+          release.resolve();
+          await opened;
           await new Promise(r => setImmediate(r));
           const p2 = server.stop(false).then(() => { resolved2 = true; });
           await new Promise(r => setImmediate(r));
@@ -1885,6 +1894,8 @@ test("server wrapper survives GC while a websocket is connected after stop()", a
   // m_routeList — while the connection was still in use. With the downgrade
   // deferred into deinit_if_we_can's idle predicate, the wrapper must outlive
   // the websocket and become collectable only after the last close.
+  // stop() now ends websockets that are already open, so the upgrade is held
+  // in fetch() until after stop() to reach the stopped-with-live-ws state.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -1923,11 +1934,15 @@ test("server wrapper survives GC while a websocket is connected after stop()", a
         })();
 
         const ws = await (async () => {
+          const entered = Promise.withResolvers();
+          const release = Promise.withResolvers();
           const server = Bun.serve({
             port: 0,
             hostname: "127.0.0.1",
             routes: { "/r": () => new Response("ok") },
-            fetch(req, server) {
+            async fetch(req, server) {
+              entered.resolve();
+              await release.promise;
               if (server.upgrade(req)) return;
               return new Response("nope", { status: 404 });
             },
@@ -1938,10 +1953,13 @@ test("server wrapper survives GC while a websocket is connected after stop()", a
           const ws = new WebSocket("ws://127.0.0.1:" + server.port);
           ws.onopen = () => opened.resolve();
           ws.onerror = e => opened.reject(e);
-          await opened.promise;
+          await entered.promise;
 
-          // Graceful stop: listener closes, the live websocket stays open.
+          // Graceful stop: listener closes; the in-flight request then
+          // upgrades, leaving a live websocket on the stopped server.
           server.stop();
+          release.resolve();
+          await opened.promise;
           return ws;
         })();
         // The only \`server\` binding is now out of scope; only the live
@@ -3269,11 +3287,20 @@ describe.concurrent("handler GC tracing (heapStats wrapper-count)", () => {
         // Nothing is returned from the arrow: a returned value would keep the
         // async frame's scope (which contains server) alive via the
         // resolved-value chain in JSC.
+        // stop() ends websockets that are already open, so the upgrade is held
+        // in fetch() until after stop() to reach the stopped-with-live-ws state.
+        const entered = Promise.withResolvers();
+        const release = Promise.withResolvers();
         await (async () => {
           const server = Bun.serve({
             port: 0,
             development: true,
-            fetch(req, s) { if (s.upgrade(req)) return; return new Response("ok"); },
+            async fetch(req, s) {
+              entered.resolve();
+              await release.promise;
+              if (s.upgrade(req)) return;
+              return new Response("ok");
+            },
             websocket: {
               open() { opened.resolve(); },
               // Closes over server — the cycle through wsHandlers.
@@ -3281,9 +3308,11 @@ describe.concurrent("handler GC tracing (heapStats wrapper-count)", () => {
             },
           });
           connect(server.url.href.replace("http", "ws"));
+          await entered.promise;
+          server.stop(); // graceful — listener gone, request still in flight
+          release.resolve();
           await opened.promise;      // server-side ws created (roots wrapper)
           await clientOpen.promise;  // client ready to send (avoid InvalidStateError)
-          server.stop(); // graceful — listener gone, ws stays
         })();
 
         // server out of scope. Wrapper is rooted only via:
@@ -3664,11 +3693,19 @@ describe.concurrent("handler GC tracing (heapStats wrapper-count)", () => {
         // Scope server so the module-level frame holds no reference to the
         // wrapper when message(ws) runs; after ws.close() downgrades js_value
         // and clears m_server, the wrapper must have zero roots for Bun.gc to
-        // reach wsOnError.
+        // reach wsOnError. stop() ends websockets that are already open, so
+        // the upgrade is held in fetch() until after stop().
+        const entered = Promise.withResolvers();
+        const release = Promise.withResolvers();
         await (async () => {
           const server = Bun.serve({
             port: 0, hostname: "127.0.0.1",
-            fetch(req, s) { if (s.upgrade(req)) return; return new Response("no"); },
+            async fetch(req, s) {
+              entered.resolve();
+              await release.promise;
+              if (s.upgrade(req)) return;
+              return new Response("no");
+            },
             websocket: {
               open() {},
               message(ws) {
@@ -3683,8 +3720,10 @@ describe.concurrent("handler GC tracing (heapStats wrapper-count)", () => {
           ws.onopen = () => opened.resolve();
           ws.onerror = e => opened.reject(e);
           ws.onclose = () => closed.resolve();
+          await entered.promise;
+          server.stop(); // graceful: listener gone, the upgrade below keeps wrapper Strong
+          release.resolve();
           await opened.promise;
-          server.stop(); // graceful: listener gone, this ws keeps wrapper Strong
         })();
         ws.send("go");
         await closed.promise;

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -2115,6 +2115,195 @@ it.each(["server", "client"] as const)(
   },
 );
 
+describe("server.stop() with open WebSockets", () => {
+  async function openServerWithWS() {
+    const serverClose = Promise.withResolvers<{ code: number; reason: string }>();
+    const srv = serve({
+      port: 0,
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response("http");
+      },
+      websocket: {
+        message(ws, m) {
+          ws.send("echo:" + m);
+        },
+        close(_ws, code, reason) {
+          serverClose.resolve({ code, reason });
+        },
+      },
+    });
+    const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/`);
+    const opened = Promise.withResolvers<void>();
+    const clientClose = Promise.withResolvers<CloseEvent>();
+    ws.onopen = () => opened.resolve();
+    ws.onerror = e => opened.reject(e);
+    ws.onclose = e => clientClose.resolve(e);
+    await opened.promise;
+    return { srv, ws, serverClose: serverClose.promise, clientClose: clientClose.promise };
+  }
+
+  it("stop(false) sends 1001 to open WebSockets and resolves", async () => {
+    const { srv, ws, serverClose, clientClose } = await openServerWithWS();
+    try {
+      expect(srv.pendingWebSockets).toBe(1);
+      await srv.stop(false);
+      const [s, c] = await Promise.all([serverClose, clientClose]);
+      expect({
+        serverCode: s.code,
+        clientCode: c.code,
+        wasClean: c.wasClean,
+        readyState: ws.readyState,
+        pendingWebSockets: srv.pendingWebSockets,
+      }).toEqual({
+        serverCode: 1001,
+        clientCode: 1001,
+        wasClean: true,
+        readyState: WebSocket.CLOSED,
+        pendingWebSockets: 0,
+      });
+    } finally {
+      ws.close();
+      srv.stop(true);
+    }
+  });
+
+  it("stop(true) sends 1001 to open WebSockets", async () => {
+    const { srv, ws, serverClose, clientClose } = await openServerWithWS();
+    try {
+      await srv.stop(true);
+      const [s, c] = await Promise.all([serverClose, clientClose]);
+      expect({
+        serverCode: s.code,
+        clientCode: c.code,
+        wasClean: c.wasClean,
+        pendingWebSockets: srv.pendingWebSockets,
+      }).toEqual({
+        serverCode: 1001,
+        clientCode: 1001,
+        wasClean: true,
+        pendingWebSockets: 0,
+      });
+    } finally {
+      ws.close();
+      srv.stop(true);
+    }
+  });
+
+  it("stop(true) after stop(false) ends a WebSocket and force-closes remaining connections", async () => {
+    // A never-finishing HTTP response keeps the graceful stop pending after
+    // the WebSocket is gone, so stop(true) has something left to force-close.
+    const httpDone = Promise.withResolvers<void>();
+    const srv = serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response(
+          new ReadableStream({
+            pull() {
+              return httpDone.promise;
+            },
+          }),
+        );
+      },
+      websocket: { message() {}, close() {} },
+    });
+    const sock = net.connect(srv.port, "127.0.0.1", () => {
+      sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    });
+    const gotData = Promise.withResolvers<void>();
+    const sockClosed = Promise.withResolvers<void>();
+    sock.once("data", () => gotData.resolve());
+    sock.on("error", e => gotData.reject(e));
+    sock.on("close", () => sockClosed.resolve());
+    const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/`);
+    const wsOpened = Promise.withResolvers<void>();
+    const wsClosed = Promise.withResolvers<CloseEvent>();
+    ws.onopen = () => wsOpened.resolve();
+    ws.onerror = e => wsOpened.reject(e);
+    ws.onclose = e => wsClosed.resolve(e);
+    await Promise.all([gotData.promise, wsOpened.promise]);
+    try {
+      const graceful = srv.stop(false);
+      expect((await wsClosed.promise).code).toBe(1001);
+      expect(srv.pendingRequests).toBe(1);
+
+      const force = srv.stop(true);
+      await Promise.all([graceful, force, sockClosed.promise]);
+      expect(srv.pendingRequests).toBe(0);
+    } finally {
+      httpDone.resolve();
+      sock.destroy();
+      ws.close();
+      srv.stop(true);
+    }
+  });
+
+  it("stop(false) is not kept alive by an already-closing WebSocket", async () => {
+    const { srv, ws } = await openServerWithWS();
+    try {
+      ws.close(1000, "bye");
+      await srv.stop(false);
+      expect(srv.pendingWebSockets).toBe(0);
+    } finally {
+      srv.stop(true);
+    }
+  });
+
+  it("stop(false) reaches every WebSocket when a close handler terminates another", async () => {
+    const sockets: ServerWebSocket<unknown>[] = [];
+    const serverCodes: number[] = [];
+    const srv = serve({
+      port: 0,
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response("http");
+      },
+      websocket: {
+        open(ws) {
+          sockets.push(ws);
+        },
+        message() {},
+        close(ws, code) {
+          serverCodes.push(code);
+          // The first close handler terminates every other socket and
+          // re-enters stop(true): the drain must survive both.
+          if (serverCodes.length === 1) {
+            for (const other of sockets) if (other !== ws) other.terminate();
+            srv.stop(true);
+          }
+        },
+      },
+    });
+    const clients: WebSocket[] = [];
+    const clientCloses: Promise<void>[] = [];
+    try {
+      for (let i = 0; i < 4; i++) {
+        const opened = Promise.withResolvers<void>();
+        const closed = Promise.withResolvers<void>();
+        const c = new WebSocket(`ws://127.0.0.1:${srv.port}/`);
+        c.onopen = () => opened.resolve();
+        c.onerror = e => opened.reject(e);
+        c.onclose = () => closed.resolve();
+        clients.push(c);
+        clientCloses.push(closed.promise);
+        await opened.promise;
+      }
+      expect(srv.pendingWebSockets).toBe(4);
+      await srv.stop(false);
+      await Promise.all(clientCloses);
+      expect({ pendingWebSockets: srv.pendingWebSockets, serverCodes: serverCodes.sort((a, b) => a - b) }).toEqual({
+        pendingWebSockets: 0,
+        serverCodes: [1001, 1006, 1006, 1006],
+      });
+    } finally {
+      for (const c of clients) c.close();
+      srv.stop(true);
+    }
+  });
+});
+
 // RFC 6455 §4.2.1 / §4.4: server.upgrade() must refuse a client handshake
 // whose Upgrade token, Sec-WebSocket-Key, or Sec-WebSocket-Version is invalid.
 describe("server.upgrade() validates the opening handshake", () => {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -2150,15 +2150,13 @@ describe("server.stop() with open WebSockets", () => {
       await srv.stop(false);
       const [s, c] = await Promise.all([serverClose, clientClose]);
       expect({
-        serverCode: s.code,
-        clientCode: c.code,
-        wasClean: c.wasClean,
+        server: s,
+        client: { code: c.code, reason: c.reason, wasClean: c.wasClean },
         readyState: ws.readyState,
         pendingWebSockets: srv.pendingWebSockets,
       }).toEqual({
-        serverCode: 1001,
-        clientCode: 1001,
-        wasClean: true,
+        server: { code: 1001, reason: "Server closed" },
+        client: { code: 1001, reason: "Server closed", wasClean: true },
         readyState: WebSocket.CLOSED,
         pendingWebSockets: 0,
       });
@@ -2174,14 +2172,12 @@ describe("server.stop() with open WebSockets", () => {
       await srv.stop(true);
       const [s, c] = await Promise.all([serverClose, clientClose]);
       expect({
-        serverCode: s.code,
-        clientCode: c.code,
-        wasClean: c.wasClean,
+        server: s,
+        client: { code: c.code, reason: c.reason, wasClean: c.wasClean },
         pendingWebSockets: srv.pendingWebSockets,
       }).toEqual({
-        serverCode: 1001,
-        clientCode: 1001,
-        wasClean: true,
+        server: { code: 1001, reason: "Server closed" },
+        client: { code: 1001, reason: "Server closed", wasClean: true },
         pendingWebSockets: 0,
       });
     } finally {

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -189,6 +189,15 @@ test.concurrent("http.Server.close() does not close open WebSocket connections",
     expect(await echoed.promise).toBe("echo:hi");
     expect(client.readyState).toBe(WebSocket.OPEN);
 
+    // close() did take effect: the listener is gone for new connections.
+    const late = new WebSocket(`ws://127.0.0.1:${port}/`);
+    const lateResult = await new Promise<string>(resolve => {
+      late.onopen = () => resolve("open");
+      late.onerror = () => resolve("error");
+    });
+    expect(lateResult).toBe("error");
+    expect(client.readyState).toBe(WebSocket.OPEN);
+
     // User-chosen code reaches the peer.
     for (const c of wss.clients) c.close(4001, "draining");
     const ev = await closed.promise;

--- a/test/js/node/http/node-http-with-ws.test.ts
+++ b/test/js/node/http/node-http-with-ws.test.ts
@@ -162,3 +162,40 @@ describe.concurrent("request handlers run to completion before the callbacks the
     expect(order).toEqual(["rest of handler", "nextTick", "microtask"]);
   });
 });
+
+test.concurrent("http.Server.close() does not close open WebSocket connections", async () => {
+  const server = http.createServer();
+  const wss = new WebSocketServer({ server });
+  const echoed = Promise.withResolvers<string>();
+  wss.on("connection", ws => {
+    ws.on("message", m => ws.send("echo:" + m));
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  const opened = Promise.withResolvers<void>();
+  const closed = Promise.withResolvers<CloseEvent>();
+  client.onopen = () => opened.resolve();
+  client.onerror = e => opened.reject(e);
+  client.onmessage = e => echoed.resolve(String(e.data));
+  client.onclose = e => closed.resolve(e);
+  await opened.promise;
+  try {
+    // Node's server.close() stops accepting but leaves upgraded sockets to
+    // the user; the ws connection must stay open.
+    server.close();
+    client.send("hi");
+    expect(await echoed.promise).toBe("echo:hi");
+    expect(client.readyState).toBe(WebSocket.OPEN);
+
+    // User-chosen code reaches the peer.
+    for (const c of wss.clients) c.close(4001, "draining");
+    const ev = await closed.promise;
+    expect({ code: ev.code, reason: ev.reason }).toEqual({ code: 4001, reason: "draining" });
+  } finally {
+    for (const c of wss.clients) c.terminate();
+    client.close();
+    server.closeAllConnections();
+  }
+});


### PR DESCRIPTION
### Problem
- `server.stop(false)` never resolves while a WebSocket is connected. It closes the listener (and, since #37074, idle HTTP connections) but leaves open WebSockets untouched, so `is_closed()` stays false and the socket keeps serving traffic. A server that does `await server.stop()` on SIGTERM hangs forever with one client attached.
- `server.stop(true)` tears WebSockets down with a raw socket close (`app.close()` in `src/runtime/server/mod.rs`, `us_socket_group_close_all`). The server `close` handler and the peer both observe `1006` with no close frame instead of `1001` Going Away.

### Fix
- Add `TemplatedApp::endAllWebSockets(code, reason)` (`packages/bun-uws/src/App.h`). It snapshots every WebSocket group, then calls `WebSocket::end()` on each open socket: close frame, close handler, FIN. The snapshot matters because a close handler can `terminate()` a later socket, which relinks it out of the group list. Exposed as `NewApp::end_all_websockets`.
- `stop_listening()` calls it with `1001 "Server closed"` on every stop path (graceful, abrupt, and abrupt after an earlier graceful stop) before it closes the listener or the app. The call runs under the existing `deinit_running` guard (save/restore), so a `deinit_if_we_can` or `server.stop(true)` reached from a close handler early-returns instead of re-entering under this frame's `&mut self`.
- node:http servers are exempt (`config.is_node_http_server`). Node's `Server#close()` leaves upgraded sockets to the user, and the `ws` shim drains its own `clients` set.
- Verified: `test/js/bun/websocket/websocket-server.test.ts` ("server.stop() with open WebSockets", 4 of 5 fail on main), `test/js/node/http/node-http-with-ws.test.ts` (new `http.Server.close()` case). Also ran `bun-server.test.ts`, `serve.test.ts`, `first_party/ws`, `web/websocket`.

### Background
- A uWS app keeps one socket group per `ws()` route. `app.close()` walks them with `us_socket_close`, which closes the fd and reports `1006` to the close handler. Only `WebSocket::end()` performs the RFC 6455 closing handshake.
- `ServerWebSocket::on_close` decrements the server's live-socket count synchronously, so after `end_all_websockets` returns, `stop()`'s own `deinit_if_we_can` sees the server as closed and resolves the stop promise.
- `deinit_running` is a re-entrance flag: `deinit_if_we_can` and `stop_from_js` no-op while it is set, because the abrupt drain already runs user close handlers under a live `&mut NewServer`.

Closes #25722

<details><summary>Notes</summary>

Repro (all three cases deterministic on stock 1.4.0 and asan main):

```js
const s = Bun.serve({ port: 0, fetch(req, sv) { if (sv.upgrade(req)) return; return new Response("http"); },
  websocket: { message(ws, m) { ws.send("echo:" + m); }, close(_w, code) { console.log("server close", code); } } });
const w = new WebSocket(`ws://127.0.0.1:${s.port}/`);
await new Promise(r => (w.onopen = r));
w.onclose = e => console.log("client close", e.code, e.wasClean);
await s.stop(false);   // before: never resolves, w keeps echoing. after: resolves, both sides 1001
// s.stop(true) alone: before: both sides 1006. after: 1001
```

Rebase on current main (2026-07-22). Main had since landed the other two pieces this PR originally carried, so they are gone from the diff: `stop(true)` after `stop(false)` now tears the app down (`already_terminated` arm in `stop_listening`, `!deinit_running` gate in `stop_from_js` / `dispose_from_js`), and `get_all_closed_promise` goes through `is_closed()`, which already counts WebSockets. What remains is the WebSocket drain itself, the node:http exemption, and the tests. The `stop(true)` after `stop(false)` test is kept because the WebSocket still has to get `1001` on that path.

Four existing tests in `bun-server.test.ts` (`websocket-only server: a second stop() returns the still-pending promise`, `server wrapper survives GC while a websocket is connected after stop()`, `server stays alive while a websocket is connected, then collects after close`, `error handler survives ws.close()+throw ...`) set up "stopped server with a live WebSocket" by opening the socket and then calling `stop()`. That ordering no longer produces the state. They now hold the upgrade in `fetch()` until after `stop()` (an in-flight request may still upgrade after a graceful stop), which reaches the same state and keeps every original assertion. A socket that upgrades in that window is ended with `1001` by a later `stop(true)`.

Environment-only failures seen locally, identical with the fix stashed: 8 `ServerWebSocket` tests in `websocket-server.test.ts` time out next to the `(benchmark)` case on this debug+ASAN box, 4 in `serve.test.ts` (IPv6, root port, egress), 2 in `web/websocket` (postman-echo).

Overlaps #33662 (that PR covers the `stop(true)` after `stop(false)` gate, which main has since fixed independently).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts, test/js/bun/http/bun-server.test.ts

<!-- robobun:evidence:end -->