### PR TITLE
install(hoisted): gate workspace .bin links on trust to stop transitive bin shadowing

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -927,6 +927,90 @@ impl<'a> PackageInstaller<'a> {
                 < self.manager().options.max_concurrent_lifecycle_scripts
     }
 
+    /// Decide whether a package's `bin` entries may be linked into
+    /// `self.current_tree_id`'s `.bin` folder.
+    ///
+    /// A root/workspace `.bin` is prepended to PATH for `bun run` and for
+    /// lifecycle scripts, so linking an untrusted transitive dependency's bins
+    /// there lets it shadow system tools (`git`, `sh`, ...) and run on the next
+    /// `bun run`, bypassing the default no-scripts trust model. For those trees
+    /// we link a bin only when:
+    ///  - the package is a direct dependency of root/a workspace, or
+    ///  - the package is trusted, or
+    ///  - the package that declares this dependency edge is trusted or has
+    ///    lifecycle scripts of its own (so the declaring package's install
+    ///    script, run now or later via `bun pm trust`, can resolve its own
+    ///    dependencies' bins under a hoisted layout).
+    ///
+    /// Nested (non-workspace) `.bin` folders are not on the project-root PATH
+    /// and keep the old behavior.
+    fn should_link_bin_for_tree(
+        &self,
+        dependency_id: DependencyID,
+        alias: &[u8],
+        pkg_name: &[u8],
+        resolution: &Resolution,
+    ) -> bool {
+        if !self.lockfile().is_workspace_tree_id(self.current_tree_id) {
+            return true;
+        }
+        if matches!(
+            resolution.tag,
+            resolution::Tag::Root | resolution::Tag::Workspace
+        ) {
+            return true;
+        }
+        if self.lockfile().is_workspace_dependency(dependency_id) {
+            return true;
+        }
+        if self.is_trusted_for_bin_link(alias, pkg_name, resolution) {
+            return true;
+        }
+        let string_buf = self.lockfile().buffers.string_bytes.as_slice();
+        for (owner_id, dep_range) in self.pkg_dependencies.iter().enumerate() {
+            if !dep_range.contains(dependency_id) {
+                continue;
+            }
+            let owner_resolution = &self.resolutions[owner_id];
+            if matches!(
+                owner_resolution.tag,
+                resolution::Tag::Root | resolution::Tag::Workspace
+            ) {
+                return true;
+            }
+            // A declaring package that has lifecycle scripts needs its own
+            // dependencies' bins on PATH for those scripts to run, both now
+            // (if already trusted) and later via `bun pm trust`. When the
+            // declaring package is untrusted this surfaces as a "Blocked N
+            // postinstall" notice, so the planted bin is not silent.
+            if self.metas[owner_id].has_install_script() {
+                return true;
+            }
+            let owner_name = self.names[owner_id].slice(string_buf);
+            return self.is_trusted_for_bin_link(owner_name, owner_name, owner_resolution);
+        }
+        false
+    }
+
+    fn is_trusted_for_bin_link(
+        &self,
+        alias: &[u8],
+        pkg_name: &[u8],
+        resolution: &Resolution,
+    ) -> bool {
+        let truncated_hash =
+            bun_semver::semver_string::Builder::string_hash(alias) as TruncatedPackageNameHash;
+        if self
+            .trusted_dependencies_from_update_requests
+            .get(&truncated_hash)
+            .is_some_and(|n| **n == *alias)
+        {
+            return true;
+        }
+        self.lockfile()
+            .has_trusted_dependency(alias, pkg_name, resolution)
+    }
+
     /// A tree can start installing packages when the parent has installed all its packages. If the parent
     /// isn't finished, we need to wait because it's possible a package installed in this tree will be deleted by the parent.
     // free fn (not `&self`) so callers can pass disjoint borrows
@@ -1815,7 +1899,14 @@ impl<'a> PackageInstaller<'a> {
                         self.node.complete_one();
                     }
 
