### PR TITLE
bundler: make --drop match bound identifiers (imports/locals), not just free globals

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6209,6 +6209,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 js_ast::ExprData::EIdentifier(id) => {
                     self.ignore_usage(id.ref_);
                 }
+                js_ast::ExprData::EImportIdentifier(id) => {
+                    self.ignore_usage(id.ref_);
+                }
                 js_ast::ExprData::EDot(dot) => {
                     current = dot.target;
                     continue;
@@ -6673,7 +6676,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // `parts` is `&[Box<[u8]>]` to match the active `DotDefine.parts:
     // Vec<Box<[u8]>>` shape (auto-derefs at call sites). The full draft uses
     // `StoreSlice<StoreStr>`; both index to a `[u8]` so the body is unchanged.
-    pub fn is_dot_define_match(&mut self, expr: Expr, parts: &[Box<[u8]>]) -> bool {
+    pub fn is_dot_define_match(
+        &mut self,
+        expr: Expr,
+        parts: &[Box<[u8]>],
+        allow_bound_root: bool,
+    ) -> bool {
         match expr.data {
             js_ast::ExprData::EDot(ex) => {
                 if parts.len() > 1 {
@@ -6683,7 +6691,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // Intermediates must be dot expressions
                     let last = parts.len() - 1;
                     let is_tail_match = strings::eql(&parts[last], &ex.name);
-                    return is_tail_match && self.is_dot_define_match(ex.target, &parts[..last]);
+                    return is_tail_match
+                        && self.is_dot_define_match(ex.target, &parts[..last], allow_bound_root);
                 }
             }
             js_ast::ExprData::EImportMeta(_) => {
@@ -6703,7 +6712,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             let last = parts.len() - 1;
                             let is_tail_match = strings::eql(&parts[last], s.slice(self.arena));
                             return is_tail_match
-                                && self.is_dot_define_match(index.target, &parts[..last]);
+                                && self.is_dot_define_match(
+                                    index.target,
+                                    &parts[..last],
+                                    allow_bound_root,
+                                );
                         }
                     }
                 }
@@ -6728,7 +6741,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // when there's actually no symbol by that name, we return Ref.None
                     // If a symbol had already existed by that name, we return .unbound
-                    return result.r#ref.is_empty()
+                    return allow_bound_root
+                        || result.r#ref.is_empty()
                         || self.symbols[result.r#ref.inner_index() as usize].kind
                             == js_ast::symbol::Kind::Unbound;
                 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -149,7 +149,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let defines = p.define;
         if let Some(meta) = defines.dots.get(b"meta".as_slice()) {
             for define in meta.as_slice() {
-                if !p.is_dot_define_match(expr, &define.parts) {
+                if !p.is_dot_define_match(expr, &define.parts, false) {
                     continue;
                 }
                 // Substitute user-specified defines
@@ -320,6 +320,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                 *e = p.value_for_require(expr.loc);
                 return;
+            }
+        } else if in_.property_access_for_method_call_maybe_should_replace_with_undefined
+            && in_.assign_target == js_ast::AssignTarget::None
+            && !is_delete_target
+            && !result.is_inside_with_scope
+        {
+            // `--drop=<name>` also matches bound identifiers (imports, local
+            // declarations). Only the call-replacement flag is consulted here;
+            // value substitution for `--define` stays unbound-only above.
+            let defines = p.define;
+            if let Some(def) = defines.for_identifier(name) {
+                if def.method_call_must_be_replaced_with_undefined() {
+                    p.method_call_must_be_replaced_with_undefined = true;
+                }
             }
         }
 
@@ -1358,7 +1372,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let defines = p.define;
         if let Some(parts) = defines.dots.get(e_.name.slice()) {
             for define in parts.as_slice() {
-                if p.is_dot_define_match(expr, &define.parts) {
+                // `--drop=<root>.<...>` matches even when <root> is a bound
+                // identifier; plain `--define` stays unbound-only.
+                let allow_bound_root = define.data.method_call_must_be_replaced_with_undefined();
+                if p.is_dot_define_match(expr, &define.parts, allow_bound_root) {
                     if in_.assign_target == js_ast::AssignTarget::None {
                         // Substitute user-specified defines
                         if !define.data.valueless() {
@@ -1983,7 +2000,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.method_call_must_be_replaced_with_undefined = false;
                 match &e_.target.data {
                     // If we're removing this call, don't count any arguments as symbol uses
-                    Data::EIndex(..) | Data::EDot(..) | Data::EIdentifier(..) => {
+                    Data::EIndex(..)
+                    | Data::EDot(..)
+                    | Data::EIdentifier(..)
+                    | Data::EImportIdentifier(..) => {
                         p.is_control_flow_dead = true;
                     }
                     // Special case from `import.meta.hot.*` functions.
@@ -2007,6 +2027,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             if method_call_should_be_replaced_with_undefined {
                 p.is_control_flow_dead = old_is_control_flow_dead;
+                p.ignore_usage_of_identifier_in_dot_chain(e_.target);
                 *e = Expr {
                     data: Data::EUndefined(E::Undefined {}),
                     loc: expr.loc,

--- a/test/bundler/bundler_drop.test.ts
+++ b/test/bundler/bundler_drop.test.ts
@@ -219,6 +219,18 @@ describe("bundler", () => {
     drop: ["devlog"],
     backend: "api",
   });
+  itBundled("drop/BoundDotNonCallNotReplaced", {
+    files: {
+      "/a.js": `
+        const logger = { debug: (s) => process.stdout.write("DEBUG " + s + "\\n") };
+        const ref = logger.debug;
+        ref("alive");
+      `,
+    },
+    run: { stdout: "DEBUG alive" },
+    drop: ["logger.debug"],
+    backend: "api",
+  });
   itBundled("drop/DefineDoesNotReplaceBoundIdentifier", {
     files: {
       "/a.js": `

--- a/test/bundler/bundler_drop.test.ts
+++ b/test/bundler/bundler_drop.test.ts
@@ -114,4 +114,120 @@ describe("bundler", () => {
     drop: ["ASSERT"],
     backend: "api",
   });
+  itBundled("drop/ImportedIdentifierCall", {
+    files: {
+      "/a.js": `
+        import { devlog } from "./log";
+        devlog("secret");
+        process.stdout.write("KEEP\\n");
+      `,
+      "/log.js": `export const devlog = (...a) => process.stdout.write("DEVLOG " + a.join(",") + "\\n");`,
+    },
+    run: { stdout: "KEEP" },
+    drop: ["devlog"],
+    backend: "api",
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude(`"secret"`);
+    },
+  });
+  itBundled("drop/ImportedDefaultCall", {
+    files: {
+      "/a.js": `
+        import devlog from "./log";
+        devlog("secret");
+        process.stdout.write("KEEP\\n");
+      `,
+      "/log.js": `export default (...a) => process.stdout.write("DEVLOG " + a.join(",") + "\\n");`,
+    },
+    run: { stdout: "KEEP" },
+    drop: ["devlog"],
+    backend: "api",
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude(`"secret"`);
+    },
+  });
+  itBundled("drop/LocalFunctionCall", {
+    files: {
+      "/a.js": `
+        function localfn(s) { process.stdout.write("LOCAL " + s + "\\n"); }
+        localfn("x");
+        process.stdout.write("KEEP\\n");
+      `,
+    },
+    run: { stdout: "KEEP" },
+    drop: ["localfn"],
+    backend: "api",
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude(`localfn("x")`);
+    },
+  });
+  itBundled("drop/LocalConstCall", {
+    files: {
+      "/a.js": `
+        const devlog2 = (s) => process.stdout.write("DEVLOG2 " + s + "\\n");
+        devlog2("y");
+        process.stdout.write("KEEP\\n");
+      `,
+    },
+    run: { stdout: "KEEP" },
+    drop: ["devlog2"],
+    backend: "api",
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude(`devlog2("y")`);
+    },
+  });
+  itBundled("drop/ImportedNamespaceRoot", {
+    files: {
+      "/a.js": `
+        import * as ns from "./log";
+        ns.devlog("namespace");
+        process.stdout.write("KEEP\\n");
+      `,
+      "/log.js": `export const devlog = (...a) => process.stdout.write("DEVLOG " + a.join(",") + "\\n");`,
+    },
+    run: { stdout: "KEEP" },
+    drop: ["ns"],
+    backend: "api",
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude(`"namespace"`);
+    },
+  });
+  itBundled("drop/BoundDotDefine", {
+    files: {
+      "/a.js": `
+        const logger = { debug: (s) => process.stdout.write("DEBUG " + s + "\\n") };
+        logger.debug("bound");
+        process.stdout.write("KEEP\\n");
+      `,
+    },
+    run: { stdout: "KEEP" },
+    drop: ["logger.debug"],
+    backend: "api",
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude(`"bound"`);
+    },
+  });
+  itBundled("drop/BoundIdentifierNonCallNotReplaced", {
+    files: {
+      "/a.js": `
+        const devlog = (s) => process.stdout.write("DEVLOG " + s + "\\n");
+        const ref = devlog;
+        ref("alive");
+      `,
+    },
+    run: { stdout: "DEVLOG alive" },
+    drop: ["devlog"],
+    backend: "api",
+  });
+  itBundled("drop/DefineDoesNotReplaceBoundIdentifier", {
+    files: {
+      "/a.js": `
+        const FOO = "local";
+        console.log(FOO);
+      `,
+    },
+    run: { stdout: "local" },
+    define: { FOO: '"replaced"' },
+    backend: "api",
+  });
 });


### PR DESCRIPTION
## Reproduction

```ts
// log.ts
export const devlog = (...a) => console.log("DEVLOG", ...a);

// app.ts
import { devlog } from "./log";
globalThis.gfn = (s) => console.log("GFN", s);
devlog("secret");
gfn("free");
console.log("KEEP");
```

```
$ bun build app.ts --drop=devlog --drop=gfn | grep -E 'devlog\(|gfn\('
devlog("secret");          # imported binding survives
                           # gfn("free") was dropped (unbound)

$ bun --drop=devlog --drop=gfn app.ts
DEVLOG secret
KEEP
```

The docs describe `drop: ["anyIdentifier.or.propertyAccess"]`, but only calls through an *unbound* identifier were removed. Calls through an import, a local `function`/`const`, or a namespace import (`ns.method(...)` with `drop: ["ns"]` or `drop: ["ns.method"]`) all survived without warning.

## Cause

`--drop` entries are stored in the define table with `method_call_must_be_replaced_with_undefined` set. `e_identifier` only consults that table when the symbol's kind is `Unbound`:

```rust
// src/js_parser/visit/visit_expr.rs
if p.symbols[e_.ref_.inner_index() as usize].kind == js_ast::symbol::Kind::Unbound { ... }
```

and `is_dot_define_match` applies the same `Unbound`-only check to the root of a dotted define. Imported bindings are `Import`, local function declarations are `HoistedFunction`, `const` is `Constant`, so the drop flag is never reached for them. When the target was an import, `handle_identifier` also rewrites it to `EImportIdentifier`, which the `e_call` drop path did not recognize as a removable target.

## Fix

- `e_identifier`: for bound symbols that are being visited as a call target, consult the drop flag on the matching define entry. Value substitution for `--define` stays unbound-only.
- `is_dot_define_match`: add `allow_bound_root`, set to `true` only for drop entries so `--drop=a.b` matches when `a` is a local or imported binding.
- `e_call`: accept `EImportIdentifier` as a droppable target, and `ignore_usage` on the target chain when a call is dropped so the now-unused import/local can tree-shake.

After the fix:

```
$ bun build app.ts --drop=devlog --drop=gfn
// app.ts
globalThis.gfn = (s) => console.log("GFN", s);
console.log("KEEP");

$ bun --drop=devlog --drop=gfn app.ts
KEEP
```

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/bundler_drop.test.ts
 16 pass
 6 fail   # ImportedIdentifierCall, ImportedDefaultCall, LocalFunctionCall,
          # LocalConstCall, ImportedNamespaceRoot, BoundDotDefine

$ bun bd test test/bundler/bundler_drop.test.ts
 22 pass
 0 fail
```

Also green: `bundler_edgecase` (116), `esbuild/dce` (73), `bundler_minify` (48), `bundler_regressions`, `transpiler/transpiler.test.js` (182).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_drop.test.ts
bun test v1.4.0 (de9efca41)

test/bundler/bundler_drop.test.ts:
(pass) bundler > drop/FunctionCall [911.15ms]
(pass) bundler > drop/DebuggerStmt [108.38ms]
(pass) bundler > drop/NoDisableDebugger [115.66ms]
(pass) bundler > drop/RemovesSideEffects [515.09ms]
(pass) bundler > drop/ReassignKeepsOutput [509.60ms]
(pass) bundler > drop/AssignKeepsOutput [525.58ms]
(pass) bundler > drop/UnaryExpression [494.86ms]
(pass) bundler > drop/0Args [497.26ms]
(pass) bundler > drop/BecomesUndefined [543.38ms]
(pass) bundler > drop/BecomesUndefinedNested1 [534.12ms]
(pass) bundler > drop/BecomesUndefinedNested2 [544.91ms]
(pass) bundler > drop/AssignTarget [517.60ms]
(pass) bundler > drop/DeleteAssignTarget [845.26ms]
(pass) bundler > drop/IdentifierCall [608.84ms]
125 |     },
126 |     run: { stdout: "KEEP" },
127 |     drop: ["devlog"],
128 |     backend: "api",
129 |     onAfterBundle(api) {
130 |       api.expectFile("out.js").not.toInclude(`"secret"`);
                                         ^
error: expect(re
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bbdac8116)

test/bundler/bundler_drop.test.ts:
(pass) bundler > drop/FunctionCall [31.63ms]
(pass) bundler > drop/DebuggerStmt [4.60ms]
(pass) bundler > drop/NoDisableDebugger [3.49ms]
(pass) bundler > drop/RemovesSideEffects [18.88ms]
(pass) bundler > drop/ReassignKeepsOutput [16.28ms]
(pass) bundler > drop/AssignKeepsOutput [15.45ms]
(pass) bundler > drop/UnaryExpression [14.64ms]
(pass) bundler > drop/0Args [14.73ms]
(pass) bundler > drop/BecomesUndefined [16.38ms]
(pass) bundler > drop/BecomesUndefinedNested1 [16.60ms]
(pass) bundler > drop/BecomesUndefinedNested2 [17.50ms]
(pass) bundler > drop/AssignTarget [16.01ms]
(pass) bundler > drop/DeleteAssignTarget [16.46ms]
(pass) bundler > drop/IdentifierCall [15.15ms]
(pass) bundler > drop/ImportedIdentifierCall [30.62ms]
(pass) bundler > drop/ImportedDefaultCall [28.12ms]
(pass) bundler > drop/LocalFunctionCall [28.78ms]
(pass) bundler > drop/LocalConstCall [28.29ms]
(pass) bundler > drop/ImportedNamespaceRoot [30.25ms]
(pass) bundler > drop/BoundDotDefine [30.52ms]
(pass) bundler > drop/BoundIdentifierNonCallNotReplaced [28.50ms]
(pass) bundler > drop/BoundDotNonCallNotReplaced [32.62ms]

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_drop.test.ts
bun test v1.4.0 (de9efca41)

test/bundler/bundler_drop.test.ts:
(pass) bundler > drop/FunctionCall [1230.28ms]
(pass) bundler > drop/DebuggerStmt [130.03ms]
(pass) bundler > drop/NoDisableDebugger [113.16ms]
(pass) bundler > drop/RemovesSideEffects [609.99ms]
(pass) bundler > drop/ReassignKeepsOutput [638.76ms]
(pass) bundler > drop/AssignKeepsOutput [506.70ms]
(pass) bundler > drop/UnaryExpression [485.50ms]
(pass) bundler > drop/0Args [502.65ms]
(pass) bundler > drop/BecomesUndefined [533.38ms]
(pass) bundler > drop/BecomesUndefinedNested1 [574.02ms]
(pass) bundler > drop/BecomesUndefinedNested2 [555.81ms]
(pass) bundler > drop/AssignTarget [919.47ms]
(pass) bundler > drop/DeleteAssignTarget [576.01ms]
(pass) bundler > drop/IdentifierCall [531.01ms]
(pass) bundler > drop/ImportedIdentifierCall [1337.95ms]
(pass) bundler > drop/ImportedDefaultCall [1587.30ms]
(pass) bundler > drop/LocalFunctionCall [1490.71ms]
(pass) bundler > drop/LocalConstCall [1510.09ms]
(pass) bundler > drop/ImportedNamespaceRoot
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 767ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                |  22 +++++--
 src/js_parser/visit/visit_expr.rs |  27 +++++++-
 test/bundler/bundler_drop.test.ts | 128 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 170 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/js_parser/p.rs                     3      2      0
src/js_parser/visit/visit_expr.rs      7      5      0
test/bundler/bundler_drop.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->