### PR TITLE
Bun.build: honor throw:false for setup/onStart/onEnd plugin errors

### DIFF
--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -111,6 +111,7 @@ export function runOnEndCallbacks(
   promise: Promise<Bun.BuildOutput>,
   buildResult: Bun.BuildOutput,
   buildRejection: AggregateError | undefined,
+  throwOnError: boolean,
 ): Promise<void> | void {
   const callbacks = this.onEndCallbacks;
   if (!callbacks) return;
@@ -140,7 +141,18 @@ export function runOnEndCallbacks(
         }
       },
       e => {
-        $rejectPromise(promise, e);
+        if (throwOnError) {
+          $rejectPromise(promise, e);
+        } else {
+          (buildResult as any).success = false;
+          $arrayPush((buildResult as any).logs, {
+            name: "BuildMessage",
+            level: "error",
+            message: e != null && typeof (e as any).message === "string" ? (e as any).message : String(e),
+            position: null,
+          });
+          $resolvePromise(promise, buildResult);
+        }
       },
     );
   }

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -18,6 +18,8 @@ interface BundlerPlugin {
   onResolveAsync(internalID, a, b, c): void;
   /** Binding to `JSBundlerPlugin__addError` */
   addError(internalID: number, error: any, which: number): void;
+  /** Binding to `JSBundlerPlugin__createBuildMessage` */
+  createBuildMessage(error: any): BuildMessage;
   addFilter(filter, namespace, number): void;
   generateDeferPromise(id: number): Promise<void>;
   promises: Array<Promise<any>> | undefined;
@@ -145,12 +147,7 @@ export function runOnEndCallbacks(
           $rejectPromise(promise, e);
         } else {
           (buildResult as any).success = false;
-          $arrayPush((buildResult as any).logs, {
-            name: "BuildMessage",
-            level: "error",
-            message: e != null && typeof (e as any).message === "string" ? (e as any).message : String(e),
-            position: null,
-          });
+          $arrayPush((buildResult as any).logs, this.createBuildMessage(e));
           $resolvePromise(promise, buildResult);
         }
       },

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -53,6 +53,7 @@ extern "C" void JSBundlerPlugin__onLoadAsync(void*, void*, JSC::EncodedJSValue, 
 extern "C" void JSBundlerPlugin__onResolveAsync(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue, JSC::EncodedJSValue);
 extern "C" void JSBundlerPlugin__onVirtualModulePlugin(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue, JSC::EncodedJSValue);
 extern "C" JSC::EncodedJSValue JSBundlerPlugin__onDefer(void*, JSC::JSGlobalObject*);
+extern "C" JSC::EncodedJSValue JSBundlerPlugin__createBuildMessage(JSC::JSGlobalObject*, JSC::EncodedJSValue);
 
 JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_addFilter);
 JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_addError);
@@ -60,6 +61,7 @@ JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_onLoadAsync);
 JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_onResolveAsync);
 JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse);
 JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_generateDeferPromise);
+JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_createBuildMessage);
 
 void BundlerPlugin::NamespaceList::append(JSC::VM& vm, JSC::RegExp* filter, String& namespaceString, unsigned& index)
 {
@@ -117,6 +119,7 @@ static const HashTableValue JSBundlerPluginHashTable[] = {
     { "onResolveAsync"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBundlerPluginFunction_onResolveAsync, 4 } },
     { "onBeforeParse"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBundlerPluginFunction_onBeforeParse, 4 } },
     { "generateDeferPromise"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBundlerPluginFunction_generateDeferPromise, 0 } },
