### PR TITLE
Bun.serve: don't panic reading server.address/port when getsockname() fails

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2883,10 +2883,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 // SAFETY: ls is a live uws ListenSocket FFI handle
                                 // (just set by on_listen).
                                 Some(ls) => {
-                                    u16::try_from(
-                                        bun_opaque::opaque_deref_mut(ls).get_local_port(),
-                                    )
-                                    .unwrap_or(port)
+                                    u16::try_from(bun_opaque::opaque_deref_mut(ls).get_local_port())
+                                        .unwrap_or(port)
                                 }
                                 None => port,
                             };

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -505,11 +505,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let mut port = *port;
                 if let Some(listener) = self.listener {
                     // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                    port = bun_opaque::opaque_deref_mut(listener).get_local_port() as u16;
+                    if let Ok(p) =
+                        u16::try_from(bun_opaque::opaque_deref_mut(listener).get_local_port())
+                    {
+                        port = p;
+                    }
                 } else if Self::HAS_H3 {
                     if let Some(h3l) = self.h3_listener {
                         // S012: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                        port = bun_opaque::opaque_deref_mut(h3l).get_local_port() as u16;
+                        if let Ok(p) =
+                            u16::try_from(bun_opaque::opaque_deref_mut(h3l).get_local_port())
+                        {
+                            port = p;
+                        }
                     }
                 }
                 URLFormatter {
@@ -1919,9 +1927,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
         let port = bun_opaque::opaque_deref_mut(socket).get_local_port();
         self.h3_listener = Some(socket);
-        self.h3_alt_svc = format!("h3=\":{port}\"; ma=86400")
-            .into_bytes()
-            .into_boxed_slice();
+        if let Ok(port) = u16::try_from(port) {
+            self.h3_alt_svc = format!("h3=\":{port}\"; ma=86400")
+                .into_bytes()
+                .into_boxed_slice();
+        }
         // An `http3_server` feature counter is not (yet) declared in
         // `bun_analytics`. No-op until it is.
     }
