### PR TITLE
node:net: honor pause() made inside the 'connection' handler

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -883,7 +883,9 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     self.emit("secureConnect", verifyError);
     if (server?.pauseOnConnect) {
       self.pause();
-    } else {
+    } else if (self.readableFlowing === null) {
+      // See onconnection: honor a pause()/'data'/'readable' touched inside
+      // the secureConnection/secureConnect handlers.
       self.resume();
     }
   },
@@ -1063,8 +1065,15 @@ function onconnection(err, clientHandle) {
   }
 
   self.emit("connection", _socket);
-  // the duplex implementation start paused, so we resume when pauseOnConnect is falsy
-  if (!pauseOnConnect && !isTLS) {
+  // The handler may have paused (readableFlowing === false) or attached
+  // 'data'/'readable' (true/false). Forcing resume() over a handler's pause()
+  // put the stream into flowing mode with no listener: inbound bytes were
+  // emitted into the void and the writer saw 'drain' against a paused peer.
+  // null means the handler left the stream untouched; keep resuming there so
+  // a write-only handler's peer-close still tears the socket down (Node
+  // leaves it null and relies on libuv's UV_EOF readStop to release the loop,
+  // which would require accepted sockets to hold the loop on their own).
+  if (!pauseOnConnect && !isTLS && _socket.readableFlowing === null) {
     _socket.resume();
   }
 }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1065,14 +1065,10 @@ function onconnection(err, clientHandle) {
   }
 
   self.emit("connection", _socket);
-  // The handler may have paused (readableFlowing === false) or attached
-  // 'data'/'readable' (true/false). Forcing resume() over a handler's pause()
-  // put the stream into flowing mode with no listener: inbound bytes were
-  // emitted into the void and the writer saw 'drain' against a paused peer.
-  // null means the handler left the stream untouched; keep resuming there so
-  // a write-only handler's peer-close still tears the socket down (Node
-  // leaves it null and relies on libuv's UV_EOF readStop to release the loop,
-  // which would require accepted sockets to hold the loop on their own).
+  // Honor a pause()/'data'/'readable' touched inside the handler. null (the
+  // handler left flowing untouched) still resumes so a write-only handler's
+  // peer-close tears down; Node would leave it null and release the loop via
+  // UV_EOF readStop, which needs accepted sockets to hold the loop themselves.
   if (!pauseOnConnect && !isTLS && _socket.readableFlowing === null) {
     _socket.resume();
   }

