### PR TITLE
test: keep --watch alive when --bail stops a run

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1348,26 +1348,23 @@ impl CommandLineReporter {
                     // sequences run; the per-file loop in `run_all_tests` and
                     // the `--rerun-each` loop in `run` both check `bailed`.
                     buntest.execution.aborted = true;
-                    if VirtualMachine::get().hot_reload == jsc::virtual_machine::HOT_RELOAD_WATCH {
-                        // Under --watch the run unwinds back to `exec`, which
-                        // prints the full summary and enters the watch loop.
-                        pretty_error!(
-                            "\nBailed out after {} failure{}<r>\n",
-                            this.jest.bail,
-                            if this.jest.bail == 1 { "" } else { "s" }
-                        );
-                        Output::flush();
-                    } else {
+                    let watching =
+                        VirtualMachine::get().hot_reload == jsc::virtual_machine::HOT_RELOAD_WATCH;
+                    if !watching {
                         this.print_summary();
-                        pretty_error!(
-                            "\nBailed out after {} failure{}<r>\n",
-                            this.jest.bail,
-                            if this.jest.bail == 1 { "" } else { "s" }
-                        );
-                        Output::flush();
+                    }
+                    pretty_error!(
+                        "\nBailed out after {} failure{}<r>\n",
+                        this.jest.bail,
+                        if this.jest.bail == 1 { "" } else { "s" }
+                    );
+                    Output::flush();
+                    if !watching {
                         this.write_junit_report_if_needed();
                         Global::exit(1);
                     }
+                    // Under --watch the run unwinds back to `exec`, which
+                    // prints the full summary and enters the watch loop.
                 }
             }
         }