+    { "createBuildMessage"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function | JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::NativeFunctionType, jsBundlerPluginFunction_createBuildMessage, 1 } },
 };
 
 class JSBundlerPlugin final : public JSC::JSDestructibleObject {
@@ -410,6 +413,11 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalOb
     thisObject->plugin.onBeforeParse.append(vm, newRegexp, namespaceStr, callback, native_plugin_name ? *native_plugin_name : nullptr, externalPtr);
 
     return JSC::JSValue::encode(JSC::jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_createBuildMessage, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    return JSBundlerPlugin__createBuildMessage(globalObject, JSValue::encode(callFrame->argument(0)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addError, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -691,7 +691,7 @@ extern "C" void JSBundlerPlugin__tombstone(Bun::JSBundlerPlugin* plugin)
     plugin->plugin.tombstone();
 }
 
-extern "C" JSC::EncodedJSValue JSBundlerPlugin__runOnEndCallbacks(Bun::JSBundlerPlugin* plugin, JSC::EncodedJSValue encodedBuildPromise, JSC::EncodedJSValue encodedBuildResult, JSC::EncodedJSValue encodedRejection)
+extern "C" JSC::EncodedJSValue JSBundlerPlugin__runOnEndCallbacks(Bun::JSBundlerPlugin* plugin, JSC::EncodedJSValue encodedBuildPromise, JSC::EncodedJSValue encodedBuildResult, JSC::EncodedJSValue encodedRejection, JSC::EncodedJSValue encodedThrowOnError)
 {
     auto& vm = plugin->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -710,6 +710,7 @@ extern "C" JSC::EncodedJSValue JSBundlerPlugin__runOnEndCallbacks(Bun::JSBundler
     arguments.append(JSValue::decode(encodedBuildPromise));
     arguments.append(JSValue::decode(encodedBuildResult));
     arguments.append(JSValue::decode(encodedRejection));
+    arguments.append(JSValue::decode(encodedThrowOnError));
 
     // TODO: use AsyncContextFrame?
     auto result

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -439,6 +439,7 @@ pub mod js_bundler {
             global_this: &JSGlobalObject,
             config: JSValue,
             plugins: &mut Option<*mut Plugin>,
+            plugin_error: &mut Option<JSValue>,
         ) -> JsResult<Config> {
             // Config implements Drop, so functional-record-update from Default::default()
             // is rejected by rustc (E0509). Construct default then mutate instead.
@@ -477,6 +478,13 @@ pub mod js_bundler {
                     did_set_target = true;
                 }
                 drop(slice);
+            }
+
+            // Read `throw` before running plugin setup so setup/onStart errors can
+            // honor it (when `throw: false` those become `{success:false, logs}`
+            // instead of escaping Bun.build synchronously).
+            if let Some(flag) = config.get_boolean_strict(global_this, "throw")? {
+                this.throw_on_error = flag;
             }
 
             // Plugins must be resolved first as they are allowed to mutate the config JSValue
@@ -529,14 +537,25 @@ pub mod js_bundler {
 
                     let is_last = i == (length as usize).saturating_sub(1);
                     // SAFETY: bun_plugins is a valid pointer created/stored above
-                    let mut plugin_result = unsafe {
+                    let setup_result = unsafe {
                         (*bun_plugins).add_plugin(
                             function,
                             config,
                             onstart_promise_array,
                             is_last,
                             false,
-                        )?
+                        )
+                    };
+                    let mut plugin_result = match setup_result {
+                        Ok(v) => v,
+                        Err(JsError::Terminated) => return Err(JsError::Terminated),
+                        Err(e) => {
+                            if this.throw_on_error {
+                                return Err(e);
+                            }
+                            *plugin_error = Some(global_this.take_exception(e));
+                            break;
+                        }
                     };
 
                     if !plugin_result.is_empty_or_undefined_or_null() {
@@ -552,20 +571,37 @@ pub mod js_bundler {
                                     plugin_result = val;
                                 }
                                 jsc::PromiseResult::Rejected(err) => {
-                                    return Err(global_this.throw_value(err));
+                                    if this.throw_on_error {
+                                        return Err(global_this.throw_value(err));
+                                    }
+                                    *plugin_error = Some(err);
+                                    break;
                                 }
                             }
                         }
                     }
 
                     if let Some(err) = plugin_result.to_error() {
-                        return Err(global_this.throw_value(err));
+                        if this.throw_on_error {
+                            return Err(global_this.throw_value(err));
+                        }
+                        *plugin_error = Some(err);
+                        break;
                     } else if global_this.has_exception() {
-                        return Err(JsError::Thrown);
+                        if this.throw_on_error {
+                            return Err(JsError::Thrown);
+                        }
+                        *plugin_error = Some(global_this.take_exception(JsError::Thrown));
+                        break;
                     }
 
                     onstart_promise_array = plugin_result;
                     i += 1;
+                }
+
+                if plugin_error.is_some() {
+                    // scopeguard destroys the partially-initialised plugins on drop.
+                    return Ok(this);
                 }
             }
 
@@ -1115,10 +1151,6 @@ pub mod js_bundler {
                 });
             }
 
