### PR TITLE
node:http: enforce server.maxConnections and emit 'drop'

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1217,6 +1217,24 @@ function onServerConnection(this: Server, socketHandle) {
     // Already wrapped (shouldn't happen for a brand-new connection).
     return;
   }
+  // Like Node.js's net.Server onconnection: once maxConnections is reached,
+  // each further accepted connection is reported via 'drop' and destroyed
+  // before http's connectionListener sees it.
+  const maxConnections = this.maxConnections;
+  if (maxConnections != null && this[kTrackedConnections].size >= maxConnections) {
+    const remote = socketHandle.remoteAddress;
+    const local = socketHandle.localAddress;
+    this.emit("drop", {
+      localAddress: local?.address,
+      localPort: local?.port,
+      localFamily: local?.family,
+      remoteAddress: remote?.address,
+      remotePort: remote?.port,
+      remoteFamily: remote?.family,
+    });
+    socketHandle.close();
+    return;
+  }
   const isTLS = !!this[tlsSymbol];
   const socket = new NodeHTTPServerSocket(this, socketHandle, isTLS);
   // Node's connectionListener attaches the HTTPParser (socket.parser) before

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1219,11 +1219,14 @@ function onServerConnection(this: Server, socketHandle) {
   }
   // Like Node.js's net.Server onconnection: once maxConnections is reached,
   // each further accepted connection is reported via 'drop' and destroyed
-  // before http's connectionListener sees it.
+  // before http's connectionListener sees it. Close before emit (same as
+  // net.ts) so a throwing 'drop' listener cannot leave the socket open for
+  // onNodeHTTPRequest to wrap and serve.
   const maxConnections = this.maxConnections;
   if (maxConnections != null && this[kTrackedConnections].size >= maxConnections) {
     const remote = socketHandle.remoteAddress;
     const local = socketHandle.localAddress;
+    socketHandle.close();
     this.emit("drop", {
       localAddress: local?.address,
       localPort: local?.port,
@@ -1232,7 +1235,6 @@ function onServerConnection(this: Server, socketHandle) {
       remotePort: remote?.port,
       remoteFamily: remote?.family,
     });
-    socketHandle.close();
     return;
   }
   const isTLS = !!this[tlsSymbol];

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,12 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: address.address,
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4054,3 +4054,78 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
   c.outputData.push({ data: "y", encoding: "utf8", callback: null });
   expect(d.outputData.length).toBe(0);
 });