--- a/test/js/node/net/net-server-accepted-socket-pause-fixture.js
+++ b/test/js/node/net/net-server-accepted-socket-pause-fixture.js
@@ -1,0 +1,71 @@
+"use strict";
+// A pause() made inside the 'connection' handler must be honored after the
+// handler returns. onconnection previously called resume() unconditionally
+// after emit("connection"), which flipped readableFlowing from false back to
+// true with no 'data' listener: inbound bytes were emitted into the void, the
+// kernel receive buffer drained, TCP signalled "go ahead" to the writer, and
+// the writer saw 'drain' (and bytesWritten reported success) against a peer
+// that would receive nothing after resume().
+const net = require("node:net");
+const { once } = require("node:events");
+
+function waitFor(cond) {
+  return new Promise(resolve => {
+    const check = () => (cond() ? resolve() : setImmediate(check));
+    check();
+  });
+}
+
+(async () => {
+  let acc;
+  const server = net.createServer();
+  server.on("connection", s => {
+    acc = s;
+    s.on("error", () => {});
+    s.pause();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const cli = net.connect(server.address().port, "127.0.0.1");
+  cli.on("error", () => {});
+  await once(cli, "connect");
+  await waitFor(() => acc);
+  // readableFlowing must be false (the handler's pause()) now that the
+  // handler has returned; before the fix it was flipped back to true.
+  console.log("flowing", acc.readableFlowing);
+
+  const chunk = Buffer.alloc(64 * 1024, 0x61);
+  let writes = 0;
+  let drains = 0;
+  cli.on("drain", () => drains++);
+  // Write until backpressure or an upper bound: with a paused peer the kernel
+  // buffers should fill long before 4000 chunks.
+  while (writes < 4000) {
+    writes++;
+    if (!cli.write(chunk)) break;
+  }
+  // Wait until either a 'drain' fires (the bug) or enough turns for the
+  // kernel buffers to have settled without one.
+  let turns = 0;
+  await waitFor(() => drains > 0 || ++turns > 200);
+  console.log("drainsWhilePaused", drains, "backpressured", writes < 4000);
+
+  let got = 0;
+  acc.on("data", d => (got += d.length));
+  acc.resume();
+  const want = writes * chunk.length;
+  // If the bytes were already discarded (the bug) nothing more is coming;
+  // bound the wait so the broken build reports false instead of hanging.
+  let dturns = 0;
+  await waitFor(() => got >= want || acc.destroyed || ++dturns > 2000);
+  console.log("delivered", got === want);
+
+  cli.destroy();
+  acc.destroy();
+  server.close();
+})().then(
+  () => process.exit(0),
+  err => {
+    console.error(err && err.stack ? err.stack : String(err));
+    process.exit(1);
+  },
+);

--- a/test/js/node/net/net-server-accepted-socket-pause-fixture.js
+++ b/test/js/node/net/net-server-accepted-socket-pause-fixture.js
@@ -1,11 +1,7 @@
 "use strict";
-// A pause() made inside the 'connection' handler must be honored after the
-// handler returns. onconnection previously called resume() unconditionally
-// after emit("connection"), which flipped readableFlowing from false back to
-// true with no 'data' listener: inbound bytes were emitted into the void, the
-// kernel receive buffer drained, TCP signalled "go ahead" to the writer, and
-// the writer saw 'drain' (and bytesWritten reported success) against a peer
-// that would receive nothing after resume().
+// onconnection's post-emit resume() previously stomped a pause() made inside
+// the 'connection' handler: flowing went back to true with no listener, bytes
+// were discarded, and the writer saw 'drain' against a paused peer.
 const net = require("node:net");
 const { once } = require("node:events");
 

--- a/test/js/node/net/net-server-accepted-socket-pause-fixture.js
+++ b/test/js/node/net/net-server-accepted-socket-pause-fixture.js
@@ -39,11 +39,13 @@ function waitFor(cond) {
     writes++;
     if (!cli.write(chunk)) break;
   }
-  // Wait until either a 'drain' fires (the bug) or enough turns for the
-  // kernel buffers to have settled without one.
   let turns = 0;
   await waitFor(() => drains > 0 || ++turns > 200);
-  console.log("drainsWhilePaused", drains, "backpressured", writes < 4000);
+  // 'drain' can fire while the peer is paused (the Writable buffer flushes
+  // into the kernel send buffer, whose capacity is platform-dependent); the
+  // distinguishing observables are readableFlowing and whether bytes are
+  // delivered after resume().
+  console.log("backpressured", writes < 4000);
 
   let got = 0;
   acc.on("data", d => (got += d.length));

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1132,3 +1132,27 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
     target.close();
   }
 });
+
+// A pause() made inside the 'connection' handler must be honored after the
+// handler returns. onconnection previously called resume() unconditionally
+// after emit("connection"), which overrode the handler's pause(): inbound
+// bytes were emitted into the void, the kernel receive buffer drained, and the
+// writer saw 'drain' against a peer that would receive nothing after resume().
+// Runs in a subprocess so nothing in the test runner touches the stream's
+// flowing state.
+it("accepted socket honors pause() made inside the 'connection' handler", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "net-server-accepted-socket-pause-fixture.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual([
+    "flowing false",
+    "drainsWhilePaused 0 backpressured true",
+    "delivered true",
+  ]);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1133,13 +1133,9 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
   }
 });
 
