### PR TITLE
fix(spawnSync): throw instead of segfaulting when event-loop creation fails

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -240,10 +240,7 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 #else
     loop->fd = kqueue();
 #endif
-    /* EMFILE/ENFILE on epoll_create1/kqueue, or on the wakeup eventfd inside
-     * us_internal_loop_data_init: return NULL so per-call loop creation
-     * (Bun.spawnSync's SpawnSyncEventLoop) can surface a catchable error
-     * instead of aborting the process. */
+    /* EMFILE/ENFILE: the caller decides whether this is fatal. */
     if (loop->fd == -1) {
         us_free(loop);
         return NULL;
@@ -802,10 +799,7 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
 
     int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (efd == -1) {
-        /* EMFILE/ENFILE: the loop is unusable without its wakeup async.
-         * Return NULL so us_internal_loop_data_init (and in turn
-         * us_create_loop) can unwind and let the caller surface a catchable
-         * error instead of taking the process down. */
+        /* EMFILE/ENFILE: us_create_loop unwinds and returns NULL. */
         if (!fallthrough) {
             loop->num_polls--;
         }

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -884,26 +884,29 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
     mach_port_t self = mach_task_self();
     kern_return_t kr = mach_port_allocate(self, MACH_PORT_RIGHT_RECEIVE, &cb->port);
 
-    if (UNLIKELY(kr != KERN_SUCCESS)) {
-        return NULL;
+    if (kr == KERN_SUCCESS) {
+        // Insert a send right into the port since we also use this to send
+        kr = mach_port_insert_right(self, cb->port, cb->port, MACH_MSG_TYPE_MAKE_SEND);
+        if (kr == KERN_SUCCESS) {
+            // Modify the port queue size to be 1 because we are only
+            // using it for notifications and not for any other purpose.
+            mach_port_limits_t limits = { .mpl_qlimit = 1 };
+            kr = mach_port_set_attributes(self, cb->port, MACH_PORT_LIMITS_INFO, (mach_port_info_t)&limits, MACH_PORT_LIMITS_INFO_COUNT);
+            if (kr == KERN_SUCCESS) {
+                return (struct us_internal_async *) cb;
+            }
+        }
+        /* Dropping the receive right destroys the port; any send right it
+         * carried becomes a dead name that the failing caller never uses. */
+        mach_port_mod_refs(self, cb->port, MACH_PORT_RIGHT_RECEIVE, -1);
     }
 
-    // Insert a send right into the port since we also use this to send
-    kr = mach_port_insert_right(self, cb->port, cb->port, MACH_MSG_TYPE_MAKE_SEND);
-    if (UNLIKELY(kr != KERN_SUCCESS)) {
-        return NULL;
+    if (!fallthrough) {
+        loop->num_polls--;
     }
-
-    // Modify the port queue size to be 1 because we are only
-    // using it for notifications and not for any other purpose.
-    mach_port_limits_t limits = { .mpl_qlimit = 1 };
-    kr = mach_port_set_attributes(self, cb->port, MACH_PORT_LIMITS_INFO, (mach_port_info_t)&limits, MACH_PORT_LIMITS_INFO_COUNT);
-
-    if (UNLIKELY(kr != KERN_SUCCESS)) {
-        return NULL;
-    }
-
-    return (struct us_internal_async *) cb;
+    us_free(cb->machport_buf);
+    us_free(cb);
+    return NULL;
 }
 
 // identical code as for timer, make it shared for "callback types"

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -240,8 +240,20 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 #else
     loop->fd = kqueue();
 #endif
+    /* EMFILE/ENFILE on epoll_create1/kqueue, or on the wakeup eventfd inside
+     * us_internal_loop_data_init: return NULL so per-call loop creation
+     * (Bun.spawnSync's SpawnSyncEventLoop) can surface a catchable error
+     * instead of aborting the process. */
+    if (loop->fd == -1) {
+        us_free(loop);
+        return NULL;
+    }
 
-    us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
+    if (us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb) != 0) {
+        close(loop->fd);
+        us_free(loop);
+        return NULL;
+    }
     return loop;
 }
 
@@ -790,10 +802,15 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
 
     int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (efd == -1) {
-        // eventfd only fails on EMFILE/ENFILE — the loop is unusable without
-        // wakeup_async, and the sole caller doesn't NULL-check. Crash loudly
-        // rather than NULL-deref or store -1 as a poll fd.
-        BUN_PANIC("eventfd() failed during loop init (out of file descriptors?)");
+        /* EMFILE/ENFILE: the loop is unusable without its wakeup async.
+         * Return NULL so us_internal_loop_data_init (and in turn
+         * us_create_loop) can unwind and let the caller surface a catchable
+         * error instead of taking the process down. */
+        if (!fallthrough) {
+            loop->num_polls--;
+        }
+        us_free(p);
+        return NULL;
     }
     us_poll_init(p, efd, POLL_TYPE_CALLBACK);
 

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -896,9 +896,12 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
                 return (struct us_internal_async *) cb;
             }
         }
-        /* Dropping the receive right destroys the port; any send right it
-         * carried becomes a dead name that the failing caller never uses. */
+        /* Dropping the receive right destroys the port; release the send
+         * right (now a dead name) so the port-name-table entry is freed too.
+         * mach_port_deallocate is a harmless KERN_INVALID_RIGHT no-op when
+         * insert_right failed and no send right exists. */
         mach_port_mod_refs(self, cb->port, MACH_PORT_RIGHT_RECEIVE, -1);
