### PR TITLE
Bun.serve HTML routes: report bundle elapsed time in ms, not ms/1000

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -577,9 +577,9 @@ impl Route {
                 if server.config().is_development() {
                     let now = bun_core::util::Timespec::now_allow_mocked_time().ns();
                     let duration = now.saturating_sub(completion_task.started_at_ns);
-                    let duration_f64 = duration as f64 / 1_000_000_000.0;
+                    let duration_ms = duration as f64 / bun_core::time::NS_PER_MS as f64;
 
-                    bun_output::print_elapsed(duration_f64);
+                    bun_output::print_elapsed(duration_ms);
                     let mut byte_length: u64 = 0;
                     for output_file in output_files.iter() {
                         byte_length += output_file.size_without_sourcemap as u64;

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -955,7 +955,10 @@ test("development: {hmr: false} bundle log reports elapsed time in ms", async ()
 
   expect({
     status: result.status,
-    order: reportedMs >= result.elapsed / 10 ? "ok" : `reported ${reportedMs}ms, fetch took ${result.elapsed}ms`,
+    order:
+      reportedMs >= result.elapsed / 10 && reportedMs <= result.elapsed * 10
+        ? "ok"
+        : `reported ${reportedMs}ms, fetch took ${result.elapsed}ms`,
   }).toEqual({ status: 200, order: "ok" });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -851,13 +851,17 @@ for (let development of [true, false, { hmr: false }]) {
       new URL("/api-potato", server.url),
       new URL("/apiii", server.url),
     ];
-    for (const url of htmlroutes) {
-      const response = await fetch(url);
-      expect(response.status).toBe(200);
-      const htmlText = await response.text();
-      const jsSrc = htmlText.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1]!;
-      await (await fetch(new URL(jsSrc, server.url))).text();
-    }
+    // Concurrent so `development: {hmr: false}` (which rebundles per request and
+    // has no DevServer cache) only builds once for the whole batch.
+    await Promise.all(
+      htmlroutes.map(async url => {
+        const response = await fetch(url);
+        expect(response.status).toBe(200);
+        const htmlText = await response.text();
+        const jsSrc = htmlText.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1]!;
+        await (await fetch(new URL(jsSrc, server.url))).text();
+      }),
+    );
     for (const url of [new URL("/api", server.url), new URL("/api/", server.url)]) {
       const response = await fetch(url);
       const json = await response.json();
@@ -895,19 +899,66 @@ for (let development of [true, false, { hmr: false }]) {
       new URL("/api/potato", server.url),
       new URL("/api/apiii", server.url),
     ];
-    for (const url of htmlroutes) {
-      const response = await fetch(url);
-      expect(response.status).toBe(200);
-      const htmlText = await response.text();
-      const jsSrc = htmlText.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1]!;
-      await (await fetch(new URL(jsSrc, server.url))).text();
-    }
+    // Concurrent so `development: {hmr: false}` (which rebundles per request and
+    // has no DevServer cache) only builds once for the whole batch.
+    await Promise.all(
+      htmlroutes.map(async url => {
+        const response = await fetch(url);
+        expect(response.status).toBe(200);
+        const htmlText = await response.text();
+        const jsSrc = htmlText.match(/<script type="module" crossorigin src="([^"]+)"/)?.[1]!;
+        await (await fetch(new URL(jsSrc, server.url))).text();
+      }),
+    );
     for (const url of apiroutes) {
       const response = await fetch(url);
       expect(await response.json()).toEqual({ url: url.toString(), method: "GET" });
     }
   });
 }
