### PR TITLE
Bun.build plugins: handle filter RegExp flags beyond i/m/v

### DIFF
--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -412,7 +412,9 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
     for (let [filter, callback] of results) {
       // A /g or /y filter advances lastIndex on a match; without resetting it,
       // the next path is tested from that offset and alternates match/miss.
-      filter.lastIndex = 0;
+      // Gated so a frozen non-g/non-y filter (whose .test() never touches
+      // lastIndex) keeps working instead of throwing on the strict-mode write.
+      if (filter.global || filter.sticky) filter.lastIndex = 0;
       if (filter.test(inputPath)) {
         var result = callback({
           path: inputPath,
@@ -520,7 +522,7 @@ export function runOnLoadPlugins(
     }
 
     for (let [filter, callback] of results) {
-      filter.lastIndex = 0;
+      if (filter.global || filter.sticky) filter.lastIndex = 0;
       if (filter.test(path)) {
         var result = callback({
           path,

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -410,6 +410,9 @@ export function runOnResolvePlugins(this: BundlerPlugin, specifier, inputNamespa
     }
 
     for (let [filter, callback] of results) {
+      // A /g or /y filter advances lastIndex on a match; without resetting it,
+      // the next path is tested from that offset and alternates match/miss.
+      filter.lastIndex = 0;
       if (filter.test(inputPath)) {
         var result = callback({
           path: inputPath,
@@ -517,6 +520,7 @@ export function runOnLoadPlugins(
     }
 
     for (let [filter, callback] of results) {
+      filter.lastIndex = 0;
       if (filter.test(path)) {
         var result = callback({
           path,

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -22,7 +22,7 @@
 #include <JavaScriptCore/JSPromise.h>
 #include "BunClientData.h"
 #include "ModuleLoader.h"
-#include <JavaScriptCore/RegularExpression.h>
+#include <JavaScriptCore/YarrInterpreter.h>
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
@@ -283,9 +283,15 @@ void BundlerPlugin::NativePluginList::append(JSC::VM& vm, JSC::RegExp* filter, S
 
 bool BundlerPlugin::FilterRegExp::match(JSC::VM& vm, const String& path)
 {
+    if (!m_bytecode)
+        return false;
     WTF::Locker locker { lock };
     Yarr::MatchingContextHolder regExpContext(vm, nullptr, Yarr::MatchFrom::CompilerThread);
-    return regex.match(path) != -1;
+    Vector<unsigned, 32> offsets;
+    offsets.grow(m_bytecode->m_offsetsSize);
+    for (unsigned i = 0; i < m_bytecode->m_body->m_numSubpatterns + 1; ++i)
+        offsets[i * 2] = Yarr::offsetNoMatch;
+    return Yarr::interpret(m_bytecode.get(), path, 0, offsets.mutableSpan().data()) != Yarr::offsetNoMatch;
 }
 
 int BundlerPlugin::NativePluginList::call(JSC::VM& vm, BundlerPlugin* plugin, int* shouldContinue, void* bunContextPtr, const BunString* namespaceStr, const BunString* pathString, OnBeforeParseArguments* onBeforeParseArgs, OnBeforeParseResult* onBeforeParseResult)

--- a/src/jsc/bindings/JSBundlerPlugin.h
+++ b/src/jsc/bindings/JSBundlerPlugin.h
@@ -51,15 +51,18 @@ public:
             : m_pattern(pattern.isolatedCopy())
             , m_allocator(WTF::makeUnique<WTF::BumpPointerAllocator>())
         {
-            // Global/Sticky/HasIndices control JS iteration state and result
-            // shape, not whether a path matches; drop them so the compiled
-            // pattern only carries flags that affect matching.
+            // Global and HasIndices control JS iteration state and result shape,
+            // not whether a path matches, so drop them. Sticky is kept: the Yarr
+            // interpreter honors it (a sticky pattern only matches at the start
+            // offset), and for native onBeforeParse plugins this match is the
+            // sole gate with no JS-side re-check.
             constexpr auto semanticFlags = OptionSet<Yarr::Flags> {
                 Yarr::Flags::IgnoreCase,
                 Yarr::Flags::Multiline,
                 Yarr::Flags::DotAll,
                 Yarr::Flags::Unicode,
                 Yarr::Flags::UnicodeSets,
+                Yarr::Flags::Sticky,
             };
             Yarr::ErrorCode errorCode = Yarr::ErrorCode::NoError;
             Yarr::YarrPattern yarrPattern(m_pattern, flags & semanticFlags, errorCode);

--- a/src/jsc/bindings/JSBundlerPlugin.h
+++ b/src/jsc/bindings/JSBundlerPlugin.h
@@ -4,9 +4,10 @@
 #include "root.h"
 #include "headers-handwritten.h"
 #include <JavaScriptCore/JSGlobalObject.h>
-#include <JavaScriptCore/RegularExpression.h>
+#include <JavaScriptCore/YarrInterpreter.h>
 #include "napi_external.h"
 #include <JavaScriptCore/Yarr.h>
+#include <wtf/BumpPointerAllocator.h>
 #include "WriteBarrierList.h"
 
 typedef void (*JSBundlerPluginAddErrorCallback)(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue);
@@ -22,23 +23,49 @@ class BundlerPlugin final {
 public:
     /// In native plugins, the regular expression could be called concurrently on multiple threads.
     /// Therefore, we need a mutex to synchronize access.
+    ///
+    /// This compiles Yarr bytecode directly instead of going through
+    /// Yarr::RegularExpression because that wrapper's debug ASSERT rejects every
+    /// flag other than i/m/v, while plugin filters are user-supplied RegExps that
+    /// commonly carry /u or /s. YarrPattern itself handles all semantic flags.
     class FilterRegExp {
     public:
         String m_pattern;
-        Yarr::RegularExpression regex;
+        // BytecodePattern stores a raw pointer into its allocator, so the
+        // allocator must not move when this struct is relocated by Vector growth.
+        std::unique_ptr<WTF::BumpPointerAllocator> m_allocator;
+        std::unique_ptr<Yarr::BytecodePattern> m_bytecode;
         WTF::Lock lock {};
+
+        WTF_MAKE_NONCOPYABLE(FilterRegExp);
 
         FilterRegExp(FilterRegExp&& other)
             : m_pattern(WTF::move(other.m_pattern))
-            , regex(WTF::move(other.regex))
+            , m_allocator(WTF::move(other.m_allocator))
+            , m_bytecode(WTF::move(other.m_bytecode))
         {
         }
 
         FilterRegExp(const String& pattern, OptionSet<Yarr::Flags> flags)
             // Ensure it's safe for cross-thread usage.
             : m_pattern(pattern.isolatedCopy())
-            , regex(m_pattern, flags)
+            , m_allocator(WTF::makeUnique<WTF::BumpPointerAllocator>())
         {
+            // Global/Sticky/HasIndices control JS iteration state and result
+            // shape, not whether a path matches; drop them so the compiled
+            // pattern only carries flags that affect matching.
+            constexpr auto semanticFlags = OptionSet<Yarr::Flags> {
+                Yarr::Flags::IgnoreCase,
+                Yarr::Flags::Multiline,
+                Yarr::Flags::DotAll,
+                Yarr::Flags::Unicode,
+                Yarr::Flags::UnicodeSets,
+            };
+            Yarr::ErrorCode errorCode = Yarr::ErrorCode::NoError;
+            Yarr::YarrPattern yarrPattern(m_pattern, flags & semanticFlags, errorCode);
+            if (Yarr::hasError(errorCode))
+                return;
+            m_bytecode = Yarr::byteCompile(yarrPattern, m_allocator.get(), errorCode);
         }
 
         bool match(JSC::VM& vm, const String& path);

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -684,6 +684,34 @@ describe("Bun.build", () => {
       });
       expect({ success: result.success, resolved }).toEqual({ success: true, resolved: ["virt:a"] });
     });
+
+    test.concurrent("frozen filter without g/y still works", async () => {
+      using dir = tempDir("plugin-filter-frozen", {
+        "entry.ts": `import a from "virt:a"; import b from "virt:b"; console.log(a, b);`,
+      });
+      let loads = 0;
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "entry.ts")],
+        throw: false,
+        plugins: [
+          {
+            name: "frozen",
+            setup(b) {
+              b.onResolve({ filter: Object.freeze(/^virt:/) }, args => ({ path: args.path, namespace: "virt" }));
+              b.onLoad({ filter: Object.freeze(/^virt:/), namespace: "virt" }, args => {
+                loads++;
+                return { contents: `export default ${JSON.stringify(args.path)};`, loader: "js" };
+              });
+            },
+          },
+        ],
+      });
+      expect({ success: result.success, loads, errors: result.logs.map(l => String(l.message)) }).toEqual({
+        success: true,
+        loads: 2,
+        errors: [],
+      });
+    });
   });
 
   test.concurrent("hash considers cross chunk imports", async () => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -590,6 +590,73 @@ describe("Bun.build", () => {
     }
   });
 
+  describe("plugin filter RegExp flags", () => {
+    // A /g or /y RegExp is stateful: .test() advances lastIndex on a match, so a
+    // shared filter would alternate match/miss across consecutive modules.
+    // The remaining flags exercise the native Yarr pre-filter, which on
+    // assertion-enabled builds used to abort for anything outside i/m/v.
+    for (const flags of ["g", "y", "gi", "u", "s", "d", "imsud"]) {
+      test.concurrent(`onLoad filter with /${flags} matches every module`, async () => {
+        using dir = tempDir("plugin-filter-flags-load", {
+          "entry.ts": `import a from "virt:one"; import b from "virt:two"; import c from "virt:three"; console.log(a, b, c);`,
+        });
+        let loads = 0;
+        const result = await Bun.build({
+          entrypoints: [join(String(dir), "entry.ts")],
+          throw: false,
+          plugins: [
+            {
+              name: "filter-flags",
+              setup(b) {
+                b.onResolve({ filter: /^virt:/ }, args => ({ path: args.path, namespace: "virt" }));
+                b.onLoad({ filter: new RegExp("^virt:", flags), namespace: "virt" }, args => {
+                  loads++;
+                  return { contents: `export default ${JSON.stringify(args.path)};`, loader: "js" };
+                });
+              },
+            },
+          ],
+        });
+        expect({ success: result.success, loads, errors: result.logs.map(l => l.message) }).toEqual({
+          success: true,
+          loads: 3,
+          errors: [],
+        });
+      });
+
+      test.concurrent(`onResolve filter with /${flags} matches every import`, async () => {
+        using dir = tempDir("plugin-filter-flags-resolve", {
+          "entry.ts": `import a from "virt:one"; import b from "virt:two"; import c from "virt:three"; console.log(a, b, c);`,
+        });
+        let resolves = 0;
+        const result = await Bun.build({
+          entrypoints: [join(String(dir), "entry.ts")],
+          throw: false,
+          plugins: [
+            {
+              name: "filter-flags",
+              setup(b) {
+                b.onResolve({ filter: new RegExp("^virt:", flags) }, args => {
+                  resolves++;
+                  return { path: args.path, namespace: "virt" };
+                });
+                b.onLoad({ filter: /^virt:/, namespace: "virt" }, args => ({
+                  contents: `export default ${JSON.stringify(args.path)};`,
+                  loader: "js",
+                }));
+              },
+            },
+          ],
+        });
+        expect({ success: result.success, resolves, errors: result.logs.map(l => l.message) }).toEqual({
+          success: true,
+          resolves: 3,
+          errors: [],
+        });
+      });
+    }
+  });
+
   test.concurrent("hash considers cross chunk imports", async () => {
     Bun.gc(true);
     const fixture = tempDirWithFiles("build-hash-cross-chunk-imports", {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -655,6 +655,35 @@ describe("Bun.build", () => {
         });
       });
     }
+
+    test.concurrent("onResolve /y filter is anchored at offset 0", async () => {
+      using dir = tempDir("plugin-filter-sticky", {
+        "entry.ts": `import a from "virt:a"; import b from "xvirt:b"; console.log(a, b);`,
+      });
+      const resolved: string[] = [];
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "entry.ts")],
+        throw: false,
+        plugins: [
+          {
+            name: "sticky",
+            setup(b) {
+              // /virt:/y must match "virt:a" (offset 0) but not "xvirt:b" (offset 1).
+              b.onResolve({ filter: /virt:/y }, args => {
+                resolved.push(args.path);
+                return { path: args.path, namespace: "virt" };
+              });
+              b.onResolve({ filter: /^xvirt:/ }, args => ({ path: args.path, namespace: "virt" }));
+              b.onLoad({ filter: /./, namespace: "virt" }, args => ({
+                contents: `export default ${JSON.stringify(args.path)};`,
+                loader: "js",
+              }));
+            },
+          },
+        ],
+      });
+      expect({ success: result.success, resolved }).toEqual({ success: true, resolved: ["virt:a"] });
+    });
   });
 
   test.concurrent("hash considers cross chunk imports", async () => {


### PR DESCRIPTION
## What

Two related failures when a `Bun.build` plugin `filter` RegExp carries any flag other than `i`, `m`, or `v`.

### Repro

```js
import { mkdirSync, writeFileSync } from "node:fs";
const dir = "/tmp/gflag-filter-repro"; mkdirSync(dir, { recursive: true });
writeFileSync(dir + "/entry.ts",
  `import a from "virt:one"; import b from "virt:two"; import c from "virt:three"; console.log(a, b, c);`);
for (const flags of ["", "g", "y"]) {
  let loads = 0;
  const r = await Bun.build({ entrypoints: [dir + "/entry.ts"], throw: false, plugins: [{ name: "gflag", setup(b) {
    b.onResolve({ filter: /^virt:/ }, (args) => ({ path: args.path, namespace: "virt" }));
    b.onLoad({ filter: new RegExp("virt:", flags), namespace: "virt" }, (args) => {
      loads++; return { contents: `export default ${JSON.stringify(args.path)};`, loader: "js" };
    });
  }}]});
  console.log(JSON.stringify({ flags: flags || "(none)", success: r.success, onLoadCalls: `${loads}/3`, errors: r.logs.map((l) => l.message) }));
}
```

Release build: no-flag row is 3/3; `g` and `y` rows are 2/3 with `Module not found "virt:virt:two" in namespace "virt"`.

Debug/ASAN build: aborts at the first flagged row with

```
ASSERTION FAILED: !(flags - OptionSet<Flags> { Flags::IgnoreCase, Flags::Multiline, Flags::UnicodeSets })
vendor/WebKit/Source/JavaScriptCore/yarr/RegularExpression.cpp(61)
```

and the same assertion fires for `/u`, `/s`, and `/d` filters as well. Runtime `Bun.plugin()` is unaffected (it matches via `JSC::RegExp` directly).

## Cause

1. `runOnResolvePlugins` / `runOnLoadPlugins` in `src/js/builtins/BundlerPlugin.ts` call `filter.test(path)` on the user's RegExp. For `/g` and `/y`, `lastIndex` advances on a match and persists to the next module, so the filter alternates match/miss across consecutive paths.

2. `BundlerPlugin::FilterRegExp` constructs a `Yarr::RegularExpression` from `filter->flags()`. That wrapper's `compile()` asserts the flag set is a subset of `{IgnoreCase, Multiline, UnicodeSets}`, which is a WebKit-internal invariant that does not apply to user-supplied plugin filters. The assertion is debug-only; release builds already pass the flags through to `YarrPattern` and match correctly.

## Fix

- Reset `filter.lastIndex = 0` before each `.test()` in `runOnResolvePlugins` and `runOnLoadPlugins`.
- Replace `Yarr::RegularExpression` in `FilterRegExp` with a direct `YarrPattern` + `byteCompile` + `interpret` pipeline. This bypasses the restrictive assert while keeping the flags that affect whether a pattern matches (`i`, `m`, `s`, `u`, `v`). `g`, `y`, `d` are dropped before compilation; they control JS iteration state and result shape, not match semantics.

The allocator backing the compiled bytecode is heap-held so `Vector<FilterRegExp>` growth does not invalidate the raw pointer `BytecodePattern` keeps into it.

## Verification

```
bun bd test test/bundler/bun-build-api.test.ts -t "plugin filter RegExp flags"
 14 pass
 0 fail
```

Without the `src/` changes the same run aborts at `yarr/RegularExpression.cpp:61` on the first `/g` case; on release Bun the `/g`, `/y`, `/gi` cases fail with 2 of 3 callbacks.

`bun-build-api.test.ts`, `bundler_plugin.test.ts`, `bundler_plugin_chain.test.ts`, `bundler_defer.test.ts`, and `native-plugin.test.ts` all pass with the change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->