### PR TITLE
process.env.TZ: map legacy POSIX zone names (EST5EDT, CET, ...) to their IANA primaries

### DIFF
--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -15,6 +15,8 @@ using namespace JSC;
 
 extern "C" int getRSS(size_t* rss);
 
+String canonicalizeLegacyTimeZoneName(StringView timeZone);
+
 class Process : public WebCore::JSEventEmitter {
     using Base = WebCore::JSEventEmitter;
 

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -482,6 +482,24 @@ static constexpr ASCIILiteral kProxyEnvVarNames[] = {
     "no_proxy"_s,
 };
 
+// JSC's intlResolveTimeZoneID drops non-'/' zone names, so TZ=EST5EDT etc.
+// silently fell back to UTC. Map the eight affected names to their tzdata
+// `backward` Link targets (case-sensitive, matching Node).
+String canonicalizeLegacyTimeZoneName(StringView timeZone)
+{
+    if (timeZone.isEmpty() || timeZone.length() > 7 || timeZone.contains('/'))
+        return String();
+    if (timeZone == "EST5EDT"_s) return "America/New_York"_s;
+    if (timeZone == "CST6CDT"_s) return "America/Chicago"_s;
+    if (timeZone == "MST7MDT"_s) return "America/Denver"_s;
+    if (timeZone == "PST8PDT"_s) return "America/Los_Angeles"_s;
+    if (timeZone == "CET"_s) return "Europe/Brussels"_s;
+    if (timeZone == "MET"_s) return "Europe/Brussels"_s;
+    if (timeZone == "EET"_s) return "Europe/Athens"_s;
+    if (timeZone == "WET"_s) return "Europe/Lisbon"_s;
+    return String();
+}
+
 // The parse-and-apply bodies for the three side-effecting env vars, shared by
 // the regular process.env CustomSetters and applySharedEnvSideEffects so a new
 // side-effecting var need only be added in one place.
@@ -489,7 +507,7 @@ static void applyTZFromString(JSGlobalObject* globalObject, const String& value)
 {
     if (value.length() >= 32)
         return;
-    auto canonical = Bun::canonicalizeLegacyTimeZoneName(value);
+    auto canonical = canonicalizeLegacyTimeZoneName(value);
     if (WTF::setTimeZoneOverride(canonical.isNull() ? value : canonical)) {
         WTF::timeZoneDidChange();
         JSC::getVM(globalObject).dateCache.clearForTimeZoneChange();

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -487,7 +487,10 @@ static constexpr ASCIILiteral kProxyEnvVarNames[] = {
 // side-effecting var need only be added in one place.
 static void applyTZFromString(JSGlobalObject* globalObject, const String& value)
 {
-    if (value.length() < 32 && WTF::setTimeZoneOverride(value)) {
+    if (value.length() >= 32)
+        return;
+    auto canonical = Bun::canonicalizeLegacyTimeZoneName(value);
+    if (WTF::setTimeZoneOverride(canonical.isNull() ? value : canonical)) {
         WTF::timeZoneDidChange();
         JSC::getVM(globalObject).dateCache.clearForTimeZoneChange();
     }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3323,11 +3323,39 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);
 }
 
+} // namespace Zig
+
+// These eight POSIX-style names are top-level tzdata zones (honored by glibc
+// and Node) that JSC's intlResolveTimeZoneID rejects because they contain no
+// '/'. Map them to their tzdata `backward` Link targets so a process started
+// with e.g. TZ=EST5EDT does not silently run on UTC. Case-sensitive to match
+// Node; EST/MST/HST already resolve via ICU's Etc/GMT aliases.
+String Bun::canonicalizeLegacyTimeZoneName(StringView timeZone)
+{
+    if (timeZone.isEmpty() || timeZone.length() > 7 || timeZone.contains('/'))
+        return String();
+    if (timeZone == "EST5EDT"_s) return "America/New_York"_s;
+    if (timeZone == "CST6CDT"_s) return "America/Chicago"_s;
+    if (timeZone == "MST7MDT"_s) return "America/Denver"_s;
+    if (timeZone == "PST8PDT"_s) return "America/Los_Angeles"_s;
+    if (timeZone == "CET"_s) return "Europe/Brussels"_s;
+    if (timeZone == "MET"_s) return "Europe/Brussels"_s;
+    if (timeZone == "EET"_s) return "Europe/Athens"_s;
+    if (timeZone == "WET"_s) return "Europe/Lisbon"_s;
+    return String();
+}
+
+namespace Zig {
+
 extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, const ZigString* timeZone)
 {
     auto& vm = JSC::getVM(globalObject);
 
-    if (WTF::setTimeZoneOverride(Zig::toString(*timeZone))) {
+    String timeZoneString = Zig::toString(*timeZone);
+    if (auto canonical = Bun::canonicalizeLegacyTimeZoneName(timeZoneString); !canonical.isNull())
+        timeZoneString = WTF::move(canonical);
+
+    if (WTF::setTimeZoneOverride(timeZoneString)) {
         WTF::timeZoneDidChange();
         vm.dateCache.clearForTimeZoneChange();
         return true;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3325,11 +3325,9 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 } // namespace Zig
 
-// These eight POSIX-style names are top-level tzdata zones (honored by glibc
-// and Node) that JSC's intlResolveTimeZoneID rejects because they contain no
-// '/'. Map them to their tzdata `backward` Link targets so a process started
-// with e.g. TZ=EST5EDT does not silently run on UTC. Case-sensitive to match
-// Node; EST/MST/HST already resolve via ICU's Etc/GMT aliases.
+// JSC's intlResolveTimeZoneID drops non-'/' zone names, so TZ=EST5EDT etc.
+// silently fell back to UTC. Map the eight affected names to their tzdata
+// `backward` Link targets (case-sensitive, matching Node).
 String Bun::canonicalizeLegacyTimeZoneName(StringView timeZone)
 {
     if (timeZone.isEmpty() || timeZone.length() > 7 || timeZone.contains('/'))

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3323,28 +3323,6 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);
 }
 
-} // namespace Zig
-
-// JSC's intlResolveTimeZoneID drops non-'/' zone names, so TZ=EST5EDT etc.
-// silently fell back to UTC. Map the eight affected names to their tzdata
-// `backward` Link targets (case-sensitive, matching Node).
-String Bun::canonicalizeLegacyTimeZoneName(StringView timeZone)
-{
-    if (timeZone.isEmpty() || timeZone.length() > 7 || timeZone.contains('/'))
-        return String();
-    if (timeZone == "EST5EDT"_s) return "America/New_York"_s;
-    if (timeZone == "CST6CDT"_s) return "America/Chicago"_s;
-    if (timeZone == "MST7MDT"_s) return "America/Denver"_s;
-    if (timeZone == "PST8PDT"_s) return "America/Los_Angeles"_s;
-    if (timeZone == "CET"_s) return "Europe/Brussels"_s;
-    if (timeZone == "MET"_s) return "Europe/Brussels"_s;
-    if (timeZone == "EET"_s) return "Europe/Athens"_s;
-    if (timeZone == "WET"_s) return "Europe/Lisbon"_s;
-    return String();
-}
-
-namespace Zig {
-
 extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, const ZigString* timeZone)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -845,8 +845,6 @@ ALWAYS_INLINE void* vm(JSC::JSGlobalObject* lexicalGlobalObject)
     return WebCore::clientData(lexicalGlobalObject->vm())->bunVM;
 }
 
-String canonicalizeLegacyTimeZoneName(StringView timeZone);
-
 }
 
 #ifndef RENAMED_JSDOM_GLOBAL_OBJECT

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -845,6 +845,8 @@ ALWAYS_INLINE void* vm(JSC::JSGlobalObject* lexicalGlobalObject)
     return WebCore::clientData(lexicalGlobalObject->vm())->bunVM;
 }
 
