### PR TITLE
Error.appendStackTrace: don't abort when stackTraceLimit is unset

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -668,11 +668,11 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
-    if (!destination->stackTrace()) {
+    if (!destination->stackTrace() && globalObject->stackTraceLimit()) {
         destination->captureStackTrace(vm, globalObject, 1);
     }
 
-    if (source->stackTrace()) {
+    if (source->stackTrace() && destination->stackTrace()) {
         destination->stackTrace()->appendVector(*source->stackTrace());
         source->stackTrace()->clear();
     }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1121,3 +1121,27 @@ test("lazy error-info materialization does not store an empty stack value when t
   });
   expect(exitCode).toBe(0);
 });
+
+test("Error.appendStackTrace does not abort when stackTraceLimit is not a number", async () => {
+  const src = `
+    Error.stackTraceLimit = undefined;
+    const a = new Error();
+    const b = new Error();
+    Error.appendStackTrace(a, b);
+
+    const c = new Error();
+    delete Error.stackTraceLimit;
+    const d = new Error();
+    Error.appendStackTrace(c, d);
+
+    process.stdout.write("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, signalCode: proc.signalCode }).toEqual({ stdout: "ok", stderr: "", signalCode: null });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1129,6 +1129,7 @@ test("Error.appendStackTrace does not abort when stackTraceLimit is not a number
     const b = new Error();
     Error.appendStackTrace(a, b);
 
+    Error.stackTraceLimit = 10;
     const c = new Error();
     delete Error.stackTraceLimit;
     const d = new Error();


### PR DESCRIPTION
Found by Fuzzilli (fingerprint `cb5f2d970ad4162c`).

Assigning a non-number to `Error.stackTraceLimit` (or deleting it) clears `JSGlobalObject::m_stackTraceLimit` to `std::nullopt`, and errors created after that point carry no native stack trace. `Error.appendStackTrace` then took the "destination has no trace" path and called `ErrorInstance::captureStackTrace`, which does `globalObject->stackTraceLimit().value()` unconditionally; with no value that's a `bad_optional_access` that aborts the process (JSC is built without exceptions).

```js
Error.stackTraceLimit = undefined;
const a = new Error();
const b = new Error();
Error.appendStackTrace(a, b); // SIGABRT
```

Fix: only call `captureStackTrace` when `stackTraceLimit()` has a value, and only append when the destination actually has a vector (so skipping the capture does not become a null deref when the source still has frames).

Related open PRs #32098 and #34713 touch the same function for the self-append and already-materialized cases respectively; this one is orthogonal (still crashes with distinct source/destination and neither materialized).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (c9787deb8)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.29ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.34ms]
(pass) capture stack trace [6.57ms]
(pass) capture stack trace with message [7.05ms]
(pass) capture stack trace with constructor [5.06ms]
(pass) capture stack trace limit [22.39ms]
(pass) prepare stack trace [10.99ms]
(pass) capture stack trace second argument [16.69ms]
(pass) capture stack trace edge cases [10.51ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [20.00ms]
(pass) prepare stack trace call sites [11.54ms]
(pass) sanity check [11.88ms]
(pass) CallFrame isEval works as expected [7.73ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.34ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.29ms]
(pass) CallFrame.p.isConstructor [3.42ms]
(pass) CallFrame.p.isNative [2.95ms]
(pass) return non-strings from Error.prepareStackTrace [3.70ms]
(pass) CallF
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (7b64c8917)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.46ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.10ms]
(pass) capture stack trace [0.06ms]
(pass) capture stack trace with message [0.07ms]
(pass) capture stack trace with constructor [0.06ms]
(pass) capture stack trace limit [0.21ms]
(pass) prepare stack trace [0.14ms]
(pass) capture stack trace second argument [0.17ms]
(pass) capture stack trace edge cases [0.10ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [0.25ms]
(pass) prepare stack trace call sites [0.13ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.10ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.12ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.09ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.03ms]
(pass) err.stack should invoke prepareStackTrace [0.22ms]
(pass) Error.prepareStackTrace inside a node:vm works [5.31ms]
(pass) Error.captureStackTrace i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (c9787deb8)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.86ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.42ms]
(pass) capture stack trace [6.68ms]
(pass) capture stack trace with message [7.65ms]
(pass) capture stack trace with constructor [5.51ms]
(pass) capture stack trace limit [22.20ms]
(pass) prepare stack trace [10.69ms]
(pass) capture stack trace second argument [17.66ms]
(pass) capture stack trace edge cases [11.75ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [21.58ms]
(pass) prepare stack trace call sites [12.28ms]
(pass) sanity check [13.09ms]
(pass) CallFrame isEval works as expected [7.42ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.20ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.21ms]
(pass) CallFrame.p.isConstructor [3.48ms]
(pass) CallFrame.p.isNative [2.88ms]
(pass) return non-strings from Error.prepareStackTrace [3.29ms]
(pass) CallF
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 674ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 37s
[3/6] link bun-profile
[4/6] bun-profile --revision
1.4.0-canary.1+c9787deb8
[6/6] strip bun
[build] done
bun test v1.4.0-canary.1 (c9787deb8)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [2.10ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.14ms]
(pass) capture stack trace [0.09ms]
(pass) capture stack trace with message [0.10ms]
(pass) capture stack trace with constructor [0.10ms]
(pass) capture stack trace limit [0.35ms]
(pass) prepare stack trace [0.16ms]
(pass) capture stack trace second argument [0.27ms]
(pass) capture stack trace edge cases [0.16ms]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/FormatStackTraceForJS.cpp  |  4 ++--
 test/js/node/v8/capture-stack-trace.test.js | 25 +++++++++++++++++++++++++
 2 files changed, 27 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/FormatStackTraceForJS.cpp       2      1      0
test/js/node/v8/capture-stack-trace.test.js      2      3      0
```

</details>

<!-- robobun:evidence:end -->