### PR TITLE
Bun.sleepSync: make worker.terminate() interrupt a worker blocked in sleepSync

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1140,9 +1140,32 @@ pub(crate) fn sleep_sync(
         )));
     }
 
-    std::thread::sleep(core::time::Duration::from_millis(
-        u64::try_from(milliseconds).expect("int cast"),
-    ));
+    let duration = core::time::Duration::from_millis(milliseconds as u64);
+
+    // In a worker, std::thread::sleep cannot be interrupted by worker.terminate():
+    // the parent thread's notify_need_termination only fires a JSC VMTrap (checked
+    // at JS safepoints) and wakes the event loop poll, neither of which unblocks a
+    // parked nanosleep/Sleep. Slice the sleep and poll the termination flag between
+    // slices so terminate() takes effect within SLEEP_SYNC_TERMINATE_SLICE instead
+    // of the full requested duration. The VMTrap then throws TerminationException
+    // at the next safepoint after we return.
+    if let Some(worker) = global_object.bun_vm().worker_ref() {
+        const SLEEP_SYNC_TERMINATE_SLICE: core::time::Duration =
+            core::time::Duration::from_millis(100);
+        let deadline = std::time::Instant::now() + duration;
+        loop {
+            if worker.has_requested_terminate() {
+                break;
+            }
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                break;
+            }
+            std::thread::sleep((deadline - now).min(SLEEP_SYNC_TERMINATE_SLICE));
+        }
+    } else {
+        std::thread::sleep(duration);
+    }
     Ok(JSValue::UNDEFINED)
 }
 

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -176,3 +176,46 @@ test.skipIf(!isASAN)(
   },
   timeout,
 );
+
+// Bun.sleepSync was a single uninterruptible std::thread::sleep, so a worker
+// parked in a long sleepSync never observed the parent's terminate(): VMTraps
+// only fire at JS safepoints and the event-loop wakeup cannot unblock nanosleep.
+test(
+  "terminate() interrupts a worker blocked in Bun.sleepSync",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const w = new Worker(
+          "data:text/javascript," + encodeURIComponent(
+            'postMessage("sleeping"); Bun.sleepSync(600000);'
+          ),
+        );
+        w.addEventListener("close", () => {
+          console.log("CLOSED");
+          process.exit(0);
+        });
+        // postMessage enqueue -> return -> sleepSync is synchronous on the worker
+        // thread; by the time this handler runs on the parent, the worker is
+        // already inside the sleep.
+        w.addEventListener("message", () => w.terminate());
+        setTimeout(() => {
+          console.log("HUNG");
+          process.exit(1);
+        }, 10000);
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("CLOSED\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);


### PR DESCRIPTION
### Problem

`worker.terminate()` never completes while the worker thread is parked in `Bun.sleepSync(N)`. The `close` event does not fire until the full `N` milliseconds elapse, so a supervisor that relies on `terminate()` to bound hostile code cannot reclaim a worker that calls `Bun.sleepSync` with a large argument.

```js
const w = new Worker(
  "data:text/javascript," +
    encodeURIComponent('postMessage("sleeping"); Bun.sleepSync(600000);'),
);
w.addEventListener("close", () => { console.log("CLOSED"); process.exit(0); });
w.addEventListener("message", () => w.terminate());
setTimeout(() => { console.log("HUNG"); process.exit(1); }, 5000);
// bun 1.4.0: prints HUNG, 4/4
```

### Cause

`sleep_sync` is a single `std::thread::sleep`. The parent-thread `WebWorker::notify_need_termination` only sets `requested_terminate`, fires the JSC `NeedTermination` VMTrap (serviced at JS safepoints), and wakes the uws/uv event-loop poll. None of those can unblock a thread parked in `nanosleep`/`Sleep`, so the worker stays asleep for the full duration.

### Fix

When `sleepSync` runs on a worker thread, slice the sleep against an `Instant` deadline and poll `WebWorker::has_requested_terminate()` between slices. Once `terminate()` sets the flag, `sleepSync` returns at the next slice boundary and the already-fired VMTrap throws the `TerminationException` at the next JS safepoint. Main-thread `sleepSync` keeps the single uninterruptible sleep (there is nothing to poll).

The slice is 100 ms: termination latency is bounded by that, and the extra wakeups are negligible (a 1 h sleep wakes ~36000 times, microseconds each).

### Verification

New test in `test/js/web/workers/worker-terminate-lifetime.test.ts`:

| build | result |
| --- | --- |
| `USE_SYSTEM_BUN=1 bun test -t "Bun.sleepSync"` | **fail** (`HUNG`) |
| `bun bd test -t "Bun.sleepSync"` | **pass** (~0.8 s), 4/4 |

`test/js/bun/util/sleepSync.test.ts` (5 tests) passes unchanged, and `sleepSync(250)` in a worker still measures 250 ms (deadline loop preserves accuracy).

### Related

This came out of a supervisor kill-switch audit that also flagged `Atomics.wait` (#32802) and nested-worker orphans. Those are independent changes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->