### PR TITLE
WebSocket client: throw TypeError for detached buffers in send/ping/pong

### DIFF
--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -841,9 +841,8 @@ ExceptionOr<void> WebSocket::send(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    char* baseAddress = reinterpret_cast<char*>(arrayBufferView.baseAddress());
-    size_t length = arrayBufferView.byteLength();
-    this->sendWebSocketData(baseAddress, length, Opcode::Binary);
+    auto bytes = arrayBufferView.span();
+    this->sendWebSocketData(reinterpret_cast<const char*>(bytes.data()), bytes.size(), Opcode::Binary);
 
     return {};
 }
@@ -1154,11 +1153,10 @@ ExceptionOr<void> WebSocket::ping(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    char* baseAddress = reinterpret_cast<char*>(arrayBufferView.baseAddress());
-    size_t length = arrayBufferView.byteLength();
-    if (length > maxControlFramePayloadSize)
-        return controlFramePayloadTooLargeException(length);
-    this->sendWebSocketData(baseAddress, length, Opcode::Ping);
+    auto bytes = arrayBufferView.span();
+    if (bytes.size() > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(bytes.size());
+    this->sendWebSocketData(reinterpret_cast<const char*>(bytes.data()), bytes.size(), Opcode::Ping);
 
     return {};
 }
@@ -1242,11 +1240,10 @@ ExceptionOr<void> WebSocket::pong(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    char* baseAddress = reinterpret_cast<char*>(arrayBufferView.baseAddress());
-    size_t length = arrayBufferView.byteLength();
-    if (length > maxControlFramePayloadSize)
-        return controlFramePayloadTooLargeException(length);
-    this->sendWebSocketData(baseAddress, length, Opcode::Pong);
+    auto bytes = arrayBufferView.span();
+    if (bytes.size() > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(bytes.size());
+    this->sendWebSocketData(reinterpret_cast<const char*>(bytes.data()), bytes.size(), Opcode::Pong);
 
     return {};
 }

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -810,6 +810,8 @@ ExceptionOr<void> WebSocket::send(ArrayBuffer& binaryData)
     // LOG(Network, "WebSocket %p send() Sending ArrayBuffer %p", this, &binaryData);
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
+    if (binaryData.isDetached()) [[unlikely]]
+        return Exception { TypeError, "ArrayBuffer is detached"_s };
     if (m_state == CLOSING || m_state == CLOSED) {
         unsigned payloadSize = binaryData.byteLength();
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
@@ -830,6 +832,8 @@ ExceptionOr<void> WebSocket::send(ArrayBufferView& arrayBufferView)
 
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
+    if (arrayBufferView.isDetached()) [[unlikely]]
+        return Exception { TypeError, "Underlying ArrayBuffer has been detached from the view"_s };
     if (m_state == CLOSING || m_state == CLOSED) {
         unsigned payloadSize = arrayBufferView.byteLength();
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
@@ -837,9 +841,7 @@ ExceptionOr<void> WebSocket::send(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    auto bufferRef = arrayBufferView.unsharedBuffer();
-    auto* buffer = bufferRef.get();
-    char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
+    char* baseAddress = reinterpret_cast<char*>(arrayBufferView.baseAddress());
     size_t length = arrayBufferView.byteLength();
     this->sendWebSocketData(baseAddress, length, Opcode::Binary);
 
@@ -1117,6 +1119,8 @@ ExceptionOr<void> WebSocket::ping(ArrayBuffer& binaryData)
     // LOG(Network, "WebSocket %p ping() Sending ArrayBuffer %p", this, &binaryData);
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
+    if (binaryData.isDetached()) [[unlikely]]
+        return Exception { TypeError, "ArrayBuffer is detached"_s };
 
     if (m_state == CLOSING || m_state == CLOSED) {
         unsigned payloadSize = binaryData.byteLength();
@@ -1140,6 +1144,8 @@ ExceptionOr<void> WebSocket::ping(ArrayBufferView& arrayBufferView)
 
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
+    if (arrayBufferView.isDetached()) [[unlikely]]
+        return Exception { TypeError, "Underlying ArrayBuffer has been detached from the view"_s };
 
     if (m_state == CLOSING || m_state == CLOSED) {
         unsigned payloadSize = arrayBufferView.byteLength();
@@ -1148,9 +1154,7 @@ ExceptionOr<void> WebSocket::ping(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    auto bufferRef = arrayBufferView.unsharedBuffer();
-    auto* buffer = bufferRef.get();
-    char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
+    char* baseAddress = reinterpret_cast<char*>(arrayBufferView.baseAddress());
     size_t length = arrayBufferView.byteLength();
     if (length > maxControlFramePayloadSize)
         return controlFramePayloadTooLargeException(length);
@@ -1203,6 +1207,8 @@ ExceptionOr<void> WebSocket::pong(ArrayBuffer& binaryData)
     // LOG(Network, "WebSocket %p pong() Sending ArrayBuffer %p", this, &binaryData);
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
+    if (binaryData.isDetached()) [[unlikely]]
+        return Exception { TypeError, "ArrayBuffer is detached"_s };
 
     if (m_state == CLOSING || m_state == CLOSED) {
         unsigned payloadSize = binaryData.byteLength();
@@ -1226,6 +1232,8 @@ ExceptionOr<void> WebSocket::pong(ArrayBufferView& arrayBufferView)
 
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
+    if (arrayBufferView.isDetached()) [[unlikely]]
+        return Exception { TypeError, "Underlying ArrayBuffer has been detached from the view"_s };
 
     if (m_state == CLOSING || m_state == CLOSED) {
         unsigned payloadSize = arrayBufferView.byteLength();
@@ -1234,9 +1242,7 @@ ExceptionOr<void> WebSocket::pong(ArrayBufferView& arrayBufferView)
         return {};
     }
 
-    auto bufferRef = arrayBufferView.unsharedBuffer();
-    auto* buffer = bufferRef.get();
-    char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
+    char* baseAddress = reinterpret_cast<char*>(arrayBufferView.baseAddress());
     size_t length = arrayBufferView.byteLength();
     if (length > maxControlFramePayloadSize)
         return controlFramePayloadTooLargeException(length);

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -328,8 +328,14 @@ describe("WebSocket send/ping/pong with detached buffers", () => {
       const expected = Buffer.from([3, 4, 5, 6]);
 
       const nextEcho = () =>
-        new Promise<Buffer>(resolve => {
-          ws.onmessage = e => resolve(Buffer.from(e.data as ArrayBuffer));
+        new Promise<Buffer>((resolve, reject) => {
+          const settle = (fn: () => void) => {
+            ws.onmessage = ws.onerror = ws.onclose = null;
+            fn();
+          };
+          ws.onmessage = e => settle(() => resolve(Buffer.from(e.data as ArrayBuffer)));
+          ws.onerror = () => settle(() => reject(new Error("socket errored before echo")));
+          ws.onclose = e => settle(() => reject(new Error(`socket closed (${e.code}) before echo`)));
         });
 
       let echoed = nextEcho();

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -245,6 +245,96 @@ describe("WebSocket", () => {
   });
 });
 
+describe("WebSocket send/ping/pong with detached buffers", () => {
+  async function withOpenSocket(fn: (ws: WebSocket, received: Buffer[]) => void | Promise<void>) {
+    const received: Buffer[] = [];
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("no", { status: 500 });
+      },
+      websocket: {
+        message(ws, message) {
+          received.push(Buffer.from(message as any));
+          ws.send(message);
+        },
+        ping(ws, data) {
+          received.push(Buffer.from(data));
+        },
+        pong(ws, data) {
+          received.push(Buffer.from(data));
+        },
+      },
+    });
+    const ws = new WebSocket(server.url.href.replace(/^http/, "ws"));
+    try {
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => resolve();
+        ws.onerror = e => reject(new Error("connect failed"));
+      });
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+      await fn(ws, received);
+    } finally {
+      ws.close();
+    }
+  }
+
+  function detachedUint8Array() {
+    const ab = new ArrayBuffer(8);
+    const view = new Uint8Array(ab).fill(0x41);
+    structuredClone(ab, { transfer: [ab] });
+    expect(ab.detached).toBe(true);
+    return view;
+  }
+
+  function detachedArrayBuffer() {
+    const ab = new ArrayBuffer(8);
+    new Uint8Array(ab).fill(0x41);
+    structuredClone(ab, { transfer: [ab] });
+    expect(ab.detached).toBe(true);
+    return ab;
+  }
+
+  function detachedDataView() {
+    const ab = new ArrayBuffer(8);
+    const view = new DataView(ab);
+    structuredClone(ab, { transfer: [ab] });
+    expect(ab.detached).toBe(true);
+    return view;
+  }
+
+  for (const method of ["send", "ping", "pong"] as const) {
+    it.concurrent(`${method}() throws TypeError for a view whose buffer was detached`, async () => {
+      await withOpenSocket(ws => {
+        expect(() => ws[method](detachedUint8Array())).toThrow(TypeError);
+        expect(() => ws[method](detachedDataView())).toThrow(TypeError);
+        expect(ws.readyState).toBe(WebSocket.OPEN);
+      });
+    });
+    it.concurrent(`${method}() throws TypeError for a detached ArrayBuffer`, async () => {
+      await withOpenSocket(ws => {
+        expect(() => ws[method](detachedArrayBuffer())).toThrow(TypeError);
+        expect(ws.readyState).toBe(WebSocket.OPEN);
+      });
+    });
+  }
+
+  it.concurrent("send(Uint8Array subarray) sends only the view's bytes", async () => {
+    await withOpenSocket(async (ws, received) => {
+      const ab = new ArrayBuffer(8);
+      new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
+      const view = new Uint8Array(ab, 2, 4);
+      const echoed = new Promise<Buffer>(resolve => {
+        ws.onmessage = e => resolve(Buffer.from(e.data as ArrayBuffer));
+      });
+      ws.send(view);
+      expect(await echoed).toEqual(Buffer.from([3, 4, 5, 6]));
+      expect(received).toEqual([Buffer.from([3, 4, 5, 6])]);
+    });
+  });
+});
+
 function makeTest(
   label: string,
   fn: (ws: WebSocket, done: (err?: unknown) => void) => void,

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -320,17 +320,29 @@ describe("WebSocket send/ping/pong with detached buffers", () => {
     });
   }
 
-  it.concurrent("send(Uint8Array subarray) sends only the view's bytes", async () => {
+  it.concurrent("send/ping/pong(Uint8Array subarray) transmit only the view's bytes", async () => {
     await withOpenSocket(async (ws, received) => {
       const ab = new ArrayBuffer(8);
       new Uint8Array(ab).set([1, 2, 3, 4, 5, 6, 7, 8]);
       const view = new Uint8Array(ab, 2, 4);
-      const echoed = new Promise<Buffer>(resolve => {
-        ws.onmessage = e => resolve(Buffer.from(e.data as ArrayBuffer));
-      });
+      const expected = Buffer.from([3, 4, 5, 6]);
+
+      const nextEcho = () =>
+        new Promise<Buffer>(resolve => {
+          ws.onmessage = e => resolve(Buffer.from(e.data as ArrayBuffer));
+        });
+
+      let echoed = nextEcho();
       ws.send(view);
-      expect(await echoed).toEqual(Buffer.from([3, 4, 5, 6]));
-      expect(received).toEqual([Buffer.from([3, 4, 5, 6])]);
+      expect(await echoed).toEqual(expected);
+
+      ws.ping(view);
+      ws.pong(view);
+      echoed = nextEcho();
+      ws.send(new Uint8Array([0xff]));
+      expect(await echoed).toEqual(Buffer.from([0xff]));
+
+      expect(received).toEqual([expected, expected, expected, Buffer.from([0xff])]);
     });
   });
 });


### PR DESCRIPTION
### Problem
- `ws.send(view)`, `ws.ping(view)` and `ws.pong(view)` abort the debug build when the buffer behind `view` is detached: `ASSERTION FAILED: m_ptr` in `RefPtr<JSC::ArrayBuffer>::operator*()`, SIGABRT. The release build sends a frame with an empty payload. Node throws `TypeError`.
- The cause is `arrayBufferView.unsharedBuffer()` in `WebSocket::send/ping/pong(ArrayBufferView&)` (`src/jsc/bindings/webcore/WebSocket.cpp`). It returns a null `RefPtr` for a detached view, and its `RELEASE_ASSERT(!result->isShared())` dereferences that pointer.

### Fix
- The six binary overloads (`send`, `ping`, `pong`, each for `ArrayBuffer&` and `ArrayBufferView&`) check `isDetached()` and return `TypeError`. No frame goes on the wire and the socket stays open.
- The view overloads read the bytes with `arrayBufferView.span()`. `span()` includes the byte offset and does not touch the buffer pointer. The 125-byte control frame check from #35030 stays.
- The check runs after the `CONNECTING` check and before the `CLOSING`/`CLOSED` branch. On a closing or closed socket Bun now throws, and Node v26.3.0 returns without an error. In the other states Bun matches Node.
- Verified: `test/js/web/websocket/websocket-client.test.ts`. Without the fix the debug build aborts with the assertion, and the release build fails 6 of 7 new tests. With the fix all 41 tests in the file pass.

### Background
- A transfer, for example `postMessage(buf, [buf.buffer])`, detaches an `ArrayBuffer`. The buffer then has no memory, and a view made before the transfer reports length 0.
- `ArrayBufferView::possiblySharedBuffer()` returns `nullptr` for a detached view. `unsharedBuffer()` calls it and asserts on the result with no null check.
- The argument converter already rejects a view over a `SharedArrayBuffer`, so `unsharedBuffer()` added no protection here.

<details><summary>Notes</summary>

Repro:

```js
const ab = new ArrayBuffer(8);
const view = new Uint8Array(ab).fill(0x41);
structuredClone(ab, { transfer: [ab] }); // detach
ws.send(view); // debug: SIGABRT. release: sends op2 len0.
```

Behaviour for a detached view or a detached `ArrayBuffer`, per `readyState`:

| readyState | Bun before | Bun with this PR | Node v26.3.0 |
| --- | --- | --- | --- |
| CONNECTING | `InvalidStateError` | `InvalidStateError` | `InvalidStateError` |
| OPEN | view: abort (debug) or empty frame (release). `ArrayBuffer`: empty frame | `TypeError` | `TypeError` |
| CLOSING, CLOSED | no error | `TypeError` | no error |

The last row is the only behaviour change outside the crash. To match Node there too, move the `isDetached()` check below the `CLOSING`/`CLOSED` branch in the six overloads.

Test output:

```
bun bd test, src/ from main (without the fix):
ASSERTION FAILED: m_ptr
wtf/RefPtr.h(126) : T &WTF::RefPtr<JSC::ArrayBuffer>::operator*() const
SIGABRT (exit 134)

release build without the fix:
6 fail (Received function did not throw), 1 pass

bun bd test with the fix:
41 pass, 0 fail (full file)
```

History of this PR:

- The first version read the pointer with `baseAddress()`. Review asked for `span()`.
- #35030 landed first and added the 125-byte check to the same `ping()` and `pong()` overloads. The rebase keeps that check and applies it to `bytes.size()`.

Other suites: `websocket-blob.test.ts` passes. In `websocket.test.js`, three tests need the external host `wss://ws.postman-echo.com`. They fail the same way without this change.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (9dc3aef7b)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:36285/
(pass) WebSocket > url [8.10ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [2.46ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [3.64ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:36285',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'AbW+l1VvQlSv69g
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (82f26dace)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:41729/
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > url [8.42ms]
(pass) WebSocket > binaryType > (default) [0.13ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [0.17ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:41729',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'a0VHLIE+TkWRIDmGR7IYlA=='
}
Received connection: 127.0.0.1
Received upgrade: {
  host: '127.0.0.1:41729',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13'
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (9dc3aef7b)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:35583/
(pass) WebSocket > url [7.26ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [2.11ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [3.56ms]
Received upgrade: {
  host: '127.0.0.1:35583',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'aSXJ1GssSC+4gkf
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 745ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen cpp.rs (cppbind)
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/WebSocket.cpp         |  33 ++++----
 test/js/web/websocket/websocket-client.test.ts | 108 +++++++++++++++++++++++++
 2 files changed, 126 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/jsc/bindings/webcore/WebSocket.cpp              2      8      0
test/js/web/websocket/websocket-client.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->
