### PR TITLE
URL: defer searchParams href sync to next read (fix O(N^2) append)

### DIFF
--- a/src/jsc/bindings/DOMURL.cpp
+++ b/src/jsc/bindings/DOMURL.cpp
@@ -118,9 +118,29 @@ ExceptionOr<void> DOMURL::setHref(const String& url)
         return Exception { InvalidURLError, makeString(redact(url), " cannot be parsed as a URL."_s) };
     }
     m_url = WTF::move(completeURL);
+    m_searchParamsDirty = false;
     if (m_searchParams)
         m_searchParams->updateFromAssociatedURL();
     return {};
+}
+
+// The update steps invoked on URLSearchParams::{append,set,delete,sort} set
+// m_searchParamsDirty instead of eagerly re-serializing m_url on every call so
+// that N appends through url.searchParams stay O(N) instead of O(N^2). All
+// reads of m_url (href/toJSON/fullURL) call this first to reconcile.
+void DOMURL::flushPendingSearchParamsUpdate() const
+{
+    if (!m_searchParamsDirty) [[likely]]
+        return;
+    m_searchParamsDirty = false;
+    auto* self = const_cast<DOMURL*>(this);
+    if (!self->m_searchParams)
+        return;
+    auto serialized = self->m_searchParams->toString();
+    if (serialized.isEmpty())
+        self->m_url.setQuery({});
+    else
+        self->m_url.setQuery(WTF::move(serialized));
 }
 
 String DOMURL::createObjectURL(ScriptExecutionContext& scriptExecutionContext, Blob& blob)

--- a/src/jsc/bindings/DOMURL.h
+++ b/src/jsc/bindings/DOMURL.h
@@ -49,12 +49,21 @@ public:
     static RefPtr<DOMURL> parse(const String& url, const String& base);
     static bool canParse(const String& url, const String& base);
 
-    const URL& href() const { return m_url; }
+    const URL& href() const
+    {
+        flushPendingSearchParamsUpdate();
+        return m_url;
+    }
     ExceptionOr<void> setHref(const String&);
 
     URLSearchParams& searchParams();
+    void markSearchParamsDirty() { m_searchParamsDirty = true; }
 
-    const String& toJSON() const { return m_url.string(); }
+    const String& toJSON() const
+    {
+        flushPendingSearchParamsUpdate();
+        return m_url.string();
+    }
 
     static String createObjectURL(ScriptExecutionContext&, Blob&);
     static void revokeObjectURL(ScriptExecutionContext&, const String&);
@@ -74,12 +83,18 @@ private:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const URL& base);
     DOMURL(URL&& completeURL);
 
-    URL fullURL() const final { return m_url; }
+    URL fullURL() const final
+    {
+        flushPendingSearchParamsUpdate();
+        return m_url;
+    }
     void setFullURL(const URL& fullURL) final { setHref(fullURL.string()); }
+    void flushPendingSearchParamsUpdate() const;
 
     URL m_url;
     RefPtr<URLSearchParams> m_searchParams;
     uint16_t m_initialURLCostForGC { 0 };
+    mutable bool m_searchParamsDirty { false };
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/URLSearchParams.cpp
+++ b/src/jsc/bindings/URLSearchParams.cpp
@@ -167,7 +167,7 @@ String URLSearchParams::toString() const
 void URLSearchParams::updateURL()
 {
     if (m_associatedURL)
-        m_associatedURL->setSearch(WTF::URLParser::serialize(m_pairs));
+        m_associatedURL->markSearchParamsDirty();
 }
 
 void URLSearchParams::updateFromAssociatedURL()

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -260,6 +260,132 @@ describe("url", () => {
   });
 });
 
