### PR TITLE
redis: copy ArrayBuffer argument bytes before a later toString() can free them

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -73,6 +73,15 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
         return JSArgument::from_js_maybe_file(global, str.to_js(), true);
     }
 
+    // A later argument's `toString()` can run user JS that detaches an earlier
+    // ArrayBuffer (`transfer()` frees its store synchronously). Copy the bytes
+    // now so the captured slice stays valid until `send_cmd` serializes it.
+    if let Some(ab) = value.as_array_buffer(global) {
+        return Ok(Some(JSArgument::StringOrBuffer(
+            crate::node::StringOrBuffer::EncodedSlice(Slice::init_owned(ab.byte_slice().to_vec())),
+        )));
+    }
+
     JSArgument::from_js_maybe_file(global, value, false)
 }
 

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -222,6 +222,105 @@ test.concurrent("RedisClient survives GC after a command throws during argument 
   expect(exitCode).toBe(0);
 });
 
+// A later argument's toString() can detach an earlier ArrayBuffer argument
+// (transfer() frees its store synchronously), so the earlier captured slice
+// pointed at freed heap by the time the command was serialized onto the wire.
+test.concurrent("set/send serialize ArrayBuffer arguments before a later toString() can free them", async () => {
+  const src = `
+    const net = require("node:net");
+
+    let wire = Buffer.alloc(0);
+    let resolveFrame;
+    let gotFrame = new Promise(r => (resolveFrame = r));
+    const server = net.createServer(socket => {
+      socket.on("data", data => {
+        if (data.includes("HELLO")) {
+          socket.write("+OK\\r\\n");
+          return;
+        }
+        wire = Buffer.concat([wire, data]);
+        socket.write("+OK\\r\\n");
+        resolveFrame();
+      });
+      socket.on("error", () => {});
+    });
+    await new Promise((resolve, reject) => {
+      server.listen(0, "127.0.0.1", resolve);
+      server.on("error", reject);
+    });
+
+    const client = new Bun.RedisClient("redis://127.0.0.1:" + server.address().port, {
+      autoReconnect: false,
+      connectionTimeout: 5000,
+    });
+    await client.connect();
+
+    const keep = [];
+    function evilValue(key) {
+      return Object.assign(new String("v"), {
+        toString() {
+          // Free the earlier key's backing store synchronously, then recycle
+          // that block with recognizable foreign bytes.
+          key.buffer.transfer(0);
+          Bun.gc(true);
+          for (let i = 0; i < 64; i++) {
+            const x = new Uint8Array(4096);
+            x.fill(0x5a);
+            Buffer.from(x.buffer).write("RECYCLEDKEY");
+            keep.push(x);
+          }
+          Bun.gc(true);
+          return "v";
+        },
+      });
+    }
+
+    // set(key, value): key is a Buffer, value.toString() frees it.
+    {
+      const key = Buffer.from(new ArrayBuffer(4096));
+      key.write("ORIGINALKEY");
+      client.set(key, evilValue(key)).catch(() => {});
+      await gotFrame;
+    }
+
+    // send("LPUSH", [key, value]): same shape through the array iterator.
+    {
+      gotFrame = new Promise(r => (resolveFrame = r));
+      const key = Buffer.from(new ArrayBuffer(4096));
+      key.write("ORIGINAL2KEY");
+      client.send("LPUSH", [key, evilValue(key)]).catch(() => {});
+      await gotFrame;
+    }
+
+    client.close();
+    server.close();
+
+    const text = wire.toString("latin1");
+    if (text.includes("RECYCLEDKEY")) {
+      throw new Error("freed/recycled heap reached the wire: " + JSON.stringify(text.slice(0, 80)));
+    }
+    if (!text.includes("ORIGINALKEY") || !text.includes("ORIGINAL2KEY")) {
+      throw new Error("original key bytes missing from the wire: " + JSON.stringify(text.slice(0, 80)));
+    }
+    console.log("OK");
+    process.exit(0);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 // Fuzzer found heap corruption (zapped cell during GC marking) when a custom
 // setter on a generated class was invoked with a receiver that is not an
 // instance of that class (e.g. through a Proxy wrapping the instance, or an

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -229,18 +229,29 @@ test.concurrent("set/send serialize ArrayBuffer arguments before a later toStrin
   const src = `
     const net = require("node:net");
 
+    // Each command frame ends in the value arg "$1\\r\\nv\\r\\n"; count those
+    // tails in the accumulated bytes so TCP fragmentation can't resolve early.
+    const TAIL = Buffer.from("$1\\r\\nv\\r\\n");
     let wire = Buffer.alloc(0);
+    let want = 0;
     let resolveFrame;
-    let gotFrame = new Promise(r => (resolveFrame = r));
+    let saidHello = false;
+    function tails() {
+      let n = 0, i = -1;
+      while ((i = wire.indexOf(TAIL, i + 1)) !== -1) n++;
+      return n;
+    }
     const server = net.createServer(socket => {
       socket.on("data", data => {
-        if (data.includes("HELLO")) {
-          socket.write("+OK\\r\\n");
+        if (!saidHello) {
+          if (data.includes("HELLO")) { saidHello = true; socket.write("+OK\\r\\n"); }
           return;
         }
         wire = Buffer.concat([wire, data]);
-        socket.write("+OK\\r\\n");
-        resolveFrame();
+        if (resolveFrame && tails() >= want) {
+          socket.write("+OK\\r\\n");
+          const r = resolveFrame; resolveFrame = null; r();
+        }
       });
       socket.on("error", () => {});
     });
@@ -279,17 +290,20 @@ test.concurrent("set/send serialize ArrayBuffer arguments before a later toStrin
     {
       const key = Buffer.from(new ArrayBuffer(4096));
       key.write("ORIGINALKEY");
+      want = 1;
+      const done = new Promise(r => (resolveFrame = r));
       client.set(key, evilValue(key)).catch(() => {});
-      await gotFrame;
+      await done;
     }
 
     // send("LPUSH", [key, value]): same shape through the array iterator.
     {
-      gotFrame = new Promise(r => (resolveFrame = r));
       const key = Buffer.from(new ArrayBuffer(4096));
       key.write("ORIGINAL2KEY");
+      want = 2;
+      const done = new Promise(r => (resolveFrame = r));
       client.send("LPUSH", [key, evilValue(key)]).catch(() => {});
-      await gotFrame;
+      await done;
     }
 
     client.close();
@@ -310,12 +324,11 @@ test.concurrent("set/send serialize ArrayBuffer arguments before a later toStrin
     cmd: [bunExe(), "-e", src],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "inherit",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-  expect(stderr).toBe("");
   expect(stdout.trim()).toBe("OK");
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## Repro

```js
const key = Buffer.from(new ArrayBuffer(4096));
key.write("ORIGINALKEY");
const keep = [];
const value = Object.assign(new String("v"), {
  toString() {
    key.buffer.transfer(0);           // free the key's backing store
    Bun.gc(true);
    for (let i = 0; i < 64; i++) {    // recycle it
      const x = new Uint8Array(4096);
      x.fill(0x5a);
      Buffer.from(x.buffer).write("RECYCLEDKEY");
      keep.push(x);
    }
    Bun.gc(true);
    return "v";
  },
});
await client.set(key, value);
```

Wire before the fix (against a mock RESP server that logs raw bytes):

```
*3\r\n$3\r\nSET\r\n$4096\r\nRECYCLEDKEYZZZZZZZZ...
```

The key sent to Redis is the recycled foreign block; `ORIGINALKEY` never appears. `client.send("LPUSH", [key, evil])` behaves the same way.

## Cause

`from_js()` in `js_valkey_functions.rs` calls `BlobOrStringOrBuffer::from_js_maybe_file(.., is_async=false)`, which for ArrayBuffer/TypedArray inputs returns a `StringOrBuffer::Buffer` holding a raw pointer into the backing store with no pin and no protect.

Multi-argument commands (`set`, `send`, `lpush`, every `cmd_key_value*!`/`cmd_*_varargs!` macro) call `from_js()` once per argument. Converting a `StringObject`/`DerivedStringObject` argument goes through `toPrimitive` and runs the user's `toString()`, which can `transfer()` an earlier argument's ArrayBuffer (freeing its store synchronously) before `send_cmd` serializes all the collected slices.

This is a use-after-free read whose freed bytes are then written to the socket: whatever allocation recycled the block is sent to the peer as the key/value.

## Fix

Copy ArrayBuffer bytes to an owned `ZigStringSlice` in `from_js()` so the captured payload owns its memory across the argument-collection loop. The String and Blob arms already hold a refcount on their backing storage; only the Buffer arm borrowed. `send_cmd` already copies everything into an owned `Box<[u8]>` for the write buffer, so this adds one memcpy per ArrayBuffer argument.

## Verification

New test in `test/js/valkey/valkey-gc.test.ts` runs a mock RESP server, issues `set(bufferKey, evilStringObject)` and `send("LPUSH", [bufferKey, evilStringObject])`, and asserts the wire carries the original key bytes and never `RECYCLEDKEY`. Fails deterministically on main (`freed/recycled heap reached the wire: "*3\r\n$3\r\nSET\r\n$4096\r\nRECYCLEDKEYZZZZ..."`), passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
bun test v1.4.0 (54978ce7d)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [555.27ms]
(pass) RedisClient survives GC after a command throws during argument validation [672.53ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [520.62ms]
(pass) RedisClient survives GC across many short-lived instances [797.03ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1547.78ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [536.67ms]
81 |     client.close();
82 |     server.close();
83 | 
84 |     const text = wire.toString("latin1");
85 |     if (text.includes("RECYCLEDKEY")) {
86 |       throw new Error("freed/recycled heap reached the wire: " + JSON.stringify(text.slice(0, 80)));
                     ^
error: freed/recycled heap reached the wire: "*3\r\n$3\r\nSET\r\n$4096\r\nRECYCLEDKEYZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b77fd43b1)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [43.33ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [22.33ms]
(pass) RedisClient survives GC across many short-lived instances [33.90ms]
(pass) RedisClient survives GC after a command throws during argument validation [40.87ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [36.14ms]
(pass) set/send serialize ArrayBuffer arguments before a later toString() can free them [58.92ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [73.95ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [459.00ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [779.13ms]

 9 pass
 0 fail
 26 expect() calls
Ran 9 tests across 1 file. [975.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
bun test v1.4.0 (54978ce7d)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [626.49ms]
(pass) RedisClient survives GC after a command throws during argument validation [645.52ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [623.30ms]
(pass) RedisClient survives GC across many short-lived instances [856.91ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1748.83ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [573.10ms]
(pass) set/send serialize ArrayBuffer arguments before a later toString() can free them [1738.35ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [2754.13ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [2293.55ms]

 9 pass
 0 fail
 26 expect() calls
Ran 9 tests across 1 file. [6.13s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 688ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[2/136] cc obj/packages/bun-usockets/src/bsd.c.o
[3/136] cc obj/packages/bun-usockets/src/fault_inject.c.o
[4/136] cc obj/packages/bun-usockets/src/loop.c.o
[5/136] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[6/136] cc obj/packages/bun-usockets/src/context.c.o
[7/136] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[8/136] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[9/136] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[10/136] cc obj/packages/bun-usockets/src/socket.c.o
[11/136] cc obj/packages/bun-usockets/src/udp.c.o
[12/136] cc obj/packages/bun-usockets/src/quic.c.o
[13/136] cc obj/src/jsc/bindings/uv-posix-polyfills.c.o
[14/136] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[15/136] cc obj/src/jsc/bindings/uv-posix-stubs.c.o
[16/136] cc obj/vendor/picohttpparser/picohttpparser.c.o
[17/136] gen cpp.rs (cppbind)
[18/136] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, gene
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey_functions.rs |   9 +++
 test/js/valkey/valkey-gc.test.ts              | 112 ++++++++++++++++++++++++++
 2 files changed, 121 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/valkey_jsc/js_valkey_functions.rs      1      2      0
test/js/valkey/valkey-gc.test.ts                   1      5      0
```

</details>

<!-- robobun:evidence:end -->