### PR TITLE
process: reallyExit() should not emit 'exit' listeners

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3361,6 +3361,11 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     }
 
     auto* zigGlobal = defaultGlobalObject(globalObject);
+    // Node's reallyExit is the raw exit that does not run 'exit' listeners.
+    // Bun__Process__exit reaches dispatchExitInternal; arm its guard here so
+    // listeners are skipped while native shutdown (profiles, cleanup hooks,
+    // SQLite close) still runs.
+    zigGlobal->processObject()->m_isExiting = true;
     Bun__Process__exit(zigGlobal, exitCode);
     // Main-thread Bun__Process__exit is noreturn. In a worker it returns; the
     // WebWorker exit path it called requests JSC termination (guarded so it's a

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3361,10 +3361,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     }
 
     auto* zigGlobal = defaultGlobalObject(globalObject);
-    // Node's reallyExit is the raw exit that does not run 'exit' listeners.
-    // Bun__Process__exit reaches dispatchExitInternal; arm its guard here so
-    // listeners are skipped while native shutdown (profiles, cleanup hooks,
-    // SQLite close) still runs.
+    // Node's reallyExit is the raw exit that does not run 'exit' listeners. Arm
+    // m_isExiting so dispatchExitInternal (via Bun__Process__exit) skips them
+    // while native shutdown (profiles, cleanup hooks, SQLite close) still runs.
     zigGlobal->processObject()->m_isExiting = true;
     Bun__Process__exit(zigGlobal, exitCode);
     // Main-thread Bun__Process__exit is noreturn. In a worker it returns; the

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -489,9 +489,7 @@ it("process.reallyExit does not emit 'exit'", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(11);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 11 });
 });
 
 describe.concurrent(() => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -477,6 +477,23 @@ it("process.exit", () => {
   expect(stdout.toString().trim()).toBe("PASS");
 });
 
+it("process.reallyExit does not emit 'exit'", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.on("exit", c => console.log("EXIT-LISTENER fired code=" + c)); process.reallyExit(11);`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(11);
+});
+
 describe.concurrent(() => {
   it.todoIf(isMacOS)("should be the node version on the host that we expect", async () => {
     const subprocess = Bun.spawn({


### PR DESCRIPTION
## Repro

```js
process.on("exit", c => console.log("EXIT-LISTENER fired code=" + c));
process.reallyExit(11);
```

| | node | bun (before) | bun (after) |
|---|---|---|---|
| stdout | *(empty)* | `EXIT-LISTENER fired code=11` | *(empty)* |
| exit code | 11 | 11 | 11 |

## Cause

`Process_functionReallyExit` calls `Bun__Process__exit`, which on the main thread runs `vm.on_exit()` → `ExitHandler::dispatch_on_exit` → `Process__dispatchOnExit` → `dispatchExitInternal`, and that emits `'exit'`. Node's `reallyExit` is the raw exit that never runs `'exit'` listeners; that is its sole distinction from `process.exit`.

This affects libraries that patch `process.reallyExit` to intercept raw exits (signal-exit v3, exit-hook, test sandboxes): their handlers see the "raw" door re-enter the full exit machinery.

## Fix

Arm `process->m_isExiting` in `Process_functionReallyExit` before calling `Bun__Process__exit`. `dispatchExitInternal` already short-circuits on that flag, so the `'exit'` emit is skipped while the rest of native shutdown (CPU/heap profile flush, cleanup hooks, SQLite close, `global_exit`) still runs. `process.exit()` is unchanged: it emits `'exit'` itself via `Process__dispatchOnExit` before reaching `reallyExit`.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/process/process.test.js -t "reallyExit does not emit"
(fail) process.reallyExit does not emit 'exit'   # "EXIT-LISTENER fired code=11"

$ bun bd test test/js/node/process/process.test.js -t "reallyExit does not emit"
(pass) process.reallyExit does not emit 'exit'
```

All 32 exit-related tests in `process.test.js` pass, as does `test/js/node/test/parallel/test-process-really-exit.js`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->