### PR TITLE
Intl.Segmenter: fix containing() at surrogate-pair segment starts

### DIFF
--- a/src/jsc/bindings/IntlSegmentsContaining.cpp
+++ b/src/jsc/bindings/IntlSegmentsContaining.cpp
@@ -1,0 +1,62 @@
+#include "root.h"
+#include "IntlSegmentsContaining.h"
+
+#include <JavaScriptCore/IntlSegments.h>
+#include <JavaScriptCore/JSCast.h>
+#include <JavaScriptCore/JSString.h>
+#include <unicode/utf16.h>
+
+namespace Bun {
+
+using namespace JSC;
+
+// Workaround for a JavaScriptCore bug in %Segments.prototype%.containing.
+//
+// IntlSegments::containing computes startIndex via ubrk_preceding(index + 1).
+// When index is the lead surrogate of a surrogate pair, index + 1 is a trail
+// surrogate; ICU snaps that back to the code-point start (index) and then
+// returns the boundary strictly before it, skipping a boundary at index
+// itself. The result is a phantom segment spanning the previous segment plus
+// the one actually containing index.
+//
+// Since index and index + 1 are the same code point in that case, the spec
+// result of containing(index) equals containing(index + 1), and the latter
+// avoids the trail-surrogate offset. We forward to JSC's implementation with
+// the adjusted index so the rest of the algorithm (and isWordLike) is reused.
+JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncContainingFix, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* segments = dynamicDowncast<IntlSegments>(callFrame->thisValue());
+    if (!segments) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "%Segments.prototype%.containing called on value that's not a Segments"_s);
+
+    JSValue indexValue = callFrame->argument(0);
+    double value = indexValue.toIntegerOrInfinity(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue result = segments->containing(globalObject, jsNumber(value));
+    RETURN_IF_EXCEPTION(scope, {});
+    if (result.isUndefined())
+        return JSValue::encode(result);
+
+    JSObject* resultObject = asObject(result);
+    JSValue input = resultObject->get(globalObject, vm.propertyNames->input);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSString* inputString = asString(input);
+    auto view = inputString->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (view->is8Bit())
+        return JSValue::encode(result);
+
+    int32_t index = toInt32(value);
+    auto span = view->span16();
+    if (static_cast<size_t>(index) + 1 < span.size() && U16_IS_LEAD(span[index]) && U16_IS_TRAIL(span[index + 1]))
+        RELEASE_AND_RETURN(scope, JSValue::encode(segments->containing(globalObject, jsNumber(index + 1))));
+
+    return JSValue::encode(result);
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/IntlSegmentsContaining.cpp
+++ b/src/jsc/bindings/IntlSegmentsContaining.cpp
@@ -1,10 +1,11 @@
 #include "root.h"
 #include "IntlSegmentsContaining.h"
+#include "ZigGlobalObject.h"
 
-#include <JavaScriptCore/IntlSegments.h>
+#include <JavaScriptCore/CallData.h>
 #include <JavaScriptCore/JSCast.h>
+#include <JavaScriptCore/JSFunction.h>
 #include <JavaScriptCore/JSString.h>
-#include <unicode/utf16.h>
 
 namespace Bun {
 
@@ -22,21 +23,31 @@ using namespace JSC;
 // Since index and index + 1 are the same code point in that case, the spec
 // result of containing(index) equals containing(index + 1), and the latter
 // avoids the trail-surrogate offset. We forward to JSC's implementation with
-// the adjusted index so the rest of the algorithm (and isWordLike) is reused.
+// the adjusted index so its algorithm (including isWordLike) is reused.
+//
+// IntlSegments.h transitively includes <unicode/ubrk.h>, which is absent from
+// Apple's public ICU headers, so this file calls the stored original host
+// function instead of IntlSegments::containing directly.
 JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncContainingFix, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* segments = dynamicDowncast<IntlSegments>(callFrame->thisValue());
-    if (!segments) [[unlikely]]
-        return throwVMTypeError(globalObject, scope, "%Segments.prototype%.containing called on value that's not a Segments"_s);
+    auto* zigGlobal = defaultGlobalObject(globalObject);
+    JSFunction* original = zigGlobal->m_intlSegmentsContainingOriginal.get();
+    ASSERT(original);
+    auto callData = JSC::getCallData(original);
 
+    JSValue thisValue = callFrame->thisValue();
     JSValue indexValue = callFrame->argument(0);
     double value = indexValue.toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    JSValue result = segments->containing(globalObject, jsNumber(value));
+    MarkedArgumentBuffer args;
+    args.append(jsNumber(value));
+    ASSERT(!args.hasOverflowed());
+
+    JSValue result = JSC::call(globalObject, original, callData, thisValue, args);
     RETURN_IF_EXCEPTION(scope, {});
     if (result.isUndefined())
         return JSValue::encode(result);
@@ -53,10 +64,31 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncContainingFix, (JSGlobalObject
 
     int32_t index = toInt32(value);
     auto span = view->span16();
-    if (static_cast<size_t>(index) + 1 < span.size() && U16_IS_LEAD(span[index]) && U16_IS_TRAIL(span[index + 1]))
-        RELEASE_AND_RETURN(scope, JSValue::encode(segments->containing(globalObject, jsNumber(index + 1))));
+    if (static_cast<size_t>(index) + 1 < span.size() && U16_IS_LEAD(span[index]) && U16_IS_TRAIL(span[index + 1])) {
+        MarkedArgumentBuffer adjustedArgs;
+        adjustedArgs.append(jsNumber(index + 1));
+        ASSERT(!adjustedArgs.hasOverflowed());
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSC::call(globalObject, original, callData, thisValue, adjustedArgs)));
+    }
 
     return JSValue::encode(result);
+}
+
+void installIntlSegmentsContainingFix(Zig::GlobalObject* globalObject, VM& vm)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* segmentsPrototype = globalObject->segmentsStructure()->storedPrototypeObject();
+    auto identifier = JSC::Identifier::fromString(vm, "containing"_s);
+    JSValue original = segmentsPrototype->get(globalObject, identifier);
+    RETURN_IF_EXCEPTION(scope, );
+
+    auto* originalFunction = dynamicDowncast<JSFunction>(original);
+    if (!originalFunction) [[unlikely]]
+        return;
+
+    globalObject->m_intlSegmentsContainingOriginal.set(vm, globalObject, originalFunction);
+    segmentsPrototype->putDirectNativeFunction(vm, globalObject, identifier, 1, intlSegmentsPrototypeFuncContainingFix, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/IntlSegmentsContaining.cpp
+++ b/src/jsc/bindings/IntlSegmentsContaining.cpp
@@ -40,6 +40,18 @@ JSC_DEFINE_HOST_FUNCTION(intlSegmentsPrototypeFuncContainingFix, (JSGlobalObject
 
     JSValue thisValue = callFrame->thisValue();
     JSValue indexValue = callFrame->argument(0);
+
+    // Brand-check before coercion so step 2 (RequireInternalSlot) precedes
+    // step 6 (ToIntegerOrInfinity). IntlSegments::info() is unreachable here,
+    // so read the ClassInfo off the cached structure instead.
+    const ClassInfo* segmentsClassInfo = zigGlobal->segmentsStructure()->classInfoForCells();
+    if (!thisValue.isCell() || !thisValue.asCell()->inherits(segmentsClassInfo)) {
+        MarkedArgumentBuffer rawArgs;
+        rawArgs.append(indexValue);
+        ASSERT(!rawArgs.hasOverflowed());
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSC::call(globalObject, original, callData, thisValue, rawArgs)));
+    }
+
     double value = indexValue.toIntegerOrInfinity(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/IntlSegmentsContaining.h
+++ b/src/jsc/bindings/IntlSegmentsContaining.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "root.h"
+
+namespace Bun {
+
+JSC_DECLARE_HOST_FUNCTION(intlSegmentsPrototypeFuncContainingFix);
+
+} // namespace Bun

--- a/src/jsc/bindings/IntlSegmentsContaining.h
+++ b/src/jsc/bindings/IntlSegmentsContaining.h
@@ -2,8 +2,12 @@
 
 #include "root.h"
 
+namespace Zig {
+class GlobalObject;
+}
+
 namespace Bun {
 
-JSC_DECLARE_HOST_FUNCTION(intlSegmentsPrototypeFuncContainingFix);
+void installIntlSegmentsContainingFix(Zig::GlobalObject*, JSC::VM&);
 
 } // namespace Bun

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -26,6 +26,8 @@
 #include "JavaScriptCore/InitializeThreading.h"
 #include "JavaScriptCore/InternalFieldTuple.h"
 #include "JavaScriptCore/InternalFunction.h"
+#include "JavaScriptCore/IntlSegments.h"
+#include "JavaScriptCore/IntlSegmentsPrototype.h"
 #include "JavaScriptCore/JSArray.h"
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSCJSValue.h"
@@ -80,6 +82,7 @@
 #include "ErrorStackTrace.h"
 #include "IDLTypes.h"
 #include "ImportMetaObject.h"
+#include "IntlSegmentsContaining.h"
 #include "JS2Native.h"
 #include "JSAbortAlgorithm.h"
 #include "JSAbortController.h"
@@ -2223,6 +2226,16 @@ void GlobalObject::finishCreation(VM& vm)
             JSObject* moduleNamespacePrototype = JSC::constructEmptyObject(init.vm, init.owner->nullPrototypeObjectStructure());
             moduleNamespacePrototype->putDirectCustomAccessor(init.vm, init.vm.propertyNames->__esModule, CustomGetterSetter::create(init.vm, moduleNamespacePrototypeGetESModuleMarker, moduleNamespacePrototypeSetESModuleMarker), PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::CustomAccessor | 0);
             init.set(JSModuleNamespaceObject::createStructure(init.vm, init.owner, moduleNamespacePrototype));
+        });
+
+    // Override %Segments.prototype%.containing to work around a JSC bug at
+    // surrogate-pair segment starts; see IntlSegmentsContaining.cpp.
+    m_segmentsStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            JSGlobalObject* globalObject = init.owner;
+            JSC::IntlSegmentsPrototype* segmentsPrototype = JSC::IntlSegmentsPrototype::create(init.vm, globalObject, JSC::IntlSegmentsPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
+            segmentsPrototype->putDirectNativeFunction(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "containing"_s), 1, Bun::intlSegmentsPrototypeFuncContainingFix, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
+            init.set(JSC::IntlSegments::createStructure(init.vm, globalObject, segmentsPrototype));
         });
 
     m_vmModuleContextMap.initLater(

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -26,8 +26,6 @@
 #include "JavaScriptCore/InitializeThreading.h"
 #include "JavaScriptCore/InternalFieldTuple.h"
 #include "JavaScriptCore/InternalFunction.h"
-#include "JavaScriptCore/IntlSegments.h"
-#include "JavaScriptCore/IntlSegmentsPrototype.h"
 #include "JavaScriptCore/JSArray.h"
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSCJSValue.h"
@@ -2228,16 +2226,6 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(JSModuleNamespaceObject::createStructure(init.vm, init.owner, moduleNamespacePrototype));
         });
 