-                    if self.bins[package_id as usize].tag != bin::Tag::None {
+                    if self.bins[package_id as usize].tag != bin::Tag::None
+                        && self.should_link_bin_for_tree(
+                            dependency_id,
+                            alias.slice(string_buf!()),
+                            pkg_name.slice(string_buf!()),
+                            resolution,
+                        )
+                    {
                         self.trees[self.current_tree_id as usize]
                             .binaries
                             .add(dependency_id)
@@ -2109,7 +2200,14 @@ impl<'a> PackageInstaller<'a> {
                 }
             }
         } else {
-            if self.bins[package_id as usize].tag != bin::Tag::None {
+            if self.bins[package_id as usize].tag != bin::Tag::None
+                && self.should_link_bin_for_tree(
+                    dependency_id,
+                    alias.slice(string_buf!()),
+                    pkg_name.slice(string_buf!()),
+                    resolution,
+                )
+            {
                 self.trees[self.current_tree_id as usize]
                     .binaries
                     .add(dependency_id)

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -292,7 +292,7 @@ pub struct TreeContext {
     /// Bins that the trust gate denied a spot in this tree's `.bin`. Deferred
     /// alongside `binaries` so the nested link into the owner's directory runs
     /// after every sibling's `uninstall_before_install` has finished.
-    pub nested_binaries: Vec<(DependencyID, PackageID)>,
+    pub nested_binaries: Vec<DependencyID>,
 
     /// Number of installed dependencies. Could be successful or failure.
     pub install_count: usize,
@@ -960,69 +960,33 @@ impl<'a> PackageInstaller<'a> {
     /// lifecycle scripts, so linking an untrusted transitive dependency's bins
     /// there lets it shadow system tools (`git`, `sh`, ...) and run on the next
     /// `bun run`, bypassing the default no-scripts trust model. For those trees
-    /// we link a bin only when:
-    ///  - the package is a direct dependency of root/a workspace, or
-    ///  - the package is trusted, or
-    ///  - the package that declares this dependency edge is trusted (so a
-    ///    trusted package's install script can still resolve its own
-    ///    dependencies' bins under a hoisted layout).
+    /// we link a bin only when the package is a direct dependency of root/a
+    /// workspace, or the package itself is trusted. Everything else is linked
+    /// into each declaring package's own `node_modules/.bin` instead (see
+    /// `link_tree_nested_bins`), which is on PATH for that package's lifecycle
+    /// scripts but not for `bun run` at the project root.
     ///
     /// Nested (non-workspace) `.bin` folders are not on the project-root PATH
     /// and keep the old behavior.
-    ///
-    /// Returns `None` when the bin may be linked into the tree's `.bin`,
-    /// otherwise `Some(owner_package_id)` identifying the package that
-    /// declares this dependency so the caller can link into that package's
-    /// nested `.bin` instead.
-    fn bin_link_redirect_for_tree(
+    fn should_redirect_bin_to_nested(
         &self,
         dependency_id: DependencyID,
         alias: &[u8],
         pkg_name: &[u8],
         resolution: &Resolution,
-    ) -> Option<PackageID> {
+    ) -> bool {
         if !self.lockfile().is_workspace_tree_id(self.current_tree_id) {
-            return None;
+            return false;
         }
         if matches!(
             resolution.tag,
             resolution::Tag::Root | resolution::Tag::Workspace
         ) {
-            return None;
+            return false;
         }
         if self.lockfile().is_workspace_dependency(dependency_id) {
-            return None;
+            return false;
         }
-        if self.is_trusted_for_bin_link(alias, pkg_name, resolution) {
-            return None;
-        }
-        let string_buf = self.lockfile().buffers.string_bytes.as_slice();
-        for (owner_id, dep_range) in self.pkg_dependencies.iter().enumerate() {
-            if !dep_range.contains(dependency_id) {
-                continue;
-            }
-            let owner_resolution = &self.resolutions[owner_id];
-            if matches!(
-                owner_resolution.tag,
-                resolution::Tag::Root | resolution::Tag::Workspace
-            ) {
-                return None;
-            }
-            let owner_name = self.names[owner_id].slice(string_buf);
-            if self.is_trusted_for_bin_link(owner_name, owner_name, owner_resolution) {
-                return None;
-            }
-            return Some(owner_id as PackageID);
-        }
-        Some(invalid_package_id)
-    }
-
-    fn is_trusted_for_bin_link(
-        &self,
-        alias: &[u8],
-        pkg_name: &[u8],
-        resolution: &Resolution,
-    ) -> bool {
         let truncated_hash =
             bun_semver::semver_string::Builder::string_hash(alias) as TruncatedPackageNameHash;
         if self
@@ -1030,19 +994,30 @@ impl<'a> PackageInstaller<'a> {
             .get(&truncated_hash)
             .is_some_and(|n| **n == *alias)
         {
-            return true;
+            return false;
         }
-        self.lockfile()
+        if self
+            .lockfile()
             .has_trusted_dependency(alias, pkg_name, resolution)
+        {
+            return false;
+        }
+        true
     }
 
-    /// Processes bins that `bin_link_redirect_for_tree` denied a spot in this
-    /// tree's `.bin`: links them into the declaring package's own
-    /// `node_modules/.bin` (so that package's lifecycle scripts still resolve
-    /// them, including via a later `bun pm trust`) and removes any stale
-    /// entries from the tree's `.bin` left behind by an install that predated
-    /// the gate or by a revoked trust. Runs after `link_tree_bins` so every
-    /// sibling's `uninstall_before_install` has already cleared the owner dir.
+    /// Processes bins that `should_redirect_bin_to_nested` denied a spot in
+    /// this tree's `.bin`: removes any stale entry from the tree's `.bin` (left
+    /// behind by an install that predated the gate or by a revoked trust), then
+    /// links the bin into every declaring package's own `node_modules/.bin`
+    /// inside this tree (each owner's lifecycle scripts, run now or later via
+    /// `bun pm trust`, resolve it there). Owners are found by scanning every
+    /// package's dependency range for an edge resolving to this package.
+    ///
+    /// Runs after every sibling in the tree has finished installing (via the
+    /// tree-completion gate) so no sibling's `uninstall_before_install` can
+    /// later wipe the owner directory, and *before* `link_tree_bins` so the
+    /// stale-unlink step cannot remove a same-named bin an allowed sibling is
+    /// about to place.
     fn link_tree_nested_bins(
         &mut self,
         tree_id: TreeContextId,
@@ -1060,13 +1035,14 @@ impl<'a> PackageInstaller<'a> {
         let manager = self.manager_mut();
         let string_buf = lockfile.buffers.string_bytes.as_slice();
         let extern_string_buf = lockfile.buffers.extern_strings.as_slice();
+        let resolutions = lockfile.buffers.resolutions.as_slice();
 
         let mut tree_node_modules: AbsPath =
             AbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
         let tree_node_modules_len = tree_node_modules.len();
 
-        for (dep_id, owner_id) in nested {
-            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+        for dep_id in nested {
+            let package_id = resolutions[dep_id as usize];
             debug_assert!(package_id != invalid_package_id);
             let bin = self.bins[package_id as usize];
             debug_assert!(bin.tag != bin::Tag::None);
@@ -1099,58 +1075,76 @@ impl<'a> PackageInstaller<'a> {
                 unlinker.unlink(false);
             }
 
-            if owner_id == invalid_package_id {
-                continue;
-            }
-            // Under hoisting the declaring package can live in a descendant
-            // tree while this package hoisted higher; the nested `.bin`
-            // belongs next to the declaring package, which is not under this
-            // tree's node_modules. Leave that case alone rather than link into
-            // the wrong directory.
-            let Some(owner_alias) = Self::alias_of_package_in_tree(lockfile, tree_id, owner_id)
-            else {
-                continue;
-            };
-
-            tree_node_modules.set_length(tree_node_modules_len);
-            let mut nested_node_modules: AbsPath =
-                AbsPath::from(tree_node_modules.slice()).unwrap_or_oom();
-            nested_node_modules.append(owner_alias).unwrap_or_oom();
-            nested_node_modules.append(b"node_modules").unwrap_or_oom();
-
-            let nested_ptr: *mut AbsPath = &raw mut nested_node_modules;
-            let mut linker = bin::Linker {
-                bin,
-                global_bin_path: manager.options.bin_path,
-                package_name,
-                target_package_name: package_name,
-                string_buf,
-                extern_string_buf,
-                seen: None,
-                target_node_modules_path: (&raw const tree_node_modules).cast(),
-                // SAFETY: `nested_ptr` is the unique borrow of `nested_node_modules`.
-                node_modules_path: unsafe { &mut *nested_ptr },
-                abs_target_buf: link_target_buf,
-                abs_dest_buf: link_dest_buf,
-                rel_buf: link_rel_buf,
-                err: None,
-                skipped_due_to_missing_bin: false,
-            };
-            linker.link(false);
-
-            if let Some(err) = linker.err {
-                if log_level != Options::LogLevel::Silent {
-                    bun_ast::add_error_pretty!(
-                        manager.log_mut(),
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        "Failed to link <b>{}<r>: {}",
-                        bstr::BStr::new(alias),
-                        err.name(),
-                    );
+            for (owner_id, dep_range) in self.pkg_dependencies.iter().enumerate() {
+                let mut owns = false;
+                for edge in dep_range.begin()..dep_range.end() {
+                    if resolutions[edge as usize] == package_id {
+                        owns = true;
+                        break;
+                    }
                 }
-                if manager.options.enable.fail_early() {
-                    manager.crash();
+                if !owns {
+                    continue;
+                }
+                if matches!(
+                    self.resolutions[owner_id].tag,
+                    resolution::Tag::Root | resolution::Tag::Workspace
+                ) {
+                    continue;
+                }
+                // Owners that hoisted to a different tree are not linked here:
+                // the path to a descendant tree can go through a workspace
+                // symlink (`node_modules/<ws>` -> `../<ws>`), which would
+                // leave a relative bin link resolving outside the package.
+                // That case needs the user to list the bin package in
+                // `trustedDependencies` (or as a direct dependency).
+                let Some(owner_alias) =
+                    Self::alias_of_package_in_tree(lockfile, tree_id, owner_id as PackageID)
+                else {
+                    continue;
+                };
+
+                tree_node_modules.set_length(tree_node_modules_len);
+                let mut nested_node_modules: AbsPath =
+                    AbsPath::from(tree_node_modules.slice()).unwrap_or_oom();
+                nested_node_modules.append(owner_alias).unwrap_or_oom();
+                nested_node_modules.append(b"node_modules").unwrap_or_oom();
+
+                tree_node_modules.set_length(tree_node_modules_len);
+                let nested_ptr: *mut AbsPath = &raw mut nested_node_modules;
+                let mut linker = bin::Linker {
+                    bin,
+                    global_bin_path: manager.options.bin_path,
+                    package_name,
+                    target_package_name: package_name,
+                    string_buf,
+                    extern_string_buf,
+                    seen: None,
+                    target_node_modules_path: (&raw const tree_node_modules).cast(),
+                    // SAFETY: `nested_ptr` is the unique borrow of `nested_node_modules`.
+                    node_modules_path: unsafe { &mut *nested_ptr },
+                    abs_target_buf: link_target_buf,
+                    abs_dest_buf: link_dest_buf,
+                    rel_buf: link_rel_buf,
+                    err: None,
+                    skipped_due_to_missing_bin: false,
+                };
+                linker.link(false);
+
+                if let Some(err) = linker.err {
+                    if log_level != Options::LogLevel::Silent {
+                        bun_ast::add_error_pretty!(
+                            manager.log_mut(),
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            "Failed to link <b>{}<r>: {}",
+                            bstr::BStr::new(alias),
+                            err.name(),
+                        );
+                    }
+                    if manager.options.enable.fail_early() {
+                        manager.crash();
+                    }
                 }
             }
         }
@@ -2065,23 +2059,20 @@ impl<'a> PackageInstaller<'a> {
                     }
 
                     if self.bins[package_id as usize].tag != bin::Tag::None {
-                        match self.bin_link_redirect_for_tree(
+                        if self.should_redirect_bin_to_nested(
                             dependency_id,
                             alias.slice(string_buf!()),
                             pkg_name.slice(string_buf!()),
                             resolution,
                         ) {
-                            None => {
-                                self.trees[self.current_tree_id as usize]
-                                    .binaries
-                                    .add(dependency_id)
-                                    .unwrap_or_oom();
-                            }
-                            Some(owner_id) => {
-                                self.trees[self.current_tree_id as usize]
-                                    .nested_binaries
-                                    .push((dependency_id, owner_id));
-                            }
+                            self.trees[self.current_tree_id as usize]
+                                .nested_binaries
+                                .push(dependency_id);
+                        } else {
+                            self.trees[self.current_tree_id as usize]
+                                .binaries
+                                .add(dependency_id)
+                                .unwrap_or_oom();
                         }
                     }
 
@@ -2373,23 +2364,20 @@ impl<'a> PackageInstaller<'a> {
             }
         } else {
             if self.bins[package_id as usize].tag != bin::Tag::None {
-                match self.bin_link_redirect_for_tree(
+                if self.should_redirect_bin_to_nested(
                     dependency_id,
                     alias.slice(string_buf!()),
                     pkg_name.slice(string_buf!()),
                     resolution,
                 ) {
-                    None => {
-                        self.trees[self.current_tree_id as usize]
-                            .binaries
-                            .add(dependency_id)
-                            .unwrap_or_oom();
-                    }
-                    Some(owner_id) => {
-                        self.trees[self.current_tree_id as usize]
-                            .nested_binaries
-                            .push((dependency_id, owner_id));
-                    }
+                    self.trees[self.current_tree_id as usize]
+                        .nested_binaries
+                        .push(dependency_id);
+                } else {
+                    self.trees[self.current_tree_id as usize]
+                        .binaries
+                        .add(dependency_id)
+                        .unwrap_or_oom();
                 }
             }
 

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -937,34 +937,38 @@ impl<'a> PackageInstaller<'a> {
     /// we link a bin only when:
     ///  - the package is a direct dependency of root/a workspace, or
     ///  - the package is trusted, or
-    ///  - the package that declares this dependency edge is trusted or has
-    ///    lifecycle scripts of its own (so the declaring package's install
-    ///    script, run now or later via `bun pm trust`, can resolve its own
+    ///  - the package that declares this dependency edge is trusted (so a
+    ///    trusted package's install script can still resolve its own
     ///    dependencies' bins under a hoisted layout).
     ///
     /// Nested (non-workspace) `.bin` folders are not on the project-root PATH
     /// and keep the old behavior.
-    fn should_link_bin_for_tree(
+    ///
+    /// Returns `None` when the bin may be linked into the tree's `.bin`,
+    /// otherwise `Some(owner_package_id)` identifying the package that
+    /// declares this dependency so the caller can link into that package's
+    /// nested `.bin` instead.
+    fn bin_link_redirect_for_tree(
         &self,
         dependency_id: DependencyID,
         alias: &[u8],
         pkg_name: &[u8],
         resolution: &Resolution,
-    ) -> bool {
+    ) -> Option<PackageID> {
         if !self.lockfile().is_workspace_tree_id(self.current_tree_id) {
-            return true;
+            return None;
         }
         if matches!(
             resolution.tag,
             resolution::Tag::Root | resolution::Tag::Workspace
         ) {
-            return true;
+            return None;
         }
         if self.lockfile().is_workspace_dependency(dependency_id) {
-            return true;
+            return None;
         }
         if self.is_trusted_for_bin_link(alias, pkg_name, resolution) {
-            return true;
+            return None;
         }
         let string_buf = self.lockfile().buffers.string_bytes.as_slice();
         for (owner_id, dep_range) in self.pkg_dependencies.iter().enumerate() {
@@ -976,20 +980,15 @@ impl<'a> PackageInstaller<'a> {
                 owner_resolution.tag,
                 resolution::Tag::Root | resolution::Tag::Workspace
             ) {
-                return true;
-            }
-            // A declaring package that has lifecycle scripts needs its own
-            // dependencies' bins on PATH for those scripts to run, both now
-            // (if already trusted) and later via `bun pm trust`. When the
-            // declaring package is untrusted this surfaces as a "Blocked N
-            // postinstall" notice, so the planted bin is not silent.
-            if self.metas[owner_id].has_install_script() {
-                return true;
+                return None;
             }
             let owner_name = self.names[owner_id].slice(string_buf);
-            return self.is_trusted_for_bin_link(owner_name, owner_name, owner_resolution);
+            if self.is_trusted_for_bin_link(owner_name, owner_name, owner_resolution) {
+                return None;
+            }
+            return Some(owner_id as PackageID);
         }
-        false
+        Some(invalid_package_id)
     }
 
     fn is_trusted_for_bin_link(
@@ -1009,6 +1008,109 @@ impl<'a> PackageInstaller<'a> {
         }
         self.lockfile()
             .has_trusted_dependency(alias, pkg_name, resolution)
+    }
+
+    /// Called when `bin_link_redirect_for_tree` denies a package's bins a spot
+    /// in the workspace tree's `.bin`. Links them into the declaring package's
+    /// own `node_modules/.bin` instead (so that package's lifecycle scripts
+    /// still resolve them, including via a later `bun pm trust`) and removes
+    /// any stale entries from the tree's `.bin` left behind by an install that
+    /// predated the gate or by a revoked trust.
+    fn redirect_bin_to_owner_nested(
+        &mut self,
+        package_id: PackageID,
+        alias: &[u8],
+        owner_id: PackageID,
+    ) {
+        let lockfile = self.lockfile();
+        let string_buf = lockfile.buffers.string_bytes.as_slice();
+        let extern_string_buf = lockfile.buffers.extern_strings.as_slice();
+        let bin = self.bins[package_id as usize];
+        debug_assert!(bin.tag != bin::Tag::None);
+
+        let mut tree_node_modules: AbsPath =
+            AbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
+        let package_name = strings::StringOrTinyString::init(alias);
+
+        let mut link_target_buf = PathBuffer::uninit();
+        let mut link_dest_buf = PathBuffer::uninit();
+        let mut link_rel_buf = PathBuffer::uninit();
+
+        {
+            let nm_ptr: *mut AbsPath = &raw mut tree_node_modules;
+            let mut unlinker = bin::Linker {
+                bin,
+                global_bin_path: self.manager().options.bin_path,
+                package_name,
+                target_package_name: package_name,
+                string_buf,
+                extern_string_buf,
+                seen: None,
+                target_node_modules_path: nm_ptr.cast_const(),
+                // SAFETY: `nm_ptr` is the unique borrow of `tree_node_modules`; only
+                // read via `target_node_modules_path` while `unlink` holds the &mut.
+                node_modules_path: unsafe { &mut *nm_ptr },
+                abs_target_buf: link_target_buf.as_mut_slice(),
+                abs_dest_buf: link_dest_buf.as_mut_slice(),
+                rel_buf: link_rel_buf.as_mut_slice(),
+                err: None,
+                skipped_due_to_missing_bin: false,
+            };
+            unlinker.unlink(false);
+        }
+
+        if owner_id == invalid_package_id {
+            return;
+        }
+
+        // Under hoisting the declaring package can live in a descendant tree
+        // while this package hoisted higher; the nested `.bin` belongs next to
+        // the declaring package, which is not under this tree's node_modules.
+        // Leave that case alone rather than link into the wrong directory.
+        let Some(owner_alias) = self.alias_of_package_in_current_tree(owner_id) else {
+            return;
+        };
+        let mut nested_node_modules: AbsPath =
+            AbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
+        nested_node_modules.append(owner_alias).unwrap_or_oom();
+        nested_node_modules.append(b"node_modules").unwrap_or_oom();
+
+        let nested_ptr: *mut AbsPath = &raw mut nested_node_modules;
+        let mut linker = bin::Linker {
+            bin,
+            global_bin_path: self.manager().options.bin_path,
+            package_name,
+            target_package_name: package_name,
+            string_buf,
+            extern_string_buf,
+            seen: None,
+            target_node_modules_path: (&raw const tree_node_modules).cast(),
+            // SAFETY: `nested_ptr` is the unique borrow of `nested_node_modules`.
+            node_modules_path: unsafe { &mut *nested_ptr },
+            abs_target_buf: link_target_buf.as_mut_slice(),
+            abs_dest_buf: link_dest_buf.as_mut_slice(),
+            rel_buf: link_rel_buf.as_mut_slice(),
+            err: None,
+            skipped_due_to_missing_bin: false,
+        };
+        linker.link(false);
+    }
+
+    fn alias_of_package_in_current_tree(&self, package_id: PackageID) -> Option<&[u8]> {
+        let lockfile = self.lockfile();
+        let tree = &lockfile.buffers.trees.as_slice()[self.current_tree_id as usize];
+        let deps = lockfile.buffers.dependencies.as_slice();
+        let resolutions = lockfile.buffers.resolutions.as_slice();
+        let string_buf = lockfile.buffers.string_bytes.as_slice();
+        for &dep_id in tree
+            .dependencies
+            .get(lockfile.buffers.hoisted_dependencies.as_slice())
+        {
+            if resolutions[dep_id as usize] == package_id {
+                return Some(deps[dep_id as usize].name.slice(string_buf));
+            }
+        }
+        None
     }
 
     /// A tree can start installing packages when the parent has installed all its packages. If the parent
@@ -1899,18 +2001,27 @@ impl<'a> PackageInstaller<'a> {
                         self.node.complete_one();
                     }
 
-                    if self.bins[package_id as usize].tag != bin::Tag::None
-                        && self.should_link_bin_for_tree(
+                    if self.bins[package_id as usize].tag != bin::Tag::None {
+                        match self.bin_link_redirect_for_tree(
                             dependency_id,
                             alias.slice(string_buf!()),
                             pkg_name.slice(string_buf!()),
                             resolution,
-                        )
-                    {
-                        self.trees[self.current_tree_id as usize]
-                            .binaries
-                            .add(dependency_id)
-                            .unwrap_or_oom();
+                        ) {
+                            None => {
+                                self.trees[self.current_tree_id as usize]
+                                    .binaries
+                                    .add(dependency_id)
+                                    .unwrap_or_oom();
+                            }
+                            Some(owner_id) => {
+                                self.redirect_bin_to_owner_nested(
+                                    package_id,
+                                    alias.slice(string_buf!()),
+                                    owner_id,
+                                );
+                            }
+                        }
                     }
 
                     let dep =
@@ -2200,18 +2311,27 @@ impl<'a> PackageInstaller<'a> {
                 }
             }
         } else {
-            if self.bins[package_id as usize].tag != bin::Tag::None
-                && self.should_link_bin_for_tree(
+            if self.bins[package_id as usize].tag != bin::Tag::None {
+                match self.bin_link_redirect_for_tree(
                     dependency_id,
                     alias.slice(string_buf!()),
                     pkg_name.slice(string_buf!()),
                     resolution,
-                )
-            {
-                self.trees[self.current_tree_id as usize]
-                    .binaries
-                    .add(dependency_id)
-                    .unwrap_or_oom();
+                ) {
+                    None => {
+                        self.trees[self.current_tree_id as usize]
+                            .binaries
+                            .add(dependency_id)
+                            .unwrap_or_oom();
+                    }
+                    Some(owner_id) => {
+                        self.redirect_bin_to_owner_nested(
+                            package_id,
+                            alias.slice(string_buf!()),
+                            owner_id,
+                        );
+                    }
+                }
             }
 
             // reshaped for borrowck — `LazyPackageDestinationDir` borrows

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -289,6 +289,11 @@ pub struct TreeContext {
 
     pub binaries: bin::PriorityQueue,
 
+    /// Bins that the trust gate denied a spot in this tree's `.bin`. Deferred
+    /// alongside `binaries` so the nested link into the owner's directory runs
+    /// after every sibling's `uninstall_before_install` has finished.
+    pub nested_binaries: Vec<(DependencyID, PackageID)>,
+
     /// Number of installed dependencies. Could be successful or failure.
     pub install_count: usize,
 }
@@ -464,12 +469,24 @@ impl<'a> PackageInstaller<'a> {
 
         self.completed_trees.set(tree_id as usize);
 
-        if self.trees[tree_id as usize].binaries.count() > 0 {
+        if self.trees[tree_id as usize].binaries.count() > 0
+            || !self.trees[tree_id as usize].nested_binaries.is_empty()
+        {
             self.seen_bin_links.clear();
 
             let mut link_target_buf = PathBuffer::uninit();
             let mut link_dest_buf = PathBuffer::uninit();
             let mut link_rel_buf = PathBuffer::uninit();
+            // Nested redirects first: their stale-unlink step must not remove
+            // a same-named bin that `link_tree_bins` is about to place for an
+            // allowed sibling.
+            self.link_tree_nested_bins(
+                tree_id,
+                link_target_buf.as_mut_slice(),
+                link_dest_buf.as_mut_slice(),
+                link_rel_buf.as_mut_slice(),
+                log_level,
+            );
             // reshaped for borrowck — pass tree_id, re-borrow tree inside.
             self.link_tree_bins(
                 tree_id,
@@ -673,7 +690,9 @@ impl<'a> PackageInstaller<'a> {
         let trees_len = self.trees.len();
         for tree_id in 0..trees_len {
             // reshaped for borrowck — index instead of `for (self.trees, 0..) |*tree, tree_id|`.
-            if self.trees[tree_id].binaries.count() > 0 {
+            if self.trees[tree_id].binaries.count() > 0
+                || !self.trees[tree_id].nested_binaries.is_empty()
+            {
                 self.seen_bin_links.clear();
                 self.node_modules.path.truncate(
                     strings::without_trailing_slash(FileSystem::instance().top_level_dir()).len()
@@ -697,6 +716,13 @@ impl<'a> PackageInstaller<'a> {
                     .path
                     .extend_from_slice(rel_path.as_bytes());
 
+                self.link_tree_nested_bins(
+                    tree_id as u32,
+                    link_target_buf.as_mut_slice(),
+                    link_dest_buf.as_mut_slice(),
+                    link_rel_buf.as_mut_slice(),
+                    log_level,
+                );
                 self.link_tree_bins(
                     tree_id as u32,
                     link_target_buf.as_mut_slice(),
@@ -1010,95 +1036,132 @@ impl<'a> PackageInstaller<'a> {
             .has_trusted_dependency(alias, pkg_name, resolution)
     }
 
-    /// Called when `bin_link_redirect_for_tree` denies a package's bins a spot
-    /// in the workspace tree's `.bin`. Links them into the declaring package's
-    /// own `node_modules/.bin` instead (so that package's lifecycle scripts
-    /// still resolve them, including via a later `bun pm trust`) and removes
-    /// any stale entries from the tree's `.bin` left behind by an install that
-    /// predated the gate or by a revoked trust.
-    fn redirect_bin_to_owner_nested(
+    /// Processes bins that `bin_link_redirect_for_tree` denied a spot in this
+    /// tree's `.bin`: links them into the declaring package's own
+    /// `node_modules/.bin` (so that package's lifecycle scripts still resolve
+    /// them, including via a later `bun pm trust`) and removes any stale
+    /// entries from the tree's `.bin` left behind by an install that predated
+    /// the gate or by a revoked trust. Runs after `link_tree_bins` so every
+    /// sibling's `uninstall_before_install` has already cleared the owner dir.
+    fn link_tree_nested_bins(
         &mut self,
-        package_id: PackageID,
-        alias: &[u8],
-        owner_id: PackageID,
+        tree_id: TreeContextId,
+        link_target_buf: &mut [u8],
+        link_dest_buf: &mut [u8],
+        link_rel_buf: &mut [u8],
+        log_level: Options::LogLevel,
     ) {
+        let nested = core::mem::take(&mut self.trees[tree_id as usize].nested_binaries);
+        if nested.is_empty() {
+            return;
+        }
+
         let lockfile = self.lockfile();
+        let manager = self.manager_mut();
         let string_buf = lockfile.buffers.string_bytes.as_slice();
         let extern_string_buf = lockfile.buffers.extern_strings.as_slice();
-        let bin = self.bins[package_id as usize];
-        debug_assert!(bin.tag != bin::Tag::None);
 
         let mut tree_node_modules: AbsPath =
             AbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
-        let package_name = strings::StringOrTinyString::init(alias);
+        let tree_node_modules_len = tree_node_modules.len();
 
-        let mut link_target_buf = PathBuffer::uninit();
-        let mut link_dest_buf = PathBuffer::uninit();
-        let mut link_rel_buf = PathBuffer::uninit();
+        for (dep_id, owner_id) in nested {
+            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+            debug_assert!(package_id != invalid_package_id);
+            let bin = self.bins[package_id as usize];
+            debug_assert!(bin.tag != bin::Tag::None);
+            let alias = lockfile.buffers.dependencies.as_slice()[dep_id as usize]
+                .name
+                .slice(string_buf);
+            let package_name = strings::StringOrTinyString::init(alias);
 
-        {
-            let nm_ptr: *mut AbsPath = &raw mut tree_node_modules;
-            let mut unlinker = bin::Linker {
+            {
+                tree_node_modules.set_length(tree_node_modules_len);
+                let nm_ptr: *mut AbsPath = &raw mut tree_node_modules;
+                let mut unlinker = bin::Linker {
+                    bin,
+                    global_bin_path: manager.options.bin_path,
+                    package_name,
+                    target_package_name: package_name,
+                    string_buf,
+                    extern_string_buf,
+                    seen: None,
+                    target_node_modules_path: nm_ptr.cast_const(),
+                    // SAFETY: `nm_ptr` is the unique borrow of `tree_node_modules`;
+                    // read-only via `target_node_modules_path` while the &mut is live.
+                    node_modules_path: unsafe { &mut *nm_ptr },
+                    abs_target_buf: link_target_buf,
+                    abs_dest_buf: link_dest_buf,
+                    rel_buf: link_rel_buf,
+                    err: None,
+                    skipped_due_to_missing_bin: false,
+                };
+                unlinker.unlink(false);
+            }
+
+            if owner_id == invalid_package_id {
+                continue;
+            }
+            // Under hoisting the declaring package can live in a descendant
+            // tree while this package hoisted higher; the nested `.bin`
+            // belongs next to the declaring package, which is not under this
+            // tree's node_modules. Leave that case alone rather than link into
+            // the wrong directory.
+            let Some(owner_alias) = Self::alias_of_package_in_tree(lockfile, tree_id, owner_id)
+            else {
+                continue;
+            };
+
+            tree_node_modules.set_length(tree_node_modules_len);
+            let mut nested_node_modules: AbsPath =
+                AbsPath::from(tree_node_modules.slice()).unwrap_or_oom();
+            nested_node_modules.append(owner_alias).unwrap_or_oom();
+            nested_node_modules.append(b"node_modules").unwrap_or_oom();
+
+            let nested_ptr: *mut AbsPath = &raw mut nested_node_modules;
+            let mut linker = bin::Linker {
                 bin,
-                global_bin_path: self.manager().options.bin_path,
+                global_bin_path: manager.options.bin_path,
                 package_name,
                 target_package_name: package_name,
                 string_buf,
                 extern_string_buf,
                 seen: None,
-                target_node_modules_path: nm_ptr.cast_const(),
-                // SAFETY: `nm_ptr` is the unique borrow of `tree_node_modules`; only
-                // read via `target_node_modules_path` while `unlink` holds the &mut.
-                node_modules_path: unsafe { &mut *nm_ptr },
-                abs_target_buf: link_target_buf.as_mut_slice(),
-                abs_dest_buf: link_dest_buf.as_mut_slice(),
-                rel_buf: link_rel_buf.as_mut_slice(),
+                target_node_modules_path: (&raw const tree_node_modules).cast(),
+                // SAFETY: `nested_ptr` is the unique borrow of `nested_node_modules`.
+                node_modules_path: unsafe { &mut *nested_ptr },
+                abs_target_buf: link_target_buf,
+                abs_dest_buf: link_dest_buf,
+                rel_buf: link_rel_buf,
                 err: None,
                 skipped_due_to_missing_bin: false,
             };
-            unlinker.unlink(false);
+            linker.link(false);
+
+            if let Some(err) = linker.err {
+                if log_level != Options::LogLevel::Silent {
+                    bun_ast::add_error_pretty!(
+                        manager.log_mut(),
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        "Failed to link <b>{}<r>: {}",
+                        bstr::BStr::new(alias),
+                        err.name(),
+                    );
+                }
+                if manager.options.enable.fail_early() {
+                    manager.crash();
+                }
+            }
         }
-
-        if owner_id == invalid_package_id {
-            return;
-        }
-
-        // Under hoisting the declaring package can live in a descendant tree
-        // while this package hoisted higher; the nested `.bin` belongs next to
-        // the declaring package, which is not under this tree's node_modules.
-        // Leave that case alone rather than link into the wrong directory.
-        let Some(owner_alias) = self.alias_of_package_in_current_tree(owner_id) else {
-            return;
-        };
-        let mut nested_node_modules: AbsPath =
-            AbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
-        nested_node_modules.append(owner_alias).unwrap_or_oom();
-        nested_node_modules.append(b"node_modules").unwrap_or_oom();
-
-        let nested_ptr: *mut AbsPath = &raw mut nested_node_modules;
-        let mut linker = bin::Linker {
-            bin,
-            global_bin_path: self.manager().options.bin_path,
-            package_name,
-            target_package_name: package_name,
-            string_buf,
-            extern_string_buf,
-            seen: None,
-            target_node_modules_path: (&raw const tree_node_modules).cast(),
-            // SAFETY: `nested_ptr` is the unique borrow of `nested_node_modules`.
-            node_modules_path: unsafe { &mut *nested_ptr },
-            abs_target_buf: link_target_buf.as_mut_slice(),
-            abs_dest_buf: link_dest_buf.as_mut_slice(),
-            rel_buf: link_rel_buf.as_mut_slice(),
-            err: None,
-            skipped_due_to_missing_bin: false,
-        };
-        linker.link(false);
     }
 
-    fn alias_of_package_in_current_tree(&self, package_id: PackageID) -> Option<&[u8]> {
-        let lockfile = self.lockfile();
-        let tree = &lockfile.buffers.trees.as_slice()[self.current_tree_id as usize];
+    fn alias_of_package_in_tree(
+        lockfile: &Lockfile,
+        tree_id: TreeContextId,
+        package_id: PackageID,
+    ) -> Option<&[u8]> {
+        let tree = &lockfile.buffers.trees.as_slice()[tree_id as usize];
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
         let string_buf = lockfile.buffers.string_bytes.as_slice();
@@ -2015,11 +2078,9 @@ impl<'a> PackageInstaller<'a> {
                                     .unwrap_or_oom();
                             }
                             Some(owner_id) => {
-                                self.redirect_bin_to_owner_nested(
-                                    package_id,
-                                    alias.slice(string_buf!()),
-                                    owner_id,
-                                );
+                                self.trees[self.current_tree_id as usize]
+                                    .nested_binaries
+                                    .push((dependency_id, owner_id));
                             }
                         }
                     }
@@ -2325,11 +2386,9 @@ impl<'a> PackageInstaller<'a> {
                             .unwrap_or_oom();
                     }
                     Some(owner_id) => {
-                        self.redirect_bin_to_owner_nested(
-                            package_id,
-                            alias.slice(string_buf!()),
-                            owner_id,
-                        );
+                        self.trees[self.current_tree_id as usize]
+                            .nested_binaries
+                            .push((dependency_id, owner_id));
                     }
                 }
             }

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -405,6 +405,7 @@ pub(crate) fn install_hoisted_packages(
                                 dependencies: buf_deps,
                                 string_buf: buf_strings,
                             }),
+                            nested_binaries: Vec::new(),
                             pending_installs: Vec::new(),
                             install_count: 0,
                         });

--- a/test/cli/install/bun-install-bin-trust.test.ts
+++ b/test/cli/install/bun-install-bin-trust.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, readdirSync } from "fs";
-import { rm, symlink, mkdir } from "fs/promises";
+import { mkdir, rm, symlink } from "fs/promises";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
@@ -201,14 +201,8 @@ describe.concurrent("hoisted linker bin trust gate", () => {
 
       // Simulate a node_modules populated before the gate existed.
       await mkdir(join(packageDir, "node_modules", ".bin"), { recursive: true });
-      await symlink(
-        join("..", "shadow-bin", "shadow.js"),
-        join(packageDir, "node_modules", ".bin", "git"),
-      );
-      await symlink(
-        join("..", "shadow-bin", "shadow.js"),
-        join(packageDir, "node_modules", ".bin", "shadow-bin-tool"),
-      );
+      await symlink(join("..", "shadow-bin", "shadow.js"), join(packageDir, "node_modules", ".bin", "git"));
+      await symlink(join("..", "shadow-bin", "shadow.js"), join(packageDir, "node_modules", ".bin", "shadow-bin-tool"));
       expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
 
       // A reinstall over the existing node_modules should clear them.

--- a/test/cli/install/bun-install-bin-trust.test.ts
+++ b/test/cli/install/bun-install-bin-trust.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, readdirSync } from "fs";
-import { rm } from "fs/promises";
+import { rm, symlink, mkdir } from "fs/promises";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 
@@ -10,8 +10,11 @@ import { join } from "path";
 // the next time a project script shells out to that tool, bypassing the
 // default no-scripts trust model. These tests cover the trust gate applied to
 // hoisted bin linking.
-
-// --- tiny in-process npm registry -----------------------------------------
+//
+// A tiny in-process registry is used instead of `VerdaccioRegistry` so the
+// test packages live next to the assertions that depend on their shape; the
+// bypass cases below need packages whose `scripts` and `bin` maps are varied
+// per test.
 
 const enc = new TextEncoder();
 function tarHeader(name: string, size: number, mode = "0000755") {
@@ -66,6 +69,19 @@ addPkg(
   { "shadow.js": shadowScript },
 );
 addPkg({ name: "dep-on-shadow-bin", version: "1.0.0", dependencies: { "shadow-bin": "1.0.0" } }, { "index.js": "0" });
+addPkg(
+  {
+    name: "scripted-dep-on-shadow-bin",
+    version: "1.0.0",
+    dependencies: { "shadow-bin": "1.0.0" },
+    scripts: { postinstall: "exit 0" },
+  },
+  { "index.js": "0" },
+);
+addPkg(
+  { name: "dep-on-scripted-dep", version: "1.0.0", dependencies: { "scripted-dep-on-shadow-bin": "1.0.0" } },
+  { "index.js": "0" },
+);
 
 let server: ReturnType<typeof Bun.serve>;
 let registryUrl: string;
@@ -85,6 +101,7 @@ beforeAll(() => {
           versions: {
             [p.pj.version]: {
               ...p.pj,
+              hasInstallScript: !!p.pj.scripts,
               dist: { tarball: `${registryUrl}t/${p.pj.name}-${p.pj.version}.tgz`, integrity: integrity(p.gz) },
             },
           },
@@ -101,8 +118,6 @@ beforeAll(() => {
 afterAll(() => {
   server?.stop(true);
 });
-
-// --- helpers ---------------------------------------------------------------
 
 async function install(packageDir: string, extraEnv: Record<string, string> = {}) {
   await using proc = Bun.spawn({
@@ -132,33 +147,37 @@ function binEntries(dir: string): string[] {
     .sort();
 }
 
-async function setup(packageJson: any) {
-  const dir = tempDir("bin-trust-", {
+function setup(packageJson: any) {
+  return tempDir("bin-trust-", {
     "bunfig.toml": `[install]\nregistry = "${registryUrl}"\ncache = false\nlinker = "hoisted"\n`,
     "package.json": JSON.stringify(packageJson),
   });
-  return String(dir);
 }
-
-// --- tests ----------------------------------------------------------------
 
 describe.concurrent("hoisted linker bin trust gate", () => {
   test("untrusted transitive dependency bins are not linked into root .bin", async () => {
-    const packageDir = await setup({
+    using dir = setup({
       name: "app",
       version: "1.0.0",
       dependencies: { "dep-on-shadow-bin": "1.0.0" },
     });
+    const packageDir = String(dir);
 
     await install(packageDir);
 
     // shadow-bin is installed (hoisted to root node_modules) but its bin
     // entries must not appear in root .bin because it is neither a direct
-    // dependency nor trusted.
+    // dependency nor trusted. They are linked into the declaring package's
+    // own nested .bin instead so that package's scripts could still find them.
     expect(existsSync(join(packageDir, "node_modules", "shadow-bin", "shadow.js"))).toBeTrue();
     expect(binEntries(packageDir)).toEqual([]);
     expect(existsSync(join(packageDir, "node_modules", ".bin", "git"))).toBeFalse();
-    expect(existsSync(join(packageDir, "node_modules", ".bin", "shadow-bin-tool"))).toBeFalse();
+    const nestedBin = join(packageDir, "node_modules", "dep-on-shadow-bin", "node_modules", ".bin");
+    expect(
+      readdirSync(nestedBin)
+        .map(n => n.replace(/\.(bunx|exe)$/i, ""))
+        .sort(),
+    ).toContain("shadow-bin-tool");
 
     // Same result after a reinstall from the lockfile (exercises the
     // already-on-disk enqueue path).
@@ -167,12 +186,61 @@ describe.concurrent("hoisted linker bin trust gate", () => {
     expect(binEntries(packageDir)).toEqual([]);
   });
 
+  test.skipIf(isWindows)(
+    "stale bins left by a previous install are removed when the gate now denies them",
+    async () => {
+      using dir = setup({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "dep-on-shadow-bin": "1.0.0" },
+      });
+      const packageDir = String(dir);
+
+      await install(packageDir);
+      expect(binEntries(packageDir)).toEqual([]);
+
+      // Simulate a node_modules populated before the gate existed.
+      await mkdir(join(packageDir, "node_modules", ".bin"), { recursive: true });
+      await symlink(
+        join("..", "shadow-bin", "shadow.js"),
+        join(packageDir, "node_modules", ".bin", "git"),
+      );
+      await symlink(
+        join("..", "shadow-bin", "shadow.js"),
+        join(packageDir, "node_modules", ".bin", "shadow-bin-tool"),
+      );
+      expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
+
+      // A reinstall over the existing node_modules should clear them.
+      await install(packageDir);
+      expect(binEntries(packageDir)).toEqual([]);
+    },
+  );
+
+  test("transitive owner with a lifecycle script does not unlock root .bin for its dependencies", async () => {
+    using dir = setup({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "dep-on-scripted-dep": "1.0.0" },
+    });
+    const packageDir = String(dir);
+
+    const { stdout } = await install(packageDir);
+
+    // scripted-dep-on-shadow-bin has a postinstall but is itself transitive
+    // and untrusted; a no-op script must not be enough to plant shadow-bin's
+    // git in the root .bin.
+    expect(stdout).toContain("Blocked 1 postinstall");
+    expect(binEntries(packageDir)).toEqual([]);
+  });
+
   test("direct dependency bins are linked regardless of trust", async () => {
-    const packageDir = await setup({
+    using dir = setup({
       name: "app",
       version: "1.0.0",
       dependencies: { "shadow-bin": "1.0.0" },
     });
+    const packageDir = String(dir);
 
     await install(packageDir);
 
@@ -180,12 +248,13 @@ describe.concurrent("hoisted linker bin trust gate", () => {
   });
 
   test("transitive dependency bins are linked when their declaring package is trusted", async () => {
-    const packageDir = await setup({
+    using dir = setup({
       name: "app",
       version: "1.0.0",
       dependencies: { "dep-on-shadow-bin": "1.0.0" },
       trustedDependencies: ["dep-on-shadow-bin"],
     });
+    const packageDir = String(dir);
 
     await install(packageDir);
 
@@ -195,12 +264,13 @@ describe.concurrent("hoisted linker bin trust gate", () => {
   });
 
   test("transitive dependency bins are linked when trusted via trustedDependencies", async () => {
-    const packageDir = await setup({
+    using dir = setup({
       name: "app",
       version: "1.0.0",
       dependencies: { "dep-on-shadow-bin": "1.0.0" },
       trustedDependencies: ["shadow-bin"],
     });
+    const packageDir = String(dir);
 
     await install(packageDir);
 
@@ -208,7 +278,7 @@ describe.concurrent("hoisted linker bin trust gate", () => {
   });
 
   test("workspace direct dependency bins are linked into root .bin", async () => {
-    const dir = tempDir("bin-trust-ws-", {
+    using dir = tempDir("bin-trust-ws-", {
       "bunfig.toml": `[install]\nregistry = "${registryUrl}"\ncache = false\nlinker = "hoisted"\n`,
       "package.json": JSON.stringify({ name: "root", version: "1.0.0", workspaces: ["packages/*"] }),
       "packages/pkg1/package.json": JSON.stringify({
@@ -229,12 +299,13 @@ describe.concurrent("hoisted linker bin trust gate", () => {
   test.skipIf(isWindows)(
     "bun run does not execute a shadowed tool from an untrusted transitive dependency",
     async () => {
-      const packageDir = await setup({
+      using dir = setup({
         name: "app",
         version: "1.0.0",
         dependencies: { "dep-on-shadow-bin": "1.0.0" },
         scripts: { rev: "git --version" },
       });
+      const packageDir = String(dir);
 
       await install(packageDir);
 

--- a/test/cli/install/bun-install-bin-trust.test.ts
+++ b/test/cli/install/bun-install-bin-trust.test.ts
@@ -241,7 +241,7 @@ describe.concurrent("hoisted linker bin trust gate", () => {
     expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
   });
 
-  test("transitive dependency bins are linked when their declaring package is trusted", async () => {
+  test("trusting the declaring package does not place its dependency bins in root .bin", async () => {
     using dir = setup({
       name: "app",
       version: "1.0.0",
@@ -252,9 +252,33 @@ describe.concurrent("hoisted linker bin trust gate", () => {
 
     await install(packageDir);
 
-    // dep-on-shadow-bin is trusted, so its direct dependency shadow-bin's bins
-    // are available for dep-on-shadow-bin's (hypothetical) install script.
-    expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
+    // dep-on-shadow-bin is trusted so its install script may run, but its
+    // dependency shadow-bin's bins are reachable from that script via
+    // dep-on-shadow-bin/node_modules/.bin, not the project-root .bin.
+    expect(binEntries(packageDir)).toEqual([]);
+    const nestedBin = join(packageDir, "node_modules", "dep-on-shadow-bin", "node_modules", ".bin");
+    expect(
+      readdirSync(nestedBin)
+        .map(n => n.replace(/\.(bunx|exe)$/i, ""))
+        .sort(),
+    ).toContain("shadow-bin-tool");
+  });
+
+  test("a default-trusted owner does not place its dependency bins in root .bin", async () => {
+    // Serve a package named after an entry in default-trusted-dependencies.txt
+    // so `has_trusted_dependency` would pass for it. The gate must not let
+    // that expose the child bin on the project PATH.
+    addPkg({ name: "puppeteer", version: "1.0.0", dependencies: { "shadow-bin": "1.0.0" } }, { "index.js": "0" });
+    using dir = setup({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { puppeteer: "1.0.0" },
+    });
+    const packageDir = String(dir);
+
+    await install(packageDir);
+
+    expect(binEntries(packageDir)).toEqual([]);
   });
 
   test("transitive dependency bins are linked when trusted via trustedDependencies", async () => {

--- a/test/cli/install/bun-install-bin-trust.test.ts
+++ b/test/cli/install/bun-install-bin-trust.test.ts
@@ -1,0 +1,257 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, readdirSync } from "fs";
+import { rm } from "fs/promises";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "path";
+
+// The hoisted linker used to put every hoisted package's `bin` entries into
+// the root `node_modules/.bin`, which `bun run` prepends to PATH. An untrusted
+// transitive dependency could plant a `git`/`sh`/... bin there and have it run
+// the next time a project script shells out to that tool, bypassing the
+// default no-scripts trust model. These tests cover the trust gate applied to
+// hoisted bin linking.
+
+// --- tiny in-process npm registry -----------------------------------------
+
+const enc = new TextEncoder();
+function tarHeader(name: string, size: number, mode = "0000755") {
+  const h = new Uint8Array(512);
+  const put = (s: string, o: number) => h.set(enc.encode(s), o);
+  put(name, 0);
+  put(mode + "\0", 100);
+  put("0000000\0", 108);
+  put("0000000\0", 116);
+  put(size.toString(8).padStart(11, "0") + "\0", 124);
+  put("00000000000\0", 136);
+  h.fill(0x20, 148, 156);
+  h[156] = 0x30;
+  put("ustar\0", 257);
+  put("00", 263);
+  let s = 0;
+  for (let i = 0; i < 512; i++) s += h[i];
+  put(s.toString(8).padStart(6, "0") + "\0 ", 148);
+  return h;
+}
+function tgz(files: Record<string, string>) {
+  const parts: Uint8Array[] = [];
+  for (const [name, body] of Object.entries(files)) {
+    const b = enc.encode(body);
+    parts.push(tarHeader(`package/${name}`, b.length), b, new Uint8Array((512 - (b.length % 512)) % 512));
+  }
+  parts.push(new Uint8Array(1024));
+  const total = parts.reduce((a, x) => a + x.length, 0);
+  const out = new Uint8Array(total);
+  let p = 0;
+  for (const x of parts) {
+    out.set(x, p);
+    p += x.length;
+  }
+  return Bun.gzipSync(out);
+}
+function integrity(gz: Uint8Array) {
+  const h = new Bun.CryptoHasher("sha512");
+  h.update(gz);
+  return "sha512-" + h.digest("base64");
+}
+
+const shadowScript = `#!/usr/bin/env node\nconsole.log("SHADOW-EXECUTED");\n`;
+
+type Pkg = { pj: any; gz: Uint8Array };
+const pkgs: Record<string, Pkg> = {};
+function addPkg(pj: any, files: Record<string, string>) {
+  pkgs[pj.name] = { pj, gz: tgz({ "package.json": JSON.stringify(pj), ...files }) };
+}
+addPkg(
+  { name: "shadow-bin", version: "1.0.0", bin: { git: "./shadow.js", "shadow-bin-tool": "./shadow.js" } },
+  { "shadow.js": shadowScript },
+);
+addPkg({ name: "dep-on-shadow-bin", version: "1.0.0", dependencies: { "shadow-bin": "1.0.0" } }, { "index.js": "0" });
+
+let server: ReturnType<typeof Bun.serve>;
+let registryUrl: string;
+
+beforeAll(() => {
+  server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req) {
+      const parts = new URL(req.url).pathname.split("/").filter(Boolean);
+      if (parts.length === 1) {
+        const p = pkgs[decodeURIComponent(parts[0])];
+        if (!p) return new Response("not found", { status: 404 });
+        return Response.json({
+          name: p.pj.name,
+          "dist-tags": { latest: p.pj.version },
+          versions: {
+            [p.pj.version]: {
+              ...p.pj,
+              dist: { tarball: `${registryUrl}t/${p.pj.name}-${p.pj.version}.tgz`, integrity: integrity(p.gz) },
+            },
+          },
+        });
+      }
+      const m = /^t\/(.+)-\d+\.\d+\.\d+\.tgz$/.exec(parts.join("/"));
+      const p = m && pkgs[m[1]];
+      return p ? new Response(p.gz) : new Response("not found", { status: 404 });
+    },
+  });
+  registryUrl = `http://127.0.0.1:${server.port}/`;
+});
+
+afterAll(() => {
+  server?.stop(true);
+});
+
+// --- helpers ---------------------------------------------------------------
+
+async function install(packageDir: string, extraEnv: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache"),
+      TMPDIR: join(packageDir, ".bun-tmp"),
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  return { stdout, stderr };
+}
+
+function binEntries(dir: string): string[] {
+  const binDir = join(dir, "node_modules", ".bin");
+  if (!existsSync(binDir)) return [];
+  return readdirSync(binDir)
+    .map(name => name.replace(/\.(bunx|exe)$/i, ""))
+    .filter((name, i, arr) => arr.indexOf(name) === i)
+    .sort();
+}
+
+async function setup(packageJson: any) {
+  const dir = tempDir("bin-trust-", {
+    "bunfig.toml": `[install]\nregistry = "${registryUrl}"\ncache = false\nlinker = "hoisted"\n`,
+    "package.json": JSON.stringify(packageJson),
+  });
+  return String(dir);
+}
+
+// --- tests ----------------------------------------------------------------
+
+describe.concurrent("hoisted linker bin trust gate", () => {
+  test("untrusted transitive dependency bins are not linked into root .bin", async () => {
+    const packageDir = await setup({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "dep-on-shadow-bin": "1.0.0" },
+    });
+
+    await install(packageDir);
+
+    // shadow-bin is installed (hoisted to root node_modules) but its bin
+    // entries must not appear in root .bin because it is neither a direct
+    // dependency nor trusted.
+    expect(existsSync(join(packageDir, "node_modules", "shadow-bin", "shadow.js"))).toBeTrue();
+    expect(binEntries(packageDir)).toEqual([]);
+    expect(existsSync(join(packageDir, "node_modules", ".bin", "git"))).toBeFalse();
+    expect(existsSync(join(packageDir, "node_modules", ".bin", "shadow-bin-tool"))).toBeFalse();
+
+    // Same result after a reinstall from the lockfile (exercises the
+    // already-on-disk enqueue path).
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await install(packageDir);
+    expect(binEntries(packageDir)).toEqual([]);
+  });
+
+  test("direct dependency bins are linked regardless of trust", async () => {
+    const packageDir = await setup({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "shadow-bin": "1.0.0" },
+    });
+
+    await install(packageDir);
+
+    expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
+  });
+
+  test("transitive dependency bins are linked when their declaring package is trusted", async () => {
+    const packageDir = await setup({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "dep-on-shadow-bin": "1.0.0" },
+      trustedDependencies: ["dep-on-shadow-bin"],
+    });
+
+    await install(packageDir);
+
+    // dep-on-shadow-bin is trusted, so its direct dependency shadow-bin's bins
+    // are available for dep-on-shadow-bin's (hypothetical) install script.
+    expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
+  });
+
+  test("transitive dependency bins are linked when trusted via trustedDependencies", async () => {
+    const packageDir = await setup({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "dep-on-shadow-bin": "1.0.0" },
+      trustedDependencies: ["shadow-bin"],
+    });
+
+    await install(packageDir);
+
+    expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
+  });
+
+  test("workspace direct dependency bins are linked into root .bin", async () => {
+    const dir = tempDir("bin-trust-ws-", {
+      "bunfig.toml": `[install]\nregistry = "${registryUrl}"\ncache = false\nlinker = "hoisted"\n`,
+      "package.json": JSON.stringify({ name: "root", version: "1.0.0", workspaces: ["packages/*"] }),
+      "packages/pkg1/package.json": JSON.stringify({
+        name: "pkg1",
+        version: "1.0.0",
+        dependencies: { "shadow-bin": "1.0.0" },
+      }),
+    });
+    const packageDir = String(dir);
+
+    await install(packageDir);
+
+    // shadow-bin is a direct dependency of workspace pkg1, so its bins link
+    // into root .bin (where it was hoisted).
+    expect(binEntries(packageDir)).toEqual(["git", "shadow-bin-tool"]);
+  });
+
+  test.skipIf(isWindows)(
+    "bun run does not execute a shadowed tool from an untrusted transitive dependency",
+    async () => {
+      const packageDir = await setup({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "dep-on-shadow-bin": "1.0.0" },
+        scripts: { rev: "git --version" },
+      });
+
+      await install(packageDir);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "rev"],
+        cwd: packageDir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).not.toContain("SHADOW-EXECUTED");
+      expect(stdout).not.toContain("SHADOW-EXECUTED");
+      // git from $PATH ran, not the planted shadow.
+      expect(stdout).toContain("git version");
+      expect(exitCode).toBe(0);
+    },
+  );
+});

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2837,9 +2837,11 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
                 // prevents real `uses-what-bin` from hoisting to root
                 "uses-what-bin": "npm:a-dep@1.0.3",
               },
-              // what-bin hoists to root while its declaring uses-what-bin
-              // stays nested under pkg1; the bin trust gate would otherwise
-              // drop it from every `.bin` on PATH for the install script.
+              // what-bin hoists to root while uses-what-bin stays nested under
+              // pkg1 (via a workspace symlink). The nested-.bin redirect does
+              // not cross a workspace symlink boundary, so opt what-bin in
+              // explicitly. This is a deliberate compat note for a contrived
+              // layout, not a gap in the security gate itself.
               trustedDependencies: ["what-bin"],
               workspaces: ["pkg1"],
             }),

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2837,6 +2837,10 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
                 // prevents real `uses-what-bin` from hoisting to root
                 "uses-what-bin": "npm:a-dep@1.0.3",
               },
+              // what-bin hoists to root while its declaring uses-what-bin
+              // stays nested under pkg1; the bin trust gate would otherwise
+              // drop it from every `.bin` on PATH for the install script.
+              trustedDependencies: ["what-bin"],
               workspaces: ["pkg1"],
             }),
           ),

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1267,7 +1267,7 @@ describe("optionalDependencies", () => {
       );
       expect(await exited).toBe(optional ? 0 : 1);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
-      expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual([".bin", "uses-what-bin", "what-bin"]);
+      expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual(["uses-what-bin", "what-bin"]);
       expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
     });
   }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -3453,15 +3453,10 @@ describe.concurrent("bun-install", () => {
         `${ctx.registry_url}baz-0.0.3.tgz`,
       ]);
       expect(ctx.requested).toBe(6);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
-        ".bin",
-        ".cache",
-        "bar",
-        "baz",
-        "moz",
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "bar", "baz", "moz"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "moz", "node_modules", ".bin"))).toHaveBins([
+        "baz-run",
       ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "bar"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
         name: "bar",
@@ -3475,7 +3470,6 @@ describe.concurrent("bun-install", () => {
           "baz-run": "index.js",
         },
       });
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "moz"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "moz", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -3517,15 +3511,10 @@ describe.concurrent("bun-install", () => {
         `${ctx.registry_url}baz-0.0.3.tgz`,
       ]);
       expect(ctx.requested).toBe(9);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
-        ".bin",
-        ".cache",
-        "bar",
-        "baz",
-        "moz",
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "bar", "baz", "moz"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "moz", "node_modules", ".bin"))).toHaveBins([
+        "baz-run",
       ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "bar"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
         name: "bar",
@@ -3539,7 +3528,6 @@ describe.concurrent("bun-install", () => {
           "baz-run": "index.js",
         },
       });
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "moz"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "moz", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -4420,18 +4408,13 @@ describe.concurrent("bun-install", () => {
         "uglify-js",
         "upper-case",
       ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins([
-        "he",
-        "html-minifier",
-        "uglifyjs",
-      ]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["html-minifier"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
         join("..", "html-minifier", "cli.js"),
       );
-      expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
-        join("..", "uglify-js", "bin", "uglifyjs"),
-      );
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "html-minifier", "node_modules", ".bin")),
+      ).toHaveBins(["he", "uglifyjs"]);
       await access(join(ctx.package_dir, "bun.lockb"));
       // Perform `bun install` again but with lockfile from before
       await rm(join(ctx.package_dir, "node_modules"), { force: true, recursive: true });
@@ -4477,18 +4460,13 @@ describe.concurrent("bun-install", () => {
         "uglify-js",
         "upper-case",
       ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins([
-        "he",
-        "html-minifier",
-        "uglifyjs",
-      ]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["html-minifier"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
         join("..", "html-minifier", "cli.js"),
       );
-      expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
-        join("..", "uglify-js", "bin", "uglifyjs"),
-      );
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "html-minifier", "node_modules", ".bin")),
+      ).toHaveBins(["he", "uglifyjs"]);
       await access(join(ctx.package_dir, "bun.lockb"));
     });
   });
@@ -5393,18 +5371,13 @@ describe.concurrent("bun-install", () => {
         "uglify-js",
         "upper-case",
       ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins([
-        "he",
-        "html-minifier",
-        "uglifyjs",
-      ]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["html-minifier"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
         join("..", "html-minifier", "cli.js"),
       );
-      expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
-        join("..", "uglify-js", "bin", "uglifyjs"),
-      );
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "html-minifier", "node_modules", ".bin")),
+      ).toHaveBins(["he", "uglifyjs"]);
       await access(join(ctx.package_dir, "bun.lockb"));
       // Perform `bun install` again but with lockfile from before
       await rm(join(ctx.package_dir, "node_modules"), { force: true, recursive: true });
@@ -5450,18 +5423,13 @@ describe.concurrent("bun-install", () => {
         "uglify-js",
         "upper-case",
       ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins([
-        "he",
-        "html-minifier",
-        "uglifyjs",
-      ]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["html-minifier"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
         join("..", "html-minifier", "cli.js"),
       );
-      expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
-        join("..", "uglify-js", "bin", "uglifyjs"),
-      );
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "html-minifier", "node_modules", ".bin")),
+      ).toHaveBins(["he", "uglifyjs"]);
       await access(join(ctx.package_dir, "bun.lockb"));
       // Perform `bun install` again but with cache & lockfile from before
       await Promise.all(
@@ -5524,18 +5492,13 @@ describe.concurrent("bun-install", () => {
         "uglify-js",
         "upper-case",
       ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins([
-        "he",
-        "html-minifier",
-        "uglifyjs",
-      ]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "he")).toBeValidBin(join("..", "he", "bin", "he"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["html-minifier"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "html-minifier")).toBeValidBin(
         join("..", "html-minifier", "cli.js"),
       );
-      expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
-        join("..", "uglify-js", "bin", "uglifyjs"),
-      );
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "html-minifier", "node_modules", ".bin")),
+      ).toHaveBins(["he", "uglifyjs"]);
       await access(join(ctx.package_dir, "bun.lockb"));
     });
   });
@@ -5903,17 +5866,16 @@ describe.concurrent("bun-install", () => {
         `${ctx.registry_url}moo-0.1.0.tgz`,
       ]);
       expect(ctx.requested).toBe(5);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
-        ".bin",
-        ".cache",
-        "@barn",
-        "bar",
-        "baz",
-      ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "@barn", "bar", "baz"]);
+      // baz is a transitive dependency of the untrusted @barn/moo, so its bin
+      // is placed under the declaring package's nested .bin rather than root.
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo", "node_modules", ".bin")),
+      ).toHaveBins(["baz-run"]);
+      expect(join(ctx.package_dir, "node_modules", "@barn", "moo", "node_modules", ".bin", "baz-run")).toBeValidBin(
+        join("..", "..", "..", "..", "baz", "index.js"),
+      );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -5994,17 +5956,11 @@ describe.concurrent("bun-install", () => {
         `${ctx.registry_url}moo-0.1.0.tgz`,
       ]);
       expect(ctx.requested).toBe(5);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
-        ".bin",
-        ".cache",
-        "@barn",
-        "bar",
-        "baz",
-      ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "@barn", "bar", "baz"]);
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo", "node_modules", ".bin")),
+      ).toHaveBins(["baz-run"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6059,17 +6015,11 @@ describe.concurrent("bun-install", () => {
         `${ctx.registry_url}moo-0.1.0.tgz`,
       ]);
       expect(ctx.requested).toBe(8);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
-        ".bin",
-        ".cache",
-        "@barn",
-        "bar",
-        "baz",
-      ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "@barn", "bar", "baz"]);
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo", "node_modules", ".bin")),
+      ).toHaveBins(["baz-run"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6149,17 +6099,11 @@ describe.concurrent("bun-install", () => {
         `${ctx.registry_url}baz-0.0.3.tgz`,
       ]);
       expect(ctx.requested).toBe(4);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
-        ".bin",
-        ".cache",
-        "@barn",
-        "bar",
-        "baz",
-      ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "@barn", "bar", "baz"]);
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo", "node_modules", ".bin")),
+      ).toHaveBins(["baz-run"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6210,17 +6154,11 @@ describe.concurrent("bun-install", () => {
       expect(await exited2).toBe(0);
       expect(urls.sort()).toEqual([`${ctx.registry_url}bar-0.0.2.tgz`, `${ctx.registry_url}baz-0.0.3.tgz`]);
       expect(ctx.requested).toBe(6);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
-        ".bin",
-        ".cache",
-        "@barn",
-        "bar",
-        "baz",
-      ]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
-      expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "@barn", "bar", "baz"]);
+      expect(
+        await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo", "node_modules", ".bin")),
+      ).toHaveBins(["baz-run"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6921,8 +6859,6 @@ describe.concurrent("bun-install", () => {
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins([
         "prettier",
-        "resolve",
-        "semver",
         "tsc",
         "tsd",
         "tsserver",

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -456,7 +456,9 @@ index d156130662798530e852e1afaec5b1c03d429cdc..b4ddf35975a952fdaed99f2b14236519
     expect(join(packageDir, "node_modules", ".bin", "pkg1-2")).toBeValidBin(join("..", "pkg1", "bin-2.js"));
     expect(join(packageDir, "node_modules", ".bin", "pkg1-3")).toBeValidBin(join("..", "pkg1", "bin-3.js"));
     expect(join(packageDir, "node_modules", ".bin", "pkg2-1")).toBeValidBin(join("..", "pkg2", "bin-1.js"));
-    expect(join(packageDir, "node_modules", ".bin", "what-bin")).toBeValidBin(join("..", "what-bin", "what-bin.js"));
+    expect(join(packageDir, "node_modules", "uses-what-bin", "node_modules", ".bin", "what-bin")).toBeValidBin(
+      join("..", "..", "..", "what-bin", "what-bin.js"),
+    );
   }
 
   let { exited, stdout } = spawn({


### PR DESCRIPTION
## What

Under the hoisted linker, an untrusted transitive dependency hoisted to a root or workspace `node_modules` had every `bin` entry linked into that tree's `.bin`. `bun run` prepends that folder to PATH, so a package deep in the tree could ship `"bin": {"git": "./x.sh"}` and have it execute the next time a project script shells out to `git`. Nothing in `bun pm untrusted` flags it because no lifecycle script is involved.

```
root -> outerdep -> deepshadow{bin:{git,make,sh,tsc,npm}}
bun install                           # deepshadow's scripts correctly blocked
ls node_modules/.bin                  # git,make,npm,sh,tsc
bun run rev  ("git rev-parse HEAD")   # runs deepshadow's planted git
```

The isolated linker already scopes bins to the declaring package's own store entry, so only the hoisted path is affected.

## Fix

`PackageInstaller::install_package_with_name_and_resolution` now consults `should_redirect_bin_to_nested` before enqueuing a bin link for a root/workspace tree. A bin goes into the tree's `.bin` only when the package is a direct dependency of root or a workspace, or the package itself is trusted (`trustedDependencies`, `--trust`, or the default-trusted list).

Everything else is redirected: `link_tree_nested_bins` removes any matching entry already in the tree's `.bin` (so a `node_modules` populated before this change, or after a trust revocation, does not keep the shadow bin live) and links the bin into every declaring package's own `node_modules/.bin` inside the same tree. That folder is on PATH for the declaring package's lifecycle scripts, so trusting the declaring package later via `bun pm trust` still finds its dependencies' bins without a reinstall, without ever exposing those bins to `bun run` at the project root. The redirect runs before `link_tree_bins` (so its stale-unlink cannot remove a same-named bin an allowed sibling is about to place) but after the tree-completion gate (so no sibling's `uninstall_before_install` can later wipe the owner directory). Nested (non-workspace) `.bin` folders are not on the project-root PATH and keep the old behavior.

## Verification

New `test/cli/install/bun-install-bin-trust.test.ts` runs a self-contained loopback registry and covers:

- untrusted transitive dep bins are not linked into root `.bin`, and land in each declaring package's nested `.bin` instead (fresh install and reinstall-from-lockfile)
- a stale root `.bin/git` planted before the gate is removed on reinstall
- a transitive owner with a (blocked) postinstall does not unlock root `.bin` for its dependencies
- a default-trusted owner (package named `puppeteer`) does not unlock root `.bin` for its dependencies
- trusting the declaring package keeps the child bin in the nested `.bin`, not root
- direct-dep and workspace-direct-dep bins still link into root `.bin` regardless of trust
- transitive bins link into root `.bin` when the package itself is in `trustedDependencies`
- end-to-end: `bun run <script>` invokes the real `git`, not the planted shadow

Existing `bun-install.test.ts` and `bun-install-registry.test.ts` assertions that documented transitive bins in root `.bin` now assert the nested placement; `bun-install-lifecycle-scripts.test.ts`, `bun-install-native-binlink.test.ts`, `bun-pm.test.ts`, and `bun-lock.test.ts` pass unchanged (one lifecycle test keeps an explicit `trustedDependencies: ["what-bin"]` for a contrived cross-tree hoist layout where the owner sits behind a workspace symlink).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-bin-trust.test.ts test/cli/install/bun-install-lifecycle-scripts.test.ts test/cli/install/bun-install-registry.test.ts test/cli/install/bun-install.test.ts test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->