### PR TITLE
usockets: re-arm the listen poll after a poll-layer error

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -662,6 +662,45 @@ void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
     }
 }
 
+void us_internal_poll_restart(struct us_poll_t *p, struct us_loop_t *loop) {
+    int events = us_poll_events(p);
+#ifdef LIBUS_USE_EPOLL
+    struct epoll_event event;
+    event.events = events;
+    event.data.ptr = p;
+    int rc;
+    do {
+        rc = epoll_ctl(loop->fd, EPOLL_CTL_MOD, p->state.fd, &event);
+    } while (IS_EINTR(rc));
+    if (rc != 0 && errno == ENOENT) {
+        do {
+            rc = epoll_ctl(loop->fd, EPOLL_CTL_ADD, p->state.fd, &event);
+        } while (IS_EINTR(rc));
+    }
+#else
+    /* EV_ADD is idempotent on kqueue. */
+    kqueue_change(loop->fd, p->state.fd, 0, events, p);
+#endif
+}
+
+#if defined(LIBUS_SOCKET_FAULT_INJECTION) && LIBUS_SOCKET_FAULT_INJECTION
+void us_internal_poll_simulate_error_stop(struct us_poll_t *p, struct us_loop_t *loop) {
+    int old_events = us_poll_events(p);
+#ifdef LIBUS_USE_EPOLL
+    struct epoll_event event;
+    int rc;
+    do {
+        rc = epoll_ctl(loop->fd, EPOLL_CTL_DEL, p->state.fd, &event);
+    } while (IS_EINTR(rc));
+#else
+    if (old_events) {
+        kqueue_change(loop->fd, p->state.fd, old_events, 0, NULL);
+    }
+#endif
+    (void) old_events;
+}
+#endif
+
 void us_poll_stop(struct us_poll_t *p, struct us_loop_t *loop) {
     int old_events = us_poll_events(p);
     int new_events = 0;

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -271,6 +271,22 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
   us_poll_start_rc(p, loop, events);
 }
 
