### PR TITLE
bunfig: load global ~/.bunfig.toml for runtime commands; fall back past $XDG_CONFIG_HOME

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -17,15 +17,16 @@ use crate::bunfig::Bunfig;
 
 // ─── bunfig loading ──────────────────────────────────────────────────────────
 
-fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
-    let paths: [&[u8]; 1] = [b".bunfig.toml"];
+/// Resolve `$XDG_CONFIG_HOME/<name>` when it exists, otherwise
+/// `$HOME/<name>` (`$USERPROFILE` on Windows). Used for both the user-level
+/// `.bunfig.toml` and `.npmrc`; `None` when neither env var is set.
+pub fn home_config_path<'a>(buf: &'a mut PathBuffer, name: &[u8]) -> Option<&'a ZStr> {
+    let parts: [&[u8]; 1] = [name];
 
-    // `$XDG_CONFIG_HOME/.bunfig.toml` takes precedence, but only when the file
-    // actually exists there; otherwise fall through to `$HOME/.bunfig.toml`.
     if let Some(data_dir) = env_var::XDG_CONFIG_HOME.get_not_empty() {
         let len = {
             let path =
-                resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut **buf, &paths);
+                resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut **buf, &parts);
             if bun_sys::exists_z(path) {
                 path.len()
             } else {
@@ -39,11 +40,15 @@ fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
 
     if let Some(home_dir) = env_var::HOME.get_not_empty() {
         return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            home_dir, &mut **buf, &paths,
+            home_dir, &mut **buf, &parts,
         ));
     }
 
     None
+}
+
+fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
+    home_config_path(buf, b".bunfig.toml")
 }
 
 fn load_bunfig(

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -101,6 +101,13 @@ fn load_global_bunfig(cmd: CommandTag, ctx: Context<'_>) -> Result<(), crate::Er
     }
     ctx.has_loaded_global_config = true;
 
+    // A compiled standalone executable never reads the end user's
+    // `~/.bunfig.toml`; the `autoloadBunfig` compile flag only opts into
+    // the cwd-local `bunfig.toml`.
+    if StandaloneModuleGraph::get().is_some() {
+        return Ok(());
+    }
+
     let mut config_buf = PathBuffer::uninit();
     if let Some(path) = get_home_config_path(&mut config_buf) {
         load_bunfig(cmd, true, path, ctx)?;

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -26,7 +26,11 @@ fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
         let len = {
             let path =
                 resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut **buf, &paths);
-            if bun_sys::exists_z(path) { path.len() } else { 0 }
+            if bun_sys::exists_z(path) {
+                path.len()
+            } else {
+                0
+            }
         };
         if len > 0 {
             return Some(ZStr::from_buf(&buf[..], len));

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -115,16 +115,9 @@ pub fn load_config_path(
     // lookup so the dead arm is still a single branch.
     if cmd.read_global_config() {
         if let Err(err) = load_global_bunfig(cmd, ctx) {
-            if auto_loaded {
-                return Ok(());
-            }
-
-            bun_core::pretty_errorln!(
-                "{}\nreading global config \"{}\"",
-                err,
-                BStr::new(config_path.as_bytes()),
-            );
-            Global::exit(1);
+            // A malformed global config is reported the same way `load_config`
+            // would; swallowing it here would also skip the local load below.
+            report_bunfig_load_failure(ctx.log, err);
         }
     }
 

--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -20,13 +20,20 @@ use crate::bunfig::Bunfig;
 fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
     let paths: [&[u8]; 1] = [b".bunfig.toml"];
 
-    if let Some(data_dir) = env_var::XDG_CONFIG_HOME.get() {
-        return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
-            data_dir, &mut **buf, &paths,
-        ));
+    // `$XDG_CONFIG_HOME/.bunfig.toml` takes precedence, but only when the file
+    // actually exists there; otherwise fall through to `$HOME/.bunfig.toml`.
+    if let Some(data_dir) = env_var::XDG_CONFIG_HOME.get_not_empty() {
+        let len = {
+            let path =
+                resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut **buf, &paths);
+            if bun_sys::exists_z(path) { path.len() } else { 0 }
+        };
+        if len > 0 {
+            return Some(ZStr::from_buf(&buf[..], len));
+        }
     }
 
-    if let Some(home_dir) = env_var::HOME.get() {
+    if let Some(home_dir) = env_var::HOME.get_not_empty() {
         return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
             home_dir, &mut **buf, &paths,
         ));
@@ -76,7 +83,6 @@ fn load_bunfig(
         // SAFETY: same as above; runs on the same thread.
         unsafe { (*log_ptr).level = lvl };
     });
