### PR TITLE
install: make `bun pm untrusted`/`trust` see packages under the isolated linker

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2664,6 +2664,79 @@ pub(crate) fn install_isolated_packages(
         let mut summary = core::mem::take(&mut installer.summary);
         summary.successfully_installed = Some(core::mem::take(&mut installer.installed));
 
+        // Hoisted fills `packages_with_blocked_scripts` inline in `install_package_with_name_and_resolution`; the worker-thread task here does not, so do it after the fact.
+        if let Some(installed) = summary.successfully_installed.as_ref() {
+            let pkg_metas = pkgs.items_meta();
+            let pkg_script_lists = pkgs.items_scripts();
+            let log_level = installer.manager().options.log_level;
+            let fail_early = installer.manager().options.enable.fail_early();
+            for _entry_id in 0..store.entries.len() {
+                let entry_id = store::entry::Id::from(u32::try_from(_entry_id).expect("int cast"));
+                let node_id = entry_node_ids[entry_id.get() as usize];
+                let pkg_id = node_pkg_ids[node_id.get() as usize];
+                let dep_id = node_dep_ids[node_id.get() as usize];
+                if dep_id == invalid_dependency_id || !installed.is_set(pkg_id as usize) {
+                    continue;
+                }
+                let pkg_res = pkg_resolutions[pkg_id as usize];
+                if matches!(pkg_res.tag, ResolutionTag::Root | ResolutionTag::Workspace) {
+                    continue;
+                }
+                if !pkg_metas[pkg_id as usize].has_install_script() {
+                    continue;
+                }
+                let dep = &lockfile_ro.buffers.dependencies[dep_id as usize];
+                let alias = dep.name.slice(string_buf);
+                let truncated_dep_name_hash = dep.name_hash as crate::TruncatedPackageNameHash;
+                let is_trusted = installer
+                    .trusted_dependencies_from_update_requests
+                    .contains(&pkg_id)
+                    || lockfile_ro.has_trusted_dependency(
+                        alias,
+                        pkg_names[pkg_id as usize].slice(string_buf),
+                        &pkg_res,
+                    );
+                if is_trusted {
+                    continue;
+                }
+                let mut pkg_cwd = AbsPath::init_top_level_dir();
+                installer.append_store_path(&mut pkg_cwd, entry_id);
+                let mut pkg_scripts = pkg_script_lists[pkg_id as usize];
+                let count = match pkg_scripts.get_list(
+                    installer.manager().log_mut(),
+                    lockfile_ro,
+                    &mut pkg_cwd,
+                    alias,
+                    &pkg_res,
+                ) {
+                    Ok(Some(list)) => list.total as usize,
+                    Ok(None) => 0,
+                    Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT)) => 0,
+                    Err(err) => {
+                        if log_level != crate::package_manager::Options::LogLevel::Silent {
+                            Output::err_generic(
+                                "failed to fill lifecycle scripts for <b>{}<r>: {}",
+                                (bstr::BStr::new(alias), err.name()),
+                            );
+                        }
+                        if fail_early {
+                            Global::crash();
+                        }
+                        0
+                    }
+                };
+                if count > 0 {
+                    let entry = summary
+                        .packages_with_blocked_scripts
+                        .get_or_put(truncated_dep_name_hash)?;
+                    if !entry.found_existing {
+                        *entry.value_ptr = 0;
+                    }
+                    *entry.value_ptr += count;
+                }
+            }
+        }
+
         return Ok(summary);
     }
 }

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -5,18 +5,20 @@ use bun_alloc::Arena as Bump;
 use bun_collections::{ArrayHashMap, ArrayIdentityContext, StringArrayHashMap};
 use bun_core::strings;
 use bun_core::{Global, Output, Progress};
+use bun_install::isolated_install::store::entry::fmt_store_key;
 use bun_install::lockfile::{
     LoadResult, Lockfile,
     package::PackageColumns as _,
     package::scripts::{List as ScriptsList, PrintFormat, Scripts},
     tree,
 };
+use bun_install::package_manager::Options::NodeLinker;
 use bun_install::package_manager_real::{
     PackageJSONEditor, ProgressStrings, ROOT_PACKAGE_JSON_PATH, update_lockfile_if_needed,
 };
 use bun_install::{
     self as install, DEFAULT_TRUSTED_DEPENDENCIES_LIST, DependencyID, LifecycleScriptSubprocess,
-    PackageID, PackageManager, Resolution,
+    PackageID, PackageManager, Resolution, ResolutionTag,
 };
 use bun_paths::AutoAbsPath;
 
@@ -24,6 +26,139 @@ use crate::cli::Command;
 use crate::package_manager_command::PackageManagerCommand;
 
 type DepIdSet = ArrayHashMap<DependencyID, (), ArrayIdentityContext>;