+        mach_port_deallocate(self, cb->port);
     }
 
     if (!fallthrough) {

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -332,6 +332,8 @@ struct us_loop_t *us_create_loop(void *hint,
   loop->uv_check->data = loop;
 
   // here we create two unreffed handles - timer and async
+  // Cannot fail on this backend: the libuv us_internal_create_async is a bare
+  // us_calloc (no OS resource), so wakeup_async is never NULL here.
   (void)us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
 
   // if we do not own this loop, we need to integrate and set up timer

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -308,6 +308,15 @@ struct us_loop_t *us_create_loop(void *hint,
       (struct us_loop_t *)us_calloc(1, sizeof(struct us_loop_t) + ext_size);
 
   loop->uv_loop = hint ? hint : uv_loop_new();
+  /* uv_loop_new() returns NULL when uv_loop_init fails (CreateIoCompletionPort
+   * under handle/non-paged-pool exhaustion on Windows). Without this check the
+   * uv_prepare_init below dereferences NULL and segfaults the process; the
+   * only hint==NULL caller is Bun.spawnSync's per-call isolated loop, so the
+   * failure must surface as a thrown error instead. */
+  if (!loop->uv_loop) {
+    us_free(loop);
+    return NULL;
+  }
   loop->is_default = hint != 0;
 
   loop->uv_pre = us_malloc(sizeof(uv_prepare_t));
@@ -323,7 +332,7 @@ struct us_loop_t *us_create_loop(void *hint,
   loop->uv_check->data = loop;
 
   // here we create two unreffed handles - timer and async
-  us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
+  (void)us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
 
   // if we do not own this loop, we need to integrate and set up timer
   if (hint) {

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -308,11 +308,7 @@ struct us_loop_t *us_create_loop(void *hint,
       (struct us_loop_t *)us_calloc(1, sizeof(struct us_loop_t) + ext_size);
 
   loop->uv_loop = hint ? hint : uv_loop_new();
-  /* uv_loop_new() returns NULL when uv_loop_init fails (CreateIoCompletionPort
-   * under handle/non-paged-pool exhaustion on Windows). Without this check the
-   * uv_prepare_init below dereferences NULL and segfaults the process; the
-   * only hint==NULL caller is Bun.spawnSync's per-call isolated loop, so the
-   * failure must surface as a thrown error instead. */
+  /* NULL when uv_loop_init fails (CreateIoCompletionPort under handle exhaustion). */
   if (!loop->uv_loop) {
     us_free(loop);
     return NULL;
@@ -332,8 +328,7 @@ struct us_loop_t *us_create_loop(void *hint,
   loop->uv_check->data = loop;
 
   // here we create two unreffed handles - timer and async
-  // Cannot fail on this backend: the libuv us_internal_create_async is a bare
-  // us_calloc (no OS resource), so wakeup_async is never NULL here.
+  // Cannot fail here: this backend's us_internal_create_async acquires no OS resource.
   (void)us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
 
   // if we do not own this loop, we need to integrate and set up timer

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -180,10 +180,10 @@ void us_internal_group_maybe_unlink(struct us_socket_group_t *group);
  * SSL path calls _raw once it's actually time to drop the fd. */
 struct us_socket_t *us_internal_socket_close_raw(us_socket_r s, int code, void *reason);
 struct us_socket_t *us_internal_ssl_close(us_socket_r s, int code, void *reason);
-void us_internal_loop_data_init(struct us_loop_t *loop,
-                                void (*wakeup_cb)(us_loop_r loop),
-                                void (*pre_cb)(us_loop_r loop),
-                                void (*post_cb)(us_loop_r loop));
+int us_internal_loop_data_init(struct us_loop_t *loop,
+                               void (*wakeup_cb)(us_loop_r loop),
+                               void (*pre_cb)(us_loop_r loop),
+                               void (*post_cb)(us_loop_r loop));
 void us_internal_loop_data_free(us_loop_r loop);
 void us_internal_loop_pre(us_loop_r loop);
 void us_internal_loop_post(us_loop_r loop);

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -121,7 +121,10 @@ void us_internal_sweep_if_due(struct us_loop_t *loop) {
 #endif
 
 
-void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct us_loop_t *loop),
+/* Returns 0 on success, -1 when the wakeup async cannot be created
+ * (eventfd/mach_port under resource exhaustion). On failure nothing is left
+ * allocated in loop->data. */
+int us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct us_loop_t *loop),
     void (*pre_cb)(struct us_loop_t *loop), void (*post_cb)(struct us_loop_t *loop)) {
     // We allocate with calloc, so we only need to initialize the specific fields in use.
 #ifdef LIBUS_USE_LIBUV
@@ -138,12 +141,21 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
     loop->data.pre_cb = pre_cb;
     loop->data.post_cb = post_cb;
     loop->data.wakeup_async = us_internal_create_async(loop, 1, 0);
+    if (!loop->data.wakeup_async) {
+        us_free(loop->data.recv_buf);
+        us_free(loop->data.send_buf);
+#ifdef LIBUS_USE_LIBUV
+        us_timer_close(loop->data.sweep_timer, 0);
+#endif
+        return -1;
+    }
     us_internal_async_set(loop->data.wakeup_async, (void (*)(struct us_internal_async *)) wakeup_cb);
 #if ASSERT_ENABLED
     if (Bun__lock__size != sizeof(loop->data.mutex)) {
         BUN_PANIC("The size of the mutex must match the size of the lock");
     }
 #endif
+    return 0;
 }
 
 void us_internal_loop_data_free(struct us_loop_t *loop) {

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -121,9 +121,7 @@ void us_internal_sweep_if_due(struct us_loop_t *loop) {
 #endif
 
 
-/* Returns 0 on success, -1 when the wakeup async cannot be created
- * (eventfd/mach_port under resource exhaustion). On failure nothing is left
- * allocated in loop->data. */
+/* -1 if the wakeup async cannot be created; nothing is left allocated in loop->data. */
 int us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct us_loop_t *loop),
     void (*pre_cb)(struct us_loop_t *loop), void (*post_cb)(struct us_loop_t *loop)) {
     // We allocate with calloc, so we only need to initialize the specific fields in use.

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -83,8 +83,11 @@ private:
     }
 
     static Loop *create(void *hint) {
-        Loop *loop = ((Loop *) us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData)))->init();
-        return loop;
+        Loop *loop = (Loop *) us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData));
+        if (!loop) {
+            return nullptr;
+        }
+        return loop->init();
     }
 
     /* What to do with loops created with existingNativeLoop? */
@@ -118,7 +121,14 @@ public:
                 getLazyLoop().loop = create(existingNativeLoop);
                 /* We cannot register automatic free here, must be manually done */
             } else {
-                getLazyLoop().loop = create(nullptr);
+                Loop *loop = create(nullptr);
+                if (!loop) {
+                    /* Resource exhaustion (epoll/kqueue/eventfd EMFILE, or
+                     * uv_loop_init). Leave lazyLoop null so a later get()
+                     * retries once resources free up. */
+                    return nullptr;
+                }
+                getLazyLoop().loop = loop;
                 getLazyLoop().cleanMe = true;
             }
         }

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -26,6 +26,7 @@
 #include "AsyncSocket.h"
 
 extern "C" int bun_is_exiting();
