### PR TITLE
build: split-debuginfo=unpacked for dev; add rust:timings profiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,16 @@ panic = "abort"
 
 [profile.dev]
 panic = "abort"
+# Split DWARF: debuginfo goes into `.dwo` files alongside each `.o` instead of
+# being packed into the rlibs and then re-packed into `libbun_rust.a`. The debug
+# `.a` was ~1.5 GB (≥80% debuginfo) and the `bun_bin` staticlib step alone spent
+# ~6s archiving it. With split DWARF the `.a` is ~1/4 the size, per-crate
+# codegen writes less to disk, and `gdb`/`lldb` still resolve full debuginfo via
+# the skeleton CUs (`DW_AT_dwo_name`) pointing into `<target>/deps/*.dwo`.
+# No effect on the compiled code. Windows uses PDB so this is a no-op there
+# (rustc ignores it); Darwin's `"unpacked"` is the `.o`-is-the-debuginfo mode
+# `dsymutil` already expects.
+split-debuginfo = "unpacked"
 
 # Fast-iteration release build for local benching when fat LTO's link time
 # (minutes) is in the way. `bun run build:release --cargo-profile=release-dev`.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "rust:check-all": "bun scripts/rust-check-all.ts",
     "rust:clippy": "cargo clippy --workspace --no-deps --keep-going",
     "rust:miri": "bun scripts/rust-miri.ts",
+    "rust:timings": "bun scripts/rust-timings.ts",
     "codegen:string-maps": "for f in src/**/*.string-map.ts; do bun src/codegen/generate-string-map.ts \"$f\" \"${f%.string-map.ts}.generated.rs\"; done",
     "codegen:verify": "bun run codegen:string-maps && git diff --exit-code 'src/**/*.generated.rs' || (echo '\\n*.generated.rs is stale — run `bun run codegen:string-maps` and commit the result.' >&2; exit 1)",
     "clang-format": "./scripts/run-clang-format.sh format",

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -66,7 +66,7 @@ export function rustTarget(cfg: Config): string {
  * cargo's stock release already keeps debuginfo (`debug = 1` is the workspace
  * default), and we don't ship a `MinSizeRel` Rust path yet.
  */