+
+/// Probes `node_modules/.bun/<name>@<res>[+<peerhash>]/node_modules/<name>` for each untrusted dep; `f`'s `bool` is "entry is a global-store symlink". Returns `Ok(false)` if the caller should do the hoisted tree walk instead.
+fn collect_isolated_untrusted_scripts(
+    node_linker: NodeLinker,
+    log: &mut bun_ast::Log,
+    lockfile: &Lockfile,
+    scripts: &[Scripts],
+    resolutions: &[Resolution],
+    untrusted_dep_ids: &DepIdSet,
+    mut f: impl FnMut(DependencyID, PackageID, ScriptsList, bool) -> crate::Result<()>,
+) -> crate::Result<bool> {
+    // A stale `.bun` can outlive a switch to the hoisted linker.
+    if node_linker == NodeLinker::Hoisted {
+        return Ok(false);
+    }
+
+    let mut store_path = AutoAbsPath::init_top_level_dir();
+    let _ = store_path.append(b"node_modules");
+    let _ = store_path.append(b".bun");
+
+    let store_fd = match bun_sys::open_dir_for_iteration(bun_sys::Fd::cwd(), store_path.slice()) {
+        Ok(fd) => fd,
+        Err(e) if e.get_errno() == bun_sys::E::ENOENT => return Ok(false),
+        Err(e) => return Err(crate::Error::from(e)),
+    };
+    let _close = scopeguard::guard(store_fd, |fd| {
+        let _ = bun_sys::close(fd);
+    });
+
+    let mut entries: Vec<(Box<[u8]>, bool)> = Vec::new();
+    let mut iter = bun_sys::iterate_dir(store_fd);
+    loop {
+        match iter.next() {
+            Ok(Some(ent)) => {
+                let name = ent.name.slice_u8();
+                if name == b"node_modules" || name.first() == Some(&b'.') {
+                    continue;
+                }
+                // Fails closed: only a confirmed directory is treated as project-local.
+                let in_global_store = match ent.kind {
+                    bun_sys::EntryKind::SymLink => true,
+                    bun_sys::EntryKind::Directory => false,
+                    #[cfg(not(windows))]
+                    bun_sys::EntryKind::Unknown => {
+                        let name_z = bun_core::ZBox::from_bytes(name);
+                        match bun_sys::lstatat(store_fd, name_z.as_zstr()) {
+                            Ok(st) => {
+                                bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode)
+                                    != bun_sys::EntryKind::Directory
+                            }
+                            Err(_) => true,
+                        }
+                    }
+                    _ => true,
+                };
+                entries.push((Box::from(name), in_global_store));
+            }
+            Ok(None) => break,
+            Err(e) => return Err(crate::Error::from(e)),
+        }
+    }
+
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let packages = lockfile.packages.slice();
+    let pkg_names = packages.items_name();
+
+    let mut seen_pkg_ids: ArrayHashMap<PackageID, (), ArrayIdentityContext> = ArrayHashMap::new();
+
+    for &dep_id in untrusted_dep_ids.keys() {
+        let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+        if package_id == install::INVALID_PACKAGE_ID
+            || package_id as usize >= resolutions.len()
+            || seen_pkg_ids.contains(&package_id)
+        {
+            continue;
+        }
+        let resolution = &resolutions[package_id as usize];
+        match resolution.tag {
+            ResolutionTag::Root | ResolutionTag::Workspace | ResolutionTag::Symlink => continue,
+            _ => {}
+        }
+        seen_pkg_ids.put(package_id, ())?;
+
+        let pkg_name = pkg_names[package_id as usize];
+        let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
+        let alias = dep.name.slice(buf);
+
+        let prefix = format!("{}", fmt_store_key(pkg_name, resolution, buf)).into_bytes();
+
+        for (entry, in_global_store) in &entries {
+            // `StorePathFormatter` emits the peer hash as `+{:016x}`; anything looser over-matches `+build` metadata.
+            const PEER_HASH_SUFFIX_LEN: usize = 1 + 16;
+            let matches = entry[..] == prefix[..]
+                || (entry.len() == prefix.len() + PEER_HASH_SUFFIX_LEN
+                    && entry[..prefix.len()] == prefix[..]
+                    && entry[prefix.len()] == b'+'
+                    && entry[prefix.len() + 1..]
+                        .iter()
+                        .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')));
+            if !matches {
+                continue;
+            }
+
+            let mut folder_path = AutoAbsPath::init_top_level_dir();
+            let _ = folder_path.append(b"node_modules");
+            let _ = folder_path.append(b".bun");
+            let _ = folder_path.append(&entry[..]);
+            let _ = folder_path.append(b"node_modules");
+            let _ = folder_path.append(pkg_name.slice(buf));
+
+            let mut package_scripts = scripts[package_id as usize];
+            let maybe_list = match package_scripts.get_list(
+                log,
+                lockfile,
+                &mut folder_path,
+                alias,
+                resolution,
+            ) {
+                Ok(v) => v,
+                Err(bun_install::Error::Sys(bun_errno::SystemErrno::ENOENT)) => continue,
+                Err(e) => return Err(e.into()),
+            };
+
+            if let Some(list) = maybe_list {
+                if list.total > 0 && !list.items.is_empty() {
+                    f(dep_id, package_id, list, *in_global_store)?;
+                }
+            }
+        }
+    }
+
+    Ok(true)
+}
 
 pub(crate) struct DefaultTrustedCommand;
 
