### PR TITLE
node:http: drain the pinned res.write() tail before socket.end() sends FIN

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -718,9 +718,12 @@ private:
             }
         }
 
-        /* Should we close this connection after a response - and is this response really done? */
+        /* Should we close this connection after a response - and is this response really done?
+         * HTTP_NODE_SOCKET_ENDED: node:http socket.end() already promised the FIN, so shut
+         * down once the buffer has drained even if res.end() was never called. */
         if (httpResponseData->shouldCloseConnection()) {
-            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0
+                || (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_SOCKET_ENDED)) {
                 if (asyncSocket->getBufferedAmount() == 0) {
 
                     asyncSocket->shutdown();

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -152,7 +152,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * keep-alive connection, so starting a new response clears the rest of the
          * word (resetResponseState) - these have to survive that. */
         HTTP_CONNECTION_SCOPED = HTTP_NODE_PARSING_STOPPED | HTTP_NODE_READS_PAUSED
-            | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN | HTTP_NODE_SOCKET_ENDED,
+            | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN,
     };
 
     /* Begin a new response on this connection. Clearing the word in one go is

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -140,13 +140,19 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * into the shared word so the shared response-end path (internalEnd) never
          * has to touch the node-only field. */
         HTTP_NODE_HAS_RESPONSE_TRAILERS = 1 << 16,
+        /* node:http socket.end() deferred its FIN because response bytes were
+         * still buffered. onWritable shuts the socket down once the buffer has
+         * drained even when HTTP_RESPONSE_PENDING is still set (res.end() may
+         * never be called; in Node the shared Writable queue orders the FIN
+         * after every byte handed to res.write()). */
+        HTTP_NODE_SOCKET_ENDED = 1 << 17,
 
         /* Bits that describe the connection rather than the response in flight.
          * There is one HttpResponseData per socket, reused by every request on a
          * keep-alive connection, so starting a new response clears the rest of the
          * word (resetResponseState) - these have to survive that. */
         HTTP_CONNECTION_SCOPED = HTTP_NODE_PARSING_STOPPED | HTTP_NODE_READS_PAUSED
-            | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN,
+            | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN | HTTP_NODE_SOCKET_ENDED,
     };
 
     /* Begin a new response on this connection. Clearing the word in one go is

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -243,7 +243,11 @@ bool JSNodeHTTPServerSocket::isClosed() const
 template<bool SSL>
 static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
 {
-    if (reinterpret_cast<uWS::AsyncSocket<SSL>*>(socket)->getBufferedAmount() == 0) {
+    auto* asyncSocket = reinterpret_cast<uWS::AsyncSocket<SSL>*>(socket);
+    /* socket.end() can run inside HttpContext::onData's corked region (e.g. from
+     * a req 'data' listener); uncork so those bytes reach getBufferedAmount(). */
+    asyncSocket->uncork();
+    if (asyncSocket->getBufferedAmount() == 0) {
         return false;
     }
     /* HttpContext<SSL>::onWritable shuts the socket down once the buffer has

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -246,11 +246,9 @@ static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
     if (reinterpret_cast<uWS::AsyncSocket<SSL>*>(socket)->getBufferedAmount() == 0) {
         return false;
     }
-    /* HttpContext<SSL>::onWritable shuts the socket down once the buffered
-     * response data has flushed and HTTP_CONNECTION_CLOSE is set, so the FIN
-     * is sequenced after the response bytes (like Node's destroySoon).
-     * HTTP_NODE_SOCKET_ENDED lets that gate fire even when res.end() was never
-     * called (so HTTP_RESPONSE_PENDING is still set). */
+    /* HttpContext<SSL>::onWritable shuts the socket down once the buffer has
+     * flushed (like Node's destroySoon). HTTP_NODE_SOCKET_ENDED lets that gate
+     * fire even when res.end() never cleared HTTP_RESPONSE_PENDING. */
     auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
     httpResponseData->state |= uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE
         | uWS::HttpResponseData<SSL>::HTTP_NODE_SOCKET_ENDED;

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -14,6 +14,7 @@
 
 extern "C" void Bun__NodeHTTPResponse_setClosed(void* zigResponse);
 extern "C" void Bun__NodeHTTPResponse_markTunneled(void* zigResponse);
