### PR TITLE
fs.writeFile: honor AbortSignal between write chunks

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -456,17 +456,19 @@ function asyncWrap(fn: any, name: string) {
       throwEBADFIfNecessary("writeFile", fd);
       let encoding = "utf8";
       let flush = false;
+      let signal;
       if (options == null || typeof options === "function") {
       } else if (typeof options === "string") {
         encoding = options;
       } else {
         encoding = options?.encoding ?? encoding;
         flush = options?.flush ?? flush;
+        signal = options?.signal ?? undefined;
       }
 
       try {
         this[kRef]();
-        return await writeFile(fd, data, { encoding, flush, flag: this[kFlag] });
+        return await writeFile(fd, data, { encoding, flush, signal, flag: this[kFlag] });
       } finally {
         this[kUnref]();
       }

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -116,7 +116,7 @@ impl AbortSignal {
         WebCore__AbortSignal__decrementPendingActivity(self)
     }
 
-    /// This function is not threadsafe. aborted is a boolean, not an atomic!
+    /// Relaxed atomic load of the aborted flag; safe to poll off the JS thread.
     pub fn aborted(&self) -> bool {
         WebCore__AbortSignal__aborted(self)
     }

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -87,7 +87,7 @@ public:
     void signalAbort(JSC::JSValue reason);
     void signalFollow(AbortSignal&);
 
-    bool aborted() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::Aborted); }
+    bool aborted() const { return m_flags.load(std::memory_order_relaxed) & static_cast<uint8_t>(AbortSignalFlags::Aborted); }
     void markAborted(JSC::JSValue reason);
     void runAbortSteps();
 
@@ -103,8 +103,8 @@ public:
     }
 
     bool hasActiveTimeoutTimer() const { return m_timeout != nullptr; }
-    bool hasAbortEventListener() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener); }
-    bool isFiringEventListeners() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners); }
+    bool hasAbortEventListener() const { return m_flags.load(std::memory_order_relaxed) & static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener); }
+    bool isFiringEventListeners() const { return m_flags.load(std::memory_order_relaxed) & static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners); }
 
     using RefCounted::deref;
     using RefCounted::ref;
@@ -132,7 +132,7 @@ public:
     void incrementPendingActivityCount() { ++pendingActivityCount; }
     void decrementPendingActivityCount() { --pendingActivityCount; }
     bool hasPendingActivity() const { return pendingActivityCount > 0; }
-    bool isDependent() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::Dependent); }
+    bool isDependent() const { return m_flags.load(std::memory_order_relaxed) & static_cast<uint8_t>(AbortSignalFlags::Dependent); }
 
     size_t memoryCost() const;
 
@@ -150,39 +150,18 @@ private:
     void addDependentSignal(AbortSignal&);
     void cancelTimer();
 
-    void applyFlags(uint8_t flags) { m_flags |= flags; }
-    void setIsDependent(bool isDependent)
+    void applyFlags(uint8_t flags) { m_flags.fetch_or(flags, std::memory_order_relaxed); }
+    void setFlag(AbortSignalFlags flag, bool value)
     {
-        if (isDependent) {
-            m_flags |= static_cast<uint8_t>(AbortSignalFlags::Dependent);
-        } else {
-            m_flags &= ~static_cast<uint8_t>(AbortSignalFlags::Dependent);
-        }
+        if (value)
+            m_flags.fetch_or(static_cast<uint8_t>(flag), std::memory_order_relaxed);
+        else
+            m_flags.fetch_and(static_cast<uint8_t>(~static_cast<uint8_t>(flag)), std::memory_order_relaxed);
     }
-    void setAborted(bool aborted)
-    {
-        if (aborted) {
-            m_flags |= static_cast<uint8_t>(AbortSignalFlags::Aborted);
-        } else {
-            m_flags &= ~static_cast<uint8_t>(AbortSignalFlags::Aborted);
-        }
-    }
-    void setHasAbortEventListener(bool hasAbortEventListener)
-    {
-        if (hasAbortEventListener) {
-            m_flags |= static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener);
-        } else {
-            m_flags &= ~static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener);
-        }
-    }
-    void setIsFiringEventListeners(bool isFiringEventListeners)
-    {
-        if (isFiringEventListeners) {
-            m_flags |= static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners);
-        } else {
-            m_flags &= ~static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners);
-        }
-    }
+    void setIsDependent(bool v) { setFlag(AbortSignalFlags::Dependent, v); }
+    void setAborted(bool v) { setFlag(AbortSignalFlags::Aborted, v); }
+    void setHasAbortEventListener(bool v) { setFlag(AbortSignalFlags::HasAbortEventListener, v); }
+    void setIsFiringEventListeners(bool v) { setFlag(AbortSignalFlags::IsFiringEventListeners, v); }
 
     // EventTarget.
     EventTargetInterface eventTargetInterface() const final { return AbortSignalEventTargetInterfaceType; }
@@ -208,7 +187,8 @@ private:
     std::atomic<uint32_t> pendingActivityCount { 0 };
     uint32_t m_algorithmIdentifier { 0 };
     AbortSignalTimeout m_timeout { nullptr };
