### PR TITLE
dotenv: load .env.{NODE_ENV} literally instead of falling back to development

### DIFF
--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -10,8 +10,11 @@ Bun reads your `.env` files automatically and provides idiomatic ways to read an
 Bun reads the following files automatically (listed in order of increasing precedence).
 
 - `.env`
-- `.env.production`, `.env.development`, `.env.test` (depending on the value of `NODE_ENV`)
+- `.env.{NODE_ENV}` (such as `.env.production`, `.env.development`, `.env.test`, or `.env.staging`)
 - `.env.local`
+- `.env.{NODE_ENV}.local`
+
+When `NODE_ENV` is unset, Bun treats it as `development`. When `NODE_ENV` is `test`, `.env.local` is skipped.
 
 ```ini .env icon="settings"
 FOO=hello

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -789,12 +789,23 @@ impl<'a> Transpiler<'a> {
                 // `--env-file` list is bounded (CLI args), not hot-path.
                 let env_files: Vec<&[u8]> = self.options.env.files.iter().map(|f| &**f).collect();
 
+                // Own the NODE_ENV value so a `Custom(&[u8])` suffix doesn't
+                // hold a borrow into `env.map` across the `&mut` `env.load`.
+                let node_env: Option<Vec<u8>> = env.get_node_env().map(|v| v.to_vec());
                 let suffix = if self.options.is_test() || env.is_test() {
                     dot_env::DotEnvFileSuffix::Test
                 } else if self.options.production {
                     dot_env::DotEnvFileSuffix::Production
                 } else {
-                    dot_env::DotEnvFileSuffix::Development
+                    match node_env.as_deref() {
+                        Some(mode) if !mode.is_empty() && mode != b"development" => {
+                            // An explicit NODE_ENV outside {development,
+                            // production, test} must not fall through to the
+                            // development files; load `.env.{mode}` instead.
+                            dot_env::DotEnvFileSuffix::Custom(mode)
+                        }
+                        _ => dot_env::DotEnvFileSuffix::Development,
+                    }
                 };
                 env.load(dir, &env_files, suffix, skip_default_env)?;
             }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -797,14 +797,16 @@ impl<'a> Transpiler<'a> {
                 } else if self.options.production {
                     dot_env::DotEnvFileSuffix::Production
                 } else {
+                    // An explicit NODE_ENV outside {development, production,
+                    // test} must not fall through to the development files;
+                    // load `.env.{mode}` instead. Empty or the literal string
+                    // `"undefined"` (a common `NODE_ENV=${NODE_ENV}` footgun
+                    // when the var is unset) still default to development.
                     match node_env.as_deref() {
-                        Some(mode) if !mode.is_empty() && mode != b"development" => {
-                            // An explicit NODE_ENV outside {development,
-                            // production, test} must not fall through to the
-                            // development files; load `.env.{mode}` instead.
-                            dot_env::DotEnvFileSuffix::Custom(mode)
+                        None | Some(b"") | Some(b"development") | Some(b"undefined") => {
+                            dot_env::DotEnvFileSuffix::Development
                         }
-                        _ => dot_env::DotEnvFileSuffix::Development,
+                        Some(mode) => dot_env::DotEnvFileSuffix::Custom(mode),
                     }
                 };
                 env.load(dir, &env_files, suffix, skip_default_env)?;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -803,10 +803,14 @@ impl<'a> Transpiler<'a> {
                     // `"undefined"` (a common `NODE_ENV=${NODE_ENV}` footgun
                     // when the var is unset) still default to development.
                     match node_env.as_deref() {
-                        None | Some(b"") | Some(b"development") | Some(b"undefined") => {
-                            dot_env::DotEnvFileSuffix::Development
+                        Some(m)
+                            if !m.is_empty()
+                                && !m.eq_ignore_ascii_case(b"development")
+                                && !m.eq_ignore_ascii_case(b"undefined") =>
+                        {
+                            dot_env::DotEnvFileSuffix::Custom(m)
                         }
-                        Some(mode) => dot_env::DotEnvFileSuffix::Custom(mode),
+                        _ => dot_env::DotEnvFileSuffix::Development,
                     }
                 };
                 env.load(dir, &env_files, suffix, skip_default_env)?;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -799,10 +799,18 @@ impl<'a> Transpiler<'a> {
                 } else {
                     // An explicit NODE_ENV outside {development, production,
                     // test} must not fall through to the development files;
-                    // load `.env.{mode}` instead. Empty or the literal string
-                    // `"undefined"` (a common `NODE_ENV=${NODE_ENV}` footgun
-                    // when the var is unset) still default to development.
+                    // load `.env.{mode}` instead. The canonical names are
+                    // matched case-insensitively so mixed-case spellings route
+                    // to the built-in arms (the byte-exact `is_production()`/
+                    // `is_test()` above would miss them). Empty or the literal
+                    // string `"undefined"` still default to development.
                     match node_env.as_deref() {
+                        Some(m) if m.eq_ignore_ascii_case(b"production") => {
+                            dot_env::DotEnvFileSuffix::Production
+                        }
+                        Some(m) if m.eq_ignore_ascii_case(b"test") => {
+                            dot_env::DotEnvFileSuffix::Test
+                        }
                         Some(m)
                             if !m.is_empty()
                                 && !m.eq_ignore_ascii_case(b"development")

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -778,7 +778,9 @@ impl<'a> Loader<'a> {
 
     /// `DotEnvFileSuffix::Custom` counterpart of `try_load_default`: build
     /// `.env.{mode}{extra}` at runtime, probe the directory listing, and load
-    /// via the dynamic path (tracked in `custom_files_loaded`).
+    /// it. Error handling matches `load_env_file` so a custom mode file
+    /// behaves like the built-in ones (EACCES/EBUSY print a diagnostic,
+    /// unexpected errnos propagate, ENOENT/EISDIR are silent).
     fn try_load_custom_mode<D: DirEntryProbe + ?Sized>(
         &mut self,
         dir: &D,
@@ -786,19 +788,75 @@ impl<'a> Loader<'a> {
         extra: &[u8],
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
+        // `NODE_ENV=local` would build `.env.local`, which the built-in
+        // `.env.local` slot already loads just before this call.
+        if extra.is_empty() && mode == b"local" {
+            return Ok(());
+        }
+
         let mut name = Vec::with_capacity(5 + mode.len() + extra.len());
         name.extend_from_slice(b".env.");
         name.extend_from_slice(mode);
         name.extend_from_slice(extra);
 
+        if self.custom_files_loaded.contains(&*name) {
+            return Ok(());
+        }
+
         // The resolver's entry map is keyed lowercase; probe with a lowered
         // copy. `mode` comes from user env so its case is unknown.
         let mut lower = name.clone();
         lower.make_ascii_lowercase();
-        if dir.has_query(&lower) {
-            self.load_env_file_dynamic::<false>(&name, value_buffer)?;
-            analytics::Features::dotenv_inc();
+        if !dir.has_query(&lower) {
+            return Ok(());
         }
+
+        let dir_handle = bun_sys::Fd::cwd();
+        let file = match bun_sys::File::openat(
+            dir_handle,
+            &name,
+            bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
+            0,
+        ) {
+            Ok(file) => file,
+            Err(err) => {
+                use bun_sys::E;
+                match err.get_errno() {
+                    E::EISDIR | E::ENOENT => return Ok(()),
+                    E::EBUSY | E::EACCES => {
+                        if !self.quiet {
+                            bun_core::pretty_errorln!(
+                                "<r><red>{}<r> error loading {} file",
+                                bstr::BStr::new(err.name()),
+                                bstr::BStr::new(&name)
+                            );
+                        }
+                        return Ok(());
+                    }
+                    _ => return Err(err.into()),
+                }
+            }
+        };
+
+        match read_env_file_contents(&file)? {
+            ReadEnvFile::Empty => {}
+            ReadEnvFile::ReadErr(err) => {
+                if !self.quiet {
+                    bun_core::pretty_errorln!(
+                        "<r><red>{}<r> error loading {} file",
+                        bstr::BStr::new(err.name()),
+                        bstr::BStr::new(&name)
+                    );
+                }
+            }
+            ReadEnvFile::Bytes(buf) => {
+                Parser::parse_bytes::<false, false, true>(&buf, &mut *self.map, value_buffer)?;
+            }
+        }
+
+        self.custom_files_loaded
+            .put(&*name, bun_ast::Source::default())?;
+        analytics::Features::dotenv_inc();
         Ok(())
     }
 

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -789,8 +789,9 @@ impl<'a> Loader<'a> {
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
         // `NODE_ENV=local` would build `.env.local`, which the built-in
-        // `.env.local` slot already loads just before this call.
-        if extra.is_empty() && mode == b"local" {
+        // `.env.local` slot already loads just before this call. The probe and
+        // case-insensitive filesystems both match regardless of case.
+        if extra.is_empty() && mode.eq_ignore_ascii_case(b"local") {
             return Ok(());
         }
 

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -14,17 +14,22 @@ use bun_which::which;
 use bun_core::analytics;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub enum DotEnvFileSuffix {
+pub enum DotEnvFileSuffix<'a> {
     Development,
     Production,
     Test,
+    /// `NODE_ENV` set to something other than development/production/test
+    /// (e.g. `staging`, `qa`). Loads `.env.{mode}` / `.env.{mode}.local`
+    /// literally, like dotenv-flow/vite, instead of falling through to the
+    /// development files.
+    Custom(&'a [u8]),
 }
 
 /// Downstream callers (transpiler, install, lockfile) variously spell the load-mode
 /// discriminant `Kind` or `Mode`; both alias the same `DotEnvFileSuffix` enum so the
 /// crate exports a single canonical type without forcing a tree-wide rename.
-pub type Kind = DotEnvFileSuffix;
-pub type Mode = DotEnvFileSuffix;
+pub type Kind<'a> = DotEnvFileSuffix<'a>;
+pub type Mode<'a> = DotEnvFileSuffix<'a>;
 
 /// Directory-entry probe used by `Loader::load`. `bun_dotenv` sits below
 /// `bun_resolver` in the crate graph, so the concrete
@@ -35,6 +40,9 @@ pub type Mode = DotEnvFileSuffix;
 pub trait DirEntryProbe {
     /// The argument MUST already be ASCII-lowercase.
     fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool;
+    /// Dynamic (non-`'static`) variant of `has_comptime_query`. The argument
+    /// MUST already be ASCII-lowercase.
+    fn has_query(&self, query_lower: &[u8]) -> bool;
 }
 
 // LAYERING: the concrete `DirEntry` lives in `bun_resolver::fs` (higher tier,
