### PR TITLE
node:http: drain already-written response bytes when the peer half-closes

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -663,9 +663,18 @@ private:
         size_t bufferedAmount = asyncSocket->getBufferedAmount();
         if (bufferedAmount > 0) {
             /* Try to flush pending data from the socket's buffer to the network */
-            asyncSocket->flush();
+            size_t flushed = asyncSocket->flush();
             /* Check if there's still data waiting to be sent after flush attempt */
             if (asyncSocket->getBufferedAmount() > 0) {
+                if constexpr (IsNodeHttp) {
+                    /* onEnd deferred close for these bytes; a writable event that
+                     * moves nothing (EPIPE) means the peer is gone and this would
+                     * otherwise spin onWritable/onEnd until idle timeout. */
+                    if (flushed == 0
+                        && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)) {
+                        return asyncSocket->close();
+                    }
+                }
                 /* Socket buffer is not completely empty yet
                 * - Reset the timeout to prevent premature connection closure
                 * - This allows time for another writable event or new request

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -733,9 +733,12 @@ private:
             if constexpr (IsNodeHttp) {
                 /* Node's socketOnEnd (!httpAllowHalfOpen) issues socket.end():
                  * once already-queued bytes have drained the connection shuts
-                 * down regardless of whether res.end() was ever called. */
+                 * down regardless of whether res.end() was ever called. A
+                 * re-armed onWritable (a 'drain' listener wrote again) means a
+                 * fresh pinned write that bufferedAmount does not count. */
                 if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)
-                    && !httpContextData->flags.httpAllowHalfOpen) {
+                    && !httpContextData->flags.httpAllowHalfOpen
+                    && httpResponseData->onWritable == nullptr) {
                     responseDone = true;
                 }
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -203,17 +203,17 @@ private:
          * so a client that connects and never sends anything still expires. */
         if constexpr (IsNodeHttp) {
             ((HttpResponseData<SSL, true> *) us_socket_ext(s))->lastMessageStartMs = nodeCompatMonotonicMs();
-            /* A peer FIN must not tear the connection down at the loop level:
-             * onEnd() below decides whether to close right away (idle) or to
-             * keep writing the responses that are still in flight / pipelined
-             * (Node's socketOnEnd semantics). Without this flag the loop
-             * force-closes the socket right after dispatching onEnd. TLS
-             * (openssl.c us_internal_ssl_on_end) does not consult this flag
-             * and force-closes on FIN regardless, so this half of the compat
-             * block is http-only for now. */
-            if constexpr (!SSL) {
-                s->flags.allow_half_open = 1;
-            }
+        }
+
+        /* A peer FIN must not tear the connection down at the loop level:
+         * onEnd() below decides whether to close right away (idle) or to keep
+         * writing response bytes that are already queued (and for node:http
+         * compat, in-flight / pipelined responses). Without this flag the loop
+         * force-closes the socket right after dispatching onEnd. TLS
+         * (openssl.c us_internal_ssl_on_end) does not consult this flag and
+         * force-closes on FIN regardless, so this is http-only for now. */
+        if constexpr (!SSL) {
+            s->flags.allow_half_open = 1;
         }
 
         if(!SSL) {
@@ -666,14 +666,12 @@ private:
             size_t flushed = asyncSocket->flush();
             /* Check if there's still data waiting to be sent after flush attempt */
             if (asyncSocket->getBufferedAmount() > 0) {
-                if constexpr (IsNodeHttp) {
-                    /* onEnd deferred close for these bytes; a writable event that
-                     * moves nothing (EPIPE) means the peer is gone and this would
-                     * otherwise spin onWritable/onEnd until idle timeout. */
-                    if (flushed == 0
-                        && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)) {
-                        return asyncSocket->close();
-                    }
+                /* onEnd deferred close for these bytes; a writable event that
+                 * moves nothing (EPIPE) means the peer is gone and this would
+                 * otherwise spin onWritable/onEnd until idle timeout. */
+                if (flushed == 0
+                    && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)) {
+                    return asyncSocket->close();
                 }
                 /* Socket buffer is not completely empty yet
                 * - Reset the timeout to prevent premature connection closure
@@ -759,6 +757,7 @@ private:
     template <bool IsNodeHttp>
     static us_socket_t *onEnd(us_socket_t *s) {
         auto *asyncSocket = reinterpret_cast<AsyncSocket<SSL> *>(s);
+        HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
 
         /* node:http compat: an EOF in the middle of a request head is a parse error.
          * Node calls parser.finish() when the socket ends and surfaces it as
@@ -766,7 +765,6 @@ private:
          * (if anything) to write and when to destroy the connection. */
         if constexpr (IsNodeHttp) {
             HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
-            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
 
             /* CONNECT/Upgrade tunnels allow half-open: the peer finishing its
              * writable side ends the JS socket's readable side ('end' event) but
@@ -791,23 +789,24 @@ private:
                 }
             }
 
-            /* Node's socketOnEnd: with httpAllowHalfOpen, in-flight and queued
+            /* Node's socketOnEnd with httpAllowHalfOpen: in-flight and queued
              * responses keep writing (Node marks the last one `_last` so
-             * resOnFinish destroySoon()s after it). Without it, Node does
-             * `socket.end()`, which drains bytes already handed to the socket
-             * before FIN. Either way, response bytes already queued
-             * (AsyncSocketData::buffer, or a pinned write an onWritable
-             * callback is still draining) must not be discarded by the close()
-             * below; the connection shuts down from the shouldCloseConnection()
-             * gates once they have flushed. */
-            bool hasQueuedOutgoing = asyncSocket->getBufferedAmount() > 0
-                || httpResponseData->onWritable != nullptr;
-            bool responseInFlight = httpResponseData->nodeHttpQueuedPipelinedCount > 0
-                || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING);
-            if (hasQueuedOutgoing || (httpContextData->flags.httpAllowHalfOpen && responseInFlight)) {
+             * resOnFinish destroySoon()s after it). */
+            if (httpContextData->flags.httpAllowHalfOpen
+                && (httpResponseData->nodeHttpQueuedPipelinedCount > 0
+                    || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING))) {
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN;
                 return s;
             }