-    uint8_t m_flags { 0 };
+    // Atomic so aborted() may be polled from thread-pool workers (fs readFile/writeFile).
+    std::atomic<uint8_t> m_flags { 0 };
 };
 
 WebCoreOpaqueRoot root(AbortSignal*);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -487,7 +487,11 @@ impl JSBundleCompletionTask {
                         dirfd: root_dir.fd,
                         signal: None,
                     };
-                    match NodeFS::write_file_with_path_buffer(&mut pathbuf, &write_args) {
+                    match NodeFS::write_file_with_path_buffer(
+                        &mut pathbuf,
+                        &write_args,
+                        node_fs::Flavor::Sync,
+                    ) {
                         Err(err) => {
                             bun_core::Output::err(
                                 err,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4218,10 +4218,9 @@ pub mod args {
                 ..Default::default()
             })
         }
-        /// Polled off-thread against a non-atomic flag; the fence keeps the
-        /// load observable under LTO and weak memory ordering.
         pub fn aborted(&self) -> bool {
             if let Some(signal) = &self.signal {
+                // Off-thread poll of a non-atomic flag: fence for LTO + weak ordering.
                 core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
                 return signal.aborted();
             }
@@ -4341,10 +4340,9 @@ pub mod args {
                 flush,
             })
         }
-        /// Polled off-thread against a non-atomic flag; the fence keeps the
-        /// load observable under LTO and weak memory ordering.
         pub fn aborted(&self) -> bool {
             if let Some(signal) = &self.signal {
+                // Off-thread poll of a non-atomic flag: fence for LTO + weak ordering.
                 core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
                 return signal.aborted();
             }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4755,9 +4755,9 @@ impl NodeFS {
         }
     }
 
-    pub fn append_file(&mut self, args: &args::AppendFile, _: Flavor) -> Maybe<ret::AppendFile> {
+    pub fn append_file(&mut self, args: &args::AppendFile, flavor: Flavor) -> Maybe<ret::AppendFile> {
         let mut data = args.data.slice();
-        let has_signal = args.signal.is_some();
+        let has_signal = flavor == Flavor::Async && args.signal.is_some();
         let fd = match &args.file {
             PathOrFileDescriptor::Fd(fd) => *fd,
             PathOrFileDescriptor::Path(path_) => {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -435,9 +435,7 @@ fn err_from_static(name: &'static str) -> crate::Error {
 const PREALLOCATE_SUPPORTED: bool = cfg!(any(target_os = "linux", target_os = "android"));
 const PREALLOCATE_LENGTH: usize = 2048 * 1024;
 
-/// Node's `kWriteFileMaxChunkSize` (lib/internal/fs/promises.js): `writeFile`
-/// polls the AbortSignal between writes of this size so an in-flight abort can
-/// stop the write before the whole buffer is committed.
+/// Node's `kWriteFileMaxChunkSize`: AbortSignal is polled between writes of this size.
 const WRITE_FILE_CHUNK_SIZE: usize = 512 * 1024;
 
 /// `CLONE_NOFOLLOW` from `<sys/clonefile.h>` — not re-exported by `bun_sys::c`
@@ -7443,11 +7441,8 @@ impl NodeFS {
         let mut written: usize = 0;
         let has_signal = args.signal.is_some();
 
-        // Attempt to pre-allocate large files.
-        // Worthwhile after 6 MB at least on ext4 linux. Skip it when an
-        // AbortSignal is attached: fallocate(mode 0) grows the file to the full
-        // length up front, and an abort mid-write would leave a zeroed tail on
-        // paths where the post-loop truncate does not run (fd targets, r+).
+        // Attempt to pre-allocate large files (worthwhile after 6 MB on ext4).
+        // Skipped under a signal: an abort would leave a fallocate-zeroed tail.
         if PREALLOCATE_SUPPORTED && !has_signal && buf.len() >= PREALLOCATE_LENGTH {
             'preallocate: {
                 let is_path = matches!(args.file, PathOrFileDescriptor::Path(_));
@@ -7487,10 +7482,6 @@ impl NodeFS {
         // the bytes that did land.
         let mut write_err: Option<sys::Error> = None;
         while !buf.is_empty() {
-            // Node checks the abort signal between 512 KiB chunks
-            // (kWriteFileMaxChunkSize in lib/internal/fs/promises.js); without
-            // the per-write bound a single write() can commit the whole buffer
-            // before the signal is consulted.
             let chunk = if has_signal {
                 if args.aborted() {
                     write_err = Some(abort_err());

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7441,8 +7441,8 @@ impl NodeFS {
         let mut written: usize = 0;
         let has_signal = args.signal.is_some();
 
-        // Attempt to pre-allocate large files (worthwhile after 6 MB on ext4).
-        // Skipped under a signal: an abort would leave a fallocate-zeroed tail.
+        // Attempt to pre-allocate large files
+        // Worthwhile after 6 MB at least on ext4 linux
         if PREALLOCATE_SUPPORTED && !has_signal && buf.len() >= PREALLOCATE_LENGTH {
             'preallocate: {
                 let is_path = matches!(args.file, PathOrFileDescriptor::Path(_));

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4220,8 +4220,6 @@ pub mod args {
         }
         pub fn aborted(&self) -> bool {
             if let Some(signal) = &self.signal {
-                // Off-thread poll of a non-atomic flag: fence for LTO + weak ordering.
-                core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
                 return signal.aborted();
             }
             false
@@ -4342,8 +4340,6 @@ pub mod args {
         }
         pub fn aborted(&self) -> bool {
             if let Some(signal) = &self.signal {
-                // Off-thread poll of a non-atomic flag: fence for LTO + weak ordering.
-                core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
                 return signal.aborted();
             }
             false

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4218,8 +4218,11 @@ pub mod args {
                 ..Default::default()
             })
         }
+        /// Polled off-thread against a non-atomic flag; the fence keeps the
+        /// load observable under LTO and weak memory ordering.
         pub fn aborted(&self) -> bool {
             if let Some(signal) = &self.signal {
+                core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
                 return signal.aborted();
             }
             false
@@ -4338,8 +4341,11 @@ pub mod args {
                 flush,
             })
         }
+        /// Polled off-thread against a non-atomic flag; the fence keeps the
+        /// load observable under LTO and weak memory ordering.
         pub fn aborted(&self) -> bool {
             if let Some(signal) = &self.signal {
+                core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
                 return signal.aborted();
             }
             false

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7409,6 +7409,7 @@ impl NodeFS {
     pub fn write_file_with_path_buffer(
         pathbuf: &mut PathBuffer,
         args: &args::WriteFile,
+        flavor: Flavor,
     ) -> Maybe<ret::WriteFile> {
         let fd = match &args.file {
             PathOrFileDescriptor::Path(p) => {
@@ -7443,7 +7444,7 @@ impl NodeFS {
         let mut buf = args.data.slice();
         #[cfg(not(windows))]
         let mut written: usize = 0;
-        let has_signal = args.signal.is_some();
+        let has_signal = flavor == Flavor::Async && args.signal.is_some();
 
         // Attempt to pre-allocate large files
         // Worthwhile after 6 MB at least on ext4 linux
@@ -7551,8 +7552,8 @@ impl NodeFS {
         Ok(())
     }
 
-    pub fn write_file(&mut self, args: &args::WriteFile, _: Flavor) -> Maybe<ret::WriteFile> {
-        Self::write_file_with_path_buffer(&mut self.sync_error_buf, args)
+    pub fn write_file(&mut self, args: &args::WriteFile, flavor: Flavor) -> Maybe<ret::WriteFile> {
+        Self::write_file_with_path_buffer(&mut self.sync_error_buf, args, flavor)
     }
 
     pub fn readlink(&mut self, args: &args::Readlink, _: Flavor) -> Maybe<ret::Readlink> {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7424,6 +7424,13 @@ impl NodeFS {
         #[cfg(not(windows))]
         let mut written: usize = 0;
 
+        // Node checks the abort signal between chunks of this size
+        // (kWriteFileMaxChunkSize in lib/internal/fs/promises.js). Without the
+        // cap a single write() call can commit the whole buffer before the
+        // signal is ever consulted.
+        const WRITE_FILE_CHUNK_SIZE: usize = 512 * 1024;
+        let has_signal = args.signal.is_some();
+
         // Attempt to pre-allocate large files
         // Worthwhile after 6 MB at least on ext4 linux
         if PREALLOCATE_SUPPORTED && buf.len() >= PREALLOCATE_LENGTH {
@@ -7465,7 +7472,16 @@ impl NodeFS {
         // the bytes that did land.
         let mut write_err: Option<sys::Error> = None;
         while !buf.is_empty() {
-            match sys::write(fd, buf) {
+            let chunk = if has_signal {
+                if args.aborted() {
+                    write_err = Some(abort_err());
+                    break;
+                }
+                &buf[..buf.len().min(WRITE_FILE_CHUNK_SIZE)]
+            } else {
+                buf
+            };
+            match sys::write(fd, chunk) {
                 Err(err) => {
                     write_err = Some(err);
                     break;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -435,6 +435,11 @@ fn err_from_static(name: &'static str) -> crate::Error {
 const PREALLOCATE_SUPPORTED: bool = cfg!(any(target_os = "linux", target_os = "android"));
 const PREALLOCATE_LENGTH: usize = 2048 * 1024;
 
+/// Node's `kWriteFileMaxChunkSize` (lib/internal/fs/promises.js): `writeFile`
+/// polls the AbortSignal between writes of this size so an in-flight abort can
+/// stop the write before the whole buffer is committed.
+const WRITE_FILE_CHUNK_SIZE: usize = 512 * 1024;
+
 /// `CLONE_NOFOLLOW` from `<sys/clonefile.h>` — not re-exported by `bun_sys::c`
 /// (or the `libc` crate), so define it locally. `clonefile(2)` then clones a
 /// symbolic-link `src` itself rather than the file it points to.
@@ -4754,25 +4759,38 @@ impl NodeFS {
 
     pub fn append_file(&mut self, args: &args::AppendFile, _: Flavor) -> Maybe<ret::AppendFile> {
         let mut data = args.data.slice();
-        match &args.file {
-            PathOrFileDescriptor::Fd(fd) => {
-                while !data.is_empty() {
-                    let written = Syscall::write(*fd, data)?;
-                    data = &data[written..];
-                }
-                Ok(())
-            }
+        let has_signal = args.signal.is_some();
+        let fd = match &args.file {
+            PathOrFileDescriptor::Fd(fd) => *fd,
             PathOrFileDescriptor::Path(path_) => {
                 let path = path_.slice_z(&mut self.sync_error_buf);
-                let fd = Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?;
-                let _close = scopeguard::guard(fd, |fd| fd.close());
-                while !data.is_empty() {
-                    let written = Syscall::write(fd, data)?;
-                    data = &data[written..];
-                }
-                Ok(())
+                Syscall::open(path, FileSystemFlags::A.as_int(), args.mode)?
             }
+        };
+        let _close = scopeguard::guard(
+            (fd, matches!(args.file, PathOrFileDescriptor::Path(_))),
+            |(fd, owned)| {
+                if owned {
+                    fd.close();
+                }
+            },
+        );
+        while !data.is_empty() {
+            let chunk = if has_signal {
+                if args.aborted() {
+                    return Err(abort_err());
+                }
+                &data[..data.len().min(WRITE_FILE_CHUNK_SIZE)]
+            } else {
+                data
+            };
+            let written = Syscall::write(fd, chunk)?;
+            if written == 0 {
+                break;
+            }
+            data = &data[written..];
         }
+        Ok(())
     }
 
     pub fn close(&mut self, args: &args::Close, _: Flavor) -> Maybe<ret::Close> {
@@ -7423,17 +7441,14 @@ impl NodeFS {
         let mut buf = args.data.slice();
         #[cfg(not(windows))]
         let mut written: usize = 0;
-
-        // Node checks the abort signal between chunks of this size
-        // (kWriteFileMaxChunkSize in lib/internal/fs/promises.js). Without the
-        // cap a single write() call can commit the whole buffer before the
-        // signal is ever consulted.
-        const WRITE_FILE_CHUNK_SIZE: usize = 512 * 1024;
         let has_signal = args.signal.is_some();
 
-        // Attempt to pre-allocate large files
-        // Worthwhile after 6 MB at least on ext4 linux
-        if PREALLOCATE_SUPPORTED && buf.len() >= PREALLOCATE_LENGTH {
+        // Attempt to pre-allocate large files.
+        // Worthwhile after 6 MB at least on ext4 linux. Skip it when an
+        // AbortSignal is attached: fallocate(mode 0) grows the file to the full
+        // length up front, and an abort mid-write would leave a zeroed tail on
+        // paths where the post-loop truncate does not run (fd targets, r+).
+        if PREALLOCATE_SUPPORTED && !has_signal && buf.len() >= PREALLOCATE_LENGTH {
             'preallocate: {
                 let is_path = matches!(args.file, PathOrFileDescriptor::Path(_));
                 // Preallocating grows the file, so skip it when the kernel picks
@@ -7472,6 +7487,10 @@ impl NodeFS {
         // the bytes that did land.
         let mut write_err: Option<sys::Error> = None;
         while !buf.is_empty() {
+            // Node checks the abort signal between 512 KiB chunks
+            // (kWriteFileMaxChunkSize in lib/internal/fs/promises.js); without
+            // the per-write bound a single write() can commit the whole buffer
+            // before the signal is consulted.
             let chunk = if has_signal {
                 if args.aborted() {
                     write_err = Some(abort_err());

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7437,14 +7437,14 @@ impl NodeFS {
             },
         );
 
-        if args.aborted() {
+        let has_signal = flavor == Flavor::Async && args.signal.is_some();
+        if has_signal && args.aborted() {
             return Err(abort_err());
         }
 
         let mut buf = args.data.slice();
         #[cfg(not(windows))]
         let mut written: usize = 0;
-        let has_signal = flavor == Flavor::Async && args.signal.is_some();
 
         // Attempt to pre-allocate large files
         // Worthwhile after 6 MB at least on ext4 linux

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4755,7 +4755,11 @@ impl NodeFS {
         }
     }
 
-    pub fn append_file(&mut self, args: &args::AppendFile, flavor: Flavor) -> Maybe<ret::AppendFile> {
+    pub fn append_file(
+        &mut self,
+        args: &args::AppendFile,
+        flavor: Flavor,
+    ) -> Maybe<ret::AppendFile> {
         let mut data = args.data.slice();
         let has_signal = flavor == Flavor::Async && args.signal.is_some();
         let fd = match &args.file {

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -492,9 +492,9 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     }
   });
 
-  test("appendFileSync ignores an AbortSignal", async () => {
-    await using dir = tempDir("fs-abort-appendfilesync", { "f.txt": "" });
-    fs.appendFileSync(join(dir, "f.txt"), "data", { signal: AbortSignal.abort() });
+  test.each(["writeFileSync", "appendFileSync"])("%s ignores an AbortSignal", async method => {
+    await using dir = tempDir(`fs-abort-${method}`, { "f.txt": "" });
+    fs[method](join(dir, "f.txt"), "data", { signal: AbortSignal.abort() });
     expect(fs.readFileSync(join(dir, "f.txt"), "utf8")).toBe("data");
   });
 

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -496,26 +496,38 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   // one-shot write that commits the whole buffer and only then rejects tells the
   // caller the operation failed while leaving the full payload on disk.
   test("writeFile aborted mid-write stops before the full buffer is committed", async () => {
-    const dir = tempDirWithFiles("fs-abort-writefile-midwrite", {});
-    const p = join(dir, "big.bin");
+    await using dir = tempDir("fs-abort-writefile-midwrite", {});
     const SIZE = 128 * 1024 * 1024;
     const buf = Buffer.alloc(SIZE, 7);
-    // The write runs on a thread-pool worker; busy-poll from the JS thread until
-    // the worker has opened the file, then abort. This lands the abort while the
-    // write loop is live without relying on a timer.
-    const ac = new AbortController();
-    const promise = fsPromises.writeFile(p, buf, { signal: ac.signal });
-    while (!fs.existsSync(p));
-    ac.abort();
-    let rejected;
-    try {
-      await promise;
-    } catch (err) {
-      rejected = err;
+    let result;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const p = join(String(dir), `big-${attempt}.bin`);
+      fs.writeFileSync(p, "");
+      const ac = new AbortController();
+      const promise = fsPromises.writeFile(p, buf, { signal: ac.signal });
+      // The write runs on a thread-pool worker; busy-poll from the JS thread
+      // until bytes have landed so abort() fires while the write loop is live.
+      for (let i = 0; fs.statSync(p).size === 0; i++) {
+        if (i > 1_000_000) throw new Error("worker never started writing");
+      }
+      const sizeAtAbort = fs.statSync(p).size;
+      ac.abort();
+      let rejected;
+      try {
+        await promise;
+      } catch (err) {
+        rejected = err;
+      }
+      const size = fs.statSync(p).size;
+      fs.unlinkSync(p);
+      result = { name: rejected?.name, code: rejected?.code, size };
+      // Only assert on an attempt that observably caught the worker mid-write;
+      // an attempt where the write raced to completion before abort() proves
+      // nothing either way.
+      if (sizeAtAbort < SIZE) break;
     }
-    const size = fs.statSync(p).size;
-    expect({ name: rejected?.name, code: rejected?.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
-    expect(size).toBeLessThan(SIZE);
+    expect({ name: result.name, code: result.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
+    expect(result.size).toBeLessThan(SIZE);
   });
 
   test("writeFile of an async iterable with a pre-aborted signal", async () => {

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -1,4 +1,4 @@
-import { tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 const assert = require("assert");
 const os = require("os");
@@ -494,44 +494,51 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   // Aborting while a large buffer is being written must stop the write mid-stream.
   // Node checks the signal between 512 KiB chunks (kWriteFileMaxChunkSize); a
   // one-shot write that commits the whole buffer and only then rejects tells the
-  // caller the operation failed while leaving the full payload on disk.
-  test.each([
-    ["writeFile", fsPromises.writeFile],
-    ["appendFile", fsPromises.appendFile],
-  ])("%s aborted mid-write stops before the full buffer is committed", async (_, writeFn) => {
-    await using dir = tempDir("fs-abort-writefile-midwrite", {});
-    const SIZE = 128 * 1024 * 1024;
-    const buf = Buffer.alloc(SIZE, 7);
-    let result;
-    for (let attempt = 0; attempt < 20; attempt++) {
-      const p = join(String(dir), `big-${attempt}.bin`);
-      fs.writeFileSync(p, "");
-      const ac = new AbortController();
-      const promise = writeFn(p, buf, { signal: ac.signal });
-      // The write runs on a thread-pool worker; busy-poll from the JS thread
-      // until bytes have landed so abort() fires while the write loop is live.
-      for (let i = 0; fs.statSync(p).size === 0; i++) {
-        if (i > 1_000_000) throw new Error("worker never started writing");
-      }
-      ac.abort();
-      let rejected;
-      try {
-        await promise;
-      } catch (err) {
-        rejected = err;
-      }
-      const size = fs.statSync(p).size;
-      fs.unlinkSync(p);
-      result = { name: rejected?.name, code: rejected?.code, size };
-      // A full-size result means abort() landed after the worker had finished
-      // (scheduler preemption between the poll and abort()); that attempt
-      // proves nothing either way, so retry. A one-shot write with no
-      // mid-loop abort check never produces size < SIZE here.
-      if (size < SIZE) break;
-    }
-    expect({ name: result.name, code: result.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
-    expect(result.size).toBeLessThan(SIZE);
-  });
+  // caller the operation failed while leaving the full payload on disk. This
+  // runs in a dedicated subprocess so the busy-poll on the JS thread and the
+  // thread-pool writer are not contending with the test runner's parallel batch.
+  test.each(["writeFile", "appendFile"])(
+    "%s aborted mid-write stops before the full buffer is committed",
+    async method => {
+      await using dir = tempDir("fs-abort-writefile-midwrite", {});
+      const SIZE = 128 * 1024 * 1024;
+      const script = `
+        const fs = require("node:fs");
+        const fsp = require("node:fs/promises");
+        const SIZE = ${SIZE};
+        const buf = Buffer.alloc(SIZE, 7);
+        for (let attempt = 0; attempt < 20; attempt++) {
+          const p = require("node:path").join(${JSON.stringify(String(dir))}, "big-" + attempt + ".bin");
+          fs.writeFileSync(p, "");
+          const ac = new AbortController();
+          const promise = fsp[${JSON.stringify(method)}](p, buf, { signal: ac.signal });
+          for (let i = 0; fs.statSync(p).size === 0; i++) {
+            if (i > 1_000_000) { console.log(JSON.stringify({ err: "worker never started" })); process.exit(1); }
+          }
+          ac.abort();
+          let name, code;
+          try { await promise; } catch (e) { name = e?.name; code = e?.code; }
+          const size = fs.statSync(p).size;
+          fs.unlinkSync(p);
+          if (size < SIZE || attempt === 19) {
+            console.log(JSON.stringify({ name, code, size, attempt }));
+            process.exit(0);
+          }
+        }
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const result = JSON.parse(stdout.trim());
+      expect({ name: result.name, code: result.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
+      expect(result.size).toBeLessThan(SIZE);
+      expect(exitCode).toBe(0);
+    },
+  );
 
   test("writeFile of an async iterable with a pre-aborted signal", async () => {
     await using dir = tempDir("fs-abort-writefile-iter", {});

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -521,11 +521,10 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
         const buf = Buffer.alloc(SIZE, 7);
         for (let attempt = 0; attempt < 20; attempt++) {
           const p = require("node:path").join(${JSON.stringify(String(dir))}, "big-" + attempt + ".bin");
-          fs.writeFileSync(p, "");
           const ac = new AbortController();
           const promise = fsp[${JSON.stringify(method)}](p, buf, { signal: ac.signal });
-          for (let i = 0; fs.statSync(p).size === 0; i++) {
-            if (i > 1_000_000) { console.log(JSON.stringify({ err: "worker never started" })); process.exit(1); }
+          for (let i = 0; !fs.existsSync(p); i++) {
+            if (i > 1_000_000) { console.log(JSON.stringify({ err: "worker never opened" })); process.exit(1); }
           }
           ac.abort();
           let name, code;

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -495,7 +495,10 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   // Node checks the signal between 512 KiB chunks (kWriteFileMaxChunkSize); a
   // one-shot write that commits the whole buffer and only then rejects tells the
   // caller the operation failed while leaving the full payload on disk.
-  test("writeFile aborted mid-write stops before the full buffer is committed", async () => {
+  test.each([
+    ["writeFile", fsPromises.writeFile],
+    ["appendFile", fsPromises.appendFile],
+  ])("%s aborted mid-write stops before the full buffer is committed", async (_, writeFn) => {
     await using dir = tempDir("fs-abort-writefile-midwrite", {});
     const SIZE = 128 * 1024 * 1024;
     const buf = Buffer.alloc(SIZE, 7);
@@ -504,13 +507,12 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
       const p = join(String(dir), `big-${attempt}.bin`);
       fs.writeFileSync(p, "");
       const ac = new AbortController();
-      const promise = fsPromises.writeFile(p, buf, { signal: ac.signal });
+      const promise = writeFn(p, buf, { signal: ac.signal });
       // The write runs on a thread-pool worker; busy-poll from the JS thread
       // until bytes have landed so abort() fires while the write loop is live.
       for (let i = 0; fs.statSync(p).size === 0; i++) {
         if (i > 1_000_000) throw new Error("worker never started writing");
       }
-      const sizeAtAbort = fs.statSync(p).size;
       ac.abort();
       let rejected;
       try {
@@ -521,10 +523,11 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
       const size = fs.statSync(p).size;
       fs.unlinkSync(p);
       result = { name: rejected?.name, code: rejected?.code, size };
-      // Only assert on an attempt that observably caught the worker mid-write;
-      // an attempt where the write raced to completion before abort() proves
-      // nothing either way.
-      if (sizeAtAbort < SIZE) break;
+      // A full-size result means abort() landed after the worker had finished
+      // (scheduler preemption between the poll and abort()); that attempt
+      // proves nothing either way, so retry. A one-shot write with no
+      // mid-loop abort check never produces size < SIZE here.
+      if (size < SIZE) break;
     }
     expect({ name: result.name, code: result.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
     expect(result.size).toBeLessThan(SIZE);

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -492,6 +492,12 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     }
   });
 
+  test("appendFileSync ignores an AbortSignal", async () => {
+    await using dir = tempDir("fs-abort-appendfilesync", { "f.txt": "" });
+    fs.appendFileSync(join(dir, "f.txt"), "data", { signal: AbortSignal.abort() });
+    expect(fs.readFileSync(join(dir, "f.txt"), "utf8")).toBe("data");
+  });
+
   test("writeFile with a pre-aborted signal", async () => {
     await using dir = tempDir("fs-abort-writefile", {});
     const signal = AbortSignal.abort();
@@ -531,7 +537,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
           try { await promise; } catch (e) { name = e?.name; code = e?.code; }
           const size = fs.statSync(p).size;
           fs.unlinkSync(p);
-          if (size < SIZE || attempt === 19) {
+          if ((size > 0 && size < SIZE) || attempt === 19) {
             console.log(JSON.stringify({ name, code, size, attempt }));
             process.exit(0);
           }

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -480,6 +480,18 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     }
   });
 
+  test("FileHandle#appendFile with a pre-aborted signal", async () => {
+    await using dir = tempDir("fs-abort-fh-appendfile", { "f.txt": "" });
+    const signal = AbortSignal.abort();
+    await using fh = await fsPromises.open(join(dir, "f.txt"), "a");
+    expect.assertions(4);
+    try {
+      await fh.appendFile("data", { signal });
+    } catch (err) {
+      expectNodeAbortError(err, signal.reason);
+    }
+  });
+
   test("writeFile with a pre-aborted signal", async () => {
     await using dir = tempDir("fs-abort-writefile", {});
     const signal = AbortSignal.abort();

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -552,6 +552,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
       expect(stderr).toBe("");
       const result = JSON.parse(stdout.trim());
       expect({ name: result.name, code: result.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
+      expect(result.size).toBeGreaterThan(0);
       expect(result.size).toBeLessThan(SIZE);
       expect(exitCode).toBe(0);
     },

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -491,6 +491,33 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     }
   });
 
+  // Aborting while a large buffer is being written must stop the write mid-stream.
+  // Node checks the signal between 512 KiB chunks (kWriteFileMaxChunkSize); a
+  // one-shot write that commits the whole buffer and only then rejects tells the
+  // caller the operation failed while leaving the full payload on disk.
+  test("writeFile aborted mid-write stops before the full buffer is committed", async () => {
+    const dir = tempDirWithFiles("fs-abort-writefile-midwrite", {});
+    const p = join(dir, "big.bin");
+    const SIZE = 128 * 1024 * 1024;
+    const buf = Buffer.alloc(SIZE, 7);
+    // The write runs on a thread-pool worker; busy-poll from the JS thread until
+    // the worker has opened the file, then abort. This lands the abort while the
+    // write loop is live without relying on a timer.
+    const ac = new AbortController();
+    const promise = fsPromises.writeFile(p, buf, { signal: ac.signal });
+    while (!fs.existsSync(p));
+    ac.abort();
+    let rejected;
+    try {
+      await promise;
+    } catch (err) {
+      rejected = err;
+    }
+    const size = fs.statSync(p).size;
+    expect({ name: rejected?.name, code: rejected?.code }).toEqual({ name: "AbortError", code: "ABORT_ERR" });
+    expect(size).toBeLessThan(SIZE);
+  });
+
   test("writeFile of an async iterable with a pre-aborted signal", async () => {
     await using dir = tempDir("fs-abort-writefile-iter", {});
     const signal = AbortSignal.abort();


### PR DESCRIPTION
## Reproduction

```js
import fs from "node:fs";
import fsp from "node:fs/promises";
import os from "node:os";
import path from "node:path";

const p = path.join(os.tmpdir(), `wfabort-${process.pid}.bin`);
const SIZE = 128 * 1024 * 1024;
const ac = new AbortController();
const wr = fsp.writeFile(p, Buffer.alloc(SIZE, 7), { signal: ac.signal });
setTimeout(() => ac.abort(), 2);
try { await wr; } catch {}
console.log(fs.statSync(p).size);
// node: a few 512 KiB chunks at most
// bun : 134217728 (the abort had no effect beyond the error)
```

The promise rejects with `AbortError` in both runtimes, but Bun has already committed the full buffer to disk: the caller is told the write failed while the file is complete, and the signal does nothing to bound the write.

## Cause

`write_file_with_path_buffer` in `src/runtime/node/node_fs.rs` checks `args.aborted()` once after opening the file, then hands the entire buffer to `sys::write` in a loop with no further abort check. On a regular file that is a single `write()` for the whole payload. The abort signal is consulted again only in `AsyncFSTask::run_from_js_thread` after the write has finished, which is what produces the rejection with a fully written file.

`NodeFS::append_file` had the same shape, and `FileHandle#appendFile` dropped `options.signal` on the floor before reaching native.

The off-thread `aborted()` poll also read a plain `uint8_t` field on `AbortSignal` while `abort()` wrote it from the JS thread, which is a data race; under cross-language LTO the optimizer is free to treat that load as loop-invariant.

## Fix

- When a `signal` is supplied, cap each `sys::write` at 512 KiB (Node's `kWriteFileMaxChunkSize` from `lib/internal/fs/promises.js`) and check `args.aborted()` at the top of every iteration. On abort the loop records `abort_err()` and breaks, so the existing post-loop truncate trims the file to the bytes that actually landed. Without a `signal` the fast path is unchanged.
- Apply the same per-iteration abort check to `append_file`, and forward `options.signal` from `FileHandle#appendFile` to the underlying `writeFile(fd, ...)` call.
- Make `AbortSignal::m_flags` a `std::atomic<uint8_t>` with relaxed loads/stores so the off-thread poll is well-defined and cannot be hoisted. This also fixes the pre-existing `readFile` abort poll.
- Skip `preallocate_file` when a signal is attached so an aborted write to an fd or with `flag: 'r+'` cannot leave a fallocate-zeroed tail past the bytes that landed.

The callback form (`fs.writeFile(path, buf, { signal }, cb)`) routes through the same native function and is fixed as well.

## Verification

`test/js/node/fs/promises.test.js` gains a parameterized mid-write abort test over `fsPromises.writeFile` and `fsPromises.appendFile`: a dedicated subprocess starts a 128 MiB write, busy-polls `existsSync` until the worker has opened the file, aborts, and asserts the on-disk size is strictly below the buffer length (retrying if the worker races to completion before `abort()`). Both cases fail on the previous build (the file is always the full 128 MiB) and pass after. A pre-aborted-signal test for `FileHandle#appendFile` covers the JS-side signal forwarding.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/promises.test.js
bun test v1.4.0 (72109fd19)

test/js/node/fs/promises.test.js:
(pass) should exist [3.44ms]
(pass) should be enumerable [1.48ms]
(pass) access > should work [5.19ms]
(pass) access > should fail on non-existant files [15.47ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [32.62ms]
(pass) open > should return an object [10.37ms]
(pass) open > should be closable [11.93ms]
(pass) more > is an object [40.75ms]
(pass) more > stat [68.59ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [61.63ms]
(pass) errors from fs.promises include async stack frames [18.98ms]
(pass) fs.promises async stack through Promise subclass [19.51ms]
(pass) fs.promises async stack through custom thenable [12.30ms]
(pass) fs.promises async stack with Promise.all [11.34ms]
(pass) an unused FileHandle.writer() does not prevent close() [46.43ms]
(pass) sources created before close() refuse
... (truncated)

release without fix: 1 failed, 5 skipped
bun test v1.4.0-canary.1 (c6b927391)

test/js/node/fs/promises.test.js:
(pass) should exist [0.06ms]
(pass) should be enumerable [0.02ms]
(pass) access > should work [0.36ms]
(pass) access > should fail on non-existant files [0.31ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [1.12ms]
(pass) open > should return an object [0.32ms]
(pass) open > should be closable [0.09ms]
(pass) more > is an object [1.13ms]
(pass) more > stat [6.15ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [6.50ms]
(pass) errors from fs.promises include async stack frames [0.25ms]
(pass) fs.promises async stack through Promise subclass [0.56ms]
(pass) fs.promises async stack through custom thenable [0.15ms]
(pass) fs.promises async stack with Promise.all [0.13ms]
(pass) an unused FileHandle.writer() does not prevent close() [1.09ms]
(pass) sources created before close() refuse to use the stale fd [1.78ms]
(pass) rm and promises.rm report ERR_FS_EISDIR for directories like rmSync [1.36ms]
(pass) close() while an operation is in flight actually
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/promises.test.js
bun test v1.4.0 (72109fd19)

test/js/node/fs/promises.test.js:
(pass) should exist [4.45ms]
(pass) should be enumerable [2.10ms]
(pass) access > should work [5.72ms]
(pass) access > should fail on non-existant files [15.51ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [33.89ms]
(pass) open > should return an object [10.99ms]
(pass) open > should be closable [12.99ms]
(pass) more > is an object [43.97ms]
(pass) more > stat [78.05ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [65.06ms]
(pass) errors from fs.promises include async stack frames [19.21ms]
(pass) fs.promises async stack through Promise subclass [20.75ms]
(pass) fs.promises async stack through custom thenable [12.37ms]
(pass) fs.promises async stack with Promise.all [11.69ms]
(pass) an unused FileHandle.writer() does not prevent close() [57.01ms]
(pass) sources created before close() refuse
... (truncated)

release with fix: 5 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 788ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/30] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/30] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[3/30] gen JS modules (bundle-modules)
Preprocess modules (9181ms)
Bundle modules (57ms)
Postprocesss modules (209ms)
Bundle Functions (810ms)
Generate Code (38ms)

[10.32s] Bundled "src/js" for production
  2570 kb
  193 internal modules
  13 native modules
  90 internal functions across 19 files
[3/20] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/fs.promises.ts                   |  4 +-
 src/jsc/AbortSignal.rs                       |  2 +-
 src/jsc/bindings/webcore/AbortSignal.h       | 52 +++++++-------------
 src/runtime/api/js_bundle_completion_task.rs |  6 ++-
 src/runtime/node/node_fs.rs                  | 71 ++++++++++++++++++++--------
 test/js/node/fs/promises.test.js             | 69 ++++++++++++++++++++++++++-
 6 files changed, 144 insertions(+), 60 deletions(-)
```

</details>

**gate history** · 10 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/js/node/fs.promises.ts                        7      1      0
src/jsc/AbortSignal.rs                            2      1      0
src/jsc/bindings/webcore/AbortSignal.h            2      5      0
src/runtime/api/js_bundle_completion_task.rs      1      2      0
src/runtime/node/node_fs.rs                      17     21      0
test/js/node/fs/promises.test.js                  8     15      0
```

</details>

<!-- robobun:evidence:end -->