### PR TITLE
Bun.serve: deliver the in-flight response when a pipelined request arrives while it is still pending

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -360,8 +360,9 @@ private:
                 if (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) {
                     httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
                     httpResponseData->isConnectRequest = false;
-                    ((HttpResponse<SSL> *) s)->resetTimeout();
+                    /* HttpResponse::pause() also does timeout(0); re-arm after. */
                     ((HttpResponse<SSL> *) s)->pause();
+                    ((HttpResponse<SSL> *) s)->resetTimeout();
                     return s;
                 }
             }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -395,13 +395,10 @@ private:
             /* node:http compat: the request arrived while an earlier response on
              * this connection is still in flight.
              * (For !IsNodeHttp, HTTP_RESPONSE_PENDING was handled above and
-             * hasQueuedPipelinedResponses stays false, so this branch is never
-             * taken; the else runs.) */
+             * hasQueuedPipelinedResponses stays false, so the else runs.) */
             bool hasQueuedPipelinedResponses = false;
             if constexpr (IsNodeHttp) hasQueuedPipelinedResponses = httpResponseData->nodeHttpQueuedPipelinedCount > 0;
             if (IsNodeHttp && ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) || hasQueuedPipelinedResponses)) {
-                if constexpr (IsNodeHttp) {
-
                 /* node:http supports async pipelining: the request is dispatched
                  * while the previous response is still in flight and the JS layer
                  * queues its response (res.socket === null until it becomes the
@@ -420,7 +417,6 @@ private:
                 if (((AsyncSocket<SSL> *) s)->getBufferedAmount() > 0) {
                     httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_READS_PAUSED;
                     ((HttpResponse<SSL> *) s)->pause();
-                }
                 }
             } else {
                 /* Reset httpResponse */

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -374,8 +374,19 @@ private:
             if constexpr (IsNodeHttp) hasQueuedPipelinedResponses = httpResponseData->nodeHttpQueuedPipelinedCount > 0;
             if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) || hasQueuedPipelinedResponses) {
                 if constexpr (!IsNodeHttp) {
-                    us_socket_close((us_socket_t *) s, 0, nullptr);
-                    return nullptr;
+                    /* Bun.serve has one HttpResponseData per socket (no queue): drop
+                     * this request and mark the in-flight response for
+                     * connection-close so the socket closes once it drains. Closing
+                     * here would lose the in-flight response before it reaches the
+                     * wire (it is still in the cork buffer, or its body has not been
+                     * produced yet). RFC 9112 9.3.2: a pipelining client must be
+                     * prepared to retry unanswered requests on a new connection.
+                     * getHeaders() writes isConnectRequest via bool& for every
+                     * parsed request; reset it so a dropped CONNECT cannot switch
+                     * the in-flight response's socket into tunnel handling. */
+                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+                    httpResponseData->isConnectRequest = false;
+                    return s;
                 } else {
 
                 /* node:http supports async pipelining: the request is dispatched

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -358,7 +358,7 @@ private:
              * cannot switch the in-flight response into tunnel handling. */
             if constexpr (!IsNodeHttp) {
                 if (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) {
-                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_PIPELINED_DROP;
                     httpResponseData->isConnectRequest = false;
                     /* HttpResponse::pause() also does timeout(0); re-arm after. */
                     ((HttpResponse<SSL> *) s)->pause();
@@ -595,6 +595,19 @@ private:
             }
             if(httpContextData->onClientError) {
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
+            }
+            /* A parse error in bytes trailing a dropped pipelined request must
+             * not overwrite the in-flight response: its bytes have not reached
+             * the wire yet, so a 4xx here would be read as the answer to the
+             * first (valid) request. The drop path already marked the
+             * connection for close-after-drain and paused reads; leave the
+             * in-flight response to finish and close. */
+            if constexpr (!IsNodeHttp) {
+                if (httpResponseData->state & HttpResponseData<SSL>::HTTP_PIPELINED_DROP) {
+                    us_socket_unref(s);
+                    ((AsyncSocket<SSL> *) s)->uncork();
+                    return s;
+                }
             }
             /* For errors, we only deliver them "at most once". We don't care if they get halfways delivered or not. */
             us_socket_write(s, httpErrorResponses[httpErrorStatusCode].data(), (int) httpErrorResponses[httpErrorStatusCode].length());

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -393,14 +393,14 @@ private:
             }
 
             /* node:http compat: the request arrived while an earlier response on
-             * this connection is still in flight. */
+             * this connection is still in flight.
+             * (For !IsNodeHttp, HTTP_RESPONSE_PENDING was handled above and
+             * hasQueuedPipelinedResponses stays false, so this branch is never
+             * taken; the else runs.) */
             bool hasQueuedPipelinedResponses = false;
             if constexpr (IsNodeHttp) hasQueuedPipelinedResponses = httpResponseData->nodeHttpQueuedPipelinedCount > 0;
-            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) || hasQueuedPipelinedResponses) {
-                if constexpr (!IsNodeHttp) {
-                    /* unreachable: handled above before the timeout clear. */
-                    __builtin_unreachable();
-                } else {
+            if (IsNodeHttp && ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) || hasQueuedPipelinedResponses)) {
+                if constexpr (IsNodeHttp) {
 
                 /* node:http supports async pipelining: the request is dispatched
                  * while the previous response is still in flight and the JS layer

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -340,11 +340,35 @@ private:
         auto result = httpResponseData->template consumePostPadded<IsNodeHttp>(httpContextData->maxHeaderSize, httpResponseData->isConnectRequest, httpContextData->flags.requireHostHeader,httpContextData->flags.useStrictMethodValidation, httpContextData->flags.useInsecureHTTPParser, nodeHttpRequestTrailers, &httpResponseData->chunkedExtensionsByteCount, data, (unsigned int) length, s, proxyParser, [httpContextData](void *s, HttpRequest *httpRequest) -> void * {
 
 
+            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext((us_socket_t *) s);
+
+            /* Are we not ready for another request yet? Bun.serve has one
+             * HttpResponseData per socket (no queue): drop this request and
+             * mark the in-flight response for connection-close so the socket
+             * closes once it drains. Closing here would lose the in-flight
+             * response before it reaches the wire. RFC 9112 9.3.2: a
+             * pipelining client must be prepared to retry unanswered requests
+             * on a new connection.
+             * Runs before the timeout clear below so a dropped request cannot
+             * disarm the in-flight request's idleTimeout; pause() stops
+             * further segments so the connection cannot be held open by a
+             * pipelined flood or a dropped request's body bytes that extend
+             * past this segment. getHeaders() writes isConnectRequest via
+             * bool& for every parsed request; reset it so a dropped CONNECT
+             * cannot switch the in-flight response into tunnel handling. */
+            if constexpr (!IsNodeHttp) {
+                if (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) {
+                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+                    httpResponseData->isConnectRequest = false;
+                    ((HttpResponse<SSL> *) s)->resetTimeout();
+                    ((HttpResponse<SSL> *) s)->pause();
+                    return s;
+                }
+            }
+
             /* For every request we reset the timeout and hang until user makes action */
             /* Warning: if we are in shutdown state, resetting the timer is a security issue! */
             us_socket_timeout((us_socket_t *) s, 0);
-
-            HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext((us_socket_t *) s);
 
             /* node:http compat: the JS layer stopped HTTP processing on this
              * connection (the user emitted 'close' on the socket - Node frees
@@ -367,26 +391,14 @@ private:
                 nodeHttpResponseData->headersCompleted = true;
             }
 
-            /* Are we not ready for another request yet? Terminate the connection.
-             * Important for denying async pipelining until, if ever, we want to support it.
-             * Otherwise requests can get mixed up on the same connection. We still support sync pipelining. */
+            /* node:http compat: the request arrived while an earlier response on
+             * this connection is still in flight. */
             bool hasQueuedPipelinedResponses = false;
             if constexpr (IsNodeHttp) hasQueuedPipelinedResponses = httpResponseData->nodeHttpQueuedPipelinedCount > 0;
             if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) || hasQueuedPipelinedResponses) {
                 if constexpr (!IsNodeHttp) {
-                    /* Bun.serve has one HttpResponseData per socket (no queue): drop
-                     * this request and mark the in-flight response for
-                     * connection-close so the socket closes once it drains. Closing
-                     * here would lose the in-flight response before it reaches the
-                     * wire (it is still in the cork buffer, or its body has not been
-                     * produced yet). RFC 9112 9.3.2: a pipelining client must be
-                     * prepared to retry unanswered requests on a new connection.
-                     * getHeaders() writes isConnectRequest via bool& for every
-                     * parsed request; reset it so a dropped CONNECT cannot switch
-                     * the in-flight response's socket into tunnel handling. */
-                    httpResponseData->state |= HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
-                    httpResponseData->isConnectRequest = false;
-                    return s;
+                    /* unreachable: handled above before the timeout clear. */
+                    __builtin_unreachable();
                 } else {
 
                 /* node:http supports async pipelining: the request is dispatched

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -126,14 +126,12 @@ public:
             /* We can only write the header once */
             if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_END_CALLED))) {
 
-                /* RFC 9112 9.6: a server that does not support persistence
-                 * SHOULD send Connection: close in its final response. The
-                 * HTTP_CONNECTION_CLOSE bit alone does not mean the client
-                 * already knows (the pipelined-drop path sets it on a
-                 * keep-alive client), so write the header whenever headers
-                 * have not been terminated yet. END_CALLED above is the
-                 * write-once guard. */
-                if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
+                /* HTTP 1.1 must send this back unless the client already sent it to us.
+                * It is a connection close when either of the two parties say so but the
+                * one party must tell the other one so.
+                *
+                * This check also serves to limit writing the header only once. */
+                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) == 0 && !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
                     writeHeader("Connection", "close");
                 }
 

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -835,9 +835,9 @@ public:
         if (!Super::isCorked()) {
             LoopData *loopData = Super::getLoopData();
             /* Captured before handler(): an upgrade inside the handler moves
-             * the socket to the WebSocket group, after which
-             * getSocketContextDataS(this) no longer points at HttpContextData. */
-            HttpContextData<SSL> *httpContextData = HttpContext<SSL>::getSocketContextDataS((us_socket_t *) this);
+             * the socket to the WebSocket group (in-place) or marks the old
+             * allocation closed (reallocated). */
+            us_socket_group_t *httpGroup = us_socket_group((us_socket_t *) this);
             Super::cork();
             handler();
 
@@ -849,12 +849,15 @@ public:
              * The upgrade case is handled by HttpContext's uncork or the drain
              * loop. */
             if (loopData->findCorkSlot(this) == LoopData::INVALID_CORK_SLOT) {
-                /* (b) and (c) only happen while onData is parsing; (a) from an
-                 * async handler completing outside onData lands here via
-                 * internalEnd()'s uncork with a connection-close mark nothing
-                 * else acts on (onData's post-parse close check is not on the
-                 * stack). */
-                if (!httpContextData->flags.isParsingHttp) {
+                /* (a) from an async handler completing outside this socket's
+                 * onData (which corks it, so that socket takes the else branch
+                 * below) lands here via internalEnd()'s uncork with a
+                 * connection-close mark nothing else acts on. For (b) the ext
+                 * is still HttpResponseData and PENDING is still set; for (c)
+                 * the group changed (in-place adopt) or this allocation was
+                 * marked closed (reallocated adopt). */
+                if (!us_socket_is_closed((us_socket_t *) this)
+                    && us_socket_group((us_socket_t *) this) == httpGroup) {
                     HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
                     if (httpResponseData->shouldCloseConnection()
                         && (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -834,6 +834,10 @@ public:
     HttpResponse *cork(MoveOnlyFunction<void()> &&handler) {
         if (!Super::isCorked()) {
             LoopData *loopData = Super::getLoopData();
+            /* Captured before handler(): an upgrade inside the handler moves
+             * the socket to the WebSocket group, after which
+             * getSocketContextDataS(this) no longer points at HttpContextData. */
+            HttpContextData<SSL> *httpContextData = HttpContext<SSL>::getSocketContextDataS((us_socket_t *) this);
             Super::cork();
             handler();
 
@@ -845,6 +849,20 @@ public:
              * The upgrade case is handled by HttpContext's uncork or the drain
              * loop. */
             if (loopData->findCorkSlot(this) == LoopData::INVALID_CORK_SLOT) {
+                /* (b) and (c) only happen while onData is parsing; (a) from an
+                 * async handler completing outside onData lands here via
+                 * internalEnd()'s uncork with a connection-close mark nothing
+                 * else acts on (onData's post-parse close check is not on the
+                 * stack). */
+                if (!httpContextData->flags.isParsingHttp) {
+                    HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+                    if (httpResponseData->shouldCloseConnection()
+                        && (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0
+                        && ((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
+                        ((AsyncSocket<SSL> *) this)->shutdown();
+                        ((AsyncSocket<SSL> *) this)->close();
+                    }
+                }
                 return this;
             }
 

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -187,8 +187,10 @@ public:
             }
             httpResponseData->markDone(this);
 
-            /* We need to check if we should close this socket here now */
-            if (!Super::isCorked()) {
+            /* keepCorked=true (only upgrade()) means the caller is adopting the
+             * socket right after this returns; closing here would destruct the
+             * ext block out from under it. */
+            if (!keepCorked && !Super::isCorked()) {
                 if (httpResponseData->shouldCloseConnection()) {
                     if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
                         if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
@@ -253,8 +255,10 @@ public:
             if (httpResponseData->offset == totalSize) {
                 httpResponseData->markDone(this);
 
-                /* We need to check if we should close this socket here now */
-                if (!Super::isCorked()) {
+                /* keepCorked=true (only upgrade()) means the caller is adopting
+                 * the socket right after this returns; closing here would
+                 * destruct the ext block out from under it. */
+                if (!keepCorked && !Super::isCorked()) {
                     if (httpResponseData->shouldCloseConnection()) {
                         if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
                             if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
@@ -366,6 +370,10 @@ public:
 
         /* Grab the httpContext from res */
         HttpContext<SSL> *httpContext = HttpContext<SSL>::fromSocket((struct us_socket_t *) this);
+
+        /* A pipelined request dropped behind this handshake may have paused
+         * reads; the adopted WebSocket needs them. No-op if not paused. */
+        Super::resume();
 
         /* Move any backpressure out of HttpResponse */
         auto* responseData = getHttpResponseData();

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -126,12 +126,14 @@ public:
             /* We can only write the header once */
             if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_END_CALLED))) {
 
-                /* HTTP 1.1 must send this back unless the client already sent it to us.
-                * It is a connection close when either of the two parties say so but the
-                * one party must tell the other one so.
-                *
-                * This check also serves to limit writing the header only once. */
-                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) == 0 && !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
+                /* RFC 9112 9.6: a server that does not support persistence
+                 * SHOULD send Connection: close in its final response. The
+                 * HTTP_CONNECTION_CLOSE bit alone does not mean the client
+                 * already knows (the pipelined-drop path sets it on a
+                 * keep-alive client), so write the header whenever headers
+                 * have not been terminated yet. END_CALLED above is the
+                 * write-once guard. */
+                if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
                     writeHeader("Connection", "close");
                 }
 

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -140,6 +140,14 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * into the shared word so the shared response-end path (internalEnd) never
          * has to touch the node-only field. */
         HTTP_NODE_HAS_RESPONSE_TRAILERS = 1 << 16,
+        /* A pipelined request arrived while the previous Bun.serve response was
+         * still pending and was dropped: the connection closes after the
+         * in-flight response drains. Distinct from HTTP_CONNECTION_CLOSE so the
+         * Connection: close header-write guards (internalEnd,
+         * uws_res_end_without_body) still fire; those guards key off
+         * HTTP_CONNECTION_CLOSE meaning "the client already knows / a caller
+         * already wrote it". */
+        HTTP_PIPELINED_DROP = 1 << 17,
 
         /* Bits that describe the connection rather than the response in flight.
          * There is one HttpResponseData per socket, reused by every request on a
@@ -210,7 +218,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     /* Whether the connection should be torn down once the in-flight response (if
      * any) has completed and all buffered outgoing data has been flushed. */
     bool shouldCloseConnection() const {
-        return (state & HTTP_CONNECTION_CLOSE)
+        return (state & (HTTP_CONNECTION_CLOSE | HTTP_PIPELINED_DROP))
             || ((state & HTTP_NODE_RECEIVED_FIN) && nodeHttpQueuedPipelinedCount == 0);
     }
 

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -1005,6 +1005,7 @@ bitflags::bitflags! {
         const HTTP_RESPONSE_PENDING            = 8;
         const HTTP_CONNECTION_CLOSE            = 16;
         const HTTP_WROTE_CONTENT_LENGTH_HEADER = 32;
+        const HTTP_PIPELINED_DROP              = 1 << 17;
     }
 }
 
@@ -1036,7 +1037,7 @@ impl State {
 
     #[inline]
     pub fn is_http_connection_close(self) -> bool {
-        self.bits() & State::HTTP_CONNECTION_CLOSE.bits() != 0
+        self.bits() & (State::HTTP_CONNECTION_CLOSE.bits() | State::HTTP_PIPELINED_DROP.bits()) != 0
     }
 }
 

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1209,7 +1209,8 @@ const server = Bun.serve({
 });
 
 const socket = connect({ port: server.port, host: "127.0.0.1" });
-await new Promise(r => socket.once("connect", r));
+socket.on("error", () => {});
+await new Promise((resolve, reject) => { socket.once("connect", resolve); socket.once("error", reject); });
 // Two pipelined requests in one TCP segment.
 socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\nGET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
 let data = "";

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1187,3 +1187,64 @@ test("file route serves a burst of concurrent requests after reloads", async () 
   const a = await fetch(`${server.url}a`).then(r => r.text());
   expect(a).toBe("a-new");
 });
+
+// On POSIX, FileResponseStream reads a regular file with a blocking read()
+// inside the request handler, so the response is complete before the parser
+// moves on to the second pipelined request. On Windows the read goes to the
+// libuv threadpool and completes on a later loop tick, so the second request
+// is parsed while HTTP_RESPONSE_PENDING is still set. The in-flight response
+// must still reach the wire; the pipelined request may be dropped with the
+// connection closing afterwards (RFC 9112 9.3.2) or, like on POSIX, served.
+test("Bun.file route answers pipelined HTTP/1.1 requests without dropping the in-flight response", async () => {
+  using dir = tempDir("serve-file-pipelined", {
+    "hello.txt": "hello",
+    "fixture.ts": /* ts */ `
+import { connect } from "node:net";
+import { join } from "node:path";
+
+const server = Bun.serve({
+  port: 0,
+  routes: { "/": new Response(Bun.file(join(import.meta.dir, "hello.txt"))) },
+  fetch: () => new Response("fallback"),
+});
+
+const socket = connect({ port: server.port, host: "127.0.0.1" });
+await new Promise(r => socket.once("connect", r));
+// Two pipelined requests in one TCP segment.
+socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\nGET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+let data = "";
+socket.on("data", chunk => {
+  data += chunk;
+  // POSIX keeps the connection open (both served synchronously); end from the
+  // client once the first response body is on the wire so both platforms
+  // converge.
+  if (data.includes("hello")) socket.end();
+});
+await new Promise(r => socket.once("close", r));
+
+const firstLine = data.slice(0, data.indexOf("\\r\\n"));
+const responses = data.split("HTTP/1.1 ").length - 1;
+console.log(JSON.stringify({ firstLine, body: data.includes("hello"), responses }));
+server.stop(true);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result.firstLine).toBe("HTTP/1.1 200 OK");
+  expect(result.body).toBe(true);
+  // At least one full response. POSIX serves both (sync file read); Windows
+  // serves the first and closes.
+  expect(result.responses).toBeGreaterThanOrEqual(1);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -1239,12 +1239,14 @@ server.stop(true);
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  const result = JSON.parse(stdout.trim());
-  expect(result.firstLine).toBe("HTTP/1.1 200 OK");
-  expect(result.body).toBe(true);
+  const result = JSON.parse(stdout.trim() || "{}");
+  expect({ firstLine: result.firstLine, body: result.body, stderr, exitCode }).toEqual({
+    firstLine: "HTTP/1.1 200 OK",
+    body: true,
+    stderr: "",
+    exitCode: 0,
+  });
   // At least one full response. POSIX serves both (sync file read); Windows
   // serves the first and closes.
   expect(result.responses).toBeGreaterThanOrEqual(1);
-  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3094,6 +3094,9 @@ describe("pipelined request behind an async fetch handler", () => {
         "GET /b HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
     );
     expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+    // RFC 9112 9.6: the final response on a connection the server is closing
+    // SHOULD carry Connection: close so the client knows not to wait for more.
+    expect(wire).toMatch(/^connection:\s*close\r$/im);
     expect(wire).toContain("FIRST");
     // The pipelined request is dropped without dispatch; only the first handler runs.
     expect(wire).not.toContain("SECOND");

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3053,6 +3053,44 @@ server.listen(0, "127.0.0.1", () => {
   expect(exitCode).toBe(0);
 });
 
+// uWS has one HttpResponseData per socket, so a request that arrives while the
+// previous fetch handler is still producing its response cannot be dispatched
+// (async pipelining). The in-flight response must still reach the wire; the
+// socket closes once it drains and the client retries the dropped request on a
+// new connection (RFC 9112 9.3.2). Previously the socket was hard-closed with
+// the cork buffer discarded, so zero bytes were written.
+it("delivers the in-flight response when a pipelined request arrives behind an async fetch handler", async () => {
+  let calls = 0;
+  await using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      calls++;
+      await new Promise(r => setImmediate(r));
+      return new Response(new URL(req.url).pathname === "/a" ? "FIRST" : "SECOND");
+    },
+  });
+
+  const wire = await new Promise<string>((resolve, reject) => {
+    const socket = net.connect(server.port!, "127.0.0.1");
+    let data = "";
+    socket.on("connect", () => {
+      socket.write(
+        "GET /a HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n" +
+          "GET /b HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
+      );
+    });
+    socket.on("data", chunk => (data += chunk));
+    socket.on("close", () => resolve(data));
+    socket.on("error", reject);
+  });
+
+  expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+  expect(wire).toContain("FIRST");
+  // The pipelined request is dropped without dispatch; only the first handler runs.
+  expect(wire).not.toContain("SECOND");
+  expect(calls).toBe(1);
+});
+
 it("only serves /bun:info to loopback clients in development mode", async () => {
   using server = Bun.serve({
     port: 0,

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3117,6 +3117,21 @@ describe("pipelined request behind an async fetch handler", () => {
     expect(wire).not.toContain("SECOND");
     expect(calls).toBe(1);
   });
+
+  // A parse error in the dropped request's bytes (here, an invalid chunked
+  // size) must not write a 4xx ahead of the in-flight response: its bytes have
+  // not reached the wire yet, so a 4xx would be read as the first request's
+  // answer and onClose would abort it.
+  it("still delivers the in-flight response when the dropped request's bytes are malformed", async () => {
+    const { wire, calls } = await pipelined(
+      "GET /a HTTP/1.1\r\nHost: x\r\n\r\n" +
+        "POST /b HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\nZZ\r\n",
+    );
+    expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(wire).toContain("FIRST");
+    expect(wire).not.toMatch(/HTTP\/1\.1 4\d\d/);
+    expect(calls).toBe(1);
+  });
 });
 
 it("only serves /bun:info to loopback clients in development mode", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3059,36 +3059,61 @@ server.listen(0, "127.0.0.1", () => {
 // socket closes once it drains and the client retries the dropped request on a
 // new connection (RFC 9112 9.3.2). Previously the socket was hard-closed with
 // the cork buffer discarded, so zero bytes were written.
-it("delivers the in-flight response when a pipelined request arrives behind an async fetch handler", async () => {
-  let calls = 0;
-  await using server = Bun.serve({
-    port: 0,
-    async fetch(req) {
-      calls++;
-      await new Promise(r => setImmediate(r));
-      return new Response(new URL(req.url).pathname === "/a" ? "FIRST" : "SECOND");
-    },
-  });
-
-  const wire = await new Promise<string>((resolve, reject) => {
-    const socket = net.connect(server.port!, "127.0.0.1");
-    let data = "";
-    socket.on("connect", () => {
-      socket.write(
-        "GET /a HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n" +
-          "GET /b HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
-      );
+describe("pipelined request behind an async fetch handler", () => {
+  // idleTimeout: 0 so a regression in the close-after-drain path cannot be
+  // masked by the idle timer closing the socket.
+  async function pipelined(segment: string): Promise<{ wire: string; calls: number }> {
+    let calls = 0;
+    await using server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      async fetch(req) {
+        calls++;
+        await new Promise(r => setImmediate(r));
+        return new Response(new URL(req.url).pathname === "/a" ? "FIRST" : "SECOND");
+      },
     });
-    socket.on("data", chunk => (data += chunk));
-    socket.on("close", () => resolve(data));
-    socket.on("error", reject);
+    const wire = await new Promise<string>((resolve, reject) => {
+      const socket = net.connect(server.port!, "127.0.0.1");
+      let data = "";
+      socket.on("connect", () => socket.write(segment));
+      socket.on("data", chunk => (data += chunk));
+      socket.on("close", () => resolve(data));
+      socket.on("error", reject);
+      socket.setTimeout(3000, () => {
+        socket.destroy();
+        reject(new Error("server did not close the connection after draining"));
+      });
+    });
+    return { wire, calls };
+  }
+
+  it("delivers the in-flight response and closes for pipelined GETs", async () => {
+    const { wire, calls } = await pipelined(
+      "GET /a HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n" +
+        "GET /b HTTP/1.1\r\nHost: x\r\nConnection: keep-alive\r\n\r\n",
+    );
+    expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(wire).toContain("FIRST");
+    // The pipelined request is dropped without dispatch; only the first handler runs.
+    expect(wire).not.toContain("SECOND");
+    expect(calls).toBe(1);
   });
 
-  expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
-  expect(wire).toContain("FIRST");
-  // The pipelined request is dropped without dispatch; only the first handler runs.
-  expect(wire).not.toContain("SECOND");
-  expect(calls).toBe(1);
+  // The dropped request may carry a body; its Content-Length must not let a
+  // third pipelined request reach the handler once the connection is marked
+  // for close.
+  it("drops a pipelined POST body and a third pipelined request", async () => {
+    const { wire, calls } = await pipelined(
+      "GET /a HTTP/1.1\r\nHost: x\r\n\r\n" +
+        "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello" +
+        "GET /c HTTP/1.1\r\nHost: x\r\n\r\n",
+    );
+    expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(wire).toContain("FIRST");
+    expect(wire).not.toContain("SECOND");
+    expect(calls).toBe(1);
+  });
 });
 
 it("only serves /bun:info to loopback clients in development mode", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3124,8 +3124,7 @@ describe("pipelined request behind an async fetch handler", () => {
   // answer and onClose would abort it.
   it("still delivers the in-flight response when the dropped request's bytes are malformed", async () => {
     const { wire, calls } = await pipelined(
-      "GET /a HTTP/1.1\r\nHost: x\r\n\r\n" +
-        "POST /b HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\nZZ\r\n",
+      "GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + "POST /b HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\nZZ\r\n",
     );
     expect(wire).toStartWith("HTTP/1.1 200 OK\r\n");
     expect(wire).toContain("FIRST");

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,7 +1,7 @@
 import type { Server, ServerWebSocket, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
 import { afterEach, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, forceGuardMalloc, isWindows } from "harness";
+import { bunEnv, bunExe, forceGuardMalloc, isWindows, tempDir } from "harness";
 import net, { isIP } from "node:net";
 import path from "node:path";
 
@@ -1562,3 +1562,61 @@ it.each(["server", "client"] as const)(
     await server.stop();
   },
 );
+
+// An HTTP request pipelined behind a WebSocket handshake in one TCP segment is
+// parsed while the handshake's async handler is still pending and marks the
+// connection for close. The later server.upgrade(req) must not let
+// internalEnd() act on that mark and close the socket mid-upgrade (onClose
+// destructs HttpResponseData; upgrade() would then read and destruct it
+// again). A partial third request populates the parser fallback buffer so the
+// double-destruct is an observable double-free under ASAN.
+it("async server.upgrade() survives a pipelined request behind the handshake", async () => {
+  using dir = tempDir("ws-async-upgrade-pipelined", {
+    "fixture.ts": /* ts */ `
+import { connect } from "node:net";
+
+const server = Bun.serve({
+  port: 0,
+  async fetch(req, server) {
+    await new Promise(r => setImmediate(r));
+    if (server.upgrade(req)) return;
+    return new Response("no");
+  },
+  websocket: { open(ws) { ws.send("hi"); }, message() {}, close() {} },
+});
+
+const socket = connect({ port: server.port, host: "127.0.0.1" });
+socket.on("error", () => {});
+await new Promise((resolve, reject) => { socket.once("connect", resolve); socket.once("error", reject); });
+socket.write(
+  "GET /ws HTTP/1.1\\r\\nHost: x\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\n" +
+  "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\\r\\nSec-WebSocket-Version: 13\\r\\n\\r\\n" +
+  "GET /b HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n" +
+  // Partial: lands in HttpParser::fallback so the ext block holds a heap alloc.
+  "GET /c HTTP/1.1\\r\\nHost: x\\r\\n",
+);
+let data = "";
+socket.on("data", d => { data += d.toString("latin1"); if (data.includes("\\r\\n\\r\\n")) socket.destroy(); });
+await new Promise(r => socket.once("close", r));
+
+const res = await fetch("http://127.0.0.1:" + server.port + "/alive");
+console.log(JSON.stringify({ firstLine: data.split("\\r\\n")[0], alive: res.status }));
+server.stop(true);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ out: stdout.trim(), stderr, exitCode }).toEqual({
+    out: JSON.stringify({ firstLine: "HTTP/1.1 101 Switching Protocols", alive: 200 }),
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
## Repro

On Windows, two pipelined HTTP/1.1 requests to a `Bun.file()` route in one TCP segment close the connection with zero bytes written. On any platform, the same happens with an async `fetch` handler:

```js
import { connect } from "node:net";
const s = Bun.serve({ port: 0, async fetch() {
  await new Promise(r => setImmediate(r));
  return new Response("hello");
}});
const sock = connect(s.port, "127.0.0.1", () => {
  sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\nGET / HTTP/1.1\r\nHost: x\r\n\r\n");
});
let buf = ""; sock.on("data", d => buf += d);
sock.on("close", () => console.log("len", buf.length));
// before: len 0
// after:  len 120 (first response, then close)
```

The Windows `Bun.file()` route case (`routes: { "/": new Response(Bun.file(p)) }`) is the same bug: on POSIX `FileResponseStream` reads a regular file synchronously inside the request handler, so the response completes before the parser moves on; on Windows the read goes to the libuv threadpool and completes on a later loop tick, so the second pipelined request is parsed while `HTTP_RESPONSE_PENDING` is still set.

## Cause

uWS has one `HttpResponseData` per socket. When a pipelined request is parsed while the previous response is still pending, the `!IsNodeHttp` branch in `HttpContext<SSL>::onData`'s per-request callback did:

```cpp
us_socket_close((us_socket_t *) s, 0, nullptr);
return nullptr;
```

The socket is still corked at that point, so the first response's bytes never reach the wire.

## Fix

**`HttpContext.h`**: mark the in-flight response for connection-close, re-arm its idleTimeout, and pause reads instead of closing. The pipelined request is dropped without dispatch; when the first handler eventually ends the response, the close-after-drain path shuts the socket down. RFC 9112 9.3.2: a pipelining client must be prepared to retry unanswered requests on a new connection. The check is hoisted above the per-request `us_socket_timeout(s, 0)` so a dropped request cannot disarm the idle timeout, and `pause()` stops further segments so a pipelined flood cannot keep extending it. Synchronous pipelining (handler responds before returning) is unchanged.

**`HttpResponse.h`**: two follow-throughs so the close mark is acted on and cannot corrupt an upgrade.

- `cork()` early-returned without running its close-after-drain check when the handler had already uncorked via `internalEnd()`; an async handler completing outside `onData` with the close mark would leave the socket open until idle timeout. The check now runs on that early-return when the socket is still in the HTTP group (excludes the WebSocket-upgrade case, per-socket).
- `internalEnd()`'s uncorked close check is gated on `!keepCorked`. Only `upgrade()` passes `keepCorked=true`; closing there would destruct `HttpResponseData` mid-`upgrade()` and double-free `HttpParser::fallback` (confirmed under ASAN). `upgrade()` also `resume()`s the socket so the adopted WebSocket can read after the drop path paused it.

The `IsNodeHttp` (node:http) branch already queues pipelined responses and is unchanged.

#32868 takes the same approach against the pre-`IsNodeHttp` `HttpContext.h` and conflicts with current main. #33664 goes further and buffers pipelined bytes to serve every request in order (full async pipelining for Bun.serve); it also conflicts with current main. This PR applies the minimal RFC-9112-conforming degradation to the current structure.

## Verification

New tests:

- `test/js/bun/http/serve.test.ts`: pipelined GETs behind an async fetch handler (first response delivered, second handler not called, socket closes), and pipelined POST-with-body plus a third request (all dropped past the first). `idleTimeout: 0` plus a bounded close-wait so a regression in the close-after-drain path is a named failure, not an idle-timeout pass.
- `test/js/bun/http/bun-serve-file.test.ts`: pipelined requests to a `Bun.file()` route. Before (Windows): `firstLine === ""`. After: at least the first response reaches the wire; POSIX still serves both (sync file read).
- `test/js/bun/websocket/websocket-server.test.ts`: WS handshake + pipelined GET + partial third request, async `server.upgrade()`. Before (with only the `HttpContext.h` change): ASAN double-free of `HttpParser::fallback`. After: upgrade succeeds and the server keeps answering.

Also ran: `serve.test.ts` (full), `bun-serve-file.test.ts` (full, Linux + Windows), `request-smuggling.test.ts`, `http-server-chunking.test.ts`, `bun-serve-headers.test.ts` (`Connection: close` cases), `bun-serve-static.test.ts`, `hspec.test.ts`, `websocket-server.test.ts`, `node-http.test.ts`, `test-http-keep-alive*.js`, `test-http-pipeline*.js`, `test-http-upgrade-server.js`. No new failures.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts test/js/bun/http/serve.test.ts test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->