### PR TITLE
Fix `import.meta.hot?.accept()` throwing in dev server

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -929,6 +929,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             },
         );
 
+        if e_.optional_chain == Some(js_ast::OptionalChain::Start)
+            && matches!(e_.target.data, Data::ESpecial(E::Special::HotEnabled))
+        {
+            e_.optional_chain = None;
+        }
+
         match e_.index.data {
             Data::EPrivateIdentifier(mut private) => {
                 let name = p.load_name_from_ref(private.ref_);
@@ -1423,6 +1429,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ..Default::default()
             },
         );
+
+        // `import.meta.hot?.accept()` should be treated like a direct
+        // `import.meta.hot.accept()` in development. `import.meta.hot` is
+        // always defined when HMR is enabled, so the `?.` guard is a no-op
+        // and would otherwise prevent `maybe_rewrite_property_access` from
+        // lowering the access to the HMR module member, leaving the
+        // throwing `indirectHot` proxy in place.
+        if e_.optional_chain == Some(js_ast::OptionalChain::Start)
+            && matches!(e_.target.data, Data::ESpecial(E::Special::HotEnabled))
+        {
+            e_.optional_chain = None;
+        }
 
         // 'require.resolve' -> .e_require_resolve_call_target
         if matches!(e_.target.data, Data::ERequireCallTarget) && e_.name == b"resolve" {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1430,12 +1430,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             },
         );
 
-        // `import.meta.hot?.accept()` should be treated like a direct
-        // `import.meta.hot.accept()` in development. `import.meta.hot` is
-        // always defined when HMR is enabled, so the `?.` guard is a no-op
-        // and would otherwise prevent `maybe_rewrite_property_access` from
-        // lowering the access to the HMR module member, leaving the
-        // throwing `indirectHot` proxy in place.
+        // `import.meta.hot` is always defined when HMR is enabled, so drop
+        // the `?.` in `import.meta.hot?.X` and let `maybe_rewrite_property_access`
+        // lower it instead of leaving the throwing `indirectHot` proxy in place.
         if e_.optional_chain == Some(js_ast::OptionalChain::Start)
             && matches!(e_.target.data, Data::ESpecial(E::Special::HotEnabled))
         {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -388,6 +388,29 @@ devTest("import.meta.hot.dispose cleanup", {
     await c.expectMessage("Cleaning up", "Third setup");
   },
 });
+devTest("import.meta.hot with optional chaining", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      const data = import.meta.hot?.data;
+      data.count ??= 0;
+      import.meta.hot?.dispose(() => console.log("Cleaning up"));
+      import.meta.hot?.on("bun:invalidate", () => {});
+      import.meta.hot?.accept();
+      console.log("Initial count: " + data.count++);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("Initial count: 0");
+    await dev.writeNoChanges("index.ts");
+    await c.expectMessage("Cleaning up", "Initial count: 1");
+    await dev.writeNoChanges("index.ts");
+    await c.expectMessage("Cleaning up", "Initial count: 2");
+  },
+});
 devTest("import.meta.hot invalid usage", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -397,7 +397,7 @@ devTest("import.meta.hot with optional chaining", {
       const data = import.meta.hot?.data;
       data.count ??= 0;
       import.meta.hot?.dispose(() => console.log("Cleaning up"));
-      import.meta.hot?.on("bun:invalidate", () => {});
+      import.meta.hot?.["on"]("bun:invalidate", () => {});
       import.meta.hot?.accept();
       console.log("Initial count: " + data.count++);
     `,


### PR DESCRIPTION
### Problem

The guarded form `import.meta.hot?.accept()` (or `?.data`, `?.on(...)`, etc.) throws at module evaluation in the dev server:

```
Error: import.meta.hot.accept cannot be used indirectly.
```

The same source is a no-op in production and in plain `bun build` (where `import.meta.hot` is `undefined`), so a file that ships fine dies only under `Bun.serve` dev. The non-optional `import.meta.hot.accept()` works; the one-character difference is the `?.`.

### Cause

`e_dot`/`e_index` in the parser visitor skip `maybe_rewrite_property_access` when `optional_chain` is set. For `import.meta.hot?.accept`:

1. The inner `import.meta.hot` access (no `?.`) rewrites to `E::Special::HotEnabled`.
2. The outer `.accept` access has `optional_chain = Start`, so the rewrite is skipped and the result stays as `EDot(HotEnabled, "accept", optional_chain=Start)`.
3. `HotEnabled` prints as `hmr.indirectHot`, yielding `hmr.indirectHot?.accept()`.
4. `indirectHot` is a truthy `Proxy` whose every property `get` throws, so `?.` cannot short-circuit and the module throws.

### Fix

`import.meta.hot` is always defined when HMR is enabled, so the `?.` after it is a no-op guard intended for production. After visiting the target, if it resolved to `HotEnabled` and `optional_chain == Start`, clear `optional_chain` so the existing direct-access rewrite fires and lowers to the appropriate HMR module member (`hmr.accept`, `hmr.data`, `hmr.on`, ...). Production (`HotDisabled`) is untouched; it already prints as `(void 0)?.x` which short-circuits correctly at runtime.

### Test

`test/bake/dev/hot.test.ts` gets a new `import.meta.hot with optional chaining` case that exercises `?.data`, `?.dispose`, `?.on`, and `?.accept` in a served module and asserts the module evaluates, self-accepts, and the dispose callback runs across reloads.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->