### PR TITLE
sql(postgres): enforce the Int32 message length as a frame boundary

### DIFF
--- a/src/sql/postgres/protocol/CommandComplete.rs
+++ b/src/sql/postgres/protocol/CommandComplete.rs
@@ -18,9 +18,9 @@ impl CommandComplete {
         &mut self,
         mut reader: NewReader<Container>,
     ) -> crate::Result<()> {
-        reader.length()?;
+        let remaining = (reader.length()? - 4) as usize;
 
-        let tag = reader.read_z()?;
+        let (tag, _) = reader.string_within(remaining)?;
         *self = Self { command_tag: tag };
         Ok(())
     }

--- a/src/sql/postgres/protocol/CommandComplete.rs
+++ b/src/sql/postgres/protocol/CommandComplete.rs
@@ -18,7 +18,7 @@ impl CommandComplete {
         &mut self,
         mut reader: NewReader<Container>,
     ) -> crate::Result<()> {
-        let remaining = (reader.length()? - 4) as usize;
+        let remaining = reader.body_length()?;
 
         let (tag, _) = reader.string_within(remaining)?;
         *self = Self { command_tag: tag };

--- a/src/sql/postgres/protocol/CopyData.rs
+++ b/src/sql/postgres/protocol/CopyData.rs
@@ -11,9 +11,9 @@ impl CopyData {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let length = reader.length()?;
+        let remaining = reader.body_length()?;
 
-        let data = reader.read(usize::try_from(length - 4).expect("int cast"))?;
+        let data = reader.read(remaining)?;
         Ok(Self { data })
     }
 }