@@ -2873,7 +2883,10 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                                 // SAFETY: ls is a live uws ListenSocket FFI handle
                                 // (just set by on_listen).
                                 Some(ls) => {
-                                    bun_opaque::opaque_deref_mut(ls).get_local_port() as u16
+                                    u16::try_from(
+                                        bun_opaque::opaque_deref_mut(ls).get_local_port(),
+                                    )
+                                    .unwrap_or(port)
                                 }
                                 None => port,
                             };

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -505,19 +505,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 let mut port = *port;
                 if let Some(listener) = self.listener {
                     // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-                    if let Ok(p) =
-                        u16::try_from(bun_opaque::opaque_deref_mut(listener).get_local_port())
-                    {
-                        port = p;
-                    }
+                    port = bun_opaque::opaque_deref_mut(listener)
+                        .get_local_port()
+                        .unwrap_or(port);
                 } else if Self::HAS_H3 {
                     if let Some(h3l) = self.h3_listener {
                         // S012: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                        if let Ok(p) =
-                            u16::try_from(bun_opaque::opaque_deref_mut(h3l).get_local_port())
-                        {
-                            port = p;
-                        }
+                        port = bun_opaque::opaque_deref_mut(h3l)
+                            .get_local_port()
+                            .unwrap_or(port);
                     }
                 }
                 URLFormatter {
@@ -1927,7 +1923,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
         let port = bun_opaque::opaque_deref_mut(socket).get_local_port();
         self.h3_listener = Some(socket);
-        if let Ok(port) = u16::try_from(port) {
+        if let Some(port) = port {
             self.h3_alt_svc = format!("h3=\":{port}\"; ma=86400")
                 .into_bytes()
                 .into_boxed_slice();
@@ -2882,10 +2878,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             let h3_port: u16 = match this_ref.listener {
                                 // SAFETY: ls is a live uws ListenSocket FFI handle
                                 // (just set by on_listen).
-                                Some(ls) => {
-                                    u16::try_from(bun_opaque::opaque_deref_mut(ls).get_local_port())
-                                        .unwrap_or(port)
-                                }
+                                Some(ls) => bun_opaque::opaque_deref_mut(ls)
+                                    .get_local_port()
+                                    .unwrap_or(port),
                                 None => port,
                             };
                             // S008: `h3::App` is an `opaque_ffi!` ZST — safe deref.

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2521,14 +2521,14 @@ where
 
         if let Some(listener) = self.listener {
             // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-            if let Ok(p) = u16::try_from(bun_opaque::opaque_deref_mut(listener).get_local_port()) {
+            if let Some(p) = bun_opaque::opaque_deref_mut(listener).get_local_port() {
                 return JSValue::js_number(p as f64);
             }
         }
         if Self::HAS_H3 {
             if let Some(h3l) = self.h3_listener {
                 // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                if let Ok(p) = u16::try_from(bun_opaque::opaque_deref_mut(h3l).get_local_port()) {
+                if let Some(p) = bun_opaque::opaque_deref_mut(h3l).get_local_port() {
                     return JSValue::js_number(p as f64);
                 }
             }
@@ -2567,12 +2567,7 @@ where
                 if let Some(listener) = self.listener {
                     // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
                     let listener = bun_opaque::opaque_deref_mut(listener);
-                    // `us_socket_local_port()` returns -1 when getsockname()
-                    // fails; fall back to the configured port rather than
-                    // panicking on the out-of-range cast.
-                    if let Ok(p) = u16::try_from(listener.get_local_port()) {
-                        port = p;
-                    }
+                    port = listener.get_local_port().unwrap_or(port);
 
                     let mut buf = [0u8; 64];
                     let Some(address_bytes) = listener.socket().local_address(&mut buf) else {
@@ -2591,9 +2586,7 @@ where
                     if let Some(h3l) = self.h3_listener {
                         // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
                         let h3l = bun_opaque::opaque_deref_mut(h3l);
-                        if let Ok(p) = u16::try_from(h3l.get_local_port()) {
-                            port = p;
-                        }
+                        port = h3l.get_local_port().unwrap_or(port);
                         let mut buf = [0u8; 64];
                         let Some(address_bytes) = h3l.get_local_address(&mut buf) else {
                             return Ok(JSValue::NULL);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2514,28 +2514,26 @@ where
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_port(&self, _: &JSGlobalObject) -> JSValue {
-        if matches!(self.config.address, server_config::Address::Unix(_)) {
-            return JSValue::UNDEFINED;
-        }
+        let config_port = match &self.config.address {
+            server_config::Address::Unix(_) => return JSValue::UNDEFINED,
+            server_config::Address::Tcp { port, .. } => *port,
+        };
 
         if let Some(listener) = self.listener {
             // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
-            return JSValue::js_number(
-                bun_opaque::opaque_deref_mut(listener).get_local_port() as f64
-            );
+            if let Ok(p) = u16::try_from(bun_opaque::opaque_deref_mut(listener).get_local_port()) {
+                return JSValue::js_number(p as f64);
+            }
         }
         if Self::HAS_H3 {
             if let Some(h3l) = self.h3_listener {
                 // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                return JSValue::js_number(
-                    bun_opaque::opaque_deref_mut(h3l).get_local_port() as f64
-                );
+                if let Ok(p) = u16::try_from(bun_opaque::opaque_deref_mut(h3l).get_local_port()) {
+                    return JSValue::js_number(p as f64);
+                }
             }
         }
-        match &self.config.address {
-            server_config::Address::Tcp { port, .. } => JSValue::js_number(*port as f64),
-            server_config::Address::Unix(_) => unreachable!(),
-        }
+        JSValue::js_number(config_port as f64)
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -2569,7 +2567,12 @@ where
                 if let Some(listener) = self.listener {
                     // S008: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
                     let listener = bun_opaque::opaque_deref_mut(listener);
-                    port = u16::try_from(listener.get_local_port()).expect("int cast");
+                    // `us_socket_local_port()` returns -1 when getsockname()
+                    // fails; fall back to the configured port rather than
+                    // panicking on the out-of-range cast.
+                    if let Ok(p) = u16::try_from(listener.get_local_port()) {
+                        port = p;
+                    }
 
                     let mut buf = [0u8; 64];
                     let Some(address_bytes) = listener.socket().local_address(&mut buf) else {
@@ -2588,7 +2591,9 @@ where
                     if let Some(h3l) = self.h3_listener {
                         // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
                         let h3l = bun_opaque::opaque_deref_mut(h3l);
-                        port = u16::try_from(h3l.get_local_port()).expect("int cast");
+                        if let Ok(p) = u16::try_from(h3l.get_local_port()) {
+                            port = p;
+                        }
                         let mut buf = [0u8; 64];
                         let Some(address_bytes) = h3l.get_local_address(&mut buf) else {
                             return Ok(JSValue::NULL);

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -440,8 +440,10 @@ impl Listener {
                 });
                 if !ls.is_null() {
                     // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                    *port = u16::try_from(bun_opaque::opaque_deref_mut(ls).get_local_port())
-                        .expect("int cast");
+                    if let Ok(p) = u16::try_from(bun_opaque::opaque_deref_mut(ls).get_local_port())
+                    {
+                        *port = p;
+                    }
                 }
                 ls
             }

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1418,7 +1418,10 @@ impl Listener {
             _ => return Ok(JSValue::UNDEFINED),
         };
         let address_js = ZigString::init(formatted).to_js(global);
-        let port_js = JSValue::js_number(socket_ref.get_local_port() as f64);
+        let port_js = match u16::try_from(socket_ref.get_local_port()) {
+            Ok(p) => JSValue::js_number(p as f64),
+            Err(_) => JSValue::UNDEFINED,
+        };
 
         out.put(global, b"family", family_js);
         out.put(global, b"address", address_js);

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -440,8 +440,7 @@ impl Listener {
                 });
                 if !ls.is_null() {
                     // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                    if let Ok(p) = u16::try_from(bun_opaque::opaque_deref_mut(ls).get_local_port())
-                    {
+                    if let Some(p) = bun_opaque::opaque_deref_mut(ls).get_local_port() {
                         *port = p;
                     }
                 }
@@ -1418,9 +1417,9 @@ impl Listener {
             _ => return Ok(JSValue::UNDEFINED),
         };
         let address_js = ZigString::init(formatted).to_js(global);
-        let port_js = match u16::try_from(socket_ref.get_local_port()) {
-            Ok(p) => JSValue::js_number(p as f64),
-            Err(_) => JSValue::UNDEFINED,
+        let port_js = match socket_ref.get_local_port() {
+            Some(p) => JSValue::js_number(p as f64),
+            None => JSValue::UNDEFINED,
         };
 
         out.put(global, b"family", family_js);

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2342,7 +2342,10 @@ impl<const SSL: bool> NewSocket<SSL> {
             return JSValue::UNDEFINED;
         }
 
-        JSValue::js_number_from_int32(this.socket.get().local_port())
+        match u16::try_from(this.socket.get().local_port()) {
+            Ok(p) => JSValue::js_number_from_int32(p as i32),
+            Err(_) => JSValue::UNDEFINED,
+        }
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -2400,7 +2403,10 @@ impl<const SSL: bool> NewSocket<SSL> {
             return JSValue::UNDEFINED;
         }
 
-        JSValue::js_number_from_int32(this.socket.get().remote_port())
+        match u16::try_from(this.socket.get().remote_port()) {
+            Ok(p) => JSValue::js_number_from_int32(p as i32),
+            Err(_) => JSValue::UNDEFINED,
+        }
     }
 
     #[inline]

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2338,13 +2338,9 @@ impl<const SSL: bool> NewSocket<SSL> {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_local_port(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        if this.socket.get().is_detached() {
-            return JSValue::UNDEFINED;
-        }
-
-        match u16::try_from(this.socket.get().local_port()) {
-            Ok(p) => JSValue::js_number_from_int32(p as i32),
-            Err(_) => JSValue::UNDEFINED,
+        match this.socket.get().local_port() {
+            Some(p) => JSValue::js_number_from_int32(p as i32),
+            None => JSValue::UNDEFINED,
         }
     }
 
@@ -2399,13 +2395,9 @@ impl<const SSL: bool> NewSocket<SSL> {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_remote_port(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        if this.socket.get().is_detached() {
-            return JSValue::UNDEFINED;
-        }
-
-        match u16::try_from(this.socket.get().remote_port()) {
-            Ok(p) => JSValue::js_number_from_int32(p as i32),
-            Err(_) => JSValue::UNDEFINED,
+        match this.socket.get().remote_port() {
+            Some(p) => JSValue::js_number_from_int32(p as i32),
+            None => JSValue::UNDEFINED,
         }
     }
 

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -429,7 +429,7 @@ impl<const SSL: bool> ListenSocket<SSL> {
     }
 
     #[inline]
-    pub fn get_local_port(&mut self) -> i32 {
+    pub fn get_local_port(&mut self) -> Option<u16> {
         // S008: opaque ZST cast as above.
         bun_opaque::opaque_deref_mut(std::ptr::from_mut::<Self>(self).cast::<UwsListenSocket>())
             .get_local_port()

--- a/src/uws_sys/ListenSocket.rs
+++ b/src/uws_sys/ListenSocket.rs
@@ -18,7 +18,7 @@ impl ListenSocket {
         self.get_socket().local_address(buf)
     }
 
-    pub fn get_local_port(&mut self) -> i32 {
+    pub fn get_local_port(&mut self) -> Option<u16> {
         self.get_socket().local_port()
     }
 

--- a/src/uws_sys/h3.rs
+++ b/src/uws_sys/h3.rs
@@ -20,8 +20,8 @@ impl ListenSocket {
     pub fn close(&mut self) {
         c::uws_h3_listen_socket_close(self)
     }
-    pub fn get_local_port(&mut self) -> i32 {
-        c::uws_h3_listen_socket_port(self)
+    pub fn get_local_port(&mut self) -> Option<u16> {
+        u16::try_from(c::uws_h3_listen_socket_port(self)).ok()
     }
     pub fn get_local_address<'a>(&mut self, buf: &'a mut [u8]) -> Option<&'a [u8]> {
         // SAFETY: self is a live FFI handle; buf ptr/len valid for write

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -651,26 +651,16 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
 
     pub fn local_address<'b>(&self, buf: &'b mut [u8]) -> Option<&'b [u8]> {
         match self.socket {
-            InternalSocket::Connected(s) => match sock(s).local_address(buf) {
-                Ok(v) => Some(v),
-                Err(e) => bun_core::Output::panic(format_args!(
-                    "Failed to get socket's local address: {}",
-                    e.name()
-                )),
-            },
+            // getsockname() can fail (EBADF/ENOTCONN/…) on a socket the OS
+            // closed or reset underneath us; callers treat that as "no address".
+            InternalSocket::Connected(s) => sock(s).local_address(buf).ok(),
             _ => None,
         }
     }
 
     pub fn remote_address<'b>(&self, buf: &'b mut [u8]) -> Option<&'b [u8]> {
         match self.socket {
-            InternalSocket::Connected(s) => match sock(s).remote_address(buf) {
-                Ok(v) => Some(v),
-                Err(e) => bun_core::Output::panic(format_args!(
-                    "Failed to get socket's remote address: {}",
-                    e.name()
-                )),
-            },
+            InternalSocket::Connected(s) => sock(s).remote_address(buf).ok(),
             _ => None,
         }
     }

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -635,17 +635,17 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         }
     }
 
-    pub fn local_port(&self) -> i32 {
+    pub fn local_port(&self) -> Option<u16> {
         match self.socket {
             InternalSocket::Connected(s) => sock(s).local_port(),
-            _ => 0,
+            _ => None,
         }
     }
 
-    pub fn remote_port(&self) -> i32 {
+    pub fn remote_port(&self) -> Option<u16> {
         match self.socket {
             InternalSocket::Connected(s) => sock(s).remote_port(),
-            _ => 0,
+            _ => None,
         }
     }
 
@@ -945,7 +945,7 @@ impl AnySocket {
         fn set_timeout(&self, seconds: c_uint);
         fn shutdown(&self);
         fn shutdown_read(&self);
-        fn local_port(&self) -> i32;
+        fn local_port(&self) -> Option<u16>;
         fn get_native_handle(&self) -> Option<*mut c_void>;
     }
 }

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -122,12 +122,14 @@ impl us_socket_t {
         c::us_socket_is_shut_down(self) > 0
     }
 
-    pub fn local_port(&self) -> i32 {
-        c::us_socket_local_port(self)
+    /// `None` when `getsockname()` fails or the address family has no port.
+    pub fn local_port(&self) -> Option<u16> {
+        u16::try_from(c::us_socket_local_port(self)).ok()
     }
 
-    pub fn remote_port(&self) -> i32 {
-        c::us_socket_remote_port(self)
+    /// `None` when `getpeername()` fails or the address family has no port.
+    pub fn remote_port(&self) -> Option<u16> {
+        u16::try_from(c::us_socket_remote_port(self)).ok()
     }
 
     /// Returned slice is a view into `buf`.

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -1,6 +1,6 @@
 import { file, serve } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tmpdirSync } from "harness";
 import type { NetworkInterfaceInfo } from "node:os";
 import { networkInterfaces } from "node:os";
 import { join } from "node:path";
@@ -159,4 +159,68 @@ describe.each([
       expect({ protocol, hostname, port, pathname }).toMatchObject(url);
     });
   });
+});
+
+// Linux-only: uses /proc/self/fd to find the listen socket and close it from
+// under the server so getsockname() fails with EBADF.
+test.skipIf(!isLinux)("server.address / server.port do not panic when getsockname() fails", async () => {
+  const script = /* js */ `
+    import { readdirSync, readlinkSync, closeSync } from "node:fs";
+
+    function socketFds() {
+      const out = new Set();
+      for (const e of readdirSync("/proc/self/fd")) {
+        let link = "";
+        try { link = readlinkSync("/proc/self/fd/" + e); } catch {}
+        if (link.startsWith("socket:")) out.add(Number(e));
+      }
+      return out;
+    }
+
+    const before = socketFds();
+    const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    const boundPort = server.port;
+    const after = socketFds();
+    const newFds = [...after].filter(fd => !before.has(fd));
+
+    if (newFds.length === 0) {
+      console.log(JSON.stringify({ skipped: true }));
+      server.stop(true);
+      process.exit(0);
+    }
+
+    for (const fd of newFds) closeSync(fd);
+
+    // These property reads must not abort the process.
+    const address = server.address;
+    const port = server.port;
+    const url = String(server.url);
+
+    console.log(JSON.stringify({ address, port, url, boundPort }));
+    server.stop(true);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  const out = JSON.parse(stdout.trim());
+  if (out.skipped) return;
+
+  // getsockname() failed, so the live query returns nothing; the configured
+  // port (0) is all that's left. The important guarantees are: no crash, and
+  // no out-of-range garbage (e.g. -1 or 65535) leaking through.
+  expect({ address: out.address, port: out.port }).toEqual({ address: null, port: 0 });
+  expect(out.url).not.toContain("65535");
+  expect(out.url).not.toContain(":-1");
 });

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -205,11 +205,7 @@ test.skipIf(!isLinux)("server.address / server.port do not panic when getsocknam
     env: bunEnv,
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -8,6 +8,7 @@ import {
   bunExe,
   expectMaxObjectTypeCount,
   getMaxFD,
+  isLinux,
   isWindows,
   libcPathForDlopen,
   tempDir,
@@ -3101,4 +3102,71 @@ Reo=
       expect(t.serverReceived.join("")).toBe("client-app-data\n");
     });
   });
+});
+
+// Linux-only: uses /proc/self/fd to find and close the connected socket's fd
+// so getsockname()/getpeername() fail with EBADF.
+it.skipIf(!isLinux)("socket.localPort / socket.remotePort return undefined when the underlying fd is gone", async () => {
+  const script = /* js */ `
+    import { readdirSync, readlinkSync, closeSync } from "node:fs";
+
+    function socketFds() {
+      const out = new Set();
+      for (const e of readdirSync("/proc/self/fd")) {
+        let link = "";
+        try { link = readlinkSync("/proc/self/fd/" + e); } catch {}
+        if (link.startsWith("socket:")) out.add(Number(e));
+      }
+      return out;
+    }
+
+    const opened = Promise.withResolvers();
+    const server = Bun.listen({
+      port: 0,
+      hostname: "127.0.0.1",
+      socket: { open() {}, data() {}, close() {} },
+    });
+
+    const before = socketFds();
+    const client = await Bun.connect({
+      port: server.port,
+      hostname: "127.0.0.1",
+      socket: { open: opened.resolve, data() {}, close() {} },
+    });
+    await opened.promise;
+
+    const after = socketFds();
+    const newFds = [...after].filter(fd => !before.has(fd));
+    if (newFds.length === 0) {
+      console.log(JSON.stringify({ skipped: true }));
+      server.stop(true);
+      process.exit(0);
+    }
+    for (const fd of newFds) closeSync(fd);
+
+    console.log(JSON.stringify({
+      localPort: client.localPort ?? null,
+      remotePort: client.remotePort ?? null,
+    }));
+    server.stop(true);
+    process.exit(0);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+
+  const out = JSON.parse(stdout.trim());
+  if (out.skipped) return;
+  expect(out).toEqual({ localPort: null, remotePort: null });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3106,8 +3106,10 @@ Reo=
 
 // Linux-only: uses /proc/self/fd to find and close the connected socket's fd
 // so getsockname()/getpeername() fail with EBADF.
-it.skipIf(!isLinux)("socket.localPort / socket.remotePort return undefined when the underlying fd is gone", async () => {
-  const script = /* js */ `
+it.skipIf(!isLinux)(
+  "socket.localPort / socket.remotePort return undefined when the underlying fd is gone",
+  async () => {
+    const script = /* js */ `
     import { readdirSync, readlinkSync, closeSync } from "node:fs";
 
     function socketFds() {
@@ -3152,21 +3154,18 @@ it.skipIf(!isLinux)("socket.localPort / socket.remotePort return undefined when 
     process.exit(0);
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
 
-  const out = JSON.parse(stdout.trim());
-  if (out.skipped) return;
-  expect(out).toEqual({ localPort: null, remotePort: null });
-});
+    const out = JSON.parse(stdout.trim());
+    if (out.skipped) return;
+    expect(out).toEqual({ localPort: null, remotePort: null });
+  },
+);


### PR DESCRIPTION
## What

Reading `server.address` (and by extension `server.port`, `server.url`) on a `Bun.serve()` server aborts the process with

```
panic: int cast: TryFromIntError(NegOverflow)
```

when the listening socket's `getsockname()` query fails. This matches a live crash class in Sentry (`int cast: TryFromIntError`, both `NegOverflow` and `PosOverflow`).

## Repro

```js
import { readdirSync, readlinkSync, closeSync } from "node:fs";

const socketFds = () =>
  new Set(
    readdirSync("/proc/self/fd").filter(e => {
      try { return readlinkSync("/proc/self/fd/" + e).startsWith("socket:"); }
      catch { return false; }
    }).map(Number),
  );

const before = socketFds();
const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
for (const fd of [...socketFds()].filter(fd => !before.has(fd))) closeSync(fd);

server.address; // panic: int cast: TryFromIntError(NegOverflow)
```

## Cause

`us_socket_local_port()` in `packages/bun-usockets/src/socket.c` documents an error return: when `getsockname()` fails it returns `-1`. `get_address` in `src/runtime/server/server_body.rs` pipes that straight into `u16::try_from(...).expect("int cast")`, so the `-1` becomes a `TryFromIntError` and `.expect` aborts the process.

The very next line would have panicked too: `NewSocketHandler::local_address()` in `src/uws_sys/socket.rs` called `Output::panic` on the same `getsockname()` error.

Several nearby sites did `as u16` on the same `-1`, silently wrapping it to `65535` (so `server.url` would read `http://localhost:65535/`).

## Fix

* `NewSocketHandler::{local_address, remote_address}` now return `None` on syscall failure instead of aborting; every caller already handles `None`.
* Every socket-derived port read (`get_address`, `get_port`, `get_url_as_string`, `on_h3_listen`, the H3 listen port, and `Bun.listen`'s port readback) now uses `u16::try_from(...)` and falls back to the configured port on an out-of-range value instead of `.expect`ing or `as`-wrapping.

After the fix, with the listening fd closed underneath:
* `server.address` returns `null` (same as its other failure paths)
* `server.port` returns the configured port
* `server.url` uses the configured port rather than `65535`

## Test

Added to `test/js/bun/http/serve-listen.test.ts` (Linux-only, uses `/proc/self/fd` to locate and close the listen fd, then reads the getters in a subprocess and asserts exit 0 with `address === null`, `port === 0`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-listen.test.ts test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->