### PR TITLE
bun:test: support tagged-template table form of test.each/describe.each

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -346,6 +346,20 @@ test.each([
 });
 ```
 
+### Tagged template table
+
+You can also write the table as a tagged template literal. The first row is a `|`-separated header of column names, and each subsequent row supplies one `${value}` per column. Each row is passed to the callback as a single object keyed by the column names.
+
+```ts title="example.test.ts" icon="/icons/typescript.svg"
+test.each`
+  a    | b    | expected
+  ${1} | ${2} | ${3}
+  ${4} | ${5} | ${9}
+`("add($a, $b) = $expected", ({ a, b, expected }) => {
+  expect(a + b).toBe(expected);
+});
+```
+
 ### Format Specifiers
 
 Use these specifiers to format the test title:

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -277,6 +277,7 @@ declare module "bun:test" {
     each<T extends Readonly<[any, ...any[]]>>(table: readonly T[]): Describe<[...T]>;
     each<T extends any[]>(table: readonly T[]): Describe<[...T]>;
     each<const T>(table: T[]): Describe<[T]>;
+    each(strings: TemplateStringsArray, ...expressions: unknown[]): Describe<[Record<string, any>]>;
   }
   /**
    * Describes a group of related tests.
@@ -573,6 +574,7 @@ declare module "bun:test" {
     each<T extends Readonly<[unknown, ...unknown[]]>>(table: readonly T[]): Test<T>;
     each<T extends unknown[]>(table: readonly T[]): Test<T>;
     each<const T>(table: T[]): Test<[T]>;
+    each(strings: TemplateStringsArray, ...expressions: unknown[]): Test<[Record<string, any>]>;
   }
   /**
    * Runs a test.

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -139,7 +139,8 @@ impl ScopeFunctions {
     pub fn fn_each(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         let _g = group_log::begin();
 
-        let [array] = frame.arguments_as_array::<1>();
+        let args = frame.arguments();
+        let array = args.first().copied().unwrap_or(JSValue::UNDEFINED);
         if array.is_undefined_or_null() || !array.is_array() {
             let mut formatter = bun_jsc::ConsoleObject::Formatter::new(global);
             return Err(global.throw(format_args!("Expected array, got {}", array.to_fmt(&mut formatter))));
@@ -148,8 +149,66 @@ impl ScopeFunctions {
         if !this.each.is_empty() {
             return Err(global.throw(format_args!("Cannot {} on {}", "each", this)));
         }
+
+        // Tagged-template form: test.each` a | b \n ${1} | ${2} `(...). The engine
+        // calls us as each(strings, ...values); `strings` is a frozen array with an
+        // own `.raw` array. Build the row-object table here so the existing
+        // array-of-objects path in `call_as_function` handles the rest.
+        if let Some(raw) = array.get_own_truthy(global, b"raw")? {
+            if raw.is_array() {
+                let table = parse_tagged_template_each(global, array, args.get(1..).unwrap_or(&[]))?;
+                return create_bound(global, this.mode, table, this.cfg, strings::EACH());
+            }
+        }
+
         create_bound(global, this.mode, array, this.cfg, strings::EACH())
     }
+}
+
+/// Build the `.each` row table for the tagged-template form. `strings[0]` is the
+/// `|`-separated header; `data` are the interpolated expressions in source order.
+fn parse_tagged_template_each(
+    global: &JSGlobalObject,
+    strings: JSValue,
+    data: &[JSValue],
+) -> JsResult<JSValue> {
+    const WS: &[u8] = b" \t\r\n";
+
+    let header_js = strings.get_index(global, 0)?;
+    let header = header_js.to_slice(global)?;
+    let mut columns: Vec<&[u8]> = Vec::new();
+    for piece in header.slice().split(|&b| b == b'|') {
+        let name = bun_core::strings::trim(piece, WS);
+        if !name.is_empty() {
+            columns.push(name);
+        }
+    }
+
+    if columns.is_empty() {
+        return Err(global.throw(format_args!(
+            ".each`...` table must have a header row with at least one column"
+        )));
+    }
+    if !data.is_empty() && data.len() % columns.len() != 0 {
+        return Err(global.throw(format_args!(
+            "Not enough arguments supplied for given headings: received {} value(s) for {} column(s)",
+            data.len(),
+            columns.len(),
+        )));
+    }
+
+    let num_cols = columns.len();
+    let num_rows = data.len() / num_cols;
+    let table = JSValue::create_empty_array(global, num_rows)?;
+    for row in 0..num_rows {
+        let obj = JSValue::create_empty_object(global, num_cols);
+        for (col, name) in columns.iter().enumerate() {
+            obj.put(global, *name, data[row * num_cols + col]);
+        }
+        table.put_index(global, row as u32, obj)?;
+    }
+    table.ensure_still_alive();
+    Ok(table)
 }
 
 #[bun_jsc::host_fn]

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -203,11 +203,12 @@ fn parse_tagged_template_each(
     for row in 0..num_rows {
         let obj = JSValue::create_empty_object(global, num_cols);
         for (col, name) in columns.iter().enumerate() {
-            obj.put(global, *name, data[row * num_cols + col]);
+            // `header.slice()` is UTF-8; tag the key so C++ decodes it as UTF-8
+            // rather than Latin-1 (PutKey<&[u8]> does not).
+            obj.put(global, bun_core::ZigString::init_utf8(name), data[row * num_cols + col]);
         }
         table.put_index(global, row as u32, obj)?;
     }
-    table.ensure_still_alive();
     Ok(table)
 }
 

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -84,12 +84,24 @@ describe("tagged template literal", () => {
     falsy.push(input);
   });
 
+  const unicode: unknown[] = [];
+  it.each`
+    café     | 名前        | 값
+    ${"one"} | ${"Alice"} | ${42}
+  `("keys non-ASCII column names correctly", row => {
+    unicode.push(row);
+    expect(row.café).toBe("one");
+    expect(row.名前).toBe("Alice");
+    expect(row.값).toBe(42);
+  });
+
   afterAll(() => {
     expect(seen).toEqual([
       { a: 1, b: 2, expected: 3 },
       { a: "x", b: "y", expected: "xy" },
     ]);
     expect(falsy).toEqual([null, undefined, 0, false, ""]);
+    expect(unicode).toEqual([{ café: "one", 名前: "Alice", 값: 42 }]);
   });
 
   it("throws on a trailing partial row", () => {

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 const NUMBERS = [
   [1, 1, 2],
@@ -56,4 +57,95 @@ describe.each(["some", "cool", "strings"])("works with describe: %s", s => {
 
 describe("does not return zero", () => {
   expect(it.each([1, 2])("wat", () => {})).toBeUndefined();
+});
+
+describe("tagged template literal", () => {
+  const seen: Array<{ a: unknown; b: unknown; expected: unknown }> = [];
+
+  it.each`
+    a      | b      | expected
+    ${1}   | ${2}   | ${3}
+    ${"x"} | ${"y"} | ${"xy"}
+  `("adds $a + $b -> $expected", ({ a, b, expected }) => {
+    seen.push({ a, b, expected });
+    expect(typeof a).not.toBe("undefined");
+    expect(a + b).toBe(expected);
+  });
+
+  const falsy: unknown[] = [];
+  it.each`
+    input
+    ${null}
+    ${undefined}
+    ${0}
+    ${false}
+    ${""}
+  `("passes falsy value through untouched", ({ input }) => {
+    falsy.push(input);
+  });
+
+  afterAll(() => {
+    expect(seen).toEqual([
+      { a: 1, b: 2, expected: 3 },
+      { a: "x", b: "y", expected: "xy" },
+    ]);
+    expect(falsy).toEqual([null, undefined, 0, false, ""]);
+  });
+
+  it("throws on a trailing partial row", () => {
+    expect(
+      () => it.each`
+        a    | b
+        ${1} | ${2}
+        ${3}
+      `,
+    ).toThrow("Not enough arguments supplied for given headings");
+  });
+});
+
+describe.each`
+  multiplier | value | expected
+  ${2}       | ${3}  | ${6}
+  ${3}       | ${4}  | ${12}
+`("describe.each tagged template: x$multiplier", ({ multiplier, value, expected }) => {
+  it(`${multiplier} * ${value} = ${expected}`, () => {
+    expect(multiplier * value).toBe(expected);
+  });
+});
+
+test.each`
+  input | output
+  ${1}  | ${2}
+  ${5}  | ${10}
+`("test.each tagged template: $input -> $output", ({ input, output }) => {
+  expect(input * 2).toBe(output);
+});
+
+test("tagged-template .each runs one test per data row with interpolated titles", async () => {
+  using dir = tempDir("each-tagged-template", {
+    "tagged.test.ts": `
+      import { test, expect } from "bun:test";
+      test.each\`
+        a      | b      | expected
+        \${1}   | \${2}   | \${3}
+        \${"x"} | \${"y"} | \${"xy"}
+      \`("adds $a + $b -> $expected", ({ a, b, expected }) => {
+        expect(a + b).toBe(expected);
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "tagged.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const out = stdout + stderr;
+  expect(out).toContain("adds 1 + 2 -> 3");
+  expect(out).toContain("adds x + y -> xy");
+  expect(out).not.toContain("$a");
+  expect(out).toMatch(/Ran 2 tests/);
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/jest-each.test.ts
+++ b/test/js/bun/test/jest-each.test.ts
@@ -86,7 +86,7 @@ describe("tagged template literal", () => {
 
   const unicode: unknown[] = [];
   it.each`
