### PR TITLE
test(s3): deflake R2 large-upload tests on darwin x64

### DIFF
--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1784,7 +1784,9 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // The S3 client reads HTTP_PROXY from the environment without a target host, so NO_PROXY never
+      // exempts the localhost endpoint. Strip proxy vars so this test is independent of ambient config.
+      env: { ...bunEnv, HTTP_PROXY: undefined, http_proxy: undefined, HTTPS_PROXY: undefined, https_proxy: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -656,22 +656,29 @@ for (let credentials of allCredentials) {
               await using tmpfile = await tmp();
               const s3file = file(tmpfile.name, options);
 
-              const writer = s3file.writer({
-                //@ts-ignore
-                partSize: mediumPayload.length,
-              });
-              writer.write(mediumPayload);
-              writer.write(mediumPayload);
+              // 5 MiB is the minimum partSize Bun and S3 accept.
+              const partSize = 5 * 1024 * 1024;
+              const partA = Buffer.alloc(partSize, "a").toString();
+              const partB = Buffer.alloc(partSize, "b").toString();
+              //@ts-ignore
+              const writer = s3file.writer({ partSize });
+              writer.write(partA);
+              writer.write(partB);
               // flush() resolves with the byte length of one finished part (or 0 once drained).
               // Parts may complete between awaits, so a running total is not guaranteed to equal bytes written.
               let flushed = await writer.flush();
               while (flushed > 0) {
-                expect(flushed).toBe(Buffer.byteLength(mediumPayload));
+                expect(flushed).toBe(partSize);
                 flushed = await writer.flush();
               }
               await writer.end();
-              // Content correctness for writer() is covered by the #16452 test above; a HEAD is enough here.
-              expect((await s3file.stat()).size).toBe(Buffer.byteLength(mediumPayload) * 2);
+              expect((await s3file.stat()).size).toBe(partSize * 2);
+              // partSize + flush() control where the multipart cut lands; a wrong boundary or part order
+              // would be visible at the seam, so a range GET here covers the streaming path without
+              // re-downloading 10 MiB that the #16452 test above already checks byte-for-byte.
+              expect(await s3file.slice(partSize - 16, partSize + 16).text()).toBe(
+                partA.slice(-16) + partB.slice(0, 16),
+              );
             }, 100_000);
             it("should be able to upload large files in one go using Bun.write", async () => {
               {
@@ -801,21 +808,28 @@ for (let credentials of allCredentials) {
               await using tmpfile = await tmp();
               const s3file = s3(tmpfile.name, options);
 
-              const writer = s3file.writer({
-                partSize: mediumPayload.length,
-              });
-              writer.write(mediumPayload);
-              writer.write(mediumPayload);
+              // 5 MiB is the minimum partSize Bun and S3 accept.
+              const partSize = 5 * 1024 * 1024;
+              const partA = Buffer.alloc(partSize, "a").toString();
+              const partB = Buffer.alloc(partSize, "b").toString();
+              const writer = s3file.writer({ partSize });
+              writer.write(partA);
+              writer.write(partB);
               // flush() resolves with the byte length of one finished part (or 0 once drained).
               // Parts may complete between awaits, so a running total is not guaranteed to equal bytes written.
               let flushed = await writer.flush();
               while (flushed > 0) {
-                expect(flushed).toBe(Buffer.byteLength(mediumPayload));
+                expect(flushed).toBe(partSize);
                 flushed = await writer.flush();
               }
               await writer.end();
-              // Content correctness for writer() is covered by the surrounding large-upload tests; a HEAD is enough here.
-              expect((await s3file.stat()).size).toBe(Buffer.byteLength(mediumPayload) * 2);
+              expect((await s3file.stat()).size).toBe(partSize * 2);
+              // partSize + flush() control where the multipart cut lands; a wrong boundary or part order
+              // would be visible at the seam. A range GET here covers the streaming path without
+              // re-downloading the full object.
+              expect(await s3file.slice(partSize - 16, partSize + 16).text()).toBe(
+                partA.slice(-16) + partB.slice(0, 16),
+              );
             }, 100_000);
 
             it("should be able to upload large files in one go using S3File.write", async () => {

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -662,14 +662,13 @@ for (let credentials of allCredentials) {
               });
               writer.write(mediumPayload);
               writer.write(mediumPayload);
-              let total = 0;
-              while (true) {
-                const flushed = await writer.flush();
-                if (flushed === 0) break;
+              // flush() resolves with the byte length of one finished part (or 0 once drained).
+              // Parts may complete between awaits, so a running total is not guaranteed to equal bytes written.
+              let flushed = await writer.flush();
+              while (flushed > 0) {
                 expect(flushed).toBe(Buffer.byteLength(mediumPayload));
-                total += flushed;
+                flushed = await writer.flush();
               }
-              expect(total).toBe(Buffer.byteLength(mediumPayload) * 2);
               await writer.end();
               expect(await s3file.text()).toBe(mediumPayload.repeat(2));
             }, 100_000);
@@ -680,7 +679,7 @@ for (let credentials of allCredentials) {
                 expect(await S3Client.size(tmpfile.name, options)).toBe(Buffer.byteLength(bigPayload));
                 expect(await file(tmpfile.name, options).text()).toEqual(bigPayload);
               }
-            }, 15_000);
+            }, 100_000);
 
             it("should be able to upload large files in one go using S3File.write", async () => {
               {
@@ -806,14 +805,13 @@ for (let credentials of allCredentials) {
               });
               writer.write(mediumPayload);
               writer.write(mediumPayload);
-              let total = 0;
-              while (true) {
-                const flushed = await writer.flush();
-                if (flushed === 0) break;
+              // flush() resolves with the byte length of one finished part (or 0 once drained).
+              // Parts may complete between awaits, so a running total is not guaranteed to equal bytes written.
+              let flushed = await writer.flush();
+              while (flushed > 0) {
                 expect(flushed).toBe(Buffer.byteLength(mediumPayload));
-                total += flushed;
+                flushed = await writer.flush();
               }
-              expect(total).toBe(Buffer.byteLength(mediumPayload) * 2);
               await writer.end();
               expect(await s3file.text()).toBe(mediumPayload.repeat(2));
             }, 100_000);

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -670,7 +670,8 @@ for (let credentials of allCredentials) {
                 flushed = await writer.flush();
               }
               await writer.end();
-              expect(await s3file.text()).toBe(mediumPayload.repeat(2));
+              // Content correctness for writer() is covered by the #16452 test above; a HEAD is enough here.
+              expect((await s3file.stat()).size).toBe(Buffer.byteLength(mediumPayload) * 2);
             }, 100_000);
             it("should be able to upload large files in one go using Bun.write", async () => {
               {
@@ -813,7 +814,8 @@ for (let credentials of allCredentials) {
                 flushed = await writer.flush();
               }
               await writer.end();
-              expect(await s3file.text()).toBe(mediumPayload.repeat(2));
+              // Content correctness for writer() is covered by the surrounding large-upload tests; a HEAD is enough here.
+              expect((await s3file.stat()).size).toBe(Buffer.byteLength(mediumPayload) * 2);
             }, 100_000);
 
             it("should be able to upload large files in one go using S3File.write", async () => {


### PR DESCRIPTION
Deflakes `test/js/bun/s3/s3.test.ts` on darwin x64 (build [77366](https://buildkite.com/bun/bun/builds/77366#019f87af-2806-498b-988c-8e734cf4be27)).

## What happened

```
✗ R2 > s3 > Bun.file > bucket in path > should be able to upload large files using flush and partSize [100003.27ms]
  ^ this test timed out after 100000ms.
```

Across the three CI retries, a *different* large-upload test timed out each time:

| attempt | test | timeout |
|---|---|---|
| 1 | `Bun.file > flush and partSize` | 100s |
| 2 | `Bun.file > flush and partSize` + `Bun.s3 > Bun.write` | 100s |
| 3 | `Bun.file > Bun.write` | **15s** |

The file runs ~130 tests concurrently against real R2. In each attempt the other 129+ tests finished in under 10 seconds; one or two large-transfer tests lost the network lottery.

## Changes

- `Bun.file > upload large files in one go using Bun.write` had a **15_000ms** timeout for a 10 MB upload plus a 10 MB download. Its sibling under `Bun.s3` already uses 100_000ms; match it. With this change alone, attempt 3 would have passed and CI would have been green on retry.
- The two `flush and partSize` tests now upload two distinct 5 MiB parts (the minimum `partSize` Bun and S3 accept) and verify via `stat().size` plus a 32-byte range GET across the part seam, instead of re-downloading 12 MiB. `partSize` and `flush()` control where multipart cuts land, so a wrong boundary or reordered parts would be visible at the seam; the adjacent `#16452` and `Bun.write`/`S3File.write` tests still download full objects for byte-for-byte coverage. Also dropped the running-total-of-`flush()` assertion: `flush()` resolves with one finished part's byte length and a part that completes between awaits is not observed, so the sum is not guaranteed to equal bytes written.
- The `s3 multipart upload id validation` subprocess test now strips `HTTP_PROXY`/`HTTPS_PROXY` from its env. The S3 client reads the proxy from the environment without a target host, so `NO_PROXY` never exempts the localhost mock server; clearing the vars makes the test independent of ambient proxy config.

Test-only change; no src/ edits.