@@ -62,6 +197,7 @@ impl UntrustedCommand {
         // as `package_manager_command.rs::print_hash`.
         let pm_raw: *mut PackageManager = pm;
         let log_level = pm.options.log_level;
+        let node_linker = pm.options.node_linker;
         let load_lockfile = pm.load_lockfile_from_cwd::<true>();
         PackageManagerCommand::handle_load_lockfile_errors_for(&load_lockfile, log_level, "list");
         // SAFETY: `pm_raw` derived from `pm` above; `update_lockfile_if_needed`
@@ -110,62 +246,73 @@ impl UntrustedCommand {
         let mut untrusted_deps: ArrayHashMap<DependencyID, ScriptsList, ArrayIdentityContext> =
             ArrayHashMap::new();
 
-        let mut tree_iterator =
-            tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
+        let found_isolated = collect_isolated_untrusted_scripts(
+            node_linker,
+            log,
+            lockfile,
+            scripts,
+            resolutions,
+            &untrusted_dep_ids,
+            |dep_id, _package_id, list, _in_global_store| {
+                untrusted_deps.put(dep_id, list)?;
+                Ok(())
+            },
+        )?;
 
-        let mut node_modules_path = AutoAbsPath::init_top_level_dir();
+        if !found_isolated {
+            let mut tree_iterator =
+                tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
 
-        while let Some(node_modules) = tree_iterator.next(None) {
-            // `ResetScope`
-            // exclusively borrows the path, so save/restore the length
-            // explicitly. Restored at end of each iteration; the inner-loop
-            // `continue`/`return` paths only need the inner `folder_saved`
-            // restore (done immediately after `get_list`).
-            let nm_saved = node_modules_path.len();
-            let _ = node_modules_path.append(node_modules.relative_path.as_bytes());
+            let mut node_modules_path = AutoAbsPath::init_top_level_dir();
 
-            for &dep_id in node_modules.dependencies {
-                if !untrusted_dep_ids.contains(&dep_id) {
-                    continue;
-                }
-                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
-                let alias = dep.name.slice(buf);
-                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+            while let Some(node_modules) = tree_iterator.next(None) {
+                // Manual save/restore: `ResetScope` would hold an exclusive borrow across the inner loop.
+                let nm_saved = node_modules_path.len();
+                let _ = node_modules_path.append(node_modules.relative_path.as_bytes());
 
-                if package_id as usize >= packages.len() {
-                    continue;
-                }
-
-                let resolution = &resolutions[package_id as usize];
-                let mut package_scripts = scripts[package_id as usize];
-
-                let folder_saved = node_modules_path.len();
-                let _ = node_modules_path.append(alias);
-
-                let result = package_scripts.get_list(
-                    log,
-                    lockfile,
-                    &mut node_modules_path,
-                    alias,
-                    resolution,
-                );
-                node_modules_path.set_length(folder_saved);
-
-                let maybe_scripts_list = match result {
-                    Ok(v) => v,
-                    Err(bun_install::Error::Sys(bun_errno::SystemErrno::ENOENT)) => continue,
-                    Err(e) => return Err(e.into()),
-                };
-
-                if let Some(scripts_list) = maybe_scripts_list {
-                    if scripts_list.total == 0 || scripts_list.items.is_empty() {
+                for &dep_id in node_modules.dependencies {
+                    if !untrusted_dep_ids.contains(&dep_id) {
                         continue;
                     }
-                    untrusted_deps.put(dep_id, scripts_list)?;
-                }
-            }
+                    let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
+                    let alias = dep.name.slice(buf);
+                    let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
 
-            node_modules_path.set_length(nm_saved);
+                    if package_id as usize >= packages.len() {
+                        continue;
+                    }
+
+                    let resolution = &resolutions[package_id as usize];
+                    let mut package_scripts = scripts[package_id as usize];
+
+                    let folder_saved = node_modules_path.len();
+                    let _ = node_modules_path.append(alias);
+
+                    let result = package_scripts.get_list(
+                        log,
+                        lockfile,
+                        &mut node_modules_path,
+                        alias,
+                        resolution,
+                    );
+                    node_modules_path.set_length(folder_saved);
+
+                    let maybe_scripts_list = match result {
+                        Ok(v) => v,
+                        Err(bun_install::Error::Sys(bun_errno::SystemErrno::ENOENT)) => continue,
+                        Err(e) => return Err(e.into()),
+                    };
+
+                    if let Some(scripts_list) = maybe_scripts_list {
+                        if scripts_list.total == 0 || scripts_list.items.is_empty() {
+                            continue;
+                        }
+                        untrusted_deps.put(dep_id, scripts_list)?;
+                    }
+                }
+
+                node_modules_path.set_length(nm_saved);
+            }
         }
 
         if untrusted_deps.count() == 0 {
@@ -212,6 +359,8 @@ struct ScriptInfo {
     package_id: PackageID,
     scripts_list: ScriptsList,
     skip: bool,
+    /// Trusted but not run here: the next `bun install` detaches the entry from the shared store and runs it.
+    in_global_store: bool,
 }
 
 impl TrustCommand {
@@ -258,6 +407,7 @@ impl TrustCommand {
         // `pm`/`pm.lockfile` access in between goes through `pm_raw`.
         let pm_raw: *mut PackageManager = pm;
         let log_level = pm.options.log_level;
+        let node_linker = pm.options.node_linker;
         let load_lockfile = pm.load_lockfile_from_cwd::<true>();
         PackageManagerCommand::handle_load_lockfile_errors_for(&load_lockfile, log_level, "trust");
         // `update_lockfile_if_needed` consumes `LoadResult` but we
@@ -331,107 +481,139 @@ impl TrustCommand {
         // Instead of running them right away, we group scripts by depth in the node_modules
         // file structure, then run them starting at max depth. This ensures lifecycle scripts are run
         // in the correct order as they would during a normal install
-        let mut tree_iter =
-            tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
-
-        let mut node_modules_path = AutoAbsPath::init_top_level_dir();
-
         let mut package_names_to_add: StringArrayHashMap<()> = StringArrayHashMap::new();
         let mut scripts_at_depth: ArrayHashMap<usize, Vec<ScriptInfo>> = ArrayHashMap::new();
 
         let mut scripts_count: usize = 0;
 
-        while let Some(node_modules) = tree_iter.next(None) {
-            let nm_saved = node_modules_path.len();
-            let _ = node_modules_path.append(node_modules.relative_path.as_bytes());
+        // Shared by the isolated and hoisted discovery paths below; skipped packages are still recorded so they can be listed.
+        let mut record = |dep_id: DependencyID,
+                          package_id: PackageID,
+                          scripts_list: ScriptsList,
+                          depth: usize,
+                          in_global_store: bool|
+         -> crate::Result<()> {
+            let alias = lockfile.buffers.dependencies.as_slice()[dep_id as usize]
+                .name
+                .slice(buf);
+            let resolution = &resolutions[package_id as usize];
 
-            let _node_modules_dir = match bun_sys::Dir::cwd()
-                .open_at(node_modules.relative_path.as_bytes())
-                .map_err(crate::Error::from)
-            {
-                Ok(d) => d,
-                Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT)) => {
-                    node_modules_path.set_length(nm_saved);
-                    continue;
+            let skip = 'brk: {
+                if trust_all {
+                    break 'brk false;
                 }
-                Err(e) => return Err(e),
+                for package_name_from_cli in &packages_to_trust {
+                    if strings::eql_long(package_name_from_cli, alias, true)
+                        && !lockfile.has_trusted_dependency(
+                            alias,
+                            packages.items_name()[package_id as usize].slice(buf),
+                            resolution,
+                        )
+                    {
+                        break 'brk false;
+                    }
+                }
+                true
             };
 
-            for &dep_id in node_modules.dependencies {
-                if !untrusted_dep_ids.contains(&dep_id) {
-                    continue;
-                }
-                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
-                let alias = dep.name.slice(buf);
-                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+            let total = scripts_list.total as usize;
+            let entry = scripts_at_depth.get_or_put(depth)?;
+            if !entry.found_existing {
+                *entry.value_ptr = Vec::new();
+            }
+            entry.value_ptr.push(ScriptInfo {
+                package_id,
+                scripts_list,
+                skip,
+                in_global_store,
+            });
 
-                if package_id as usize >= packages.len() {
-                    continue;
-                }
-
-                let resolution = &resolutions[package_id as usize];
-                let mut package_scripts = scripts[package_id as usize];
-
-                let folder_saved = node_modules_path.len();
-                let _ = node_modules_path.append(alias);
-
-                // SAFETY: `log` derived from `pm.log`; single-threaded CLI.
-                let result = package_scripts.get_list(
-                    unsafe { &mut *log },
-                    lockfile,
-                    &mut node_modules_path,
-                    alias,
-                    resolution,
-                );
-                node_modules_path.set_length(folder_saved);
-
-                let maybe_scripts_list = match result {
-                    Ok(v) => v,
-                    Err(bun_install::Error::Sys(bun_errno::SystemErrno::ENOENT)) => continue,
-                    Err(e) => return Err(e.into()),
-                };
-
-                if let Some(scripts_list) = maybe_scripts_list {
-                    let skip = 'brk: {
-                        if trust_all {
-                            break 'brk false;
-                        }
-
-                        for package_name_from_cli in &packages_to_trust {
-                            if strings::eql_long(package_name_from_cli, alias, true)
-                                && !lockfile.has_trusted_dependency(
-                                    alias,
-                                    packages.items_name()[package_id as usize].slice(buf),
-                                    resolution,
-                                )
-                            {
-                                break 'brk false;
-                            }
-                        }
-
-                        true
-                    };
-
-                    let total = scripts_list.total as usize;
-                    // even if it is skipped we still add to scripts_at_depth for logging later
-                    let entry = scripts_at_depth.get_or_put(node_modules.depth)?;
-                    if !entry.found_existing {
-                        *entry.value_ptr = Vec::new();
-                    }
-                    entry.value_ptr.push(ScriptInfo {
-                        package_id,
-                        scripts_list,
-                        skip,
-                    });
-
-                    if !skip {
-                        package_names_to_add.put(alias, ())?;
-                        scripts_count += total;
-                    }
+            if !skip {
+                package_names_to_add.put(alias, ())?;
+                if !in_global_store {
+                    scripts_count += total;
                 }
             }
+            Ok(())
+        };
 
-            node_modules_path.set_length(nm_saved);
+        // SAFETY: `log` derived from `pm.log`; single-threaded CLI.
+        let found_isolated = collect_isolated_untrusted_scripts(
+            node_linker,
+            unsafe { &mut *log },
+            lockfile,
+            scripts,
+            resolutions,
+            &untrusted_dep_ids,
+            // The store is flat, so everything is depth 0 (same as a fully hoisted tree).
+            |dep_id, package_id, scripts_list, in_global_store| {
+                record(dep_id, package_id, scripts_list, 0, in_global_store)
+            },
+        )?;
+
+        if !found_isolated {
+            let mut tree_iter =
+                tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
+
+            let mut node_modules_path = AutoAbsPath::init_top_level_dir();
+
+            while let Some(node_modules) = tree_iter.next(None) {
+                let nm_saved = node_modules_path.len();
+                let _ = node_modules_path.append(node_modules.relative_path.as_bytes());
+
+                let _node_modules_dir = match bun_sys::Dir::cwd()
+                    .open_at(node_modules.relative_path.as_bytes())
+                    .map_err(crate::Error::from)
+                {
+                    Ok(d) => d,
+                    Err(crate::Error::Sys(bun_errno::SystemErrno::ENOENT)) => {
+                        node_modules_path.set_length(nm_saved);
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                };
+
+                for &dep_id in node_modules.dependencies {
+                    if !untrusted_dep_ids.contains(&dep_id) {
+                        continue;
+                    }
+                    let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
+                    let alias = dep.name.slice(buf);
+                    let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+
+                    if package_id as usize >= packages.len() {
+                        continue;
+                    }
+
+                    let resolution = &resolutions[package_id as usize];
+                    let mut package_scripts = scripts[package_id as usize];
+
+                    let folder_saved = node_modules_path.len();
+                    let _ = node_modules_path.append(alias);
+
+                    // SAFETY: `log` derived from `pm.log`; single-threaded CLI.
+                    let result = package_scripts.get_list(
+                        unsafe { &mut *log },
+                        lockfile,
+                        &mut node_modules_path,
+                        alias,
+                        resolution,
+                    );
+                    node_modules_path.set_length(folder_saved);
+
+                    let maybe_scripts_list = match result {
+                        Ok(v) => v,
+                        Err(bun_install::Error::Sys(bun_errno::SystemErrno::ENOENT)) => continue,
+                        Err(e) => return Err(e.into()),
+                    };
+
+                    if let Some(scripts_list) = maybe_scripts_list {
+                        record(dep_id, package_id, scripts_list, node_modules.depth, false)?;
+                    }
+                }
+
+                node_modules_path.set_length(nm_saved);
+            }
         }
 
         if scripts_at_depth.count() == 0 || package_names_to_add.count() == 0 {
@@ -463,7 +645,7 @@ impl TrustCommand {
         // the `List` per spawn.
         for entry in scripts_at_depth.values().iter().rev() {
             for info in entry.iter() {
-                if info.skip {
+                if info.skip || info.in_global_store {
                     continue;
                 }
 
@@ -587,6 +769,7 @@ impl TrustCommand {
         let mut total_scripts_ran: usize = 0;
         let mut total_packages_with_scripts: usize = 0;
         let mut total_skipped_packages: usize = 0;
+        let mut total_global_store_packages: usize = 0;
 
         Output::print(format_args!("\n"));
 
@@ -600,6 +783,10 @@ impl TrustCommand {
                     info.scripts_list
                         .print_scripts(resolution, buf, PrintFormat::Untrusted);
                     total_skipped_packages += 1;
+                } else if info.in_global_store {
+                    info.scripts_list
+                        .print_scripts(resolution, buf, PrintFormat::Untrusted);
+                    total_global_store_packages += 1;
                 } else {
                     total_packages_with_scripts += 1;
                     total_scripts_ran += info.scripts_list.total as usize;
@@ -675,22 +862,45 @@ impl TrustCommand {
         let _ = bun_sys::ftruncate(root_file.handle, new_package_json_contents.len() as i64);
         let _ = root_file.close();
 
-        debug_assert!(total_scripts_ran > 0);
+        debug_assert!(total_scripts_ran > 0 || total_global_store_packages > 0);
 
-        bun_core::pretty!(
-            " <green>{}<r> script{} ran across {} package{} ",
-            total_scripts_ran,
-            if total_scripts_ran > 1 { "s" } else { "" },
-            total_packages_with_scripts,
-            if total_packages_with_scripts > 1 {
-                "s"
-            } else {
-                ""
-            },
-        );
+        if total_scripts_ran > 0 {
+            bun_core::pretty!(
+                " <green>{}<r> script{} ran across {} package{} ",
+                total_scripts_ran,
+                if total_scripts_ran > 1 { "s" } else { "" },
+                total_packages_with_scripts,
+                if total_packages_with_scripts > 1 {
+                    "s"
+                } else {
+                    ""
+                },
+            );
 
-        Output::print_start_end_stdout(bun_core::start_time(), bun_core::time::nano_timestamp());
-        Output::print(format_args!("\n"));
+            Output::print_start_end_stdout(
+                bun_core::start_time(),
+                bun_core::time::nano_timestamp(),
+            );
+            Output::print(format_args!("\n"));
+        }
+
+        if total_global_store_packages > 0 {
+            Output::print(format_args!("\n"));
+            bun_core::prettyln!(
+                " <yellow>{}<r> package{} linked from the global store; run <d>`<r><blue>bun install<r><d>`<r> to run {} scripts in a project-local copy",
+                total_global_store_packages,
+                if total_global_store_packages > 1 {
+                    "s are"
+                } else {
+                    " is"
+                },
+                if total_global_store_packages > 1 {
+                    "their"
+                } else {
+                    "its"
+                },
+            );
+        }
 
         if total_skipped_packages > 0 {
             Output::print(format_args!("\n"));

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1,5 +1,6 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { readdirSync } from "fs";
 import { exists, mkdir, rm, writeFile } from "fs/promises";
 import {
   VerdaccioRegistry,
@@ -10,6 +11,7 @@ import {
   isWindows,
   readdirSorted,
   runBunInstall,
+  tempDir,
 } from "harness";
 import { join, sep } from "path";
 
@@ -4217,3 +4219,232 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
   });
 }
+
+// These tests use a self-contained registry instead of verdaccio because the
+// verdaccio fixture set is installed under a hoisted `setupTest()`, and the
+// isolated-linker code path needs a workspace layout.
+describe.concurrent("pm untrusted/trust under the isolated linker", () => {
+  function makeTarball(pkg: Record<string, unknown>): Uint8Array {
+    const enc = new TextEncoder();
+    const hdr = (name: string, size: number) => {
+      const h = new Uint8Array(512);
+      const put = (s: string, o: number) => h.set(enc.encode(s), o);
+      put(name, 0);
+      put("0000644\0", 100);
+      put("0000000\0", 108);
+      put("0000000\0", 116);
+      put(size.toString(8).padStart(11, "0") + "\0", 124);
+      put("00000000000\0", 136);
+      h.fill(0x20, 148, 156);
+      h[156] = 0x30;
+      put("ustar\0", 257);
+      put("00", 263);
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += h[i];
+      put(sum.toString(8).padStart(6, "0") + "\0 ", 148);
+      return h;
+    };
+    const entry = (name: string, data: string) => {
+      const body = enc.encode(data);
+      const pad = new Uint8Array((512 - (body.length % 512)) % 512);
+      return [hdr(name, body.length), body, pad];
+    };
+    const parts = [
+      ...entry("package/package.json", JSON.stringify(pkg)),
+      ...entry("package/index.js", "module.exports = {}"),
+      new Uint8Array(1024),
+    ];
+    const out = new Uint8Array(parts.reduce((a, x) => a + x.length, 0));
+    let off = 0;
+    for (const p of parts) {
+      out.set(p, off);
+      off += p.length;
+    }
+    return Bun.gzipSync(out);
+  }
+
+  /**
+   * Workspace root + `packages/b` depending on `pkgName`, which has a postinstall
+   * that drops `RAN-marker` in its own directory. Served from an in-process registry.
+   * `depSpec(serverUrl)` controls how `packages/b` depends on it.
+   */
+  async function setup(opts: { pkgName: string; bunfigExtra?: string; depSpec?: (serverUrl: string) => string }) {
+    const { pkgName } = opts;
+    const pj = {
+      name: pkgName,
+      version: "1.0.0",
+      scripts: {
+        postinstall: `${bunExe()} -e 'require("fs").writeFileSync("RAN-marker","ok")'`,
+      },
+    };
+    const tgz = makeTarball(pj);
+    const integrity = "sha512-" + new Bun.CryptoHasher("sha512").update(tgz).digest("base64");
+
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname.endsWith(".tgz")) return new Response(tgz);
+        return Response.json({
+          name: pkgName,
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              ...pj,
+              hasInstallScript: true,
+              dist: { tarball: `${server.url}${pkgName}-1.0.0.tgz`, integrity },
+            },
+          },
+        });
+      },
+    });
+    const serverUrl = String(server.url);
+
+    const dir = tempDir("pm-trust-isolated", {
+      "package.json": JSON.stringify({ name: "root", private: true, workspaces: ["packages/*"] }),
+      "packages/b/package.json": JSON.stringify({
+        name: "ws-b",
+        version: "1.0.0",
+        dependencies: { [pkgName]: opts.depSpec ? opts.depSpec(serverUrl) : "1.0.0" },
+      }),
+    });
+    const packageDir = String(dir);
+    const cacheDir = join(packageDir, ".bun-cache");
+    await write(
+      join(packageDir, "bunfig.toml"),
+      `[install]\nregistry = "${serverUrl}"\ncache = "${cacheDir.replaceAll("\\", "\\\\")}"\nlinker = "isolated"\n${opts.bunfigExtra ?? ""}`,
+    );
+
+    return {
+      packageDir,
+      cacheDir,
+      env: { ...baseEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
+      async [Symbol.asyncDispose]() {
+        await server.stop(true);
+        await dir[Symbol.asyncDispose]();
+      },
+    };
+  }
+
+  async function run(ctx: { packageDir: string; env: Record<string, string> }, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: ctx.packageDir,
+      env: ctx.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err, exitCode };
+  }
+
+  function findMarkers(root: string): string[] {
+    const found: string[] = [];
+    const walk = (d: string) => {
+      for (const e of readdirSync(d, { withFileTypes: true })) {
+        const full = join(d, e.name);
+        if (e.name === "RAN-marker") found.push(full);
+        else if (e.isDirectory() && !e.isSymbolicLink()) walk(full);
+      }
+    };
+    walk(root);
+    return found;
+  }
+
+  test("finds and runs workspace-member dep scripts in node_modules/.bun", async () => {
+    const pkgName = "lifecycle-postinstall-pkg";
+    await using ctx = await setup({ pkgName });
+    const { packageDir } = ctx;
+
+    {
+      const { out, err, exitCode } = await run(ctx, "install");
+      expect(err).not.toContain("error:");
+      expect(out).toContain("Blocked 1 postinstall. Run `bun pm untrusted` for details.");
+      expect(exitCode).toBe(0);
+    }
+
+    const storePkgDir = join(packageDir, "node_modules", ".bun", `${pkgName}@1.0.0`, "node_modules", pkgName);
+    expect(await exists(storePkgDir)).toBe(true);
+    expect(await exists(join(storePkgDir, "RAN-marker"))).toBe(false);
+
+    {
+      const { out, err, exitCode } = await run(ctx, "pm", "untrusted");
+      expect(err).toContain("bun pm untrusted");
+      expect(out).toContain(join("node_modules", ".bun", `${pkgName}@1.0.0`, "node_modules", pkgName));
+      expect(out).toContain("[postinstall]");
+      expect(exitCode).toBe(0);
+    }
+
+    {
+      const { out, err, exitCode } = await run(ctx, "pm", "trust", pkgName);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("1 script ran across 1 package");
+      expect(exitCode).toBe(0);
+    }
+
+    expect(await exists(join(storePkgDir, "RAN-marker"))).toBe(true);
+    expect(JSON.parse(await file(join(packageDir, "package.json")).text()).trustedDependencies).toEqual([pkgName]);
+  });
+
+  test("matches store entries whose resolution was truncated and hashed", async () => {
+    const pkgName = "lifecycle-long-url-pkg";
+    // The store dir is `<name>@<resolution>`, and the resolution part is capped
+    // (Store.rs MAX_RESOLUTION_LEN); a long tarball URL forces the
+    // `<cut>+<hash>` form, which a naive `<name>@<full resolution>` lookup misses.
+    const longSegment = Buffer.alloc(120, "x").toString();
+    await using ctx = await setup({ pkgName, depSpec: url => `${url}${longSegment}/${pkgName}-1.0.0.tgz` });
+    const { packageDir } = ctx;
+
+    {
+      const { out, err, exitCode } = await run(ctx, "install");
+      expect(err).not.toContain("error:");
+      expect(out).toContain("Blocked 1 postinstall. Run `bun pm untrusted` for details.");
+      expect(exitCode).toBe(0);
+    }
+
+    const bunStore = join(packageDir, "node_modules", ".bun");
+    const [entryName, ...rest] = readdirSync(bunStore).filter(n => n.startsWith(`${pkgName}@`));
+    expect(rest).toEqual([]);
+    // Proves the truncation path was taken: far shorter than the URL we depended on.
+    expect(entryName.length).toBeLessThan(`${pkgName}@`.length + longSegment.length);
+    expect(entryName).toMatch(/\+[0-9a-f]{16}$/);
+
+    {
+      const { out, exitCode } = await run(ctx, "pm", "untrusted");
+      expect(out).toContain(join("node_modules", ".bun", entryName, "node_modules", pkgName));
+      expect(out).toContain("[postinstall]");
+      expect(exitCode).toBe(0);
+    }
+
+    {
+      const { out, err, exitCode } = await run(ctx, "pm", "trust", pkgName);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("1 script ran across 1 package");
+      expect(exitCode).toBe(0);
+    }
+
+    expect(findMarkers(bunStore)).toEqual([join(bunStore, entryName, "node_modules", pkgName, "RAN-marker")]);
+    expect(JSON.parse(await file(join(packageDir, "package.json")).text()).trustedDependencies).toEqual([pkgName]);
+  });
+
+  test("does not run scripts inside the shared global store", async () => {
+    const pkgName = "lifecycle-globalstore-pkg";
+    await using ctx = await setup({ pkgName, bunfigExtra: "globalStore = true\n" });
+    const { packageDir, cacheDir } = ctx;
+
+    {
+      const { err, exitCode } = await run(ctx, "install");
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    {
+      const { out, err, exitCode } = await run(ctx, "pm", "trust", pkgName);
+      expect(err).not.toContain("error:");
+      expect(out).toContain("linked from the global store");
+      expect(exitCode).toBe(0);
+    }
+
+    expect(JSON.parse(await file(join(packageDir, "package.json")).text()).trustedDependencies).toEqual([pkgName]);
+    expect(findMarkers(cacheDir)).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Problem

- Under the isolated linker (the default once `workspaces` is declared), a workspace member's registry dep with a `postinstall` is invisible to the script audit: `bun install` prints no "Blocked N postinstalls" hint, `bun pm untrusted` reports `Found 0 untrusted dependencies with scripts`, and `bun pm trust <name>` fails with "already trusted, don't have scripts to run, or don't exist". The same tree with `linker = "hoisted"` works.
- The script does not run untrusted (fail-closed); only the audit and remediation surface is blind.
- Cause, `src/runtime/cli/pm_trusted_command.rs`: both commands walk `lockfile::tree::Iterator`, which is always the hoisted layout, and probe `node_modules/<alias>/package.json`. Under isolated the package lives at `node_modules/.bun/<name>@<res>[+<peerhash>]/node_modules/<name>`, so every probe is `ENOENT` and is skipped.
- Cause, `src/install/isolated_install.rs`: the per-entry install task skips untrusted packages without touching `summary.packages_with_blocked_scripts`, so the install summary never prints the hint (the hoisted installer fills it in `install_package_with_name_and_resolution`).

### Fix

- `pm_trusted_command.rs`: new `collect_isolated_untrusted_scripts`, called by both commands before the tree walk. If the configured linker is hoisted or `node_modules/.bun` is absent it returns `false` and the existing walk runs. Otherwise it readdirs `.bun` once and, per untrusted package, builds the entry name with the installer's own `store::entry::fmt_store_key` (which also applies the 80-byte resolution cap and `+<hash>` truncation) and probes entries that match it exactly or with one extra `+<16 lowercase hex>` peer-hash suffix; anything looser over-matches semver `+build` metadata.
- `TrustCommand` decides skip-or-run, records the `ScriptInfo`, and updates `trustedDependencies` in one `record` closure fed by both discovery paths, so the pending `npm:` alias change in #39443 has a single place to land regardless of merge order.
- Entries that are symlinks are global-virtual-store links. `pm untrusted` still lists them; `pm trust` adds the name to `trustedDependencies` but does not spawn the script there (it would mutate the shared cache) and tells the user to run `bun install`, which detaches the entry and runs it. `DT_UNKNOWN` dirents are resolved with `lstat`; anything that is not a directory takes the symlink path, so the guard fails closed.
- `isolated_install.rs`: after the tasks drain, fill `packages_with_blocked_scripts` for untrusted entries that were installed this run (`successfully_installed`, matching the hoisted `needs_install` gate). `get_list` errors other than `ENOENT` are reported the same way `get_installed_package_scripts_count` reports them.
- Verified by three tests in `test/cli/install/bun-install-lifecycle-scripts.test.ts`, all on an in-process registry: "finds and runs workspace-member dep scripts in node_modules/.bun" asserts the install hint, the `pm untrusted` listing at the `.bun` path, and that `pm trust` runs the script and writes `trustedDependencies`; "matches store entries whose resolution was truncated and hashed" depends on the package through a tarball URL long enough to hit the resolution cap and asserts both commands still find the `+<hash>` entry; "does not run scripts inside the shared global store" uses `globalStore = true` and asserts nothing was written under the cache. All fail against `main`'s `src/` and pass with this diff; `bun-pm.test.ts` still passes.
- Rebased onto current `main` (one squashed commit). Three API changes landed underneath and were adapted: `Installer.trusted_dependencies_from_update_requests` is now keyed by `PackageID` (`.contains(&pkg_id)`), the dirent `Name::as_zstr` became crate-private (use `ZBox::from_bytes(..).as_zstr()`), and `PrintFormat::Info` was deleted (global-store entries print with `Untrusted`, which is accurate since the script did not run). The test's `stderrForInstall` helper no longer exists; the harness now suppresses that warning itself.

### Background

- Hoisted vs isolated linker: hoisted installs every package into a `node_modules/<name>` tree described by `lockfile.buffers.trees`; isolated installs each package once into `node_modules/.bun/<store path>/node_modules/<name>` and symlinks dependents to it. `tree::Iterator` only knows the former, so code built on it cannot find isolated packages.
- Store entry names: `fmt_store_key` produces `<name>@<resolution>`, capping the resolution part at 80 bytes by cutting it and appending `+<16 hex hash>` (keeps script cwds under Windows' path limit). When one version is installed under different peer-dependency sets, the store keeps one copy per set and appends a second `+<16 hex>` peer hash.
- Global virtual store (`install.globalStore`): store entries are materialised once under the cache and `node_modules/.bun/<entry>` becomes a symlink into it. The installer already refuses to run lifecycle scripts inside such entries (`entry_uses_global_store`); `pm trust` needs the same rule. Trusting a package makes it ineligible, so the next install copies it into the project and runs the script there.
- `trustedDependencies`: lifecycle scripts only run for packages listed there (or in the built-in default list). `pm untrusted` lists installed packages that have scripts but are not listed; `pm trust` runs their scripts and adds them.

<details>
<summary>Earlier revisions</summary>

The first revision matched any `<name>@<res>+…` entry, did not consult the configured linker, did not distinguish global-store symlinks, counted blocked scripts on every install rather than only fresh ones, swallowed `get_list` errors, and (after the rebase) formatted the entry name by hand and so missed resolutions long enough to be truncated. Each was tightened during review; the description above is the current state.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->