-    // Override %Segments.prototype%.containing to work around a JSC bug at
-    // surrogate-pair segment starts; see IntlSegmentsContaining.cpp.
-    m_segmentsStructure.initLater(
-        [](const Initializer<Structure>& init) {
-            JSGlobalObject* globalObject = init.owner;
-            JSC::IntlSegmentsPrototype* segmentsPrototype = JSC::IntlSegmentsPrototype::create(init.vm, globalObject, JSC::IntlSegmentsPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
-            segmentsPrototype->putDirectNativeFunction(init.vm, globalObject, JSC::Identifier::fromString(init.vm, "containing"_s), 1, Bun::intlSegmentsPrototypeFuncContainingFix, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
-            init.set(JSC::IntlSegments::createStructure(init.vm, globalObject, segmentsPrototype));
-        });
-
     m_vmModuleContextMap.initLater(
         [](const Initializer<JSWeakMap>& init) {
             init.set(JSWeakMap::create(init.vm, init.owner->weakMapStructure()));
@@ -3169,6 +3157,9 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     errorConstructor->putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "captureStackTrace"_s), 2, errorConstructorFuncCaptureStackTrace, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
     errorConstructor->putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "appendStackTrace"_s), 2, errorConstructorFuncAppendStackTrace, ImplementationVisibility::Private, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
     errorConstructor->putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "prepareStackTrace"_s), JSC::CustomGetterSetter::create(vm, errorConstructorPrepareStackTraceGetter, errorConstructorPrepareStackTraceSetter), PropertyAttribute::DontEnum | PropertyAttribute::CustomValue);