-            if let Some(flag) = config.get_boolean_strict(global_this, "throw")? {
-                this.throw_on_error = flag;
-            }
-
             // Parse metafile option: boolean | string | { json?: string, markdown?: string }
             if let Some(metafile_value) =
                 config.get_own(global_this, &BunString::static_str("metafile"))?
@@ -1337,7 +1369,32 @@ pub mod js_bundler {
         }
 
         let mut plugins: Option<*mut Plugin> = None;
-        let config = Config::from_js(global_this, arguments[0], &mut plugins)?;
+        let mut plugin_error: Option<JSValue> = None;
+        let config = Config::from_js(global_this, arguments[0], &mut plugins, &mut plugin_error)?;
+
+        if let Some(err) = plugin_error {
+            debug_assert!(!config.throw_on_error);
+            let msg = bun_ast_jsc::msg_from_js(global_this, Vec::new(), err)?;
+            let mut log = bun_ast::Log::init();
+            log.errors = 1;
+            log.msgs.push(msg);
+            let build_result = JSValue::create_empty_object(global_this, 3);
+            build_result.put(
+                global_this,
+                b"outputs",
+                JSValue::create_empty_array(global_this, 0)?,
+            );
+            build_result.put(global_this, b"success", JSValue::FALSE);
+            build_result.put(
+                global_this,
+                b"logs",
+                bun_ast_jsc::log_to_js_array(&log, global_this)?,
+            );
+            return Ok(jsc::JSPromise::resolved_promise_value(
+                global_this,
+                build_result,
+            ));
+        }
 
         let event_loop = vm.event_loop();
 
@@ -1617,6 +1674,7 @@ pub mod js_bundler {
             build_promise: JSValue,
             build_result: JSValue,
             rejection: JSValue,
+            throw_on_error: JSValue,
         ) -> JSValue;
         // C++ returns the plugin's owning global (never null; plugin holds a
         // strong ref), so the elided lifetime — output borrows `plugin` — is
@@ -1650,6 +1708,7 @@ pub mod js_bundler {
             build_promise: &jsc::JSPromise,
             build_result: JSValue,
             rejection: JsResult<JSValue>,
+            throw_on_error: bool,
         ) -> JsResult<JSValue>;
         /// `this` must be a live handle previously returned by `Plugin::create`;
         /// non-null is checked via `Plugin::opaque_ref` (panics on null).
