### PR TITLE
test: surface ASAN status to leak fixtures via bunEnv

### DIFF
--- a/test/cli/run/cjs-fixture-leak-small.js
+++ b/test/cli/run/cjs-fixture-leak-small.js
@@ -1,14 +1,9 @@
 const dest = require.resolve("./leak-fixture-small-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under ASAN; widen the threshold to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 
 let gc = globalThis.gc;
 if (typeof Bun !== "undefined") {

--- a/test/cli/run/cjs-fixture-leak-small.js
+++ b/test/cli/run/cjs-fixture-leak-small.js
@@ -1,7 +1,14 @@
 const dest = require.resolve("./leak-fixture-small-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the threshold to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the threshold to avoid false positives.
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 
 let gc = globalThis.gc;
 if (typeof Bun !== "undefined") {

--- a/test/cli/run/esm-bug-leak-fixture.mjs
+++ b/test/cli/run/esm-bug-leak-fixture.mjs
@@ -3,14 +3,9 @@ const require = createRequire(import.meta.url);
 const dest = await import.meta.resolve("./esm-leak-fixture-large-ast.mjs");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under ASAN; widen the threshold to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/esm-bug-leak-fixture.mjs
+++ b/test/cli/run/esm-bug-leak-fixture.mjs
@@ -2,8 +2,15 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const dest = await import.meta.resolve("./esm-leak-fixture-large-ast.mjs");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the threshold to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the threshold to avoid false positives.
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/esm-fixture-leak-small.mjs
+++ b/test/cli/run/esm-fixture-leak-small.mjs
@@ -3,14 +3,9 @@ const require = createRequire(import.meta.url);
 const dest = require.resolve("./leak-fixture-small-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under ASAN; widen the threshold to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/esm-fixture-leak-small.mjs
+++ b/test/cli/run/esm-fixture-leak-small.mjs
@@ -2,8 +2,15 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const dest = require.resolve("./leak-fixture-small-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the threshold to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the threshold to avoid false positives.
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/require-cache-bug-leak-fixture.js
+++ b/test/cli/run/require-cache-bug-leak-fixture.js
@@ -1,14 +1,9 @@
 const dest = require.resolve("./require-cache-bug-leak-fixture-large-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under ASAN; widen the threshold to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/require-cache-bug-leak-fixture.js
+++ b/test/cli/run/require-cache-bug-leak-fixture.js
@@ -1,7 +1,14 @@
 const dest = require.resolve("./require-cache-bug-leak-fixture-large-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the threshold to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the threshold to avoid false positives.
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -85,6 +85,10 @@ const ciEnv = { ...bunEnv };
 
 if (isASAN) {
   bunEnv.ASAN_OPTIONS ??= "allow_user_segv_handler=1:disable_coredump=0";
+  // Leak fixtures spawned as subprocesses can't import from "harness", so
+  // surface the detectASAN() result through the environment and let them
+  // branch their RSS thresholds on `process.env.BUN_TEST_IS_ASAN`.
+  bunEnv.BUN_TEST_IS_ASAN = "1";
 }
 
 if (isWindows) {

--- a/test/js/bun/http/server-fetch-string-leak-fixture.js
+++ b/test/js/bun/http/server-fetch-string-leak-fixture.js
@@ -3,7 +3,14 @@
 // bun.String. Both code paths are exercised:
 //   - absolute URL with a hostname (dupe branch)
 //   - relative path with no hostname (append-to-base-url branch)
-const isASAN = process.execPath.includes("bun-asan");
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 using server = Bun.serve({
   port: 0,
   fetch() {

--- a/test/js/bun/http/server-fetch-string-leak-fixture.js
+++ b/test/js/bun/http/server-fetch-string-leak-fixture.js
@@ -3,14 +3,9 @@
 // bun.String. Both code paths are exercised:
 //   - absolute URL with a hostname (dupe branch)
 //   - relative path with no hostname (append-to-base-url branch)
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 using server = Bun.serve({
   port: 0,
   fetch() {

--- a/test/js/bun/io/bun-write-leak-fixture.js
+++ b/test/js/bun/io/bun-write-leak-fixture.js
@@ -2,7 +2,14 @@
 // debug builds of JavaScriptCore
 // ASAN's quarantine retains freed allocations (default 256 MB) and shadow memory
 // raises the absolute RSS floor, so widen the cap to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 const MAX_ALLOWED_MEMORY_USAGE = isASAN ? 768 : 256;
 const dest = process.argv.at(-1);
 

--- a/test/js/bun/io/bun-write-leak-fixture.js
+++ b/test/js/bun/io/bun-write-leak-fixture.js
@@ -2,14 +2,9 @@
 // debug builds of JavaScriptCore
 // ASAN's quarantine retains freed allocations (default 256 MB) and shadow memory
 // raises the absolute RSS floor, so widen the cap to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 const MAX_ALLOWED_MEMORY_USAGE = isASAN ? 768 : 256;
 const dest = process.argv.at(-1);
 

--- a/test/js/node/http2/node-http2-memory-leak.js
+++ b/test/js/node/http2/node-http2-memory-leak.js
@@ -2,8 +2,15 @@ import { heapStats } from "bun:jsc";
 
 // This file is meant to be able to run in node and bun
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the threshold to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the threshold to avoid false positives.
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 const http2 = require("http2");
 const { TLS_OPTIONS, nodeEchoServer } = require("./http2-helpers.cjs");
 function getHeapStats() {

--- a/test/js/node/http2/node-http2-memory-leak.js
+++ b/test/js/node/http2/node-http2-memory-leak.js
@@ -3,14 +3,9 @@ import { heapStats } from "bun:jsc";
 // This file is meant to be able to run in node and bun
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under ASAN; widen the threshold to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 const http2 = require("http2");
 const { TLS_OPTIONS, nodeEchoServer } = require("./http2-helpers.cjs");
 function getHeapStats() {

--- a/test/js/node/url/pathToFileURL-leak-fixture.js
+++ b/test/js/node/url/pathToFileURL-leak-fixture.js
@@ -2,14 +2,9 @@ var longPath = Buffer.alloc(1021, "Z").toString();
 const isDebugBuildOfBun = globalThis?.Bun?.revision?.includes("debug");
 // ASAN's quarantine retains freed allocations (default 256 MB) and shadow
 // memory raises the absolute RSS floor; widen the cap to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 import { pathToFileURL } from "url";
 for (let i = 0; i < 1024 * (isDebugBuildOfBun ? 32 : 256); i++) {
   pathToFileURL(longPath);

--- a/test/js/node/url/pathToFileURL-leak-fixture.js
+++ b/test/js/node/url/pathToFileURL-leak-fixture.js
@@ -2,7 +2,14 @@ var longPath = Buffer.alloc(1021, "Z").toString();
 const isDebugBuildOfBun = globalThis?.Bun?.revision?.includes("debug");
 // ASAN's quarantine retains freed allocations (default 256 MB) and shadow
 // memory raises the absolute RSS floor; widen the cap to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 import { pathToFileURL } from "url";
 for (let i = 0; i < 1024 * (isDebugBuildOfBun ? 32 : 256); i++) {
   pathToFileURL(longPath);

--- a/test/js/web/fetch/fetch-leak-test-fixture-2.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-2.js
@@ -8,15 +8,10 @@ if (typeof SERVER === "undefined" || !SERVER?.length) {
 
 const COUNT = parseInt(process.env.COUNT || "50", 10);
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under ASAN; widen the per-request threshold there. Probe the
-// runtime (same as harness.ts) because a local `bun bd` debug build is
-// ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// run far higher under ASAN; widen the per-request threshold there. harness.ts
+// sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is ASAN-instrumented
+// (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 var oks = 0;
 var textLength = 0;
 Bun.gc(true);

--- a/test/js/web/fetch/fetch-leak-test-fixture-2.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-2.js
@@ -8,8 +8,15 @@ if (typeof SERVER === "undefined" || !SERVER?.length) {
 
 const COUNT = parseInt(process.env.COUNT || "50", 10);
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the per-request threshold there.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the per-request threshold there. Probe the
+// runtime (same as harness.ts) because a local `bun bd` debug build is
+// ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 var oks = 0;
 var textLength = 0;
 Bun.gc(true);

--- a/test/js/web/timers/setInterval-leak-fixture.js
+++ b/test/js/web/timers/setInterval-leak-fixture.js
@@ -3,14 +3,9 @@ const initialRuns = 10_000;
 let runs = initialRuns;
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under ASAN; widen the threshold to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 
 function usage() {
   return process.memoryUsage.rss();

--- a/test/js/web/timers/setInterval-leak-fixture.js
+++ b/test/js/web/timers/setInterval-leak-fixture.js
@@ -2,8 +2,15 @@ const delta = 1;
 const initialRuns = 10_000;
 let runs = initialRuns;
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the threshold to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the threshold to avoid false positives.
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 
 function usage() {
   return process.memoryUsage.rss();

--- a/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
+++ b/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
@@ -10,8 +10,15 @@ if (mode !== "clear" && mode !== "refresh" && mode !== "repeat") {
 }
 
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
-// run far higher under bun-asan; widen the threshold to avoid false positives.
-const isASAN = process.execPath.includes("bun-asan");
+// run far higher under ASAN; widen the threshold to avoid false positives.
+// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
+// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
+const isASAN = (() => {
+  try {
+    return require("bun:internal-for-testing").isASANEnabled();
+  } catch {}
+  return process.execPath.includes("bun-asan");
+})();
 
 const BATCH = 2_000;
 

--- a/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
+++ b/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
@@ -11,14 +11,9 @@ if (mode !== "clear" && mode !== "refresh" && mode !== "repeat") {
 
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under ASAN; widen the threshold to avoid false positives.
-// Probe the runtime (same as harness.ts) because a local `bun bd` debug build
-// is ASAN-instrumented but named `bun-debug`, not `bun-asan`.
-const isASAN = (() => {
-  try {
-    return require("bun:internal-for-testing").isASANEnabled();
-  } catch {}
-  return process.execPath.includes("bun-asan");
-})();
+// harness.ts sets BUN_TEST_IS_ASAN in bunEnv when the parent test process is
+// ASAN-instrumented (covers both CI's `bun-asan` and local `bun bd` debug builds).
+const isASAN = process.env.BUN_TEST_IS_ASAN === "1";
 
 const BATCH = 2_000;
 


### PR DESCRIPTION
## Problem

Eleven leak-test fixtures detect ASAN with `process.execPath.includes("bun-asan")`. That is true on CI's ASAN lane (the binary is literally named `bun-asan`) but false for a local `bun bd` build, which is ASAN-instrumented but named `bun-debug`. So the fixtures apply the tight non-ASAN RSS threshold locally and report false leaks.

Repro on main:

```
$ bun bd test test/js/web/timers/setTimeout.test.js -t "doesn't leak when"
(fail) setTimeout doesn't leak when clear is called inside its own callback
  error: Memory leak detected: RSS grew by 139.7 MB
(fail) setTimeout doesn't leak when refresh is called inside its own callback
(fail) setTimeout doesn't leak when repeat is called inside its own callback
 0 pass / 3 fail
```

The 10 MB cap is compared against the ~138 MB ASAN-quarantine growth because `isASAN` is false; the 192 MB ASAN cap is never selected. CI does not see this because `bun-asan` matches the name check.

## Fix

`test/harness.ts` already detects ASAN correctly via `isASANEnabled()` from `bun:internal-for-testing` (a compile-time `#if ASAN_ENABLED` probe), and every one of these fixtures is spawned with `env: bunEnv` (either directly or via the `toRun` matcher). So set `bunEnv.BUN_TEST_IS_ASAN = "1"` once inside harness.ts's existing `if (isASAN)` block, and have each fixture read `process.env.BUN_TEST_IS_ASAN` instead of re-detecting.

This is the second lockstep edit of the same detection snippet across these eleven files (`fba43af684` added the name check to each); centralizing it in `bunEnv` means there isn't a third. The env var is runtime-agnostic (works under Node for the dual-runtime fixtures) and survives the tempdir-copy pattern used by `bun-write-leak.test.ts`.

The change only widens the RSS threshold on a binary the harness has confirmed is ASAN-instrumented, so a real leak still trips the tight threshold on release builds. CI behaviour is unchanged: `bun-asan` was already detected before, and still is.

## Verification

Under `./build/debug/bun-debug`:

```
execPath.includes("bun-asan") -> false   (old check)
harness.ts detectASAN()        -> true   (now surfaced as BUN_TEST_IS_ASAN=1)
```

`bun bd test test/js/web/timers/setTimeout.test.js -t "doesn't leak when"` now passes (3/3).

Files touched (all with the identical one-line env read):

- `test/harness.ts` (+`BUN_TEST_IS_ASAN` inside the existing `if (isASAN)` block)
- `test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js`
- `test/js/web/timers/setInterval-leak-fixture.js`
- `test/js/bun/http/server-fetch-string-leak-fixture.js`
- `test/js/bun/io/bun-write-leak-fixture.js`
- `test/js/web/fetch/fetch-leak-test-fixture-2.js`
- `test/js/node/url/pathToFileURL-leak-fixture.js`
- `test/js/node/http2/node-http2-memory-leak.js`
- `test/cli/run/esm-bug-leak-fixture.mjs`
- `test/cli/run/require-cache-bug-leak-fixture.js`
- `test/cli/run/cjs-fixture-leak-small.js`
- `test/cli/run/esm-fixture-leak-small.mjs`

`test/js/node/async_hooks/async-context/async-context-fs-watch.js` is intentionally excluded: it is a skip guard (`process.exit(0)`) rather than an RSS threshold, and the fixture already passes under `bun bd`, so widening the skip there would hide a passing test.

This is a test-infrastructure fix with no `src/` change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->