### PR TITLE
bun test: create parent directories for JUnit --reporter-outfile

### DIFF
--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -109,7 +109,7 @@ pub(crate) fn merge_junit_fragments(coord: &mut Coordinator, outfile: &[u8], sum
     contents.extend_from_slice(b"</testsuites>\n");
 
     let out_z = ZBox::from_bytes(outfile);
-    match File::openat(Fd::cwd(), &out_z, O::WRONLY | O::CREAT | O::TRUNC, 0o664) {
+    match File::make_openat(Fd::cwd(), &out_z, O::WRONLY | O::CREAT | O::TRUNC, 0o664) {
         bun_sys::Result::Err(e) => Output::err(
             crate::Error::JUnitReportFailed,
             "Failed to write JUnit report to {}\n{}",

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -736,7 +736,7 @@ impl JunitReporter {
 
         // SAFETY: junit_path_buf[path.len()] == 0 written above
         let zpath = bun_core::ZStr::from_buf(&junit_path_buf[..], path.len());
-        match File::openat(
+        match File::make_openat(
             Fd::cwd(),
             zpath,
             bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC,

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -385,18 +385,23 @@ describe("junit reporter", () => {
     expect(proc.exitCode).toBe(1);
   });
 
-  it("creates parent directories for --reporter-outfile", async () => {
+  it.each([[[]], [["--parallel=2"]]])("creates parent directories for --reporter-outfile %j", async extra => {
     const tmpDir = tempDirWithFiles("junit-mkdir", {
       "package.json": "{}",
+      // Two files so --parallel=2 actually shards and goes through merge_junit_fragments.
       "pass.test.js": `
         import { test, expect } from "bun:test";
         test("ok", () => expect(1).toBe(1));
+      `,
+      "pass2.test.js": `
+        import { test, expect } from "bun:test";
+        test("ok2", () => expect(1).toBe(1));
       `,
     });
 
     const junitPath = `${tmpDir}/out/nested/junit.xml`;
     await using proc = spawn({
-      cmd: [bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath, "pass.test.js"],
+      cmd: [bunExe(), "test", ...extra, "--reporter=junit", "--reporter-outfile", junitPath],
       cwd: tmpDir,
       env: bunEnv,
       stdout: "pipe",
@@ -408,6 +413,7 @@ describe("junit reporter", () => {
     const xmlContent = await file(junitPath).text();
     expect(xmlContent).toContain("<testsuites");
     expect(xmlContent).toContain('name="ok"');
+    expect(xmlContent).toContain('name="ok2"');
     expect(proc.exitCode).toBe(0);
   });
 });

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -384,6 +384,32 @@ describe("junit reporter", () => {
 
     expect(proc.exitCode).toBe(1);
   });
+
+  it("creates parent directories for --reporter-outfile", async () => {
+    const tmpDir = tempDirWithFiles("junit-mkdir", {
+      "package.json": "{}",
+      "pass.test.js": `
+        import { test, expect } from "bun:test";
+        test("ok", () => expect(1).toBe(1));
+      `,
+    });
+
+    const junitPath = `${tmpDir}/out/nested/junit.xml`;
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath, "pass.test.js"],
+      cwd: tmpDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("JUnitReportFailed");
+    const xmlContent = await file(junitPath).text();
+    expect(xmlContent).toContain("<testsuites");
+    expect(xmlContent).toContain('name="ok"');
+    expect(proc.exitCode).toBe(0);
+  });
 });
 
 function filterJunitXmlOutput(xmlContent) {


### PR DESCRIPTION
## What

`bun test --reporter=junit --reporter-outfile=reports/junit.xml` silently drops the report when `reports/` does not exist:

```
Ran 1 test across 1 file. [10.00ms]
JUnitReportFailed: Failed to write JUnit report to reports/junit.xml
ENOENT: reports/junit.xml: No such file or directory (open())
```

The error is printed after the summary and the process still exits 0, so in CI the missing artifact is easy to miss. The lcov coverage reporter already creates its output directory (`mkdir_recursive` on `reports_directory`), so the two reporters disagree.

## Fix

Use `File::make_openat` instead of `File::openat` at both JUnit write sites (serial `JunitReporter::write_to_file` and parallel `merge_junit_fragments`). `make_openat` tries the open, then `mkdir -p dirname(path)` and retries once on failure, so the fast path is unchanged.

## Tests

Added a case to `test/js/junit-reporter/junit.test.js` that writes to `<tmp>/out/nested/junit.xml` and asserts the file exists, contains the expected `<testsuites>`, and that stderr has no `JUnitReportFailed`.

```
USE_SYSTEM_BUN=1 bun test test/js/junit-reporter/junit.test.js -t "parent directories"  # fails: JUnitReportFailed / ENOENT
bun bd test test/js/junit-reporter/junit.test.js                                        # 5 pass
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.0 (811e37275)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [822.72ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [687.96ms]
/tmp/junit-comprehensive_QqhfrR
(pass) junit reporter > more scenarios [1203.91ms]
(pass) junit reporter > should report only the final result for a retried test [554.38ms]
407 |       stdout: "pipe",
408 |       stderr: "pipe",
409 |     });
410 |     const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
411 | 
412 |     expect(stderr).not.toContain("JUnitReportFailed");
                             ^
error: expect(received).not.toContain(expected)

Expected to not contain: "JUnitReportFailed"
Received: "\npass.test.js:\n(pass) ok [2.18ms]\n\npass2.test.js:\n(pass) ok2 [9.87ms]\n\n 2 pass\n 0 fail\n 2 expect() calls\nRan 2 tests across 2 files. [431.00ms]\nJUnitReportFailed: Failed to write JUnit report to /tmp/junit-mkdi
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8d71ffcd8)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [27.61ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [16.57ms]
/tmp/junit-comprehensive_dyJNKi
(pass) junit reporter > more scenarios [32.29ms]
(pass) junit reporter > should report only the final result for a retried test [15.00ms]
(pass) junit reporter > creates parent directories for --reporter-outfile [] [14.44ms]
(pass) junit reporter > creates parent directories for --reporter-outfile ["--parallel=2"] [25.86ms]

 6 pass
 0 fail
 2 snapshots, 110 expect() calls
Ran 6 tests across 1 file. [294.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/junit-reporter/junit.test.js
bun test v1.4.0 (811e37275)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [815.66ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [616.05ms]
/tmp/junit-comprehensive_jiUWUd
(pass) junit reporter > more scenarios [1198.44ms]
(pass) junit reporter > should report only the final result for a retried test [590.19ms]
(pass) junit reporter > creates parent directories for --reporter-outfile [] [774.63ms]
(pass) junit reporter > creates parent directories for --reporter-outfile ["--parallel=2"] [1112.23ms]

 6 pass
 0 fail
 2 snapshots, 110 expect() calls
Ran 6 tests across 1 file. [8.13s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1275ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 52s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+811e37275
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (811e37275)

test/js/junit-reporter/junit.test.js:
(pass) junit reporter > should generate valid junit xml for passing tests %s [19.90ms]
(pass) junit reporter > should generate valid junit xml for passing tests %s [15.14ms]
/tmp/junit-comprehensive_mIRgay
(pass) junit r
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test/parallel/aggregate.rs |  2 +-
 src/runtime/cli/test_command.rs            |  2 +-
 test/js/junit-reporter/junit.test.js       | 32 ++++++++++++++++++++++++++++++
 3 files changed, 34 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/cli/test/parallel/aggregate.rs      3      3      0
src/runtime/cli/test_command.rs                 4      3      0
test/js/junit-reporter/junit.test.js            4      2      0
```

</details>

<!-- robobun:evidence:end -->