### PR TITLE
FileSink: clear O_NONBLOCK on regular-file fds so short writes drain

### DIFF
--- a/src/io/openForWriting.rs
+++ b/src/io/openForWriting.rs
@@ -147,21 +147,33 @@ where
                     // this.force_sync = true;
                     // this.writer.force_sync = true;
                     on_force_sync_or_isa_tty(ctx);
-                } else if !is_nonblocking {
-                    let flags = match bun_sys::get_fcntl_flags(fd) {
-                        Ok(flags) => flags,
-                        Err(err) => {
-                            fd.close();
-                            return Err(err);
-                        }
-                    };
-                    is_nonblocking = (flags as i32 & bun_sys::O::NONBLOCK) != 0;
-
+                } else if *pollable {
                     if !is_nonblocking {
-                        if bun_sys::set_nonblocking(fd).is_ok() {
-                            is_nonblocking = true;
+                        let flags = match bun_sys::get_fcntl_flags(fd) {
+                            Ok(flags) => flags,
+                            Err(err) => {
+                                fd.close();
+                                return Err(err);
+                            }
+                        };
+                        is_nonblocking = (flags as i32 & bun_sys::O::NONBLOCK) != 0;
+
+                        if !is_nonblocking {
+                            if bun_sys::set_nonblocking(fd).is_ok() {
+                                is_nonblocking = true;
+                            }
                         }
                     }
+                } else {
+                    // Regular file / block device / anything else epoll can't wait
+                    // on: the streaming writer has no poll to re-drive an EAGAIN, so
+                    // an O_NONBLOCK short write would strand the unwritten tail in
+                    // its buffer and close() would drop it. O_NONBLOCK is only on
+                    // the open flags so open() itself never blocks on a FIFO; once
+                    // fstat says this isn't one, clear it and let write() block so
+                    // the try_write loop drains every short write synchronously.
+                    let _ = bun_sys::update_nonblocking(fd, false);
+                    is_nonblocking = false;
                 }
 
                 *out_nonblocking = is_nonblocking && *pollable;

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -234,6 +234,14 @@ impl Lazy {
             }
 
             if sys::S::ISREG(mode) {
+                // A regular file can't be polled, so an EAGAIN would leave
+                // the reader with no re-drive path (PipeReader's FileType::File
+                // arm only warns and returns). O_NONBLOCK is on the open flags
+                // solely so open() itself never blocks on a FIFO; clear it now
+                // so read() blocks and drains synchronously.
+                if is_nonblocking {
+                    let _ = sys::update_nonblocking(fd, false);
+                }
                 is_nonblocking = false;
             }
 

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,8 +1,9 @@
+import { dlopen } from "bun:ffi";
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, libcPathForDlopen, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
-import { closeSync, constants as fsConstants, openSync, readFileSync } from "node:fs";
+import { closeSync, constants as fsConstants, openSync } from "node:fs";
 import { join } from "node:path";
 
 describe("FileSink", () => {
@@ -442,33 +443,35 @@ it("fs.promises.writeFile with iterables under GC pressure does not crash", asyn
 // error. The open flags carry O_NONBLOCK only so open() itself never blocks on
 // a FIFO target; once fstat says "regular file" the flag must be cleared.
 describe.skipIf(!isPosix)("FileSink regular-file fd is kept blocking", () => {
-  // F_SETFL acts on the open file description, so the sink's dup() and the
-  // caller's fd share the flag. /proc/self/fdinfo is Linux-only; on macOS the
-  // behavioural test below covers it.
-  it.skipIf(!isLinux)("Bun.file(fd).writer() does not set O_NONBLOCK on a regular file", async () => {
-    const flagsOf = (fd: number) =>
-      parseInt(/flags:\s*([0-7]+)/.exec(readFileSync(`/proc/self/fdinfo/${fd}`, "utf8"))![1], 8);
+  const F_GETFL = 3; // same value on Linux, macOS and the BSDs
+  const fcntl = isPosix
+    ? dlopen(libcPathForDlopen(), { fcntl: { args: ["i32", "i32"], returns: "i32" } }).symbols.fcntl
+    : undefined;
+  const nonblock = (fd: number) => Number(fcntl!(fd, F_GETFL)) & fsConstants.O_NONBLOCK;
 
+  // F_SETFL acts on the open file description, so the sink's dup() and the
+  // caller's fd observe the same flags.
+  it("Bun.file(fd).writer() does not set O_NONBLOCK on a regular file", async () => {
     const path = join(tmpdirSync(), "out.txt");
     const fd = openSync(path, "w");
     try {
-      expect(flagsOf(fd) & fsConstants.O_NONBLOCK).toBe(0);
+      expect(nonblock(fd)).toBe(0);
 
       const sink = Bun.file(fd).writer();
       sink.write("a");
-      const nonblockAfter = flagsOf(fd) & fsConstants.O_NONBLOCK;
+      const after = nonblock(fd);
       await sink.end();
 
-      expect(nonblockAfter).toBe(0);
+      expect(after).toBe(0);
     } finally {
       closeSync(fd);
     }
   });
 
+  // The Path arm of open_for_writing opens with O_NONBLOCK in the flags (so a
+  // FIFO target doesn't block open()) and must clear it afterwards. The sink
+  // owns that fd privately; use /proc/self/fd to find it from the child.
   it.skipIf(!isLinux)("Bun.file(path).writer() does not leave O_NONBLOCK on a regular file", async () => {
-    // The sink opens the path itself; spawn so we can read fdinfo while the
-    // sink still owns the fd (the test process can't see the child's fd, but
-    // the child can read its own /proc/self).
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -502,32 +505,5 @@ describe.skipIf(!isPosix)("FileSink regular-file fd is kept blocking", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0", stderr: "", exitCode: 0 });
-  });
-
-  it("fs.createWriteStream writes every byte of a many-chunk payload", async () => {
-    // 4234 bytes = 33 x 128-byte chunks + a 10-byte tail; crosses the 4 KiB
-    // CHUNK_SIZE boundary so both the buffered and flushed paths are exercised.
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const fs = require("fs");
-          const path = process.argv[1];
-          const ws = fs.createWriteStream(path);
-          const chunk = Buffer.alloc(128, 0x61);
-          for (let i = 0; i < 33; i++) ws.write(chunk);
-          ws.write(Buffer.alloc(10, 0x62));
-          ws.end();
-          ws.on("finish", () => process.stdout.write(String(fs.statSync(path).size)));
-          ws.on("error", e => { console.error(e); process.exit(1); });
-        `,
-        join(tmpdirSync(), "out.txt"),
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "4234", stderr: "", exitCode: 0 });
   });
 });

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,7 +1,8 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isPosix, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
+import { constants as fsConstants, closeSync, openSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("FileSink", () => {
@@ -432,4 +433,101 @@ it("fs.promises.writeFile with iterables under GC pressure does not crash", asyn
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+});
+
+// A regular file can't be polled for writability, so the streaming writer has
+// no way to re-drive an EAGAIN. If the fd is left O_NONBLOCK, a short write on
+// a filesystem that honors it (FUSE, NFS, overlay, cgroup writes) strands the
+// unwritten tail in the writer's buffer and the stream closes truncated with no
+// error. The open flags carry O_NONBLOCK only so open() itself never blocks on
+// a FIFO target; once fstat says "regular file" the flag must be cleared.
+describe.skipIf(!isPosix)("FileSink regular-file fd is kept blocking", () => {
+  // F_SETFL acts on the open file description, so the sink's dup() and the
+  // caller's fd share the flag. /proc/self/fdinfo is Linux-only; on macOS the
+  // behavioural test below covers it.
+  it.skipIf(!isLinux)("Bun.file(fd).writer() does not set O_NONBLOCK on a regular file", async () => {
+    const flagsOf = (fd: number) =>
+      parseInt(/flags:\s*([0-7]+)/.exec(readFileSync(`/proc/self/fdinfo/${fd}`, "utf8"))![1], 8);
+
+    const path = join(tmpdirSync(), "out.txt");
+    const fd = openSync(path, "w");
+    try {
+      expect(flagsOf(fd) & fsConstants.O_NONBLOCK).toBe(0);
+
+      const sink = Bun.file(fd).writer();
+      sink.write("a");
+      const nonblockAfter = flagsOf(fd) & fsConstants.O_NONBLOCK;
+      await sink.end();
+
+      expect(nonblockAfter).toBe(0);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it.skipIf(!isLinux)("Bun.file(path).writer() does not leave O_NONBLOCK on a regular file", async () => {
+    // The sink opens the path itself; spawn so we can read fdinfo while the
+    // sink still owns the fd (the test process can't see the child's fd, but
+    // the child can read its own /proc/self).
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("fs");
+          const path = process.argv[1];
+          const sink = Bun.file(path).writer();
+          sink.write("a");
+          sink.flush();
+          let found = -1;
+          for (const name of fs.readdirSync("/proc/self/fd")) {
+            const n = Number(name);
+            if (!Number.isFinite(n)) continue;
+            try {
+              if (fs.realpathSync("/proc/self/fd/" + name) === path) { found = n; break; }
+            } catch {}
+          }
+          if (found < 0) throw new Error("fd not found");
+          const flags = parseInt(
+            /flags:\\s*([0-7]+)/.exec(fs.readFileSync("/proc/self/fdinfo/" + found, "utf8"))[1],
+            8,
+          );
+          process.stdout.write(String(flags & fs.constants.O_NONBLOCK));
+          await sink.end();
+        `,
+        join(tmpdirSync(), "out.txt"),
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0", stderr: "", exitCode: 0 });
+  });
+
+  it("fs.createWriteStream writes every byte of a many-chunk payload", async () => {
+    // 4234 bytes = 33 x 128-byte chunks + a 10-byte tail; crosses the 4 KiB
+    // CHUNK_SIZE boundary so both the buffered and flushed paths are exercised.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("fs");
+          const path = process.argv[1];
+          const ws = fs.createWriteStream(path);
+          const chunk = Buffer.alloc(128, 0x61);
+          for (let i = 0; i < 33; i++) ws.write(chunk);
+          ws.write(Buffer.alloc(10, 0x62));
+          ws.end();
+          ws.on("finish", () => process.stdout.write(String(fs.statSync(path).size)));
+          ws.on("error", e => { console.error(e); process.exit(1); });
+        `,
+        join(tmpdirSync(), "out.txt"),
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "4234", stderr: "", exitCode: 0 });
+  });
 });

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -2,7 +2,7 @@ import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
-import { constants as fsConstants, closeSync, openSync, readFileSync } from "node:fs";
+import { closeSync, constants as fsConstants, openSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("FileSink", () => {

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,7 +1,16 @@
 import { dlopen } from "bun:ffi";
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, fileDescriptorLeakChecker, isLinux, isPosix, isWindows, libcPathForDlopen, tmpdirSync } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  fileDescriptorLeakChecker,
+  isLinux,
+  isPosix,
+  isWindows,
+  libcPathForDlopen,
+  tmpdirSync,
+} from "harness";
 import { mkfifo } from "mkfifo";
 import { closeSync, constants as fsConstants, openSync } from "node:fs";
 import { join } from "node:path";

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -12,7 +12,7 @@ import {
   tmpdirSync,
 } from "harness";
 import { mkfifo } from "mkfifo";
-import { closeSync, constants as fsConstants, openSync } from "node:fs";
+import { closeSync, constants as fsConstants, openSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 describe("FileSink", () => {
@@ -445,13 +445,13 @@ it("fs.promises.writeFile with iterables under GC pressure does not crash", asyn
   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
 });
 
-// A regular file can't be polled for writability, so the streaming writer has
-// no way to re-drive an EAGAIN. If the fd is left O_NONBLOCK, a short write on
-// a filesystem that honors it (FUSE, NFS, overlay, cgroup writes) strands the
-// unwritten tail in the writer's buffer and the stream closes truncated with no
+// A regular file can't be polled for readability or writability, so the
+// streaming reader/writer have no poll to re-drive an EAGAIN. If the fd is
+// left O_NONBLOCK, a short write (or an EAGAIN read) on a filesystem that
+// honors it (FUSE, NFS, overlay, cgroup writes) strands the remainder with no
 // error. The open flags carry O_NONBLOCK only so open() itself never blocks on
 // a FIFO target; once fstat says "regular file" the flag must be cleared.
-describe.skipIf(!isPosix)("FileSink regular-file fd is kept blocking", () => {
+describe.skipIf(!isPosix)("Bun.file() regular-file fd is kept blocking", () => {
   const F_GETFL = 3; // same value on Linux, macOS and the BSDs
   const fcntl = isPosix
     ? dlopen(libcPathForDlopen(), { fcntl: { args: ["i32", "i32"], returns: "i32" } }).symbols.fcntl
@@ -471,6 +471,25 @@ describe.skipIf(!isPosix)("FileSink regular-file fd is kept blocking", () => {
       const after = nonblock(fd);
       await sink.end();
 
+      expect(after).toBe(0);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it("Bun.file(fd).stream() clears O_NONBLOCK on a regular file", async () => {
+    const path = join(tmpdirSync(), "in.txt");
+    writeFileSync(path, "hello world");
+    const fd = openSync(path, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
+    try {
+      expect(nonblock(fd)).toBe(fsConstants.O_NONBLOCK);
+
+      const reader = Bun.file(fd).stream().getReader();
+      const { value } = await reader.read();
+      const after = nonblock(fd);
+      reader.releaseLock();
+
+      expect(Buffer.from(value!).toString()).toBe("hello world");
       expect(after).toBe(0);
     } finally {
       closeSync(fd);


### PR DESCRIPTION
## Problem

`fs.createWriteStream` / `Bun.file(path).writer()` can silently truncate a regular file when the kernel returns a short `write()`.

`PosixStreamingWriter::write` handles a short write by buffering the remainder in `outgoing` and calling `register_poll()` to be re-driven when the fd becomes writable. For a regular file that wakeup never comes: the writer was started with `is_pollable = false`, so `handle` is a bare `Fd` and `register_poll()` early-returns on `get_poll() == None`. The only other re-drive path is the deferred auto-flusher, but `end_from_js` sets `done = true` on a `Pending` flush result and `on_auto_flush` then bails without flushing. `enable_keeping_process_alive` is also a no-op without a poll, so the event loop is not ref'd, the process exits, and the tail is dropped.

Observed in the wild: 4234 bytes written in 128-byte chunks produced a 4170-byte file (64 bytes missing: one short write's remainder).

## Cause

`open_for_writing` leaves the fd `O_NONBLOCK` regardless of file type:

* `Path` input opens with `O_NONBLOCK | O_CLOEXEC | O_CREAT | O_WRONLY` (`Options::flags`), so `open()` itself never blocks on a FIFO target.
* `Fd` input dup's and then calls `set_nonblocking(fd)`.

On ext4/XFS `O_NONBLOCK` is a no-op for regular-file writes, so this never bites there. On filesystems that do honor it (FUSE, NFS, overlay, cgroup/proc writes, some filter drivers) `write()` can return short-then-`EAGAIN`, which is exactly the `Pending(n)` case the writer cannot recover from without a poll.

The read side has the same defect: `FileReader::Lazy::open_file_blob` opens `Path` inputs with `O_NONBLOCK` and its `S_ISREG` arm only clears the local `is_nonblocking` bool, leaving the flag on the fd. `PipeReader`'s `FileType::File` EAGAIN arm logs "this is a bug" and returns with no poll and no retry.

## Fix

After `fstat` determines the fd is not pollable (not a FIFO/socket/TTY), clear `O_NONBLOCK`. The existing `try_write_with_write_fn` loop already retries short writes to completion; with a blocking fd it can no longer be cut off by `EAGAIN`, so the whole payload lands before `write()` returns. FIFO/socket fds still get `O_NONBLOCK` (now gated on `*pollable`); TTYs keep their existing `force_sync` treatment. The symmetric change is applied in `open_file_blob`'s `S_ISREG` arm so the reader's fd is blocking too.

This also stops the `Fd`-input path from flipping the caller's open file description to nonblocking behind their back (`F_SETFL` is shared across dup'd fds).

## Verification

```console
$ USE_SYSTEM_BUN=1 bun test test/js/bun/util/filesink.test.ts -t "kept blocking"
(fail) Bun.file(fd).writer() does not set O_NONBLOCK on a regular file   # Received: 2048
(fail) Bun.file(fd).stream() clears O_NONBLOCK on a regular file         # Received: 2048
(fail) Bun.file(path).writer() does not leave O_NONBLOCK on a regular file   # stdout: "2048"

$ bun bd test test/js/bun/util/filesink.test.ts -t "kept blocking"
(pass) Bun.file(fd).writer() does not set O_NONBLOCK on a regular file
(pass) Bun.file(fd).stream() clears O_NONBLOCK on a regular file
(pass) Bun.file(path).writer() does not leave O_NONBLOCK on a regular file
```

The first two flag checks read `fcntl(fd, F_GETFL)` via `bun:ffi` so they run (and fail on the unfixed build) on macOS as well as Linux. Full `filesink.test.ts` (49 tests), `test/js/bun/shell/file-io.test.ts` (27 tests, the other `open_for_writing_impl` caller), and `fs.test.ts -t "createWriteStream|WriteStream"` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesink.test.ts

<!-- robobun:evidence:end -->