-    café     | 名前        | 값
+    café     | 名前       | 값
     ${"one"} | ${"Alice"} | ${42}
   `("keys non-ASCII column names correctly", row => {
     unicode.push(row);


### PR DESCRIPTION
## What does this PR do?

Implements the Jest-documented tagged-template form of `test.each` / `it.each` / `describe.each`:

```ts
test.each`
  a      | b      | expected
  ${1}   | ${2}   | ${3}
  ${"x"} | ${"y"} | ${"xy"}
`("adds $a + $b -> $expected", ({ a, b, expected }) => {
  expect(a + b).toBe(expected);
});
```

**Before:** the `TemplateStringsArray` passed `is_array()`, so each of its raw string segments became a phantom row. The example above ran **7** tests (one per segment), every callback arg was `undefined`, and the title was never interpolated. With a body that tolerates `undefined` this silently passed N green rows that tested nothing.

**After:** `fn_each` detects an own `.raw` array on the first argument, parses `strings[0]` as the `|`-separated header, groups the interpolated expressions into row objects `{a, b, expected}`, and hands that array to the existing array-of-objects `.each` path unchanged. The example runs **2** tests with interpolated titles (`adds 1 + 2 -> 3`, `adds x + y -> xy`).

Fixes #6364. Supersedes #30625 (same feature from an external contributor; this takes a simpler approach that reuses the existing object-each path instead of threading a marker through to `call_as_function`).

## How did you verify your code works?

```
bun bd test test/js/bun/test/jest-each.test.ts
# 38 pass 0 fail (25 existing + 13 new)
USE_SYSTEM_BUN=1 bun test test/js/bun/test/jest-each.test.ts
# 31 pass 22 fail (every new tagged-template case fails)
```

Also ran `bun_test.test.ts` and `jest-each-gc-root.test.ts` (both pass) and the `bun-types` integration test for the new `.each(TemplateStringsArray, ...)` overload.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 26 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-each.test.ts
bun test v1.4.0 (c1977bf05)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [2.21ms]
(pass) jest-each > 1 + 1 = 2 [1.20ms]
(pass) jest-each > 1 + 2 = 3 [0.37ms]
(pass) jest-each > 2 + 1 = 3 [0.24ms]
(pass) jest-each > with callback: 1 + 1 = 2 [2.07ms]
(pass) jest-each > with callback: 1 + 2 = 3 [0.77ms]
(pass) jest-each > with callback: 2 + 1 = 3 [0.54ms]
(pass) jest-each > a + b = ab [2.55ms]
(pass) jest-each > c + d = cd [1.42ms]
(pass) jest-each > e + f = ef [0.81ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [1.55ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3} [0.44ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.63ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.32ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125} [0.31ms]
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28} [0.43ms]
(pass) jest-each > stringify 0:  [0.74ms]
(pass)
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (5368235d5)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [0.02ms]
(pass) jest-each > 1 + 1 = 2 [0.02ms]
(pass) jest-each > 1 + 2 = 3
(pass) jest-each > 2 + 1 = 3
(pass) jest-each > with callback: 1 + 1 = 2 [0.04ms]
(pass) jest-each > with callback: 1 + 2 = 3
(pass) jest-each > with callback: 2 + 1 = 3
(pass) jest-each > a + b = ab [0.04ms]
(pass) jest-each > c + d = cd
(pass) jest-each > e + f = ef
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [0.03ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3}
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15}
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15}
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125}
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28}
(pass) jest-each > stringify 0:  [0.01ms]
(pass) jest-each > stringify 1: null
(pass) jest-each > stringify 2: null
(pass) jest-each > stringify 3: null
(pass) works with describe: some > has access to params : some [0.02ms]
(pass) works with describe: cool > has access to params : cool
(pass) works with 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-each.test.ts
bun test v1.4.0 (c1977bf05)

test/js/bun/test/jest-each.test.ts:
(pass) jest-each > check types [2.00ms]
(pass) jest-each > 1 + 1 = 2 [1.59ms]
(pass) jest-each > 1 + 2 = 3 [0.37ms]
(pass) jest-each > 2 + 1 = 3 [0.24ms]
(pass) jest-each > with callback: 1 + 1 = 2 [2.04ms]
(pass) jest-each > with callback: 1 + 2 = 3 [0.79ms]
(pass) jest-each > with callback: 2 + 1 = 3 [0.54ms]
(pass) jest-each > a + b = ab [2.20ms]
(pass) jest-each > c + d = cd [1.18ms]
(pass) jest-each > e + f = ef [1.08ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":1,"e":2} [1.63ms]
(pass) jest-each > add two numbers with object: {"a":1,"b":2,"e":3} [0.47ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.37ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":13,"e":15} [0.31ms]
(pass) jest-each > add two numbers with object: {"a":2,"b":123,"e":125} [0.57ms]
(pass) jest-each > add two numbers with object: {"a":15,"b":13,"e":28} [0.45ms]
(pass) jest-each > stringify 0:  [0.82ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 741ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[2/136] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[3/136] cc obj/packages/bun-usockets/src/bsd.c.o
[4/136] cc obj/packages/bun-usockets/src/fault_inject.c.o
[5/136] cc obj/packages/bun-usockets/src/context.c.o
[6/136] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[7/136] cc obj/packages/bun-usockets/src/udp.c.o
[8/136] cc obj/packages/bun-usockets/src/socket.c.o
[9/136] cc obj/packages/bun-usockets/src/loop.c.o
[10/136] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[11/136] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[12/136] cc obj/packages/bun-usockets/src/quic.c.o
[13/136] cc obj/src/jsc/bindings/uv-posix-polyfills.c.o
[14/136] cc obj/src/jsc/bindings/uv-posix-stubs.c.o
[15/136] cc obj/vendor/picohttpparser/picohttpparser.c.o
[16/136] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[17/136] gen cpp.rs (cppbind)
[18/136] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, gene
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/test/writing-tests.mdx               |  14 ++++
 packages/bun-types/test.d.ts              |   2 +
 src/runtime/test_runner/ScopeFunctions.rs |  62 ++++++++++++++++-
 test/js/bun/test/jest-each.test.ts        | 106 +++++++++++++++++++++++++++++-
 4 files changed, 182 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/test/writing-tests.mdx                    1      1      0
packages/bun-types/test.d.ts                   1      2      0
src/runtime/test_runner/ScopeFunctions.rs      4      2      0
test/js/bun/test/jest-each.test.ts             2      9      0
```

</details>

<!-- robobun:evidence:end -->