### PR TITLE
stdio: surface EPIPE from console.log/process.stdout.write as 'error' on process.stdout

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -566,6 +566,7 @@ bun_dispatch::link_interface! {
         fn create_file(cwd: Fd, path: &[u8]) -> core::result::Result<Fd, Error>;
         fn quiet_writer_from_fd(fd: Fd) -> output::QuietWriter;
         fn quiet_writer_adapt(qw: output::QuietWriter, buf: *mut u8, len: usize) -> output::QuietWriterAdapter;
+        fn quiet_writer_adapter_take_err(a: &mut output::QuietWriterAdapter) -> i32;
         fn quiet_writer_flush(qw: &mut output::QuietWriter);
         fn quiet_writer_write_all(qw: &mut output::QuietWriter, bytes: &[u8]) -> bool;
         fn quiet_writer_fd(qw: &output::QuietWriter) -> Fd;

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -106,6 +106,17 @@ impl QuietWriterAdapter {
         // the io::Writer is the first field (repr(C)).
         unsafe { &mut *std::ptr::from_mut::<Self>(self).cast::<io::Writer>() }
     }
+    /// Take and clear the sticky write errno recorded by this adapter's
+    /// `write_all`/`flush` (raw `libc` value; `None` if no error). Lets
+    /// `ConsoleObject` surface `console.*` write failures on
+    /// `process.stdout`/`stderr` after the native writer has swallowed them.
+    #[inline]
+    pub fn take_err(&mut self) -> Option<i32> {
+        match output_sink().quiet_writer_adapter_take_err(self) {
+            0 => None,
+            errno => Some(errno),
+        }
+    }
 }
 
 /// Opaque file handle. Replaces `bun_sys::File` in this crate.

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -106,10 +106,8 @@ impl QuietWriterAdapter {
         // the io::Writer is the first field (repr(C)).
         unsafe { &mut *std::ptr::from_mut::<Self>(self).cast::<io::Writer>() }
     }
-    /// Take and clear the sticky write errno recorded by this adapter's
-    /// `write_all`/`flush` (raw `libc` value; `None` if no error). Lets
-    /// `ConsoleObject` surface `console.*` write failures on
-    /// `process.stdout`/`stderr` after the native writer has swallowed them.
+    /// Take and clear the sticky write errno this adapter's `write_all`/`flush`
+    /// recorded (raw `libc` value). See `ConsoleObject::forward_write_error`.
     #[inline]
     pub fn take_err(&mut self) -> Option<i32> {
         match output_sink().quiet_writer_adapter_take_err(self) {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -55,6 +55,13 @@ export function getStdioWriteStream(
     stream = new fs.WriteStream(null, { autoClose: false, fd, $fastPath: true });
     stream.readable = false;
     stream._type = "fs";
+    // Node's stdio streams (net.Socket for pipe/socket, SyncWriteStream for
+    // file) all have autoDestroy:true with _destroy overridden below to
+    // _undestroy(), so a write error goes errorOrDestroy -> destroy ->
+    // _undestroy -> emit 'error' on nextTick, and the stream remains writable.
+    // autoClose:false left it off, so errorOrDestroy latched on errorEmitted
+    // after the first failure and later writes never surfaced an error.
+    stream._writableState.autoDestroy = true;
 
     // When stdout/stderr are piped or connected to a socket, they should have Symbol.asyncIterator
     // to match Node.js behavior where they become Duplex streams (Socket)
@@ -65,11 +72,6 @@ export function getStdioWriteStream(
           // stdout/stderr don't produce readable data, so yield nothing
         })();
       };
-    } else {
-      // File-backed stdio: Node's SyncWriteStream runs end() -> finish ->
-      // destroy -> the _destroy override below -> _undestroy(), which resets
-      // writable state so later writes succeed. autoClose:false disabled that.
-      stream._writableState.autoDestroy = true;
     }
   }
 
