### PR TITLE
test(parallel): deterministic rendezvous + drop node:fs from timing-sensitive fixtures

### DIFF
--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -7,16 +7,17 @@ test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID
   // 1's file before worker 1 has booted (under ASAN, worker startup easily
   // exceeds any fixed sleep, which is why this used to be flaky).
   const print = `console.log("WID="+process.env.JEST_WORKER_ID+" "+process.env.BUN_TEST_WORKER_ID+" pid="+process.pid)`;
-  const fixture = `import {test} from "bun:test"; import {appendFileSync,readFileSync} from "fs";
+  const fixture = `import {test} from "bun:test";
     test("t", async () => {
-      appendFileSync(process.env.GATE, process.pid+"\\n");
-      while (readFileSync(process.env.GATE,"utf8").trimEnd().split("\\n").length < 3) await Bun.sleep(1);
+      await Bun.write(process.env.GATE+"/"+process.pid, "");
+      while ((await Array.fromAsync(new Bun.Glob("*").scan(process.env.GATE))).length < 3) await Bun.sleep(1);
       ${print};
     });`;
   using dir = tempDir("parallel-worker-id", {
     "a.test.js": fixture,
     "b.test.js": fixture,
     "c.test.js": fixture,
+    "gate/.keep": "",
   });
   const gate = String(dir) + "/gate";
   await using proc = Bun.spawn({
@@ -517,10 +518,13 @@ test("--parallel never interleaves console output across files", async () => {
 });
 
 test("--parallel lazily scales workers based on file duration", async () => {
-  // Each test file appends its PID so we can count distinct worker processes.
+  // Each test file prints its PID so we can count distinct worker processes.
+  // (Avoid `import "fs"` here: under debug+ASAN+isolate it re-evaluates the
+  // node:fs module per file and adds ~800ms each, which by itself blows past
+  // the fast-case threshold below.)
   const body = (sleepMs: number) =>
-    `import {test,expect} from "bun:test"; import {appendFileSync} from "fs";
-     test("t", async()=>{ appendFileSync(process.env.PIDS, process.pid+"\\n"); await Bun.sleep(${sleepMs}); expect(1).toBe(1); });`;
+    `import {test,expect} from "bun:test";
+     test("t", async()=>{ console.error("PID="+process.pid); await Bun.sleep(${sleepMs}); expect(1).toBe(1); });`;
   const fixture = (sleepMs: number) => ({
     "a.test.js": body(sleepMs),
     "b.test.js": body(sleepMs),
@@ -528,16 +532,15 @@ test("--parallel lazily scales workers based on file duration", async () => {
     "d.test.js": body(sleepMs),
   });
   const run = async (dir: string, scaleMs: number) => {
-    const pids = dir + "/pids.txt";
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", "--parallel=4"],
-      env: { ...bunEnv, PIDS: pids, BUN_TEST_PARALLEL_SCALE_MS: String(scaleMs) },
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: String(scaleMs) },
       cwd: dir,
       stderr: "pipe",
       stdout: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stderr, exitCode, pids: new Set((await Bun.file(pids).text()).trim().split("\n")) };
+    return { stderr, exitCode, pids: new Set([...stderr.matchAll(/^PID=(\d+)$/gm)].map(m => m[1])) };
   };
 
   // Fast: 4 files × 0ms with a 250ms threshold. Each file (load + run +
@@ -572,19 +575,18 @@ test("--parallel partitions by directory and steals from the end", async () => {
   // exhausts its own chunk. With K=4 each worker's initial chunk is one
   // directory; the assertion is that each directory's first-dispatched file
   // ran on a distinct PID (i.e. files were not round-robined across workers).
-  const body = `import {test,expect} from "bun:test"; import {appendFileSync} from "fs";
+  const body = `import {test,expect} from "bun:test";
     test("t", async () => {
-      appendFileSync(process.env.LOG, JSON.stringify({pid: process.pid, file: import.meta.path}) + "\\n");
+      console.error("ROW="+JSON.stringify({pid: process.pid, file: import.meta.path}));
       await Bun.sleep(150);
       expect(1).toBe(1);
     });`;
   const files: Record<string, string> = {};
   for (const d of ["a", "b", "c", "d"]) for (let i = 0; i < 4; i++) files[`${d}/${d}${i}.test.js`] = body;
   using dir = tempDir("parallel-affinity", files);
