### PR TITLE
cli: make -c/--config require a path; stop treating the config path as a package to install

### DIFF
--- a/src/clap/streaming.rs
+++ b/src/clap/streaming.rs
@@ -242,16 +242,17 @@ where
             } else {
                 false
             };
-            if param.takes_value == clap::Values::None
-                || param.takes_value == clap::Values::OneOptional
-            {
-                if next_is_eql && param.takes_value == clap::Values::None {
+            if param.takes_value == clap::Values::None {
+                if next_is_eql {
                     return Err(self.err(arg, Some(short), None, ArgError::DoesntTakeValue));
                 }
                 return Ok(Some(Arg { param, value: None }));
             }
 
             if arg.len() <= next_index {
+                if param.takes_value == clap::Values::OneOptional {
+                    return Ok(Some(Arg { param, value: None }));
+                }
                 let value = match self.iter.next() {
                     Some(v) => v,
                     None => {
@@ -549,6 +550,90 @@ mod tests {
                 Arg {
                     param: d,
                     value: Some(b"0"),
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn short_one_optional() {
+        let params: [clap::Param<u8>; 3] = [
+            clap::Param {
+                id: 0,
+                names: clap::Names {
+                    short: Some(b'a'),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            clap::Param {
+                id: 1,
+                names: clap::Names {
+                    short: Some(b'c'),
+                    ..Default::default()
+                },
+                takes_value: clap::Values::OneOptional,
+                ..Default::default()
+            },
+            clap::Param {
+                id: 2,
+                takes_value: clap::Values::One,
+                ..Default::default()
+            },
+        ];
+        let a = &params[0];
+        let c = &params[1];
+        let pos = &params[2];
+
+        test_no_err(
+            &params,
+            &[
+                b"-c", b"-c=v", b"-cv", b"-ac", b"-ac=v", b"-acv", b"-c", b"p",
+            ],
+            &[
+                Arg {
+                    param: c,
+                    value: None,
+                },
+                Arg {
+                    param: c,
+                    value: Some(b"v"),
+                },
+                Arg {
+                    param: c,
+                    value: Some(b"v"),
+                },
+                Arg {
+                    param: a,
+                    value: None,
+                },
+                Arg {
+                    param: c,
+                    value: None,
+                },
+                Arg {
+                    param: a,
+                    value: None,
+                },
+                Arg {
+                    param: c,
+                    value: Some(b"v"),
+                },
+                Arg {
+                    param: a,
+                    value: None,
+                },
+                Arg {
+                    param: c,
+                    value: Some(b"v"),
+                },
+                Arg {
+                    param: c,
+                    value: None,
+                },
+                Arg {
+                    param: pos,
+                    value: Some(b"p"),
                 },
             ],
         );

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -51,7 +51,7 @@ const BACKEND_PARAM: ParamType = clap::param!(
 );
 
 const SHARED_HEAD_PARAMS: &[ParamType] = &[
-    clap::param!("-c, --config <STR>?                   Specify path to config file (bunfig.toml)"),
+    clap::param!("-c, --config <STR>                    Specify path to config file (bunfig.toml)"),
     clap::param!("-y, --yarn                            Write a yarn.lock file (yarn v1)"),
 ];
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -100,7 +100,7 @@ const BASE_PARAMS_: &[ParamType] = concat_params!(
             "--cwd <STR>                       Absolute path to resolve files & entry points from. This just changes the process' cwd."
         ),
         parse_param!(
-            "-c, --config <PATH>?              Specify path to Bun config file. Default <d>$cwd<r>/bunfig.toml"
+            "-c, --config <PATH>               Specify path to Bun config file. Default <d>$cwd<r>/bunfig.toml"
         ),
         parse_param!("-h, --help                        Display this menu and exit"),
     ],

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -221,11 +221,10 @@ describe.concurrent("bun run", () => {
                   2,
                 ),
                 "index.js": "console.log('hi')",
-                ...(withLogLevel ? { "bunfig.toml": `logLevel = "debug"` } : {}),
+                "bunfig.toml": withLogLevel ? `logLevel = "debug"` : ``,
               });
 
               await using proc = Bun.spawn({
-                // TODO: figure out why -c is necessary here.
                 cmd: [
                   bunExe(),
                   ...(withRun ? ["run"] : []),

--- a/test/config/bunfig/config-flag.test.ts
+++ b/test/config/bunfig/config-flag.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// `-c` / `--config` must bind its path argument in every spelling.
+// https://github.com/oven-sh/bun/issues/6300, https://github.com/oven-sh/bun/issues/21431
+
+async function run(cwd: string, argv: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...argv],
+    env: bunEnv,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+const spellings = [
+  ["--config=cfg.toml"],
+  ["--config", "cfg.toml"],
+  ["-c=cfg.toml"],
+  ["-c", "cfg.toml"],
+  ["-ccfg.toml"],
+];
+
+describe.concurrent("bun install --config path binding", () => {
+  test.each(spellings)("install %p loads the named config, never treats it as a package", async (...flag) => {
+    // Local 404 registry so nothing ever reaches the public network, even if
+    // parsing regresses and routes the path to `bun add`.
+    const hits: string[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        hits.push(new URL(req.url).pathname);
+        return new Response("{}", { status: 404 });
+      },
+    });
+    const base = `http://localhost:${server.port}`;
+
+    using dir = tempDir("config-flag-install", {
+      "package.json": JSON.stringify({ name: "x", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } }),
+      // Auto-loaded when `--config` is NOT effective (regression).
+      "bunfig.toml": `[install]\nregistry = "${base}/default/"\ncache = false\n`,
+      // Loaded when `--config cfg.toml` IS effective (the fix).
+      "cfg.toml": `[install]\nregistry = "${base}/fromcfg/"\ncache = false\n`,
+    });
+
+    const { stdout, stderr, exitCode } = await run(String(dir), ["install", ...flag]);
+    const out = stdout + stderr;
+
+    // The path must never be routed to `bun add` as a package name.
+    expect(out).not.toContain("bun add");
+    expect(hits).not.toContain("/default/cfg.toml");
+    // The named config must have been loaded, not the auto-loaded bunfig.toml.
+    expect(hits).toContain("/fromcfg/no-deps");
+    expect(hits).not.toContain("/default/no-deps");
+    expect(exitCode).not.toBe(0);
+  });
+});
+
+describe.concurrent("bare -c / --config requires a value", () => {
+  test.each([[["install", "--config"]], [["install", "-c"]], [["--config"]], [["-c"]]])(
+    "bun %p errors instead of silently defaulting",
+    async argv => {
+      using dir = tempDir("config-flag-bare", {
+        "package.json": JSON.stringify({ name: "x", version: "1.0.0" }),
+      });
+      const { stderr, exitCode } = await run(String(dir), argv);
+      expect(stderr).toContain(argv.at(-1)!);
+      expect(stderr.toLowerCase()).toContain("requires a value");
+      expect(exitCode).not.toBe(0);
+    },
+  );
+});
+
+describe.concurrent("bun <script> --config path binding", () => {
+  test.each(spellings)("%p loads the named config and runs the script positional", async (...flag) => {
+    using dir = tempDir("config-flag-run", {
+      "app.ts": `console.log(JSON.stringify({ fromCfg: process.env.FROM_CFG ?? "no", argv: process.argv.slice(2) }));`,
+      "cfg.toml": `[define]\n"process.env.FROM_CFG" = '"yes"'\n`,
+    });
+
+    const { stdout, stderr, exitCode } = await run(String(dir), [...flag, join(String(dir), "app.ts"), "pass-through"]);
+    // The config path must not be treated as the entry point.
+    expect(stderr).not.toContain("cfg.toml");
+    expect(JSON.parse(stdout.trim())).toEqual({ fromCfg: "yes", argv: ["pass-through"] });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/config/bunfig/config-flag.test.ts
+++ b/test/config/bunfig/config-flag.test.ts
@@ -75,14 +75,22 @@ describe.concurrent("bare -c / --config requires a value", () => {
   );
 });
 
-describe.concurrent("bun <script> --config path binding", () => {
-  test.each(spellings)("%p loads the named config and runs the script positional", async (...flag) => {
+// The subcommand keyword is picked before flag values are parsed, so only the
+// single-token spellings can precede `run`; the space forms go after it.
+const scriptArgv = [
+  ...spellings,
+  ...spellings.map(flag => ["run", ...flag]),
+  ...spellings.filter(flag => flag.length === 1).map(flag => [...flag, "run"]),
+];
+
+describe.concurrent("bun [run] --config path binding", () => {
+  test.each(scriptArgv.map(argv => [argv]))("bun %p app.ts loads the named config and runs app.ts", async argv => {
     using dir = tempDir("config-flag-run", {
       "app.ts": `console.log(JSON.stringify({ fromCfg: process.env.FROM_CFG ?? "no", argv: process.argv.slice(2) }));`,
       "cfg.toml": `[define]\n"process.env.FROM_CFG" = '"yes"'\n`,
     });
 
-    const { stdout, stderr, exitCode } = await run(String(dir), [...flag, join(String(dir), "app.ts"), "pass-through"]);
+    const { stdout, stderr, exitCode } = await run(String(dir), [...argv, join(String(dir), "app.ts"), "pass-through"]);
     // The config path must not be treated as the entry point.
     expect(stderr).not.toContain("cfg.toml");
     expect(JSON.parse(stdout.trim())).toEqual({ fromCfg: "yes", argv: ["pass-through"] });


### PR DESCRIPTION
### Problem

- Of the five ways to spell the config flag, only `--config=path` loads the named file (reproduced on 1.4.0):
  - `-c=path` and `-cpath` silently drop the path and load the default `bunfig.toml` instead.
  - `--config path` and `-c path` leave `path` as a positional: `bun -c bunfig.toml .` fails with `Cannot run "bunfig.toml"` (#6300), and `bun install --config cfg.toml` becomes `bun add cfg.toml`, a registry lookup for a package named after the config file while the config itself (registry, scopes, tokens) is never loaded.
- Cause 1: `StreamingClap::chainging` (src/clap/streaming.rs:245) groups `Values::OneOptional` with `Values::None` and returns `value: None` without looking at the rest of the token, so `-c=path` / `-cpath` lose their value.
- Cause 2: `-c, --config` is declared `<PATH>?` (optional value) in src/runtime/cli/Arguments.rs:103 and src/install/PackageManager/CommandLineArguments.rs:54. An optional-value flag never consumes the next argv token, so the space forms cannot bind.

### Fix

- `-c, --config` takes a required `<PATH>` in both param tables. `--config=p`, `--config p`, `-c=p`, `-c p` and `-cp` all bind the path; a bare `-c` / `--config` now errors with `requires a value but none was supplied`.
- `chainging` only short-circuits for `Values::None`; `OneOptional` goes through the same `=value` / attached-value handling as `One` and yields `None` only when the token ends at the flag. The other `OneOptional` flags in tree (`--inspect`, `--bail`, `--sourcemap`, `--catalog`, ...) are long-only and never reach `chainging`, so after the table change this path has no in-tree user; the long-flag path is untouched.
- Why this is right: the flag's only purpose is to name a file, so a bare `-c` had no meaning beyond the default that applies without it (for `install` it was already a no-op, since install always auto-loads `bunfig.toml`). The help text (`--config=<val>`), the docs (`--config` typed as string) and the shell completions (`-c|--config` completes a `.toml` file; the zsh entry's example is `-c bunfig.toml`) all already describe a required path; the parser was the odd one out.
- `bun --config cfg.toml run app.ts` (space form before a subcommand keyword) is still not routed to `run`, because `Command::which()` picks the keyword before any flag value is parsed. It fails as before; #36644 handles that classifier separately and is waiting on this change to add `--config` to its skip set.
- Verified:
  - `test/config/bunfig/config-flag.test.ts`: the five spellings for `bun install` (against a local port 0 registry, asserting which config's registry is hit and that nothing is routed to `bun add`), for `bun <flag> app.ts`, `bun run <flag> app.ts` and `bun <flag> run app.ts`, plus the bare-flag error for both tables. 18 of 22 cases fail on 1.4.0 (the four `--config=path` cases already passed), 22 pass with this change.
  - `bun run rust:miri -p bun_clap`: new `short_one_optional` unit test covers `-c`, `-c=v`, `-cv`, `-ac`, `-ac=v`, `-acv` and `-c p`.
  - `test/cli/install/bun-run.test.ts` now writes `bunfig.toml` unconditionally: its `-c=<path>` used to be silently ignored and now opens the file. Passes along with the other tests that pass `-c=` / `--config=` (bun-run-bunfig, bun-workspaces, bun-install-registry, preload, bun.test.ts).
- Supersedes #31077, which fixed the `-c=path` case in `chainging`; its `run`-keyword argv shapes are carried over into the test matrix here.

### Background

- `bun_clap` (src/clap) is Bun's own argv parser. Each flag declares `takes_value` as `None` (boolean flag), `One` (required value: `--x=v`, `--x v`, `-x=v`, `-xv`, `-x v`), `OneOptional` (value only when attached to the same token) or `Many`. The `?` suffix in a `param!` spec selects `OneOptional`.
- `chainging` is the short-flag path: it walks a token such as `-acv` one character at a time so several boolean flags can share a token, and the first value-taking flag claims the rest of the token.
- `Command::which()` (src/runtime/cli/mod.rs) decides the subcommand before any parsing by skipping dash-prefixed tokens and matching the first other token against the keyword list. That is why a flag value given as a separate token before `run` / `install` is misread; it is independent of how the flag is declared.

Fixes #6300
Fixes #21431

<details>
<summary>Earlier iterations</summary>

An earlier revision also taught `which()` to step past `--config` / `--cwd` / `--env-file` values. It was reverted within this PR: once the keyword is classified correctly, handlers that re-read raw argv at a fixed offset (`info`, `init`, `create`) and install's param table (no `--env-file`) misbehave, e.g. `bun --env-file .env install` became `bun add install`. That work now lives in #36644.

The branch was squashed and rebased after main split install's `SHARED_PARAMS` into `SHARED_HEAD_PARAMS` / `PRODUCTION_PARAMS` / `SHARED_TAIL_PARAMS`; the one-line declaration change moved accordingly.

</details>