+extern "C" void __attribute__((__noreturn__)) Bun__panic(const char *message, size_t length);
 
 namespace uWS {
 struct Loop {
@@ -85,7 +86,11 @@ private:
     static Loop *create(void *hint) {
         Loop *loop = (Loop *) us_create_loop(hint, wakeupCb, preCb, postCb, sizeof(LoopData));
         if (!loop) {
-            return nullptr;
+            /* The per-thread loop is not recoverable; every caller of get()
+             * dereferences it. Only Bun.spawnSync's isolated loop (created
+             * through the Rust uws::Loop::create) surfaces this as an error. */
+            static const char msg[] = "failed to create the event loop (out of file descriptors?)";
+            Bun__panic(msg, sizeof(msg) - 1);
         }
         return loop->init();
     }
@@ -121,14 +126,7 @@ public:
                 getLazyLoop().loop = create(existingNativeLoop);
                 /* We cannot register automatic free here, must be manually done */
             } else {
-                Loop *loop = create(nullptr);
-                if (!loop) {
-                    /* Resource exhaustion (epoll/kqueue/eventfd EMFILE, or
-                     * uv_loop_init). Leave lazyLoop null so a later get()
-                     * retries once resources free up. */
-                    return nullptr;
-                }
-                getLazyLoop().loop = loop;
+                getLazyLoop().loop = create(nullptr);
                 getLazyLoop().cleanMe = true;
             }
         }

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -143,15 +143,18 @@ impl SpawnSyncEventLoop {
     // below, so `Self` MUST NOT move after `init` returns (no-move invariant
     // upheld by the caller). The caller provides uninitialized storage, hence
     // `MaybeUninit<Self>` (out-param ctor exception).
+    //
+    // Returns `false` when the isolated event loop cannot be created
+    // (uv_loop_init / epoll_create1 / kqueue failure under resource
+    // exhaustion). `this` is left uninitialized on failure.
     pub fn init(
         this: &mut core::mem::MaybeUninit<Self>,
         vm: *mut (), /* SAFETY: erased *mut VirtualMachine */
-    ) {
+    ) -> bool {
         // `uws::Loop::create` takes a `LoopHandler` impl with associated-const fn ptrs.
-        let loop_ = uws::Loop::create::<handler::Handler>();
-
-        let loop_ =
-            NonNull::new(loop_).expect("uws::Loop::create never returns null (asserts on OOM)");
+        let Some(loop_) = uws::Loop::create::<handler::Handler>() else {
+            return false;
+        };
 
         // A fresh `jsc::EventLoop` whose `uws_loop` is the isolated loop.
         let event_loop = __bun_spawn_sync_create_event_loop(vm, loop_.as_ptr());
@@ -178,6 +181,7 @@ impl SpawnSyncEventLoop {
         let loop_data = &mut this.uws_loop_mut().internal_loop_data;
         loop_data.set_parent_raw(tag, ptr);
         loop_data.jsc_vm = core::ptr::null();
+        true
     }
 
     /// Erased `*mut bun_jsc::event_loop::EventLoop` (heap-owned via

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -200,8 +200,9 @@ impl SpawnSyncEventLoop {
     /// Shared borrow of the isolated `uws::Loop`.
     ///
     /// # Safety (invariant)
-    /// `uws_loop` is created in `init` via `uws::Loop::create` (asserts
-    /// non-null) and freed only in `Drop`, so it is valid for all of `self`'s
+    /// `uws_loop` is created in `init` via `uws::Loop::create`; `init` returns
+    /// `false` on `None`, so `Self` is never constructed with a null loop. It
+    /// is freed only in `Drop`, so it is valid for all of `self`'s
     /// lifetime. The loop is only mutated through `&mut self` paths
     /// (`uws_loop_mut`), so a shared borrow tied to `&self` cannot overlap a
     /// unique borrow.

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -144,9 +144,7 @@ impl SpawnSyncEventLoop {
     // upheld by the caller). The caller provides uninitialized storage, hence
     // `MaybeUninit<Self>` (out-param ctor exception).
     //
-    // Returns `false` when the isolated event loop cannot be created
-    // (uv_loop_init / epoll_create1 / kqueue failure under resource
-    // exhaustion). `this` is left uninitialized on failure.
+    // Returns `false`, leaving `this` uninitialized, if the loop cannot be created.
     pub fn init(
         this: &mut core::mem::MaybeUninit<Self>,
         vm: *mut (), /* SAFETY: erased *mut VirtualMachine */
@@ -200,10 +198,9 @@ impl SpawnSyncEventLoop {
     /// Shared borrow of the isolated `uws::Loop`.
     ///
     /// # Safety (invariant)
-    /// `uws_loop` is created in `init` via `uws::Loop::create`; `init` returns
-    /// `false` on `None`, so `Self` is never constructed with a null loop. It
-    /// is freed only in `Drop`, so it is valid for all of `self`'s
-    /// lifetime. The loop is only mutated through `&mut self` paths
+    /// `uws_loop` is set in `init` (which fails instead of constructing `Self`
+    /// with a null loop) and freed only in `Drop`, so it is valid for all of
+    /// `self`'s lifetime. The loop is only mutated through `&mut self` paths
     /// (`uws_loop_mut`), so a shared borrow tied to `&self` cannot overlap a
     /// unique borrow.
     #[inline]

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -142,9 +142,7 @@ impl SpawnSyncEventLoop {
     // In-place init: `self.event_loop` is captured by `setParentEventLoop`
     // below, so `Self` MUST NOT move after `init` returns (no-move invariant
     // upheld by the caller). The caller provides uninitialized storage, hence
-    // `MaybeUninit<Self>` (out-param ctor exception).
-    //
-    // Returns `false`, leaving `this` uninitialized, if the loop cannot be created.
+    // `MaybeUninit<Self>` (out-param ctor exception). `false` leaves it uninitialized.
     pub fn init(
         this: &mut core::mem::MaybeUninit<Self>,
         vm: *mut (), /* SAFETY: erased *mut VirtualMachine */
@@ -198,11 +196,10 @@ impl SpawnSyncEventLoop {
     /// Shared borrow of the isolated `uws::Loop`.
     ///
     /// # Safety (invariant)
-    /// `uws_loop` is set in `init` (which fails instead of constructing `Self`
-    /// with a null loop) and freed only in `Drop`, so it is valid for all of
-    /// `self`'s lifetime. The loop is only mutated through `&mut self` paths
-    /// (`uws_loop_mut`), so a shared borrow tied to `&self` cannot overlap a
-    /// unique borrow.
+    /// `uws_loop` is set in `init` and freed only in `Drop`, so it is valid for
+    /// all of `self`'s lifetime. The loop is only mutated through `&mut self`
+    /// paths (`uws_loop_mut`), so a shared borrow tied to `&self` cannot
+    /// overlap a unique borrow.
     #[inline]
     pub fn uws_loop(&self) -> &uws::Loop {
         // SAFETY: see doc invariant above — non-null, owned for `self`'s lifetime,

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -728,20 +728,31 @@ impl RareData {
             .push(CleanupHook::from(global_this, ctx, func));
     }
 
-    pub fn spawn_sync_event_loop(&mut self, vm: &mut VirtualMachine) -> &mut SpawnSyncEventLoop {
+    /// Returns `None` when the isolated event loop cannot be created
+    /// (uv_loop_init / epoll_create1 / kqueue failure under resource
+    /// exhaustion); the caller surfaces that as a thrown JS error so a
+    /// `Bun.spawnSync` under resource pressure fails the one call instead of
+    /// taking the process down. Once created the loop is cached, so only the
+    /// first call per VM can return `None`.
+    pub fn spawn_sync_event_loop(
+        &mut self,
+        vm: &mut VirtualMachine,
+    ) -> Option<&mut SpawnSyncEventLoop> {
         if self.spawn_sync_event_loop_.is_none() {
             // In-place out-param init: `event_loop` inside captures the
             // `self` address, so the value must not move after init; allocate
             // the Box first, then init into it.
             let mut boxed = Box::<SpawnSyncEventLoop>::new_uninit();
-            SpawnSyncEventLoop::init(
+            if !SpawnSyncEventLoop::init(
                 &mut *boxed,
                 core::ptr::from_mut::<VirtualMachine>(vm).cast::<()>(),
-            );
-            // SAFETY: `init` fully initialised the slot.
+            ) {
+                return None;
+            }
+            // SAFETY: `init` fully initialised the slot when it returned `true`.
             self.spawn_sync_event_loop_ = Some(unsafe { boxed.assume_init() });
         }
-        self.spawn_sync_event_loop_.as_mut().unwrap()
+        self.spawn_sync_event_loop_.as_deref_mut()
     }
 
     // ── watch-mode listen sockets ─────────────────────────────────────────

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -728,12 +728,8 @@ impl RareData {
             .push(CleanupHook::from(global_this, ctx, func));
     }
 
-    /// Returns `None` when the isolated event loop cannot be created
-    /// (uv_loop_init / epoll_create1 / kqueue failure under resource
-    /// exhaustion); the caller surfaces that as a thrown JS error so a
-    /// `Bun.spawnSync` under resource pressure fails the one call instead of
-    /// taking the process down. Once created the loop is cached, so only the
-    /// first call per VM can return `None`.
+    /// `None` if the loop cannot be created (resource exhaustion). Nothing is
+    /// cached on failure, so a later call retries.
     pub fn spawn_sync_event_loop(
         &mut self,
         vm: &mut VirtualMachine,

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -728,8 +728,7 @@ impl RareData {
             .push(CleanupHook::from(global_this, ctx, func));
     }
 
-    /// `None` if the loop cannot be created (resource exhaustion). Nothing is
-    /// cached on failure, so a later call retries.
+    /// `None` if the loop cannot be created; nothing is cached, so a later call retries.
     pub fn spawn_sync_event_loop(
         &mut self,
         vm: &mut VirtualMachine,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1062,6 +1062,10 @@ fn spawn_maybe_sync(
                 // (uv_loop_init on Windows, epoll_create1/kqueue on POSIX).
                 // Throw instead of letting the unchecked NULL dereference in
                 // us_create_loop segfault the whole process.
+                #[cfg(windows)]
+                for e in &mut extra_fds {
+                    e.deinit();
+                }
                 return Err(throw_spawn_sync_loop_init_failed(global_this));
             };
             sync_loop.prepare(jsc_vm_ptr.cast());

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1058,10 +1058,7 @@ fn spawn_maybe_sync(
                 .rare_data()
                 .spawn_sync_event_loop(&mut *jsc_vm_ptr)
             else {
-                // The per-spawnSync isolated event loop could not be created
-                // (uv_loop_init on Windows, epoll_create1/kqueue on POSIX).
-                // Throw instead of letting the unchecked NULL dereference in
-                // us_create_loop segfault the whole process.
+                // `WindowsStdio` has no `Drop`; free the pipes `as_spawn_option` allocated.
                 #[cfg(windows)]
                 for e in &mut extra_fds {
                     e.deinit();
@@ -2074,9 +2071,7 @@ fn spawn_maybe_sync(
 }
 
 fn throw_spawn_sync_loop_init_failed(global_this: &JSGlobalObject) -> JsError {
-    // us_create_loop discards the real errno by returning NULL, so the exact
-    // cause (EMFILE vs ENFILE, epoll_create1 vs eventfd) is not recoverable
-    // here. Report the common case with a platform-appropriate syscall name.
+    // us_create_loop returns NULL without the errno; EMFILE is the common cause.
     let err = SystemError {
         message: BunString::static_(
             b"spawnSync failed to initialize its event loop (system resource exhaustion)",

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2070,6 +2070,9 @@ fn spawn_maybe_sync(
 }
 
 fn throw_spawn_sync_loop_init_failed(global_this: &JSGlobalObject) -> JsError {
+    // us_create_loop discards the real errno by returning NULL, so the exact
+    // cause (EMFILE vs ENFILE, epoll_create1 vs eventfd) is not recoverable
+    // here. Report the common case with a platform-appropriate syscall name.
     let err = SystemError {
         message: BunString::static_(
             b"spawnSync failed to initialize its event loop (system resource exhaustion)",
@@ -2077,7 +2080,12 @@ fn throw_spawn_sync_loop_init_failed(global_this: &JSGlobalObject) -> JsError {
         code: BunString::static_("EMFILE"),
         errno: -UV_E::MFILE,
         path: BunString::EMPTY,
+        #[cfg(windows)]
         syscall: BunString::static_("uv_loop_init"),
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        syscall: BunString::static_("epoll_create1"),
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        syscall: BunString::static_("kqueue"),
         hostname: BunString::EMPTY,
         fd: -1,
         dest: BunString::EMPTY,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1054,9 +1054,16 @@ fn spawn_maybe_sync(
         // SAFETY: see note above; `spawn_sync_event_loop` re-borrows the
         // same VM via the raw pointer for its `vm` arg.
         unsafe {
-            let sync_loop = (*jsc_vm_ptr)
+            let Some(sync_loop) = (*jsc_vm_ptr)
                 .rare_data()
-                .spawn_sync_event_loop(&mut *jsc_vm_ptr);
+                .spawn_sync_event_loop(&mut *jsc_vm_ptr)
+            else {
+                // The per-spawnSync isolated event loop could not be created
+                // (uv_loop_init on Windows, epoll_create1/kqueue on POSIX).
+                // Throw instead of letting the unchecked NULL dereference in
+                // us_create_loop segfault the whole process.
+                return Err(throw_spawn_sync_loop_init_failed(global_this));
+            };
             sync_loop.prepare(jsc_vm_ptr.cast());
             // `SpawnSyncEventLoop.event_loop` is type-erased to `*mut ()`
             // (bun_event_loop is below bun_jsc); the accessor returns the
@@ -1082,6 +1089,7 @@ fn spawn_maybe_sync(
                 (*jsc_vm_ptr_cleanup)
                     .rare_data()
                     .spawn_sync_event_loop(&mut *jsc_vm_ptr_cleanup)
+                    .expect("cached by the is_sync prepare above")
                     .cleanup(jsc_vm_ptr_cleanup.cast());
             }
         }
@@ -1899,7 +1907,8 @@ fn spawn_maybe_sync(
         // SAFETY: jsc_vm_ptr is the live thread VM; re-borrowed for the nested arg.
         let sync_loop = unsafe { &mut *jsc_vm_ptr }
             .rare_data()
-            .spawn_sync_event_loop(unsafe { &mut *jsc_vm_ptr });
+            .spawn_sync_event_loop(unsafe { &mut *jsc_vm_ptr })
+            .expect("cached by the is_sync prepare above");
 
         while subprocess.compute_has_pending_activity() {
             // Re-evaluate this at each iteration of the loop since it may change between iterations.
@@ -2058,6 +2067,22 @@ fn spawn_maybe_sync(
     sync_value.put(global_this, b"pid", result_pid);
 
     Ok(sync_value)
+}
+
+fn throw_spawn_sync_loop_init_failed(global_this: &JSGlobalObject) -> JsError {
+    let err = SystemError {
+        message: BunString::static_(
+            b"spawnSync failed to initialize its event loop (system resource exhaustion)",
+        ),
+        code: BunString::static_("EMFILE"),
+        errno: -UV_E::MFILE,
+        path: BunString::EMPTY,
+        syscall: BunString::static_("uv_loop_init"),
+        hostname: BunString::EMPTY,
+        fd: -1,
+        dest: BunString::EMPTY,
+    };
+    global_this.throw_value(err.to_error_instance(global_this))
 }
 
 fn throw_command_not_found(global_this: &JSGlobalObject, command: &[u8]) -> JsError {

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -1,4 +1,5 @@
 use core::ffi::{c_int, c_uint, c_void};
+use core::ptr::NonNull;
 
 use crate::InternalLoopData;
 use crate::Timespec;
@@ -229,13 +230,14 @@ impl PosixLoop {
         unsafe { c::us_quic_loop_flush_if_pending(self) };
     }
 
-    pub fn create<H: LoopHandler>() -> *mut Loop {
+    /// Returns `None` when the kernel cannot create the backing event
+    /// provider (epoll/kqueue EMFILE); callers surface that as an error.
+    pub fn create<H: LoopHandler>() -> Option<NonNull<Loop>> {
         // SAFETY: us_create_loop allocates and returns a new loop; null hint is valid
         let p = unsafe {
             c::us_create_loop(core::ptr::null_mut(), Some(H::WAKEUP), H::PRE, H::POST, 0)
         };
-        assert!(!p.is_null(), "us_create_loop returned null");
-        p
+        NonNull::new(p)
     }
 
     pub fn wakeup(&mut self) {
@@ -406,13 +408,14 @@ impl WindowsLoop {
         unsafe { c::us_quic_loop_flush_if_pending(self) };
     }
 
-    pub fn create<H: LoopHandler>() -> *mut WindowsLoop {
+    /// Returns `None` when `uv_loop_init` fails (CreateIoCompletionPort under
+    /// handle/non-paged-pool exhaustion); callers surface that as an error.
+    pub fn create<H: LoopHandler>() -> Option<NonNull<WindowsLoop>> {
         // SAFETY: us_create_loop allocates and returns a new loop; null hint is valid
         let p = unsafe {
             c::us_create_loop(core::ptr::null_mut(), Some(H::WAKEUP), H::PRE, H::POST, 0)
         };
-        assert!(!p.is_null(), "us_create_loop returned null");
-        p
+        NonNull::new(p)
     }
 
     pub fn run(&mut self) {

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -230,8 +230,7 @@ impl PosixLoop {
         unsafe { c::us_quic_loop_flush_if_pending(self) };
     }
 
-    /// Returns `None` when the kernel cannot create the backing event
-    /// provider (epoll/kqueue EMFILE); callers surface that as an error.
+    /// `None` if epoll/kqueue cannot be created (EMFILE).
     pub fn create<H: LoopHandler>() -> Option<NonNull<Loop>> {
         // SAFETY: us_create_loop allocates and returns a new loop; null hint is valid
         let p = unsafe {
@@ -408,8 +407,7 @@ impl WindowsLoop {
         unsafe { c::us_quic_loop_flush_if_pending(self) };
     }
 
-    /// Returns `None` when `uv_loop_init` fails (CreateIoCompletionPort under
-    /// handle/non-paged-pool exhaustion); callers surface that as an error.
+    /// `None` if `uv_loop_init` fails (handle exhaustion).
     pub fn create<H: LoopHandler>() -> Option<NonNull<WindowsLoop>> {
         // SAFETY: us_create_loop allocates and returns a new loop; null hint is valid
         let p = unsafe {

--- a/test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
+++ b/test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
@@ -1,0 +1,62 @@
+// Bun.spawnSync lazily creates an isolated uSockets event loop per VM
+// (epoll_create1/kqueue on POSIX, uv_loop_new on Windows). When that syscall
+// fails under resource exhaustion, us_create_loop used to dereference the
+// NULL/invalid result and crash the whole process. The one spawnSync call must
+// throw a catchable error instead, and once resources are freed a retry must
+// work.
+//
+// The Windows variant (uv_loop_new -> CreateIoCompletionPort failing under
+// handle/non-paged-pool exhaustion) routes through the same NULL propagation
+// in us_create_loop / WindowsLoop::create / SpawnSyncEventLoop::init; this
+// test exercises the POSIX half where the failure is reproducible with a file
+// descriptor limit.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+
+const fixture = /* js */ `
+  import * as fs from "node:fs";
+  // Warm anything lazily opened on first use so the fd fill below leaves zero
+  // descriptors for us_create_loop itself (not for a module loader read).
+  process.nextTick(() => {});
+
+  const held = [];
+  for (;;) { try { held.push(fs.openSync("/dev/null", "r")); } catch { break; } }
+
+  let first;
+  try {
+    Bun.spawnSync({ cmd: ["true"], stdio: ["ignore", "ignore", "ignore"] });
+    first = { ok: false, msg: "UNEXPECTED: spawnSync succeeded" };
+  } catch (e) {
+    first = { ok: true, code: e?.code, msg: String(e?.message ?? e) };
+  }
+
+  for (const fd of held) fs.closeSync(fd);
+
+  if (!first.ok) { console.error(first.msg); process.exit(1); }
+  console.error("spawnSync threw:", first.code, first.msg);
+
+  // Descriptors are free again: the isolated loop was not cached on failure,
+  // so this call creates it successfully and runs the child.
+  const retry = Bun.spawnSync({ cmd: ["true"], stdio: ["ignore", "ignore", "ignore"] });
+  console.error("retry exit:", retry.exitCode);
+  console.error("SURVIVED");
+`;
+
+describe.skipIf(!isPosix)("Bun.spawnSync event-loop creation under EMFILE", () => {
+  test("throws instead of aborting the process", async () => {
+    await using proc = Bun.spawn({
+      cmd: ["/bin/sh", "-c", `ulimit -n 512 && exec "$1" --no-install -e "$2"`, "sh", bunExe(), fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("SURVIVED"),
+      exitCode: 0,
+    });
+    expect(stderr).toContain("spawnSync threw: EMFILE");
+    expect(stderr).toContain("retry exit: 0");
+  });
+});

--- a/test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
+++ b/test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
@@ -13,6 +13,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix } from "harness";
 
+// Absolute argv[0] so PATH lookup (which_for_spawn) is skipped; on musl that
+// lookup fails under EMFILE before the event loop is created and turns the
+// failure into ENOENT instead of exercising us_create_loop.
 const fixture = /* js */ `
   import * as fs from "node:fs";
   // Warm anything lazily opened on first use so the fd fill below leaves zero
@@ -24,7 +27,7 @@ const fixture = /* js */ `
 
   let first;
   try {
-    Bun.spawnSync({ cmd: ["true"], stdio: ["ignore", "ignore", "ignore"] });
+    Bun.spawnSync({ cmd: ["/bin/sh", "-c", ":"], stdio: ["ignore", "ignore", "ignore"] });
     first = { ok: false, msg: "UNEXPECTED: spawnSync succeeded" };
   } catch (e) {
     first = { ok: true, code: e?.code, msg: String(e?.message ?? e) };
@@ -37,7 +40,7 @@ const fixture = /* js */ `
 
   // Descriptors are free again: the isolated loop was not cached on failure,
   // so this call creates it successfully and runs the child.
-  const retry = Bun.spawnSync({ cmd: ["true"], stdio: ["ignore", "ignore", "ignore"] });
+  const retry = Bun.spawnSync({ cmd: ["/bin/sh", "-c", ":"], stdio: ["ignore", "ignore", "ignore"] });
   console.error("retry exit:", retry.exitCode);
   console.error("SURVIVED");
 `;

--- a/test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
+++ b/test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
@@ -54,12 +54,10 @@ describe.skipIf(!isPosix)("Bun.spawnSync event-loop creation under EMFILE", () =
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "",
-      stderr: expect.stringContaining("SURVIVED"),
-      exitCode: 0,
-    });
+    expect(stdout).toBe("");
     expect(stderr).toContain("spawnSync threw: EMFILE");
     expect(stderr).toContain("retry exit: 0");
+    expect(stderr).toContain("SURVIVED");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.spawnSync` segfaults the whole process on Windows when `uv_loop_new()` fails. `us_create_loop` (`packages/bun-usockets/src/eventing/libuv.c`) passes the NULL to `uv_prepare_init`, which faults in `uv__queue_insert_tail` at `+0x18`. The null assert in `WindowsLoop::create` never runs.
- `uv_loop_init` fails when `CreateIoCompletionPort` returns `ERROR_INSUFFICIENT_RESOURCES` (handle or non-paged-pool exhaustion). POSIX has the same shape: `epoll_create1`/`kqueue` returning -1 is unchecked, and the Linux wakeup `eventfd()` aborts with `BUN_PANIC`.
- `spawnSync` creates a fresh isolated loop per VM, so one call under resource pressure kills the process instead of failing that call.

### Fix
- `us_create_loop` returns NULL when the event provider cannot be created, on all three backends, and frees what it allocated. `us_internal_loop_data_init` returns -1 when the wakeup async fails (eventfd, mach_port), with cleanup on each path.
- `PosixLoop::create` / `WindowsLoop::create` return `Option<NonNull<Loop>>`. `SpawnSyncEventLoop::init` returns `false`, `RareData::spawn_sync_event_loop` returns `None` and caches nothing, and `spawn_maybe_sync` throws a `SystemError` (`code: "EMFILE"`) for that one call. A later call retries.
- The per-thread loop (`uWS::Loop::get()`) stays fatal: every caller dereferences it unchecked, so `Loop::create` panics with a message there, the same outcome the eventfd site had before. Only the spawnSync loop is fallible. This follows the review on #33850.
- Verified: `test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts` (POSIX, `ulimit -n 512`). Stock bun exits 134 with `panic: eventfd() failed during loop init`; with the fix spawnSync throws EMFILE and a retry after freeing descriptors succeeds. Also `child_process.test.ts -t spawnSync`, `spawn-many-teardown.test.ts`, `rust:check-all`, and a Windows x64 build plus spawnSync run.

### Background
- uSockets creates one `us_loop_t` per thread through `uWS::Loop::get()`. `Bun.spawnSync` creates a second, isolated loop (`SpawnSyncEventLoop`) so JS timers and the main loop do not run while the child is awaited.
- On Windows `us_loop_t` wraps a libuv `uv_loop_t`. `uv_loop_new()` is `malloc` + `uv_loop_init`, and returns NULL when init fails.
- On Linux the loop needs an epoll fd and an eventfd for cross-thread wakeups. On macOS it needs a kqueue and a mach port.

<details><summary>Notes</summary>

- The Windows failure (`uv_loop_new()` NULL) cannot be induced in CI. It routes through the same `WindowsLoop::create` -> `SpawnSyncEventLoop::init` -> `spawn_maybe_sync` path the POSIX test exercises.
- The test uses an absolute `/bin/sh` so PATH lookup does not run: on musl `which_for_spawn` fails with ENOENT under EMFILE before the loop is created.
- On Linux with 0 spare fds the first failing call is `epoll_create1`, with 1 spare it is `eventfd`. The error names `epoll_create1` on Linux, `kqueue` on macOS/FreeBSD, `uv_loop_init` on Windows. The real errno is not propagated through the NULL return.
- The Windows early return frees the `uv::Pipe` allocations in `extra_fds` (`WindowsStdio` has no `Drop`).
- macOS `us_internal_create_async` now frees `cb`, `machport_buf`, the receive right, and the send right's dead name on each `mach_port_*` failure.
- #39641 changes the same three POSIX sites to report EMFILE/ENFILE through `handle_root_error` (fatal, exit 1). If it lands first those hunks need a merge; the `libuv.c` NULL check and the spawnSync plumbing are independent of it.
- Rebased onto main 2026-08-26. One conflict in `spawn_maybe_sync`: main dropped the `main_loop` argument from `SpawnSyncEventLoop::cleanup` and renamed `IS_SYNC` to `is_sync`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts:
52 |       env: bunEnv,
53 |       stdout: "pipe",
54 |       stderr: "pipe",
55 |     });
56 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
57 |     expect(stdout).toBe("");
                        ^
error: expect(received).toBe(expected)

- ""
+ "<bun_crash_handler::draft::rust_panic_hook as core::ops::function::Fn<(&std::panic::PanicHookInfo,)>>::call
+ /root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:79:5
+ 
+ <alloc::boxed::Box<dyn for<'a, 'b> core::ops::function::Fn<(&'a std::panic::PanicHookInfo<'b>,), Output = ()> + core::marker::Sync + core::marker::Send> as core::ops::function::Fn<(&std::panic::PanicHookInfo,)>>::call
+ /root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:2335:9
+ 
+ std::pan
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (2d3dc00fe)

test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts:
(pass) Bun.spawnSync event-loop creation under EMFILE > throws instead of aborting the process [11.31ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [94.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts:
(pass) Bun.spawnSync event-loop creation under EMFILE > throws instead of aborting the process [656.37ms]

 1 pass
 0 fail
 5 expect() calls
Ran 1 test across 1 file. [2.73s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 632ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] cc obj/packages/bun-usockets/src/bsd.c.o
[2/26] cc obj/packages/bun-usockets/src/context.c.o
[3/26] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[4/26] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[5/26] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[6/26] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[7/26] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[8/26] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[9/26] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[10/26] cc obj/packages/bun-usockets/src/fault_inject.c.o
[11/26] cc obj/packages/bun-usockets/src/loop.c.o
[12/26] cxx obj/src/jsc/bindings/bindings.cpp.o
[13/26] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[14/26] cc obj/packages/bun-usockets/src/socket.c.o
[15/26] cc obj/packages/bun-usockets/src/quic.c.o
[16/26] cc obj/packages/bun-usockets/src/udp.c.o
[17/26] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[18/26] cxx obj/unified/UnifiedSource-src_j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/eventing/epoll_kqueue.c  | 61 +++++++++++++--------
 packages/bun-usockets/src/eventing/libuv.c         |  8 ++-
 packages/bun-usockets/src/internal/internal.h      |  8 +--
 packages/bun-usockets/src/loop.c                   | 12 ++++-
 packages/bun-uws/src/Loop.h                        | 12 ++++-
 src/event_loop/SpawnSyncEventLoop.rs               | 21 ++++----
 src/jsc/rare_data.rs                               | 16 ++++--
 src/runtime/api/bun/js_bun_spawn_bindings.rs       | 38 +++++++++++--
 src/uws_sys/Loop.rs                                | 13 ++---
 .../js/bun/spawn/spawn-sync-loop-init-fail.test.ts | 63 ++++++++++++++++++++++
 10 files changed, 197 insertions(+), 55 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
packages/bun-usockets/src/eventing/epoll_kqueue.c        5      7      0
packages/bun-usockets/src/eventing/libuv.c               3      5      0
packages/bun-usockets/src/internal/internal.h            1      1      0
packages/bun-usockets/src/loop.c                         2      3      0
packages/bun-uws/src/Loop.h                              2      2      0
src/event_loop/SpawnSyncEventLoop.rs                     4      4      0
src/jsc/rare_data.rs                                     3      5      0
src/runtime/api/bun/js_bun_spawn_bindings.rs             8      9      0
src/uws_sys/Loop.rs                                      2      2      0
test/js/bun/spawn/spawn-sync-loop-init-fail.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->