+extern "C" void Bun__NodeHTTPResponse_spillPendingPinnedWrite(void* zigResponse);
 extern "C" void Bun__NodeHTTPResponse_onClose(void* zigResponse, JSC::EncodedJSValue jsValue);
 extern "C" void us_socket_free_stream_buffer(us_socket_stream_buffer_t* streamBuffer);
 extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
@@ -246,10 +247,14 @@ static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
         return false;
     }
     /* HttpContext<SSL>::onWritable shuts the socket down once the buffered
-     * response data has flushed and HTTP_CONNECTION_CLOSE is set, so the FIN
-     * is sequenced after the response bytes (like Node's destroySoon). */
+     * response data has flushed, HTTP_CONNECTION_CLOSE is set and
+     * HTTP_RESPONSE_PENDING is clear, so the FIN is sequenced after the
+     * response bytes (like Node's destroySoon). socket.end() means no more
+     * response bytes will ever be written, so the pending bit is cleared here
+     * too (res.end() may never be called). */
     auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
-    httpResponseData->state |= uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+    httpResponseData->state = (httpResponseData->state | uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE)
+        & ~uWS::HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
     return true;
 }
 
@@ -257,6 +262,12 @@ bool JSNodeHTTPServerSocket::shutdownAfterResponseDrains()
 {
     if (!socket || upgraded || us_socket_is_closed(socket) || us_socket_is_shut_down(socket)) {
         return false;
+    }
+    /* A large res.write() that hit backpressure keeps its unsent tail pinned in
+     * the response (not in AsyncSocketData::buffer). Move it there before the
+     * getBufferedAmount() probe so the FIN is sequenced after those bytes. */
+    if (auto* res = currentResponseObject.get(); res != nullptr && res->m_ctx != nullptr) {
+        Bun__NodeHTTPResponse_spillPendingPinnedWrite(res->m_ctx);
     }
     if (is_ssl) {
         return deferShutdownUntilResponseDrains<true>(socket);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -247,14 +247,13 @@ static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
         return false;
     }
     /* HttpContext<SSL>::onWritable shuts the socket down once the buffered
-     * response data has flushed, HTTP_CONNECTION_CLOSE is set and
-     * HTTP_RESPONSE_PENDING is clear, so the FIN is sequenced after the
-     * response bytes (like Node's destroySoon). socket.end() means no more
-     * response bytes will ever be written, so the pending bit is cleared here
-     * too (res.end() may never be called). */
+     * response data has flushed and HTTP_CONNECTION_CLOSE is set, so the FIN
+     * is sequenced after the response bytes (like Node's destroySoon).
+     * HTTP_NODE_SOCKET_ENDED lets that gate fire even when res.end() was never
+     * called (so HTTP_RESPONSE_PENDING is still set). */
     auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
-    httpResponseData->state = (httpResponseData->state | uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE)
-        & ~uWS::HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
+    httpResponseData->state |= uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE
+        | uWS::HttpResponseData<SSL>::HTTP_NODE_SOCKET_ENDED;
     return true;
 }
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1331,6 +1331,14 @@ impl NodeHTTPResponse {
         self.update_flags(|f| f.insert(Flags::TUNNELED));
     }
 
+    /// `socket.end()` is about to probe the uWS buffered amount to decide
+    /// whether the FIN can go out now; move any held zero-copy write tail
+    /// there first so it is counted (and so it drains ahead of the FIN).
+    #[uws::uws_callback(export = "Bun__NodeHTTPResponse_spillPendingPinnedWrite", no_catch)]
+    pub(crate) fn spill_pending_pinned_write_for_end(&self) {
+        self.spill_pending_pinned_write(self.server.global_this());
+    }
+
     pub(crate) fn on_timeout(&self, _resp: uws::AnyResponse) {
         scoped_log!(NodeHTTPResponse, "onTimeout");
         self.handle_abort_or_timeout::<{ AbortEvent::Timeout }>(JSValue::ZERO);

--- a/test/js/node/http/node-http-pinned-write.test.ts
+++ b/test/js/node/http/node-http-pinned-write.test.ts
@@ -340,6 +340,67 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
     expect(exitCode).toBe(0);
   });
 