-// A pause() made inside the 'connection' handler must be honored after the
-// handler returns. onconnection previously called resume() unconditionally
-// after emit("connection"), which overrode the handler's pause(): inbound
-// bytes were emitted into the void, the kernel receive buffer drained, and the
-// writer saw 'drain' against a peer that would receive nothing after resume().
-// Runs in a subprocess so nothing in the test runner touches the stream's
-// flowing state.
+// onconnection / ServerHandlers.handshake previously resume()d after emit,
+// stomping a pause() made inside the handler. Subprocess-isolated so nothing
+// in the test runner touches readableFlowing.
 describe.each([
   [
     "net.createServer 'connection'",

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1137,13 +1137,9 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
 // stomping a pause() made inside the handler. Subprocess-isolated so nothing
 // in the test runner touches readableFlowing.
 describe.each([
-  [
-    "net.createServer 'connection'",
-    "net-server-accepted-socket-pause-fixture.js",
-    "drainsWhilePaused 0 backpressured true",
-  ],
-  ["tls.createServer 'secureConnection'", "tls-server-accepted-socket-pause-fixture.js", "backpressured true"],
-])("accepted socket honors pause() made inside the %s handler", (_, fixture, backpressureLine) => {
+  ["net.createServer 'connection'", "net-server-accepted-socket-pause-fixture.js"],
+  ["tls.createServer 'secureConnection'", "tls-server-accepted-socket-pause-fixture.js"],
+])("accepted socket honors pause() made inside the %s handler", (_, fixture) => {
   it("leaves readableFlowing false and delivers every byte after resume()", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), join(import.meta.dir, fixture)],
@@ -1153,7 +1149,7 @@ describe.each([
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout.trim().split("\n")).toEqual(["flowing false", backpressureLine, "delivered true"]);
+    expect(stdout.trim().split("\n")).toEqual(["flowing false", "backpressured true", "delivered true"]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1140,19 +1140,20 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
 // writer saw 'drain' against a peer that would receive nothing after resume().
 // Runs in a subprocess so nothing in the test runner touches the stream's
 // flowing state.
-it("accepted socket honors pause() made inside the 'connection' handler", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "net-server-accepted-socket-pause-fixture.js")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+describe.each([
+  ["net.createServer 'connection'", "net-server-accepted-socket-pause-fixture.js", "drainsWhilePaused 0 backpressured true"],
+  ["tls.createServer 'secureConnection'", "tls-server-accepted-socket-pause-fixture.js", "backpressured true"],
+])("accepted socket honors pause() made inside the %s handler", (_, fixture, backpressureLine) => {
+  it("leaves readableFlowing false and delivers every byte after resume()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, fixture)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim().split("\n")).toEqual(["flowing false", backpressureLine, "delivered true"]);
+    expect(exitCode).toBe(0);
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout.trim().split("\n")).toEqual([
-    "flowing false",
-    "drainsWhilePaused 0 backpressured true",
-    "delivered true",
-  ]);
-  expect(exitCode).toBe(0);
 });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1141,7 +1141,11 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
 // Runs in a subprocess so nothing in the test runner touches the stream's
 // flowing state.
 describe.each([
-  ["net.createServer 'connection'", "net-server-accepted-socket-pause-fixture.js", "drainsWhilePaused 0 backpressured true"],
+  [
+    "net.createServer 'connection'",
+    "net-server-accepted-socket-pause-fixture.js",
+    "drainsWhilePaused 0 backpressured true",
+  ],
   ["tls.createServer 'secureConnection'", "tls-server-accepted-socket-pause-fixture.js", "backpressured true"],
 ])("accepted socket honors pause() made inside the %s handler", (_, fixture, backpressureLine) => {
   it("leaves readableFlowing false and delivers every byte after resume()", async () => {

--- a/test/js/node/net/tls-server-accepted-socket-pause-fixture.js
+++ b/test/js/node/net/tls-server-accepted-socket-pause-fixture.js
@@ -1,8 +1,7 @@
 "use strict";
-// TLS sibling of net-server-accepted-socket-pause-fixture.js: a pause() made
-// inside the 'secureConnection' handler must be honored after the handshake
-// handler returns (ServerHandlers.handshake gates its post-emit resume() on
-// readableFlowing === null the same way onconnection does).
+// TLS sibling of net-server-accepted-socket-pause-fixture.js: pause() inside
+// 'secureConnection' must be honored by ServerHandlers.handshake's post-emit
+// resume() gate.
 const tls = require("node:tls");
 const fs = require("node:fs");
 const path = require("node:path");

--- a/test/js/node/net/tls-server-accepted-socket-pause-fixture.js
+++ b/test/js/node/net/tls-server-accepted-socket-pause-fixture.js
@@ -1,0 +1,70 @@
+"use strict";
+// TLS sibling of net-server-accepted-socket-pause-fixture.js: a pause() made
+// inside the 'secureConnection' handler must be honored after the handshake
+// handler returns (ServerHandlers.handshake gates its post-emit resume() on
+// readableFlowing === null the same way onconnection does).
+const tls = require("node:tls");
+const fs = require("node:fs");
+const path = require("node:path");
+const { once } = require("node:events");
+
+const keys = path.join(__dirname, "..", "test", "fixtures", "keys");
+
+function waitFor(cond) {
+  return new Promise(resolve => {
+    const check = () => (cond() ? resolve() : setImmediate(check));
+    check();
+  });
+}
+
+(async () => {
+  let acc;
+  const server = tls.createServer({
+    key: fs.readFileSync(path.join(keys, "agent1-key.pem")),
+    cert: fs.readFileSync(path.join(keys, "agent1-cert.pem")),
+  });
+  server.on("secureConnection", s => {
+    acc = s;
+    s.on("error", () => {});
+    s.pause();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const cli = tls.connect({ port: server.address().port, host: "127.0.0.1", rejectUnauthorized: false });
+  cli.on("error", () => {});
+  await once(cli, "secureConnect");
+  await waitFor(() => acc);
+  console.log("flowing", acc.readableFlowing);
+
+  const chunk = Buffer.alloc(64 * 1024, 0x61);
+  let writes = 0;
+  let drains = 0;
+  cli.on("drain", () => drains++);
+  while (writes < 4000) {
+    writes++;
+    if (!cli.write(chunk)) break;
+  }
+  let turns = 0;
+  await waitFor(() => drains > 0 || ++turns > 200);
+  // drains can be >0 under TLS (engine-internal buffering flushes to the
+  // kernel independently of the peer's read state); the distinguishing
+  // observables are readableFlowing and whether the bytes are delivered.
+  console.log("backpressured", writes < 4000);
+
+  let got = 0;
+  acc.on("data", d => (got += d.length));
+  acc.resume();
+  const want = writes * chunk.length;
+  let dturns = 0;
+  await waitFor(() => got >= want || acc.destroyed || ++dturns > 2000);
+  console.log("delivered", got === want);
+
+  cli.destroy();
+  acc.destroy();
+  server.close();
+})().then(
+  () => process.exit(0),
+  err => {
+    console.error(err && err.stack ? err.stack : String(err));
+    process.exit(1);
+  },
+);


### PR DESCRIPTION
## What

`onconnection` calls `_socket.resume()` unconditionally after `emit("connection", _socket)`. When the handler called `s.pause()`, that flipped `readableFlowing` from `false` back to `true` with no `'data'` listener attached: inbound bytes were emitted into the void, the kernel receive buffer drained, and the writer saw `'drain'` / `bytesWritten` progress against a paused reader that received nothing after `resume()`.

## Repro

```js
import net from "node:net";
const server = net.createServer(); let srv;
server.on("connection", s => { srv = s; s.pause(); });          // documented backpressure idiom
await new Promise(r => server.listen(0, "127.0.0.1", r));
const cli = net.connect(server.address().port, "127.0.0.1");
await new Promise(r => cli.on("connect", r));
const chunk = Buffer.alloc(64 * 1024, 0x61); let writes = 0, drains = 0;
cli.on("drain", () => drains++);
while (writes < 4000) { writes++; if (!cli.write(chunk)) break; }
await new Promise(r => setTimeout(r, 400));
let got = 0; srv.on("data", d => got += d.length); srv.resume();
await new Promise(r => setTimeout(r, 1500));
console.log({ want: writes * chunk.length, got, drainsWhilePaused: drains });
// node: want==got, drainsWhilePaused 0
// bun:  got 0, drainsWhilePaused 1, cli.bytesWritten claims full delivery
```

## Fix

Gate the post-emit `resume()` on `_socket.readableFlowing === null` (the handler left the stream untouched). A handler that paused (`false`) or attached `'data'`/`'readable'` (`true`/`false`) is honored. Same for `ServerHandlers.handshake`.

A handler that left the stream untouched still resumes the way it did before, so a write-only handler's peer-close still tears the accepted socket down. (Node instead leaves `readableFlowing` at `null` there and relies on libuv's UV_EOF readStop to release the loop; matching that would require accepted sockets to hold the loop on their own.)

## Verification

```
bun bd test test/js/node/net/node-net.test.ts -t "accepted socket honors pause"
```

Fails on main (`flowing true`, `drainsWhilePaused 1`, `delivered false`), passes with this change and matches Node line for line.

Related: #35006 and #34285 both cover the full `readableFlowing === null` accept semantics with the accompanying per-socket `poll_ref` rework. This PR is the scoped fix for the in-handler `pause()` case only; #35006 subsumes it if that lands first.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->