### PR TITLE
Remove dead code from bun_url

### DIFF
--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -3,8 +3,6 @@
 pub mod error;
 pub use error::{Error, Result};
 
-use core::cell::RefCell;
-
 use bun_collections::bit_set::{ArrayBitSet, num_masks_for};
 use bun_core::{self, fmt as bun_fmt};
 use bun_core::{String as BunString, Tag as BunStringTag, strings};
@@ -373,10 +371,6 @@ impl<'a> URL<'a> {
 
     pub fn from_utf8(input: &[u8]) -> crate::Result<OwnedURL> {
         Self::from_string(&BunString::borrow_utf8(input))
-    }
-
-    pub fn is_localhost(&self) -> bool {
-        self.hostname.is_empty() || self.hostname == b"localhost" || self.hostname == b"0.0.0.0"
     }
 
     #[inline]
@@ -936,23 +930,9 @@ impl Clone for QueryStringMap {
     }
 }
 
-thread_local! {
-    // Unused in current code (commented-out path in get_name_count).
-    static NAME_COUNT_BUF: RefCell<[*const [u8]; 8]> = const { RefCell::new([std::ptr::from_ref::<[u8]>(&[]); 8]) };
-}
-
 impl QueryStringMap {
     pub fn get_name_count(&mut self) -> usize {
         self.list.len()
-        // if (this.name_count == null) {
-        //     var count: usize = 0;
-        //     var iterate = this.iter();
-        //     while (iterate.next(&_name_count) != null) {
-        //         count += 1;
-        //     }
-        //     this.name_count = count;
-        // }
-        // return this.name_count.?;
     }
 
     pub fn iter(&self) -> Iterator<'_> {
@@ -964,45 +944,6 @@ impl QueryStringMap {
         // `self.buffer` or an external query_string the caller keeps alive).
         let slice = unsafe { &*self.slice };
         &slice[ptr.offset as usize..ptr.offset as usize + ptr.length as usize]
-    }
-
-    pub fn get_index(&self, input: &[u8]) -> Option<usize> {
-        let hash = wyhash(input);
-        self.list.iter().position(|p| p.name_hash == hash)
-    }
-
-    pub fn get(&self, input: &[u8]) -> Option<&[u8]> {
-        let hash = wyhash(input);
-        let i = self.list.iter().position(|p| p.name_hash == hash)?;
-        Some(self.str(self.list[i].value))
-    }
-
-    pub fn has(&self, input: &[u8]) -> bool {
-        self.get_index(input).is_some()
-    }
-
-    pub fn get_all<'s>(&'s self, input: &[u8], target: &mut [&'s [u8]]) -> usize {
-        let hash = wyhash(input);
-        self.get_all_with_hash_from_offset(target, hash, 0)
-    }
-
-    pub fn get_all_with_hash_from_offset<'s>(
-        &'s self,
-        target: &mut [&'s [u8]],
-        hash: u64,
-        offset: usize,
-    ) -> usize {
-        let mut remainder = &self.list[offset..];
-        let mut target_i: usize = 0;
-        while !remainder.is_empty() && target_i < target.len() {
-            let Some(i) = remainder.iter().position(|p| p.name_hash == hash) else {
-                break;
-            };
-            target[target_i] = self.str(remainder[i].value);
-            remainder = &remainder[i + 1..];
-            target_i += 1;
-        }
-        target_i
     }
 
     pub fn init_with_scanner(

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -900,7 +900,6 @@ pub struct QueryStringMap {
     slice: *const [u8],
     pub buffer: Vec<u8>,
     pub list: ParamList,
-    pub name_count: Option<usize>,
 }
 
 impl Clone for QueryStringMap {
@@ -925,13 +924,12 @@ impl Clone for QueryStringMap {
             slice,
             buffer,
             list: self.list.clone(),
-            name_count: self.name_count,
         }
     }
 }
 
 impl QueryStringMap {
-    pub fn get_name_count(&mut self) -> usize {
+    pub fn get_name_count(&self) -> usize {
         self.list.len()
     }
 
@@ -1084,7 +1082,6 @@ impl QueryStringMap {
             list,
             buffer: buf,
             slice: slice_ptr,
-            name_count: None,
         }))
     }
 
@@ -1138,7 +1135,6 @@ impl QueryStringMap {
                 buffer: Vec::new(),
                 // `slice` borrows the caller's query_string; lifetime not tracked here
                 slice: std::ptr::from_ref::<[u8]>(query_string),
-                name_count: None,
             }));
         }
 
@@ -1203,7 +1199,6 @@ impl QueryStringMap {
             list,
             buffer: buf,
             slice: slice_ptr,
-            name_count: None,
         }))
     }
 }


### PR DESCRIPTION
Removes unreferenced items from `src/url/lib.rs` that were carried over from the Zig port but have no callers anywhere in the workspace.

### Removed

- `URL::is_localhost()`: zero references.
- `QueryStringMap::get_index()`: only called by `has()`, which is itself unused.
- `QueryStringMap::get()`: zero references.
- `QueryStringMap::has()`: zero references.
- `QueryStringMap::get_all()`: only called `get_all_with_hash_from_offset()`, zero external references.
- `QueryStringMap::get_all_with_hash_from_offset()`: only called by `get_all()`.
- `NAME_COUNT_BUF` thread-local static: already annotated as unused, for the commented-out Zig path in `get_name_count`.
- `QueryStringMap.name_count` field: set to `None` at all three construction sites and cloned, never read. Part of the same never-enabled caching mechanism as `NAME_COUNT_BUF`.
- `use core::cell::RefCell`: only used by `NAME_COUNT_BUF`.
- Commented-out Zig body inside `get_name_count()`.

Also relaxes `get_name_count(&mut self)` to `&self` since the removed caching write was the only mutation.

The only out-of-crate consumer of `QueryStringMap` is `src/runtime/api/filesystem_router.rs`, which uses `init`, `init_with_scanner`, `iter`, `get_name_count`, and `str` only.

### Verification

- `rg` for each symbol across `src/`, `build/debug/codegen/`, and `src/codegen/`: zero hits outside `src/url/lib.rs`.
- `bun bd`: builds clean.
- `bun run rust:check-all`: all 10 targets pass.
- `bun bd test test/js/bun/util/filesystem_router.test.ts`: 29 pass, 0 fail.

Net: 1 file changed, 1 insertion, 65 deletions.
