### PR TITLE
sql(postgres): evict prepared-statement cache on SQLSTATE 0A000/26000

### DIFF
--- a/src/sql/postgres/protocol/ErrorResponse.rs
+++ b/src/sql/postgres/protocol/ErrorResponse.rs
@@ -19,6 +19,24 @@ impl fmt::Display for ErrorResponse {
 }
 
 impl ErrorResponse {
+    /// SQLSTATE codes whose ErrorResponse means the server no longer holds (or
+    /// no longer accepts) the prepared statement this query was bound to. The
+    /// client-side cache entry for that statement must be dropped so the next
+    /// execution re-prepares instead of failing forever.
+    ///
+    /// - 26000 invalid_sql_statement_name: statement was deallocated
+    ///   (DEALLOCATE / DISCARD ALL, or a pooler recycled the backend).
+    /// - 0A000 feature_not_supported: "cached plan must not change result
+    ///   type" after DDL altered a referenced table.
+    pub fn is_prepared_statement_invalid(&self) -> bool {
+        for msg in &self.messages {
+            if let FieldMessage::Code(code) = msg {
+                return code.eql_comptime(b"26000") || code.eql_comptime(b"0A000");
+            }
+        }
+        false
+    }
+
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(
         mut reader: NewReader<Container>,
     ) -> Result<Self, AnyPostgresError> {

--- a/src/sql/postgres/protocol/ErrorResponse.rs
+++ b/src/sql/postgres/protocol/ErrorResponse.rs
@@ -26,15 +26,31 @@ impl ErrorResponse {
     ///
     /// - 26000 invalid_sql_statement_name: statement was deallocated
     ///   (DEALLOCATE / DISCARD ALL, or a pooler recycled the backend).
-    /// - 0A000 feature_not_supported: "cached plan must not change result
-    ///   type" after DDL altered a referenced table.
+    /// - 0A000 feature_not_supported with routine RevalidateCachedQuery:
+    ///   "cached plan must not change result type" after DDL altered a
+    ///   referenced table. 0A000 alone is the generic feature_not_supported
+    ///   class and does not mean the plan is invalid; the routine check is
+    ///   what pgjdbc uses (`willHealViaReparse`).
     pub fn is_prepared_statement_invalid(&self) -> bool {
+        let mut is_26000 = false;
+        let mut is_0a000 = false;
+        let mut is_revalidate_cached_query = false;
         for msg in &self.messages {
-            if let FieldMessage::Code(code) = msg {
-                return code.eql_comptime(b"26000") || code.eql_comptime(b"0A000");
+            match msg {
+                FieldMessage::Code(code) => {
+                    is_26000 = code.eql_comptime(b"26000");
+                    is_0a000 = code.eql_comptime(b"0A000");
+                    if !is_26000 && !is_0a000 {
+                        return false;
+                    }
+                }
+                FieldMessage::Routine(r) => {
+                    is_revalidate_cached_query = r.eql_comptime(b"RevalidateCachedQuery");
+                }
+                _ => {}
             }
         }
-        false
+        is_26000 || (is_0a000 && is_revalidate_cached_query)
     }
 
     pub fn decode_internal<Container: super::new_reader::ReaderContext>(

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2990,9 +2990,13 @@ impl PostgresSQLConnection {
                     // plan: DEALLOCATE / DISCARD ALL / a pooler backend swap,
                     // or DDL changed the result type. The next execution then
                     // re-prepares instead of failing forever on this
-                    // connection.
-                    if stmt.status == StatementStatus::Parsing
-                        || err.is_prepared_statement_invalid()
+                    // connection. The Failed guard makes this idempotent: a
+                    // second pipelined 26000/0A000 on the same statement must
+                    // not remove()+deref again, since the map may by then hold
+                    // a fresh entry inserted by a rejection handler's retry.
+                    if stmt.status != StatementStatus::Failed
+                        && (stmt.status == StatementStatus::Parsing
+                            || err.is_prepared_statement_invalid())
                     {
                         stmt.status = StatementStatus::Failed;
                         stmt.error_response = Some(

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2983,12 +2983,30 @@ impl PostgresSQLConnection {
                 // `on_js_error` to avoid double-ownership of the non-Clone ErrorResponse.
                 let js_err =
                     crate::postgres::protocol::error_response_jsc::to_js(&err, self.global());
+                let invalidates_cache = err.is_prepared_statement_invalid();
                 if let Some(stmt) = request.statement_mut() {
                     if stmt.status == StatementStatus::Parsing {
                         stmt.status = StatementStatus::Failed;
                         stmt.error_response = Some(
                             crate::postgres::postgres_sql_statement::Error::Protocol(err),
                         );
+                        if self
+                            .statements
+                            .with_mut(|m| m.remove(&stmt.signature.name[..]))
+                            .is_some()
+                        {
+                            // SAFETY: `stmt` is a live `Box`-allocated statement; the
+                            // request still holds its own ref so this cannot drop to 0.
+                            unsafe { PostgresSQLStatement::deref(core::ptr::from_mut(stmt)) };
+                        }
+                    } else if invalidates_cache {
+                        // SQLSTATE 26000/0A000 on an already-parsed statement:
+                        // the server dropped or rejected the prepared plan
+                        // (DEALLOCATE, DISCARD ALL, pooler backend swap, or
+                        // DDL changed the result type). Evict it so the next
+                        // execution re-prepares instead of failing forever on
+                        // this connection.
+                        stmt.status = StatementStatus::Failed;
                         if self
                             .statements
                             .with_mut(|m| m.remove(&stmt.signature.name[..]))

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -3007,6 +3007,9 @@ impl PostgresSQLConnection {
                         // execution re-prepares instead of failing forever on
                         // this connection.
                         stmt.status = StatementStatus::Failed;
+                        stmt.error_response = Some(
+                            crate::postgres::postgres_sql_statement::Error::Protocol(err),
+                        );
                         if self
                             .statements
                             .with_mut(|m| m.remove(&stmt.signature.name[..]))

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2983,29 +2983,17 @@ impl PostgresSQLConnection {
                 // `on_js_error` to avoid double-ownership of the non-Clone ErrorResponse.
                 let js_err =
                     crate::postgres::protocol::error_response_jsc::to_js(&err, self.global());
-                let invalidates_cache = err.is_prepared_statement_invalid();
                 if let Some(stmt) = request.statement_mut() {
-                    if stmt.status == StatementStatus::Parsing {
-                        stmt.status = StatementStatus::Failed;
-                        stmt.error_response = Some(
-                            crate::postgres::postgres_sql_statement::Error::Protocol(err),
-                        );
-                        if self
-                            .statements
-                            .with_mut(|m| m.remove(&stmt.signature.name[..]))
-                            .is_some()
-                        {
-                            // SAFETY: `stmt` is a live `Box`-allocated statement; the
-                            // request still holds its own ref so this cannot drop to 0.
-                            unsafe { PostgresSQLStatement::deref(core::ptr::from_mut(stmt)) };
-                        }
-                    } else if invalidates_cache {
-                        // SQLSTATE 26000/0A000 on an already-parsed statement:
-                        // the server dropped or rejected the prepared plan
-                        // (DEALLOCATE, DISCARD ALL, pooler backend swap, or
-                        // DDL changed the result type). Evict it so the next
-                        // execution re-prepares instead of failing forever on
-                        // this connection.
+                    // Evict and mark Failed when either the Parse itself was
+                    // rejected, or SQLSTATE 26000/0A000 reported that the
+                    // server no longer holds (or accepts) an already-parsed
+                    // plan: DEALLOCATE / DISCARD ALL / a pooler backend swap,
+                    // or DDL changed the result type. The next execution then
+                    // re-prepares instead of failing forever on this
+                    // connection.
+                    if stmt.status == StatementStatus::Parsing
+                        || err.is_prepared_statement_invalid()
+                    {
                         stmt.status = StatementStatus::Failed;
                         stmt.error_response = Some(
                             crate::postgres::postgres_sql_statement::Error::Protocol(err),

--- a/test/js/sql/postgres-prepared-cache-invalidation.test.ts
+++ b/test/js/sql/postgres-prepared-cache-invalidation.test.ts
@@ -43,6 +43,38 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     }
   });
 
+  test("0A000 from a source other than RevalidateCachedQuery does not evict", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+
+    const fn = `fn_0a000_${randomUUIDv7("hex").slice(-12)}`;
+    // This 0A000 comes from PL/pgSQL (routine exec_stmt_raise, not
+    // RevalidateCachedQuery); the prepared plan is fine and must stay cached.
+    await sql.unsafe(
+      `CREATE FUNCTION ${fn}(int) RETURNS int AS $$ BEGIN RAISE feature_not_supported; END $$ LANGUAGE plpgsql`,
+    );
+    try {
+      // First call prepares and caches.
+      const first = await sql.unsafe(`SELECT ${fn}($1)`, [0]).catch((e: any) => e);
+      expect((first as any).errno).toBe("0A000");
+      expect((first as any).routine).not.toBe("RevalidateCachedQuery");
+
+      // pg_prepared_statements must hold exactly one entry for this query,
+      // and it must stay the same one across repeated executions.
+      const sel = `SELECT name FROM pg_prepared_statements WHERE statement LIKE 'SELECT ${fn}%'`;
+      const before = await sql.unsafe(sel);
+      expect(before.length).toBe(1);
+      for (let i = 0; i < 3; i++) {
+        const e = await sql.unsafe(`SELECT ${fn}($1)`, [0]).catch((e: any) => e);
+        expect((e as any).errno).toBe("0A000");
+      }
+      const after = await sql.unsafe(sel);
+      expect(after).toEqual(before);
+    } finally {
+      await sql.unsafe(`DROP FUNCTION IF EXISTS ${fn}(int)`);
+    }
+  });
+
   test("26000 (invalid_sql_statement_name) after DISCARD ALL evicts the prepared statement", async () => {
     await container.ready;
     await using sql = new SQL({ url: url(), max: 1 });

--- a/test/js/sql/postgres-prepared-cache-invalidation.test.ts
+++ b/test/js/sql/postgres-prepared-cache-invalidation.test.ts
@@ -69,10 +69,10 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     expect(await sql`SELECT ${1}::int AS v`).toEqual([{ v: 1 }]);
     await sql`DISCARD ALL`.simple();
 
-    // Two executions of the same cached statement queued back-to-back: the
-    // first sees 26000 and marks the shared statement Failed; the second is
-    // settled from statement.error_response by the flush loop. Both promises
-    // must reject rather than hang.
+    // Two executions of the same cached statement queued back-to-back. With
+    // auto-pipelining both write Bind immediately and each receives its own
+    // 26000 ErrorResponse; both must reject (not hang), and the next
+    // execution must re-prepare.
     const [a, b] = await Promise.all([
       sql`SELECT ${2}::int AS v`.then(
         v => ({ ok: v }),

--- a/test/js/sql/postgres-prepared-cache-invalidation.test.ts
+++ b/test/js/sql/postgres-prepared-cache-invalidation.test.ts
@@ -1,0 +1,64 @@
+// Regression test for https://github.com/oven-sh/bun/issues/29484.
+//
+// After a prepared statement has been parsed, PostgreSQL may later reject it
+// with SQLSTATE 0A000 ("cached plan must not change result type", after DDL
+// alters a referenced column) or 26000 ("prepared statement ... does not
+// exist", after DEALLOCATE / DISCARD ALL / a pooler swapping the backend).
+// The per-connection prepared-statement cache must drop that entry so the next
+// execution re-prepares; otherwise every future attempt on the connection
+// keeps sending Bind against a plan the server no longer accepts.
+import { SQL, randomUUIDv7 } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  test("0A000 (cached plan must not change result type) evicts the prepared statement", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+
+    const table = `t_cache_0a000_${randomUUIDv7("hex").slice(-12)}`;
+    await sql.unsafe(`CREATE TABLE ${table} (a int)`);
+    // A non-empty parameter list is what routes unsafe() through the
+    // extended protocol (named Parse + Bind), so the plan is cached.
+    const query = `SELECT a FROM ${table} WHERE $1::int = 0`;
+    try {
+      await sql.unsafe(query, [0]);
+
+      // Change the result type server-side.
+      await sql.unsafe(`ALTER TABLE ${table} ALTER COLUMN a TYPE text`);
+
+      // The first re-run sees the server's 0A000 and the cache entry is dropped.
+      const first = await sql.unsafe(query, [0]).catch((e: any) => e);
+      expect(first).toBeInstanceOf(Error);
+      expect((first as any).errno).toBe("0A000");
+
+      // The second re-run must re-prepare and succeed. Before the fix it
+      // failed 0A000 forever on this connection.
+      const second = await sql.unsafe(query, [0]);
+      expect(second).toEqual([]);
+    } finally {
+      await sql.unsafe(`DROP TABLE IF EXISTS ${table}`);
+    }
+  });
+
+  test("26000 (invalid_sql_statement_name) after DISCARD ALL evicts the prepared statement", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+
+    // Prepare and cache a parameterised SELECT.
+    expect(await sql`SELECT ${1}::int AS v`).toEqual([{ v: 1 }]);
+
+    // DISCARD ALL drops every server-side prepared statement on the session.
+    await sql`DISCARD ALL`.simple();
+
+    // The first re-run sees 26000 and the cache entry is dropped.
+    const first = await sql`SELECT ${2}::int AS v`.catch((e: any) => e);
+    expect(first).toBeInstanceOf(Error);
+    expect((first as any).errno).toBe("26000");
+
+    // The second re-run must re-prepare and succeed.
+    expect(await sql`SELECT ${3}::int AS v`).toEqual([{ v: 3 }]);
+  });
+});

--- a/test/js/sql/postgres-prepared-cache-invalidation.test.ts
+++ b/test/js/sql/postgres-prepared-cache-invalidation.test.ts
@@ -61,4 +61,32 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     // The second re-run must re-prepare and succeed.
     expect(await sql`SELECT ${3}::int AS v`).toEqual([{ v: 3 }]);
   });
+
+  test("26000 with a second queued request sharing the cached statement settles both", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+
+    expect(await sql`SELECT ${1}::int AS v`).toEqual([{ v: 1 }]);
+    await sql`DISCARD ALL`.simple();
+
+    // Two executions of the same cached statement queued back-to-back: the
+    // first sees 26000 and marks the shared statement Failed; the second is
+    // settled from statement.error_response by the flush loop. Both promises
+    // must reject rather than hang.
+    const [a, b] = await Promise.all([
+      sql`SELECT ${2}::int AS v`.then(
+        v => ({ ok: v }),
+        e => ({ err: (e as any).errno ?? (e as any).code }),
+      ),
+      sql`SELECT ${3}::int AS v`.then(
+        v => ({ ok: v }),
+        e => ({ err: (e as any).errno ?? (e as any).code }),
+      ),
+    ]);
+    expect(a).toEqual({ err: "26000" });
+    expect(b).toEqual({ err: "26000" });
+
+    // And the next execution re-prepares and succeeds.
+    expect(await sql`SELECT ${4}::int AS v`).toEqual([{ v: 4 }]);
+  });
 });


### PR DESCRIPTION
Fixes #29484

## Problem

After a statement has been parsed and cached, PostgreSQL may later reject a Bind against it with:
- `0A000` "cached plan must not change result type", after DDL alters a referenced column
- `26000` "prepared statement ... does not exist", after `DEALLOCATE` / `DISCARD ALL` / a pooler swapping the backend

The `ErrorResponse` handler only evicted the per-connection cache entry when the statement was still in the `Parsing` state, so an already-parsed statement hit with one of these codes stayed cached. Every future execution of the same query on that connection kept sending Bind against a plan the server no longer accepts, failing forever until the connection is recycled.

```js
await using sql = new SQL({ url, max: 1 });
await sql`SELECT ${1}::int AS v`;   // prepare + cache
await sql`DISCARD ALL`.simple();    // server drops every prepared statement
await sql`SELECT ${2}::int AS v`;   // 26000
await sql`SELECT ${3}::int AS v`;   // still 26000, forever
```

## Fix

`ErrorResponse::is_prepared_statement_invalid()` checks the SQLSTATE; the handler in `PostgresSQLConnection::on(ErrorResponse)` drops the cache entry on these codes regardless of the statement's state. The failing query still rejects (the server already said no), but the next execution re-prepares and succeeds.

## Verification

`test/js/sql/postgres-prepared-cache-invalidation.test.ts` (against a real Postgres):
- `0A000` after `ALTER TABLE ... ALTER COLUMN ... TYPE`: first re-run rejects with `0A000`, second re-run succeeds.
- `26000` after `DISCARD ALL`: first re-run rejects with `26000`, second re-run succeeds.

Both fail on a released build (the second re-run keeps rejecting) and pass on this branch.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-prepared-cache-invalidation.test.ts
bun test v1.4.0 (59a7877ce)

test/js/sql/postgres-prepared-cache-invalidation.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
PostgresError: cached plan must not change result type
    errno: "0A000",
 severity: "ERROR",
     file: "plancache.c",
  routine: "RevalidateCachedQuery",
     code: "ERR_POSTGRES_SERVER_ERROR"

      at wrapPostgresError (internal:sql/postgres:209:27)
      at onRejectPostgresQuery (internal:sql/postgres:245:29)
(fail) postgres > 0A000 (cached plan must not change result type) evicts the prepared statement [527.14ms]
(pass) postgres > 0A000 from a source other than RevalidateCachedQuery does not evict [222.85ms]
PostgresError: prepared statement "PSELECT $1 ::int AS v.int4$0" does not exist
    errno: "26000",
 severity: "ERROR",
     file: "prepare.c",
  routine: "FetchPreparedStatement",
     code: "ERR_POSTGRES_SERVER_ERROR"

      at wrapPostgresError (internal:sql/postgres:209:27)
      at onRejectPostgresQuery (intern
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (a510fcf27)

test/js/sql/postgres-prepared-cache-invalidation.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > 0A000 (cached plan must not change result type) evicts the prepared statement [23.47ms]
67 |       for (let i = 0; i < 3; i++) {
68 |         const e = await sql.unsafe(`SELECT ${fn}($1)`, [0]).catch((e: any) => e);
69 |         expect((e as any).errno).toBe("0A000");
70 |       }
71 |       const after = await sql.unsafe(sel);
72 |       expect(after).toEqual(before);
                         ^
error: expect(received).toEqual(expected)

  [
    {
+     "name": "PSELECT fn_0a000_1d15c12f39df($1).int4$2",
+   },
+   {
+     "name": "PSELECT fn_0a000_1d15c12f39df($1).int4$1",
+   },
+   {
+     "name": "PSELECT fn_0a000_1d15c12f39df($1).int4$3",
+   },
+   {
      "name": "PSELECT fn_0a000_1d15c12f39df($1).int4$0",
    },
  ]

- Expected  - 0
+ Received  + 9

      at <anonymous> (/workspace/bun/test/js/sql/postgres-prepared-cache-invalidation.test.ts:72:21)
(fail) postgres > 0A000 from a source other than RevalidateCachedQuery does not evict [10.35ms]
(pass) postgres > 26000 (invalid_sql
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-prepared-cache-invalidation.test.ts
bun test v1.4.0 (59a7877ce)

test/js/sql/postgres-prepared-cache-invalidation.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > 0A000 (cached plan must not change result type) evicts the prepared statement [502.17ms]
(pass) postgres > 0A000 from a source other than RevalidateCachedQuery does not evict [216.35ms]
(pass) postgres > 26000 (invalid_sql_statement_name) after DISCARD ALL evicts the prepared statement [169.67ms]
(pass) postgres > 26000 with a second queued request sharing the cached statement settles both [172.91ms]

 4 pass
 0 fail
 18 expect() calls
Ran 4 tests across 1 file. [5.42s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 996ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_collections v0.0.0 (/workspace/bun/src/collections)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/postgres/protocol/ErrorResponse.rs         |  34 ++++++
 src/sql_jsc/postgres/PostgresSQLConnection.rs      |  15 ++-
 .../postgres-prepared-cache-invalidation.test.ts   | 124 +++++++++++++++++++++
 3 files changed, 172 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/sql/postgres/protocol/ErrorResponse.rs                    3      4      0
src/sql_jsc/postgres/PostgresSQLConnection.rs                 9      6      0
test/js/sql/postgres-prepared-cache-invalidation.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->