### PR TITLE
FormData: preserve NUL bytes in parsed multipart name/filename

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -6,7 +6,6 @@ use bun_jsc::{
     AnyPromise, CallFrame, DOMFormData, JSGlobalObject, JSValue, JsError, JsResult, JsTerminated,
     ZigStringJsc as _,
 };
-use bun_semver::{self, SlicedString};
 use core::ffi::c_void;
 
 use crate::webcore::Blob;
@@ -72,26 +71,23 @@ impl AsyncFormDataExt for AsyncFormData {
     }
 }
 
-/// Raw slice into the input buffer. Not using `bun.Semver.String` because
-/// file bodies are binary data that can contain null bytes, which
-/// Semver.String's inline storage treats as terminators.
+/// Raw slices into the input buffer. Not using `bun.Semver.String` because
+/// any of these can contain null bytes, which Semver.String's inline storage
+/// treats as terminators.
 pub struct Field<'a> {
-    /// Borrows into the caller-owned input buffer (binary body slice).
     pub value: &'a [u8],
-    pub filename: bun_semver::String,
-    pub content_type: bun_semver::String,
+    pub filename: &'a [u8],
+    pub content_type: &'a [u8],
     pub is_file: bool,
-    pub zero_count: u8,
 }
 
 impl Default for Field<'_> {
     fn default() -> Self {
         Field {
             value: b"",
-            filename: bun_semver::String::default(),
-            content_type: bun_semver::String::default(),
+            filename: b"",
+            content_type: b"",
             is_file: false,
-            zero_count: 0,
         }
     }
 }
