### PR TITLE
install: fix try_ssh scp-style fallback URL truncation

### DIFF
--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -588,11 +588,17 @@ impl RepositoryExt for Repository {
         }
 
         if Dependency::is_scp_like_path(url) {
-            const PREFIX: &[u8] = b"ssh://git@";
-            ssh_path_buf[..PREFIX.len()].copy_from_slice(PREFIX);
-            let rest = &mut ssh_path_buf[PREFIX.len()..];
-
             let colon_index = strings::index_of_char(url, b':');
+
+            // scp-style is `[user@]host:path`. Only inject a `git@` user when the
+            // input omitted one; otherwise `ssh://git@user@host/...` is sent to git.
+            let has_user = colon_index
+                .map(|c| strings::index_of_char(&url[..c as usize], b'@').is_some())
+                .unwrap_or(false);
+            let prefix: &[u8] = if has_user { b"ssh://" } else { b"ssh://git@" };
+
+            ssh_path_buf[..prefix.len()].copy_from_slice(prefix);
+            let rest = &mut ssh_path_buf[prefix.len()..];
 
             if let Some(colon) = colon_index {
                 let colon = colon as usize;
@@ -603,7 +609,7 @@ impl RepositoryExt for Repository {
                     rest[colon + tld.len()] = b'/';
                     rest[colon + tld.len() + 1..colon + tld.len() + 1 + (url.len() - colon - 1)]
                         .copy_from_slice(&url[colon + 1..]);
-                    let out = &ssh_path_buf[..url.len() + PREFIX.len() + tld.len()];
+                    let out = &ssh_path_buf[..url.len() + prefix.len() + tld.len()];
                     return Some(out);
                 }
             }
@@ -612,8 +618,7 @@ impl RepositoryExt for Repository {
             if let Some(colon) = colon_index {
                 rest[colon as usize] = b'/';
             }
-            let final_ = &ssh_path_buf[..url.len() + b"ssh://".len()];
-            return Some(final_);
+            return Some(&ssh_path_buf[..url.len() + prefix.len()]);
         }
 
         None

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -590,10 +590,12 @@ impl RepositoryExt for Repository {
         if Dependency::is_scp_like_path(url) {
             let colon_index = strings::index_of_char(url, b':');
 
-            // scp-style is `[user@]host:path`. Only inject a `git@` user when the
+            // scp-style is `[user@]host:path` (is_scp_like_path also accepts the
+            // colon-less `user@host/path` form). Only inject a `git@` user when the
             // input omitted one; otherwise `ssh://git@user@host/...` is sent to git.
-            let has_user = colon_index
-                .map(|c| strings::index_of_char(&url[..c as usize], b'@').is_some())
+            let sep = colon_index.or_else(|| strings::index_of_char(url, b'/'));
+            let has_user = sep
+                .map(|s| strings::index_of_char(&url[..s as usize], b'@').is_some())
                 .unwrap_or(false);
             let prefix: &[u8] = if has_user { b"ssh://" } else { b"ssh://git@" };
 

--- a/test/cli/install/bun-install-git-url.test.ts
+++ b/test/cli/install/bun-install-git-url.test.ts
@@ -58,4 +58,14 @@ describe.skipIf(isWindows)("scp-style git dependency URL rewriting", () => {
     const urls = await cloneUrlsFor("git+deploy@myhost.example:org/repo.git");
     expect(urls).toEqual(["https://deploy@myhost.example/org/repo.git", "ssh://deploy@myhost.example/org/repo.git"]);
   });
+
+  test.concurrent("explicit user@ is kept (colon-less form)", async () => {
+    const urls = await cloneUrlsFor("git+deploy@myhost.example/org/repo.git");
+    expect(urls).toEqual(["https://deploy@myhost.example/org/repo.git", "ssh://deploy@myhost.example/org/repo.git"]);
+  });
+
+  test.concurrent("@ in path does not suppress git@ user", async () => {
+    const urls = await cloneUrlsFor("git+myhost.example:org/name@1.git");
+    expect(urls).toEqual(["https://myhost.example/org/name@1.git", "ssh://git@myhost.example/org/name@1.git"]);
+  });
 });

--- a/test/cli/install/bun-install-git-url.test.ts
+++ b/test/cli/install/bun-install-git-url.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 // A fake `git` that logs its argv to a file and exits 128 so the package
 // manager falls through HTTPS -> SSH without touching the network. The SSH
 // attempt is what exercises `Repository::try_ssh`'s scp-style fallback.
-async function cloneUrlsFor(dep: string): Promise<string[]> {
+async function cloneUrlsFor(dep: string): Promise<{ urls: string[]; stderr: string }> {
   using dir = tempDir("install-git-scp", {
     "fakegit/git": `#!/bin/sh\nprintf '%s\\n' "$*" >> "$GIT_LOG_FILE"\nexit 128\n`,
     "cwd/package.json": JSON.stringify({
@@ -30,10 +30,12 @@ async function cloneUrlsFor(dep: string): Promise<string[]> {
     stderr: "pipe",
     stdout: "pipe",
   });
-  await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  const gitLog = await Bun.file(gitLogFile).text();
-  return gitLog
+  const gitLog = await Bun.file(gitLogFile)
+    .text()
+    .catch(() => "");
+  const urls = gitLog
     .split("\n")
     .filter(line => line.startsWith("clone"))
     .map(line => {
@@ -41,31 +43,44 @@ async function cloneUrlsFor(dep: string): Promise<string[]> {
       const tokens = line.split(/\s+/);
       return tokens[tokens.length - 2];
     });
+  return { urls, stderr };
 }
 
 describe.skipIf(isWindows)("scp-style git dependency URL rewriting", () => {
+  const cloneFailed = expect.stringContaining(`"git clone" for "pkg" failed`);
+
   test.concurrent("host with TLD preserves full path on SSH fallback", async () => {
-    const urls = await cloneUrlsFor("git+myhost.example:org/repo.git");
-    expect(urls).toEqual(["https://myhost.example/org/repo.git", "ssh://git@myhost.example/org/repo.git"]);
+    expect(await cloneUrlsFor("git+myhost.example:org/repo.git")).toEqual({
+      urls: ["https://myhost.example/org/repo.git", "ssh://git@myhost.example/org/repo.git"],
+      stderr: cloneFailed,
+    });
   });
 
   test.concurrent("bare known host gets TLD appended", async () => {
-    const urls = await cloneUrlsFor("git+github:mishoo/UglifyJS.git");
-    expect(urls).toEqual(["https://github.com/mishoo/UglifyJS.git", "ssh://git@github.com/mishoo/UglifyJS.git"]);
+    expect(await cloneUrlsFor("git+github:mishoo/UglifyJS.git")).toEqual({
+      urls: ["https://github.com/mishoo/UglifyJS.git", "ssh://git@github.com/mishoo/UglifyJS.git"],
+      stderr: cloneFailed,
+    });
   });
 
   test.concurrent("explicit user@ is kept (no double user)", async () => {
-    const urls = await cloneUrlsFor("git+deploy@myhost.example:org/repo.git");
-    expect(urls).toEqual(["https://deploy@myhost.example/org/repo.git", "ssh://deploy@myhost.example/org/repo.git"]);
+    expect(await cloneUrlsFor("git+deploy@myhost.example:org/repo.git")).toEqual({
+      urls: ["https://deploy@myhost.example/org/repo.git", "ssh://deploy@myhost.example/org/repo.git"],
+      stderr: cloneFailed,
+    });
   });
 
   test.concurrent("explicit user@ is kept (colon-less form)", async () => {
-    const urls = await cloneUrlsFor("git+deploy@myhost.example/org/repo.git");
-    expect(urls).toEqual(["https://deploy@myhost.example/org/repo.git", "ssh://deploy@myhost.example/org/repo.git"]);
+    expect(await cloneUrlsFor("git+deploy@myhost.example/org/repo.git")).toEqual({
+      urls: ["https://deploy@myhost.example/org/repo.git", "ssh://deploy@myhost.example/org/repo.git"],
+      stderr: cloneFailed,
+    });
   });
 
   test.concurrent("@ in path does not suppress git@ user", async () => {
-    const urls = await cloneUrlsFor("git+myhost.example:org/name@1.git");
-    expect(urls).toEqual(["https://myhost.example/org/name@1.git", "ssh://git@myhost.example/org/name@1.git"]);
+    expect(await cloneUrlsFor("git+myhost.example:org/name@1.git")).toEqual({
+      urls: ["https://myhost.example/org/name@1.git", "ssh://git@myhost.example/org/name@1.git"],
+      stderr: cloneFailed,
+    });
   });
 });

--- a/test/cli/install/bun-install-git-url.test.ts
+++ b/test/cli/install/bun-install-git-url.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { chmodSync } from "node:fs";
+import { join } from "node:path";
+
+// A fake `git` that logs its argv to a file and exits 128 so the package
+// manager falls through HTTPS -> SSH without touching the network. The SSH
+// attempt is what exercises `Repository::try_ssh`'s scp-style fallback.
+async function cloneUrlsFor(dep: string): Promise<string[]> {
+  using dir = tempDir("install-git-scp", {
+    "fakegit/git": `#!/bin/sh\nprintf '%s\\n' "$*" >> "$GIT_LOG_FILE"\nexit 128\n`,
+    "cwd/package.json": JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: { pkg: dep },
+    }),
+  });
+  chmodSync(join(String(dir), "fakegit", "git"), 0o755);
+
+  const gitLogFile = join(String(dir), "git.log");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: join(String(dir), "cwd"),
+    env: {
+      ...bunEnv,
+      PATH: `${join(String(dir), "fakegit")}:${bunEnv.PATH}`,
+      GIT_LOG_FILE: gitLogFile,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), "cache"),
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const gitLog = await Bun.file(gitLogFile).text();
+  return gitLog
+    .split("\n")
+    .filter(line => line.startsWith("clone"))
+    .map(line => {
+      // `git clone -c core.longpaths=true --quiet --bare <url> <target>`
+      const tokens = line.split(/\s+/);
+      return tokens[tokens.length - 2];
+    });
+}
+
+describe.skipIf(isWindows)("scp-style git dependency URL rewriting", () => {
+  test.concurrent("host with TLD preserves full path on SSH fallback", async () => {
+    const urls = await cloneUrlsFor("git+myhost.example:org/repo.git");
+    expect(urls).toEqual(["https://myhost.example/org/repo.git", "ssh://git@myhost.example/org/repo.git"]);
+  });
+
+  test.concurrent("bare known host gets TLD appended", async () => {
+    const urls = await cloneUrlsFor("git+github:mishoo/UglifyJS.git");
+    expect(urls).toEqual(["https://github.com/mishoo/UglifyJS.git", "ssh://git@github.com/mishoo/UglifyJS.git"]);
+  });
+
+  test.concurrent("explicit user@ is kept (no double user)", async () => {
+    const urls = await cloneUrlsFor("git+deploy@myhost.example:org/repo.git");
+    expect(urls).toEqual(["https://deploy@myhost.example/org/repo.git", "ssh://deploy@myhost.example/org/repo.git"]);
+  });
+});


### PR DESCRIPTION
## Reproduction

With a git dependency in scp-style syntax whose host is not one of the bare keywords `github` / `gitlab` / `bitbucket`, the SSH fallback after a failed HTTPS clone passes a truncated URL to `git clone`:

```
dep:  git+myhost.example:org/repo.git
try_https -> https://myhost.example/org/repo.git      (correct)
try_ssh   -> ssh://git@myhost.example/org/repo        (last 4 bytes dropped)
```

If the scp-style input also carries an explicit user, the SSH URL gets a doubled userinfo on top of the truncation:

```
dep:  git+deploy@myhost.example:org/repo.git
try_ssh -> ssh://git@deploy@myhost.example/org/repo
```

## Cause

In `Repository::try_ssh` (`src/install/repository.rs`) the scp-like fallback wrote `b"ssh://git@"` (10 bytes) + `url` into `ssh_path_buf` but returned `&ssh_path_buf[..url.len() + b"ssh://".len()]` (6 bytes), slicing 4 bytes short of what was written. The same branch unconditionally prefixed `git@` even when the input already had `user@`, producing `ssh://git@user@host/...`.

The sibling `try_https` already uses `PREFIX.len()` for the same computation and is correct. This off-by-four existed in the pre-port Zig implementation and was carried over; the prior Zig-side fix in #28815 was closed unmerged when the Zig sources were removed.

## Fix

Compute `colon_index` first, pick the prefix (`ssh://` if a `user@` is already present before the colon, `ssh://git@` otherwise), and slice the return using that same `prefix.len()` so written and returned lengths agree.

## Verification

`test/cli/install/bun-install-git-url.test.ts` intercepts `git` with a PATH shim that logs argv and exits 128, so `bun install` falls through HTTPS to SSH and both clone URLs are asserted exactly, with no network access. Covers the fallback host, the bare known-host (`github:...`) path, and the explicit-user path.

```
USE_SYSTEM_BUN=1 bun test test/cli/install/bun-install-git-url.test.ts   2 fail / 1 pass
bun bd test test/cli/install/bun-install-git-url.test.ts                 3 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-git-url.test.ts

<!-- robobun:evidence:end -->