-function cargoProfile(cfg: Config): { name: string; subdir: string } {
+export function cargoProfile(cfg: Config): { name: string; subdir: string } {
   return cfg.buildType === "Debug" ? { name: "dev", subdir: "debug" } : { name: "release", subdir: "release" };
 }
 
@@ -309,24 +309,32 @@ export interface RustBuildInputs {
 }
 
 /**
- * Emit the cargo build step. Returns the output staticlib path as a
- * one-element array so the link step can spread it alongside the C++
- * object list.
+ * The exact `cargo build` invocation the Rust step uses.
+ *
+ * Extracted so tooling (`scripts/rust-timings.ts`) can run cargo with the same
+ * args/rustflags/env that `emitRust()` puts into the ninja edge, without
+ * re-deriving any of it. `emitRust()` is the only build-graph caller.
  */
-export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string[] {
-  assert(cfg.cargo !== undefined, "building bun's Rust crates requires cargo but no rust toolchain was found", {
-    hint: "Install rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
-  });
+export interface CargoInvocation {
+  /** `cargo build <args>` — everything after `build`. */
+  args: string[];
+  /** Env vars the cargo process runs under. `CARGO_ENCODED_RUSTFLAGS` included. */
+  env: Record<string, string>;
+  /** `--target-dir` absolute path (also present in `args`). */
+  targetDir: string;
+  /** `--target` triple (also present in `args`). */
+  triple: string;
+}
 
-  n.comment("─── Rust ───");
-  n.blank();
-
-  const hostWin = cfg.host.os === "windows";
+/**
+ * Compute the cargo command line + environment for `cargo build -p bun_bin`.
+ * Pure function of `cfg`; does no I/O.
+ */
+export function cargoBuildInvocation(cfg: Config): CargoInvocation {
   const targetDir = rustTargetDir(cfg);
   const triple = rustTarget(cfg);
   const tier3 = rustTargetIsTier3(triple);
   const profile = cargoProfile(cfg);
-  const lib = rustLibPath(cfg);
 
   // ─── Build args ───
   const args: string[] = [
@@ -691,6 +699,27 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     env.CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS = "true";
   }
   if (rustflags.length > 0) env.CARGO_ENCODED_RUSTFLAGS = rustflags.join("\x1f");
+
+  return { args, env, targetDir, triple };
+}
+
+/**
+ * Emit the cargo build step. Returns the output staticlib path as a
+ * one-element array so the link step can spread it alongside the C++
+ * object list.
+ */
+export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string[] {
+  assert(cfg.cargo !== undefined, "building bun's Rust crates requires cargo but no rust toolchain was found", {
+    hint: "Install rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+  });
+
+  n.comment("─── Rust ───");
+  n.blank();
+
+  const hostWin = cfg.host.os === "windows";
+  const lib = rustLibPath(cfg);
+  const tier3 = rustTargetIsTier3(rustTarget(cfg));
+  const { args, env, targetDir, triple } = cargoBuildInvocation(cfg);
 
   // ─── Windows .bin/ shim PE ───
   // Builds `src/install/windows-shim/bun_shim_impl.rs` as a freestanding release PE and wires the artifact into `include_bytes!`. Without this step `include_bytes!` embeds the

--- a/scripts/rust-timings.ts
+++ b/scripts/rust-timings.ts
@@ -89,10 +89,10 @@ interface Unit {
 
 function parseTimingsHtml(path: string): { units: Unit[]; total: number } {
   const html = readFileSync(path, "utf8");
-  const m = html.match(/const UNIT_DATA = (\[[\s\S]*?\n\]);/);
+  const m = html.match(/const UNIT_DATA = (\[[\s\S]*?\n?\]);/);
   if (!m) throw new Error(`no UNIT_DATA in ${path}`);
   const units: Unit[] = JSON.parse(m[1]);
-  const total = Math.max(...units.map(u => u.start + u.duration));
+  const total = units.length === 0 ? 0 : Math.max(...units.map(u => u.start + u.duration));
   return { units, total };
 }
 
@@ -118,7 +118,6 @@ function section(u: Unit, name: string): number {
  * inverting that map gives "who was I waiting on".
  */
 function criticalPath(units: Unit[]): Unit[] {
-  const byIdx = new Map(units.map(u => [u.i, u]));
   const waitsOn = new Map<number, { unit: Unit; at: number }[]>();
   for (const u of units) {
     for (const d of u.unblocked_units ?? []) {
@@ -152,7 +151,9 @@ function serialWindows(units: Unit[], maxActive: number, minDur: number): [numbe
   events.sort((a, b) => a[0] - b[0]);
   const out: [number, number, string[]][] = [];
   let active = 0;
-  let since: number | null = null;
+  // The build starts in a ≤maxActive window (nothing is running yet), so open
+  // the first window at t=0 rather than waiting for a downward crossing.
+  let since: number | null = 0;
   for (const [t, d] of events) {
     const was = active;
     active += d;
@@ -261,7 +262,11 @@ if (!existsSync(cfg.codegenDir) || !existsSync(join(repo, "vendor/lolhtml/Cargo.
     cwd: repo,
   });
   if (r.status !== 0) process.exit(1);
-  spawnSync("ninja", ["-C", cfg.buildDir, "codegen", "clone-lolhtml"], { stdio: "inherit", cwd: repo });
+  const nr = spawnSync("ninja", ["-C", cfg.buildDir, "codegen", "clone-lolhtml"], { stdio: "inherit", cwd: repo });
+  if (nr.error || nr.status !== 0) {
+    console.error(nr.error ? `ninja: ${nr.error.message}` : "ninja codegen/clone-lolhtml failed");
+    process.exit(1);
+  }
 }
 
 const inv = cargoBuildInvocation(cfg);

--- a/scripts/rust-timings.ts
+++ b/scripts/rust-timings.ts
@@ -185,7 +185,9 @@ function report(htmlPath: string, top: number): void {
 
   console.log(`\n${dim("report:")} ${htmlPath}`);
   if (total < 0.1) {
-    console.log(`${bold("total")}  ${fmt(total)}  ${dim(`(all ${units.length} units fresh; run with --clean for a cold baseline)`)}\n`);
+    console.log(
+      `${bold("total")}  ${fmt(total)}  ${dim(`(all ${units.length} units fresh; run with --clean for a cold baseline)`)}\n`,
+    );
     return;
   }
   console.log(
@@ -254,11 +256,10 @@ if (cfg.cargo === undefined) {
 // manifest. The configure step is a no-op when already done.
 if (!existsSync(cfg.codegenDir) || !existsSync(join(repo, "vendor/lolhtml/Cargo.toml"))) {
   console.log(cyan("[setup]") + " bun scripts/build.ts --configure-only --profile=" + opts.profile);
-  const r = spawnSync(
-    process.execPath,
-    ["scripts/build.ts", "--configure-only", `--profile=${opts.profile}`],
-    { stdio: "inherit", cwd: repo },
-  );
+  const r = spawnSync(process.execPath, ["scripts/build.ts", "--configure-only", `--profile=${opts.profile}`], {
+    stdio: "inherit",
+    cwd: repo,
+  });
   if (r.status !== 0) process.exit(1);
   spawnSync("ninja", ["-C", cfg.buildDir, "codegen", "clone-lolhtml"], { stdio: "inherit", cwd: repo });
 }
@@ -270,7 +271,17 @@ const inv = cargoBuildInvocation(cfg);
 // at a scratch target dir so it doesn't poison incremental state.
 if (opts.llvmLines !== undefined) {
   const llDir = join(cfg.buildDir, "rust-llvm-lines");
-  const llArgs = ["llvm-lines", "-p", opts.llvmLines, "--target", inv.triple, "--target-dir", llDir, "--profile", cargoProfile(cfg).name];
+  const llArgs = [
+    "llvm-lines",
+    "-p",
+    opts.llvmLines,
+    "--target",
+    inv.triple,
+    "--target-dir",
+    llDir,
+    "--profile",
+    cargoProfile(cfg).name,
+  ];
   console.log(cyan("[llvm-lines]") + ` cargo ${llArgs.join(" ")}`);
   const r = spawnSync(cfg.cargo, llArgs, {
     cwd: repo,

--- a/scripts/rust-timings.ts
+++ b/scripts/rust-timings.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env bun
+/**
+ * Rust build-time profiler.
+ *
+ * Runs `cargo build --timings` with the exact args/rustflags/env the real
+ * build uses (shared with `scripts/build/rust.ts::emitRust`), parses the
+ * HTML report, and prints the critical path, slowest crates, and
+ * low-parallelism windows so you can see where wall time actually goes.
+ *
+ * Usage:
+ *   bun run rust:timings                 # incremental timing (warm cache)
+ *   bun run rust:timings --clean         # clean-build timing into a scratch target dir
+ *   bun run rust:timings --profile=release
+ *   bun run rust:timings --report <path/to/cargo-timing.html>   # re-analyze an existing report
+ *   bun run rust:timings --self-profile  # also emit per-crate rustc -Zself-profile traces
+ *   bun run rust:timings --llvm-lines bun_runtime   # cargo-llvm-lines for one crate
+ *
+ * The raw `cargo-timing.html` is written under the target dir; open it in a
+ * browser for the Gantt chart.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { resolveConfig } from "./build/config.ts";
+import { resolveToolchain } from "./build/configure.ts";
+import { getProfile } from "./build/profiles.ts";
+import { cargoBuildInvocation, cargoProfile } from "./build/rust.ts";
+
+const repo = resolve(import.meta.dirname, "..");
+
+interface Options {
+  profile: string;
+  clean: boolean;
+  report: string | undefined;
+  selfProfile: boolean;
+  llvmLines: string | undefined;
+  top: number;
+}
+
+function parseArgs(argv: string[]): Options {
+  const opts: Options = {
+    profile: "debug",
+    clean: false,
+    report: undefined,
+    selfProfile: false,
+    llvmLines: undefined,
+    top: 20,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--clean") opts.clean = true;
+    else if (a === "--self-profile") opts.selfProfile = true;
+    else if (a === "--report") opts.report = argv[++i];
+    else if (a === "--llvm-lines") opts.llvmLines = argv[++i];
+    else if (a === "--top") opts.top = parseInt(argv[++i], 10);
+    else if (a.startsWith("--profile=")) opts.profile = a.slice("--profile=".length);
+    else if (a === "--profile") opts.profile = argv[++i];
+    else if (a === "--help" || a === "-h") {
+      console.log(readFileSync(import.meta.filename, "utf8").match(/\/\*\*[\s\S]*?\*\//)![0]);
+      process.exit(0);
+    } else {
+      console.error(`unknown arg: ${a}`);
+      process.exit(1);
+    }
+  }
+  return opts;
+}
+
+// ─── cargo-timings HTML parsing ────────────────────────────────────────────
+
+interface Section {
+  start: number;
+  end: number;
+}
+interface Unit {
+  i: number;
+  name: string;
+  version: string;
+  target: string;
+  start: number;
+  duration: number;
+  /** Units unblocked when this unit's rlib is done. */
+  unblocked_units: number[];
+  /** Units unblocked when this unit's rmeta is done (pipelining). */
+  unblocked_rmeta_units: number[];
+  sections?: [string, Section][];
+}
+
+function parseTimingsHtml(path: string): { units: Unit[]; total: number } {
+  const html = readFileSync(path, "utf8");
+  const m = html.match(/const UNIT_DATA = (\[[\s\S]*?\n\]);/);
+  if (!m) throw new Error(`no UNIT_DATA in ${path}`);
+  const units: Unit[] = JSON.parse(m[1]);
+  const total = Math.max(...units.map(u => u.start + u.duration));
+  return { units, total };
+}
+
+/**
+ * Time at which this unit unblocks downstream rmeta-dependents. For a
+ * pipelined rlib that's when the frontend finishes (rmeta written), not
+ * when codegen is done.
+ */
+function rmetaEnd(u: Unit): number {
+  const fe = u.sections?.find(s => s[0] === "frontend");
+  return u.start + (fe ? fe[1].end : u.duration);
+}
+
+function section(u: Unit, name: string): number {
+  const s = u.sections?.find(x => x[0] === name);
+  return s ? s[1].end - s[1].start : 0;
+}
+
+/**
+ * Trace the critical path: walk backwards from the last unit, at each step
+ * picking the dependency whose unblock time matches this unit's start. cargo
+ * records `unblocked_units`/`unblocked_rmeta_units` on the *blocker*, so
+ * inverting that map gives "who was I waiting on".
+ */
+function criticalPath(units: Unit[]): Unit[] {
+  const byIdx = new Map(units.map(u => [u.i, u]));
+  const waitsOn = new Map<number, { unit: Unit; at: number }[]>();
+  for (const u of units) {
+    for (const d of u.unblocked_units ?? []) {
+      (waitsOn.get(d) ?? waitsOn.set(d, []).get(d)!).push({ unit: u, at: u.start + u.duration });
+    }
+    for (const d of u.unblocked_rmeta_units ?? []) {
+      (waitsOn.get(d) ?? waitsOn.set(d, []).get(d)!).push({ unit: u, at: rmetaEnd(u) });
+    }
+  }
+  let cur = units.reduce((a, b) => (a.start + a.duration > b.start + b.duration ? a : b));
+  const path = [cur];
+  while (true) {
+    const blockers = waitsOn.get(cur.i) ?? [];
+    // The immediate cause of `cur` starting is whichever blocker unblocked
+    // latest (≤ cur.start, modulo cargo's scheduler jitter).
+    const next = blockers.filter(b => b.at <= cur.start + 0.5).sort((a, b) => b.at - a.at)[0];
+    if (!next || path.length > 80) break;
+    path.push(next.unit);
+    cur = next.unit;
+  }
+  return path.reverse();
+}
+
+/** Wall-clock windows where ≤ `maxActive` units are running for > `minDur` s. */
+function serialWindows(units: Unit[], maxActive: number, minDur: number): [number, number, string[]][] {
+  const events: [number, number][] = [];
+  for (const u of units) {
+    events.push([u.start, 1]);
+    events.push([u.start + u.duration, -1]);
+  }
+  events.sort((a, b) => a[0] - b[0]);
+  const out: [number, number, string[]][] = [];
+  let active = 0;
+  let since: number | null = null;
+  for (const [t, d] of events) {
+    const was = active;
+    active += d;
+    if (was > maxActive && active <= maxActive) since = t;
+    if (was <= maxActive && active > maxActive && since !== null) {
+      if (t - since > minDur) {
+        const running = [...new Set(units.filter(u => u.start < t && u.start + u.duration > since!).map(u => u.name))];
+        out.push([since, t, running]);
+      }
+      since = null;
+    }
+  }
+  if (since !== null) {
+    const end = Math.max(...units.map(u => u.start + u.duration));
+    if (end - since > minDur) {
+      const running = [...new Set(units.filter(u => u.start + u.duration > since!).map(u => u.name))];
+      out.push([since, end, running]);
+    }
+  }
+  return out;
+}
+
+function fmt(s: number): string {
+  return s.toFixed(1).padStart(5) + "s";
+}
+
+function report(htmlPath: string, top: number): void {
+  const { units, total } = parseTimingsHtml(htmlPath);
+  const cpuSecs = units.reduce((s, u) => s + u.duration, 0);
+
+  console.log(`\n${dim("report:")} ${htmlPath}`);
+  if (total < 0.1) {
+    console.log(`${bold("total")}  ${fmt(total)}  ${dim(`(all ${units.length} units fresh; run with --clean for a cold baseline)`)}\n`);
+    return;
+  }
+  console.log(
+    `${bold("total")}  ${fmt(total)} wall   ${cpuSecs.toFixed(0)} unit-s   ` +
+      `${(cpuSecs / total).toFixed(1)}× avg parallelism   ${units.length} units\n`,
+  );
+
+  console.log(bold(`slowest ${top} units`));
+  const byDur = [...units].sort((a, b) => b.duration - a.duration).slice(0, top);
+  for (const u of byDur) {
+    const fe = section(u, "frontend");
+    const cg = section(u, "codegen");
+    const suffix = u.target && u.target !== "lib" ? ` ${dim(u.target)}` : "";
+    const split = cg > 0 ? `  ${dim(`fe=${fe.toFixed(1)}s cg=${cg.toFixed(1)}s`)}` : "";
+    console.log(`  ${fmt(u.duration)}  ${u.name}${suffix}${split}`);
+  }
+
+  console.log(`\n${bold("critical path")}  ${dim("(last-blocker chain to final unit)")}`);
+  const path = criticalPath(units);
+  let sum = 0;
+  for (const u of path) {
+    const fe = u.sections?.find(s => s[0] === "frontend");
+    const unblocks = u.unblocked_rmeta_units.length > 0 && fe ? fe[1].end : u.duration;
+    sum += unblocks;
+    console.log(
+      `  ${fmt(u.start)} → ${fmt(u.start + u.duration)}  ${u.name.padEnd(24)}` +
+        `  ${dim(`blocks next for ${unblocks.toFixed(1)}s`)}`,
+    );
+  }
+  console.log(`  ${dim(`critical-path sum: ${sum.toFixed(1)}s`)}`);
+
+  const serial = serialWindows(units, 2, 1.0);
+  if (serial.length > 0) {
+    console.log(`\n${bold("low-parallelism windows")}  ${dim("(≤2 units active for >1s)")}`);
+    for (const [s, e, names] of serial) {
+      console.log(`  ${fmt(s)} – ${fmt(e)}  (${(e - s).toFixed(1)}s)  ${names.slice(0, 4).join(", ")}`);
+    }
+  }
+  console.log();
+}
+
+// ─── terminal helpers ──────────────────────────────────────────────────────
+
+const isTTY = process.stdout.isTTY;
+const bold = (s: string) => (isTTY ? `\x1b[1m${s}\x1b[0m` : s);
+const dim = (s: string) => (isTTY ? `\x1b[2m${s}\x1b[0m` : s);
+const cyan = (s: string) => (isTTY ? `\x1b[36m${s}\x1b[0m` : s);
+
+// ─── main ──────────────────────────────────────────────────────────────────
+
+const opts = parseArgs(process.argv.slice(2));
+
+if (opts.report !== undefined) {
+  report(opts.report, opts.top);
+  process.exit(0);
+}
+
+const toolchain = resolveToolchain();
+const cfg = resolveConfig(getProfile(opts.profile), toolchain);
+if (cfg.cargo === undefined) {
+  console.error("cargo not found (resolveToolchain)");
+  process.exit(1);
+}
+
+// Codegen + vendored path deps must exist before cargo can load the workspace
+// manifest. The configure step is a no-op when already done.
+if (!existsSync(cfg.codegenDir) || !existsSync(join(repo, "vendor/lolhtml/Cargo.toml"))) {
+  console.log(cyan("[setup]") + " bun scripts/build.ts --configure-only --profile=" + opts.profile);
+  const r = spawnSync(
+    process.execPath,
+    ["scripts/build.ts", "--configure-only", `--profile=${opts.profile}`],
+    { stdio: "inherit", cwd: repo },
+  );
+  if (r.status !== 0) process.exit(1);
+  spawnSync("ninja", ["-C", cfg.buildDir, "codegen", "clone-lolhtml"], { stdio: "inherit", cwd: repo });
+}
+
+const inv = cargoBuildInvocation(cfg);
+
+// `--llvm-lines <crate>`: delegate to cargo-llvm-lines with our rustflags.
+// Forces codegen-units=1 and emits LLVM IR, so it's a separate build; point it
+// at a scratch target dir so it doesn't poison incremental state.
+if (opts.llvmLines !== undefined) {
+  const llDir = join(cfg.buildDir, "rust-llvm-lines");
+  const llArgs = ["llvm-lines", "-p", opts.llvmLines, "--target", inv.triple, "--target-dir", llDir, "--profile", cargoProfile(cfg).name];
+  console.log(cyan("[llvm-lines]") + ` cargo ${llArgs.join(" ")}`);
+  const r = spawnSync(cfg.cargo, llArgs, {
+    cwd: repo,
+    stdio: "inherit",
+    env: { ...process.env, ...inv.env },
+  });
+  process.exit(r.status ?? 1);
+}
+
+// `--clean`: profile a from-scratch build into a throwaway target dir so the
+// real one keeps its incremental cache.
+let targetDir = inv.targetDir;
+let args = inv.args;
+if (opts.clean) {
+  targetDir = join(cfg.buildDir, "rust-timings");
+  console.log(cyan("[clean]") + ` removing ${targetDir}`);
+  rmSync(targetDir, { recursive: true, force: true });
+  args = args.map(a => (a === inv.targetDir ? targetDir : a));
+}
+
+// `--self-profile`: also write per-crate rustc self-profile traces. Summarize
+// with `cargo install --locked measureme-cli && summarize <dir>/<crate>-*`.
+const env = { ...process.env, ...inv.env };
+if (opts.selfProfile) {
+  const spDir = join(targetDir, "self-profile");
+  rmSync(spDir, { recursive: true, force: true });
+  const extra = `-Zself-profile=${spDir}\x1f-Zself-profile-events=default`;
+  env.CARGO_ENCODED_RUSTFLAGS = env.CARGO_ENCODED_RUSTFLAGS ? `${env.CARGO_ENCODED_RUSTFLAGS}\x1f${extra}` : extra;
+  console.log(cyan("[self-profile]") + ` rustc traces → ${spDir}`);
+}
+
+console.log(cyan("[cargo]") + ` build ${args.join(" ")} --timings`);
+const r = spawnSync(cfg.cargo, ["build", ...args, "--timings"], {
+  cwd: repo,
+  stdio: "inherit",
+  env,
+});
+if (r.status !== 0) process.exit(r.status ?? 1);
+
+const htmlPath = join(targetDir, "cargo-timings", "cargo-timing.html");
+if (!existsSync(htmlPath)) {
+  console.error(`no timing report at ${htmlPath}`);
+  process.exit(1);
+}
+report(htmlPath, opts.top);


### PR DESCRIPTION
## What

Two things:

1. **`[profile.dev] split-debuginfo = "unpacked"`** in `Cargo.toml`. Rust debuginfo goes into `.dwo` files next to each `.o` instead of being packed into rlibs and then into `libbun_rust.a`.
2. **`bun run rust:timings`** (`scripts/rust-timings.ts`): runs `cargo build --timings` with the exact args/rustflags/env the real build uses, parses the report, and prints slowest crates + critical path + low-parallelism windows. Also fronts `cargo-llvm-lines` and rustc `-Zself-profile` with the same env.

`scripts/build/rust.ts` now exports `cargoBuildInvocation(cfg)` so the tool and `emitRust()` share one source of truth. Verified the generated `build.ninja` is byte-identical before/after the refactor.

## Why split-debuginfo

The debug `libbun_rust.a` was ~1.5 GB, ~80% of which was DWARF (`bun_runtime.rlib` alone: 493 MB, of which 157 MB `.debug_*` vs 35 MB `.text`). Every clean build writes that into ~100 rlibs, re-packs it into the `.a`, and the `bun_bin` staticlib step alone archived 1.5 GB for ~6 s.

With `split-debuginfo = "unpacked"` rustc writes a ~50-byte skeleton CU per codegen unit (plus `.debug_line`/`.debug_addr`, which stay in the `.o`), and the full type/variable info goes to sibling `.dwo` files that never enter `ar` or `lld`. Clean debug+asan build on a 16-core linux box:

|                  | before | after |
|------------------|-------:|------:|
| cargo wall time  |  76.7s | 59.9s |
| `bun_runtime` crate | 33.1s | 27.3s |
| `bun_bin` staticlib |  6.2s |  1.2s |
| `libbun_rust.a`  | 1.5 GB | 1.1 GB |

Debugging is unchanged: `bun-debug` still carries `.debug_line` for every Rust frame (backtraces/`addr2line` work from the exe alone), plus the skeleton CUs; `gdb`/`lldb` follow `DW_AT_GNU_dwo_name` into `build/debug/rust-target/.../deps/*.dwo` for variable/type info. C++ debuginfo is untouched. Windows (PDB) and Darwin (`.o`-is-the-debuginfo) are unaffected by this setting. No change to compiled code.

## `rust:timings`

```
$ bun run rust:timings --clean
...
total   59.9s wall   196 unit-s   3.3× avg parallelism   253 units

slowest 5 units
   27.3s  bun_runtime         fe=11.5s cg=15.8s
    9.1s  bun_react_compiler  fe=3.8s  cg=5.3s
    8.9s  bun_css             fe=4.0s  cg=4.9s
    7.5s  bun_install         fe=2.5s  cg=5.0s
    7.3s  bun_bundler         fe=2.2s  cg=5.1s

critical path  (last-blocker chain to final unit)
    0.4s →   7.0s  core            blocks next for 6.2s
    ...
   28.8s →  34.0s  bun_jsc         blocks next for 1.6s
   30.5s →  33.7s  bun_sql_jsc     blocks next for 1.2s
   31.4s →  58.7s  bun_runtime     blocks next for 27.3s
   58.7s →  59.9s  bun_bin         blocks next for 1.2s

low-parallelism windows  (≤2 units active for >1s)
   34.0s – 59.9s  (25.9s)  bun_runtime, bun_bin
```

The raw `cargo-timing.html` Gantt chart is written under the target dir for browsing. `--llvm-lines <crate>` runs `cargo-llvm-lines` with bun's rustflags; `--self-profile` adds per-crate rustc self-profile traces; `--report <html>` re-analyzes an existing report.

## What the tooling surfaced (not in this PR)

- `bun_runtime` is the bottleneck: ~27 s serial at the end, 325 k LoC in one crate. Splitting along the existing subdirectory seams (`server/`, `node/`, `webcore/`, `test_runner/`, `shell/`, `cli/`, `bake/`) would let those compile in parallel during the ~25 s the other cores currently idle.
- `bun_jsc` can't start until `bun_install`'s rmeta is ready (adds ~3 s to the critical path). The uses are `AsyncModule.rs` and `VirtualMachine::package_manager()`; moving those types into `bun_install_types` would let `bun_jsc` start earlier.
- `cargo-llvm-lines` flagged `test_runner::pretty_format::Formatter::print_as` as 29% of `bun_runtime`'s pre-opt LLVM IR (const-generic `<W, const Tag, const bool>` = ~3,360 instantiations). Making `Tag` a runtime parameter drops that to ~40 k lines, but a clean rebuild measured no wall-clock change: rustc's MIR-level const-prop + SimplifyCfg already dead-strips the unused arms before LLVM sees them. Left as-is.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->