### PR TITLE
sql: union batch-insert keys across all rows; encode null as SQL NULL in sql.array

### DIFF
--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -146,6 +146,12 @@ function arrayValueSerializer(type: ArrayType, is_numeric: boolean, is_json: boo
   // we do minimal to none type validation, we just try to format nicely and let the server handle if is valid SQL
   // postgres will try to convert string -> array type
   // postgres will emit a nice error saying what value dont have the expected format outputing the value in the error
+  if (value === null) {
+    // Unquoted null is SQL NULL in array literal syntax. typeof null is "object",
+    // so without this check the default branch would JSON.stringify it and emit
+    // the quoted string "null".
+    return "null";
+  }
   if ($isArray(value) || isTypedArray(value)) {
     if (!value.length) return "{}";
     const delimiter = type === "BOX" ? ";" : ",";

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -147,6 +147,23 @@ function normalizeSSLMode(value: string): SSLMode {
   throw $ERR_INVALID_ARG_VALUE("sslmode", value, "must be one of: disable, prefer, require, verify-ca, verify-full");
 }
 
+/**
+ * Reject helper keys that are neither identifier-like strings nor small
+ * non-negative integers. Numeric strings are coerced first so the same rule
+ * applies regardless of how the key was spelled.
+ */
+function validateHelperKey(key: unknown): void {
+  if (typeof key === "string") {
+    const asNumber = Number(key);
+    if (Number.isNaN(asNumber)) return;
+    key = asNumber;
+  }
+  if (typeof key !== "string") {
+    if (Number.isSafeInteger(key) && (key as number) >= 0 && (key as number) <= 64 * 1024) return;
+    throw new Error(`Keys must be strings or numbers: ${String(key)}`);
+  }
+}
+
 export type { SQLHelper };
 class SQLHelper<T> {
   public readonly value: T;
@@ -167,25 +184,7 @@ class SQLHelper<T> {
     }
 
     if (keys !== undefined) {
-      for (let key of keys) {
-        if (typeof key === "string") {
-          const asNumber = Number(key);
-          if (Number.isNaN(asNumber)) {
-            continue;
-          }
-          key = asNumber as keyof T;
-        }
-
-        if (typeof key !== "string") {
-          if (Number.isSafeInteger(key)) {
-            if (key >= 0 && key <= 64 * 1024) {
-              continue;
-            }
-          }
-
-          throw new Error(`Keys must be strings or numbers: ${String(key)}`);
-        }
-      }
+      for (const key of keys) validateHelperKey(key);
     }
 
     this.value = value;
@@ -210,6 +209,7 @@ function unionRowKeys<T>(firstRowKeys: (keyof T)[], items: T[]): (keyof T)[] {
     for (let k = 0; k < itemKeys.length; k++) {
       const key = itemKeys[k] as keyof T;
       if (!seen.has(key)) {
+        validateHelperKey(key);
         seen.add(key);
         union.push(key);
       }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -154,7 +154,30 @@ class SQLHelper<T> {
 
   constructor(value: T, keys?: (keyof T)[]) {
     if (keys !== undefined && keys.length === 0 && ($isObject(value[0]) || $isArray(value[0]))) {
-      keys = Object.keys(value[0]) as (keyof T)[];
+      // For batch inserts the caller may pass rows whose key sets differ
+      // (a key missing entirely, not just set to undefined). Union the keys
+      // across every row so a column that first appears in a later row is
+      // still emitted; rows that lack it bind null, which is what
+      // buildDefinedColumnsAndQuery already does for explicit `undefined`.
+      if ($isArray(value) && (value as unknown[]).length > 1 && !$isArray(value[0])) {
+        const seen = new Set<keyof T>();
+        const unionKeys: (keyof T)[] = [];
+        for (let i = 0; i < (value as unknown[]).length; i++) {
+          const item = value[i];
+          if (item == null || !$isObject(item)) continue;
+          const itemKeys = Object.keys(item);
+          for (let k = 0; k < itemKeys.length; k++) {
+            const key = itemKeys[k] as keyof T;
+            if (!seen.has(key)) {
+              seen.add(key);
+              unionKeys.push(key);
+            }
+          }
+        }
+        keys = unionKeys;
+      } else {
+        keys = Object.keys(value[0]) as (keyof T)[];
+      }
     }
 
     if (keys !== undefined) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -151,33 +151,19 @@ export type { SQLHelper };
 class SQLHelper<T> {
   public readonly value: T;
   public readonly columns: (keyof T)[];
+  /**
+   * True when the column list was derived from the first row's own keys
+   * rather than supplied explicitly by the caller. The INSERT path uses this
+   * to widen the column list to the union of keys across every row so that
+   * keys first appearing on a later row are not silently dropped.
+   */
+  public readonly autoColumns: boolean;
 
   constructor(value: T, keys?: (keyof T)[]) {
+    let autoColumns = false;
     if (keys !== undefined && keys.length === 0 && ($isObject(value[0]) || $isArray(value[0]))) {
-      // For batch inserts the caller may pass rows whose key sets differ
-      // (a key missing entirely, not just set to undefined). Union the keys
-      // across every row so a column that first appears in a later row is
-      // still emitted; rows that lack it bind null, which is what
-      // buildDefinedColumnsAndQuery already does for explicit `undefined`.
-      if ($isArray(value) && (value as unknown[]).length > 1 && !$isArray(value[0])) {
-        const seen = new Set<keyof T>();
-        const unionKeys: (keyof T)[] = [];
-        for (let i = 0; i < (value as unknown[]).length; i++) {
-          const item = value[i];
-          if (item == null || !$isObject(item)) continue;
-          const itemKeys = Object.keys(item);
-          for (let k = 0; k < itemKeys.length; k++) {
-            const key = itemKeys[k] as keyof T;
-            if (!seen.has(key)) {
-              seen.add(key);
-              unionKeys.push(key);
-            }
-          }
-        }
-        keys = unionKeys;
-      } else {
-        keys = Object.keys(value[0]) as (keyof T)[];
-      }
+      keys = Object.keys(value[0]) as (keyof T)[];
+      autoColumns = true;
     }
 
     if (keys !== undefined) {
@@ -204,7 +190,32 @@ class SQLHelper<T> {
 
     this.value = value;
     this.columns = keys ?? [];
+    this.autoColumns = autoColumns;
   }
+}
+
+/**
+ * Return the union of own keys across every object in a multi-row array,
+ * seeded from the first row's key list so column order is stable. Used by the
+ * INSERT helper when no explicit column list was given, so a key that first
+ * appears on a later row is still emitted instead of being silently dropped.
+ */
+function unionRowKeys<T>(firstRowKeys: (keyof T)[], items: T[]): (keyof T)[] {
+  const seen = new Set<keyof T>(firstRowKeys);
+  const union = firstRowKeys.slice();
+  for (let i = 1; i < items.length; i++) {
+    const item = items[i];
+    if (item == null || !$isObject(item)) continue;
+    const itemKeys = Object.keys(item);
+    for (let k = 0; k < itemKeys.length; k++) {
+      const key = itemKeys[k] as keyof T;
+      if (!seen.has(key)) {
+        seen.add(key);
+        union.push(key);
+      }
+    }
+  }
+  return union;
 }
 
 /**
@@ -444,7 +455,7 @@ function normalizeQuery(
           binding_idx += sub_values.length;
         } else if (value instanceof SQLHelper) {
           const command = adapter.getHelperCommand(query);
-          const { columns, value: items } = value as SQLHelper<any>;
+          const { columns, value: items, autoColumns } = value as SQLHelper<any>;
           const columnCount = columns.length;
           if (columnCount === 0 && command !== SQLCommand.in) {
             throw new SyntaxError(`Cannot ${commandToString(command)} with no columns`);
@@ -456,9 +467,18 @@ function normalizeQuery(
             // insert into users ${sql(users)} or insert into users ${sql(user)}
             //
 
+            // When the column list came from Object.keys(rows[0]) and there are
+            // further rows, widen it to the union of keys across every row so a
+            // key that first appears on a later row is still emitted. Explicit
+            // column lists and single-row inserts are left as supplied.
+            const insertColumns =
+              autoColumns && $isArray(items) && items.length > 1 && !$isArray(items[0])
+                ? unionRowKeys(columns, items)
+                : columns;
+
             // Build column list while determining which columns have at least one defined value
             const { definedColumns, columnsSql } = buildDefinedColumnsAndQuery(
-              columns,
+              insertColumns,
               items,
               adapter.escapeIdentifier.bind(adapter),
             );

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -457,7 +457,9 @@ function normalizeQuery(
           const command = adapter.getHelperCommand(query);
           const { columns, value: items, autoColumns } = value as SQLHelper<any>;
           const columnCount = columns.length;
-          if (columnCount === 0 && command !== SQLCommand.in) {
+          // INSERT widens the column list below and has its own empty-column
+          // guard after widening, so an empty first row is allowed here.
+          if (columnCount === 0 && command !== SQLCommand.in && command !== SQLCommand.insert) {
             throw new SyntaxError(`Cannot ${commandToString(command)} with no columns`);
           }
           const lastColumnIndex = columns.length - 1;

--- a/test/js/sql/sql-helpers-validation.test.ts
+++ b/test/js/sql/sql-helpers-validation.test.ts
@@ -189,6 +189,17 @@ describe("sqlite helper behavior preserved", () => {
       { id: 2, a: "y" },
     ]);
   });
+
+  // Column-list widening is scoped to INSERT. A WHERE IN helper over objects
+  // with no explicit column keeps deriving its single column from the first
+  // row's keys so existing queries keep working.
+  test("WHERE IN helper with heterogeneous objects still uses first-row keys", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (id INTEGER)`;
+    await sql`INSERT INTO t VALUES (1), (2), (3)`;
+    const rows = await sql`SELECT id FROM t WHERE id IN ${sql([{ id: 1 }, { id: 2, other: "x" }] as any)} ORDER BY id`;
+    expect(rows).toEqual([{ id: 1 }, { id: 2 }]);
+  });
 });
 
 // sql.array() builds the Postgres array literal up front, so its serialization

--- a/test/js/sql/sql-helpers-validation.test.ts
+++ b/test/js/sql/sql-helpers-validation.test.ts
@@ -172,6 +172,19 @@ describe("sqlite helper behavior preserved", () => {
       { id: 2, a: "hasB", b: "IMPORTANT-DATA" },
       { id: 3, a: null, b: "b-only" },
     ]);
+
+    // Boundary case of the same widening: an empty first row contributes no
+    // keys of its own, so the column list comes entirely from later rows.
+    const withEmptyFirst = await sql`INSERT INTO h ${sql([{}, { id: 4, a: "later" }])} RETURNING id, a, b`;
+    expect(withEmptyFirst).toEqual([
+      { id: null, a: null, b: null },
+      { id: 4, a: "later", b: null },
+    ]);
+
+    // When no row supplies any key, the INSERT path's own guard still fires.
+    const err = await sql`INSERT INTO h ${sql([{}, {}])}`.catch(e => e);
+    expect(err).toBeInstanceOf(SyntaxError);
+    expect(err.message).toBe("Insert needs to have at least one column with a defined value");
   });
 
   test("batch insert helper with explicit columns ignores extra keys", async () => {

--- a/test/js/sql/sql-helpers-validation.test.ts
+++ b/test/js/sql/sql-helpers-validation.test.ts
@@ -179,7 +179,10 @@ describe("sqlite helper behavior preserved", () => {
     await sql`CREATE TABLE h (id INTEGER, a TEXT)`;
     // When the caller names the columns explicitly, keys outside that set are
     // ignored regardless of which row they appear on.
-    const rows = [{ id: 1, a: "x" }, { id: 2, a: "y", b: "ignored" }];
+    const rows = [
+      { id: 1, a: "x" },
+      { id: 2, a: "y", b: "ignored" },
+    ];
     const result = await sql`INSERT INTO h ${sql(rows, "id", "a")} RETURNING id, a`;
     expect(result).toEqual([
       { id: 1, a: "x" },
@@ -210,7 +213,15 @@ describe("postgres sql.array serialization (no server)", () => {
 
   test("null in a nested array serializes as SQL NULL", async () => {
     await using sql = makeSql();
-    expect(sql.array([[1, null], [null, 4]], "INTEGER").serializedValues).toBe("{{1,null},{null,4}}");
+    expect(
+      sql.array(
+        [
+          [1, null],
+          [null, 4],
+        ],
+        "INTEGER",
+      ).serializedValues,
+    ).toBe("{{1,null},{null,4}}");
   });
 
   test("undefined still serializes as SQL NULL", async () => {

--- a/test/js/sql/sql-helpers-validation.test.ts
+++ b/test/js/sql/sql-helpers-validation.test.ts
@@ -152,4 +152,69 @@ describe("sqlite helper behavior preserved", () => {
     // a null item without a column binds NULL
     expect(await sql`SELECT 1 as num WHERE 1 IN ${sql([null, 1])}`).toEqual([{ num: 1 }]);
   });
+
+  // The insert helper derives its column list from the supplied rows. When a
+  // key is entirely absent from the first row (not merely set to undefined) it
+  // must still be emitted as a column if any later row supplies it; otherwise
+  // that later row's value is silently discarded and NULL is stored.
+  test("batch insert helper unions keys across all rows", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE h (id INTEGER, a TEXT, b TEXT)`;
+
+    const rows = [
+      { id: 1, a: "onlyA" }, // no `b` key at all
+      { id: 2, a: "hasB", b: "IMPORTANT-DATA" },
+      { id: 3, b: "b-only" }, // no `a` key at all
+    ];
+    const result = await sql`INSERT INTO h ${sql(rows)} RETURNING id, a, b`;
+    expect(result).toEqual([
+      { id: 1, a: "onlyA", b: null },
+      { id: 2, a: "hasB", b: "IMPORTANT-DATA" },
+      { id: 3, a: null, b: "b-only" },
+    ]);
+  });
+
+  test("batch insert helper with explicit columns ignores extra keys", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE h (id INTEGER, a TEXT)`;
+    // When the caller names the columns explicitly, keys outside that set are
+    // ignored regardless of which row they appear on.
+    const rows = [{ id: 1, a: "x" }, { id: 2, a: "y", b: "ignored" }];
+    const result = await sql`INSERT INTO h ${sql(rows, "id", "a")} RETURNING id, a`;
+    expect(result).toEqual([
+      { id: 1, a: "x" },
+      { id: 2, a: "y" },
+    ]);
+  });
+});
+
+// sql.array() builds the Postgres array literal up front, so its serialization
+// can be asserted without a server. A JS null must become the unquoted token
+// `null` (SQL NULL in array-literal syntax); previously `typeof null ===
+// "object"` sent it through JSON.stringify and produced the quoted string
+// `"null"`, which a TEXT[] column stores as the four-character string and an
+// INTEGER[] column rejects with 22P02.
+describe("postgres sql.array serialization (no server)", () => {
+  const makeSql = () => new SQL("postgres://bun_sql_test@127.0.0.1:1/bun_sql_test", { max: 1 });
+
+  test("null in a TEXT array serializes as SQL NULL", async () => {
+    await using sql = makeSql();
+    expect(sql.array(["a", null, "b"], "TEXT").serializedValues).toBe('{"a",null,"b"}');
+  });
+
+  test("null in a numeric array serializes as SQL NULL", async () => {
+    await using sql = makeSql();
+    expect(sql.array([1, null, 2], "INTEGER").serializedValues).toBe("{1,null,2}");
+    expect(sql.array([1.5, null], "DOUBLE PRECISION").serializedValues).toBe("{1.5,null}");
+  });
+
+  test("null in a nested array serializes as SQL NULL", async () => {
+    await using sql = makeSql();
+    expect(sql.array([[1, null], [null, 4]], "INTEGER").serializedValues).toBe("{{1,null},{null,4}}");
+  });
+
+  test("undefined still serializes as SQL NULL", async () => {
+    await using sql = makeSql();
+    expect(sql.array(["a", undefined, "b"], "TEXT").serializedValues).toBe('{"a",null,"b"}');
+  });
 });

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -242,6 +242,23 @@ if (isDockerEnabled()) {
         expect(x).toEqual(["hello", "world", "test"]);
       });
 
+      test("sql.array should encode null elements as SQL NULL", async () => {
+        await using sql = postgres(options);
+        // TEXT[]: null must round-trip as SQL NULL, not the four-character string "null"
+        {
+          const [{ x }] = await sql`select ${sql.array(["a", null, "b"], "TEXT")} as x`;
+          expect(x).toEqual(["a", null, "b"]);
+        }
+        // INTEGER[]: previously the quoted "null" was rejected by the server with 22P02
+        {
+          const [{ second_is_null, arr }] =
+            await sql`select (${sql.array([1, null, 2], "INTEGER")})[2] is null as second_is_null,
+                             ${sql.array([1, null, 2], "INTEGER")}::text as arr`;
+          expect(arr).toBe("{1,NULL,2}");
+          expect(second_is_null).toBe(true);
+        }
+      });
+
       test("sql.array should support BOOLEAN arrays", async () => {
         await using sql = postgres(options);
 
@@ -1055,6 +1072,26 @@ if (isDockerEnabled()) {
         ]);
       } finally {
         await sql`drop table users`;
+      }
+    });
+
+    test("bulk insert unions keys across heterogeneous rows", async () => {
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql`create table ${sql(random_name)} (id int, a text, b text)`;
+      try {
+        const rows = [
+          { id: 1, a: "onlyA" }, // no `b` key
+          { id: 2, a: "hasB", b: "IMPORTANT-DATA" },
+          { id: 3, b: "b-only" }, // no `a` key
+        ];
+        const result = await sql`insert into ${sql(random_name)} ${sql(rows)} returning id, a, b`;
+        expect(result).toEqual([
+          { id: 1, a: "onlyA", b: null },
+          { id: 2, a: "hasB", b: "IMPORTANT-DATA" },
+          { id: 3, a: null, b: "b-only" },
+        ]);
+      } finally {
+        await sql`drop table ${sql(random_name)}`;
       }
     });
 


### PR DESCRIPTION
## What

Two silent data-loss bugs in `Bun.SQL` helpers.

### Batch insert drops keys not present on the first row

```ts
const rows = [
  { id: 1, a: "onlyA" },                     // no `b` key
  { id: 2, a: "hasB", b: "IMPORTANT-DATA" },
  { id: 3, b: "b-only" },
];
await sql`insert into h ${sql(rows)} returning id, a, b`;
// before: [{id:1,a:"onlyA",b:null},{id:2,a:"hasB",b:null},{id:3,a:null,b:null}]
// after:  [{id:1,a:"onlyA",b:null},{id:2,a:"hasB",b:"IMPORTANT-DATA"},{id:3,a:null,b:"b-only"}]
```

`SQLHelper` derived the column list from `Object.keys(rows[0])` only, so a key that first appears on a later row was never emitted and its value was silently discarded. `buildDefinedColumnsAndQuery` already scans every row and null-fills missing values, so the fix is to union the keys across all rows when no explicit column list is given. Explicit columns (`sql(rows, "a", "b")`) and single-row / positional-array inputs are unchanged.

### `sql.array([..., null, ...])` stores the string `"null"`

```ts
sql.array(["a", null, "b"], "TEXT").serializedValues
// before: {"a","null","b"}   -> TEXT[] stores the four-character string "null"
// after:  {"a",null,"b"}     -> SQL NULL

sql.array([1, null, 2], "INTEGER").serializedValues
// before: {1,"null",2}       -> server rejects with 22P02 "invalid input syntax for type integer"
// after:  {1,null,2}
```

`arrayValueSerializer` had no branch for `null`; `typeof null === "object"` sent it through `JSON.stringify` and produced the quoted string `"null"`. It now emits the unquoted `null` token (SQL NULL in Postgres array-literal syntax), matching the existing `undefined` handling.

## Tests

`test/js/sql/sql-helpers-validation.test.ts` gains no-server coverage for both fixes (sqlite in-memory for the insert helper, `serializedValues` inspection for `sql.array`). `test/js/sql/sql.test.ts` gains live-Postgres round-trip tests under the docker guard.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-helpers-validation.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (b210150fb)

test/js/sql/sql-helpers-validation.test.ts:
(pass) sqlite helper validation > null items in WHERE IN helper with a column are rejected [194.48ms]
(pass) sqlite helper validation > null and undefined items in INSERT helper are rejected [27.32ms]
(pass) sqlite helper validation > null and undefined items in UPDATE helper are rejected [21.02ms]
(pass) sqlite helper validation > empty update helper throws regardless of SET casing [31.67ms]
(pass) sqlite helper validation > empty update helper throws even alongside a literal assignment [26.39ms]
(pass) postgres helper validation > null items in WHERE IN helper with a column are rejected [46.28ms]
(pass) postgres helper validation > null and undefined items in INSERT helper are rejected [12.66ms]
(pass) postgres helper validation > null and undefined items in UPDATE helper are rejected [9.68ms]
(pass) postgres helper validation > empty update helper throws regardless of SET casing [16.01ms]
(pass)
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (3e0954da1)

test/js/sql/sql-helpers-validation.test.ts:
(pass) sqlite helper validation > null items in WHERE IN helper with a column are rejected [3.54ms]
(pass) sqlite helper validation > null and undefined items in INSERT helper are rejected [0.52ms]
(pass) sqlite helper validation > null and undefined items in UPDATE helper are rejected [0.30ms]
(pass) sqlite helper validation > empty update helper throws regardless of SET casing [0.41ms]
(pass) sqlite helper validation > empty update helper throws even alongside a literal assignment [0.30ms]
(pass) postgres helper validation > null items in WHERE IN helper with a column are rejected [1.02ms]
(pass) postgres helper validation > null and undefined items in INSERT helper are rejected [0.15ms]
(pass) postgres helper validation > null and undefined items in UPDATE helper are rejected [0.09ms]
(pass) postgres helper validation > empty update helper throws regardless of SET casing [0.24ms]
(pass) postgres helper validation > empty update helper throws even alongside a literal assignment [0.09ms]
(pass) mysql helper validation > null items in WHERE IN helper with a column are rejected [0.16ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-helpers-validation.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (b210150fb)

test/js/sql/sql-helpers-validation.test.ts:
(pass) sqlite helper validation > null items in WHERE IN helper with a column are rejected [240.55ms]
(pass) sqlite helper validation > null and undefined items in INSERT helper are rejected [31.64ms]
(pass) sqlite helper validation > null and undefined items in UPDATE helper are rejected [27.11ms]
(pass) sqlite helper validation > empty update helper throws regardless of SET casing [44.50ms]
(pass) sqlite helper validation > empty update helper throws even alongside a literal assignment [27.47ms]
(pass) postgres helper validation > null items in WHERE IN helper with a column are rejected [48.25ms]
(pass) postgres helper validation > null and undefined items in INSERT helper are rejected [12.79ms]
(pass) postgres helper validation > null and undefined items in UPDATE helper are rejected [10.02ms]
(pass) postgres helper validation > empty update helper throws regardless of SET casing [17.11ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 786ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8542ms)
Bundle modules (36ms)
Postprocesss modules (161ms)
Bundle Functions (795ms)
Generate Code (27ms)

[9.57s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/postgres.ts            |   6 ++
 src/js/internal/sql/shared.ts              |  89 ++++++++++++++++++-------
 test/js/sql/sql-helpers-validation.test.ts | 100 +++++++++++++++++++++++++++++
 test/js/sql/sql.test.ts                    |  37 +++++++++++
 4 files changed, 210 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/internal/sql/postgres.ts                 2      1      0
src/js/internal/sql/shared.ts                  11     10      0
test/js/sql/sql-helpers-validation.test.ts      4      4      0
test/js/sql/sql.test.ts                         2      3      0
```

</details>

<!-- robobun:evidence:end -->