### PR TITLE
timers: O(n^2) GC sweep when many timers had their numeric id read

### DIFF
--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -833,13 +833,17 @@ impl TimerObjectInternals {
             unsafe { (*state).timer.remove(self.event_loop_timer()) };
         }
 
-        // (c) `vm.timer.maps.get(kind).orderedRemove(id)` if
+        // (c) `vm.timer.maps.get(kind).swapRemove(id)` if
         //     `has_accessed_primitive` — drops the i32→*mut EventLoopTimer
-        //     entry minted by `toPrimitive`.
+        //     entry minted by `toPrimitive`. Swap-remove: the id map is only
+        //     ever keyed into, never iterated in order, and `deinit` runs for
+        //     every id-accessed timer a GC sweep collects, so the ordered
+        //     remove's O(n) shift + index rebuild here was O(n²) across a
+        //     sweep.
         if self.flags.get().has_accessed_primitive() {
             // SAFETY: as above — fresh `&mut` to `.timer.maps` for this call.
             let map = unsafe { (*state).timer.maps.get(kind) };
-            if map.remove(&self.id).is_some() {
+            if map.swap_remove(&self.id) {
                 // If this map got
                 // large, shrink it back down. Keys are i32, values are one
                 // pointer (~12 bytes per entry), so 21,000 timers accessed by
@@ -858,7 +862,7 @@ impl TimerObjectInternals {
                 // too, or `remove_timer_by_id` would hand out a dangling
                 // `*mut EventLoopTimer` after the parent is freed.
                 // SAFETY: as above.
-                let _ = unsafe { (*state).timer.maps.set_timeout.remove(&self.id) };
+                unsafe { (*state).timer.maps.set_timeout.swap_remove(&self.id) };
             }
         }
 

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -682,6 +682,52 @@ it("setTimeout(1) is not quantized to the ~15.6ms Windows system tick", async ()
   expect(exitCode).toBe(0);
 });
 
+// Reading a timer's numeric id (`+t`, `${t}`, obj[t]=x, any Symbol.toPrimitive
+// use) registers it in the id->timer map. Finalize removed that entry with the
+// ordered ArrayHashMap.remove(), which is three O(n) vec shifts plus a full
+// hash-index rebuild per timer, so a GC sweep of n id-accessed timers was
+// O(n^2). 20k such timers froze the loop for ~2-3 s on release, tens of
+// seconds at 30k+. Node: ~5 ms for 200k. With swap_remove() the sweep is O(n).
+it(
+  "GC of many id-accessed timers is not quadratic",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const N = 20000;
+          for (let i = 0; i < N; i++) {
+            const t = setTimeout(() => {}, 3_600_000);
+            Number(t);          // mint the id-map entry via Symbol.toPrimitive
+            clearTimeout(t);
+          }
+          const t0 = performance.now();
+          Bun.gc(true);
+          const ms = performance.now() - t0;
+          process.stdout.write(JSON.stringify({ ms: Math.round(ms) }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const filteredStderr = stderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(filteredStderr).toBe("");
+    const { ms } = JSON.parse(stdout);
+    // Before: ~2100-3400 ms release, far more on debug+ASAN (quadratic in N).
+    // After: <10 ms release, ~100-170 ms debug+ASAN (linear). 1500 ms splits
+    // the two with ~9x headroom over the fixed debug+ASAN number.
+    expect(ms).toBeLessThan(1500);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
 it("timer heap clock is monotonic, not wall-clock", () => {
   // The clock that schedules setTimeout/setInterval deadlines must be monotonic
   // (boot-relative) on every platform so NTP steps / user clock changes can't

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -688,14 +688,12 @@ it("setTimeout(1) is not quantized to the ~15.6ms Windows system tick", async ()
 // hash-index rebuild per timer, so a GC sweep of n id-accessed timers was
 // O(n^2). 20k such timers froze the loop for ~2-3 s on release, tens of
 // seconds at 30k+. Node: ~5 ms for 200k. With swap_remove() the sweep is O(n).
-it(
-  "GC of many id-accessed timers is not quadratic",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+it("GC of many id-accessed timers is not quadratic", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
           const N = 20000;
           for (let i = 0; i < N; i++) {
             const t = setTimeout(() => {}, 3_600_000);
@@ -707,26 +705,24 @@ it(
           const ms = performance.now() - t0;
           process.stdout.write(JSON.stringify({ ms: Math.round(ms) }));
         `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const filteredStderr = stderr
-      .split("\n")
-      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-      .join("\n");
-    expect(filteredStderr).toBe("");
-    const { ms } = JSON.parse(stdout);
-    // Before: ~2100-3400 ms release, far more on debug+ASAN (quadratic in N).
-    // After: <10 ms release, ~100-170 ms debug+ASAN (linear). 1500 ms splits
-    // the two with ~9x headroom over the fixed debug+ASAN number.
-    expect(ms).toBeLessThan(1500);
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const filteredStderr = stderr
+    .split("\n")
+    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+    .join("\n");
+  expect(filteredStderr).toBe("");
+  const { ms } = JSON.parse(stdout);
+  // Before: ~2100-3400 ms release, far more on debug+ASAN (quadratic in N).
+  // After: <10 ms release, ~100-170 ms debug+ASAN (linear). 1500 ms splits
+  // the two with ~9x headroom over the fixed debug+ASAN number.
+  expect(ms).toBeLessThan(1500);
+  expect(exitCode).toBe(0);
+}, 30_000);
 
 it("timer heap clock is monotonic, not wall-clock", () => {
   // The clock that schedules setTimeout/setInterval deadlines must be monotonic


### PR DESCRIPTION
## Repro

```js
// bun repro.mjs   (compare: node --expose-gc repro.mjs)
const N = 30000;
for (let i = 0; i < N; i++) {
  const t = setTimeout(() => {}, 3_600_000);
  Number(t);          // or `${t}`, t+"", String(t), t>0, obj[t]=1: any toPrimitive
  clearTimeout(t);    // (also reproduces if you let them fire)
}
const t0 = performance.now();
if (typeof Bun !== "undefined") Bun.gc(true); else globalThis.gc?.();
console.log("gc ms", Math.round(performance.now() - t0)); // bun ~23000, node ~5
```

| N | `Bun.gc(true)` before | after |
| ---: | ---: | ---: |
| 15k | 1888 ms | 1 ms |
| 20k | 2095-3412 ms | 2 ms |
| 30k | ~23 s | 3 ms |

Without the `Number(t)` line the sweep is already ~1 ms; only timers whose id was ever read (via `Symbol.toPrimitive`) are affected.

## Cause

`to_primitive` puts `id -> *mut EventLoopTimer` into `All.maps` (an `ArrayHashMap`) so `clearTimeout(+t)` can resolve it. `TimerObjectInternals::deinit` (run for every collected timer during GC finalize) removed that entry with the ordered `remove()`, which does three O(n) `Vec::remove` shifts and then rebuilds the whole hash index. With n live id-accessed timers in the map, sweeping all of them costs O(n^2).

`clearTimeout(obj)` never drops the map entry, so cleared timers accumulate there and pay the full quadratic bill in one sweep. The numeric `clearTimeout(id)` path already uses `swap_remove_at`.

## Fix

The id map is only ever keyed into; its order is never observed. Use `swap_remove` in `deinit` (both the per-kind map and the `setTimeout -> setInterval` promotion fallback), matching what `remove_timer_by_id` already does.

## Verification

New test in `test/js/web/timers/setTimeout.test.js` creates 20k id-accessed timers, clears them, and asserts `Bun.gc(true)` finishes in under 1500 ms.

```
USE_SYSTEM_BUN=1 bun test -t "GC of many id-accessed"  # fails: Received: 2062
bun bd test           -t "GC of many id-accessed"      # passes (~110 ms debug+ASAN)
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/timers/setTimeout.test.js

<!-- robobun:evidence:end -->