### PR TITLE
s3: honor AWS_DEFAULT_REGION for Bun.S3Client region

### DIFF
--- a/docs/runtime/s3.mdx
+++ b/docs/runtime/s3.mdx
@@ -465,6 +465,8 @@ For each option, if the `S3_*` environment variable is not set, Bun falls back t
 | `bucket`          | `AWS_BUCKET`                  |
 | `sessionToken`    | `AWS_SESSION_TOKEN`           |
 
+For `region` only, if neither `S3_REGION` nor `AWS_REGION` is set, Bun also falls back to `AWS_DEFAULT_REGION`, matching the AWS CLI and SDKs.
+
 Bun reads these environment variables from [`.env` files](/runtime/environment-variables) or from the process environment at initialization time (`process.env` is not used for this).
 
 Options you pass to `s3.file(credentials)`, `new Bun.S3Client(credentials)`, or any of the methods that accept credentials override these defaults. So if you use the same credentials for different buckets, you can set the credentials once in your `.env` file and pass only `bucket: "my-bucket"` to `s3.file()`.

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -153,7 +153,7 @@ declare module "bun" {
     bucket?: string;
 
     /**
-     * The AWS region. Defaults to `S3_REGION` or `AWS_REGION` environment variables.
+     * The AWS region. Defaults to `S3_REGION`, `AWS_REGION`, or `AWS_DEFAULT_REGION` environment variables.
      *
      * @example
      * ```ts

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -250,6 +250,7 @@ impl<'a> Loader<'a> {
             let region: Box<[u8]> = self
                 .get(b"S3_REGION")
                 .or_else(|| self.get(b"AWS_REGION"))
+                .or_else(|| self.get(b"AWS_DEFAULT_REGION"))
                 .map(Box::from)
                 .unwrap_or_default();
 

--- a/test/js/bun/s3/s3-env-region.test.ts
+++ b/test/js/bun/s3/s3-env-region.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Bun.S3Client reads region from the process environment once and caches it,
+// so each case spawns a fresh process with only the env var under test set.
+describe("Bun.S3Client region from environment", () => {
+  const script = `
+    const s3 = new Bun.S3Client({ bucket: "b", endpoint: "https://s3.example.invalid" });
+    const url = new URL(s3.presign("k", { expiresIn: 60 }));
+    process.stdout.write(url.searchParams.get("X-Amz-Credential"));
+  `;
+
+  const baseEnv = {
+    ...bunEnv,
+    S3_REGION: undefined,
+    AWS_REGION: undefined,
+    AWS_DEFAULT_REGION: undefined,
+    S3_ENDPOINT: undefined,
+    AWS_ENDPOINT: undefined,
+    AWS_ACCESS_KEY_ID: "AK",
+    AWS_SECRET_ACCESS_KEY: "SK",
+  };
+
+  async function credentialScope(env: Record<string, string | undefined>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...baseEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/^AK\/\d{8}\/[^/]+\/s3\/aws4_request$/);
+    expect(exitCode).toBe(0);
+    return stdout.split("/")[2];
+  }
+
+  test.concurrent("AWS_DEFAULT_REGION is honored when no other region is set", async () => {
+    expect(await credentialScope({ AWS_DEFAULT_REGION: "eu-west-1" })).toBe("eu-west-1");
+  });
+
+  test.concurrent("AWS_REGION takes precedence over AWS_DEFAULT_REGION", async () => {
+    expect(
+      await credentialScope({
+        AWS_REGION: "us-west-2",
+        AWS_DEFAULT_REGION: "eu-west-1",
+      }),
+    ).toBe("us-west-2");
+  });
+
+  test.concurrent("S3_REGION takes precedence over AWS_REGION and AWS_DEFAULT_REGION", async () => {
+    expect(
+      await credentialScope({
+        S3_REGION: "ap-south-1",
+        AWS_REGION: "us-west-2",
+        AWS_DEFAULT_REGION: "eu-west-1",
+      }),
+    ).toBe("ap-south-1");
+  });
+
+  test.concurrent("explicit region option overrides AWS_DEFAULT_REGION", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const s3 = new Bun.S3Client({ bucket: "b", endpoint: "https://s3.example.invalid", region: "ca-central-1" });
+          const url = new URL(s3.presign("k", { expiresIn: 60 }));
+          process.stdout.write(url.searchParams.get("X-Amz-Credential").split("/")[2]);
+        `,
+      ],
+      env: { ...baseEnv, AWS_DEFAULT_REGION: "eu-west-1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ca-central-1");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/s3/s3-env-region.test.ts
+++ b/test/js/bun/s3/s3-env-region.test.ts
@@ -58,7 +58,7 @@ describe("Bun.S3Client region from environment", () => {
     ).toBe("ap-south-1");
   });
 
-  test.concurrent("explicit region option overrides AWS_DEFAULT_REGION", async () => {
+  test.concurrent("explicit region option overrides all region environment variables", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -69,7 +69,12 @@ describe("Bun.S3Client region from environment", () => {
           process.stdout.write(url.searchParams.get("X-Amz-Credential").split("/")[2]);
         `,
       ],
-      env: { ...baseEnv, AWS_DEFAULT_REGION: "eu-west-1" },
+      env: {
+        ...baseEnv,
+        S3_REGION: "ap-south-1",
+        AWS_REGION: "us-west-2",
+        AWS_DEFAULT_REGION: "eu-west-1",
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3-env-region.test.ts
+++ b/test/js/bun/s3/s3-env-region.test.ts
@@ -17,6 +17,8 @@ describe("Bun.S3Client region from environment", () => {
     AWS_DEFAULT_REGION: undefined,
     S3_ENDPOINT: undefined,
     AWS_ENDPOINT: undefined,
+    S3_ACCESS_KEY_ID: undefined,
+    S3_SECRET_ACCESS_KEY: undefined,
     AWS_ACCESS_KEY_ID: "AK",
     AWS_SECRET_ACCESS_KEY: "SK",
   };


### PR DESCRIPTION
## What

`Bun.S3Client` now reads `AWS_DEFAULT_REGION` as a fallback when neither `S3_REGION` nor `AWS_REGION` is set.

## Why

`AWS_DEFAULT_REGION` is the standard env var the AWS CLI and every AWS SDK fall back to when `AWS_REGION` is unset, and it is the variable commonly set in container/CI environments. Bun only checked `S3_REGION` and `AWS_REGION`, so in a stock AWS environment with only `AWS_DEFAULT_REGION` set, the region resolved to empty and `guess_region` fell through to the literal `"auto"`. Every request was then signed with a credential scope of `.../auto/s3/aws4_request`, which real S3 rejects as `400 AuthorizationHeaderMalformed: the region 'auto' is wrong; expecting '<region>'` with no client-side hint.

## Repro

```sh
env -i AWS_ACCESS_KEY_ID=AK AWS_SECRET_ACCESS_KEY=SK AWS_DEFAULT_REGION=eu-west-1 bun -e '
  const s3 = new Bun.S3Client({ bucket: "b", endpoint: "https://s3.example.invalid" });
  console.log(new URL(s3.presign("k", { expiresIn: 60 })).searchParams.get("X-Amz-Credential"));'
```

Before: `AK/<date>/auto/s3/aws4_request`
After: `AK/<date>/eu-west-1/s3/aws4_request`

## Fix

Add `AWS_DEFAULT_REGION` as a third fallback in the env credential loader (`src/dotenv/env_loader.rs`). Precedence is `S3_REGION` > `AWS_REGION` > `AWS_DEFAULT_REGION`, matching AWS SDK behavior where `AWS_REGION` overrides `AWS_DEFAULT_REGION`.

Tests in `test/js/bun/s3/s3-env-region.test.ts` spawn a subprocess per case with a clean env and assert the region in the presigned `X-Amz-Credential` scope, covering the new fallback and the precedence order.

## Not in this PR

The `"auto"` default for non-R2 endpoints in `guess_region` (`src/s3_signing/credentials.rs`) is left as-is; changing that default is a behavior change for non-AWS S3-compatible backends and is better handled separately.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-env-region.test.ts"
bun test v1.4.0 (f4ad28623)

test/js/bun/s3/s3-env-region.test.ts:
(pass) Bun.S3Client region from environment > AWS_REGION takes precedence over AWS_DEFAULT_REGION [1283.58ms]
36 |     expect(exitCode).toBe(0);
37 |     return stdout.split("/")[2];
38 |   }
39 | 
40 |   test.concurrent("AWS_DEFAULT_REGION is honored when no other region is set", async () => {
41 |     expect(await credentialScope({ AWS_DEFAULT_REGION: "eu-west-1" })).toBe("eu-west-1");
                                                                            ^
error: expect(received).toBe(expected)

Expected: "eu-west-1"
Received: "auto"

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-env-region.test.ts:41:72)
(fail) Bun.S3Client region from environment > AWS_DEFAULT_REGION is honored when no other region is set [1487.94ms]
(pass) Bun.S3Client region from environment > S3_REGION takes precedence over AWS_REGION and AWS_DEFAULT_REGION [1434.28ms]
(pass) Bun.S3Client region from environment > explicit region option overri
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (edfa36fa0)

test/js/bun/s3/s3-env-region.test.ts:
(pass) Bun.S3Client region from environment > explicit region option overrides all region environment variables [27.42ms]
(pass) Bun.S3Client region from environment > AWS_REGION takes precedence over AWS_DEFAULT_REGION [51.84ms]
(pass) Bun.S3Client region from environment > S3_REGION takes precedence over AWS_REGION and AWS_DEFAULT_REGION [51.35ms]
(pass) Bun.S3Client region from environment > AWS_DEFAULT_REGION is honored when no other region is set [61.71ms]

 4 pass
 0 fail
 15 expect() calls
Ran 4 tests across 1 file. [240.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-env-region.test.ts"
bun test v1.4.0 (f4ad28623)

test/js/bun/s3/s3-env-region.test.ts:
(pass) Bun.S3Client region from environment > AWS_DEFAULT_REGION is honored when no other region is set [1373.10ms]
(pass) Bun.S3Client region from environment > AWS_REGION takes precedence over AWS_DEFAULT_REGION [1344.58ms]
(pass) Bun.S3Client region from environment > S3_REGION takes precedence over AWS_REGION and AWS_DEFAULT_REGION [1364.68ms]
(pass) Bun.S3Client region from environment > explicit region option overrides all region environment variables [1384.30ms]

 4 pass
 0 fail
 15 expect() calls
Ran 4 tests across 1 file. [3.70s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 700ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/135] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[2/135] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[3/135] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[4/135] cc obj/packages/bun-usockets/src/bsd.c.o
[5/135] cc obj/packages/bun-usockets/src/udp.c.o
[6/135] cc obj/packages/bun-usockets/src/fault_inject.c.o
[7/135] cc obj/packages/bun-usockets/src/context.c.o
[8/135] cc obj/packages/bun-usockets/src/loop.c.o
[9/135] cc obj/packages/bun-usockets/src/quic.c.o
[10/135] cc obj/packages/bun-usockets/src/socket.c.o
[11/135] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[12/135] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[13/135] cc obj/src/jsc/bindings/uv-posix-polyfills.c.o
[14/135] cc obj/vendor/picohttpparser/picohttpparser.c.o
[15/135] cc obj/src/jsc/bindings/uv-posix-stubs.c.o
[16/135] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[17/135] gen cpp.rs (cppbind)
[17/135] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/s3.mdx                  |  2 +
 packages/bun-types/s3.d.ts           |  2 +-
 src/dotenv/env_loader.rs             |  1 +
 test/js/bun/s3/s3-env-region.test.ts | 88 ++++++++++++++++++++++++++++++++++++
 4 files changed, 92 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
docs/runtime/s3.mdx                       1      1      0
packages/bun-types/s3.d.ts                1      1      0
src/dotenv/env_loader.rs                  1      1      0
test/js/bun/s3/s3-env-region.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->