### PR TITLE
watch: kill the previous generation's child processes before execve

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4525,6 +4525,18 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
     // a null pointer; on success `execve` never returns, on failure errno is
     // read. No borrowed Rust state is observed after the exec.
     unsafe {
+        {
+            // `execve` preserves the pid, so child processes spawned by the
+            // outgoing generation stay parented to us but the new generation
+            // has no record of them. SIGTERM them now and reap what exits so
+            // each `--watch` restart doesn't accumulate orphans. Defined in
+            // `bun_io::ParentDeathWatchdog` (OS-level child enumeration).
+            unsafe extern "C" {
+                safe fn bun_kill_children_before_reload();
+            }
+            bun_kill_children_before_reload();
+        }
+
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
         {
             unsafe extern "C" {

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -361,6 +361,83 @@ extern "C" fn on_process_exit() {
     kill_sync_pgroups_and_descendants();
 }
 
+/// SIGTERM every direct child of this process, reap whatever exits, then
+/// SIGKILL the survivors. Called from `bun_core::reload_process()` immediately
+/// before `execve()` so `bun --watch` / `bun test --watch` / `bun build
+/// --watch` restarts don't leak the previous generation's `Bun.spawn` /
+/// `child_process` children (they stay parented to the same pid across
+/// `execve` and the new generation has no record of them).
+///
+/// Runs on whichever thread triggered the reload (usually the file-watcher
+/// thread), so it cannot touch the VM's `ProcessAutoKiller` registry; instead
+/// it enumerates direct children from the OS via [`list_child_pids`]. Unlike
+/// [`kill_descendants`] this sends SIGTERM first so children that handle it
+/// can shut down cleanly; survivors after ~100ms get SIGKILL. The `waitpid`
+/// reap loop prevents them from lingering as zombies of the post-`execve`
+/// process (which has no record of them and would never reap them).
+#[unsafe(no_mangle)]
+pub extern "C" fn bun_kill_children_before_reload() {
+    #[cfg(unix)]
+    {
+        let self_pid = getpid();
+        let mut buf: [libc::pid_t; 4096] = [0; 4096];
+        let n = match list_child_pids(self_pid, &mut buf) {
+            Some(n) if n > 0 => n,
+            _ => return,
+        };
+        for &pid in &buf[..n] {
+            if pid > 1 && pid != self_pid {
+                let _ = kill(pid, libc::SIGTERM);
+            }
+        }
+        // Give SIGTERM handlers a moment; reap as they exit. ~100ms ceiling.
+        for _ in 0u32..10 {
+            reap_nohang();
+            match list_child_pids(self_pid, &mut buf) {
+                Some(0) | None => return,
+                Some(_) => {}
+            }
+            // SAFETY: `req` points at a valid `timespec`; `rem` may be null.
+            unsafe {
+                libc::nanosleep(
+                    &libc::timespec {
+                        tv_sec: 0,
+                        tv_nsec: 10_000_000,
+                    },
+                    core::ptr::null_mut(),
+                );
+            }
+        }
+        if let Some(m) = list_child_pids(self_pid, &mut buf) {
+            for &pid in &buf[..m] {
+                if pid > 1 && pid != self_pid {
+                    let _ = kill(pid, libc::SIGKILL);
+                }
+            }
+        }
+        // SIGKILL is immediate; one short nap then a final reap pass.
+        // SAFETY: `req` points at a valid `timespec`; `rem` may be null.
+        unsafe {
+            libc::nanosleep(
+                &libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 10_000_000,
+                },
+                core::ptr::null_mut(),
+            );
+        }
+        reap_nohang();
+    }
+}
+
+/// Drain `waitpid(-1, WNOHANG)` until it stops returning a reaped pid.
+#[cfg(unix)]
+fn reap_nohang() {
+    let mut st: c_int = 0;
+    // SAFETY: `status` is a valid out-pointer; WNOHANG never blocks.
+    while unsafe { libc::waitpid(-1, &mut st, libc::WNOHANG) } > 0 {}
+}
+
 /// Walk the process tree rooted at `getpid()` and SIGKILL every descendant.
 ///
 /// Pid-reuse safety: enumeration is a point-in-time snapshot, so a pid we

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -179,11 +179,6 @@ unsafe extern "C" {
     // safe: by-value `pid_t`/`c_int` only; bad pid → `ESRCH`, bad sig →
     // `EINVAL`, never UB. Async-signal-safe.
     safe fn kill(pid: libc::pid_t, sig: c_int) -> c_int;
-    // safe: out-param is `&mut c_int` (non-null, valid for write); kernel only
-    // writes the slot and reports failure via the return value — bad pid →
-    // `ECHILD`, never UB. Async-signal-safe.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    safe fn waitpid(pid: libc::pid_t, status: &mut c_int, options: c_int) -> libc::pid_t;
 }
 
 // `should_default_spawn_pdeathsig` moved down to `bun_spawn_sys::pdeathsig::
@@ -570,12 +565,7 @@ pub fn kill_subreaper_adoptees(siblings: &[libc::pid_t]) {
                 killed_any = true;
             }
             // Reap what we just killed so their children (if any raced) reparent.
-            loop {
-                let mut st: c_int = 0;
-                if waitpid(-1, &mut st, libc::WNOHANG) <= 0 {
-                    break;
-                }
-            }
+            reap_nohang();
             if !killed_any {
                 return;
             }

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,7 +1,7 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBroken, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isBroken, isLinux, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -60,7 +60,7 @@ function pidAlive(pid: number): boolean {
 // previous generation stay parented to the watcher. Without cleanup every
 // restart leaks one child forever (and the first one to bind a port blocks
 // every later generation with EADDRINUSE).
-it.skipIf(!isPosix)("--watch kills the previous generation's child processes on restart", async () => {
+it.skipIf(!(isLinux || isMacOS))("--watch kills the previous generation's child processes on restart", async () => {
   using dir = tempDir("watch-subprocess-leak", {
     "dep.ts": "export const v = 0;\n",
     "entry.ts": `

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,8 +1,8 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBroken, isWindows, tmpdirSync } from "harness";
-import { rmSync } from "node:fs";
+import { bunEnv, bunExe, isBroken, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
+import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 let watchee: Subprocess;
@@ -45,4 +45,77 @@ for (const dir of ["dir", "©️"]) {
 
 afterEach(() => {
   watchee?.kill();
+});
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// --watch restarts via execve() on the same pid, so children spawned by the
+// previous generation stay parented to the watcher. Without cleanup every
+// restart leaks one child forever (and the first one to bind a port blocks
+// every later generation with EADDRINUSE).
+it.skipIf(!isPosix)("--watch kills the previous generation's child processes on restart", async () => {
+  using dir = tempDir("watch-subprocess-leak", {
+    "dep.ts": "export const v = 0;\n",
+    "entry.ts": `
+      import { v } from "./dep";
+      const kid = Bun.spawn({ cmd: ["sleep", "555"], stdout: "ignore", stderr: "ignore" });
+      console.log("BOOT gen=" + v + " kid=" + kid.pid);
+      setInterval(() => {}, 1000);
+    `,
+  });
+  const depPath = join(String(dir), "dep.ts");
+
+  const kids: number[] = [];
+  watchee = spawn({
+    cmd: [bunExe(), "--no-clear-screen", "--watch", "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+  try {
+    const GENERATIONS = 4;
+    const decoder = new TextDecoder();
+    let buffered = "";
+    outer: for await (const chunk of watchee.stdout) {
+      buffered += decoder.decode(chunk);
+      let nl: number;
+      while ((nl = buffered.indexOf("\n")) !== -1) {
+        const line = buffered.slice(0, nl);
+        buffered = buffered.slice(nl + 1);
+        const m = /^BOOT gen=(\d+) kid=(\d+)$/.exec(line);
+        if (!m) continue;
+        const gen = Number(m[1]);
+        kids.push(Number(m[2]));
+        if (gen === GENERATIONS) break outer;
+        // Touch the dependency to trigger the next restart. Wait for the
+        // next BOOT line (condition, not time) to know it took effect.
+        writeFileSync(depPath, `export const v = ${gen + 1};\n`);
+      }
+    }
+
+    expect(kids.length).toBe(GENERATIONS + 1);
+
+    // Every generation's child except the current one should be gone.
+    const leaked = kids.slice(0, -1).filter(pidAlive);
+    expect(leaked).toEqual([]);
+    // The current generation's child is still running.
+    expect(pidAlive(kids.at(-1)!)).toBe(true);
+  } finally {
+    watchee.kill("SIGKILL");
+    await watchee.exited;
+    for (const pid of kids) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+    }
+  }
 });


### PR DESCRIPTION
## What

`bun --watch` restarts by `execve()`ing the same pid. Child processes spawned by the outgoing generation stay parented to that pid, but the new generation has no record of them, so every restart leaked one child per `Bun.spawn` / `child_process` call. A script that spawns one child and is edited 20 times leaves 21 live children; if the child holds a port, every later generation fails `EADDRINUSE` while the first generation's server keeps answering. Node's `--watch` spawns the script as a separate child and SIGTERMs it on each restart, so it has never had this problem.

## Reproduction

```sh
D=$(mktemp -d); cd "$D"
cat > entry.ts <<'JS'
import { v } from "./dep";
const kid = Bun.spawn(["sleep", "555"], { stdout: "ignore" });
console.log("BOOT pid=" + process.pid + " gen=" + v + " kid=" + kid.pid);
setInterval(() => {}, 1000);
JS
echo 'export const v = 0;' > dep.ts
bun --watch entry.ts > out.log 2>&1 & W=$!
sleep 2
for i in $(seq 1 8); do echo "export const v = $i;" > dep.ts; sleep 1.2; done
sleep 1
echo "gens=$(grep -c '^BOOT' out.log) live_children=$(ps -eo ppid,cmd | awk -v w=$W '$1==w && /sleep 555/' | wc -l)"
kill -9 $W; pkill -9 -f 'sleep 555'
```

Before: `gens=9 live_children=9`
After: `gens=9 live_children=1`

## Fix

`reload_process()` now enumerates direct children from the OS (`/proc/<pid>/task/*/children` on Linux, `proc_listchildpids` on macOS, reusing the walker from `ParentDeathWatchdog`) immediately before `execve()`, SIGTERMs each one, reaps for up to ~100ms so they don't become zombies of the new process, then SIGKILLs any survivors. This runs on the file-watcher thread so it doesn't depend on the JS thread being responsive, and catches children from any source (`Bun.spawn`, `node:child_process`, native addons that fork).

`process.on('exit')` / `process.on('SIGTERM')` handlers in the watched script still do not fire at the restart boundary: the restart is triggered from the watcher thread, and routing it through the JS event loop would stop `--watch` from recovering a script stuck in a tight loop. With children now killed by the runtime the script no longer needs those handlers to avoid the leak.

Windows `--watch` uses a separate watcher-manager parent that respawns the script process; the script's children break away from the Job Object (`JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK`) and so still leak there. That path needs a different fix and is not addressed here.

## Verification

New test in `test/cli/watch/watch.test.ts` spawns `bun --watch`, triggers 4 restarts, and asserts that only the current generation's child pid is alive.

```
(fail) --watch kills the previous generation's child processes on restart  # USE_SYSTEM_BUN=1: 4 leaked pids
(pass) --watch kills the previous generation's child processes on restart  # bun bd
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->

Related to #13539 (the file-change half; the Ctrl+C exit path there is separate).