+String canonicalizeLegacyTimeZoneName(StringView timeZone);
+
 }
 
 #ifndef RENAMED_JSDOM_GLOBAL_OBJECT

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -646,6 +646,9 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeZone, (JSGlobalObject * globalObject, Ca
     String timeZoneName = callFrame->argument(0).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
+    if (auto canonical = Bun::canonicalizeLegacyTimeZoneName(timeZoneName); !canonical.isNull())
+        timeZoneName = WTF::move(canonical);
+
     if (!WTF::setTimeZoneOverride(timeZoneName)) {
         throwTypeError(globalObject, scope,
             makeString("Invalid timezone: \""_s, timeZoneName, "\""_s));

--- a/test/js/node/process/process-env-TZ-legacy-zones.test.ts
+++ b/test/js/node/process/process-env-TZ-legacy-zones.test.ts
@@ -1,10 +1,6 @@
-// TZ=EST5EDT (and CET/EET/MET/WET/CST6CDT/MST7MDT/PST8PDT) are top-level tzdata
-// zones that POSIX shells, glibc `date`, and Node honor. They were silently
-// falling back to UTC in Bun because JSC's intlResolveTimeZoneID drops every
-// non-'/' name except UTC/GMT. Bun now canonicalizes them to their tzdata
-// `backward` Link targets before calling into JSC, matching Node's resolution.
-// The Intl.DateTimeFormat({ timeZone: "EST5EDT" }) option path is tracked
-// separately in issue #30618.
+// JSC's intlResolveTimeZoneID drops non-'/' zone names, so TZ=EST5EDT (and the
+// seven others below) silently fell back to UTC. Bun maps them to their tzdata
+// `backward` Link targets before calling into JSC, matching Node.
 
 import { setTimeZone } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
@@ -114,17 +110,17 @@ test("unrelated IANA zones still work", async () => {
 });
 
 test("unknown TZ values remain unknown", async () => {
-  // ICU rejects this and Bun leaves the override unset; the host default
-  // applies. On CI the host default is UTC, but that's not guaranteed, so only
-  // assert the process doesn't crash and doesn't adopt a bogus offset.
+  // ICU rejects this; the override stays unset and the host default applies.
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", `process.stdout.write(String(new Date(${JSON.stringify(summer)}).getTimezoneOffset()))`],
+    cmd: [bunExe(), "-e", probe],
     env: { ...bunEnv, TZ: "Not/A_Zone" },
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(Number.isFinite(Number(stdout))).toBe(true);
+  const out = JSON.parse(stdout);
+  expect(Number.isInteger(out.offset)).toBe(true);
+  expect(out.resolved).not.toBe("Not/A_Zone");
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/process/process-env-TZ-legacy-zones.test.ts
+++ b/test/js/node/process/process-env-TZ-legacy-zones.test.ts
@@ -39,8 +39,7 @@ describe("TZ=<legacy zone> at process start", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     const out = JSON.parse(stdout);
     expect(out.tz).toBe(tz);
     expect(out.offset).toBe(offset);
@@ -69,8 +68,7 @@ describe("process.env.TZ = <legacy zone> at runtime", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
+      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       const out = JSON.parse(stdout);
       expect(out.offset).toBe(offset);
       expect(out.string).toMatch(display);
@@ -101,8 +99,7 @@ test("unrelated IANA zones still work", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const out = JSON.parse(stdout);
   expect(out.offset).toBe(240);
   expect(out.resolved).toBe("America/New_York");
@@ -117,8 +114,7 @@ test("unknown TZ values remain unknown", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const out = JSON.parse(stdout);
   expect(Number.isInteger(out.offset)).toBe(true);
   expect(out.resolved).not.toBe("Not/A_Zone");

--- a/test/js/node/process/process-env-TZ-legacy-zones.test.ts
+++ b/test/js/node/process/process-env-TZ-legacy-zones.test.ts
@@ -1,0 +1,127 @@
+// TZ=EST5EDT (and CET/EET/MET/WET/CST6CDT/MST7MDT/PST8PDT) are top-level tzdata
+// zones that POSIX shells, glibc `date`, and Node honor. They were silently
+// falling back to UTC in Bun because JSC's intlResolveTimeZoneID drops every
+// non-'/' name except UTC/GMT. Bun now canonicalizes them to their tzdata
+// `backward` Link targets before calling into JSC, matching Node's resolution.
+// The Intl.DateTimeFormat({ timeZone: "EST5EDT" }) option path is tracked
+// separately in issue #30618.
+
+import { describe, expect, test } from "bun:test";
+import { setTimeZone } from "bun:jsc";
+import { bunEnv, bunExe } from "harness";
+
+// July 14 2018 12:34:56 UTC: northern-hemisphere summer, so the DST-bearing
+// zones are on daylight offsets. Offsets are what `new Date().getTimezoneOffset()`
+// returns (UTC - local, in minutes).
+const summer = "2018-07-14T12:34:56Z";
+const zones = [
+  { tz: "EST5EDT", canonical: "America/New_York", offset: 240, display: /Eastern Daylight Time/ },
+  { tz: "CST6CDT", canonical: "America/Chicago", offset: 300, display: /Central Daylight Time/ },
+  { tz: "MST7MDT", canonical: "America/Denver", offset: 360, display: /Mountain Daylight Time/ },
+  { tz: "PST8PDT", canonical: "America/Los_Angeles", offset: 420, display: /Pacific Daylight Time/ },
+  { tz: "CET", canonical: "Europe/Brussels", offset: -120, display: /Central European Summer Time/ },
+  { tz: "MET", canonical: "Europe/Brussels", offset: -120, display: /Central European Summer Time/ },
+  { tz: "EET", canonical: "Europe/Athens", offset: -180, display: /Eastern European Summer Time/ },
+  { tz: "WET", canonical: "Europe/Lisbon", offset: -60, display: /Western European Summer Time/ },
+] as const;
+
+const probe = `
+  const d = new Date(${JSON.stringify(summer)});
+  process.stdout.write(JSON.stringify({
+    tz: process.env.TZ,
+    offset: d.getTimezoneOffset(),
+    string: d.toString(),
+    resolved: new Intl.DateTimeFormat().resolvedOptions().timeZone,
+  }));
+`;
+
+describe("TZ=<legacy zone> at process start", () => {
+  test.concurrent.each(zones)("TZ=$tz resolves to $canonical", async ({ tz, canonical, offset, display }) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", probe],
+      env: { ...bunEnv, TZ: tz },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out.tz).toBe(tz);
+    expect(out.offset).toBe(offset);
+    expect(out.string).toMatch(display);
+    expect(out.resolved).toBe(canonical);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("process.env.TZ = <legacy zone> at runtime", () => {
+  test.concurrent.each(zones)("process.env.TZ = $tz resolves to $canonical", async ({ tz, canonical, offset, display }) => {
+    const script = `
+      process.env.TZ = ${JSON.stringify(tz)};
+      const d = new Date(${JSON.stringify(summer)});
+      process.stdout.write(JSON.stringify({
+        offset: d.getTimezoneOffset(),
+        string: d.toString(),
+        resolved: new Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, TZ: "UTC" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const out = JSON.parse(stdout);
+    expect(out.offset).toBe(offset);
+    expect(out.string).toMatch(display);
+    expect(out.resolved).toBe(canonical);
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("bun:jsc setTimeZone(<legacy zone>)", () => {
+  test.each(zones)("setTimeZone($tz) resolves to $canonical", ({ tz, canonical, offset }) => {
+    const before = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    try {
+      const ret = setTimeZone(tz);
+      expect(ret).toBe(canonical);
+      expect(new Intl.DateTimeFormat().resolvedOptions().timeZone).toBe(canonical);
+      expect(new Date(summer).getTimezoneOffset()).toBe(offset);
+    } finally {
+      setTimeZone(before);
+    }
+  });
+});
+
+test("unrelated IANA zones still work", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", probe],
+    env: { ...bunEnv, TZ: "America/New_York" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout);
+  expect(out.offset).toBe(240);
+  expect(out.resolved).toBe("America/New_York");
+  expect(exitCode).toBe(0);
+});
+
+test("unknown TZ values remain unknown", async () => {
+  // ICU rejects this and Bun leaves the override unset; the host default
+  // applies. On CI the host default is UTC, but that's not guaranteed, so only
+  // assert the process doesn't crash and doesn't adopt a bogus offset.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `process.stdout.write(String(new Date(${JSON.stringify(summer)}).getTimezoneOffset()))`],
+    env: { ...bunEnv, TZ: "Not/A_Zone" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(Number.isFinite(Number(stdout))).toBe(true);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/process/process-env-TZ-legacy-zones.test.ts
+++ b/test/js/node/process/process-env-TZ-legacy-zones.test.ts
@@ -6,8 +6,8 @@
 // The Intl.DateTimeFormat({ timeZone: "EST5EDT" }) option path is tracked
 // separately in issue #30618.
 
-import { describe, expect, test } from "bun:test";
 import { setTimeZone } from "bun:jsc";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // July 14 2018 12:34:56 UTC: northern-hemisphere summer, so the DST-bearing
@@ -55,8 +55,10 @@ describe("TZ=<legacy zone> at process start", () => {
 });
 
 describe("process.env.TZ = <legacy zone> at runtime", () => {
-  test.concurrent.each(zones)("process.env.TZ = $tz resolves to $canonical", async ({ tz, canonical, offset, display }) => {
-    const script = `
+  test.concurrent.each(zones)(
+    "process.env.TZ = $tz resolves to $canonical",
+    async ({ tz, canonical, offset, display }) => {
+      const script = `
       process.env.TZ = ${JSON.stringify(tz)};
       const d = new Date(${JSON.stringify(summer)});
       process.stdout.write(JSON.stringify({
@@ -65,20 +67,21 @@ describe("process.env.TZ = <legacy zone> at runtime", () => {
         resolved: new Intl.DateTimeFormat().resolvedOptions().timeZone,
       }));
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: { ...bunEnv, TZ: "UTC" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const out = JSON.parse(stdout);
-    expect(out.offset).toBe(offset);
-    expect(out.string).toMatch(display);
-    expect(out.resolved).toBe(canonical);
-    expect(exitCode).toBe(0);
-  });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, TZ: "UTC" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const out = JSON.parse(stdout);
+      expect(out.offset).toBe(offset);
+      expect(out.string).toMatch(display);
+      expect(out.resolved).toBe(canonical);
+      expect(exitCode).toBe(0);
+    },
+  );
 });
 
 describe("bun:jsc setTimeZone(<legacy zone>)", () => {

--- a/test/js/node/process/process-env-TZ-legacy-zones.test.ts
+++ b/test/js/node/process/process-env-TZ-legacy-zones.test.ts
@@ -92,7 +92,7 @@ describe("bun:jsc setTimeZone(<legacy zone>)", () => {
   });
 });
 
-test("unrelated IANA zones still work", async () => {
+test.concurrent("unrelated IANA zones still work", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", probe],
     env: { ...bunEnv, TZ: "America/New_York" },
@@ -106,7 +106,7 @@ test("unrelated IANA zones still work", async () => {
   expect(exitCode).toBe(0);
 });
 
-test("unknown TZ values remain unknown", async () => {
+test.concurrent("unknown TZ values remain unknown", async () => {
   // ICU rejects this; the override stays unset and the host default applies.
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", probe],


### PR DESCRIPTION
## Repro

```js
// TZ=EST5EDT bun t.mjs   vs   TZ=EST5EDT node t.mjs
const d = new Date("2018-07-14T12:34:56Z");
console.log(process.env.TZ, d.getTimezoneOffset(), d.toString());
console.log(new Intl.DateTimeFormat().resolvedOptions().timeZone);
// node: EST5EDT 240 "...08:34:56 GMT-0400 (Eastern Daylight Time)" / America/New_York
// bun : EST5EDT 0   "...12:34:56 GMT+0000 (Coordinated Universal Time)" / UTC
```

Same for `CET`, `EET`, `MET`, `WET`, `CST6CDT`, `MST7MDT`, `PST8PDT`. A process started with one of these common POSIX-style `TZ` settings runs on UTC with no error.

## Cause

ICU's `ucal_getCanonicalTimeZoneID` accepts these eight names, so `WTF::setTimeZoneOverride("EST5EDT")` succeeds and stores the string as the override. But JSC's `intlResolveTimeZoneID` (via `isValidTimeZoneNameFromICUTimeZone` in `IntlObject.cpp`) drops every non-`/` name except `UTC`/`GMT`, so `DateCache::retrieveTimeZoneInformation` can't map the override back to a `TimeZoneID` and falls through to UTC.

These eight names are top-level tzdata zones that glibc `date` and Node both honor. tzdata 2024b links them to city-based primaries (`EST5EDT` -> `America/New_York`, `CET` -> `Europe/Brussels`, ...), and Node resolves them to exactly those primaries. `EST`/`MST`/`HST` already work because ICU canonicalizes them to `Etc/GMT+5/+7/+10`.

## Fix

Add `Bun::canonicalizeLegacyTimeZoneName` which maps the eight names to their tzdata `backward` targets, and call it from the three Bun-side entry points that hand a zone name to JSC:

- `JSGlobalObject__setTimeZone` (process-start `TZ=...`, via `run_command.rs`/`test_command.rs`/`repl_command.rs`)
- `applyTZFromString` (`process.env.TZ = "..."` setter)
- `functionSetTimeZone` (`bun:jsc`'s `setTimeZone`)

This does not change JavaScriptCore. The `Intl.DateTimeFormat({ timeZone: "EST5EDT" })` option path still throws `RangeError`; that lives entirely in JSC and is tracked by #30618 / #30620 (requires oven-sh/WebKit#227 to land).

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/process/process-env-TZ-legacy-zones.test.ts
  2 pass / 24 fail  (offset 0, "UTC", "Coordinated Universal Time")

$ bun bd test test/js/node/process/process-env-TZ-legacy-zones.test.ts
  26 pass / 0 fail
```

After, with the original repro:

```
$ TZ=EST5EDT ./build/debug/bun-debug t.mjs
EST5EDT 240 Sat Jul 14 2018 08:34:56 GMT-0400 (Eastern Daylight Time)
America/New_York
```

which matches Node 26.3.0.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 24 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-env-TZ-legacy-zones.test.ts
bun test v1.4.0 (db6a985a2)

test/js/node/process/process-env-TZ-legacy-zones.test.ts:
40 |       stderr: "pipe",
41 |     });
42 |     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
43 |     const out = JSON.parse(stdout);
44 |     expect(out.tz).toBe(tz);
45 |     expect(out.offset).toBe(offset);
                            ^
error: expect(received).toBe(expected)

Expected: 360
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/process/process-env-TZ-legacy-zones.test.ts:45:24)
40 |       stderr: "pipe",
41 |     });
42 |     const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
43 |     const out = JSON.parse(stdout);
44 |     expect(out.tz).toBe(tz);
45 |     expect(out.offset).toBe(offset);
                            ^
error: expect(received).toBe(expected)

Expected: 300
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/process/process-env-TZ-l
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (de12c5a4a)

test/js/node/process/process-env-TZ-legacy-zones.test.ts:
(pass) TZ=<legacy zone> at process start > TZ=CST6CDT resolves to America/Chicago [25.02ms]
(pass) TZ=<legacy zone> at process start > TZ=EST5EDT resolves to America/New_York [26.34ms]
(pass) TZ=<legacy zone> at process start > TZ=MST7MDT resolves to America/Denver [26.92ms]
(pass) TZ=<legacy zone> at process start > TZ=CET resolves to Europe/Brussels [26.07ms]
(pass) TZ=<legacy zone> at process start > TZ=WET resolves to Europe/Lisbon [25.18ms]
(pass) TZ=<legacy zone> at process start > TZ=MET resolves to Europe/Brussels [26.83ms]
(pass) process.env.TZ = <legacy zone> at runtime > process.env.TZ = EST5EDT resolves to America/New_York [25.59ms]
(pass) TZ=<legacy zone> at process start > TZ=EET resolves to Europe/Athens [26.72ms]
(pass) process.env.TZ = <legacy zone> at runtime > process.env.TZ = CST6CDT resolves to America/Chicago [24.99ms]
(pass) process.env.TZ = <legacy zone> at runtime > process.env.TZ = PST8PDT resolves to America/Los_Angeles [26.29ms]
(pass) process.env.TZ = <legacy zone> at runtime > process.env.TZ = WET resolves to Europe/Lisbon [24.97ms]
(pass) TZ
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/process/process-env-TZ-legacy-zones.test.ts
bun test v1.4.0 (db6a985a2)

test/js/node/process/process-env-TZ-legacy-zones.test.ts:
(pass) TZ=<legacy zone> at process start > TZ=EST5EDT resolves to America/New_York [1262.37ms]
(pass) TZ=<legacy zone> at process start > TZ=CST6CDT resolves to America/Chicago [1246.39ms]
(pass) TZ=<legacy zone> at process start > TZ=PST8PDT resolves to America/Los_Angeles [1248.01ms]
(pass) TZ=<legacy zone> at process start > TZ=CET resolves to Europe/Brussels [1256.70ms]
(pass) TZ=<legacy zone> at process start > TZ=MST7MDT resolves to America/Denver [1301.13ms]
(pass) TZ=<legacy zone> at process start > TZ=EET resolves to Europe/Athens [1235.88ms]
(pass) TZ=<legacy zone> at process start > TZ=WET resolves to Europe/Lisbon [1249.15ms]
(pass) TZ=<legacy zone> at process start > TZ=MET resolves to Europe/Brussels [1323.71ms]
(pass) process.env.TZ = <legacy zone> at runtime > process.env.TZ = EST5EDT resolves to America/New_York [1325.29ms]
(pass) process.env.TZ = <legacy zone> at runtime > pro
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 625ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/15] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[2/15] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[3/15] cxx obj/src/jsc/bindings/napi.cpp.o
[4/15] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[5/15] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[6/15] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[7/15] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[8/15] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[9/15] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[10/15] gen cpp.rs (cppbind)
[10/15] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_bor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunProcess.h                      |   2 +
 src/jsc/bindings/JSEnvironmentVariableMap.cpp      |  23 +++-
 src/jsc/bindings/ZigGlobalObject.cpp               |   6 +-
 src/jsc/modules/BunJSCModule.h                     |   3 +
 .../process/process-env-TZ-legacy-zones.test.ts    | 122 +++++++++++++++++++++
 5 files changed, 154 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/BunProcess.h                                 1      1      0
src/jsc/bindings/JSEnvironmentVariableMap.cpp                 3      4      0
src/jsc/bindings/ZigGlobalObject.cpp                          3      5      0
src/jsc/modules/BunJSCModule.h                                1      1      0
test/js/node/process/process-env-TZ-legacy-zones.test.ts      2     11      0
```

</details>

<!-- robobun:evidence:end -->