+
+test("development: {hmr: false} bundle log reports elapsed time in ms", async () => {
+  // The `[XXms] bundle index.html` line should be within an order of magnitude
+  // of the wall-clock fetch time. It previously divided by ns/s instead of
+  // ns/ms, reporting e.g. `[0.03ms]` for a 30ms bundle.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import html from "./index.html";
+        const server = Bun.serve({
+          port: 0,
+          development: { hmr: false },
+          routes: { "/": html },
+          fetch: () => new Response("nope", { status: 404 }),
+        });
+        const t0 = performance.now();
+        const r = await fetch(server.url);
+        await r.text();
+        const elapsed = performance.now() - t0;
+        console.log(JSON.stringify({ status: r.status, elapsed }));
+        server.stop(true);
+      `,
+    ],
+    cwd: join(import.meta.dir, "jsx-runtime"),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = JSON.parse(stdout.trim());
+
+  const match = stderr.match(/\[([\d.]+)(ms|s)\]\s+bundle\s+index\.html/);
+  expect(match, `expected a '[XXms] bundle index.html' line in stderr, got:\n${stderr}`).not.toBeNull();
+  const reportedMs = parseFloat(match![1]) * (match![2] === "s" ? 1000 : 1);
+
+  expect({
+    status: result.status,
+    order: reportedMs >= result.elapsed / 10 ? "ok" : `reported ${reportedMs}ms, fetch took ${result.elapsed}ms`,
+  }).toEqual({ status: 200, order: "ok" });
+  expect(exitCode).toBe(0);
+});
 
 describe("production headers and import.meta.env", () => {
   async function collect(development: string) {


### PR DESCRIPTION
### Problem

The `[XXms] bundle <file>` line printed when a `Bun.serve` HTML route bundles in `development: { hmr: false }` mode was off by 1000x:

```
$ bun serve.ts         # routes: { "/": html }, development: { hmr: false }
[0.03ms] bundle index.html 970.34 KB
status 200 in 36 ms    # actual wall clock
```

`Route::on_complete` divided the nanosecond duration by `1_000_000_000.0` (ns/s) and passed the result to `bun_output::print_elapsed`, which takes milliseconds (every other caller divides by `NS_PER_MS`). The same mistake was in the original Zig (`duration /= std.time.ns_per_s`) and carried over.

This also showed up as the two `mixed api and html routes` tests in `bun-serve-html.test.ts` timing out under debug+ASAN: the `{hmr: false}` iteration has no DevServer, so each request rebundles the React fixture (~2.5s in that build), and the tests fetched four HTML URLs sequentially.

### Fix

- `HTMLBundle.rs`: divide by `bun_core::time::NS_PER_MS` so `print_elapsed` receives milliseconds.
- `bun-serve-html.test.ts`: batch the HTML-route fetches with `Promise.all` so the `{hmr: false}` iteration shares one bundle instead of four. The route-matching assertions are unchanged; the loop was never order-sensitive.
- New test that spawns a server with `{hmr: false}`, parses the `[XXms]`/`[XXs] bundle` line from stderr, and asserts it is within an order of magnitude of the wall-clock fetch time.

Caching the `{hmr: false}` bundle between requests was considered and rejected: that path deliberately rebundles on every request so edit-and-refresh works without a file watcher, and release builds do it in tens of milliseconds.

### Verification

Fail-before (main debug build):

```
[2.50ms] bundle index.html 970.34 KB
(fail) mixed api and html routes with non-* false routes [5004.21ms]
[2.46ms] bundle index.html 970.34 KB
(fail) mixed api and html routes with development: {"hmr":false} [5004.88ms]
```

New timer test on main:

```
error: expect(received).toEqual(expected)
  {
-   "order": "ok",
+   "order": "reported 2.58ms, fetch took 2588.57ms",
    "status": 200,
  }
```

With this change, debug+ASAN:

```
[2.42s] bundle index.html 970.32 KB
(pass) mixed api and html routes with non-* false routes [2484.42ms]
[2.29s] bundle index.html 970.32 KB
(pass) mixed api and html routes with development: {"hmr":false} [2359.30ms]
(pass) development: {hmr: false} bundle log reports elapsed time in ms [3121.10ms]
```

All 20 tests in `test/js/bun/http/bun-serve-html.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (09eeba682)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_oBeq6U {
  "/": "/tmp/html-css-js_oBeq6U/index.html",
  "/dashboard": "/tmp/html-css-js_oBeq6U/dashboard.html",
}
[0.11ms] bundle index.html 1.09 KB
[0.07ms] bundle dashboard.html 1.27 KB
(pass) serve html [747.35ms]
waitForServer /tmp/bun-serve-html-txt_F2Bg9q {
  "/": "/tmp/bun-serve-html-txt_F2Bg9q/index.html",
}
[0.15ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [702.09ms]
waitForServer /tmp/html-css-js-failing-plugin_hB8CJq {
  "/": "/tmp/html-css-js-failing-plugin_hB8CJq/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_hB8CJq/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_hB8CJq/styles.css:0
(pass) serve plugins > serve html with failing plugin [646.90ms]
waitForServer /tmp/html-css-js-empty-plugins_f8iKmo {
  "/": "/tmp/html-css-js-empty-plugins_f8iKmo/index.html",
}
[0.11ms] bu
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_YI779U {
  "/": "/tmp/html-css-js_YI779U/index.html",
  "/dashboard": "/tmp/html-css-js_YI779U/dashboard.html",
}
[0.00ms] bundle index.html 1.09 KB
[0.00ms] bundle dashboard.html 1.27 KB
(pass) serve html [23.37ms]
waitForServer /tmp/bun-serve-html-txt_NT3n0z {
  "/": "/tmp/bun-serve-html-txt_NT3n0z/index.html",
}
[0.00ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [20.39ms]
waitForServer /tmp/html-css-js-failing-plugin_E8EukC {
  "/": "/tmp/html-css-js-failing-plugin_E8EukC/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_E8EukC/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_E8EukC/styles.css:0
(pass) serve plugins > serve html with failing plugin [20.92ms]
waitForServer /tmp/html-css-js-empty-plugins_Pj8chR {
  "/": "/tmp/html-css-js-empty-plugins_Pj8chR/index.html",
}
[0.00ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [16.97ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_NJtuTk {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (09eeba682)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_JwhdPM {
  "/": "/tmp/html-css-js_JwhdPM/index.html",
  "/dashboard": "/tmp/html-css-js_JwhdPM/dashboard.html",
}
[108.43ms] bundle index.html 1.09 KB
[62.04ms] bundle dashboard.html 1.27 KB
(pass) serve html [963.15ms]
waitForServer /tmp/bun-serve-html-txt_S68bRh {
  "/": "/tmp/bun-serve-html-txt_S68bRh/index.html",
}
[146.87ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [684.23ms]
waitForServer /tmp/html-css-js-failing-plugin_zzRDEv {
  "/": "/tmp/html-css-js-failing-plugin_zzRDEv/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_zzRDEv/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_zzRDEv/styles.css:0
(pass) serve plugins > serve html with failing plugin [680.18ms]
waitForServer /tmp/html-css-js-empty-plugins_Y9ursb {
  "/": "/tmp/html-css-js-empty-plugins_Y9ursb/index.html",
}
[110.5
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 731ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[4/23] gen JS modules (bundle-modules)
Preprocess modules (7511ms)
Bundle modules (34ms)
Postprocesss modules (21ms)
Bundle Functions (699ms)
Generate Code (80ms)

[8.36s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[5/8] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[5/8] link bun-profile
[6/8] bun-profile --revision
1.4.0-canary.1+09eeba682
[8/8] strip bun
[build] done
bun test v1.4.0-canary.1 (09eeba682)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_MIryzv {
  "/": "/tmp/html-css-js_MIryzv/index.html",
  "/dashboard": "/tmp/html-css-js_MIryzv/dashboard.html",
}
[2.93ms] bundle index.html 1.09
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/HTMLBundle.rs        |  4 +-
 test/js/bun/http/bun-serve-html.test.ts | 82 +++++++++++++++++++++++++++------
 2 files changed, 70 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/server/HTMLBundle.rs             3      1      0
test/js/bun/http/bun-serve-html.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->