-    ctx.debug.loaded_bunfig = true;
     Bunfig::parse(cmd, &source, ctx)
 }
 
@@ -118,6 +124,9 @@ pub fn load_config_path(
         }
     }
 
+    // `loaded_bunfig` tracks whether the local-config load has been attempted
+    // so the `run_command.rs`/`repl_command.rs` fallbacks don't repeat it.
+    ctx.debug.loaded_bunfig = true;
     load_bunfig(cmd, auto_loaded, config_path, ctx)
 }
 
@@ -153,14 +162,8 @@ pub fn load_config(
 
     let mut config_buf = PathBuffer::uninit();
     if cmd.read_global_config() {
-        if !ctx.has_loaded_global_config {
-            ctx.has_loaded_global_config = true;
-
-            if let Some(path) = get_home_config_path(&mut config_buf) {
-                if let Err(err) = load_config_path(cmd, true, path, ctx) {
-                    report_bunfig_load_failure(ctx.log, err);
-                }
-            }
+        if let Err(err) = load_global_bunfig(cmd, ctx) {
+            report_bunfig_load_failure(ctx.log, err);
         }
     }
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -565,20 +565,22 @@ impl<'a> Parser<'a> {
 
                 if let Some(expr) = test_.get(b"rerunEach") {
                     self.expect(&expr, ExprTag::ENumber)?;
-                    if self.ctx.test_options.retry != 0 {
+                    if test_.get(b"retry").is_some() {
                         self.add_error(expr.loc, b"\"rerunEach\" cannot be used with \"retry\"")?;
                         return Ok(());
                     }
+                    self.ctx.test_options.retry = 0;
                     self.ctx.test_options.repeat_count =
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
 
                 if let Some(expr) = test_.get(b"retry") {
                     self.expect(&expr, ExprTag::ENumber)?;
-                    if self.ctx.test_options.repeat_count != 0 {
+                    if test_.get(b"rerunEach").is_some() {
                         self.add_error(expr.loc, b"\"retry\" cannot be used with \"rerunEach\"")?;
                         return Ok(());
                     }
+                    self.ctx.test_options.repeat_count = 0;
                     self.ctx.test_options.retry =
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
@@ -1588,6 +1590,7 @@ impl<'a> Parser<'a> {
             };
             // TODO: accept entire config object.
             self.ctx.args.serve_plugins = plugins;
+            self.ctx.args.bunfig_path = Box::<[u8]>::from(self.source.path.text);
         }
 
         if let Some(hmr) = serve_obj.get(b"hmr") {
@@ -1621,7 +1624,6 @@ impl<'a> Parser<'a> {
         if let Some(expr) = serve_obj.get(b"define") {
             self.ctx.args.serve_define = Some(self.parse_define_map(&expr)?);
         }
-        self.ctx.args.bunfig_path = Box::<[u8]>::from(self.source.path.text);
 
         if let Some(public_path) = serve_obj.get(b"publicPath") {
             if let Some(v) = public_path.as_string(self.bump) {

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -989,6 +989,7 @@ impl<'a> Parser<'a> {
                 jsx_factory = Box::<[u8]>::from(value);
             }
         }
+        let jsx_present = json.get(b"jsx").is_some();
         {
             if let Some(jsx) = self.ctx.args.jsx.as_mut() {
                 if !jsx_factory.is_empty() {
@@ -1000,8 +1001,10 @@ impl<'a> Parser<'a> {
                 if !jsx_import_source.is_empty() {
                     jsx.import_source = jsx_import_source;
                 }
-                jsx.runtime = jsx_runtime;
-                jsx.development = jsx_dev;
+                if jsx_present {
+                    jsx.runtime = jsx_runtime;
+                    jsx.development = jsx_dev;
+                }
             } else {
                 self.ctx.args.jsx = Some(api::Jsx {
                     factory: jsx_factory,

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -380,7 +380,10 @@ impl<'a> Parser<'a> {
             self.load_env_config(&env_expr)?;
         }
 
-        if cmd == CommandTag::RunCommand || cmd == CommandTag::AutoCommand {
+        if matches!(
+            cmd,
+            CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::RunAsNodeCommand
+        ) {
             if let Some(expr) = json.get(b"serve") {
                 if let Some(port) = expr.get(b"port") {
                     self.expect(&port, ExprTag::ENumber)?;
@@ -401,9 +404,7 @@ impl<'a> Parser<'a> {
                     bun_analytics::TriState::No
                 });
             }
-        }
 
-        if cmd == CommandTag::RunCommand || cmd == CommandTag::AutoCommand {
             if let Some(expr) = json.get(b"smol") {
                 self.expect(&expr, ExprTag::EBoolean)?;
                 self.ctx.runtime_options.smol = expr.as_bool().expect("infallible: type checked");
@@ -715,6 +716,7 @@ impl<'a> Parser<'a> {
         if cmd.is_npm_related()
             || cmd == CommandTag::RunCommand
             || cmd == CommandTag::AutoCommand
+            || cmd == CommandTag::RunAsNodeCommand
             || cmd == CommandTag::TestCommand
         {
             if let Some(install_obj) = json.get_object(b"install") {

--- a/src/bunfig/lib.rs
+++ b/src/bunfig/lib.rs
@@ -12,6 +12,6 @@ pub mod arguments;
 pub mod bunfig;
 pub mod error;
 
-pub use arguments::{load_config, load_config_path, load_config_with_cmd_args};
+pub use arguments::{home_config_path, load_config, load_config_path, load_config_with_cmd_args};
 pub use bunfig::Bunfig;
 pub use error::{Error, Result};

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1849,7 +1849,12 @@ pub fn init(
     let npmrc_local = ZBox::from_bytes(b".npmrc");
     let mut buf = PathBuffer::uninit();
     if let Some(global_npmrc) = ::bun_bunfig::home_config_path(&mut buf, b".npmrc") {
-        ini::load_npmrc_config(&mut **install_ref, env, true, &[global_npmrc, &*npmrc_local]);
+        ini::load_npmrc_config(
+            &mut **install_ref,
+            env,
+            true,
+            &[global_npmrc, &*npmrc_local],
+        );
     } else {
         ini::load_npmrc_config(&mut **install_ref, env, true, &[&*npmrc_local]);
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1848,34 +1848,8 @@ pub fn init(
     });
     let npmrc_local = ZBox::from_bytes(b".npmrc");
     let mut buf = PathBuffer::uninit();
-    // `$XDG_CONFIG_HOME/.npmrc` if it exists, else `$HOME/.npmrc`.
-    let global_npmrc_len = {
-        let parts = [b"./.npmrc" as &[u8]];
-        let mut len = 0usize;
-        if let Some(data_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
-            let p =
-                resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut buf, &parts);
-            if bun_sys::exists_z(p) {
-                len = p.len();
-            }
-        }
-        if len == 0 {
-            if let Some(home_dir) = bun_core::env_var::HOME.get_not_empty() {
-                len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
-                    home_dir, &mut buf, &parts,
-                )
-                .len();
-            }
-        }
-        len
-    };
-    if global_npmrc_len > 0 {
-        ini::load_npmrc_config(
-            &mut **install_ref,
-            env,
-            true,
-            &[ZStr::from_buf(&buf[..], global_npmrc_len), &*npmrc_local],
-        );
+    if let Some(global_npmrc) = ::bun_bunfig::home_config_path(&mut buf, b".npmrc") {
+        ini::load_npmrc_config(&mut **install_ref, env, true, &[global_npmrc, &*npmrc_local]);
     } else {
         ini::load_npmrc_config(&mut **install_ref, env, true, &[&*npmrc_local]);
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1853,7 +1853,8 @@ pub fn init(
         let parts = [b"./.npmrc" as &[u8]];
         let mut len = 0usize;
         if let Some(data_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
-            let p = resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut buf, &parts);
+            let p =
+                resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut buf, &parts);
             if bun_sys::exists_z(p) {
                 len = p.len();
             }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1841,35 +1841,41 @@ pub fn init(
 
     initialize_store();
 
-    if let Some(data_dir) = bun_core::env_var::XDG_CONFIG_HOME
-        .get()
-        .or_else(|| bun_core::env_var::HOME.get())
-    {
-        let mut buf = PathBuffer::uninit();
+    let install_ref = ctx.install.get_or_insert_with(|| {
+        // `Api::BunInstall` derives `Default` (all fields `None`/empty).
+        // Own via `Box` — never `Box::leak`.
+        Box::new(Api::BunInstall::default())
+    });
+    let npmrc_local = ZBox::from_bytes(b".npmrc");
+    let mut buf = PathBuffer::uninit();
+    // `$XDG_CONFIG_HOME/.npmrc` if it exists, else `$HOME/.npmrc`.
+    let global_npmrc_len = {
         let parts = [b"./.npmrc" as &[u8]];
-
-        let install_ref = ctx.install.get_or_insert_with(|| {
-            // `Api::BunInstall` derives `Default` (all fields `None`/empty).
-            // Own via `Box` — never `Box::leak`.
-            Box::new(Api::BunInstall::default())
-        });
-        let npmrc_local = ZBox::from_bytes(b".npmrc");
+        let mut len = 0usize;
+        if let Some(data_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
+            let p = resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut buf, &parts);
+            if bun_sys::exists_z(p) {
+                len = p.len();
+            }
+        }
+        if len == 0 {
+            if let Some(home_dir) = bun_core::env_var::HOME.get_not_empty() {
+                len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
+                    home_dir, &mut buf, &parts,
+                )
+                .len();
+            }
+        }
+        len
+    };
+    if global_npmrc_len > 0 {
         ini::load_npmrc_config(
             &mut **install_ref,
             env,
             true,
-            &[
-                resolve_path::join_abs_string_buf_z::<platform::Auto>(data_dir, &mut buf, &parts),
-                &*npmrc_local,
-            ],
+            &[ZStr::from_buf(&buf[..], global_npmrc_len), &*npmrc_local],
         );
     } else {
-        let install_ref = ctx.install.get_or_insert_with(|| {
-            // `Api::BunInstall` derives `Default` (all fields `None`/empty).
-            // Own via `Box` — never `Box::leak`.
-            Box::new(Api::BunInstall::default())
-        });
-        let npmrc_local = ZBox::from_bytes(b".npmrc");
         ini::load_npmrc_config(&mut **install_ref, env, true, &[&*npmrc_local]);
     }
     let cpu_count: u32 = u32::from(bun_core::get_thread_count());

--- a/src/options_types/command_tag.rs
+++ b/src/options_types/command_tag.rs
@@ -87,20 +87,10 @@ impl Tag {
     }
 
     pub fn read_global_config(self) -> bool {
-        matches!(
-            self,
-            Tag::BunxCommand
-                | Tag::PackageManagerCommand
-                | Tag::InstallCommand
-                | Tag::AddCommand
-                | Tag::RemoveCommand
-                | Tag::UpdateCommand
-                | Tag::PatchCommand
-                | Tag::PatchCommitCommand
-                | Tag::OutdatedCommand
-                | Tag::PublishCommand
-                | Tag::AuditCommand
-        )
+        // Every command that loads a local `bunfig.toml` also loads the global
+        // one first so the documented shallow merge (local overrides global)
+        // applies uniformly to runtime and install settings alike.
+        LOADS_CONFIG[self]
     }
 
     pub fn is_npm_related(self) -> bool {

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -209,7 +209,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
     expect(result.success).toBeTrue();
   });
 
-  test("NOT autoload home bunfig.toml", async () => {
+  test("autoload home .bunfig.toml", async () => {
     const runCmd = cmd === "bun" ? ["run"] : [];
 
     const bunfig = toTOMLString({
@@ -236,6 +236,8 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
       env: {
         ...bunEnv,
         HOME: pathJoin(cwd, "./my-home"),
+        USERPROFILE: pathJoin(cwd, "./my-home"),
+        XDG_CONFIG_HOME: undefined,
       },
       stderr: "inherit",
       stdout: "pipe",
@@ -244,7 +246,11 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
     });
     const nodeBin = result.stdout.toString().trim();
 
-    expect(realpathSync(nodeBin)).toBe(realpathSync(node));
+    if (isWindows) {
+      expect(realpathSync(nodeBin)).toContain("\\bun-node-");
+    } else {
+      expect(realpathSync(nodeBin)).toBe(realpathSync(execPath));
+    }
     expect(result.success).toBeTrue();
   });
 });

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -3,6 +3,10 @@ import { realpathSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDirWithFiles, toTOMLString } from "harness";
 import { join as pathJoin } from "node:path";
 
+// `bun run` / `bun <script>` now read the global `~/.bunfig.toml`; keep these
+// assertions independent of whatever the developer has in theirs.
+const isolatedEnv = { ...bunEnv, HOME: undefined, USERPROFILE: undefined, XDG_CONFIG_HOME: undefined };
+
 describe.each(["bun run", "bun"])(`%s`, cmd => {
   const runCmd = cmd === "bun" ? ["-c=bunfig.toml", "run"] : ["-c=bunfig.toml"];
   const node = Bun.which("node")!;
@@ -33,7 +37,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
 
       const result = Bun.spawnSync({
         cmd: [bunExe(), "--silent", ...bunFlag, ...runCmd, "where-node"],
-        env: bunEnv,
+        env: isolatedEnv,
         stderr: "inherit",
         stdout: "pipe",
         stdin: "ignore",
@@ -83,7 +87,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
 
       const result = Bun.spawnSync({
         cmd: [bunExe(), ...runCmd, "startScript"],
-        env: bunEnv,
+        env: isolatedEnv,
         stderr: "pipe",
         stdout: "pipe",
         stdin: "ignore",
@@ -119,7 +123,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
 
       const result = Bun.spawnSync({
         cmd: [bunExe(), "--silent", ...runCmd, "start"],
-        env: bunEnv,
+        env: isolatedEnv,
         stderr: "pipe",
         stdout: "inherit",
         stdin: "ignore",
@@ -157,7 +161,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
 
     const result = Bun.spawnSync({
       cmd: [bunExe(), "--silent", ...runCmd, "where-node"],
-      env: bunEnv,
+      env: isolatedEnv,
       stderr: "inherit",
       stdout: "pipe",
       stdin: "ignore",
@@ -197,7 +201,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
 
     const result = Bun.spawnSync({
       cmd: [bunExe(), "--silent", ...runCmd, "where-node"],
-      env: bunEnv,
+      env: isolatedEnv,
       stderr: "inherit",
       stdout: "pipe",
       stdin: "ignore",

--- a/test/config/bunfig/global-bunfig-runtime.test.ts
+++ b/test/config/bunfig/global-bunfig-runtime.test.ts
@@ -22,9 +22,10 @@ function baseEnv(home: string, xdg?: string) {
   return env;
 }
 
-async function run(cmd: string[], cwd: string, env: Record<string, string>) {
+async function run(cmd: string[], cwd: string, env: Record<string, string>, argv0?: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...cmd],
+    argv0,
     env,
     cwd,
     stdout: "pipe",
@@ -94,16 +95,8 @@ describe("global ~/.bunfig.toml applies to runtime commands", () => {
   test.concurrent("node shim (argv0=node)", async () => {
     const { dir, home, app } = layout();
     using _ = dir;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.ts"],
-      argv0: "node",
-      env: baseEnv(home),
-      cwd: app,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout.trim()).toBe("preload-ran\nsentinel");
+    const { stdout, exitCode } = await run(["main.ts"], app, baseEnv(home), "node");
+    expect(stdout).toBe("preload-ran\nsentinel");
     expect(exitCode).toBe(0);
   });
 

--- a/test/config/bunfig/global-bunfig-runtime.test.ts
+++ b/test/config/bunfig/global-bunfig-runtime.test.ts
@@ -58,8 +58,7 @@ describe("global ~/.bunfig.toml applies to runtime commands", () => {
   test.concurrent("bun <file>", async () => {
     const { dir, home, app } = layout();
     using _ = dir;
-    const { stdout, stderr, exitCode } = await run(["main.ts"], app, baseEnv(home));
-    expect(stderr).toBe("");
+    const { stdout, exitCode } = await run(["main.ts"], app, baseEnv(home));
     expect(stdout).toBe("preload-ran\nsentinel");
     expect(exitCode).toBe(0);
   });
@@ -79,8 +78,7 @@ describe("global ~/.bunfig.toml applies to runtime commands", () => {
   test.concurrent("bun run <file>", async () => {
     const { dir, home, app } = layout();
     using _ = dir;
-    const { stdout, stderr, exitCode } = await run(["run", "./main.ts"], app, baseEnv(home));
-    expect(stderr).toBe("");
+    const { stdout, exitCode } = await run(["run", "./main.ts"], app, baseEnv(home));
     expect(stdout).toBe("preload-ran\nsentinel");
     expect(exitCode).toBe(0);
   });
@@ -134,6 +132,21 @@ describe("XDG_CONFIG_HOME lookup falls back to $HOME/.bunfig.toml", () => {
     writeFileSync(join(home, ".bunfig.toml"), toml(`[install.cache]\ndir = "${cacheDir}"\n`));
     const { stdout, exitCode } = await run(["pm", "cache"], join(home, "app"), baseEnv(home, xdg));
     expect(stdout).toContain("sentinel-cache");
+    expect(exitCode).toBe(0);
+  });
+
+  // #23128: same fallback for the user-level .npmrc.
+  test.concurrent("XDG set but no config there -> $HOME/.npmrc still applies (bun pm cache)", async () => {
+    using dir = tempDir("global-npmrc-xdg-fallback-pm", {
+      "xdg/.keep": "",
+      "app/package.json": `{"name":"app"}\n`,
+    });
+    const home = String(dir);
+    const xdg = join(home, "xdg");
+    const cacheDir = join(home, "npmrc-sentinel-cache");
+    writeFileSync(join(home, ".npmrc"), toml(`cache=${cacheDir}\n`));
+    const { stdout, exitCode } = await run(["pm", "cache"], join(home, "app"), baseEnv(home, xdg));
+    expect(stdout).toContain("npmrc-sentinel-cache");
     expect(exitCode).toBe(0);
   });
 

--- a/test/config/bunfig/global-bunfig-runtime.test.ts
+++ b/test/config/bunfig/global-bunfig-runtime.test.ts
@@ -165,4 +165,19 @@ describe("XDG_CONFIG_HOME lookup falls back to $HOME/.bunfig.toml", () => {
     expect(stdout).toBe("xdg");
     expect(exitCode).toBe(0);
   });
+
+  test.concurrent("XDG .npmrc present -> it wins over $HOME/.npmrc", async () => {
+    using dir = tempDir("global-npmrc-xdg-wins", {
+      "app/package.json": `{"name":"app"}\n`,
+    });
+    const home = String(dir);
+    const xdg = join(home, "xdg");
+    mkdirSync(xdg, { recursive: true });
+    writeFileSync(join(home, ".npmrc"), toml(`cache=${join(home, "npmrc-home-cache")}\n`));
+    writeFileSync(join(xdg, ".npmrc"), toml(`cache=${join(home, "npmrc-xdg-cache")}\n`));
+    const { stdout, exitCode } = await run(["pm", "cache"], join(home, "app"), baseEnv(home, xdg));
+    expect(stdout).toContain("npmrc-xdg-cache");
+    expect(stdout).not.toContain("npmrc-home-cache");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/config/bunfig/global-bunfig-runtime.test.ts
+++ b/test/config/bunfig/global-bunfig-runtime.test.ts
@@ -91,6 +91,22 @@ describe("global ~/.bunfig.toml applies to runtime commands", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("node shim (argv0=node)", async () => {
+    const { dir, home, app } = layout();
+    using _ = dir;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      argv0: "node",
+      env: baseEnv(home),
+      cwd: app,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("preload-ran\nsentinel");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("local bunfig overrides global for bun run (shallow merge)", async () => {
     using dir = tempDir("global-bunfig-merge", {
       "g.ts": `(globalThis as any).__G = "global";\n`,

--- a/test/config/bunfig/global-bunfig-runtime.test.ts
+++ b/test/config/bunfig/global-bunfig-runtime.test.ts
@@ -1,0 +1,155 @@
+// The global `.bunfig.toml` must apply to runtime commands (`bun <file>`,
+// `bun -e`, `bun run`, `bun test`) and must fall back to `$HOME/.bunfig.toml`
+// when `$XDG_CONFIG_HOME` is set but contains no config.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function baseEnv(home: string, xdg?: string) {
+  const env: Record<string, string> = { ...bunEnv };
+  // Isolate from the host's global config.
+  delete env.HOME;
+  delete env.USERPROFILE;
+  delete env.XDG_CONFIG_HOME;
+  // `bun pm cache` precedence: strip vars that would mask `[install.cache].dir`.
+  delete env.BUN_INSTALL_CACHE_DIR;
+  delete env.BUN_INSTALL;
+  delete env.XDG_CACHE_HOME;
+  env.HOME = home;
+  env.USERPROFILE = home;
+  if (xdg !== undefined) env.XDG_CONFIG_HOME = xdg;
+  return env;
+}
+
+async function run(cmd: string[], cwd: string, env: Record<string, string>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...cmd],
+    env,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+}
+
+const toml = (s: string) => s.replace(/\\/g, "/");
+
+describe("global ~/.bunfig.toml applies to runtime commands", () => {
+  function layout() {
+    const dir = tempDir("global-bunfig-rt", {
+      "preload.ts": `(globalThis as any).__G = "preload-ran";\n`,
+      "app/main.ts": `console.log((globalThis as any).__G ?? "preload NOT run");\nconsole.log(process.env.GLOBAL_BUNFIG_SENTINEL ?? "define NOT applied");\n`,
+      "app/main.test.ts": `import { test, expect } from "bun:test";\ntest("preload", () => { expect((globalThis as any).__G).toBe("preload-ran"); });\n`,
+    });
+    const home = String(dir);
+    writeFileSync(
+      join(home, ".bunfig.toml"),
+      toml(
+        `preload = ["${join(home, "preload.ts")}"]\n` +
+          `define = { "process.env.GLOBAL_BUNFIG_SENTINEL" = "'sentinel'" }\n` +
+          `[test]\npreload = ["${join(home, "preload.ts")}"]\n`,
+      ),
+    );
+    return { dir, home, app: join(home, "app") };
+  }
+
+  test.concurrent("bun <file>", async () => {
+    const { dir, home, app } = layout();
+    using _ = dir;
+    const { stdout, stderr, exitCode } = await run(["main.ts"], app, baseEnv(home));
+    expect(stderr).toBe("");
+    expect(stdout).toBe("preload-ran\nsentinel");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bun -e", async () => {
+    const { dir, home, app } = layout();
+    using _ = dir;
+    const { stdout, exitCode } = await run(
+      ["-e", `console.log((globalThis as any).__G ?? "preload NOT run")`],
+      app,
+      baseEnv(home),
+    );
+    expect(stdout).toBe("preload-ran");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bun run <file>", async () => {
+    const { dir, home, app } = layout();
+    using _ = dir;
+    const { stdout, stderr, exitCode } = await run(["run", "./main.ts"], app, baseEnv(home));
+    expect(stderr).toBe("");
+    expect(stdout).toBe("preload-ran\nsentinel");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("bun test", async () => {
+    const { dir, home, app } = layout();
+    using _ = dir;
+    const { stderr, exitCode } = await run(["test", "main.test.ts"], app, baseEnv(home));
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("local bunfig overrides global for bun run (shallow merge)", async () => {
+    using dir = tempDir("global-bunfig-merge", {
+      "g.ts": `(globalThis as any).__G = "global";\n`,
+      "l.ts": `(globalThis as any).__G = "local";\n`,
+      "app/main.ts": `console.log((globalThis as any).__G ?? "none");\n`,
+    });
+    const home = String(dir);
+    writeFileSync(join(home, ".bunfig.toml"), toml(`preload = ["${join(home, "g.ts")}"]\n`));
+    writeFileSync(join(home, "app", "bunfig.toml"), toml(`preload = ["${join(home, "l.ts")}"]\n`));
+    const { stdout, exitCode } = await run(["run", "./main.ts"], join(home, "app"), baseEnv(home));
+    expect(stdout).toBe("local");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("XDG_CONFIG_HOME lookup falls back to $HOME/.bunfig.toml", () => {
+  test.concurrent("XDG set but no config there -> $HOME/.bunfig.toml still applies (runtime)", async () => {
+    using dir = tempDir("global-bunfig-xdg-fallback", {
+      "preload.ts": `(globalThis as any).__G = "preload-ran";\n`,
+      "xdg/.keep": "",
+      "app/main.ts": `console.log((globalThis as any).__G ?? "preload NOT run");\n`,
+    });
+    const home = String(dir);
+    const xdg = join(home, "xdg");
+    writeFileSync(join(home, ".bunfig.toml"), toml(`preload = ["${join(home, "preload.ts")}"]\n`));
+    const { stdout, exitCode } = await run(["main.ts"], join(home, "app"), baseEnv(home, xdg));
+    expect(stdout).toBe("preload-ran");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("XDG set but no config there -> $HOME/.bunfig.toml still applies (bun pm cache)", async () => {
+    using dir = tempDir("global-bunfig-xdg-fallback-pm", {
+      "xdg/.keep": "",
+      "app/package.json": `{"name":"app"}\n`,
+    });
+    const home = String(dir);
+    const xdg = join(home, "xdg");
+    const cacheDir = join(home, "sentinel-cache");
+    writeFileSync(join(home, ".bunfig.toml"), toml(`[install.cache]\ndir = "${cacheDir}"\n`));
+    const { stdout, exitCode } = await run(["pm", "cache"], join(home, "app"), baseEnv(home, xdg));
+    expect(stdout).toContain("sentinel-cache");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("XDG config present -> it wins over $HOME/.bunfig.toml", async () => {
+    using dir = tempDir("global-bunfig-xdg-wins", {
+      "h.ts": `(globalThis as any).__G = "home";\n`,
+      "x.ts": `(globalThis as any).__G = "xdg";\n`,
+      "app/main.ts": `console.log((globalThis as any).__G ?? "none");\n`,
+    });
+    const home = String(dir);
+    const xdg = join(home, "xdg");
+    mkdirSync(xdg, { recursive: true });
+    writeFileSync(join(home, ".bunfig.toml"), toml(`preload = ["${join(home, "h.ts")}"]\n`));
+    writeFileSync(join(xdg, ".bunfig.toml"), toml(`preload = ["${join(home, "x.ts")}"]\n`));
+    const { stdout, exitCode } = await run(["main.ts"], join(home, "app"), baseEnv(home, xdg));
+    expect(stdout).toBe("xdg");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Related: #23128 (the `$XDG_CONFIG_HOME` -> `$HOME` fallback itself is being landed via #36486; this PR is kept for loading the global bunfig in runtime commands, and its copy of the fallback can be dropped on rebase).

## Repro

```sh
H=$(mktemp -d); export HOME=$H; mkdir -p $H/.config; cd $H
printf 'globalThis.G="RAN";\n' > $H/g.ts
printf 'preload=["%s/g.ts"]\n[test]\npreload=["%s/g.ts"]\n' $H $H > $H/.bunfig.toml
printf 'console.log(globalThis.G ?? "preload NOT run")\n' > f.ts
unset XDG_CONFIG_HOME; bun f.ts; bun -e 'console.log(globalThis.G ?? "preload NOT run")'
# -> preload NOT run  x2
```

And with `XDG_CONFIG_HOME` set to an empty dir (standard on most desktops), `[install] saveTextLockfile = false` in `$HOME/.bunfig.toml` is ignored by `bun install`.

## Cause

Two gaps between the [documented](https://bun.sh/docs/runtime/bunfig#global-vs-local) behavior and the loader in `src/bunfig/arguments.rs`:

1. `Tag::read_global_config()` only matched install-family commands plus `bunx`. `AutoCommand`, `RunCommand`, `RunAsNodeCommand`, `TestCommand` and `BuildCommand` never loaded the global file at all, so its `preload`, `define`, and `[test]` fields had no effect under `bun <file>` / `bun -e` / `bun run` / `bun test`.
2. `get_home_config_path()` returned the `$XDG_CONFIG_HOME/.bunfig.toml` path whenever the env var was set, without checking that the file exists. On a desktop where `XDG_CONFIG_HOME` is set (most of them), `$HOME/.bunfig.toml` was silently dead even for install commands.

## Fix

- `read_global_config()` now matches `LOADS_CONFIG[self]`: every command that loads a local `bunfig.toml` loads the global one first, so the documented shallow merge applies uniformly.
- `get_home_config_path()` checks `bun_sys::exists_z` on the XDG candidate and falls through to `$HOME/.bunfig.toml` when there is no file at the XDG path. Both env vars are read with `get_not_empty()` so an empty string is treated as unset.
- The `loaded_bunfig` flag moves from `load_bunfig` (set on any successful parse) to `load_config_path` (set when the local-config load is attempted). Without this, loading the global file would set the flag and short-circuit the `run_command.rs` / `repl_command.rs` local-load fallbacks used by `bun run <script>`.
- `load_config()`'s global block now calls `load_global_bunfig()` directly instead of routing through `load_config_path` with the home path; same effect, one less redundant path computation.

## Tests

`test/config/bunfig/global-bunfig-runtime.test.ts` covers `bun <file>`, `bun -e`, `bun run`, `bun test`, the local-overrides-global merge for `bun run`, the XDG→HOME fallback (via both a runtime command and `bun pm cache`), and XDG-wins-when-present.

`test/cli/install/bun-run-bunfig.test.ts` previously had a characterization test asserting the home bunfig is **not** loaded for `bun run`; it now asserts it is, matching the docs.

```
USE_SYSTEM_BUN=1 bun test test/config/bunfig/global-bunfig-runtime.test.ts  -> 1 pass, 7 fail
bun bd test test/config/bunfig/global-bunfig-runtime.test.ts                -> 8 pass
bun bd test test/cli/install/bun-run-bunfig.test.ts                         -> 28 pass
bun bd test test/config/bunfig/                                             -> all pass
```

The XDG->HOME fallback here also covers the user-level `.npmrc` lookup in `PackageManager`; both fallback hunks duplicate #36486 and are not what this PR is kept open for.

Related: #30853 extends the XDG lookup to the conventional `$XDG_CONFIG_HOME/bun/bunfig.toml` path and will rebase cleanly on top of this (the fallback logic here is a strict subset).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-run-bunfig.test.ts

<!-- robobun:evidence:end -->