+describe("url.searchParams lazy href sync", () => {
+  // The URLSearchParams update steps are applied lazily to the associated
+  // URL's serialized string: each getter below must observe the change without
+  // any intermediate href read having forced a sync.
+  it("reflects mutations in every URL getter and across component setters", () => {
+    const u = new URL("http://user:pw@host:81/path?initial=1#frag");
+    const sp = u.searchParams;
+
+    sp.append("a", "1");
+    sp.append("b", "2");
+    sp.set("initial", "x");
+    expect({
+      href: u.href,
+      search: u.search,
+      toString: u.toString(),
+      toJSON: u.toJSON(),
+      hash: u.hash,
+      pathname: u.pathname,
+      protocol: u.protocol,
+      origin: u.origin,
+      username: u.username,
+      password: u.password,
+      host: u.host,
+      hostname: u.hostname,
+      port: u.port,
+      spSize: sp.size,
+      spString: sp.toString(),
+      inspect: Bun.inspect(u).includes("initial=x&a=1&b=2"),
+    }).toEqual({
+      href: "http://user:pw@host:81/path?initial=x&a=1&b=2#frag",
+      search: "?initial=x&a=1&b=2",
+      toString: "http://user:pw@host:81/path?initial=x&a=1&b=2#frag",
+      toJSON: "http://user:pw@host:81/path?initial=x&a=1&b=2#frag",
+      hash: "#frag",
+      pathname: "/path",
+      protocol: "http:",
+      origin: "http://host:81",
+      username: "user",
+      password: "pw",
+      host: "host:81",
+      hostname: "host",
+      port: "81",
+      spSize: 3,
+      spString: "initial=x&a=1&b=2",
+      inspect: true,
+    });
+
+    // Setting an unrelated component while a searchParams mutation is pending
+    // must keep the pending query.
+    sp.append("c", "3");
+    u.pathname = "/p2";
+    expect({ href: u.href, get: sp.get("c") }).toEqual({
+      href: "http://user:pw@host:81/p2?initial=x&a=1&b=2&c=3#frag",
+      get: "3",
+    });
+
+    sp.set("d", "4");
+    u.hash = "#h2";
+    expect(u.href).toBe("http://user:pw@host:81/p2?initial=x&a=1&b=2&c=3&d=4#h2");
+
+    // Setting search directly discards any pending searchParams mutation
+    // (the new search wins) and rebuilds searchParams from it.
+    sp.append("dropped", "y");
+    u.search = "?only=1";
+    expect({ href: u.href, entries: [...sp] }).toEqual({
+      href: "http://user:pw@host:81/p2?only=1#h2",
+      entries: [["only", "1"]],
+    });
+
+    // Setting href discards any pending searchParams mutation and rebuilds
+    // searchParams from the new href.
+    sp.append("dropped", "z");
+    u.href = "https://other/?n=v";
+    expect({ href: u.href, entries: [...sp] }).toEqual({
+      href: "https://other/?n=v",
+      entries: [["n", "v"]],
+    });
+
+    // Deleting all params removes the '?' entirely.
+    sp.delete("n");
+    expect({ href: u.href, search: u.search, size: sp.size }).toEqual({
+      href: "https://other/",
+      search: "",
+      size: 0,
+    });
+
+    // sort() is also a mutation; href must reflect the sorted order.
+    sp.append("z", "1");
+    sp.append("a", "2");
+    sp.sort();
+    expect(u.search).toBe("?a=2&z=1");
+  });
+
+  // N appends through a URL-bound URLSearchParams used to re-serialize and
+  // re-parse the full href on every mutation, so 10000 appends ran for tens of
+  // seconds. With the sync deferred to the next href/search read, this is O(N)
+  // and finishes near-instantly; the spawn timeout is the discriminator.
+  test("N appends through url.searchParams are O(N), not O(N^2)", async () => {
+    const fixture = `
+      const N = 10000;
+      const u = new URL("http://h/");
+      for (let i = 0; i < N; i++) u.searchParams.append("k" + i, "v" + i);
+      const href = u.href;
+      if (u.searchParams.size !== N) throw new Error("size=" + u.searchParams.size);
+      if (!href.startsWith("http://h/?k0=v0&")) throw new Error("href=" + href.slice(0, 40));
+      if (!href.endsWith("&k9999=v9999")) throw new Error("hrefEnd=" + href.slice(-20));
+      console.log("done");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 15_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "done",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 60_000);
+});
+
 describe("object URL prefix check", () => {
   // The "blob:" prefix check dispatches on encoding and only reads
   // prefix.len() code units; these inputs must not be transcoded first.


### PR DESCRIPTION
## Repro

```js
const N = 4000;
const u = new URL("http://h/");
const t0 = Date.now();
for (let i = 0; i < N; i++) u.searchParams.append("k" + i, "v" + i);
console.log({ viaUrl: Date.now() - t0 });
```

Before (release): `{ viaUrl: ~4700 }` for N=4000, `~18700` for N=8000 (roughly 4x per doubling). The same loop on a detached `new URLSearchParams()` takes ~3ms; Node does the URL-bound case in ~5ms.

## Cause

`URLSearchParams::updateURL()` ran eagerly on every mutation:

```
append -> updateURL()
  -> URLParser::serialize(m_pairs)                  // O(N) string build
  -> DOMURL::setSearch(...)
       -> fullURL copy + setQuery(...)              // rebuild href + full URL parse
       -> setFullURL -> setHref(href.string())      // second full URL parse
            -> m_searchParams->updateFromAssociatedURL()  // re-parse query back into m_pairs
```

Four O(N) passes per mutation, so N mutations were O(N^2).

## Fix

`updateURL()` now just marks a dirty bit on the associated `DOMURL`. Every read of `m_url` (`href()`, `toJSON()`, `fullURL()`, which also backs every `URLDecomposition` getter/setter and native callers like `fetch`/`Worker`/`deepEquals`/`fileURLToPath`) reconciles first via a single `m_url.setQuery(m_searchParams->toString())`. `setHref()` clears the bit so an explicit `href`/`search` assignment still wins and rebuilds `m_pairs` from the new URL.

Live-binding coherence is unchanged; see the new `reflects mutations in every URL getter and across component setters` test for the interleaved cases (append then read each getter, append then set an unrelated component, append then overwrite `search`/`href`, delete-all removes `?`, `sort`).

## Verification

```
# before (release):  N=1000 189ms  N=2000 787ms  N=4000 3183ms
# after  (debug+asan):  N=1000 107ms  N=2000 226ms  N=4000 386ms  N=8000 751ms
# (linear; viaUrl now within noise of a detached URLSearchParams)
```

- `bun bd test test/js/web/url/url.test.ts` 18/18 pass
- `bun bd test test/js/deno/url/*.test.ts test/js/node/url/url.test.ts test/js/node/url/url-format-whatwg.test.js test/js/web/urlpattern/urlpattern.test.ts` 480/480 pass
- all `test/js/node/test/parallel/test-whatwg-url-custom-searchparams*.js` pass
- fail-before: `USE_SYSTEM_BUN=1 bun test test/js/web/url/url.test.ts -t "O(N)"` times out at 15s

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (609206c65)

test/js/web/url/url.test.ts:
(pass) url > URL throws [14.85ms]
(pass) url > should have correct origin and protocol [12.56ms]
(pass) url > blob urls [8.60ms]
(pass) url > prints [9.75ms]
(pass) url > works [13.66ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.72ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.34ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.29ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.50ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.31ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.27ms]
(pass) url > URL.canParse > URL.canParse(a, https://b/) [0.30ms]
(pass) url > URL.canParse > URL.canParse.length should be 1 [1.44ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [4.83ms]
(pass) url.searchParams lazy href sync > reflects mutations in every URL getter and across component setters [25.48ms]
375 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/url/url.test.ts:
(pass) url > URL throws [0.22ms]
(pass) url > should have correct origin and protocol [0.14ms]
(pass) url > blob urls [0.07ms]
(pass) url > prints [0.20ms]
(pass) url > works [0.14ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [0.02ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:b)
(pass) url > URL.canParse > URL.canParse(a:/b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:/b)
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined)
(pass) url > URL.canParse > URL.canParse(a, https://b/)
(pass) url > URL.canParse > URL.canParse.length should be 1 [0.02ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [0.06ms]
(pass) url.searchParams lazy href sync > reflects mutations in every URL getter and across component setters [0.32ms]
375 |       stderr: "pipe",
376 |       timeout: 15_000,
377 |       killSignal: "SIGKILL",
378 |     });
379 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (609206c65)

test/js/web/url/url.test.ts:
(pass) url > URL throws [13.19ms]
(pass) url > should have correct origin and protocol [12.44ms]
(pass) url > blob urls [8.15ms]
(pass) url > prints [8.14ms]
(pass) url > works [13.09ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.54ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.59ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.30ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.24ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.27ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.27ms]
(pass) url > URL.canParse > URL.canParse(a, https://b/) [0.30ms]
(pass) url > URL.canParse > URL.canParse.length should be 1 [1.49ms]
(pass) url > URLSearchParams constructed from an object interleaves Get with value conversion [4.34ms]
(pass) url.searchParams lazy href sync > reflects mutations in every URL getter and across component setters [20.72ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     609206c65d
  features     baseline

22 deps, 106 codegen, 1169 objects in 905ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [27.00ms]
[2/1232] fetch picohttpparser
[picohttpparser] up to date
[3/1232] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1232] gen ErrorCode+*.h
[5/1232] fetch zlib
[zlib] up to date
[6/1232] fetch tinycc
[tinycc] up to date
[7/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1232] gen .bind.ts → GeneratedBindings.cpp
[9/1232] gen bindgenv2
[10/1232] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [20.00ms]
[11/1232] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/binding
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/DOMURL.cpp          |  20 ++++++
 src/jsc/bindings/DOMURL.h            |  21 +++++-
 src/jsc/bindings/URLSearchParams.cpp |   2 +-
 test/js/web/url/url.test.ts          | 126 +++++++++++++++++++++++++++++++++++
 4 files changed, 165 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/jsc/bindings/DOMURL.cpp               1      1      0
src/jsc/bindings/DOMURL.h                 1      2      0
src/jsc/bindings/URLSearchParams.cpp      1      1      0
test/js/web/url/url.test.ts               1      1      0
```

</details>

<!-- robobun:evidence:end -->