### PR TITLE
sql: make begin() await its callback when the tx connection dies

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -259,7 +259,7 @@ const SQL: typeof Bun.SQL = function SQL(
         state.connectionState & ReservedConnectionState.closed ||
         !(state.connectionState & ReservedConnectionState.acceptQueries)
       ) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
       if ($isArray(strings)) {
         // detect if is tagged template
@@ -287,7 +287,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
     reserved_sql.connect = () => {
       if (state.connectionState & ReservedConnectionState.closed) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
       return Promise.$resolve(reserved_sql);
     };
@@ -319,7 +319,7 @@ const SQL: typeof Bun.SQL = function SQL(
     reserved_sql.beginDistributed = (name: string, fn: TransactionCallback) => {
       // begin is allowed the difference is that we need to make sure to use the same connection and never release it
       if (state.connectionState & ReservedConnectionState.closed) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
       let callback = fn;
 
@@ -343,7 +343,7 @@ const SQL: typeof Bun.SQL = function SQL(
         state.connectionState & ReservedConnectionState.closed ||
         !(state.connectionState & ReservedConnectionState.acceptQueries)
       ) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
       let callback = fn;
       let options: string | undefined = options_or_fn as unknown as string;
@@ -366,7 +366,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
     reserved_sql.flush = () => {
       if (state.connectionState & ReservedConnectionState.closed) {
-        throw pool.connectionClosedError();
+        throw state.storedError ?? pool.connectionClosedError();
       }
       // Use pooled connection's flush if available, otherwise use adapter's flush
       if (pooledConnection.flush) {
@@ -426,7 +426,7 @@ const SQL: typeof Bun.SQL = function SQL(
         state.connectionState & ReservedConnectionState.closed ||
         !(state.connectionState & ReservedConnectionState.acceptQueries)
       ) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
       // just release the connection back to the pool
       state.connectionState |= ReservedConnectionState.closed;
@@ -591,7 +591,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
     transaction_sql.connect = () => {
       if (state.connectionState & ReservedConnectionState.closed) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
 
       return Promise.$resolve(transaction_sql);
@@ -631,7 +631,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
     transaction_sql.flush = function () {
       if (state.connectionState & ReservedConnectionState.closed) {
-        throw pool.connectionClosedError();
+        throw state.storedError ?? pool.connectionClosedError();
       }
       // Use pooled connection's flush if available, otherwise use adapter's flush
       if (pooledConnection.flush) {
@@ -730,7 +730,7 @@ const SQL: typeof Bun.SQL = function SQL(
           state.connectionState & ReservedConnectionState.closed ||
           !(state.connectionState & ReservedConnectionState.acceptQueries)
         ) {
-          throw pool.connectionClosedError();
+          throw state.storedError ?? pool.connectionClosedError();
         }
 
         if ($isCallable(name)) {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -22,8 +22,7 @@ enum ReservedConnectionState {
 
 interface TransactionState {
   connectionState: ReservedConnectionState;
-  reject: (err: Error) => void;
-  storedError?: Error | null | undefined;
+  storedError: Error | null | undefined;
   queries: Set<Query<any, any>>;
 }
 
@@ -225,15 +224,13 @@ const SQL: typeof Bun.SQL = function SQL(
   }
 
   function onTransactionDisconnected(this: TransactionState, err: Error) {
-    const reject = this.reject;
     this.connectionState |= ReservedConnectionState.closed;
+    if (err && !this.storedError) {
+      this.storedError = err;
+    }
 
     for (const query of this.queries) {
       query.reject(err);
-    }
-
-    if (err) {
-      return reject(err);
     }
   }
 
@@ -248,7 +245,6 @@ const SQL: typeof Bun.SQL = function SQL(
 
     const state: TransactionState = {
       connectionState: ReservedConnectionState.acceptQueries,
-      reject,
       storedError: null,
       queries: new Set(),
     };
@@ -490,7 +486,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
     const state: TransactionState = {
       connectionState: ReservedConnectionState.acceptQueries,
-      reject,
+      storedError: null,
       queries: new Set(),
     };
 
@@ -553,7 +549,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
     function run_internal_transaction_sql(string) {
       if (state.connectionState & ReservedConnectionState.closed) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
       return unsafeQueryFromTransaction(string, [], pooledConnection, state.queries);
     }
@@ -565,7 +561,7 @@ const SQL: typeof Bun.SQL = function SQL(
         state.connectionState & ReservedConnectionState.closed ||
         !(state.connectionState & ReservedConnectionState.acceptQueries)
       ) {
-        return Promise.$reject(pool.connectionClosedError());
+        return Promise.$reject(state.storedError ?? pool.connectionClosedError());
       }
       if ($isArray(strings)) {
         // detect if is tagged template
@@ -761,6 +757,9 @@ const SQL: typeof Bun.SQL = function SQL(
       if ($isArray(transaction_result)) {
         transaction_result = await Promise.all(transaction_result);
       }
+      if (state.storedError) {
+        throw state.storedError;
+      }
       // at this point we dont need to rollback anymore
       needs_rollback = false;
       if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
@@ -776,10 +775,10 @@ const SQL: typeof Bun.SQL = function SQL(
           }
           await run_internal_transaction_sql(ROLLBACK_COMMAND);
         }
-      } catch (err) {
-        return reject(err);
+      } catch (rollbackErr) {
+        return reject(state.storedError ?? rollbackErr);
       }
-      return reject(err);
+      return reject(state.storedError ?? err);
     } finally {
       state.connectionState |= ReservedConnectionState.closed;
       // Use adapter method to detach connection close handler

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -757,8 +757,9 @@ const SQL: typeof Bun.SQL = function SQL(
       if ($isArray(transaction_result)) {
         transaction_result = await Promise.all(transaction_result);
       }
-      if (state.storedError) {
-        throw state.storedError;
+      const storedError = state.storedError;
+      if (storedError) {
+        throw storedError;
       }
       // at this point we dont need to rollback anymore
       needs_rollback = false;

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2977,7 +2977,11 @@ impl PostgresSQLConnection {
 
                 let Some(request) = self.current() else {
                     debug!("ErrorResponse: {}", err);
-                    return Err(AnyPostgresError::ExpectedRequest);
+                    let v =
+                        crate::postgres::protocol::error_response_jsc::to_js(&err, self.global());
+                    drop(err);
+                    self.fail_with_js_value(v);
+                    return Ok(());
                 };
                 // Convert to JS while we still own `err` — materialize the JS value once and route through
                 // `on_js_error` to avoid double-ownership of the non-Clone ErrorResponse.

--- a/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
+++ b/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
@@ -1,0 +1,74 @@
+// sql.begin() must not settle before its callback settles.
+//
+// When the transaction's backend dies mid-callback (failover, OOM, admin
+// pg_terminate_backend), the pooled connection's onClose handler calls
+// onTransactionDisconnected. That handler used to reject the *outer*
+// begin() promise immediately, while `await callback(tx)` was still pending.
+// The caller would observe "transaction failed" and move on, but the
+// callback kept running and could still perform side effects on healthy
+// pool connections: a caller/callback split-brain.
+//
+// Secondary: an ErrorResponse that arrives on an idle-in-transaction
+// connection (no current request) was surfaced as the opaque
+// ERR_POSTGRES_EXPECTED_REQUEST / "Failed to read data" instead of the
+// server's actual FATAL.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  test("sql.begin() waits for its callback to settle when the tx connection dies", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 4, idleTimeout: 5 });
+    await using adm = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+
+    const txReady = Promise.withResolvers<number>();
+    const gate = Promise.withResolvers<void>();
+    let callbackDone = false;
+
+    const p = sql.begin(async tx => {
+      const [{ pid }] = await tx`select pg_backend_pid() as pid`;
+      txReady.resolve(pid);
+      // The callback is *not* touching `tx` here; it is doing other async
+      // work while the backend is killed and the close event propagates.
+      await gate.promise;
+      callbackDone = true;
+      return "done";
+    });
+
+    let caught: any;
+    let settledBeforeCallback: boolean | undefined;
+    const settled = p.then(
+      () => {
+        settledBeforeCallback = !callbackDone;
+      },
+      e => {
+        settledBeforeCallback = !callbackDone;
+        caught = e;
+      },
+    );
+
+    const pid = await txReady.promise;
+    await adm`select pg_terminate_backend(${pid})`;
+
+    // Give the tx connection's socket time to observe the FATAL + close
+    // and fire its onClose handler. On the buggy build p settles inside
+    // this window; on the fixed build it stays pending.
+    for (let i = 0; i < 50 && settledBeforeCallback === undefined; i++) {
+      await new Promise<void>(r => setTimeout(r, 5));
+    }
+
+    gate.resolve();
+    await settled;
+
+    expect(callbackDone).toBe(true);
+    expect(settledBeforeCallback).toBe(false);
+    expect(caught).toBeDefined();
+    // The rejection must carry the server's FATAL (57P01) or a
+    // connection-closed identity, not the opaque "Failed to read data".
+    expect(caught.code).not.toBe("ERR_POSTGRES_EXPECTED_REQUEST");
+    expect(String(caught.message ?? "")).not.toContain("Failed to read data");
+  });
+});

--- a/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
+++ b/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
@@ -52,35 +52,37 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
 
     p.catch(txReady.reject);
     const { tx, pid } = await txReady.promise;
-    await adm`select pg_terminate_backend(${pid})`;
+    try {
+      await adm`select pg_terminate_backend(${pid})`;
 
-    // Wait until the terminated backend has exited (observed via adm on a
-    // separate connection). By the time it is gone from pg_stat_activity the
-    // server has already sent FATAL + FIN to the tx socket, and the adm
-    // round-trip yields to the event loop so the tx socket's readable event
-    // delivers the FATAL through the idle-connection ErrorResponse path.
-    let gone = false;
-    for (let i = 0; i < 500 && !gone; i++) {
-      const [{ n }] = await adm`select count(*)::int as n from pg_stat_activity where pid = ${pid}`;
-      gone = n === 0;
-      if (!gone) await new Promise<void>(r => setTimeout(r, 5));
+      // Wait until the terminated backend has exited (observed via adm on a
+      // separate connection). By the time it is gone from pg_stat_activity the
+      // server has already sent FATAL + FIN to the tx socket, and the adm
+      // round-trip yields to the event loop so the tx socket's readable event
+      // delivers the FATAL through the idle-connection ErrorResponse path.
+      let gone = false;
+      for (let i = 0; i < 500 && !gone; i++) {
+        const [{ n }] = await adm`select count(*)::int as n from pg_stat_activity where pid = ${pid}`;
+        gone = n === 0;
+        if (!gone) await new Promise<void>(r => setTimeout(r, 5));
+      }
+      expect(gone).toBe(true);
+
+      // Positive precondition: onTransactionDisconnected has fired (state is
+      // closed) so tx`...` rejects. Fail loudly if the disconnect never
+      // reached the tx handle before the ordering check below.
+      let txClosed = false;
+      for (let i = 0; i < 500 && !txClosed; i++) {
+        txClosed = await tx`select 1`.then(
+          () => false,
+          () => true,
+        );
+        if (!txClosed) await new Promise<void>(r => setTimeout(r, 5));
+      }
+      expect(txClosed).toBe(true);
+    } finally {
+      gate.resolve();
     }
-    expect(gone).toBe(true);
-
-    // Positive precondition: onTransactionDisconnected has fired (state is
-    // closed) so tx`...` rejects. Fail loudly if the disconnect never
-    // reached the tx handle before the ordering check below.
-    let txClosed = false;
-    for (let i = 0; i < 500 && !txClosed; i++) {
-      txClosed = await tx`select 1`.then(
-        () => false,
-        () => true,
-      );
-      if (!txClosed) await new Promise<void>(r => setTimeout(r, 5));
-    }
-    expect(txClosed).toBe(true);
-
-    gate.resolve();
     await settled;
 
     expect(callbackDone).toBe(true);

--- a/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
+++ b/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
@@ -24,13 +24,13 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     await using sql = new SQL({ url: url(), max: 4, idleTimeout: 5 });
     await using adm = new SQL({ url: url(), max: 1, idleTimeout: 5 });
 
-    const txReady = Promise.withResolvers<number>();
+    const txReady = Promise.withResolvers<{ tx: any; pid: number }>();
     const gate = Promise.withResolvers<void>();
     let callbackDone = false;
 
     const p = sql.begin(async tx => {
       const [{ pid }] = await tx`select pg_backend_pid() as pid`;
-      txReady.resolve(pid);
+      txReady.resolve({ tx, pid });
       // The callback is *not* touching `tx` here; it is doing other async
       // work while the backend is killed and the close event propagates.
       await gate.promise;
@@ -50,15 +50,34 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       },
     );
 
-    const pid = await txReady.promise;
+    const { tx, pid } = await txReady.promise;
     await adm`select pg_terminate_backend(${pid})`;
 
-    // Give the tx connection's socket time to observe the FATAL + close
-    // and fire its onClose handler. On the buggy build p settles inside
-    // this window; on the fixed build it stays pending.
-    for (let i = 0; i < 50 && settledBeforeCallback === undefined; i++) {
-      await new Promise<void>(r => setTimeout(r, 5));
+    // Wait until the terminated backend has exited (observed via adm on a
+    // separate connection). By the time it is gone from pg_stat_activity the
+    // server has already sent FATAL + FIN to the tx socket, and the adm
+    // round-trip yields to the event loop so the tx socket's readable event
+    // delivers the FATAL through the idle-connection ErrorResponse path.
+    let gone = false;
+    for (let i = 0; i < 500 && !gone; i++) {
+      const [{ n }] = await adm`select count(*)::int as n from pg_stat_activity where pid = ${pid}`;
+      gone = n === 0;
+      if (!gone) await new Promise<void>(r => setTimeout(r, 5));
     }
+    expect(gone).toBe(true);
+
+    // Positive precondition: onTransactionDisconnected has fired (state is
+    // closed) so tx`...` rejects. Fail loudly if the disconnect never
+    // reached the tx handle before the ordering check below.
+    let txClosed = false;
+    for (let i = 0; i < 500 && !txClosed; i++) {
+      txClosed = await tx`select 1`.then(
+        () => false,
+        () => true,
+      );
+      if (!txClosed) await new Promise<void>(r => setTimeout(r, 5));
+    }
+    expect(txClosed).toBe(true);
 
     gate.resolve();
     await settled;
@@ -68,7 +87,6 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     expect(caught).toBeDefined();
     // The rejection must carry the server's FATAL (57P01) or a
     // connection-closed identity, not the opaque "Failed to read data".
-    expect(caught.code).not.toBe("ERR_POSTGRES_EXPECTED_REQUEST");
-    expect(String(caught.message ?? "")).not.toContain("Failed to read data");
+    expect(["ERR_POSTGRES_SERVER_ERROR", "ERR_POSTGRES_CONNECTION_CLOSED"]).toContain(caught.code);
   });
 });

--- a/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
+++ b/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
@@ -50,6 +50,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       },
     );
 
+    p.catch(txReady.reject);
     const { tx, pid } = await txReady.promise;
     await adm`select pg_terminate_backend(${pid})`;
 


### PR DESCRIPTION
### Repro

```ts
const sql = new SQL(url, { max: 4 });
const adm = new SQL(url, { max: 1 });

let cbDone = 0;
const p = sql.begin(async tx => {
  const [{ pid }] = await tx`select pg_backend_pid() as pid`;
  await adm`select pg_terminate_backend(${pid})`;   // failover / admin kill
  await Bun.sleep(1500);                            // callback keeps working
  await sql`insert into side values ('after-caller-was-told-tx-failed')`;
  cbDone = performance.now();
});
await p.catch(e => console.log(`begin() rejected: ${e.code} ${e.message}`));
// -> begin() rejected at ~15ms: ERR_POSTGRES_EXPECTED_REQUEST "Failed to read data"
// callback is still running; side row commits at ~1560ms.
```

`sql.begin()` rejects the instant the transaction's backend dies while the user callback is still running. The caller moves on believing the transaction failed, but the callback keeps going and can still produce side effects on healthy pool connections.

### Cause

`onTransactionDisconnected` (the pooled connection's onClose handler for a transaction) rejected the outer `begin()` promise directly:

```js
function onTransactionDisconnected(this: TransactionState, err) {
  const reject = this.reject;
  this.connectionState |= ReservedConnectionState.closed;
  for (const query of this.queries) query.reject(err);
  if (err) return reject(err);   // rejects begin() while callback(tx) is still pending
}
```

`onTransactionConnected` is already structured around `await callback(transaction_sql)` in a try/catch that `resolve`s or `reject`s the outer promise after the callback settles; the close handler just bypassed it.

Secondary: an `ErrorResponse` that arrives on an idle connection (no `current()` request, which is exactly what `pg_terminate_backend` on an idle-in-transaction backend produces) returned `Err(ExpectedRequest)` from the message dispatch, surfacing as `ERR_POSTGRES_EXPECTED_REQUEST` / `"Failed to read data"` instead of the server's actual FATAL (`57P01 terminating connection due to administrator command`).

### Fix

`src/js/bun/sql.ts`: `onTransactionDisconnected` now marks the state closed, stores the error, and rejects in-flight tx queries (so the callback observes the failure on its next `tx\`...\``). It no longer settles the outer promise. `onTransactionConnected` rejects with `state.storedError` once `await callback(...)` has settled, and `transaction_sql` / `run_internal_transaction_sql` reject with the stored error instead of a fresh `connectionClosedError()` so the server's FATAL reaches both the callback and the caller.

`src/sql_jsc/postgres/PostgresSQLConnection.rs`: an `ErrorResponse` with no current request now calls `fail_with_js_value` with the server error (same as the connecting-phase path just above it) instead of returning `ExpectedRequest`.

### Verification

`test/js/sql/postgres-begin-disconnect-lifecycle.test.ts` starts a transaction, kills its backend via a second connection while the callback is parked on other async work, and asserts `begin()` only settles after the callback does, and that the rejection carries the server FATAL rather than `"Failed to read data"`.

Before:
```
error code=ERR_POSTGRES_EXPECTED_REQUEST msg="Failed to read data"
callback still running when begin() settled: true
```
After:
```
error code=ERR_POSTGRES_SERVER_ERROR msg="terminating connection due to administrator command"
callback still running when begin() settled: false
```

5/5 fail on the unfixed build, 5/5 pass with the fix. The sqlite transaction suite stays green; the sqlite `"properly finalizes prepared statements"` timeout reproduces on main's debug build without this change (10000-iteration ASAN slowness, does not use `begin()`).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
bun test v1.4.0 (c1263d5e0)

test/js/sql/postgres-begin-disconnect-lifecycle.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
84 |       gate.resolve();
85 |     }
86 |     await settled;
87 | 
88 |     expect(callbackDone).toBe(true);
89 |     expect(settledBeforeCallback).toBe(false);
                                       ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/js/sql/postgres-begin-disconnect-lifecycle.test.ts:89:35)
(fail) postgres > sql.begin() waits for its callback to settle when the tx connection dies [433.26ms]

 0 pass
 1 fail
 4 expect() calls
Ran 1 test across 1 file. [4.47s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (a45f41871)

test/js/sql/postgres-begin-disconnect-lifecycle.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > sql.begin() waits for its callback to settle when the tx connection dies [19.24ms]

 1 pass
 0 fail
 6 expect() calls
Ran 1 test across 1 file. [219.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-begin-disconnect-lifecycle.test.ts
bun test v1.4.0 (c1263d5e0)

test/js/sql/postgres-begin-disconnect-lifecycle.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > sql.begin() waits for its callback to settle when the tx connection dies [429.72ms]

 1 pass
 0 fail
 6 expect() calls
Ran 1 test across 1 file. [3.77s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 823ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7756ms)
Bundle modules (144ms)
Postprocesss modules (138ms)
Bundle Functions (726ms)
Generate Code (33ms)

[8.81s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/bun/sql.ts                                  | 46 +++++------
 src/sql_jsc/postgres/PostgresSQLConnection.rs      |  6 +-
 .../postgres-begin-disconnect-lifecycle.test.ts    | 95 ++++++++++++++++++++++
 3 files changed, 123 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js/bun/sql.ts                                           13     21      0
src/sql_jsc/postgres/PostgresSQLConnection.rs                4      1      0
test/js/sql/postgres-begin-disconnect-lifecycle.test.ts      3      7      0
```

</details>

<!-- robobun:evidence:end -->