### PR TITLE
s3: preserve trailing separators in object keys

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -849,12 +849,8 @@ pub mod store {
 
         pub fn path(&self) -> &[u8] {
             let mut path_name = bun_url::URL::parse(self.pathlike.slice()).s3_path();
-            // normalize start and ending
-            if bun_core::strings::ends_with(path_name, b"/") {
-                path_name = &path_name[0..path_name.len()];
-            } else if bun_core::strings::ends_with(path_name, b"\\") {
-                path_name = &path_name[0..path_name.len() - 1];
-            }
+            // Trim a leading separator only; a trailing one is part of the key
+            // (`folder/` and `folder` name distinct S3 objects).
             if bun_core::strings::starts_with(path_name, b"/")
                 || bun_core::strings::starts_with(path_name, b"\\")
             {

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -362,7 +362,7 @@ impl S3Credentials {
             }
         }
 
-        let path = normalize_name(path);
+        let path = normalize_key(path);
         let bucket = normalize_name(bucket);
 
         // if we allow path.len == 0 it will list the bucket for now we disallow
@@ -1215,6 +1215,12 @@ fn normalize_name(name: &[u8]) -> &[u8] {
         return name;
     }
     strings::trim(name, b"/\\")
+}
+
+/// Trims leading separators only. A trailing separator is part of the key:
+/// `folder/` and `folder` name distinct S3 objects (folder markers).
+fn normalize_key(key: &[u8]) -> &[u8] {
+    strings::trim_left(key, b"/\\")
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/bun/s3/s3-key-trailing-slash.test.ts
+++ b/test/js/bun/s3/s3-key-trailing-slash.test.ts
@@ -1,0 +1,57 @@
+import { S3Client } from "bun";
+import { describe, expect, it } from "bun:test";
+
+// No network: presign() signs and builds the URL locally.
+// https://github.com/oven-sh/bun/issues/34959
+const client = new S3Client({
+  accessKeyId: "test",
+  secretAccessKey: "test",
+  bucket: "bucket",
+  region: "auto",
+  endpoint: "https://example.com",
+});
+
+describe("S3 keys with trailing separators", () => {
+  it("preserves a trailing slash in presigned URLs", () => {
+    const url = new URL(client.presign("folder/", { method: "PUT" }));
+    expect(url.pathname).toBe("/bucket/folder/");
+  });
+
+  it("preserves a trailing slash in nested keys", () => {
+    const url = new URL(client.presign("a/b/c/", { method: "PUT" }));
+    expect(url.pathname).toBe("/bucket/a/b/c/");
+  });
+
+  it("keys without a trailing slash are unchanged", () => {
+    const url = new URL(client.presign("folder", { method: "PUT" }));
+    expect(url.pathname).toBe("/bucket/folder");
+  });
+
+  it("still trims the leading slash", () => {
+    const url = new URL(client.presign("/folder/", { method: "PUT" }));
+    expect(url.pathname).toBe("/bucket/folder/");
+  });
+
+  it("preserves a trailing slash for S3File-based presign", () => {
+    const url = new URL(client.file("folder/").presign({ method: "PUT" }));
+    expect(url.pathname).toBe("/bucket/folder/");
+  });
+
+  it("does not discard a trailing backslash", () => {
+    // The exact encoding of `\` is covered elsewhere; it must not be dropped.
+    for (const presigned of [
+      client.presign("folder\\", { method: "PUT" }),
+      client.file("folder\\").presign({ method: "PUT" }),
+    ]) {
+      const url = new URL(presigned);
+      expect(url.pathname).not.toBe("/bucket/folder");
+      expect(url.pathname.startsWith("/bucket/folder")).toBe(true);
+      expect(url.pathname.length).toBeGreaterThan("/bucket/folder".length);
+    }
+  });
+
+  it("a bare separator key is still rejected as empty", () => {
+    expect(() => client.presign("/", { method: "PUT" })).toThrow();
+    expect(() => client.presign("///", { method: "PUT" })).toThrow();
+  });
+});

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -968,20 +968,19 @@ for (let credentials of allCredentials) {
 
         it("should allow ending with forward slash", async () => {
           const options = { ...s3Options, bucket: S3Bucket };
+          // trailing-slash keys are zero-byte folder markers; the slash is part of the key
           const s3file = s3(`${randomUUID()}/`, options);
-          await s3file.write("Hello Bun!");
-          await s3file.exists();
+          await s3file.write("");
+          expect(await s3file.exists()).toBe(true);
           await s3file.unlink();
-          expect().pass();
         });
 
         it("should allow ending with backslash", async () => {
           const options = { ...s3Options, bucket: S3Bucket };
           const s3file = s3(`${randomUUID()}\\`, options);
-          await s3file.write("Hello Bun!");
-          await s3file.exists();
+          await s3file.write("");
+          expect(await s3file.exists()).toBe(true);
           await s3file.unlink();
-          expect().pass();
         });
       });
 


### PR DESCRIPTION
Fixes #34959

S3 keys are opaque strings: `folder/` and `folder` name distinct objects (a trailing slash is the standard zero-byte folder-marker convention, and AWS SDKs preserve it). Bun trimmed trailing `/` and `\` from every key before signing, so requests silently addressed the wrong object.

## Repro

```ts
import { S3Client } from "bun";

const s3 = new S3Client({
  accessKeyId: "test",
  secretAccessKey: "test",
  bucket: "bucket",
  region: "auto",
  endpoint: "https://example.com",
});

for (const key of ["folder", "folder/"]) {
  console.log(key, new URL(s3.presign(key, { method: "PUT" })).pathname);
}
// before: folder -> /bucket/folder, folder/ -> /bucket/folder
// after:  folder -> /bucket/folder, folder/ -> /bucket/folder/
```

## Cause

Two places stripped trailing separators from the key:

- `normalize_name` in `src/s3_signing/credentials.rs` did `strings::trim(name, b"/\\")`, trimming both ends of the key (and the bucket) on every signed request.
- `S3::path()` in `src/jsc/webcore_types.rs` (the accessor used by `S3File`-based operations) stripped a trailing `\`. Its trailing-`/` branch was a latent no-op (`&path[0..path.len()]`), so only `normalize_name` was actually dropping the slash.

## Fix

Trim only leading separators from the key. Bucket names keep both-end trimming (a `/` is never a legal bucket-name byte, and existing tests rely on it). `S3::path()` no longer strips a trailing `\` either, so `file()`-based operations and direct `presign()` agree on the key. Keys that are only separators (`"/"`) still reject with `InvalidPath`. listObjects is unaffected: its prefix is sent as a query parameter and never passed through key normalization.

The two existing round-trip tests for trailing-separator keys now write zero-byte bodies: with the separator preserved, those keys are real folder markers, which MinIO only accepts as zero-byte objects.

## Verification

New test `test/js/bun/s3/s3-key-trailing-slash.test.ts` (presign only, no network) fails on the previous behavior (5/7) and passes with this change (7/7).