### PR TITLE
FormData: honor filename override in append/set when value is already a File

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4065,8 +4065,7 @@ pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob
     )
 }
 
-/// https://xhr.spec.whatwg.org/#create-an-entry step 3: an explicit FormData
-/// `filename` overrides an already-named File. `this` is the FormData-held dupe.
+/// https://xhr.spec.whatwg.org/#create-an-entry step 3; `this` is the FormData-held dupe.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &BunString) {
     this.is_jsdom_file.set(true);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4065,10 +4065,15 @@ pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob
     )
 }
 
+/// `path_str` is the FormData entry's filename. With an explicit `filename`
+/// argument it must win over an already-named File
+/// (https://xhr.spec.whatwg.org/#create-an-entry step 3). Without one, the C++
+/// caller defaulted it from `Blob__getFileNameString(this)`, so the write is a
+/// no-op. `this` is the FormData-held dupe, so the caller's File is untouched.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &BunString) {
     this.is_jsdom_file.set(true);
-    if !path_str.is_empty() && this.get_file_name().is_none() {
+    if !path_str.is_empty() {
         this.name.set(path_str.clone());
     }
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4065,11 +4065,8 @@ pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob
     )
 }
 
-/// `path_str` is the FormData entry's filename. With an explicit `filename`
-/// argument it must win over an already-named File
-/// (https://xhr.spec.whatwg.org/#create-an-entry step 3). Without one, the C++
-/// caller defaulted it from `Blob__getFileNameString(this)`, so the write is a
-/// no-op. `this` is the FormData-held dupe, so the caller's File is untouched.
+/// https://xhr.spec.whatwg.org/#create-an-entry step 3: an explicit FormData
+/// `filename` overrides an already-named File. `this` is the FormData-held dupe.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &BunString) {
     this.is_jsdom_file.set(true);

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { join } from "path";
 
 describe("FormData", () => {
@@ -61,6 +61,84 @@ describe("FormData", () => {
     b1 = form.get("foo") as Blob;
     expect(blob.name).toBeUndefined();
     expect(b1.name).toBe("foo.txt");
+  });
+
+  // https://xhr.spec.whatwg.org/#create-an-entry — when `filename` is given,
+  // the entry value is a new File named `filename` regardless of whether the
+  // input is a Blob or already a File.
+  it("append/set honor the filename argument when value is already a File", () => {
+    const origA = new File(["x"], "orig-a.txt", { type: "text/plain" });
+    const origB = new File(["x"], "orig-b.txt");
+    const origC = new File([], "orig-c.txt");
+    const fd = new FormData();
+
+    fd.append("a", origA, "over-a.txt");
+    fd.set("b", origB, "over-b.txt");
+    fd.append("c", origC, "over-c.txt");
+    fd.append("shared1", origA, "shared-1.txt");
+    fd.append("shared2", origA, "shared-2.txt");
+
+    expect({
+      a: (fd.get("a") as File).name,
+      b: (fd.get("b") as File).name,
+      c: (fd.get("c") as File).name,
+      shared1: (fd.get("shared1") as File).name,
+      shared2: (fd.get("shared2") as File).name,
+      getAllA: (fd.getAll("a") as File[]).map(f => f.name),
+      iter: [...fd].map(([k, v]) => [k, (v as File).name]),
+    }).toEqual({
+      a: "over-a.txt",
+      b: "over-b.txt",
+      c: "over-c.txt",
+      shared1: "shared-1.txt",
+      shared2: "shared-2.txt",
+      getAllA: ["over-a.txt"],
+      iter: [
+        ["a", "over-a.txt"],
+        ["b", "over-b.txt"],
+        ["c", "over-c.txt"],
+        ["shared1", "shared-1.txt"],
+        ["shared2", "shared-2.txt"],
+      ],
+    });
+
+    // The caller's original File must not be mutated.
+    expect([origA.name, origB.name, origC.name]).toEqual(["orig-a.txt", "orig-b.txt", "orig-c.txt"]);
+    // Entry value is a distinct File and preserves the type.
+    const a = fd.get("a") as File;
+    expect(a).not.toBe(origA);
+    expect(a instanceof File).toBe(true);
+    expect(a.type).toBe(origA.type);
+  });
+
+  // When no filename argument is given, the entry keeps the File's own
+  // user-visible `.name`, not the store-derived path or stored_name.
+  it("append/set without a filename keep the File's own name", async () => {
+    using dir = tempDir("formdata-file-name", { "payload.bin": "payload" });
+    const onDisk = join(String(dir), "payload.bin");
+
+    const fileBacked = new File([Bun.file(onDisk)], "display.txt");
+    expect(fileBacked.name).toBe("display.txt");
+
+    const renamed = new File(["abc"], "one.txt") as File & { name: string };
+    renamed.name = "two.txt";
+    expect(renamed.name).toBe("two.txt");
+
+    const fd = new FormData();
+    fd.append("file", fileBacked);
+    fd.set("renamed", renamed);
+
+    expect({
+      file: (fd.get("file") as File).name,
+      renamed: (fd.get("renamed") as File).name,
+    }).toEqual({
+      file: "display.txt",
+      renamed: "two.txt",
+    });
+
+    const body = await new Response(fd).text();
+    expect(body).toContain('Content-Disposition: form-data; name="file"; filename="display.txt"\r\n');
+    expect(body).toContain('Content-Disposition: form-data; name="renamed"; filename="two.txt"\r\n');
   });
 
   const multipartFormDataFixturesRawBody = [

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -66,7 +66,7 @@ describe("FormData", () => {
   // https://xhr.spec.whatwg.org/#create-an-entry — when `filename` is given,
   // the entry value is a new File named `filename` regardless of whether the
   // input is a Blob or already a File.
-  it("append/set honor the filename argument when value is already a File", () => {
+  it("append/set honor the filename argument when value is already a File", async () => {
     const origA = new File(["x"], "orig-a.txt", { type: "text/plain" });
     const origB = new File(["x"], "orig-b.txt");
     const origC = new File([], "orig-c.txt");
@@ -77,6 +77,7 @@ describe("FormData", () => {
     fd.append("c", origC, "over-c.txt");
     fd.append("shared1", origA, "shared-1.txt");
     fd.append("shared2", origA, "shared-2.txt");
+    fd.append("emptyblob", new Blob([]), "empty-blob.txt");
 
     expect({
       a: (fd.get("a") as File).name,
@@ -84,6 +85,7 @@ describe("FormData", () => {
       c: (fd.get("c") as File).name,
       shared1: (fd.get("shared1") as File).name,
       shared2: (fd.get("shared2") as File).name,
+      emptyblob: (fd.get("emptyblob") as File).name,
       getAllA: (fd.getAll("a") as File[]).map(f => f.name),
       iter: [...fd].map(([k, v]) => [k, (v as File).name]),
     }).toEqual({
@@ -92,6 +94,7 @@ describe("FormData", () => {
       c: "over-c.txt",
       shared1: "shared-1.txt",
       shared2: "shared-2.txt",
+      emptyblob: "empty-blob.txt",
       getAllA: ["over-a.txt"],
       iter: [
         ["a", "over-a.txt"],
@@ -99,6 +102,7 @@ describe("FormData", () => {
         ["c", "over-c.txt"],
         ["shared1", "shared-1.txt"],
         ["shared2", "shared-2.txt"],
+        ["emptyblob", "empty-blob.txt"],
       ],
     });
 
@@ -108,7 +112,18 @@ describe("FormData", () => {
     const a = fd.get("a") as File;
     expect(a).not.toBe(origA);
     expect(a instanceof File).toBe(true);
+    expect(fd.get("emptyblob") instanceof File).toBe(true);
     expect(a.type).toBe(origA.type);
+
+    const filenames = [...(await new Response(fd).text()).matchAll(/filename="([^"]*)"/g)].map(m => m[1]);
+    expect(filenames).toEqual([
+      "over-a.txt",
+      "over-b.txt",
+      "over-c.txt",
+      "shared-1.txt",
+      "shared-2.txt",
+      "empty-blob.txt",
+    ]);
   });
 
   // When no filename argument is given, the entry keeps the File's own


### PR DESCRIPTION
### Problem
- `formData.append(name, file, "new.txt")` and `set(...)` ignore the `filename` argument when the value is already a `File`. `fd.get(name).name` returns the File's original name. The same call with a plain `Blob` honors it. Node, undici, and browsers honor it for both.
- The cause is `Blob__setAsFile` (`src/runtime/webcore/Blob.rs:4070`). It applies the entry filename only when `get_file_name().is_none()`, so a value that already has a name keeps it. Multipart serialization reads the entry filename from the C++ side and was already correct.

```js
const fd = new FormData();
fd.append("file", new File(["x"], "orig.txt"), "over.txt");
fd.get("file").name; // bun: "orig.txt", node: "over.txt"
```

### Fix
- Drop the `get_file_name().is_none()` guard so a non-empty entry filename always sets the per-Blob `name`.
- Correct because [create an entry](https://xhr.spec.whatwg.org/#create-an-entry) step 3 makes the override unconditional: a File is a Blob. When no `filename` argument is given, the C++ caller defaults it from `Blob__getFileNameString`, which returns this same per-Blob name, so the write is a no-op. The Blob written to is the FormData-held dupe, so the caller's `File` is not mutated and two entries that share one `File` keep distinct names.
- Verified: `test/js/web/html/FormData.test.ts` (two new cases, the override case fails on main). Also ran `form-data-set-append.test.js`, `FormData-multipart-serialization.test.ts`, and `test/js/web/fetch/blob.test.ts`.

### Background
- `DOMFormData` (C++) stores each file entry as a `WebCore::Blob` wrapper: a refcounted pointer to a Rust `Blob` dupe plus the entry's `m_fileName`. `get()`/`getAll()`/iteration convert it back to JS through `toJS` in `blob.cpp`, which calls `Blob__setAsFile(dupe, m_fileName)` and wraps a fresh dupe.
- A Rust `Blob` has a per-instance `name` and a shared, refcounted `Store`. `file.name` reads `name` first and falls back to the store path. Dupes share the store but copy `name`, so writing `name` on a dupe is local to that entry.

<details><summary>Notes</summary>

- The second new test (`append/set without a filename keep the File's own name`) covers `new File([Bun.file(p)], "display.txt")` and a File whose `.name` was reassigned, both appended without a filename, including the multipart `Content-Disposition` line. It passes on current main and guards the no-op path described above. An earlier revision of this PR (before #40436 reworked `Blob__setAsFile` on main) needed a second change in `Blob__getFileNameString` for that case; main already has it.
- `append(name, file, "")` (explicit empty filename) keeps the original name, as on main. Supporting it needs an "argument was given" bit threaded through `JSDOMFormData.cpp`/`blob.cpp`; left out of scope.
- Sibling of #32431 (default `filename="blob"` for a bare Blob), which touches the same function from the other branch of the same spec step.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [5.19ms]
(pass) FormData > should be able to append a Blob [12.31ms]
(pass) FormData > should be able to set a Blob [9.21ms]
(pass) FormData > should be able to set a string [4.32ms]
(pass) FormData > should get filename from file [5.96ms]
(pass) FormData > should use the correct filenames [7.83ms]
86 |       shared1: (fd.get("shared1") as File).name,
87 |       shared2: (fd.get("shared2") as File).name,
88 |       emptyblob: (fd.get("emptyblob") as File).name,
89 |       getAllA: (fd.getAll("a") as File[]).map(f => f.name),
90 |       iter: [...fd].map(([k, v]) => [k, (v as File).name]),
91 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
-   "a": "over-a.txt",
-   "b": "over-b.txt",
-   "c": "over-c.txt",
+   "a": "orig-a.txt",
+   "b": "orig-b.txt",
+   "c": "orig-c.txt",
    "emptyblob": "empty-blob.txt",
    "getAllA": [
-     "over-a.txt",
+     "orig-a
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.09ms]
(pass) FormData > should be able to append a Blob [0.20ms]
(pass) FormData > should be able to set a Blob [0.11ms]
(pass) FormData > should be able to set a string [0.05ms]
(pass) FormData > should get filename from file [0.07ms]
(pass) FormData > should use the correct filenames [0.08ms]
86 |       shared1: (fd.get("shared1") as File).name,
87 |       shared2: (fd.get("shared2") as File).name,
88 |       emptyblob: (fd.get("emptyblob") as File).name,
89 |       getAllA: (fd.getAll("a") as File[]).map(f => f.name),
90 |       iter: [...fd].map(([k, v]) => [k, (v as File).name]),
91 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
-   "a": "over-a.txt",
-   "b": "over-b.txt",
-   "c": "over-c.txt",
+   "a": "orig-a.txt",
+   "b": "orig-b.txt",
+   "c": "orig-c.txt",
    "emptyblob": "empty-blob.txt",
    "getAllA": [
-     "over-a.txt",
+     "orig-a.txt",
    ],
    "iter": [
      [
        "a",
-       "over-a.txt",
+       "orig-a.txt",
      ],
      [
        "b",
-       "over-b.txt",
+       "orig
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [5.65ms]
(pass) FormData > should be able to append a Blob [13.14ms]
(pass) FormData > should be able to set a Blob [10.94ms]
(pass) FormData > should be able to set a string [4.66ms]
(pass) FormData > should get filename from file [6.54ms]
(pass) FormData > should use the correct filenames [8.82ms]
(pass) FormData > append/set honor the filename argument when value is already a File [46.15ms]
(pass) FormData > append/set without a filename keep the File's own name [61.57ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [23.17ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [50.81ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [4.63ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [8.18ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) wit
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a203c3f99f
  features     baseline

23 deps, 131 codegen, 1172 objects in 952ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [16.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [5.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] fetch zlib
[zlib] up to date
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen .bind.ts → Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs       |  3 +-
 test/js/web/html/FormData.test.ts | 95 ++++++++++++++++++++++++++++++++++++++-
 2 files changed, 96 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/Blob.rs            9      9     24
test/js/web/html/FormData.test.ts      3      4     22
```

</details>

<!-- robobun:evidence:end -->