### PR TITLE
sql(postgres): bound ErrorResponse/NoticeResponse parsing to the declared frame length

### DIFF
--- a/src/sql/postgres/protocol/ErrorResponse.rs
+++ b/src/sql/postgres/protocol/ErrorResponse.rs
@@ -25,12 +25,17 @@ impl ErrorResponse {
         // A length of exactly 4 is an empty message (no fields); `length()`
         // already rejected anything smaller.
         let remaining_bytes = reader.length()? - 4;
-        if remaining_bytes > 0 {
-            return Ok(Self {
-                messages: FieldMessage::decode_list::<Container>(reader)?,
-            });
+        if remaining_bytes == 0 {
+            return Ok(Self::default());
         }
-        Ok(Self::default())
+        // Read the entire declared body as one slice so the connection
+        // reader advances by exactly the frame length. Parsing the field
+        // list out of that slice then cannot under- or over-run into the
+        // next message regardless of what the body contains.
+        let body = reader.read(remaining_bytes as usize)?;
+        Ok(Self {
+            messages: FieldMessage::decode_list_from_slice(body.slice()),
+        })
     }
 }
 

--- a/src/sql/postgres/protocol/FieldMessage.rs
+++ b/src/sql/postgres/protocol/FieldMessage.rs
@@ -3,8 +3,6 @@ use core::fmt;
 use bun_core::String;
 
 use super::field_type::FieldType;
-use super::new_reader::NewReader;
-use crate::postgres::AnyPostgresError;
 
 pub enum FieldMessage {
     Severity(String),
@@ -56,29 +54,30 @@ impl FieldMessage {
         }
     }
 
