### PR TITLE
fs: persist in-flight WriteStream bytes when destroy() follows write() in the same tick

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -264,9 +264,8 @@ function streamConstruct(this: FSStream, callback: (e?: any) => void) {
       //   // @ts-expect-error
       //   this.fd = (this[kWriteStreamFastPath] = Bun.file(this.path).writer())._getFd();
       // }
+      process.nextTick(emitOpenReady, this);
       callback();
-      this.emit("open", this.fd);
-      this.emit("ready");
       return;
     }
 
@@ -275,9 +274,8 @@ function streamConstruct(this: FSStream, callback: (e?: any) => void) {
         callback(err);
       } else {
         this.fd = fd;
+        process.nextTick(emitOpenReady, this);
         callback();
-        this.emit("open", this.fd);
-        this.emit("ready");
       }
     });
   }
@@ -286,6 +284,22 @@ function streamConstruct(this: FSStream, callback: (e?: any) => void) {
 readStreamPrototype.open = streamNoop;
 
 readStreamPrototype._construct = streamConstruct;
+
+// _construct's callback schedules the `constructed` flag flip via
+// process.nextTick. Node drains nextTick before microtasks after an I/O
+// callback, so `await once(stream, "open")` resumes with the stream already
+// constructed. Bun drains microtasks first, so emitting "open" synchronously
+// let the awaited continuation observe `constructed === false`; the next
+// write() buffered instead of dispatching, and a same-tick destroy() discarded
+// it (node persists those bytes). Queue "open"/"ready" before the _construct
+// callback so both land in the same nextTick batch as `onConstruct`, with
+// "open" first: "open" still precedes "finish"/"data", and microtasks scheduled
+// from the "open" listener run after `onConstruct` has marked the stream
+// constructed.
+function emitOpenReady(stream) {
+  stream.emit("open", stream.fd);
+  stream.emit("ready");
+}
 
 readStreamPrototype._read = function (n) {
   n = this.pos !== undefined ? $min(this.end - this.pos + 1, n) : $min(this.end - this.bytesRead + 1, n);

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -236,11 +236,22 @@ function streamConstruct(this: FSStream, callback: (e?: any) => void) {
 
     // Backwards compat for monkey patching open().
     const orgEmit: any = this.emit;
+    let deferred: any[][] | null = null;
     this.emit = function (...args) {
-      if (args[0] === "open") {
-        this.emit = orgEmit;
+      if (deferred !== null) {
+        deferred.push(args);
+      } else if (args[0] === "open") {
+        // Defer "open" (and anything the patched open() emits synchronously
+        // after it, typically "ready") to the same nextTick batch as
+        // onConstruct; see emitOpenReady below.
+        deferred = [args];
+        const self = this;
+        process.nextTick(() => {
+          self.emit = orgEmit;
+          for (let i = 0; i < deferred!.length; i++) orgEmit.$apply(self, deferred![i]);
+          deferred = null;
+        });
         callback();
-        orgEmit.$apply(this, args);
       } else if (args[0] === "error") {
         this.emit = orgEmit;
         callback(args[1]);

--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -241,9 +241,8 @@ function streamConstruct(this: FSStream, callback: (e?: any) => void) {
       if (deferred !== null) {
         deferred.push(args);
       } else if (args[0] === "open") {
-        // Defer "open" (and anything the patched open() emits synchronously
-        // after it, typically "ready") to the same nextTick batch as
-        // onConstruct; see emitOpenReady below.
+        // Defer "open" (and anything emitted synchronously after it, typically
+        // "ready") to onConstruct's nextTick batch; see emitOpenReady below.
         deferred = [args];
         const self = this;
         process.nextTick(() => {
@@ -296,17 +295,9 @@ readStreamPrototype.open = streamNoop;
 
 readStreamPrototype._construct = streamConstruct;
 
-// _construct's callback schedules the `constructed` flag flip via
-// process.nextTick. Node drains nextTick before microtasks after an I/O
-// callback, so `await once(stream, "open")` resumes with the stream already
-// constructed. Bun drains microtasks first, so emitting "open" synchronously
-// let the awaited continuation observe `constructed === false`; the next
-// write() buffered instead of dispatching, and a same-tick destroy() discarded
-// it (node persists those bytes). Queue "open"/"ready" before the _construct
-// callback so both land in the same nextTick batch as `onConstruct`, with
-// "open" first: "open" still precedes "finish"/"data", and microtasks scheduled
-// from the "open" listener run after `onConstruct` has marked the stream
-// constructed.
+// Bun drains microtasks before nextTick after I/O (Node is the reverse), so
+// queue "open"/"ready" ahead of callback()'s nextTick(onConstruct): "open"
+// still precedes "finish"/"data", and `await once(s, "open")` resumes constructed.
 function emitOpenReady(stream) {
   stream.emit("open", stream.fd);
   stream.emit("ready");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3613,6 +3613,37 @@ describe("createWriteStream", () => {
       }
     });
   });
+
+  it.each([false, true])(
+    "destroy() in the same tick as an accepted write() persists the in-flight bytes (destroy with error: %p)",
+    async withErr => {
+      // In Node the first write() after 'open' is dispatched to _write
+      // synchronously, so a same-tick destroy() must wait for that I/O to
+      // finish before closing the fd. The bytes reach disk and the write
+      // callback receives ERR_STREAM_DESTROYED (not the destroy error).
+      const p = join(tmpdirSync(), "write-then-destroy.bin");
+      const ws = createWriteStream(p);
+      const { promise: opened, resolve: onOpen } = Promise.withResolvers<void>();
+      ws.once("open", () => onOpen());
+      await opened;
+      ws.on("error", () => {});
+      let cbErr: unknown = "<not called>";
+      ws.write(Buffer.alloc(65536, 0x5a), e => {
+        cbErr = e;
+      });
+      ws.destroy(withErr ? new Error("boom") : undefined);
+      const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+      ws.once("close", () => onClose());
+      await closed;
+      expect({
+        sizeOnDisk: statSync(p).size,
+        cbCode: (cbErr as NodeJS.ErrnoException | null)?.code,
+      }).toEqual({
+        sizeOnDisk: 65536,
+        cbCode: "ERR_STREAM_DESTROYED",
+      });
+    },
+  );
 });
 
 describe("fs/promises", () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3617,10 +3617,9 @@ describe("createWriteStream", () => {
   it.each([false, true])(
     "destroy() in the same tick as an accepted write() persists the in-flight bytes (destroy with error: %p)",
     async withErr => {
-      // In Node the first write() after 'open' is dispatched to _write
-      // synchronously, so a same-tick destroy() must wait for that I/O to
-      // finish before closing the fd. The bytes reach disk and the write
-      // callback receives ERR_STREAM_DESTROYED (not the destroy error).
+      // Node dispatches the first post-'open' write() to _write synchronously, so
+      // a same-tick destroy() waits for that I/O: bytes reach disk and the write
+      // callback gets ERR_STREAM_DESTROYED, not the destroy error.
       const p = join(tmpdirSync(), "write-then-destroy.bin");
       const ws = createWriteStream(p);
       const { promise: opened, resolve: onOpen } = Promise.withResolvers<void>();


### PR DESCRIPTION
## Repro

```js
import fs from 'node:fs'; import os from 'node:os'; import path from 'node:path';
const p = path.join(os.tmpdir(), `wsdes-${process.pid}.bin`);
const ws = fs.createWriteStream(p);
await new Promise(r => ws.on('open', r));
ws.on('error', () => {});
ws.write(Buffer.alloc(65536, 0x5a), e => console.log('cb:', e?.code ?? e?.message ?? 'ok'));
ws.destroy();              // same tick as write()
await new Promise(r => ws.on('close', r));
console.log('sizeOnDisk:', fs.statSync(p).size);
```

|                | before | after | node v26.3.0 |
|----------------|--------|-------|--------------|
| `sizeOnDisk`   | 0      | 65536 | 65536        |
| cb (`destroy(err)`) | destroy error | `ERR_STREAM_DESTROYED` | `ERR_STREAM_DESTROYED` |

## Cause

Node drains the nextTick queue before microtasks after an I/O callback; Bun drains microtasks first. `_construct`'s callback schedules the `constructed` flag flip via `process.nextTick`, and `'open'` was emitted synchronously from the `fs.open` callback. So in Bun a continuation from `await once(stream, 'open')` resumed with `_writableState.constructed === false`, the following `write()` buffered instead of dispatching `_write`, and a same-tick `destroy()` discarded the buffered chunk (no `kIsPerformingIO` to wait on). In Node the same write is already in-flight by the time `_destroy` runs, so the bytes reach disk.

## Fix

Queue `'open'`/`'ready'` via `process.nextTick` immediately before calling the `_construct` callback in `streamConstruct`. Both end up in the same nextTick batch as `onConstruct`, with `'open'` first, so:
- `'open'` still precedes `'finish'` (for `end()` with no data) and `'data'` (ReadStream), matching Node's ordering.
- Microtasks scheduled from the `'open'` listener (the `await once(ws, 'open')` continuation) resume after `onConstruct` has marked the stream constructed, so the next `write()` dispatches `_write` synchronously and `destroy()` waits for it via `kIsPerformingIO`/`kIoDone`.

## Verification

```
# fail-before
USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs.test.ts -t "destroy\(\) in the same tick"
# 2 fail: sizeOnDisk 0, cbCode undefined/boom

# pass-after
bun bd test test/js/node/fs/fs.test.ts -t "destroy\(\) in the same tick"
# 2 pass
```

Also ran: `test/js/node/fs/fs.test.ts` (429 pass), `test/js/node/fs/fs-leak.test.js` (4 pass), `test/js/node/stream/node-stream.test.js` (98 pass), and all 43 runnable `test/js/node/test/parallel/*{fs,file}*stream*` tests.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->