+void us_internal_poll_restart(struct us_poll_t *p, struct us_loop_t *loop) {
+  (void) loop;
+  if (!p->uv_p) return;
+  uv_poll_start(p->uv_p, us_poll_events(p) | UV_DISCONNECT, poll_cb);
+}
+
+#if defined(LIBUS_SOCKET_FAULT_INJECTION) && LIBUS_SOCKET_FAULT_INJECTION
+void us_internal_poll_simulate_error_stop(struct us_poll_t *p, struct us_loop_t *loop) {
+  (void) loop;
+  /* uv_poll_stop zeroes handle->events and masks pending reqs, matching the
+   * state uv__fast_poll_process_poll_req's !REQ_SUCCESS branch leaves the
+   * handle in. The handle is not closed, so uv_poll_start still re-arms. */
+  if (p->uv_p) uv_poll_stop(p->uv_p);
+}
+#endif
+
 void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
   if(!p->uv_p) return;
   if (us_poll_events(p) != events) {

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -54,6 +54,12 @@ enum us_fault_syscall {
      * US_FAULT_ERRNO applies, and the errno value is ignored — the simulated
      * failure is a thrown JS out-of-memory error, not an errno. */
     US_FAULT_SESSION_BUFFER,
+    /* Not a syscall: the event-loop poll delivery for a listening socket.
+     * Simulates libuv's uv_poll_cb(status < 0) path — the AFD poll ioctl
+     * failing (e.g. INSUFFICIENT_RESOURCES) — which zeroes handle->events so
+     * the listen poll stops firing until re-armed. Only US_FAULT_ERRNO
+     * applies; the errno value is not surfaced. */
+    US_FAULT_LISTEN_POLL,
     US_FAULT_COUNT
 };
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -197,6 +197,18 @@ void us_internal_async_wakeup(struct us_internal_async *a);
 size_t us_internal_accept_poll_event(struct us_poll_t *p);
 int us_internal_poll_type(struct us_poll_t *p);
 void us_internal_poll_set_type(struct us_poll_t *p, int poll_type);
+/* Re-register this poll for its current us_poll_events(). Idempotent when the
+ * poll is already registered. Needed on the libuv backend after a status<0
+ * poll_cb delivery, which zeroes handle->events; on epoll/kqueue the
+ * registration survives an error event so this is a MOD/EV_ADD no-op. */
+void us_internal_poll_restart(struct us_poll_t *p, struct us_loop_t *loop);
+#if defined(LIBUS_SOCKET_FAULT_INJECTION) && LIBUS_SOCKET_FAULT_INJECTION
+/* Fault-injection only: put the poll into the same state libuv's
+ * uv__fast_poll_process_poll_req !REQ_SUCCESS branch leaves it in (watching
+ * nothing, handle still live) so the error-recovery path can be exercised on
+ * every backend. */
+void us_internal_poll_simulate_error_stop(struct us_poll_t *p, struct us_loop_t *loop);
+#endif
 
 /* SSL loop data */
 void us_internal_init_loop_ssl_data(us_loop_r loop);

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -17,6 +17,7 @@
 // clang-format off
 #include "libusockets.h"
 #include "internal/internal.h"
+#include "internal/fault_inject.h"
 #include "quic.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -503,6 +504,32 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                 struct us_socket_group_t *accept_group = listen_socket->accept_group;
                 struct us_loop_t *loop = accept_group->loop;
                 struct bsd_addr_t addr;
+
+#if defined(LIBUS_SOCKET_FAULT_INJECTION) && LIBUS_SOCKET_FAULT_INJECTION
+                {
+                    ssize_t injected = 0; int unused = 0;
+                    if (US_FAULT_CHECK(US_FAULT_LISTEN_POLL, us_poll_fd(p), injected, unused)) {
+                        us_internal_poll_simulate_error_stop(p, loop);
+                        error = 1;
+                    }
+                    (void) injected; (void) unused;
+                }
+#endif
+
+                if (error) {
+                    /* A poll-layer error on a listening socket. On libuv the
+                     * fast-poll !REQ_SUCCESS path (src/win/poll.c) zeroes
+                     * handle->events before invoking poll_cb with status < 0,
+                     * so no further AFD poll ioctl is submitted until
+                     * uv_poll_start runs again: without re-arming, the
+                     * listener stays alive but never accepts another
+                     * connection. Clear any latched SO_ERROR so a level-
+                     * triggered EPOLLERR does not spin, then re-arm;
+                     * epoll/kqueue registrations survive an error event so
+                     * the restart is an idempotent MOD/EV_ADD there. */
+                    (void) us_socket_get_error(&listen_socket->s);
+                    us_internal_poll_restart(p, loop);
+                }
 
                 LIBUS_SOCKET_DESCRIPTOR client_fd = bsd_accept_socket(us_poll_fd(p), &addr);
                 if (client_fd == LIBUS_SOCKET_ERROR) {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -345,8 +345,8 @@ export const setSocketOptions: setSocketOptionsFn = $newRustFunction(
 /**
  * The syscalls instrumented in bsd.c, plus non-syscall hooks whose failure
  * paths are otherwise unreachable without injection ("ssl_loop_buffer",
- * "poll_start", "session_buffer"; see fault_inject.h for the per-hook
- * description). Arming anything else is rejected.
+ * "poll_start", "session_buffer", "listen_poll"; see fault_inject.h for the
+ * per-hook description). Arming anything else is rejected.
  */
 export type SocketFaultSyscall =
   | "recv"
@@ -358,7 +358,8 @@ export type SocketFaultSyscall =
   | "accept"
   | "ssl_loop_buffer"
   | "poll_start"
-  | "session_buffer";
+  | "session_buffer"
+  | "listen_poll";
 
 export type SocketFaultRule = {
   syscall: SocketFaultSyscall;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -5098,11 +5098,13 @@ pub mod testing_apis {
                 fi::POLL_START
             } else if syscall_str.eql_comptime(b"session_buffer") {
                 fi::SESSION_BUFFER
+            } else if syscall_str.eql_comptime(b"listen_poll") {
+                fi::LISTEN_POLL
             } else {
                 // socket/close/shutdown have enum slots but no bsd.c hooks;
                 // accepting them would arm rules that can never fire.
                 return Err(global.throw(format_args!(
-                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, ssl_loop_buffer, poll_start, session_buffer"
+                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, ssl_loop_buffer, poll_start, session_buffer, listen_poll"
                 )));
             };
 

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -418,9 +418,8 @@ pub mod fault_inject {
     /// Not a syscall: the JS `Buffer` allocated for a TLS session/keylog
     /// payload in the `on_session`/`on_keylog` dispatch.
     pub const SESSION_BUFFER: c_int = 12;
-    /// Not a syscall: the event-loop poll delivery for a listening socket.
-    /// Simulates libuv's `uv_poll_cb(status < 0)` path, which leaves the
-    /// poll handle watching nothing until re-armed.
+    /// Not a syscall: a poll-layer error delivered for a listening socket
+    /// (libuv's `uv_poll_cb(status < 0)`).
     pub const LISTEN_POLL: c_int = 13;
 
     pub const ACTION_NONE: c_int = 0;

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -418,6 +418,10 @@ pub mod fault_inject {
     /// Not a syscall: the JS `Buffer` allocated for a TLS session/keylog
     /// payload in the `on_session`/`on_keylog` dispatch.
     pub const SESSION_BUFFER: c_int = 12;
+    /// Not a syscall: the event-loop poll delivery for a listening socket.
+    /// Simulates libuv's `uv_poll_cb(status < 0)` path, which leaves the
+    /// poll handle watching nothing until re-armed.
+    pub const LISTEN_POLL: c_int = 13;
 
     pub const ACTION_NONE: c_int = 0;
     pub const ACTION_ERRNO: c_int = 1;

--- a/test/js/bun/http/serve-syscall-fault.test.ts
+++ b/test/js/bun/http/serve-syscall-fault.test.ts
@@ -117,6 +117,46 @@ describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
     expect(proc.exitCode).toBe(0);
   });
 
+  // A poll-layer error on a listening socket (Windows AFD ioctl returning
+  // INSUFFICIENT_RESOURCES, surfaced as uv_poll_cb(status < 0)) used to be
+  // dropped by the POLL_TYPE_SEMI_SOCKET listen branch: libuv zeroes
+  // handle->events before the callback, so without an explicit uv_poll_start
+  // the listener stays alive but never fires again. The listen_poll fault
+  // reproduces that state on every backend by stopping the listen poll at
+  // the top of the dispatch; the fix re-arms it.
+  test("listen poll error: listener re-arms and keeps accepting", async () => {
+    const { proc, port } = await spawnServer(/* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch: () => new Response("ok") });
+      // One-shot: next readable dispatch on the listening socket is delivered
+      // as a poll error with the poll left stopped.
+      fault.set({ syscall: "listen_poll", action: "errno", errno: "ENOMEM", repeat: 1 });
+      console.log(s.port);
+      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
+    `);
+    try {
+      // First request triggers the fault (the listen poll's readable dispatch
+      // runs into it). The pending connection is still in the kernel accept
+      // queue, so accept() still succeeds on this dispatch.
+      const first = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await first.text()).toBe("ok");
+      // Second and third requests prove the listen poll was re-armed: without
+      // the fix it was de-registered and no further readable event fires, so
+      // these connections would sit in the backlog forever.
+      const [second, third] = await Promise.all([
+        fetch(`http://127.0.0.1:${port}/`).then(r => r.text()),
+        fetch(`http://127.0.0.1:${port}/`).then(r => r.text()),
+      ]);
+      expect({ second, third }).toEqual({ second: "ok", third: "ok" });
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited;
+    }
+    expect(proc.signalCode).toBeNull();
+    expect(proc.exitCode).toBe(0);
+  });
+
   test("client abort under server-side 1-byte sends: every response reaches a terminal state", async () => {
     const { proc, port } = await spawnServer(/* js */ `
       const { socketFaultInjection: fault } = require("bun:internal-for-testing");

--- a/test/js/bun/http/serve-syscall-fault.test.ts
+++ b/test/js/bun/http/serve-syscall-fault.test.ts
@@ -11,6 +11,7 @@ async function spawnServer(body: string, env: Record<string, string> = {}) {
   const proc = Bun.spawn({
     cmd: [bunExe(), "-e", body],
     env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1", ...env },
+    stdin: "pipe",
     stderr: "pipe",
     stdout: "pipe",
   });
@@ -117,46 +118,6 @@ describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
     expect(proc.exitCode).toBe(0);
   });
 
-  // A poll-layer error on a listening socket (Windows AFD ioctl returning
-  // INSUFFICIENT_RESOURCES, surfaced as uv_poll_cb(status < 0)) used to be
-  // dropped by the POLL_TYPE_SEMI_SOCKET listen branch: libuv zeroes
-  // handle->events before the callback, so without an explicit uv_poll_start
-  // the listener stays alive but never fires again. The listen_poll fault
-  // reproduces that state on every backend by stopping the listen poll at
-  // the top of the dispatch; the fix re-arms it.
-  test("listen poll error: listener re-arms and keeps accepting", async () => {
-    const { proc, port } = await spawnServer(/* js */ `
-      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
-      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
-        fetch: () => new Response("ok") });
-      // One-shot: next readable dispatch on the listening socket is delivered
-      // as a poll error with the poll left stopped.
-      fault.set({ syscall: "listen_poll", action: "errno", errno: "ENOMEM", repeat: 1 });
-      console.log(s.port);
-      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
-    `);
-    try {
-      // First request triggers the fault (the listen poll's readable dispatch
-      // runs into it). The pending connection is still in the kernel accept
-      // queue, so accept() still succeeds on this dispatch.
-      const first = await fetch(`http://127.0.0.1:${port}/`);
-      expect(await first.text()).toBe("ok");
-      // Second and third requests prove the listen poll was re-armed: without
-      // the fix it was de-registered and no further readable event fires, so
-      // these connections would sit in the backlog forever.
-      const [second, third] = await Promise.all([
-        fetch(`http://127.0.0.1:${port}/`).then(r => r.text()),
-        fetch(`http://127.0.0.1:${port}/`).then(r => r.text()),
-      ]);
-      expect({ second, third }).toEqual({ second: "ok", third: "ok" });
-    } finally {
-      proc.kill("SIGTERM");
-      await proc.exited;
-    }
-    expect(proc.signalCode).toBeNull();
-    expect(proc.exitCode).toBe(0);
-  });
-
   test("client abort under server-side 1-byte sends: every response reaches a terminal state", async () => {
     const { proc, port } = await spawnServer(/* js */ `
       const { socketFaultInjection: fault } = require("bun:internal-for-testing");
@@ -188,4 +149,50 @@ describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
     expect(proc.signalCode).toBeNull();
     expect(proc.exitCode).toBe(0);
   });
+});
+
+// A poll-layer error on a listening socket (Windows AFD ioctl returning
+// INSUFFICIENT_RESOURCES, surfaced as uv_poll_cb(status < 0)) used to be
+// dropped by the POLL_TYPE_SEMI_SOCKET listen branch: libuv zeroes
+// handle->events before the callback, so without an explicit uv_poll_start
+// the listener stays alive but never fires again. The listen_poll fault
+// reproduces that state on every backend by stopping the listen poll at the
+// top of the dispatch; the fix re-arms it.
+//
+// Not under the isWindows skip: this is the backend the fix targets, and the
+// hook was built to work there. Windows CI currently builds without
+// socketFaultInjection (it follows the asan default, which is off on
+// Windows), so the !fault.available() gate still applies there; a Windows
+// build with --socket-fault-injection=on runs this.
+test.skipIf(!fault.available())("listen poll error: listener re-arms and keeps accepting", async () => {
+  const { proc, port } = await spawnServer(/* js */ `
+    const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+    const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+      fetch: () => new Response("ok") });
+    // One-shot: next readable dispatch on the listening socket is delivered
+    // as a poll error with the poll left stopped.
+    fault.set({ syscall: "listen_poll", action: "errno", errno: "ENOMEM", repeat: 1 });
+    console.log(s.port);
+    process.stdin.once("data", () => { fault.clear(); s.stop(true); process.exit(0); });
+  `);
+  try {
+    // First request triggers the fault (the listen poll's readable dispatch
+    // runs into it). The pending connection is still in the kernel accept
+    // queue, so accept() still succeeds on this dispatch.
+    const first = await fetch(`http://127.0.0.1:${port}/`);
+    expect(await first.text()).toBe("ok");
+    // Second and third requests prove the listen poll was re-armed: without
+    // the fix it was de-registered and no further readable event fires, so
+    // these connections would sit in the backlog forever.
+    const [second, third] = await Promise.all([
+      fetch(`http://127.0.0.1:${port}/`).then(r => r.text()),
+      fetch(`http://127.0.0.1:${port}/`).then(r => r.text()),
+    ]);
+    expect({ second, third }).toEqual({ second: "ok", third: "ok" });
+  } finally {
+    proc.stdin.write("q\n");
+    proc.stdin.end();
+    await proc.exited;
+  }
+  expect({ signal: proc.signalCode, exit: proc.exitCode }).toEqual({ signal: null, exit: 0 });
 });


