### PR TITLE
test(install): deflake SCP-style git URL test in bun-add.test.ts

### DIFF
--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1630,7 +1630,7 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
     stderr: stderr1,
     exited: exited1,
   } = spawn({
-    cmd: [bunExe(), "add", "bun@github.com:mishoo/UglifyJS.git"],
+    cmd: [bunExe(), "add", "bun@github.com:dylan-conway/install-test2.git"],
     cwd: package_dir,
     stdout: "pipe",
     stdin: "pipe",
@@ -1646,43 +1646,29 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(out1.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
     expect.stringContaining("bun add v1."),
     "",
-    "installed uglify-js@git+ssh://bun@github.com:mishoo/UglifyJS.git with binaries:",
-    " - uglifyjs",
+    "installed install-test2@git+ssh://bun@github.com:dylan-conway/install-test2.git",
     "",
     "1 package installed",
   ]);
   expect(await exited1).toBe(0);
   expect(urls.sort()).toBeEmpty();
   expect(requested).toBe(0);
-  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
-    join("..", "uglify-js", "bin", "uglifyjs"),
-  );
-  expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");
-  expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
+  expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".cache", "install-test2"]);
+  expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("998078e703122291.git");
+  expect(await readdirSorted(join(package_dir, "node_modules", "install-test2"))).toEqual([
     ".bun-tag",
-    ".gitattributes",
-    ".github",
-    ".gitignore",
-    "CONTRIBUTING.md",
-    "LICENSE",
-    "README.md",
-    "bin",
-    "lib",
+    "index.js",
     "package.json",
-    "test",
-    "tools",
   ]);
-  const package_json = await file(join(package_dir, "node_modules", "uglify-js", "package.json")).json();
-  expect(package_json.name).toBe("uglify-js");
+  const package_json = await file(join(package_dir, "node_modules", "install-test2", "package.json")).json();
+  expect(package_json.name).toBe("install-test2");
   expect(await file(join(package_dir, "package.json")).text()).toEqual(
     JSON.stringify(
       {
         name: "foo",
         version: "0.0.1",
         dependencies: {
-          "uglify-js": "bun@github.com:mishoo/UglifyJS.git",
+          "install-test2": "bun@github.com:dylan-conway/install-test2.git",
         },
       },
       null,
@@ -1714,7 +1700,7 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(await exited2).toBe(0);
   expect(urls.sort()).toBeEmpty();
   expect(requested).toBe(0);
-}, 20000);
+});
 
 it("should not save git urls twice", async () => {
   const urls: string[] = [];
@@ -1757,7 +1743,7 @@ it("should not save git urls twice", async () => {
   expect(package_json_content2.dependencies).toEqual({
     "test-repo": "https://github.com/liz3/empty-bun-repo",
   });
-}, 20000);
+});
 
 it("should prefer optionalDependencies over dependencies of the same name", async () => {
   const urls: string[] = [];


### PR DESCRIPTION
## Problem

`should handle Git URL in dependencies (SCP-style)` in `test/cli/install/bun-add.test.ts` intermittently fails on darwin x64:

```
✗ should handle Git URL in dependencies (SCP-style) [20003.21ms]
  ^ this test timed out after 20000ms.

Received: "Resolving dependencies\nfatal: early EOF\nerror: git failed with signal 15\n...git@bun@github.com: Permission denied (publickey)..."
```

## Cause

The test performs a real `git clone --bare https://bun@github.com/mishoo/UglifyJS.git` (~20MB) against github.com with an explicit `20000` ms timeout. That override was added in #3048 back when the file-level default was 5s; the file now sets `setDefaultTimeout(1000 * 60 * 5)`, so the explicit `20000` is actually a reduction from the default.

On a loaded CI box the clone occasionally exceeds 20s. The test timeout SIGTERMs the git process (`signal 15`), bun install treats the HTTPS attempt as failed and falls back to SSH, and SSH fails with `Permission denied (publickey)` because the CI machine has no github SSH keys. The stderr assertion then fires as an "unhandled error between tests" because the test body has already been marked timed out.

## Fix

- Switch the test repo from `mishoo/UglifyJS` (~20MB bare clone) to `dylan-conway/install-test2` (tiny, clones in <1s), which is already used by other install tests. The SCP-style `user@host:path` parsing path with a non-`git` user is exercised identically.
- Drop the stale `, 20000)` overrides on this test and the adjacent `should not save git urls twice` so they use the 5-minute file default like every other git-dependency test in the file.

## Verification

```
$ bun bd test test/cli/install/bun-add.test.ts
...
(pass) should handle Git URL in dependencies (SCP-style) [624.36ms]
(pass) should not save git urls twice [670.83ms]
...
 54 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->