+  // In Node.js res.write() and socket.end() share one Writable queue, so the
+  // FIN is ordered after every byte already handed to write(). The pinned tail
+  // sits outside AsyncSocketData::buffer; socket.end() must spill it there and
+  // hand the close to onWritable so the full body reaches the client before
+  // the FIN.
+  describe.each([
+    ["with Content-Length", { "Content-Length": String(RESIZABLE_CHUNK_SIZE) }],
+    ["chunked", {}],
+  ] as const)("req.socket.end() without res.end() delivers the full pinned body (%s)", (_name, extraHeaders) => {
+    test.concurrent.skipIf(isWindows)("body reaches the client before FIN", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const http = require("node:http");
+            const net = require("node:net");
+            const { once } = require("node:events");
+            const CHUNK_SIZE = ${RESIZABLE_CHUNK_SIZE};
+            const payload = Buffer.alloc(CHUNK_SIZE, 0x61);
+            const server = http.createServer((req, res) => {
+              res.writeHead(200, ${JSON.stringify({ "Content-Type": "application/octet-stream", ...extraHeaders })});
+              res.write(payload);
+              req.socket.end();
+            });
+            await once(server.listen(0, "127.0.0.1"), "listening");
+            const socket = net.connect(server.address().port, "127.0.0.1");
+            await once(socket, "connect");
+            const chunks = [];
+            socket.on("data", c => chunks.push(c));
+            socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+            await new Promise(r => socket.once("close", r));
+            const received = Buffer.concat(chunks);
+            const headerEnd = received.indexOf("\\r\\n\\r\\n");
+            const body = received.subarray(headerEnd + 4);
+            let as = 0;
+            for (let i = 0; i < body.length; i++) if (body[i] === 0x61) as++;
+            console.log(JSON.stringify({ bodyLength: body.length, as }));
+            server.close();
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const result = JSON.parse(stdout.trim());
+      // Chunked framing adds a hex size line and a trailing CRLF around the
+      // payload (no terminating 0 chunk since res.end() was never called);
+      // the Content-Length case delivers exactly the payload. Node.js matches
+      // on both the payload byte count and the absence of extra body bytes.
+      expect({ as: result.as, exitCode, stderr }).toEqual({
+        as: RESIZABLE_CHUNK_SIZE,
+        exitCode: 0,
+        stderr: expect.any(String),
+      });
+      expect(result.bodyLength).toBeGreaterThanOrEqual(RESIZABLE_CHUNK_SIZE);
+    });
+  });
+
   test("a second write before drain releases the pin on the first buffer", async () => {
     let detachedAfterSecondWrite: boolean | undefined;
     const total = CHUNK_SIZE + 1024;

--- a/test/js/node/http/node-http-pinned-write.test.ts
+++ b/test/js/node/http/node-http-pinned-write.test.ts
@@ -350,7 +350,12 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
     ["chunked", {}, RESIZABLE_CHUNK_SIZE.toString(16).length + 4, "Connection: close\\r\\n"],
     // Two pipelined keep-alive requests in one write: the second request must
     // take the queued pipelined branch (HTTP_RESPONSE_PENDING left intact).
-    ["pipelined keep-alive", { "Content-Length": String(RESIZABLE_CHUNK_SIZE) }, 0, "\\r\\nGET / HTTP/1.1\\r\\nHost: x\\r\\n"],
+    [
+      "pipelined keep-alive",
+      { "Content-Length": String(RESIZABLE_CHUNK_SIZE) },
+      0,
+      "\\r\\nGET / HTTP/1.1\\r\\nHost: x\\r\\n",
+    ],
   ] as const)(
     "req.socket.end() without res.end() delivers the full pinned body (%s)",
     (_name, extraHeaders, framingOverhead, trailer) => {

--- a/test/js/node/http/node-http-pinned-write.test.ts
+++ b/test/js/node/http/node-http-pinned-write.test.ts
@@ -340,11 +340,9 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
     expect(exitCode).toBe(0);
   });
 