+        }
+
+        /* Response bytes already queued (AsyncSocketData::buffer, or a pinned
+         * write / streaming body an onWritable callback is still draining) must
+         * not be discarded by the close() below; the connection shuts down from
+         * the shouldCloseConnection() gates once they have flushed. */
+        if (asyncSocket->getBufferedAmount() > 0 || httpResponseData->onWritable != nullptr) {
+            httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN;
+            return s;
         }
 
         asyncSocket->uncorkWithoutSending();

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -791,12 +791,12 @@ private:
             /* Node's socketOnEnd: with httpAllowHalfOpen, in-flight and queued
              * responses keep writing (Node marks the last one `_last` so
              * resOnFinish destroySoon()s after it). Without it, Node does
-             * `socket.end()` — no new writes, but bytes already handed to the
-             * socket via res.write() drain before FIN. Either way, response
-             * bytes already queued (AsyncSocketData::buffer, or a pinned write
-             * an onWritable callback is still draining) must not be discarded
-             * by the close() below; the connection shuts down from the
-             * shouldCloseConnection() gates once they have flushed. */
+             * `socket.end()`, which drains bytes already handed to the socket
+             * before FIN. Either way, response bytes already queued
+             * (AsyncSocketData::buffer, or a pinned write an onWritable
+             * callback is still draining) must not be discarded by the close()
+             * below; the connection shuts down from the shouldCloseConnection()
+             * gates once they have flushed. */
             bool hasQueuedOutgoing = asyncSocket->getBufferedAmount() > 0
                 || httpResponseData->onWritable != nullptr;
             bool responseInFlight = httpResponseData->nodeHttpQueuedPipelinedCount > 0

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -720,14 +720,21 @@ private:
 
         /* Should we close this connection after a response - and is this response really done? */
         if (httpResponseData->shouldCloseConnection()) {
-            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                if (asyncSocket->getBufferedAmount() == 0) {
-
-                    asyncSocket->shutdown();
-                    /* We need to force close after sending FIN since we want to hinder
-                     * clients from keeping to send their huge data */
-                    asyncSocket->close();
+            bool responseDone = (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0;
+            if constexpr (IsNodeHttp) {
+                /* Node's socketOnEnd (!httpAllowHalfOpen) issues socket.end():
+                 * once already-queued bytes have drained the connection shuts
+                 * down regardless of whether res.end() was ever called. */
+                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)
+                    && !httpContextData->flags.httpAllowHalfOpen) {
+                    responseDone = true;
                 }
+            }
+            if (responseDone && asyncSocket->getBufferedAmount() == 0) {
+                asyncSocket->shutdown();
+                /* We need to force close after sending FIN since we want to hinder
+                 * clients from keeping to send their huge data */
+                asyncSocket->close();
             }
         }
 
@@ -772,15 +779,20 @@ private:
                 }
             }
 