@@ -187,20 +183,21 @@ pub fn to_js_from_multipart_data(
     }
 
     impl<'a> Wrapper<'a> {
-        fn on_entry(wrap: &mut Self, name: bun_semver::String, field: &Field<'_>, buf: &[u8]) {
+        fn on_entry(wrap: &mut Self, name: &[u8], field: &Field<'_>) {
             let value_str: &[u8] = field.value;
-            let key = ZigString::init_utf8(name.slice(buf));
+            let key = ZigString::init_utf8(name);
 
             if field.is_file {
-                let filename_str = field.filename.slice(buf);
+                let filename_str = field.filename;
 
                 let mut blob = Blob::create(value_str, wrap.global, false);
                 let filename = ZigString::init_utf8(filename_str);
 
                 if !field.content_type.is_empty() {
-                    let ct = field.content_type.slice(buf);
                     blob.content_type
-                        .set(crate::webcore::blob::BlobContentType::Owned(ct.into()));
+                        .set(crate::webcore::blob::BlobContentType::Owned(
+                            field.content_type.into(),
+                        ));
                     blob.content_type_was_set.set(true);
                 } else {
                     let mime = 'brk: {
@@ -263,10 +260,9 @@ pub fn for_each_multipart_entry<C>(
     input: &[u8],
     boundary: &[u8],
     ctx: &mut C,
-    mut iterator: impl FnMut(&mut C, bun_semver::String, &Field<'_>, &[u8]),
+    mut iterator: impl FnMut(&mut C, &[u8], &Field<'_>),
 ) -> crate::Result<()> {
     let mut slice = input;
-    let subslicer = SlicedString::init(input, input);
 
     let mut buf = [0u8; 76];
     {
@@ -306,11 +302,11 @@ pub fn for_each_multipart_entry<C>(
         remain = &remain[header_end + 4..];
 
         let mut field = Field::default();
-        let mut name = bun_semver::String::default();
-        let mut filename: Option<bun_semver::String> = None;
+        let mut name: Option<&[u8]> = None;
+        let mut filename: Option<&[u8]> = None;
         let mut header_chunk = header;
         let mut is_file = false;
-        while !header_chunk.is_empty() && (filename.is_none() || name.len() == 0) {
+        while !header_chunk.is_empty() && (filename.is_none() || name.is_none()) {
             let line_end = strings::index_of(header_chunk, b"\r\n")
                 .ok_or(crate::Error::IsMissingHeaderLineEnd)?;
             let line = &header_chunk[..line_end];
@@ -362,13 +358,13 @@ pub fn for_each_multipart_entry<C>(
                     }
 
                     if strings::eql_case_insensitive_ascii(eql_key, b"name", true) {
-                        name = subslicer.sub(field_value).value();
+                        name = Some(field_value);
                     } else if strings::eql_case_insensitive_ascii(eql_key, b"filename", true) {
-                        filename = Some(subslicer.sub(field_value).value());
+                        filename = Some(field_value);
                         is_file = true;
                     }
 
-                    if !name.is_empty() && filename.is_some() {
+                    if name.is_some() && filename.is_some() {
                         break;
                     }
 
@@ -393,14 +389,14 @@ pub fn for_each_multipart_entry<C>(
                     .iter()
                     .all(|&b| b == b'\t' || (0x20..=0x7E).contains(&b))
                 {
-                    field.content_type = subslicer.sub(trimmed).value();
+                    field.content_type = trimmed;
                 }
             }
         }
 
-        if name.len() + field.zero_count as usize == 0 {
+        let Some(name) = name else {
             continue;
-        }
+        };
 
         let mut body = remain;
         if body.ends_with(b"\r\n") {
@@ -410,7 +406,7 @@ pub fn for_each_multipart_entry<C>(
         field.filename = filename.unwrap_or_default();
         field.is_file = is_file;
 
-        iterator(ctx, name, &field, input);
+        iterator(ctx, name, &field);
     }
 
     Ok(())

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -387,6 +387,10 @@ describe("FormData", () => {
         ["\0lead", "2"],
       ]);
     });
+
+    it('keeps an explicit name="" as an empty-key entry', async () => {
+      expect([...(await parse([`name=""`])).entries()]).toEqual([["", "V0"]]);
+    });
   });
 
   test("FormData.from (URLSearchParams)", () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -339,6 +339,56 @@ describe("FormData", () => {
     }
   });
 
+  // A NUL byte inside a name/filename is just a byte: it must not be treated
+  // as a terminator (short inline-string storage used to scan for the first 0).
+  describe("multipart name/filename containing NUL bytes", () => {
+    const parse = (disps: string[]) =>
+      new Response(
+        disps.map((d, i) => `--XX\r\nContent-Disposition: form-data; ${d}\r\n\r\nV${i}\r\n`).join("") + "--XX--\r\n",
+        { headers: { "content-type": "multipart/form-data; boundary=XX" } },
+      ).formData();
+
+    it("preserves an embedded NUL in short (<=8 byte) and long names", async () => {
+      expect([...(await parse([`name="ab\0cd"`])).entries()]).toEqual([["ab\0cd", "V0"]]);
+      expect([...(await parse([`name="abcdefg\0"`])).entries()]).toEqual([["abcdefg\0", "V0"]]);
+      expect([...(await parse([`name="q\0nine789"`])).entries()]).toEqual([["q\0nine789", "V0"]]);
+    });
+
+    it("keeps an entry whose name starts with a NUL byte", async () => {
+      expect([...(await parse([`name="\0gone"`, `name="after"`])).entries()]).toEqual([
+        ["\0gone", "V0"],
+        ["after", "V1"],
+      ]);
+    });
+
+    it("keeps short names distinct when they differ only after a NUL", async () => {
+      const fd = await parse([`name="a\0admin"`, `name="a\0other"`]);
+      expect([...fd.entries()]).toEqual([
+        ["a\0admin", "V0"],
+        ["a\0other", "V1"],
+      ]);
+    });
+
+    it("preserves an embedded NUL in a short filename", async () => {
+      const fd = await parse([`name="f"; filename="a\0b.txt"`]);
+      const file = fd.get("f") as File;
+      expect(file).toBeInstanceOf(File);
+      expect(file.name).toBe("a\0b.txt");
+      expect(await file.text()).toBe("V0");
+    });
+
+    it("round-trips NUL-bearing names through its own serializer", async () => {
+      const src = new FormData();
+      src.append("x\0y", "1");
+      src.append("\0lead", "2");
+      const parsed = await new Response(src).formData();
+      expect([...parsed.entries()]).toEqual([
+        ["x\0y", "1"],
+        ["\0lead", "2"],
+      ]);
+    });
+  });
+
   test("FormData.from (URLSearchParams)", () => {
     expect(
       // @ts-expect-error


### PR DESCRIPTION
## What

`Response#formData()` / `Request#formData()` truncated a multipart entry's `name` or `filename` at the first NUL byte when the value was at most 8 bytes long, and dropped the entry entirely when the name *started* with a NUL. Names of 9+ bytes were unaffected, so two short names differing only after a NUL (`a\0admin` / `a\0other`) collided onto the same key. Bun's own `new Response(formData)` serializer emits the NUL verbatim, so Bun could not round-trip its own multipart body.

```js
const parse = d =>
  new Response(
    d.map((h, i) => `--XX\r\nContent-Disposition: form-data; ${h}\r\n\r\nV${i}\r\n`).join("") + "--XX--\r\n",
    { headers: { "content-type": "multipart/form-data; boundary=XX" } },
  ).formData();

[...(await parse([`name="ab\0cd"`])).keys()];               // before: ["ab"]     after: ["ab\0cd"]
[...(await parse([`name="\0gone"`, `name="after"`])).keys()]; // before: ["after"]   after: ["\0gone","after"]
```

Node 26 preserves every NUL, so a name-inspecting proxy or WAF in front of a Bun server saw a different field-name set than the application.

## Why

`for_each_multipart_entry` stored the parsed `name`/`filename`/`content_type` in `bun_semver::String`. That type inlines values up to 8 bytes and recovers the length of an inline value by scanning for the first `0` byte (there is no stored length), so any embedded NUL terminated the slice early and a leading NUL read as empty. The `value` field already used a plain `&[u8]` to avoid exactly this; the other three fields did not.

## Fix

Store `name`, `filename`, and `content_type` as `&[u8]` slices into the input buffer, the same as `value`. This removes the `bun_semver` dependency from the parser, the `SlicedString` helper, the unused `buf` callback parameter, and the dead `zero_count` field. An entry is now skipped only when no `name=` parameter is present at all.

## Verification

```
# before (USE_SYSTEM_BUN=1): 5 fail
# after  (bun bd):            5 pass, full FormData.test.ts 154 pass
bun bd test test/js/web/html/FormData.test.ts -t NUL
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (d049ae5fe)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [7.84ms]
(pass) FormData > should be able to append a Blob [9.49ms]
(pass) FormData > should be able to set a Blob [7.36ms]
(pass) FormData > should be able to set a string [4.20ms]
(pass) FormData > should get filename from file [4.26ms]
(pass) FormData > should use the correct filenames [6.05ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [15.23ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [38.54ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.06ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.68ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.96ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.79ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f240d2698)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.39ms]
(pass) FormData > should be able to append a Blob [0.18ms]
(pass) FormData > should be able to set a Blob [0.08ms]
(pass) FormData > should be able to set a string [0.03ms]
(pass) FormData > should get filename from file [0.05ms]
(pass) FormData > should use the correct filenames [0.05ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.32ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.88ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.05ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.04ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (d049ae5fe)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [7.84ms]
(pass) FormData > should be able to append a Blob [8.87ms]
(pass) FormData > should be able to set a Blob [7.29ms]
(pass) FormData > should be able to set a string [4.14ms]
(pass) FormData > should get filename from file [4.27ms]
(pass) FormData > should use the correct filenames [5.44ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [14.98ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [38.06ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [3.27ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [6.63ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [3.31ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [4.32ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 790ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 46s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+d049ae5fe
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (d049ae5fe)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.17ms]
(pass) FormData > should be able to append a Blob [0.15ms]
(pass) FormData > should be able to set a Blob [0.09ms]
(pass) FormData > should be able to set a string
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/FormData.rs   | 52 +++++++++++++++++--------------------
 test/js/web/html/FormData.test.ts | 54 +++++++++++++++++++++++++++++++++++++++
 2 files changed, 78 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/FormData.rs        2      7      0
test/js/web/html/FormData.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->