-  const log = String(dir) + "/log.ndjson";
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--parallel=4"],
-    env: { ...bunEnv, LOG: log, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
     cwd: String(dir),
     stderr: "pipe",
     stdout: "pipe",
@@ -593,11 +595,10 @@ test("--parallel partitions by directory and steals from the end", async () => {
   expect(stdout).toContain("PARALLEL");
   expect(stderr).toContain("16 pass");
 
+  // ROW= lines are flushed at test_done, so within a PID they appear in
+  // dispatch order; across PIDs they interleave, which the grouping tolerates.
   type Row = { pid: number; file: string };
-  const rows: Row[] = (await Bun.file(log).text())
-    .trim()
-    .split("\n")
-    .map(l => JSON.parse(l));
+  const rows: Row[] = [...stderr.matchAll(/^ROW=(.+)$/gm)].map(m => JSON.parse(m[1]));
   const dirOf = (r: Row) => r.file.replaceAll("\\", "/").split("/").slice(-2, -1)[0]!;
   const byPid = new Map<number, Row[]>();
   for (const r of rows) (byPid.get(r.pid) ?? byPid.set(r.pid, []).get(r.pid)!).push(r);
@@ -616,20 +617,19 @@ test("--parallel work-stealing balances an uneven directory split", async () => 
   // worker 3 owns the three fast files and finishes first. It then steals
   // from the back of the largest a-range. Assertions: all 11 complete, and the
   // PID that ran d/ also ran at least one a/ file (the steal).
-  const slow = `import {test,expect} from "bun:test"; import {appendFileSync} from "fs";
-    test("t", async () => { appendFileSync(process.env.LOG, JSON.stringify({pid: process.pid, file: import.meta.path}) + "\\n"); await Bun.sleep(250); expect(1).toBe(1); });`;
-  const fast = `import {test,expect} from "bun:test"; import {appendFileSync} from "fs";
-    test("t", () => { appendFileSync(process.env.LOG, JSON.stringify({pid: process.pid, file: import.meta.path}) + "\\n"); expect(1).toBe(1); });`;
+  const slow = `import {test,expect} from "bun:test";
+    test("t", async () => { console.error("ROW="+JSON.stringify({pid: process.pid, file: import.meta.path})); await Bun.sleep(250); expect(1).toBe(1); });`;
+  const fast = `import {test,expect} from "bun:test";
+    test("t", () => { console.error("ROW="+JSON.stringify({pid: process.pid, file: import.meta.path})); expect(1).toBe(1); });`;
   const files: Record<string, string> = {};
   for (let i = 0; i < 8; i++) files[`a/a${i}.test.js`] = slow;
   files["b/b0.test.js"] = fast;
   files["c/c0.test.js"] = fast;
   files["d/d0.test.js"] = fast;
   using dir = tempDir("parallel-steal", files);
-  const log = String(dir) + "/log.ndjson";
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--parallel=4"],
-    env: { ...bunEnv, LOG: log, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
     cwd: String(dir),
     stderr: "pipe",
     stdout: "pipe",
@@ -640,10 +640,7 @@ test("--parallel work-stealing balances an uneven directory split", async () => 
   expect(stderr).toContain("0 fail");
 
   type Row = { pid: number; file: string };
-  const rows: Row[] = (await Bun.file(log).text())
-    .trim()
-    .split("\n")
-    .map(l => JSON.parse(l));
+  const rows: Row[] = [...stderr.matchAll(/^ROW=(.+)$/gm)].map(m => JSON.parse(m[1]));
   // The PID that ran b0/c0/d0 (worker 3's chunk) must also appear on at least
   // one a/ file — that's the steal.
   const norm = (s: string) => s.replaceAll("\\", "/");

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -597,6 +597,7 @@ test("--parallel partitions by directory and steals from the end", async () => {
   // dispatch order; across PIDs they interleave, which the grouping tolerates.
   type Row = { pid: number; file: string };
   const rows: Row[] = [...stderr.matchAll(/^ROW=(.+)$/gm)].map(m => JSON.parse(m[1]));
+  expect(rows.length).toBe(16);
   const dirOf = (r: Row) => r.file.replaceAll("\\", "/").split("/").slice(-2, -1)[0]!;
   const byPid = new Map<number, Row[]>();
   for (const r of rows) (byPid.get(r.pid) ?? byPid.set(r.pid, []).get(r.pid)!).push(r);

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -2,17 +2,26 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tls } from "harness";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
-  // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
-  // remaining files; otherwise one fast worker handles all three.
-  const fixture = `import {test} from "bun:test"; test("t", async () => { await Bun.sleep(200); console.log("WID="+process.env.JEST_WORKER_ID+" "+process.env.BUN_TEST_WORKER_ID); });`;
+  // Each file rendezvous-waits on a shared gate file until all three workers
+  // have started one, so worker 0 can't finish early and work-steal worker
+  // 1's file before worker 1 has booted (under ASAN, worker startup easily
+  // exceeds any fixed sleep, which is why this used to be flaky).
+  const print = `console.log("WID="+process.env.JEST_WORKER_ID+" "+process.env.BUN_TEST_WORKER_ID+" pid="+process.pid)`;
+  const fixture = `import {test} from "bun:test"; import {appendFileSync,readFileSync} from "fs";
+    test("t", async () => {
+      appendFileSync(process.env.GATE, process.pid+"\\n");
+      while (readFileSync(process.env.GATE,"utf8").trimEnd().split("\\n").length < 3) await Bun.sleep(1);
+      ${print};
+    });`;
   using dir = tempDir("parallel-worker-id", {
     "a.test.js": fixture,
     "b.test.js": fixture,
     "c.test.js": fixture,
   });
+  const gate = String(dir) + "/gate";
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--parallel=3"],
-    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+    env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0", GATE: gate },
     cwd: String(dir),
     stderr: "pipe",
     stdout: "pipe",
@@ -20,17 +29,21 @@ test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const out = stdout + stderr;
   expect(out).not.toContain("WID=undefined");
-  // 1-indexed; JEST_WORKER_ID and BUN_TEST_WORKER_ID always match.
-  const seen = [...out.matchAll(/WID=(\d+) (\d+)/g)].map(m => {
+  // 1-indexed; JEST_WORKER_ID and BUN_TEST_WORKER_ID always match; each
+  // pid sees exactly one WID (stable per worker process).
+  const seen = [...out.matchAll(/WID=(\d+) (\d+) pid=(\d+)/g)].map(m => {
     expect(m[1]).toBe(m[2]);
-    return m[1];
+    return { wid: m[1], pid: m[3] };
   });
-  expect(seen.sort()).toEqual(["1", "2", "3"]);
+  expect(seen.map(s => s.wid).sort()).toEqual(["1", "2", "3"]);
+  expect(new Set(seen.map(s => s.pid)).size).toBe(3);
   expect(exitCode).toBe(0);
 
   // K<=1 serial-fallback (single file, or --parallel=1) still sets WORKER_ID=1
   // so tests can rely on it whenever --parallel is passed (matches Jest).
-  using single = tempDir("parallel-worker-id-single", { "a.test.js": fixture });
+  using single = tempDir("parallel-worker-id-single", {
+    "a.test.js": `import {test} from "bun:test"; test("t", () => { ${print}; });`,
+  });
   await using p2 = Bun.spawn({
     cmd: [bunExe(), "test", "--parallel=5"],
     env: bunEnv,

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -2,10 +2,9 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tls } from "harness";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
-  // Each file rendezvous-waits on a shared gate file until all three workers
-  // have started one, so worker 0 can't finish early and work-steal worker
-  // 1's file before worker 1 has booted (under ASAN, worker startup easily
-  // exceeds any fixed sleep, which is why this used to be flaky).
+  // Each file rendezvous-waits on a shared gate dir until all three workers
+  // have started one, so worker 0 can't finish and work-steal worker 1's file
+  // before worker 1 boots (ASAN worker startup exceeds any fixed sleep).
   const print = `console.log("WID="+process.env.JEST_WORKER_ID+" "+process.env.BUN_TEST_WORKER_ID+" pid="+process.pid)`;
   const fixture = `import {test} from "bun:test";
     test("t", async () => {
@@ -518,10 +517,9 @@ test("--parallel never interleaves console output across files", async () => {
 });
 
 test("--parallel lazily scales workers based on file duration", async () => {
-  // Each test file prints its PID so we can count distinct worker processes.
-  // (Avoid `import "fs"` here: under debug+ASAN+isolate it re-evaluates the
-  // node:fs module per file and adds ~800ms each, which by itself blows past
-  // the fast-case threshold below.)
+  // Each file prints its PID so we can count distinct workers. Avoid
+  // `import "fs"`: under debug+ASAN+isolate it re-evaluates node:fs per file
+  // (~800ms each), which by itself blows past the fast-case threshold below.
   const body = (sleepMs: number) =>
     `import {test,expect} from "bun:test";
      test("t", async()=>{ console.error("PID="+process.pid); await Bun.sleep(${sleepMs}); expect(1).toBe(1); });`;


### PR DESCRIPTION
## What

`test/cli/test/parallel.test.ts` → `--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID` went red on the debian-13 x64-asan lane (build 77013, plus retried sightings in 76807 and 76821):

```
expect(seen.sort()).toEqual(["1", "2", "3"])
  [
    "1",
-   "2",
+   "1",
    "3",
  ]
```

Under a local `bun bd` (debug+ASAN) build the whole file additionally fails `lazily scales workers` / `partitions by directory` / `work-stealing balances`, which pass on the CI asan lane but sit right at (or past) the 5s default there.

## Cause

**Not an id-assignment bug.** Each worker *slot* still gets its own `JEST_WORKER_ID` (slot `i` → `envps[i]` → id `i+1`; `Worker::start()` indexes by `self.idx`). The duplicate `1` is work-stealing: the fixture does `await Bun.sleep(200)` so worker 0 stays busy while workers 1/2 boot, but under debug+ASAN worker *startup* now exceeds 200ms, so worker 0 finishes `a.test.js`, `steal_back_half` takes the single file out of worker 1's range before worker 1 sends `.ready`, and both `a` and `b` run in the same process (`assign_work` explicitly allows stealing from not-yet-spawned slots; this is intended).

Reproduces 5/5 on a local `bun bd` build:

```
a.test.js:  WID=1 pid=20211
b.test.js:  WID=1 pid=20211
c.test.js:  WID=3 pid=20216
```

For the other three, the fixtures `import {appendFileSync} from "fs"` purely to record a pid marker. Under debug+ASAN `--isolate`, evaluating the full `node:fs` module costs ~500-800ms *per file* (measured: `bun-debug -e 'import {appendFileSync} from "fs"'` → ~1.18s vs ~0.40s baseline). That overhead alone exceeds the 250ms fast-case scale-up threshold in `lazily scales`, pushes the 16-file `partitions by directory` run to ~4.9s against the default 5s timeout, and erases the slow/fast distinction `work-stealing balances` depends on.

Both tipped after #34782 (debian-13 build host, ThinLTO, WebKit bump, new rust toolchain): the race has existed since #29413, the margin moved.

## Fix

- **JEST_WORKER_ID**: replace the fixed sleep with a gate-directory rendezvous: each fixture `Bun.write($GATE/<pid>, "")` then polls `Bun.Glob("*").scan($GATE)` until three entries appear, so no worker can finish (and steal) until all three slots have a file in flight. `Bun.Glob("*")` skips the `.keep` dotfile that pre-creates the directory. Assertions unchanged (sorted `[1,2,3]`, `JEST_WORKER_ID == BUN_TEST_WORKER_ID`), plus a check that three distinct pids ran. The K≤1 serial-fallback half now uses a non-gated fixture.
- **lazily scales / partitions / work-stealing**: drop the `import "fs"` from the fixtures and write the pid / `{pid,file}` marker with `console.error(...)` instead; parse it out of the coordinator-captured stderr with `/^PID=/m` / `/^ROW=/m`. The coordinator flushes each worker's captured bytes at `test_done`, so within a pid the ROW lines appear in dispatch order (which is all the `byPid[pid][0]` assertions need). No `appendFileSync` side-file, no per-file `node:fs` evaluation.

No assertions weakened; no `src/**` changes.

## Verification

```sh
bun bd test test/cli/test/parallel.test.ts
# before: 24 pass / 3 fail, ~56s (+ the JEST_WORKER_ID failure)
# after:  27 pass /  0 fail, ~49s  (4 full-file runs + 10 filtered runs, all green)
USE_SYSTEM_BUN=1 bun test test/cli/test/parallel.test.ts
# 27 pass / 0 fail, ~6s
```

`partitions by directory` drops from ~4.97s to ~1.98s under `bun bd`; `work-stealing balances` from ~4.35s to ~1.78s.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/test/parallel.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/test/parallel.test.ts
bun test v1.4.0 (10dce7554)

test/cli/test/parallel.test.ts:
(pass) --parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID [1733.78ms]
(pass) --parallel runs files across workers and aggregates totals [1156.19ms]
(pass) --parallel surfaces failures and exits non-zero [1133.59ms]
(pass) --parallel marks a file whose worker exits mid-run as failed (no retry) [1286.91ms]
(pass) --parallel without N is accepted and runs all files [1151.27ms]
(pass) --parallel forwards -t to workers [1143.61ms]
(pass) --parallel --bail stops dispatching new files after threshold [1129.74ms]
(pass) --parallel prints per-test lines under their file's header [1133.16ms]
(pass) --parallel streams test results in realtime, not buffered per-file [1799.30ms]
(pass) --parallel aggregates failure summary across workers [1403.83ms]
(pass) --parallel --reporter=junit produces a merged report covering all files [1114.75ms]
(pass) --parallel --coverage merges LCOV across workers [1141.36ms]
(pass) --parallel --coverage prints merged text table [1140.70ms]
(pass) --parallel --coverage enforces coverageThreshold with lcov-only reporter [2256.77ms]
(pass) --parallel --dots prints one status character per test [1124.95ms]
(pass) --parallel never interleaves console output across files [2963.70ms]
(pass) --parallel lazily scales workers based on file duration [2484.66ms]
(pass) --parallel partitions by directory and steals from the end [1973.89ms]
(pass) --parallel work-stealing balances an uneven directory split [1825.26ms]
(pass) --parallel writes new snapshots from every worker [2295.81ms]
(pass) --parallel: a test producing a >64MB result line is truncated, not treated as a crash [2501.61ms]
(pass) --parallel: a test writing garbage to fd 3 does not hang the coordinator [1641.36ms]
(pass) --parallel --randomize without --seed is reproducible via the printed seed
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/test/parallel.test.ts | 75 +++++++++++++++++++++++-------------------
 1 file changed, 42 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
test/cli/test/parallel.test.ts      7      9      0
```

</details>

<!-- robobun:evidence:end -->