### PR TITLE
node:http: order req.socket.write() behind the corked response head

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -741,6 +741,7 @@ int us_socket_set_tos(us_socket_r s, int tos);
 int us_socket_get_tos(us_socket_r s);
 void us_socket_resume(us_socket_r s);
 void us_socket_pause(us_socket_r s);
+int us_socket_is_paused(us_socket_r s);
 
 #ifdef __cplusplus
 }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -844,6 +844,10 @@ void us_socket_unref(struct us_socket_t *s) {
     // do nothing if not using libuv
 }
 
+int us_socket_is_paused(struct us_socket_t *s) {
+    return s->flags.is_paused;
+}
+
 void us_socket_pause(struct us_socket_t *s) {
     if (s->flags.is_paused) return;
     // closed cannot be paused because it is already closed

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -776,9 +776,6 @@ private:
         auto *httpContextData = getSocketContextDataS(s);
 
 
-        if (httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketDrain) {
-            httpContextData->onSocketDrain(httpResponseData->socketData, SSL, (struct us_socket_t *) s);
-        }
         /* Ask the developer to write data and return success (true) or failure (false), OR skip sending anything and return success (true). */
         if (httpResponseData->onWritable) {
             /* We are now writable, so hang timeout again, the user does not have to do anything so we should hang until end or tryEnd rearms timeout */
@@ -816,6 +813,17 @@ private:
 
         /* Drain any socket buffer, this might empty our backpressure and thus finish the request */
         asyncSocket->flush();
+
+        /* Was the socket closed by the onWritable handler? Its ext block is gone then. */
+        if (us_socket_is_closed((us_socket_t *) s)) {
+            return s;
+        }
+
+        /* After callOnWritable: a deferred socket.end() FIN issued from this
+         * hook must follow the response's own drain writes. */
+        if (httpResponseData->socketData && httpContextData->onSocketDrain) {
+            httpContextData->onSocketDrain(httpResponseData->socketData, SSL, (struct us_socket_t *) s);
+        }
 
         /* node:http compat: reads were paused while pipelined responses were
          * queued and stayed paused because the socket still had outgoing

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1553,10 +1553,10 @@ function getNodeHTTPServerSocket() {
         this[kStreamingEnabled] = enable;
         if (enable) {
           handle.ondata = this.#onData.bind(this);
-          handle.ondrain = this.#onDrain.bind(this);
+          handle.ondrain ??= this.#onDrain.bind(this);
         } else {
           handle.ondata = undefined;
-          handle.ondrain = undefined;
+          // ondrain stays armed: _write relies on it too.
         }
       }
     }
@@ -1566,9 +1566,9 @@ function getNodeHTTPServerSocket() {
       const callback = this.#pendingCallback;
       if (callback) {
         this.#pendingCallback = null;
+        // Writable emits 'drain' from here when a write() returned false.
         (callback as Function)();
       }
-      this.emit("drain");
     }
     #onData(chunk, last) {
       this._unrefTimer();
@@ -1613,6 +1613,11 @@ function getNodeHTTPServerSocket() {
       releaseServerParserShim(this);
       this[kHandle] = null;
       this.server?.[kTrackedConnections]?.delete(this);
+      const pendingWriteCallback = this.#pendingCallback;
+      if (pendingWriteCallback) {
+        this.#pendingCallback = null;
+        (pendingWriteCallback as Function)(new ConnResetException("aborted"));
+      }
       const timer = this[kSocketTimeoutTimer];
       if (timer) {
         clearTimeout(timer);
@@ -1955,9 +1960,9 @@ function getNodeHTTPServerSocket() {
       try {
         if (handle) {
           const flushed = handle.write(_chunk, _encoding);
-          if (!flushed && handle.ondrain) {
-            // Streaming mode (CONNECT tunnels): wait for the native drain
-            // callback before completing the write.
+          if (flushed === false) {
+            // The remainder is buffered natively; complete the write on drain.
+            handle.ondrain ??= this.#onDrain.bind(this);
             this.#pendingCallback = _callback;
             return false;
           }

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -16,10 +16,10 @@
 extern "C" void Bun__NodeHTTPResponse_setClosed(void* zigResponse);
 extern "C" void Bun__NodeHTTPResponse_markTunneled(void* zigResponse);
 extern "C" void Bun__NodeHTTPResponse_onClose(void* zigResponse, JSC::EncodedJSValue jsValue);
-extern "C" void us_socket_free_stream_buffer(us_socket_stream_buffer_t* streamBuffer);
+extern "C" void Bun__NodeHTTPResponse_spillPendingPinnedWrite(void* ctx);
 extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
-extern "C" EncodedJSValue us_socket_buffered_js_write(void* socket, bool is_ssl, bool ended, us_socket_stream_buffer_t* streamBuffer, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue data, JSC::EncodedJSValue encoding);
+extern "C" EncodedJSValue us_socket_buffered_js_write(void* socket, bool is_ssl, bool ended, us_socket_stream_buffer_t* streamBuffer, void* responseCtx, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue data, JSC::EncodedJSValue encoding);
 extern "C" int us_socket_is_ssl_handshake_finished(struct us_socket_t* s);
 extern "C" int us_socket_ssl_handshake_callback_has_fired(struct us_socket_t* s);
 
@@ -242,6 +242,12 @@ bool JSNodeHTTPServerSocket::isClosed() const
     return !socket || us_socket_is_closed(socket);
 }
 
+void* JSNodeHTTPServerSocket::currentResponseCtx() const
+{
+    auto* res = currentResponseObject.get();
+    return res ? res->m_ctx : nullptr;
+}
+
 template<bool SSL>
 static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
 {
@@ -261,10 +267,37 @@ bool JSNodeHTTPServerSocket::shutdownAfterResponseDrains()
     if (!socket || upgraded || us_socket_is_closed(socket) || us_socket_is_shut_down(socket)) {
         return false;
     }
+    /* A zero-copy res.write() tail is not in the send buffer until spilled. */
+    if (void* ctx = currentResponseCtx()) {
+        Bun__NodeHTTPResponse_spillPendingPinnedWrite(ctx);
+    }
     if (is_ssl) {
         return deferShutdownUntilResponseDrains<true>(socket);
     }
     return deferShutdownUntilResponseDrains<false>(socket);
+}
+
+JSC::EncodedJSValue JSNodeHTTPServerSocket::shutdownNow(JSC::JSGlobalObject* globalObject)
+{
+    if (!socket) {
+        return JSValue::encode(JSC::jsUndefined());
+    }
+    // onNodeHTTPRequest no longer pauses at dispatch; pause here so the
+    // shutdown+resume below still cycles kqueue's EVFILT_READ (delete then
+    // re-add), without which macOS 26 does not deliver the peer's close.
+    // An existing pause is someone else's to resume (which re-adds it).
+    bool cycleRead = !upgraded && !us_socket_is_paused(socket);
+    if (cycleRead) {
+        us_socket_pause(socket);
+    }
+    auto result = us_socket_buffered_js_write(socket, is_ssl, ended, &streamBuffer, currentResponseCtx(), globalObject, JSValue::encode(JSC::jsUndefined()), JSValue::encode(JSC::jsUndefined()));
+    // Undo the pause above after the shutdown so the unread body drains
+    // and kqueue's one-shot EVFILT_WRITE (which delivers EV_EOF on
+    // SHUT_WR) is not deleted by a W -> R|W -> R step.
+    if (cycleRead) {
+        us_socket_resume(socket);
+    }
+    return result;
 }
 
 template<bool SSL>
@@ -373,7 +406,6 @@ JSNodeHTTPServerSocket::~JSNodeHTTPServerSocket()
             clearSocketData<false>(this->upgraded, socket);
         }
     }