-  // In Node.js res.write() and socket.end() share one Writable queue, so the
-  // FIN is ordered after every byte already handed to write(). The pinned tail
-  // sits outside AsyncSocketData::buffer; socket.end() must spill it there and
-  // hand the close to onWritable so the full body reaches the client before
-  // the FIN.
+  // In Node res.write() and socket.end() share one Writable, so FIN is ordered
+  // after every queued byte. The pinned tail sits outside AsyncSocketData::buffer;
+  // socket.end() must spill it so the full body reaches the client before FIN.
   describe.each([
     ["with Content-Length", { "Content-Length": String(RESIZABLE_CHUNK_SIZE) }],
     ["chunked", {}],
@@ -388,10 +386,8 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       const result = JSON.parse(stdout.trim());
-      // Chunked framing adds a hex size line and a trailing CRLF around the
-      // payload (no terminating 0 chunk since res.end() was never called);
-      // the Content-Length case delivers exactly the payload. Node.js matches
-      // on both the payload byte count and the absence of extra body bytes.
+      // Chunked adds a hex size + CRLF around the payload (no 0 chunk, since
+      // res.end() was never called); Content-Length delivers exactly the payload.
       expect({ as: result.as, exitCode, stderr }).toEqual({
         as: RESIZABLE_CHUNK_SIZE,
         exitCode: 0,

--- a/test/js/node/http/node-http-pinned-write.test.ts
+++ b/test/js/node/http/node-http-pinned-write.test.ts
@@ -344,15 +344,22 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
   // after every queued byte. The pinned tail sits outside AsyncSocketData::buffer;
   // socket.end() must spill it so the full body reaches the client before FIN.
   describe.each([
-    ["with Content-Length", { "Content-Length": String(RESIZABLE_CHUNK_SIZE) }],
-    ["chunked", {}],
-  ] as const)("req.socket.end() without res.end() delivers the full pinned body (%s)", (_name, extraHeaders) => {
-    test.concurrent.skipIf(isWindows)("body reaches the client before FIN", async () => {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
+    // Chunked adds a hex size + CRLF around the payload (no 0 chunk, since
+    // res.end() was never called); Content-Length delivers exactly the payload.
+    ["with Content-Length", { "Content-Length": String(RESIZABLE_CHUNK_SIZE) }, 0, "Connection: close\\r\\n"],
+    ["chunked", {}, RESIZABLE_CHUNK_SIZE.toString(16).length + 4, "Connection: close\\r\\n"],
+    // Two pipelined keep-alive requests in one write: the second request must
+    // take the queued pipelined branch (HTTP_RESPONSE_PENDING left intact).
+    ["pipelined keep-alive", { "Content-Length": String(RESIZABLE_CHUNK_SIZE) }, 0, "\\r\\nGET / HTTP/1.1\\r\\nHost: x\\r\\n"],
+  ] as const)(
+    "req.socket.end() without res.end() delivers the full pinned body (%s)",
+    (_name, extraHeaders, framingOverhead, trailer) => {
+      test.concurrent.skipIf(isWindows)("body reaches the client before FIN", async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `
             const http = require("node:http");
             const net = require("node:net");
             const { once } = require("node:events");
@@ -368,7 +375,8 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
             await once(socket, "connect");
             const chunks = [];
             socket.on("data", c => chunks.push(c));
-            socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+            socket.on("error", () => {});
+            socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n${trailer}\\r\\n");
             await new Promise(r => socket.once("close", r));
             const received = Buffer.concat(chunks);
             const headerEnd = received.indexOf("\\r\\n\\r\\n");
@@ -378,24 +386,23 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
             console.log(JSON.stringify({ bodyLength: body.length, as }));
             server.close();
           `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
 
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      const result = JSON.parse(stdout.trim());
-      // Chunked adds a hex size + CRLF around the payload (no 0 chunk, since
-      // res.end() was never called); Content-Length delivers exactly the payload.
-      expect({ as: result.as, exitCode, stderr }).toEqual({
-        as: RESIZABLE_CHUNK_SIZE,
-        exitCode: 0,
-        stderr: expect.any(String),
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        const result = JSON.parse(stdout.trim());
+        expect({ bodyLength: result.bodyLength, as: result.as, exitCode, stderr }).toEqual({
+          bodyLength: RESIZABLE_CHUNK_SIZE + framingOverhead,
+          as: RESIZABLE_CHUNK_SIZE,
+          exitCode: 0,
+          stderr: expect.any(String),
+        });
       });
-      expect(result.bodyLength).toBeGreaterThanOrEqual(RESIZABLE_CHUNK_SIZE);
-    });
-  });
+    },
+  );
 
   test("a second write before drain releases the pin on the first buffer", async () => {
     let detachedAfterSecondWrite: boolean | undefined;


### PR DESCRIPTION
### Problem

```js
const server = http.createServer((req, res) => {
  res.writeHead(200, { "Content-Length": String(BIG.length) });
  res.write(BIG);        // 8 MiB
  req.socket.end();      // no res.end()
});
// raw net client reads: ~2.5 MiB of body, then FIN.
// node:              8 MiB of body, then FIN.
```

Since #34511, `res.write()` payloads larger than the 16 KB cork buffer take a zero-copy path: `tryWriteBody` writes what the kernel accepts and the unsent tail is held by reference in `NodeHTTPResponse::pending_pinned_write`, not copied into `AsyncSocketData::buffer`. `req.socket.end()` (`jsFunctionNodeHTTPServerSocketEnd` -> `shutdownAfterResponseDrains`) only consults `AsyncSocket::getBufferedAmount()`, sees 0, and shuts the socket down immediately. In Node.js `res.write()` and `socket.end()` go through one `net.Socket` Writable, so the FIN is already ordered behind every queued byte.

### Fix

- `shutdownAfterResponseDrains()` first spills the current response's `pending_pinned_write` into `AsyncSocketData::buffer` (new `Bun__NodeHTTPResponse_spillPendingPinnedWrite`, the same spill path `res.end()` already uses), so `getBufferedAmount()` counts it and `deferShutdownUntilResponseDrains` hands the close to `HttpContext::onWritable`.
- `deferShutdownUntilResponseDrains` uncorks before probing `getBufferedAmount()`: `socket.end()` can run inside `HttpContext::onData`'s corked region (e.g. from a `req` `'data'` listener), and a sub-cork-buffer spill or prior `res.write(small)` would otherwise be invisible to the probe.
- New `HttpResponseData::HTTP_NODE_SOCKET_ENDED` bit is set alongside `HTTP_CONNECTION_CLOSE`, and `HttpContext::onWritable`'s shutdown gate also checks it: `socket.end()` means no more response bytes will ever be written, so the gate fires once the buffer has drained even when `res.end()` was never called. `HTTP_RESPONSE_PENDING` is left alone so `onEnd`'s `httpAllowHalfOpen` gate and `onData`'s pipelined-dispatch branch keep their existing semantics. The bit is per-response (cleared by `resetResponseState()`) so it cannot leak into a subsequent keep-alive response and trip the gate while that response still has a pinned tail outstanding.

### Verification

New `describe.each` in `test/js/node/http/node-http-pinned-write.test.ts` covers Content-Length, chunked, and two pipelined keep-alive requests in one write; each receives ~2.5 MiB on main and the full 8 MiB with the fix, matching Node.js byte-for-byte (the test asserts the exact body length per framing). `node-http-pinned-write.test.ts` (12/12), `node-http-backpressure.test.ts`, `node-http-server-socket-end-drain.test.ts`, `node-http-nested-cork.test.ts`, `node-http-transfer-encoding.test.ts` and `node-http.test.ts` pass (the one `request via http proxy` failure there is pre-existing on released bun in this environment).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http/node-http-pinned-write.test.ts

<!-- robobun:evidence:end -->