### PR TITLE
WebSocket: reject ping()/pong() payloads over 125 bytes (client, Bun.serve, ws shim)

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -16,6 +16,15 @@ const readyStates = ["CONNECTING", "OPEN", "CLOSING", "CLOSED"];
 
 const encoder = new TextEncoder();
 
+// npm ws's sendAfterClose: a ping/pong/send on a CLOSING/CLOSED socket delivers
+// a "not open" Error to the callback on the next tick and never throws.
+function sendAfterClose(state, cb) {
+  if (typeof cb === "function") {
+    const err = new Error(`WebSocket is not open: readyState ${state} (${readyStates[state]})`);
+    process.nextTick(cb, err);
+  }
+}
+
 /**
  * Extracts TLS and proxy options from an agent object.
  * @param {Object} agent The agent object to extract options from
@@ -473,7 +482,8 @@ class BunWebSocket extends EventEmitter {
   }
 
   ping(data, mask, cb) {
-    if (this.#ws.readyState === 0) {
+    const state = this.#ws.readyState;
+    if (state === ReadyState_CONNECTING) {
       throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
     }
 
@@ -484,6 +494,8 @@ class BunWebSocket extends EventEmitter {
       cb = mask;
       mask = undefined;
     }
+
+    if (state !== ReadyState_OPEN) return sendAfterClose(state, cb);
 
     if (typeof data === "number") data = data.toString();
 
@@ -496,7 +508,8 @@ class BunWebSocket extends EventEmitter {
   }
 
   pong(data, mask, cb) {
-    if (this.#ws.readyState === 0) {
+    const state = this.#ws.readyState;
+    if (state === ReadyState_CONNECTING) {
       throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
     }
 
@@ -507,6 +520,8 @@ class BunWebSocket extends EventEmitter {
       cb = mask;
       mask = undefined;
     }
+
+    if (state !== ReadyState_OPEN) return sendAfterClose(state, cb);
 
     if (typeof data === "number") data = data.toString();
 
@@ -888,7 +903,8 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   ping(data, mask, cb) {
-    if (this.#state === ReadyState_CONNECTING) {
+    const state = this.#state;
+    if (state === ReadyState_CONNECTING) {
       throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
     }
 
@@ -899,6 +915,8 @@ class BunWebSocketMocked extends EventEmitter {
       cb = mask;
       mask = undefined;
     }
+
+    if (state !== ReadyState_OPEN) return sendAfterClose(state, cb);
 
     if (typeof data === "number") data = data.toString();
 
@@ -909,7 +927,8 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   pong(data, mask, cb) {
-    if (this.#state === ReadyState_CONNECTING) {
+    const state = this.#state;
+    if (state === ReadyState_CONNECTING) {
       throw new Error("WebSocket is not open: readyState 0 (CONNECTING)");
     }
 
@@ -920,6 +939,8 @@ class BunWebSocketMocked extends EventEmitter {
       cb = mask;
       mask = undefined;
     }
+
+    if (state !== ReadyState_OPEN) return sendAfterClose(state, cb);
 
     if (typeof data === "number") data = data.toString();
 

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -491,6 +491,9 @@ class BunWebSocket extends EventEmitter {
       if (data === undefined) this.#ws.ping();
       else this.#ws.ping(data);
     } catch (error) {
+      // npm ws throws RangeError synchronously from Sender.prototype.ping for a
+      // >125-byte payload; it never reaches cb or an 'error' event.
+      if (error instanceof RangeError) throw error;
       if (typeof cb === "function") {
         cb(error);
         return;
@@ -521,6 +524,7 @@ class BunWebSocket extends EventEmitter {
       if (data === undefined) this.#ws.pong();
       else this.#ws.pong(data);
     } catch (error) {
+      if (error instanceof RangeError) throw error;
       if (typeof cb === "function") {
         cb(error);
         return;
@@ -922,6 +926,7 @@ class BunWebSocketMocked extends EventEmitter {
       if (data === undefined) this.#ws.ping();
       else this.#ws.ping(data);
     } catch (error) {
+      if (error instanceof RangeError) throw error;
       if (typeof cb === "function") cb(error);
       return;
     }
@@ -948,6 +953,7 @@ class BunWebSocketMocked extends EventEmitter {
       if (data === undefined) this.#ws.pong();
       else this.#ws.pong(data);
     } catch (error) {
+      if (error instanceof RangeError) throw error;
       if (typeof cb === "function") cb(error);
       return;
     }

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -487,20 +487,10 @@ class BunWebSocket extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    try {
-      if (data === undefined) this.#ws.ping();
-      else this.#ws.ping(data);
-    } catch (error) {
-      // npm ws throws RangeError synchronously from Sender.prototype.ping for a
-      // >125-byte payload; it never reaches cb or an 'error' event.
-      if (error instanceof RangeError) throw error;
-      if (typeof cb === "function") {
-        cb(error);
-        return;
-      }
-      this.emit("error", error);
-      return;
-    }
+    // npm ws has no try/catch here: Sender.prototype.ping throws RangeError
+    // synchronously for a >125-byte payload and never reaches cb.
+    if (data === undefined) this.#ws.ping();
+    else this.#ws.ping(data);
 
     if (typeof cb === "function") cb();
   }
@@ -520,18 +510,8 @@ class BunWebSocket extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    try {
-      if (data === undefined) this.#ws.pong();
-      else this.#ws.pong(data);
-    } catch (error) {
-      if (error instanceof RangeError) throw error;
-      if (typeof cb === "function") {
-        cb(error);
-        return;
-      }
-      this.emit("error", error);
-      return;
-    }
+    if (data === undefined) this.#ws.pong();
+    else this.#ws.pong(data);
 
     if (typeof cb === "function") cb();
   }
@@ -922,14 +902,8 @@ class BunWebSocketMocked extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    try {
-      if (data === undefined) this.#ws.ping();
-      else this.#ws.ping(data);
-    } catch (error) {
-      if (error instanceof RangeError) throw error;
-      if (typeof cb === "function") cb(error);
-      return;
-    }
+    if (data === undefined) this.#ws.ping();
+    else this.#ws.ping(data);
 
     if (typeof cb === "function") cb();
   }
@@ -949,14 +923,8 @@ class BunWebSocketMocked extends EventEmitter {
 
     if (typeof data === "number") data = data.toString();
 
-    try {
-      if (data === undefined) this.#ws.pong();
-      else this.#ws.pong(data);
-    } catch (error) {
-      if (error instanceof RangeError) throw error;
-      if (typeof cb === "function") cb(error);
-      return;
-    }
+    if (data === undefined) this.#ws.pong();
+    else this.#ws.pong(data);
 
     if (typeof cb === "function") cb();
   }

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -117,6 +117,13 @@ static size_t getFramingOverhead(size_t payloadSize)
 }
 
 const size_t maxReasonSizeInBytes = 123;
+// RFC 6455 §5.5: control frame payloads are at most 125 bytes.
+const size_t maxControlFramePayloadSize = 125;
+
+static Exception controlFramePayloadTooLargeException(size_t length)
+{
+    return Exception { RangeError, makeString("The data size must not be greater than "_s, maxControlFramePayloadSize, " bytes. Received "_s, length, " bytes."_s) };
+}
 
 // Close codes an endpoint may put on the wire (RFC 6455 7.4 + the IANA registry).
 // Deliberately the RFC endpoint set, not the browser's "1000 or 3000-4999":
@@ -1088,16 +1095,19 @@ ExceptionOr<void> WebSocket::ping(const String& message)
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
 
+    auto utf8 = message.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
+    size_t payloadSize = utf8.length();
     // No exception is raised if the connection was once established but has subsequently been closed.
     if (m_state == CLOSING || m_state == CLOSED) {
-        auto utf8 = message.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
-        size_t payloadSize = utf8.length();
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
 
-    this->sendWebSocketString(message, Opcode::Ping);
+    if (payloadSize > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(payloadSize);
+
+    this->sendWebSocketData(utf8.data(), payloadSize, Opcode::Ping);
 
     return {};
 }
@@ -1117,6 +1127,8 @@ ExceptionOr<void> WebSocket::ping(ArrayBuffer& binaryData)
 
     char* data = static_cast<char*>(binaryData.data());
     size_t length = binaryData.byteLength();
+    if (length > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(length);
     this->sendWebSocketData(data, length, Opcode::Ping);
 
     return {};
@@ -1140,6 +1152,8 @@ ExceptionOr<void> WebSocket::ping(ArrayBufferView& arrayBufferView)
     auto* buffer = bufferRef.get();
     char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
     size_t length = arrayBufferView.byteLength();
+    if (length > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(length);
     this->sendWebSocketData(baseAddress, length, Opcode::Ping);
 
     return {};
@@ -1167,16 +1181,19 @@ ExceptionOr<void> WebSocket::pong(const String& message)
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
 
+    auto utf8 = message.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
+    size_t payloadSize = utf8.length();
     // No exception is raised if the connection was once established but has subsequently been closed.
     if (m_state == CLOSING || m_state == CLOSED) {
-        auto utf8 = message.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
-        size_t payloadSize = utf8.length();
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
 
-    this->sendWebSocketString(message, Opcode::Pong);
+    if (payloadSize > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(payloadSize);
+
+    this->sendWebSocketData(utf8.data(), payloadSize, Opcode::Pong);
 
     return {};
 }
@@ -1196,6 +1213,8 @@ ExceptionOr<void> WebSocket::pong(ArrayBuffer& binaryData)
 
     char* data = static_cast<char*>(binaryData.data());
     size_t length = binaryData.byteLength();
+    if (length > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(length);
     this->sendWebSocketData(data, length, Opcode::Pong);
 
     return {};
@@ -1219,6 +1238,8 @@ ExceptionOr<void> WebSocket::pong(ArrayBufferView& arrayBufferView)
     auto* buffer = bufferRef.get();
     char* baseAddress = reinterpret_cast<char*>(buffer->data()) + arrayBufferView.byteOffset();
     size_t length = arrayBufferView.byteLength();
+    if (length > maxControlFramePayloadSize)
+        return controlFramePayloadTooLargeException(length);
     this->sendWebSocketData(baseAddress, length, Opcode::Pong);
 
     return {};
@@ -1969,6 +1990,8 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::ping(WebCore::JSBlob* blob)
     size_t dataSize = Blob__getSize(JSC::JSValue::encode(blob));
 
     if (dataPtr && dataSize > 0) {
+        if (dataSize > maxControlFramePayloadSize)
+            return controlFramePayloadTooLargeException(dataSize);
         this->sendWebSocketData(static_cast<const char*>(dataPtr), dataSize, Opcode::Ping);
     } else {
         // Send empty frame for empty blobs
@@ -1991,6 +2014,8 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::pong(WebCore::JSBlob* blob)
     size_t dataSize = Blob__getSize(JSC::JSValue::encode(blob));
 
     if (dataPtr && dataSize > 0) {
+        if (dataSize > maxControlFramePayloadSize)
+            return controlFramePayloadTooLargeException(dataSize);
         this->sendWebSocketData(static_cast<const char*>(dataPtr), dataSize, Opcode::Pong);
     } else {
         // Send empty frame for empty blobs

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -11,7 +11,7 @@ use bun_uws_sys::{Opcode, SendStatus};
 use crate::server::WebSocketServerHandler;
 use crate::server::jsc::{
     self, AbortSignal, ArrayBuffer, BinaryType, CallFrame, CommonAbortReason, JSGlobalObject,
-    JSType, JSValue, JsRef, JsResult, ZigStringSlice,
+    JSType, JSValue, JsError, JsRef, JsResult, ZigStringSlice,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
 
@@ -146,6 +146,17 @@ pub mod js {
     // Emits `{data,server}_{get,set}_cached`. Getter maps `JSValue::ZERO` → `None`;
     // setter forwards through the JSC `WriteBarrier<Unknown>` slot.
     ::bun_jsc::codegen_cached_accessors!("ServerWebSocket"; data, server);
+}
+
+/// RFC 6455 §5.5: control frame payloads are at most 125 bytes.
+const MAX_CONTROL_FRAME_PAYLOAD: usize = 125;
+
+fn throw_control_frame_too_large(global: &JSGlobalObject, len: usize) -> JsError {
+    let err = global.create_range_error_instance(format_args!(
+        "The data size must not be greater than {} bytes. Received {} bytes.",
+        MAX_CONTROL_FRAME_PAYLOAD, len,
+    ));
+    global.throw_value(err)
 }
 
 /// Maps a uWS `SendStatus` to the JS-visible number contract shared by every
@@ -1180,6 +1191,9 @@ impl ServerWebSocket {
             if !value.is_empty_or_undefined_or_null() {
                 if let Some(data) = value.as_array_buffer(global_this) {
                     let buffer = data.slice();
+                    if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
+                        return Err(throw_control_frame_too_large(global_this, buffer.len()));
+                    }
                     return Ok(send_status_to_js(
                         self.websocket().send(buffer, opcode, false, true),
                         buffer.len(),
@@ -1190,6 +1204,9 @@ impl ServerWebSocket {
                     // SAFETY: to_js_string returns a non-null *mut JSString on the Ok path.
                     let string_value = value.to_js_string(global_this)?.to_slice(global_this);
                     let buffer = string_value.slice();
+                    if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
+                        return Err(throw_control_frame_too_large(global_this, buffer.len()));
+                    }
                     return Ok(send_status_to_js(
                         self.websocket().send(buffer, opcode, false, true),
                         buffer.len(),

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -3,7 +3,7 @@ import { spawn } from "bun";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import crypto from "crypto";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 import { createServer } from "http";
 import { AddressInfo, connect } from "net";
 import path from "node:path";
@@ -475,7 +475,9 @@ function test(label: string, fn: (ws: WebSocket, done: (err?: unknown) => void) 
         })
         .catch(done);
     },
-    { timeout: timeout ?? 1000 },
+    // Each test spawns its own echo-server subprocess; debug builds take
+    // well over 1s to spawn + connect on slow CI runners.
+    { timeout: timeout ?? (isDebug ? 10000 : 1000) },
   );
 }
 

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -800,10 +800,12 @@ it("Server should be able to send empty pings", async () => {
   }
 
   {
-    // should not be equal because is bigger than 125 bytes
+    // > 125 bytes throws RangeError synchronously, matching npm ws
     const pingPayload = Buffer.alloc(126, "b").toString();
-    const pingMessage = await checkPing("Hello, World", pingPayload);
-    expect(pingMessage).not.toBe(pingPayload);
+    let err: unknown;
+    await checkPing("Hello, World", pingPayload).catch(e => (err = e));
+    expect(err).toBeInstanceOf(RangeError);
+    expect((err as Error).message).toContain("must not be greater than 125 bytes");
   }
 });
 

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:net";
 import * as path from "node:path";
+import { WebSocket as NodeWS } from "ws";
 function test(
   label: string,
   fn: (ws: WebSocket, done: (err?: unknown) => void) => void,
@@ -280,14 +281,31 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
 
   type Frame = { opcode: number; payloadLen: number; extendedLen: boolean };
 
+  // events.once() only auto-rejects on 'error' for EventEmitters; WebSocket is an
+  // EventTarget, so wire error/close explicitly to surface handshake failures.
+  function openOrFail(ws: WebSocket) {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", e => reject((e as ErrorEvent).error ?? new Error((e as ErrorEvent).message)), {
+      once: true,
+    });
+    ws.addEventListener("close", e => reject(new Error(`closed ${e.code} before open`)), { once: true });
+    return promise;
+  }
+
   async function rawHandshakeServer() {
     const frames: Frame[] = [];
-    const { promise: onFrames, resolve: gotFrames } = Promise.withResolvers<void>();
+    const { promise: onFrames, resolve: gotFrames, reject: failFrames } = Promise.withResolvers<void>();
+    onFrames.catch(() => {});
     let want = Infinity;
+    let closing = false;
     const sockets = new Set<import("node:net").Socket>();
     const server = createServer(sock => {
       sockets.add(sock);
-      sock.on("close", () => sockets.delete(sock));
+      sock.on("close", () => {
+        sockets.delete(sock);
+        if (!closing && frames.length < want) failFrames(new Error(`socket closed after ${frames.length} frames`));
+      });
       sock.on("error", () => {});
       let buf = Buffer.alloc(0);
       let shaken = false;
@@ -341,6 +359,7 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
       },
       close: () =>
         new Promise<void>(r => {
+          closing = true;
           for (const s of sockets) s.destroy();
           server.close(() => r());
         }),
@@ -363,7 +382,7 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
     const srv = await rawHandshakeServer();
     const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/`);
     try {
-      await once(ws, "open");
+      await openOrFail(ws);
 
       const s125 = Buffer.alloc(125, "a").toString();
       const s126 = Buffer.alloc(126, "b").toString();
@@ -410,7 +429,8 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   });
 
   it("a 125-byte ping round-trips through Bun.serve without a protocol error", async () => {
-    const { promise: gotPing, resolve: onPing } = Promise.withResolvers<Buffer>();
+    const { promise: gotPing, resolve: onPing, reject: failPing } = Promise.withResolvers<Buffer>();
+    gotPing.catch(() => {});
     await using server = Bun.serve({
       port: 0,
       fetch(req, server) {
@@ -422,22 +442,115 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
         ping(_ws, data) {
           onPing(Buffer.from(data));
         },
+        close(_ws, code) {
+          failPing(new Error(`server ws closed ${code} before ping`));
+        },
       },
     });
 
     const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
-    const { promise: closed, resolve: onClose } = Promise.withResolvers<CloseEvent>();
-    ws.addEventListener("close", onClose);
-    await once(ws, "open");
+    try {
+      const { promise: closed, resolve: onClose } = Promise.withResolvers<CloseEvent>();
+      ws.addEventListener("close", onClose);
+      await openOrFail(ws);
 
-    const payload = Buffer.alloc(125, "z");
-    ws.ping(payload);
-    const received = await gotPing;
-    expect(received.equals(payload)).toBe(true);
+      const payload = Buffer.alloc(125, "z");
+      ws.ping(payload);
+      const received = await gotPing;
+      expect(received.equals(payload)).toBe(true);
 
-    ws.close();
-    const ev = await closed;
-    expect(ev.code).toBe(1000);
+      ws.close();
+      const ev = await closed;
+      expect(ev.code).toBe(1000);
+    } finally {
+      ws.terminate();
+    }
+  });
+
+  it("require('ws') client throws RangeError synchronously for oversized ping/pong", async () => {
+    const srv = await rawHandshakeServer();
+    const ws = new NodeWS(`ws://127.0.0.1:${srv.port}/`);
+    try {
+      await once(ws, "open");
+      ws.on("error", (e: unknown) => {
+        throw new Error("unexpected 'error' event: " + e);
+      });
+
+      // 125 is the boundary: cb invoked with no error.
+      let cbErr: unknown = "not called";
+      ws.ping(new Uint8Array(125), true, (e: unknown) => (cbErr = e));
+      expect(cbErr).toBeUndefined();
+
+      // > 125: npm ws throws synchronously from Sender.prototype.ping; cb is never invoked.
+      const big = new Uint8Array(200);
+      let pingCb = 0;
+      expectRangeError(() => ws.ping(big, true, () => pingCb++), 200);
+      expectRangeError(() => ws.pong(big, true, () => pingCb++), 200);
+      expect(pingCb).toBe(0);
+
+      await srv.waitForFrames(1);
+      expect(srv.frames).toEqual([{ opcode: 0x9, payloadLen: 125, extendedLen: false }]);
+    } finally {
+      ws.terminate();
+      await srv.close();
+    }
+  });
+
+  it("Bun.serve ServerWebSocket.ping()/pong() throws RangeError for payloads > 125 bytes", async () => {
+    const { promise: result, resolve } = Promise.withResolvers<{ errs: unknown[]; ok125: number }>();
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          const errs: unknown[] = [];
+          for (const fn of [
+            () => ws.ping(new Uint8Array(126)),
+            () => ws.ping(Buffer.alloc(300, "c").toString()),
+            () => ws.pong(new Uint8Array(200)),
+            () => ws.pong(Buffer.alloc(126, "d").toString()),
+          ]) {
+            try {
+              fn();
+              errs.push(undefined);
+            } catch (e) {
+              errs.push(e);
+            }
+          }
+          const ok125 = ws.ping(new Uint8Array(125));
+          resolve({ errs, ok125 });
+        },
+        message() {},
+      },
+    });
+
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    try {
+      const { promise: gotPing, resolve: onServerPing, reject: failPing } = Promise.withResolvers<Buffer>();
+      gotPing.catch(() => {});
+      ws.binaryType = "nodebuffer";
+      ws.addEventListener("ping", e => onServerPing(e.data as Buffer));
+      ws.addEventListener("close", e => failPing(new Error(`closed ${e.code} before ping`)));
+      await openOrFail(ws);
+
+      const { errs, ok125 } = await result;
+      expect(errs).toHaveLength(4);
+      for (const e of errs) {
+        expect(e).toBeInstanceOf(RangeError);
+        expect((e as Error).message).toContain("must not be greater than 125 bytes");
+      }
+      expect(ok125).toBe(125);
+
+      // the server's 125-byte ping reaches the client intact; no protocol error
+      const ping = await gotPing;
+      expect(ping.length).toBe(125);
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+    } finally {
+      ws.terminate();
+    }
   });
 });
 

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -517,12 +517,16 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
       });
       const port = (wss.address() as import("node:net").AddressInfo).port;
       const client = new NodeWS(`ws://127.0.0.1:${port}/`);
-      await once(client, "open");
-      client.close();
-      const err = await closedCbErr;
-      expect(err).toBeInstanceOf(Error);
-      expect(err).not.toBeInstanceOf(TypeError);
-      expect((err as Error).message).toContain("WebSocket is not open: readyState 3 (CLOSED)");
+      try {
+        await once(client, "open");
+        client.close();
+        const err = await closedCbErr;
+        expect(err).toBeInstanceOf(Error);
+        expect(err).not.toBeInstanceOf(TypeError);
+        expect((err as Error).message).toContain("WebSocket is not open: readyState 3 (CLOSED)");
+      } finally {
+        client.terminate();
+      }
     } finally {
       wss.close();
     }

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -2,6 +2,9 @@ import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, nodeExe } from "harness";
+import { createHash } from "node:crypto";
+import { createServer } from "node:net";
+import { once } from "node:events";
 import * as path from "node:path";
 function test(
   label: string,
@@ -268,6 +271,173 @@ function makeTest(
     { timeout: timeout ?? 1000 },
   );
 }
+
+// RFC 6455 §5.5: control frame payloads are at most 125 bytes. ping()/pong()
+// must reject oversized payloads instead of emitting an extended-length control
+// frame that every conformant peer treats as a protocol error.
+describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
+  const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+  type Frame = { opcode: number; payloadLen: number; extendedLen: boolean };
+
+  async function rawHandshakeServer() {
+    const frames: Frame[] = [];
+    const { promise: onFrames, resolve: gotFrames } = Promise.withResolvers<void>();
+    let want = Infinity;
+    const sockets = new Set<import("node:net").Socket>();
+    const server = createServer(sock => {
+      sockets.add(sock);
+      sock.on("close", () => sockets.delete(sock));
+      sock.on("error", () => {});
+      let buf = Buffer.alloc(0);
+      let shaken = false;
+      sock.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        if (!shaken) {
+          const i = buf.indexOf("\r\n\r\n");
+          if (i < 0) return;
+          const key = /sec-websocket-key: *([^\r\n]+)/i.exec(buf.toString("latin1"))![1];
+          const accept = createHash("sha1").update(key + GUID).digest("base64");
+          sock.write(
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+              `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+          );
+          shaken = true;
+          buf = buf.subarray(i + 4);
+        }
+        while (buf.length >= 2) {
+          const opcode = buf[0] & 0x0f;
+          const lenByte = buf[1] & 0x7f;
+          let len = lenByte;
+          let off = 2;
+          if (lenByte === 126) {
+            if (buf.length < 4) return;
+            len = buf.readUInt16BE(2);
+            off = 4;
+          } else if (lenByte === 127) {
+            if (buf.length < 10) return;
+            len = Number(buf.readBigUInt64BE(2));
+            off = 10;
+          }
+          // client frames are always masked: +4 for the masking key
+          if (buf.length < off + 4 + len) return;
+          frames.push({ opcode, payloadLen: len, extendedLen: lenByte >= 126 });
+          buf = buf.subarray(off + 4 + len);
+          if (frames.length >= want) gotFrames();
+        }
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    return {
+      frames,
+      port,
+      waitForFrames(n: number) {
+        want = n;
+        if (frames.length >= n) return Promise.resolve();
+        return onFrames;
+      },
+      close: () =>
+        new Promise<void>(r => {
+          for (const s of sockets) s.destroy();
+          server.close(() => r());
+        }),
+    };
+  }
+
+  function expectRangeError(fn: () => void, bytes: number) {
+    let err: Error | undefined;
+    try {
+      fn();
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeInstanceOf(RangeError);
+    expect(err!.message).toContain("must not be greater than 125 bytes");
+    expect(err!.message).toContain(`${bytes} bytes`);
+  }
+
+  it("throws RangeError for payloads > 125 bytes and never puts an extended-length control frame on the wire", async () => {
+    const srv = await rawHandshakeServer();
+    const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/`);
+    try {
+      await once(ws, "open");
+
+      const s125 = Buffer.alloc(125, "a").toString();
+      const s126 = Buffer.alloc(126, "b").toString();
+      const s300 = Buffer.alloc(300, "c").toString();
+      // 63 × "é" (2 UTF-8 bytes each) = 63 JS chars but 126 bytes on the wire:
+      // the limit is on the encoded length.
+      const multibyte126 = Buffer.alloc(126, "é").toString();
+
+      // 125 is the boundary: must succeed for every overload.
+      ws.ping(s125);
+      ws.ping(new Uint8Array(125));
+      ws.pong(s125);
+      ws.pong(new ArrayBuffer(125));
+
+      // > 125: must throw for every overload. Matches the `ws` npm package (RangeError).
+      expectRangeError(() => ws.ping(s126), 126);
+      expectRangeError(() => ws.ping(s300), 300);
+      expectRangeError(() => ws.ping(multibyte126), 126);
+      expectRangeError(() => ws.ping(new Uint8Array(126)), 126);
+      expectRangeError(() => ws.ping(new ArrayBuffer(200)), 200);
+      expectRangeError(() => ws.ping(new Blob([new Uint8Array(130)])), 130);
+      expectRangeError(() => ws.pong(s126), 126);
+      expectRangeError(() => ws.pong(new Uint8Array(400)), 400);
+      expectRangeError(() => ws.pong(new ArrayBuffer(126)), 126);
+      expectRangeError(() => ws.pong(new Blob([new Uint8Array(200)])), 200);
+
+      // socket must still be usable after the RangeErrors
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+      ws.ping();
+
+      // Only the four 125-byte frames plus the final empty ping may have been sent.
+      await srv.waitForFrames(5);
+      expect(srv.frames).toEqual([
+        { opcode: 0x9, payloadLen: 125, extendedLen: false },
+        { opcode: 0x9, payloadLen: 125, extendedLen: false },
+        { opcode: 0xa, payloadLen: 125, extendedLen: false },
+        { opcode: 0xa, payloadLen: 125, extendedLen: false },
+        { opcode: 0x9, payloadLen: 0, extendedLen: false },
+      ]);
+    } finally {
+      ws.terminate();
+      await srv.close();
+    }
+  });
+
+  it("a 125-byte ping round-trips through Bun.serve without a protocol error", async () => {
+    const { promise: gotPing, resolve: onPing } = Promise.withResolvers<Buffer>();
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        message() {},
+        ping(_ws, data) {
+          onPing(Buffer.from(data));
+        },
+      },
+    });
+
+    const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<CloseEvent>();
+    ws.addEventListener("close", onClose);
+    await once(ws, "open");
+
+    const payload = Buffer.alloc(125, "z");
+    ws.ping(payload);
+    const received = await gotPing;
+    expect(received.equals(payload)).toBe(true);
+
+    ws.close();
+    const ev = await closed;
+    expect(ev.code).toBe(1000);
+  });
+});
 
 async function listen(): Promise<URL> {
   const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -6,7 +6,7 @@ import { createHash } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:net";
 import * as path from "node:path";
-import { WebSocket as NodeWS } from "ws";
+import { WebSocket as NodeWS, WebSocketServer } from "ws";
 function test(
   label: string,
   fn: (ws: WebSocket, done: (err?: unknown) => void) => void,
@@ -491,6 +491,54 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
       expect(srv.frames).toEqual([{ opcode: 0x9, payloadLen: 125, extendedLen: false }]);
       // the shim must not have routed the RangeError to an 'error' event
       expect(errorEvents).toEqual([]);
+    } finally {
+      ws.terminate();
+      await srv.close();
+    }
+  });
+
+  it("require('ws') ping()/pong() after close delivers a 'not open' error to the callback", async () => {
+    // Server side (BunWebSocketMocked): #close() nulls #ws, so this would be a
+    // TypeError without the not-OPEN guard.
+    const wss = new WebSocketServer({ port: 0 });
+    try {
+      const { promise: closedCbErr, resolve: onCbErr, reject } = Promise.withResolvers<unknown>();
+      closedCbErr.catch(() => {});
+      wss.on("connection", serverWs => {
+        serverWs.on("close", () => {
+          try {
+            serverWs.ping();
+            serverWs.pong();
+            serverWs.ping("data", true, onCbErr);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+      const port = (wss.address() as import("node:net").AddressInfo).port;
+      const client = new NodeWS(`ws://127.0.0.1:${port}/`);
+      await once(client, "open");
+      client.close();
+      const err = await closedCbErr;
+      expect(err).toBeInstanceOf(Error);
+      expect(err).not.toBeInstanceOf(TypeError);
+      expect((err as Error).message).toContain("WebSocket is not open: readyState 3 (CLOSED)");
+    } finally {
+      wss.close();
+    }
+
+    // Client side (BunWebSocket): native WebSocket no-ops on CLOSING/CLOSED, but
+    // npm ws still delivers the error to cb.
+    const srv = await rawHandshakeServer();
+    const ws = new NodeWS(`ws://127.0.0.1:${srv.port}/`);
+    try {
+      await once(ws, "open");
+      ws.close();
+      const { promise: cbErr, resolve: onCb } = Promise.withResolvers<unknown>();
+      ws.ping("data", true, onCb);
+      const err = await cbErr;
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/WebSocket is not open: readyState [23] \((CLOSING|CLOSED)\)/);
     } finally {
       ws.terminate();
       await srv.close();

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -470,11 +470,10 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   it("require('ws') client throws RangeError synchronously for oversized ping/pong", async () => {
     const srv = await rawHandshakeServer();
     const ws = new NodeWS(`ws://127.0.0.1:${srv.port}/`);
+    const errorEvents: unknown[] = [];
+    ws.on("error", (e: unknown) => errorEvents.push(e));
     try {
       await once(ws, "open");
-      ws.on("error", (e: unknown) => {
-        throw new Error("unexpected 'error' event: " + e);
-      });
 
       // 125 is the boundary: cb invoked with no error.
       let cbErr: unknown = "not called";
@@ -490,6 +489,8 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
 
       await srv.waitForFrames(1);
       expect(srv.frames).toEqual([{ opcode: 0x9, payloadLen: 125, extendedLen: false }]);
+      // the shim must not have routed the RangeError to an 'error' event
+      expect(errorEvents).toEqual([]);
     } finally {
       ws.terminate();
       await srv.close();
@@ -497,7 +498,8 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   });
 
   it("Bun.serve ServerWebSocket.ping()/pong() throws RangeError for payloads > 125 bytes", async () => {
-    const { promise: result, resolve } = Promise.withResolvers<{ errs: unknown[]; ok125: number }>();
+    const { promise: result, resolve, reject: failResult } = Promise.withResolvers<{ errs: unknown[]; ok125: number }>();
+    result.catch(() => {});
     await using server = Bun.serve({
       port: 0,
       fetch(req, server) {
@@ -506,24 +508,31 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
       },
       websocket: {
         open(ws) {
-          const errs: unknown[] = [];
-          for (const fn of [
-            () => ws.ping(new Uint8Array(126)),
-            () => ws.ping(Buffer.alloc(300, "c").toString()),
-            () => ws.pong(new Uint8Array(200)),
-            () => ws.pong(Buffer.alloc(126, "d").toString()),
-          ]) {
-            try {
-              fn();
-              errs.push(undefined);
-            } catch (e) {
-              errs.push(e);
+          try {
+            const errs: unknown[] = [];
+            for (const fn of [
+              () => ws.ping(new Uint8Array(126)),
+              () => ws.ping(Buffer.alloc(300, "c").toString()),
+              () => ws.pong(new Uint8Array(200)),
+              () => ws.pong(Buffer.alloc(126, "d").toString()),
+            ]) {
+              try {
+                fn();
+                errs.push(undefined);
+              } catch (e) {
+                errs.push(e);
+              }
             }
+            const ok125 = ws.ping(new Uint8Array(125));
+            resolve({ errs, ok125 });
+          } catch (e) {
+            failResult(e);
           }
-          const ok125 = ws.ping(new Uint8Array(125));
-          resolve({ errs, ok125 });
         },
         message() {},
+        close(_ws, code) {
+          failResult(new Error(`server ws closed ${code} before result`));
+        },
       },
     });
 

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -3,8 +3,8 @@ import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, nodeExe } from "harness";
 import { createHash } from "node:crypto";
-import { createServer } from "node:net";
 import { once } from "node:events";
+import { createServer } from "node:net";
 import * as path from "node:path";
 function test(
   label: string,
@@ -297,7 +297,9 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
           const i = buf.indexOf("\r\n\r\n");
           if (i < 0) return;
           const key = /sec-websocket-key: *([^\r\n]+)/i.exec(buf.toString("latin1"))![1];
-          const accept = createHash("sha1").update(key + GUID).digest("base64");
+          const accept = createHash("sha1")
+            .update(key + GUID)
+            .digest("base64");
           sock.write(
             "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
               `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -498,7 +498,11 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   });
 
   it("Bun.serve ServerWebSocket.ping()/pong() throws RangeError for payloads > 125 bytes", async () => {
-    const { promise: result, resolve, reject: failResult } = Promise.withResolvers<{ errs: unknown[]; ok125: number }>();
+    const {
+      promise: result,
+      resolve,
+      reject: failResult,
+    } = Promise.withResolvers<{ errs: unknown[]; ok125: number }>();
     result.catch(() => {});
     await using server = Bun.serve({
       port: 0,


### PR DESCRIPTION
## Reproduction

```js
// a raw TCP server that speaks the handshake and logs incoming frames
ws.ping("b".repeat(126));
ws.ping("c".repeat(300));
ws.pong(new Uint8Array(400));
// => [{"opcode":9,"payloadLen":126,"extendedLen":true},
//     {"opcode":9,"payloadLen":300,"extendedLen":true},
//     {"opcode":10,"payloadLen":400,"extendedLen":true}]
```

Bun emits a single control frame with an extended 16-bit length header. RFC 6455 §5.5 says "All control frames MUST have a payload length of 125 bytes or less", so every conformant peer closes the connection as a protocol error. Bun is self-inconsistent here: its own client receive path enforces `MAX_CONTROL_PAYLOAD = 125` and closes with 1002 "invalid control frame", and `Bun.serve` drops the connection with 1006 without ever invoking the `ping`/`pong` handlers.

## Cause

None of the `ping()`/`pong()` send paths check payload length:

- `WebSocket::ping()` / `WebSocket::pong()` in `src/jsc/bindings/webcore/WebSocket.cpp` pass the payload straight to `sendWebSocketData(Opcode::Ping|Pong)`.
- `ServerWebSocket::send_ping` in `src/runtime/server/ServerWebSocket.rs` passes the payload straight to uWS `send()`; `protocol::formatMessage` picks the frame header purely by length and writes the extended-length form for anything over 125 bytes.
- The `require("ws")` shim wraps both of the above in a `try/catch` that routes any error to `cb`/`'error'`, which would have diverged from npm ws even once the throw was added.

## Fix

- Client `WebSocket`: add a `maxControlFramePayloadSize = 125` check to every `ping()`/`pong()` overload (String, ArrayBuffer, ArrayBufferView, Blob) that returns `Exception { RangeError, "The data size must not be greater than 125 bytes. Received N bytes." }` before sending. The String overloads now encode to UTF-8 once and reuse that buffer for both the length check and the send, so the limit applies to the on-wire byte length.
- `Bun.serve` `ServerWebSocket`: add the same check to `send_ping` (backs both `ws.ping()` and `ws.pong()`), throwing a `RangeError` with the identical message before calling uWS.
- `require("ws")` shim: drop the `try/catch` around `this.#ws.ping()`/`pong()`. npm ws has no catch around `this._sender.ping(...)`, so the RangeError (and any other validation error) propagates synchronously to the caller, never reaching `cb` or an `'error'` event. The catch was effectively dead before this PR anyway since the CONNECTING state is pre-checked.

## Verification

```
$ bun bd test test/js/web/websocket/websocket-client.test.ts -t "payload size limit"
(pass) ... > throws RangeError for payloads > 125 bytes and never puts an extended-length control frame on the wire
(pass) ... > a 125-byte ping round-trips through Bun.serve without a protocol error
(pass) ... > require('ws') client throws RangeError synchronously for oversized ping/pong
(pass) ... > Bun.serve ServerWebSocket.ping()/pong() throws RangeError for payloads > 125 bytes
 4 pass  0 fail
```

The wire-level test connects to a raw TCP server that parses incoming frames and asserts that only the four 125-byte frames (plus a trailing empty ping) are ever sent; every oversized call throws and leaves the socket open. The full `websocket-client.test.ts` (33 tests), `websocket-server.test.ts` (107 tests), `websocket-blob.test.ts`, and the updated 126-byte case in `ws.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (6f411aaab)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:37789/
(pass) WebSocket > url [1903.87ms]
Listening: ws://127.0.0.1:39121/
Received upgrade: {
  host: "127.0.0.1:39121",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "xC93BzukSNOUn0A1nZhRxg==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [2202.10ms]
Listening: ws://127.0.0.1:46811/
(pass) WebSocket > binaryType > (default) [1927.10ms]
Listening: ws://127.0.0.1:41121/
(pass) WebSocket > binaryType > (invalid) [1880.52ms]
Listening: ws://127.0.0.1:39693/
Received upgrade: {
  host: "127.0.0.1:39693",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "60iuzG0zTp2QR5Zso+HZDg==",
}
Received 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2a79098cc)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:45843/
(pass) WebSocket > url [38.71ms]
Listening: ws://127.0.0.1:34325/
Received upgrade: {
  host: "127.0.0.1:34325",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "WfQrs37aRSOI3RjnY0pWug==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [40.51ms]
Listening: ws://127.0.0.1:38117/
(pass) WebSocket > binaryType > (default) [37.12ms]
Listening: ws://127.0.0.1:45171/
(pass) WebSocket > binaryType > (invalid) [36.74ms]
Listening: ws://127.0.0.1:43211/
Received upgrade: {
  host: "127.0.0.1:43211",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "Q+5Va2H6TjG5XDS0smYAHw==",
}
Received connection: 127.0.0.1
Received message: <Buffer 00>
Received ping: <Buffer >
(pass) WebSocket > binaryType > nodebuffer [40.28ms]
Listening: ws://127.0.0.1:35875/
Received upgrade: {
  host: "127.0.0.1:35875",
  c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (6f411aaab)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:45807/
(pass) WebSocket > url [1974.39ms]
Listening: ws://127.0.0.1:35023/
Received upgrade: {
  host: "127.0.0.1:35023",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "PIPYFX48Q46ZtL6cLvtZLQ==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [2187.19ms]
Listening: ws://127.0.0.1:39153/
(pass) WebSocket > binaryType > (default) [1890.36ms]
Listening: ws://127.0.0.1:43671/
(pass) WebSocket > binaryType > (invalid) [1881.96ms]
Listening: ws://127.0.0.1:32833/
Received upgrade: {
  host: "127.0.0.1:32833",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "3arbGXM3RBuMVUUxNs0V7A==",
}
Received 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 665ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/23] gen JS modules (bundle-modules)
Preprocess modules (7067ms)
Bundle modules (50ms)
Postprocesss modules (27ms)
Bundle Functions (711ms)
Generate Code (86ms)

[7.96s] Bundled "src/js" for production
  2040 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/ws.js                        |  75 +++---
 src/jsc/bindings/webcore/WebSocket.cpp         |  37 ++-
 src/runtime/server/ServerWebSocket.rs          |  19 +-
 test/js/first_party/ws/ws.test.ts              |  14 +-
 test/js/web/websocket/websocket-client.test.ts | 350 +++++++++++++++++++++++++
 5 files changed, 443 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/js/thirdparty/ws.js                             7      8      0
src/jsc/bindings/webcore/WebSocket.cpp              4      9      0
src/runtime/server/ServerWebSocket.rs               2      3      0
test/js/first_party/ws/ws.test.ts                   1      3      0
test/js/web/websocket/websocket-client.test.ts      8     23      0
```

</details>

<!-- robobun:evidence:end -->