### PR TITLE
WebSocket.close(): reject close codes 1001-1014 per WHATWG

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -94,7 +94,9 @@ function emitWarning(type, message) {
 // RFC 6455 7.4 + IANA: the status codes an endpoint may send in a Close
 // frame. Matches npm `ws` lib/validation.js isValidStatusCode.
 function isValidStatusCode(code) {
-  return (code >= 1000 && code <= 1014 && code !== 1004 && code !== 1005 && code !== 1006) || (code >= 3000 && code <= 4999);
+  return (
+    (code >= 1000 && code <= 1014 && code !== 1004 && code !== 1005 && code !== 1006) || (code >= 3000 && code <= 4999)
+  );
 }
 
 // TODO: add private method on WebSocket to avoid these allocations

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -91,6 +91,12 @@ function emitWarning(type, message) {
   console.warn("[bun] Warning:", message);
 }
 
+// RFC 6455 7.4 + IANA: the status codes an endpoint may send in a Close
+// frame. Matches npm `ws` lib/validation.js isValidStatusCode.
+function isValidStatusCode(code) {
+  return (code >= 1000 && code <= 1014 && code !== 1004 && code !== 1005 && code !== 1006) || (code >= 3000 && code <= 4999);
+}
+
 // TODO: add private method on WebSocket to avoid these allocations
 function normalizeData(data, opts) {
   const isBinary = opts?.binary;
@@ -376,9 +382,15 @@ class BunWebSocket extends EventEmitter {
   }
 
   close(code, reason) {
+    // Match npm `ws`: TypeError for a code outside the RFC 6455 endpoint set.
+    // The native close() is WHATWG-strict (only 1000, 3000-4999); the third
+    // argument opts into the wider endpoint set so 1001-1014 pass.
+    if (code !== undefined && (typeof code !== "number" || !isValidStatusCode(code))) {
+      throw new TypeError("First argument must be a valid error code number");
+    }
     const ws = this.#ws;
     if (ws) {
-      ws.close(code, reason);
+      ws.close(code, reason, true);
     }
   }
 
@@ -986,6 +998,9 @@ class BunWebSocketMocked extends EventEmitter {
   }
 
   close(code, reason) {
+    if (code !== undefined && (typeof code !== "number" || !isValidStatusCode(code))) {
+      throw new TypeError("First argument must be a valid error code number");
+    }
     if (this.#state === ReadyState_OPEN) {
       this.#state = ReadyState_CLOSING;
       this.#ws.close(code, reason);

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -761,7 +761,11 @@ static inline JSC::EncodedJSValue jsWebSocketPrototypeFunction_closeBody(JSC::JS
     EnsureStillAliveScope argument1 = callFrame->argument(1);
     auto reason = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.close(WTF::move(code), WTF::move(reason)); })));
+    // Non-standard third argument: when truthy, validate the code against the
+    // RFC 6455 endpoint set instead of the WHATWG API set. Only the `ws` shim
+    // passes it, so npm `ws` clients can still close with 1001-1014.
+    bool allowEndpointCodes = callFrame->argument(2).toBoolean(lexicalGlobalObject);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.close(WTF::move(code), WTF::move(reason), allowEndpointCodes); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsWebSocketPrototypeFunction_close, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -118,10 +118,19 @@ static size_t getFramingOverhead(size_t payloadSize)
 
 const size_t maxReasonSizeInBytes = 123;
 
-// Close codes an endpoint may put on the wire (RFC 6455 7.4 + the IANA registry).
-// Deliberately the RFC endpoint set, not the browser's "1000 or 3000-4999":
-// non-browser clients legitimately send 1001 or 1011, and `ws` accepts the same set.
-static inline bool isValidCloseCodeForSending(uint16_t code)
+// https://websockets.spec.whatwg.org/#dom-websocket-close step 1: the API
+// close code set is exactly 1000 and 3000-4999. 1001-1014 are legal RFC 6455
+// endpoint codes on the wire but the WHATWG interface forbids passing them.
+static inline bool isValidWHATWGCloseCode(uint16_t code)
+{
+    return code == 1000 || (code >= 3000 && code <= 4999);
+}
+
+// RFC 6455 7.4 + the IANA registry: every code an endpoint may put on the
+// wire. The `ws` npm package validates against this set, and Bun's `ws` shim
+// forwards to this class, so close() accepts this wider set when the shim
+// asks for it (undocumented third argument).
+static inline bool isValidEndpointCloseCode(uint16_t code)
 {
     return (code >= 1000 && code <= 1014 && code != 1004 && code != 1005 && code != 1006)
         || (code >= 3000 && code <= 4999);
@@ -976,13 +985,17 @@ void WebSocket::failConnectingWebSocket()
     updateHasPendingActivity();
 }
 
-ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, const String& reason)
+ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, const String& reason, bool allowEndpointCodes)
 {
     // https://websockets.spec.whatwg.org/#dom-websocket-close
     // Validation happens before the readyState checks: an invalid code or an
     // over-long reason throws even on a CLOSING/CLOSED socket.
-    if (optionalCode && !isValidCloseCodeForSending(optionalCode.value()))
-        return Exception { InvalidAccessError, makeString("The close code must be a valid WebSocket close code (1000-1014, excluding the reserved codes 1004-1006, or in the range of 3000 to 4999). Received "_s, optionalCode.value(), '.') };
+    if (optionalCode) {
+        unsigned short code = optionalCode.value();
+        bool valid = allowEndpointCodes ? isValidEndpointCloseCode(code) : isValidWHATWGCloseCode(code);
+        if (!valid)
+            return Exception { InvalidAccessError, makeString("The close code must be either 1000 or in the range of 3000 to 4999. Received "_s, code, '.') };
+    }
     if (!reason.isEmpty()) {
         // The limit is on the UTF-8 encoding of the reason, not its UTF-16 length.
         auto utf8Reason = reason.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -177,7 +177,7 @@ public:
     ExceptionOr<void> pong(JSC::ArrayBufferView&);
     ExceptionOr<void> pong(JSBlob*);
 
-    ExceptionOr<void> close(std::optional<unsigned short> code, const String& reason);
+    ExceptionOr<void> close(std::optional<unsigned short> code, const String& reason, bool allowEndpointCodes = false);
     ExceptionOr<void> terminate();
 
     void setProtocol(const String& protocol);

--- a/test/integration/bun-types/fixture/websocket.ts
+++ b/test/integration/bun-types/fixture/websocket.ts
@@ -231,7 +231,7 @@ import { expectType } from "./utilities";
   ws.close(1000);
 
   // Close with code and reason
-  ws.close(1001, "Going away");
+  ws.close(3001, "Going away");
 }
 
 // Bun-specific WebSocket extensions test

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -200,10 +200,10 @@ describe("WebSocket", () => {
     });
     test("(no reason)", (ws, done) => {
       ws.addEventListener("open", () => {
-        ws.close(1001);
+        ws.close(3001);
       });
       ws.addEventListener("close", ({ code, reason, wasClean }) => {
-        expect(code).toBe(1001);
+        expect(code).toBe(3001);
         expect(reason).toBeString();
         expect(wasClean).toBeTrue();
         done();

--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -6,15 +6,19 @@
 import { describe, expect, it } from "bun:test";
 import crypto from "node:crypto";
 import { createServer, type Socket } from "node:net";
+import { WebSocket as WsWebSocket } from "ws";
 
 describe.concurrent("WebSocket close() argument validation", () => {
-  // Close codes an RFC 6455 endpoint must never put on the wire. close() has to
-  // reject them: the peer treats them as a protocol error.
-  const INVALID_CODES = [0, 999, 1004, 1005, 1006, 1015, 1016, 2999, 5000, 65535];
-  // Every code an endpoint may send (RFC 6455 7.4 + IANA): 1000-1014 minus the
-  // reserved 1004-1006, plus the 3000-4999 boundaries. Unlike browsers, the
-  // 1001-1014 band stays permitted: `ws` clients and Bun's inspector use 1001/1011.
-  const VALID_CODES = [1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 3000, 4999];
+  // https://websockets.spec.whatwg.org/#dom-websocket-close step 1: the WHATWG
+  // API accepts only 1000 and 3000-4999. 1001-1014 are legal on the wire for an
+  // RFC 6455 endpoint but the browser interface forbids passing them; undici
+  // and every browser throw InvalidAccessError for them. The `ws` npm package
+  // accepts the wider endpoint set, covered in the "ws" describe below.
+  const INVALID_CODES = [
+    0, 999, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 1015, 1016, 2999, 5000,
+    65535,
+  ];
+  const VALID_CODES = [1000, 3000, 4000, 4999];
   const LONG_REASON = Buffer.alloc(124, "R").toString();
 
   // `constructor` is DOMException for InvalidAccessError, but the native
@@ -137,6 +141,48 @@ describe.concurrent("WebSocket close() argument validation", () => {
       ws.close(code, "bye");
       expect(await serverGotClose.promise).toEqual({ code, reason: "bye" });
       expect(await clientClosed).toBe(code);
+    });
+  });
+
+  describe("ws package close() argument validation", () => {
+    // npm `ws` validates against the RFC 6455 endpoint set and throws a
+    // TypeError, not a DOMException. Bun's shim forwards to the native
+    // WebSocket, so it has to opt out of the WHATWG-strict check above to
+    // keep 1001-1014 working.
+    const WS_VALID = [1000, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1011, 1012, 1013, 1014, 3000, 4999];
+    const WS_INVALID = [0, 999, 1004, 1005, 1006, 1015, 2999, 5000, 65535];
+
+    async function openWs(server: Bun.Server) {
+      const ws = new WsWebSocket(`ws://127.0.0.1:${server.port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      ws.on("open", resolve);
+      ws.on("error", reject);
+      await promise;
+      return ws;
+    }
+
+    it("throws TypeError for codes outside the RFC 6455 endpoint set", async () => {
+      using server = upgradeServer();
+      const ws = await openWs(server);
+      try {
+        for (const code of WS_INVALID) {
+          expectThrows(() => ws.close(code), TypeError, "TypeError", "valid error code number");
+          expect(ws.readyState).toBe(WsWebSocket.OPEN);
+        }
+        expectThrows(() => ws.close("1000" as any), TypeError, "TypeError", "valid error code number");
+      } finally {
+        ws.close();
+      }
+    });
+
+    describe.each(WS_VALID)("close(%i) is allowed", code => {
+      it("and the code reaches the server", async () => {
+        const serverGotClose = Promise.withResolvers<{ code: number; reason: string }>();
+        using server = upgradeServer(serverGotClose.resolve);
+        const ws = await openWs(server);
+        ws.close(code, "bye");
+        expect(await serverGotClose.promise).toEqual({ code, reason: "bye" });
+      });
     });
   });
 });


### PR DESCRIPTION
`WebSocket#close(code)` validated against the RFC 6455 registered endpoint range instead of the WHATWG API range, so `close(1001)`, `close(1002)`, `close(1003)` and `close(1007..1014)` were accepted and the code went on the wire. The WHATWG spec requires `InvalidAccessError` for every code that is not `1000` or in `3000-4999`; undici and every browser throw for all eleven.

```js
const ws = new WebSocket(url);
ws.onopen = () => ws.close(1001);
// before: no throw, 1001 on the wire
// after:  InvalidAccessError: The close code must be either 1000 or in the range of 3000 to 4999. Received 1001.
```

### Cause

`isValidCloseCodeForSending` in `WebSocket.cpp` was the RFC endpoint set (`1000-1014` minus `1004-1006`, plus `3000-4999`), a deliberate choice from #32820 so the `ws` shim (which forwards straight to this method) would keep accepting the codes npm `ws` accepts.

### Fix

`WebSocket::close()` now validates against the WHATWG set (`code == 1000 || 3000-4999`) by default. An undocumented third argument opts into the wider RFC endpoint set; only the `ws` shim passes it. The shim now also validates the code itself and throws the same `TypeError('First argument must be a valid error code number')` npm `ws` throws, instead of leaking the native `InvalidAccessError`. `bun-inspector-protocol`'s `close(1001, "Restarting...")` goes through the `ws` shim so it keeps working.

### Verification

`test/js/web/websocket/websocket-close-code.test.ts` now asserts `1001-1014` all throw `InvalidAccessError` on the global `WebSocket`, that `1000`/`3000`/`4000`/`4999` still round-trip to the server, and that the `ws` package accepts `1001-1014` (round-tripped to the server) while throwing `TypeError` for `0`/`999`/`1004`/`1005`/`1006`/`1015`/`2999`/`5000`/`65535` and non-number codes. With `src/` reverted, the `InvalidAccessError` matrix and the `ws` `TypeError` check both fail; with the fix, all 29 tests pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts test/js/web/websocket/websocket-close-code.test.ts
bun test v1.4.0 (e59f1269a)

test/js/web/websocket/websocket-close-code.test.ts:
29 |     try {
30 |       fn();
31 |     } catch (e) {
32 |       error = e as Error;
33 |     }
34 |     expect(error).toBeInstanceOf(constructor);
                       ^
error: expect(received).toBeInstanceOf(expected)

Expected constructor: [class DOMException]
Received value: undefined

      at expectThrows (/workspace/bun/test/js/web/websocket/websocket-close-code.test.ts:34:19)
      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-close-code.test.ts:73:9)
(fail) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [161.80ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [156.54ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [129.41ms]
(pass) WebSocket clos
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (368bfa128)

test/js/web/websocket/websocket-close-code.test.ts:
(pass) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [25.94ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [17.54ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [16.58ms]
(pass) WebSocket close() argument validation > validates arguments while the socket is still connecting [16.23ms]
(pass) WebSocket close() argument validation > ws package close() argument validation > throws TypeError for codes outside the RFC 6455 endpoint set [11.97ms]
(pass) WebSocket close() argument validation > accepts a reason of exactly 123 UTF-8 bytes [20.83ms]
(pass) WebSocket close() argument validation > close(1000) is allowed > and the code and reason reach the server [17.06ms]
(pass) WebSocket close() argument validation > close(3000) is allowed > and the code and reason reach the server [16.61ms]
(pass) WebSocket close() argument validation > close(4000) is allowed > and the code and reason reach the serv
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts test/js/web/websocket/websocket-close-code.test.ts
bun test v1.4.0 (e59f1269a)

test/js/web/websocket/websocket-close-code.test.ts:
(pass) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [170.20ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [165.93ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [138.34ms]
(pass) WebSocket close() argument validation > validates arguments while the socket is still connecting [131.31ms]
(pass) WebSocket close() argument validation > accepts a reason of exactly 123 UTF-8 bytes [182.91ms]
(pass) WebSocket close() argument validation > close(1000) is allowed > and the code and reason reach the server [158.47ms]
(pass) WebSocket close() argument validation > close(3000) is allowed > and the code and reason reach the server [156.00ms]
(pass) WebSocket close() argument valida
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 655ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen cpp.rs (cppbind)
[2/25] gen JS modules (bundle-modules)
Preprocess modules (7495ms)
Bundle modules (34ms)
Postprocesss modules (179ms)
Bundle Functions (877ms)
Generate Code (121ms)

[8.72s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[2/14] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/ws.js                            | 19 ++++++-
 src/jsc/bindings/webcore/JSWebSocket.cpp           |  6 ++-
 src/jsc/bindings/webcore/WebSocket.cpp             | 27 +++++++---
 src/jsc/bindings/webcore/WebSocket.h               |  2 +-
 test/integration/bun-types/fixture/websocket.ts    |  2 +-
 test/js/web/websocket/websocket-client.test.ts     |  4 +-
 test/js/web/websocket/websocket-close-code.test.ts | 60 +++++++++++++++++++---
 7 files changed, 100 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/thirdparty/ws.js                                 4      4      0
src/jsc/bindings/webcore/JSWebSocket.cpp                1      1      0
src/jsc/bindings/webcore/WebSocket.cpp                  2      2      0
src/jsc/bindings/webcore/WebSocket.h                    1      1      0
test/integration/bun-types/fixture/websocket.ts         1      1      0
test/js/web/websocket/websocket-client.test.ts          1      1      0
test/js/web/websocket/websocket-close-code.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->