### PR DESCRIPTION
## What

The `POLL_TYPE_SEMI_SOCKET` listen branch in `us_internal_dispatch_ready_poll()` never consumed the `error` parameter. Every sibling branch does: connecting sockets turn it into `connect_error`, established sockets close with the real errno, UDP drains the error queue. The listen branch called `bsd_accept_socket()` regardless, hit the `/* Todo: start timer here */` stub when it failed, and returned.

## Why it matters

On the libuv backend a poll error is delivered as `uv_poll_cb(status < 0)`, and `uv__fast_poll_process_poll_req`'s `!REQ_SUCCESS` path does:

```c
handle->events = 0;                                  /* Stop the watcher */
handle->poll_cb(handle, uv_translate_sys_error(error), 0);
```

The trailing re-submit check keys on `handle->events`, so no further AFD poll ioctl is issued until `uv_poll_start` runs again. The AFD poll ioctl does fail in the field (it allocates kernel resources per poll and returns `INSUFFICIENT_RESOURCES` under pool exhaustion). After that one error the listener object stays live, the process keeps running, and the socket never accepts another connection. No error reaches JS.

There is no upstream close/error hook for `us_listen_socket_t`, and closing it from below would dangle the raw pointer `Listener`/`NewServer` cache, so re-arming is the correct recovery.

## Fix

When `error` is set on a listen-socket dispatch:
- read `SO_ERROR` to clear any latched kernel state so a level-triggered `EPOLLERR` cannot spin the loop, then
- re-arm via a new `us_internal_poll_restart()` helper. On libuv it calls `uv_poll_start` on the still-live handle; on epoll/kqueue the registration survives an error event so the restart is an idempotent `EPOLL_CTL_MOD`/`EV_ADD`.

## Test

New `listen_poll` socket-fault-injection hook (`US_FAULT_LISTEN_POLL`) reproduces the stopped-poll state on every backend by de-registering the listen poll at the top of the dispatch. The test in `test/js/bun/http/serve-syscall-fault.test.ts` arms it one-shot and then issues three requests; the second and third hang forever without the re-arm (verified: removing the `us_internal_poll_restart` call times the test out).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-syscall-fault.test.ts

<!-- robobun:evidence:end -->