-    pub fn decode_list<Context: super::new_reader::ReaderContext>(
-        mut reader: NewReader<Context>,
-    ) -> Result<Vec<FieldMessage>, AnyPostgresError> {
+    /// Decode an ErrorResponse/NoticeResponse body that has already been sliced
+    /// out of the connection buffer. Parsing stops at the body end regardless of
+    /// what the field list contains, so a malformed or truncated field cannot
+    /// spill into the next message.
+    pub fn decode_list_from_slice(body: &[u8]) -> Vec<FieldMessage> {
         let mut messages: Vec<FieldMessage> = Vec::new();
-        loop {
-            let field_int: u8 = reader.int::<u8>()?;
+        let mut off: usize = 0;
+        while off < body.len() {
+            let field_int = body[off];
+            off += 1;
             if field_int == 0 {
                 break;
             }
-            let field: FieldType = FieldType::from(field_int);
-
-            let message = reader.read_z()?;
-            if message.slice().is_empty() {
+            let Some(nul) = bun_core::strings::index_of_char(&body[off..], 0) else {
                 break;
-            }
-
-            let Ok(field_msg) = FieldMessage::init(field, message.slice()) else {
-                continue;
             };
-            messages.push(field_msg);
+            let nul = nul as usize;
+            let value = &body[off..off + nul];
+            off += nul + 1;
+            if let Ok(field_msg) = FieldMessage::init(FieldType::from(field_int), value) {
+                messages.push(field_msg);
+            }
         }
-
-        Ok(messages)
+        messages
     }
 
     pub fn init(tag: FieldType, message: &[u8]) -> crate::Result<FieldMessage> {

--- a/test/js/sql/postgres-error-notice-frame-bound.test.ts
+++ b/test/js/sql/postgres-error-notice-frame-bound.test.ts
@@ -1,0 +1,82 @@
+// Fault-injection test: requires a server that sends ErrorResponse /
+// NoticeResponse bodies a healthy container will not produce on demand.
+// DO NOT COPY THIS PATTERN — anything a real server can produce belongs in
+// describeWithContainer. All wire-protocol bytes come from
+// test/js/sql/wire-frames.ts; do not inline Buffer.alloc frame construction here.
+//
+// ErrorResponse / NoticeResponse bodies are a sequence of (Byte1 code, String
+// value) pairs terminated by a zero byte (§55.7). The old decoder scanned the
+// connection buffer for field terminators without bounding to the message's
+// declared Int32 length, and additionally stopped early on an empty field
+// value. Either way the reader was left mid-frame, so the next dispatch read
+// body bytes as a new message type and the connection wedged.
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import { listeningServer, pgAuthenticationOk, pgCString, pgRaw, pgReadyForQuery } from "./wire-frames";
+
+// One mock server for the file; each test sets `current` before connecting.
+let current!: { atStartup: Buffer[] };
+const { port, server } = await listeningServer(socket => {
+  const { atStartup } = current;
+  socket.once("data", () => {
+    socket.write(Buffer.concat([pgAuthenticationOk(), ...atStartup]));
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => server.close(() => r())));
+
+// Build an ErrorResponse/NoticeResponse body from (code, value) pairs. Values
+// may be empty; the terminator is a single zero byte.
+function fieldBody(fields: [string, string][]): Buffer {
+  return Buffer.concat([
+    ...fields.map(([k, v]) => Buffer.concat([Buffer.from(k, "latin1"), pgCString(v)])),
+    Buffer.from([0]),
+  ]);
+}
+
+// A NoticeResponse with an empty Hint ('H') field in the middle is protocol-
+// legal. Previously the empty value ended parsing early, so the trailing
+// "C00000\0Mmsg\0\0" bytes were dispatched as a CommandComplete ('C') and the
+// connection desynced.
+test("postgres: NoticeResponse with an empty field value does not desync the connection", async () => {
+  current = {
+    atStartup: [
+      pgRaw(
+        "N",
+        fieldBody([
+          ["S", "NOTICE"],
+          ["H", ""],
+          ["C", "00000"],
+          ["M", "msg"],
+        ]),
+      ),
+      pgReadyForQuery(),
+    ],
+  };
+  const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1, connectionTimeout: 2 });
+  try {
+    await expect(db.connect()).resolves.toBeDefined();
+  } finally {
+    await db.close({ timeout: 0 });
+  }
+});
+
+// A NoticeResponse whose declared length is longer than its field list (padding
+// bytes after the terminator) must consume the whole frame so the following
+// ReadyForQuery stays aligned.
+test("postgres: NoticeResponse with trailing bytes after the field terminator is bounded to its declared length", async () => {
+  const body = Buffer.concat([
+    fieldBody([
+      ["S", "NOTICE"],
+      ["M", "msg"],
+    ]),
+    Buffer.from([0x7a, 0x7a, 0x7a]),
+  ]);
+  current = { atStartup: [pgRaw("N", body), pgReadyForQuery()] };
+  const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1, connectionTimeout: 2 });
+  try {
+    await expect(db.connect()).resolves.toBeDefined();
+  } finally {
+    await db.close({ timeout: 0 });
+  }
+});


### PR DESCRIPTION
## Problem

ErrorResponse and NoticeResponse bodies are a sequence of `(Byte1 code, String value)` pairs terminated by a zero byte (protocol §55.7). The decoder scanned the connection buffer for field terminators directly, without bounding to the message's declared Int32 length, and additionally broke out of the field loop on an empty string value:

```rust
let message = reader.read_z()?;
if message.slice().is_empty() {
    break;   // empty-string field value is protocol-legal; this leaves the
}            // rest of the frame (further fields + 0-terminator) unconsumed
```

Either way the reader was left mid-frame. The next dispatch at `PostgresRequest::on_data` then read body bytes as a new message type. For a Notice with an empty field in the middle the trailing bytes look like a huge unknown-message length, `length()` returns `ShortRead`, and the connection buffers and waits forever: a single message permanently wedges the connection and its pool slot.

## Fix

`ErrorResponse::decode_internal` now reads the entire declared body as one `reader.read(remaining_bytes)` slice, so the outer reader always advances by exactly the frame length. Field parsing is done over that slice (`FieldMessage::decode_list_from_slice`), so whatever the body contains (empty values, trailing padding, a truncated final string) cannot under- or over-run into the next message. `NoticeResponse` is a type alias for `ErrorResponse` and is covered by the same change.

## Verification

`test/js/sql/postgres-error-notice-frame-bound.test.ts` (wire-mock, no container):
- a NoticeResponse with an empty `H` (hint) field in the middle: on main `connect()` rejects / wedges, with the fix it resolves.
- a NoticeResponse with padding bytes after the field terminator: on main `connect()` times out after 2s, with the fix it resolves immediately.

Both fail on a released build and pass on this branch. Existing `postgres-invalid-message-length.test.ts` and `wire-frames.test.ts` pass unchanged.