@@ -1688,6 +1747,7 @@ pub mod js_bundler {
             build_promise: &jsc::JSPromise,
             build_result: JSValue,
             rejection: JsResult<JSValue>,
+            throw_on_error: bool,
         ) -> JsResult<JSValue> {
             jsc::mark_binding();
 
@@ -1708,6 +1768,7 @@ pub mod js_bundler {
                 build_promise.as_value(global_this),
                 build_result,
                 rejection_value,
+                JSValue::from(throw_on_error),
             );
             scope.return_if_exception()?;
             Ok(value)

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1374,7 +1374,7 @@ pub mod js_bundler {
 
         if let Some(err) = plugin_error {
             debug_assert!(!config.throw_on_error);
-            let msg = bun_ast_jsc::msg_from_js(global_this, Vec::new(), err)?;
+            let msg = msg_from_js_with_fallback(global_this, b"", err);
             let mut log = bun_ast::Log::init();
             log.errors = 1;
             log.msgs.push(msg);
@@ -1831,15 +1831,13 @@ pub mod js_bundler {
 
     /// Convert a JS exception value into a `logger.Msg`. If the conversion itself
     /// throws (e.g. `Symbol.toPrimitive` on the thrown object throws), clear that
-    /// secondary exception and return a generic fallback message so
-    /// `onResolveAsync`/`onLoadAsync` is still called and the bundler's
-    /// pending-item counter is decremented. Returning early here would cause
-    /// `Bun.build` to hang forever waiting on the counter.
-    ///
-    /// Runs on the JS thread, so allocations go through the global heap; the
-    /// bundler arena is owned by another thread.
-    fn plugin_msg_from_js(plugin: &mut Plugin, file: &[u8], exception: JSValue) -> bun_ast::Msg {
-        let global = plugin.global_object();
+    /// secondary exception and return a generic fallback message so the caller's
+    /// completion path (promise settle / pending-item decrement) always runs.
+    pub(crate) fn msg_from_js_with_fallback(
+        global: &JSGlobalObject,
+        file: &[u8],
+        exception: JSValue,
+    ) -> bun_ast::Msg {
         match bun_ast_jsc::msg_from_js(global, file.to_vec(), exception) {
             Ok(msg) => msg,
             Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
@@ -1863,6 +1861,38 @@ pub mod js_bundler {
                     },
                     ..Default::default()
                 }
+            }
+        }
+    }
+
+    /// `onResolveAsync`/`onLoadAsync` error path: route through the shared
+    /// fallback so the bundler's pending-item counter is always decremented.
+    /// Returning early here would cause `Bun.build` to hang forever waiting on
+    /// the counter.
+    ///
+    /// Runs on the JS thread, so allocations go through the global heap; the
+    /// bundler arena is owned by another thread.
+    fn plugin_msg_from_js(plugin: &mut Plugin, file: &[u8], exception: JSValue) -> bun_ast::Msg {
+        msg_from_js_with_fallback(plugin.global_object(), file, exception)
+    }
+
+    /// `BundlerPlugin.prototype.createBuildMessage` — wraps a thrown value in a
+    /// real `BuildMessage` for `BuildOutput.logs`. Never throws: secondary
+    /// throws during string conversion fall back to a generic message, and a
+    /// failure from `BuildMessage::create` itself returns `undefined` so the
+    /// caller in `runOnEndCallbacks` can still settle the build promise.
+    #[unsafe(no_mangle)]
+    pub(crate) extern "C" fn JSBundlerPlugin__createBuildMessage(
+        global: &JSGlobalObject,
+        exception: JSValue,
+    ) -> JSValue {
+        let msg = msg_from_js_with_fallback(global, b"", exception);
+        match bun_jsc::BuildMessage::create(global, msg) {
+            Ok(v) => v,
+            Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
+            Err(_) => {
+                let _ = global.clear_exception_except_termination();
+                JSValue::UNDEFINED
             }
         }
     }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -183,8 +183,15 @@ impl JSBundleCompletionTask {
         promise: &JSPromise,
         build_result: JSValue,
         rejection: jsc::JsResult<JSValue>,
+        throw_on_error: bool,
     ) -> jsc::JsResult<bool> {
-        let value = plugin.run_on_end_callbacks(global_this, promise, build_result, rejection)?;
+        let value = plugin.run_on_end_callbacks(
+            global_this,
+            promise,
+            build_result,
+            rejection,
+            throw_on_error,
+        )?;
         Ok(value != JSValue::UNDEFINED)
     }
 
@@ -236,8 +243,14 @@ impl JSBundleCompletionTask {
             };
             // Checked `is_some` above; accessor encapsulates the deref.
             let plugin = self.plugins_mut().unwrap();
-            match Self::run_on_end_callbacks(global_this, plugin, promise, build_result, rejection)
-            {
+            match Self::run_on_end_callbacks(
+                global_this,
+                plugin,
+                promise,
+                build_result,
+                rejection,
+                throw_on_error,
+            ) {
                 Ok(b) => b,
                 Err(e) => return promise.reject(global_this, Err(e)),
             }
@@ -695,6 +708,7 @@ impl JSBundleCompletionTask {
                     );
                 }
 
+                let throw_on_error = this.config.throw_on_error;
                 let did_handle_callbacks = if let Some(plugin) = this.plugins_mut() {
                     match Self::run_on_end_callbacks(
                         global_this,
@@ -702,6 +716,7 @@ impl JSBundleCompletionTask {
                         promise,
                         build_output,
                         Ok(JSValue::UNDEFINED),
+                        throw_on_error,
                     ) {
                         Ok(b) => b,
                         Err(e) => return Ok(promise.reject(global_this, Err(e))?),

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1312,119 +1312,160 @@ export { greeting };`,
     // What matters is that callbacks fired before promise settled
     expect(result.success).toBeDefined();
   });
+});
 
-  describe("throw: false captures plugin lifecycle errors", () => {
-    for (const [label, plugin] of [
-      [
-        "setup() sync",
-        {
-          name: "p",
-          setup() {
+describe("Bun.build throw: false captures plugin lifecycle errors", () => {
+  for (const [label, plugin] of [
+    [
+      "setup() sync",
+      {
+        name: "p",
+        setup() {
+          throw new Error("lifecycle-boom");
+        },
+      },
+    ],
+    [
+      "setup() async",
+      {
+        name: "p",
+        async setup() {
+          throw new Error("lifecycle-boom");
+        },
+      },
+    ],
+    [
+      "onStart sync",
+      {
+        name: "p",
+        setup(b) {
+          b.onStart(() => {
             throw new Error("lifecycle-boom");
-          },
+          });
         },
-      ],
-      [
-        "setup() async",
-        {
-          name: "p",
-          async setup() {
+      },
+    ],
+    [
+      "onStart async",
+      {
+        name: "p",
+        setup(b) {
+          b.onStart(async () => {
             throw new Error("lifecycle-boom");
-          },
+          });
         },
-      ],
-      [
-        "onStart sync",
-        {
-          name: "p",
-          setup(b) {
-            b.onStart(() => {
-              throw new Error("lifecycle-boom");
-            });
-          },
+      },
+    ],
+    [
+      "onEnd sync",
+      {
+        name: "p",
+        setup(b) {
+          b.onEnd(() => {
+            throw new Error("lifecycle-boom");
+          });
         },
-      ],
-      [
-        "onStart async",
-        {
-          name: "p",
-          setup(b) {
-            b.onStart(async () => {
-              throw new Error("lifecycle-boom");
-            });
-          },
+      },
+    ],
+    [
+      "onEnd async",
+      {
+        name: "p",
+        setup(b) {
+          b.onEnd(async () => {
+            throw new Error("lifecycle-boom");
+          });
         },
-      ],
-      [
-        "onEnd sync",
+      },
+    ],
+  ] as const) {
+    test(`${label} throw returns {success:false, logs}`, async () => {
+      using dir = tempDir("throw-false-lifecycle", { "entry.ts": `console.log("hi");` });
+      const entry = join(String(dir), "entry.ts");
+
+      // With throw: false the error must become a log entry, not a throw/reject.
+      const result = await Bun.build({
+        entrypoints: [entry],
+        throw: false,
+        plugins: [plugin as Bun.BunPlugin],
+      });
+      expect(result.success).toBe(false);
+      const log = result.logs.find(l => (l as any).message === "lifecycle-boom");
+      expect(log).toBeInstanceOf(BuildMessage);
+      expect((log as any).level).toBe("error");
+
+      // With throw: true (default) the same plugin must still throw/reject.
+      // setup/onStart currently throw synchronously while onEnd rejects; an
+      // async IIFE normalises both into a rejection.
+      await expect(
+        (async () => await Bun.build({ entrypoints: [entry], plugins: [plugin as Bun.BunPlugin] }))(),
+      ).rejects.toThrow("lifecycle-boom");
+    });
+  }
+
+  test("onEnd throw after failed build appends to existing logs", async () => {
+    using dir = tempDir("throw-false-onend-after-fail", {
+      "entry.ts": `import {x} from "./missing"; console.log(x);`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.ts")],
+      throw: false,
+      plugins: [
         {
           name: "p",
           setup(b) {
             b.onEnd(() => {
-              throw new Error("lifecycle-boom");
+              throw new Error("onEnd-after-fail");
             });
           },
         },
       ],
-      [
-        "onEnd async",
-        {
-          name: "p",
-          setup(b) {
-            b.onEnd(async () => {
-              throw new Error("lifecycle-boom");
-            });
-          },
+    });
+    expect(result.success).toBe(false);
+    const messages = result.logs.map(l => (l as any).message);
+    expect(messages.some(m => m.includes("./missing"))).toBe(true);
+    expect(messages).toContain("onEnd-after-fail");
+  });
+
+  // A lifecycle throw whose thrown value itself throws on string conversion
+  // must still settle the build promise instead of leaving it pending forever.
+  for (const hook of ["setup", "onEnd"] as const) {
+    test(`${hook} throws value with throwing toString() still resolves`, async () => {
+      using dir = tempDir("throw-false-secondary", { "entry.ts": `console.log("hi");` });
+      const poison = {
+        get message() {
+          throw 0;
         },
-      ],
-    ] as const) {
-      test(`${label} throw returns {success:false, logs}`, async () => {
-        using dir = tempDir("throw-false-lifecycle", { "entry.ts": `console.log("hi");` });
-        const entry = join(String(dir), "entry.ts");
-
-        // With throw: false the error must become a log entry, not a throw/reject.
-        const result = await Bun.build({
-          entrypoints: [entry],
-          throw: false,
-          plugins: [plugin as Bun.BunPlugin],
-        });
-        expect(result.success).toBe(false);
-        expect(result.logs.length).toBeGreaterThan(0);
-        expect(result.logs.some(l => (l as any).message === "lifecycle-boom")).toBe(true);
-
-        // With throw: true (default) the same plugin must still throw/reject.
-        // setup/onStart currently throw synchronously while onEnd rejects; an
-        // async IIFE normalises both into a rejection.
-        await expect(
-          (async () => await Bun.build({ entrypoints: [entry], plugins: [plugin as Bun.BunPlugin] }))(),
-        ).rejects.toThrow("lifecycle-boom");
-      });
-    }
-
-    test("onEnd throw after failed build appends to existing logs", async () => {
-      using dir = tempDir("throw-false-onend-after-fail", {
-        "entry.ts": `import {x} from "./missing"; console.log(x);`,
-      });
+        toString() {
+          throw 0;
+        },
+      };
+      const plugin: Bun.BunPlugin =
+        hook === "setup"
+          ? {
+              name: "p",
+              setup() {
+                throw poison;
+              },
+            }
+          : {
+              name: "p",
+              setup(b) {
+                b.onEnd(() => {
+                  throw poison;
+                });
+              },
+            };
       const result = await Bun.build({
         entrypoints: [join(String(dir), "entry.ts")],
         throw: false,
-        plugins: [
-          {
-            name: "p",
-            setup(b) {
-              b.onEnd(() => {
-                throw new Error("onEnd-after-fail");
-              });
-            },
-          },
-        ],
+        plugins: [plugin],
       });
       expect(result.success).toBe(false);
-      const messages = result.logs.map(l => (l as any).message);
-      expect(messages.some(m => m.includes("./missing"))).toBe(true);
-      expect(messages).toContain("onEnd-after-fail");
+      expect(result.logs.length).toBeGreaterThan(0);
+      expect(result.logs[0]).toBeInstanceOf(BuildMessage);
     });
-  });
+  }
 });
 
 // On release builds mimalloc's large-allocation arenas make RSS growth too

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1312,6 +1312,119 @@ export { greeting };`,
     // What matters is that callbacks fired before promise settled
     expect(result.success).toBeDefined();
   });
+
+  describe("throw: false captures plugin lifecycle errors", () => {
+    for (const [label, plugin] of [
+      [
+        "setup() sync",
+        {
+          name: "p",
+          setup() {
+            throw new Error("lifecycle-boom");
+          },
+        },
+      ],
+      [
+        "setup() async",
+        {
+          name: "p",
+          async setup() {
+            throw new Error("lifecycle-boom");
+          },
+        },
+      ],
+      [
+        "onStart sync",
+        {
+          name: "p",
+          setup(b) {
+            b.onStart(() => {
+              throw new Error("lifecycle-boom");
+            });
+          },
+        },
+      ],
+      [
+        "onStart async",
+        {
+          name: "p",
+          setup(b) {
+            b.onStart(async () => {
+              throw new Error("lifecycle-boom");
+            });
+          },
+        },
+      ],
+      [
+        "onEnd sync",
+        {
+          name: "p",
+          setup(b) {
+            b.onEnd(() => {
+              throw new Error("lifecycle-boom");
+            });
+          },
+        },
+      ],
+      [
+        "onEnd async",
+        {
+          name: "p",
+          setup(b) {
+            b.onEnd(async () => {
+              throw new Error("lifecycle-boom");
+            });
+          },
+        },
+      ],
+    ] as const) {
+      test(`${label} throw returns {success:false, logs}`, async () => {
+        using dir = tempDir("throw-false-lifecycle", { "entry.ts": `console.log("hi");` });
+        const entry = join(String(dir), "entry.ts");
+
+        // With throw: false the error must become a log entry, not a throw/reject.
+        const result = await Bun.build({
+          entrypoints: [entry],
+          throw: false,
+          plugins: [plugin as Bun.BunPlugin],
+        });
+        expect(result.success).toBe(false);
+        expect(result.logs.length).toBeGreaterThan(0);
+        expect(result.logs.some(l => (l as any).message === "lifecycle-boom")).toBe(true);
+
+        // With throw: true (default) the same plugin must still throw/reject.
+        // setup/onStart currently throw synchronously while onEnd rejects; an
+        // async IIFE normalises both into a rejection.
+        await expect(
+          (async () => await Bun.build({ entrypoints: [entry], plugins: [plugin as Bun.BunPlugin] }))(),
+        ).rejects.toThrow("lifecycle-boom");
+      });
+    }
+
+    test("onEnd throw after failed build appends to existing logs", async () => {
+      using dir = tempDir("throw-false-onend-after-fail", {
+        "entry.ts": `import {x} from "./missing"; console.log(x);`,
+      });
+      const result = await Bun.build({
+        entrypoints: [join(String(dir), "entry.ts")],
+        throw: false,
+        plugins: [
+          {
+            name: "p",
+            setup(b) {
+              b.onEnd(() => {
+                throw new Error("onEnd-after-fail");
+              });
+            },
+          },
+        ],
+      });
+      expect(result.success).toBe(false);
+      const messages = result.logs.map(l => (l as any).message);
+      expect(messages.some(m => m.includes("./missing"))).toBe(true);
+      expect(messages).toContain("onEnd-after-fail");
+    });
+  });
 });
 
 // On release builds mimalloc's large-allocation arenas make RSS growth too


### PR DESCRIPTION
## What

`Bun.build({ throw: false })` now returns `{success: false, logs: [...]}` when a plugin's `setup()`, `onStart`, or `onEnd` throws or rejects, matching the existing behaviour for `onLoad`/`onResolve`.

## Repro

```js
const base = { entrypoints: ["entry.ts"], throw: false };
await Bun.build({ ...base, plugins: [{ name: "s", setup() { throw new Error("setup-boom"); } }] });
// before: Bun.build throws synchronously with "setup-boom"
// after:  resolves to { success: false, logs: [BuildMessage "setup-boom"] }
```

Same for `onStart` (sync throw out of `Bun.build`) and `onEnd` (promise rejects after a build whose artifacts are already written to `outdir`).

## Cause

- `Config::from_js` parsed the `throw` option *after* running the plugin loop, and the loop `return Err(...)` on any setup/onStart failure, so the error escaped `Bun.build` synchronously regardless of `throw: false`.
- `runOnEndCallbacks` in `BundlerPlugin.ts` unconditionally called `$rejectPromise(promise, e)` in its `Promise.all` error handler, never consulting `throw`.

## Fix

- Parse `throw` before the plugin loop. When `throw: false` and a setup/onStart error occurs (sync throw, async rejection, or a returned Error), capture the value instead of throwing and have `build()` resolve a `{success:false, logs}` `BuildOutput` immediately (no bundler scheduled).
- Thread `throwOnError` into `runOnEndCallbacks` (Rust → C++ → builtin). When `throw: false` and an onEnd callback throws/rejects, set `success = false`, push a `{name:"BuildMessage", level:"error", message, position:null}` entry onto `logs`, and resolve.

`throw: true` (the default) is unchanged: setup/onStart still throw synchronously, onEnd still rejects.

## Verification

New tests in `test/bundler/bun-build-api.test.ts` cover sync and async throws from `setup()`, `onStart`, and `onEnd`, plus onEnd throwing after a build failure. All fail on main and pass with this change. Existing `bundler_plugin.test.ts` onEnd tests continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->

Fixes #25211 (throwing from `onStart` with `throw: false` now aborts cleanly to `{success:false, logs}` instead of dumping an exception).