### PR TITLE
Bun.Transpiler: coerce loader before capturing the code buffer

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1320,14 +1320,10 @@ impl JSTranspiler {
         let Some(code_arg) = args.next() else {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
-
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
-            return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
-        };
-        // defer code_holder.deinit() → Drop
-        let code = code_holder.slice();
         args.eat();
 
+        // Coerce `loader` before reading `code`'s bytes: `loader_from_js` may run a
+        // user `toString()` that detaches the code ArrayBuffer.
         let loader: Option<Loader> = 'brk: {
             if let Some(arg) = args.next() {
                 args.eat();
@@ -1339,6 +1335,12 @@ impl JSTranspiler {
         if global.has_exception() {
             return Ok(JSValue::ZERO);
         }
+
+        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+            return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
+        };
+        // defer code_holder.deinit() → Drop
+        let code = code_holder.slice();
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
@@ -1479,20 +1481,10 @@ impl JSTranspiler {
             ));
         };
 
-        let arena = Arena::new();
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
-            return Err(global.throw_invalid_argument_type(
-                "transformSync",
-                "code",
-                "string or Uint8Array",
-            ));
-        };
-        // defer code_holder.deinit() → Drop
-        let code = code_holder.slice();
-        arguments.ptr[0].ensure_still_alive();
-        let _keep0 = bun_jsc::EnsureStillAlive(arguments.ptr[0]);
-
         args.eat();
+
+        // Coerce `loader` before reading `code`'s bytes: `loader_from_js` may run a
+        // user `toString()` that detaches the code ArrayBuffer.
         let mut js_ctx_value: JSValue = JSValue::ZERO;
         let loader: Option<Loader> = 'brk: {
             if let Some(arg) = args.next() {
@@ -1508,6 +1500,19 @@ impl JSTranspiler {
             }
             break 'brk None;
         };
+
+        let arena = Arena::new();
+        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+            return Err(global.throw_invalid_argument_type(
+                "transformSync",
+                "code",
+                "string or Uint8Array",
+            ));
+        };
+        // defer code_holder.deinit() → Drop
+        let code = code_holder.slice();
+        arguments.ptr[0].ensure_still_alive();
+        let _keep0 = bun_jsc::EnsureStillAlive(arguments.ptr[0]);
 
         if let Some(arg) = args.next_eat() {
             if arg.is_object() {
@@ -1692,6 +1697,18 @@ impl JSTranspiler {
             ));
         };
 
