### PR TITLE
node:http server: keep req.rawHeaders complete under maxHeadersCount for <32 fields

### DIFF
--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -218,19 +218,14 @@ ObjectDefineProperty(IncomingMessage.prototype, "rawHeaders", {
       const source = this[kHeaderSource];
       let built = source != null ? source.takeRawHeaders() : undefined;
       if (built === undefined) built = [];
-      // Node clamps the count fed to _addHeaderLines to parser.maxHeaderPairs
-      // (= server.maxHeadersCount << 1); rawHeaders itself is the parser's
-      // raw list, which Node's llhttp binding flushes through parserOnHeaders
-      // in 32-pair batches. Fewer than 32 pairs arrive in a single
-      // parserOnHeadersComplete call and bypass parserOnHeaders entirely, so
-      // rawHeaders is the full list and only req.headers is clamped. The
-      // native server delivers everything in one shot; reproduce the split
-      // here so proxies/loggers see the same rawHeaders Node would.
+      // Node clamps only the count fed to _addHeaderLines; rawHeaders itself is
+      // truncated only once >= 32 pairs route through parserOnHeaders (the llhttp
+      // binding's kMaxHeaderFieldsCount flush batch). Reproduce that split here.
       let count = built.length;
       const maxHeadersCount = this[fakeSocketSymbol]?.server?.maxHeadersCount;
-      if (typeof maxHeadersCount === "number" && maxHeadersCount > 0) {
-        const maxHeaderPairs = maxHeadersCount * 2;
-        if (count > maxHeaderPairs) {
+      if (typeof maxHeadersCount === "number") {
+        const maxHeaderPairs = maxHeadersCount << 1;
+        if (maxHeaderPairs > 0 && count > maxHeaderPairs) {
           if (count >= 64) built = ArrayPrototypeSlice.$call(built, 0, maxHeaderPairs);
           count = maxHeaderPairs;
         }

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -218,15 +218,25 @@ ObjectDefineProperty(IncomingMessage.prototype, "rawHeaders", {
       const source = this[kHeaderSource];
       let built = source != null ? source.takeRawHeaders() : undefined;
       if (built === undefined) built = [];
-      // Node.js's parser keeps at most server.maxHeadersCount header pairs
-      // (parser.maxHeaderPairs); the native parser does not enforce it, so
-      // truncate here.
+      // Node clamps the count fed to _addHeaderLines to parser.maxHeaderPairs
+      // (= server.maxHeadersCount << 1); rawHeaders itself is the parser's
+      // raw list, which Node's llhttp binding flushes through parserOnHeaders
+      // in 32-pair batches. Fewer than 32 pairs arrive in a single
+      // parserOnHeadersComplete call and bypass parserOnHeaders entirely, so
+      // rawHeaders is the full list and only req.headers is clamped. The
+      // native server delivers everything in one shot; reproduce the split
+      // here so proxies/loggers see the same rawHeaders Node would.
+      let count = built.length;
       const maxHeadersCount = this[fakeSocketSymbol]?.server?.maxHeadersCount;
-      if (typeof maxHeadersCount === "number" && maxHeadersCount > 0 && built.length > maxHeadersCount * 2) {
-        built = ArrayPrototypeSlice.$call(built, 0, maxHeadersCount * 2);
+      if (typeof maxHeadersCount === "number" && maxHeadersCount > 0) {
+        const maxHeaderPairs = maxHeadersCount * 2;
+        if (count > maxHeaderPairs) {
+          if (count >= 64) built = ArrayPrototypeSlice.$call(built, 0, maxHeaderPairs);
+          count = maxHeaderPairs;
+        }
       }
       raw = this[kRawHeaders] = built;
-      this[kHeadersCount] = built.length;
+      this[kHeadersCount] = count;
     }
     return raw;
   },

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,12 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1892,6 +1892,7 @@ describe("HTTP Server Security Tests - Advanced", () => {
     // flush batch size). Expected values below verified against Node.js v26.3.0.
     test.each([
       { sent: 12, max: 6, headerKeys: 6, rawLen: 24 },
+      { sent: 12, max: 3.7, headerKeys: 3, rawLen: 24 },
       { sent: 31, max: 6, headerKeys: 6, rawLen: 62 },
       { sent: 32, max: 6, headerKeys: 6, rawLen: 12 },
       { sent: 40, max: 6, headerKeys: 6, rawLen: 12 },
@@ -1905,9 +1906,11 @@ describe("HTTP Server Security Tests - Advanced", () => {
         const { promise, resolve, reject } = Promise.withResolvers();
         server.on("request", (req, res) => {
           try {
+            // rawHeaders first so the lazy getter runs before any clamped view.
+            const rawLen = req.rawHeaders.length;
             resolve({
+              rawLen,
               headerKeys: Object.keys(req.headers).length,
-              rawLen: req.rawHeaders.length,
               distinctKeys: Object.keys(req.headersDistinct).length,
             });
             res.end("ok");
@@ -1920,7 +1923,7 @@ describe("HTTP Server Security Tests - Advanced", () => {
         const msg = ["GET / HTTP/1.1", "Host: h", "Connection: close", ...extra, "", ""].join("\r\n");
         const response = await sendRequest(msg);
         expect(response).toInclude("200");
-        expect(await promise).toEqual({ headerKeys, rawLen, distinctKeys: headerKeys });
+        expect(await promise).toEqual({ rawLen, headerKeys, distinctKeys: headerKeys });
       },
     );
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -1886,6 +1886,69 @@ describe("HTTP Server Security Tests - Advanced", () => {
     });
   });
 
+  describe("server.maxHeadersCount", () => {
+    // Node clamps req.headers to maxHeadersCount but only clamps req.rawHeaders
+    // once the request carries at least 32 header fields (the llhttp binding's
+    // flush batch size). Expected values below verified against Node.js v26.3.0.
+    test.each([
+      { sent: 12, max: 6, headerKeys: 6, rawLen: 24 },
+      { sent: 31, max: 6, headerKeys: 6, rawLen: 62 },
+      { sent: 32, max: 6, headerKeys: 6, rawLen: 12 },
+      { sent: 40, max: 6, headerKeys: 6, rawLen: 12 },
+      { sent: 32, max: 40, headerKeys: 32, rawLen: 64 },
+      { sent: 50, max: 40, headerKeys: 40, rawLen: 80 },
+      { sent: 66, max: 50, headerKeys: 50, rawLen: 100 },
+    ])(
+      "sent=$sent max=$max -> headers=$headerKeys rawHeaders.length=$rawLen",
+      async ({ sent, max, headerKeys, rawLen }) => {
+        server.maxHeadersCount = max;
+        const { promise, resolve, reject } = Promise.withResolvers();
+        server.on("request", (req, res) => {
+          try {
+            resolve({
+              headerKeys: Object.keys(req.headers).length,
+              rawLen: req.rawHeaders.length,
+              distinctKeys: Object.keys(req.headersDistinct).length,
+            });
+            res.end("ok");
+          } catch (err) {
+            reject(err);
+          }
+        });
+
+        const extra = Array.from({ length: sent - 2 }, (_, i) => `X-H${i}: ${i}`);
+        const msg = ["GET / HTTP/1.1", "Host: h", "Connection: close", ...extra, "", ""].join("\r\n");
+        const response = await sendRequest(msg);
+        expect(response).toInclude("200");
+        expect(await promise).toEqual({ headerKeys, rawLen, distinctKeys: headerKeys });
+      },
+    );
+
+    test("rawHeaders retains fields past the clamp when access order is headers-first", async () => {
+      server.maxHeadersCount = 3;
+      const { promise, resolve, reject } = Promise.withResolvers();
+      server.on("request", (req, res) => {
+        try {
+          // Touch req.headers first so the rawHeaders materialization happens
+          // inside the headers getter; rawHeaders must still be complete.
+          const headerKeys = Object.keys(req.headers).length;
+          resolve({ headerKeys, rawHeaders: req.rawHeaders });
+          res.end("ok");
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      const msg = ["GET / HTTP/1.1", "Host: h", "Connection: close", "X-A: 1", "X-B: 2", "X-C: 3", "", ""].join("\r\n");
+      const response = await sendRequest(msg);
+      expect(response).toInclude("200");
+      expect(await promise).toEqual({
+        headerKeys: 3,
+        rawHeaders: ["Host", "h", "Connection", "close", "X-A", "1", "X-B", "2", "X-C", "3"],
+      });
+    });
+  });
+
   describe("HTTP Protocol Violations", () => {
     test("rejects requests with invalid HTTP version", async () => {
       const mockHandler = createMockHandler();


### PR DESCRIPTION
### What does this PR do?

With `server.maxHeadersCount` set, Bun's `node:http` server was truncating `req.rawHeaders` to `maxHeadersCount * 2` entries. Node only clamps the count fed to `_addHeaderLines` (which builds `req.headers`), so `req.rawHeaders` stays complete for requests with fewer than 32 header fields; proxies, request loggers, and header-signature verifiers that read `req.rawHeaders` were silently losing fields.

```js
const s = http.createServer((rq, rs) => {
  out = { headerKeys: Object.keys(rq.headers).length, rawLen: rq.rawHeaders.length };
  rs.end("ok");
});
s.maxHeadersCount = 6;
// send 12 header fields (Host, Connection, X-H0..X-H9)
// node:  { headerKeys: 6, rawLen: 24 }   (all 12 pairs in rawHeaders)
// bun:   { headerKeys: 6, rawLen: 12 }   (rawHeaders truncated too)
```

### Cause

`IncomingMessage.prototype.rawHeaders` (the native server's lazy materialization path in `_http_incoming.ts`) sliced the raw list to `maxHeadersCount * 2` before storing it, instead of storing the full list and only clamping `kHeadersCount`.

Node's actual behavior has a split: the llhttp binding flushes headers to `parserOnHeaders` in 32-pair batches (`kMaxHeaderFieldsCount` in `node_http_parser.cc`), and `parserOnHeaders` clamps the accumulated list. Fewer than 32 pairs arrive in a single `parserOnHeadersComplete` call whose `headers` argument is the full list and bypasses `parserOnHeaders`, so only the processed count is clamped. Verified against Node v26.3.0:

| sent | maxHeadersCount | `req.headers` keys | `req.rawHeaders.length` |
|---|---|---|---|
| 12 | 6 | 6 | 24 (full) |
| 31 | 6 | 6 | 62 (full) |
| 32 | 6 | 6 | 12 (clamped) |
| 66 | 50 | 50 | 100 (clamped) |

### Fix

In the `rawHeaders` getter, store the full raw list and clamp `kHeadersCount` to `maxHeadersCount * 2`. Slice the raw list itself only when it carries 32 or more pairs, reproducing Node's split. `req.headers` and `req.headersDistinct` iterate to `kHeadersCount` so they remain clamped. The llhttp-based client path (`_http_common.ts`) already matches Node and is unchanged.

### How did you verify your code works?

New `server.maxHeadersCount` cases in `test/js/node/http/node-http.test.ts` assert the exact `(headers, rawHeaders.length)` pairs observed in Node v26.3.0 across the 32-field boundary and for both access orders. Vendored `test-http-rawheaders-limit.js` and `test-http-max-headers-count.js` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.0 (e52e102d3)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [650.89ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [126.19ms]
(pass) node:http > createServer > request & response body streaming (large) [203.02ms]
(pass) node:http > createServer > request & response body streaming (small) [124.74ms]
(pass) node:http > createServer > listen should return server [30.57ms]
(pass) node:http > createServer > listen callback should be bound to server [39.97ms]
(pass) node:http > createServer > should use the provided port [69.51ms]
(pass) node:http > createServer > should assign a random port when undefined [45.96ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [103.37ms]
(pass) node:http > response > set-cookie works with getHeader [8.05ms]
(pass) node:http > response > set-cookie works with getHeaders [10.94ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [137.59ms]

... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (e52e102d3)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [14.63ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [3.98ms]
(pass) node:http > createServer > request & response body streaming (large) [6.75ms]
(pass) node:http > createServer > request & response body streaming (small) [4.80ms]
(pass) node:http > createServer > listen should return server [1.06ms]
(pass) node:http > createServer > listen callback should be bound to server [2.15ms]
(pass) node:http > createServer > should use the provided port [1.61ms]
(pass) node:http > createServer > should assign a random port when undefined [1.42ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [2.91ms]
(pass) node:http > response > set-cookie works with getHeader [0.10ms]
(pass) node:http > response > set-cookie works with getHeaders [0.14ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [2.89ms]
(pass) node:http > request > multiple Set-Cookie headers works #6810 [16.28ms]
(pass) node:http > request > should make a standard GET request when passed string as first arg [
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.0 (e52e102d3)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [427.33ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [79.00ms]
(pass) node:http > createServer > request & response body streaming (large) [155.84ms]
(pass) node:http > createServer > request & response body streaming (small) [89.44ms]
(pass) node:http > createServer > listen should return server [19.82ms]
(pass) node:http > createServer > listen callback should be bound to server [25.48ms]
(pass) node:http > createServer > should use the provided port [56.63ms]
(pass) node:http > createServer > should assign a random port when undefined [28.83ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [63.99ms]
(pass) node:http > response > set-cookie works with getHeader [5.10ms]
(pass) node:http > response > set-cookie works with getHeaders [6.70ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [100.76ms]
(pas
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 723ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/22] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/22] gen JS modules (bundle-modules)
Preprocess modules (7674ms)
Bundle modules (29ms)
Postprocesss modules (161ms)
Bundle Functions (765ms)
Generate Code (93ms)

[8.74s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m bun_highway v0.0.0 (/workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_incoming.ts        | 17 ++++++----
 test/js/node/http/node-http-proxy.js |  4 +--
 test/js/node/http/node-http.test.ts  | 66 ++++++++++++++++++++++++++++++++++++
 3 files changed, 79 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js/node/_http_incoming.ts             4      2      0
test/js/node/http/node-http-proxy.js      1      1      0
test/js/node/http/node-http.test.ts       4      2      0
```

</details>

<!-- robobun:evidence:end -->