### PR TITLE
usockets: wait for the TLS spill at the HTTP close gates; drain a large https response after peer FIN

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1821,8 +1821,22 @@ struct us_socket_t *us_internal_ssl_on_writable(struct us_socket_t *s) {
     struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
     /* Ciphertext from a partial batch flush goes out before anything else;
      * while it is pending nothing new may be written for this socket. */
+    unsigned int spill_off_before = loop_ssl_data ? loop_ssl_data->ssl_spill_off : 0;
     if (loop_ssl_data && !ssl_drain_spill(loop_ssl_data, s)) {
-      return s;
+      /* A writable event that moves zero spill bytes after the peer's
+       * readable side has already ended means the peer is gone (send()
+       * hit EPIPE/ECONNRESET, folded to 0 by us_socket_raw_write) and
+       * this spill will never drain. Returning here without reaching
+       * us_dispatch_writable would spin the re-armed writable poll on
+       * kqueue until idle timeout, since neither EPOLLERR nor the uWS
+       * layer's zero-progress-after-FIN close guard can fire. Release
+       * the dead bytes so the dispatch below proceeds and that guard
+       * closes the connection. */
+      if (s->ssl_end_delivered && loop_ssl_data->ssl_spill_off == spill_off_before) {
+        ssl_release_spill(s->group->loop, s);
+      } else {
+        return s;
+      }
     }
     if (s->ssl_shutdown_after_spill) {
       s->ssl_shutdown_after_spill = 0;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2098,6 +2098,16 @@ void *us_internal_ssl_get_native_handle(struct us_socket_t *s) {
   return s->ssl ? s_ssl(s) : NULL;
 }
 
+/* Ciphertext bytes already sealed for `s` and counted as written by
+ * us_internal_ssl_write, still waiting on a writable event to reach the
+ * kernel. uWS's getBufferedAmount() adds this so its close-after-drain
+ * gates do not fire while the last batch is still in userspace. */
+unsigned int us_internal_ssl_spill_pending(struct us_socket_t *s) {
+  struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
+  if (!loop_ssl_data || loop_ssl_data->ssl_spill_owner != s) return 0;
+  return loop_ssl_data->ssl_spill_len - loop_ssl_data->ssl_spill_off;
+}
+
 int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
   if (us_socket_is_closed(s) || us_internal_ssl_is_shut_down(s) || length == 0) return 0;
 

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1826,17 +1826,19 @@ struct us_socket_t *us_internal_ssl_on_writable(struct us_socket_t *s) {
       /* A writable event that moves zero spill bytes after the peer's
        * readable side has already ended means the peer is gone (send()
        * hit EPIPE/ECONNRESET, folded to 0 by us_socket_raw_write) and
-       * this spill will never drain. Returning here without reaching
-       * us_dispatch_writable would spin the re-armed writable poll on
-       * kqueue until idle timeout, since neither EPOLLERR nor the uWS
-       * layer's zero-progress-after-FIN close guard can fire. Release
-       * the dead bytes so the dispatch below proceeds and that guard
-       * closes the connection. */
+       * this spill will never drain. Returning here would spin the
+       * re-armed writable poll on kqueue, since EPOLLERR is not delivered
+       * there. Mark the SSL fatal so us_internal_ssl_write returns 0 (the
+       * uWS layer's flushed==0-after-FIN guard, or hasFullyDrained() when
+       * nothing is buffered, then closes the connection on this dispatch)
+       * and dispatch directly, bypassing the is_shut_down gate below that
+       * ssl_fatal_error would otherwise trip. */
       if (s->ssl_end_delivered && loop_ssl_data->ssl_spill_off == spill_off_before) {
         ssl_release_spill(s->group->loop, s);
-      } else {
-        return s;
+        s->ssl_fatal_error = 1;
+        return us_dispatch_writable(s);
       }
+      return s;
     }
     if (s->ssl_shutdown_after_spill) {
       s->ssl_shutdown_after_spill = 0;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2114,8 +2114,9 @@ void *us_internal_ssl_get_native_handle(struct us_socket_t *s) {
 
 /* Ciphertext bytes already sealed for `s` and counted as written by
  * us_internal_ssl_write, still waiting on a writable event to reach the
- * kernel. uWS's getBufferedAmount() adds this so its close-after-drain
- * gates do not fire while the last batch is still in userspace. */
+ * kernel. uWS's AsyncSocket::hasFullyDrained() checks this so the HTTP
+ * close-after-drain gates do not fire while the last batch is still in
+ * userspace. */
 unsigned int us_internal_ssl_spill_pending(struct us_socket_t *s) {
   struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
   if (!loop_ssl_data || loop_ssl_data->ssl_spill_owner != s) return 0;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -224,6 +224,7 @@ int us_internal_ssl_handshake_callback_has_fired(us_socket_r s);
 int us_internal_ssl_is_shut_down(us_socket_r s);
 void us_internal_ssl_shutdown(us_socket_r s);
 int us_internal_ssl_write(us_socket_r s, const char *data, int length);
+unsigned int us_internal_ssl_spill_pending(us_socket_r s);
 void *us_internal_ssl_get_native_handle(us_socket_r s);
 struct us_bun_verify_error_t us_internal_ssl_verify_error(us_socket_r s);
 void *us_internal_ssl_sni_userdata(us_socket_r s);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -632,6 +632,11 @@ int us_socket_is_closed(us_socket_r s) nonnull_fn_decl;
 int us_socket_is_tls(us_socket_r s) nonnull_fn_decl;
 int us_socket_is_ssl_handshake_finished(us_socket_r s) nonnull_fn_decl;
 int us_socket_ssl_handshake_callback_has_fired(us_socket_r s) nonnull_fn_decl;
+/* TLS ciphertext bytes already sealed for this socket and reported as
+ * written by us_socket_write(), still waiting on a writable event to reach
+ * the kernel (the loop-wide spill slot owned by this socket). 0 for
+ * plain-TCP sockets and for TLS sockets with nothing spilled. */
+unsigned int us_socket_ssl_spill_pending(us_socket_r s) nonnull_fn_decl;
 
 struct us_socket_t *us_socket_close(us_socket_r s, int code, void *reason) __attribute__((nonnull(1)));
 

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -757,6 +757,19 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         }
                         #undef LOOP_ISNT_VERY_BUSY_THRESHOLD
                         #else
+                        /* Windows eof-drain, same as the POSIX branch above:
+                         * poll_cb maps AFD DISCONNECT to the eof hint for a
+                         * socket whose write side we already shut down, and
+                         * AFD reports DISCONNECT with the tail of the peer's
+                         * stream still queued in the kernel. Stopping here
+                         * lets the is_shut_down raw-close below discard it
+                         * (a half-closed TLS/net client dropping the end of
+                         * a large response on Windows only). recv() returning
+                         * 0 or WSAEWOULDBLOCK ends the loop, so this is
+                         * bounded by the kernel receive buffer. */
+                        if (s && !us_socket_is_closed(s) && !s->flags.is_paused && (eof || error)) {
+                            continue;
+                        }
                         /* Windows AFD_POLL_ABORT is not level-triggered the way
                          * epoll's EPOLLHUP|EPOLLERR are: a peer RST that lands
                          * while this poll_cb is on the stack — typically when an

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -157,6 +157,13 @@ int us_socket_ssl_handshake_callback_has_fired(struct us_socket_t *s) {
     return 1;
 }
 
+unsigned int us_socket_ssl_spill_pending(struct us_socket_t *s) {
+    if (s->ssl) {
+        return us_internal_ssl_spill_pending(s);
+    }
+    return 0;
+}
+
 int us_connecting_socket_is_closed(struct us_connecting_socket_t *c) {
     return c->closed;
 }

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -184,8 +184,16 @@ public:
     /* Returns the user space backpressure. */
     size_t getBufferedAmount() {
         /* Unsent bytes; already-written bytes sitting behind the head cursor
-         * are not backpressure (maxBackpressure checks, drain progress). */
-        return getAsyncSocketData()->buffer.length();
+         * are not backpressure (maxBackpressure checks, drain progress).
+         * For TLS, us_socket_write() can report a batch as written while its
+         * ciphertext still sits in the loop's spill slot (openssl.c
+         * ssl_flush_write_batch); count that so the close-after-drain gates
+         * in HttpResponse/HttpContext/WebSocketContext wait for it. */
+        size_t buffered = getAsyncSocketData()->buffer.length();
+        if constexpr (SSL) {
+            buffered += us_socket_ssl_spill_pending((us_socket_t *) this);
+        }
+        return buffered;
     }
 
     /* Returns the text representation of an IPv4 or IPv6 address */

--- a/packages/bun-uws/src/AsyncSocket.h
+++ b/packages/bun-uws/src/AsyncSocket.h
@@ -184,16 +184,23 @@ public:
     /* Returns the user space backpressure. */
     size_t getBufferedAmount() {
         /* Unsent bytes; already-written bytes sitting behind the head cursor
-         * are not backpressure (maxBackpressure checks, drain progress).
-         * For TLS, us_socket_write() can report a batch as written while its
-         * ciphertext still sits in the loop's spill slot (openssl.c
-         * ssl_flush_write_batch); count that so the close-after-drain gates
-         * in HttpResponse/HttpContext/WebSocketContext wait for it. */
-        size_t buffered = getAsyncSocketData()->buffer.length();
+         * are not backpressure (maxBackpressure checks, drain progress). */
+        return getAsyncSocketData()->buffer.length();
+    }
+
+    /* Whether every byte handed to us_socket_write() has reached the kernel.
+     * For TLS, us_socket_write() can report a batch as written while its
+     * ciphertext still sits in the loop's spill slot (openssl.c
+     * ssl_flush_write_batch); the close-after-drain gates in HttpResponse /
+     * HttpContext must wait for that too. Kept separate from
+     * getBufferedAmount() so WebSocket's maxBackpressure policy and the
+     * JS-exposed bufferedAmount stay a plaintext count. */
+    bool hasFullyDrained() {
+        if (getAsyncSocketData()->buffer.length()) return false;
         if constexpr (SSL) {
-            buffered += us_socket_ssl_spill_pending((us_socket_t *) this);
+            return us_socket_ssl_spill_pending((us_socket_t *) this) == 0;
         }
-        return buffered;
+        return true;
     }
 
     /* Returns the text representation of an IPv4 or IPv6 address */

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -209,9 +209,9 @@ private:
              * (Node's socketOnEnd semantics). Without this flag the loop (and
              * openssl.c us_internal_ssl_on_end for TLS) force-closes the
              * socket right after dispatching onEnd, discarding the buffered
-             * response bytes. getBufferedAmount() counts the TLS spill, so
-             * onEnd's defer and onWritable's close gate are accurate for both
-             * transports. */
+             * response bytes. onEnd's defer and onWritable's close gate use
+             * hasFullyDrained(), which accounts for the TLS ciphertext spill,
+             * so they are accurate for both transports. */
             s->flags.allow_half_open = 1;
         }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -206,14 +206,13 @@ private:
             /* A peer FIN must not tear the connection down at the loop level:
              * onEnd() below decides whether to close right away (idle) or to
              * keep writing the responses that are still in flight / pipelined
-             * (Node's socketOnEnd semantics). Without this flag the loop
-             * force-closes the socket right after dispatching onEnd. TLS
-             * (openssl.c us_internal_ssl_on_end) does not consult this flag
-             * and force-closes on FIN regardless, so this half of the compat
-             * block is http-only for now. */
-            if constexpr (!SSL) {
-                s->flags.allow_half_open = 1;
-            }
+             * (Node's socketOnEnd semantics). Without this flag the loop (and
+             * openssl.c us_internal_ssl_on_end for TLS) force-closes the
+             * socket right after dispatching onEnd, discarding the buffered
+             * response bytes. getBufferedAmount() counts the TLS spill, so
+             * onEnd's defer and onWritable's close gate are accurate for both
+             * transports. */
+            s->flags.allow_half_open = 1;
         }
 
         if(!SSL) {

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -611,7 +611,7 @@ private:
             /* We need to check if we should close this socket here now */
             if (httpResponseData->shouldCloseConnection()) {
                 if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                    if (((AsyncSocket<SSL> *) s)->getBufferedAmount() == 0) {
+                    if (((AsyncSocket<SSL> *) s)->hasFullyDrained()) {
                         ((AsyncSocket<SSL> *) s)->shutdown();
                         /* We need to force close after sending FIN since we want to hinder
                          * clients from keeping to send their huge data */
@@ -741,7 +741,7 @@ private:
                     responseDone = true;
                 }
             }
-            if (responseDone && asyncSocket->getBufferedAmount() == 0) {
+            if (responseDone && asyncSocket->hasFullyDrained()) {
                 asyncSocket->shutdown();
                 /* We need to force close after sending FIN since we want to hinder
                  * clients from keeping to send their huge data */
@@ -799,7 +799,7 @@ private:
              * callback is still draining) must not be discarded by the close()
              * below; the connection shuts down from the shouldCloseConnection()
              * gates once they have flushed. */
-            bool hasQueuedOutgoing = asyncSocket->getBufferedAmount() > 0
+            bool hasQueuedOutgoing = !asyncSocket->hasFullyDrained()
                 || httpResponseData->onWritable != nullptr;
             bool responseInFlight = httpResponseData->nodeHttpQueuedPipelinedCount > 0
                 || (httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING);

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -191,7 +191,7 @@ public:
             if (!Super::isCorked()) {
                 if (httpResponseData->shouldCloseConnection()) {
                     if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                        if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
+                        if (((AsyncSocket<SSL> *) this)->hasFullyDrained()) {
                             ((AsyncSocket<SSL> *) this)->shutdown();
                             /* We need to force close after sending FIN since we want to hinder
                                 * clients from keeping to send their huge data */
@@ -257,7 +257,7 @@ public:
                 if (!Super::isCorked()) {
                     if (httpResponseData->shouldCloseConnection()) {
                         if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                            if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
+                            if (((AsyncSocket<SSL> *) this)->hasFullyDrained()) {
                                 ((AsyncSocket<SSL> *) this)->shutdown();
                                 /* We need to force close after sending FIN since we want to hinder
                                 * clients from keeping to send their huge data */
@@ -861,7 +861,7 @@ public:
             HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
             if (httpResponseData->shouldCloseConnection()) {
                 if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                    if (((AsyncSocket<SSL> *) this)->getBufferedAmount() == 0) {
+                    if (((AsyncSocket<SSL> *) this)->hasFullyDrained()) {
                         ((AsyncSocket<SSL> *) this)->shutdown();
                         /* We need to force close after sending FIN since we want to hinder
                         * clients from keeping to send their huge data */

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -201,11 +201,30 @@ describe("backpressure", () => {
     // rejects the second write (socketOnEnd already called socket.end()); Bun
     // currently accepts and drains it. Both are consistent: the client sees
     // either the first write only, or both, never a torn second write.
-    // Same scenario over TLS: the server's TLS write-batch spill (up to one
-    // 128 KiB ciphertext batch the kernel did not fully accept) must be
-    // counted as buffered and drained before the post-FIN close gate fires.
-    // Cycling several times proves the on_writable drain loop, not just the
-    // first kernel-accepted write.
+    it("res.write() from 'drain' after client FIN is not torn mid-write", async () => {
+      await using server = http.createServer((req, res) => {
+        res.writeHead(200, { "Content-Length": String(BODY * 2) });
+        res.write(payload);
+        res.once("drain", () => {
+          res.write(payload);
+          res.end();
+        });
+        res.on("error", () => {});
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const { body, ended } = await halfCloseRequestBodyBytes(server);
+      expect(ended).toBe(true);
+      expect([BODY, BODY * 2]).toContain(body);
+    });
+
+    // TLS variants of the it.each above: the server's TLS write-batch spill
+    // (up to one 128 KiB ciphertext batch the kernel did not fully accept) is
+    // reported as written by us_socket_write() while it sits in userspace, so
+    // getBufferedAmount() must count it before the post-FIN close gate fires.
+    // Looped a few times so the on_writable drain cycle is exercised past the
+    // first kernel-accepted write. This is also the client-side regression
+    // test for the Windows eof-drain (a half-closed client must read out the
+    // kernel receive buffer when AFD DISCONNECT is mapped to eof).
     describe("https", () => {
       const keysDir = path.join(import.meta.dirname, "..", "test", "fixtures", "keys");
       const tlsOptions = {
@@ -213,11 +232,7 @@ describe("backpressure", () => {
         key: readFileSync(path.join(keysDir, "agent1-key.pem")),
       };
 
-      async function halfCloseTlsRequestBodyBytes(
-        port: number,
-        request: string,
-        halfClose: boolean,
-      ): Promise<{ body: number; ended: boolean }> {
+      async function halfCloseTlsRequestBodyBytes(port: number): Promise<{ body: number; ended: boolean }> {
         const socket = nodeTls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
         let body = 0;
         let head = "";
@@ -238,17 +253,16 @@ describe("backpressure", () => {
         socket.on("end", () => (ended = true));
         socket.on("error", () => {});
         await once(socket, "secureConnect");
-        if (halfClose) socket.end(request);
-        else socket.write(request);
+        socket.end("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
         await once(socket, "close");
         return { body, ended };
       }
 
       it.each([
-        ["client half-close, res.write() then res.end()", "write-end", true],
-        ["client half-close, res.end(payload)", "end", true],
-        ["client half-close, httpAllowHalfOpen, res.end() after drain", "drain", true],
-      ] as const)("%s", async (_name, endMode, halfClose) => {
+        ["client half-close, res.write() then res.end()", "write-end"],
+        ["client half-close, res.end(payload)", "end"],
+        ["client half-close, httpAllowHalfOpen, res.end() after drain", "drain"],
+      ] as const)("%s", async (_name, endMode) => {
         await using server = https.createServer(tlsOptions, (req, res) => {
           res.writeHead(200, { "Content-Length": String(BODY) });
           if (endMode === "end") {
@@ -262,34 +276,10 @@ describe("backpressure", () => {
         if (endMode === "drain") server.httpAllowHalfOpen = true;
         await once(server.listen(0, "127.0.0.1"), "listening");
         const port = (server.address() as AddressInfo).port;
-        // Loop a few times: the bug is an ordering race between the final
-        // spilled TLS batch and the close gate, so a single pass on a fast
-        // loopback may not catch the last-batch truncation.
         for (let i = 0; i < 5; i++) {
-          const { body, ended } = await halfCloseTlsRequestBodyBytes(
-            port,
-            "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
-            halfClose,
-          );
-          expect({ body, ended }).toEqual({ body: BODY, ended: true });
+          expect(await halfCloseTlsRequestBodyBytes(port)).toEqual({ body: BODY, ended: true });
         }
       });
-    });
-
-    it("res.write() from 'drain' after client FIN is not torn mid-write", async () => {
-      await using server = http.createServer((req, res) => {
-        res.writeHead(200, { "Content-Length": String(BODY * 2) });
-        res.write(payload);
-        res.once("drain", () => {
-          res.write(payload);
-          res.end();
-        });
-        res.on("error", () => {});
-      });
-      await once(server.listen(0, "127.0.0.1"), "listening");
-      const { body, ended } = await halfCloseRequestBodyBytes(server);
-      expect(ended).toBe(true);
-      expect([BODY, BODY * 2]).toContain(body);
     });
   });
 

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -6,9 +6,13 @@
  * A handful of older tests do not run in Node in this file. These tests should be updated to run in Node, or deleted.
  */
 import { once } from "node:events";
+import { readFileSync } from "node:fs";
 import http from "node:http";
+import https from "node:https";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
+import path from "node:path";
+import nodeTls from "node:tls";
 
 describe("backpressure", () => {
   // Writes `total` bytes to `res` in `chunk`-sized pieces, waiting for "drain"
@@ -197,6 +201,81 @@ describe("backpressure", () => {
     // rejects the second write (socketOnEnd already called socket.end()); Bun
     // currently accepts and drains it. Both are consistent: the client sees
     // either the first write only, or both, never a torn second write.
+    // Same scenario over TLS: the server's TLS write-batch spill (up to one
+    // 128 KiB ciphertext batch the kernel did not fully accept) must be
+    // counted as buffered and drained before the post-FIN close gate fires.
+    // Cycling several times proves the on_writable drain loop, not just the
+    // first kernel-accepted write.
+    describe("https", () => {
+      const keysDir = path.join(import.meta.dirname, "..", "test", "fixtures", "keys");
+      const tlsOptions = {
+        cert: readFileSync(path.join(keysDir, "agent1-cert.pem")),
+        key: readFileSync(path.join(keysDir, "agent1-key.pem")),
+      };
+
+      async function halfCloseTlsRequestBodyBytes(
+        port: number,
+        request: string,
+        halfClose: boolean,
+      ): Promise<{ body: number; ended: boolean }> {
+        const socket = nodeTls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+        let body = 0;
+        let head = "";
+        let gotHead = false;
+        let ended = false;
+        socket.on("data", chunk => {
+          if (!gotHead) {
+            head += chunk.toString("latin1");
+            const i = head.indexOf("\r\n\r\n");
+            if (i >= 0) {
+              gotHead = true;
+              body = Buffer.byteLength(head.slice(i + 4), "latin1");
+            }
+          } else {
+            body += chunk.length;
+          }
+        });
+        socket.on("end", () => (ended = true));
+        socket.on("error", () => {});
+        await once(socket, "secureConnect");
+        if (halfClose) socket.end(request);
+        else socket.write(request);
+        await once(socket, "close");
+        return { body, ended };
+      }
+
+      it.each([
+        ["client half-close, res.write() then res.end()", "write-end", true],
+        ["client half-close, res.end(payload)", "end", true],
+        ["client half-close, httpAllowHalfOpen, res.end() after drain", "drain", true],
+      ] as const)("%s", async (_name, endMode, halfClose) => {
+        await using server = https.createServer(tlsOptions, (req, res) => {
+          res.writeHead(200, { "Content-Length": String(BODY) });
+          if (endMode === "end") {
+            res.end(payload);
+          } else {
+            res.write(payload);
+            if (endMode === "write-end") res.end();
+            else res.once("drain", () => res.end());
+          }
+        });
+        if (endMode === "drain") server.httpAllowHalfOpen = true;
+        await once(server.listen(0, "127.0.0.1"), "listening");
+        const port = (server.address() as AddressInfo).port;
+        // Loop a few times: the bug is an ordering race between the final
+        // spilled TLS batch and the close gate, so a single pass on a fast
+        // loopback may not catch the last-batch truncation.
+        for (let i = 0; i < 5; i++) {
+          const { body, ended } = await halfCloseTlsRequestBodyBytes(
+            port,
+            "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            halfClose,
+          );
+          expect({ body, ended }).toEqual({ body: BODY, ended: true });
+        }
+      });
+    });
+
     it("res.write() from 'drain' after client FIN is not torn mid-write", async () => {
       await using server = http.createServer((req, res) => {
         res.writeHead(200, { "Content-Length": String(BODY * 2) });

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -280,6 +280,32 @@ describe("backpressure", () => {
           expect(await halfCloseTlsRequestBodyBytes(port)).toEqual({ body: BODY, ended: true });
         }
       });
+
+      // allow_half_open defers the close to the writable drain; a peer that
+      // FINs then resets must not wedge that drain on a spill send() that
+      // keeps failing (us_internal_ssl_on_writable releases a zero-progress
+      // spill after EOF so the dispatch reaches the close gate). A wedge
+      // would leave the server-side socket open past the test timeout.
+      it("closes promptly when the client half-closes then resets mid-drain", async () => {
+        const closed = Promise.withResolvers<void>();
+        await using server = https.createServer(tlsOptions, (req, res) => {
+          req.socket.on("close", () => closed.resolve());
+          res.writeHead(200, { "Content-Length": String(BODY) });
+          res.end(payload);
+          res.on("error", () => {});
+        });
+        server.requestTimeout = 0;
+        server.headersTimeout = 0;
+        await once(server.listen(0, "127.0.0.1"), "listening");
+        const port = (server.address() as AddressInfo).port;
+        const sock = nodeTls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+        sock.on("error", () => {});
+        await once(sock, "secureConnect");
+        sock.end("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+        await once(sock, "data");
+        sock.destroy();
+        await closed.promise;
+      });
     });
   });
 

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -220,11 +220,11 @@ describe("backpressure", () => {
     // TLS variants of the it.each above: the server's TLS write-batch spill
     // (up to one 128 KiB ciphertext batch the kernel did not fully accept) is
     // reported as written by us_socket_write() while it sits in userspace, so
-    // getBufferedAmount() must count it before the post-FIN close gate fires.
-    // Looped a few times so the on_writable drain cycle is exercised past the
-    // first kernel-accepted write. This is also the client-side regression
-    // test for the Windows eof-drain (a half-closed client must read out the
-    // kernel receive buffer when AFD DISCONNECT is mapped to eof).
+    // the post-FIN close gate (hasFullyDrained()) must wait for it. Looped a
+    // few times so the on_writable drain cycle is exercised past the first
+    // kernel-accepted write. This is also the client-side regression test for
+    // the Windows eof-drain (a half-closed client must read out the kernel
+    // receive buffer when AFD DISCONNECT is mapped to eof).
     describe("https", () => {
       const keysDir = path.join(import.meta.dirname, "..", "test", "fixtures", "keys");
       const tlsOptions = {


### PR DESCRIPTION
### Problem

```js
import https from 'node:https';
const server = https.createServer({ key, cert }, (req, res) => {
  res.writeHead(200, { 'content-length': String(8 * 1024 * 1024) });
  res.write(Buffer.alloc(8 * 1024 * 1024, 'a'));
  res.end();
});
// raw tls client: socket.end('GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n')
// Node: body bytes 8388608
// Bun:  body bytes 2637824 (truncated at the first kernel-accepted batch)
```

A node:https server responding with a body that backpressures truncates at the first kernel-accepted write when the client half-closes right after its request. Same for `res.end(bigBuffer)`. Node.js delivers the full body.

### Cause

Two server-side layers and one Windows-only client-side layer:

* **TLS spill not counted at the close gates**: `us_internal_ssl_write()` seals plaintext into 16 KB TLS records and flushes them to the kernel in ~128 KB batches. A partial kernel write parks the remainder of the batch in the loop's `ssl_spill` slot and returns the full plaintext count as written, so `AsyncSocket::getBufferedAmount()` (which reads only `AsyncSocketData::buffer`) reports 0 while up to one batch of ciphertext is still in userspace. The `shouldCloseConnection()` close gates in `HttpResponse::internalEnd` / `HttpResponse::cork` / `HttpContext::onData` / `HttpContext::onWritable` key on `getBufferedAmount() == 0` and so fire early; `us_internal_ssl_close(code=0)` does one best-effort drain and frees the rest.
* **`allow_half_open` gated on `!SSL` for node:http**: `HttpContext::onOpen` only set `allow_half_open` for non-TLS `IsNodeHttp` sockets, so a client FIN on a node:https connection made `us_internal_ssl_on_end` force-close the socket right after dispatching `onEnd`, discarding the buffered response. `onEnd<IsNodeHttp>`'s existing defer was never reached. #35034 fixed the plain-TCP case; the TLS side was left gated out because the spill made the close gates unsafe.
* **Windows eof-drain** (surfaced by the new test's client side): `poll_cb` (libuv.c) maps AFD `UV_DISCONNECT` to the eof hint for a socket whose write side we already shut down. AFD reports DISCONNECT while the tail of the peer's stream is still queued in the kernel, but the Windows branch of `loop.c`'s read loop only did one extra `recv()` (the RST probe) before falling through to the `is_shut_down` raw-close, discarding the rest. Reproduces on released bun against a Node.js server: a half-closed `net.Socket`/`tls` client intermittently loses the end of a large response on Windows only.

### Fix

* **`us_socket_ssl_spill_pending()`** (openssl.c / socket.c / libusockets.h): ciphertext bytes already sealed for this socket and reported as written by `us_socket_write()`, still waiting on a writable event. Returns 0 for plain-TCP sockets.
* **`AsyncSocket::hasFullyDrained()`**: `buffer.length() == 0 && spill_pending == 0`. The HTTP close-after-drain gates (`HttpResponse::internalEnd` / `cork`, `HttpContext::onData` tail / `onWritable` / `onEnd<IsNodeHttp>`) switch from `getBufferedAmount() == 0` to this. `getBufferedAmount()` itself is unchanged so WebSocket's `maxBackpressure` policy and the JS-exposed `bufferedAmount` stay a plaintext count. The spill is bounded (≤ one 128 KB batch) and `us_internal_ssl_on_writable` drains it before dispatching the user-level writable, so the existing drain loops terminate: once `AsyncSocketData::buffer` empties, the next writable event drains the final spill and the close gate fires with nothing pending.
* **`HttpContext::onOpen<IsNodeHttp>`**: drop the `!SSL` guard on `allow_half_open`. `us_internal_ssl_on_end` already honours the flag; `onEnd<IsNodeHttp>`'s `hasQueuedOutgoing` now accounts for the spill, and `onWritable`'s zero-progress-after-FIN close is not gated on `!SSL`.
* **`us_internal_ssl_on_writable`**: release a zero-progress spill once the peer's readable side has ended, so a FIN-then-RST client does not wedge the writable dispatch before the close gate is reached (the drain would otherwise re-arm writable on a send() that keeps failing). #34510 is the general fix for stuck TLS sends; this is the narrow case the new `allow_half_open` path opens.
* **`loop.c` Windows read loop**: drain on the eof hint like the POSIX branch already does (`recv()` returning 0 or `WSAEWOULDBLOCK` ends the loop, bounded by the kernel receive buffer).

### Relation to #35088

\#35088 is the `Bun.serve` (`!IsNodeHttp`) sibling and is currently gated on `!SSL` because the spill was invisible to its `onEnd` defer's `doneButBuffered` check and to `internalEnd`'s close gate (its scope note says so). With `hasFullyDrained()` at those gates that PR's `onEnd` defer is accurate for TLS too, so it can drop its `!SSL` gates (switching its `getBufferedAmount() > 0` to `!hasFullyDrained()`).

### Verification

New `describe('https')` in `test/js/node/http/node-http-backpressure.test.ts` mirrors the existing plain-HTTP half-close tests over TLS for `res.write()+res.end()`, `res.end(payload)` (the `optional=false` `internalEnd` buffer path), and `httpAllowHalfOpen` with `res.end()` after drain; each receives ~2.6 MB on main and the full 8 MiB with the fix, matching Node.js. Looped 5× per case so the on_writable drain cycle is exercised past the first kernel-accepted write; the loop also covers the Windows client-side eof-drain. A fourth test half-closes then destroys the client after first data and asserts the server-side socket `'close'` fires (would wedge on a stuck spill).

Verified on linux-x64 (14/14) and windows-x64 (14/14, 5 consecutive runs of the new tests). `node-http-backpressure.test.ts`, `node-http-pinned-write.test.ts`, `node-http-server-socket-end-drain.test.ts`, `bun-serve-ssl.test.ts`, `node-tls-connect.test.ts`, `node-https-checkServerIdentity.test.ts`, `serve.test.ts`, `socket.test.ts` pass (pre-existing container-only / debug-timeout failures unchanged from main).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-backpressure.test.ts
bun test v1.4.0 (41c2fbba3)

test/js/node/http/node-http-backpressure.test.ts:
(pass) backpressure > should handle backpressure [588.62ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the client requested the close [400.31ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the server sets Connection: close on a keep-alive request [190.66ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the whole body is passed to res.end() [216.37ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() then res.end() [179.05ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() without res.end() [136.15ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3d1c56be5)

test/js/node/http/node-http-backpressure.test.ts:
(pass) backpressure > should handle backpressure [32.49ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the client requested the close [22.78ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the server sets Connection: close on a keep-alive request [18.46ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the whole body is passed to res.end() [11.04ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() then res.end() [9.60ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() without res.end() [7.83ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() then res.end() after drain, httpAllowHalfOpen [6.33ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-backpressure.test.ts
bun test v1.4.0 (41c2fbba3)

test/js/node/http/node-http-backpressure.test.ts:
(pass) backpressure > should handle backpressure [517.49ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the client requested the close [423.69ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the server sets Connection: close on a keep-alive request [187.06ms]
(pass) backpressure > Connection: close does not truncate a response that is still flushing > when the whole body is passed to res.end() [172.00ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() then res.end() [215.92ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still flushing > res.write() without res.end() [158.36ms]
(pass) backpressure > a client FIN right after the request does not truncate a response that is still
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 738ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/25] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c       | 27 +++++++
 packages/bun-usockets/src/internal/internal.h    |  1 +
 packages/bun-usockets/src/libusockets.h          |  5 ++
 packages/bun-usockets/src/loop.c                 | 13 ++++
 packages/bun-usockets/src/socket.c               |  7 ++
 packages/bun-uws/src/AsyncSocket.h               | 15 ++++
 packages/bun-uws/src/HttpContext.h               | 21 +++---
 packages/bun-uws/src/HttpResponse.h              |  6 +-
 test/js/node/http/node-http-backpressure.test.ts | 95 ++++++++++++++++++++++++
 9 files changed, 176 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c            9      4      0
packages/bun-usockets/src/internal/internal.h         1      1      0
packages/bun-usockets/src/libusockets.h               1      1      0
packages/bun-usockets/src/loop.c                      4      1      0
packages/bun-usockets/src/socket.c                    6      1      0
packages/bun-uws/src/AsyncSocket.h                    5      3      0
packages/bun-uws/src/HttpContext.h                    4      7      0
packages/bun-uws/src/HttpResponse.h                   5      3      0
test/js/node/http/node-http-backpressure.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->