### PR TITLE
bun test --reporter=junit: fix broken XML, double-escaped classname, and empty <failure>

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1162,13 +1162,13 @@ impl<'a> TablePrinter<'a> {
 /// recover `&mut Self` from the `*mut io::Writer` they receive (same pattern as
 /// `Output::QuietWriterAdapter::new_interface`).
 #[repr(C)]
-pub struct DynWriteAdapter<'a> {
+pub(crate) struct DynWriteAdapter<'a> {
     head: bun_core::io::Writer,
     inner: &'a mut dyn bun_io::Write,
 }
 
 impl<'a> DynWriteAdapter<'a> {
-    pub fn new(inner: &'a mut dyn bun_io::Write) -> Self {
+    pub(crate) fn new(inner: &'a mut dyn bun_io::Write) -> Self {
         Self {
             head: bun_core::io::Writer {
                 write_all: Self::thunk_write_all,
@@ -1180,7 +1180,7 @@ impl<'a> DynWriteAdapter<'a> {
 
     /// Reborrow as the `io::Writer` head.
     #[inline]
-    pub fn interface(&mut self) -> &mut bun_core::io::Writer {
+    pub(crate) fn interface(&mut self) -> &mut bun_core::io::Writer {
         // SAFETY: `head` is the first `#[repr(C)]` field, so `&mut self.head`
         // and `&mut *self as *mut io::Writer` are the same address; the thunks
         // below cast back to `*mut Self`.

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1162,13 +1162,13 @@ impl<'a> TablePrinter<'a> {
 /// recover `&mut Self` from the `*mut io::Writer` they receive (same pattern as
 /// `Output::QuietWriterAdapter::new_interface`).
 #[repr(C)]
-pub(crate) struct DynWriteAdapter<'a> {
+pub struct DynWriteAdapter<'a> {
     head: bun_core::io::Writer,
     inner: &'a mut dyn bun_io::Write,
 }
 
 impl<'a> DynWriteAdapter<'a> {
-    pub(crate) fn new(inner: &'a mut dyn bun_io::Write) -> Self {
+    pub fn new(inner: &'a mut dyn bun_io::Write) -> Self {
         Self {
             head: bun_core::io::Writer {
                 write_all: Self::thunk_write_all,
@@ -1180,7 +1180,7 @@ impl<'a> DynWriteAdapter<'a> {
 
     /// Reborrow as the `io::Writer` head.
     #[inline]
-    pub(crate) fn interface(&mut self) -> &mut bun_core::io::Writer {
+    pub fn interface(&mut self) -> &mut bun_core::io::Writer {
         // SAFETY: `head` is the first `#[repr(C)]` field, so `&mut self.head`
         // and `&mut *self as *mut io::Writer` are the same address; the thunks
         // below cast back to `*mut Self`.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -300,6 +300,13 @@ pub struct VirtualMachine {
     pub on_unhandled_rejection_ctx: Option<*mut c_void>,
     pub on_unhandled_rejection_exception_list: Option<NonNull<ExceptionList>>,
     pub unhandled_error_counter: usize,
+    /// When set, `print_error_instance_body` calls this with the remapped
+    /// `ZigException` (same lifecycle as the GitHub Actions annotation hook),
+    /// so observers can read name/message/stack without re-running the
+    /// formatter. Installed by `bun test --reporter=junit` around
+    /// `run_error_handler`.
+    pub on_print_error_zig_exception: Option<fn(*mut c_void, &ZigException)>,
+    pub on_print_error_zig_exception_ctx: *mut c_void,
     pub is_handling_uncaught_exception: bool,
     pub exit_on_uncaught_exception: bool,
 
@@ -5710,6 +5717,9 @@ impl VirtualMachine {
         if allow_side_effects {
             if let Some(debugger) = self.debugger.as_deref_mut() {
                 debugger.lifecycle_reporter_agent.report_error(exception);
+            }
+            if let Some(cb) = self.on_print_error_zig_exception {
+                cb(self.on_print_error_zig_exception_ctx, exception);
             }
         }
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -157,9 +157,16 @@ pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate:
                 writer.write_all(bun_core::strings::xml_escape_entity(c).unwrap())?;
                 last = i + 1;
             }
+            b'\t' | b'\n' | b'\r' => {
+                // Valid XML 1.0 Char; pass through as-is.
+            }
             0..=0x1f => {
-                // Escape all control characters
-                write!(writer, "&#{};", c)?;
+                // Any other C0 control character is not a valid XML 1.0 Char and
+                // cannot be represented even as a numeric reference, so drop it.
+                if i > last {
+                    writer.write_all(&str_[last..i])?;
+                }
+                last = i + 1;
             }
             _ => {}
         }
@@ -211,6 +218,13 @@ pub fn write_test_status_line(
 // `&mut io::Writer`; the previous local `err_w`/`out_w` wrappers were no-op
 // reborrows. Call sites use the `Output` accessors directly.
 
+#[derive(Default)]
+pub struct JunitFailure {
+    pub name: Vec<u8>,
+    pub message: Vec<u8>,
+    pub body: Vec<u8>,
+}
+
 // Remaining TODOs:
 // - Add stdout/stderr to the JUnit report
 // - Add timestamp field to the JUnit report
@@ -226,6 +240,10 @@ pub struct JunitReporter {
 
     pub suite_stack: Vec<SuiteInfo>,
     pub current_depth: u32,
+
+    /// Error captured by `on_uncaught_exception` for the currently-failing
+    /// test; consumed by `write_test_case` on the next `Result::Fail`.
+    pub last_failure: Option<JunitFailure>,
 
     pub hostname_value: Option<Box<[u8]>>,
 }
@@ -300,6 +318,46 @@ impl JunitReporter {
     }
 
     // `pub const new = bun.TrivialNew(JunitReporter);` → Box::new
+
+    /// Capture the thrown value's name/message plus a plain-text (no ANSI)
+    /// rendering so the next `write_test_case` can populate `<failure>`.
+    pub fn record_failure(&mut self, global_this: &jsc::JSGlobalObject, exception: jsc::JSValue) {
+        let vm = global_this.bun_vm().as_mut();
+        let (value, exc_ref): (jsc::JSValue, Option<&jsc::Exception>) =
+            match exception.as_exception(vm.jsc_vm) {
+                // SAFETY: `as_exception` returned a live JSC-heap `Exception`;
+                // read-only for the duration of this call.
+                Some(exc) => unsafe { ((*exc).value(), Some(&*exc)) },
+                None => (exception, None),
+            };
+
+        let mut failure = JunitFailure::default();
+
+        {
+            let mut holder = jsc::zig_exception::Holder::init();
+            let zig_exc = holder.zig_exception();
+            value.to_zig_exception(global_this, zig_exc);
+            failure.name = zig_exc.name.to_utf8_bytes();
+            failure.message = zig_exc.message.to_utf8_bytes();
+            holder.deinit(vm);
+        }
+
+        {
+            let mut adapter = jsc::console_object::DynWriteAdapter::new(&mut failure.body);
+            let mut formatter = jsc::console_object::Formatter::new(global_this);
+            vm.print_errorlike_object(
+                value,
+                exc_ref,
+                None,
+                &mut formatter,
+                adapter.interface(),
+                false,
+                false,
+            );
+        }
+
+        self.last_failure = Some(failure);
+    }
 
     fn generate_properties_list(&mut self) -> crate::Result<()> {
         struct PropertiesList<'a> {
@@ -583,16 +641,34 @@ impl JunitReporter {
                     let last = self.suite_stack.len() - 1;
                     self.suite_stack[last].metrics.failures += 1;
                 }
-                // TODO: add the failure message
-                // if (failure_message) |msg| {
-                //     try this.contents.appendSlice(bun.default_allocator, " message=\"");
-                //     try escapeXml(msg, this.contents.writer(bun.default_allocator));
-                //     try this.contents.appendSlice(bun.default_allocator, "\"");
-                // }
                 self.contents.extend_from_slice(b">\n");
                 self.contents.extend_from_slice(indent);
-                self.contents
-                    .extend_from_slice(b"  <failure type=\"AssertionError\" />\n");
+                let failure = self.last_failure.take();
+                let type_name: &[u8] = failure
+                    .as_ref()
+                    .map(|f| f.name.as_slice())
+                    .filter(|n| !n.is_empty())
+                    .unwrap_or(b"Error");
+                self.contents.extend_from_slice(b"  <failure type=\"");
+                escape_xml(type_name, &mut self.contents)?;
+                self.contents.extend_from_slice(b"\"");
+                if let Some(f) = failure.as_ref() {
+                    if !f.message.is_empty() {
+                        self.contents.extend_from_slice(b" message=\"");
+                        escape_xml(&f.message, &mut self.contents)?;
+                        self.contents.extend_from_slice(b"\"");
+                    }
+                }
+                match failure.as_ref().filter(|f| !f.body.is_empty()) {
+                    Some(f) => {
+                        self.contents.extend_from_slice(b">");
+                        escape_xml(&f.body, &mut self.contents)?;
+                        self.contents.extend_from_slice(b"</failure>\n");
+                    }
+                    None => {
+                        self.contents.extend_from_slice(b" />\n");
+                    }
+                }
                 self.contents.extend_from_slice(indent);
                 self.contents.extend_from_slice(b"</testcase>\n");
             }
@@ -686,13 +762,15 @@ impl JunitReporter {
                 }
                 self.contents.extend_from_slice(b">\n");
                 self.contents.extend_from_slice(indent);
-                self.contents
-                    .extend_from_slice(b"  <failure type=\"TimeoutError\" />\n");
+                self.contents.extend_from_slice(
+                    b"  <failure type=\"TimeoutError\" message=\"test timed out\" />\n",
+                );
                 self.contents.extend_from_slice(indent);
                 self.contents.extend_from_slice(b"</testcase>\n");
             }
             R::Pending => unreachable!(),
         }
+        self.last_failure = None;
         Ok(())
     }
 
@@ -1187,10 +1265,11 @@ impl CommandLineReporter {
                     if let Some(name) = unsafe { (*scope).base.name.as_deref() } {
                         if !name.is_empty() {
                             if initial_length != concatenated_describe_scopes.len() {
-                                concatenated_describe_scopes.extend_from_slice(b" &gt; ");
+                                concatenated_describe_scopes.extend_from_slice(b" > ");
                             }
 
-                            escape_xml(name, &mut concatenated_describe_scopes).expect("oom");
+                            // write_test_case escapes class_name once; do not pre-escape here.
+                            concatenated_describe_scopes.extend_from_slice(name);
                         }
                     }
                 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -231,6 +231,26 @@ pub struct JunitFailure {
     pub body: Vec<u8>,
 }
 
+/// Append `input` to `out`, dropping CSI sequences (`ESC '[' ... final`), so a
+/// matcher message built with colour does not reach the report as SGR residue.
+fn push_stripping_ansi(out: &mut Vec<u8>, input: &[u8]) {
+    let mut i = 0;
+    while i < input.len() {
+        if input[i] == 0x1b && i + 1 < input.len() && input[i + 1] == b'[' {
+            i += 2;
+            while i < input.len() && !(0x40..=0x7e).contains(&input[i]) {
+                i += 1;
+            }
+            if i < input.len() {
+                i += 1;
+            }
+            continue;
+        }
+        out.push(input[i]);
+        i += 1;
+    }
+}
+
 // Remaining TODOs:
 // - Add stdout/stderr to the JUnit report
 // - Add timestamp field to the JUnit report
@@ -331,27 +351,42 @@ impl JunitReporter {
     /// the exception formatter.
     pub fn record_failure(&mut self, exception: &jsc::ZigException) {
         let failure = self.last_failure.get_or_insert_default();
+        let name = exception.name.to_utf8();
+        let raw_message = exception.message.to_utf8();
+        let mut message = Vec::with_capacity(raw_message.slice().len());
+        push_stripping_ansi(&mut message, raw_message.slice());
+
+        let is_assertion = strings::has_prefix_comptime(&message, b"expect(")
+            && (name.slice().is_empty() || strings::eql(name.slice(), b"Error"));
+
         if failure.name.is_empty() {
-            failure.name = exception.name.to_utf8_bytes();
+            if is_assertion {
+                failure.name.extend_from_slice(b"AssertionError");
+            } else {
+                failure.name.extend_from_slice(name.slice());
+            }
         }
         if failure.message.is_empty() {
-            failure.message = exception.message.to_utf8_bytes();
+            failure.message.extend_from_slice(&message);
         }
 
         let body = &mut failure.body;
         if !body.is_empty() {
             body.push(b'\n');
         }
-        let name = exception.name.to_utf8();
-        let message = exception.message.to_utf8();
-        match (name.slice().is_empty(), message.slice().is_empty()) {
+        let header: &[u8] = if is_assertion {
+            b"AssertionError"
+        } else {
+            name.slice()
+        };
+        match (header.is_empty(), message.is_empty()) {
             (true, true) => body.extend_from_slice(b"error"),
-            (true, false) => body.extend_from_slice(message.slice()),
-            (false, true) => body.extend_from_slice(name.slice()),
+            (true, false) => body.extend_from_slice(&message),
+            (false, true) => body.extend_from_slice(header),
             (false, false) => {
-                body.extend_from_slice(name.slice());
+                body.extend_from_slice(header);
                 body.extend_from_slice(b": ");
-                body.extend_from_slice(message.slice());
+                body.extend_from_slice(&message);
             }
         }
         body.push(b'\n');

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -158,7 +158,13 @@ pub(crate) fn escape_xml(str_: &[u8], writer: &mut impl bun_io::Write) -> crate:
                 last = i + 1;
             }
             b'\t' | b'\n' | b'\r' => {
-                // Valid XML 1.0 Char; pass through as-is.
+                // Valid XML 1.0 Char. Emit as a numeric reference so the literal
+                // byte survives attribute-value normalisation (XML 1.0 §3.3.3).
+                if i > last {
+                    writer.write_all(&str_[last..i])?;
+                }
+                write!(writer, "&#{};", c)?;
+                last = i + 1;
             }
             0..=0x1f => {
                 // Any other C0 control character is not a valid XML 1.0 Char and

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -319,44 +319,63 @@ impl JunitReporter {
 
     // `pub const new = bun.TrivialNew(JunitReporter);` → Box::new
 
-    /// Capture the thrown value's name/message plus a plain-text (no ANSI)
-    /// rendering so the next `write_test_case` can populate `<failure>`.
-    pub fn record_failure(&mut self, global_this: &jsc::JSGlobalObject, exception: jsc::JSValue) {
-        let vm = global_this.bun_vm().as_mut();
-        let (value, exc_ref): (jsc::JSValue, Option<&jsc::Exception>) =
-            match exception.as_exception(vm.jsc_vm) {
-                // SAFETY: `as_exception` returned a live JSC-heap `Exception`;
-                // read-only for the duration of this call.
-                Some(exc) => unsafe { ((*exc).value(), Some(&*exc)) },
-                None => (exception, None),
-            };
-
-        let mut failure = JunitFailure::default();
-
-        {
-            let mut holder = jsc::zig_exception::Holder::init();
-            let zig_exc = holder.zig_exception();
-            value.to_zig_exception(global_this, zig_exc);
-            failure.name = zig_exc.name.to_utf8_bytes();
-            failure.message = zig_exc.message.to_utf8_bytes();
-            holder.deinit(vm);
+    /// Capture name/message/stack from the `ZigException` that
+    /// `print_error_instance_body` has already populated, so the next
+    /// `write_test_case` can emit a useful `<failure>` without re-running
+    /// the exception formatter.
+    pub fn record_failure(&mut self, exception: &jsc::ZigException) {
+        let failure = self.last_failure.get_or_insert_default();
+        if failure.name.is_empty() {
+            failure.name = exception.name.to_utf8_bytes();
+        }
+        if failure.message.is_empty() {
+            failure.message = exception.message.to_utf8_bytes();
         }
 
-        {
-            let mut adapter = jsc::console_object::DynWriteAdapter::new(&mut failure.body);
-            let mut formatter = jsc::console_object::Formatter::new(global_this);
-            vm.print_errorlike_object(
-                value,
-                exc_ref,
-                None,
-                &mut formatter,
-                adapter.interface(),
-                false,
-                false,
-            );
+        let body = &mut failure.body;
+        if !body.is_empty() {
+            body.push(b'\n');
         }
+        let name = exception.name.to_utf8();
+        let message = exception.message.to_utf8();
+        match (name.slice().is_empty(), message.slice().is_empty()) {
+            (true, true) => body.extend_from_slice(b"error"),
+            (true, false) => body.extend_from_slice(message.slice()),
+            (false, true) => body.extend_from_slice(name.slice()),
+            (false, false) => {
+                body.extend_from_slice(name.slice());
+                body.extend_from_slice(b": ");
+                body.extend_from_slice(message.slice());
+            }
+        }
+        body.push(b'\n');
+        let dir = FileSystem::instance().top_level_dir;
+        for frame in exception.stack.frames() {
+            let source_url = frame.source_url.to_utf8();
+            let file = resolve_path::relative(dir, source_url.slice());
+            let func = frame.function_name.to_utf8();
+            if file.is_empty() && func.slice().is_empty() {
+                continue;
+            }
+            body.extend_from_slice(b"      at ");
+            let name_fmt = frame.name_formatter(false);
+            let url_fmt = frame.source_url_formatter(file, None, false, false);
+            if func.slice().is_empty() {
+                let _ = write!(body, "{}", url_fmt);
+            } else {
+                let _ = write!(body, "{} ({})", name_fmt, url_fmt);
+            }
+            body.push(b'\n');
+        }
+    }
 
-        self.last_failure = Some(failure);
+    /// VirtualMachine::on_print_error_zig_exception thunk.
+    pub fn record_failure_cb(ctx: *mut core::ffi::c_void, exception: &jsc::ZigException) {
+        // SAFETY: `ctx` was set to `&mut JunitReporter` by `on_uncaught_exception`
+        // for the duration of a single `run_error_handler` call; single-threaded,
+        // no other borrow of the reporter is live across that call.
+        let this = unsafe { &mut *ctx.cast::<JunitReporter>() };
+        this.record_failure(exception);
     }
 
     fn generate_properties_list(&mut self) -> crate::Result<()> {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -358,12 +358,26 @@ impl JunitReporter {
                 continue;
             }
             body.extend_from_slice(b"      at ");
-            let name_fmt = frame.name_formatter(false);
-            let url_fmt = frame.source_url_formatter(file, None, false, false);
-            if func.slice().is_empty() {
-                let _ = write!(body, "{}", url_fmt);
-            } else {
-                let _ = write!(body, "{} ({})", name_fmt, url_fmt);
+            if !func.slice().is_empty() {
+                let _ = write!(body, "{} (", frame.name_formatter(false));
+            }
+            let file_start = body.len();
+            body.extend_from_slice(file);
+            if cfg!(windows) {
+                for b in &mut body[file_start..] {
+                    if *b == b'\\' {
+                        *b = b'/';
+                    }
+                }
+            }
+            let pos = frame.position;
+            if pos.line.is_valid() && pos.column.is_valid() {
+                let _ = write!(body, ":{}:{}", pos.line.one_based(), pos.column.one_based());
+            } else if pos.line.is_valid() {
+                let _ = write!(body, ":{}", pos.line.one_based());
+            }
+            if !func.slice().is_empty() {
+                body.push(b')');
             }
             body.push(b'\n');
         }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -708,10 +708,11 @@ impl Execution {
     /// afterEach after the test body already threw) accumulate instead of
     /// clobbering the primary failure.
     fn discard_junit_failure(buntest: NonNull<BunTest>) {
-        // SAFETY: `buntest` points at the live per-file BunTest; `reporter` is a
-        // `NonNull<CommandLineReporter>` with write provenance (see BunTest docs);
-        // single-threaded test runner, no other borrow live here.
+        // SAFETY: `buntest` points at the live per-file BunTest; single-threaded
+        // test runner, no other borrow live here.
         if let Some(reporter) = unsafe { (*buntest.as_ptr()).reporter } {
+            // SAFETY: `reporter` is a `NonNull<CommandLineReporter>` with write
+            // provenance (see BunTest docs); single-threaded, no other borrow.
             if let Some(junit) = unsafe { (*reporter.as_ptr()).reporters.junit.as_deref_mut() } {
                 junit.last_failure = None;
             }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -537,6 +537,7 @@ impl Execution {
             // Handle retry logic: if test failed and we have retries remaining, retry it
             if test_failed && sequence.remaining_retry_count > 0 {
                 sequence.remaining_retry_count -= 1;
+                Execution::discard_junit_failure(buntest);
                 Execution::reset_sequence(sequence);
                 return;
             }
@@ -544,6 +545,7 @@ impl Execution {
             // Handle repeat logic: if test passed and we have repeats remaining, repeat it
             if test_passed && sequence.remaining_repeat_count > 0 {
                 sequence.remaining_repeat_count -= 1;
+                Execution::discard_junit_failure(buntest);
                 Execution::reset_sequence(sequence);
                 return;
             }
@@ -697,6 +699,21 @@ impl Execution {
                         );
                     }
                 }
+            }
+        }
+    }
+
+    /// Drop any captured junit failure so the next retry/repeat starts fresh.
+    /// Kept out of `reset_sequence` so within-attempt errors (e.g. a throwing
+    /// afterEach after the test body already threw) accumulate instead of
+    /// clobbering the primary failure.
+    fn discard_junit_failure(buntest: NonNull<BunTest>) {
+        // SAFETY: `buntest` points at the live per-file BunTest; `reporter` is a
+        // `NonNull<CommandLineReporter>` with write provenance (see BunTest docs);
+        // single-threaded test runner, no other borrow live here.
+        if let Some(reporter) = unsafe { (*buntest.as_ptr()).reporter } {
+            if let Some(junit) = unsafe { (*reporter.as_ptr()).reporters.junit.as_deref_mut() } {
+                junit.last_failure = None;
             }
         }
     }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1322,7 +1322,12 @@ impl BunTest {
             // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
             // `&mut`; single-threaded test runner, no other borrow live here.
             match unsafe { (*reporter.as_ptr()).reporters.junit.as_deref_mut() } {
-                Some(junit) => (junit as *mut crate::cli::test_command::JunitReporter).cast(),
+                Some(junit) => {
+                    // Each top-level exception starts a fresh capture so a retried
+                    // test reports the final attempt rather than accumulating.
+                    junit.last_failure = None;
+                    (junit as *mut crate::cli::test_command::JunitReporter).cast()
+                }
                 None => core::ptr::null_mut(),
             }
         };

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1326,7 +1326,7 @@ impl BunTest {
                     // Each top-level exception starts a fresh capture so a retried
                     // test reports the final attempt rather than accumulating.
                     junit.last_failure = None;
-                    (junit as *mut crate::cli::test_command::JunitReporter).cast()
+                    core::ptr::from_mut(junit).cast()
                 }
                 None => core::ptr::null_mut(),
             }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1322,12 +1322,7 @@ impl BunTest {
             // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
             // `&mut`; single-threaded test runner, no other borrow live here.
             match unsafe { (*reporter.as_ptr()).reporters.junit.as_deref_mut() } {
-                Some(junit) => {
-                    // Each top-level exception starts a fresh capture so a retried
-                    // test reports the final attempt rather than accumulating.
-                    junit.last_failure = None;
-                    core::ptr::from_mut(junit).cast()
-                }
+                Some(junit) => core::ptr::from_mut(junit).cast(),
                 None => core::ptr::null_mut(),
             }
         };

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1312,15 +1312,20 @@ impl BunTest {
             return; // the exception should not be visible (eg m_terminationException)
         };
 
-        if handle_status == HandleUncaughtExceptionResult::ShowHandledError {
-            if let Some(reporter) = self.reporter {
-                // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
-                // `&mut`; single-threaded test runner, no other borrow live here.
-                if let Some(junit) = unsafe { (*reporter.as_ptr()).reporters.junit.as_mut() } {
-                    junit.record_failure(global_this, exception);
-                }
+        let junit_ctx: *mut core::ffi::c_void = 'ctx: {
+            if handle_status != HandleUncaughtExceptionResult::ShowHandledError {
+                break 'ctx core::ptr::null_mut();
             }
-        }
+            let Some(reporter) = self.reporter else {
+                break 'ctx core::ptr::null_mut();
+            };
+            // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
+            // `&mut`; single-threaded test runner, no other borrow live here.
+            match unsafe { (*reporter.as_ptr()).reporters.junit.as_deref_mut() } {
+                Some(junit) => (junit as *mut crate::cli::test_command::JunitReporter).cast(),
+                None => core::ptr::null_mut(),
+            }
+        };
 
         self.bun_test_root.on_before_print();
         if matches!(
@@ -1340,7 +1345,17 @@ impl BunTest {
             Output::flush();
         }
 
-        global_this.bun_vm().as_mut().run_error_handler(exception, None);
+        let vm = global_this.bun_vm().as_mut();
+        if !junit_ctx.is_null() {
+            vm.on_print_error_zig_exception =
+                Some(crate::cli::test_command::JunitReporter::record_failure_cb);
+            vm.on_print_error_zig_exception_ctx = junit_ctx;
+        }
+        vm.run_error_handler(exception, None);
+        if !junit_ctx.is_null() {
+            vm.on_print_error_zig_exception = None;
+            vm.on_print_error_zig_exception_ctx = core::ptr::null_mut();
+        }
 
         if matches!(
             handle_status,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1312,6 +1312,16 @@ impl BunTest {
             return; // the exception should not be visible (eg m_terminationException)
         };
 
+        if handle_status == HandleUncaughtExceptionResult::ShowHandledError {
+            if let Some(reporter) = self.reporter {
+                // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
+                // `&mut`; single-threaded test runner, no other borrow live here.
+                if let Some(junit) = unsafe { (*reporter.as_ptr()).reporters.junit.as_mut() } {
+                    junit.record_failure(global_this, exception);
+                }
+            }
+        }
+
         self.bun_test_root.on_before_print();
         if matches!(
             handle_status,

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -21,7 +21,7 @@ exports[`junit reporter more scenarios 1`] = `
       </testsuite>
       <testcase name="basic passing test" classname="comprehensive test suite" file="comprehensive.test.js" line="26" assertions="1" />
       <testcase name="basic failing test" classname="comprehensive test suite" file="comprehensive.test.js" line="30" assertions="1">
-        <failure type="Error" message="expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;">Error: expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;&#10;      at comprehensive.test.js:31:27&#10;</failure>
+        <failure type="AssertionError" message="expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;">AssertionError: expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;&#10;      at comprehensive.test.js:31:27&#10;</failure>
       </testcase>
       <testcase name="basic skipped test" classname="comprehensive test suite" file="comprehensive.test.js" line="34" assertions="0">
         <skipped />

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -21,17 +21,7 @@ exports[`junit reporter more scenarios 1`] = `
       </testsuite>
       <testcase name="basic passing test" classname="comprehensive test suite" file="comprehensive.test.js" line="26" assertions="1" />
       <testcase name="basic failing test" classname="comprehensive test suite" file="comprehensive.test.js" line="30" assertions="1">
-        <failure type="Error" message="expect(received).toBe(expected)
-
-Expected: 3
-Received: 2
-">Error: expect(received).toBe(expected)
-
-Expected: 3
-Received: 2
-
-      at comprehensive.test.js:31:27
-</failure>
+        <failure type="Error" message="expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;">Error: expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;&#10;      at comprehensive.test.js:31:27&#10;</failure>
       </testcase>
       <testcase name="basic skipped test" classname="comprehensive test suite" file="comprehensive.test.js" line="34" assertions="0">
         <skipped />

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -6,22 +6,39 @@ exports[`junit reporter more scenarios 1`] = `
   <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="16" failures="1" skipped="6">
     <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="16" failures="1" skipped="6">
       <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" skipped="0">
-        <testcase name="should divide correctly" classname="division suite 10 / 5 &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
+        <testcase name="should divide correctly" classname="division suite 10 / 5 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
       </testsuite>
       <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" skipped="0">
-        <testcase name="should divide correctly" classname="division suite 20 / 10 &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
+        <testcase name="should divide correctly" classname="division suite 20 / 10 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
       </testsuite>
       <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="1" failures="0" skipped="0">
-        <testcase name="nested test in conditional describe" classname="conditional describe that runs &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="1" />
+        <testcase name="nested test in conditional describe" classname="conditional describe that runs &gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="1" />
       </testsuite>
       <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="nested test that gets skipped" classname="conditional describe that skips &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
+        <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
       <testcase name="basic passing test" classname="comprehensive test suite" file="comprehensive.test.js" line="26" assertions="1" />
       <testcase name="basic failing test" classname="comprehensive test suite" file="comprehensive.test.js" line="30" assertions="1">
-        <failure type="AssertionError" />
+        <failure type="Error" message="expect(received).toBe(expected)
+
+Expected: 3
+Received: 2
+">26 |           test(&quot;basic passing test&quot;, () =&gt; {
+27 |             expect(1 + 1).toBe(2);
+28 |           });
+29 | 
+30 |           test(&quot;basic failing test&quot;, () =&gt; {
+31 |             expect(1 + 1).toBe(3);
+                               ^
+error: expect(received).toBe(expected)
+
+Expected: 3
+Received: 2
+
+      at &lt;anonymous&gt; (<dir>/comprehensive.test.js:31:27)
+</failure>
       </testcase>
       <testcase name="basic skipped test" classname="comprehensive test suite" file="comprehensive.test.js" line="34" assertions="0">
         <skipped />
@@ -61,22 +78,22 @@ exports[`junit reporter more scenarios 2`] = `
   <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="1" failures="0" skipped="21">
     <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="1" failures="0" skipped="21">
       <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="should divide correctly" classname="division suite 10 / 5 &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
+        <testcase name="should divide correctly" classname="division suite 10 / 5 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
       <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="should divide correctly" classname="division suite 20 / 10 &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
+        <testcase name="should divide correctly" classname="division suite 20 / 10 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
       <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="nested test in conditional describe" classname="conditional describe that runs &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="0">
+        <testcase name="nested test in conditional describe" classname="conditional describe that runs &gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
       <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="nested test that gets skipped" classname="conditional describe that skips &amp;gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
+        <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
           <skipped />
         </testcase>
       </testsuite>

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -25,19 +25,12 @@ exports[`junit reporter more scenarios 1`] = `
 
 Expected: 3
 Received: 2
-">26 |           test(&quot;basic passing test&quot;, () =&gt; {
-27 |             expect(1 + 1).toBe(2);
-28 |           });
-29 | 
-30 |           test(&quot;basic failing test&quot;, () =&gt; {
-31 |             expect(1 + 1).toBe(3);
-                               ^
-error: expect(received).toBe(expected)
+">Error: expect(received).toBe(expected)
 
 Expected: 3
 Received: 2
 
-      at &lt;anonymous&gt; (<dir>/comprehensive.test.js:31:27)
+      at <dir>/comprehensive.test.js:31:27
 </failure>
       </testcase>
       <testcase name="basic skipped test" classname="comprehensive test suite" file="comprehensive.test.js" line="34" assertions="0">

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -30,7 +30,7 @@ Received: 2
 Expected: 3
 Received: 2
 
-      at <dir>/comprehensive.test.js:31:27
+      at comprehensive.test.js:31:27
 </failure>
       </testcase>
       <testcase name="basic skipped test" classname="comprehensive test suite" file="comprehensive.test.js" line="34" assertions="0">

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -514,8 +514,9 @@ describe("junit reporter", () => {
     expect(assertion.failure[0]._).toContain("Received: 1");
     expect(assertion.failure[0]._).toContain("fail.test.js:5");
 
-    // No ANSI escape sequences should leak into the report.
-    expect(xmlContent).not.toContain("\x1b[");
+    // No ANSI escape sequences should leak into the report. escape_xml drops
+    // the ESC byte, so a colour leak would surface as bare SGR residue.
+    expect(xmlContent).not.toMatch(/\[\d+m/);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -519,6 +519,11 @@ describe("junit reporter", () => {
 
 function filterJunitXmlOutput(xmlContent, dir) {
   let out = xmlContent.replaceAll(/ (time|hostname)=".*?"/g, "");
-  if (dir) out = out.replaceAll(String(dir), "<dir>");
+  if (dir) {
+    out = out.replaceAll(String(dir), "<dir>");
+    out = out.replaceAll(String(dir).replaceAll("\\", "/"), "<dir>");
+  }
+  // <failure> bodies render stack-frame paths with the platform separator.
+  out = out.replaceAll(/(<dir>)[\\\/]/g, "$1/");
   return out;
 }

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -517,7 +517,9 @@ describe("junit reporter", () => {
     const junitPath = join(tmpDir, "junit.xml");
     await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
       cwd: tmpDir,
-      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      // FORCE_COLOR so the matcher builds a coloured message, to exercise the
+      // ANSI-strip path.
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1", FORCE_COLOR: "1" },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -541,6 +543,7 @@ describe("junit reporter", () => {
     expect(typeErr.failure[0].$.message).toContain("null is not an object");
     expect(typeErr.failure[0]._).toContain("fail.test.js:4");
 
+    expect(assertion.failure[0].$.type).toBe("AssertionError");
     expect(assertion.failure[0].$.message).toContain("expect(received).toBe(expected)");
     expect(assertion.failure[0]._).toContain("Expected: 2");
     expect(assertion.failure[0]._).toContain("Received: 1");

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -550,8 +550,8 @@ describe("junit reporter", () => {
     expect(assertion.failure[0]._).toContain("fail.test.js:5");
 
     // No ANSI escape sequences should leak into the report. escape_xml drops
-    // the ESC byte, so a colour leak would surface as bare SGR residue.
-    expect(xmlContent).not.toMatch(/\[\d+m/);
+    // the ESC byte, so a leak would surface as bare CSI residue.
+    expect(xmlContent).not.toMatch(/\[[\d;]*[A-HJKSTfm]/);
     expect(exitCode).toBe(1);
   });
 });

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -1,6 +1,7 @@
 import { file, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { join } from "node:path";
 
 const xml2js = require("xml2js");
 
@@ -254,7 +255,7 @@ describe("junit reporter", () => {
     await proc1.exited;
 
     const xmlContent1 = await file(junitPath1).text();
-    expect(filterJunitXmlOutput(xmlContent1)).toMatchSnapshot();
+    expect(filterJunitXmlOutput(xmlContent1, tmpDir)).toMatchSnapshot();
     const result1 = await new Promise((resolve, reject) => {
       xml2js.parseString(xmlContent1, (err, result) => {
         if (err) reject(err);
@@ -282,7 +283,7 @@ describe("junit reporter", () => {
     await proc2.exited;
 
     const xmlContent2 = await file(junitPath2).text();
-    expect(filterJunitXmlOutput(xmlContent2)).toMatchSnapshot();
+    expect(filterJunitXmlOutput(xmlContent2, tmpDir)).toMatchSnapshot();
     const result2 = await new Promise((resolve, reject) => {
       xml2js.parseString(xmlContent2, (err, result) => {
         if (err) reject(err);
@@ -384,8 +385,140 @@ describe("junit reporter", () => {
 
     expect(proc.exitCode).toBe(1);
   });
+
+  it("produces well-formed XML when test names contain control characters", async () => {
+    const tmpDir = tempDirWithFiles("junit-ctrl", {
+      "package.json": "{}",
+      "ctrl.test.js":
+        'import { test } from "bun:test";\n' +
+        'test("ctrl \\x00nul\\x1besc\\x07bell", () => { throw new Error("x"); });\n' +
+        'test("keeps\\twhitespace\\nfine", () => {});\n',
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlBytes = await file(junitPath).bytes();
+    // Raw control characters (other than TAB/LF/CR) are not well-formed XML 1.0
+    // and must not appear in the output at all.
+    for (const c of [0x00, 0x07, 0x1b]) {
+      expect(xmlBytes).not.toContain(c);
+    }
+
+    const xmlContent = new TextDecoder().decode(xmlBytes);
+    // &#0; / &#27; are also illegal as numeric references in XML 1.0.
+    expect(xmlContent).not.toMatch(/&#(0|7|27);/);
+
+    // The report must parse as XML.
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const testcases = result.testsuites.testsuite[0].testcase;
+    expect(testcases[0].$.name).toBe("ctrl nulescbell");
+    // TAB and LF are valid XML Chars and should pass through untouched.
+    expect(testcases[1].$.name).toBe("keeps\twhitespace\nfine");
+    expect(exitCode).toBe(1);
+  });
+
+  it("escapes the classname attribute exactly once", async () => {
+    const tmpDir = tempDirWithFiles("junit-escape", {
+      "package.json": "{}",
+      "escape.test.js": `
+        import { describe, test } from "bun:test";
+        describe("suite <a> & \\"b\\"", () => {
+          describe("inner > stuff", () => {
+            test("t", () => {});
+          });
+        });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    // Double-escaping would produce &amp;lt; / &amp;amp; etc.
+    expect(xmlContent).not.toContain("&amp;lt;");
+    expect(xmlContent).not.toContain("&amp;amp;");
+    expect(xmlContent).not.toContain("&amp;gt;");
+    expect(xmlContent).not.toContain("&amp;quot;");
+
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const fileSuite = result.testsuites.testsuite[0];
+    const outer = fileSuite.testsuite[0];
+    const inner = outer.testsuite[0];
+    const tc = inner.testcase[0];
+    // The classname should decode back to the original describe names joined by " > ".
+    expect(outer.$.name).toBe('suite <a> & "b"');
+    expect(tc.$.classname).toBe('inner > stuff > suite <a> & "b"');
+    expect(exitCode).toBe(0);
+  });
+
+  it("includes the error type, message and stack in <failure>", async () => {
+    const tmpDir = tempDirWithFiles("junit-failure", {
+      "package.json": "{}",
+      "fail.test.js": `
+        import { test, expect } from "bun:test";
+        test("thrown error", () => { throw new Error("boom: the important message"); });
+        test("type error", () => { null.foo; });
+        test("assertion", () => { expect(1).toBe(2); });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const testcases = result.testsuites.testsuite[0].testcase;
+    expect(testcases).toHaveLength(3);
+
+    const [thrown, typeErr, assertion] = testcases;
+
+    expect(thrown.failure[0].$.type).toBe("Error");
+    expect(thrown.failure[0].$.message).toContain("boom: the important message");
+    expect(thrown.failure[0]._).toContain("boom: the important message");
+    expect(thrown.failure[0]._).toContain("fail.test.js:3");
+
+    expect(typeErr.failure[0].$.type).toBe("TypeError");
+    expect(typeErr.failure[0].$.message).toContain("null is not an object");
+    expect(typeErr.failure[0]._).toContain("fail.test.js:4");
+
+    expect(assertion.failure[0].$.message).toContain("expect(received).toBe(expected)");
+    expect(assertion.failure[0]._).toContain("Expected: 2");
+    expect(assertion.failure[0]._).toContain("Received: 1");
+    expect(assertion.failure[0]._).toContain("fail.test.js:5");
+
+    // No ANSI escape sequences should leak into the report.
+    expect(xmlContent).not.toContain("\x1b[");
+    expect(exitCode).toBe(1);
+  });
 });
 
-function filterJunitXmlOutput(xmlContent) {
-  return xmlContent.replaceAll(/ (time|hostname)=".*?"/g, "");
+function filterJunitXmlOutput(xmlContent, dir) {
+  let out = xmlContent.replaceAll(/ (time|hostname)=".*?"/g, "");
+  if (dir) out = out.replaceAll(String(dir), "<dir>");
+  return out;
 }

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -255,7 +255,7 @@ describe("junit reporter", () => {
     await proc1.exited;
 
     const xmlContent1 = await file(junitPath1).text();
-    expect(filterJunitXmlOutput(xmlContent1, tmpDir)).toMatchSnapshot();
+    expect(filterJunitXmlOutput(xmlContent1)).toMatchSnapshot();
     const result1 = await new Promise((resolve, reject) => {
       xml2js.parseString(xmlContent1, (err, result) => {
         if (err) reject(err);
@@ -283,7 +283,7 @@ describe("junit reporter", () => {
     await proc2.exited;
 
     const xmlContent2 = await file(junitPath2).text();
-    expect(filterJunitXmlOutput(xmlContent2, tmpDir)).toMatchSnapshot();
+    expect(filterJunitXmlOutput(xmlContent2)).toMatchSnapshot();
     const result2 = await new Promise((resolve, reject) => {
       xml2js.parseString(xmlContent2, (err, result) => {
         if (err) reject(err);
@@ -366,12 +366,15 @@ describe("junit reporter", () => {
     expect(flakyEntries).toHaveLength(1);
     expect(flakyEntries[0][0]).not.toContain("<failure");
 
-    // A test that fails every retry attempt is reported once, as a failure.
+    // A test that fails every retry attempt is reported once, as a failure,
+    // and the failure message reflects the final attempt (not the first).
     const exhaustedEntries = [
       ...xmlContent.matchAll(/<testcase[^>]*name="exhausted test"[^/]*(?:\/>|>[\s\S]*?<\/testcase>)/g),
     ];
     expect(exhaustedEntries).toHaveLength(1);
     expect(exhaustedEntries[0][0]).toContain("<failure");
+    expect(exhaustedEntries[0][0]).toContain("always fails 3");
+    expect(exhaustedEntries[0][0]).not.toContain("always fails 1");
 
     expect(xmlContent).toContain('name="stable test"');
 
@@ -517,13 +520,6 @@ describe("junit reporter", () => {
   });
 });
 
-function filterJunitXmlOutput(xmlContent, dir) {
-  let out = xmlContent.replaceAll(/ (time|hostname)=".*?"/g, "");
-  if (dir) {
-    out = out.replaceAll(String(dir), "<dir>");
-    out = out.replaceAll(String(dir).replaceAll("\\", "/"), "<dir>");
-  }
-  // <failure> bodies render stack-frame paths with the platform separator.
-  out = out.replaceAll(/(<dir>)[\\\/]/g, "$1/");
-  return out;
+function filterJunitXmlOutput(xmlContent) {
+  return xmlContent.replaceAll(/ (time|hostname)=".*?"/g, "");
 }

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -471,6 +471,38 @@ describe("junit reporter", () => {
     expect(exitCode).toBe(0);
   });
 
+  it("keeps the test body's error in <failure> when afterEach also throws", async () => {
+    const tmpDir = tempDirWithFiles("junit-aftereach", {
+      "package.json": "{}",
+      "after.test.js": `
+        import { test, afterEach } from "bun:test";
+        afterEach(() => { throw new Error("cleanup broke"); });
+        test("t", () => { throw new Error("actual test failure"); });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const tc = result.testsuites.testsuite[0].testcase[0];
+    // The primary failure (from the test body) should win type/message;
+    // the afterEach error should be appended to the body.
+    expect(tc.failure[0].$.message).toContain("actual test failure");
+    expect(tc.failure[0]._).toContain("actual test failure");
+    expect(tc.failure[0]._).toContain("cleanup broke");
+    expect(exitCode).toBe(1);
+  });
+
   it("includes the error type, message and stack in <failure>", async () => {
     const tmpDir = tempDirWithFiles("junit-failure", {
       "package.json": "{}",


### PR DESCRIPTION
### What does this PR do?

Fixes three problems with the JUnit XML reporter that, together, made the report unparseable and stripped of any useful failure information.

#### Repro

```sh
cat > x.test.js <<'JS'
describe('suite <a> & "b"', () => {
  test("plain fail", () => { throw new Error("boom: important message"); });
  test("ctrl \x00nul\x1besc", () => { throw new Error("x"); });
});
JS
bun test --reporter=junit --reporter-outfile=r.xml
python3 -c "import xml.etree.ElementTree as ET; ET.parse('r.xml')"
# xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 8, column 36
```

#### 1. Control characters in test names produce malformed XML

`escape_xml` wrote `&#N;` for every C0 control byte but neither flushed the pending run nor advanced `last`, so the raw byte was *also* emitted, and the references appeared at the start of the string instead of in place. Since bytes 0x00..=0x08 / 0x0B / 0x0C / 0x0E..=0x1F are not legal XML 1.0 `Char`s even as numeric references, the fix passes TAB/LF/CR through and drops every other C0 byte.

Before: `name="&#0;&#27;ctrl ^@nul^[esc"` (parse error).
After: `name="ctrl nulesc"` (parses).

#### 2. `classname` is double-escaped

The describe-scope names were XML-escaped while being joined with `" &gt; "`, then escaped again inside `write_test_case`, so `describe('suite <a> & "b"')` produced `classname="suite &amp;lt;a&amp;gt; &amp;amp; &amp;quot;b&amp;quot;"`. The inner `<testsuite name="">` was only escaped once, so the two disagreed. The join now concatenates the raw names with a raw `" > "` separator and leaves the single escape to `write_test_case`.

#### 3. `<failure>` carries no message, stack, or correct type

Every thrown error was reported as `<failure type="AssertionError" />` with no message or stack. `on_uncaught_exception` now records the error's name, message, and a colourless `print_errorlike_object` rendering on the `JunitReporter`; `write_test_case` emits them as the `type` and `message` attributes and the element body:

```xml
<failure type="Error" message="boom: important message">1 | describe(...
   ...
error: boom: important message
      at &lt;anonymous&gt; (x.test.js:3:71)
</failure>
```

`TypeError`, `RangeError`, etc. now report their real name in `type`. Timeouts also gain `message="test timed out"`.

### How did you verify your code works?

New tests in `test/js/junit-reporter/junit.test.js`:

- `produces well-formed XML when test names contain control characters`: asserts the raw bytes contain no illegal C0 characters, no `&#0;`/`&#27;`, the report parses with a strict XML parser, and TAB/LF survive.
- `escapes the classname attribute exactly once`: asserts no `&amp;lt;` / `&amp;amp;` etc. appear and the decoded `classname` round-trips to the original describe titles.
- `includes the error type, message and stack in <failure>`: asserts `type`/`message` and body text for a plain `Error`, a `TypeError`, and an `expect().toBe()` failure, and that no ANSI escapes leak into the report.

All three fail against `main` and pass with this change. The existing `junit reporter` tests and the `--parallel --reporter=junit` tests still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/184] gen bindgenv2
[2/184] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/184] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 240 extern-C blocks audited
[4/184] gen cpp.rs (cppbind)
[5/184] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [20.52ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [15.13ms]
/tmp/junit-comprehensive_5eGMij
253 |       stderr: "pipe",
254 |     });
255 |     await proc1.exited;
256 | 
257 |     const xmlContent1 = await file(junitPath1).text();
258 |     expect(filterJunitXmlOutput(xmlContent1)).toMatchSnapshot();
                                                    ^
error: expect(received).toMatchSnapshot(expected)

@@ -2,26 +2,26 @@
  "
  
    
      
        
-         
+         
        
        
-         
+         
        
        
-         
+         
        
        
-         
+         
            
          
        
        
        
-         AssertionError: expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;&#10;      at comprehensive.test.js:31:27&#10;
+         
        
        
          
        
        

- Expected  - 5
+ Received  + 5

      at <anonymous> (/workspace/bun/test/js/junit-reporter/junit.test.js:258:47)
(fail) junit reporter > mor
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.0 (a93ab8bcc)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [796.77ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [576.89ms]
/tmp/junit-comprehensive_Py8zho
(pass) junit reporter > more scenarios [1138.97ms]
(pass) junit reporter > should report only the final result for a retried test [652.04ms]
(pass) junit reporter > produces well-formed XML when test names contain control characters [531.82ms]
(pass) junit reporter > escapes the classname attribute exactly once [467.97ms]
(pass) junit reporter > keeps the test body's error in <failure> when afterEach also throws [456.76ms]
(pass) junit reporter > includes the error type, message and stack in <failure> [525.69ms]

 8 pass
 0 fail
 2 snapshots, 135 expect() calls
Ran 8 tests across 1 file. [8.06s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 882ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/142] gen bindgenv2
[2/142] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/142] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[4/142] gen cpp.rs (cppbind)
[5/142] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/ap
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          |  10 ++
 src/runtime/cli/test_command.rs                    | 181 +++++++++++++++++++--
 src/runtime/test_runner/Execution.rs               |  18 ++
 src/runtime/test_runner/bun_test.rs                |  27 ++-
 .../__snapshots__/junit.test.js.snap               |  18 +-
 test/js/junit-reporter/junit.test.js               | 172 +++++++++++++++++++-
 6 files changed, 401 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 6 passed · 1 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/VirtualMachine.rs                                    8      2      0
src/runtime/cli/test_command.rs                             12     14      0
src/runtime/test_runner/Execution.rs                         4      3      0
src/runtime/test_runner/bun_test.rs                          6      8      0
test/js/junit-reporter/__snapshots__/junit.test.js.snap      0      0      0
test/js/junit-reporter/junit.test.js                         7     16      0
```

</details>

<!-- robobun:evidence:end -->