### PR TITLE
mock.module: apply builtin mocks to require() under bun test

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1380,8 +1380,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
     memset(&res.result, 0, sizeof res.result);
     BunString specifierStr = Bun::toString(specifier);
 
-    // Under `bun test`, let mock.module() override builtin modules for require()
-    // the same way fetchCommonJSModule/fetchESMSourceCode do for the non-fast-path.
     if (isBunTest && globalObject->onLoadPlugins.hasVirtualModules()) {
         bool wasModuleMock = false;
         JSC::JSValue mocked = Bun::runVirtualModule(globalObject, &specifierStr, wasModuleMock);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -71,6 +71,7 @@
 #include <JavaScriptCore/FunctionPrototype.h>
 #include "JSCommonJSModule.h"
 #include <JavaScriptCore/JSModuleNamespaceObject.h>
+#include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSSourceCode.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
@@ -1378,6 +1379,36 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
     res.success = false;
     memset(&res.result, 0, sizeof res.result);
     BunString specifierStr = Bun::toString(specifier);
+
+    // Under `bun test`, let mock.module() override builtin modules for require()
+    // the same way fetchCommonJSModule/fetchESMSourceCode do for the non-fast-path.
+    if (isBunTest && globalObject->onLoadPlugins.hasVirtualModules()) {
+        bool wasModuleMock = false;
+        JSC::JSValue mocked = Bun::runVirtualModule(globalObject, &specifierStr, wasModuleMock);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (mocked && wasModuleMock) {
+            if (auto* promise = dynamicDowncast<JSC::JSPromise>(mocked)) {
+                if (promise->status() == JSC::JSPromise::Status::Rejected) {
+                    promise->markAsHandled();
+                    return throwVMError(globalObject, throwScope, promise->result());
+                }
+                return throwVMTypeError(globalObject, throwScope, makeString("require() async module \""_s, specifier, "\" is unsupported. use \"await import()\" instead."_s));
+            }
+            if (auto* object = mocked.getObject()) {
+                auto esModuleValue = object->getIfPropertyExists(globalObject, vm.propertyNames->__esModule);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                if (esModuleValue && esModuleValue.toBoolean(globalObject)) {
+                    auto defaultValue = object->getIfPropertyExists(globalObject, vm.propertyNames->defaultKeyword);
+                    RETURN_IF_EXCEPTION(throwScope, {});
+                    if (defaultValue && !defaultValue.isUndefined()) {
+                        return JSValue::encode(defaultValue);
+                    }
+                }
+            }
+            return JSValue::encode(mocked);
+        }
+    }
+
     auto result = fetchBuiltinModuleWithoutResolution(globalObject, &specifierStr, &res);
     RETURN_IF_EXCEPTION(throwScope, {});
     if (result) {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -213,3 +213,22 @@ test("onResolve plugin errors surface from mock.module; an unresolvable specifie
     Bun.plugin.clearAll();
   }
 });
+
+test("mocking a builtin applies to require() the same as import()", () => {
+  mock.module("node:querystring", () => ({
+    stringify: () => "MOCKED",
+    default: { stringify: () => "MOCKED" },
+  }));
+
+  expect(require("node:querystring").stringify({})).toBe("MOCKED");
+  expect(require("querystring").stringify({})).toBe("MOCKED");
+});
+
+test("mocking a builtin with __esModule returns default for require()", () => {
+  mock.module("node:punycode", () => ({
+    __esModule: true,
+    default: { encode: () => "MOCKED-DEFAULT" },
+  }));
+
+  expect(require("node:punycode").encode("x")).toBe("MOCKED-DEFAULT");
+});


### PR DESCRIPTION
`require()` of a `mock.module()`'d builtin silently returned the real module while `import()` of the same specifier returned the mock. Specifier form (`node:os` vs `os`) did not matter.

## Repro

```js
import { test, expect, mock } from "bun:test";
test("builtin module mock: import vs require", async () => {
  mock.module("node:os", () => ({ hostname: () => "MOCK-HOST" }));
  (await import("node:os")).hostname();  // "MOCK-HOST"
  require("node:os").hostname();         // real hostname  <-- bypass
  expect(require("node:os").hostname()).toBe("MOCK-HOST"); // FAILS
});
```

For user modules, `require()` after `mock.module()` already returns the mock, so whether a mock applied depended on which loader the code under test happened to use. A CJS dependency that `require("fs")`s hit the real filesystem while the ESM half of the same test was mocked.

## Cause

