### PR TITLE
bundler: honor onResolve `{ external: true }` with no path, and clear a stale source_index on external answers

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5087,6 +5087,8 @@ pub mod bv2_impl {
                                 .as_mut_slice()
                                 [resolve.import_record.import_record_index as usize];
                         import_record.path = path_as_static(&path);
+                        // The path map pass may have matched the source specifier to a module.
+                        import_record.source_index = Index::INVALID;
                     }
 
                     if let Some(source_index) = out_source_index {

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -441,15 +441,17 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
           throw new TypeError("onResolve plugins 'namespace' field must be a string if provided");
         }
 
+        if (typeof external !== "boolean" && !$isUndefinedOrNull(external)) {
+          throw new TypeError('onResolve plugins "external" field must be boolean or unspecified');
+        }
+
         if (!path) {
-          continue;
+          if (external) path = inputPath;
+          else continue;
         }
 
         if (!userNamespace) {
           userNamespace = inputNamespace;
-        }
-        if (typeof external !== "boolean" && !$isUndefinedOrNull(external)) {
-          throw new TypeError('onResolve plugins "external" field must be boolean or unspecified');
         }
 
         if (!external) {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -540,6 +540,23 @@ describe("bundler", () => {
       },
     });
   }
+  itBundled("plugin/ResolveExternalWithoutPath", {
+    files: {
+      "index.ts": /* ts */ `
+        import lodash from "lodash";
+        console.log(lodash);
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /^lodash$/ }, () => {
+        return { external: true };
+      });
+    },
+    onAfterBundle(api) {
+      const contents = api.readFile("/out.js");
+      expect(contents).toContain(`from "lodash"`);
+    },
+  });
   itBundled("plugin/ResolveOverrideFile", ({ root }) => {
     return {
       files: {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -557,6 +557,122 @@ describe("bundler", () => {
       expect(contents).toContain(`from "lodash"`);
     },
   });
+  itBundled("plugin/ResolveExternalSamePath", {
+    files: {
+      "index.ts": /* ts */ `
+        import React from "react";
+        console.log(React);
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /^react$/ }, args => {
+        return { path: args.path, external: true };
+      });
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toContain(`from "react"`);
+    },
+  });
+  // The path map is keyed by path text alone. Once the "virt" answer has put
+  // "react" in it, the map pass over late.js matches its import of "react" to the
+  // virt module before the plugin answers external for it. late.js is loaded
+  // only after the virt answer is queued, so that order is fixed. Released Bun
+  // keeps that match and prints `__INVALID__REF__` and `__toESM(, 1)`.
+  for (const [name, answer] of [
+    ["WithPath", (args: { path: string }) => ({ path: args.path, external: true })],
+    ["WithoutPath", () => ({ external: true })],
+  ] as const) {
+    itBundled(`plugin/ResolveExternalClearsModuleMatchedBySpecifier${name}`, () => {
+      const virtAnswered = Promise.withResolvers<void>();
+      return {
+        files: {
+          "/entry.js": /* js */ `
+            import { x } from "virt";
+            import "./late.js";
+            console.log(x);
+          `,
+          "/late.js": ``,
+        },
+        plugins(builder) {
+          builder.onResolve({ filter: /^virt$/ }, () => {
+            virtAnswered.resolve();
+            return { path: "react", namespace: "virt" };
+          });
+          builder.onLoad({ filter: /.*/, namespace: "virt" }, () => {
+            return { contents: `export const x = "x";`, loader: "js" };
+          });
+          builder.onResolve({ filter: /^react$/ }, answer);
+          builder.onLoad({ filter: /late\.js$/ }, async () => {
+            await virtAnswered.promise;
+            return { contents: `import React from "react"; console.log(React);`, loader: "js" };
+          });
+        },
+        onAfterBundle(api) {
+          const contents = api.readFile("/out.js");
+          expect(contents).toContain(`from "react"`);
+          expect(contents).toContain(`"x"`);
+          expect(contents).not.toContain(`__toESM(,`);
+          expect(contents).not.toContain(`__INVALID__REF__`);
+        },
+      };
+    });
+  }
+  // A barrel's records are resolved and patched again each time a consumer
+  // un-defers one of them. The rewritten external must survive both: it must
+  // not be resolved as the vendored specifier, and its path must not be matched
+  // against the bundled "virt" module that shares the same path text. late.js is
+  // loaded only after both answers are queued, so its un-defer of `a` runs after
+  // the rewrite landed.
+  itBundled("plugin/ResolveExternalRewriteSurvivesBarrelRevisit", () => {
+    const reactAnswered = Promise.withResolvers<void>();
+    const virtAnswered = Promise.withResolvers<void>();
+    return {
+      files: {
+        "/entry.js": /* js */ `
+          import { React, x } from "barrel";
+          import "./late.js";
+          console.log(React, x);
+        `,
+        "/late.js": ``,
+        "/node_modules/barrel/package.json": JSON.stringify({
+          name: "barrel",
+          main: "./index.js",
+          sideEffects: false,
+        }),
+        "/node_modules/barrel/index.js": /* js */ `
+          export { default as React } from "react";
+          export { x } from "virt";
+          export { a } from "./a.js";
+          export { b } from "./b.js";
+        `,
+        "/node_modules/barrel/a.js": `export const a = "a";`,
+        "/node_modules/barrel/b.js": `export const b = "b";`,
+      },
+      plugins(builder) {
+        builder.onResolve({ filter: /^react$/ }, () => {
+          reactAnswered.resolve();
+          return { path: "react-vendored", external: true };
+        });
+        builder.onResolve({ filter: /^virt$/ }, () => {
+          virtAnswered.resolve();
+          return { path: "react-vendored", namespace: "virt" };
+        });
+        builder.onLoad({ filter: /.*/, namespace: "virt" }, () => {
+          return { contents: `export const x = "x";`, loader: "js" };
+        });
+        builder.onLoad({ filter: /late\.js$/ }, async () => {
+          await Promise.all([reactAnswered.promise, virtAnswered.promise]);
+          return { contents: `import { a } from "barrel"; console.log(a);`, loader: "js" };
+        });
+      },
+      onAfterBundle(api) {
+        const contents = api.readFile("/out.js");
+        expect(contents).toContain(`from "react-vendored"`);
+        expect(contents).toContain(`"x"`);
+        expect(contents).not.toContain(`"react"`);
+      },
+    };
+  });
   itBundled("plugin/ResolveOverrideFile", ({ root }) => {
     return {
       files: {

--- a/test/regression/issue/29264.test.ts
+++ b/test/regression/issue/29264.test.ts
@@ -12,7 +12,13 @@ test("#29264 bundler survives external + missing imports in same file", { timeou
             {
               name: "mark-bare-external",
               setup(build) {
-                build.onResolve({ filter: /^[^.]/ }, () => ({ external: true }));
+                build.onResolve({ filter: /^[^.]/ }, args => {
+                  if (args.kind === "entry-point-build") return;
+                  if (args.path === "src") return { external: true };
+                  // "other": fall through to NoMatch -> run_resolver so the
+                  // unchecked import_records[..] access there is still
+                  // exercised against the error-path store (#29264).
+                });
               },
             },
           ],
@@ -27,6 +33,7 @@ test("#29264 bundler survives external + missing imports in same file", { timeou
     `,
     "index.js": /* js */ `
       import "src";
+      import "other";
       import "./src";
     `,
   });
@@ -43,11 +50,9 @@ test("#29264 bundler survives external + missing imports in same file", { timeou
 
   // Before the fix, the child crashed in Bun.build — segfault (release) or
   // index-out-of-bounds panic (debug/ASAN) — so "DONE:caught" never printed.
-  // We deliberately don't assert on the bare "src" import; whether the
-  // plugin's `{ external: true }` (with no `path`) falls through to a
-  // resolver error is plugin semantics, not what this test guards against.
   const combined = stdout + stderr;
   expect(combined).toContain("DONE:caught");
   expect(combined).toContain('Could not resolve: "./src"');
+  expect(combined).toContain('Could not resolve: "other"');
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- An `onResolve` answer of `{ external: true }` with no `path` is ignored. `runOnResolvePlugins` hits `if (!path) continue` (`src/js/builtins/BundlerPlugin.ts:444` on main), the native resolver runs, and the build fails with `Could not resolve: "lodash"`. esbuild keeps the import external under its original specifier.
- An external `onResolve` answer can leave the import linked to a bundled module. The path map is keyed by path text, and its pass in `patch_import_record_source_indices` runs while a plugin answer is pending. If an earlier answer bundled a module whose path text equals this import's specifier, the import gets that module's `source_index`, and the external arm of `on_resolve` (`src/bundler/bundle_v2.rs:5089` on main) never clears it. Released Bun prints `var __INVALID__REF__ = __commonJS(function(exports) {});` and `__toESM(, 1)`. The debug build asserts `!ref_.is_empty()` in `print_code_for_file_in_chunk_js`.

### Fix
- `runOnResolvePlugins` falls back to the input specifier when `external` is set and `path` is empty, and validates `external` before that check.
- The external arm of `on_resolve` sets `source_index = Index::INVALID` after it stores the returned path. An external record is one with no `source_index`, so this is the same invariant the arm already relies on.
- `test/regression/issue/29264.test.ts` relied on the old fall-through: its catch-all filter also answered for the entry point, which now reaches the entry point error. The plugin skips entry points, and a third bare import that the plugin declines keeps the `NoMatch -> run_resolver` path that #29264 guards live. Verified by commenting out the error-path store: the test panics in `run_resolver` again.
- Verified: `test/bundler/bundler_plugin.test.ts`, `plugin/ResolveExternalWithoutPath` and `plugin/ResolveExternalClearsModuleMatchedBySpecifier{WithPath,WithoutPath}` fail on main and pass here. Also `bundler_barrel`, `bundler_plugin_chain`, `bundler_edgecase`, `bake/dev/plugins`, `29264`, `40606`.

### Background
- `onResolve` answers run on the bundle thread as posted tasks, after `on_parse_task_complete` has stored the importer's records and run the path map pass over them. That pass gives every record whose `path.text` is a key in `path_to_source_index_map` a `source_index`. Bundled plugin answers insert their returned path text into that map.
- The printed path fix that this PR started as landed in #41230. What remains here is the no-path fallback and the `source_index` clear.

<details><summary>Notes</summary>

`ResolveExternalClearsModuleMatchedBySpecifier*`: `entry.js` imports `virt`, which the plugin bundles at path text `react` in namespace `virt`. `late.js` is loaded through `onLoad` only after that answer is queued, and imports `react`, which the plugin externalizes. So the map pass over `late.js` always sees `react` in the map. One variant answers `{ path: args.path, external: true }`, the other `{ external: true }`. Released Bun fails the first with the invalid output above and the second with `Could not resolve`.

`ResolveExternalSamePath` and `ResolveExternalRewriteSurvivesBarrelRevisit` pass on main. They pin cases that broke in earlier revisions of this PR: an answer that returns the specifier unchanged, and a rewritten external re-export in a `sideEffects: false` barrel that a later consumer un-defers, next to a bundled module that shares its path text. #39874 and #41230 cover both today.

History: this PR first carried the printed path fix, the entry point error, an `IS_EXTERNAL` flag, and a `PendingImport` enum. #39799 took the entry point error, #39874 made the flag unnecessary, #41230 took the path fix, and the enum only served a queue (`resolve_tasks_waiting_for_import_source_index`) that is not reached today, as #41230 notes. The branch was rebuilt on main with the two remaining fixes.

Earlier revisions linked issue 2805 by mistake. That issue is about `define` and `loaders` in `Bun.build`. No issue tracks either fix here.

In this container, `bun-build-api.test.ts` > `bytecode: function record on an encoder page boundary` and `bytecode: repeated builds don't retain the generated code` exceed their 5 s budget under the ASAN debug build with main's sources as well. They do not involve plugins.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->