+
+it("http.Server maxConnections destroys the excess and emits 'drop' like net.Server", async () => {
+  let served = 0;
+  const drops: any[] = [];
+  const server = createServer((_req, res) => {
+    served++;
+    res.end("ok");
+  });
+  server.maxConnections = 2;
+  server.on("drop", data => drops.push(data));
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const port = (server.address() as AddressInfo).port;
+
+  const openAndRequest = async () => {
+    const sock = connect(port, "127.0.0.1");
+    sock.on("error", () => {});
+    await once(sock, "connect");
+    let body = "";
+    sock.setEncoding("utf8");
+    sock.on("data", c => (body += c));
+    sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    while (!body.endsWith("ok")) await once(sock, "data");
+    return sock;
+  };
+
+  const s1 = await openAndRequest();
+  const s2 = await openAndRequest();
+  expect(served).toBe(2);
+  expect(drops).toEqual([]);
+
+  // Connections 3 and 4 are over the limit: the server emits 'drop' and
+  // destroys them on accept; the client side observes the close, and no
+  // 'request' is dispatched.
+  const outcomes: string[] = [];
+  for (let i = 0; i < 2; i++) {
+    const sock = connect(port, "127.0.0.1");
+    sock.on("error", () => {});
+    const outcome = new Promise<string>(r => {
+      sock.once("data", () => r("served"));
+      sock.once("close", () => r("dropped"));
+    });
+    await once(sock, "connect");
+    sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    outcomes.push(await outcome);
+    sock.destroy();
+  }
+
+  expect({ served, drops: drops.length, outcomes }).toEqual({
+    served: 2,
+    drops: 2,
+    outcomes: ["dropped", "dropped"],
+  });
+  expect(drops[0]).toEqual({
+    localAddress: "127.0.0.1",
+    localPort: port,
+    localFamily: "IPv4",
+    remoteAddress: "127.0.0.1",
+    remotePort: expect.any(Number),
+    remoteFamily: "IPv4",
+  });
+  const connectionCount = await new Promise<number>(r => server.getConnections((_e, n) => r(n)));
+  expect(connectionCount).toBe(2);
+
+  // Freeing a slot lets the next connection through again.
+  s1.destroy();
+  while ((await new Promise<number>(r => server.getConnections((_e, n) => r(n)))) !== 1) {
+    await new Promise(r => setImmediate(r));
+  }
+  const s5 = await openAndRequest();
+  expect(served).toBe(3);
+  expect(drops.length).toBe(2);
+
+  for (const s of [s2, s5]) s.destroy();
+  await new Promise<void>(r => server.close(() => r()));
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4066,66 +4066,70 @@ it("http.Server maxConnections destroys the excess and emits 'drop' like net.Ser
   server.on("drop", data => drops.push(data));
   await once(server.listen(0, "127.0.0.1"), "listening");
   const port = (server.address() as AddressInfo).port;
+  const clients: import("node:net").Socket[] = [];
 
-  const openAndRequest = async () => {
-    const sock = connect(port, "127.0.0.1");
-    sock.on("error", () => {});
-    await once(sock, "connect");
-    let body = "";
-    sock.setEncoding("utf8");
-    sock.on("data", c => (body += c));
-    sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
-    while (!body.endsWith("ok")) await once(sock, "data");
-    return sock;
-  };
-
-  const s1 = await openAndRequest();
-  const s2 = await openAndRequest();
-  expect(served).toBe(2);
-  expect(drops).toEqual([]);
-
-  // Connections 3 and 4 are over the limit: the server emits 'drop' and
-  // destroys them on accept; the client side observes the close, and no
-  // 'request' is dispatched.
-  const outcomes: string[] = [];
-  for (let i = 0; i < 2; i++) {
-    const sock = connect(port, "127.0.0.1");
-    sock.on("error", () => {});
-    const outcome = new Promise<string>(r => {
-      sock.once("data", () => r("served"));
-      sock.once("close", () => r("dropped"));
+  const openAndRequest = () =>
+    new Promise<import("node:net").Socket>((resolve, reject) => {
+      const sock = connect(port, "127.0.0.1");
+      clients.push(sock);
+      sock.on("error", () => {});
+      let body = "";
+      sock.setEncoding("utf8");
+      sock.on("data", c => body.endsWith("ok") || (body += c).endsWith("ok") && resolve(sock));
+      sock.once("close", () => reject(new Error(`closed before response, got: ${JSON.stringify(body)}`)));
+      sock.once("connect", () => sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
     });
-    await once(sock, "connect");
-    sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
-    outcomes.push(await outcome);
-    sock.destroy();
+
+  try {
+    const s1 = await openAndRequest();
+    await openAndRequest();
+    expect(served).toBe(2);
+    expect(drops).toEqual([]);
+
+    // Connections 3 and 4 are over the limit: the server emits 'drop' and
+    // destroys them on accept; the client side observes the close, and no
+    // 'request' is dispatched.
+    const outcomes: string[] = [];
+    for (let i = 0; i < 2; i++) {
+      const sock = connect(port, "127.0.0.1");
+      clients.push(sock);
+      sock.on("error", () => {});
+      const outcome = new Promise<string>(r => {
+        sock.once("data", () => r("served"));
+        sock.once("close", () => r("dropped"));
+      });
+      await once(sock, "connect");
+      sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+      outcomes.push(await outcome);
+      sock.destroy();
+    }
+
+    expect({ served, drops: drops.length, outcomes }).toEqual({
+      served: 2,
+      drops: 2,
+      outcomes: ["dropped", "dropped"],
+    });
+    expect(drops[0]).toEqual({
+      localAddress: "127.0.0.1",
+      localPort: port,
+      localFamily: "IPv4",
+      remoteAddress: "127.0.0.1",
+      remotePort: expect.any(Number),
+      remoteFamily: "IPv4",
+    });
+    const connectionCount = await new Promise<number>(r => server.getConnections((_e, n) => r(n)));
+    expect(connectionCount).toBe(2);
+
+    // Freeing a slot lets the next connection through again.
+    s1.destroy();
+    while ((await new Promise<number>(r => server.getConnections((_e, n) => r(n)))) !== 1) {
+      await new Promise(r => setImmediate(r));
+    }
+    await openAndRequest();
+    expect(served).toBe(3);
+    expect(drops.length).toBe(2);
+  } finally {
+    for (const s of clients) s.destroy();
+    await new Promise<void>(r => server.close(() => r()));
   }
-
-  expect({ served, drops: drops.length, outcomes }).toEqual({
-    served: 2,
-    drops: 2,
-    outcomes: ["dropped", "dropped"],
-  });
-  expect(drops[0]).toEqual({
-    localAddress: "127.0.0.1",
-    localPort: port,
-    localFamily: "IPv4",
-    remoteAddress: "127.0.0.1",
-    remotePort: expect.any(Number),
-    remoteFamily: "IPv4",
-  });
-  const connectionCount = await new Promise<number>(r => server.getConnections((_e, n) => r(n)));
-  expect(connectionCount).toBe(2);
-
-  // Freeing a slot lets the next connection through again.
-  s1.destroy();
-  while ((await new Promise<number>(r => server.getConnections((_e, n) => r(n)))) !== 1) {
-    await new Promise(r => setImmediate(r));
-  }
-  const s5 = await openAndRequest();
-  expect(served).toBe(3);
-  expect(drops.length).toBe(2);
-
-  for (const s of [s2, s5]) s.destroy();
-  await new Promise<void>(r => server.close(() => r()));
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4075,7 +4075,7 @@ it("http.Server maxConnections destroys the excess and emits 'drop' like net.Ser
       sock.on("error", () => {});
       let body = "";
       sock.setEncoding("utf8");
-      sock.on("data", c => body.endsWith("ok") || (body += c).endsWith("ok") && resolve(sock));
+      sock.on("data", c => body.endsWith("ok") || ((body += c).endsWith("ok") && resolve(sock)));
       sock.once("close", () => reject(new Error(`closed before response, got: ${JSON.stringify(body)}`)));
       sock.once("connect", () => sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
     });


### PR DESCRIPTION
## Problem

`server.maxConnections` did nothing on an `http.Server`. With `maxConnections = 2`, every concurrent connection was accepted, every request answered, `getConnections()` counted them all, and no `'drop'` event fired. The same option works on a plain `net.Server` (#953), but `http.Server` is backed by `Bun.serve` directly and never goes through `net.Server`'s `onconnection` path where the check lives.

## Repro

```js
import http from "node:http";
import net from "node:net";

let served = 0, drops = 0;
const s = http.createServer((_q, r) => { served++; r.end("ok"); });
s.maxConnections = 2;
s.on("drop", () => drops++);
s.listen(0, "127.0.0.1", async () => {
  for (let i = 0; i < 4; i++) {
    const c = net.connect(s.address().port, "127.0.0.1");
    await new Promise(r => c.once("connect", r));
    c.on("error", () => {}); c.on("data", () => {});
    c.write("GET / HTTP/1.1\r\nHost: h\r\n\r\n");
    await new Promise(r => setTimeout(r, 50));
  }
  s.getConnections((_e, n) => console.log({ served, drops, n }));
});
// node: { served: 2, drops: 2, n: 2 }
// bun:  { served: 4, drops: 0, n: 4 }
```

## Cause

`src/js/node/_http_server.ts`'s `onServerConnection` (the uws accept filter registered by `applyServerCustomOptions`) wrapped every accepted socket in a `NodeHTTPServerSocket` and emitted `'connection'` unconditionally. The `maxConnections` check in `src/js/node/net.ts`'s `onConnection` is only reached by `net.createServer()`/`tls.createServer()`, not by the `Bun.serve`-backed http server.

## Fix

Apply the same check `net.Server` uses, in `onServerConnection`: once the tracked-connection count reaches `maxConnections`, emit `'drop'` with the same `{localAddress, localPort, localFamily, remoteAddress, remotePort, remoteFamily}` payload and close the native socket before a `NodeHTTPServerSocket` is created, so no `'connection'`/`'request'` is dispatched for the excess.

## Verification

New test in `test/js/node/http/node-http.test.ts` opens two keep-alive connections (served), then two more (dropped), checks `served`, `'drop'` count and payload, `getConnections()`, and that freeing one slot lets the next connection through. The same logic passes under Node v26.

```
USE_SYSTEM_BUN=1 bun test node-http.test.ts -t maxConnections
  served: 4, drops: 0, outcomes: ["served","served"]   (fail)

bun bd test node-http.test.ts -t maxConnections
  7 expect() calls                                     (pass)
```

Related: #2793

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.0 (e61b64774)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [417.87ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [82.57ms]
(pass) node:http > createServer > request & response body streaming (large) [134.72ms]
(pass) node:http > createServer > request & response body streaming (small) [83.95ms]
(pass) node:http > createServer > listen should return server [21.89ms]
(pass) node:http > createServer > listen callback should be bound to server [24.80ms]
(pass) node:http > createServer > should use the provided port [52.85ms]
(pass) node:http > createServer > should assign a random port when undefined [30.72ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [69.49ms]
(pass) node:http > response > set-cookie works with getHeader [4.70ms]
(pass) node:http > response > set-cookie works with getHeaders [5.99ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [89.15ms]
(pass
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (9f92ff453)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [9.25ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [3.54ms]
(pass) node:http > createServer > request & response body streaming (large) [5.49ms]
(pass) node:http > createServer > request & response body streaming (small) [2.70ms]
(pass) node:http > createServer > listen should return server [0.67ms]
(pass) node:http > createServer > listen callback should be bound to server [1.69ms]
(pass) node:http > createServer > should use the provided port [1.46ms]
(pass) node:http > createServer > should assign a random port when undefined [0.96ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [2.17ms]
(pass) node:http > response > set-cookie works with getHeader [0.07ms]
(pass) node:http > response > set-cookie works with getHeaders [0.10ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [2.21ms]
(pass) node:http > request > multiple Set-Cookie headers works #6810 [10.75ms]
(pass) node:http > request > should make a standard GET request when passed string as first arg [5
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.0 (e61b64774)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [576.20ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [90.73ms]
(pass) node:http > createServer > request & response body streaming (large) [143.47ms]
(pass) node:http > createServer > request & response body streaming (small) [84.48ms]
(pass) node:http > createServer > listen should return server [21.84ms]
(pass) node:http > createServer > listen callback should be bound to server [52.95ms]
(pass) node:http > createServer > should use the provided port [43.48ms]
(pass) node:http > createServer > should assign a random port when undefined [28.76ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [71.87ms]
(pass) node:http > response > set-cookie works with getHeader [5.07ms]
(pass) node:http > response > set-cookie works with getHeaders [6.28ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [95.88ms]
(pass
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 830ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/22] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 244 extern-C blocks audited
[3/22] gen JS modules (bundle-modules)
Preprocess modules (7284ms)
Bundle modules (76ms)
Postprocesss modules (166ms)
Bundle Functions (649ms)
Generate Code (82ms)

[8.28s] Bundled "src/js" for production
  2042 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mim
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts          | 20 +++++++++
 test/js/node/http/node-http-proxy.js |  4 +-
 test/js/node/http/node-http.test.ts  | 79 ++++++++++++++++++++++++++++++++++++
 3 files changed, 101 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js/node/_http_server.ts               5      2      0
test/js/node/http/node-http-proxy.js      1      1      0
test/js/node/http/node-http.test.ts       2      4      0
```

</details>

<!-- robobun:evidence:end -->