+
+    Bun::installIntlSegmentsContainingFix(this, vm);
+    scope.assertNoExceptionExceptTermination();
 
     JSC::JSObject* consoleObject = this->get(this, JSC::Identifier::fromString(vm, "console"_s)).getObject();
     scope.assertNoExceptionExceptTermination();

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -500,6 +500,9 @@ public:
     /* Error.prepareStackTrace */                                                                            \
     V(public, WriteBarrier<JSC::Unknown>, m_errorConstructorPrepareStackTraceValue)                          \
                                                                                                              \
+    /* JSC's original %Segments.prototype%.containing; see IntlSegmentsContaining.cpp. */                    \
+    V(public, WriteBarrier<JSC::JSFunction>, m_intlSegmentsContainingOriginal)                               \
+                                                                                                             \
     /* When a napi module initializes on dlopen, we need to know what the value is */                        \
     V(public, NapiModuleAndExports, m_pendingNapiModuleAndExports)                                           \
                                                                                                              \

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -160,6 +160,51 @@ describe("Intl.Segmenter", () => {
       th: seg("th", "word", "สวัสดีครับ"),
     }).toMatchSnapshot();
   });
+
+  // JSC's containing() miscomputed startIndex when the index is the lead
+  // surrogate of a surrogate pair that begins a segment, merging it with the
+  // previous segment. Iteration was always correct, so for every code unit i,
+  // containing(i) must equal the segment from [...segments] that covers i.
+  describe("containing() at surrogate-pair segment starts", () => {
+    const cases: [string, Intl.SegmenterOptions["granularity"]][] = [
+      ["Hello, world! 👍🏽 x", "word"],
+      ["x👍🏽y", "grapheme"],
+      ["a🇯🇵b", "grapheme"],
+      ["👍🏽", "grapheme"],
+      ["a👨‍👩‍👧‍👦b", "grapheme"],
+      ["Hi. 👍 Bye.", "sentence"],
+      ["x\ud83d", "grapheme"], // unpaired lead surrogate
+      ["abc", "grapheme"], // 8-bit string, no surrogates
+    ];
+    const pick = ({ segment, index, isWordLike }: Intl.SegmentData) => ({ segment, index, isWordLike });
+
+    test.each(cases)("%j (%s)", (input, granularity) => {
+      const segments = new Intl.Segmenter("en", { granularity }).segment(input);
+      const iterated = [...segments].map(pick);
+      const via = Array.from({ length: input.length }, (_, i) => pick(segments.containing(i)));
+      const expected = Array.from({ length: input.length }, (_, i) => iterated.findLast(s => s.index <= i)!);
+      expect(via).toEqual(expected);
+    });
+
+    test("out of range returns undefined", () => {
+      const segments = new Intl.Segmenter("en").segment("x👍🏽y");
+      expect(segments.containing(-1)).toBeUndefined();
+      expect(segments.containing(6)).toBeUndefined();
+      expect(segments.containing(Infinity)).toBeUndefined();
+    });
+
+    test("observable ToIntegerOrInfinity called once", () => {
+      const segments = new Intl.Segmenter("en").segment("x👍🏽y");
+      let calls = 0;
+      const index = { valueOf: () => (calls++, 1) };
+      expect(pick(segments.containing(index as unknown as number))).toEqual({
+        segment: "👍🏽",
+        index: 1,
+        isWordLike: undefined,
+      });
+      expect(calls).toBe(1);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -204,6 +204,14 @@ describe("Intl.Segmenter", () => {
       });
       expect(calls).toBe(1);
     });
+
+    test("brand check precedes ToIntegerOrInfinity", () => {
+      const { containing } = Object.getPrototypeOf(new Intl.Segmenter("en").segment("x"));
+      let coerced = false;
+      const index = { valueOf: () => ((coerced = true), 0) };
+      expect(() => containing.call({}, index)).toThrow(TypeError);
+      expect(coerced).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

`%Segments.prototype%.containing(i)` returns a phantom merged segment when `i` is the lead surrogate of an astral code point that begins a segment. It reports the previous segment's start index with text spanning both segments, contradicting iteration over the same `Segments` object (which is correct). Word, grapheme and sentence granularity are all affected.

```js
const seg = new Intl.Segmenter("en", { granularity: "word" }).segment("Hello, world! 👍🏽 x");
[...seg].map(x => [x.index, x.segment]);
// ..., [13," "], [14,"👍🏽"], [18," "], [19,"x"]
seg.containing(14);
// node: { segment: "👍🏽", index: 14 }
// bun : { segment: " 👍🏽", index: 13 }   <- no such segment; overlaps [13," "]

new Intl.Segmenter("en").segment("x👍🏽y").containing(1);
// node: { segment: "👍🏽", index: 1 }
// bun : { segment: "x👍🏽", index: 0 }
```

## Cause

JSC's `IntlSegments::containing` computes `startIndex = ubrk_preceding(index + 1)`. When `index` is a lead surrogate, `index + 1` is a trail surrogate; ICU's break iterator snaps a trail-surrogate offset back to the lead (the code-point start, i.e. `index`) before scanning, so `ubrk_preceding` returns the boundary strictly before `index` and skips a boundary at `index` itself. V8 avoids this by checking `isBoundary(n)` first.

## Fix

`IntlSegments.h` transitively includes `<unicode/ubrk.h>`, which is absent from Apple's public ICU headers, so bun's bindings can't reach `IntlSegments::containing` directly. Instead, `addBuiltinGlobals` reads JSC's original `containing` off `%Segments.prototype%` (via `segmentsStructure()->storedPrototypeObject()`), stores it in a `WriteBarrier<JSFunction>` on `Zig::GlobalObject`, and installs a wrapper in its place. The wrapper forwards to the stored original with `index + 1` whenever the requested index is the lead of a surrogate pair: same code point and therefore same spec result, but `index + 2` is a code-point start so the ICU snap never fires.

The underlying bug should also be fixed in oven-sh/WebKit (`IntlSegments.cpp`), at which point this override can be dropped.

## Verification

New tests in `test/js/web/intl/intl.test.ts` probe `containing(i)` for every code unit `i` across word/grapheme/sentence inputs (emoji with skin-tone modifier, regional-indicator flag, ZWJ family, unpaired lead surrogate, 8-bit string) and assert each result equals the iteration-derived segment covering `i`. Also covers out-of-range indices and that `ToIntegerOrInfinity` is observed exactly once.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/intl/intl.test.ts

<!-- robobun:evidence:end -->