--- a/src/sql/postgres/protocol/ErrorResponse.rs
+++ b/src/sql/postgres/protocol/ErrorResponse.rs
@@ -24,10 +24,10 @@ impl ErrorResponse {
     ) -> Result<Self, AnyPostgresError> {
         // A length of exactly 4 is an empty message (no fields); `length()`
         // already rejected anything smaller.
-        let remaining_bytes = reader.length()? - 4;
+        let remaining_bytes = (reader.length()? - 4) as usize;
         if remaining_bytes > 0 {
             return Ok(Self {
-                messages: FieldMessage::decode_list::<Container>(reader)?,
+                messages: FieldMessage::decode_list::<Container>(reader, remaining_bytes)?,
             });
         }
         Ok(Self::default())

--- a/src/sql/postgres/protocol/ErrorResponse.rs
+++ b/src/sql/postgres/protocol/ErrorResponse.rs
@@ -22,9 +22,7 @@ impl ErrorResponse {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        // A length of exactly 4 is an empty message (no fields); `length()`
-        // already rejected anything smaller.
-        let remaining_bytes = (reader.length()? - 4) as usize;
+        let remaining_bytes = reader.body_length()?;
         if remaining_bytes > 0 {
             return Ok(Self {
                 messages: FieldMessage::decode_list::<Container>(reader, remaining_bytes)?,

--- a/src/sql/postgres/protocol/FieldMessage.rs
+++ b/src/sql/postgres/protocol/FieldMessage.rs
@@ -58,19 +58,19 @@ impl FieldMessage {
 
     pub fn decode_list<Context: super::new_reader::ReaderContext>(
         mut reader: NewReader<Context>,
+        mut remaining: usize,
     ) -> Result<Vec<FieldMessage>, AnyPostgresError> {
         let mut messages: Vec<FieldMessage> = Vec::new();
-        loop {
+        while remaining > 0 {
             let field_int: u8 = reader.int::<u8>()?;
+            remaining -= 1;
             if field_int == 0 {
                 break;
             }
             let field: FieldType = FieldType::from(field_int);
 
-            let message = reader.read_z()?;
-            if message.slice().is_empty() {
-                break;
-            }
+            let (message, consumed) = reader.string_within(remaining)?;
+            remaining -= consumed;
 
             let Ok(field_msg) = FieldMessage::init(field, message.slice()) else {
                 continue;

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -116,6 +116,23 @@ impl<Context: ReaderContext> NewReaderWrap<Context> {
         self.wrapped.read_z()
     }
 
+    /// Read a NUL-terminated string whose terminator must appear within the
+    /// next `limit` bytes. Returns `InvalidMessage` (not `ShortRead`) when it
+    /// does not: the caller has already established via `length()` that those
+    /// bytes are the message body, so a missing terminator is a framing
+    /// violation, not a partial read. Returns the string without its NUL and
+    /// the total bytes consumed (string + NUL).
+    pub fn string_within(&mut self, limit: usize) -> Result<(Data, usize), AnyPostgresError> {
+        let view = self.wrapped.peek();
+        let bound = view.len().min(limit);
+        let Some(zero) = view[..bound].iter().position(|&b| b == 0) else {
+            return Err(AnyPostgresError::InvalidMessage);
+        };
+        let data = self.wrapped.read(zero)?;
+        self.wrapped.skip(1);
+        Ok((data, zero + 1))
+    }
+
     #[inline]
     pub fn ensure_capacity(&mut self, count: usize) -> Result<(), AnyPostgresError> {
         if !self.wrapped.ensure_length(count) {

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -172,9 +172,18 @@ impl<Context: ReaderContext> NewReaderWrap<Context> {
         Ok(expected)
     }
 
+    /// `length()` minus the 4 bytes the length field itself occupies, i.e. the
+    /// number of body bytes remaining in this message. Cannot underflow:
+    /// `length()` has already returned `InvalidMessageLength` for any value
+    /// below 4, and `ensure_capacity` has confirmed those bytes are present.
+    #[inline]
+    pub fn body_length(&mut self) -> Result<usize, AnyPostgresError> {
+        Ok((self.length()? - 4) as usize)
+    }
+
     pub fn skip_message(&mut self) -> Result<(), AnyPostgresError> {
-        let length = self.length()?;
-        self.skip(usize::try_from(length - 4).expect("int cast"))
+        let body = self.body_length()?;
+        self.skip(body)
     }
 
     #[inline]

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -159,17 +159,39 @@ impl<Context: ReaderContext> NewReaderWrap<Context> {
         self.int::<PostgresShort>()
     }
 
-    pub fn length(&mut self) -> Result<PostgresInt32, AnyPostgresError> {
-        let expected = self.int::<PostgresInt32>()?;
-        // The length of every Postgres v3 message is a signed Int32 that
-        // includes its own 4 bytes, so a value below 4 (or negative, i.e. the
-        // sign bit set on the wire) is malformed. `expected` is server-controlled.
-        if expected < 4 || expected > i32::MAX as u32 {
+    /// The length of every Postgres v3 message is a signed Int32 that includes
+    /// its own 4 bytes, so a value below 4 (or negative, i.e. the sign bit set
+    /// on the wire) is malformed. `raw` is server-controlled.
+    #[inline]
+    fn validate_length(raw: PostgresInt32) -> Result<PostgresInt32, AnyPostgresError> {
+        if raw < 4 || raw > i32::MAX as u32 {
             return Err(AnyPostgresError::InvalidMessageLength);
         }
-        self.ensure_capacity((expected - 4) as usize)?;
+        Ok(raw)
+    }
 
+    pub fn length(&mut self) -> Result<PostgresInt32, AnyPostgresError> {
+        let expected = Self::validate_length(self.int::<PostgresInt32>()?)?;
+        self.ensure_capacity((expected - 4) as usize)?;
         Ok(expected)
+    }
+
+    /// `length()` without consuming: validates the Int32 at the cursor and
+    /// confirms the whole message body is present, but leaves both for the
+    /// handler to read. Returns `(remaining, length)` where `remaining` is the
+    /// buffer's byte count before the length field, so after the handler runs
+    /// the frame boundary is `remaining - length`.
+    pub fn peek_length(&mut self) -> Result<(usize, usize), AnyPostgresError> {
+        let view = self.wrapped.peek();
+        if view.len() < 4 {
+            return Err(AnyPostgresError::ShortRead);
+        }
+        let raw = PostgresInt32::from_be_slice(&view[..4]);
+        let length = Self::validate_length(raw)? as usize;
+        if view.len() < length {
+            return Err(AnyPostgresError::ShortRead);
+        }
+        Ok((view.len(), length))
     }
 
     /// `length()` minus the 4 bytes the length field itself occupies, i.e. the

--- a/src/sql/postgres/protocol/NotificationResponse.rs
+++ b/src/sql/postgres/protocol/NotificationResponse.rs
@@ -16,16 +16,22 @@ impl NotificationResponse {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        reader.length()?;
+        let mut remaining = (reader.length()? - 4) as usize;
+        if remaining < 4 {
+            return Err(AnyPostgresError::InvalidMessage);
+        }
+        let pid = reader.int4()?;
+        remaining -= 4;
+        let (channel, consumed) = reader.string_within(remaining)?;
+        remaining -= consumed;
+        let (payload, _) = reader.string_within(remaining)?;
 
         Ok(Self {
-            pid: reader.int4()?,
-            channel: reader
-                .read_z()?
+            pid,
+            channel: channel
                 .to_owned()
                 .map_err(|_| AnyPostgresError::OutOfMemory)?,
-            payload: reader
-                .read_z()?
+            payload: payload
                 .to_owned()
                 .map_err(|_| AnyPostgresError::OutOfMemory)?,
         })

--- a/src/sql/postgres/protocol/NotificationResponse.rs
+++ b/src/sql/postgres/protocol/NotificationResponse.rs
@@ -16,7 +16,7 @@ impl NotificationResponse {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let mut remaining = (reader.length()? - 4) as usize;
+        let mut remaining = reader.body_length()?;
         if remaining < 4 {
             return Err(AnyPostgresError::InvalidMessage);
         }

--- a/src/sql/postgres/protocol/ParameterStatus.rs
+++ b/src/sql/postgres/protocol/ParameterStatus.rs
@@ -14,7 +14,7 @@ impl ParameterStatus {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        let mut remaining = (reader.length()? - 4) as usize;
+        let mut remaining = reader.body_length()?;
 
         let (name, consumed) = reader.string_within(remaining)?;
         remaining -= consumed;

--- a/src/sql/postgres/protocol/ParameterStatus.rs
+++ b/src/sql/postgres/protocol/ParameterStatus.rs
@@ -14,11 +14,11 @@ impl ParameterStatus {
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {
-        reader.length()?;
+        let mut remaining = (reader.length()? - 4) as usize;
 
-        Ok(Self {
-            name: reader.read_z()?,
-            value: reader.read_z()?,
-        })
+        let (name, consumed) = reader.string_within(remaining)?;
+        remaining -= consumed;
+        let (value, _) = reader.string_within(remaining)?;
+        Ok(Self { name, value })
     }
 }

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -447,40 +447,19 @@ pub(crate) fn on_data<Context: ReaderContext>(
         reader.mark_message_start();
         let c = reader.int::<u8>()?;
         bun_core::scoped_log!(Postgres, "read: {}", c as char);
-        if matches!(connection.tls_status.get(), TlsStatus::MessageSent(_))
-            && c != b'S'
-            && c != b'N'
-        {
-            return Err(AnyPostgresError::UnexpectedMessage);
-        }
-        match c {
-            b'D' => connection.on(M::DataRow, reader.reborrow())?,
-            b'd' => connection.on(M::CopyData, reader.reborrow())?,
-            b'S' => {
-                if let TlsStatus::MessageSent(n) = connection.tls_status.get() {
+
+        // The SSLRequest reply is a bare Byte1('S'|'N') with no Int32 length;
+        // it is the only unframed backend byte and must be handled before the
+        // frame peek below.
+        if let TlsStatus::MessageSent(n) = connection.tls_status.get() {
+            match c {
+                b'S' => {
                     debug_assert!(n == 8);
                     connection.tls_status.set(TlsStatus::SslOk);
                     connection.setup_tls();
                     return Ok(());
                 }
-
-                connection.on(M::ParameterStatus, reader.reborrow())?;
-            }
-            b'Z' => connection.on(M::ReadyForQuery, reader.reborrow())?,
-            b'C' => connection.on(M::CommandComplete, reader.reborrow())?,
-            b'2' => connection.on(M::BindComplete, reader.reborrow())?,
-            b'1' => connection.on(M::ParseComplete, reader.reborrow())?,
-            b't' => connection.on(M::ParameterDescription, reader.reborrow())?,
-            b'T' => connection.on(M::RowDescription, reader.reborrow())?,
-            b'R' => connection.on(M::Authentication, reader.reborrow())?,
-            b'n' => connection.on(M::NoData, reader.reborrow())?,
-            b'K' => connection.on(M::BackendKeyData, reader.reborrow())?,
-            b'E' => connection.on(M::ErrorResponse, reader.reborrow())?,
-            b's' => connection.on(M::PortalSuspended, reader.reborrow())?,
-            b'3' => connection.on(M::CloseComplete, reader.reborrow())?,
-            b'G' => connection.on(M::CopyInResponse, reader.reborrow())?,
-            b'N' => {
-                if matches!(connection.tls_status.get(), TlsStatus::MessageSent(_)) {
+                b'N' => {
                     connection.tls_status.set(TlsStatus::SslNotAvailable);
                     bun_core::scoped_log!(Postgres, "Server does not support SSL");
                     if matches!(
@@ -495,9 +474,52 @@ pub(crate) fn on_data<Context: ReaderContext>(
                     }
                     continue;
                 }
-
-                connection.on(M::NoticeResponse, reader.reborrow())?;
+                _ => return Err(AnyPostgresError::UnexpectedMessage),
             }
+        }
+
+        // Every other backend message is Byte1(type) Int32(length) body[length-4].
+        // Peek the length here (each handler reads it again) so the handler's
+        // net consumption can be checked against it: a handler that leaves the
+        // cursor anywhere but the next message's type byte has either scanned a
+        // string past the frame or returned with tail bytes still in it, and
+        // the stream is unrecoverable (libpq: "message contents do not agree
+        // with length in message").
+        let before = reader.peek().len();
+        if before < 4 {
+            return Err(AnyPostgresError::ShortRead);
+        }
+        let length = {
+            let v = reader.peek();
+            u32::from_be_bytes([v[0], v[1], v[2], v[3]])
+        };
+        if length < 4 || length > i32::MAX as u32 {
+            return Err(AnyPostgresError::InvalidMessageLength);
+        }
+        let length = length as usize;
+        if before < length {
+            return Err(AnyPostgresError::ShortRead);
+        }
+        let after = before - length;
+
+        match c {
+            b'D' => connection.on(M::DataRow, reader.reborrow())?,
+            b'd' => connection.on(M::CopyData, reader.reborrow())?,
+            b'S' => connection.on(M::ParameterStatus, reader.reborrow())?,
+            b'Z' => connection.on(M::ReadyForQuery, reader.reborrow())?,
+            b'C' => connection.on(M::CommandComplete, reader.reborrow())?,
+            b'2' => connection.on(M::BindComplete, reader.reborrow())?,
+            b'1' => connection.on(M::ParseComplete, reader.reborrow())?,
+            b't' => connection.on(M::ParameterDescription, reader.reborrow())?,
+            b'T' => connection.on(M::RowDescription, reader.reborrow())?,
+            b'R' => connection.on(M::Authentication, reader.reborrow())?,
+            b'n' => connection.on(M::NoData, reader.reborrow())?,
+            b'K' => connection.on(M::BackendKeyData, reader.reborrow())?,
+            b'E' => connection.on(M::ErrorResponse, reader.reborrow())?,
+            b's' => connection.on(M::PortalSuspended, reader.reborrow())?,
+            b'3' => connection.on(M::CloseComplete, reader.reborrow())?,
+            b'G' => connection.on(M::CopyInResponse, reader.reborrow())?,
+            b'N' => connection.on(M::NoticeResponse, reader.reborrow())?,
             b'I' => connection.on(M::EmptyQueryResponse, reader.reborrow())?,
             b'H' => connection.on(M::CopyOutResponse, reader.reborrow())?,
             b'c' => connection.on(M::CopyDone, reader.reborrow())?,
@@ -506,11 +528,23 @@ pub(crate) fn on_data<Context: ReaderContext>(
 
             _ => {
                 bun_core::scoped_log!(Postgres, "Unknown message: {}", c as char);
-                let length = reader.length()?;
-                let to_skip = length - 4;
-                bun_core::scoped_log!(Postgres, "to_skip: {}", to_skip);
-                reader.skip(usize::try_from(to_skip).expect("int cast"))?;
+                reader.skip_message()?;
             }
+        }
+
+        if connection.status.get() == Status::Failed {
+            return Ok(());
+        }
+        if reader.peek().len() != after {
+            bun_core::scoped_log!(
+                Postgres,
+                "message contents do not agree with length ({}): '{}' left {} of {}",
+                length,
+                c as char,
+                reader.peek().len(),
+                after,
+            );
+            return Err(AnyPostgresError::InvalidMessage);
         }
     }
 }

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -485,21 +485,7 @@ pub(crate) fn on_data<Context: ReaderContext>(
         // string past the frame or returned with tail bytes still in it, and
         // the stream is unrecoverable (libpq: "message contents do not agree
         // with length in message").
-        let before = reader.peek().len();
-        if before < 4 {
-            return Err(AnyPostgresError::ShortRead);
-        }
-        let length = {
-            let v = reader.peek();
-            u32::from_be_bytes([v[0], v[1], v[2], v[3]])
-        };
-        if length < 4 || length > i32::MAX as u32 {
-            return Err(AnyPostgresError::InvalidMessageLength);
-        }
-        let length = length as usize;
-        if before < length {
-            return Err(AnyPostgresError::ShortRead);
-        }
+        let (before, length) = reader.peek_length()?;
         let after = before - length;
 
         match c {

--- a/test/js/sql/postgres-frame-boundary.test.ts
+++ b/test/js/sql/postgres-frame-boundary.test.ts
@@ -142,10 +142,7 @@ const malformed: { name: string; frame: Buffer }[] = [
     // ErrorResponse whose last field value has no NUL (so the list terminator
     // is missing too); the value scan must not spill into CommandComplete.
     name: "ErrorResponse whose last field value has no NUL terminator",
-    frame: pgRaw(
-      "E",
-      Buffer.concat([Buffer.from("S"), pgCString("ERROR"), Buffer.from("M"), Buffer.from("msg")]),
-    ),
+    frame: pgRaw("E", Buffer.concat([Buffer.from("S"), pgCString("ERROR"), Buffer.from("M"), Buffer.from("msg")])),
   },
   {
     // DataRow whose declared frame is longer than its body: the decoder reads

--- a/test/js/sql/postgres-frame-boundary.test.ts
+++ b/test/js/sql/postgres-frame-boundary.test.ts
@@ -1,0 +1,185 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// Every PostgreSQL v3 backend message is framed by a Byte1 type + Int32 length.
+// A decoder that treats that length as advisory and either scans a C-string
+// past it or returns before consuming all of it leaves the cursor inside what
+// should be the next message's header. The next dispatch then reads garbage
+// (type byte, or a length in the billions) and returns ShortRead, which the
+// outer loop treats as "wait for more socket data": the query never settles
+// and every later query queues behind it forever (libpq: "message contents do
+// not agree with length in message" and drops the connection). The dispatch
+// loop must enforce the frame boundary on every message.
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgCommandComplete,
+  pgCString,
+  pgDataRow,
+  pgErrorResponse,
+  pgInt32,
+  pgNotificationResponse,
+  pgParameterStatus,
+  pgRaw,
+  pgReadyForQuery,
+  pgRowDescription,
+} from "./wire-frames";
+
+// One mock server for the file; each test sets `current` before connecting and
+// the accept handler latches it per connection.
+let current!: { atStartup: Buffer[]; atQuery?: Buffer[] };
+const { port, server } = await listeningServer(socket => {
+  const { atStartup, atQuery } = current;
+  let startup = true;
+  socket.on("data", data => {
+    if (startup) {
+      startup = false;
+      socket.write(Buffer.concat([pgAuthenticationOk(), ...atStartup]));
+      return;
+    }
+    if (atQuery && data[0] === 0x51 /* 'Q' */) socket.write(Buffer.concat(atQuery));
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => server.close(() => r())));
+
+/** Complete the handshake, then answer the first simple query with `frames`; returns the query's rejection. */
+async function queryError(frames: Buffer[]): Promise<any> {
+  current = { atStartup: [pgReadyForQuery()], atQuery: frames };
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1, idleTimeout: 1 });
+  try {
+    await db`select x`.simple();
+    throw new Error("expected the query to reject");
+  } catch (err) {
+    return err;
+  } finally {
+    await db.close({ timeout: 0 }).catch(() => {});
+  }
+}
+
+// An ErrorResponse/NoticeResponse field may carry an empty value (the empty
+// string followed by its NUL): https://www.postgresql.org/docs/current/protocol-error-fields.html
+// places no lower bound on a value's length. A field decoder that treats an
+// empty value as the list terminator stops short; the un-consumed tail (the
+// real M field and the terminating NUL) is then parsed as the next message's
+// type byte and length.
+test("postgres: ErrorResponse field with an empty value does not wedge the connection", async () => {
+  // S=ERROR C=42P01 W="" (empty, protocol-legal) M=<real message>
+  const err = await queryError([
+    pgErrorResponse({ S: "ERROR", C: "42P01", W: "", M: "relation t does not exist" }),
+    pgReadyForQuery(),
+  ]);
+  // Before the fix the W field's empty value broke decode_list early, losing
+  // the M field (err.message === "") and leaving the M bytes as the next
+  // dispatch's header; the following ReadyForQuery was then never seen and a
+  // second query would wait forever. With the fix the whole body is consumed.
+  expect({ code: err.code, errno: err.errno, message: err.message }).toEqual({
+    code: "ERR_POSTGRES_SERVER_ERROR",
+    errno: "42P01",
+    message: "relation t does not exist",
+  });
+});
+
+test("postgres: NoticeResponse field with an empty value does not wedge the connection", async () => {
+  // NoticeResponse has the same body as ErrorResponse but is advisory: the
+  // query continues afterwards. The empty D field must not leave tail bytes.
+  const notice = pgErrorResponse({ S: "NOTICE", C: "00000", D: "", M: "notice text" });
+  notice[0] = 0x4e; // 'N'
+  current = {
+    atStartup: [pgReadyForQuery()],
+    atQuery: [
+      notice,
+      pgRowDescription([{ name: "n", typeOid: 25 }]),
+      pgDataRow([Buffer.from("ok")]),
+      pgCommandComplete("SELECT 1"),
+      pgReadyForQuery(),
+    ],
+  };
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1, idleTimeout: 1 });
+  try {
+    const rows: any = await db`select n`.simple();
+    expect(rows[0]).toEqual({ n: "ok" });
+  } finally {
+    await db.close({ timeout: 0 }).catch(() => {});
+  }
+});
+
+// The remaining faces are all under-/over-reads the frame length catches.
+// libpq fails the connection ("message contents do not agree with length in
+// message") on every one; the decoder must do the same rather than misparse
+// the following ReadyForQuery's bytes.
+const disagree = "ERR_POSTGRES_INVALID_MESSAGE";
+const malformed: { name: string; frame: Buffer }[] = [
+  {
+    // CommandComplete body is a single C-string; drop the NUL so the scan
+    // would walk into the next message.
+    name: "CommandComplete whose tag has no NUL terminator",
+    frame: pgRaw("C", Buffer.from("SELECT 1")),
+  },
+  {
+    // ParameterStatus: name is terminated, value is not.
+    name: "ParameterStatus whose value has no NUL terminator",
+    frame: pgRaw("S", Buffer.concat([pgCString("TimeZone"), Buffer.from("UTC")])),
+  },
+  {
+    // ParameterStatus: name has an embedded NUL; the first NUL ends the name,
+    // so the second C-string read starts at 'Zone\0' and the trailing value
+    // string is never consumed, leaving tail bytes.
+    name: "ParameterStatus with tail bytes after the value",
+    frame: pgRaw("S", Buffer.concat([pgCString("Time"), pgCString("Zone"), pgCString("UTC")])),
+  },
+  {
+    // NotificationResponse: payload has no terminator.
+    name: "NotificationResponse whose payload has no NUL terminator",
+    frame: pgRaw("A", Buffer.concat([pgInt32(1), pgCString("ch"), Buffer.from("payload")])),
+  },
+  {
+    // ErrorResponse whose last field value has no NUL (so the list terminator
+    // is missing too); the value scan must not spill into CommandComplete.
+    name: "ErrorResponse whose last field value has no NUL terminator",
+    frame: pgRaw(
+      "E",
+      Buffer.concat([Buffer.from("S"), pgCString("ERROR"), Buffer.from("M"), Buffer.from("msg")]),
+    ),
+  },
+  {
+    // DataRow whose declared frame is longer than its body: the decoder reads
+    // the one cell and returns, leaving the 8 padding bytes for the next
+    // dispatch to misparse.
+    name: "DataRow body shorter than its declared frame",
+    frame: Buffer.concat([
+      pgRowDescription([{ name: "n", typeOid: 25 }]),
+      pgRaw("D", Buffer.concat([Buffer.from([0, 1]), pgInt32(2), Buffer.from("ab"), Buffer.alloc(8)])),
+    ]),
+  },
+];
+
+test.each(malformed)("postgres: $name fails the connection", async ({ frame }) => {
+  const err = await queryError([frame, pgCommandComplete("SELECT 1"), pgReadyForQuery()]);
+  expect({ code: err.code, name: err.name }).toEqual({ code: disagree, name: "PostgresError" });
+});
+
+// Boundary: well-formed messages whose decoders read exactly length-4 bytes
+// are still accepted; the connection reaches ReadyForQuery and the next query
+// runs.
+test("postgres: well-formed ParameterStatus and NotificationResponse during startup are accepted", async () => {
+  current = {
+    atStartup: [
+      pgParameterStatus("TimeZone", "UTC"),
+      pgParameterStatus("server_version", "17.0"),
+      pgNotificationResponse(42, "ch", ""),
+      pgReadyForQuery(),
+    ],
+  };
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1, idleTimeout: 1 });
+  try {
+    await expect(db.connect()).resolves.toBeDefined();
+  } finally {
+    await db.close({ timeout: 0 }).catch(() => {});
+  }
+});

--- a/test/js/sql/postgres-frame-boundary.test.ts
+++ b/test/js/sql/postgres-frame-boundary.test.ts
@@ -31,8 +31,10 @@ import {
 } from "./wire-frames";
 
 // One mock server for the file; each test sets `current` before connecting and
-// the accept handler latches it per connection.
-let current!: { atStartup: Buffer[]; atQuery?: Buffer[] };
+// the accept handler latches it per connection. Each simple-Query ('Q') read
+// shifts the next reply off `atQuery`, so a test can script a different
+// response per query on the same connection.
+let current!: { atStartup: Buffer[]; atQuery?: Buffer[][] };
 const { port, server } = await listeningServer(socket => {
   const { atStartup, atQuery } = current;
   let startup = true;
@@ -42,15 +44,25 @@ const { port, server } = await listeningServer(socket => {
       socket.write(Buffer.concat([pgAuthenticationOk(), ...atStartup]));
       return;
     }
-    if (atQuery && data[0] === 0x51 /* 'Q' */) socket.write(Buffer.concat(atQuery));
+    if (atQuery && data[0] === 0x51 /* 'Q' */) {
+      const reply = atQuery.shift();
+      if (reply) socket.write(Buffer.concat(reply));
+    }
   });
   socket.on("error", () => {});
 });
 afterAll(() => new Promise<void>(r => server.close(() => r())));
 
+const okRow = (value: string) => [
+  pgRowDescription([{ name: "n", typeOid: 25 }]),
+  pgDataRow([Buffer.from(value)]),
+  pgCommandComplete("SELECT 1"),
+  pgReadyForQuery(),
+];
+
 /** Complete the handshake, then answer the first simple query with `frames`; returns the query's rejection. */
 async function queryError(frames: Buffer[]): Promise<any> {
-  current = { atStartup: [pgReadyForQuery()], atQuery: frames };
+  current = { atStartup: [pgReadyForQuery()], atQuery: [frames] };
   const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1, idleTimeout: 1 });
   try {
     await db`select x`.simple();
@@ -70,19 +82,37 @@ async function queryError(frames: Buffer[]): Promise<any> {
 // type byte and length.
 test("postgres: ErrorResponse field with an empty value does not wedge the connection", async () => {
   // S=ERROR C=42P01 W="" (empty, protocol-legal) M=<real message>
-  const err = await queryError([
-    pgErrorResponse({ S: "ERROR", C: "42P01", W: "", M: "relation t does not exist" }),
-    pgReadyForQuery(),
-  ]);
-  // Before the fix the W field's empty value broke decode_list early, losing
-  // the M field (err.message === "") and leaving the M bytes as the next
-  // dispatch's header; the following ReadyForQuery was then never seen and a
-  // second query would wait forever. With the fix the whole body is consumed.
-  expect({ code: err.code, errno: err.errno, message: err.message }).toEqual({
-    code: "ERR_POSTGRES_SERVER_ERROR",
-    errno: "42P01",
-    message: "relation t does not exist",
-  });
+  current = {
+    atStartup: [pgReadyForQuery()],
+    atQuery: [
+      [pgErrorResponse({ S: "ERROR", C: "42P01", W: "", M: "relation t does not exist" }), pgReadyForQuery()],
+      okRow("second"),
+    ],
+  };
+  const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1, idleTimeout: 1 });
+  try {
+    let err: any;
+    try {
+      await db`select x`.simple();
+      err = new Error("expected the query to reject");
+    } catch (e) {
+      err = e;
+    }
+    // Before the fix the W field's empty value broke decode_list early, losing
+    // the M field (err.message === "") and leaving the M bytes as the next
+    // dispatch's header; the following ReadyForQuery was never seen.
+    expect({ code: err.code, errno: err.errno, message: err.message }).toEqual({
+      code: "ERR_POSTGRES_SERVER_ERROR",
+      errno: "42P01",
+      message: "relation t does not exist",
+    });
+    // With the whole body consumed the connection is back at ReadyForQuery, so
+    // a second query on it runs instead of waiting forever.
+    const rows: any = await db`select n`.simple();
+    expect(rows[0]).toEqual({ n: "second" });
+  } finally {
+    await db.close({ timeout: 0 }).catch(() => {});
+  }
 });
 
 test("postgres: NoticeResponse field with an empty value does not wedge the connection", async () => {
@@ -92,18 +122,14 @@ test("postgres: NoticeResponse field with an empty value does not wedge the conn
   notice[0] = 0x4e; // 'N'
   current = {
     atStartup: [pgReadyForQuery()],
-    atQuery: [
-      notice,
-      pgRowDescription([{ name: "n", typeOid: 25 }]),
-      pgDataRow([Buffer.from("ok")]),
-      pgCommandComplete("SELECT 1"),
-      pgReadyForQuery(),
-    ],
+    atQuery: [[notice, ...okRow("first")], okRow("second")],
   };
   const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1, idleTimeout: 1 });
   try {
-    const rows: any = await db`select n`.simple();
-    expect(rows[0]).toEqual({ n: "ok" });
+    const first: any = await db`select n`.simple();
+    expect(first[0]).toEqual({ n: "first" });
+    const second: any = await db`select n`.simple();
+    expect(second[0]).toEqual({ n: "second" });
   } finally {
     await db.close({ timeout: 0 }).catch(() => {});
   }
@@ -172,10 +198,12 @@ test("postgres: well-formed ParameterStatus and NotificationResponse during star
       pgNotificationResponse(42, "ch", ""),
       pgReadyForQuery(),
     ],
+    atQuery: [okRow("after")],
   };
   const db = new SQL({ url: `postgres://u@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 1, idleTimeout: 1 });
   try {
-    await expect(db.connect()).resolves.toBeDefined();
+    const rows: any = await db`select n`.simple();
+    expect(rows[0]).toEqual({ n: "after" });
   } finally {
     await db.close({ timeout: 0 }).catch(() => {});
   }

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -117,6 +117,16 @@ export function pgErrorResponse(fields: { S: string; C: string; M: string; [k: s
   return buf;
 }
 
+// PostgreSQL FE/BE protocol §55.7 ParameterStatus: Byte1('S') Int32(len) String(name) String(value)
+export function pgParameterStatus(name: string, value: string): Buffer {
+  return pgRaw("S", Buffer.concat([pgCString(name), pgCString(value)]));
+}
+
+// PostgreSQL FE/BE protocol §55.7 NotificationResponse: Byte1('A') Int32(len) Int32(pid) String(channel) String(payload)
+export function pgNotificationResponse(pid: number, channel: string, payload: string): Buffer {
+  return pgRaw("A", Buffer.concat([pgInt32(pid), pgCString(channel), pgCString(payload)]));
+}
+
 // PostgreSQL FE/BE protocol §55.7 generic backend message: Byte1(type) Int32(len = 4 + body.length) body
 // Low-level escape hatch for fault-injection tests that need a deliberately malformed body,
 // or (via `declaredLength`) a length field that lies about the body it precedes.


### PR DESCRIPTION
## Problem

The Postgres backend-message dispatch loop never enforced the wire-protocol Int32 length as a frame boundary. It read a type byte and handed the rest of the buffer to a per-message decoder without recording where that message was supposed to end. Two things went wrong:

- Decoders that scan a C string (`read_z`) searched the whole remaining buffer rather than the `length-4` message body, so an unterminated string walked into the next message.
- Decoders that returned before consuming `length-4` bytes left tail bytes in place.

Either way the next loop iteration read those bytes as the next message's type/length, usually landing on a length in the billions, which `ensure_capacity()` turns into `ShortRead`, which the outer loop treats as "wait for more socket data". The in-flight query never settles and every later query queues behind it forever. With the default `idleTimeout: 0` that is a permanent hang with no error, no rejection and no close.

One face is protocol-legal and can come from any pg-wire proxy: an ErrorResponse/NoticeResponse field whose value is the empty string. `FieldMessage::decode_list` broke out of the field loop on an empty value, dropping every field after it (including the error's `M` text) and leaving those field bytes as the next header.

```js
// ErrorResponse S=ERROR C=42P01 W="" (empty, protocol-legal) M=<real message>
q1: rej: ERR_POSTGRES_SERVER_ERROR msg=""            // M field lost
q2: WEDGED (after 8s => forever)                     // connection desynced
```

libpq fails every one of these with "message contents do not agree with length in message" and drops the connection: bounded and visible.

## Fix

- `NewReaderWrap::string_within(limit)` reads a NUL-terminated string whose terminator must appear within the next `limit` bytes, returning `InvalidMessage` (not `ShortRead`) when it does not.
- `CommandComplete`, `ParameterStatus`, `NotificationResponse` and `ErrorResponse`/`NoticeResponse` now bound their string reads to the message body via `string_within`, and `decode_list` no longer treats an empty value as the list terminator.
- The dispatch loop peeks the Int32 length before calling the handler and requires the cursor to sit exactly at the next message's type byte afterwards, so any under- or over-consumption fails the connection with `ERR_POSTGRES_INVALID_MESSAGE` instead of wedging it. The SSLRequest single-byte reply is handled before the frame peek since it is the only unframed backend byte.

## Verification

`test/js/sql/postgres-frame-boundary.test.ts` drives a mock server through each face (empty ErrorResponse/NoticeResponse field value, unterminated CommandComplete/ParameterStatus/NotificationResponse/ErrorResponse strings, DataRow body shorter than its declared frame) plus a well-formed boundary case.

```
USE_SYSTEM_BUN=1: 8 fail (1 boundary passes)
bun bd:           9 pass
```

The real-postgres container suites (`postgres-simple-query-pipeline`, `postgres-prepared-pipeline-reorder`, `postgres-multi-statement-fields`, `postgres-binary-*`) and the sibling fault-injection suites (`postgres-invalid-message-length`, `postgres-datarow-overrun`, `postgres-error-then-datarow`) all pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-frame-boundary.test.ts
bun test v1.4.0 (a49410f22)

test/js/sql/postgres-frame-boundary.test.ts:
 99 |       err = e;
100 |     }
101 |     // Before the fix the W field's empty value broke decode_list early, losing
102 |     // the M field (err.message === "") and leaving the M bytes as the next
103 |     // dispatch's header; the following ReadyForQuery was never seen.
104 |     expect({ code: err.code, errno: err.errno, message: err.message }).toEqual({
                                                                             ^
error: expect(received).toEqual(expected)

  {
    "code": "ERR_POSTGRES_SERVER_ERROR",
    "errno": "42P01",
-   "message": "relation t does not exist",
+   "message": "",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/sql/postgres-frame-boundary.test.ts:104:72)
(fail) postgres: ErrorResponse field with an empty value does not wedge the connection [423.50ms]
204 |   return `{${values.map(arrayValueSerializer.bind(this, type, isPostgresNumericType(ty
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (205ec9b0d)

test/js/sql/postgres-frame-boundary.test.ts:
(pass) postgres: ErrorResponse field with an empty value does not wedge the connection [6.95ms]
(pass) postgres: NoticeResponse field with an empty value does not wedge the connection [2.25ms]
(pass) postgres: CommandComplete whose tag has no NUL terminator fails the connection [0.95ms]
(pass) postgres: ParameterStatus whose value has no NUL terminator fails the connection [0.56ms]
(pass) postgres: ParameterStatus with tail bytes after the value fails the connection [0.66ms]
(pass) postgres: NotificationResponse whose payload has no NUL terminator fails the connection [0.47ms]
(pass) postgres: ErrorResponse whose last field value has no NUL terminator fails the connection [0.56ms]
(pass) postgres: DataRow body shorter than its declared frame fails the connection [0.52ms]
(pass) postgres: well-formed ParameterStatus and NotificationResponse during startup are accepted [0.77ms]

 9 pass
 0 fail
 11 expect() calls
Ran 9 tests across 1 file. [198.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-frame-boundary.test.ts
bun test v1.4.0 (a49410f22)

test/js/sql/postgres-frame-boundary.test.ts:
(pass) postgres: ErrorResponse field with an empty value does not wedge the connection [454.42ms]
(pass) postgres: NoticeResponse field with an empty value does not wedge the connection [178.32ms]
(pass) postgres: CommandComplete whose tag has no NUL terminator fails the connection [84.92ms]
(pass) postgres: ParameterStatus whose value has no NUL terminator fails the connection [61.42ms]
(pass) postgres: ParameterStatus with tail bytes after the value fails the connection [58.45ms]
(pass) postgres: NotificationResponse whose payload has no NUL terminator fails the connection [39.49ms]
(pass) postgres: ErrorResponse whose last field value has no NUL terminator fails the connection [68.67ms]
(pass) postgres: DataRow body shorter than its declared frame fails the connection [100.73ms]
(pass) postgres: well-formed ParameterStatus and NotificationResponse during startup are accepted [118.73ms]

 9 pass
 0 fail
 11 expect() c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 698ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] cc obj/packages/bun-usockets/src/bsd.c.o
[2/28] cc obj/packages/bun-usockets/src/context.c.o
[3/28] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[4/28] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[5/28] cc obj/packages/bun-usockets/src/fault_inject.c.o
[6/28] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[7/28] cc obj/packages/bun-usockets/src/quic.c.o
[8/28] cc obj/packages/bun-usockets/src/socket.c.o
[9/28] cc obj/packages/bun-usockets/src/loop.c.o
[10/28] cc obj/packages/bun-usockets/src/udp.c.o
[11/28] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[12/28] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[13/28] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[14/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[15/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[16/28] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[17/28] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[18/28] cxx ob
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/postgres/protocol/CommandComplete.rs      |   4 +-
 src/sql/postgres/protocol/CopyData.rs             |   4 +-
 src/sql/postgres/protocol/ErrorResponse.rs        |   6 +-
 src/sql/postgres/protocol/FieldMessage.rs         |  10 +-
 src/sql/postgres/protocol/NewReader.rs            |  66 ++++++-
 src/sql/postgres/protocol/NotificationResponse.rs |  18 +-
 src/sql/postgres/protocol/ParameterStatus.rs      |  10 +-
 src/sql_jsc/postgres/PostgresRequest.rs           |  90 ++++++----
 test/js/sql/postgres-frame-boundary.test.ts       | 210 ++++++++++++++++++++++
 test/js/sql/wire-frames.ts                        |  10 ++
 10 files changed, 360 insertions(+), 68 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/sql/postgres/protocol/CommandComplete.rs           2      2      0
src/sql/postgres/protocol/CopyData.rs                  3      1      0
src/sql/postgres/protocol/ErrorResponse.rs             2      2      0
src/sql/postgres/protocol/FieldMessage.rs              1      1      0
src/sql/postgres/protocol/NewReader.rs                 3      3      0
src/sql/postgres/protocol/NotificationResponse.rs      2      2      0
src/sql/postgres/protocol/ParameterStatus.rs           2      2      0
src/sql_jsc/postgres/PostgresRequest.rs                2      2      0
test/js/sql/postgres-frame-boundary.test.ts            1      6      0
test/js/sql/wire-frames.ts                             1      1      0
```

</details>

<!-- robobun:evidence:end -->