### PR TITLE
console: honor util.inspect.defaultOptions on the global console

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -362,7 +362,7 @@ const ERROR_STACK_OVERFLOW_MSG = "Maximum call stack size exceeded.";
 // be added or removed, `getUserOptions` must also be updated accordingly.
 const inspectDefaultOptions = ObjectSeal({
   showHidden: false,
-  depth: 2,
+  depth: $newRustFunction("node_util_binding.rs", "getConsoleDepth", 0)() ?? 2,
   colors: false,
   customInspect: true,
   showProxy: false,

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -362,7 +362,7 @@ const ERROR_STACK_OVERFLOW_MSG = "Maximum call stack size exceeded.";
 // be added or removed, `getUserOptions` must also be updated accordingly.
 const inspectDefaultOptions = ObjectSeal({
   showHidden: false,
-  depth: $newRustFunction("node_util_binding.rs", "getConsoleDepth", 0)() ?? 2,
+  depth: 2,
   colors: false,
   customInspect: true,
   showProxy: false,
@@ -733,17 +733,23 @@ inspect.custom = customInspectSymbol;
 // The global console's native formatter ignores `inspectDefaultOptions`; on the
 // first mutation, hand it JS formatters so its output matches Node.js.
 let defaultOptionsOverridden = false;
+let defaultOptionsDepthSet = false;
+const cliConsoleDepth = $newRustFunction("node_util_binding.rs", "getConsoleDepth", 0)();
 const setDefaultInspectOptionsOverridden = $newRustFunction(
   "node_util_binding.rs",
   "setDefaultInspectOptionsOverridden",
   2,
 );
-function onDefaultOptionsChanged() {
+function consoleInspectOptions(colors) {
+  return cliConsoleDepth !== undefined && !defaultOptionsDepthSet ? { colors, depth: cliConsoleDepth } : { colors };
+}
+function onDefaultOptionsChanged(key) {
+  if (key === "depth") defaultOptionsDepthSet = true;
   if (defaultOptionsOverridden) return;
   defaultOptionsOverridden = true;
   setDefaultInspectOptionsOverridden(
-    (colors, ...args) => formatWithOptionsInternal({ colors }, args),
-    (colors, value, options) => inspect(value, { customInspect: false, colors, ...options }),
+    (colors, ...args) => formatWithOptionsInternal(consoleInspectOptions(colors), args),
+    (colors, value, options) => inspect(value, { customInspect: false, ...consoleInspectOptions(colors), ...options }),
   );
 }
 const inspectDefaultOptionsProxy = new Proxy(inspectDefaultOptions, {
@@ -753,12 +759,12 @@ const inspectDefaultOptionsProxy = new Proxy(inspectDefaultOptions, {
       return ReflectSet(target, key, value, receiver);
     }
     const ok = ReflectSet(target, key, value);
-    if (ok) onDefaultOptionsChanged();
+    if (ok) onDefaultOptionsChanged(key);
     return ok;
   },
   defineProperty(target, key, desc) {
     const ok = ReflectDefineProperty(target, key, desc);
-    if (ok) onDefaultOptionsChanged();
+    if (ok) onDefaultOptionsChanged(key);
     return ok;
   },
 });

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -748,7 +748,10 @@ function onDefaultOptionsChanged() {
 }
 const inspectDefaultOptionsProxy = new Proxy(inspectDefaultOptions, {
   __proto__: null,
-  set(target, key, value) {
+  set(target, key, value, receiver) {
+    if (receiver !== inspectDefaultOptionsProxy) {
+      return ReflectSet(target, key, value, receiver);
+    }
     const ok = ReflectSet(target, key, value);
     if (ok) onDefaultOptionsChanged();
     return ok;

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -730,10 +730,8 @@ function inspect(value, opts) {
 }
 inspect.custom = customInspectSymbol;
 
-// The global console uses a native formatter that knows nothing about
-// `inspectDefaultOptions`. The first time user code mutates the defaults we
-// hand the native side a pair of JS formatters so it can switch over and the
-// global console matches `new console.Console(...)` / Node.js behavior.
+// The global console's native formatter ignores `inspectDefaultOptions`; on the
+// first mutation, hand it JS formatters so its output matches Node.js.
 let defaultOptionsOverridden = false;
 const setDefaultInspectOptionsOverridden = $newRustFunction(
   "node_util_binding.rs",

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -97,7 +97,9 @@ const ObjectPrototypePropertyIsEnumerable = uncurryThis(Object.prototype.propert
 const ObjectPrototypeToString = uncurryThis(Object.prototype.toString);
 const ObjectSeal = Object.seal;
 const ObjectSetPrototypeOf = Object.setPrototypeOf;
+const ReflectDefineProperty = Reflect.defineProperty;
 const ReflectOwnKeys = Reflect.ownKeys;
+const ReflectSet = Reflect.set;
 const RegExpPrototypeExec = uncurryThis(RegExp.prototype.exec);
 const RegExpPrototypeSymbolReplace = uncurryThis(RegExp.prototype[Symbol.replace]);
 const RegExpPrototypeSymbolSplit = uncurryThis(RegExp.prototype[Symbol.split]);
@@ -728,14 +730,46 @@ function inspect(value, opts) {
 }
 inspect.custom = customInspectSymbol;
 
+// The global console uses a native formatter that knows nothing about
+// `inspectDefaultOptions`. The first time user code mutates the defaults we
+// hand the native side a pair of JS formatters so it can switch over and the
+// global console matches `new console.Console(...)` / Node.js behavior.
+let defaultOptionsOverridden = false;
+const setDefaultInspectOptionsOverridden = $newRustFunction(
+  "node_util_binding.rs",
+  "setDefaultInspectOptionsOverridden",
+  2,
+);
+function onDefaultOptionsChanged() {
+  if (defaultOptionsOverridden) return;
+  defaultOptionsOverridden = true;
+  setDefaultInspectOptionsOverridden(
+    (colors, ...args) => formatWithOptionsInternal({ colors }, args),
+    (colors, value, options) => inspect(value, { customInspect: false, colors, ...options }),
+  );
+}
+const inspectDefaultOptionsProxy = new Proxy(inspectDefaultOptions, {
+  __proto__: null,
+  set(target, key, value) {
+    const ok = ReflectSet(target, key, value);
+    if (ok) onDefaultOptionsChanged();
+    return ok;
+  },
+  defineProperty(target, key, desc) {
+    const ok = ReflectDefineProperty(target, key, desc);
+    if (ok) onDefaultOptionsChanged();
+    return ok;
+  },
+});
+
 ObjectDefineProperty(inspect, "defaultOptions", {
   __proto__: null,
   get() {
-    return inspectDefaultOptions;
+    return inspectDefaultOptionsProxy;
   },
   set(options) {
     validateObject(options, "options");
-    return ObjectAssign(inspectDefaultOptions, options);
+    return ObjectAssign(inspectDefaultOptionsProxy, options);
   },
 });
 ObjectDefineProperty(inspect, "replDefaults", {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -6015,6 +6015,34 @@ pub extern "C" fn Bun__ConsoleObject__timeLog(
     }
     Output::flush();
 
+    let colors = Output::enable_ansi_colors_stderr();
+    let console = vm_console(global);
+    // SAFETY: see [`vm_console`] — points at the live boxed `ConsoleObject` for
+    // this VM; JS-thread-only. Kept as a raw deref (not `vm_console_mut`) so the
+    // resulting `writer` borrow does not pin a long-lived `&mut ConsoleObject`
+    // across the `fmt.format(...)` calls below, which can re-enter JS.
+    let mut writer = unsafe { (*console).error_writer() };
+
+    // SAFETY: caller passes a valid (args, args_len) pair.
+    let args_slice = unsafe { bun_core::ffi::slice(args, args_len) };
+
+    if args_len >= 1 {
+        if let Some(func) = global.bun_vm().console_util_format.get() {
+            let mut call_args: Vec<JSValue> = Vec::with_capacity(1 + args_len);
+            call_args.push(JSValue::js_boolean(colors));
+            call_args.extend_from_slice(args_slice);
+            if let Ok(formatted) = func.call_with_global_this(global, &call_args) {
+                if let Ok(text) = formatted.to_slice(global) {
+                    let _ = bun_io::Write::write_all(&mut writer, b" ");
+                    let _ = bun_io::Write::write_all(&mut writer, text.slice());
+                }
+            }
+            let _ = bun_io::Write::write_all(&mut writer, b"\n");
+            let _ = bun_io::Write::flush(&mut writer);
+            return;
+        }
+    }
+
     // print the arguments
     // `Formatter` has a `Drop` impl, so struct-update from a
     // temporary is rejected (E0509). Construct via `new()` then mutate.
@@ -6024,19 +6052,12 @@ pub extern "C" fn Bun__ConsoleObject__timeLog(
         .unwrap_or(DEFAULT_CONSOLE_LOG_DEPTH);
     fmt.stack_check = StackCheck::init();
     fmt.can_throw_stack_overflow = true;
-    let console = vm_console(global);
-    // SAFETY: see [`vm_console`] — points at the live boxed `ConsoleObject` for
-    // this VM; JS-thread-only. Kept as a raw deref (not `vm_console_mut`) so the
-    // resulting `writer` borrow does not pin a long-lived `&mut ConsoleObject`
-    // across the `fmt.format(...)` calls below, which can re-enter JS.
-    let mut writer = unsafe { (*console).error_writer() };
-    // SAFETY: caller passes a valid (args, args_len) pair.
-    for &arg in unsafe { bun_core::ffi::slice(args, args_len) } {
+    for &arg in args_slice {
         let Ok(tag) = formatter::Tag::get(arg, global) else {
             return;
         };
         let _ = bun_io::Write::write_all(&mut writer, b" ");
-        if Output::enable_ansi_colors_stderr() {
+        if colors {
             let _ = fmt.format::<true>(tag, &mut writer, arg, global);
         } else {
             let _ = fmt.format::<false>(tag, &mut writer, arg, global);

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -558,10 +558,9 @@ fn message_with_type_and_level_(
         }
     }
 
-    // `util.inspect.defaultOptions` was modified: the native formatter does not
-    // implement most of those knobs (maxArrayLength, numericSeparator, ...), so
-    // hand off to the `util.formatWithOptions`-backed closures `node:util`
-    // installed on the VM. The unmodified fast path above stays native.
+    // `util.inspect.defaultOptions` was modified: hand off to the JS
+    // formatters `node:util` installed so those knobs (maxArrayLength,
+    // numericSeparator, ...) apply. Untouched defaults keep the native path.
     if len >= 1 {
         let vm = global.bun_vm();
         let fallback = if message_type == MessageType::Dir {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -558,6 +558,58 @@ fn message_with_type_and_level_(
         }
     }
 
+    // `util.inspect.defaultOptions` was modified: the native formatter does not
+    // implement most of those knobs (maxArrayLength, numericSeparator, ...), so
+    // hand off to the `util.formatWithOptions`-backed closures `node:util`
+    // installed on the VM. The unmodified fast path above stays native.
+    if len >= 1 {
+        let vm = global.bun_vm();
+        let fallback = if message_type == MessageType::Dir {
+            vm.console_util_dir.get()
+        } else {
+            vm.console_util_format.get()
+        };
+        if let Some(func) = fallback {
+            let formatted = if message_type == MessageType::Dir {
+                let opts = if len >= 2 {
+                    vals_slice[1]
+                } else {
+                    JSValue::UNDEFINED
+                };
+                func.call_with_global_this(
+                    global,
+                    &[JSValue::js_boolean(enable_colors), vals_slice[0], opts],
+                )?
+            } else {
+                let mut call_args: Vec<JSValue> = Vec::with_capacity(1 + len);
+                call_args.push(JSValue::js_boolean(enable_colors));
+                call_args.extend_from_slice(vals_slice);
+                func.call_with_global_this(global, &call_args)?
+            };
+            let text = formatted.to_slice(global)?;
+            let bytes = text.slice();
+            let _ = formatter::write_indent_n(u32::from(default_indent), writer);
+            if default_indent > 0 && strings::contains(bytes, b"\n") {
+                let mut rest = bytes;
+                while let Some(i) = strings::index_of(rest, b"\n") {
+                    let _ = writer.write_all(&rest[..=i]);
+                    let _ = formatter::write_indent_n(u32::from(default_indent), writer);
+                    rest = &rest[i + 1..];
+                }
+                let _ = writer.write_all(rest);
+            } else {
+                let _ = writer.write_all(bytes);
+            }
+            let _ = writer.write_all(b"\n");
+            let _ = writer.flush();
+            if message_type == MessageType::Trace {
+                write_trace(writer, global);
+                let _ = writer.flush();
+            }
+            return Ok(());
+        }
+    }
+
     if message_type == MessageType::Dir && len >= 2 {
         print_length = 1;
         let opts = vals_slice[1];

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -323,6 +323,15 @@ pub struct VirtualMachine {
     pub channel_ref_overridden: bool,
     pub channel_ref_should_ignore_one_disconnect_event_listener: bool,
 
+    /// `util.formatWithOptions`-backed formatter for the global console. Set by
+    /// `node:util` the first time `util.inspect.defaultOptions` is mutated;
+    /// when present, `console.log`/`warn`/etc. route through it instead of the
+    /// native formatter so option changes (depth, maxArrayLength, ...) apply.
+    pub console_util_format: crate::strong::Optional,
+    /// `util.inspect`-backed formatter for global `console.dir`; installed
+    /// together with [`console_util_format`](Self::console_util_format).
+    pub console_util_dir: crate::strong::Optional,
+
     /// A set of extensions that exist in the require.extensions map.
     pub commonjs_custom_extensions:
         bun_collections::StringArrayHashMap<crate::node_module_module::CustomLoader>,
@@ -4428,6 +4437,8 @@ impl VirtualMachine {
         drop(core::mem::take(&mut self.resolved_path_dups));
 
         self.overridden_main.deinit();
+        self.console_util_format.deinit();
+        self.console_util_dir.deinit();
 
         // `timer`/`entry_point` live in the high-tier `RuntimeState` box, so
         // dispatch the reclaim through the hook.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -323,13 +323,10 @@ pub struct VirtualMachine {
     pub channel_ref_overridden: bool,
     pub channel_ref_should_ignore_one_disconnect_event_listener: bool,
 
-    /// `util.formatWithOptions`-backed formatter for the global console. Set by
-    /// `node:util` the first time `util.inspect.defaultOptions` is mutated;
-    /// when present, `console.log`/`warn`/etc. route through it instead of the
-    /// native formatter so option changes (depth, maxArrayLength, ...) apply.
+    /// JS formatter the global console switches to once
+    /// `util.inspect.defaultOptions` is mutated; empty keeps the native path.
     pub console_util_format: crate::strong::Optional,
-    /// `util.inspect`-backed formatter for global `console.dir`; installed
-    /// together with [`console_util_format`](Self::console_util_format).
+    /// `util.inspect` formatter for global `console.dir`; paired with the above.
     pub console_util_dir: crate::strong::Optional,
 
     /// A set of extensions that exist in the require.extensions map.
@@ -4698,6 +4695,8 @@ impl VirtualMachine {
         }
 
         self.overridden_main.deinit();
+        self.console_util_format.deinit();
+        self.console_util_dir.deinit();
         self.entry_point_result.value.deinit();
         self.entry_point_result.cjs_set_value = false;
         if let Some(promise) = self.pending_internal_promise {

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -162,6 +162,22 @@ impl<'a, T: Copy + PartialEq + From<u8>> SplitNewlineIterator<'a, T> {
     }
 }
 
+/// Returns the `--console-depth` / bunfig `console.depth` value, or
+/// `undefined` when unset, so `inspect.js` can seed `defaultOptions.depth`.
+#[bun_jsc::host_fn]
+pub(crate) fn get_console_depth(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(
+        match bun_options_types::context::try_get().and_then(|ctx| ctx.runtime_options.console_depth)
+        {
+            Some(depth) => JSValue::js_number_from_int32(i32::from(depth)),
+            None => JSValue::UNDEFINED,
+        },
+    )
+}
+
 /// Stores the `(colors, ...args)` and `(colors, value, opts)` JS formatters on
 /// the VM so the global console honors mutated `util.inspect.defaultOptions`.
 #[bun_jsc::host_fn]

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -162,10 +162,8 @@ impl<'a, T: Copy + PartialEq + From<u8>> SplitNewlineIterator<'a, T> {
     }
 }
 
-/// Installed by `node:util` the first time `util.inspect.defaultOptions` is
-/// mutated. Stores a `(colors, ...args) -> string` formatter and a
-/// `(colors, value, options) -> string` `console.dir` formatter on the VM so
-/// the native global console can honor the modified defaults.
+/// Stores the `(colors, ...args)` and `(colors, value, opts)` JS formatters on
+/// the VM so the global console honors mutated `util.inspect.defaultOptions`.
 #[bun_jsc::host_fn]
 pub(crate) fn set_default_inspect_options_overridden(
     global: &JSGlobalObject,

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -165,12 +165,10 @@ impl<'a, T: Copy + PartialEq + From<u8>> SplitNewlineIterator<'a, T> {
 /// Returns the `--console-depth` / bunfig `console.depth` value, or
 /// `undefined` when unset, so `inspect.js` can seed `defaultOptions.depth`.
 #[bun_jsc::host_fn]
-pub(crate) fn get_console_depth(
-    _global: &JSGlobalObject,
-    _frame: &CallFrame,
-) -> JsResult<JSValue> {
+pub(crate) fn get_console_depth(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
     Ok(
-        match bun_options_types::context::try_get().and_then(|ctx| ctx.runtime_options.console_depth)
+        match bun_options_types::context::try_get()
+            .and_then(|ctx| ctx.runtime_options.console_depth)
         {
             Some(depth) => JSValue::js_number_from_int32(i32::from(depth)),
             None => JSValue::UNDEFINED,

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -162,6 +162,21 @@ impl<'a, T: Copy + PartialEq + From<u8>> SplitNewlineIterator<'a, T> {
     }
 }
 
+/// Installed by `node:util` the first time `util.inspect.defaultOptions` is
+/// mutated. Stores a `(colors, ...args) -> string` formatter and a
+/// `(colors, value, options) -> string` `console.dir` formatter on the VM so
+/// the native global console can honor the modified defaults.
+#[bun_jsc::host_fn]
+pub(crate) fn set_default_inspect_options_overridden(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    let vm = global.bun_vm().as_mut();
+    vm.console_util_format.set(global, frame.argument(0));
+    vm.console_util_dir.set(global, frame.argument(1));
+    Ok(JSValue::UNDEFINED)
+}
+
 #[bun_jsc::host_fn]
 pub(crate) fn normalize_encoding(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let input = frame.argument(0);

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -164,4 +164,21 @@ describe("global console honors util.inspect.defaultOptions", () => {
     expect(JSON.parse(stdout)).toEqual({ sealed: true, same: true, hasDepth: true });
     expect(exitCode).toBe(0);
   });
+
+  test.concurrent("writes via an inheriting object do not leak into the shared defaults", async () => {
+    const { stdout, exitCode } = await run(`
+      const util = require("node:util");
+      const my = Object.create(util.inspect.defaultOptions);
+      my.depth = 10;
+      process.stdout.write(JSON.stringify({
+        sharedDepth: util.inspect.defaultOptions.depth,
+        ownDepth: Object.hasOwn(my, "depth"),
+      }) + "\\n");
+      console.log({ a: { b: { c: { d: 1 } } } });
+    `);
+    const [json, ...rest] = stdout.split("\n");
+    expect(JSON.parse(json)).toEqual({ sharedDepth: 2, ownDepth: true });
+    expect(rest.join("\n")).not.toContain("[Object]");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -117,6 +117,16 @@ describe("global console honors util.inspect.defaultOptions", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("Object.defineProperty on defaultOptions", async () => {
+    const { stdout, exitCode } = await run(`
+      const util = require("node:util");
+      Object.defineProperty(util.inspect.defaultOptions, "depth", { value: 0 });
+      console.log({ a: { b: 1 } });
+    `);
+    expect(stdout).toBe("{ a: [Object] }\n");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("setter form and console.dir", async () => {
     const { stdout, exitCode } = await run(`
       const util = require("node:util");

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { Console } from "node:console";
 
 import { Writable } from "node:stream";
@@ -86,5 +87,71 @@ test("console._stderr", () => {
     writable: true,
     enumerable: false,
     configurable: true,
+  });
+});
+
+describe("global console honors util.inspect.defaultOptions", () => {
+  async function run(src: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("depth / maxArrayLength / numericSeparator on console.log", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const util = require("node:util");
+      util.inspect.defaultOptions.depth = 0;
+      util.inspect.defaultOptions.maxArrayLength = 2;
+      util.inspect.defaultOptions.numericSeparator = true;
+      console.log({ a: { b: { c: { d: 1 } } } });
+      console.log([1, 2, 3, 4, 5, 6]);
+      console.log(1234567);
+      console.warn("%O", { x: { y: 1 } });
+    `);
+    expect(stderr).toBe("{ x: [Object] }\n");
+    expect(stdout).toBe("{ a: [Object] }\n" + "[ 1, 2, ... 4 more items ]\n" + "1_234_567\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("setter form and console.dir", async () => {
+    const { stdout, exitCode } = await run(`
+      const util = require("node:util");
+      util.inspect.defaultOptions = { depth: 0 };
+      console.log({ a: { b: 1 } });
+      console.dir({ a: { b: { c: 1 } } }, { depth: 5 });
+      console.dir({ a: { b: 1 } });
+    `);
+    expect(stdout).toBe("{ a: [Object] }\n" + "{ a: { b: { c: 1 } } }\n" + "{ a: [Object] }\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("group indentation still applied", async () => {
+    const { stdout, exitCode } = await run(`
+      const util = require("node:util");
+      util.inspect.defaultOptions.depth = 0;
+      console.group("g");
+      console.log({ a: { b: 1 } });
+      console.groupEnd();
+    `);
+    expect(stdout).toBe("g\n  { a: [Object] }\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("defaultOptions remains sealed and stable", async () => {
+    const { stdout, exitCode } = await run(`
+      const util = require("node:util");
+      const opts = util.inspect.defaultOptions;
+      process.stdout.write(JSON.stringify({
+        sealed: Object.isSealed(opts),
+        same: opts === util.inspect.defaultOptions,
+        hasDepth: Object.prototype.hasOwnProperty.call(opts, "depth"),
+      }));
+    `);
+    expect(JSON.parse(stdout)).toEqual({ sealed: true, same: true, hasDepth: true });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -139,6 +139,35 @@ describe("global console honors util.inspect.defaultOptions", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.concurrent("console.timeLog extra args", async () => {
+    const { stderr, exitCode } = await run(`
+      const util = require("node:util");
+      util.inspect.defaultOptions.depth = 0;
+      console.time("t");
+      console.timeLog("t", { a: { b: { c: 1 } } });
+    `);
+    expect(stderr).toContain("{ a: [Object] }");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--console-depth still applies when an unrelated default is changed", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--console-depth=5",
+        "-e",
+        `require("util").inspect.defaultOptions.maxArrayLength = 5;` +
+          `console.log({ a: { b: { c: { d: { e: 1 } } } } });`,
+      ],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toContain("e: 1");
+    expect(stdout).not.toContain("[Object]");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("group indentation still applied", async () => {
     const { stdout, exitCode } = await run(`
       const util = require("node:util");

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -156,15 +156,24 @@ describe("global console honors util.inspect.defaultOptions", () => {
         bunExe(),
         "--console-depth=5",
         "-e",
-        `require("util").inspect.defaultOptions.maxArrayLength = 5;` +
-          `console.log({ a: { b: { c: { d: { e: 1 } } } } });`,
+        `const util = require("util");` +
+          `util.inspect.defaultOptions.maxArrayLength = 5;` +
+          `console.log({ a: { b: { c: { d: { e: 1 } } } } });` +
+          `process.stdout.write(JSON.stringify({` +
+          `  defaultDepth: util.inspect.defaultOptions.depth,` +
+          `  inspected: util.inspect({ a: { b: { c: { d: 1 } } } }),` +
+          `}));`,
       ],
       env: { ...bunEnv, NO_COLOR: "1" },
       stderr: "pipe",
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const lastLine = stdout.trimEnd().split("\n").pop()!;
     expect(stdout).toContain("e: 1");
-    expect(stdout).not.toContain("[Object]");
+    expect(JSON.parse(lastLine)).toEqual({
+      defaultDepth: 2,
+      inspected: "{ a: { b: { c: [Object] } } }",
+    });
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
## Problem

The global `console.log`/`warn`/`error`/`dir` use Bun's native formatter, which has no knowledge of `util.inspect.defaultOptions`. Setting `depth`, `maxArrayLength`, `numericSeparator`, etc. correctly changed `util.inspect`, `util.format('%O')`, and `new console.Console(stream)` output, but left global `console` output untouched, so Node's documented process-wide knob was a silent no-op on the one console most code actually uses.

```js
import util from "node:util";
util.inspect.defaultOptions.depth = 0;
util.inspect.defaultOptions.maxArrayLength = 2;
util.inspect.defaultOptions.numericSeparator = true;
console.log({ a: { b: { c: { d: 1 } } } });
console.log([1, 2, 3, 4, 5, 6]);
console.log(1234567);
```

| | Node | Bun (before) |
|---|---|---|
| depth | `{ a: [Object] }` | full depth |
| maxArrayLength | `[ 1, 2, ... 4 more items ]` | all 6 items |
| numericSeparator | `1_234_567` | `1234567` |

## Cause

`message_with_type_and_level_` in `src/jsc/ConsoleObject.rs` builds its `FormatOptions` from compiled-in defaults (plus `--console-depth`) and hands them to the native `Formatter`. Nothing on that path reads `inspectDefaultOptions`, and the native formatter does not implement most of the option keys anyway.

## Fix

`util.inspect.defaultOptions` now returns a `Proxy` over the sealed defaults object. The first write installs a pair of JS formatters on the VM (`formatWithOptions` for log-style calls, `inspect` for `console.dir`); once installed, `message_with_type_and_level_` routes argument formatting through them instead of the native printer, so every documented option applies. The fast native path is kept for the common case where `defaultOptions` is never touched. State is per-VM, so workers are isolated.

## Verification

```
$ bun bd test test/js/node/console/console.test.ts
 11 pass
 0 fail
```

New tests fail on released Bun (depth/maxArrayLength/numericSeparator ignored) and pass with this change; output now matches Node byte-for-byte for the cases above.


Fixes #12762

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/console/console.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/57] gen cpp.rs (cppbind)
[2/57] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/57] gen JS modules (bundle-modules)
Preprocess modules (9115ms)
Bundle modules (70ms)
Postprocesss modules (26ms)
Bundle Functions (733ms)
Generate Code (8ms)

[9.97s] Bundled "src/js" for development
  2210 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/45] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[11/45] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-15.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings_webcore-15.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -g3 -gz=zstd -glldb -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9641b92ed)

test/js/node/console/console.test.ts:
(pass) console.Console > global instanceof Console [3.27ms]
(pass) console.Console > new Console instanceof Console [1.28ms]

(pass) console.Console > it can write to a stream [3.26ms]
(pass) console.Console > can enable colors [0.43ms]
(pass) console.Console > stderr and stdout are separate [0.28ms]
(pass) console._stdout [0.05ms]
(pass) console._stderr [0.05ms]
(pass) global console honors util.inspect.defaultOptions > depth / maxArrayLength / numericSeparator on console.log [27.54ms]
(pass) global console honors util.inspect.defaultOptions > Object.defineProperty on defaultOptions [23.66ms]
(pass) global console honors util.inspect.defaultOptions > console.timeLog extra args [36.50ms]
(pass) global console honors util.inspect.defaultOptions > setter form and console.dir [37.50ms]
(pass) global console honors util.inspect.defaultOptions > group indentation still applied [31.50ms]
(pass) global console honors util.inspect.defaultOptions > writes via an inheriting object do not leak into the shared defaults [32.02ms]
(pass) global console honors util.inspect.defaultOptions > defaultOptions r
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/console/console.test.ts
bun test v1.4.0 (4bf7b6024)

test/js/node/console/console.test.ts:
(pass) console.Console > global instanceof Console [3.52ms]
(pass) console.Console > new Console instanceof Console [71.93ms]

(pass) console.Console > it can write to a stream [174.57ms]
(pass) console.Console > can enable colors [21.91ms]
(pass) console.Console > stderr and stdout are separate [19.06ms]
(pass) console._stdout [2.35ms]
(pass) console._stderr [2.67ms]
(pass) global console honors util.inspect.defaultOptions > Object.defineProperty on defaultOptions [941.69ms]
(pass) global console honors util.inspect.defaultOptions > depth / maxArrayLength / numericSeparator on console.log [986.49ms]
(pass) global console honors util.inspect.defaultOptions > console.timeLog extra args [957.48ms]
(pass) global console honors util.inspect.defaultOptions > setter form and console.dir [1066.23ms]
(pass) global console honors util.inspect.defaultOptions > --console-depth still applies when an unrelated default is changed [1761.16ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1043ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/54] gen cpp.rs (cppbind)
[2/54] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/54] gen JS modules (bundle-modules)
Preprocess modules (8164ms)
Bundle modules (50ms)
Postprocesss modules (206ms)
Bundle Functions (798ms)
Generate Code (120ms)

[9.37s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/44] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/util/inspect.js       |  45 +++++++++++-
 src/jsc/ConsoleObject.rs              |  90 ++++++++++++++++++++---
 src/jsc/VirtualMachine.rs             |  10 +++
 src/runtime/node/node_util_binding.rs |  27 +++++++
 test/js/node/console/console.test.ts  | 132 ++++++++++++++++++++++++++++++++++
 5 files changed, 293 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/internal/util/inspect.js            7     10      0
src/jsc/ConsoleObject.rs                  10      4      0
src/jsc/VirtualMachine.rs                  6      4      0
src/runtime/node/node_util_binding.rs      4      5      0
test/js/node/console/console.test.ts       2      8      0
```

</details>

<!-- robobun:evidence:end -->