### PR TITLE
inspector: print the bound address in the --inspect banner

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -169,6 +169,9 @@ function unescapeUnixSocketUrl(href: string) {
 
 class Debugger {
   #url?: URL;
+  // Hostname the user passed to --inspect; the Host-header allowlist must accept this
+  // name even after #url!.hostname is rewritten to the numeric bound address.
+  #requestedHostname?: string;
   #createBackend: (refEventLoop: boolean, receive: (...messages: string[]) => void) => Backend;
 
   constructor(
@@ -233,6 +236,7 @@ class Debugger {
 
   #listen(): void {
     const { protocol, hostname, port, pathname } = this.#url!;
+    this.#requestedHostname = hostname;
 
     if (protocol === "ws:" || protocol === "wss:" || protocol === "ws+tcp:") {
       const server = Bun.serve({
@@ -247,8 +251,9 @@ class Debugger {
       // binds 127.0.0.1:port. server.hostname echoes the requested name; print the bound address instead
       // so the banner URL routes to this process rather than whoever holds the other loopback family.
       const addr = (server as { address?: { address?: string; family?: string } }).address;
-      if (addr && typeof addr === "object" && typeof addr.address === "string" && addr.address) {
-        this.#url!.hostname = addr.family === "IPv6" ? `[${addr.address}]` : addr.address;
+      const { address: boundIp, family } = typeof addr === "object" && addr ? addr : {};
+      if (typeof boundIp === "string" && boundIp) {
+        this.#url!.hostname = family === "IPv6" ? `[${boundIp}]` : boundIp;
       } else {
         this.#url!.hostname = server.hostname;
       }
@@ -347,7 +352,7 @@ class Debugger {
     }
 
     const isUnix = this.#url!.protocol.includes("unix");
-    if (!isUnix && !isHostAllowed(headers.get("Host"), this.#url!.hostname)) {
+    if (!isUnix && !isHostAllowed(headers.get("Host"), this.#requestedHostname ?? this.#url!.hostname)) {
       return new Response(null, {
         status: 400, // Bad Request
       });

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -243,7 +243,15 @@ class Debugger {
         websocket: this.#websocket,
       });
 
-      this.#url!.hostname = server.hostname;
+      // Bun.serve walks every getaddrinfo result for `hostname`, so if [::1]:port is held it silently
+      // binds 127.0.0.1:port. server.hostname echoes the requested name; print the bound address instead
+      // so the banner URL routes to this process rather than whoever holds the other loopback family.
+      const addr = (server as { address?: { address?: string; family?: string } }).address;
+      if (addr && typeof addr === "object" && typeof addr.address === "string" && addr.address) {
+        this.#url!.hostname = addr.family === "IPv6" ? `[${addr.address}]` : addr.address;
+      } else {
+        this.#url!.hostname = server.hostname;
+      }
       this.#url!.port = `${server.port}`;
       return;
     }

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -2,7 +2,7 @@ import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
 import { bunEnv, bunExe, isPosix, randomPort, tempDirWithFiles } from "harness";
-import { createServer as createTcpServer, Socket } from "node:net";
+import { Socket, createServer as createTcpServer } from "node:net";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -304,11 +304,6 @@ describe("websocket", () => {
   });
 });
 
-// Bun.serve walks every getaddrinfo result for "localhost" (v6 then v4), so a second
-// --inspect on a port whose [::1] side is already held silently binds 127.0.0.1
-// instead. The banner must name the address actually bound, otherwise clients that
-// resolve localhost -> ::1 reach the other listener and the printed URL is dead.
-// https://github.com/oven-sh/bun/issues/2778
 test("bun --inspect banner names the bound address when [::1]:port is held by another listener", async () => {
   const foreign = createTcpServer((socket: Socket) => socket.destroy());
   const port: number = await new Promise((resolve, reject) => {

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -351,8 +351,10 @@ test("bun --inspect banner names the bound address when [::1]:port is held by an
       ws.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
     });
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
-    const reply = await new Promise<any>(resolve => {
+    const reply = await new Promise<any>((resolve, reject) => {
       ws.addEventListener("message", ({ data }) => resolve(JSON.parse(String(data))));
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+      ws.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
     });
     expect(reply).toMatchObject({ id: 1, result: { result: { type: "number", value: 2 } } });
     ws.close();

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -2,6 +2,7 @@ import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
 import { bunEnv, bunExe, isPosix, randomPort, tempDirWithFiles } from "harness";
+import { createServer as createTcpServer, Socket } from "node:net";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -10,6 +11,9 @@ import { SocketFramer } from "./socket-framer";
 let inspectee: Subprocess;
 const anyPort = expect.stringMatching(/^\d+$/);
 const anyPathname = expect.stringMatching(/^\/[a-z0-9-]+$/);
+// The inspector now prints the address it actually bound (not the requested
+// hostname), so "localhost" surfaces as whichever loopback family bound first.
+const localhostBoundIp = expect.stringMatching(/^(\[::1\]|127\.0\.0\.1)$/);
 
 /**
  * Get a function that creates a random `.sock` file in the specified temporary directory.
@@ -23,7 +27,7 @@ describe("websocket", () => {
       args: ["--inspect"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: anyPathname,
       },
@@ -32,7 +36,7 @@ describe("websocket", () => {
       args: ["--inspect=0"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: anyPathname,
       },
@@ -41,7 +45,7 @@ describe("websocket", () => {
       args: [`--inspect=${randomPort()}`],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: anyPathname,
       },
@@ -50,7 +54,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: anyPathname,
       },
@@ -59,7 +63,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/",
       },
@@ -68,7 +72,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost:0"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: anyPathname,
       },
@@ -77,7 +81,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost:0/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: "/",
       },
@@ -86,7 +90,7 @@ describe("websocket", () => {
       args: ["--inspect=localhost/foo/bar"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/foo/bar",
       },
@@ -149,7 +153,7 @@ describe("websocket", () => {
       args: ["--inspect=/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/",
       },
@@ -158,7 +162,7 @@ describe("websocket", () => {
       args: ["--inspect=/foo"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/foo",
       },
@@ -167,7 +171,7 @@ describe("websocket", () => {
       args: ["--inspect=/foo/baz/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/foo/baz/",
       },
@@ -176,7 +180,7 @@ describe("websocket", () => {
       args: ["--inspect=:0"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: anyPathname,
       },
@@ -185,7 +189,7 @@ describe("websocket", () => {
       args: ["--inspect=:0/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: "/",
       },
@@ -194,7 +198,7 @@ describe("websocket", () => {
       args: ["--inspect=ws://localhost/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: "/",
       },
@@ -203,7 +207,7 @@ describe("websocket", () => {
       args: ["--inspect=ws://localhost:0/"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: anyPort,
         pathname: "/",
       },
@@ -212,7 +216,7 @@ describe("websocket", () => {
       args: ["--inspect=ws://localhost:6499/foo/bar"],
       url: {
         protocol: "ws:",
-        hostname: "localhost",
+        hostname: localhostBoundIp,
         port: "6499",
         pathname: "/foo/bar",
       },
@@ -298,6 +302,64 @@ describe("websocket", () => {
   afterEach(() => {
     inspectee?.kill();
   });
+});
+
+// Bun.serve walks every getaddrinfo result for "localhost" (v6 then v4), so a second
+// --inspect on a port whose [::1] side is already held silently binds 127.0.0.1
+// instead. The banner must name the address actually bound, otherwise clients that
+// resolve localhost -> ::1 reach the other listener and the printed URL is dead.
+// https://github.com/oven-sh/bun/issues/2778
+test("bun --inspect banner names the bound address when [::1]:port is held by another listener", async () => {
+  const foreign = createTcpServer((socket: Socket) => socket.destroy());
+  const port: number = await new Promise((resolve, reject) => {
+    foreign.once("error", reject);
+    foreign.listen(0, "::1", () => resolve((foreign.address() as { port: number }).port));
+  });
+  try {
+    await using proc = spawn({
+      cwd: import.meta.dir,
+      cmd: [bunExe(), `--inspect=localhost:${port}`, "inspectee.js"],
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    let url: URL | undefined;
+    let stderr = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr as ReadableStream) {
+      stderr += decoder.decode(chunk);
+      const match = stripAnsi(stderr).match(/ws:\/\/\S+/);
+      if (match) {
+        url = new URL(match[0]);
+        break;
+      }
+      if (stderr.includes("Failed to start inspector")) break;
+    }
+    if (!url) {
+      process.stderr.write(stderr);
+      throw new Error("Unable to find listening URL");
+    }
+
+    // Before the fix the banner said "localhost", which routes to the foreign ::1 listener.
+    expect({ hostname: url.hostname, port: url.port }).toEqual({ hostname: "127.0.0.1", port: String(port) });
+
+    const ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+      ws.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
+    });
+    ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
+    const reply = await new Promise<any>(resolve => {
+      ws.addEventListener("message", ({ data }) => resolve(JSON.parse(String(data))));
+    });
+    expect(reply).toMatchObject({ id: 1, result: { result: { type: "number", value: 2 } } });
+    ws.close();
+    proc.kill();
+  } finally {
+    foreign.close();
+  }
 });
 
 describe("http metadata endpoint", () => {


### PR DESCRIPTION
## Problem

`Bun.serve` resolves the requested hostname and walks every `getaddrinfo` result (IPv6 first, then IPv4) until one binds. So when a second `bun --inspect` starts on the default port, `[::1]:6499` is already held by the first debuggee and the second one silently binds `127.0.0.1:6499` instead of failing.

Both processes then print the identical banner `ws://localhost:6499/<uuid>` because `internal/debugger.ts` builds the URL from `server.hostname`, which just echoes the requested name. Any client that resolves `localhost` to `::1` first reaches the first process, whose pathname token differs, so the upgrade is refused and the second process's own printed URL is dead. Nothing warns; only rewriting the URL to `127.0.0.1` by hand works.

The same mechanism bites `--inspect=localhost:PORT` when `[::1]:PORT` is held by an unrelated listener: Bun binds `127.0.0.1:PORT` and prints a `localhost` URL that routes clients to the foreign listener.

## Fix

Read `server.address` (getsockname) after the listen succeeds and build the banner from the actual bound IP instead of the requested hostname. Now:

```
first:  Listening:  ws://[::1]:6499/<uuid-a>
second: Listening:  ws://127.0.0.1:6499/<uuid-b>
```

Each URL routes to its own process. This also matches `node --inspect`, which prints `ws://127.0.0.1:9229/...` rather than `localhost`.

## Verification

New test holds `[::1]:P` with a plain TCP server, spawns `bun --inspect=localhost:P`, and asserts the banner says `127.0.0.1` and that a WebSocket to that URL reaches the inspector (`Runtime.evaluate` round-trips). Fails on main with `hostname: "localhost"`.

The existing parametrized URL tests are updated to expect the bound loopback IP (either `[::1]` or `127.0.0.1`) where they previously expected the literal string `localhost`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 17 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.0 (96ae948eb)

test/cli/inspect/inspect.test.ts:
262 |       expect({
263 |         protocol,
264 |         hostname,
265 |         port,
266 |         pathname,
267 |       }).toMatchObject(expected);
               ^
error: expect(received).toMatchObject(expected)

  {
-   "hostname": StringMatching /^(\[::1\]|127\.0\.0\.1)$/,
-   "pathname": StringMatching /^\/[a-z0-9-]+$/,
+   "hostname": "localhost",
+   "pathname": "/20da237e-464d-463a-b9cf-cf870409bf3d",
    "port": "6499",
    "protocol": "ws:",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/cli/inspect/inspect.test.ts:267:10)
(fail) websocket > bun --inspect [578.97ms]
262 |       expect({
263 |         protocol,
264 |         hostname,
265 |         port,
266 |         pathname,
267 |       }).toMatchObject(expected);
               ^
error: expect(received).toMatchObject(expected)

  {
-   "hostname": StringMatching /^(\[::1\]|127\.0\.0\.1)$/,
-   "pathname": StringMatching /^\/[a-z0-9-]+$/,
-   
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (2848d6716)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [38.95ms]
(pass) websocket > bun --inspect=0 [16.39ms]
(pass) websocket > bun --inspect=18548 [16.92ms]
(pass) websocket > bun --inspect=localhost [16.10ms]
(pass) websocket > bun --inspect=localhost/ [17.39ms]
(pass) websocket > bun --inspect=localhost:0 [16.11ms]
(pass) websocket > bun --inspect=localhost:0/ [16.49ms]
(pass) websocket > bun --inspect=localhost/foo/bar [15.59ms]
(pass) websocket > bun --inspect=127.0.0.1 [17.25ms]
(pass) websocket > bun --inspect=127.0.0.1/ [15.38ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [15.56ms]
(pass) websocket > bun --inspect=[::1] [15.81ms]
(pass) websocket > bun --inspect=[::1]:0 [16.21ms]
(pass) websocket > bun --inspect=[::1]:0/ [15.07ms]
(pass) websocket > bun --inspect=/ [16.17ms]
(pass) websocket > bun --inspect=/foo [15.64ms]
(pass) websocket > bun --inspect=/foo/baz/ [16.57ms]
(pass) websocket > bun --inspect=:0 [15.68ms]
(pass) websocket > bun --inspect=:0/ [16.80ms]
(pass) websocket > bun --inspect=ws://localhost/ [17.50ms]
(pass) websocket > bun --inspect=ws://localhost:0/ [17.06ms]
(pass) websocket > bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.0 (96ae948eb)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [745.42ms]
(pass) websocket > bun --inspect=0 [679.55ms]
(pass) websocket > bun --inspect=44905 [677.85ms]
(pass) websocket > bun --inspect=localhost [683.07ms]
(pass) websocket > bun --inspect=localhost/ [683.55ms]
(pass) websocket > bun --inspect=localhost:0 [679.26ms]
(pass) websocket > bun --inspect=localhost:0/ [684.23ms]
(pass) websocket > bun --inspect=localhost/foo/bar [685.31ms]
(pass) websocket > bun --inspect=127.0.0.1 [682.13ms]
(pass) websocket > bun --inspect=127.0.0.1/ [680.35ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [678.97ms]
(pass) websocket > bun --inspect=[::1] [675.76ms]
(pass) websocket > bun --inspect=[::1]:0 [675.78ms]
(pass) websocket > bun --inspect=[::1]:0/ [684.45ms]
(pass) websocket > bun --inspect=/ [675.56ms]
(pass) websocket > bun --inspect=/foo [670.54ms]
(pass) websocket > bun --inspect=/foo/baz/ [685.01ms]
(pass) websocket > bun --inspect=:0 [676.86ms]
(pass) websock
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 644ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (7228ms)
Bundle modules (53ms)
Postprocesss modules (180ms)
Bundle Functions (793ms)
Generate Code (111ms)

[8.38s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/debugger.ts      | 17 +++++++-
 test/cli/inspect/inspect.test.ts | 91 +++++++++++++++++++++++++++++++++-------
 2 files changed, 90 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/js/internal/debugger.ts           3      4      0
test/cli/inspect/inspect.test.ts      5      7      0
```

</details>

<!-- robobun:evidence:end -->