-            /* Node's socketOnEnd: if !server.httpAllowHalfOpen (the default),
-             * end the socket right away — an in-flight response is dropped
-             * exactly like Node does. If httpAllowHalfOpen is set, keep the
-             * connection open so in-flight and queued responses can still be
-             * written; it is shut down once the pipeline has drained (the
-             * shouldCloseConnection() checks on response completion). */
-            if (httpContextData->flags.httpAllowHalfOpen
-                && (httpResponseData->nodeHttpQueuedPipelinedCount > 0
-                    || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING))) {
+            /* Node's socketOnEnd: with httpAllowHalfOpen, in-flight and queued
+             * responses keep writing (Node marks the last one `_last` so
+             * resOnFinish destroySoon()s after it). Without it, Node does
+             * `socket.end()` — no new writes, but bytes already handed to the
+             * socket via res.write() drain before FIN. Either way, response
+             * bytes already queued (AsyncSocketData::buffer, or a pinned write
+             * an onWritable callback is still draining) must not be discarded
+             * by the close() below; the connection shuts down from the
+             * shouldCloseConnection() gates once they have flushed. */
+            bool hasQueuedOutgoing = asyncSocket->getBufferedAmount() > 0
+                || httpResponseData->onWritable != nullptr;
+            bool responseInFlight = httpResponseData->nodeHttpQueuedPipelinedCount > 0
+                || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING);
+            if (hasQueuedOutgoing || (httpContextData->flags.httpAllowHalfOpen && responseInFlight)) {
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN;
                 return s;
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -203,17 +203,17 @@ private:
          * so a client that connects and never sends anything still expires. */
         if constexpr (IsNodeHttp) {
             ((HttpResponseData<SSL, true> *) us_socket_ext(s))->lastMessageStartMs = nodeCompatMonotonicMs();
-        }
-
-        /* A peer FIN must not tear the connection down at the loop level:
-         * onEnd() below decides whether to close right away (idle) or to keep
-         * writing response bytes that are already queued (and for node:http
-         * compat, in-flight / pipelined responses). Without this flag the loop
-         * force-closes the socket right after dispatching onEnd. TLS
-         * (openssl.c us_internal_ssl_on_end) does not consult this flag and
-         * force-closes on FIN regardless, so this is http-only for now. */
-        if constexpr (!SSL) {
-            s->flags.allow_half_open = 1;
+            /* A peer FIN must not tear the connection down at the loop level:
+             * onEnd() below decides whether to close right away (idle) or to
+             * keep writing the responses that are still in flight / pipelined
+             * (Node's socketOnEnd semantics). Without this flag the loop
+             * force-closes the socket right after dispatching onEnd. TLS
+             * (openssl.c us_internal_ssl_on_end) does not consult this flag
+             * and force-closes on FIN regardless, so this half of the compat
+             * block is http-only for now. */
+            if constexpr (!SSL) {
+                s->flags.allow_half_open = 1;
+            }
         }
 
         if(!SSL) {
@@ -666,12 +666,14 @@ private:
             size_t flushed = asyncSocket->flush();
             /* Check if there's still data waiting to be sent after flush attempt */
             if (asyncSocket->getBufferedAmount() > 0) {
-                /* onEnd deferred close for these bytes; a writable event that
-                 * moves nothing (EPIPE) means the peer is gone and this would
-                 * otherwise spin onWritable/onEnd until idle timeout. */
-                if (flushed == 0
-                    && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)) {
-                    return asyncSocket->close();
+                if constexpr (IsNodeHttp) {
+                    /* onEnd deferred close for these bytes; a writable event that
+                     * moves nothing (EPIPE) means the peer is gone and this would
+                     * otherwise spin onWritable/onEnd until idle timeout. */
+                    if (flushed == 0
+                        && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN)) {
+                        return asyncSocket->close();
+                    }
                 }
                 /* Socket buffer is not completely empty yet
                 * - Reset the timeout to prevent premature connection closure
@@ -757,7 +759,6 @@ private:
     template <bool IsNodeHttp>
     static us_socket_t *onEnd(us_socket_t *s) {
         auto *asyncSocket = reinterpret_cast<AsyncSocket<SSL> *>(s);
-        HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
 
         /* node:http compat: an EOF in the middle of a request head is a parse error.
          * Node calls parser.finish() when the socket ends and surfaces it as
@@ -765,6 +766,7 @@ private:
          * (if anything) to write and when to destroy the connection. */
         if constexpr (IsNodeHttp) {
             HttpContextData<SSL> *httpContextData = getSocketContextDataS(s);
+            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
 
             /* CONNECT/Upgrade tunnels allow half-open: the peer finishing its
              * writable side ends the JS socket's readable side ('end' event) but
@@ -789,24 +791,23 @@ private:
                 }
             }
 
-            /* Node's socketOnEnd with httpAllowHalfOpen: in-flight and queued
+            /* Node's socketOnEnd: with httpAllowHalfOpen, in-flight and queued
              * responses keep writing (Node marks the last one `_last` so
-             * resOnFinish destroySoon()s after it). */
-            if (httpContextData->flags.httpAllowHalfOpen
-                && (httpResponseData->nodeHttpQueuedPipelinedCount > 0
-                    || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING))) {
+             * resOnFinish destroySoon()s after it). Without it, Node does
+             * `socket.end()`, which drains bytes already handed to the socket
+             * before FIN. Either way, response bytes already queued
+             * (AsyncSocketData::buffer, or a pinned write an onWritable
+             * callback is still draining) must not be discarded by the close()
+             * below; the connection shuts down from the shouldCloseConnection()
+             * gates once they have flushed. */
+            bool hasQueuedOutgoing = asyncSocket->getBufferedAmount() > 0
+                || httpResponseData->onWritable != nullptr;
+            bool responseInFlight = httpResponseData->nodeHttpQueuedPipelinedCount > 0
+                || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING);
+            if (hasQueuedOutgoing || (httpContextData->flags.httpAllowHalfOpen && responseInFlight)) {
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN;
                 return s;
             }
-        }
-
-        /* Response bytes already queued (AsyncSocketData::buffer, or a pinned
-         * write / streaming body an onWritable callback is still draining) must
-         * not be discarded by the close() below; the connection shuts down from
-         * the shouldCloseConnection() gates once they have flushed. */
-        if (asyncSocket->getBufferedAmount() > 0 || httpResponseData->onWritable != nullptr) {
-            httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_RECEIVED_FIN;
-            return s;
         }
 
         asyncSocket->uncorkWithoutSending();

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -131,10 +131,13 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * and everything after the end of the message is opaque data for the
          * 'upgrade' listener's socket. */
         HTTP_NODE_TUNNEL_AFTER_BODY = 1 << 14,