`overridableRequire` in `src/js/builtins/CommonJS.ts` sends every `node:*` specifier to `$requireNativeModule` (`jsFunctionRequireNativeModule`), which calls `fetchBuiltinModuleWithoutResolution` directly. That helper never consults `onLoadPlugins.virtualModules`.

The ESM path (`fetchESMSourceCode`) and the non-fast-path CJS loader (`fetchCommonJSModule`) both call `Bun::runVirtualModule` before the builtin lookup when `isBunTest` is set; the `node:*` fast path was the only entry that skipped it.

## Fix

Mirror the `isBunTest` virtual-module check in `jsFunctionRequireNativeModule`. When a `mock.module()` entry exists for the specifier, return its factory result (unwrapping `default` when `__esModule` is set, matching the existing user-module handling in `handleVirtualModuleResult`). Non-mock virtual modules and the non-test path are unchanged.

## Verification

Two new cases in `test/js/bun/test/mock/mock-module.test.ts`:

- `require("node:querystring")` / `require("querystring")` return the mock
- `__esModule: true` mock returns its `default` for `require()`

Both fail on main, pass with the fix. The full `test/js/bun/test/mock/` suite (21 pass, 1 todo) and `test/js/node/module/` (91 pass) run clean against the debug build. Exception-scope validation passes on the new code path.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [13.80ms]
(pass) mock.restore [5.25ms]
(pass) spyOn [2.31ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [7.43ms]
(pass) mocking a non-existant relative file with a file URL [17.57ms]
(pass) mocking a non-existant relative file [12.47ms]
(pass) mocking a local file [22.41ms]
(todo) adding a default on a module with no default
(pass) mocking a package [16.01ms]
(pass) mocking a builtin [14.83ms]
(pass) a factory export getter that throws fails the import [7.76ms]
(pass) a factory export getter that throws while patching an already-imported module throws from mock.module and leaves the namespace untouched [6.77ms]
(pass) onResolve plugin errors surface from mock.module; an unresolvable specifier is still mockable [18.01ms]
218 |   mock.module("node:querystring", () => ({
219 |     stringify: () => "MOCKED",
220 |     default: { stringify: () => "MOCKED
... (truncated)

release without fix: 3 failed, 1 skipped
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [0.47ms]
(pass) mock.restore [0.09ms]
(pass) spyOn [0.02ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [0.14ms]
(pass) mocking a non-existant relative file with a file URL [0.29ms]
(pass) mocking a non-existant relative file [0.21ms]
(pass) mocking a local file [0.30ms]
(todo) adding a default on a module with no default
(pass) mocking a package [0.19ms]
(pass) mocking a builtin [0.12ms]
(pass) a factory export getter that throws fails the import [0.13ms]
(pass) a factory export getter that throws while patching an already-imported module throws from mock.module and leaves the namespace untouched [0.07ms]
201 |       });
202 |       build.onResolve({ filter: /\.mock-onresolve-invalid$/ }, () => ({ path: 42 }) as any);
203 |     },
204 |   });
205 |   try {
206 |     expect(() => mock.module("./thing.mock-onresolve-throws", () => ({ default: 1 }))).toThrow("onResolve threw");
                                                                                             ^
error: expect(received).toThrow(expected)

E
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/mock/mock-module.test.ts:
(pass) mock.module async [13.97ms]
(pass) mock.restore [5.78ms]
(pass) spyOn [2.33ms]
(pass) mocking a module that points to a file which does not resolve successfully still works [7.39ms]
(pass) mocking a non-existant relative file with a file URL [16.79ms]
(pass) mocking a non-existant relative file [12.53ms]
(pass) mocking a local file [22.08ms]
(todo) adding a default on a module with no default
(pass) mocking a package [12.07ms]
(pass) mocking a builtin [14.25ms]
(pass) a factory export getter that throws fails the import [7.33ms]
(pass) a factory export getter that throws while patching an already-imported module throws from mock.module and leaves the namespace untouched [6.91ms]
(pass) onResolve plugin errors surface from mock.module; an unresolvable specifier is still mockable [16.22ms]
(pass) mocking a builtin applies to require() the same as import() [5.61ms]
(pass) mocking a builtin with __esModule returns defaul
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5ace0b79db
  features     baseline

23 deps, 129 codegen, 1172 objects in 696ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [4.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] gen bindgenv2
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] fetch zlib
[zlib] up to date
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCommonJSModule.cpp     | 29 +++++++++++++++++++++++++++++
 test/js/bun/test/mock/mock-module.test.ts | 19 +++++++++++++++++++
 2 files changed, 48 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/JSCommonJSModule.cpp          3      3      0
test/js/bun/test/mock/mock-module.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->