@@ -3162,16 +3159,22 @@ impl TestCommand {
                     reporter.summary().fail += 1;
 
                     if reporter.jest.bail == reporter.summary().fail {
+                        reporter.bailed = true;
+                        let watching = vm.hot_reload == jsc::virtual_machine::HOT_RELOAD_WATCH;
+                        if !watching {
+                            reporter.print_summary();
+                        }
                         pretty_error!(
                             "\nBailed out after {} failure{}<r>\n",
                             reporter.jest.bail,
                             if reporter.jest.bail == 1 { "" } else { "s" }
                         );
-                        reporter.bailed = true;
-                        if vm.hot_reload == jsc::virtual_machine::HOT_RELOAD_WATCH {
+                        if watching {
+                            // Under --watch the run unwinds back to `exec`,
+                            // which prints the full summary and enters the
+                            // watch loop.
                             return Ok(());
                         }
-                        reporter.print_summary();
                         reporter.write_junit_report_if_needed();
 
                         vm.exit_handler.exit_code = 1;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -769,6 +769,12 @@ pub struct CommandLineReporter {
     pub skips_to_repeat_buf: Vec<u8>,
     pub todos_to_repeat_buf: Vec<u8>,
 
+    /// Set once `summary.fail` reaches `jest.bail`. Stops the per-file loop
+    /// and the `--rerun-each` repeat loop so control returns to `exec` and,
+    /// under `--watch`, reaches `run_event_loop_for_watch` instead of having
+    /// the bail path `Global::exit(1)` and kill the watcher.
+    pub bailed: bool,
+
     pub reporters: ReportersConfig,
 }
 
@@ -1337,15 +1343,31 @@ impl CommandLineReporter {
                 this.summary().fail += 1;
 
                 if this.summary().fail == this.jest.bail {
-                    this.print_summary();
-                    pretty_error!(
-                        "\nBailed out after {} failure{}<r>\n",
-                        this.jest.bail,
-                        if this.jest.bail == 1 { "" } else { "s" }
-                    );
-                    Output::flush();
-                    this.write_junit_report_if_needed();
-                    Global::exit(1);
+                    this.bailed = true;
+                    // Stop the current file's step loops so no further
+                    // sequences run; the per-file loop in `run_all_tests` and
+                    // the `--rerun-each` loop in `run` both check `bailed`.
+                    buntest.execution.aborted = true;
+                    if VirtualMachine::get().hot_reload == jsc::virtual_machine::HOT_RELOAD_WATCH {
+                        // Under --watch the run unwinds back to `exec`, which
+                        // prints the full summary and enters the watch loop.
+                        pretty_error!(
+                            "\nBailed out after {} failure{}<r>\n",
+                            this.jest.bail,
+                            if this.jest.bail == 1 { "" } else { "s" }
+                        );
+                        Output::flush();
+                    } else {
+                        this.print_summary();
+                        pretty_error!(
+                            "\nBailed out after {} failure{}<r>\n",
+                            this.jest.bail,
+                            if this.jest.bail == 1 { "" } else { "s" }
+                        );
+                        Output::flush();
+                        this.write_junit_report_if_needed();
+                        Global::exit(1);
+                    }
                 }
             }
         }
@@ -2102,6 +2124,7 @@ impl TestCommand {
             failures_to_repeat_buf: Vec::new(),
             skips_to_repeat_buf: Vec::new(),
             todos_to_repeat_buf: Vec::new(),
+            bailed: false,
             reporters: ReportersConfig::default(),
         });
         // `defer { if (reporter.reporters.junit) |fr| fr.deinit() }` — handled by Drop.
@@ -2967,6 +2990,9 @@ impl TestCommand {
                         ) {
                             handle_top_level_test_error_before_javascript_start(&err);
                         }
+                        if reporter.bailed {
+                            return;
+                        }
                         reporter.jest.default_timeout_override = u32::MAX;
                         Global::mimalloc_cleanup(false);
                         if isolate {
@@ -3136,12 +3162,16 @@ impl TestCommand {
                     reporter.summary().fail += 1;
 
                     if reporter.jest.bail == reporter.summary().fail {
-                        reporter.print_summary();
                         pretty_error!(
                             "\nBailed out after {} failure{}<r>\n",
                             reporter.jest.bail,
                             if reporter.jest.bail == 1 { "" } else { "s" }
                         );
+                        reporter.bailed = true;
+                        if vm.hot_reload == jsc::virtual_machine::HOT_RELOAD_WATCH {
+                            return Ok(());
+                        }
+                        reporter.print_summary();
                         reporter.write_junit_report_if_needed();
 
                         vm.exit_handler.exit_code = 1;
@@ -3230,6 +3260,9 @@ impl TestCommand {
                 vm.auto_killer.disable();
             }
 
+            if reporter.bailed {
+                break;
+            }
             repeat_index += 1;
         }
         Ok(())

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -100,6 +100,11 @@ pub struct Execution {
     /// `t.skip()`/`t.todo()` mark lands there before the DoneCallback is
     /// stamped).
     pub on_stack_entry_data: core::cell::Cell<Option<super::bun_test::EntryData>>,
+    /// Set by `--bail` from within `handle_test_completed` to stop the step
+    /// loops mid-run so no further sequences execute. Checked by `step_group`,
+    /// `step_group_one`, and `step`'s per-group loop; lets the run unwind
+    /// cleanly instead of `Global::exit(1)` when `--watch` is active.
+    pub aborted: bool,
 }
 
 pub struct ConcurrentGroup {
@@ -282,6 +287,7 @@ impl Execution {
             group_index: 0,
             on_stack_entry: core::cell::Cell::new(None),
             on_stack_entry_data: core::cell::Cell::new(None),
+            aborted: false,
         }
     }
 
@@ -384,6 +390,9 @@ impl Execution {
                 // re-slice from `this` each iteration via the group's range; carry
                 // `group` as NonNull so no `&mut ConcurrentGroup` aliases `&mut Execution`.
                 loop {
+                    if this.aborted {
+                        return Ok(StepResult::Complete);
+                    }
                     // SAFETY: group_ptr points into this.groups (disjoint from this.sequences).
                     let group = unsafe { &mut *group_ptr.as_ptr() };
                     let seq_len = group.sequence_end - group.sequence_start;
@@ -798,6 +807,9 @@ pub(crate) fn step_group(
     let this = &mut buntest.execution;
 
     loop {
+        if this.aborted {
+            return Ok(StepResult::Complete);
+        }
         // Carry the active group as NonNull so it does not alias `&mut Execution` re-derived
         // inside step_group_one.
         let group_ptr: NonNull<ConcurrentGroup> = match this.active_group() {
@@ -879,6 +891,11 @@ fn step_group_one(
         g.sequence_end - g.sequence_start
     };
     for sequence_index in 0..len {
+        // Fresh short-lived reborrow each iteration so it does not span
+        // `step_sequence`'s own `.get()` (stacked-borrows hygiene).
+        if buntest_strong.get().execution.aborted {
+            break;
+        }
         let sequence_status =
             step_sequence(buntest_strong, global_this, group, sequence_index, now)?;
         match sequence_status {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -369,8 +369,8 @@ describe("bun test", () => {
           "bail.test.ts": `
           import { test, expect } from "bun:test";
           import { v } from "./v";
-          test("t1", () => { expect(v).toBe(1); });
-          test("t2", () => { expect(2).toBe(2); });
+          test("test #1", () => { expect(v).toBe(1); });
+          test("test #2", () => { expect(2).toBe(2); });
         `,
         });
 
@@ -396,11 +396,12 @@ describe("bun test", () => {
           return buf.length;
         }
 
-        // First run: t1 fails, bail fires, t2 must not run, and the normal
-        // end-of-run summary must still print (not a hard exit mid-run).
+        // First run: test #1 fails, bail fires, test #2 must not run, and
+        // the normal end-of-run summary must still print (not a hard exit
+        // mid-run).
         const afterBail = await waitFor("Bailed out after 1 failure");
         await waitFor("Ran 1 test across 1 file");
-        expect(buf).not.toContain("t2");
+        expect(buf).not.toContain("test #2");
         expect(proc.exitCode).toBeNull();
 
         // Fix the failing test. The watcher should still be alive, pick up

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -356,6 +356,59 @@ describe("bun test", () => {
       expect(stderr).toContain("Bailed out after 3 failures");
       expect(stderr).not.toContain("test #4");
     });
+
+    // On Windows, `bun test --watch` runs a parent watcher-manager that
+    // respawns a child on change rather than exec()-in-place, which makes
+    // the stderr stream sync points here unreliable.
+    test.skipIf(isWindows)("--bail with --watch keeps watching after a bail", async () => {
+      using dir = tempDir("bun-test-bail-watch", {
+        "package.json": "{}",
+        "v.ts": `export const v = 0;\n`,
+        "bail.test.ts": `
+          import { test, expect } from "bun:test";
+          import { v } from "./v";
+          test("t1", () => { expect(v).toBe(1); });
+          test("t2", () => { expect(2).toBe(2); });
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--watch", "--bail", "--no-clear-screen"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "ignore",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
+
+      const reader = proc.stderr.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+
+      async function waitFor(needle: string, from = 0): Promise<number> {
+        while (!buf.slice(from).includes(needle)) {
+          const { value, done } = await reader.read();
+          if (done) throw new Error(`stream closed before seeing ${JSON.stringify(needle)}\n${buf}`);
+          buf += decoder.decode(value, { stream: true });
+        }
+        return buf.length;
+      }
+
+      // First run: t1 fails, bail fires, t2 must not run, and the normal
+      // end-of-run summary must still print (not a hard exit mid-run).
+      const afterBail = await waitFor("Bailed out after 1 failure");
+      await waitFor("Ran 1 test across 1 file");
+      expect(buf).not.toContain("t2");
+      expect(proc.exitCode).toBeNull();
+
+      // Fix the failing test. The watcher should still be alive, pick up
+      // the change, and re-run to green.
+      writeFileSync(join(String(dir), "v.ts"), "export const v = 1;\n");
+      await waitFor("2 pass", afterBail);
+
+      proc.kill();
+      reader.releaseLock();
+    }, 30_000);
   });
   describe("--timeout", () => {
     test("must provide a number timeout", () => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -360,55 +360,59 @@ describe("bun test", () => {
     // On Windows, `bun test --watch` runs a parent watcher-manager that
     // respawns a child on change rather than exec()-in-place, which makes
     // the stderr stream sync points here unreliable.
-    test.skipIf(isWindows)("--bail with --watch keeps watching after a bail", async () => {
-      using dir = tempDir("bun-test-bail-watch", {
-        "package.json": "{}",
-        "v.ts": `export const v = 0;\n`,
-        "bail.test.ts": `
+    test.skipIf(isWindows)(
+      "--bail with --watch keeps watching after a bail",
+      async () => {
+        using dir = tempDir("bun-test-bail-watch", {
+          "package.json": "{}",
+          "v.ts": `export const v = 0;\n`,
+          "bail.test.ts": `
           import { test, expect } from "bun:test";
           import { v } from "./v";
           test("t1", () => { expect(v).toBe(1); });
           test("t2", () => { expect(2).toBe(2); });
         `,
-      });
+        });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test", "--watch", "--bail", "--no-clear-screen"],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "ignore",
-        stderr: "pipe",
-        stdin: "ignore",
-      });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test", "--watch", "--bail", "--no-clear-screen"],
+          cwd: String(dir),
+          env: bunEnv,
+          stdout: "ignore",
+          stderr: "pipe",
+          stdin: "ignore",
+        });
 
-      const reader = proc.stderr.getReader();
-      const decoder = new TextDecoder();
-      let buf = "";
+        const reader = proc.stderr.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
 
-      async function waitFor(needle: string, from = 0): Promise<number> {
-        while (!buf.slice(from).includes(needle)) {
-          const { value, done } = await reader.read();
-          if (done) throw new Error(`stream closed before seeing ${JSON.stringify(needle)}\n${buf}`);
-          buf += decoder.decode(value, { stream: true });
+        async function waitFor(needle: string, from = 0): Promise<number> {
+          while (!buf.slice(from).includes(needle)) {
+            const { value, done } = await reader.read();
+            if (done) throw new Error(`stream closed before seeing ${JSON.stringify(needle)}\n${buf}`);
+            buf += decoder.decode(value, { stream: true });
+          }
+          return buf.length;
         }
-        return buf.length;
-      }
 
-      // First run: t1 fails, bail fires, t2 must not run, and the normal
-      // end-of-run summary must still print (not a hard exit mid-run).
-      const afterBail = await waitFor("Bailed out after 1 failure");
-      await waitFor("Ran 1 test across 1 file");
-      expect(buf).not.toContain("t2");
-      expect(proc.exitCode).toBeNull();
+        // First run: t1 fails, bail fires, t2 must not run, and the normal
+        // end-of-run summary must still print (not a hard exit mid-run).
+        const afterBail = await waitFor("Bailed out after 1 failure");
+        await waitFor("Ran 1 test across 1 file");
+        expect(buf).not.toContain("t2");
+        expect(proc.exitCode).toBeNull();
 
-      // Fix the failing test. The watcher should still be alive, pick up
-      // the change, and re-run to green.
-      writeFileSync(join(String(dir), "v.ts"), "export const v = 1;\n");
-      await waitFor("2 pass", afterBail);
+        // Fix the failing test. The watcher should still be alive, pick up
+        // the change, and re-run to green.
+        writeFileSync(join(String(dir), "v.ts"), "export const v = 1;\n");
+        await waitFor("2 pass", afterBail);
 
-      proc.kill();
-      reader.releaseLock();
-    }, 30_000);
+        proc.kill();
+        reader.releaseLock();
+      },
+      30_000,
+    );
   });
   describe("--timeout", () => {
     test("must provide a number timeout", () => {


### PR DESCRIPTION
## What

`bun test --watch --bail` exits the whole watch process on the first bail-out. The edit that would fix the failing test never re-runs. Without `--bail` the same watcher survives and reruns on the next edit.

## Repro

```sh
mkdir d && cd d
cat > b.test.ts <<'EOF'
import { test, expect } from "bun:test";
import { v } from "./v";
test("t1", () => { expect(v).toBe(1); });
test("t2", () => { expect(2).toBe(2); });
EOF
echo 'export const v = 0;' > v.ts
echo '{}' > package.json
bun test --watch --bail
# => prints 'Bailed out after 1 failure' and exits 1 instead of watching
```

## Cause

`CommandLineReporter::handle_test_completed` calls `Global::exit(1)` directly when the fail count reaches the bail threshold, inside the per-test completion callback. Under `--watch` that kills the process before control reaches `run_event_loop_for_watch`. The module-load-rejection bail path in `TestCommand::run` has the same hard exit.

The parallel coordinator already handles this correctly: it sets a `bailed` flag and drains, returning normally.

## Fix

Give the serial runner the same flag-based bail:

- `Execution.aborted` stops the step loops (`step_group`, `step_group_one`, `step`'s per-group loop) so no further tests in the current file run.
- `CommandLineReporter.bailed` stops the per-file loop in `run_all_tests` and the `--rerun-each` repeat loop in `TestCommand::run`.

Under `--watch` the bail path now prints the banner, sets the flags, and lets the run unwind back to `exec`, which prints the full summary and enters `run_event_loop_for_watch`. When the watched file changes, `reload_process` re-execs as before. When not watching, the existing `Global::exit(1)` is unchanged.

## Verification

```sh
# fail-before (released bun): process exits, never sees the fixing edit
USE_SYSTEM_BUN=1 bun test test/cli/test/bun-test.test.ts -t 'keeps watching after a bail'
# pass-after
bun bd test test/cli/test/bun-test.test.ts -t bail
```

The test spawns `bun test --watch --bail` with a failing test, waits for the bail banner and the end-of-run summary on stderr, then fixes the dep file and waits for `2 pass` from the re-run. Skipped on Windows where `--watch` uses a respawning parent instead of exec-in-place (same as the existing `--changed --watch` test).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->

Supersedes #19918 (same approach against the pre-Rust Zig sources, which no longer exist).

Fixes #20318
Fixes #6453