-        /* The peer half-closed (FIN) while pipelined responses were still queued
-         * behind the in-flight one. Like Node's http server, the connection stays
-         * open so those responses can still be written; it is shut down once the
-         * pipeline has drained (see shouldCloseConnection()). */
+        /* The peer half-closed (FIN) while there was still something to flush
+         * before teardown: buffered/pinned response bytes, or (with
+         * httpAllowHalfOpen) an in-flight or queued pipelined response. The
+         * connection is shut down from the shouldCloseConnection()/onWritable
+         * gates once those have drained. Without httpAllowHalfOpen, onWritable
+         * forces the close as soon as the buffer has flushed (Node's
+         * socketOnEnd -> socket.end()). */
         HTTP_NODE_RECEIVED_FIN = 1 << 15,
         /* NodeHttpResponseData::nodeHttpResponseTrailers is non-empty. Mirrored
          * into the shared word so the shared response-end path (internalEnd) never

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1822,19 +1822,17 @@ impl NodeHTTPResponse {
 
         // Partial pinned progress: return false so onWritable's close gate
         // waits (bufferedAmount does not count the pinned tail). Zero progress
-        // after the peer's FIN mirrors the `flushed == 0 && RECEIVED_FIN`
-        // close in HttpContext::onWritable: drop and disarm so the gate can
-        // close. Zero progress without FIN (SSL WANT_READ, ENOBUFS) retries.
+        // after the peer's FIN is handed to the buffered path (spill) so the
+        // sibling `flushed == 0 && RECEIVED_FIN` close in HttpContext::
+        // onWritable decides; without FIN (SSL WANT_READ, ENOBUFS) retries.
         let pinned_before = self.pending_pinned_write.get().remaining.len();
         if self.drain_pending_pinned_write(response) {
             if self.pending_pinned_write.get().remaining.len() < pinned_before {
                 return false;
             }
-            if !response.state().is_node_received_fin() {
-                return true;
+            if response.state().is_node_received_fin() {
+                self.spill_pending_pinned_write(self.server.global_this());
             }
-            self.clear_pending_pinned_write(self.server.global_this(), JSValue::ZERO);
-            response.clear_on_writable();
             return true;
         }
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1820,9 +1820,13 @@ impl NodeHTTPResponse {
             return false;
         }
 
-        // Finish any zero-copy write before telling JS we're drained.
+        // Finish any zero-copy write before telling JS we're drained. While
+        // bytes are still outstanding return `false` (the uWS onWritable
+        // contract's "write failed") so HttpContext::onWritable waits for the
+        // next writable event instead of evaluating its close gate against a
+        // bufferedAmount that does not count the pinned tail.
         if self.drain_pending_pinned_write(response) {
-            return true;
+            return false;
         }
 
         response.corked(|| self.on_drain_corked(offset));

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1820,22 +1820,16 @@ impl NodeHTTPResponse {
             return false;
         }
 
-        // Finish any zero-copy write before telling JS we're drained. While
-        // bytes are still outstanding return `false` (the uWS onWritable
-        // contract's "write failed") so HttpContext::onWritable waits for the
-        // next writable event instead of evaluating its close gate against a
-        // bufferedAmount that does not count the pinned tail. Zero progress on
-        // a writable event means send() is failing (EPIPE): returning `false`
-        // would spin this callback, so fall through to the close gate instead.
+        // Partial pinned progress: return false so onWritable's close gate
+        // waits (bufferedAmount does not count the pinned tail). Zero progress
+        // on a writable event is EPIPE: fall through so the gate can close.
         let pinned_before = self.pending_pinned_write.get().remaining.len();
         if self.drain_pending_pinned_write(response) {
             return self.pending_pinned_write.get().remaining.len() >= pinned_before;
         }
 
-        // Drained (or nothing was pinned): disarm the native callback so
-        // HttpContext::onEnd's `onWritable != nullptr` check does not mistake
-        // this stale shim for a pending write. callOnWritable borrowed the slot
-        // and would otherwise restore it; a later backpressured write re-arms.
+        // Drained: disarm so onEnd's `onWritable != nullptr` probe does not see
+        // a stale shim (callOnWritable would restore it); writes re-arm.
         response.clear_on_writable();
         response.corked(|| self.on_drain_corked(offset));
         // return true means we may have something to drain

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1822,12 +1822,16 @@ impl NodeHTTPResponse {
 
         // Partial pinned progress: return false so onWritable's close gate
         // waits (bufferedAmount does not count the pinned tail). Zero progress
-        // on a writable event is EPIPE: drop the tail and disarm so the gate
-        // can close instead of spinning this callback.
+        // after the peer's FIN mirrors the `flushed == 0 && RECEIVED_FIN`
+        // close in HttpContext::onWritable: drop and disarm so the gate can
+        // close. Zero progress without FIN (SSL WANT_READ, ENOBUFS) retries.
         let pinned_before = self.pending_pinned_write.get().remaining.len();
         if self.drain_pending_pinned_write(response) {
             if self.pending_pinned_write.get().remaining.len() < pinned_before {
                 return false;
+            }
+            if !response.state().is_node_received_fin() {
+                return true;
             }
             self.clear_pending_pinned_write(self.server.global_this(), JSValue::ZERO);
             response.clear_on_writable();

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1822,10 +1822,16 @@ impl NodeHTTPResponse {
 
         // Partial pinned progress: return false so onWritable's close gate
         // waits (bufferedAmount does not count the pinned tail). Zero progress
-        // on a writable event is EPIPE: fall through so the gate can close.
+        // on a writable event is EPIPE: drop the tail and disarm so the gate
+        // can close instead of spinning this callback.
         let pinned_before = self.pending_pinned_write.get().remaining.len();
         if self.drain_pending_pinned_write(response) {
-            return self.pending_pinned_write.get().remaining.len() >= pinned_before;
+            if self.pending_pinned_write.get().remaining.len() < pinned_before {
+                return false;
+            }
+            self.clear_pending_pinned_write(self.server.global_this(), JSValue::ZERO);
+            response.clear_on_writable();
+            return true;
         }
 
         // Drained: disarm so onEnd's `onWritable != nullptr` probe does not see

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1829,6 +1829,11 @@ impl NodeHTTPResponse {
             return false;
         }
 
+        // Drained (or nothing was pinned): disarm the native callback so
+        // HttpContext::onEnd's `onWritable != nullptr` check does not mistake
+        // this stale shim for a pending write. callOnWritable borrowed the slot
+        // and would otherwise restore it; a later backpressured write re-arms.
+        response.clear_on_writable();
         response.corked(|| self.on_drain_corked(offset));
         // return true means we may have something to drain
         true

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1824,9 +1824,12 @@ impl NodeHTTPResponse {
         // bytes are still outstanding return `false` (the uWS onWritable
         // contract's "write failed") so HttpContext::onWritable waits for the
         // next writable event instead of evaluating its close gate against a
-        // bufferedAmount that does not count the pinned tail.
+        // bufferedAmount that does not count the pinned tail. Zero progress on
+        // a writable event means send() is failing (EPIPE): returning `false`
+        // would spin this callback, so fall through to the close gate instead.
+        let pinned_before = self.pending_pinned_write.get().remaining.len();
         if self.drain_pending_pinned_write(response) {
-            return false;
+            return self.pending_pinned_write.get().remaining.len() >= pinned_before;
         }
 
         // Drained (or nothing was pinned): disarm the native callback so

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -1005,6 +1005,7 @@ bitflags::bitflags! {
         const HTTP_RESPONSE_PENDING            = 8;
         const HTTP_CONNECTION_CLOSE            = 16;
         const HTTP_WROTE_CONTENT_LENGTH_HEADER = 32;
+        const HTTP_NODE_RECEIVED_FIN           = 1 << 15;
     }
 }
 
@@ -1037,6 +1038,11 @@ impl State {
     #[inline]
     pub fn is_http_connection_close(self) -> bool {
         self.bits() & State::HTTP_CONNECTION_CLOSE.bits() != 0
+    }
+
+    #[inline]
+    pub fn is_node_received_fin(self) -> bool {
+        self.bits() & State::HTTP_NODE_RECEIVED_FIN.bits() != 0
     }
 }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3513,41 +3513,6 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
   });
 });
 
-// A client that half-closes its write side right after the request (the raw
-// socket.end(request) pattern) must receive every response byte already queued,
-// not just what the kernel accepted on the first send.
-it("a client FIN right after the request does not truncate a large response body", async () => {
-  const BODY = 8 * 1024 * 1024;
-  using server = serve({
-    port: 0,
-    fetch: () => new Response(Buffer.alloc(BODY, "a"), { headers: { "content-length": String(BODY) } }),
-  });
-  const socket = connect(server.port, "127.0.0.1");
-  let body = 0;
-  let head = "";
-  let gotHead = false;
-  let ended = false;
-  socket.on("data", chunk => {
-    if (!gotHead) {
-      head += chunk.toString("latin1");
-      const i = head.indexOf("\r\n\r\n");
-      if (i >= 0) {
-        gotHead = true;
-        body = Buffer.byteLength(head.slice(i + 4), "latin1");
-      }
-    } else {
-      body += chunk.length;
-    }
-  });
-  socket.on("end", () => (ended = true));
-  socket.on("error", () => {});
-  const closed = new Promise<void>(r => socket.once("close", () => r()));
-  await new Promise<void>(r => socket.once("connect", () => r()));
-  socket.end("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-  await closed;
-  expect({ body, ended }).toEqual({ body: BODY, ended: true });
-});
-
 // The node:http compat parser tolerates empty lines (and a bare CR/LF) before the
 // request-line like llhttp's s_start state. That leniency must stay behind the
 // node-http flag: Bun.serve still rejects a request that does not begin with the

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3513,6 +3513,41 @@ it("survives aborted uploads while responding with a tee()d request-body branch"
   });
 });
 
+// A client that half-closes its write side right after the request (the raw
+// socket.end(request) pattern) must receive every response byte already queued,
+// not just what the kernel accepted on the first send.
+it("a client FIN right after the request does not truncate a large response body", async () => {
+  const BODY = 8 * 1024 * 1024;
+  using server = serve({
+    port: 0,
+    fetch: () => new Response(Buffer.alloc(BODY, "a"), { headers: { "content-length": String(BODY) } }),
+  });
+  const socket = connect(server.port, "127.0.0.1");
+  let body = 0;
+  let head = "";
+  let gotHead = false;
+  let ended = false;
+  socket.on("data", chunk => {
+    if (!gotHead) {
+      head += chunk.toString("latin1");
+      const i = head.indexOf("\r\n\r\n");
+      if (i >= 0) {
+        gotHead = true;
+        body = Buffer.byteLength(head.slice(i + 4), "latin1");
+      }
+    } else {
+      body += chunk.length;
+    }
+  });
+  socket.on("end", () => (ended = true));
+  socket.on("error", () => {});
+  const closed = new Promise<void>(r => socket.once("close", () => r()));
+  await new Promise<void>(r => socket.once("connect", () => r()));
+  socket.end("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+  await closed;
+  expect({ body, ended }).toEqual({ body: BODY, ended: true });
+});
+
 // The node:http compat parser tolerates empty lines (and a bare CR/LF) before the
 // request-line like llhttp's s_start state. That leniency must stay behind the
 // node-http flag: Bun.serve still rejects a request that does not begin with the

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -190,6 +190,28 @@ describe("backpressure", () => {
       const { body, ended } = await halfCloseRequestBodyBytes(server);
       expect({ body, ended }).toEqual({ body: BODY, ended: true });
     });
+
+    // A 'drain' listener that writes again after the first chunk has flushed
+    // re-arms onWritable; the !httpAllowHalfOpen close gate must not fire over
+    // the freshly-pinned bytes (bufferedAmount does not count them). Node
+    // rejects the second write (socketOnEnd already called socket.end()); Bun
+    // currently accepts and drains it. Both are consistent: the client sees
+    // either the first write only, or both, never a torn second write.
+    it("res.write() from 'drain' after client FIN is not torn mid-write", async () => {
+      await using server = http.createServer((req, res) => {
+        res.writeHead(200, { "Content-Length": String(BODY * 2) });
+        res.write(payload);
+        res.once("drain", () => {
+          res.write(payload);
+          res.end();
+        });
+        res.on("error", () => {});
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body, ended } = await halfCloseRequestBodyBytes(server);
+      expect(ended).toBe(true);
+      expect([BODY, BODY * 2]).toContain(body);
+    });
   });
 
   it("should handle backpressure with INT_MAX bytes", async () => {

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -172,14 +172,17 @@ describe("backpressure", () => {
     }
 
     it.each([
-      ["res.write() then res.end()", false, true],
-      ["res.write() without res.end()", false, false],
-      ["res.write() then res.end(), httpAllowHalfOpen", true, true],
-    ] as const)("%s", async (_name, halfOpen, callEnd) => {
+      ["res.write() then res.end()", false, "sync"],
+      ["res.write() without res.end()", false, "never"],
+      // httpAllowHalfOpen: the close gate must wait for the handler's own
+      // res.end() after drain, not force-close on the !httpAllowHalfOpen term.
+      ["res.write() then res.end() after drain, httpAllowHalfOpen", true, "drain"],
+    ] as const)("%s", async (_name, halfOpen, endMode) => {
       await using server = http.createServer((req, res) => {
         res.writeHead(200, { "Content-Length": String(BODY) });
         res.write(payload);
-        if (callEnd) res.end();
+        if (endMode === "sync") res.end();
+        else if (endMode === "drain") res.once("drain", () => res.end());
       });
       if (halfOpen) server.httpAllowHalfOpen = true;
       await once(server.listen(0, "127.0.0.1"), "listening");

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -136,6 +136,58 @@ describe("backpressure", () => {
     });
   });
 
+  // Node's socketOnEnd: with httpAllowHalfOpen=false (the default) it issues
+  // socket.end(), with it true it marks the last response `_last` so resOnFinish
+  // destroySoon()s. Either way, bytes already handed to the socket via
+  // res.write() drain before the connection shuts down; the client half-closing
+  // right after its request must not truncate them.
+  describe("a client FIN right after the request does not truncate a response that is still flushing", () => {
+    const BODY = 8 * 1024 * 1024;
+    const payload = Buffer.alloc(BODY, "a");
+
+    async function halfCloseRequestBodyBytes(server: http.Server): Promise<{ body: number; ended: boolean }> {
+      const port = (server.address() as AddressInfo).port;
+      const socket = net.connect(port, "127.0.0.1");
+      let body = 0;
+      let head = "";
+      let gotHead = false;
+      let ended = false;
+      socket.on("data", chunk => {
+        if (!gotHead) {
+          head += chunk.toString("latin1");
+          const i = head.indexOf("\r\n\r\n");
+          if (i >= 0) {
+            gotHead = true;
+            body = Buffer.byteLength(head.slice(i + 4), "latin1");
+          }
+        } else {
+          body += chunk.length;
+        }
+      });
+      socket.on("end", () => (ended = true));
+      await once(socket, "connect");
+      socket.end("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+      await once(socket, "close");
+      return { body, ended };
+    }
+
+    it.each([
+      ["res.write() then res.end()", false, true],
+      ["res.write() without res.end()", false, false],
+      ["res.write() then res.end(), httpAllowHalfOpen", true, true],
+    ] as const)("%s", async (_name, halfOpen, callEnd) => {
+      await using server = http.createServer((req, res) => {
+        res.writeHead(200, { "Content-Length": String(BODY) });
+        res.write(payload);
+        if (callEnd) res.end();
+      });
+      if (halfOpen) server.httpAllowHalfOpen = true;
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body, ended } = await halfCloseRequestBodyBytes(server);
+      expect({ body, ended }).toEqual({ body: BODY, ended: true });
+    });
+  });
+
   it("should handle backpressure with INT_MAX bytes", async () => {
     const totalSize = 1024 * 1024 * 1024 * 2; // 2^31, one past INT_MAX
     const chunk = Buffer.alloc(64 * 1024 * 1024, "a");

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -165,6 +165,7 @@ describe("backpressure", () => {
         }
       });
       socket.on("end", () => (ended = true));
+      socket.on("error", () => {});
       await once(socket, "connect");
       socket.end("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
       await once(socket, "close");


### PR DESCRIPTION
### Problem

```js
const server = http.createServer((req, res) => {
  res.writeHead(200, { 'Content-Length': String(BIG.length) });
  res.write(BIG);   // 8 MiB
  res.end();
});
// raw net client does: c.end('GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n')
// node: body bytes 8388608
// bun:  body bytes 2621440 (truncated at the first kernel send), then connection drops
```

A raw-socket client that sends its request with `socket.end(...)` (half-closes its write side) receives only what the kernel accepted on the first `send()`; the rest of the response body is dropped. Same result without `res.end()`, and for `server.httpAllowHalfOpen = true`.

Debug trace at onEnd: `state=0x77 buf=5767168 pipelined=0` (res.end called, HTTP_RESPONSE_PENDING cleared, 5.8 MiB still in AsyncSocketData::buffer) or `state=0x7b buf=0` (no res.end, pinned write held in `NodeHTTPResponse::pending_pinned_write`); in both cases the half-open gate does not hold and the fall-through `asyncSocket->close()` discards the unsent bytes.

### Cause

`HttpContext::onEnd<true>` only defers close for `httpAllowHalfOpen && (HTTP_RESPONSE_PENDING || pipelined)`; the fall-through close runs even when `AsyncSocketData::buffer` (or a zero-copy `res.write()` tail being drained via the onWritable callback) still holds response bytes. Node's `socketOnEnd` issues `socket.end()`, which in Node's single-Writable model queues FIN behind every byte already handed to `res.write()`, so nothing is dropped.

### Fix

* `onEnd<true>`: also defer close while `getBufferedAmount() > 0` or an onWritable callback is armed (covers the pinned tail). The connection is shut down from the existing `shouldCloseConnection()` gates once those bytes have flushed.
* `onWritable<true>`'s close gate: with `!httpAllowHalfOpen` and the peer's FIN received, shut the socket down once the buffer has drained even if `res.end()` was never called (Node's `socket.end()` semantics). A writable event that moves zero bytes after FIN (EPIPE, peer gone) closes immediately so the deferred connection does not spin between onWritable and onEnd.
* `NodeHTTPResponse::on_drain`: return `false` only while a pinned drain made partial progress (so onWritable waits instead of evaluating its close gate against a `bufferedAmount` that does not count the pinned tail); zero progress falls through to the close gate, and once drained the native callback is disarmed so onEnd does not read a stale shim as pending output.

`Bun.serve` is unaffected (the new close-gate terms are `if constexpr (IsNodeHttp)`).

### Verification

New `describe.each` in `test/js/node/http/node-http-backpressure.test.ts` covers three variants (default + end, default + no end, httpAllowHalfOpen + delayed end-after-drain); all three receive 2621440 bytes on main and the full 8 MiB with the fix, matching Node.js. `node-http-backpressure.test.ts`, `node-http-pinned-write.test.ts`, `node-http-server-socket-end-drain.test.ts`, `test-http-server.js`, `test-http-1.0.js` pass; the EPIPE spin showed up first as `node-http-uaf.test.ts` timing out in CI build 77357 and is eliminated by the zero-progress close.

### Relation to #35027

\#35027 is the `req.socket.end()` initiator (server-side JS triggers the FIN); this PR is the peer-FIN initiator (client half-closes after its request). Different triggers, no file conflicts beyond the `onWritable` close-gate hunk both touch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-backpressure.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/63] gen cpp.rs (cppbind)
[2/63] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/63] gen JS modules (bundle-modules)
Preprocess modules (9420ms)
Bundle modules (60ms)
Postprocesss modules (35ms)
Bundle Functions (683ms)
Generate Code (9ms)

[10.23s] Bundled "src/js" for development
  2210 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/50] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[37/50] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-15.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings_webcore-15.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -g3 -gz=zstd -glldb -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -f
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (95ba710ed)

test/js/node/http/node-http-backpressure.test.ts:
(pass) backpressure > should handle backpressure [14.69ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the client requested the close [24.12ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the server sets Connection: close on a keep-alive request [21.54ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the whole body is passed to res.end() [12.22ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() then res.end() [8.84ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() without res.end() [8.88ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() then res.end() after drain, httpAllowHalfOpen [7.14ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-backpressure.test.ts
bun test v1.4.0 (afac658ca)

test/js/node/http/node-http-backpressure.test.ts:
(pass) backpressure > should handle backpressure [496.43ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the client requested the close [425.44ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the server sets Connection: close on a keep-alive request [239.88ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the whole body is passed to res.end() [249.10ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() then res.end() [237.24ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() without res.end() [163.07ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     afac658ca8
  features     baseline

22 deps, 106 codegen, 1169 objects in 671ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (95ba710ed)

Checked 124 installs across 170 packages (no changes) [6.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (95ba710ed)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (95ba710ed)

Checked 129 installs across 147 packages (no changes) [4.00ms]
[4/1231] gen ErrorCode+*.h
[5/1231] gen bindgenv2
[6/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1231] fetch picohttpparser
[picohttpparser] up to date
[8/1231] fetch zlib
[zlib] up to date
[9/1231] fetch tinycc
[tinycc] up to date
[10/1230] gen .bind.ts → GeneratedBindings.cpp
[11/1230] subst deps/zlib/zlib.h
[12/1230] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Proc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpContext.h               | 58 ++++++++++++------
 packages/bun-uws/src/HttpResponseData.h          | 11 ++--
 src/runtime/server/NodeHTTPResponse.rs           | 16 ++++-
 src/uws_sys/Response.rs                          |  6 ++
 test/js/node/http/node-http-backpressure.test.ts | 78 ++++++++++++++++++++++++
 5 files changed, 147 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
packages/bun-uws/src/HttpContext.h                   14     16      0
packages/bun-uws/src/HttpResponseData.h               2      1      0
src/runtime/server/NodeHTTPResponse.rs               17     14      0
src/uws_sys/Response.rs                               2      2      0
test/js/node/http/node-http-backpressure.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->