### PR TITLE
Bun.serve dev HTML route: frame the 405 response so non-GET requests don't hang

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3244,6 +3244,12 @@ impl DeferredRequest {
                 drop(saved);
             }
             Handler::BundledHtmlPage(r) => {
+                // Reached from JS event-loop tasks (on_plugins_rejected, the
+                // bundle-completion OOM cleanup defer), so end_without_body
+                // alone cannot close the socket; write Content-Length so the
+                // client has framing.
+                r.response.write_status(b"500 Internal Server Error");
+                r.response.write_header_int(b"Content-Length", 0);
                 r.response.end_without_body(true);
             }
             Handler::Aborted => {}

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -767,10 +767,10 @@ impl Route {
                         // TODO: Show a generic error page.
                     }
                     resp.write_status(b"500 Build Failed");
-                    resp.end_without_body(false);
+                    resp.end_without_body(true);
                 }
                 _ => {
-                    resp.end_without_body(false);
+                    resp.end_without_body(true);
                 }
             }
         }

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -766,10 +766,15 @@ impl Route {
                         // To protect privacy, do not show errors to end users in production.
                         // TODO: Show a generic error page.
                     }
+                    // This runs from a JS event-loop task, not a uWS handler,
+                    // so `end_without_body(true)` alone cannot close the
+                    // socket; write Content-Length so the client has framing.
                     resp.write_status(b"500 Build Failed");
+                    resp.write_header_int(b"Content-Length", 0);
                     resp.end_without_body(true);
                 }
                 _ => {
+                    resp.write_header_int(b"Content-Length", 0);
                     resp.end_without_body(true);
                 }
             }

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -534,6 +534,8 @@ impl StaticRoute {
                 Method::HEAD => Self::on_head(this, resp),
                 _ => {
                     (*this).do_write_status(405, resp); // Method not allowed
+                    resp.write_header(b"Allow", b"GET, HEAD");
+                    resp.write_header_int(b"Content-Length", 0);
                     resp.end_without_body(resp.should_close_connection());
                 }
             }

