### PR TITLE
Bun.spawn/spawnSync, Bun.which: inherit live process.env instead of the startup snapshot

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1155,6 +1155,12 @@ impl JSGlobalObject {
         ZigGlobalObject__makeNapiEnvForFFI(self)
     }
 
+    /// The live `process.env` JS object (forces the lazy init). Mutations made
+    /// via `process.env.X = ...` / `delete process.env.X` are visible here.
+    pub fn process_env_object(&self) -> JsResult<JSValue> {
+        crate::from_js_host_call(self, || ZigGlobalObject__processEnvObject(self))
+    }
+
     // returns false if it throws
     pub fn validate_object(
         &self,
@@ -1558,6 +1564,7 @@ unsafe extern "C" {
     -> JSValue;
 
     safe fn ZigGlobalObject__makeNapiEnvForFFI(this: &JSGlobalObject) -> *mut c_void;
+    safe fn ZigGlobalObject__processEnvObject(this: &JSGlobalObject) -> JSValue;
 
     safe fn JSC__JSGlobalObject__bunVM(this: &JSGlobalObject) -> *mut c_void;
     safe fn JSC__JSGlobalObject__vm(this: &JSGlobalObject) -> *mut VM;

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1155,8 +1155,7 @@ impl JSGlobalObject {
         ZigGlobalObject__makeNapiEnvForFFI(self)
     }
 
-    /// The live `process.env` JS object (forces the lazy init). Mutations made
-    /// via `process.env.X = ...` / `delete process.env.X` are visible here.
+    /// The live `process.env` object. Forces the lazy init, which can throw.
     pub fn process_env_object(&self) -> JsResult<JSValue> {
         crate::from_js_host_call(self, || ZigGlobalObject__processEnvObject(self))
     }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1912,6 +1912,15 @@ extern "C" napi_env ZigGlobalObject__makeNapiEnvForFFI(Zig::GlobalObject* global
     return globalObject->makeNapiEnvForFFI();
 }
 
+extern "C" JSC::EncodedJSValue ZigGlobalObject__processEnvObject(Zig::GlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSObject* object = globalObject->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(object);
+}
+
 extern "C" JSC::EncodedJSValue CryptoObject__create(JSGlobalObject*);
 JSC_DEFINE_CUSTOM_GETTER(moduleNamespacePrototypeGetESModuleMarker, (JSGlobalObject * globalObject, JSC::EncodedJSValue encodedThisValue, PropertyName))
 {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -543,8 +543,10 @@ fn which(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValu
         return Ok(JSValue::NULL);
     }
 
-    // SAFETY: `transpiler.env` / `.fs` are process-lifetime singletons set during VM init.
-    let mut path_str = Utf8Bytes::Borrowed(vm.env_loader().get(b"PATH").unwrap_or(b""));
+    let mut path_str = match global_this.process_env_object()?.get(global_this, "PATH")? {
+        Some(v) if !v.is_undefined_or_null() => v.to_utf8(global_this)?,
+        _ => Utf8Bytes::Borrowed(b""),
+    };
     let mut cwd_str = Utf8Bytes::Borrowed(vm.top_level_dir());
 
     if let Some(arg) = arguments.next_eat() {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -346,8 +346,6 @@ fn spawn_maybe_sync(
     let mut lazy = false;
     let mut on_exit_callback = JSValue::ZERO;
     let mut on_disconnect_callback = JSValue::ZERO;
-    // Populated from the explicit `env:` option or, when absent, the live
-    // `process.env` object; both via `append_envp_from_js` below.
     let mut path: &[u8] = b"";
     let mut argv: Vec<CStrPtr> = Vec::new();
     let cmd_value: JSValue;
@@ -2050,8 +2048,7 @@ fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsEr
     global_this.throw_value(err.to_error_instance(global_this))
 }
 
-/// Populate `envp` / `path` from the live `process.env` JS object so runtime
-/// mutations (set/delete/PATH edits) reach the child.
+/// Default env for a child: the live `process.env` object, not the startup snapshot.
 fn inherit_process_env(
     global_this: &JSGlobalObject,
     envp: &mut Vec<CStrPtr>,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -329,7 +329,6 @@ fn spawn_maybe_sync(
     // drops after `spawn_process` returns, freeing all argv/env allocations.
     let mut cstr_storage: Vec<ZBox> = Vec::new();
 
-    let mut override_env = false;
     let mut env_array: Vec<CStrPtr> = Vec::new();
     // SAFETY: `bun_vm()` returns the live VirtualMachine for this thread; it
     // outlives this call frame.
@@ -347,9 +346,9 @@ fn spawn_maybe_sync(
     let mut lazy = false;
     let mut on_exit_callback = JSValue::ZERO;
     let mut on_disconnect_callback = JSValue::ZERO;
-    // `env_loader()` is the audited safe accessor for the per-VM DotEnv loader
-    // (process-lifetime; centralised non-null deref in `VirtualMachine`).
-    let mut path: &[u8] = jsc_vm.env_loader().get(b"PATH").unwrap_or(b"");
+    // Populated from the explicit `env:` option or, when absent, the live
+    // `process.env` object; both via `append_envp_from_js` below.
+    let mut path: &[u8] = b"";
     let mut argv: Vec<CStrPtr> = Vec::new();
     let cmd_value: JSValue;
     let mut detached = false;
@@ -568,7 +567,6 @@ fn spawn_maybe_sync(
                     );
                 };
 
-                override_env = true;
                 // If the env object does not include a $PATH, it must disable path lookup for argv[0]
                 let mut new_path: &[u8] = b"";
                 // `JSObject` is an `opaque_ffi!` ZST handle; `opaque_ref` is the
@@ -581,6 +579,8 @@ fn spawn_maybe_sync(
                     &mut cstr_storage,
                 )?;
                 path = new_path;
+            } else {
+                inherit_process_env(global_this, &mut env_array, &mut path, &mut cstr_storage)?;
             }
 
             get_argv(
@@ -878,6 +878,7 @@ fn spawn_maybe_sync(
                 }
             }
         } else {
+            inherit_process_env(global_this, &mut env_array, &mut path, &mut cstr_storage)?;
             get_argv(
                 global_this,
                 cmd_value,
@@ -891,31 +892,6 @@ fn spawn_maybe_sync(
     }
 
     bun_output::scoped_log!(Subprocess, "spawn maxBuffer: {:?}", max_buffer);
-
-    // Owns the `K=V\0` storage when inheriting the parent env; the struct
-    // lives until spawn returns.
-    let mut inherited_env_storage: Option<bun_dotenv::NullDelimitedEnvMap> = None;
-    if !override_env && env_array.is_empty() {
-        // `Transpiler::env_mut()` is the audited safe `&mut Loader` accessor
-        // (per-VM DotEnv loader, valid for VM lifetime; centralised
-        // single-unsafe deref). `.map` is its `&'a mut Map` slot.
-        let envmap = match jsc_vm
-            .transpiler
-            .env_mut()
-            .map
-            .create_null_delimited_env_map()
-        {
-            Ok(m) => m,
-            Err(_) => return Err(global_this.throw_out_of_memory()),
-        };
-        // Note: `as_slice()` *includes* the trailing null, so strip it; the
-        // common tail below re-appends one after the optional NODE_CHANNEL_*
-        // entries.
-        let entries = envmap.as_slice();
-        env_array.extend_from_slice(&entries[..entries.len().saturating_sub(1)]);
-        inherited_env_storage = Some(envmap);
-    }
-    let _ = &inherited_env_storage;
 
     for fd_index in 0..stdio.len() {
         if stdio[fd_index].can_use_memfd() {
@@ -2072,6 +2048,28 @@ fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsEr
         ..Default::default()
     };
     global_this.throw_value(err.to_error_instance(global_this))
+}
+
+/// Populate `envp` / `path` from the live `process.env` JS object so runtime
+/// mutations (set/delete/PATH edits) reach the child.
+fn inherit_process_env(
+    global_this: &JSGlobalObject,
+    envp: &mut Vec<CStrPtr>,
+    path: &mut &[u8],
+    storage: &mut Vec<ZBox>,
+) -> JsResult<()> {
+    let process_env = global_this.process_env_object()?;
+    process_env.ensure_still_alive();
+    if let Some(object) = process_env.get_object() {
+        append_envp_from_js(
+            global_this,
+            JSObject::opaque_ref(object),
+            envp,
+            path,
+            storage,
+        )?;
+    }
+    Ok(())
 }
 
 /// `storage` receives ownership of every `K=V\0` line whose pointer is pushed

--- a/test/js/bun/spawn/spawn-env.test.ts
+++ b/test/js/bun/spawn/spawn-env.test.ts
@@ -1,6 +1,69 @@
 import { spawn } from "bun";
-import { test } from "bun:test";
-import { bunExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+
+// Bun.spawn / Bun.spawnSync with no `env:` option must inherit the *live*
+// process.env, including runtime mutations, not the startup snapshot.
+describe("default env inherits live process.env", () => {
+  const printEnv = isWindows
+    ? `[process.execPath, "-e", "process.stdout.write((process.env.BUN_TEST_SPAWN_ENV_SET ?? '[unset]') + ',' + (process.env.BUN_TEST_SPAWN_ENV_DEL ?? '[unset]'))"]`
+    : `["/bin/sh", "-c", "printf '%s,%s' \\"\${BUN_TEST_SPAWN_ENV_SET-[unset]}\\" \\"\${BUN_TEST_SPAWN_ENV_DEL-[unset]}\\""]`;
+
+  for (const [label, call] of [
+    ["Bun.spawnSync({cmd})", `Bun.spawnSync({ cmd: ${printEnv} }).stdout.toString()`],
+    ["Bun.spawnSync([cmd])", `Bun.spawnSync(${printEnv}).stdout.toString()`],
+    ["Bun.spawn({cmd})", `await (await Bun.spawn({ cmd: ${printEnv} }).stdout).text()`],
+  ] as const) {
+    test.concurrent(label, async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.env.BUN_TEST_SPAWN_ENV_SET = "runtime-value";
+           delete process.env.BUN_TEST_SPAWN_ENV_DEL;
+           process.stdout.write(${call});`,
+        ],
+        env: { ...bunEnv, BUN_TEST_SPAWN_ENV_DEL: "startup-value" },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "runtime-value,[unset]",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  }
+
+  test.concurrent.skipIf(isWindows)("PATH mutation is used for argv0 lookup and Bun.which", async () => {
+    using dir = tempDir("spawn-env-path", {
+      "bun_test_spawn_env_tool": "#!/bin/sh\nprintf found-the-tool\n",
+    });
+    const toolDir = String(dir);
+    chmodSync(join(toolDir, "bun_test_spawn_env_tool"), 0o755);
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.env.PATH = ${JSON.stringify(toolDir)} + ":" + process.env.PATH;
+         console.log(Bun.which("bun_test_spawn_env_tool") !== null);
+         console.log(Bun.spawnSync({ cmd: ["bun_test_spawn_env_tool"] }).stdout.toString());
+         console.log(Bun.spawnSync(["bun_test_spawn_env_tool"]).stdout.toString());`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "true\nfound-the-tool\nfound-the-tool\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
 
 test("spawn env", async () => {
   const env = {};


### PR DESCRIPTION
## Repro

```js
process.env.MYVAR = "hello";
delete process.env.DELME;                    // DELME was set at process start
console.log(String(Bun.spawnSync({
  cmd: ["/bin/sh", "-c", "echo MYVAR=[$MYVAR] DELME=[$DELME]"],
}).stdout));
// before: MYVAR=[] DELME=[startup-value]   (set invisible, delete invisible)
// after:  MYVAR=[hello] DELME=[]
```

```js
process.env.PATH = dir + ":" + process.env.PATH;
Bun.which("tool");            // before: null    after: /.../tool
Bun.spawnSync(["tool"]);      // before: ENOENT  after: runs
```

`child_process.spawn*` was already correct (it always passes an explicit `env` built from `process.env` on the JS side). `env: {...process.env}` was already correct.

## Cause

- `js_bun_spawn_bindings.rs`: the no-`env:` fallback serialized `jsc_vm.transpiler.env_mut().map` (the `bun_dotenv::Loader` map, populated once from libc `environ` at startup), and the initial PATH for argv0 lookup came from `jsc_vm.env_loader().get(b"PATH")`, the same snapshot.
- `BunObject.rs::which`: default PATH came from `vm.env_loader().get(b"PATH")`.
- `process.env.X = ...` (the generic `jsSetterEnvironmentVariable` in `JSEnvironmentVariableMap.cpp`) writes only to the JS object, never the native map; `delete process.env.X` likewise.

## Fix

Expose `ZigGlobalObject::processEnvObject()` to Rust and use the live `process.env` JS object as the default env source:

- `Bun.spawn/spawnSync` with no `env:` now enumerates `processEnvObject()` via the existing `append_envp_from_js`, which also extracts PATH for argv0 lookup. This is the same code path `env: {...process.env}` already exercised.
- `Bun.which` now reads its default PATH from `processEnvObject().PATH`.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn-env.test.ts -t "default env"
(fail) Bun.spawnSync({cmd})  Expected "runtime-value,[unset]" Received "[unset],startup-value"
(fail) Bun.spawnSync([cmd])  Expected "runtime-value,[unset]" Received "[unset],startup-value"
(fail) Bun.spawn({cmd})      Expected "runtime-value,[unset]" Received "[unset],startup-value"
(fail) PATH mutation ...     ENOENT: Executable not found in $PATH: "bun_test_spawn_env_tool"

$ bun bd test test/js/bun/spawn/spawn-env.test.ts
5 pass, 0 fail
```

`test/js/bun/spawn/spawn.test.ts`, `test/js/bun/spawn/spawn-path.test.ts`, `test/js/bun/util/which.test.ts`, `test/js/bun/spawn/null-byte-injection.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-env.test.ts

<!-- robobun:evidence:end -->