+        args.eat();
+
+        // Coerce `loader` before reading `code`'s bytes: `loader_from_js` may run a
+        // user `toString()` that detaches the code ArrayBuffer.
+        let mut loader: Loader = self.config.get().default_loader;
+        if let Some(arg) = args.next() {
+            if let Some(l) = loader_from_js(global, arg)? {
+                loader = l;
+            }
+            args.eat();
+        }
+
         let code_holder = match StringOrBuffer::from_js(global, code_arg)? {
             Some(h) => h,
             None => {
@@ -1705,17 +1722,8 @@ impl JSTranspiler {
                 return Ok(JSValue::ZERO);
             }
         };
-        args.eat();
         // defer code_holder.deinit() → Drop
         let code = code_holder.slice();
-
-        let mut loader: Loader = self.config.get().default_loader;
-        if let Some(arg) = args.next() {
-            if let Some(l) = loader_from_js(global, arg)? {
-                loader = l;
-            }
-            args.eat();
-        }
 
         if !loader.is_java_script_like() {
             return Err(global.throw_invalid_arguments(format_args!(

--- a/test/js/bun/transpiler/transpiler-loader-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-loader-uaf.test.ts
@@ -1,11 +1,7 @@
-// transformSync/scan/scanImports captured the code ArrayBuffer's ptr/len
-// before coercing the `loader` argument. `is_string()` accepts String
-// *objects*, so `loader_from_js` runs a user-supplied `toString()` that can
-// detach and free the code buffer, leaving the parser reading whatever heap
-// block replaces it. Async `transform()` was already safe because it copies
-// the bytes before coercing the loader.
+// `is_string()` accepts String *objects*, so a `new String("js")` loader with a
+// hostile `toString()` can detach the code buffer during loader coercion.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 
 const fixture = `
 const N = 1 << 20;
@@ -84,8 +80,10 @@ describe("Bun.Transpiler loader coercion ordering", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
+    expect({ stdout: normalizeBunSnapshot(stdout), stderr: normalizeBunSnapshot(stderr), exitCode }).toEqual({
+      stdout: "OK",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/bun/transpiler/transpiler-loader-uaf.test.ts
+++ b/test/js/bun/transpiler/transpiler-loader-uaf.test.ts
@@ -1,0 +1,91 @@
+// transformSync/scan/scanImports captured the code ArrayBuffer's ptr/len
+// before coercing the `loader` argument. `is_string()` accepts String
+// *objects*, so `loader_from_js` runs a user-supplied `toString()` that can
+// detach and free the code buffer, leaving the parser reading whatever heap
+// block replaces it. Async `transform()` was already safe because it copies
+// the bytes before coercing the loader.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const fixture = `
+const N = 1 << 20;
+const enc = new TextEncoder();
+const fill = (u, s) => { u.fill(0x20); enc.encodeInto(s, u); };
+
+function hostile(src) {
+  const keep = [];
+  return Object.assign(new String("js"), {
+    toString() {
+      src.buffer.transfer(0);
+      Bun.gc(true);
+      for (let i = 0; i < 64; i++) {
+        const x = new Uint8Array(N);
+        fill(x, 'import "recycled-mod"; export const WHICH = "RECYCLED_FOREIGN_HEAP";');
+        keep.push(x);
+      }
+      Bun.gc(true);
+      return "js";
+    },
+  });
+}
+
+function mkSrc() {
+  const src = new Uint8Array(new ArrayBuffer(N));
+  fill(src, 'import "original-mod"; export const WHICH = "ORIGINAL_INPUT";');
+  return src;
+}
+
+const t = new Bun.Transpiler();
+
+{
+  const src = mkSrc();
+  const out = t.transformSync(src, hostile(src));
+  if (out.includes("recycled-mod") || out.includes("RECYCLED_FOREIGN_HEAP")) {
+    throw new Error("transformSync emitted recycled heap: " + JSON.stringify(out.slice(0, 120)));
+  }
+  if (out.trim() !== "") {
+    throw new Error("transformSync: detached buffer should yield empty output, got " + JSON.stringify(out.slice(0, 120)));
+  }
+}
+
+{
+  const src = mkSrc();
+  const { imports, exports } = t.scan(src, hostile(src));
+  if (imports.some(i => i.path === "recycled-mod")) {
+    throw new Error("scan returned recycled heap import: " + JSON.stringify(imports));
+  }
+  if (imports.length !== 0 || exports.length !== 0) {
+    throw new Error("scan: detached buffer should yield no imports/exports, got " + JSON.stringify({ imports, exports }));
+  }
+}
+
+{
+  const src = mkSrc();
+  const imports = t.scanImports(src, hostile(src));
+  if (imports.some(i => i.path === "recycled-mod")) {
+    throw new Error("scanImports returned recycled heap import: " + JSON.stringify(imports));
+  }
+  if (imports.length !== 0) {
+    throw new Error("scanImports: detached buffer should yield no imports, got " + JSON.stringify(imports));
+  }
+}
+
+console.log("OK");
+`;
+
+describe("Bun.Transpiler loader coercion ordering", () => {
+  test("transformSync/scan/scanImports read code after loader toString() runs", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

`transformSync()`, `scan()`, and `scanImports()` read the `code` argument's backing bytes before coercing the `loader` argument. `JSValue::is_string()` is `is_string_like()`, so a `String` object passes the check and `loader_from_js` calls `toString()` on it. A hostile `toString()` can `transfer()` the code ArrayBuffer, free its backing store, and have the allocator recycle the block before the parser reads from the stale pointer. The result is the transpiler emitting / scanning whatever foreign heap block now lives at that address.

```js
const N = 1 << 20, keep = [], enc = new TextEncoder();
const fill = (u, s) => { u.fill(0x20); enc.encodeInto(s, u); };
const src = new Uint8Array(new ArrayBuffer(N));
fill(src, 'import "original-mod"; export const WHICH = "ORIGINAL_INPUT";');
const loader = Object.assign(new String("js"), { toString() {
  src.buffer.transfer(0); Bun.gc(true);
  for (let i = 0; i < 64; i++) { const x = new Uint8Array(N);
    fill(x, 'import "recycled-mod"; export const WHICH = "RECYCLED_FOREIGN_HEAP";'); keep.push(x); }
  Bun.gc(true); return "js"; } });
console.log(new Bun.Transpiler().transformSync(src, loader));
```

Before:
```
import"recycled-mod";
export const WHICH = "RECYCLED_FOREIGN_HEAP";
```

After: empty output (the buffer is detached before its bytes are read, so the parser sees a zero-length input).

The fix moves the `loader_from_js` call ahead of `StringOrBuffer::from_js(code)` in all three functions, so any user `toString()` runs before the code buffer's ptr/len are captured. Async `transform()` was already safe because it copies the bytes into an owned slice before coercing the loader.

Related: #34966 pins the backing buffer inside `StringOrBuffer::from_js` on the sync path, which closes the same class of bug at a lower layer for the `node:crypto` call sites. The two changes touch different files and are complementary.

### How did you verify your code works?

`test/js/bun/transpiler/transpiler-loader-uaf.test.ts` spawns a subprocess that exercises `transformSync`, `scan`, and `scanImports` with a hostile String-object loader. It fails on the released binary (`USE_SYSTEM_BUN=1 bun test ...` emits `transformSync emitted recycled heap: "import\"recycled-mod\";..."`) and passes on the debug build. `test/js/bun/transpiler/` and `test/bundler/transpiler/transpiler.test.js` pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/transpiler-loader-uaf.test.ts
bun test v1.4.0 (ba8b645a2)

test/js/bun/transpiler/transpiler-loader-uaf.test.ts:
78 |       stdout: "pipe",
79 |     });
80 | 
81 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
82 | 
83 |     expect({ stdout: normalizeBunSnapshot(stdout), stderr: normalizeBunSnapshot(stderr), exitCode }).toEqual({
                                                                                                          ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": "OK",
+   "exitCode": 1,
+   "stderr": 
+ "30 | 
+ 31 | {
+ 32 |   const src = mkSrc();
+ 33 |   const out = t.transformSync(src, hostile(src));
+ 34 |   if (out.includes("recycled-mod") || out.includes("RECYCLED_FOREIGN_HEAP")) {
+ 35 |     throw new Error("transformSync emitted recycled heap: " + JSON.stringify(out.slice(0, 120)));
+                    ^
+ error: transformSync emitted recycled heap: "import/"recycled-
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ba8b645a2)

test/js/bun/transpiler/transpiler-loader-uaf.test.ts:
(pass) Bun.Transpiler loader coercion ordering > transformSync/scan/scanImports read code after loader toString() runs [63.01ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [213.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/transpiler-loader-uaf.test.ts
bun test v1.4.0 (ba8b645a2)

test/js/bun/transpiler/transpiler-loader-uaf.test.ts:
(pass) Bun.Transpiler loader coercion ordering > transformSync/scan/scanImports read code after loader toString() runs [806.61ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [2.84s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 693ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 44s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+ba8b645a2
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (ba8b645a2)

test/js/bun/transpiler/transpiler-loader-uaf.test.ts:
(pass) Bun.Transpiler loader coercion ordering > transformSync/scan/scanImports read code after loader toString() runs [62.20ms]

 1 pass
 0 fail
 1 expect() calls
Ran 1 test across 1 file. [215.00ms]
__F:0:S:0
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/JSTranspiler.rs                    | 64 +++++++++-------
 .../bun/transpiler/transpiler-loader-uaf.test.ts   | 89 ++++++++++++++++++++++
 2 files changed, 125 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/runtime/api/JSTranspiler.rs                           3      3      0
test/js/bun/transpiler/transpiler-loader-uaf.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->