-    us_socket_free_stream_buffer(&streamBuffer);
 }
 
 JSNodeHTTPServerSocket::JSNodeHTTPServerSocket(JSC::VM& vm, JSC::Structure* structure, us_socket_t* socket, bool is_ssl, WebCore::JSNodeHTTPResponse* response)
@@ -701,27 +733,14 @@ void JSNodeHTTPServerSocket::onDrain()
 {
     // This function can be called during GC!
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(this->globalObject());
-    if (!functionToCallOnDrain) {
-        return;
+
+    // Retry a socket.end() whose FIN was deferred behind buffered bytes.
+    if (this->ended && this->socket && !us_socket_is_shut_down(this->socket)) {
+        shutdownNow(globalObject);
     }
 
-    auto bufferedSize = this->streamBuffer.bufferedSize();
-    if (bufferedSize > 0) {
-        auto* globalObject = defaultGlobalObject(this->globalObject());
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
-        us_socket_buffered_js_write(this->socket, this->is_ssl, this->ended, &this->streamBuffer, globalObject, JSValue::encode(JSC::jsUndefined()), JSValue::encode(JSC::jsUndefined()));
-        if (auto* exception = scope.exception()) {
-            (void)scope.tryClearException();
-            globalObject->reportUncaughtExceptionAtEventLoop(globalObject, exception);
-            RETURN_IF_EXCEPTION(scope, );
-            return;
-        }
-        bufferedSize = this->streamBuffer.bufferedSize();
-
-        if (bufferedSize > 0) {
-            // need to drain more
-            return;
-        }
+    if (!functionToCallOnDrain) {
+        return;
     }
     WebCore::ScriptExecutionContext* scriptExecutionContext = globalObject->scriptExecutionContext();
 

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -10,16 +10,8 @@
 
 extern "C" {
 struct us_socket_stream_buffer_t {
-    char* list_ptr = nullptr;
-    size_t list_cap = 0;
-    size_t listLen = 0;
     size_t total_bytes_written = 0;
-    size_t cursor = 0;
 
-    size_t bufferedSize() const
-    {
-        return listLen - cursor;
-    }
     size_t totalBytesWritten() const
     {
         return total_bytes_written;
@@ -71,6 +63,8 @@ public:
     void close();
     bool isClosed() const;
     bool isAuthorized() const;
+    /* NodeHTTPResponse ctx of the in-flight response, or null. */
+    void* currentResponseCtx() const;
 
     /* SNI hostname the client sent in its ClientHello; null when the socket is
      * not TLS or the client sent no SNI. The pointer is owned by the SSL
@@ -107,6 +101,8 @@ public:
      * uWS's send buffer, a shutdown now would put the FIN ahead of them and
      * truncate the response. Returns true after handing the close to uWS. */
     bool shutdownAfterResponseDrains();
+    /* The shutdown half of socket.end(), once nothing is left to drain. */
+    JSC::EncodedJSValue shutdownNow(JSC::JSGlobalObject*);
 
     /* Switch the connection into CONNECT-style tunnel mode after an accepted
      * Upgrade: subsequent bytes bypass the HTTP parser and stream to the

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -8,11 +8,9 @@
 #include <wtf/text/WTFString.h>
 #include <cmath>
 
-extern "C" EncodedJSValue us_socket_buffered_js_write(void* socket, bool is_ssl, bool ended, us_socket_stream_buffer_t* streamBuffer, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue data, JSC::EncodedJSValue encoding);
+extern "C" EncodedJSValue us_socket_buffered_js_write(void* socket, bool is_ssl, bool ended, us_socket_stream_buffer_t* streamBuffer, void* responseCtx, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue data, JSC::EncodedJSValue encoding);
 extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
-extern "C" void us_socket_resume(us_socket_t*);
-extern "C" void us_socket_pause(us_socket_t*);
 
 namespace Bun {
 
@@ -202,7 +200,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocketWrite, (JSC::JSGlobalObje
         return JSValue::encode(JSC::jsNumber(0));
     }
 
-    return us_socket_buffered_js_write(thisObject->socket, thisObject->is_ssl, thisObject->ended, &thisObject->streamBuffer, globalObject, JSValue::encode(callFrame->argument(0)), JSValue::encode(callFrame->argument(1)));
+    return us_socket_buffered_js_write(thisObject->socket, thisObject->is_ssl, thisObject->ended, &thisObject->streamBuffer, thisObject->currentResponseCtx(), globalObject, JSValue::encode(callFrame->argument(0)), JSValue::encode(callFrame->argument(1)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocketEnd, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -221,24 +219,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocketEnd, (JSC::JSGlobalObject
     if (thisObject->shutdownAfterResponseDrains()) {
         return JSValue::encode(JSC::jsUndefined());
     }
-    auto bufferedSize = thisObject->streamBuffer.bufferedSize();
-    if (bufferedSize == 0) {
-        // onNodeHTTPRequest no longer pauses at dispatch; pause here so the
-        // shutdown+resume below still cycles kqueue's EVFILT_READ (delete then
-        // re-add), without which macOS 26 does not deliver the peer's close.
-        if (thisObject->socket && !thisObject->upgraded) {
-            us_socket_pause(thisObject->socket);
-        }
-        auto result = us_socket_buffered_js_write(thisObject->socket, thisObject->is_ssl, thisObject->ended, &thisObject->streamBuffer, globalObject, JSValue::encode(JSC::jsUndefined()), JSValue::encode(JSC::jsUndefined()));
-        // Undo the pause above after the shutdown so the unread body drains
-        // and kqueue's one-shot EVFILT_WRITE (which delivers EV_EOF on
-        // SHUT_WR) is not deleted by a W -> R|W -> R step.
-        if (thisObject->socket && !thisObject->upgraded) {
-            us_socket_resume(thisObject->socket);
-        }
-        return result;
-    }
-    return JSValue::encode(JSC::jsUndefined());
+    return thisObject->shutdownNow(globalObject);
 }
 
 // Implementation of custom getters

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1752,10 +1752,19 @@ impl NodeHTTPResponse {
         if !p.is_some() {
             return;
         }
-        if let Some(raw) = self.raw_response.get() {
-            raw.spill_body(p.remaining());
+        // `raw_response` is cleared later than the close that destructs its buffer.
+        if !self.flags.get().contains(Flags::SOCKET_CLOSED) {
+            if let Some(raw) = self.raw_response.get() {
+                raw.spill_body(p.remaining());
+            }
         }
         self.clear_pending_pinned_write(global_object, JSValue::ZERO);
+    }
+
+    /// The same, for a raw `req.socket.write()`/`end()` on this connection.
+    #[uws::uws_callback(export = "Bun__NodeHTTPResponse_spillPendingPinnedWrite", no_catch)]
+    pub(crate) fn spill_pending_pinned_write_from_socket(&self) {
+        self.spill_pending_pinned_write(self.server.global_this());
     }
 
     /// Continue a zero-copy write from the stored offset. Returns `true` if

--- a/src/runtime/socket/uws_jsc.rs
+++ b/src/runtime/socket/uws_jsc.rs
@@ -9,33 +9,6 @@ use bun_uws::{
 
 use crate::node::{BlobOrStringOrBuffer, StringOrBuffer};
 
-// ── local extension: StreamBuffer accessors (upstream `bun_uws_sys::us_socket::StreamBuffer`
-// is a bare `{ list: Vec<u8>, cursor: usize }`; mirror `bun_io::StreamBuffer` API here) ──
-trait StreamBufferExt {
-    fn is_not_empty(&self) -> bool;
-    fn slice(&self) -> &[u8];
-    fn wrote(&mut self, amount: usize);
-    fn write(&mut self, buffer: &[u8]);
-}
-impl StreamBufferExt for bun_uws_sys::us_socket::StreamBuffer {
-    #[inline]
-    fn is_not_empty(&self) -> bool {
-        self.list.len() > self.cursor
-    }
-    #[inline]
-    fn slice(&self) -> &[u8] {
-        &self.list[self.cursor..]
-    }
-    #[inline]
-    fn wrote(&mut self, amount: usize) {
-        self.cursor += amount;
-    }
-    #[inline]
-    fn write(&mut self, buffer: &[u8]) {
-        self.list.extend_from_slice(buffer);
-    }
-}
-
 // ── create_bun_socket_error_t.toJS / us_bun_verify_error_t.toJS ────────────
 pub(crate) fn create_bun_socket_error_to_js(
     this: create_bun_socket_error_t,
@@ -119,17 +92,31 @@ pub(crate) fn any_web_socket_get_topics_as_js_array(
     uws_ws_get_topics_as_js_array(ssl, ws, global_object)
 }
 
+unsafe extern "C" {
+    /// `AsyncSocket::write`; returns true while bytes remain buffered.
+    fn uws_async_socket_write(
+        ssl: i32,
+        socket: &mut us_socket_t,
+        data: *const u8,
+        length: usize,
+    ) -> bool;
+
+    /// Half-close, or return true to defer it until the buffer drains.
+    safe fn uws_async_socket_end(ssl: i32, socket: &mut us_socket_t) -> bool;
+
+    fn Bun__NodeHTTPResponse_spillPendingPinnedWrite(ctx: *mut core::ffi::c_void);
+}
+
 // ── us_socket_buffered_js_write (C-exported, called from JSNodeHTTPServerSocket.cpp) ──
 /// # Safety
-/// `socket` and `buffer` must be valid, non-null pointers for the duration of the call
-/// (guaranteed by the C++ caller `JSNodeHTTPServerSocket.cpp`).
+/// `socket` and `buffer` are live for the call; `response_ctx` is null or a live `NodeHTTPResponse`.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn us_socket_buffered_js_write(
     socket: *mut us_socket_t,
-    // kept for ABI parity with the C++ caller; TLS is now per-socket
-    _ssl: bool,
+    ssl: bool,
     ended: bool,
     buffer: *mut us_socket_stream_buffer_t,
+    response_ctx: *mut core::ffi::c_void,
     global_object: &JSGlobalObject,
     data: JSValue,
     encoding: JSValue,
@@ -140,13 +127,6 @@ unsafe extern "C" fn us_socket_buffered_js_write(
     // `JSNodeHTTPServerSocket.write` on the same socket, which would alias a long-lived
     // `&mut *socket` / `&mut *buffer` under Stacked Borrows, so raw pointers with
     // no uniqueness assertion are used throughout.
-
-    // Convert `data`/`encoding` BEFORE materializing the stream buffer into an owning
-    // `Vec<u8>`: the conversion can run arbitrary JS (toString/Symbol.toPrimitive,
-    // Request/Response body coercion) which can re-enter this function on the same
-    // socket. Taking the buffer first would leave two owning `Vec`s over the same
-    // `list_ptr`; the inner call's realloc would free the allocation out from under
-    // the outer frame (use-after-free).
     let node_buffer: BlobOrStringOrBuffer = if data.is_undefined() {
         BlobOrStringOrBuffer::StringOrBuffer(StringOrBuffer::EMPTY)
     } else {
@@ -180,55 +160,32 @@ unsafe extern "C" fn us_socket_buffered_js_write(
         }
     }
 
-    // SAFETY: caller (JSNodeHTTPServerSocket.cpp) guarantees `buffer` is valid for the call.
-    // No JS executes between here and the `update()` below, so this owning `Vec` is the
-    // sole owner of `list_ptr` for the remainder of the function.
-    let mut stream_buffer = unsafe { &mut *buffer }.to_stream_buffer();
-    let mut total_written: usize = 0;
-
-    // Labeled block + post-block cleanup so the `buffer.update` / `buffer.wrote`
-    // side effects run on every
-    // exit path without a scopeguard borrow conflict.
-    let result: JSValue = 'body: {
-        let data_slice = node_buffer.slice();
-        // `us_socket_t` is an `opaque_ffi!` ZST — `opaque_mut` is the safe deref.
-        // No JS executes between here and `JSValue::TRUE/FALSE` below, so the
-        // single `&mut` does not alias the re-entrant write path documented at
-        // the top of this fn (raw `socket` is still kept for that reason).
-        let socket_ref = us_socket_t::opaque_mut(socket);
-        if stream_buffer.is_not_empty() {
-            let to_flush = stream_buffer.slice();
-            let to_flush_len = to_flush.len();
-            let written: u32 = u32::try_from(socket_ref.write(to_flush).max(0)).unwrap();
-            stream_buffer.wrote(written as usize);
-            total_written = total_written.saturating_add(written as usize);
-            if (written as usize) < to_flush_len {
-                if !data_slice.is_empty() {
-                    stream_buffer.write(data_slice);
-                }
-                break 'body JSValue::FALSE;
-            }
-        }
-
-        if !data_slice.is_empty() {
-            let written: u32 = u32::try_from(socket_ref.write(data_slice).max(0)).unwrap();
-            total_written = total_written.saturating_add(written as usize);
-            if (written as usize) < data_slice.len() {
-                stream_buffer.write(&data_slice[written as usize..]);
-                break 'body JSValue::FALSE;
-            }
-        }
-        if ended {
-            socket_ref.shutdown();
-        }
-        JSValue::TRUE
-    };
-
-    // SAFETY: caller guarantees `buffer` is valid for the call; no JS executes between here
-    // and return, so no re-entrancy aliasing.
-    unsafe {
-        (*buffer).update(stream_buffer);
-        (*buffer).wrote(total_written);
+    // After the coercion above: it can re-enter JS and arm a new pinned write.
+    if !response_ctx.is_null() {
+        // SAFETY: caller guarantees `response_ctx` is live when non-null.
+        unsafe { Bun__NodeHTTPResponse_spillPendingPinnedWrite(response_ctx) };
     }
-    result
+
+    let data_slice = node_buffer.slice();
+    // No JS runs from here on, so this `&mut` cannot alias a re-entrant call.
+    let socket_ref = us_socket_t::opaque_mut(socket);
+    let ssl_flag: i32 = if ssl { 1 } else { 0 };
+
+    let backpressure = if !data_slice.is_empty() {
+        // SAFETY: caller guarantees `buffer` is valid for the call.
+        unsafe { (*buffer).wrote(data_slice.len()) };
+        // SAFETY: data_slice is a live &[u8]; ptr valid for len bytes.
+        unsafe {
+            uws_async_socket_write(ssl_flag, socket_ref, data_slice.as_ptr(), data_slice.len())
+        }
+    } else {
+        false
+    };
+    if backpressure {
+        return JSValue::FALSE;
+    }
+    if ended && uws_async_socket_end(ssl_flag, socket_ref) {
+        return JSValue::FALSE;
+    }
+    JSValue::TRUE
 }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1525,6 +1525,49 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     }
   }
 
+  /* Returns true while bytes remain buffered. */
+  bool uws_async_socket_write(int ssl, us_socket_t *s, const char *data, size_t length)
+  {
+    if (us_socket_is_closed(s)) {
+      return false;
+    }
+    auto body = [&](auto *asyncSocket) {
+      /* The corked response head must precede these raw bytes. */
+      auto [uncorked, bp0] = asyncSocket->uncork();
+      (void)uncorked;
+      bool backpressure = bp0;
+      while (length > 0) {
+        int len = (int)std::min(length, (size_t)INT_MAX);
+        auto [written, bp] = asyncSocket->write(data, len);
+        (void)written;
+        backpressure |= bp;
+        data += (size_t)len;
+        length -= (size_t)len;
+      }
+      return backpressure || !asyncSocket->hasFullyDrained();
+    };
+    return ssl ? body(reinterpret_cast<uWS::AsyncSocket<true> *>(s))
+               : body(reinterpret_cast<uWS::AsyncSocket<false> *>(s));
+  }
+
+  /* Returns true when the shutdown is deferred until the buffer drains. */
+  bool uws_async_socket_end(int ssl, us_socket_t *s)
+  {
+    if (us_socket_is_closed(s)) {
+      return false;
+    }
+    auto body = [](auto *asyncSocket) {
+      asyncSocket->uncork();
+      if (!asyncSocket->hasFullyDrained()) {
+        return true;
+      }
+      asyncSocket->shutdown();
+      return false;
+    };
+    return ssl ? body(reinterpret_cast<uWS::AsyncSocket<true> *>(s))
+               : body(reinterpret_cast<uWS::AsyncSocket<false> *>(s));
+  }
+
   void us_socket_mark_needs_more_not_ssl(uws_res_r res)
   {
     us_socket_r s = (us_socket_t *)res;

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -605,76 +605,14 @@ mod c {
 }
 
 #[repr(C)]
+#[derive(Default)]
 pub struct us_socket_stream_buffer_t {
-    pub(crate) list_ptr: *mut u8,
-    pub(crate) list_cap: usize,
-    pub(crate) list_len: usize,
-    pub(crate) total_bytes_written: usize,
-    pub(crate) cursor: usize,
-}
-
-/// Minimal structural mirror of `bun_io::StreamBuffer` for tier-0 interop.
-/// The higher-tier `bun_io::StreamBuffer` is field-identical and converts via
-/// `From`/`Into` (added in the move-in pass).
-pub struct StreamBuffer {
-    pub list: Vec<u8>,
-    pub cursor: usize,
+    pub total_bytes_written: usize,
 }
 
 impl us_socket_stream_buffer_t {
-    pub fn update(&mut self, stream_buffer: StreamBuffer) {
-        // Decompose the Vec<u8> backing `stream_buffer.list` into raw parts so
-        // the C side can read ptr/len/cap directly.
-        let mut list = core::mem::ManuallyDrop::new(stream_buffer.list);
-        if list.capacity() > 0 {
-            self.list_ptr = list.as_mut_ptr();
-        } else {
-            self.list_ptr = ptr::null_mut();
-        }
-        self.list_len = list.len();
-        self.list_cap = list.capacity();
-        self.cursor = stream_buffer.cursor;
-    }
-
     pub fn wrote(&mut self, written: usize) {
         self.total_bytes_written = self.total_bytes_written.saturating_add(written);
     }
-
-    pub fn to_stream_buffer(&self) -> StreamBuffer {
-        StreamBuffer {
-            list: if !self.list_ptr.is_null() {
-                unsafe {
-                    // SAFETY: list_ptr/list_len/list_cap were produced by decomposing a
-                    // Vec<u8> in `update`; global allocator (mimalloc) matches.
-                    Vec::from_raw_parts(self.list_ptr, self.list_len, self.list_cap)
-                }
-            } else {
-                Vec::new()
-            },
-            cursor: self.cursor,
-        }
-    }
-
-    /// Explicit teardown — this struct is `#[repr(C)]` and freed via the
-    /// exported `us_socket_free_stream_buffer`, so no `Drop` impl.
-    ///
-    /// SAFETY: `list_ptr`/`list_cap` were produced by `update` (decomposed
-    /// `Vec<u8>` on the global mimalloc allocator). Not called more than once.
-    pub(crate) unsafe fn destroy(&mut self) {
-        if !self.list_ptr.is_null() {
-            unsafe {
-                // SAFETY: list_ptr/list_cap came from a decomposed Vec<u8> (global mimalloc).
-                drop(Vec::from_raw_parts(self.list_ptr, 0, self.list_cap));
-            }
-            self.list_ptr = core::ptr::null_mut();
-            self.list_cap = 0;
-        }
-    }
-}
-
-#[unsafe(no_mangle)]
-extern "C" fn us_socket_free_stream_buffer(buffer: *mut us_socket_stream_buffer_t) {
-    // SAFETY: caller (C) passes a live us_socket_stream_buffer_t*
-    unsafe { (*buffer).destroy() };
 }
 // us_socket_buffered_js_write moved to src/runtime/socket/uws_jsc.rs

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4366,3 +4366,82 @@ describe("response header values are written as latin-1 bytes", () => {
     ]);
   });
 });
+
+// In Node.js res.write() and req.socket.write() land on the same net.Socket
+// Writable, so raw bytes written between framework writes appear on the wire in
+// call order. Bun routed req.socket.write() straight to the fd while the
+// response head sat in a cork buffer, so the raw bytes would overtake the
+// status line and the client parsed a garbage "RAWHTTP/1.1 200 OK".
+describe.each(["http", "https"] as const)("req.socket.write() interleaved with res.write() (%s)", protocol => {
+  async function readWire(handler: http.RequestListener) {
+    const server = protocol === "https" ? createHttpsServer(tlsCert, handler) : createServer(handler);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const { port } = server.address() as AddressInfo;
+      const c =
+        protocol === "https"
+          ? tlsConnect({ port, host: "127.0.0.1", ca: tlsCert.cert, servername: "localhost" })
+          : connect(port, "127.0.0.1");
+      await once(c, protocol === "https" ? "secureConnect" : "connect");
+      const chunks: Buffer[] = [];
+      c.on("data", d => chunks.push(d));
+      c.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+      await once(c, "close");
+      const all = Buffer.concat(chunks);
+      const headEnd = all.indexOf("\r\n\r\n");
+      return { status: all.subarray(0, all.indexOf("\r\n")).toString(), body: all.subarray(headEnd + 4) };
+    } finally {
+      server.close();
+    }
+  }
+
+  it.each([true, false])(
+    "reaches the wire after the response head and in call order (flushHeaders=%p)",
+    async flush => {
+      const { status, body } = await readWire((req, res) => {
+        res.setHeader("Content-Length", "9");
+        if (flush) res.flushHeaders();
+        res.write("AAA");
+        req.socket.write("RAW");
+        res.write("BBB");
+        res.end();
+      });
+      expect(status).toBe("HTTP/1.1 200 OK");
+      expect(body.toString()).toBe("AAARAWBBB");
+    },
+  );
+
+  // A >16KB res.write() takes the zero-copy path (the unwritten tail is held
+  // in NodeHTTPResponse::pending_pinned_write, not the cork or AsyncSocket
+  // buffers); the raw write must still land after that tail, not mid-body.
+  // The body has to outgrow the loopback send+receive buffers (several MB on
+  // Linux) or the whole write lands in the kernel and nothing is pending.
+  it("is ordered after a >16KB res.write()'s zero-copy tail", async () => {
+    const BIG = Buffer.alloc(16 * 1024 * 1024, 0x61);
+    const { status, body } = await readWire((req, res) => {
+      res.setHeader("Content-Length", String(BIG.length + 6));
+      res.write(BIG);
+      req.socket.write("RAW");
+      res.end("BBB");
+    });
+    expect(status).toBe("HTTP/1.1 200 OK");
+    expect(body.length).toBe(BIG.length + 6);
+    // Where RAW starts must be BIG.length, not the kernel send-buffer boundary.
+    const i = body.indexOf("R");
+    expect({ rawAt: i, tail: body.subarray(i).toString() }).toEqual({
+      rawAt: BIG.length,
+      tail: "RAWBBB",
+    });
+  });
+
+  it("socket.end() after a >16KB res.write() delivers the full body before FIN", async () => {
+    const BIG = Buffer.alloc(8 * 1024 * 1024, 0x61);
+    const { status, body } = await readWire((req, res) => {
+      res.writeHead(200, { "Content-Length": String(BIG.length) });
+      res.write(BIG);
+      req.socket.end();
+    });
+    expect(status).toBe("HTTP/1.1 200 OK");
+    expect(body.length).toBe(BIG.length);
+  });
+});


### PR DESCRIPTION
### Problem

Raw `req.socket.write()` interleaved with `res.write()` lands on the wire **before the status line**, even after an explicit `res.flushHeaders()`:

```js
const s = http.createServer((rq, rs) => {
  rs.setHeader("Content-Length", "9");
  rs.flushHeaders();          // same result without this line
  rs.write("AAA");
  rq.socket.write("RAW");     // raw write between framework writes
  rs.write("BBB");
  rs.end();
});
// raw net client reads the wire bytes:
// node: "HTTP/1.1 200 OK\r\n...\r\n\r\nAAARAWBBB"
// bun : "RAWHTTP/1.1 200 OK\r\n...\r\n\r\nAAABBB"
```

Every client parses `RAWHTTP/1.1 200 OK` as a garbage status line. This is the raw-socket + framework interleave corruption class (early bytes / hijack-style handoffs / on-headers timing shims), and `flushHeaders()`, the documented way to force the head out, does not defend against it. Deterministic; public API only.

### Cause

`req.socket.write()` reached the fd through a path that none of the response's three outgoing buffers participated in:

- `res.write()` / `res.writeHead()` go through `HttpResponse::write` / `NodeHTTPServer__writeHead`, which cork the socket and copy into the per-loop cork buffer. `handle.flushHeaders()` calls `flushHeaders(false)` (no synchronous uncork) and registers a deferred microtask that uncorks later. Under backpressure the spill goes to `AsyncSocketData::buffer`; a >16 KB `res.write()` additionally holds its unwritten tail in `NodeHTTPResponse::pending_pinned_write` (the zero-copy path).
- `req.socket.write()` (the `NodeHTTPServerSocket` Duplex `_write`) called `us_socket_buffered_js_write`, which went straight to `us_socket_write` on the fd, bypassing all of the above.

So the raw bytes hit the fd while the head + `AAA` were still parked in the cork buffer, or mid-chunk-body while a zero-copy tail was still outstanding. And `req.socket.end()` after a large `res.write()` sent FIN ahead of the pinned tail (`shutdownAfterResponseDrains` only looks at `AsyncSocketData::buffer`), truncating the body at the first kernel send-buffer fill. In Node.js both writes go through the same `net.Socket` Writable and preserve call order.

This is the same root cause as #32723 (which focuses on the backpressure-drop manifestation); that branch no longer rebases cleanly so this reimplements the same approach on current main.

### Fix

- `jsFunctionNodeHTTPServerSocketWrite`/`End` first spill the active response's `pending_pinned_write` into `AsyncSocketData::buffer` (new `Bun__NodeHTTPResponse_spillPendingPinnedWrite` export), the same step `write_or_end` already takes before a second `res.write()`.
- New `uws_async_socket_write(ssl, s, data, len)` wrapper: uncork the socket (so prior response output flushes first), then `AsyncSocket<SSL>::write` the raw bytes, which orders them behind `AsyncSocketData::buffer` too. Returns whether bytes remain buffered. `uws_async_socket_end` does the matching uncork-then-shutdown.
- `us_socket_buffered_js_write` routes through that wrapper instead of raw `us_socket_write`, so `req.socket.write()` bytes share one ordered buffer and drain path with the response. The separate `streamBuffer` backpressure path is gone (its helpers and dead fields removed).
- `HttpContext::onWritable` invokes `onSocketDrain` whenever `socketData` is set (not only for CONNECT), after `callOnWritable` + `flush`, so the response's own drain (pinned tail, 'drain' handler writes) lands first and a backpressured `socket.write()` completes its Writable callback once `AsyncSocketData::buffer` empties; `onDrain` also fires the deferred `socket.end()` FIN there.
- `NodeHTTPServerSocket._write` arms `handle.ondrain` lazily when the native write reports backpressure and holds the Writable callback until drain; `#onClose` settles that callback with `ECONNRESET` if the socket dies first. `#onDrain` no longer emits 'drain' itself: completing the callback lets the Writable emit it only after a `write()` that returned false.
- Lifecycle hardening from review: the wrappers and the pinned-write spill bail once the socket is closed (the data/encoding coercion can re-enter JS and close it), `onWritable` returns early when its handler closed the socket, both wrappers use `hasFullyDrained()` so TLS spill counts as buffered, and the deferred FIN goes through the same `shutdownNow()` as an immediate `socket.end()`. That path only cycles the read filter when nobody else holds the pause (new `us_socket_is_paused()` in usockets).

### Verification

New tests in `test/js/node/http/node-http.test.ts` cover the cork case (with/without `flushHeaders()`), the >16 KB zero-copy case, and `socket.end()` after a >16 KB `res.write()`, each for http and https (8 cases); all fail on main / 1.3.14 and pass after, and pass in Node.js. Node's own `test-http-pipeline-flood.js`, `test-http-pause*.js` and the pipelined destroy tests also pass. `node-http.test.ts` 147/147 (+1 skip), plus `node-http-connect.test.ts` CONNECT backpressure, `node-http-backpressure.test.ts`, `node-http-server-socket-end-drain.test.ts`, `node-http-with-ws.test.ts`, `node-http-pinned-write.test.ts`, `node-http-req-socket-pause.test.ts`, `node-http-nested-cork.test.ts` and `early-hints-crlf-injection.test.ts` all pass.

Fixes #31971 (the unsound `to_stream_buffer`/`update` pair is removed).
Related: #31314, #32723.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 12 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/176] gen cpp.rs (cppbind)
[2/176] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/176] gen JS modules (bundle-modules)
Preprocess modules (7857ms)
Bundle modules (69ms)
Postprocesss modules (170ms)
Bundle Functions (506ms)
Generate Code (46ms)

[8.66s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/176] cargo bun_runtime → libbun_runtime.a
[96/176] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronou
... (truncated)

release without fix: 12 failed, 1 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [9.03ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [1.64ms]
(pass) node:http > createServer > request & response body streaming (large) [3.15ms]
(pass) node:http > createServer > request & response body streaming (small) [1.53ms]
(pass) node:http > createServer > listen should return server [0.63ms]
(pass) node:http > createServer > listen callback should be bound to server [0.64ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [0.88ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [1.10ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [2.27ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [22.64ms]
(pass) node:http > createServer > https: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [32.72ms]
(pass) node:http > createServer > should use the provided port [0.96ms]
(pas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.1 (65362b53b)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [437.10ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [63.54ms]
(pass) node:http > createServer > request & response body streaming (large) [113.86ms]
(pass) node:http > createServer > request & response body streaming (small) [68.58ms]
(pass) node:http > createServer > listen should return server [26.80ms]
(pass) node:http > createServer > listen callback should be bound to server [27.22ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [38.04ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [45.89ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [55.72ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [1274.49ms]
(pass) node:http > cre
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     431f124587
  features     baseline

23 deps, 131 codegen, 1172 objects in 858ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] gen ErrorCode+*.h
[6/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[7/1217] fetch zlib
[zlib] up to date
[8/1217] gen .bind.ts → GeneratedBindings.cpp
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/libusockets.h            |   1 +
 packages/bun-usockets/src/socket.c                 |   4 +
 packages/bun-uws/src/HttpContext.h                 |  14 ++-
 src/js/node/_http_server.ts                        |  17 ++-
 src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp   |  63 +++++++----
 src/jsc/bindings/node/JSNodeHTTPServerSocket.h     |  12 +-
 .../node/JSNodeHTTPServerSocketPrototype.cpp       |  25 +----
 src/runtime/server/NodeHTTPResponse.rs             |  13 ++-
 src/runtime/socket/uws_jsc.rs                      | 125 +++++++--------------
 src/uws_sys/libuwsockets.cpp                       |  43 +++++++
 src/uws_sys/us_socket_t.rs                         |  66 +----------
 test/js/node/http/node-http.test.ts                |  79 +++++++++++++
 12 files changed, 251 insertions(+), 211 deletions(-)
```

</details>

**gate history** · 8 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
packages/bun-usockets/src/libusockets.h                       1      1      0
packages/bun-usockets/src/socket.c                            2      1      0
packages/bun-uws/src/HttpContext.h                            6      6      0
src/js/node/_http_server.ts                                  10      7      0
src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp             14     14      0
src/jsc/bindings/node/JSNodeHTTPServerSocket.h                6      4      0
…c/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp      9      8      0
src/runtime/server/NodeHTTPResponse.rs                       11      5      0
src/runtime/socket/uws_jsc.rs                                 7      7      0
src/uws_sys/libuwsockets.cpp                                  6      6      0
src/uws_sys/us_socket_t.rs                                    5      3      0
test/js/node/http/node-http.test.ts                           7      5      0
```

</details>

<!-- robobun:evidence:end -->