### PR TITLE
crypto,util: coerce later arguments before capturing input buffers in Bun.* hash/UUID/indexOfLine/verifySync

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -230,19 +230,20 @@ mod static_adapters {
         // re-enters the VM).
         let _a0_guard = a0.protected();
         let _a1_guard = a1.protected();
-        let Some(mut input) = BlobOrStringOrBuffer::from_js(g, a0)? else {
-            return Err(g.throw_invalid_arguments(format_args!(
-                "expected string, buffer, TypedArray, or Blob",
-            )));
-        };
+        // Coerce the output argument first: `StringOrBuffer::from_js` can call a
+        // boxed String's `toString`, which may detach the input's ArrayBuffer.
         let output = if a1.is_undefined_or_null() {
             None
         } else {
             StringOrBuffer::from_js(g, a1)?
         };
-        // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
-        // which can detach `input`'s backing ArrayBuffer (use-after-free).
-        input.refresh_buffer(g);
+        // `from_js_no_string_object` never runs user JS, so `output`'s buffer
+        // (captured above) stays valid.
+        let Some(input) = BlobOrStringOrBuffer::from_js_no_string_object(g, a0)? else {
+            return Err(g.throw_invalid_arguments(format_args!(
+                "expected string, buffer, TypedArray, or Blob",
+            )));
+        };
         Crypto::SHA512_256::hash_(g, &input, output)
     }
 }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -230,7 +230,7 @@ mod static_adapters {
         // re-enters the VM).
         let _a0_guard = a0.protected();
         let _a1_guard = a1.protected();
-        let Some(input) = BlobOrStringOrBuffer::from_js(g, a0)? else {
+        let Some(mut input) = BlobOrStringOrBuffer::from_js(g, a0)? else {
             return Err(g.throw_invalid_arguments(format_args!(
                 "expected string, buffer, TypedArray, or Blob",
             )));
@@ -240,6 +240,9 @@ mod static_adapters {
         } else {
             StringOrBuffer::from_js(g, a1)?
         };
+        // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
+        // which can detach `input`'s backing ArrayBuffer (use-after-free).
+        input.refresh_buffer(g);
         Crypto::SHA512_256::hash_(g, &input, output)
     }
 }
@@ -1517,15 +1520,17 @@ pub(crate) fn index_of_line(
         return Ok(JSValue::js_number_from_int32(-1));
     }
 
-    let Some(buffer) = arguments[0].as_array_buffer(global_this) else {
-        return Ok(JSValue::js_number_from_int32(-1));
-    };
-
+    // Coerce `offset` before snapshotting the buffer: `coerce_to_int64` can run
+    // `valueOf`/`toString`, which may detach `arguments[0]` (use-after-free).
     let mut offset: usize = 0;
     if arguments.len() > 1 {
         let offset_value = arguments[1].coerce_to_int64(global_this)?;
         offset = offset_value.max(0) as usize;
     }
+
+    let Some(buffer) = arguments[0].as_array_buffer(global_this) else {
+        return Ok(JSValue::js_number_from_int32(-1));
+    };
 
     let bytes = buffer.byte_slice();
     let mut current_offset = offset;

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -242,47 +242,30 @@ impl CryptoHasher {
     /// Hand-expanded static-method argument decode for the parameter list
     /// `(algorithm string, input, optional output buffer/encoding)`.
     pub fn hash(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let arguments = callframe.arguments_old::<3>();
-        let mut i = 0usize;
-        let mut next_eat = || {
-            if i < arguments.len {
-                let v = arguments.ptr[i];
-                i += 1;
-                Some(v)
-            } else {
-                None
-            }
-        };
+        let arguments = callframe.arguments_undef::<3>();
 
         let algorithm = {
-            let Some(string_value) = next_eat() else {
-                return Err(global.throw_invalid_arguments(format_args!("Missing argument")));
-            };
+            let string_value = arguments.ptr[0];
             if string_value.is_undefined_or_null() {
+                if arguments.len == 0 {
+                    return Err(global.throw_invalid_arguments(format_args!("Missing argument")));
+                }
                 return Err(global.throw_invalid_arguments(format_args!("Expected string")));
             }
             string_value.get_zig_string(global)?
         };
 
-        // Node.BlobOrStringOrBuffer
-        let mut input = {
-            let Some(arg) = next_eat() else {
-                return Err(
-                    global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
-                );
-            };
-            match BlobOrStringOrBuffer::from_js(global, arg)? {
-                Some(b) => b,
-                None => {
-                    return Err(global
-                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
-                }
-            }
-        };
+        if arguments.len < 2 {
+            return Err(
+                global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
+            );
+        }
 
-        // ?Node.StringOrBuffer (static-method arm: only `undefined` → None)
-        let output: Option<StringOrBuffer> = match next_eat() {
-            Some(arg) => match StringOrBuffer::from_js(global, arg)? {
+        // Coerce the output argument first: `StringOrBuffer::from_js` can call a
+        // boxed String's `toString`, which may detach the input's ArrayBuffer.
+        let output: Option<StringOrBuffer> = if arguments.len > 2 {
+            let arg = arguments.ptr[2];
+            match StringOrBuffer::from_js(global, arg)? {
                 Some(v) => Some(v),
                 None => {
                     if arg.is_undefined() {
@@ -292,13 +275,20 @@ impl CryptoHasher {
                             .throw_invalid_arguments(format_args!("expected string or buffer")));
                     }
                 }
-            },
-            None => None,
+            }
+        } else {
+            None
         };
 
-        // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
-        // which can detach `input`'s backing ArrayBuffer (use-after-free).
-        input.refresh_buffer(global);
+        // `from_js_no_string_object` never runs user JS, so `output`'s buffer
+        // (captured above) stays valid.
+        let input = match BlobOrStringOrBuffer::from_js_no_string_object(global, arguments.ptr[1])? {
+            Some(b) => b,
+            None => {
+                return Err(global
+                    .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
+            }
+        };
 
         Self::hash_(global, algorithm, &input, output)
     }
@@ -1227,37 +1217,19 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
     /// Hand-expanded `wrapStaticMethod` decode for the parameter list
     /// `(*JSGlobalObject, Node.BlobOrStringOrBuffer, ?Node.StringOrBuffer)`.
     pub fn hash(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let arguments = callframe.arguments_old::<2>();
-        let mut i = 0usize;
-        let mut next_eat = || {
-            if i < arguments.len {
-                let v = arguments.ptr[i];
-                i += 1;
-                Some(v)
-            } else {
-                None
-            }
-        };
+        let arguments = callframe.arguments_undef::<2>();
 
-        // Node.BlobOrStringOrBuffer
-        let mut input = {
-            let Some(arg) = next_eat() else {
-                return Err(
-                    global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
-                );
-            };
-            match BlobOrStringOrBuffer::from_js(global, arg)? {
-                Some(b) => b,
-                None => {
-                    return Err(global
-                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
-                }
-            }
-        };
+        if arguments.len == 0 {
+            return Err(
+                global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
+            );
+        }
 
-        // ?Node.StringOrBuffer (static-method arm: only `undefined` → None)
-        let output: Option<StringOrBuffer> = match next_eat() {
-            Some(arg) => match StringOrBuffer::from_js(global, arg)? {
+        // Coerce the output argument first: `StringOrBuffer::from_js` can call a
+        // boxed String's `toString`, which may detach the input's ArrayBuffer.
+        let output: Option<StringOrBuffer> = if arguments.len > 1 {
+            let arg = arguments.ptr[1];
+            match StringOrBuffer::from_js(global, arg)? {
                 Some(v) => Some(v),
                 None => {
                     if arg.is_undefined() {
@@ -1267,13 +1239,20 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
                             .throw_invalid_arguments(format_args!("expected string or buffer")));
                     }
                 }
-            },
-            None => None,
+            }
+        } else {
+            None
         };
 
-        // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
-        // which can detach `input`'s backing ArrayBuffer (use-after-free).
-        input.refresh_buffer(global);
+        // `from_js_no_string_object` never runs user JS, so `output`'s buffer
+        // (captured above) stays valid.
+        let input = match BlobOrStringOrBuffer::from_js_no_string_object(global, arguments.ptr[0])? {
+            Some(b) => b,
+            None => {
+                return Err(global
+                    .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
+            }
+        };
 
         Self::hash_(global, &input, output)
     }

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -265,7 +265,7 @@ impl CryptoHasher {
         };
 
         // Node.BlobOrStringOrBuffer
-        let input = {
+        let mut input = {
             let Some(arg) = next_eat() else {
                 return Err(
                     global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
@@ -295,6 +295,10 @@ impl CryptoHasher {
             },
             None => None,
         };
+
+        // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
+        // which can detach `input`'s backing ArrayBuffer (use-after-free).
+        input.refresh_buffer(global);
 
         Self::hash_(global, algorithm, &input, output)
     }
@@ -1236,7 +1240,7 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
         };
 
         // Node.BlobOrStringOrBuffer
-        let input = {
+        let mut input = {
             let Some(arg) = next_eat() else {
                 return Err(
                     global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
@@ -1266,6 +1270,10 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
             },
             None => None,
         };
+
+        // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
+        // which can detach `input`'s backing ArrayBuffer (use-after-free).
+        input.refresh_buffer(global);
 
         Self::hash_(global, &input, output)
     }

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -282,13 +282,14 @@ impl CryptoHasher {
 
         // `from_js_no_string_object` never runs user JS, so `output`'s buffer
         // (captured above) stays valid.
-        let input = match BlobOrStringOrBuffer::from_js_no_string_object(global, arguments.ptr[1])? {
-            Some(b) => b,
-            None => {
-                return Err(global
-                    .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
-            }
-        };
+        let input =
+            match BlobOrStringOrBuffer::from_js_no_string_object(global, arguments.ptr[1])? {
+                Some(b) => b,
+                None => {
+                    return Err(global
+                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
+                }
+            };
 
         Self::hash_(global, algorithm, &input, output)
     }
@@ -1246,13 +1247,14 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
 
         // `from_js_no_string_object` never runs user JS, so `output`'s buffer
         // (captured above) stays valid.
-        let input = match BlobOrStringOrBuffer::from_js_no_string_object(global, arguments.ptr[0])? {
-            Some(b) => b,
-            None => {
-                return Err(global
-                    .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
-            }
-        };
+        let input =
+            match BlobOrStringOrBuffer::from_js_no_string_object(global, arguments.ptr[0])? {
+                Some(b) => b,
+                None => {
+                    return Err(global
+                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
+                }
+            };
 
         Self::hash_(global, &input, output)
     }

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -929,16 +929,9 @@ pub(crate) fn js_password_object_verify_sync(
         };
     }
 
-    let Some(mut password) = StringOrBuffer::from_js(global_object, arguments[0])? else {
-        return Err(global_object.throw_invalid_argument_type(
-            "verify",
-            "password",
-            "string or TypedArray",
-        ));
-    };
-
+    // Coerce the hash argument first: `StringOrBuffer::from_js` can call a
+    // boxed String's `toString`, which may detach the password's ArrayBuffer.
     let Some(hash_) = StringOrBuffer::from_js(global_object, arguments[1])? else {
-        drop(password);
         return Err(global_object.throw_invalid_argument_type(
             "verify",
             "hash",
@@ -946,9 +939,18 @@ pub(crate) fn js_password_object_verify_sync(
         ));
     };
 
-    // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
-    // which can detach `password`'s backing ArrayBuffer (use-after-free).
-    password.refresh_buffer(global_object);
+    // `allow_string_object = false`: the password decode never runs user JS, so
+    // `hash_`'s buffer (captured above) stays valid.
+    let Some(password) =
+        StringOrBuffer::from_js_maybe_async(global_object, arguments[0], false, false)?
+    else {
+        drop(hash_);
+        return Err(global_object.throw_invalid_argument_type(
+            "verify",
+            "password",
+            "string or TypedArray",
+        ));
+    };
 
     // defer password.deinit() / hash_.deinit() — Drop at scope exit.
 

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -929,7 +929,7 @@ pub(crate) fn js_password_object_verify_sync(
         };
     }
 
-    let Some(password) = StringOrBuffer::from_js(global_object, arguments[0])? else {
+    let Some(mut password) = StringOrBuffer::from_js(global_object, arguments[0])? else {
         return Err(global_object.throw_invalid_argument_type(
             "verify",
             "password",
@@ -945,6 +945,10 @@ pub(crate) fn js_password_object_verify_sync(
             "string or TypedArray",
         ));
     };
+
+    // `StringOrBuffer::from_js` above may call a boxed String's `toString`,
+    // which can detach `password`'s backing ArrayBuffer (use-after-free).
+    password.refresh_buffer(global_object);
 
     // defer password.deinit() / hash_.deinit() — Drop at scope exit.
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -85,14 +85,6 @@ impl BlobOrStringOrBuffer {
         }
     }
 
-    /// See [`StringOrBuffer::refresh_buffer`].
-    #[inline]
-    pub fn refresh_buffer(&mut self, global: &JSGlobalObject) {
-        if let Self::StringOrBuffer(sob) = self {
-            sob.refresh_buffer(global);
-        }
-    }
-
     pub fn protect(&self) {
         match self {
             Self::StringOrBuffer(sob) => sob.protect(),
@@ -109,9 +101,15 @@ impl BlobOrStringOrBuffer {
         value: JSValue,
         allow_file: bool,
         is_async: bool,
+        allow_string_object: bool,
     ) -> JsResult<Option<BlobOrStringOrBuffer>> {
         // Check StringOrBuffer first because it's more common and cheaper.
-        let str = match StringOrBuffer::from_js_maybe_async(global, value, is_async, true)? {
+        let str = match StringOrBuffer::from_js_maybe_async(
+            global,
+            value,
+            is_async,
+            allow_string_object,
+        )? {
             Some(s) => s,
             None => {
                 // `as_class_ref` is the safe shared-borrow downcast (centralised
@@ -149,7 +147,7 @@ impl BlobOrStringOrBuffer {
         value: JSValue,
         allow_file: bool,
     ) -> JsResult<Option<BlobOrStringOrBuffer>> {
-        Self::from_js_maybe_file_maybe_async(global, value, allow_file, false)
+        Self::from_js_maybe_file_maybe_async(global, value, allow_file, false, true)
     }
 
     pub fn from_js(
@@ -159,11 +157,21 @@ impl BlobOrStringOrBuffer {
         Self::from_js_maybe_file(global, value, true)
     }
 
+    /// [`from_js`] with `allow_string_object = false`: boxed `String` inputs are
+    /// rejected, so this never calls user `toString` and is safe to call after
+    /// an earlier argument's ArrayBuffer slice has been captured.
+    pub fn from_js_no_string_object(
+        global: &JSGlobalObject,
+        value: JSValue,
+    ) -> JsResult<Option<BlobOrStringOrBuffer>> {
+        Self::from_js_maybe_file_maybe_async(global, value, true, false, false)
+    }
+
     pub fn from_js_async(
         global: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<BlobOrStringOrBuffer>> {
-        Self::from_js_maybe_file_maybe_async(global, value, true, true)
+        Self::from_js_maybe_file_maybe_async(global, value, true, true, true)
     }
 
     pub fn from_js_with_encoding_value(
@@ -265,22 +273,6 @@ impl StringOrBuffer {
             Self::ThreadsafeString(str) => str.slice(),
             Self::EncodedSlice(str) => str.slice(),
             Self::Buffer(str) => str.slice(),
-        }
-    }
-
-    /// Re-snapshot the `Buffer` variant's backing `ArrayBuffer` from its
-    /// underlying `JSValue`. Call after coercing a later argument whose
-    /// `toString`/`valueOf` may have detached the backing store.
-    #[inline]
-    pub fn refresh_buffer(&mut self, global: &JSGlobalObject) {
-        if let Self::Buffer(buf) = self {
-            if let Some(fresh) = buf.buffer.value.as_array_buffer(global) {
-                buf.buffer = fresh;
-            } else {
-                buf.buffer.ptr = core::ptr::null_mut();
-                buf.buffer.len = 0;
-                buf.buffer.byte_len = 0;
-            }
         }
     }
 }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -85,6 +85,14 @@ impl BlobOrStringOrBuffer {
         }
     }
 
+    /// See [`StringOrBuffer::refresh_buffer`].
+    #[inline]
+    pub fn refresh_buffer(&mut self, global: &JSGlobalObject) {
+        if let Self::StringOrBuffer(sob) = self {
+            sob.refresh_buffer(global);
+        }
+    }
+
     pub fn protect(&self) {
         match self {
             Self::StringOrBuffer(sob) => sob.protect(),
@@ -257,6 +265,22 @@ impl StringOrBuffer {
             Self::ThreadsafeString(str) => str.slice(),
             Self::EncodedSlice(str) => str.slice(),
             Self::Buffer(str) => str.slice(),
+        }
+    }
+
+    /// Re-snapshot the `Buffer` variant's backing `ArrayBuffer` from its
+    /// underlying `JSValue`. Call after coercing a later argument whose
+    /// `toString`/`valueOf` may have detached the backing store.
+    #[inline]
+    pub fn refresh_buffer(&mut self, global: &JSGlobalObject) {
+        if let Self::Buffer(buf) = self {
+            if let Some(fresh) = buf.buffer.value.as_array_buffer(global) {
+                buf.buffer = fresh;
+            } else {
+                buf.buffer.ptr = core::ptr::null_mut();
+                buf.buffer.len = 0;
+                buf.buffer.byte_len = 0;
+            }
         }
     }
 }

--- a/src/runtime/webcore/Crypto.rs
+++ b/src/runtime/webcore/Crypto.rs
@@ -351,27 +351,9 @@ pub(crate) fn bun_random_uuid_v5(
     let name_value = arguments.ptr[0];
     let namespace_value = arguments.ptr[1];
 
-    // `bun_core::ZigStringSlice` is a borrow-or-own UTF-8 slice.
-    let name: bun_core::ZigStringSlice = 'brk: {
-        if name_value.is_string() {
-            let name_str = bun_core::OwnedString::new(name_value.to_bun_string(global)?);
-            let result = name_str.to_utf8();
-
-            break 'brk result;
-        } else if let Some(array_buffer) = name_value.as_array_buffer(global) {
-            let bytes: &[u8] = array_buffer.byte_slice();
-            break 'brk bun_core::ZigStringSlice::from_utf8_never_free(bytes);
-        } else {
-            return Err(global
-                .err(
-                    bun_jsc::ErrorCode::INVALID_ARG_TYPE,
-                    format_args!("The \"name\" argument must be of type string or BufferSource"),
-                )
-                .throw());
-        }
-    };
-    // `defer name.deinit()` — Utf8Slice's Drop handles cleanup.
-
+    // Decode `namespace` first: its `to_bun_string` can call a boxed String's
+    // `toString`, which may detach `name`'s backing ArrayBuffer. `namespace`
+    // is copied to a local `[u8; 16]`, so it's safe against the reverse.
     let namespace: [u8; 16] = 'brk: {
         if namespace_value.is_string() {
             let namespace_str = bun_core::OwnedString::new(namespace_value.to_bun_string(global)?);
@@ -419,6 +401,27 @@ pub(crate) fn bun_random_uuid_v5(
             )
             .throw());
     };
+
+    // `bun_core::ZigStringSlice` is a borrow-or-own UTF-8 slice.
+    let name: bun_core::ZigStringSlice = 'brk: {
+        if name_value.is_string() {
+            let name_str = bun_core::OwnedString::new(name_value.to_bun_string(global)?);
+            let result = name_str.to_utf8();
+
+            break 'brk result;
+        } else if let Some(array_buffer) = name_value.as_array_buffer(global) {
+            let bytes: &[u8] = array_buffer.byte_slice();
+            break 'brk bun_core::ZigStringSlice::from_utf8_never_free(bytes);
+        } else {
+            return Err(global
+                .err(
+                    bun_jsc::ErrorCode::INVALID_ARG_TYPE,
+                    format_args!("The \"name\" argument must be of type string or BufferSource"),
+                )
+                .throw());
+        }
+    };
+    // `defer name.deinit()` — Utf8Slice's Drop handles cleanup.
 
     let uuid = UUID5::init(&namespace, name.slice());
 

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -1,6 +1,60 @@
 import { describe, expect, test } from "bun:test";
 import { withoutAggressiveGC } from "harness";
 
+describe("input buffer detached by output argument's toString", () => {
+  // A boxed String's `toString` runs during output-encoding coercion. If the
+  // input buffer's slice was snapshotted before that, detaching it here leaves
+  // the hasher reading freed memory. After the fix, the input is re-snapshotted
+  // as detached (length 0), so the result is the digest of the empty input.
+  const N = 1 << 16;
+  const keep: Uint8Array[] = [];
+  const mk = () => Buffer.from(new ArrayBuffer(N)).fill(0x41);
+  const evilEncoding = (victim: Buffer, s: string) =>
+    Object.assign(new String(s), {
+      toString() {
+        victim.buffer.transfer(0);
+        for (let i = 0; i < 8; i++) keep.push(new Uint8Array(N).fill(0x5a));
+        return s;
+      },
+    }) as string;
+
+  test("Bun.CryptoHasher.hash", () => {
+    const b = mk();
+    const got = Bun.CryptoHasher.hash("sha256", b, evilEncoding(b, "hex"));
+    expect(b.byteLength).toBe(0);
+    expect(got).toBe(Bun.CryptoHasher.hash("sha256", new Uint8Array(0), "hex"));
+  });
+
+  test("Bun.SHA256.hash", () => {
+    const b = mk();
+    const got = Bun.SHA256.hash(b, evilEncoding(b, "hex"));
+    expect(b.byteLength).toBe(0);
+    expect(got).toBe(Bun.SHA256.hash(new Uint8Array(0), "hex"));
+  });
+
+  test("Bun.sha", () => {
+    const b = mk();
+    const got = Bun.sha(b, evilEncoding(b, "hex"));
+    expect(b.byteLength).toBe(0);
+    expect(got).toBe(Bun.sha(new Uint8Array(0), "hex"));
+  });
+
+  test("Bun.CryptoHasher.hash (output=Uint8Array, input=String object)", () => {
+    // Reverse direction stays safe: input is a boxed String whose toString
+    // detaches the output buffer before it is snapshotted. The output buffer
+    // is captured as detached (length 0) and a length check throws.
+    const out = Buffer.from(new ArrayBuffer(32));
+    const evilInput = Object.assign(new String("A"), {
+      toString() {
+        out.buffer.transfer(0);
+        return "A";
+      },
+    });
+    expect(() => Bun.CryptoHasher.hash("sha256", evilInput as unknown as string, out)).toThrow();
+    expect(out.byteLength).toBe(0);
+  });
+});
+
 test("Bun.file in CryptoHasher is not supported yet", () => {
   expect(() => Bun.SHA1.hash(Bun.file(import.meta.path))).toThrow();
   expect(() => Bun.CryptoHasher.hash("sha1", Bun.file(import.meta.path))).toThrow();

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -37,9 +37,9 @@ describe("input buffer detached by output argument's toString", () => {
     expect(got).toBe(Bun.sha(new Uint8Array(0), "hex"));
   });
 
-  test("Bun.CryptoHasher.hash (output=Uint8Array, input=String object)", () => {
-    // Reverse direction: input's toString detaches the output buffer, which
-    // is then captured at length 0 and rejected by the length check.
+  test("Bun.CryptoHasher.hash rejects boxed String as input", () => {
+    // Boxed `String` inputs are rejected so the input decode never runs user
+    // JS, keeping the already-captured output buffer valid.
     const out = Buffer.from(new ArrayBuffer(32));
     const evilInput = Object.assign(new String("A"), {
       toString() {
@@ -48,9 +48,9 @@ describe("input buffer detached by output argument's toString", () => {
       },
     });
     expect(() => Bun.CryptoHasher.hash("sha256", evilInput as unknown as string, out)).toThrow(
-      /TypedArray must be at least 32 bytes/,
+      /expected blob, string or buffer/,
     );
-    expect(out.byteLength).toBe(0);
+    expect(out.byteLength).toBe(32);
   });
 });
 

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { withoutAggressiveGC } from "harness";
 
 describe("input buffer detached by output argument's toString", () => {
-  // A boxed String's `toString` runs during output-encoding coercion. If the
-  // input buffer's slice was snapshotted before that, detaching it here leaves
-  // the hasher reading freed memory. After the fix, the input is re-snapshotted
-  // as detached (length 0), so the result is the digest of the empty input.
+  // Detaching the input during output-arg coercion must be observed as
+  // length 0, so the result is the digest of the empty input.
   const N = 1 << 16;
   const keep: Uint8Array[] = [];
   const mk = () => Buffer.from(new ArrayBuffer(N)).fill(0x41);
@@ -40,9 +38,8 @@ describe("input buffer detached by output argument's toString", () => {
   });
 
   test("Bun.CryptoHasher.hash (output=Uint8Array, input=String object)", () => {
-    // Reverse direction stays safe: input is a boxed String whose toString
-    // detaches the output buffer before it is snapshotted. The output buffer
-    // is captured as detached (length 0) and a length check throws.
+    // Reverse direction: input's toString detaches the output buffer, which
+    // is then captured at length 0 and rejected by the length check.
     const out = Buffer.from(new ArrayBuffer(32));
     const evilInput = Object.assign(new String("A"), {
       toString() {
@@ -50,7 +47,9 @@ describe("input buffer detached by output argument's toString", () => {
         return "A";
       },
     });
-    expect(() => Bun.CryptoHasher.hash("sha256", evilInput as unknown as string, out)).toThrow();
+    expect(() => Bun.CryptoHasher.hash("sha256", evilInput as unknown as string, out)).toThrow(
+      /TypedArray must be at least 32 bytes/,
+    );
     expect(out.byteLength).toBe(0);
   });
 });

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -86,9 +86,8 @@ test("indexOfLine is linear on large input with a non-ASCII byte", async () => {
 }, 60_000);
 
 test("indexOfLine coerces offset before snapshotting the buffer", () => {
-  // `offset.valueOf()` can detach the buffer. Before the fix, the stale
-  // snapshot was scanned (reading freed memory); now the buffer is captured
-  // after coercion and seen as detached (length 0) so the result is -1.
+  // Detaching the buffer during offset coercion must be observed as
+  // length 0, so the result is -1.
   const N = 1 << 16;
   const keep: Uint8Array[] = [];
   const b = Buffer.from(new ArrayBuffer(N)).fill(0x41);

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -85,6 +85,26 @@ test("indexOfLine is linear on large input with a non-ASCII byte", async () => {
   expect(proc.signalCode).toBeNull();
 }, 60_000);
 
+test("indexOfLine coerces offset before snapshotting the buffer", () => {
+  // `offset.valueOf()` can detach the buffer. Before the fix, the stale
+  // snapshot was scanned (reading freed memory); now the buffer is captured
+  // after coercion and seen as detached (length 0) so the result is -1.
+  const N = 1 << 16;
+  const keep: Uint8Array[] = [];
+  const b = Buffer.from(new ArrayBuffer(N)).fill(0x41);
+  b[100] = 0x0a;
+  const evilOffset = {
+    valueOf() {
+      b.buffer.transfer(0);
+      for (let i = 0; i < 8; i++) keep.push(new Uint8Array(N).fill(0x0a));
+      return 0;
+    },
+  };
+  const got = indexOfLine(b, evilOffset as unknown as number);
+  expect(b.byteLength).toBe(0);
+  expect(got).toBe(-1);
+});
+
 test("indexOfLine skips multi-byte sequences correctly", () => {
   // ascii prefix, multi-byte char, ascii, newline
   const buf = Buffer.from("abé d\n");

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -424,3 +424,22 @@ test("verify rejects encoded argon2 hashes with cost parameters above the suppor
   expect(() => password.verifySync("correct horse", hugeParallelism)).toThrow("WeakParameters");
   await expect(password.verify("correct horse", hugeParallelism)).rejects.toThrow("WeakParameters");
 });
+
+test("verifySync: password buffer detached by hash argument's toString", () => {
+  // Detaching the password buffer during hash coercion must be observed as
+  // length 0, so verification short-circuits to false.
+  const N = 1 << 16;
+  const keep: Uint8Array[] = [];
+  const hashed = password.hashSync(Buffer.alloc(N, 0x5a), "bcrypt");
+  const b = Buffer.from(new ArrayBuffer(N)).fill(0x41);
+  const evilHash = Object.assign(new String(hashed), {
+    toString() {
+      b.buffer.transfer(0);
+      for (let i = 0; i < 8; i++) keep.push(new Uint8Array(N).fill(0x5a));
+      return hashed;
+    },
+  }) as string;
+  const got = password.verifySync(b, evilHash);
+  expect(b.byteLength).toBe(0);
+  expect(got).toBe(false);
+});

--- a/test/js/bun/util/randomUUIDv5.test.ts
+++ b/test/js/bun/util/randomUUIDv5.test.ts
@@ -367,6 +367,26 @@ describe("randomUUIDv5", () => {
     expect(result).toEqual(uuid.v5("test", uuid.v5.DNS));
   });
 
+  test("name buffer detached by namespace argument's toString", () => {
+    // A boxed String namespace's `toString` runs during coercion. Before the
+    // fix, the name buffer's slice was snapshotted first, so detaching it here
+    // left UUID5 reading freed memory. Now namespace is decoded first and the
+    // name buffer is captured as detached (length 0).
+    const N = 1 << 16;
+    const keep: Uint8Array[] = [];
+    const b = Buffer.from(new ArrayBuffer(N)).fill(0x41);
+    const evilNamespace = Object.assign(new String(dnsNamespace), {
+      toString() {
+        b.buffer.transfer(0);
+        for (let i = 0; i < 8; i++) keep.push(new Uint8Array(N).fill(0x5a));
+        return dnsNamespace;
+      },
+    }) as string;
+    const got = Bun.randomUUIDv5(b, evilNamespace);
+    expect(b.byteLength).toBe(0);
+    expect(got).toBe(Bun.randomUUIDv5(new Uint8Array(0), dnsNamespace));
+  });
+
   test("consistent across multiple calls", () => {
     const results: string[] = [];
     for (let i = 0; i < 100; i++) {

--- a/test/js/bun/util/randomUUIDv5.test.ts
+++ b/test/js/bun/util/randomUUIDv5.test.ts
@@ -368,10 +368,8 @@ describe("randomUUIDv5", () => {
   });
 
   test("name buffer detached by namespace argument's toString", () => {
-    // A boxed String namespace's `toString` runs during coercion. Before the
-    // fix, the name buffer's slice was snapshotted first, so detaching it here
-    // left UUID5 reading freed memory. Now namespace is decoded first and the
-    // name buffer is captured as detached (length 0).
+    // Detaching the name buffer during namespace coercion must be observed
+    // as length 0, so the result is UUIDv5 of the empty name.
     const N = 1 << 16;
     const keep: Uint8Array[] = [];
     const b = Buffer.from(new ArrayBuffer(N)).fill(0x41);


### PR DESCRIPTION
## Problem

`Bun.CryptoHasher.hash`, `Bun.SHA*.hash` / `Bun.MD5.hash`, `Bun.sha`, `Bun.password.verifySync`, `Bun.randomUUIDv5` and `Bun.indexOfLine` all snapshot an ArrayBuffer-backed input as a raw `(ptr, len)` and only afterwards coerce a later argument that can run JS: `StringOrBuffer::from_js(allow_string_object=true)` calls a boxed `String`'s `toString`, and `coerce_to_int64` calls `valueOf`. That JS can `input.buffer.transfer(0)` and spray a same-size allocation, after which the captured slice points at a recycled foreign heap block. ASan does not flag this because the backing store lives in bmalloc.

```js
const N = 1 << 20, keep = [];
const mk = (b = 0x41) => Buffer.from(new ArrayBuffer(N)).fill(b);
const evil = (v, s) =>
  Object.assign(new String(s), {
    toString() {
      v.buffer.transfer(0);
      for (let i = 0; i < 64; i++) keep.push(new Uint8Array(N).fill(0x5a));
      return s;
    },
  });
const H = x => require("crypto").createHash("sha256").update(x).digest("hex");
const b = mk();
const got = Bun.CryptoHasher.hash("sha256", b, evil(b, "hex"));
console.log(got === H(mk()), got === H(mk(0x5a)));
// before: false true   (digest of the recycled foreign block)
// after:  false false  (digest of the detached, length-0 input)
```

## Fix

Coerce the later argument before capturing the input buffer's slice:

* `Bun.CryptoHasher.hash` / `Bun.SHA*.hash` / `Bun.sha`: decode the output argument first, then the input via `BlobOrStringOrBuffer::from_js_no_string_object` so the input decode never calls user `toString` and the already-captured output buffer stays valid.
* `Bun.password.verifySync`: decode the hash argument first, then the password with `allow_string_object = false`.
* `Bun.randomUUIDv5`: decode the namespace before the name; the namespace is copied into a local `[u8; 16]`.
* `Bun.indexOfLine`: coerce `offset` before calling `as_array_buffer` on the first argument.

`BlobOrStringOrBuffer::from_js_maybe_file_maybe_async` now takes `allow_string_object` and `from_js_no_string_object` is added as a convenience wrapper. Boxed `String` inputs to the hash/verifySync entry points are now rejected with "expected string or buffer" (matching Node's `ERR_INVALID_ARG_TYPE` for `crypto.Hash#update`); primitive string inputs are unchanged.

`CryptoHasher#update(input, encoding)` and `Bun.password.hashSync(password, algorithm)` were audited and already decode the later argument before capturing the input buffer.

## Tests

New tests in `test/js/bun/util/bun-cryptohasher.test.ts`, `test/js/bun/util/password.test.ts`, `test/js/bun/util/randomUUIDv5.test.ts` and `test/js/bun/util/index-of-line.test.ts` detach the input during the later argument's coercion and assert the result matches the detached (empty) input rather than the recycled spray. Each test fails on current main and passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 8 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts test/js/bun/util/index-of-line.test.ts test/js/bun/util/password.test.ts "test/js/bun/util/randomUUIDv5.test.ts"
bun test v1.4.0 (3557f2a21)

test/js/bun/util/bun-cryptohasher.test.ts:
18 | 
19 |   test("Bun.CryptoHasher.hash", () => {
20 |     const b = mk();
21 |     const got = Bun.CryptoHasher.hash("sha256", b, evilEncoding(b, "hex"));
22 |     expect(b.byteLength).toBe(0);
23 |     expect(got).toBe(Bun.CryptoHasher.hash("sha256", new Uint8Array(0), "hex"));
                     ^
error: expect(received).toBe(expected)

Expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
Received: "944044fe482bc4e91085c15c5a923a1b9e02eac98d3bce04997d6dbecd2a5b8d"

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-cryptohasher.test.ts:23:17)
(fail) input buffer detached by output argument's toString > Bun.CryptoHasher.hash [18.20ms]
25 | 
26 |   test("Bun.SHA256.hash", () => {
27 |     const b = mk();
28 |     const got = Bun.SHA256.hash(b, evilEncoding(b, "hex"));
29 |     e
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/bun-cryptohasher.test.ts:
18 | 
19 |   test("Bun.CryptoHasher.hash", () => {
20 |     const b = mk();
21 |     const got = Bun.CryptoHasher.hash("sha256", b, evilEncoding(b, "hex"));
22 |     expect(b.byteLength).toBe(0);
23 |     expect(got).toBe(Bun.CryptoHasher.hash("sha256", new Uint8Array(0), "hex"));
                     ^
error: expect(received).toBe(expected)

Expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
Received: "944044fe482bc4e91085c15c5a923a1b9e02eac98d3bce04997d6dbecd2a5b8d"

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-cryptohasher.test.ts:23:17)
(fail) input buffer detached by output argument's toString > Bun.CryptoHasher.hash [0.88ms]
25 | 
26 |   test("Bun.SHA256.hash", () => {
27 |     const b = mk();
28 |     const got = Bun.SHA256.hash(b, evilEncoding(b, "hex"));
29 |     expect(b.byteLength).toBe(0);
30 |     expect(got).toBe(Bun.SHA256.hash(new Uint8Array(0), "hex"));
                     ^
error: expect(received).toBe(expected)

Expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
Received: "944044fe482bc4e91085c15c5a923a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 8 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts test/js/bun/util/index-of-line.test.ts test/js/bun/util/password.test.ts "test/js/bun/util/randomUUIDv5.test.ts"
bun test v1.4.0 (3557f2a21)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) input buffer detached by output argument's toString > Bun.CryptoHasher.hash [11.00ms]
(pass) input buffer detached by output argument's toString > Bun.SHA256.hash [3.88ms]
(pass) input buffer detached by output argument's toString > Bun.sha [3.85ms]
(pass) input buffer detached by output argument's toString > Bun.CryptoHasher.hash rejects boxed String as input [8.13ms]
(pass) Bun.file in CryptoHasher is not supported yet [10.95ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [6.61ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [9.78ms]
(pass) HMAC > sha1 (key: String) [15.60ms]
(pass) HMAC > sha256 (key: String) [6.79ms]
(pass) HMAC > sha384 (key: String) [4.06ms]
(pass) HMAC > sha512 (key: String) [4.14ms]
(pass) HMAC > blake2b512 (key
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 931ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/139] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/139] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/139] gen cpp.rs (cppbind)
[4/139] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/139] gen JS modules (bundle-modules)
Preprocess modules (11790ms)
Bundle modules (40ms)
Postprocesss modules (153ms)
Bundle Functions (964ms)
Generate Code (155ms)

[13.12s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[5/139] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/BunObject.rs              |  24 +++---
 src/runtime/crypto/CryptoHasher.rs        | 119 ++++++++++++++----------------
 src/runtime/crypto/PasswordObject.rs      |  16 ++--
 src/runtime/node/types.rs                 |  22 +++++-
 src/runtime/webcore/Crypto.rs             |  45 +++++------
 test/js/bun/util/bun-cryptohasher.test.ts |  53 +++++++++++++
 test/js/bun/util/index-of-line.test.ts    |  19 +++++
 test/js/bun/util/password.test.ts         |  19 +++++
 test/js/bun/util/randomUUIDv5.test.ts     |  18 +++++
 9 files changed, 232 insertions(+), 103 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/BunObject.rs                   2      3      0
src/runtime/crypto/CryptoHasher.rs             9      4      0
src/runtime/crypto/PasswordObject.rs           3      2      0
src/runtime/node/types.rs                      6      6      0
src/runtime/webcore/Crypto.rs                  3      2      0
test/js/bun/util/bun-cryptohasher.test.ts      2      5      0
test/js/bun/util/index-of-line.test.ts         1      2      0
test/js/bun/util/password.test.ts              1      1      0
test/js/bun/util/randomUUIDv5.test.ts          1      2      0
```

</details>

<!-- robobun:evidence:end -->