### PR TITLE
build --compile: reject cross-compile base binary whose header mismatches --target

### DIFF
--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -666,7 +666,8 @@ const PF_W: u32 = 2;
 const SHT_NOBITS: u32 = 8;
 
 const EM_PPC64: u16 = 21;
-const EM_AARCH64: u16 = 183;
+pub(crate) const EM_X86_64: u16 = 62;
+pub(crate) const EM_AARCH64: u16 = 183;
 
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/exe_format/lib.rs
+++ b/src/exe_format/lib.rs
@@ -139,7 +139,8 @@ pub fn detect_header(data: &[u8]) -> Option<DetectedHeader> {
     // PE: "MZ" at 0, e_lfanew (u32) at 0x3c points to "PE\0\0" followed by COFF
     // header whose first u16 is Machine.
     if data.len() >= 0x40 && &data[0..2] == b"MZ" {
-        let e_lfanew = u32::from_le_bytes([data[0x3c], data[0x3d], data[0x3e], data[0x3f]]) as usize;
+        let e_lfanew =
+            u32::from_le_bytes([data[0x3c], data[0x3d], data[0x3e], data[0x3f]]) as usize;
         if let Some(pe) = data.get(e_lfanew..e_lfanew.checked_add(6)?) {
             if &pe[0..4] == b"PE\0\0" {
                 let machine = u16::from_le_bytes([pe[4], pe[5]]);

--- a/src/exe_format/lib.rs
+++ b/src/exe_format/lib.rs
@@ -103,11 +103,9 @@ pub fn detect_header(data: &[u8]) -> Option<DetectedHeader> {
             return None;
         }
         let e_machine = u16::from_le_bytes([data[18], data[19]]);
-        const EM_X86_64: u16 = 62;
-        const EM_AARCH64: u16 = 183;
         let arch = match e_machine {
-            EM_X86_64 => DetectedArch::X64,
-            EM_AARCH64 => DetectedArch::Arm64,
+            elf::EM_X86_64 => DetectedArch::X64,
+            elf::EM_AARCH64 => DetectedArch::Arm64,
             other => DetectedArch::Other(other as u32),
         };
         return Some(DetectedHeader {
@@ -119,15 +117,12 @@ pub fn detect_header(data: &[u8]) -> Option<DetectedHeader> {
     // Mach-O 64-bit: magic at 0, cputype (i32) at 4.
     if data.len() >= 8 {
         let magic = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
-        const MH_MAGIC_64: u32 = 0xfeed_facf;
-        if magic == MH_MAGIC_64 {
-            let cputype = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
-            const CPU_TYPE_X86_64: u32 = 0x0100_0007;
-            const CPU_TYPE_ARM64: u32 = 0x0100_000C;
+        if magic == macho_types::MH_MAGIC_64 {
+            let cputype = i32::from_le_bytes([data[4], data[5], data[6], data[7]]);
             let arch = match cputype {
-                CPU_TYPE_X86_64 => DetectedArch::X64,
-                CPU_TYPE_ARM64 => DetectedArch::Arm64,
-                other => DetectedArch::Other(other),
+                macho_types::CPU_TYPE_X86_64 => DetectedArch::X64,
+                macho_types::CPU_TYPE_ARM64 => DetectedArch::Arm64,
+                other => DetectedArch::Other(other as u32),
             };
             return Some(DetectedHeader {
                 format: DetectedFormat::MachO,
@@ -141,14 +136,12 @@ pub fn detect_header(data: &[u8]) -> Option<DetectedHeader> {
     if data.len() >= 0x40 && &data[0..2] == b"MZ" {
         let e_lfanew =
             u32::from_le_bytes([data[0x3c], data[0x3d], data[0x3e], data[0x3f]]) as usize;
-        if let Some(pe) = data.get(e_lfanew..e_lfanew.checked_add(6)?) {
-            if &pe[0..4] == b"PE\0\0" {
-                let machine = u16::from_le_bytes([pe[4], pe[5]]);
-                const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
-                const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
+        if let Some(coff) = data.get(e_lfanew..e_lfanew.checked_add(6)?) {
+            if &coff[0..4] == b"PE\0\0" {
+                let machine = u16::from_le_bytes([coff[4], coff[5]]);
                 let arch = match machine {
-                    IMAGE_FILE_MACHINE_AMD64 => DetectedArch::X64,
-                    IMAGE_FILE_MACHINE_ARM64 => DetectedArch::Arm64,
+                    pe::IMAGE_FILE_MACHINE_AMD64 => DetectedArch::X64,
+                    pe::IMAGE_FILE_MACHINE_ARM64 => DetectedArch::Arm64,
                     other => DetectedArch::Other(other as u32),
                 };
                 return Some(DetectedHeader {

--- a/src/exe_format/lib.rs
+++ b/src/exe_format/lib.rs
@@ -41,6 +41,126 @@ pub(crate) fn write_struct<T: Copy>(bytes: &mut [u8], value: &T) {
     unsafe { core::ptr::write_unaligned(bytes.as_mut_ptr().cast::<T>(), *value) }
 }
 
+/// Executable container format sniffed from a binary's first bytes.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DetectedFormat {
+    Elf,
+    MachO,
+    Pe,
+}
+
+impl DetectedFormat {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Elf => "ELF",
+            Self::MachO => "Mach-O",
+            Self::Pe => "PE",
+        }
+    }
+}
+
+/// Machine architecture sniffed from an executable header.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DetectedArch {
+    X64,
+    Arm64,
+    /// Machine type value this crate doesn't map (e.g. ppc64, riscv).
+    Other(u32),
+}
+
+impl DetectedArch {
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::X64 => "x64",
+            Self::Arm64 => "arm64",
+            Self::Other(_) => "unknown",
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct DetectedHeader {
+    pub format: DetectedFormat,
+    pub arch: DetectedArch,
+}
+
+/// Sniff the container format and machine architecture from an executable's
+/// header. Returns `None` if `data` is not a recognized 64-bit little-endian
+/// ELF, Mach-O, or PE image.
+///
+/// Used by `bun build --compile` to reject a cached cross-compile base binary
+/// whose on-disk header disagrees with the requested `--target` (e.g. an x64
+/// ELF planted under an arm64 cache key).
+///
+/// `data` only needs to cover the fixed header; 256 bytes is sufficient for
+/// ELF/Mach-O, and for PE the caller should pass at least
+/// `e_lfanew + sizeof(PEHeader)` bytes (in practice the full file).
+pub fn detect_header(data: &[u8]) -> Option<DetectedHeader> {
+    // ELF: e_machine is a u16 at offset 18.
+    if data.len() >= 20 && &data[0..4] == b"\x7fELF" {
+        // EI_CLASS == ELFCLASS64 && EI_DATA == ELFDATA2LSB
+        if data[4] != 2 || data[5] != 1 {
+            return None;
+        }
+        let e_machine = u16::from_le_bytes([data[18], data[19]]);
+        const EM_X86_64: u16 = 62;
+        const EM_AARCH64: u16 = 183;
+        let arch = match e_machine {
+            EM_X86_64 => DetectedArch::X64,
+            EM_AARCH64 => DetectedArch::Arm64,
+            other => DetectedArch::Other(other as u32),
+        };
+        return Some(DetectedHeader {
+            format: DetectedFormat::Elf,
+            arch,
+        });
+    }
+
+    // Mach-O 64-bit: magic at 0, cputype (i32) at 4.
+    if data.len() >= 8 {
+        let magic = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        const MH_MAGIC_64: u32 = 0xfeed_facf;
+        if magic == MH_MAGIC_64 {
+            let cputype = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+            const CPU_TYPE_X86_64: u32 = 0x0100_0007;
+            const CPU_TYPE_ARM64: u32 = 0x0100_000C;
+            let arch = match cputype {
+                CPU_TYPE_X86_64 => DetectedArch::X64,
+                CPU_TYPE_ARM64 => DetectedArch::Arm64,
+                other => DetectedArch::Other(other),
+            };
+            return Some(DetectedHeader {
+                format: DetectedFormat::MachO,
+                arch,
+            });
+        }
+    }
+
+    // PE: "MZ" at 0, e_lfanew (u32) at 0x3c points to "PE\0\0" followed by COFF
+    // header whose first u16 is Machine.
+    if data.len() >= 0x40 && &data[0..2] == b"MZ" {
+        let e_lfanew = u32::from_le_bytes([data[0x3c], data[0x3d], data[0x3e], data[0x3f]]) as usize;
+        if let Some(pe) = data.get(e_lfanew..e_lfanew.checked_add(6)?) {
+            if &pe[0..4] == b"PE\0\0" {
+                let machine = u16::from_le_bytes([pe[4], pe[5]]);
+                const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
+                const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
+                let arch = match machine {
+                    IMAGE_FILE_MACHINE_AMD64 => DetectedArch::X64,
+                    IMAGE_FILE_MACHINE_ARM64 => DetectedArch::Arm64,
+                    other => DetectedArch::Other(other as u32),
+                };
+                return Some(DetectedHeader {
+                    format: DetectedFormat::Pe,
+                    arch,
+                });
+            }
+        }
+    }
+
+    None
+}
+
 /// Round `value` up to the next multiple of `alignment`.
 ///
 /// Handles `alignment == 0` (returns `value` unchanged) and non-power-of-two

--- a/src/exe_format/macho_types.rs
+++ b/src/exe_format/macho_types.rs
@@ -18,6 +18,8 @@ pub use bun_sys::macho::{
     cpu_subtype_t, cpu_type_t, load_command, mach_header_64, segment_command_64, vm_prot_t,
 };
 
+pub(crate) const MH_MAGIC_64: u32 = 0xfeed_facf;
+pub(crate) const CPU_TYPE_X86_64: cpu_type_t = 0x0100_0007;
 pub(crate) const CPU_TYPE_ARM64: cpu_type_t = 0x0100_000C;
 
 pub(crate) const S_REGULAR: u32 = 0x0;

--- a/src/exe_format/pe.rs
+++ b/src/exe_format/pe.rs
@@ -187,6 +187,9 @@ const PE_SIGNATURE: u32 = 0x0000_4550; // "PE\0\0"
 const DOS_SIGNATURE: u16 = 0x5A4D; // "MZ"
 const OPTIONAL_HEADER_MAGIC_64: u16 = 0x020B;
 
+pub(crate) const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
+pub(crate) const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
+
 // Section characteristics
 const IMAGE_SCN_CNT_INITIALIZED_DATA: u32 = 0x0000_0040;
 const IMAGE_SCN_MEM_READ: u32 = 0x4000_0000;

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1512,8 +1512,8 @@ pub(crate) fn inject(
     }
 }
 
+use bun_core::Environment::Architecture as CompileTargetArch;
 use bun_core::Environment::OperatingSystem as CompileTargetOs;
-use bun_core::env::Architecture as CompileTargetArch;
 pub use bun_options_types::compile_target::CompileTarget;
 
 /// Validate that the executable at `path` has a header (ELF / Mach-O / PE
@@ -1523,8 +1523,21 @@ pub use bun_options_types::compile_target::CompileTarget;
 ///
 /// On mismatch, returns a user-facing `CompileResult` error describing the
 /// detected vs. expected target and naming the offending file.
-fn validate_base_binary_header(target: &CompileTarget, path: &ZStr) -> Option<CompileResult> {
+///
+/// `from_explicit_path` selects the remedy hint: an explicit
+/// `--compile-executable-path` has no cache entry to delete.
+fn validate_base_binary_header(
+    target: &CompileTarget,
+    path: &ZStr,
+    from_explicit_path: bool,
+) -> Option<CompileResult> {
     use bun_exe_format::{DetectedArch, DetectedFormat, detect_header};
+
+    let remedy = if from_explicit_path {
+        "Pass a --compile-executable-path that matches the requested target."
+    } else {
+        "The cache entry may be corrupt or tampered with; delete it and try again."
+    };
 
     let expected_format = match target.os {
         CompileTargetOs::Mac => DetectedFormat::MachO,
@@ -1565,34 +1578,34 @@ fn validate_base_binary_header(target: &CompileTarget, path: &ZStr) -> Option<Co
 
     let Some(detected) = detect_header(&buf[..n]) else {
         return Some(CompileResult::fail_fmt(format_args!(
-            "Base executable for '{}' at {} is not a recognized {} file. \
-             The cache entry may be corrupt or tampered with; delete it and try again.",
+            "Base executable for '{}' at {} is not a recognized {} file. {}",
             target,
             bstr::BStr::new(path.as_bytes()),
             expected_format.name(),
+            remedy,
         )));
     };
 
     if detected.format != expected_format {
         return Some(CompileResult::fail_fmt(format_args!(
-            "Base executable for '{}' at {} is a {} file, expected {}. \
-             The cache entry may be corrupt or tampered with; delete it and try again.",
+            "Base executable for '{}' at {} is a {} file, expected {}. {}",
             target,
             bstr::BStr::new(path.as_bytes()),
             detected.format.name(),
             expected_format.name(),
+            remedy,
         )));
     }
 
     if detected.arch != expected_arch {
         return Some(CompileResult::fail_fmt(format_args!(
-            "Base executable for '{}' at {} is {} {}, expected {}. \
-             The cache entry may be corrupt or tampered with; delete it and try again.",
+            "Base executable for '{}' at {} is {} {}, expected {}. {}",
             target,
             bstr::BStr::new(path.as_bytes()),
             detected.format.name(),
             detected.arch.name(),
             expected_arch.name(),
+            remedy,
         )));
     }
 
@@ -1865,7 +1878,9 @@ pub fn to_executable(
     // embedding it verbatim. A wrong-arch or wrong-format file here becomes the
     // runtime of every produced executable.
     if self_exe_path.is_some() || !target.is_default() {
-        if let Some(failure) = validate_base_binary_header(target, &self_exe) {
+        if let Some(failure) =
+            validate_base_binary_header(target, &self_exe, self_exe_path.is_some())
+        {
             return Ok(failure);
         }
     }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1513,7 +1513,91 @@ pub(crate) fn inject(
 }
 
 use bun_core::Environment::OperatingSystem as CompileTargetOs;
+use bun_core::env::Architecture as CompileTargetArch;
 pub use bun_options_types::compile_target::CompileTarget;
+
+/// Validate that the executable at `path` has a header (ELF / Mach-O / PE
+/// format and machine type) consistent with the requested cross-compile
+/// `target`. Guards `bun build --compile` against embedding a cached or
+/// downloaded base binary that was written under the wrong cache key.
+///
+/// On mismatch, returns a user-facing `CompileResult` error describing the
+/// detected vs. expected target and naming the offending file.
+fn validate_base_binary_header(target: &CompileTarget, path: &ZStr) -> Option<CompileResult> {
+    use bun_exe_format::{DetectedArch, DetectedFormat, detect_header};
+
+    let expected_format = match target.os {
+        CompileTargetOs::Mac => DetectedFormat::MachO,
+        CompileTargetOs::Windows => DetectedFormat::Pe,
+        CompileTargetOs::Linux | CompileTargetOs::Freebsd => DetectedFormat::Elf,
+        CompileTargetOs::Wasm => return None,
+    };
+    let expected_arch = match target.arch {
+        CompileTargetArch::X64 => DetectedArch::X64,
+        CompileTargetArch::Arm64 => DetectedArch::Arm64,
+        CompileTargetArch::Wasm => return None,
+    };
+
+    // PE's COFF header sits at DOSHeader.e_lfanew, which for a typical
+    // toolchain-produced binary is well under 1 KiB; ELF/Mach-O need <32 bytes.
+    let mut buf = [0u8; 1024];
+    let n = match bun_sys::File::open(path, bun_sys::O::RDONLY, 0) {
+        Ok(f) => match f.read_all(&mut buf) {
+            Ok(n) => n,
+            Err(err) => {
+                return Some(CompileResult::fail_fmt(format_args!(
+                    "failed to read base executable for '{}' at {}: {}",
+                    target,
+                    bstr::BStr::new(path.as_bytes()),
+                    err,
+                )));
+            }
+        },
+        Err(err) => {
+            return Some(CompileResult::fail_fmt(format_args!(
+                "failed to open base executable for '{}' at {}: {}",
+                target,
+                bstr::BStr::new(path.as_bytes()),
+                err,
+            )));
+        }
+    };
+
+    let Some(detected) = detect_header(&buf[..n]) else {
+        return Some(CompileResult::fail_fmt(format_args!(
+            "Base executable for '{}' at {} is not a recognized {} file. \
+             The cache entry may be corrupt or tampered with; delete it and try again.",
+            target,
+            bstr::BStr::new(path.as_bytes()),
+            expected_format.name(),
+        )));
+    };
+
+    if detected.format != expected_format {
+        return Some(CompileResult::fail_fmt(format_args!(
+            "Base executable for '{}' at {} is a {} file, expected {}. \
+             The cache entry may be corrupt or tampered with; delete it and try again.",
+            target,
+            bstr::BStr::new(path.as_bytes()),
+            detected.format.name(),
+            expected_format.name(),
+        )));
+    }
+
+    if detected.arch != expected_arch {
+        return Some(CompileResult::fail_fmt(format_args!(
+            "Base executable for '{}' at {} is {} {}, expected {}. \
+             The cache entry may be corrupt or tampered with; delete it and try again.",
+            target,
+            bstr::BStr::new(path.as_bytes()),
+            detected.format.name(),
+            detected.arch.name(),
+            expected_arch.name(),
+        )));
+    }
+
+    None
+}
 
 /// Moved up from `bun_options_types` (T3) so it can name
 /// `bun_http::AsyncHTTP` directly
@@ -1774,6 +1858,17 @@ pub fn to_executable(
 
         bun_core::ZBox::from_vec_with_nul(dest_z.as_bytes().to_vec())
     };
+
+    // When the base runtime is anything other than the running process itself
+    // (an explicit --compile-executable-path, a cwd/cache hit, or a fresh
+    // download), verify its on-disk header matches the requested target before
+    // embedding it verbatim. A wrong-arch or wrong-format file here becomes the
+    // runtime of every produced executable.
+    if self_exe_path.is_some() || !target.is_default() {
+        if let Some(failure) = validate_base_binary_header(target, &self_exe) {
+            return Ok(failure);
+        }
+    }
 
     let fd = inject(&bytes, &self_exe, windows_options, target);
     // Note: a scopeguard closure capturing `fd` by value would not observe

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isArm64, isLinux, isMacOS, isMusl, isPosix, isWindows, tempDir } from "harness";
-import { chmodSync } from "node:fs";
+import { chmodSync, copyFileSync } from "node:fs";
 import { join } from "path";
 
 describe("Bun.build compile", () => {
@@ -576,6 +576,97 @@ describe("compiled binary in a deleted cwd", () => {
     },
     60_000,
   );
+});
+
+// `bun build --compile --target=<other>` resolves its base runtime from the
+// install cache (or cwd) by filename and embeds it verbatim. A file planted
+// under the wrong key (wrong arch, wrong OS) must be rejected instead of
+// shipped as the runtime of every produced executable.
+describe("Bun.build compile base binary validation", () => {
+  const hostOs = isMacOS ? "darwin" : isWindows ? "windows" : "linux";
+  const hostArch = isArm64 ? "aarch64" : "x64";
+  const otherArch = isArm64 ? "x64" : "aarch64";
+  const targetOtherArch = isArm64 ? "x64" : "arm64";
+  const libc = isMusl ? "-musl" : "";
+
+  async function bunVersion(): Promise<string> {
+    await using p = Bun.spawn({ cmd: [bunExe(), "--version"], env: bunEnv, stdout: "pipe" });
+    // CompileTarget::Display formats only major.minor.patch (no pre-release tag),
+    // so strip anything after a '-' (e.g. "1.4.0-debug" -> "1.4.0").
+    return (await p.stdout.text()).trim().split("-")[0];
+  }
+
+  test("rejects cached base binary with wrong architecture", async () => {
+    const version = await bunVersion();
+    // Cache-key filename as formatted by CompileTarget::Display for the
+    // *other* arch on the same OS.
+    const plantedName = `bun-${hostOs}-${otherArch}${libc}-v${version}`;
+
+    using dir = tempDir("compile-base-wrong-arch", {
+      "app.ts": `console.log("tenant B app; claims arch =", process.arch)`,
+    });
+    const cwd = String(dir);
+    // Plant the host's own binary under the other-arch key. exe_path() finds
+    // a file with this exact name in cwd and treats it as a cache hit.
+    copyFileSync(bunExe(), join(cwd, plantedName));
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        `--target=bun-${hostOs}-${targetOtherArch}${isMusl ? "-musl" : ""}`,
+        "app.ts",
+        "--outfile",
+        "app",
+      ],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const output = stdout + stderr;
+    expect(output).toContain(plantedName);
+    expect(output).toContain(`expected ${targetOtherArch}`);
+    expect(output.toLowerCase()).toContain("tampered");
+    expect(exitCode).not.toBe(0);
+
+    // The wrong-arch artifact must not have been produced.
+    expect(await Bun.file(join(cwd, "app")).exists()).toBe(false);
+    expect(await Bun.file(join(cwd, "app.exe")).exists()).toBe(false);
+  });
+
+  test("rejects cached base binary with wrong format", async () => {
+    const version = await bunVersion();
+    // Ask for a different OS so the expected container format differs from the
+    // host binary's (ELF vs Mach-O vs PE). Keep the host arch so only the
+    // format check fires.
+    const crossOs = isMacOS ? "linux" : "darwin";
+    const targetArch = isArm64 ? "arm64" : "x64";
+    const plantedName = `bun-${crossOs}-${hostArch}-v${version}`;
+
+    using dir = tempDir("compile-base-wrong-os", {
+      "app.ts": `console.log("hi")`,
+    });
+    const cwd = String(dir);
+    copyFileSync(bunExe(), join(cwd, plantedName));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", `--target=bun-${crossOs}-${targetArch}`, "app.ts", "--outfile", "app"],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const output = stdout + stderr;
+    expect(output).toContain(plantedName);
+    expect(output.toLowerCase()).toContain("tampered");
+    expect(exitCode).not.toBe(0);
+  });
 });
 
 // file command test works well


### PR DESCRIPTION
## Problem

`bun build --compile --target=<other-platform>` resolves its base runtime to `<install cache>/bun-<os>-<arch>[-musl][-baseline]-v<version>` (or a same-named file in cwd). `compile_target.rs::exe_path()` sets `needs_download = false` on a bare `exists_at()` hit, and the file is then embedded verbatim as the runtime of the produced executable. The only subsequent guard is the per-format init parser; on the ELF path that accepts any 64-bit LE ELF regardless of `e_machine`.

So a writer to the shared cache directory controls the runtime of every executable a cross-compiling tenant ships:

```sh
# plant the local x86-64 bun under the arm64 key
cp $(which bun) ~/.bun/install/cache/bun-linux-aarch64-v$(bun --version)
# another tenant cross-compiles for arm64 as usual
echo 'console.log("tenant B app; claims arch =", process.arch)' > app.ts
bun build --compile --target=bun-linux-arm64 app.ts --outfile app
file app   # ELF 64-bit LSB executable, x86-64  <- planted file, verbatim
./app      # runs on the x86-64 host: "tenant B app; claims arch = arm64"
```

Any bun-shaped binary (older vulnerable release, rebuilt with modifications) is accepted; a non-bun ELF is only refused later for lacking the `.bun` section.

## Fix

Add `bun_exe_format::detect_header()` that sniffs the container format (ELF/Mach-O/PE) and machine type (`e_machine` / `cputype` / COFF `Machine`) from the first bytes of an image. In `to_executable()`, before `inject()`, whenever the base runtime is anything other than the running process itself (cache hit, fresh download, or `--compile-executable-path`), read the first 1 KiB and fail the build if the detected format or arch disagrees with the requested `--target`:

```
Base executable for 'bun-linux-aarch64-v1.4.0' at bun-linux-aarch64-v1.4.0 is ELF x64, expected arm64.
The cache entry may be corrupt or tampered with; delete it and try again.
```

This catches wrong-arch and wrong-OS plantings deterministically with no network dependency. It does not catch a correctly-targeted but modified binary; that needs registry `dist.integrity` verification on download and persisted re-verification on cache hit, which is a larger change (extra registry round-trip, and anywhere the attacker can write the cached binary they can also write a sidecar hash). Operator mitigation today remains a per-tenant `BUN_INSTALL_CACHE_DIR`.

## Verification

`test/bundler/bun-build-compile.test.ts` gains two cases that plant the host binary under (a) the other-arch key and (b) a different-OS key, then assert the build fails naming the planted file. Both fail on `main` (the wrong-arch case succeeds silently and produces an x64 ELF; the wrong-OS case fails with an unhelpful `InvalidObject`) and pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->