### PR TITLE
glob: return absolute literal patterns from scan()/scanSync()

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -87,6 +87,7 @@ pub trait Accessor {
 
     fn open(path: &ZStr) -> Result<Maybe<Self::Handle>, Error>;
     fn openat(handle: Self::Handle, path: &ZStr) -> Result<Maybe<Self::Handle>, Error>;
+    fn stat(path: &ZStr) -> Maybe<Stat>;
     fn statat(handle: Self::Handle, path: &ZStr) -> Maybe<Stat>;
     /// Like statat but does not follow symlinks.
     fn lstatat(handle: Self::Handle, path: &ZStr) -> Maybe<Stat>;
@@ -177,6 +178,10 @@ impl Accessor for SyscallAccessor {
 
     fn open(path: &ZStr) -> Result<Maybe<SyscallHandle>, Error> {
         Ok(Syscall::open(path, O::DIRECTORY | O::RDONLY, 0).map(|fd| SyscallHandle { value: fd }))
+    }
+
+    fn stat(path: &ZStr) -> Maybe<Stat> {
+        Syscall::stat(path)
     }
 
     fn statat(handle: SyscallHandle, path: &ZStr) -> Maybe<Stat> {
@@ -449,36 +454,32 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                 //
                 // In that case we don't need to do any walking and can just open up the FS entry
                 if starting_component_idx as usize >= self.walker.pattern_components.len() {
-                    // Matched-path payload must respect SENTINEL. The open()
+                    // Matched-path payload must respect SENTINEL. The stat()
                     // probe always needs a NUL — use a separate dupeZ for it so
                     // SENTINEL=false matched paths don't carry a spurious 0x00.
                     let path = dupe_matched::<SENTINEL>(path_without_special_syntax);
                     let pathz_owned = dupe_z(path_without_special_syntax);
                     // SAFETY: dupe_z appends NUL at len()-1; ZStr len excludes it.
                     let pathz = ZStr::from_slice_with_nul(&pathz_owned[..]);
-                    let fd = match A::open(pathz)? {
+                    let stat_result = match A::stat(pathz) {
                         Err(e) => {
-                            if e.get_errno() == E::ENOTDIR {
-                                self.walker.matched_paths.insert(&path, ());
-                                self.iter_state = IterState::Matched(path);
-                                return Ok(Ok(()));
-                            }
-                            // Doesn't exist
-                            if e.get_errno() == E::ENOENT {
+                            // ENOTDIR here means a path component is not a directory,
+                            // i.e. the target does not exist.
+                            if e.get_errno() == E::ENOENT || e.get_errno() == E::ENOTDIR {
                                 self.iter_state = IterState::GetNext;
                                 return Ok(Ok(()));
                             }
                             return Ok(Err(e.with_path(matched_as_slice::<SENTINEL>(&path))));
                         }
-                        Ok(fd) => fd,
+                        Ok(stat) => stat,
                     };
-                    let _ = A::close(fd);
-                    if self.walker.only_files {
+                    let mode = stat_result.st_mode as u32;
+                    if S::ISREG(mode) || !self.walker.only_files {
+                        self.walker.matched_paths.insert(&path, ());
+                        self.iter_state = IterState::Matched(path);
+                    } else {
                         self.iter_state = IterState::GetNext;
-                        return Ok(Ok(()));
                     }
-                    self.walker.matched_paths.insert(&path, ());
-                    self.iter_state = IterState::Matched(path);
                     return Ok(Ok(()));
                 }
 

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -459,6 +459,7 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                     let fd = match A::open(pathz)? {
                         Err(e) => {
                             if e.get_errno() == E::ENOTDIR {
+                                self.walker.matched_paths.insert(&path, ());
                                 self.iter_state = IterState::Matched(path);
                                 return Ok(Ok(()));
                             }
@@ -472,6 +473,11 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                         Ok(fd) => fd,
                     };
                     let _ = A::close(fd);
+                    if self.walker.only_files {
+                        self.iter_state = IterState::GetNext;
+                        return Ok(Ok(()));
+                    }
+                    self.walker.matched_paths.insert(&path, ());
                     self.iter_state = IterState::Matched(path);
                     return Ok(Ok(()));
                 }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1995,6 +1995,10 @@ pub mod dir_entry_accessor {
         type Handle = DirEntryHandle;
         type DirIter = DirEntryDirIter;
 
+        fn stat(path: &ZStr) -> Maybe<Stat> {
+            Syscall::stat(path)
+        }
+
         fn statat(handle: DirEntryHandle, path_: &ZStr) -> Maybe<Stat> {
             let mut buf = PathBuffer::uninit();
             let path: &ZStr = if !Platform::AUTO.is_absolute(path_.as_bytes()) {

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -693,6 +693,21 @@ describe("absolute path pattern", async () => {
     const glob = new Glob(`${tmpdir}/hello/friends/nice.json`);
     console.log(Array.from(glob.scanSync({ cwd: tmpdir })));
   });
+
+  test("fully-literal absolute path returns the entry", async () => {
+    using dir = tempDir("glob-abs-literal", {
+      "a.js": "x",
+      "sub/keep": "",
+    });
+    const file = path.join(String(dir), "a.js");
+    const subdir = path.join(String(dir), "sub");
+
+    expect([...new Glob(file).scanSync()]).toEqual([file]);
+    expect(await Array.fromAsync(new Glob(file).scan())).toEqual([file]);
+    expect([...new Glob(subdir).scanSync({ onlyFiles: false })]).toEqual([subdir]);
+    expect([...new Glob(subdir).scanSync({ onlyFiles: true })]).toEqual([]);
+    expect([...new Glob(path.join(String(dir), "missing.js")).scanSync()]).toEqual([]);
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/24936


### PR DESCRIPTION
## What does this PR do?

`new Bun.Glob("/abs/path/file.js").scanSync()` returned `[]` for an existing file, and `new Bun.Glob("/abs/dir").scanSync({ onlyFiles: false })` returned `[]` for an existing directory. The same pattern worked via `fs.globSync`, via `Glob#match`, via a relative literal with `cwd`, and via any pattern that contained a wildcard.

```js
import fs from "node:fs";
const D = fs.mkdtempSync("/tmp/glob-abs-literal-");
fs.writeFileSync(D + "/a.js", "x");
fs.mkdirSync(D + "/dir");
[...new Bun.Glob(D + "/a.js").scanSync()];                      // [] (bug)
[...new Bun.Glob(D + "/dir").scanSync({ onlyFiles: false })];   // [] (bug)
[...new Bun.Glob(D + "/*.js").scanSync()];                      // [".../a.js"]
fs.globSync(D + "/a.js");                                       // [".../a.js"]
```

### Cause

`Iterator::init` has a fast path for an absolute pattern with no glob syntax: it probes the path with `open(O_DIRECTORY)` and sets `IterState::Matched(path)` directly. Every other match site routes through `prepare_matched_path`, which inserts into `GlobWalker::matched_paths` before yielding. The fast path skipped the insert, so `walk()` (which discards the yielded path, relying on `matched_paths`) left the map empty and `glob_walk_result_to_js` returned `[]`.

### Fix

Insert into `matched_paths` before setting `IterState::Matched` in both fast-path arms, and honour `only_files` when the probe opens a directory (so `scanSync()` with the default `onlyFiles: true` does not now start returning directories).

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/glob/scan.test.ts -t "fully-literal absolute path"
(fail) absolute path pattern > fully-literal absolute path returns the entry

$ bun bd test test/js/bun/glob/scan.test.ts -t "fully-literal absolute path"
(pass) absolute path pattern > fully-literal absolute path returns the entry
```

Full `test/js/bun/glob/scan.test.ts` (195 pass), `match.test.ts`, and `test/js/node/fs/glob.test.ts` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->

Fixes #16709

Fixes #40936