--- a/src/uws_sys/BodyReaderMixin.rs
+++ b/src/uws_sys/BodyReaderMixin.rs
@@ -202,7 +202,7 @@ impl<Wrap: BodyReaderHandler> BodyReaderMixin<Wrap> {
         r.clear_on_writable();
 
         r.write_status(b"500 Internal Server Error");
-        r.end_without_body(false);
+        r.end_without_body(true);
 
         // SAFETY: wrap is the original heap-allocated pointer; the &mut to
         // mixin.body above has ended; on_error may heap::take it.
@@ -219,7 +219,7 @@ impl<Wrap: BodyReaderHandler> BodyReaderMixin<Wrap> {
         r.clear_on_writable();
 
         r.write_status(b"400 Bad Request");
-        r.end_without_body(false);
+        r.end_without_body(true);
 
         // SAFETY: wrap is the original heap-allocated pointer; the &mut to
         // mixin.body above has ended; on_error may heap::take it.

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -30,10 +30,16 @@ test("dev server html route: non-GET/HEAD requests complete without hanging", as
   for (const method of ["POST", "PUT", "DELETE", "OPTIONS", "PATCH"]) {
     const res = await fetch(server.url, { method });
     await res.arrayBuffer();
-    expect({ method, status: res.status, contentLength: res.headers.get("content-length") }).toEqual({
+    expect({
+      method,
+      status: res.status,
+      contentLength: res.headers.get("content-length"),
+      allow: res.headers.get("allow"),
+    }).toEqual({
       method,
       status: 405,
       contentLength: "0",
+      allow: "GET, HEAD",
     });
   }
 });

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { tempDirWithFiles } from "harness";
+import { join } from "path";
+
+test("dev server html route: non-GET/HEAD requests complete without hanging", async () => {
+  const dir = tempDirWithFiles("html-route-405", {
+    "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body>hi</body></html>`,
+  });
+  const { default: html } = await import(join(dir, "index.html"));
+
+  using server = Bun.serve({
+    port: 0,
+    development: true,
+    routes: { "/": html },
+    fetch(req) {
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  // GET should serve the page.
+  {
+    const res = await fetch(server.url);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("<title>t</title>");
+  }
+
+  // Non-GET/HEAD requests used to write a bare `405` status line with no
+  // Content-Length, so HTTP/1.1 keep-alive clients would block forever
+  // waiting for framing.
+  for (const method of ["POST", "PUT", "DELETE", "OPTIONS", "PATCH"]) {
+    const res = await fetch(server.url, { method });
+    await res.arrayBuffer();
+    expect({ method, status: res.status, contentLength: res.headers.get("content-length") }).toEqual({
+      method,
+      status: 405,
+      contentLength: "0",
+    });
+  }
+});

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -821,42 +821,6 @@ test("you can have HTML imports apply to only specific methods outside of the de
   expect(await (await fetch(server.url + "/boop", { method: "PATCH" })).text()).toBe(htmlText);
 });
 
-test("dev server html route: non-GET/HEAD requests complete without hanging", async () => {
-  const dir = tempDirWithFiles("html-route-405", {
-    "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body>hi</body></html>`,
-  });
-  const { default: html } = await import(join(dir, "index.html"));
-
-  using server = Bun.serve({
-    port: 0,
-    development: true,
-    routes: { "/": html },
-    fetch(req) {
-      return new Response("Not found", { status: 404 });
-    },
-  });
-
-  // GET should serve the page.
-  {
-    const res = await fetch(server.url);
-    expect(res.status).toBe(200);
-    expect(await res.text()).toContain("<title>t</title>");
-  }
-
-  // Non-GET/HEAD requests used to write a bare `405` status line with no
-  // Content-Length, so HTTP/1.1 keep-alive clients would block forever
-  // waiting for framing.
-  for (const method of ["POST", "PUT", "DELETE", "OPTIONS", "PATCH"]) {
-    const res = await fetch(server.url, { method });
-    await res.arrayBuffer();
-    expect({ method, status: res.status, contentLength: res.headers.get("content-length") }).toEqual({
-      method,
-      status: 405,
-      contentLength: "0",
-    });
-  }
-});
-
 for (let development of [true, false, { hmr: false }]) {
   test(`mixed api and html routes with non-* false routes`, async () => {
     const dir = join(import.meta.dir, "jsx-runtime");

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -821,6 +821,42 @@ test("you can have HTML imports apply to only specific methods outside of the de
   expect(await (await fetch(server.url + "/boop", { method: "PATCH" })).text()).toBe(htmlText);
 });
 
+test("dev server html route: non-GET/HEAD requests complete without hanging", async () => {
+  const dir = tempDirWithFiles("html-route-405", {
+    "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body>hi</body></html>`,
+  });
+  const { default: html } = await import(join(dir, "index.html"));
+
+  using server = Bun.serve({
+    port: 0,
+    development: true,
+    routes: { "/": html },
+    fetch(req) {
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  // GET should serve the page.
+  {
+    const res = await fetch(server.url);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("<title>t</title>");
+  }
+
+  // Non-GET/HEAD requests used to write a bare `405` status line with no
+  // Content-Length, so HTTP/1.1 keep-alive clients would block forever
+  // waiting for framing.
+  for (const method of ["POST", "PUT", "DELETE", "OPTIONS", "PATCH"]) {
+    const res = await fetch(server.url, { method });
+    await res.arrayBuffer();
+    expect({ method, status: res.status, contentLength: res.headers.get("content-length") }).toEqual({
+      method,
+      status: 405,
+      contentLength: "0",
+    });
+  }
+});
+
 for (let development of [true, false, { hmr: false }]) {
   test(`mixed api and html routes with non-* false routes`, async () => {
     const dir = join(import.meta.dir, "jsx-runtime");


### PR DESCRIPTION
## Repro

```ts
import page from "./index.html";
const s = Bun.serve({ port: 0, development: true, routes: { "/": page } });
await fetch(s.url, { method: "POST" }); // hangs until the client's own timeout
```

With `development: true` and an HTML-import route, any non-GET/HEAD request writes `HTTP/1.1 405 Method Not Allowed\r\n\r\n` and nothing else: no `Content-Length`, no `Connection: close`, socket left open. HTTP/1.1 keep-alive clients (fetch, curl, a browser form POST) block forever waiting for body framing. `development: false` serves the same route with `200` instantly.

## Cause

The dev server routes these requests through `StaticRoute::on_with_method`, whose non-GET/HEAD arm does

```rust
(*this).do_write_status(405, resp);
resp.end_without_body(resp.should_close_connection());
```

`end_without_body` terminates the header section but writes no `Content-Length`, and `should_close_connection()` is `false` on a keep-alive connection, so the response has no framing at all.

## Fix

Write `Content-Length: 0` (and the RFC 9110 §15.5.6 required `Allow` header) before `end_without_body`, matching the HEAD path in `render_metadata_and_end`.

Wire after:

```
HTTP/1.1 405 Method Not Allowed
Allow: GET, HEAD
Content-Length: 0

```

### Same-class sibling sites (dev server / HTML route scope)

- `BodyReaderMixin::on_oom` (500) and `on_invalid` (400), reachable via the dev server error-report endpoint. These run inside the uWS data callback, so passing `close_connection=true` is sufficient: the post-handler uncork path closes the socket.
- `HTMLBundle::resume_pending_responses` `State::Err` (500 Build Failed) and its fallthrough arm, reached when an async HTML bundle build fails while requests are queued. These run from a JS event-loop task rather than a uWS handler, so they additionally write `Content-Length: 0`.
- `DevServer::DeferredRequest::abort` for `BundledHtmlPage`, reached from `on_plugins_rejected` and the bundle-completion OOM cleanup defer (both JS event-loop tasks). Now writes `500` + `Content-Length: 0`.

A broader audit found more `end_without_body` call sites outside the dev-server scope (general `RequestContext` error rendering, `NodeHTTPResponse`, `FileRoute` 307/308 and non-regular-file HEAD, `FileResponseStream` pipe EOF) that share the pattern. Those touch different subsystems with their own semantics and are intentionally left for a follow-up so this PR stays focused on the reported dev-server bug.

## Verification

New `test/js/bun/http/bun-serve-html-405.test.ts` starts a `development: true` server with an HTML route and asserts POST/PUT/DELETE/OPTIONS/PATCH each return `405` with `Content-Length: 0` and `Allow: GET, HEAD`. Before the fix the first non-GET request hangs and the test times out; after, it completes in ~100ms.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/bun-serve-html-405.test.ts"
bun test v1.4.0 (5e785fc99)

test/js/bun/http/bun-serve-html-405.test.ts:
Bundled page in 91ms: ../../tmp/html-route-405_t7Rlcm/index.html
(fail) dev server html route: non-GET/HEAD requests complete without hanging [5001.28ms]
  ^ this test timed out after 5000ms.

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [7.15s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (e5e801317)

test/js/bun/http/bun-serve-html-405.test.ts:
Bundled page in 6ms: ../../tmp/html-route-405_ShZ7Kp/index.html
(pass) dev server html route: non-GET/HEAD requests complete without hanging [26.97ms]

 1 pass
 0 fail
 7 expect() calls
Ran 1 test across 1 file. [233.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/http/bun-serve-html-405.test.ts"
bun test v1.4.0 (5e785fc99)

test/js/bun/http/bun-serve-html-405.test.ts:
Bundled page in 90ms: ../../tmp/html-route-405_YnkfEf/index.html
(pass) dev server html route: non-GET/HEAD requests complete without hanging [206.01ms]

 1 pass
 0 fail
 7 expect() calls
Ran 1 test across 1 file. [2.40s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 892ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[4/23] gen JS modules (bundle-modules)
Preprocess modules (13857ms)
Bundle modules (62ms)
Postprocesss modules (96ms)
Bundle Functions (918ms)
Generate Code (131ms)

[15.08s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[4/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compilin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServer.rs               |  6 ++++
 src/runtime/server/HTMLBundle.rs            |  9 ++++--
 src/runtime/server/StaticRoute.rs           |  2 ++
 src/uws_sys/BodyReaderMixin.rs              |  4 +--
 test/js/bun/http/bun-serve-html-405.test.ts | 45 +++++++++++++++++++++++++++++
 5 files changed, 62 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/runtime/bake/DevServer.rs                    3      1      0
src/runtime/server/HTMLBundle.rs                 4      2      0
src/runtime/server/StaticRoute.rs                3      1      0
src/uws_sys/BodyReaderMixin.rs                   2      1      0
test/js/bun/http/bun-serve-html-405.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->