### PR TITLE
watch: keep watching when the entrypoint is transiently missing

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1723,6 +1723,13 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
 /// (re)appear, then call `reload_process()` so the next restart runs the full
 /// resolver again. The VM does not exist yet so there are no signal handlers
 /// installed; Ctrl+C terminates the poll loop normally.
+///
+/// `target_name` is the raw CLI positional, not the resolved path the previous
+/// process was running, so the probe mirrors the resolver's own candidate set
+/// (literal path → `+ext` → `index.ext`) enough to see `./entry` → `entry.ts`
+/// and `.` → `./index.ts` reappear. Anything more exotic (package.json `main`,
+/// tsconfig paths) just keeps sleeping, which is the pre-existing behaviour
+/// less the exit.
 #[cold]
 #[inline(never)]
 #[cfg_attr(
@@ -1735,11 +1742,50 @@ fn wait_for_entrypoint_and_reload(target_name: &[u8]) -> ! {
         bstr::BStr::new(target_name),
     );
     Output::flush();
+
+    let mut buf = paths::path_buffer_pool::get();
+    let has_extension = !paths::extension(target_name).is_empty();
+
+    let is_file = |buf: &mut PathBuffer, parts: &[&[u8]]| -> bool {
+        let mut len = 0usize;
+        for p in parts {
+            if len + p.len() >= buf.0.len() {
+                return false;
+            }
+            buf.0[len..len + p.len()].copy_from_slice(p);
+            len += p.len();
+        }
+        buf.0[len] = 0;
+        // SAFETY: NUL-terminated at `len` above.
+        let z = ZStr::from_buf(&buf.0[..], len);
+        matches!(
+            sys::exists_at_type(Fd::cwd(), z),
+            Ok(sys::ExistsAtType::File)
+        )
+    };
+
     loop {
-        if sys::exists(target_name) {
+        // Sleep first so a misclassification below is rate-limited, not a hot
+        // execve spin.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        let found = 'probe: {
+            if is_file(&mut buf, &[target_name]) {
+                break 'probe true;
+            }
+            for ext in bun_bundler::options::bundle_options_defaults::EXTENSION_ORDER {
+                if !has_extension && is_file(&mut buf, &[target_name, ext]) {
+                    break 'probe true;
+                }
+                if is_file(&mut buf, &[target_name, paths::SEP_STR.as_bytes(), b"index", ext]) {
+                    break 'probe true;
+                }
+            }
+            false
+        };
+        if found {
             bun_core::reload_process(false, false);
         }
-        std::thread::sleep(std::time::Duration::from_millis(100));
     }
 }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1744,7 +1744,6 @@ fn wait_for_entrypoint_and_reload(target_name: &[u8]) -> ! {
     Output::flush();
 
     let mut buf = paths::path_buffer_pool::get();
-    let has_extension = !paths::extension(target_name).is_empty();
 
     let is_file = |buf: &mut PathBuffer, parts: &[&[u8]]| -> bool {
         let mut len = 0usize;
@@ -1774,7 +1773,7 @@ fn wait_for_entrypoint_and_reload(target_name: &[u8]) -> ! {
                 break 'probe true;
             }
             for ext in bun_bundler::options::bundle_options_defaults::EXTENSION_ORDER {
-                if !has_extension && is_file(&mut buf, &[target_name, ext]) {
+                if is_file(&mut buf, &[target_name, ext]) {
                     break 'probe true;
                 }
                 if is_file(

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1777,7 +1777,10 @@ fn wait_for_entrypoint_and_reload(target_name: &[u8]) -> ! {
                 if !has_extension && is_file(&mut buf, &[target_name, ext]) {
                     break 'probe true;
                 }
-                if is_file(&mut buf, &[target_name, paths::SEP_STR.as_bytes(), b"index", ext]) {
+                if is_file(
+                    &mut buf,
+                    &[target_name, paths::SEP_STR.as_bytes(), b"index", ext],
+                ) {
                     break 'probe true;
                 }
             }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1715,6 +1715,34 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     vm.global_exit();
 }
 
+/// `--watch` restart is an `execve` (POSIX) / child respawn (Windows). When the
+/// entrypoint file is transiently absent at the moment of restart — editors
+/// that save by delete-then-write, `git checkout`, build output not yet
+/// written — `RunCommand::exec` lands in its failure tail before the file
+/// watcher is ever installed. Instead of exiting, park and poll for the file to
+/// (re)appear, then call `reload_process()` so the next restart runs the full
+/// resolver again. The VM does not exist yet so there are no signal handlers
+/// installed; Ctrl+C terminates the poll loop normally.
+#[cold]
+#[inline(never)]
+#[cfg_attr(
+    any(target_os = "linux", target_os = "android"),
+    unsafe(link_section = ".text.unlikely")
+)]
+fn wait_for_entrypoint_and_reload(target_name: &[u8]) -> ! {
+    pretty_errorln!(
+        "<r><d>Waiting for \"<b>{}<r><d>\" before restarting...<r>",
+        bstr::BStr::new(target_name),
+    );
+    Output::flush();
+    loop {
+        if sys::exists(target_name) {
+            bun_core::reload_process(false, false);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
 #[cold]
 #[inline(never)]
@@ -2755,14 +2783,14 @@ impl RunCommand {
                 );
             } else {
                 let default_loader = Self::default_loader_for(target_name);
-                if default_loader
+                let looks_like_file = default_loader
                     .map(Loader::is_javascript_like_or_json)
                     .unwrap_or(false)
                     || (!target_name.is_empty()
                         && (target_name[0] == b'.'
                             || target_name[0] == b'/'
-                            || paths::is_absolute(target_name)))
-                {
+                            || paths::is_absolute(target_name)));
+                if looks_like_file {
                     pretty_errorln!(
                         "<r><red>error<r><d>:<r> <b>Module not found \"<b>{}<r>\"",
                         bstr::BStr::new(target_name),
@@ -2777,6 +2805,11 @@ impl RunCommand {
                         "<r><red>error<r><d>:<r> <b>Script not found \"<b>{}<r>\"",
                         bstr::BStr::new(target_name),
                     );
+                }
+                if ctx.debug.hot_reload == cli::command::HotReload::Watch
+                    && (looks_like_file || !paths::extension(target_name).is_empty())
+                {
+                    wait_for_entrypoint_and_reload(target_name);
                 }
             }
             Global::exit(1);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2854,9 +2854,7 @@ impl RunCommand {
                         bstr::BStr::new(target_name),
                     );
                 }
-                if ctx.debug.hot_reload == cli::command::HotReload::Watch
-                    && (looks_like_file || !paths::extension(target_name).is_empty())
-                {
+                if looks_like_file && ctx.debug.hot_reload == cli::command::HotReload::Watch {
                     wait_for_entrypoint_and_reload(target_name);
                 }
             }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2854,7 +2854,9 @@ impl RunCommand {
                         bstr::BStr::new(target_name),
                     );
                 }
-                if looks_like_file && ctx.debug.hot_reload == cli::command::HotReload::Watch {
+                if (looks_like_file || default_loader.is_some())
+                    && ctx.debug.hot_reload == cli::command::HotReload::Watch
+                {
                     wait_for_entrypoint_and_reload(target_name);
                 }
             }

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -83,7 +83,7 @@ for (const { label, arg, file } of [
     // Entrypoint goes away; the watcher restarts into a process that cannot
     // resolve it. Previously this killed the whole watch session with exit 1.
     unlinkSync(entry);
-    expect(await nextMatching(stderr, "Module not found")).toContain(arg);
+    expect(await nextMatching(stderr, "Module not found")).toContain(JSON.stringify(arg));
     expect(watchee.exitCode).toBeNull();
 
     writeFileSync(entry, `console.log("BOOT 2"); setInterval(() => {}, 1000);`);

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -58,6 +58,7 @@ async function nextMatching(iter: AsyncGenerator<string>, needle: string): Promi
 for (const { label, arg, file } of [
   { label: "explicit path", arg: "entry.ts", file: "entry.ts" },
   { label: "extensionless path", arg: "./entry", file: "entry.ts" },
+  { label: "dotted extensionless path", arg: "./vite.config", file: "vite.config.ts" },
   { label: "directory path", arg: ".", file: "index.ts" },
 ]) {
   it(`should survive the entrypoint being transiently deleted (${label})`, async () => {

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,8 +1,8 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBroken, isWindows, tmpdirSync } from "harness";
-import { rmSync } from "node:fs";
+import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir, tmpdirSync } from "harness";
+import { rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 let watchee: Subprocess;
@@ -45,4 +45,73 @@ for (const dir of ["dir", "©️"]) {
 
 afterEach(() => {
   watchee?.kill();
+});
+
+async function nextMatching(iter: AsyncGenerator<string>, needle: string): Promise<string> {
+  while (true) {
+    const { value, done } = await iter.next();
+    if (done) throw new Error(`stream ended before a line containing ${JSON.stringify(needle)} was seen`);
+    if (value.includes(needle)) return value;
+  }
+}
+
+it("should survive the entrypoint being transiently deleted", async () => {
+  using dir = tempDir("watch-entry-delete", {
+    "entry.ts": `console.log("BOOT 1"); setInterval(() => {}, 1000);`,
+  });
+  const entry = join(String(dir), "entry.ts");
+
+  watchee = spawn({
+    cmd: [bunExe(), "--no-clear-screen", "--watch", "entry.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const stdout = forEachLine(watchee.stdout);
+  const stderr = forEachLine(watchee.stderr);
+
+  expect(await nextMatching(stdout, "BOOT")).toContain("BOOT 1");
+
+  // Entrypoint goes away; the watcher restarts into a process that cannot
+  // resolve it. Previously this killed the whole watch session with exit 1.
+  unlinkSync(entry);
+  expect(await nextMatching(stderr, "Module not found")).toContain("entry.ts");
+  expect(watchee.exitCode).toBeNull();
+
+  writeFileSync(entry, `console.log("BOOT 2"); setInterval(() => {}, 1000);`);
+  expect(await nextMatching(stdout, "BOOT")).toContain("BOOT 2");
+  expect(watchee.exitCode).toBeNull();
+
+  watchee.kill();
+  await watchee.exited;
+});
+
+it("should start watching when the entrypoint does not yet exist", async () => {
+  using dir = tempDir("watch-entry-missing", {
+    "placeholder.txt": "",
+  });
+  const entry = join(String(dir), "entry.ts");
+
+  watchee = spawn({
+    cmd: [bunExe(), "--no-clear-screen", "--watch", "entry.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const stdout = forEachLine(watchee.stdout);
+  const stderr = forEachLine(watchee.stderr);
+
+  expect(await nextMatching(stderr, "Module not found")).toContain("entry.ts");
+  expect(watchee.exitCode).toBeNull();
+
+  writeFileSync(entry, `console.log("BOOT ok"); setInterval(() => {}, 1000);`);
+  expect(await nextMatching(stdout, "BOOT")).toContain("BOOT ok");
+  expect(watchee.exitCode).toBeNull();
+
+  watchee.kill();
+  await watchee.exited;
 });

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -55,38 +55,44 @@ async function nextMatching(iter: AsyncGenerator<string>, needle: string): Promi
   }
 }
 
-it("should survive the entrypoint being transiently deleted", async () => {
-  using dir = tempDir("watch-entry-delete", {
-    "entry.ts": `console.log("BOOT 1"); setInterval(() => {}, 1000);`,
+for (const { label, arg, file } of [
+  { label: "explicit path", arg: "entry.ts", file: "entry.ts" },
+  { label: "extensionless path", arg: "./entry", file: "entry.ts" },
+  { label: "directory path", arg: ".", file: "index.ts" },
+]) {
+  it(`should survive the entrypoint being transiently deleted (${label})`, async () => {
+    using dir = tempDir("watch-entry-delete", {
+      [file]: `console.log("BOOT 1"); setInterval(() => {}, 1000);`,
+    });
+    const entry = join(String(dir), file);
+
+    watchee = spawn({
+      cmd: [bunExe(), "--no-clear-screen", "--watch", arg],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const stdout = forEachLine(watchee.stdout);
+    const stderr = forEachLine(watchee.stderr);
+
+    expect(await nextMatching(stdout, "BOOT")).toContain("BOOT 1");
+
+    // Entrypoint goes away; the watcher restarts into a process that cannot
+    // resolve it. Previously this killed the whole watch session with exit 1.
+    unlinkSync(entry);
+    expect(await nextMatching(stderr, "Module not found")).toContain(arg);
+    expect(watchee.exitCode).toBeNull();
+
+    writeFileSync(entry, `console.log("BOOT 2"); setInterval(() => {}, 1000);`);
+    expect(await nextMatching(stdout, "BOOT")).toContain("BOOT 2");
+    expect(watchee.exitCode).toBeNull();
+
+    watchee.kill();
+    await watchee.exited;
   });
-  const entry = join(String(dir), "entry.ts");
-
-  watchee = spawn({
-    cmd: [bunExe(), "--no-clear-screen", "--watch", "entry.ts"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-    stdin: "ignore",
-  });
-  const stdout = forEachLine(watchee.stdout);
-  const stderr = forEachLine(watchee.stderr);
-
-  expect(await nextMatching(stdout, "BOOT")).toContain("BOOT 1");
-
-  // Entrypoint goes away; the watcher restarts into a process that cannot
-  // resolve it. Previously this killed the whole watch session with exit 1.
-  unlinkSync(entry);
-  expect(await nextMatching(stderr, "Module not found")).toContain("entry.ts");
-  expect(watchee.exitCode).toBeNull();
-
-  writeFileSync(entry, `console.log("BOOT 2"); setInterval(() => {}, 1000);`);
-  expect(await nextMatching(stdout, "BOOT")).toContain("BOOT 2");
-  expect(watchee.exitCode).toBeNull();
-
-  watchee.kill();
-  await watchee.exited;
-});
+}
 
 it("should start watching when the entrypoint does not yet exist", async () => {
   using dir = tempDir("watch-entry-missing", {


### PR DESCRIPTION
## What does this PR do?

Under `--watch`, a file-change restart is an `execve` (POSIX) or a child respawn via the watcher-manager (Windows). When that restart lands while the entrypoint itself does not exist on disk, `RunCommand::exec` reaches its `Module not found` failure tail before the file watcher is ever installed and the whole watch session exits with code 1.

Editors that save by delete-then-write, `git checkout` of a branch without the file, `git stash`, and build loops that rewrite the output file all hit this. `node --watch` on the same script stays alive with `Failed running '…'. Waiting for file changes before restarting...`.

```console
$ bun --watch entry.ts &
BOOT pid=444 v=1
$ rm entry.ts; sleep 1; echo '…' > entry.ts
error: Module not found "entry.ts"
[1]+  Exit 1                  bun --watch entry.ts
```

Instead of exiting, print the error plus a waiting note, poll for the entrypoint to (re)appear, then `reload_process()` so the next restart runs the full resolver again. Only engaged for targets that look like file paths (not package.json script names) so a mistyped script name still exits immediately. The VM has not been created yet at this point so there are no JS signal handlers installed; Ctrl+C terminates the poll loop normally.

```console
$ bun --watch entry.ts &
BOOT pid=444 v=1
$ rm entry.ts; sleep 1; echo '…' > entry.ts
error: Module not found "entry.ts"
Waiting for "entry.ts" before restarting...
BOOT pid=444 v=1 RECREATED
```

Fixes #22404. Also addresses the delete-then-recreate face of #8520 and #14702.

## How did you verify your code works?

Two new tests in `test/cli/watch/watch.test.ts`:
- `should survive the entrypoint being transiently deleted`: boot, unlink the entrypoint, assert `Module not found` appears on stderr with the process still alive, recreate the file, assert the new boot line appears on stdout.
- `should start watching when the entrypoint does not yet exist`: spawn `--watch` on a path that does not exist, assert the process stays alive and boots once the file is written.

Both fail on the current canary (`stream ended before … "BOOT"`) and pass with this change. `test/cli/hot/hot.test.ts` and `test/cli/hot/watch.test.ts` continue to pass; `bun run rust:check-all` is clean on all 10 targets.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->