### PR TITLE
fix(Bun.serve): ServerWebSocket.send() re-checks closed after message toString()

### DIFF
--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -1120,6 +1120,12 @@ impl ServerWebSocket {
 
         {
             let js_string = message_value.to_js_string(global_this)?;
+            // `to_js_string` can run user `toString()`, which may re-entrantly
+            // `ws.close()`/`terminate()` and end the raw socket; re-check.
+            if self.is_closed() {
+                bun_output::scoped_log!(WebSocketServer, "send() closed");
+                return Ok(JSValue::js_number(0.0));
+            }
             let view = js_string.view(global_this);
             let slice = view.to_slice();
 

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -737,6 +737,46 @@ describe("ServerWebSocket", () => {
       done();
     },
   }));
+  for (const how of ["close", "terminate"] as const) {
+    it.concurrent(`send() returns 0 when message toString() calls ws.${how}()`, async () => {
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      using server = serve({
+        port: 0,
+        fetch(req, srv) {
+          if (srv.upgrade(req)) return;
+          return new Response();
+        },
+        websocket: {
+          open(ws) {
+            try {
+              // @ts-expect-error send() accepts toString()-able objects
+              const ret = ws.send({
+                toString() {
+                  ws[how]();
+                  return "hello-from-server";
+                },
+              });
+              resolve(ret);
+            } catch (e) {
+              reject(e);
+            }
+          },
+          message() {},
+          close() {},
+        },
+      });
+      const ws = new WebSocket(`ws://${server.hostname}:${server.port}/`);
+      let received: string | undefined;
+      ws.onmessage = e => (received = String(e.data));
+      const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+      ws.onclose = () => onClosed();
+      const sendReturn = await promise;
+      await closed;
+      // The socket was closed during toString() coercion before the write, so
+      // send() must report dropped (0), not the byte length of the message.
+      expect({ sendReturn, received }).toEqual({ sendReturn: 0, received: undefined });
+    });
+  }
   describe("sendBinary()", () => {
     for (const { label, message, bytes } of buffers) {
       test(label, done => ({

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -766,6 +766,7 @@ describe("ServerWebSocket", () => {
         },
       });
       const ws = new WebSocket(`ws://${server.hostname}:${server.port}/`);
+      ws.onerror = e => reject(new Error(`client ws error: ${e}`));
       let received: string | undefined;
       ws.onmessage = e => (received = String(e.data));
       const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();


### PR DESCRIPTION
## What

`ServerWebSocket.send(msg)` with a non-string, non-ArrayBuffer `msg` coerces it via `toString()`. The closed check ran once before coercion, but `toString()` can run user JS that calls `ws.close()` / `ws.terminate()` / `server.stop(true)`, ending the raw uWS socket. `send()` then wrote to the packed raw pointer anyway and returned the byte length as if the write succeeded, even though the client never receives the message.

## Repro

```js
Bun.serve({
  port: 0,
  fetch(req, srv) { if (srv.upgrade(req)) return; return new Response("x"); },
  websocket: {
    open(ws) {
      console.log("send returned:", ws.send({
        toString() { ws.close(); return "hello-from-server"; },
      }));
    },
    message() {}, close() {},
  },
});
// send returned: 17   (client closes without receiving anything)
```

`ws.close(code, reason)` already re-checks `is_closed()` after coercing its `reason` argument (src/runtime/server/ServerWebSocket.rs around L1390). This PR applies the same guard to `send()` after `to_js_string()` and returns `0` (dropped), matching the top-of-function closed check.

`sendText()` / `publishText()` are unaffected because they require `is_string()` before coercion, so `to_js_string()` cannot invoke user `toString()`. `publish()` routes through `do_publish()` which already re-checks `is_closed()` before touching the per-socket handle.

## Verification

```
USE_SYSTEM_BUN=1 bun test websocket-server.test.ts -t "returns 0 when message toString"
  (fail) send() returns 0 when message toString() calls ws.close()      sendReturn: 17
  (fail) send() returns 0 when message toString() calls ws.terminate()  sendReturn: 17

bun bd test websocket-server.test.ts -t "returns 0 when message toString"
  (pass) send() returns 0 when message toString() calls ws.close()
  (pass) send() returns 0 when message toString() calls ws.terminate()
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->