@@ -645,7 +653,7 @@ impl<'a> Loader<'a> {
         &mut self,
         dir: &D,
         env_files: &[&[u8]],
-        suffix: DotEnvFileSuffix,
+        suffix: DotEnvFileSuffix<'_>,
         skip_default_env: bool,
     ) -> crate::Result<()> {
         // `suffix` is a runtime arg (avoids unstable adt_const_params; cold path).
@@ -704,7 +712,7 @@ impl<'a> Loader<'a> {
     // .env goes last
     fn load_default_files<D: DirEntryProbe + ?Sized>(
         &mut self,
-        suffix: DotEnvFileSuffix,
+        suffix: DotEnvFileSuffix<'_>,
         dir: &D,
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
@@ -723,9 +731,12 @@ impl<'a> Loader<'a> {
             DotEnvFileSuffix::Test => {
                 self.try_load_default(dir, dir_handle, b".env.test.local", value_buffer)?
             }
+            DotEnvFileSuffix::Custom(mode) => {
+                self.try_load_custom_mode(dir, mode, b".local", value_buffer)?
+            }
         }
 
-        if suffix != DotEnvFileSuffix::Test {
+        if !matches!(suffix, DotEnvFileSuffix::Test) {
             self.try_load_default(dir, dir_handle, b".env.local", value_buffer)?;
         }
 
@@ -738,6 +749,9 @@ impl<'a> Loader<'a> {
             }
             DotEnvFileSuffix::Test => {
                 self.try_load_default(dir, dir_handle, b".env.test", value_buffer)?
+            }
+            DotEnvFileSuffix::Custom(mode) => {
+                self.try_load_custom_mode(dir, mode, b"", value_buffer)?
             }
         }
 
@@ -757,6 +771,32 @@ impl<'a> Loader<'a> {
     ) -> crate::Result<()> {
         if dir.has_comptime_query(name) {
             self.load_env_file::<false>(dir_handle, name, value_buffer)?;
+            analytics::Features::dotenv_inc();
+        }
+        Ok(())
+    }
+
+    /// `DotEnvFileSuffix::Custom` counterpart of `try_load_default`: build
+    /// `.env.{mode}{extra}` at runtime, probe the directory listing, and load
+    /// via the dynamic path (tracked in `custom_files_loaded`).
+    fn try_load_custom_mode<D: DirEntryProbe + ?Sized>(
+        &mut self,
+        dir: &D,
+        mode: &[u8],
+        extra: &[u8],
+        value_buffer: &mut Vec<u8>,
+    ) -> crate::Result<()> {
+        let mut name = Vec::with_capacity(5 + mode.len() + extra.len());
+        name.extend_from_slice(b".env.");
+        name.extend_from_slice(mode);
+        name.extend_from_slice(extra);
+
+        // The resolver's entry map is keyed lowercase; probe with a lowered
+        // copy. `mode` comes from user env so its case is unknown.
+        let mut lower = name.clone();
+        lower.make_ascii_lowercase();
+        if dir.has_query(&lower) {
+            self.load_env_file_dynamic::<false>(&name, value_buffer)?;
             analytics::Features::dotenv_inc();
         }
         Ok(())

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -873,6 +873,10 @@ impl bun_dotenv::DirEntryProbe for DirEntry {
     fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool {
         DirEntry::has_comptime_query(self, query_lower)
     }
+    #[inline]
+    fn has_query(&self, query_lower: &[u8]) -> bool {
+        self.data.contains_key(query_lower)
+    }
 }
 
 /// Compat re-exports for callers that named the seam-type aliases.

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -105,6 +105,47 @@ describe(".env file is loaded", () => {
     const { stdout } = bunRun(`${dir}/index.ts`, {});
     expect(stdout).toBe("bar baz true");
   });
+  test(".env.{NODE_ENV} loaded for custom NODE_ENV; development files skipped", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "MODE=base\n",
+      ".env.development": "MODE=dev\nSECRET=DEV\n",
+      ".env.development.local": "MODE=devlocal\nSECRET=DEVLOCAL\n",
+      ".env.production": "MODE=production\nSECRET=PROD\n",
+      ".env.staging": "MODE=staging\nSECRET=STAGING\n",
+      ".env.staging.local": "MODE=staging.local\n",
+      "index.ts": "console.log(process.env.NODE_ENV, process.env.MODE, process.env.SECRET);",
+    });
+    // NODE_ENV outside {development, production, test} loads .env.{NODE_ENV}
+    // and .env.{NODE_ENV}.local, never the development files.
+    const { stdout: staging } = bunRun(`${dir}/index.ts`, { NODE_ENV: "staging" });
+    expect(staging).toBe("staging staging.local STAGING");
+    // A custom NODE_ENV with no matching file still must not leak dev secrets.
+    const { stdout: preview } = bunRun(`${dir}/index.ts`, { NODE_ENV: "preview" });
+    expect(preview).toBe("preview base undefined");
+    // sanity: production still works
+    const { stdout: prod } = bunRun(`${dir}/index.ts`, { NODE_ENV: "production" });
+    expect(prod).toBe("production production PROD");
+  });
+  test("custom NODE_ENV precedence: .env.{mode}.local > .env.local > .env.{mode} > .env", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env": "A=.env\nB=.env\nC=.env\nD=.env\n",
+      ".env.staging": "A=.env.staging\nB=.env.staging\nC=.env.staging\n",
+      ".env.local": "A=.env.local\nB=.env.local\n",
+      ".env.staging.local": "A=.env.staging.local\n",
+      "index.ts": "console.log(process.env.A, process.env.B, process.env.C, process.env.D);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, { NODE_ENV: "staging" });
+    expect(stdout).toBe(".env.staging.local .env.local .env.staging .env");
+  });
+  test("BUN_ENV with custom value skips development files", () => {
+    const dir = tempDirWithFiles("dotenv", {
+      ".env.development.local": "SECRET=DEVLOCAL\n",
+      ".env.qa": "SECRET=QA\n",
+      "index.ts": "console.log(process.env.SECRET);",
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, { BUN_ENV: "qa" });
+    expect(stdout).toBe("QA");
+  });
   test(".env and .env.test used in testing", () => {
     const dir = tempDirWithFiles("dotenv", {
       ".env": "A=a\n",


### PR DESCRIPTION
## What

When `NODE_ENV` (or `BUN_ENV`) is set to a value other than `development`, `production`, or `test`, Bun no longer falls through to loading `.env.development` / `.env.development.local`. Instead it loads `.env.{NODE_ENV}` and `.env.{NODE_ENV}.local` literally, matching dotenv-flow and Vite.

## Repro

```sh
d=$(mktemp -d); cd $d
printf 'MODE=base\n'                       > .env
printf 'MODE=devlocal\nSECRET=DEVLOCAL\n'  > .env.development.local
printf 'MODE=staging\nSECRET=STAGING\n'    > .env.staging
printf 'console.log(process.env.NODE_ENV, process.env.MODE, process.env.SECRET)\n' > a.ts
NODE_ENV=staging bun a.ts
```

Before: `staging devlocal DEVLOCAL` (dev secrets leaked into staging; `.env.staging` unread)
After: `staging staging STAGING`

## Cause

`run_env_loader` mapped `NODE_ENV` onto a 3-valued `DotEnvFileSuffix` enum (`Development` / `Production` / `Test`). Any value that wasn't `test` or `production` fell into the `else` arm and picked `Development`, so `.env.development.local` was loaded for `NODE_ENV=staging`, `NODE_ENV=qa`, typos like `NODE_ENV=prod`, etc.

## Fix

- Add `DotEnvFileSuffix::Custom(&[u8])` carrying the literal `NODE_ENV` value.
- `load_default_files` builds `.env.{mode}` / `.env.{mode}.local` at runtime for the `Custom` arm, probes the directory listing (new `DirEntryProbe::has_query` for non-`'static` names), and loads via the existing dynamic-file path.
- `run_env_loader` selects `Custom` only when `NODE_ENV` is explicitly set, non-empty, and not `development`; unset/empty still defaults to `Development` so existing projects are unaffected.

Precedence for a custom mode matches the existing dev/prod ordering: `.env.{mode}.local` > `.env.local` > `.env.{mode}` > `.env`.

## Verification

```
bun bd test test/cli/run/env.test.ts
# 94 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->

Fixes #9090