@@ -77,9 +79,21 @@ export function getStdioWriteStream(
     stream.destroySoon = stream.destroy;
     stream._destroy = function (err, cb) {
       cb(err);
+      // Node terminates on the first uncaught 'error', so _undestroy()'s
+      // reset of errorEmitted never matters there. Bun keeps running after
+      // an uncaughtException, so a write loop on a dead pipe with no 'error'
+      // listener would re-emit (and re-report) forever. Preserve errorEmitted
+      // across _undestroy() when nobody is listening so emitErrorNT's
+      // one-shot guard stays latched; with a listener, reset it so the
+      // listener fires per write like Node.
+      const w = this._writableState;
+      const hadErrorEmitted = w.errorEmitted;
       this._undestroy();
+      if (this.listenerCount("error") === 0) {
+        w.errorEmitted = hadErrorEmitted;
+      }
 
-      if (!this._writableState.emitClose) {
+      if (!w.emitClose) {
         process.nextTick(() => {
           this.emit("close");
         });

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -55,12 +55,9 @@ export function getStdioWriteStream(
     stream = new fs.WriteStream(null, { autoClose: false, fd, $fastPath: true });
     stream.readable = false;
     stream._type = "fs";
-    // Node's stdio streams (net.Socket for pipe/socket, SyncWriteStream for
-    // file) all have autoDestroy:true with _destroy overridden below to
-    // _undestroy(), so a write error goes errorOrDestroy -> destroy ->
-    // _undestroy -> emit 'error' on nextTick, and the stream remains writable.
-    // autoClose:false left it off, so errorOrDestroy latched on errorEmitted
-    // after the first failure and later writes never surfaced an error.
+    // Node's stdio (net.Socket / SyncWriteStream) has autoDestroy:true paired
+    // with the _destroy -> _undestroy() override below, so errorOrDestroy
+    // emits 'error' per failed write and the stream stays writable.
     stream._writableState.autoDestroy = true;
 
     // When stdout/stderr are piped or connected to a socket, they should have Symbol.asyncIterator
@@ -79,13 +76,10 @@ export function getStdioWriteStream(
     stream.destroySoon = stream.destroy;
     stream._destroy = function (err, cb) {
       cb(err);
-      // Node terminates on the first uncaught 'error', so _undestroy()'s
-      // reset of errorEmitted never matters there. Bun keeps running after
-      // an uncaughtException, so a write loop on a dead pipe with no 'error'
-      // listener would re-emit (and re-report) forever. Preserve errorEmitted
-      // across _undestroy() when nobody is listening so emitErrorNT's
-      // one-shot guard stays latched; with a listener, reset it so the
-      // listener fires per write like Node.
+      // Bun keeps running after an uncaughtException (unlike Node), so preserve
+      // errorEmitted across _undestroy() when no 'error' listener is attached
+      // to keep emitErrorNT's one-shot guard latched instead of re-reporting
+      // forever. With a listener, reset it so the listener fires per write.
       const w = this._writableState;
       const hadErrorEmitted = w.errorEmitted;
       this._undestroy();

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -361,9 +361,10 @@ unsafe extern "C" {
 /// than letting it become an uncaught exception (matching
 /// `test-process-external-stdio-close`).
 fn forward_write_error(global: &JSGlobalObject, is_stderr: bool) {
-    // SAFETY: single-JS-thread top-level host call; `&mut` is scoped to this
-    // block so nothing derived from it is live across the re-entrant FFI below.
     let errno = {
+        // SAFETY: single-JS-thread top-level host call; `&mut` is scoped to
+        // this block so nothing derived from it is live across the re-entrant
+        // FFI below.
         let console = unsafe { vm_console_mut(global) };
         let backing = if is_stderr {
             &mut console.error_writer_backing

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -383,10 +383,9 @@ fn forward_write_error(global: &JSGlobalObject, is_stderr: bool) {
     if global.has_exception() {
         return;
     }
-    // Transient: Node/libuv retry these internally and never emit `'error'`.
-    if errno == bun_sys::E::EAGAIN as i32 || errno == bun_sys::E::EINTR as i32 {
-        return;
-    }
+    // EAGAIN/EINTR are filtered at record time (drain_to_fd), so any errno
+    // reaching here is non-transient.
+    debug_assert!(errno != bun_sys::E::EAGAIN as i32 && errno != bun_sys::E::EINTR as i32);
     let sys_err = bun_sys::Error::new(errno, bun_sys::Tag::write);
     let js_err = crate::SysErrorJsc::to_js(&sys_err, global);
     if global.has_exception() {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -348,6 +348,12 @@ impl Drop for FlushOnDrop<'_> {
     }
 }
 
+#[inline]
+fn level_uses_stderr(message_type: MessageType, level: MessageLevel) -> bool {
+    matches!(level, MessageLevel::Warning | MessageLevel::Error)
+        || message_type == MessageType::Assert
+}
+
 unsafe extern "C" {
     fn Bun__ConsoleObject__onStdioWriteError(global: &JSGlobalObject, fd: i32, err: JSValue);
 }
@@ -401,8 +407,7 @@ pub extern "C" fn message_with_type_and_level(
     vals: *const JSValue,
     len: usize,
 ) {
-    let is_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
-        || message_type == MessageType::Assert;
+    let is_stderr = level_uses_stderr(message_type, level);
     if let Err(err) = message_with_type_and_level_(ctype, message_type, level, global, vals, len) {
         // The exception is already set on the VM (`JsError::Thrown`); for OOM
         // make sure something is pending. Mirrors `host_fn::void_from_js_error`.
@@ -454,8 +459,7 @@ fn message_with_type_and_level_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same
     // time. We do this the slightly annoying way to avoid assigning a pointer.
-    let use_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
-        || message_type == MessageType::Assert;
+    let use_stderr = level_uses_stderr(message_type, level);
     let _stream_lock = ConsoleStreamLock::acquire(use_stderr);
 
     if message_type == MessageType::Clear {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -348,6 +348,47 @@ impl Drop for FlushOnDrop<'_> {
     }
 }
 
+unsafe extern "C" {
+    fn Bun__ConsoleObject__onStdioWriteError(global: &JSGlobalObject, fd: i32, err: JSValue);
+}
+
+/// If the writer backing recorded an I/O errno during this `console.*` call,
+/// surface it on `process.stdout`/`stderr` as an `'error'` event so user
+/// listeners fire. Node routes `console.log` through `process.stdout.write()`,
+/// so a broken-pipe `EPIPE` reaches the stream's error machinery; Bun's native
+/// writer bypasses the stream entirely, hence this after-the-fact forward.
+/// When no `'error'` listener is attached the C++ side drops the error rather
+/// than letting it become an uncaught exception (matching
+/// `test-process-external-stdio-close`).
+fn forward_write_error(global: &JSGlobalObject, is_stderr: bool) {
+    // SAFETY: single-JS-thread top-level host call; `&mut` is scoped to this
+    // block so nothing derived from it is live across the re-entrant FFI below.
+    let errno = {
+        let console = unsafe { vm_console_mut(global) };
+        let backing = if is_stderr {
+            &mut console.error_writer_backing
+        } else {
+            &mut console.writer_backing
+        };
+        match backing.take_err() {
+            None => return,
+            Some(e) => e,
+        }
+    };
+    // Transient: Node/libuv retry these internally and never emit `'error'`.
+    if errno == bun_sys::E::EAGAIN as i32 || errno == bun_sys::E::EINTR as i32 {
+        return;
+    }
+    let sys_err = bun_sys::Error::new(errno, bun_sys::Tag::write);
+    let js_err = crate::SysErrorJsc::to_js(&sys_err, global);
+    if global.has_exception() {
+        return;
+    }
+    // SAFETY: C++ side resolves `process.stdout`/`stderr` and calls
+    // `.destroy(err)`; `js_err` is stack-rooted for the call's duration.
+    unsafe { Bun__ConsoleObject__onStdioWriteError(global, if is_stderr { 2 } else { 1 }, js_err) };
+}
+
 /// <https://console.spec.whatwg.org/#formatter>
 #[crate::host_call]
 pub extern "C" fn message_with_type_and_level(
@@ -358,14 +399,31 @@ pub extern "C" fn message_with_type_and_level(
     vals: *const JSValue,
     len: usize,
 ) {
+    let is_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
+        || message_type == MessageType::Assert;
     if let Err(err) = message_with_type_and_level_(ctype, message_type, level, global, vals, len) {
+        // A JS exception is pending; don't call into JS to forward the write
+        // error. Clear the recorded errno so the pending exception is what
+        // the caller observes; the next `console.*` call will hit the dead
+        // pipe again and forward then.
+        {
+            // SAFETY: single-JS-thread; no other `&mut` is live in this arm.
+            let console = unsafe { vm_console_mut(global) };
+            if is_stderr {
+                let _ = console.error_writer_backing.take_err();
+            } else {
+                let _ = console.writer_backing.take_err();
+            }
+        }
         // The exception is already set on the VM (`JsError::Thrown`); for OOM
         // make sure something is pending. Mirrors `host_fn::void_from_js_error`.
         if matches!(err, jsc::JsError::OutOfMemory) {
             global.throw_out_of_memory_value();
         }
         debug_assert!(global.has_exception());
+        return;
     }
+    forward_write_error(global, is_stderr);
 }
 
 fn message_with_type_and_level_(

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -594,7 +594,13 @@ fn message_with_type_and_level_(
         // SAFETY: see [`vm_console`]. `writer` (above) is dead in this arm —
         // the only later uses are in the mutually-exclusive `Trace` block, and
         // `message_type == Log` here.
-        let w = unsafe { (*console).writer() };
+        let w = unsafe {
+            if use_stderr {
+                (*console).error_writer()
+            } else {
+                (*console).writer()
+            }
+        };
         let _ = w.write_all(b"\n");
         let _ = w.flush();
     } else if message_type != MessageType::Trace {
@@ -5984,7 +5990,7 @@ pub(crate) extern "C" fn Bun__ConsoleObject__timeLog(
     // SAFETY: caller passes a valid (args, args_len) pair.
     for &arg in unsafe { bun_core::ffi::slice(args, args_len) } {
         let Ok(tag) = formatter::Tag::get(arg, global) else {
-            return;
+            break;
         };
         let _ = bun_io::Write::write_all(&mut writer, b" ");
         if Output::enable_ansi_colors_stderr() {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -375,6 +375,12 @@ fn forward_write_error(global: &JSGlobalObject, is_stderr: bool) {
             Some(e) => e,
         }
     };
+    // A pending JS exception (thrown by the caller's formatting path) takes
+    // precedence; don't call into JS under it. The sticky errno was cleared
+    // above and the next `console.*` call hits the dead pipe again.
+    if global.has_exception() {
+        return;
+    }
     // Transient: Node/libuv retry these internally and never emit `'error'`.
     if errno == bun_sys::E::EAGAIN as i32 || errno == bun_sys::E::EINTR as i32 {
         return;
@@ -402,27 +408,14 @@ pub extern "C" fn message_with_type_and_level(
     let is_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
         || message_type == MessageType::Assert;
     if let Err(err) = message_with_type_and_level_(ctype, message_type, level, global, vals, len) {
-        // A JS exception is pending; don't call into JS to forward the write
-        // error. Clear the recorded errno so the pending exception is what
-        // the caller observes; the next `console.*` call will hit the dead
-        // pipe again and forward then.
-        {
-            // SAFETY: single-JS-thread; no other `&mut` is live in this arm.
-            let console = unsafe { vm_console_mut(global) };
-            if is_stderr {
-                let _ = console.error_writer_backing.take_err();
-            } else {
-                let _ = console.writer_backing.take_err();
-            }
-        }
         // The exception is already set on the VM (`JsError::Thrown`); for OOM
         // make sure something is pending. Mirrors `host_fn::void_from_js_error`.
         if matches!(err, jsc::JsError::OutOfMemory) {
             global.throw_out_of_memory_value();
         }
         debug_assert!(global.has_exception());
-        return;
     }
+    // Safe with a pending exception: clears the sticky errno and returns early.
     forward_write_error(global, is_stderr);
 }
 
@@ -5859,6 +5852,7 @@ pub(crate) extern "C" fn Bun__ConsoleObject__count(
         let _ = writeln!(writer, "{}: {}", bstr::BStr::new(slice), current);
     }
     let _ = writer.flush();
+    forward_write_error(global_this, false);
 }
 
 #[unsafe(no_mangle)]
@@ -6002,6 +5996,7 @@ pub(crate) extern "C" fn Bun__ConsoleObject__timeLog(
     }
     let _ = bun_io::Write::write_all(&mut writer, b"\n");
     let _ = bun_io::Write::flush(&mut writer);
+    forward_write_error(global, true);
 }
 
 /// Stamp out the empty `Bun__ConsoleObject__*` C-ABI hooks that JSC's

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -352,14 +352,11 @@ unsafe extern "C" {
     fn Bun__ConsoleObject__onStdioWriteError(global: &JSGlobalObject, fd: i32, err: JSValue);
 }
 
-/// If the writer backing recorded an I/O errno during this `console.*` call,
-/// surface it on `process.stdout`/`stderr` as an `'error'` event so user
-/// listeners fire. Node routes `console.log` through `process.stdout.write()`,
-/// so a broken-pipe `EPIPE` reaches the stream's error machinery; Bun's native
-/// writer bypasses the stream entirely, hence this after-the-fact forward.
-/// When no `'error'` listener is attached the C++ side drops the error rather
-/// than letting it become an uncaught exception (matching
-/// `test-process-external-stdio-close`).
+/// Surface any write errno the console adapter recorded on
+/// `process.stdout`/`stderr` as an `'error'` event. Bun's native `console.*`
+/// writes to the fd directly, bypassing the stream; Node routes through
+/// `process.stdout.write()`. The C++ side drops it when no `'error'` listener
+/// is attached (matching `test-process-external-stdio-close`).
 fn forward_write_error(global: &JSGlobalObject, is_stderr: bool) {
     let errno = {
         // SAFETY: single-JS-thread top-level host call; `&mut` is scoped to
@@ -376,9 +373,7 @@ fn forward_write_error(global: &JSGlobalObject, is_stderr: bool) {
             Some(e) => e,
         }
     };
-    // A pending JS exception (thrown by the caller's formatting path) takes
-    // precedence; don't call into JS under it. The sticky errno was cleared
-    // above and the next `console.*` call hits the dead pipe again.
+    // Don't call into JS under a pending exception; errno was cleared above.
     if global.has_exception() {
         return;
     }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4463,12 +4463,10 @@ extern "C" void Bun__ConsoleObject__onStdioWriteError(Zig::GlobalObject* global,
     if (!process)
         return;
 
-    JSValue stream = process->get(global, fd == 2 ? Identifier::fromString(vm, "stderr"_s) : Identifier::fromString(vm, "stdout"_s));
-    if (scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        return;
-    }
-    if (!stream.isObject())
+    // getDirect so we don't reify the lazy stdout/stderr PropertyCallback: if the
+    // user never touched the stream, no 'error' listener can be attached.
+    JSValue stream = process->getDirect(vm, fd == 2 ? Identifier::fromString(vm, "stderr"_s) : Identifier::fromString(vm, "stdout"_s));
+    if (!stream || !stream.isObject())
         return;
     JSObject* streamObj = stream.getObject();
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4449,18 +4449,11 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
     }
 }
 
-// Called from ConsoleObject.rs when a console.log/console.error write to fd 1/2 fails
-// (EPIPE on a dead pipe, EIO on a hung-up tty, etc.). Node's console.log writes through
-// process.stdout.write(), so the failure reaches the stream's 'error' machinery; Bun's
-// native console writer bypasses the stream. Forward here by calling stream.destroy(err):
-// process.stdout/stderr's overridden _destroy immediately _undestroy()s, so the stream
-// stays writable and 'error' fires on nextTick.
-//
-// When nobody is listening for 'error' the failure is dropped rather than turned into an
-// uncaught exception: Node's createWriteErrorHandler swallows the first such failure
-// (test-process-external-stdio-close), and console.* is a debugging utility that shouldn't
-// terminate a program whose output consumer went away. A direct process.stdout.write()
-// still surfaces an uncaught EPIPE via the writeFast path.
+// Surface a failed native console.* write on process.stdout/stderr via
+// stream.destroy(err); its _destroy override _undestroy()s so the stream stays
+// writable and 'error' fires on nextTick. Dropped when no 'error' listener is
+// attached, matching Node's createWriteErrorHandler (test-process-external-stdio-close);
+// a direct process.stdout.write() still surfaces an uncaught EPIPE via writeFast.
 extern "C" void Bun__ConsoleObject__onStdioWriteError(Zig::GlobalObject* global, int32_t fd, EncodedJSValue encodedError)
 {
     auto& vm = JSC::getVM(global);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4449,6 +4449,68 @@ extern "C" void Process__emitErrorEvent(Zig::GlobalObject* global, EncodedJSValu
     }
 }
 
+// Called from ConsoleObject.rs when a console.log/console.error write to fd 1/2 fails
+// (EPIPE on a dead pipe, EIO on a hung-up tty, etc.). Node's console.log writes through
+// process.stdout.write(), so the failure reaches the stream's 'error' machinery; Bun's
+// native console writer bypasses the stream. Forward here by calling stream.destroy(err):
+// process.stdout/stderr's overridden _destroy immediately _undestroy()s, so the stream
+// stays writable and 'error' fires on nextTick.
+//
+// When nobody is listening for 'error' the failure is dropped rather than turned into an
+// uncaught exception: Node's createWriteErrorHandler swallows the first such failure
+// (test-process-external-stdio-close), and console.* is a debugging utility that shouldn't
+// terminate a program whose output consumer went away. A direct process.stdout.write()
+// still surfaces an uncaught EPIPE via the writeFast path.
+extern "C" void Bun__ConsoleObject__onStdioWriteError(Zig::GlobalObject* global, int32_t fd, EncodedJSValue encodedError)
+{
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    auto* process = global->processObject();
+    if (!process)
+        return;
+
+    JSValue stream = process->get(global, fd == 2 ? Identifier::fromString(vm, "stderr"_s) : Identifier::fromString(vm, "stdout"_s));
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return;
+    }
+    if (!stream.isObject())
+        return;
+    JSObject* streamObj = stream.getObject();
+
+    JSValue listenerCountFn = streamObj->get(global, Identifier::fromString(vm, "listenerCount"_s));
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return;
+    }
+    if (listenerCountFn.isCallable()) {
+        JSC::MarkedArgumentBuffer lcArgs;
+        lcArgs.append(jsString(vm, String("error"_s)));
+        JSValue count = JSC::call(global, listenerCountFn, JSC::getCallData(listenerCountFn), stream, lcArgs);
+        if (scope.exception()) [[unlikely]] {
+            (void)scope.tryClearException();
+            return;
+        }
+        if (count.isNumber() && count.asNumber() == 0)
+            return;
+    }
+
+    JSValue destroyFn = streamObj->get(global, Identifier::fromString(vm, "destroy"_s));
+    if (scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        return;
+    }
+    if (!destroyFn.isCallable())
+        return;
+
+    JSC::MarkedArgumentBuffer args;
+    args.append(JSValue::decode(encodedError));
+    JSC::call(global, destroyFn, JSC::getCallData(destroyFn), stream, args);
+    if (scope.exception()) [[unlikely]]
+        (void)scope.tryClearException();
+}
+
 /* Source for Process.lut.h
 @begin processObjectTable
   _debugEnd                        Process_stubEmptyFunction                           Function 0

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4459,12 +4459,11 @@ extern "C" void Bun__ConsoleObject__onStdioWriteError(Zig::GlobalObject* global,
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    auto* process = global->processObject();
-    if (!process)
+    // If process (or the target stream) was never touched, no 'error' listener
+    // can be attached; getDirect avoids reifying the lazy PropertyCallback.
+    if (!global->hasProcessObject())
         return;
-
-    // getDirect so we don't reify the lazy stdout/stderr PropertyCallback: if the
-    // user never touched the stream, no 'error' listener can be attached.
+    auto* process = global->processObject();
     JSValue stream = process->getDirect(vm, fd == 2 ? Identifier::fromString(vm, "stderr"_s) : Identifier::fromString(vm, "stdout"_s));
     if (!stream || !stream.isObject())
         return;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9453,6 +9453,11 @@ struct SysQuietWriterAdapter {
     buf: *mut u8,
     cap: usize,
     pos: usize,
+    /// Raw errno of the first write error since the last `take_err()`
+    /// (`0` = none). Sticky so `ConsoleObject` can check once after all of a
+    /// `console.*` call's formatting writes and surface it on
+    /// `process.stdout`/`stderr`.
+    err: i32,
 }
 const _: () = {
     assert!(
@@ -9466,16 +9471,27 @@ const _: () = {
 };
 
 impl SysQuietWriterAdapter {
-    /// View of the bytes buffered so far (`buf[0..pos]`). Centralises the
-    /// (ptr, len) → slice reconstruction; the buffer is owned by the adapter
-    /// and lives for `&self`.
+    /// `fd_write_all_quiet` that also records the first I/O error's errno into
+    /// `self.err` (sticky across calls; cleared by `quiet_writer_adapter_take_err`).
     #[inline]
-    fn buffered(&self) -> &[u8] {
-        // SAFETY: `buf` is a `cap`-byte allocation owned by this adapter (set
-        // at construction); `pos <= cap` is upheld by `adapter_write_all`
-        // (drains before writing past `cap`). Bytes `[0, pos)` were written by
-        // `copy_nonoverlapping` and are initialized. Borrow tied to `&self`.
-        unsafe { core::slice::from_raw_parts(self.buf, self.pos) }
+    fn drain_to_fd(&mut self, mut bytes: &[u8]) {
+        while !bytes.is_empty() {
+            match write(self.fd, bytes) {
+                Ok(0) => {
+                    if self.err == 0 {
+                        self.err = E::EPIPE as i32;
+                    }
+                    return;
+                }
+                Ok(n) => bytes = &bytes[n..],
+                Err(e) => {
+                    if self.err == 0 {
+                        self.err = e.get_errno() as i32;
+                    }
+                    return;
+                }
+            }
+        }
     }
 }
 
@@ -9486,18 +9502,21 @@ unsafe fn adapter_write_all(
     // SAFETY: `w` points at the first field of a SysQuietWriterAdapter (repr(C)).
     let this = unsafe { &mut *w.cast::<SysQuietWriterAdapter>() };
     if this.cap == 0 {
-        let _ = fd_write_all_quiet(this.fd, bytes);
+        this.drain_to_fd(bytes);
         return Ok(());
     }
     if this.pos + bytes.len() > this.cap {
         // Drain buffered bytes first.
         if this.pos > 0 {
-            let _ = fd_write_all_quiet(this.fd, this.buffered());
+            // SAFETY: `buf[0..pos]` was initialized by the `copy_nonoverlapping`
+            // below on a prior call; `pos <= cap` is upheld by this guard.
+            let buffered = unsafe { core::slice::from_raw_parts(this.buf, this.pos) };
+            this.drain_to_fd(buffered);
             this.pos = 0;
         }
         // Large writes bypass the buffer so the next small write still coalesces.
         if bytes.len() >= this.cap {
-            let _ = fd_write_all_quiet(this.fd, bytes);
+            this.drain_to_fd(bytes);
             return Ok(());
         }
     }
@@ -9514,7 +9533,9 @@ unsafe fn adapter_flush(w: *mut bun_core::io::Writer) -> core::result::Result<()
     // SAFETY: `w` points at the first field of a SysQuietWriterAdapter (repr(C)).
     let this = unsafe { &mut *w.cast::<SysQuietWriterAdapter>() };
     if this.pos > 0 {
-        let _ = fd_write_all_quiet(this.fd, this.buffered());
+        // SAFETY: `buf[0..pos]` is initialized — see `adapter_write_all`.
+        let buffered = unsafe { core::slice::from_raw_parts(this.buf, this.pos) };
+        this.drain_to_fd(buffered);
         this.pos = 0;
     }
     Ok(())
@@ -9566,11 +9587,18 @@ bun_core::link_impl_OutputSink! {
                 buf,
                 cap: len,
                 pos: 0,
+                err: 0,
             };
             let mut out = bun_core::output::QuietWriterAdapter::uninit();
             // SAFETY: size/align asserted in const block above; out is repr(C) [u8;64].
             core::ptr::write((&raw mut out).cast::<SysQuietWriterAdapter>(), concrete);
             out
+        },
+        quiet_writer_adapter_take_err(a) => {
+            // SAFETY: `a` is the opaque envelope written by `quiet_writer_adapt`
+            // above; concrete repr is `SysQuietWriterAdapter` (size/align asserted).
+            let concrete = (&raw mut *a).cast::<SysQuietWriterAdapter>();
+            core::mem::take(&mut (*concrete).err)
         },
         // QuietWriter itself is unbuffered (buffering lives in the Adapter).
         quiet_writer_flush(_qw) => (),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9483,8 +9483,11 @@ impl SysQuietWriterAdapter {
                 }
                 Ok(n) => bytes = &bytes[n..],
                 Err(e) => {
-                    if self.err == 0 {
-                        self.err = e.get_errno() as i32;
+                    let errno = e.get_errno();
+                    // Transients are never forwarded; recording one would mask
+                    // a real error from a later drain in the same console.* call.
+                    if self.err == 0 && errno != E::EAGAIN && errno != E::EINTR {
+                        self.err = errno as i32;
                     }
                     return;
                 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -9453,10 +9453,8 @@ struct SysQuietWriterAdapter {
     buf: *mut u8,
     cap: usize,
     pos: usize,
-    /// Raw errno of the first write error since the last `take_err()`
-    /// (`0` = none). Sticky so `ConsoleObject` can check once after all of a
-    /// `console.*` call's formatting writes and surface it on
-    /// `process.stdout`/`stderr`.
+    /// First write errno since the last `take_err()` (`0` = none); sticky so
+    /// `ConsoleObject` can check once after a `console.*` call's writes.
     err: i32,
 }
 const _: () = {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -157,5 +157,112 @@ describe.concurrent("process-stdio", () => {
     expect(stdout?.toString()).toBe(
       `hello worldhello again|😋 Get Emoji — All Emojis to ✂️ Copy and 📋 Paste 👌`.repeat(9999),
     );
+  });
+});
+
+// EPIPE on a broken-pipe stdout: once the reader is gone, both console.log and
+// process.stdout.write should surface an 'error' event on process.stdout with
+// code EPIPE, and (absent a listener) report one uncaught error and exit 1.
+// console.log writes natively to fd 1 and used to swallow the error entirely;
+// process.stdout.write went through errorOrDestroy with autoDestroy:false and
+// latched after the first emit. https://github.com/oven-sh/bun/issues/7251
+describe.concurrent.skipIf(isWindows)("process.stdout/stderr EPIPE after reader closes", () => {
+  // Parent spawns a child with piped stdout and immediately destroys the read
+  // end; the child waits for that by reading stdin to EOF (the parent closes
+  // it), then writes. Pure event-driven: no timers.
+  const childBody = (fn: "log" | "write", withListener: boolean) => `
+    const seen = [];
+    ${
+      withListener
+        ? `process.stdout.on("error", e => seen.push(e.code + ":" + e.syscall + ":" + e.errno));`
+        : `process.on("uncaughtException", e => seen.push("uncaught:" + e.code));`
+    }
+    process.on("exit", c => process.stderr.write(JSON.stringify({ seen, exit: c }) + "\\n"));
+    process.stdin.resume();
+    process.stdin.on("end", async () => {
+      for (let i = 0; i < 4; i++) {
+        ${fn === "write" ? `process.stdout.write("x" + i + "\\n");` : `console.log("x" + i);`}
+        await new Promise(r => process.nextTick(r));
+        await new Promise(r => process.nextTick(r));
+      }
+      process.stderr.write("[done]\\n");
+      process.exit();
+    });`;
+
+  const parentFor = (child: string) => `
+    const cp = require("node:child_process");
+    const c = cp.spawn(process.execPath, ["-e", ${JSON.stringify(child)}],
+      { stdio: ["pipe", "pipe", "inherit"] });
+    c.stdout.destroy();
+    c.stdin.end();
+    c.on("close", code => { console.error("child-exit=" + code); process.exit(0); });`;
+
+  async function run(fn: "log" | "write", withListener: boolean) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", parentFor(childBody(fn, withListener))],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("");
+    const lines = stderr.trim().split("\n");
+    const result = JSON.parse(lines.find(l => l.startsWith("{"))!);
+    expect(lines).toContain("[done]");
+    expect(lines).toContain("child-exit=" + result.exit);
+    expect(exitCode).toBe(0);
+    return result as { seen: string[]; exit: number };
+  }
+
+  test.each(["log", "write"] as const)("%s with 'error' listener: fires EPIPE per write, exit 0", async fn => {
+    const { seen, exit } = await run(fn, true);
+    // One 'error' event per write that hit the dead pipe. The first one or two
+    // may land before the kernel notices the reader is gone, so require at
+    // least 2 (out of 4) rather than exactly 4.
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    for (const e of seen) expect(e).toBe("EPIPE:write:-32");
+    expect(exit).toBe(0);
+  });
+
+  test("console.log without 'error' listener: failure is swallowed", async () => {
+    // Node's createWriteErrorHandler adds a noop 'error' listener so a
+    // console.log to a dead pipe doesn't crash (test-process-external-stdio-close).
+    const { seen, exit } = await run("log", false);
+    expect(seen).toEqual([]);
+    expect(exit).toBe(0);
+  });
+
+  test("process.stdout.write without 'error' listener: one uncaughtException EPIPE", async () => {
+    const { seen, exit } = await run("write", false);
+    // emitErrorNT's one-shot guard stays latched once nobody is listening, so
+    // exactly one uncaughtException is delivered for the whole sequence (not
+    // one per write). The test's uncaughtException handler swallows it, hence
+    // exit 0.
+    expect(seen).toEqual(["uncaught:EPIPE"]);
+    expect(exit).toBe(0);
+  });
+
+  test("console.log | head with listener can break the loop (#7251)", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const cp = require("node:child_process");
+         const child = cp.spawn(process.execPath, ["-e", \`
+           process.stdout.on("error", e => { process.stderr.write("handler:" + e.code); process.exit(0); });
+           (function go() { console.log("line"); setImmediate(go); })();
+         \`], { stdio: ["ignore", "pipe", "inherit"] });
+         let n = 0;
+         child.stdout.on("data", () => { if (++n === 1) child.stdout.destroy(); });
+         child.on("close", code => { console.error("child-exit=" + code); process.exit(0); });`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("handler:EPIPE");
+    expect(stderr).toContain("child-exit=0");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
+import cp from "node:child_process";
 import path from "path";
 import { isatty } from "tty";
 describe.concurrent("process-stdio", () => {
@@ -167,9 +168,9 @@ describe.concurrent("process-stdio", () => {
 // process.stdout.write went through errorOrDestroy with autoDestroy:false and
 // latched after the first emit. https://github.com/oven-sh/bun/issues/7251
 describe.concurrent.skipIf(isWindows)("process.stdout/stderr EPIPE after reader closes", () => {
-  // Parent spawns a child with piped stdout and immediately destroys the read
-  // end; the child waits for that by reading stdin to EOF (the parent closes
-  // it), then writes. Pure event-driven: no timers.
+  // Spawn a child with piped stdout and immediately destroy the read end; the
+  // child waits for that by reading stdin to EOF (we close it), then writes.
+  // Pure event-driven: no timers.
   const childBody = (fn: "log" | "write", withListener: boolean) => `
     const seen = [];
     ${
@@ -189,28 +190,20 @@ describe.concurrent.skipIf(isWindows)("process.stdout/stderr EPIPE after reader 
       process.exit();
     });`;
 
-  const parentFor = (child: string) => `
-    const cp = require("node:child_process");
-    const c = cp.spawn(process.execPath, ["-e", ${JSON.stringify(child)}],
-      { stdio: ["pipe", "pipe", "inherit"] });
-    c.stdout.destroy();
-    c.stdin.end();
-    c.on("close", code => { console.error("child-exit=" + code); process.exit(0); });`;
-
   async function run(fn: "log" | "write", withListener: boolean) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", parentFor(childBody(fn, withListener))],
+    const child = cp.spawn(bunExe(), ["-e", childBody(fn, withListener)], {
+      stdio: ["pipe", "pipe", "pipe"],
       env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
     });
-    const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
-    expect(stdout).toBe("");
+    let stderr = "";
+    child.stderr.on("data", d => (stderr += d.toString()));
+    child.stdout.destroy();
+    child.stdin.end();
+    const exitCode = await new Promise<number>(r => child.on("close", code => r(code ?? -1)));
     const lines = stderr.trim().split("\n");
     const result = JSON.parse(lines.find(l => l.startsWith("{"))!);
     expect(lines).toContain("[done]");
-    expect(lines).toContain("child-exit=" + result.exit);
-    expect(exitCode).toBe(0);
+    expect(exitCode).toBe(result.exit);
     return result as { seen: string[]; exit: number };
   }
 
@@ -243,26 +236,20 @@ describe.concurrent.skipIf(isWindows)("process.stdout/stderr EPIPE after reader 
   });
 
   test("console.log | head with listener can break the loop (#7251)", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
+    const child = cp.spawn(
+      bunExe(),
+      [
         "-e",
-        `const cp = require("node:child_process");
-         const child = cp.spawn(process.execPath, ["-e", \`
-           process.stdout.on("error", e => { process.stderr.write("handler:" + e.code); process.exit(0); });
-           (function go() { console.log("line"); setImmediate(go); })();
-         \`], { stdio: ["ignore", "pipe", "inherit"] });
-         let n = 0;
-         child.stdout.on("data", () => { if (++n === 1) child.stdout.destroy(); });
-         child.on("close", code => { console.error("child-exit=" + code); process.exit(0); });`,
+        `process.stdout.on("error", e => { process.stderr.write("handler:" + e.code + "\\n"); process.exit(0); });
+         (function go() { console.log("line"); setImmediate(go); })();`,
       ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      { stdio: ["ignore", "pipe", "pipe"], env: bunEnv },
+    );
+    let stderr = "";
+    child.stderr.on("data", d => (stderr += d.toString()));
+    child.stdout.once("data", () => child.stdout.destroy());
+    const exitCode = await new Promise<number>(r => child.on("close", code => r(code ?? -1)));
     expect(stderr).toContain("handler:EPIPE");
-    expect(stderr).toContain("child-exit=0");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -205,10 +205,14 @@ describe.skipIf(isWindows)("process.stdout/stderr EPIPE after reader closes", ()
     child.stdin.end();
     const exitCode = await new Promise<number>(r => child.on("close", code => r(code ?? -1)));
     const lines = stderr.trim().split("\n");
-    const result = JSON.parse(lines.find(l => l.startsWith("{"))!);
-    expect(lines).toContain("[done]");
+    const reportLine = lines.find(l => l.startsWith("{"));
+    if (!reportLine || !lines.includes("[done]")) {
+      // Surface the child's actual stderr/exit instead of a JSON.parse error.
+      expect({ stderr, exitCode }).toEqual({ stderr: expect.stringContaining("[done]"), exitCode: 0 });
+    }
+    const result = JSON.parse(reportLine!) as { seen: string[]; exit: number };
     expect(exitCode).toBe(result.exit);
-    return result as { seen: string[]; exit: number };
+    return result;
   }
 
   test.each(["log", "write"] as const)("%s with 'error' listener: fires EPIPE per write, exit 0", async fn => {

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -167,7 +167,11 @@ describe.concurrent("process-stdio", () => {
 // console.log writes natively to fd 1 and used to swallow the error entirely;
 // process.stdout.write went through errorOrDestroy with autoDestroy:false and
 // latched after the first emit. https://github.com/oven-sh/bun/issues/7251
-describe.concurrent.skipIf(isWindows)("process.stdout/stderr EPIPE after reader closes", () => {
+//
+// Not describe.concurrent: the existing process-stdio block above already
+// saturates the debug+ASAN process budget; adding five more concurrent children
+// pushes the timer-paced stdin tests over their 5s timeout.
+describe.skipIf(isWindows)("process.stdout/stderr EPIPE after reader closes", () => {
   // Spawn a child with piped stdout and immediately destroy the read end; the
   // child waits for that by reading stdin to EOF (we close it), then writes.
   // Pure event-driven: no timers.

--- a/test/js/node/process/process-stdio.test.ts
+++ b/test/js/node/process/process-stdio.test.ts
@@ -172,51 +172,61 @@ describe.concurrent("process-stdio", () => {
 // saturates the debug+ASAN process budget; adding five more concurrent children
 // pushes the timer-paced stdin tests over their 5s timeout.
 describe.skipIf(isWindows)("process.stdout/stderr EPIPE after reader closes", () => {
-  // Spawn a child with piped stdout and immediately destroy the read end; the
-  // child waits for that by reading stdin to EOF (we close it), then writes.
-  // Pure event-driven: no timers.
-  const childBody = (fn: "log" | "write", withListener: boolean) => `
+  // Spawn a child with the target stream piped and immediately destroy the read
+  // end; the child waits for that by reading stdin to EOF (we close it), then
+  // writes. Pure event-driven: no timers.
+  const childBody = (which: "stdout" | "stderr", fn: "console" | "write", withListener: boolean) => {
+    const other = which === "stdout" ? "stderr" : "stdout";
+    const consoleFn = which === "stdout" ? "log" : "error";
+    return `
     const seen = [];
     ${
       withListener
-        ? `process.stdout.on("error", e => seen.push(e.code + ":" + e.syscall + ":" + e.errno));`
+        ? `process.${which}.on("error", e => seen.push(e.code + ":" + e.syscall + ":" + e.errno));`
         : `process.on("uncaughtException", e => seen.push("uncaught:" + e.code));`
     }
-    process.on("exit", c => process.stderr.write(JSON.stringify({ seen, exit: c }) + "\\n"));
+    process.on("exit", c => process.${other}.write(JSON.stringify({ seen, exit: c }) + "\\n"));
     process.stdin.resume();
     process.stdin.on("end", async () => {
       for (let i = 0; i < 4; i++) {
-        ${fn === "write" ? `process.stdout.write("x" + i + "\\n");` : `console.log("x" + i);`}
+        ${fn === "write" ? `process.${which}.write("x" + i + "\\n");` : `console.${consoleFn}("x" + i);`}
         await new Promise(r => process.nextTick(r));
         await new Promise(r => process.nextTick(r));
       }
-      process.stderr.write("[done]\\n");
+      process.${other}.write("[done]\\n");
       process.exit();
     });`;
+  };
 
-  async function run(fn: "log" | "write", withListener: boolean) {
-    const child = cp.spawn(bunExe(), ["-e", childBody(fn, withListener)], {
+  async function run(which: "stdout" | "stderr", fn: "console" | "write", withListener: boolean) {
+    const other = which === "stdout" ? "stderr" : "stdout";
+    const child = cp.spawn(bunExe(), ["-e", childBody(which, fn, withListener)], {
       stdio: ["pipe", "pipe", "pipe"],
       env: bunEnv,
     });
-    let stderr = "";
-    child.stderr.on("data", d => (stderr += d.toString()));
-    child.stdout.destroy();
+    let report = "";
+    child[other].on("data", d => (report += d.toString()));
+    child[which].destroy();
     child.stdin.end();
     const exitCode = await new Promise<number>(r => child.on("close", code => r(code ?? -1)));
-    const lines = stderr.trim().split("\n");
+    const lines = report.trim().split("\n");
     const reportLine = lines.find(l => l.startsWith("{"));
     if (!reportLine || !lines.includes("[done]")) {
-      // Surface the child's actual stderr/exit instead of a JSON.parse error.
-      expect({ stderr, exitCode }).toEqual({ stderr: expect.stringContaining("[done]"), exitCode: 0 });
+      // Surface the child's actual output/exit instead of a JSON.parse error.
+      expect({ report, exitCode }).toEqual({ report: expect.stringContaining("[done]"), exitCode: 0 });
     }
     const result = JSON.parse(reportLine!) as { seen: string[]; exit: number };
     expect(exitCode).toBe(result.exit);
     return result;
   }
 
-  test.each(["log", "write"] as const)("%s with 'error' listener: fires EPIPE per write, exit 0", async fn => {
-    const { seen, exit } = await run(fn, true);
+  test.each([
+    ["stdout", "console"],
+    ["stdout", "write"],
+    ["stderr", "console"],
+    ["stderr", "write"],
+  ] as const)("%s %s with 'error' listener: fires EPIPE per write, exit 0", async (which, fn) => {
+    const { seen, exit } = await run(which, fn, true);
     // One 'error' event per write that hit the dead pipe. The first one or two
     // may land before the kernel notices the reader is gone, so require at
     // least 2 (out of 4) rather than exactly 4.
@@ -228,13 +238,13 @@ describe.skipIf(isWindows)("process.stdout/stderr EPIPE after reader closes", ()
   test("console.log without 'error' listener: failure is swallowed", async () => {
     // Node's createWriteErrorHandler adds a noop 'error' listener so a
     // console.log to a dead pipe doesn't crash (test-process-external-stdio-close).
-    const { seen, exit } = await run("log", false);
+    const { seen, exit } = await run("stdout", "console", false);
     expect(seen).toEqual([]);
     expect(exit).toBe(0);
   });
 
   test("process.stdout.write without 'error' listener: one uncaughtException EPIPE", async () => {
-    const { seen, exit } = await run("write", false);
+    const { seen, exit } = await run("stdout", "write", false);
     // emitErrorNT's one-shot guard stays latched once nobody is listening, so
     // exactly one uncaughtException is delivered for the whole sequence (not
     // one per write). The test's uncaughtException handler swallows it, hence

--- a/test/js/node/process/process-stdout-write-after-end.test.ts
+++ b/test/js/node/process/process-stdout-write-after-end.test.ts
@@ -24,9 +24,13 @@ test.concurrent.each(["stdout", "stderr"] as const)(
     const lines = reportPipe.trim().split("\n");
     const report = JSON.parse(lines[lines.length - 1]);
 
+    // Node's pipe stdio is a net.Socket with autoDestroy:true, so end() runs
+    // finish -> destroy -> _undestroy, which resets writableEnded/writable.
+    // The write-after-end contract (ret=false, ERR_STREAM_WRITE_AFTER_END,
+    // bytes not delivered) is enforced at write() time, before that reset.
     expect(report).toEqual({
-      writableEnded: true,
-      writable: false,
+      writableEnded: false,
+      writable: true,
       ret: false,
       cbErr: "ERR_STREAM_WRITE_AFTER_END",
       ev: ["err:ERR_STREAM_WRITE_AFTER_END"],


### PR DESCRIPTION
Once stdout's reader is gone (piped to a consumer that exited), `console.log` and `process.stdout.write` disagreed on whether the program failed, and neither matched Node.

## Repro

```js
// epipe.mjs  (WHICH=log bun epipe.mjs / WHICH=write bun epipe.mjs)
import { spawn } from "node:child_process";
if (process.env.__CHILD) {
  process.stdout.on("error", e => process.stderr.write("[stdout error " + e.code + "]\n"));
  process.on("exit", c => process.stderr.write("[exit " + c + "]\n"));
  const wait = ms => new Promise(r => setTimeout(r, ms));
  await wait(300);
  for (let i = 0; i < 5; i++) {
    if (process.env.WHICH === "write") process.stdout.write("x" + i + "\n");
    else console.log("x" + i);
    await wait(30);
  }
} else {
  const c = spawn(process.execPath, [import.meta.filename],
    { env: { ...process.env, __CHILD: "1" }, stdio: ["ignore", "pipe", "inherit"] });
  c.stdout.destroy();
  c.on("close", code => console.error("--- child exit=" + code + " ---"));
}
```

| | node v26.3.0 | bun main | bun this PR |
|---|---|---|---|
| `WHICH=log` | `[stdout error EPIPE]` ×5, exit 0 | listener never called, exit 0 | `[stdout error EPIPE]` ×5, exit 0 |
| `WHICH=write` | `[stdout error EPIPE]` ×5, exit 0 | `[stdout error EPIPE]` ×1, exit 0 | `[stdout error EPIPE]` ×5, exit 0 |

## Cause

**console.log** writes natively to fd 1 via `SysQuietWriterAdapter` (`src/sys/lib.rs`), whose `write_all`/`flush` always return `Ok(())` and drop the errno. `process.stdout` never hears about it.

**process.stdout.write** on a pipe is a `fs.WriteStream` with `autoClose:false`, which leaves `_writableState.autoDestroy` at `false`. `writeFast`'s rejection handler calls `errorOrDestroy`, which with `autoDestroy:false` goes straight to `emitErrorNT`; that latches on `errorEmitted` after the first emit, so writes 2..N never surface. Node's pipe stdio is a `net.Socket` (`autoDestroy:true`) whose `_destroy` is overridden to `_undestroy()`, so each failed write goes `errorOrDestroy -> destroy -> _undestroy -> emit 'error'` and the stream stays writable.

## Fix

- `ProcessObjectInternals.ts`: set `autoDestroy:true` on non-TTY stdio write streams so `errorOrDestroy` takes the destroy path. In the `_destroy` override, preserve `errorEmitted` across `_undestroy()` when no `'error'` listener is attached so a write loop on a dead pipe emits at most one uncaught (Node terminates on the first; Bun doesn't, so the latch lives here).
- `SysQuietWriterAdapter`: record the first write errno in a sticky field; expose via `QuietWriterAdapter::take_err()`.
- `ConsoleObject.rs` / `BunProcess.cpp`: after each `console.*` call, if an errno was recorded (and isn't `EAGAIN`/`EINTR`), hand it to `process.stdout`/`stderr` via `stream.destroy(err)` so `'error'` fires on nextTick. When no `'error'` listener is attached the failure is dropped rather than becoming an uncaught exception, matching Node's `createWriteErrorHandler` and `test-process-external-stdio-close`.

Error shape matches Node:
```json
{"code":"EPIPE","syscall":"write","errno":-32}
```

## Verification

New tests in `test/js/node/process/process-stdio.test.ts` cover all four listener × write-API combinations plus the #7251 `| head` loop with a listener that exits. All fail on main (except the `console.log`-without-listener regression guard, which matches main's silent behavior) and pass here.

Still passing: `test/regression/issue/1632.test.ts`, `test/js/web/console/`, `test/js/bun/console/`, `test/js/node/tty.test.ts`, `test/js/node/child_process/child-process-stdio.test.js`, `test/js/node/fs/fs.test.ts -t WriteStream`, and node's `test-process-external-stdio-close{,-spawn}`, `test-console-log-stdio-broken-dest`, `test-stdio-{closed,undestroy,pipe-access,pipe-stderr}`, `test-stdout-stderr-{reading,write}`, `test-console-{async,sync}-write-error`, `test-child-process-stdout-flush{,-exit}`.

Supersedes #30635 (same surface for the console path, plus the `autoDestroy` fix for the write path).

Fixes #7251 for the with-listener case.

`console.timeEnd` is intentionally excluded: it writes through the process-wide `Output` source adapters rather than the `ConsoleObject` backings `forward_write_error` reads, and Node routes it to stdout (Bun routes it to stderr, a pre-existing divergence). The errno those adapters record is an inert `i32` that nothing reads.
 The setImmediate loop with no `'error'` listener still hangs (pre-existing Bun `uncaughtException` semantics, unchanged by this PR), but no longer spams stderr.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-stdio.test.ts

<!-- robobun:evidence:end -->