### PR TITLE
node:http: write server statusMessage as latin1 and honour an empty reason phrase

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3699,7 +3699,10 @@ function callWriteHeadIfObservable(self, headerState) {
     headerState === NodeHTTPHeaderState.none &&
     !(self.writeHead === OriginalWriteHeadFn && self._implicitHeader === OriginalImplicitHeadFn)
   ) {
-    self.writeHead(self.statusCode, self.statusMessage);
+    // One arg, like Node's _implicitHeader: _writeHead's else branch then
+    // applies `if (!statusMessage) STATUS_CODES[code]` so a falsy
+    // res.statusMessage defaults instead of snapshotting "".
+    self.writeHead(self.statusCode);
   }
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3170,7 +3170,7 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
         // corks natively around both phases).
         this._contentLength = handle.writeHeadAndEnd(
           this[kSnapshotStatusCode] ?? this.statusCode,
-          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          this[kSnapshotStatusMessage] ?? (this.statusMessage || undefined),
           renderedHeaders,
           chunk,
           encoding,
@@ -3337,7 +3337,7 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
       try {
         handle.writeHead(
           this[kSnapshotStatusCode] ?? this.statusCode,
-          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          this[kSnapshotStatusMessage] ?? (this.statusMessage || undefined),
           renderedHeaders,
           renderedAutoHeaders,
           renderedKeepAliveSecs,
@@ -3521,7 +3521,7 @@ ServerResponse.prototype._send = function (data, encoding, callback, _byteLength
       try {
         handle.writeHead(
           this[kSnapshotStatusCode] ?? this.statusCode,
-          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          this[kSnapshotStatusMessage] ?? (this.statusMessage || undefined),
           renderedHeaders,
           renderedAutoHeaders,
           renderedKeepAliveSecs,
@@ -3639,7 +3639,7 @@ ServerResponse.prototype.flushHeaders = function () {
       try {
         handle.writeHead(
           this[kSnapshotStatusCode] ?? this.statusCode,
-          this[kSnapshotStatusMessage] ?? this.statusMessage,
+          this[kSnapshotStatusMessage] ?? (this.statusMessage || undefined),
           renderedHeaders,
           renderedAutoHeaders,
           renderedKeepAliveSecs,

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6312,7 +6312,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     headWritten = true;
     const statusCode = head?.statusCode ?? 200;
     let statusMessage = head?.statusMessage;
-    if (typeof statusMessage !== "string" || statusMessage === "") {
+    if (typeof statusMessage !== "string") {
       statusMessage = STATUS_CODES[statusCode] || "unknown";
     }
     let out = `HTTP/1.1 ${statusCode} ${statusMessage}\r\n`;
@@ -6401,7 +6401,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
       }
     }
     out += "\r\n";
-    socket.write(out);
+    socket.write(out, "latin1");
   }
 
   function toBuffer(chunk, encoding) {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -921,13 +921,26 @@ impl NodeHTTPResponse {
         // 2×ref + 2×deref FFI (OwnedString + ZigStringSlice::WTF); instead hold
         // the +1 from `to_bun_string` in an `OwnedString` and borrow the bytes
         // without the inner ref bump.
+        //
+        // Node.js writes the status line with 'latin1' encoding (lib/_http_outgoing.js
+        // _storeHeader), so the reason-phrase bytes are the JS string's code units
+        // (RFC 9112 obs-text), not its UTF-8 encoding. For an 8-bit WTFStringImpl that
+        // is `latin1()` directly; a 16-bit backing (rare here: checkInvalidHeaderChar
+        // rejects > U+00FF) narrows via `copy_u16_into_u8`.
+        let has_status_message = !status_message_value.is_undefined();
         let status_message_str;
-        let status_message_slice;
-        let status_message_bytes: &[u8] = if !status_message_value.is_undefined() {
+        let mut status_message_heap;
+        let status_message_bytes: &[u8] = if has_status_message {
             status_message_str =
                 bun_core::OwnedString::new(status_message_value.to_bun_string(global_object)?);
-            status_message_slice = status_message_str.to_utf8_without_ref();
-            status_message_slice.slice()
+            if status_message_str.is_8bit() {
+                status_message_str.latin1()
+            } else {
+                let utf16 = status_message_str.utf16();
+                status_message_heap = vec![0u8; utf16.len()];
+                bun_core::strings::copy_u16_into_u8(&mut status_message_heap, utf16);
+                &status_message_heap
+            }
         } else {
             &[]
         };
@@ -959,7 +972,7 @@ impl NodeHTTPResponse {
 
         let wrote_head_ok;
         'do_it: {
-            if status_message_bytes.is_empty() {
+            if !has_status_message {
                 if let Some(status_message) =
                     HTTPStatusText::get(u16::try_from(status_code).expect("int cast"))
                 {
@@ -975,7 +988,7 @@ impl NodeHTTPResponse {
                 }
             }
 
-            let message: &[u8] = if !status_message_bytes.is_empty() {
+            let message: &[u8] = if has_status_message {
                 status_message_bytes
             } else {
                 b"HM"

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -937,6 +937,18 @@ impl NodeHTTPResponse {
                 status_message_str.latin1()
             } else {
                 let utf16 = status_message_str.utf16();
+                // The fast implicit-header path (callWriteHeadIfObservable) can
+                // reach here without going through _writeHead's
+                // checkInvalidHeaderChar, so reject > U+00FF before the
+                // narrowing below truncates it into a byte the validation
+                // loop would accept.
+                if utf16.iter().any(|&c| c > 0xff) {
+                    return err_throw(
+                        global_object,
+                        ErrorCode::ERR_INVALID_CHAR,
+                        "Invalid character in statusMessage",
+                    );
+                }
                 status_message_heap = vec![0u8; utf16.len()];
                 bun_core::strings::copy_u16_into_u8(&mut status_message_heap, utf16);
                 &status_message_heap

--- a/test/js/node/http/node-http-status-message.test.ts
+++ b/test/js/node/http/node-http-status-message.test.ts
@@ -38,12 +38,16 @@ describe("node:http ServerResponse statusMessage wire bytes", () => {
     expect(line).toBe("HTTP/1.1 200 ");
   });
 
-  test("statusMessage = '' without writeHead still defaults the reason phrase", async () => {
+  test.each([
+    ["end()", (res: http.ServerResponse) => res.end("x")],
+    ["write()", (res: http.ServerResponse) => (res.write("x"), res.end())],
+    ["flushHeaders()", (res: http.ServerResponse) => (res.flushHeaders(), res.end("x"))],
+  ] as const)("statusMessage = '' then %s still defaults the reason phrase", async (_, send) => {
     // Node's _implicitHeader applies `if (!statusMessage) STATUS_CODES[code]`,
     // which treats "" as unset; only an explicit writeHead(N, "") preserves it.
     const line = await rawStatusLine((req, res) => {
       res.statusMessage = "";
-      res.end("x");
+      send(res);
     });
     expect(line).toBe("HTTP/1.1 200 OK");
   });
@@ -57,5 +61,21 @@ describe("node:http ServerResponse statusMessage wire bytes", () => {
     // Node.js writes the status line with latin1 encoding (lib/_http_outgoing.js
     // _storeHeader): one byte per JS code unit, RFC 9112 obs-text.
     expect(phraseBytes).toEqual([0xdc, 0x6e, 0xef, 0x63, 0xf6, 0x64, 0xe9]);
+  });
+
+  test("statusMessage = U+0100..U+FFFF without writeHead throws ERR_INVALID_CHAR", async () => {
+    let thrown: unknown;
+    const line = await rawStatusLine((req, res) => {
+      res.statusMessage = "\u0120";
+      try {
+        res.end("x");
+      } catch (e) {
+        thrown = e;
+        res.statusMessage = "threw";
+        res.end("x");
+      }
+    });
+    expect((thrown as NodeJS.ErrnoException)?.code).toBe("ERR_INVALID_CHAR");
+    expect(line).toBe("HTTP/1.1 200 threw");
   });
 });

--- a/test/js/node/http/node-http-status-message.test.ts
+++ b/test/js/node/http/node-http-status-message.test.ts
@@ -52,6 +52,25 @@ describe("node:http ServerResponse statusMessage wire bytes", () => {
     expect(line).toBe("HTTP/1.1 200 OK");
   });
 
+  test("statusMessage = '' with an overridden writeHead still defaults the reason phrase", async () => {
+    // on-headers/compression/morgan wrap ServerResponse.prototype.writeHead;
+    // Node's _implicitHeader calls the override with one arg (statusCode), so
+    // reason reaches _writeHead as undefined and the falsy default applies.
+    const orig = http.ServerResponse.prototype.writeHead;
+    http.ServerResponse.prototype.writeHead = function (this: http.ServerResponse, ...a: Parameters<typeof orig>) {
+      return orig.apply(this, a);
+    };
+    try {
+      const line = await rawStatusLine((req, res) => {
+        res.statusMessage = "";
+        res.end("x");
+      });
+      expect(line).toBe("HTTP/1.1 200 OK");
+    } finally {
+      http.ServerResponse.prototype.writeHead = orig;
+    }
+  });
+
   test("writeHead(200, obs-text) writes latin1 bytes", async () => {
     const line = await rawStatusLine((req, res) => {
       res.writeHead(200, "Ünïcödé");

--- a/test/js/node/http/node-http-status-message.test.ts
+++ b/test/js/node/http/node-http-status-message.test.ts
@@ -1,0 +1,61 @@
+/**
+ * All tests in this file also run in Node.js.
+ */
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { connect } from "node:net";
+
+async function rawStatusLine(handler: http.RequestListener): Promise<string> {
+  const server = http.createServer(handler);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = (server.address() as AddressInfo).port;
+  try {
+    const response = await new Promise<string>((resolve, reject) => {
+      const client = connect(port, "127.0.0.1");
+      let data = "";
+      // latin1 so every wire byte maps to one code unit (U+0000..U+00FF).
+      client.setEncoding("latin1");
+      client.on("data", chunk => (data += chunk));
+      client.on("error", reject);
+      client.on("end", () => resolve(data));
+      client.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
+    });
+    return response.split("\r\n")[0];
+  } finally {
+    server.close();
+  }
+}
+
+describe("node:http ServerResponse statusMessage wire bytes", () => {
+  test("writeHead(200, '') writes an empty reason phrase", async () => {
+    const line = await rawStatusLine((req, res) => {
+      res.writeHead(200, "");
+      res.end("x");
+    });
+    expect(line).toBe("HTTP/1.1 200 ");
+  });
+
+  test("statusMessage = '' without writeHead still defaults the reason phrase", async () => {
+    // Node's _implicitHeader applies `if (!statusMessage) STATUS_CODES[code]`,
+    // which treats "" as unset; only an explicit writeHead(N, "") preserves it.
+    const line = await rawStatusLine((req, res) => {
+      res.statusMessage = "";
+      res.end("x");
+    });
+    expect(line).toBe("HTTP/1.1 200 OK");
+  });
+
+  test("writeHead(200, obs-text) writes latin1 bytes", async () => {
+    const line = await rawStatusLine((req, res) => {
+      res.writeHead(200, "Ünïcödé");
+      res.end("x");
+    });
+    const phraseBytes = [...line.slice(13)].map(c => c.charCodeAt(0));
+    // Node.js writes the status line with latin1 encoding (lib/_http_outgoing.js
+    // _storeHeader): one byte per JS code unit, RFC 9112 obs-text.
+    expect(phraseBytes).toEqual([0xdc, 0x6e, 0xef, 0x63, 0xf6, 0x64, 0xe9]);
+  });
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2058,6 +2058,17 @@ describe("HTTP Server Security Tests - Advanced", () => {
       expect(response.split("\r\n")[0]).toBe("HTTP/1.1 200 ");
     });
 
+    test("statusMessage = '' without writeHead still defaults the reason phrase", async () => {
+      // Node's _implicitHeader applies `if (!statusMessage) STATUS_CODES[code]`,
+      // which treats "" as unset; only an explicit writeHead(N, "") preserves it.
+      server.on("request", (req, res) => {
+        res.statusMessage = "";
+        res.end("x");
+      });
+      const response = await sendRequestLatin1("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
+      expect(response.split("\r\n")[0]).toBe("HTTP/1.1 200 OK");
+    });
+
     test("writeHead(200, 'Ünïcödé') writes latin1 obs-text", async () => {
       server.on("request", (req, res) => {
         res.writeHead(200, "Ünïcödé");

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2035,6 +2035,42 @@ describe("HTTP Server Security Tests - Advanced", () => {
     });
   });
 
+  describe("statusMessage wire bytes", () => {
+    // Read raw response bytes as latin1 so U+0080..U+00FF map 1:1 to bytes.
+    const sendRequestLatin1 = (message: string) => {
+      return new Promise<string>((resolve, reject) => {
+        const client = connect(port, "127.0.0.1");
+        let response = "";
+        client.setEncoding("latin1");
+        client.on("data", chunk => (response += chunk));
+        client.on("error", reject);
+        client.on("end", () => resolve(response));
+        client.write(message);
+      });
+    };
+
+    test("writeHead(200, '') writes an empty reason phrase", async () => {
+      server.on("request", (req, res) => {
+        res.writeHead(200, "");
+        res.end("x");
+      });
+      const response = await sendRequestLatin1("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
+      expect(response.split("\r\n")[0]).toBe("HTTP/1.1 200 ");
+    });
+
+    test("writeHead(200, 'Ünïcödé') writes latin1 obs-text", async () => {
+      server.on("request", (req, res) => {
+        res.writeHead(200, "Ünïcödé");
+        res.end("x");
+      });
+      const response = await sendRequestLatin1("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
+      const statusLine = response.split("\r\n")[0];
+      const phraseBytes = [...statusLine.slice(13)].map(c => c.charCodeAt(0));
+      // Node.js latin1 encoding of "Ünïcödé": one byte per code unit.
+      expect(phraseBytes).toEqual([0xdc, 0x6e, 0xef, 0x63, 0xf6, 0x64, 0xe9]);
+    });
+  });
+
   test("Server should not crash in clientError is emitted when calling destroy", async () => {
     // A Host-less request is NOT a client error in Node: parserOnIncoming answers
     // it with 400 itself. An invalid method is what reaches 'clientError'.

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2035,53 +2035,6 @@ describe("HTTP Server Security Tests - Advanced", () => {
     });
   });
 
-  describe("statusMessage wire bytes", () => {
-    // Read raw response bytes as latin1 so U+0080..U+00FF map 1:1 to bytes.
-    const sendRequestLatin1 = (message: string) => {
-      return new Promise<string>((resolve, reject) => {
-        const client = connect(port, "127.0.0.1");
-        let response = "";
-        client.setEncoding("latin1");
-        client.on("data", chunk => (response += chunk));
-        client.on("error", reject);
-        client.on("end", () => resolve(response));
-        client.write(message);
-      });
-    };
-
-    test("writeHead(200, '') writes an empty reason phrase", async () => {
-      server.on("request", (req, res) => {
-        res.writeHead(200, "");
-        res.end("x");
-      });
-      const response = await sendRequestLatin1("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
-      expect(response.split("\r\n")[0]).toBe("HTTP/1.1 200 ");
-    });
-
-    test("statusMessage = '' without writeHead still defaults the reason phrase", async () => {
-      // Node's _implicitHeader applies `if (!statusMessage) STATUS_CODES[code]`,
-      // which treats "" as unset; only an explicit writeHead(N, "") preserves it.
-      server.on("request", (req, res) => {
-        res.statusMessage = "";
-        res.end("x");
-      });
-      const response = await sendRequestLatin1("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
-      expect(response.split("\r\n")[0]).toBe("HTTP/1.1 200 OK");
-    });
-
-    test("writeHead(200, 'Ünïcödé') writes latin1 obs-text", async () => {
-      server.on("request", (req, res) => {
-        res.writeHead(200, "Ünïcödé");
-        res.end("x");
-      });
-      const response = await sendRequestLatin1("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
-      const statusLine = response.split("\r\n")[0];
-      const phraseBytes = [...statusLine.slice(13)].map(c => c.charCodeAt(0));
-      // Node.js latin1 encoding of "Ünïcödé": one byte per code unit.
-      expect(phraseBytes).toEqual([0xdc, 0x6e, 0xef, 0x63, 0xf6, 0x64, 0xe9]);
-    });
-  });
-
   test("Server should not crash in clientError is emitted when calling destroy", async () => {
     // A Host-less request is NOT a client error in Node: parserOnIncoming answers
     // it with 400 itself. An invalid method is what reaches 'clientError'.


### PR DESCRIPTION
### What does this PR do?

Fixes two Node.js parity gaps in how `http.ServerResponse` serializes the status line's reason phrase.

**Repro**

```js
import http from "node:http";
import net from "node:net";

async function statusLine(msg) {
  const s = http.createServer((rq, rs) => { rs.writeHead(200, msg); rs.end("x"); });
  await new Promise(r => s.listen(0, "127.0.0.1", r));
  const c = net.connect(s.address().port, "127.0.0.1");
  await new Promise(r => c.once("connect", r));
  let all = ""; c.setEncoding("latin1"); c.on("data", d => (all += d));
  c.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n");
  await new Promise(r => c.once("close", r)); s.close();
  return all.split("\r\n")[0];
}

console.log(JSON.stringify(await statusLine("")));
// node: "HTTP/1.1 200 "    bun (before): "HTTP/1.1 200 OK"
const u = await statusLine("Ünïcödé");
console.log([...u.slice(13)].map(c => c.charCodeAt(0).toString(16)).join(" "));
// node: dc 6e ef 63 f6 64 e9    bun (before): c3 9c 6e c3 af 63 c3 b6 64 c3 a9
```

**Cause**

`NodeHTTPResponse::write_head_impl` converted the reason phrase via `to_utf8_without_ref()`, so any obs-text character (U+0080..U+00FF) went on the wire as its UTF-8 multi-byte encoding instead of the single latin1 byte Node.js writes from `_storeHeader`. The same function also keyed its default-phrase fallback on `status_message_bytes.is_empty()`, which cannot distinguish an explicit `""` from `undefined`, so `writeHead(200, "")` was rewritten to `HTTP/1.1 200 OK`.

**Fix**

`write_head_impl` now takes the `WTFStringImpl`'s latin1 byte view directly (narrowing a 16-bit backing with `copy_u16_into_u8`), and substitutes the default reason phrase only when the JS value is actually `undefined`. An explicit empty string produces `"200 "` on the wire, matching Node.

On the JS side, `callWriteHeadIfObservable` skips `_writeHead` when neither `writeHead` nor `_implicitHeader` is overridden, so the four direct `handle.writeHead*` call sites could deliver a falsy `res.statusMessage` (set by property assignment) straight to native. Those sites now pass `this[kSnapshotStatusMessage] ?? (this.statusMessage || undefined)` so Node's `if (!statusMessage)` default still applies on the implicit-header fast path, while `kSnapshotStatusMessage` carries an explicit `writeHead(N, "")` through unchanged.

**Verification**

```
bun bd test test/js/node/http/node-http-status-message.test.ts
```

Both wire-byte tests fail on main and pass with this change; the regression guard for the implicit-header fast path (`res.statusMessage = ""; res.end()` → `HTTP/1.1 200 OK`) passes on both. `test/js/node/test/parallel/test-http-{status-message,status-reason-invalid-chars,write-head,write-head-2}.js` and the "Response Splitting Protection" suite in `node-http.test.ts` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-status-message.test.ts
bun test v1.4.0 (9c4d4870d)

test/js/node/http/node-http-status-message.test.ts:
33 |   test("writeHead(200, '') writes an empty reason phrase", async () => {
34 |     const line = await rawStatusLine((req, res) => {
35 |       res.writeHead(200, "");
36 |       res.end("x");
37 |     });
38 |     expect(line).toBe("HTTP/1.1 200 ");
                      ^
error: expect(received).toBe(expected)

Expected: "HTTP/1.1 200 "
Received: "HTTP/1.1 200 OK"

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-status-message.test.ts:38:18)
(fail) node:http ServerResponse statusMessage wire bytes > writeHead(200, '') writes an empty reason phrase [640.60ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then end() still defaults the reason phrase [120.12ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then write() still defaults the reason phrase [125.46ms]
(pass) node:http ServerResponse statusMessage wire bytes > statu
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (36d5f45c5)

test/js/node/http/node-http-status-message.test.ts:
(pass) node:http ServerResponse statusMessage wire bytes > writeHead(200, '') writes an empty reason phrase [10.42ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then end() still defaults the reason phrase [3.68ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then write() still defaults the reason phrase [3.44ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then flushHeaders() still defaults the reason phrase [2.81ms]
63 |     try {
64 |       const line = await rawStatusLine((req, res) => {
65 |         res.statusMessage = "";
66 |         res.end("x");
67 |       });
68 |       expect(line).toBe("HTTP/1.1 200 OK");
                        ^
error: expect(received).toBe(expected)

Expected: "HTTP/1.1 200 OK"
Received: "HTTP/1.1 200 "

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-status-message.test.ts:68:20)
(fail) node:http ServerResponse statusMessage wire bytes > statusMessage = '' with an overridden writeHead still defaults the reason phrase [2.71ms]
(pas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-status-message.test.ts
bun test v1.4.0 (9c4d4870d)

test/js/node/http/node-http-status-message.test.ts:
(pass) node:http ServerResponse statusMessage wire bytes > writeHead(200, '') writes an empty reason phrase [654.94ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then end() still defaults the reason phrase [125.17ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then write() still defaults the reason phrase [138.82ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' then flushHeaders() still defaults the reason phrase [94.92ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = '' with an overridden writeHead still defaults the reason phrase [100.86ms]
(pass) node:http ServerResponse statusMessage wire bytes > writeHead(200, obs-text) writes latin1 bytes [110.93ms]
(pass) node:http ServerResponse statusMessage wire bytes > statusMessage = U+0100..U+FFFF without writeHead throws ERR_INVALI
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 709ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/22] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/22] gen JS modules (bundle-modules)
Preprocess modules (7771ms)
Bundle modules (77ms)
Postprocesss modules (236ms)
Bundle Functions (1157ms)
Generate Code (92ms)

[9.35s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        |  13 +--
 src/js/node/http2.ts                               |   4 +-
 src/runtime/server/NodeHTTPResponse.rs             |  37 ++++++--
 test/js/node/http/node-http-status-message.test.ts | 100 +++++++++++++++++++++
 4 files changed, 141 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/node/_http_server.ts                            10      2      0
src/js/node/http2.ts                                    2      2      0
src/runtime/server/NodeHTTPResponse.rs                  5      4      0
test/js/node/http/node-http-status-message.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->