### PR TITLE
cli: apply --extension-order to ESM imports; split --main-fields/--extension-order on commas

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1878,11 +1878,15 @@ impl<'a> BundleOptions<'a> {
         }
 
         if !transform.extension_order.is_empty() {
-            opts.extension_order.default.default = transform
+            let user_list: Box<[Box<[u8]>]> = transform
                 .extension_order
                 .iter()
                 .map(|s| Box::<[u8]>::from(s.as_ref()))
                 .collect();
+            opts.extension_order.default.esm = user_list.clone();
+            opts.extension_order.node_modules.default = user_list.clone();
+            opts.extension_order.node_modules.esm = user_list.clone();
+            opts.extension_order.default.default = user_list;
         }
 
         if let Some(t) = transform.target {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -36,6 +36,18 @@ fn slice_to_owned(input: &[&[u8]]) -> Vec<Box<[u8]>> {
     input.iter().map(|s| Box::<[u8]>::from(*s)).collect()
 }
 
+/// Like [`slice_to_owned`], but splits each argument on commas so a single
+/// `--flag=a,b,c` behaves the same as repeated `--flag=a --flag=b --flag=c`.
+#[inline]
+fn comma_list_to_owned(input: &[&[u8]]) -> Vec<Box<[u8]>> {
+    input
+        .iter()
+        .flat_map(|s| s.split(|&b| b == b','))
+        .filter(|s| !s.is_empty())
+        .map(Box::<[u8]>::from)
+        .collect()
+}
+
 pub(crate) fn loader_resolver(input: &[u8]) -> crate::Result<api::Loader> {
     let option_loader = bun_ast::Loader::from_string(input).ok_or(crate::Error::InvalidLoader)?;
     Ok(option_loader.to_api())
@@ -896,11 +908,11 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         None
     };
 
-    opts.main_fields = slice_to_owned(args.options(b"--main-fields"));
+    opts.main_fields = comma_list_to_owned(args.options(b"--main-fields"));
     // we never actually supported inject.
     // opts.inject = args.options(b"--inject");
     opts.env_files = slice_to_owned(args.options(b"--env-file"));
-    opts.extension_order = slice_to_owned(args.options(b"--extension-order"));
+    opts.extension_order = comma_list_to_owned(args.options(b"--extension-order"));
 
     if args.flag(b"--no-env-file") {
         opts.disable_default_env_files = true;

--- a/test/cli/run/resolve-flags.test.ts
+++ b/test/cli/run/resolve-flags.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function run(cwd: string, argv: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...argv],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("--extension-order", () => {
+  const files = {
+    "d.ts": `export default "TS";\n`,
+    "d.js": `export default "JS";\n`,
+    "i.ts": `import x from "./d"; console.log("import", x);\n`,
+    "r.cjs": `console.log("require", require("./d").default);\n`,
+    "dyn.ts": `import("./d").then(m => console.log("dynamic", m.default));\n`,
+    "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "./index.js" }),
+    "node_modules/pkg/index.js": `import x from "./sub"; export default x;\n`,
+    "node_modules/pkg/sub.mjs": `export default "PKG-MJS";\n`,
+    "node_modules/pkg/sub.js": `export default "PKG-JS";\n`,
+    "p.ts": `import x from "pkg"; console.log("pkg", x);\n`,
+  };
+
+  describe.each([
+    [["--extension-order=.js", "--extension-order=.ts"]],
+    [["--extension-order=.js,.ts"]],
+    [["--extension-order", ".js,.ts"]],
+  ])("%p", flags => {
+    test.concurrent("applies to import statements", async () => {
+      using dir = tempDir("ext-order", files);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "i.ts"]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("import JS\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("applies to require()", async () => {
+      using dir = tempDir("ext-order", files);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "r.cjs"]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("require JS\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("applies to dynamic import", async () => {
+      using dir = tempDir("ext-order", files);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "dyn.ts"]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("dynamic JS\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("applies inside node_modules", async () => {
+      using dir = tempDir("ext-order", files);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "p.ts"]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("pkg PKG-JS\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  test.concurrent("defaults still prefer .ts over .js for import without the flag", async () => {
+    using dir = tempDir("ext-order", files);
+    const { stdout, exitCode } = await run(String(dir), ["i.ts"]);
+    expect(stdout).toBe("import TS\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("--main-fields", () => {
+  const files = {
+    "node_modules/mf/package.json": JSON.stringify({
+      name: "mf",
+      main: "./main.js",
+      module: "./module.js",
+    }),
+    "node_modules/mf/main.js": `export default "main";\n`,
+    "node_modules/mf/module.js": `export default "module";\n`,
+    "m.ts": `import x from "mf"; console.log(x);\n`,
+  };
+
+  describe.each([
+    [["--main-fields=module", "--main-fields=main"]],
+    [["--main-fields=module,main"]],
+    [["--main-fields", "module,main"]],
+  ])("%p", flags => {
+    test.concurrent("resolves the first matching field", async () => {
+      using dir = tempDir("main-fields", files);
+      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "m.ts"]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("module\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  test.concurrent("--main-fields=main,module prefers main", async () => {
+    using dir = tempDir("main-fields", files);
+    const { stdout, stderr, exitCode } = await run(String(dir), ["--main-fields=main,module", "m.ts"]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("main\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/run/resolve-flags.test.ts
+++ b/test/cli/run/resolve-flags.test.ts
@@ -13,6 +13,8 @@ async function run(cwd: string, argv: string[]) {
   return { stdout, stderr, exitCode };
 }
 
+const ok = (stdout: string) => ({ stdout, stderr: "", exitCode: 0 });
+
 describe("--extension-order", () => {
   const files = {
     "d.ts": `export default "TS";\n`,
@@ -34,42 +36,28 @@ describe("--extension-order", () => {
   ])("%p", flags => {
     test.concurrent("applies to import statements", async () => {
       using dir = tempDir("ext-order", files);
-      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "i.ts"]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("import JS\n");
-      expect(exitCode).toBe(0);
+      expect(await run(String(dir), [...flags, "i.ts"])).toEqual(ok("import JS\n"));
     });
 
     test.concurrent("applies to require()", async () => {
       using dir = tempDir("ext-order", files);
-      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "r.cjs"]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("require JS\n");
-      expect(exitCode).toBe(0);
+      expect(await run(String(dir), [...flags, "r.cjs"])).toEqual(ok("require JS\n"));
     });
 
     test.concurrent("applies to dynamic import", async () => {
       using dir = tempDir("ext-order", files);
-      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "dyn.ts"]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("dynamic JS\n");
-      expect(exitCode).toBe(0);
+      expect(await run(String(dir), [...flags, "dyn.ts"])).toEqual(ok("dynamic JS\n"));
     });
 
     test.concurrent("applies inside node_modules", async () => {
       using dir = tempDir("ext-order", files);
-      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "p.ts"]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("pkg PKG-JS\n");
-      expect(exitCode).toBe(0);
+      expect(await run(String(dir), [...flags, "p.ts"])).toEqual(ok("pkg PKG-JS\n"));
     });
   });
 
   test.concurrent("defaults still prefer .ts over .js for import without the flag", async () => {
     using dir = tempDir("ext-order", files);
-    const { stdout, exitCode } = await run(String(dir), ["i.ts"]);
-    expect(stdout).toBe("import TS\n");
-    expect(exitCode).toBe(0);
+    expect(await run(String(dir), ["i.ts"])).toEqual(ok("import TS\n"));
   });
 });
 
@@ -92,18 +80,12 @@ describe("--main-fields", () => {
   ])("%p", flags => {
     test.concurrent("resolves the first matching field", async () => {
       using dir = tempDir("main-fields", files);
-      const { stdout, stderr, exitCode } = await run(String(dir), [...flags, "m.ts"]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("module\n");
-      expect(exitCode).toBe(0);
+      expect(await run(String(dir), [...flags, "m.ts"])).toEqual(ok("module\n"));
     });
   });
 
   test.concurrent("--main-fields=main,module prefers main", async () => {
     using dir = tempDir("main-fields", files);
-    const { stdout, stderr, exitCode } = await run(String(dir), ["--main-fields=main,module", "m.ts"]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("main\n");
-    expect(exitCode).toBe(0);
+    expect(await run(String(dir), ["--main-fields=main,module", "m.ts"])).toEqual(ok("main\n"));
   });
 });


### PR DESCRIPTION
## What

Two resolver CLI flag bugs:

1. `--extension-order` was a no-op for ES `import`, dynamic `import()`, entry points, and relative imports inside `node_modules`. Only `require()` honored it.
2. `--main-fields=module,main` and `--extension-order=.js,.ts` were each parsed as one literal value, so resolution failed (looked for a package.json field named `"module,main"` / tried the extension `".js,.ts"`).

## Repro

```sh
d=$(mktemp -d); cd $d
printf 'export default "TS";\n' > d.ts; printf 'export default "JS";\n' > d.js
printf 'import x from "./d"; console.log("import", x)\n' > i.ts
printf 'console.log("require", require("./d").default)\n' > r.cjs
bun --extension-order=.js --extension-order=.ts i.ts    # import TS   (flag ignored)
bun --extension-order=.js --extension-order=.ts r.cjs   # require JS  (flag honored)

mkdir -p node_modules/mf
printf '{"name":"mf","main":"./main.js","module":"./module.js"}\n' > node_modules/mf/package.json
printf 'export default "main"\n' > node_modules/mf/main.js
printf 'export default "module"\n' > node_modules/mf/module.js
printf 'import x from "mf"; console.log(x)\n' > m.ts
bun --main-fields=module,main m.ts   # error: Cannot find package 'mf'
```

## Cause

- `BundleOptions::from_api` wrote the user's `--extension-order` only into `extension_order.default.default`. `ResolveFileExtensions::kind()` reads from the `.esm` group for `ImportKind::Stmt` / `Dynamic` / `EntryPoint*`, and the resolver switches to the `.node_modules` group when the absolute path contains `node_modules`, so the other three groups kept their built-in defaults.
- `Arguments.rs` passes `args.options(b"--main-fields")` / `args.options(b"--extension-order")` straight to `slice_to_owned`, which clones each argv token as-is. `--flag=a,b` is one token, so it became one literal field/extension. The flag's own help default `".tsx,.ts,.jsx,.js,.json"` reads as comma-separated.

## Fix

- When `transform.extension_order` is non-empty, copy it into all four `ResolveFileExtensions` slots (`default.{default,esm}` and `node_modules.{default,esm}`).
- Add `comma_list_to_owned` and use it for `--main-fields` and `--extension-order`, splitting on `,` and dropping empty segments so the repeated form, `--flag=a,b`, and `--flag a,b` all behave the same.

## Verification

`test/cli/run/resolve-flags.test.ts` covers import / require / dynamic import / node_modules for all three `--extension-order` spellings and all three `--main-fields` spellings. 14/17 cases fail on the released bun (the 3 that pass are the repeated-flag `require()` case, repeated-flag `--main-fields`, and the no-flag baseline); all 17 pass with this change.

Fixes #24783
Fixes #14575

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/resolve-flags.test.ts
bun test v1.4.0 (0673ff722)

test/cli/run/resolve-flags.test.ts:
34 |     [["--extension-order=.js,.ts"]],
35 |     [["--extension-order", ".js,.ts"]],
36 |   ])("%p", flags => {
37 |     test.concurrent("applies to import statements", async () => {
38 |       using dir = tempDir("ext-order", files);
39 |       expect(await run(String(dir), [...flags, "i.ts"])).toEqual(ok("import JS\n"));
                                                              ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
- "import JS
+ "import TS
  "
  ,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/run/resolve-flags.test.ts:39:58)
(fail) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to import statements [485.54ms]
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to require() [459.42ms]
34 |     [["--extension-order=.js,.ts"]],
35 |     [["--extension-order", 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (70032a962)

test/cli/run/resolve-flags.test.ts:
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to import statements [35.46ms]
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to require() [26.54ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies to import statements [23.03ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies to require() [23.02ms]
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies inside node_modules [25.00ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies to dynamic import [22.18ms]
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to dynamic import [26.23ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies inside node_modules [21.42ms]
(pass) --extension-order > [ "--extension-order", ".js,.ts" ] > applies to require() [20.69ms]
(pass) --extension-order > [ "--extension-order", ".js,.ts" ] > applies to import statements [21.43ms]
(pass) --extension-order > [ "--extension-order", ".
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/resolve-flags.test.ts
bun test v1.4.0 (0673ff722)

test/cli/run/resolve-flags.test.ts:
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to import statements [491.02ms]
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to require() [466.95ms]
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies to dynamic import [461.37ms]
(pass) --extension-order > [ "--extension-order=.js", "--extension-order=.ts" ] > applies inside node_modules [457.98ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies to import statements [465.67ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies to require() [479.86ms]
(pass) --extension-order > [ "--extension-order", ".js,.ts" ] > applies to import statements [454.64ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies inside node_modules [483.34ms]
(pass) --extension-order > [ "--extension-order=.js,.ts" ] > applies to dynam
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 655ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/options.rs             |  6 ++-
 src/runtime/cli/Arguments.rs       | 16 ++++++-
 test/cli/run/resolve-flags.test.ts | 91 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 110 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/bundler/options.rs                  1      1      0
src/runtime/cli/Arguments.rs            4      2      0
test/cli/run/resolve-flags.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->