### PR TITLE
build: unify webcore/streams, add C++ build profiling (bun run build:analyze)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "build:logs": "bun scripts/build.ts --profile=release --logs=on --build-dir=build/release-logs",
     "build:smol": "bun scripts/build.ts --profile=release --build-type=MinSizeRel --build-dir=build/release-smol",
     "build:local": "bun scripts/build.ts --profile=debug-local --build-dir=build/debug-local",
+    "build:analyze": "bun scripts/analyze-cpp-build.ts",
     "build:release:local": "bun scripts/build.ts --profile=release-local --build-dir=build/release-local",
     "run:linux": "docker run --rm  -v \"$PWD:/root/bun/\" -w /root/bun ghcr.io/oven-sh/bun-development-docker-image",
     "uv-posix-stubs": "bun run src/jsc/bindings/libuv/generate_uv_posix_stubs.ts",

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -71,7 +71,10 @@ const buildDir = resolve(repo, flag("dir") || "build/time-trace");
   const buildFromRepo = relative(repo, buildDir);
   const insideRepo = !(buildFromRepo.startsWith(`..${sep}`) || isAbsolute(buildFromRepo));
   if (containsRepo || (insideRepo && !buildFromRepo.startsWith(`build${sep}`))) {
-    console.error(`refusing --dir ${JSON.stringify(buildDir)}: the clean step would rm -rf a repo path outside build/`);
+    console.error(
+      `refusing --dir ${JSON.stringify(buildDir)}: the clean step runs rm -rf on it, ` +
+        `so an in-repo --dir must be a subdirectory of build/ (e.g. build/time-trace)`,
+    );
     process.exit(1);
   }
 }

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -154,8 +154,15 @@ function readNinjaLog(dir: string): Edge[] {
     const [s, e, , out] = line.split("\t");
     if (!out) continue;
     const edge = { start: +s, end: +e, out };
-    if (edge.end < prevEnd && byOut.has(out)) byOut.clear();
-    prevEnd = edge.end;
+    if (edge.end < prevEnd && byOut.has(out)) {
+      byOut.clear();
+      prevEnd = edge.end;
+    } else {
+      // Monotone except across a detected boundary, so a brand-new output at
+      // the start of an appended run can't mask the drop from the repeat
+      // that follows it. (New-run entries before that repeat are dropped.)
+      prevEnd = Math.max(prevEnd, edge.end);
+    }
     byOut.set(out, edge);
   }
   return [...byOut.values()];

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env bun
+/**
+ * Profile the C++ build step.
+ *
+ * Does a clean release cpp-only build with clang's -ftime-trace in a dedicated
+ * build directory, then produces two reports:
+ *
+ *   1. Wall-clock view — parses ninja's .ninja_log to show per-edge durations,
+ *      category breakdown, and what's on the critical path. This is what
+ *      actually determines "how long the build takes".
+ *
+ *   2. Compiler-time view — runs ClangBuildAnalyzer over every .json trace
+ *      clang emitted to show which headers / templates / instantiations eat
+ *      aggregate frontend time. This is what to fix to make the wall clock
+ *      shorter.
+ *
+ * Usage:
+ *   bun scripts/analyze-cpp-build.ts              # clean build + analyze
+ *   bun scripts/analyze-cpp-build.ts --no-build   # analyze an existing build dir
+ *   bun scripts/analyze-cpp-build.ts --dir build/my-experiment
+ *   bun scripts/analyze-cpp-build.ts --lto=off    # profile non-LTO
+ *
+ * The build directory defaults to build/time-trace and is separate from
+ * build/release so profiling never perturbs your normal cache.
+ *
+ * Interpreting the output:
+ *   - "Expensive headers" with high include-count × avg-ms → candidates for
+ *     root-pch.h (every TU that includes them re-parses the same bytes).
+ *   - A single unified bundle much slower than its siblings → one of its
+ *     members belongs in unified.ts's noUnify list.
+ *   - Large "Templates that took longest to instantiate" with N× instantiations
+ *     → extern-template declarations, or move the instantiating header to PCH.
+ */
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const args = process.argv.slice(2);
+const flag = (name: string, dflt?: string): string | undefined => {
+  const i = args.findIndex(a => a === `--${name}` || a.startsWith(`--${name}=`));
+  if (i < 0) return dflt;
+  const a = args[i]!;
+  return a.includes("=") ? a.slice(a.indexOf("=") + 1) : (args[i + 1] ?? "");
+};
+const has = (name: string) => args.includes(`--${name}`);
+
+const repo = resolve(import.meta.dir, "..");
+const buildDir = resolve(repo, flag("dir", "build/time-trace")!);
+const lto = flag("lto", "on");
+const top = Number(flag("top", "25"));
+const noBuild = has("no-build");
+const noClean = has("no-clean");
+
+// ───────────────────────────────────────────────────────────────────────────
+// ClangBuildAnalyzer — fetched once into the shared build cache.
+// ───────────────────────────────────────────────────────────────────────────
+
+const cbaVersion = "1.6.0";
+async function resolveClangBuildAnalyzer(): Promise<string> {
+  const cacheRoot =
+    process.env.BUN_BUILD_CACHE ??
+    resolve(process.env.BUN_INSTALL ?? `${process.env.HOME ?? process.env.USERPROFILE}/.bun`, "build-cache");
+  const suffix =
+    process.platform === "darwin" ? "mac" : process.platform === "win32" ? "windows.exe" : "linux";
+  const bin = resolve(
+    cacheRoot,
+    "tools",
+    `ClangBuildAnalyzer-${cbaVersion}${process.platform === "win32" ? ".exe" : ""}`,
+  );
+  if (existsSync(bin)) return bin;
+  const url = `https://github.com/aras-p/ClangBuildAnalyzer/releases/download/v${cbaVersion}/ClangBuildAnalyzer-${suffix}`;
+  console.error(`fetching ${url}`);
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`download failed: ${res.status} ${res.statusText}`);
+  mkdirSync(dirname(bin), { recursive: true });
+  await Bun.write(bin, res);
+  if (process.platform !== "win32") chmodSync(bin, 0o755);
+  return bin;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// .ninja_log — wall-clock per-edge timing.
+// ───────────────────────────────────────────────────────────────────────────
+
+interface Edge {
+  start: number;
+  end: number;
+  out: string;
+}
+
+function readNinjaLog(dir: string): Edge[] {
+  const path = resolve(dir, ".ninja_log");
+  if (!existsSync(path)) throw new Error(`no .ninja_log at ${path} — run a build first`);
+  // Last entry per output wins (ninja appends on every build).
+  const byOut = new Map<string, Edge>();
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    if (line.startsWith("#") || !line.includes("\t")) continue;
+    const [s, e, , out] = line.split("\t");
+    if (!out) continue;
+    byOut.set(out, { start: +s, end: +e, out });
+  }
+  return [...byOut.values()];
+}
+
+function categorize(out: string): string {
+  if (out.endsWith(".pch")) return "pch";
+  if (out.startsWith("obj/unified/")) return "cxx (unified)";
+  if (out.startsWith("obj/codegen/")) return "cxx (codegen)";
+  if (out.startsWith("obj/vendor/")) return "cc/cxx (deps)";
+  if (out.startsWith("obj/") && (out.endsWith(".o") || out.endsWith(".obj"))) return "cxx (standalone)";
+  if (out.startsWith("codegen/")) return "codegen script";
+  if (out.endsWith(".a") || out.endsWith(".lib")) return "archive";
+  if (out.includes("/webkit-") || out.includes("tarballs/") || out.endsWith(".ref")) return "fetch";
+  return "other";
+}
+
+function reportNinjaLog(edges: Edge[]): void {
+  const fmt = (ms: number) => `${(ms / 1000).toFixed(1)}s`;
+  const minStart = Math.min(...edges.map(e => e.start));
+  const maxEnd = Math.max(...edges.map(e => e.end));
+  const wall = maxEnd - minStart;
+  const sum = edges.reduce((a, e) => a + (e.end - e.start), 0);
+
+  console.log(`\n━━━ wall-clock (.ninja_log) ━━━`);
+  console.log(
+    `  ${edges.length} edges   wall: ${fmt(wall)}   Σduration: ${fmt(sum)}   parallelism≈${(sum / wall).toFixed(1)}×\n`,
+  );
+
+  const cats = new Map<string, { n: number; ms: number }>();
+  for (const e of edges) {
+    const k = categorize(e.out);
+    const c = cats.get(k) ?? { n: 0, ms: 0 };
+    c.n++;
+    c.ms += e.end - e.start;
+    cats.set(k, c);
+  }
+  console.log(`  by category:`);
+  for (const [k, v] of [...cats].sort((a, b) => b[1].ms - a[1].ms)) {
+    console.log(
+      `    ${k.padEnd(18)} ${String(v.n).padStart(5)} edges   ${fmt(v.ms).padStart(8)}  (${((v.ms / sum) * 100).toFixed(1)}%)`,
+    );
+  }
+
+  console.log(`\n  slowest ${top} edges:`);
+  for (const e of [...edges].sort((a, b) => b.end - b.start - (a.end - a.start)).slice(0, top)) {
+    console.log(`    ${fmt(e.end - e.start).padStart(8)}  ${e.out}`);
+  }
+
+  // Unified-bundle balance: imbalance here is critical-path waste.
+  const bundles = edges.filter(e => /obj\/unified\/UnifiedSource-.*\.(o|obj)$/.test(e.out));
+  const byGroup = new Map<string, Edge[]>();
+  for (const b of bundles) {
+    const m = /UnifiedSource-(.+?)-\d+\./.exec(b.out);
+    if (!m) continue;
+    (byGroup.get(m[1]!) ?? byGroup.set(m[1]!, []).get(m[1]!)!).push(b);
+  }
+  console.log(`\n  unified-bundle balance (max/min per directory group):`);
+  for (const [g, bs] of [...byGroup].sort((a, b) => Math.max(...b[1].map(e => e.end - e.start)) - Math.max(...a[1].map(e => e.end - e.start)))) {
+    if (bs.length < 2) continue;
+    const ds = bs.map(b => b.end - b.start).sort((a, b) => b - a);
+    const max = ds[0]!;
+    const min = ds[ds.length - 1]!;
+    const ratio = max / min;
+    const flag = ratio >= 1.5 ? "  ⟵ imbalanced" : "";
+    console.log(`    ${g.padEnd(40)} ${bs.length}×   max ${fmt(max)}  min ${fmt(min)}  (${ratio.toFixed(1)}×)${flag}`);
+  }
+
+  // Crude critical path: longest chain of (pch) → (slowest cxx that waits on
+  // pch). Real critical path needs the full dep graph; this approximation is
+  // what matters in practice since every cxx_pch edge waits on the PCH.
+  const pch = edges.find(e => e.out.endsWith(".pch"));
+  const slowestCxx = [...edges]
+    .filter(e => e.out.startsWith("obj/") && (e.out.endsWith(".o") || e.out.endsWith(".obj")))
+    .sort((a, b) => b.end - b.start - (a.end - a.start))[0];
+  if (pch && slowestCxx) {
+    console.log(
+      `\n  critical-path floor (pch → slowest cxx): ` +
+        `${fmt(pch.end - pch.start)} + ${fmt(slowestCxx.end - slowestCxx.start)} = ` +
+        `${fmt(pch.end - pch.start + (slowestCxx.end - slowestCxx.start))}`,
+    );
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// main
+// ───────────────────────────────────────────────────────────────────────────
+
+const cba = await resolveClangBuildAnalyzer();
+
+if (!noBuild) {
+  if (!noClean && existsSync(buildDir)) {
+    console.error(`cleaning ${buildDir}`);
+    rmSync(buildDir, { recursive: true, force: true });
+  }
+  console.error(`building (release, cpp-only, lto=${lto}, timeTrace) → ${buildDir}`);
+  const r = spawnSync(
+    process.execPath,
+    [
+      resolve(repo, "scripts/build.ts"),
+      "--profile=release",
+      "--mode=cpp-only",
+      `--lto=${lto}`,
+      "--timeTrace=on",
+      `--buildDir=${buildDir}`,
+    ],
+    { stdio: "inherit", cwd: repo },
+  );
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
+
+reportNinjaLog(readNinjaLog(buildDir));
+
+// ClangBuildAnalyzer: aggregate every -ftime-trace json under buildDir. Its
+// ini file must live in the CWD it's invoked from; write a transient one next
+// to the capture so section counts are useful (defaults are tiny).
+const capture = resolve(buildDir, "time-trace.capture");
+const ini = resolve(buildDir, "ClangBuildAnalyzer.ini");
+await Bun.write(
+  ini,
+  `[counts]\nfileParse=20\nfileCodegen=15\nfunction=0\ntemplate=30\nheader=30\nheaderChain=5\n`,
+);
+let r = spawnSync(cba, ["--all", buildDir, capture], { stdio: ["ignore", "ignore", "inherit"] });
+if (r.status !== 0) process.exit(r.status ?? 1);
+
+console.log(`\n━━━ compiler time (-ftime-trace, ClangBuildAnalyzer) ━━━`);
+r = spawnSync(cba, ["--analyze", capture], { stdio: "inherit", cwd: buildDir });
+if (r.status !== 0) process.exit(r.status ?? 1);

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -32,9 +32,18 @@
  *     → extern-template declarations, or move the instantiating header to PCH.
  */
 
-import { spawnSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+
+function run(argv: string[], opts: SpawnSyncOptions): void {
+  const r = spawnSync(argv[0]!, argv.slice(1), opts);
+  if (r.error) {
+    console.error(`failed to spawn ${argv[0]}: ${r.error.message}`);
+    process.exit(1);
+  }
+  if (r.status !== 0) process.exit(r.status ?? 1);
+}
 
 const args = process.argv.slice(2);
 const flag = (name: string, dflt?: string): string | undefined => {
@@ -73,8 +82,13 @@ async function resolveClangBuildAnalyzer(): Promise<string> {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`download failed: ${res.status} ${res.statusText}`);
   mkdirSync(dirname(bin), { recursive: true });
-  await Bun.write(bin, res);
-  if (process.platform !== "win32") chmodSync(bin, 0o755);
+  // .partial + rename: an interrupted fetch would otherwise leave a truncated
+  // file that existsSync() above happily reuses forever (same idiom as
+  // scripts/build/download.ts).
+  const partial = `${bin}.${process.pid}.partial`;
+  await Bun.write(partial, res);
+  if (process.platform !== "win32") chmodSync(partial, 0o755);
+  renameSync(partial, bin);
   return bin;
 }
 
@@ -115,13 +129,17 @@ function categorize(out: string): string {
 }
 
 function reportNinjaLog(edges: Edge[]): void {
+  console.log(`\n━━━ wall-clock (.ninja_log) ━━━`);
+  if (edges.length === 0) {
+    console.log(`  no edges recorded in ${buildDir}/.ninja_log — run without --no-build first.`);
+    return;
+  }
   const fmt = (ms: number) => `${(ms / 1000).toFixed(1)}s`;
   const minStart = Math.min(...edges.map(e => e.start));
   const maxEnd = Math.max(...edges.map(e => e.end));
   const wall = maxEnd - minStart;
   const sum = edges.reduce((a, e) => a + (e.end - e.start), 0);
 
-  console.log(`\n━━━ wall-clock (.ninja_log) ━━━`);
   console.log(
     `  ${edges.length} edges   wall: ${fmt(wall)}   Σduration: ${fmt(sum)}   parallelism≈${(sum / wall).toFixed(1)}×\n`,
   );
@@ -195,9 +213,9 @@ if (!noBuild) {
     rmSync(buildDir, { recursive: true, force: true });
   }
   console.error(`building (release, cpp-only, lto=${lto}, timeTrace) → ${buildDir}`);
-  const r = spawnSync(
-    process.execPath,
+  run(
     [
+      process.execPath,
       resolve(repo, "scripts/build.ts"),
       "--profile=release",
       "--mode=cpp-only",
@@ -207,7 +225,6 @@ if (!noBuild) {
     ],
     { stdio: "inherit", cwd: repo },
   );
-  if (r.status !== 0) process.exit(r.status ?? 1);
 }
 
 reportNinjaLog(readNinjaLog(buildDir));
@@ -218,9 +235,7 @@ reportNinjaLog(readNinjaLog(buildDir));
 const capture = resolve(buildDir, "time-trace.capture");
 const ini = resolve(buildDir, "ClangBuildAnalyzer.ini");
 await Bun.write(ini, `[counts]\nfileParse=20\nfileCodegen=15\nfunction=0\ntemplate=30\nheader=30\nheaderChain=5\n`);
-let r = spawnSync(cba, ["--all", buildDir, capture], { stdio: ["ignore", "ignore", "inherit"] });
-if (r.status !== 0) process.exit(r.status ?? 1);
+run([cba, "--all", buildDir, capture], { stdio: ["ignore", "ignore", "inherit"] });
 
 console.log(`\n━━━ compiler time (-ftime-trace, ClangBuildAnalyzer) ━━━`);
-r = spawnSync(cba, ["--analyze", capture], { stdio: "inherit", cwd: buildDir });
-if (r.status !== 0) process.exit(r.status ?? 1);
+run([cba, "--analyze", capture], { stdio: "inherit", cwd: buildDir });

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -66,18 +66,12 @@ const buildDir = resolve(repo, flag("dir") || "build/time-trace");
   // On Windows, relative() across drive roots returns the absolute `to` path;
   // a buildDir on a different drive cannot contain the repo, so allow it.
   const repoFromBuild = relative(buildDir, repo);
-  const containsRepo = !(
-    repoFromBuild === ".." ||
-    repoFromBuild.startsWith(`..${sep}`) ||
-    isAbsolute(repoFromBuild)
-  );
+  const containsRepo = !(repoFromBuild === ".." || repoFromBuild.startsWith(`..${sep}`) || isAbsolute(repoFromBuild));
   // Refuse in-repo paths outside build/ (--dir src, --dir .git).
   const buildFromRepo = relative(repo, buildDir);
   const insideRepo = !(buildFromRepo.startsWith(`..${sep}`) || isAbsolute(buildFromRepo));
   if (containsRepo || (insideRepo && !buildFromRepo.startsWith(`build${sep}`))) {
-    console.error(
-      `refusing --dir ${JSON.stringify(buildDir)}: the clean step would rm -rf a repo path outside build/`,
-    );
+    console.error(`refusing --dir ${JSON.stringify(buildDir)}: the clean step would rm -rf a repo path outside build/`);
     process.exit(1);
   }
 }

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -34,7 +34,7 @@
 
 import { spawnSync, type SpawnSyncOptions } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve, sep } from "node:path";
 
 function run(argv: string[], opts: SpawnSyncOptions): void {
   const r = spawnSync(argv[0]!, argv.slice(1), opts);
@@ -55,7 +55,17 @@ const flag = (name: string, dflt?: string): string | undefined => {
 const has = (name: string) => args.includes(`--${name}`);
 
 const repo = resolve(import.meta.dir, "..");
-const buildDir = resolve(repo, flag("dir", "build/time-trace")!);
+const buildDir = resolve(repo, flag("dir") || "build/time-trace");
+// The default clean step is rmSync(buildDir, {recursive}). Refuse any buildDir
+// that is the repo root or an ancestor of it (which is what --dir "", --dir .,
+// --dir / all resolve to) so a typo can't recursively delete the checkout.
+{
+  const repoFromBuild = relative(buildDir, repo);
+  if (repoFromBuild === "" || !(repoFromBuild === ".." || repoFromBuild.startsWith(`..${sep}`))) {
+    console.error(`refusing --dir ${JSON.stringify(buildDir)}: contains the repository root`);
+    process.exit(1);
+  }
+}
 const lto = flag("lto", "on");
 const top = Number(flag("top", "25"));
 const noBuild = has("no-build");

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -238,8 +238,6 @@ function reportNinjaLog(edges: Edge[]): void {
 // main
 // ───────────────────────────────────────────────────────────────────────────
 
-const cba = await resolveClangBuildAnalyzer();
-
 if (!noBuild) {
   if (!noClean && existsSync(buildDir)) {
     console.error(`cleaning ${buildDir}`);
@@ -267,6 +265,9 @@ reportNinjaLog(readNinjaLog(buildDir));
 // ClangBuildAnalyzer: aggregate every -ftime-trace json under buildDir. Its
 // ini file must live in the CWD it's invoked from; write a transient one next
 // to the capture so section counts are useful (defaults are tiny).
+// Resolved here, after the wall-clock report, so a platform without a usable
+// binary still gets the CBA-independent .ninja_log half of the output.
+const cba = await resolveClangBuildAnalyzer();
 const capture = resolve(buildDir, "time-trace.capture");
 const ini = resolve(buildDir, "ClangBuildAnalyzer.ini");
 await Bun.write(ini, `[counts]\nfileParse=20\nfileCodegen=15\nfunction=0\ntemplate=30\nheader=30\nheaderChain=5\n`);

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -34,7 +34,7 @@
 
 import { spawnSync, type SpawnSyncOptions } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from "node:fs";
-import { dirname, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 function run(argv: string[], opts: SpawnSyncOptions): void {
   const r = spawnSync(argv[0]!, argv.slice(1), opts);
@@ -60,8 +60,13 @@ const buildDir = resolve(repo, flag("dir") || "build/time-trace");
 // that is the repo root or an ancestor of it (which is what --dir "", --dir .,
 // --dir / all resolve to) so a typo can't recursively delete the checkout.
 {
+  // On Windows, relative() across drive roots returns the absolute `to` path;
+  // a buildDir on a different drive cannot contain the repo, so allow it.
   const repoFromBuild = relative(buildDir, repo);
-  if (repoFromBuild === "" || !(repoFromBuild === ".." || repoFromBuild.startsWith(`..${sep}`))) {
+  if (
+    repoFromBuild === "" ||
+    !(repoFromBuild === ".." || repoFromBuild.startsWith(`..${sep}`) || isAbsolute(repoFromBuild))
+  ) {
     console.error(`refusing --dir ${JSON.stringify(buildDir)}: contains the repository root`);
     process.exit(1);
   }
@@ -77,6 +82,16 @@ const noClean = has("no-clean");
 
 const cbaVersion = "1.6.0";
 async function resolveClangBuildAnalyzer(): Promise<string> {
+  // A system install always wins — it's the only option on platforms without
+  // a matching prebuilt (the upstream release ships x64-only binaries).
+  const system = Bun.which("ClangBuildAnalyzer");
+  if (system) return system;
+  if (process.platform === "linux" && process.arch !== "x64") {
+    throw new Error(
+      `ClangBuildAnalyzer v${cbaVersion} has no linux-${process.arch} prebuilt; ` +
+        `build it from source (github.com/aras-p/ClangBuildAnalyzer) and put it on PATH`,
+    );
+  }
   const cacheRoot =
     process.env.BUN_BUILD_CACHE ??
     resolve(process.env.BUN_INSTALL ?? `${process.env.HOME ?? process.env.USERPROFILE}/.bun`, "build-cache");

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -252,7 +252,9 @@ if (!noBuild) {
       "--timeTrace=on",
       `--buildDir=${buildDir}`,
     ],
-    { stdio: "inherit", cwd: repo },
+    // ccache is machine-shared and survives the buildDir clean; a cache hit
+    // records ~ms edge durations that make the wall-clock report meaningless.
+    { stdio: "inherit", cwd: repo, env: { ...process.env, CCACHE_DISABLE: "1" } },
   );
 }
 

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -87,7 +87,8 @@ const noClean = has("no-clean");
 const cbaVersion = "1.6.0";
 async function resolveClangBuildAnalyzer(): Promise<string> {
   // A system install always wins — it's the only option on platforms without
-  // a matching prebuilt (the upstream release ships x64-only binaries).
+  // a matching prebuilt. The mac prebuilt is universal (x64+arm64) and the
+  // windows one runs on arm64 via emulation; linux non-x64 has no fallback.
   const system = Bun.which("ClangBuildAnalyzer");
   if (system) return system;
   if (process.platform === "linux" && process.arch !== "x64") {

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -61,8 +61,7 @@ async function resolveClangBuildAnalyzer(): Promise<string> {
   const cacheRoot =
     process.env.BUN_BUILD_CACHE ??
     resolve(process.env.BUN_INSTALL ?? `${process.env.HOME ?? process.env.USERPROFILE}/.bun`, "build-cache");
-  const suffix =
-    process.platform === "darwin" ? "mac" : process.platform === "win32" ? "windows.exe" : "linux";
+  const suffix = process.platform === "darwin" ? "mac" : process.platform === "win32" ? "windows.exe" : "linux";
   const bin = resolve(
     cacheRoot,
     "tools",
@@ -156,7 +155,9 @@ function reportNinjaLog(edges: Edge[]): void {
     (byGroup.get(m[1]!) ?? byGroup.set(m[1]!, []).get(m[1]!)!).push(b);
   }
   console.log(`\n  unified-bundle balance (max/min per directory group):`);
-  for (const [g, bs] of [...byGroup].sort((a, b) => Math.max(...b[1].map(e => e.end - e.start)) - Math.max(...a[1].map(e => e.end - e.start)))) {
+  for (const [g, bs] of [...byGroup].sort(
+    (a, b) => Math.max(...b[1].map(e => e.end - e.start)) - Math.max(...a[1].map(e => e.end - e.start)),
+  )) {
     if (bs.length < 2) continue;
     const ds = bs.map(b => b.end - b.start).sort((a, b) => b - a);
     const max = ds[0]!;
@@ -216,10 +217,7 @@ reportNinjaLog(readNinjaLog(buildDir));
 // to the capture so section counts are useful (defaults are tiny).
 const capture = resolve(buildDir, "time-trace.capture");
 const ini = resolve(buildDir, "ClangBuildAnalyzer.ini");
-await Bun.write(
-  ini,
-  `[counts]\nfileParse=20\nfileCodegen=15\nfunction=0\ntemplate=30\nheader=30\nheaderChain=5\n`,
-);
+await Bun.write(ini, `[counts]\nfileParse=20\nfileCodegen=15\nfunction=0\ntemplate=30\nheader=30\nheaderChain=5\n`);
 let r = spawnSync(cba, ["--all", buildDir, capture], { stdio: ["ignore", "ignore", "inherit"] });
 if (r.status !== 0) process.exit(r.status ?? 1);
 

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -140,10 +140,13 @@ function readNinjaLog(dir: string): Edge[] {
   if (!existsSync(path)) throw new Error(`no .ninja_log at ${path} — run a build first`);
   // Timestamps are ms since THAT ninja invocation started, and ninja appends
   // across runs, so entries from different runs have different time origins
-  // (which would make wall/parallelism nonsense). Entries are appended in
+  // (which would make wall/parallelism nonsense). Appended entries arrive in
   // completion order, so a drop in `end` marks a new run: keep only the last
-  // run's entries. The default clean flow has exactly one run, so this only
-  // matters for --no-build / --no-clean against an incrementally built dir.
+  // run's entries. Ninja's periodic recompaction rewrites the log in hash-map
+  // order (ends bounce, but one entry per output), so also require a repeated
+  // output before clearing; a recompacted log then keeps every entry, which
+  // at worst mixes time origins in the wall/parallelism headline. The default
+  // clean flow has exactly one run, so none of this applies there.
   const byOut = new Map<string, Edge>();
   let prevEnd = -1;
   for (const line of readFileSync(path, "utf8").split("\n")) {
@@ -151,7 +154,7 @@ function readNinjaLog(dir: string): Edge[] {
     const [s, e, , out] = line.split("\t");
     if (!out) continue;
     const edge = { start: +s, end: +e, out };
-    if (edge.end < prevEnd) byOut.clear();
+    if (edge.end < prevEnd && byOut.has(out)) byOut.clear();
     prevEnd = edge.end;
     byOut.set(out, edge);
   }

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -138,13 +138,22 @@ interface Edge {
 function readNinjaLog(dir: string): Edge[] {
   const path = resolve(dir, ".ninja_log");
   if (!existsSync(path)) throw new Error(`no .ninja_log at ${path} — run a build first`);
-  // Last entry per output wins (ninja appends on every build).
+  // Timestamps are ms since THAT ninja invocation started, and ninja appends
+  // across runs, so entries from different runs have different time origins
+  // (which would make wall/parallelism nonsense). Entries are appended in
+  // completion order, so a drop in `end` marks a new run: keep only the last
+  // run's entries. The default clean flow has exactly one run, so this only
+  // matters for --no-build / --no-clean against an incrementally built dir.
   const byOut = new Map<string, Edge>();
+  let prevEnd = -1;
   for (const line of readFileSync(path, "utf8").split("\n")) {
     if (line.startsWith("#") || !line.includes("\t")) continue;
     const [s, e, , out] = line.split("\t");
     if (!out) continue;
-    byOut.set(out, { start: +s, end: +e, out });
+    const edge = { start: +s, end: +e, out };
+    if (edge.end < prevEnd) byOut.clear();
+    prevEnd = edge.end;
+    byOut.set(out, edge);
   }
   return [...byOut.values()];
 }

--- a/scripts/analyze-cpp-build.ts
+++ b/scripts/analyze-cpp-build.ts
@@ -56,18 +56,28 @@ const has = (name: string) => args.includes(`--${name}`);
 
 const repo = resolve(import.meta.dir, "..");
 const buildDir = resolve(repo, flag("dir") || "build/time-trace");
-// The default clean step is rmSync(buildDir, {recursive}). Refuse any buildDir
-// that is the repo root or an ancestor of it (which is what --dir "", --dir .,
-// --dir / all resolve to) so a typo can't recursively delete the checkout.
+// The default clean step is rmSync(buildDir, {recursive}). A buildDir inside
+// the repo must sit under build/ (so --dir "", --dir ., --dir src, --dir .git
+// can't recursively delete checkout contents); anything outside the repo is
+// fine. On Windows, relative() across drive roots returns the absolute `to`
+// path, which correctly counts as outside.
 {
+  // Refuse the repo root or an ancestor of it (--dir "", --dir ., --dir /).
   // On Windows, relative() across drive roots returns the absolute `to` path;
   // a buildDir on a different drive cannot contain the repo, so allow it.
   const repoFromBuild = relative(buildDir, repo);
-  if (
-    repoFromBuild === "" ||
-    !(repoFromBuild === ".." || repoFromBuild.startsWith(`..${sep}`) || isAbsolute(repoFromBuild))
-  ) {
-    console.error(`refusing --dir ${JSON.stringify(buildDir)}: contains the repository root`);
+  const containsRepo = !(
+    repoFromBuild === ".." ||
+    repoFromBuild.startsWith(`..${sep}`) ||
+    isAbsolute(repoFromBuild)
+  );
+  // Refuse in-repo paths outside build/ (--dir src, --dir .git).
+  const buildFromRepo = relative(repo, buildDir);
+  const insideRepo = !(buildFromRepo.startsWith(`..${sep}`) || isAbsolute(buildFromRepo));
+  if (containsRepo || (insideRepo && !buildFromRepo.startsWith(`build${sep}`))) {
+    console.error(
+      `refusing --dir ${JSON.stringify(buildDir)}: the clean step would rm -rf a repo path outside build/`,
+    );
     process.exit(1);
   }
 }

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -59,6 +59,12 @@ const noUnify: readonly string[] = [
   "src/jsc/bindings/webcore/SerializedScriptValue.cpp",
   "src/jsc/bindings/webcore/HTTPParsers.cpp",
 
+  // #includes InternalModuleRegistryConstants.h — ~3 MB of embedded byte
+  // arrays for every bundled JS module, ~16s to parse on its own
+  // (-ftime-trace). Bundling it made its unified TU ~18s slower than its
+  // siblings and put it on the release critical path.
+  "src/jsc/bindings/InternalModuleRegistry.cpp",
+
   // Duplicates static MIME-parsing helpers from JSMIMEParams.cpp verbatim;
   // both end up in the same bundle. TODO: extract helpers to a shared header.
   "src/jsc/bindings/webcore/JSMIMEType.cpp",
@@ -151,14 +157,8 @@ const noUnify: readonly string[] = [
 /**
  * Directories whose every .cpp compiles standalone (repo-root-relative,
  * posix-style, no trailing slash). Same semantics as `noUnify`, per-directory.
- * The streams entry exists because its sibling TUs repeat file-local static
- * helper names; it can be lifted once those are deduplicated.
  */
-const noUnifyDirs: readonly string[] = [
-  // One WHATWG spec algorithm group per TU, each with file-local static
-  // helpers written assuming TU isolation; a unified bundle collides them.
-  "src/jsc/bindings/webcore/streams",
-];
+const noUnifyDirs: readonly string[] = [];
 
 /**
  * How many .cpp files per bundle. WebKit defaults to 8.

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -22,7 +22,9 @@
  *
  * Pitfalls (handled by convention, not by this script — fix at the source):
  *   - File-static names from N files now share a TU. On collision, wrap the
- *     statics in an anonymous or `namespace FILENAME { }` block, or rename.
+ *     statics in a per-file `namespace FILENAME { }` block, or rename.
+ *     (An anonymous namespace does not help: unnamed namespaces merge
+ *     within a TU.)
  *   - `using namespace X;` at file scope leaks into later includes in the
  *     same bundle.
  *   - A file may build only because an earlier sibling already pulled a

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -59,12 +59,6 @@ const noUnify: readonly string[] = [
   "src/jsc/bindings/webcore/SerializedScriptValue.cpp",
   "src/jsc/bindings/webcore/HTTPParsers.cpp",
 
-  // #includes InternalModuleRegistryConstants.h — ~3 MB of embedded byte
-  // arrays for every bundled JS module, ~16s to parse on its own
-  // (-ftime-trace). Bundling it made its unified TU ~18s slower than its
-  // siblings and put it on the release critical path.
-  "src/jsc/bindings/InternalModuleRegistry.cpp",
-
   // Duplicates static MIME-parsing helpers from JSMIMEParams.cpp verbatim;
   // both end up in the same bundle. TODO: extract helpers to a shared header.
   "src/jsc/bindings/webcore/JSMIMEType.cpp",

--- a/src/jsc/STREAMS.md
+++ b/src/jsc/STREAMS.md
@@ -70,9 +70,10 @@ Blob,JSON,Array,ArrayBuffer,FormData}` and the `Request`/`Response` body consume
   stream classes themselves (only the JSSink classes are generated). For a fast per-TU
   syntax check without a full build, look up the TU's compile command in
   `build/debug/compile_commands.json` and re-run it with `-fsyntax-only`.
-- Each TU compiles standalone (see `noUnifyDirs` in `scripts/build/unified.ts`): file-local
-  `static` helpers are written assuming TU isolation, so don't move them into headers
-  without renaming.
+- The directory is unified-source bundled (see `scripts/build/unified.ts`): sibling `.cpp`
+  files share a translation unit, so file-local `static` helper names must be unique across
+  the directory (or wrapped in an anonymous namespace). A helper used from more than one
+  file belongs in `WebStreamsInternals.h` with its definition in one `.cpp`.
 - Exception discipline: any call that can enter user JS needs `RETURN_IF_EXCEPTION` under a
   `ThrowScope` before its result is used. The `// userJS:` annotations in
   `WebStreamsInternals.h` are the source of truth for which operations can.

--- a/src/jsc/STREAMS.md
+++ b/src/jsc/STREAMS.md
@@ -72,8 +72,9 @@ Blob,JSON,Array,ArrayBuffer,FormData}` and the `Request`/`Response` body consume
   `build/debug/compile_commands.json` and re-run it with `-fsyntax-only`.
 - The directory is unified-source bundled (see `scripts/build/unified.ts`): sibling `.cpp`
   files share a translation unit, so file-local `static` helper names must be unique across
-  the directory (or wrapped in an anonymous namespace). A helper used from more than one
-  file belongs in `WebStreamsInternals.h` with its definition in one `.cpp`.
+  the directory (an anonymous namespace does not help: unnamed namespaces merge within a
+  TU). A helper used from more than one file belongs in `WebStreamsInternals.h` with its
+  definition in one `.cpp`.
 - Exception discipline: any call that can enter user JS needs `RETURN_IF_EXCEPTION` under a
   `ThrowScope` before its result is used. The `// userJS:` annotations in
   `WebStreamsInternals.h` are the source of truth for which operations can.

--- a/src/jsc/STREAMS.md
+++ b/src/jsc/STREAMS.md
@@ -3,9 +3,9 @@
 Bun's WHATWG Streams implementation (`ReadableStream`, `WritableStream`, `TransformStream`,
 their controllers/readers/writers, `TextEncoderStream`/`TextDecoderStream`, and the
 `ByteLength`/`Count` queuing strategies) is written entirely in C++ under
-`src/jsc/bindings/webcore/streams/` — 33 translation units, zero JavaScript builtins.
+`src/jsc/bindings/webcore/streams/` — 35 `.cpp` files, zero JavaScript builtins.
 
-Each TU owns one spec object or one spec algorithm group. Public classes
+Each file owns one spec object or one spec algorithm group. Public classes
 (`JSReadableStream.cpp`, `JSWritableStream.cpp`, …) hold the per-instance state and the
 prototype/constructor tables; the abstract-operation files (`ReadableStreamOperations.cpp`,
 `WritableStreamOperations.cpp`, `TransformStreamOperations.cpp`, `WebStreamsMisc.cpp`) hold

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -283,20 +283,6 @@ static size_t writeUTF8(const WTF::String& string, std::span<uint8_t> destinatio
     return Bun__encoding__writeUTF16(string.span16().data(), string.span16().size(), destination.data(), destination.size(), utf8);
 }
 
-// `obj[name](...args)` with `this` = obj.
-static JSValue invokeMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* object, const Identifier& name, const MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue method = object->get(globalObject, name);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto callData = JSC::getCallData(method);
-    if (callData.type == CallData::Type::None) [[unlikely]] {
-        throwTypeError(globalObject, scope, makeString(name.string(), " is not a function"_s));
-        return {};
-    }
-    RELEASE_AND_RETURN(scope, JSC::call(globalObject, method, callData, object, args));
-}
-
 static JSC::JSUint8Array* encodeStringToUint8Array(JSC::VM& vm, JSGlobalObject* globalObject, JSValue stringValue)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -308,19 +308,6 @@ static inline JSBoundFunction* createBoundHandler(JSGlobalObject* globalObject, 
     return createStreamsBoundHandler(globalObject, target, context);
 }
 
-// object.<name>(...args) with a real [[Get]], as the replaced builtins did.
-static JSValue invokeMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* object, const Identifier& name, const MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue method = object->get(globalObject, name);
-    RETURN_IF_EXCEPTION(scope, {});
-    if (!method.isCallable()) [[unlikely]] {
-        throwTypeError(globalObject, scope, makeString(name.string(), " is not a function"_s));
-        return {};
-    }
-    RELEASE_AND_RETURN(scope, call(globalObject, method, getCallData(method), object, args));
-}
-
 // The native-handle cancel protocol shared by nativeSourceCancel / cancelPendingNativeSource.
 static void invokeNativeHandleCancel(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* handle, JSValue reason)
 {
@@ -336,6 +323,7 @@ static void invokeNativeHandleCancel(JSC::VM& vm, JSGlobalObject* globalObject, 
     scope.release();
     invokeMethod(vm, globalObject, handle, builtinNames(vm).cancelPublicName(), cancelArgs);
 }
+
 
 static JSValue wrapWithAsyncContext(JSGlobalObject* globalObject, JSReadableStream* stream, JSValue callable)
 {

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -324,7 +324,6 @@ static void invokeNativeHandleCancel(JSC::VM& vm, JSGlobalObject* globalObject, 
     invokeMethod(vm, globalObject, handle, builtinNames(vm).cancelPublicName(), cancelArgs);
 }
 
-
 static JSValue wrapWithAsyncContext(JSGlobalObject* globalObject, JSReadableStream* stream, JSValue callable)
 {
     JSValue asyncContext = stream->m_asyncContext.get();

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -112,27 +112,6 @@ template<> void JSByteLengthQueuingStrategyConstructor::finishCreation(VM& vm, J
     m_instanceStructure.set(vm, this, getDOMStructure<JSByteLengthQueuingStrategy>(vm, globalObject));
 }
 
-// `QueuingStrategyInit init` — `highWaterMark` is a required `unrestricted double` member.
-static double convertQueuingStrategyInit(JSC::VM& vm, JSGlobalObject* globalObject, JSValue init)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    if (!init.isObject()) {
-        if (!init.isUndefinedOrNull()) {
-            throwTypeError(globalObject, scope, "The QueuingStrategyInit argument must be an object"_s);
-            return 0;
-        }
-        throwTypeError(globalObject, scope, "QueuingStrategyInit requires a 'highWaterMark' member"_s);
-        return 0;
-    }
-    JSValue highWaterMark = asObject(init)->get(globalObject, builtinNames(vm).highWaterMarkPublicName());
-    RETURN_IF_EXCEPTION(scope, 0);
-    if (highWaterMark.isUndefined()) {
-        throwTypeError(globalObject, scope, "QueuingStrategyInit requires a 'highWaterMark' member"_s);
-        return 0;
-    }
-    RELEASE_AND_RETURN(scope, highWaterMark.toNumber(globalObject));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSByteLengthQueuingStrategyConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -112,27 +112,6 @@ template<> void JSCountQueuingStrategyConstructor::finishCreation(VM& vm, JSDOMG
     m_instanceStructure.set(vm, this, getDOMStructure<JSCountQueuingStrategy>(vm, globalObject));
 }
 
-// `QueuingStrategyInit init` — `highWaterMark` is a required `unrestricted double` member.
-static double convertQueuingStrategyInit(JSC::VM& vm, JSGlobalObject* globalObject, JSValue init)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    if (!init.isObject()) {
-        if (!init.isUndefinedOrNull()) {
-            throwTypeError(globalObject, scope, "The QueuingStrategyInit argument must be an object"_s);
-            return 0;
-        }
-        throwTypeError(globalObject, scope, "QueuingStrategyInit requires a 'highWaterMark' member"_s);
-        return 0;
-    }
-    JSValue highWaterMark = asObject(init)->get(globalObject, builtinNames(vm).highWaterMarkPublicName());
-    RETURN_IF_EXCEPTION(scope, 0);
-    if (highWaterMark.isUndefined()) {
-        throwTypeError(globalObject, scope, "QueuingStrategyInit requires a 'highWaterMark' member"_s);
-        return 0;
-    }
-    RELEASE_AND_RETURN(scope, highWaterMark.toNumber(globalObject));
-}
-
 template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCountQueuingStrategyConstructor::construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -29,34 +29,6 @@ namespace WebCore {
 using namespace JSC;
 using namespace Bun::WebStreams;
 
-// Null-safe tee-branch controller recovery: Bun's native-sink pumps clear a consumed
-// stream's controller slot in their finally step, so a tee reaction queued before that
-// teardown can see a branch with no controller. A torn-down branch is terminal; skip it.
-static JSReadableStreamDefaultController* teeBranchDefaultController(JSReadableStream* branch)
-{
-    if (branch->m_controllerKind != ControllerKind::Default)
-        return nullptr;
-    return uncheckedDowncast<JSReadableStreamDefaultController>(branch->m_controller.get());
-}
-
-static JSReadableByteStreamController* teeBranchByteController(JSReadableStream* branch)
-{
-    if (branch->m_controllerKind != ControllerKind::Byte)
-        return nullptr;
-    return uncheckedDowncast<JSReadableByteStreamController>(branch->m_controller.get());
-}
-
-// [reaction-convention] deferral: runs handler(value, context) as its own microtask,
-// carrying the current async context, without allocating a promise.
-static void queueReactionJob(JSC::VM& vm, JSGlobalObject* globalObject, JSFunction* handler, JSValue value, JSValue context)
-{
-    JSValue asyncContext = globalObject->m_asyncContextData.get()->getInternalField(0);
-    if (asyncContext.isEmpty())
-        asyncContext = jsUndefined();
-    QueuedTask task { nullptr, InternalMicrotask::BunPerformMicrotaskJob, 0, globalObject, handler, asyncContext, value, context };
-    vm.queueMicrotask(WTF::move(task));
-}
-
 const ClassInfo JSReadRequest::s_info = { "ReadRequest"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSReadRequest) };
 
 JSReadRequest::JSReadRequest(VM& vm, Structure* structure, ReadRequestKind kind)

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -91,28 +91,6 @@ static JSC::JSArrayBufferView* constructViewOfType(JSC::JSGlobalObject* globalOb
     return nullptr;
 }
 
-// WebIDL "invoke a callback function" with a Promise<T> return type: an abrupt completion is
-// converted into a rejected promise (a completion-record conversion), never a synchronous throw.
-static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSValue result;
-    JSC::JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(method);
-        ASSERT(callData.type != JSC::CallData::Type::None);
-        result = JSC::call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
 // The [[pullAlgorithm]] dispatch. The reachable kind set on a byte controller is exactly
 // {JavaScript, Nothing, ByteTeeBranch}; the switch is total over SourceKind.
 // Returns nullptr with no exception pending when the pull completed synchronously with a

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -39,14 +39,6 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSStreamsRuntime;
 
-// The only cast of the erased stream->m_controller slot in this file: a BYOB reader can
-// only be attached to a byte-controlled stream (SetUpReadableStreamBYOBReader enforces it).
-static WebCore::JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream)
-{
-    ASSERT(stream->m_controllerKind == ControllerKind::Byte);
-    return uncheckedDowncast<WebCore::JSReadableByteStreamController>(stream->m_controller.get());
-}
-
 // Detaches [[readIntoRequests]] before dispatch ("set to an empty list, then iterate"): once
 // the requests leave the visited deque the MarkedArgumentBuffer is their only root.
 static void detachReadIntoRequests(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStreamBYOBReader* reader, MarkedArgumentBuffer& out)

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -39,28 +39,13 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSStreamsRuntime;
 
-// Detaches [[readIntoRequests]] before dispatch ("set to an empty list, then iterate"): once
-// the requests leave the visited deque the MarkedArgumentBuffer is their only root.
-static void detachReadIntoRequests(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStreamBYOBReader* reader, MarkedArgumentBuffer& out)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    {
-        WTF::Locker locker { reader->cellLock() };
-        for (auto& request : reader->m_readIntoRequests)
-            out.append(request.get());
-        reader->m_readIntoRequests.clear();
-    }
-    if (out.hasOverflowed()) [[unlikely]]
-        throwOutOfMemoryError(globalObject, scope);
-}
-
 // ReadableStreamBYOBReaderErrorReadIntoRequests(reader, e)
 void readableStreamBYOBReaderErrorReadIntoRequests(JSGlobalObject* globalObject, JSReadableStreamBYOBReader* reader, JSValue error)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     MarkedArgumentBuffer readIntoRequests;
-    detachReadIntoRequests(vm, globalObject, reader, readIntoRequests);
+    detachReadRequests(vm, globalObject, reader, readIntoRequests);
     RETURN_IF_EXCEPTION(scope, void());
     for (size_t i = 0, count = readIntoRequests.size(); i < count; ++i) {
         uncheckedDowncast<WebCore::JSReadIntoRequest>(readIntoRequests.at(i))->errorSteps(globalObject, error);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -31,28 +31,6 @@ namespace WebStreams {
 
 using namespace JSC;
 
-// WebIDL "invoke a callback function" with a Promise<T> return type: an abrupt completion is
-// converted into a rejected promise (a completion-record conversion), never a synchronous throw.
-static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSValue result;
-    JSC::JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(method);
-        ASSERT(callData.type != JSC::CallData::Type::None);
-        result = JSC::call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
 // The [[pullAlgorithm]] dispatch. ByteTeeBranch is byte-controller-only and CrossRealm sources
 // are never created (transferable streams are unimplemented); the switch is total over SourceKind.
 // Returns nullptr with no exception pending when the pull completed synchronously with a

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -39,21 +39,6 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSStreamsRuntime;
 
-// Detaches [[readRequests]] before dispatch ("set to an empty list, then iterate"): once the
-// requests leave the visited deque the MarkedArgumentBuffer is their only root.
-static void detachReadRequests(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStreamDefaultReader* reader, MarkedArgumentBuffer& out)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    {
-        WTF::Locker locker { reader->cellLock() };
-        for (auto& request : reader->m_readRequests)
-            out.append(request.get());
-        reader->m_readRequests.clear();
-    }
-    if (out.hasOverflowed()) [[unlikely]]
-        throwOutOfMemoryError(globalObject, scope);
-}
-
 // ReadableStreamDefaultReaderErrorReadRequests(reader, e)
 void readableStreamDefaultReaderErrorReadRequests(JSGlobalObject* globalObject, JSReadableStreamDefaultReader* reader, JSValue error)
 {

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -39,19 +39,6 @@ namespace WebStreams {
 using namespace JSC;
 using WebCore::JSStreamsRuntime;
 
-// The only cast of the erased stream->m_controller slot in this file; every switch is TOTAL.
-static WebCore::JSReadableStreamDefaultController* defaultControllerOf(JSReadableStream* stream)
-{
-    ASSERT(stream->m_controllerKind == ControllerKind::Default);
-    return uncheckedDowncast<WebCore::JSReadableStreamDefaultController>(stream->m_controller.get());
-}
-
-static WebCore::JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream)
-{
-    ASSERT(stream->m_controllerKind == ControllerKind::Byte);
-    return uncheckedDowncast<WebCore::JSReadableByteStreamController>(stream->m_controller.get());
-}
-
 // Detaches [[readRequests]] before dispatch ("set to an empty list, then iterate"): once the
 // requests leave the visited deque the MarkedArgumentBuffer is their only root.
 static void detachReadRequests(JSC::VM& vm, JSGlobalObject* globalObject, JSReadableStreamDefaultReader* reader, MarkedArgumentBuffer& out)

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -30,39 +30,6 @@ namespace WebStreams {
 
 using namespace JSC;
 
-// Null-safe: Bun's native-sink pumps clear a consumed stream's controller slot in their
-// finally step, so a transform reaction (or an async transform()/flush() resuming after
-// that teardown) can see a readable with no controller. A torn-down readable is terminal.
-static JSReadableStreamDefaultController* transformReadableController(JSTransformStream* stream)
-{
-    const auto* readable = stream->m_readable.get();
-    if (readable->m_controllerKind != ControllerKind::Default)
-        return nullptr;
-    return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
-}
-
-// WebIDL callback invoke returning Promise<undefined>: an abrupt completion becomes a
-// rejected promise (a sanctioned completion-record catch). Returns nullptr on VM termination.
-static JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* method, JSValue thisValue, const MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue result;
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = getCallData(method);
-        ASSERT(callData.type != CallData::Type::None);
-        result = call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
 // The default [[transformAlgorithm]]: enqueue the chunk unchanged; the enqueue's abrupt
 // completion becomes a rejected promise (a sanctioned completion-record catch).
 static JSPromise* defaultTransformAlgorithm(JSC::VM& vm, JSGlobalObject* globalObject, JSTransformStreamDefaultController* controller, JSValue chunk)

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -30,28 +30,6 @@ namespace WebStreams {
 
 using namespace JSC;
 
-// WebIDL "invoke a callback function" with a Promise<T> return type: an abrupt completion is
-// converted into a rejected promise (a completion-record conversion), never a synchronous throw.
-static JSC::JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSC::JSValue result;
-    JSC::JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = JSC::getCallData(method);
-        ASSERT(callData.type != JSC::CallData::Type::None);
-        result = JSC::call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
-}
-
 // As invokePromiseReturningMethod, but returns nullptr for a synchronous non-thenable completion
 // and returns a vanilla JSPromise unwrapped (isThenFastAndNonObservable); the caller queues the
 // upon-fulfillment handler directly when the result is nullptr or already Fulfilled.

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -124,29 +124,6 @@ static void reactToStartResult(JSC::VM& vm, JSGlobalObject* globalObject, JSValu
     RETURN_IF_EXCEPTION(scope, void());
 }
 
-// Detaches the reader's request list before dispatch, per the spec's "set to an empty list,
-// then iterate". A MarkedArgumentBuffer is the only GC-visible holder once the requests
-// leave the visited deque.
-template<typename Reader>
-static void detachReadRequests(JSC::VM& vm, JSGlobalObject* globalObject, Reader* reader, MarkedArgumentBuffer& out)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    {
-        WTF::Locker locker { reader->cellLock() };
-        if constexpr (std::is_same_v<Reader, WebCore::JSReadableStreamDefaultReader>) {
-            for (auto& request : reader->m_readRequests)
-                out.append(request.get());
-            reader->m_readRequests.clear();
-        } else {
-            for (auto& request : reader->m_readIntoRequests)
-                out.append(request.get());
-            reader->m_readIntoRequests.clear();
-        }
-    }
-    if (out.hasOverflowed()) [[unlikely]]
-        throwOutOfMemoryError(globalObject, scope);
-}
-
 // InitializeReadableStream(stream)
 void initializeReadableStream(JSReadableStream* stream)
 {

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -41,7 +41,7 @@ using WebCore::JSStreamsRuntime;
 
 // Every switch over ControllerKind is TOTAL; these two are the only casts of the erased
 // stream->m_controller slot in this file.
-static JSReadableStreamDefaultController* defaultControllerOf(JSReadableStream* stream)
+JSReadableStreamDefaultController* defaultControllerOf(JSReadableStream* stream)
 {
     switch (stream->m_controllerKind) {
     case ControllerKind::Default:
@@ -56,7 +56,7 @@ static JSReadableStreamDefaultController* defaultControllerOf(JSReadableStream* 
     return nullptr;
 }
 
-static JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream)
+JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream)
 {
     switch (stream->m_controllerKind) {
     case ControllerKind::Byte:
@@ -74,14 +74,14 @@ static JSReadableByteStreamController* byteControllerOf(JSReadableStream* stream
 // Null-safe tee-branch controller recovery: Bun's native-sink pumps clear a consumed
 // stream's controller slot in their finally step, so a tee reaction queued before that
 // teardown can see a branch with no controller. A torn-down branch is terminal; skip it.
-static JSReadableStreamDefaultController* teeBranchDefaultController(JSReadableStream* branch)
+JSReadableStreamDefaultController* teeBranchDefaultController(JSReadableStream* branch)
 {
     if (branch->m_controllerKind != ControllerKind::Default)
         return nullptr;
     return uncheckedDowncast<JSReadableStreamDefaultController>(branch->m_controller.get());
 }
 
-static JSReadableByteStreamController* teeBranchByteController(JSReadableStream* branch)
+JSReadableByteStreamController* teeBranchByteController(JSReadableStream* branch)
 {
     if (branch->m_controllerKind != ControllerKind::Byte)
         return nullptr;
@@ -100,7 +100,7 @@ static JSReadableStreamReaderBase* teeReader(JSStreamTeeState* teeState)
 
 // [reaction-convention] deferral: runs handler(value, context) as its own microtask,
 // carrying the current async context, without allocating a promise.
-static void queueReactionJob(JSC::VM& vm, JSGlobalObject* globalObject, JSFunction* handler, JSValue value, JSValue context)
+void queueReactionJob(JSC::VM& vm, JSGlobalObject* globalObject, JSFunction* handler, JSValue value, JSValue context)
 {
     JSValue asyncContext = globalObject->m_asyncContextData.get()->getInternalField(0);
     if (asyncContext.isEmpty())

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -30,34 +30,12 @@ using WebCore::JSStreamsRuntime;
 // Null-safe: Bun's native-sink pumps clear a consumed stream's controller slot in their
 // finally step, so a transform reaction (or an async transform()/flush() resuming after
 // that teardown) can see a readable with no controller. A torn-down readable is terminal.
-static JSReadableStreamDefaultController* transformReadableController(JSTransformStream* stream)
+JSReadableStreamDefaultController* transformReadableController(JSTransformStream* stream)
 {
     const auto* readable = stream->m_readable.get();
     if (readable->m_controllerKind != ControllerKind::Default)
         return nullptr;
     return uncheckedDowncast<JSReadableStreamDefaultController>(readable->m_controller.get());
-}
-
-// WebIDL callback invoke returning Promise<undefined>: an abrupt completion becomes a
-// rejected promise (a sanctioned completion-record catch). Returns nullptr on VM termination.
-static JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* method, JSValue thisValue, const MarkedArgumentBuffer& args)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue result;
-    JSValue thrown;
-    {
-        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto callData = getCallData(method);
-        ASSERT(callData.type != CallData::Type::None);
-        result = call(globalObject, method, callData, thisValue, args);
-        if (catchScope.exception()) [[unlikely]]
-            thrown = takeAbruptCompletion(globalObject, catchScope);
-    }
-    if (!thrown.isEmpty())
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
-    if (result.isEmpty())
-        return nullptr;
-    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
 }
 
 // [[flushAlgorithm]] dispatch (needed only by the default sink close algorithm below).

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -142,6 +142,8 @@ bool canCopyDataBlockBytes(JSC::ArrayBuffer& toBuffer, size_t toIndex, JSC::Arra
 UnderlyingSinkDict convertUnderlyingSinkDict(JSC::JSGlobalObject*, JSC::JSValue underlyingSink); // userJS: yes — WebStreamsMisc.cpp
 TransformerDict convertTransformerDict(JSC::JSGlobalObject*, JSC::JSValue transformer); // userJS: yes — WebStreamsMisc.cpp
 QueuingStrategyDict convertQueuingStrategyDict(JSC::JSGlobalObject*, JSC::JSValue strategy); // userJS: yes — WebStreamsMisc.cpp
+// `QueuingStrategyInit init` — `highWaterMark` is a required `unrestricted double`.
+double convertQueuingStrategyInit(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue init); // userJS: yes — WebStreamsMisc.cpp
 
 // Promise helpers (thin, named after the spec phrases).
 // "a promise resolved with v" — resolving with ANY OBJECT (not only a user thenable) performs
@@ -154,6 +156,11 @@ JSC::JSPromise* promiseFulfilledWith(JSC::JSGlobalObject*, JSC::JSValue); // use
 JSC::JSBoundFunction* createStreamsBoundHandler(JSC::JSGlobalObject*, JSC::JSFunction* target, JSC::JSCell* context);
 // obj.name(...args); returns the EMPTY value when `name` is not callable. userJS: yes — WebStreamsMisc.cpp
 JSC::JSValue invokeOptionalMethod(JSC::JSGlobalObject*, JSC::JSObject*, const JSC::Identifier& name, const JSC::MarkedArgumentBuffer&);
+// obj.name(...args); TypeError if `name` is not callable. userJS: yes — WebStreamsMisc.cpp
+JSC::JSValue invokeMethod(JSC::VM&, JSC::JSGlobalObject*, JSC::JSObject*, const JSC::Identifier&, const JSC::MarkedArgumentBuffer&);
+// WebIDL callback invoke returning Promise<undefined>: an abrupt completion becomes a rejected
+// promise. Returns nullptr on VM termination. userJS: yes — WebStreamsMisc.cpp
+JSC::JSPromise* invokePromiseReturningMethod(JSC::VM&, JSC::JSGlobalObject*, JSC::JSObject* method, JSC::JSValue thisValue, const JSC::MarkedArgumentBuffer&);
 // error.code === code, swallowing any lookup exception. userJS: yes — WebStreamsMisc.cpp
 bool errorCodeIs(JSC::JSGlobalObject*, JSC::JSValue error, WTF::ASCIILiteral code);
 JSC::JSPromise* promiseResolvedWith(JSC::JSGlobalObject*, JSC::JSValue); // userJS: yes — WebStreamsMisc.cpp
@@ -194,6 +201,15 @@ JSC::JSValue takeAbruptCompletion(JSC::JSGlobalObject*, JSC::TopExceptionScope&)
 
 // ReadableStreamOperations.cpp — stream-level RS ops, reader set-up, controller set-up,
 // tee, from-iterable.
+
+// Checked downcasts for the erased `stream->m_controller` slot.
+JSReadableStreamDefaultController* defaultControllerOf(JSReadableStream*); // userJS: no — ReadableStreamOperations.cpp
+JSReadableByteStreamController* byteControllerOf(JSReadableStream*); // userJS: no — ReadableStreamOperations.cpp
+// Null-safe tee-branch controller recovery (torn-down branch returns nullptr).
+JSReadableStreamDefaultController* teeBranchDefaultController(JSReadableStream* branch); // userJS: no — ReadableStreamOperations.cpp
+JSReadableByteStreamController* teeBranchByteController(JSReadableStream* branch); // userJS: no — ReadableStreamOperations.cpp
+// [reaction-convention] microtask deferral without allocating a promise.
+void queueReactionJob(JSC::VM&, JSC::JSGlobalObject*, JSC::JSFunction* handler, JSC::JSValue value, JSC::JSValue context); // userJS: no — ReadableStreamOperations.cpp
 
 // Internal creation.
 // `startResult` = the value "the start algorithm returned" (a pre-existing pending promise
@@ -419,6 +435,8 @@ void writableStreamDefaultControllerWrite(JSC::JSGlobalObject*, JSWritableStream
 
 // TransformStreamOperations.cpp
 
+// Null-safe: returns nullptr when the readable's controller was torn down.
+JSReadableStreamDefaultController* transformReadableController(JSTransformStream*); // userJS: no — TransformStreamOperations.cpp
 // The internal-creation parallel of createReadableStream.
 JSTransformStream* createTransformStream(JSC::JSGlobalObject*, TransformerKind, JSC::JSCell* algorithmContext, double writableHighWaterMark = 1, JSC::JSObject* writableSizeAlgorithm = nullptr, double readableHighWaterMark = 0, JSC::JSObject* readableSizeAlgorithm = nullptr); // userJS: yes — TransformStreamOperations.cpp
 void initializeTransformStream(JSC::JSGlobalObject*, JSTransformStream*, JSC::JSPromise* startPromise, double writableHighWaterMark, JSC::JSObject* writableSizeAlgorithm, double readableHighWaterMark, JSC::JSObject* readableSizeAlgorithm); // userJS: yes — TransformStreamOperations.cpp

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -22,6 +22,7 @@
 // These three are used by name below (`JSC::JSUint8Array*` is a typedef and cannot be
 // forward-declared; `const JSC::Identifier&`; `WTF::String`) — do not rely on transitive
 // includes from root.h for them. MarkedVector.h supplies JSC::MarkedArgumentBuffer.
+#include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/JSTypedArrays.h>
@@ -29,7 +30,9 @@
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/ThrowScope.h>
 #include <optional>
+#include <type_traits>
 #include <utility>
+#include <wtf/Locker.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 #include "helpers.h"
@@ -198,6 +201,30 @@ void webStreamControllerError(JSC::JSGlobalObject*, JSWritableStream*, JSC::JSVa
 // termination (which the caller must propagate, never consume). Never call bare
 // clearException() anywhere in the subsystem.
 JSC::JSValue takeAbruptCompletion(JSC::JSGlobalObject*, JSC::TopExceptionScope&); // userJS: no — WebStreamsMisc.cpp
+
+// Detaches the reader's request list before dispatch, per the spec's "set to an empty
+// list, then iterate": once the requests leave the visited deque the MarkedArgumentBuffer
+// is their only GC-visible root. A template so both reader types share one body; defined
+// here because every consumer TU must see it. userJS: no (may throw OOM).
+template<typename Reader>
+void detachReadRequests(JSC::VM& vm, JSC::JSGlobalObject* globalObject, Reader* reader, JSC::MarkedArgumentBuffer& out)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    {
+        WTF::Locker locker { reader->cellLock() };
+        if constexpr (std::is_same_v<Reader, JSReadableStreamDefaultReader>) {
+            for (auto& request : reader->m_readRequests)
+                out.append(request.get());
+            reader->m_readRequests.clear();
+        } else {
+            for (auto& request : reader->m_readIntoRequests)
+                out.append(request.get());
+            reader->m_readIntoRequests.clear();
+        }
+    }
+    if (out.hasOverflowed()) [[unlikely]]
+        JSC::throwOutOfMemoryError(globalObject, scope);
+}
 
 // ReadableStreamOperations.cpp — stream-level RS ops, reader set-up, controller set-up,
 // tee, from-iterable.

--- a/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp
@@ -256,6 +256,27 @@ QueuingStrategyDict convertQueuingStrategyDict(JSGlobalObject* globalObject, JSV
     return result;
 }
 
+// `QueuingStrategyInit init` — `highWaterMark` is a required `unrestricted double` member.
+double convertQueuingStrategyInit(JSC::VM& vm, JSGlobalObject* globalObject, JSValue init)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!init.isObject()) {
+        if (!init.isUndefinedOrNull()) {
+            throwTypeError(globalObject, scope, "The QueuingStrategyInit argument must be an object"_s);
+            return 0;
+        }
+        throwTypeError(globalObject, scope, "QueuingStrategyInit requires a 'highWaterMark' member"_s);
+        return 0;
+    }
+    JSValue highWaterMark = asObject(init)->get(globalObject, WebCore::builtinNames(vm).highWaterMarkPublicName());
+    RETURN_IF_EXCEPTION(scope, 0);
+    if (highWaterMark.isUndefined()) {
+        throwTypeError(globalObject, scope, "QueuingStrategyInit requires a 'highWaterMark' member"_s);
+        return 0;
+    }
+    RELEASE_AND_RETURN(scope, highWaterMark.toNumber(globalObject));
+}
+
 // Promise helpers.
 
 // Web IDL "a promise resolved with v": a NEW promise resolved with v; a promise/thenable v is
@@ -294,6 +315,41 @@ JSValue invokeOptionalMethod(JSGlobalObject* globalObject, JSObject* object, con
     if (!method.isCallable())
         return {};
     RELEASE_AND_RETURN(scope, JSC::call(globalObject, method, object, args, "method is not a function"_s));
+}
+
+JSC::JSValue invokeMethod(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* object, const JSC::Identifier& name, const JSC::MarkedArgumentBuffer& args)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSValue method = object->get(globalObject, name);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto callData = JSC::getCallData(method);
+    if (callData.type == JSC::CallData::Type::None) [[unlikely]] {
+        throwTypeError(globalObject, scope, makeString(name.string(), " is not a function"_s));
+        return {};
+    }
+    RELEASE_AND_RETURN(scope, JSC::call(globalObject, method, callData, object, args));
+}
+
+// WebIDL callback invoke returning Promise<undefined>: an abrupt completion becomes a
+// rejected promise (a sanctioned completion-record catch). Returns nullptr on VM termination.
+JSPromise* invokePromiseReturningMethod(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* method, JSValue thisValue, const MarkedArgumentBuffer& args)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue result;
+    JSValue thrown;
+    {
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+        auto callData = getCallData(method);
+        ASSERT(callData.type != CallData::Type::None);
+        result = call(globalObject, method, callData, thisValue, args);
+        if (catchScope.exception()) [[unlikely]]
+            thrown = takeAbruptCompletion(globalObject, catchScope);
+    }
+    if (!thrown.isEmpty())
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, thrown));
+    if (result.isEmpty())
+        return nullptr;
+    RELEASE_AND_RETURN(scope, promiseResolvedWith(globalObject, result));
 }
 
 bool errorCodeIs(JSGlobalObject* globalObject, JSValue error, ASCIILiteral code)

--- a/test/js/bun/perf/unified-sources.test.ts
+++ b/test/js/bun/perf/unified-sources.test.ts
@@ -9,9 +9,8 @@ import { generateUnifiedSources } from "../../../../scripts/build/unified.ts";
  *   codegen-critical-path + pch + max(cxx) + sum(cxx)/cores
  * so an outsized bundle or a directory compiling standalone dominates both the
  * tail and the aggregate. `bun run build:analyze` surfaces the numbers, and
- * these checks lock in the two worst offenders it found: webcore/streams
- * bundled (not `noUnifyDirs`) and `InternalModuleRegistry.cpp` compiled on its
- * own instead of inflating its siblings.
+ * these checks lock in the bundling decisions it informed, chiefly
+ * webcore/streams bundled (not `noUnifyDirs`).
  */
 
 const repo = resolve(import.meta.dir, "../../../..");
@@ -58,21 +57,17 @@ describe("unified-source bundling", () => {
     expect(unified).toEqual(["UnifiedSource-src_jsc_bindings_webcore_streams-0.cpp"]);
   });
 
-  test("InternalModuleRegistry.cpp compiles standalone", () => {
-    // It #includes InternalModuleRegistryConstants.h, a multi-megabyte
-    // byte-array header (~16s frontend). Bundled, it made its unified TU the
-    // release critical-path straggler; standalone it runs alongside them.
+  test("InternalModuleRegistry.cpp bundles with its siblings", () => {
+    // InternalModuleRegistryConstants.h stopped embedding module source bytes
+    // (#35071 links them via .incbin), so the file is an ordinary small TU.
     const bindings = [
       "src/jsc/bindings/AsyncContextFrame.cpp",
       "src/jsc/bindings/InternalModuleRegistry.cpp",
       "src/jsc/bindings/ErrorCode.cpp",
     ];
     const { standalone, bundled } = split(true, bindings);
-    expect(standalone.has("src/jsc/bindings/InternalModuleRegistry.cpp")).toBe(true);
-    expect(bundled.has("src/jsc/bindings/InternalModuleRegistry.cpp")).toBe(false);
-    // siblings still bundle
-    expect(bundled.has("src/jsc/bindings/AsyncContextFrame.cpp")).toBe(true);
-    expect(bundled.has("src/jsc/bindings/ErrorCode.cpp")).toBe(true);
+    expect(standalone.has("src/jsc/bindings/InternalModuleRegistry.cpp")).toBe(false);
+    expect(bundled.has("src/jsc/bindings/InternalModuleRegistry.cpp")).toBe(true);
   });
 
   test("the heavy standalone list stays in noUnify", () => {

--- a/test/js/bun/perf/unified-sources.test.ts
+++ b/test/js/bun/perf/unified-sources.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { basename, resolve } from "node:path";
+import type { Config } from "../../../../scripts/build/config.ts";
+import { generateUnifiedSources } from "../../../../scripts/build/unified.ts";
+
+/**
+ * The C++ build's wall-clock floor is roughly
+ *   codegen-critical-path + pch + max(cxx) + sum(cxx)/cores
+ * so an outsized bundle or a directory compiling standalone dominates both the
+ * tail and the aggregate. `bun run build:analyze` surfaces the numbers, and
+ * these checks lock in the two worst offenders it found: webcore/streams
+ * bundled (not `noUnifyDirs`) and `InternalModuleRegistry.cpp` compiled on its
+ * own instead of inflating its siblings.
+ */
+
+const repo = resolve(import.meta.dir, "../../../..");
+
+function split(release: boolean, sources: readonly string[]) {
+  using dir = tempDir("unified-sources", {});
+  const cfg = {
+    cwd: repo,
+    buildDir: String(dir),
+    release,
+    unifiedSources: true,
+  } as Config;
+  const abs = sources.map(s => resolve(repo, s));
+  const result = generateUnifiedSources(cfg, abs);
+  return {
+    unified: result.unified.map(p => basename(p)),
+    standalone: new Set(result.standalone.map(p => p.slice(repo.length + 1).replaceAll("\\", "/"))),
+    bundled: new Set(result.bundled.map(p => p.slice(repo.length + 1).replaceAll("\\", "/"))),
+  };
+}
+
+describe("unified-source bundling", () => {
+  test("webcore/streams compiles as unified bundles, not standalone", () => {
+    // Each of these used to be a standalone compile re-parsing the same
+    // JSC/WebCore headers (~256s aggregate frontend). With the copy-pasted
+    // static helpers deduplicated they bundle cleanly; falling back to
+    // noUnifyDirs would give that time back.
+    const streams = [
+      "src/jsc/bindings/webcore/streams/JSReadableStream.cpp",
+      "src/jsc/bindings/webcore/streams/JSWritableStream.cpp",
+      "src/jsc/bindings/webcore/streams/JSTransformStream.cpp",
+      "src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp",
+      "src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp",
+      "src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp",
+      "src/jsc/bindings/webcore/streams/WebStreamsMisc.cpp",
+      "src/jsc/bindings/webcore/streams/WebStreamsExports.cpp",
+      "src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp",
+    ];
+    const { unified, standalone, bundled } = split(true, streams);
+    for (const s of streams) {
+      expect(standalone.has(s)).toBe(false);
+      expect(bundled.has(s)).toBe(true);
+    }
+    expect(unified).toEqual(["UnifiedSource-src_jsc_bindings_webcore_streams-0.cpp"]);
+  });
+
+  test("InternalModuleRegistry.cpp compiles standalone", () => {
+    // It #includes InternalModuleRegistryConstants.h, a multi-megabyte
+    // byte-array header (~16s frontend). Bundled, it made its unified TU the
+    // release critical-path straggler; standalone it runs alongside them.
+    const bindings = [
+      "src/jsc/bindings/AsyncContextFrame.cpp",
+      "src/jsc/bindings/InternalModuleRegistry.cpp",
+      "src/jsc/bindings/ErrorCode.cpp",
+    ];
+    const { standalone, bundled } = split(true, bindings);
+    expect(standalone.has("src/jsc/bindings/InternalModuleRegistry.cpp")).toBe(true);
+    expect(bundled.has("src/jsc/bindings/InternalModuleRegistry.cpp")).toBe(false);
+    // siblings still bundle
+    expect(bundled.has("src/jsc/bindings/AsyncContextFrame.cpp")).toBe(true);
+    expect(bundled.has("src/jsc/bindings/ErrorCode.cpp")).toBe(true);
+  });
+
+  test("the heavy standalone list stays in noUnify", () => {
+    // These already saturate a core on their own (or have per-file flag
+    // overrides / macro pollution); re-bundling them serializes work that
+    // should run in parallel.
+    const bindings = [
+      "src/jsc/bindings/ZigGlobalObject.cpp",
+      "src/jsc/bindings/BunObject.cpp",
+      "src/jsc/bindings/bindings.cpp",
+      "src/jsc/bindings/BunProcess.cpp",
+      "src/jsc/bindings/napi.cpp",
+      // two ordinary siblings so the directory doesn't fall through the
+      // single-file-in-dir path:
+      "src/jsc/bindings/AsyncContextFrame.cpp",
+      "src/jsc/bindings/ErrorCode.cpp",
+    ];
+    const { standalone, bundled } = split(true, bindings);
+    expect(standalone.has("src/jsc/bindings/ZigGlobalObject.cpp")).toBe(true);
+    expect(standalone.has("src/jsc/bindings/BunObject.cpp")).toBe(true);
+    expect(standalone.has("src/jsc/bindings/bindings.cpp")).toBe(true);
+    expect(standalone.has("src/jsc/bindings/BunProcess.cpp")).toBe(true);
+    expect(standalone.has("src/jsc/bindings/napi.cpp")).toBe(true);
+    expect(bundled.has("src/jsc/bindings/AsyncContextFrame.cpp")).toBe(true);
+    expect(bundled.has("src/jsc/bindings/ErrorCode.cpp")).toBe(true);
+  });
+
+  test("debug builds use a smaller batch so incremental edits stay cheap", () => {
+    const many = Array.from({ length: 40 }, (_, i) => `src/jsc/bindings/webcore/Gen${i}.cpp`);
+    expect(split(true, many).unified.length).toBe(2);
+    expect(split(false, many).unified.length).toBe(5);
+  });
+});


### PR DESCRIPTION
Two build-time wins plus a profiling script to find more.

## What changed

### webcore/streams is now a unified-source directory

`src/jsc/bindings/webcore/streams/` was the only `noUnifyDirs` entry: 35 standalone `.cpp` files, each re-parsing the same JSC/WebCore header set, for ~256s of aggregate clang frontend work per release build.

The reason it was excluded was nine small helpers (`invokeMethod`, `invokePromiseReturningMethod`, `convertQueuingStrategyInit`, `defaultControllerOf`, `byteControllerOf`, `teeBranchDefaultController`, `teeBranchByteController`, `queueReactionJob`, `transformReadableController`) that had been copy-pasted as file-`static` into 2 to 5 `.cpp` files each; with all 35 in one TU those collide. The first commit declares them once in `WebStreamsInternals.h` (next to the other shared ops) and keeps one canonical definition per helper. Net -165 lines of duplicated C++.

With that done the directory bundles cleanly (2 unified TUs in release, 5 in debug).

### `InternalModuleRegistry.cpp` compiles standalone

It `#include`s the generated `InternalModuleRegistryConstants.h`, ~3 MB of comma-separated byte-array literals for every bundled JS module, which takes ~16s of frontend on its own. Bundling it made its unified TU ~18s slower than its siblings and the release critical-path straggler; standalone it runs in parallel with them. (A separate change is replacing that header with a linked blob.)

### `bun run build:analyze`

New `scripts/analyze-cpp-build.ts`: does a clean release cpp-only build with `-ftime-trace` in `build/time-trace/`, then prints

- wall-clock view from `.ninja_log`: per-category sums, slowest edges, unified-bundle balance per directory group, `pch + slowest cxx` floor
- ClangBuildAnalyzer over every `-ftime-trace` json: aggregate frontend/backend, expensive headers and template instantiations

ClangBuildAnalyzer is fetched once into the shared build cache. `--no-build` reuses an existing directory, `--dir` points at any build dir.

## Numbers

Release `cpp-only` with LTO, 16 cores, `CCACHE_DISABLE=1`, cxx-only rebuild, best of two runs:

|  | before | after |
|---|---:|---:|
| wall clock | 113.9s | 98.0s |
| clang invocations | 114 | 82 |
| aggregate frontend | 854.9s | 732.7s |
| slowest cxx edge | 49.8s | 36.1s |
| `src_jsc_bindings` bundle spread | 21.1–53.8s | 28.2–36.1s |

The slowest-TU reduction matters more at CI core counts: at 32 cores the build is tail-bound, not aggregate-bound.

## What I tried that did not help

Adding `IteratorOperations.h` and `JSDOMGlobalObject.h` to `root-pch.h` looked like a ~60s aggregate win on paper (31 + 75 TUs re-parse them). In practice the PCH grew 151 → 165 MB and the extra per-TU deserialize cost cancelled the savings; wall clock moved the wrong way. The current three-include `root-pch.h` is already near the right size.

## Next candidates (not in this PR)

Surfaced by the new profiler, roughly by expected impact:

- `InternalModuleRegistryConstants.h` as a linked blob instead of a 16s-to-parse header (being handled separately).
- `bundle-modules.ts` codegen is 13.5s on the critical path before PCH can start.
- `JSC::GenericTypedArrayView<Uint8Adaptor>` is instantiated 16× at ~1.6s each (27s aggregate); an `extern template` in the WebKit prebuilt would remove it.
- `src_jsc_bindings_webcore` bundles are still 1.7× spread; worth one more `noUnify` pass.

## Verification

- `bun bd` (debug, asan, batch-8 bundles) builds clean
- `bun bd test test/js/third_party/wpt-streams/` passes all 1175 tests
- `bun bd test test/js/web/streams/streams.test.js` passes except two pre-existing debug-asan timeouts that also reproduce on main

<!-- robobun:evidence:begin -->

---

**[decide:dep]** gate passed · iteration 4 · 20 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/perf/unified-sources.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/137] gen cpp.rs (cppbind)
[2/137] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/137] gen JS modules (bundle-modules)
Preprocess modules (12006ms)
Bundle modules (53ms)
Postprocesss modules (30ms)
Bundle Functions (683ms)
Generate Code (8ms)

[12.79s] Bundled "src/js" for development
  2210 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/137] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[132/137] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore_streams-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings_webcore_streams-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -g3 -gz=zstd -glldb -fsanitize=address -fno-exceptions -fno-c++-static-destructors
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (777d975df)

test/js/bun/perf/unified-sources.test.ts:
(pass) unified-source bundling > webcore/streams compiles as unified bundles, not standalone [3.18ms]
(pass) unified-source bundling > InternalModuleRegistry.cpp bundles with its siblings [0.44ms]
(pass) unified-source bundling > the heavy standalone list stays in noUnify [0.39ms]
(pass) unified-source bundling > debug builds use a smaller batch so incremental edits stay cheap [1.49ms]

 4 pass
 0 fail
 30 expect() calls
Ran 4 tests across 1 file. [228.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/perf/unified-sources.test.ts
bun test v1.4.0 (ab1713cef)

test/js/bun/perf/unified-sources.test.ts:
(pass) unified-source bundling > webcore/streams compiles as unified bundles, not standalone [89.90ms]
(pass) unified-source bundling > InternalModuleRegistry.cpp bundles with its siblings [12.11ms]
(pass) unified-source bundling > the heavy standalone list stays in noUnify [14.25ms]
(pass) unified-source bundling > debug builds use a smaller batch so incremental edits stay cheap [69.76ms]

 4 pass
 0 fail
 30 expect() calls
Ran 4 tests across 1 file. [3.17s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 810ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/93] gen cpp.rs (cppbind)
[2/93] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/93] gen JS modules (bundle-modules)
Preprocess modules (11472ms)
Bundle modules (118ms)
Postprocesss modules (241ms)
Bundle Functions (1302ms)
Generate Code (108ms)

[13.26s] Bundled "src/js" for production
  2040 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[3/93] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
package.json                                       |   1 +
 scripts/analyze-cpp-build.ts                       | 296 +++++++++++++++++++++
 scripts/build/unified.ts                           |  12 +-
 src/jsc/STREAMS.md                                 |  12 +-
 .../webcore/streams/BunStreamConsumers.cpp         |  14 -
 .../bindings/webcore/streams/BunStreamSource.cpp   |  13 -
 .../streams/JSByteLengthQueuingStrategy.cpp        |  21 --
 .../webcore/streams/JSCountQueuingStrategy.cpp     |  21 --
 src/jsc/bindings/webcore/streams/JSReadRequest.cpp |  28 --
 .../streams/JSReadableByteStreamController.cpp     |  22 --
 .../webcore/streams/JSReadableStreamBYOBReader.cpp |  25 +-
 .../streams/JSReadableStreamDefaultController.cpp  |  22 --
 .../streams/JSReadableStreamDefaultReader.cpp      |  28 --
 .../streams/JSTransformStreamDefaultController.cpp |  33 ---
 .../streams/JSWritableStreamDefaultController.cpp  |  22 --
 .../webcore/streams/ReadableStreamOperations.cpp   |  33 +--
 .../webcore/streams/TransformStreamOperations.cpp  |  24 +-
 .../bindings/webcore/streams/WebStreamsInternals.h |  45 ++++
 .../bindings/webcore/streams/WebStreamsMisc.cpp    |  56 ++++
 test/js/bun/perf/unified-sources.test.ts           | 103 +++++++
 20 files changed, 519 insertions(+), 312 deletions(-)
```

</details>

**gate history** · 12 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
package.json                                                  0      0      0
scripts/analyze-cpp-build.ts                                  4     14      0
scripts/build/unified.ts                                      2      2      0
src/jsc/STREAMS.md                                            3      5      0
src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp       0      0      0
src/jsc/bindings/webcore/streams/BunStreamSource.cpp          0      0      0
…indings/webcore/streams/JSByteLengthQueuingStrategy.cpp      0      0      0
…jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp      0      0      0
src/jsc/bindings/webcore/streams/JSReadRequest.cpp            0      0      0
…ings/webcore/streams/JSReadableByteStreamController.cpp      0      0      0
…bindings/webcore/streams/JSReadableStreamBYOBReader.cpp      1      2      0
…s/webcore/streams/JSReadableStreamDefaultController.cpp      0      0      0
…dings/webcore/streams/JSReadableStreamDefaultReader.cpp      1      1      0
…/webcore/streams/JSTransformStreamDefaultController.cpp      0      0      0
…s/webcore/streams/JSWritableStreamDefaultController.cpp      0      0      0
…c/bindings/webcore/streams/ReadableStreamOperations.cpp      1      2      0
(+ 4 more files)
```

</details>

**root cause** · written by the author bot

The ninja log parser detected a new build run by a drop in edge end times, but it updated its prevEnd tracker unconditionally, so when the first completed output of a new run was one the previous run never built, the guard skipped the clear while prevEnd still fell to the new run's low value, masking the drop from any subsequent repeated output and leaving stale entries from the earlier run mixed into the wall time and parallelism calculations. The fix keeps prevEnd monotonically non-decreasing within a run, only letting it reset when a boundary is actually detected via a repeated output, s…

<!-- robobun:evidence:end -->