### PR TITLE
s3: add a timeout option to S3Options

### DIFF
--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -1465,7 +1465,10 @@ declare module "bun" {
      */
     list(
       input?: S3ListObjectsOptions | null,
-      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "timeout">,
+      options?: Pick<
+        S3Options,
+        "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "timeout"
+      >,
     ): Promise<S3ListObjectsResponse>;
 
     /**
@@ -1503,7 +1506,10 @@ declare module "bun" {
      */
     static list(
       input?: S3ListObjectsOptions | null,
-      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "timeout">,
+      options?: Pick<
+        S3Options,
+        "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "timeout"
+      >,
     ): Promise<S3ListObjectsResponse>;
   }
 

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -1465,7 +1465,7 @@ declare module "bun" {
      */
     list(
       input?: S3ListObjectsOptions | null,
-      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint">,
+      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "timeout">,
     ): Promise<S3ListObjectsResponse>;
 
     /**
@@ -1503,7 +1503,7 @@ declare module "bun" {
      */
     static list(
       input?: S3ListObjectsOptions | null,
-      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint">,
+      options?: Pick<S3Options, "accessKeyId" | "secretAccessKey" | "sessionToken" | "region" | "bucket" | "endpoint" | "timeout">,
     ): Promise<S3ListObjectsResponse>;
   }
 

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -293,6 +293,36 @@ declare module "bun" {
     retry?: number;
 
     /**
+     * The socket idle timeout in milliseconds. If no bytes move in either
+     * direction for this long the request fails with a `Timeout` error. This
+     * is an inactivity timeout (re-armed on every byte sent or received), not
+     * a wall-clock deadline for the whole request. For multipart uploads the
+     * timeout applies to each individual part request. Setting this to `false`
+     * (or `0`) disables the idle timeout for the request.
+     *
+     * When omitted the global HTTP idle timeout applies (defaults to 5
+     * minutes and can be overridden via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`).
+     *
+     * This option has the same semantics as `fetch()`'s `timeout` option.
+     *
+     * @example
+     * ```ts
+     * // Fail fast against a wedged endpoint
+     * await s3.file("object.txt", { timeout: 2000 }).text();
+     * ```
+     *
+     * @example
+     * ```ts
+     * // Set a default timeout for every operation on this client
+     * const s3 = new Bun.S3Client({
+     *   bucket: "my-bucket",
+     *   timeout: 10_000,
+     * });
+     * ```
+     */
+    timeout?: number | false;
+
+    /**
      * The Content-Type of the file.
      * Automatically set based on file extension when possible.
      *

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2625,6 +2625,7 @@ where
                         std::ptr::from_mut::<Self>(this).cast::<c_void>(),
                         proxy_url,
                         s3.request_payer,
+                        s3.options.idle_timeout_seconds,
                     ); // TODO: properly propagate exception upwards
                     return;
                 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -623,7 +623,7 @@ impl BlobExt for Blob {
             // so clone the `Rc<S3Credentials>` out (cheap ref bump)
             // and stash `path` as a raw `*const [u8]` whose backing store is
             // kept alive by the same `t.blob` now owned by the heap task.
-            let (cred, path, payer);
+            let (cred, path, payer, idle_timeout);
             {
                 let s3 = t
                     .blob
@@ -634,6 +634,7 @@ impl BlobExt for Blob {
                 cred = std::rc::Rc::clone(s3.get_credentials());
                 path = std::ptr::from_ref::<[u8]>(s3.path());
                 payer = s3.request_payer;
+                idle_timeout = s3.options.idle_timeout_seconds;
             }
             // SAFETY: `path` borrows the store held by `t.blob` (a fresh +1 ref);
             // it stays valid until `Task::done` deinits the blob in the callback.
@@ -654,6 +655,7 @@ impl BlobExt for Blob {
                     t_ptr,
                     proxy.as_deref(),
                     payer,
+                    idle_timeout,
                 )?;
             } else {
                 crate::webcore::__s3_client::download(
@@ -663,6 +665,7 @@ impl BlobExt for Blob {
                     t_ptr,
                     proxy.as_deref(),
                     payer,
+                    idle_timeout,
                 )?;
             }
             return Ok(());
@@ -1847,12 +1850,12 @@ impl BlobExt for Blob {
                 s3.get_credentials().dupe(),
                 path,
                 global_this,
-                Default::default(),
+                s3.options,
                 self.content_type_or_mime_type(),
                 None,
                 None,
                 proxy,
-                None,
+                s3.storage_class,
                 s3.request_payer,
             );
         }
@@ -4697,6 +4700,7 @@ fn write_file_with_empty_source_to_destination(
                 proxy_url,
                 aws_options.storage_class,
                 aws_options.request_payer,
+                aws_options.options.idle_timeout_seconds,
                 Wrapper::resolve,
                 bun_core::heap::into_raw(Box::new(Wrapper {
                     promise,
@@ -4976,6 +4980,7 @@ pub fn write_file_with_source_destination(
                         proxy_url,
                         aws_options.storage_class,
                         aws_options.request_payer,
+                        aws_options.options.idle_timeout_seconds,
                         Wrapper::resolve,
                         bun_core::heap::into_raw(Box::new(Wrapper {
                             store: source_store.clone(),
@@ -5940,6 +5945,7 @@ impl S3BlobDownloadTask {
             S3BlobDownloadTask::on_s3_download_resolved(result, ctx.cast::<S3BlobDownloadTask>())
         }
 
+        let idle_timeout = s3_store.options.idle_timeout_seconds;
         if blob.offset.get() > 0 {
             let len: Option<usize> = if blob.size.get() != MAX_SIZE {
                 Some(usize::try_from(blob.size.get()).expect("int cast"))
@@ -5956,6 +5962,7 @@ impl S3BlobDownloadTask {
                 this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
+                idle_timeout,
             )?;
         } else if blob.size.get() == MAX_SIZE {
             crate::webcore::__s3_client::download(
@@ -5965,6 +5972,7 @@ impl S3BlobDownloadTask {
                 this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
+                idle_timeout,
             )?;
         } else {
             let len: usize = usize::try_from(blob.size.get()).expect("int cast");
@@ -5978,6 +5986,7 @@ impl S3BlobDownloadTask {
                 this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
+                idle_timeout,
             )?;
         }
         Ok(promise)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5011,7 +5011,7 @@ pub fn write_file_with_source_destination(
                         s3.path(),
                         stream,
                         ctx,
-                        s3.options,
+                        aws_options.options,
                         aws_options.acl,
                         aws_options.storage_class,
                         destination_blob.content_type_or_mime_type(),

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -385,6 +385,7 @@ impl ReadableStream {
                     },
                     proxy_url,
                     s3.request_payer,
+                    s3.options.idle_timeout_seconds,
                     global_this,
                 )
             }

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -220,6 +220,33 @@ where
         formatter.print_comma::<W, ENABLE_ANSI_COLORS>(writer)?;
         writer.write_str("\n")?;
 
+        if let Some(secs) = options.idle_timeout_seconds {
+            formatter.write_indent(writer)?;
+            writer.write_str(pfmt!("<r>timeout<d>:<r> ", ENABLE_ANSI_COLORS))?;
+            // Render in the option's JS-facing unit (`number | false`, ms).
+            if secs == 0 {
+                formatter
+                    .print_as::<W, ENABLE_ANSI_COLORS>(
+                        FormatTag::Boolean,
+                        writer,
+                        JSValue::FALSE,
+                        JSType::BooleanObject,
+                    )
+                    .map_err(|_| core::fmt::Error)?;
+            } else {
+                formatter
+                    .print_as::<W, ENABLE_ANSI_COLORS>(
+                        FormatTag::Double,
+                        writer,
+                        JSValue::js_number(secs as f64 * 1000.0),
+                        JSType::NumberObject,
+                    )
+                    .map_err(|_| core::fmt::Error)?;
+            }
+            formatter.print_comma::<W, ENABLE_ANSI_COLORS>(writer)?;
+            writer.write_str("\n")?;
+        }
+
         formatter.write_indent(writer)?;
         writer.write_str(pfmt!("<r>retry<d>:<r> ", ENABLE_ANSI_COLORS))?;
         formatter

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -604,6 +604,7 @@ impl S3BlobStatTask {
             this.cast::<core::ffi::c_void>(),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
+            s3_store.options.idle_timeout_seconds,
         )?;
         Ok(promise)
     }
@@ -631,6 +632,7 @@ impl S3BlobStatTask {
             this.cast::<core::ffi::c_void>(),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
+            s3_store.options.idle_timeout_seconds,
         )?;
         Ok(promise)
     }
@@ -658,6 +660,7 @@ impl S3BlobStatTask {
             this.cast::<core::ffi::c_void>(),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
+            s3_store.options.idle_timeout_seconds,
         )?;
         Ok(promise)
     }

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -404,6 +404,7 @@ impl S3Ext for S3 {
             .cast::<c_void>(),
             proxy,
             aws_options.request_payer,
+            aws_options.options.idle_timeout_seconds,
         )?;
 
         Ok(value)
@@ -509,6 +510,7 @@ impl S3Ext for S3 {
             Wrapper::resolve,
             wrapper.cast::<c_void>(),
             proxy,
+            aws_options.options.idle_timeout_seconds,
         )?;
 
         Ok(value)

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -68,6 +68,7 @@ pub(crate) fn stat(
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
 ) -> JsTerminatedResult<()> {
     s3_simple_request::execute_simple_s3_request(
         this,
@@ -77,6 +78,7 @@ pub(crate) fn stat(
             proxy_url,
             body: b"",
             request_payer,
+            idle_timeout_seconds,
             ..Default::default()
         },
         s3_simple_request::Callback::Stat(callback),
@@ -91,6 +93,7 @@ pub(crate) fn download(
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
 ) -> JsTerminatedResult<()> {
     s3_simple_request::execute_simple_s3_request(
         this,
@@ -100,6 +103,7 @@ pub(crate) fn download(
             proxy_url,
             body: b"",
             request_payer,
+            idle_timeout_seconds,
             ..Default::default()
         },
         s3_simple_request::Callback::Download(callback),
@@ -107,6 +111,7 @@ pub(crate) fn download(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn download_slice(
     this: &S3Credentials,
     path: &[u8],
@@ -116,6 +121,7 @@ pub(crate) fn download_slice(
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
 ) -> JsTerminatedResult<()> {
     let range: Option<Vec<u8>> = 'brk: {
         if let Some(size_) = size {
@@ -144,6 +150,7 @@ pub(crate) fn download_slice(
             body: b"",
             range: range.map(Vec::into_boxed_slice),
             request_payer,
+            idle_timeout_seconds,
             ..Default::default()
         },
         s3_simple_request::Callback::Download(callback),
@@ -158,6 +165,7 @@ pub(crate) fn delete(
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
 ) -> JsTerminatedResult<()> {
     s3_simple_request::execute_simple_s3_request(
         this,
@@ -167,6 +175,7 @@ pub(crate) fn delete(
             proxy_url,
             body: b"",
             request_payer,
+            idle_timeout_seconds,
             ..Default::default()
         },
         s3_simple_request::Callback::Delete(callback),
@@ -184,6 +193,7 @@ pub(crate) fn list_objects(
     callback: fn(S3ListObjectsResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
 ) -> JsTerminatedResult<()> {
     let mut search_params: Vec<u8> = Vec::<u8>::default();
 
@@ -362,11 +372,17 @@ pub(crate) fn list_objects(
             S3HttpSimpleTask::http_callback,
         ),
         bun_http::FetchRedirect::Follow,
-        bun_http::async_http::Options {
-            http_proxy,
-            verbose: Some(vm.get_verbose_fetch()),
-            reject_unauthorized: Some(vm.get_tls_reject_unauthorized()),
-            ..Default::default()
+        {
+            let (disable_timeout, idle_timeout_seconds) =
+                s3_simple_request::http_timeout_options(idle_timeout_seconds);
+            bun_http::async_http::Options {
+                http_proxy,
+                verbose: Some(vm.get_verbose_fetch()),
+                reject_unauthorized: Some(vm.get_tls_reject_unauthorized()),
+                disable_timeout,
+                idle_timeout_seconds,
+                ..Default::default()
+            }
         },
     ));
 
@@ -379,6 +395,7 @@ pub(crate) fn list_objects(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn upload(
     this: &S3Credentials,
     path: &[u8],
@@ -390,6 +407,7 @@ pub fn upload(
     proxy_url: Option<&[u8]>,
     storage_class: Option<StorageClass>,
     request_payer: bool,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
     callback: fn(S3UploadResult, *mut c_void) -> JsTerminatedResult<()>,
     callback_context: *mut c_void,
 ) -> JsTerminatedResult<()> {
@@ -406,6 +424,7 @@ pub fn upload(
             acl,
             storage_class,
             request_payer,
+            idle_timeout_seconds,
             ..Default::default()
         },
         s3_simple_request::Callback::Upload(callback),
@@ -918,6 +937,7 @@ pub fn upload_stream(
 }
 
 /// download a file from s3 chunk by chunk aka streaming (used on readableStream)
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn download_stream(
     this: &S3Credentials,
     path: &[u8],
@@ -925,6 +945,7 @@ pub(crate) fn download_stream(
     size: Option<usize>,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
     callback: fn(
         chunk: &MutableString,
         has_more: bool,
@@ -1079,12 +1100,18 @@ pub(crate) fn download_stream(
             S3HttpDownloadStreamingTask::http_callback,
         ),
         bun_http::FetchRedirect::Follow,
-        bun_http::async_http::Options {
-            http_proxy,
-            verbose: Some(verbose),
-            signals: Some(task.signals),
-            reject_unauthorized: Some(reject_unauthorized),
-            ..Default::default()
+        {
+            let (disable_timeout, idle_timeout_seconds) =
+                s3_simple_request::http_timeout_options(idle_timeout_seconds);
+            bun_http::async_http::Options {
+                http_proxy,
+                verbose: Some(verbose),
+                signals: Some(task.signals),
+                reject_unauthorized: Some(reject_unauthorized),
+                disable_timeout,
+                idle_timeout_seconds,
+                ..Default::default()
+            }
         },
     ));
     // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
@@ -1108,6 +1135,7 @@ pub fn readable_stream(
     size: Option<usize>,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
     struct S3DownloadStreamWrapper {
@@ -1279,6 +1307,7 @@ pub fn readable_stream(
         size,
         proxy_url,
         request_payer,
+        idle_timeout_seconds,
         S3DownloadStreamWrapper::opaque_callback,
         wrapper.cast::<c_void>(),
     );

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -233,6 +233,31 @@ pub(crate) fn get_credentials_with_options(
                     new_credentials.options.retry = retry as u8;
                 }
             }
+
+            // timeout: number (ms) | false — matches fetch()'s `timeout` option.
+            if let Some(timeout_value) = opts.get(global_object, "timeout")? {
+                if timeout_value.is_boolean() {
+                    if !timeout_value.as_boolean() {
+                        new_credentials.options.idle_timeout_seconds = Some(0);
+                    }
+                } else if timeout_value.is_number() {
+                    let ms = timeout_value.as_number();
+                    new_credentials.options.idle_timeout_seconds =
+                        Some(if ms.is_finite() && ms > 0.0 {
+                            (ms / 1000.0).ceil().min(core::ffi::c_uint::MAX as f64)
+                                as core::ffi::c_uint
+                        } else {
+                            0
+                        });
+                } else if !timeout_value.is_empty_or_undefined_or_null() {
+                    return Err(global_object.throw_invalid_argument_type_value(
+                        b"timeout",
+                        b"number or boolean",
+                        timeout_value,
+                    ));
+                }
+            }
+
             if let Some(acl) =
                 opts.get_optional_enum_from_map(global_object, "acl", &ACL::MAP, ACL_ONE_OF)?
             {

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -234,7 +234,9 @@ pub(crate) fn get_credentials_with_options(
                 }
             }
 
-            // timeout: number (ms) | false — matches fetch()'s `timeout` option.
+            // timeout: number (ms) | false — same semantics as fetch()'s `timeout`
+            // option: `0`/`false`/`Infinity`/`NaN` disable the idle timer; finite
+            // negatives fall through to the inherited default.
             if let Some(timeout_value) = opts.get(global_object, "timeout")? {
                 if timeout_value.is_boolean() {
                     if !timeout_value.as_boolean() {
@@ -242,13 +244,14 @@ pub(crate) fn get_credentials_with_options(
                     }
                 } else if timeout_value.is_number() {
                     let ms = timeout_value.as_number();
-                    new_credentials.options.idle_timeout_seconds =
-                        Some(if ms.is_finite() && ms > 0.0 {
+                    if ms.is_finite() && ms > 0.0 {
+                        new_credentials.options.idle_timeout_seconds = Some(
                             (ms / 1000.0).ceil().min(core::ffi::c_uint::MAX as f64)
-                                as core::ffi::c_uint
-                        } else {
-                            0
-                        });
+                                as core::ffi::c_uint,
+                        );
+                    } else if !ms.is_finite() || timeout_value.to_int32() == 0 {
+                        new_credentials.options.idle_timeout_seconds = Some(0);
+                    }
                 } else if !timeout_value.is_empty_or_undefined_or_null() {
                     return Err(global_object.throw_invalid_argument_type_value(
                         b"timeout",

--- a/src/runtime/webcore/s3/credentials_jsc.rs
+++ b/src/runtime/webcore/s3/credentials_jsc.rs
@@ -245,10 +245,9 @@ pub(crate) fn get_credentials_with_options(
                 } else if timeout_value.is_number() {
                     let ms = timeout_value.as_number();
                     if ms.is_finite() && ms > 0.0 {
-                        new_credentials.options.idle_timeout_seconds = Some(
-                            (ms / 1000.0).ceil().min(core::ffi::c_uint::MAX as f64)
-                                as core::ffi::c_uint,
-                        );
+                        new_credentials.options.idle_timeout_seconds =
+                            Some((ms / 1000.0).ceil().min(core::ffi::c_uint::MAX as f64)
+                                as core::ffi::c_uint);
                     } else if !ms.is_finite() || timeout_value.to_int32() == 0 {
                         new_credentials.options.idle_timeout_seconds = Some(0);
                     }

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -361,6 +361,7 @@ impl UploadPart {
                 body: self.data(),
                 search_params: Some(search_params),
                 request_payer: ctx.request_payer,
+                idle_timeout_seconds: ctx.options.idle_timeout_seconds,
                 ..Default::default()
             },
             s3_simple_request::S3Callback::Part(Self::on_part_response),
@@ -448,6 +449,7 @@ impl MultiPartUpload {
                             acl: this.acl,
                             storage_class: this.storage_class,
                             request_payer: this.request_payer,
+                            idle_timeout_seconds: this.options.idle_timeout_seconds,
                             ..Default::default()
                         },
                         s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
@@ -830,6 +832,7 @@ impl MultiPartUpload {
                 body: &self.multipart_upload_list,
                 search_params: Some(search_params),
                 request_payer: self.request_payer,
+                idle_timeout_seconds: self.options.idle_timeout_seconds,
                 ..Default::default()
             },
             s3_simple_request::S3Callback::Commit(Self::on_commit_multi_part_request),
@@ -861,6 +864,7 @@ impl MultiPartUpload {
                 body: b"",
                 search_params: Some(search_params),
                 request_payer: self.request_payer,
+                idle_timeout_seconds: self.options.idle_timeout_seconds,
                 ..Default::default()
             },
             s3_simple_request::S3Callback::Upload(Self::on_rollback_multi_part_request),
@@ -897,6 +901,7 @@ impl MultiPartUpload {
                     acl: self.acl,
                     storage_class: self.storage_class,
                     request_payer: self.request_payer,
+                    idle_timeout_seconds: self.options.idle_timeout_seconds,
                     ..Default::default()
                 },
                 s3_simple_request::S3Callback::Download(Self::start_multi_part_request_result),
@@ -1039,6 +1044,7 @@ impl MultiPartUpload {
                     acl: self.acl,
                     storage_class: self.storage_class,
                     request_payer: self.request_payer,
+                    idle_timeout_seconds: self.options.idle_timeout_seconds,
                     ..Default::default()
                 },
                 s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -549,6 +549,8 @@ pub struct S3SimpleRequestOptions<'a> {
     pub acl: Option<ACL>,
     pub storage_class: Option<StorageClass>,
     pub request_payer: bool,
+    /// `None` = global default; `Some(0)` = disable idle timer; `Some(n)` = n seconds.
+    pub idle_timeout_seconds: Option<core::ffi::c_uint>,
 }
 
 impl<'a> Default for S3SimpleRequestOptions<'a> {
@@ -566,7 +568,22 @@ impl<'a> Default for S3SimpleRequestOptions<'a> {
             acl: None,
             storage_class: None,
             request_payer: false,
+            idle_timeout_seconds: None,
         }
+    }
+}
+
+/// Translate the `S3Options.timeout`-style field (`None` = global default,
+/// `Some(0)` = disable, `Some(n)` = n seconds) into the pair of
+/// `bun_http::async_http::Options` fields.
+#[inline]
+pub(crate) fn http_timeout_options(
+    idle_timeout_seconds: Option<core::ffi::c_uint>,
+) -> (Option<bool>, Option<core::ffi::c_uint>) {
+    match idle_timeout_seconds {
+        None => (None, None),
+        Some(0) => (Some(true), None),
+        Some(s) => (None, Some(s)),
     }
 }
 
@@ -679,6 +696,7 @@ pub(crate) fn execute_simple_s3_request(
     let vm = VirtualMachine::get();
     let verbose = vm.as_mut().get_verbose_fetch();
     let reject_unauthorized = vm.get_tls_reject_unauthorized();
+    let (disable_timeout, idle_timeout_seconds) = http_timeout_options(options.idle_timeout_seconds);
     task.http.write(AsyncHTTP::init(
         options.method,
         url,
@@ -697,6 +715,8 @@ pub(crate) fn execute_simple_s3_request(
             http_proxy,
             verbose: Some(verbose),
             reject_unauthorized: Some(reject_unauthorized),
+            disable_timeout,
+            idle_timeout_seconds,
             ..Default::default()
         },
     ));

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -696,7 +696,8 @@ pub(crate) fn execute_simple_s3_request(
     let vm = VirtualMachine::get();
     let verbose = vm.as_mut().get_verbose_fetch();
     let reject_unauthorized = vm.get_tls_reject_unauthorized();
-    let (disable_timeout, idle_timeout_seconds) = http_timeout_options(options.idle_timeout_seconds);
+    let (disable_timeout, idle_timeout_seconds) =
+        http_timeout_options(options.idle_timeout_seconds);
     task.http.write(AsyncHTTP::init(
         options.method,
         url,

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -60,6 +60,10 @@ pub struct MultiPartUploadOptions {
     pub part_size: u64,
     /// default is 3, max 255
     pub retry: u8,
+    /// Per-request idle timeout override for the underlying HTTP socket, in
+    /// seconds. `None` uses the global default (5 min, `BUN_CONFIG_HTTP_IDLE_TIMEOUT`);
+    /// `Some(0)` disables the idle timer entirely.
+    pub idle_timeout_seconds: Option<core::ffi::c_uint>,
 }
 
 impl MultiPartUploadOptions {
@@ -78,6 +82,7 @@ impl Default for MultiPartUploadOptions {
             queue_size: 5,
             part_size: Self::DEFAULT_PART_SIZE as u64,
             retry: 3,
+            idle_timeout_seconds: None,
         }
     }
 }

--- a/test/js/bun/s3/s3-timeout.test.ts
+++ b/test/js/bun/s3/s3-timeout.test.ts
@@ -103,11 +103,7 @@ async function run(op: Op) {
     env,
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const result = JSON.parse(stdout.trim());
   expect(exitCode).toBe(0);

--- a/test/js/bun/s3/s3-timeout.test.ts
+++ b/test/js/bun/s3/s3-timeout.test.ts
@@ -110,10 +110,14 @@ async function run(op: Op) {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const result = JSON.parse(stdout.trim());
-  expect(exitCode).toBe(0);
-  return result;
+  try {
+    const result = JSON.parse(stdout.trim());
+    expect(exitCode).toBe(0);
+    return result;
+  } catch (e) {
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "<valid JSON>", stderr: "", exitCode: 0 });
+    throw e;
+  }
 }
 
 // uSockets sweeps short socket timeouts on a ~4s tick, so a 1s idle timeout

--- a/test/js/bun/s3/s3-timeout.test.ts
+++ b/test/js/bun/s3/s3-timeout.test.ts
@@ -141,4 +141,11 @@ describe("S3Options.timeout", () => {
     expect(result.ok).toBe(false);
     expect(result.code).toBe("ERR_INVALID_ARG_TYPE");
   });
+
+  test("Bun.inspect shows a configured timeout", () => {
+    const base = { accessKeyId: "a", secretAccessKey: "b", bucket: "c" };
+    expect(Bun.inspect(new Bun.S3Client({ ...base, timeout: 5000 }))).toContain("timeout: 5000");
+    expect(Bun.inspect(new Bun.S3Client({ ...base, timeout: false }))).toContain("timeout: false");
+    expect(Bun.inspect(new Bun.S3Client(base))).not.toContain("timeout:");
+  });
 });

--- a/test/js/bun/s3/s3-timeout.test.ts
+++ b/test/js/bun/s3/s3-timeout.test.ts
@@ -106,10 +106,9 @@ async function run(op: Op) {
   }
 }
 
-// uSockets sweeps short socket timeouts on a ~4s tick, so a 1s idle timeout
-// fires anywhere up to ~4s after the last byte. Add subprocess startup under
-// a debug + ASAN build and a single case sits around 5-6s; this is the rare
-// outlier where the default 5s budget is too tight.
+// uSockets sweeps short socket timeouts on a ~4s tick, so a 1s idle timeout can fire up
+// to ~4s late; with debug+ASAN subprocess startup a case runs ~5-6s, the rare outlier
+// where the default 5s budget is too tight.
 const perTestTimeoutMs = 15_000;
 
 describe("S3Options.timeout", () => {

--- a/test/js/bun/s3/s3-timeout.test.ts
+++ b/test/js/bun/s3/s3-timeout.test.ts
@@ -18,8 +18,6 @@ type Op =
   | "stream"
   | "client-text"
   | "override-text"
-  | "writer"
-  | "writer-multipart"
   | "type-error";
 
 function fixture(op: Op) {
@@ -64,18 +62,6 @@ const calls = {
   },
   "client-text": () => s3short.file("k").text(),
   "override-text": () => s3off.file("k", { timeout: 500 }).text(),
-  // writer() under partSize: single-file PUT path inside MultiPartUpload
-  writer: async () => {
-    const w = s3.file("k", { timeout: 500, retry: 0 }).writer();
-    w.write("hello");
-    await w.end();
-  },
-  // writer() at partSize: CreateMultipartUpload (?uploads=) request path
-  "writer-multipart": async () => {
-    const w = s3.file("k", { timeout: 500, retry: 0 }).writer({ partSize: 5 * 1024 * 1024 });
-    w.write(Buffer.alloc(5 * 1024 * 1024, "x"));
-    await w.end();
-  },
   "type-error": () => s3.file("k", { timeout: "soon" }).text(),
 };
 
@@ -140,8 +126,6 @@ describe("S3Options.timeout", () => {
     "stream",
     "client-text",
     "override-text",
-    "writer",
-    "writer-multipart",
   ] as const)(
     "%s rejects with Timeout against a stalled endpoint",
     async op => {

--- a/test/js/bun/s3/s3-timeout.test.ts
+++ b/test/js/bun/s3/s3-timeout.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// The S3 client had no way to bound a request against a wedged endpoint other
+// than the global 5-minute idle timeout. These tests spawn a server that accepts
+// the TCP connection, reads the request, writes a partial response and then goes
+// silent, and verify `{ timeout: N }` rejects the promise instead of hanging.
+
+type Op =
+  | "text"
+  | "slice"
+  | "bytes"
+  | "exists"
+  | "stat"
+  | "size"
+  | "delete"
+  | "write"
+  | "list"
+  | "stream"
+  | "client-text"
+  | "override-text"
+  | "writer"
+  | "type-error";
+
+function fixture(op: Op) {
+  return `
+import net from "node:net";
+
+let connections = 0;
+// Accept the connection and swallow the request without ever responding.
+const server = net.createServer(socket => {
+  connections++;
+  socket.on("error", () => {});
+  socket.on("data", () => {});
+});
+await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+const port = server.address().port;
+
+const base = {
+  accessKeyId: "key",
+  secretAccessKey: "secret",
+  bucket: "bucket",
+  endpoint: "http://127.0.0.1:" + port,
+};
+const s3 = new Bun.S3Client(base);
+const s3short = new Bun.S3Client({ ...base, timeout: 500 });
+// client-level timeout disabled; per-call override should still apply.
+const s3off = new Bun.S3Client({ ...base, timeout: false });
+
+const calls = {
+  text: () => s3.file("k", { timeout: 500 }).text(),
+  slice: () => s3.file("k", { timeout: 500 }).slice(1, 4).text(),
+  bytes: () => s3.file("k", { timeout: 500 }).bytes(),
+  exists: () => s3.exists("k", { timeout: 500 }),
+  stat: () => s3.stat("k", { timeout: 500 }),
+  size: () => s3.size("k", { timeout: 500 }),
+  delete: () => s3.delete("k", { timeout: 500 }),
+  write: () => s3.write("k", "hello", { timeout: 500, retry: 0 }),
+  list: () => s3.list({}, { timeout: 500 }),
+  stream: async () => {
+    const reader = s3.file("k", { timeout: 500 }).stream().getReader();
+    try { while (!(await reader.read()).done) {} }
+    finally { reader.releaseLock(); }
+  },
+  "client-text": () => s3short.file("k").text(),
+  "override-text": () => s3off.file("k", { timeout: 500 }).text(),
+  // multipart path via writer(): retry: 0 so a single timed-out PUT surfaces
+  writer: async () => {
+    const w = s3.file("k", { timeout: 500, retry: 0 }).writer();
+    w.write("hello");
+    await w.end();
+  },
+  "type-error": () => s3.file("k", { timeout: "soon" }).text(),
+};
+
+const start = Date.now();
+try {
+  const value = await calls[${JSON.stringify(op)}]();
+  console.log(JSON.stringify({ ok: true, value: String(value), connections }));
+} catch (e) {
+  console.log(JSON.stringify({
+    ok: false,
+    code: e?.code,
+    name: e?.name,
+    message: String(e?.message ?? e),
+    elapsed: Date.now() - start,
+    connections,
+  }));
+}
+process.exit(0);
+`;
+}
+
+async function run(op: Op) {
+  const env = { ...bunEnv } as Record<string, string>;
+  // S3 currently reads HTTP_PROXY unconditionally; keep the request local.
+  delete env.HTTP_PROXY;
+  delete env.HTTPS_PROXY;
+  delete env.http_proxy;
+  delete env.https_proxy;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture(op)],
+    env,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(exitCode).toBe(0);
+  return result;
+}
+
+// uSockets sweeps short socket timeouts on a ~4s tick, so a 1s idle timeout
+// fires anywhere up to ~4s after the last byte. Add subprocess startup under
+// a debug + ASAN build and a single case sits around 5-6s; this is the rare
+// outlier where the default 5s budget is too tight.
+const perTestTimeoutMs = 15_000;
+
+describe("S3Options.timeout", () => {
+  test.concurrent.each([
+    "text",
+    "slice",
+    "bytes",
+    "exists",
+    "stat",
+    "size",
+    "delete",
+    "write",
+    "list",
+    "stream",
+    "client-text",
+    "override-text",
+    "writer",
+  ] as const)(
+    "%s rejects with Timeout against a stalled endpoint",
+    async op => {
+      const result = await run(op);
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("Timeout");
+      expect(result.connections).toBeGreaterThanOrEqual(1);
+    },
+    perTestTimeoutMs,
+  );
+
+  test.concurrent("non-numeric timeout throws ERR_INVALID_ARG_TYPE", async () => {
+    const result = await run("type-error");
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("ERR_INVALID_ARG_TYPE");
+  });
+});

--- a/test/js/bun/s3/s3-timeout.test.ts
+++ b/test/js/bun/s3/s3-timeout.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// The S3 client had no way to bound a request against a wedged endpoint other
-// than the global 5-minute idle timeout. These tests spawn a server that accepts
-// the TCP connection, reads the request, writes a partial response and then goes
-// silent, and verify `{ timeout: N }` rejects the promise instead of hanging.
+// The S3 client had no per-request way to bound a call against an unresponsive
+// endpoint. These tests spawn a server that accepts the connection, consumes the
+// request and never responds, and verify `{ timeout: N }` rejects instead of hanging.
 
 type Op =
   | "text"
@@ -20,6 +19,7 @@ type Op =
   | "client-text"
   | "override-text"
   | "writer"
+  | "writer-multipart"
   | "type-error";
 
 function fixture(op: Op) {
@@ -64,10 +64,16 @@ const calls = {
   },
   "client-text": () => s3short.file("k").text(),
   "override-text": () => s3off.file("k", { timeout: 500 }).text(),
-  // multipart path via writer(): retry: 0 so a single timed-out PUT surfaces
+  // writer() under partSize: single-file PUT path inside MultiPartUpload
   writer: async () => {
     const w = s3.file("k", { timeout: 500, retry: 0 }).writer();
     w.write("hello");
+    await w.end();
+  },
+  // writer() at partSize: CreateMultipartUpload (?uploads=) request path
+  "writer-multipart": async () => {
+    const w = s3.file("k", { timeout: 500, retry: 0 }).writer({ partSize: 5 * 1024 * 1024 });
+    w.write(Buffer.alloc(5 * 1024 * 1024, "x"));
     await w.end();
   },
   "type-error": () => s3.file("k", { timeout: "soon" }).text(),
@@ -131,6 +137,7 @@ describe("S3Options.timeout", () => {
     "client-text",
     "override-text",
     "writer",
+    "writer-multipart",
   ] as const)(
     "%s rejects with Timeout against a stalled endpoint",
     async op => {


### PR DESCRIPTION
## What

Adds `timeout` to `S3Options`, with the same semantics as `fetch()`'s `timeout` option:

- A number (milliseconds) sets a socket **idle** timeout for the request. If no bytes move in either direction for this long the promise rejects with an `S3Error` whose `code` is `"Timeout"`.
- `false` (or `0`) disables the idle timer for the request.
- Unset keeps the current behavior (the global default, 5 minutes, overridable via `BUN_CONFIG_HTTP_IDLE_TIMEOUT`).

The option can be set on `new Bun.S3Client({ timeout })` as a default for every operation and overridden per call on `file() / exists() / stat() / size() / write() / delete() / list() / writer()`. For multipart uploads the timeout applies to each individual part, create, and commit request.

## Repro

```ts
import net from "node:net";
const srv = net.createServer(s => { s.on("error", () => {}); s.on("data", () => {}); });
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const s3 = new Bun.S3Client({
  accessKeyId: "a", secretAccessKey: "b", bucket: "b",
  endpoint: `http://127.0.0.1:${srv.address().port}`,
});
// Before: pends for 5 minutes. After: rejects with code "Timeout" in ~1-4s.
await s3.file("k", { timeout: 500 }).text();
```

## Cause

S3 has three `AsyncHTTP::init` call sites (the shared `execute_simple_s3_request`, plus inline setups in `list_objects` and `download_stream`) and none of them set `idle_timeout_seconds` or `disable_timeout` on `bun_http::async_http::Options`. They all fell through to the global 300s default, and nothing in the S3 option parser read a `timeout` key. `bun_http` already had the fields; they just weren't plumbed from S3.

## Fix

- `MultiPartUploadOptions` (the existing per-call tunables struct alongside `partSize`/`queueSize`/`retry`) gains `idle_timeout_seconds: Option<c_uint>`: `None` = global default, `Some(0)` = disabled, `Some(n)` = n seconds.
- `get_credentials_with_options` parses the `timeout` key (ms -> seconds, same rounding as fetch).
- A new `idle_timeout_seconds` parameter is threaded through `stat`/`download`/`download_slice`/`delete`/`upload`/`list_objects`/`download_stream`/`readable_stream` and every caller, and mapped onto the two `bun_http` fields at each `AsyncHTTP::init`.
- Every `execute_simple_s3_request` call inside `MultiPartUpload` now passes `self.options.idle_timeout_seconds`.
- `s3file.writer()` with no argument now passes the options already stored on the `S3File` instead of `Default::default()`, so `timeout` (and the existing `partSize`/`queueSize`/`retry`/`storageClass`) reach the upload. This overlaps with part of #33502, which fixes the broader option-persistence problem for `acl`/`contentDisposition`/etc.

`AbortSignal` support (aborting an in-flight request rather than bounding its idle time) involves per-task listener lifecycle across multipart and is left for a follow-up.

## Verification

`test/js/bun/s3/s3-timeout.test.ts` spawns a server that accepts the connection and never responds, then checks that each of `text`/`slice`/`bytes`/`exists`/`stat`/`size`/`delete`/`write`/`list`/`stream`/`writer` (plus a client-level default and a per-call override of `timeout: false`) reject with `code: "Timeout"`, and that a non-numeric `timeout` throws `ERR_INVALID_ARG_TYPE`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 13 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-timeout.test.ts"
bun test v1.4.0 (028f0bd88)

test/js/bun/s3/s3-timeout.test.ts:
(fail) S3Options.timeout > text rejects with Timeout against a stalled endpoint [15008.03ms]
  ^ this test timed out after 15000ms.
(fail) S3Options.timeout > slice rejects with Timeout against a stalled endpoint [15009.21ms]
  ^ this test timed out after 15000ms.
(fail) S3Options.timeout > bytes rejects with Timeout against a stalled endpoint [15004.11ms]
  ^ this test timed out after 15000ms.
(fail) S3Options.timeout > exists rejects with Timeout against a stalled endpoint [15013.02ms]
  ^ this test timed out after 15000ms.
(fail) S3Options.timeout > stat rejects with Timeout against a stalled endpoint [15004.12ms]
  ^ this test timed out after 15000ms.
(fail) S3Options.timeout > size rejects with Timeout against a stalled endpoint [15007.80ms]
  ^ this test timed out after 15000ms.
(fail) S3Options.timeout > delete rejects with Timeout against a stalled endpoint [15000.26ms]
  ^ this test timed out after 15000ms.
(fail) S3Options.time
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (06033b9a7)

test/js/bun/s3/s3-timeout.test.ts:
(pass) S3Options.timeout > non-numeric timeout throws ERR_INVALID_ARG_TYPE [22.62ms]
(pass) S3Options.timeout > size rejects with Timeout against a stalled endpoint [4031.74ms]
(pass) S3Options.timeout > slice rejects with Timeout against a stalled endpoint [4035.06ms]
(pass) S3Options.timeout > bytes rejects with Timeout against a stalled endpoint [4035.95ms]
(pass) S3Options.timeout > delete rejects with Timeout against a stalled endpoint [4034.97ms]
(pass) S3Options.timeout > write rejects with Timeout against a stalled endpoint [4029.73ms]
(pass) S3Options.timeout > client-text rejects with Timeout against a stalled endpoint [4027.61ms]
(pass) S3Options.timeout > list rejects with Timeout against a stalled endpoint [4030.79ms]
(pass) S3Options.timeout > override-text rejects with Timeout against a stalled endpoint [4027.76ms]
(pass) S3Options.timeout > stream rejects with Timeout against a stalled endpoint [4029.39ms]
(pass) S3Options.timeout > exists rejects with Timeout against a stalled endpoint [4043.00ms]
(pass) S3Options.timeout > text rejects with Timeout against a stalled endpoint [
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-timeout.test.ts"
bun test v1.4.0 (028f0bd88)

test/js/bun/s3/s3-timeout.test.ts:
(pass) S3Options.timeout > text rejects with Timeout against a stalled endpoint [5162.99ms]
(pass) S3Options.timeout > stat rejects with Timeout against a stalled endpoint [5123.76ms]
(pass) S3Options.timeout > slice rejects with Timeout against a stalled endpoint [5154.63ms]
(pass) S3Options.timeout > bytes rejects with Timeout against a stalled endpoint [5155.97ms]
(pass) S3Options.timeout > exists rejects with Timeout against a stalled endpoint [5394.00ms]
(pass) S3Options.timeout > delete rejects with Timeout against a stalled endpoint [5111.95ms]
(pass) S3Options.timeout > write rejects with Timeout against a stalled endpoint [5108.25ms]
(pass) S3Options.timeout > list rejects with Timeout against a stalled endpoint [5166.67ms]
(pass) S3Options.timeout > size rejects with Timeout against a stalled endpoint [5389.35ms]
(pass) S3Options.timeout > stream rejects with Timeout against a stalled endpoint [5120.62ms]
(pass) S3Options.timeo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 666ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] cc obj/packages/bun-usockets/src/bsd.c.o
[2/136] cc obj/packages/bun-usockets/src/context.c.o
[3/136] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[4/136] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[5/136] cc obj/packages/bun-usockets/src/fault_inject.c.o
[6/136] cc obj/packages/bun-usockets/src/socket.c.o
[7/136] cc obj/packages/bun-usockets/src/udp.c.o
[8/136] cc obj/packages/bun-usockets/src/loop.c.o
[9/136] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[10/136] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[11/136] cc obj/src/jsc/bindings/uv-posix-polyfills.c.o
[12/136] cc obj/packages/bun-usockets/src/quic.c.o
[13/136] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[14/136] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[15/136] cc obj/src/jsc/bindings/uv-posix-stubs.c.o
[16/136] cc obj/vendor/picohttpparser/picohttpparser.c.o
[17/136] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/s3.d.ts                |  40 +++++++-
 src/runtime/server/RequestContext.rs      |   1 +
 src/runtime/webcore/Blob.rs               |  17 +++-
 src/runtime/webcore/ReadableStream.rs     |   1 +
 src/runtime/webcore/S3Client.rs           |  27 ++++++
 src/runtime/webcore/S3File.rs             |   3 +
 src/runtime/webcore/blob/Store.rs         |   2 +
 src/runtime/webcore/s3/client.rs          |  51 +++++++---
 src/runtime/webcore/s3/credentials_jsc.rs |  27 ++++++
 src/runtime/webcore/s3/multipart.rs       |   6 ++
 src/runtime/webcore/s3/simple_request.rs  |  21 +++++
 src/s3_signing/credentials.rs             |   5 +
 test/js/bun/s3/s3-timeout.test.ts         | 151 ++++++++++++++++++++++++++++++
 13 files changed, 335 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
packages/bun-types/s3.d.ts                     5      3      0
src/runtime/server/RequestContext.rs           1      1      0
src/runtime/webcore/Blob.rs                    5      6      0
src/runtime/webcore/ReadableStream.rs          1      1      0
src/runtime/webcore/S3Client.rs                1      1      0
src/runtime/webcore/S3File.rs                  1      3      0
src/runtime/webcore/blob/Store.rs              1      2      0
src/runtime/webcore/s3/client.rs               4      7      0
src/runtime/webcore/s3/credentials_jsc.rs      2      3      0
src/runtime/webcore/s3/multipart.rs            4      6      0
src/runtime/webcore/s3/simple_request.rs       1      3      0
src/s3_signing/credentials.rs                  2      2      0
test/js/bun/s3/s3-timeout.test.ts              5     13      0
```

</details>

<!-- robobun:evidence:end -->