### PR TITLE
sql: release reserve() clients that are garbage collected without release()

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -40,10 +40,13 @@ interface ReserveAbortState {
   onAbort: (() => void) | null;
 }
 
+/// `_client` is bound so the reserved client stays reachable, and so is not collected and
+/// released by reservationRegistry, until its transaction settles.
 function settleReservedTransaction(
   reservedTransaction: Set<Promise<void>>,
   finished: { promise: Promise<void>; resolve: () => void },
   settle: (value: any) => void,
+  _client: unknown,
   value: any,
 ) {
   reservedTransaction.delete(finished.promise);
@@ -333,6 +336,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
   // Never attach a handler to the caller's promise: it changes which rejections are reported as unhandled.
   function runReservedTransaction(
+    client: unknown,
     reservedTransaction: Set<Promise<void>>,
     pooledConnection,
     callback: TransactionCallback,
@@ -346,8 +350,8 @@ const SQL: typeof Bun.SQL = function SQL(
     onTransactionConnected(
       callback,
       options,
-      settleReservedTransaction.bind(null, reservedTransaction, finished, resolve),
-      settleReservedTransaction.bind(null, reservedTransaction, finished, reject),
+      settleReservedTransaction.bind(null, reservedTransaction, finished, resolve, client),
+      settleReservedTransaction.bind(null, reservedTransaction, finished, reject, client),
       true,
       distributed,
       null,
@@ -453,7 +457,7 @@ const SQL: typeof Bun.SQL = function SQL(
       if (!$isCallable(callback)) {
         return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
       }
-      return runReservedTransaction(reservedTransaction, pooledConnection, callback, name, true);
+      return runReservedTransaction(reserved_sql, reservedTransaction, pooledConnection, callback, name, true);
     };
     reserved_sql.begin = (options_or_fn: string | TransactionCallback, fn?: TransactionCallback) => {
       // begin is allowed the difference is that we need to make sure to use the same connection and never release it
@@ -474,7 +478,7 @@ const SQL: typeof Bun.SQL = function SQL(
       if (!$isCallable(callback)) {
         return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
       }
-      return runReservedTransaction(reservedTransaction, pooledConnection, callback, options, false);
+      return runReservedTransaction(reserved_sql, reservedTransaction, pooledConnection, callback, options, false);
     };
 
     reserved_sql.flush = () => {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -90,7 +90,8 @@ function onReservedConnectionClosed(this: Reservation, err: Error) {
 let reservationRegistry: FinalizationRegistry<Reservation> | undefined;
 function onReservationCollected(reservation: Reservation) {
   const { pool, pooledConnection, state } = reservation;
-  if (state.connectionState & ReservedConnectionState.released) return;
+  // closed: close() is tearing the connection down and its close handler releases the slot.
+  if (state.connectionState & (ReservedConnectionState.closed | ReservedConnectionState.released)) return;
   state.connectionState |= ReservedConnectionState.closed;
   state.connectionState &= ~ReservedConnectionState.acceptQueries;
   if (pool.detachConnectionCloseHandler) {
@@ -499,7 +500,6 @@ const SQL: typeof Bun.SQL = function SQL(
         return Promise.$resolve(undefined);
       }
       state.connectionState &= ~ReservedConnectionState.acceptQueries;
-      reservationRegistry!.unregister(state);
       let timeout = options?.timeout;
       if (timeout) {
         timeout = Number(timeout);

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -25,7 +25,8 @@ enum ReservedConnectionState {
 
 interface TransactionState {
   connectionState: ReservedConnectionState;
-  reject: (err: Error) => void;
+  /// null once resolved: the rejecter retains the promise, whose value is the reserved client.
+  reject: ((err: Error) => void) | null;
   storedError?: Error | null | undefined;
   queries: Set<Query<any, any>>;
 }
@@ -48,6 +49,54 @@ function settleReservedTransaction(
   reservedTransaction.delete(finished.promise);
   finished.resolve();
   settle(value);
+}
+
+function onTransactionDisconnected(this: TransactionState, err: Error) {
+  const reject = this.reject;
+  this.connectionState |= ReservedConnectionState.closed;
+
+  for (const query of this.queries) {
+    query.reject(err);
+  }
+
+  if (err && reject !== null) {
+    return reject(err);
+  }
+}
+
+/// The pool side of one reserve(): what the connection's close handler and the
+/// collection callback need. Held by the pooled connection and by
+/// reservationRegistry, so it must not reference the client itself.
+interface Reservation {
+  pool: ReturnType<typeof adapterFromOptions>;
+  pooledConnection: any;
+  state: TransactionState;
+  onClose: ((err: Error) => void) | null;
+}
+
+function releaseReservation(reservation: Reservation) {
+  const state = reservation.state;
+  if (state.connectionState & ReservedConnectionState.released) return;
+  state.connectionState |= ReservedConnectionState.released;
+  reservation.pool.release(reservation.pooledConnection);
+}
+
+function onReservedConnectionClosed(this: Reservation, err: Error) {
+  onTransactionDisconnected.$call(this.state, err);
+  releaseReservation(this);
+}
+
+/// Releases clients that were garbage collected without release()/close().
+let reservationRegistry: FinalizationRegistry<Reservation> | undefined;
+function onReservationCollected(reservation: Reservation) {
+  const { pool, pooledConnection, state } = reservation;
+  if (state.connectionState & ReservedConnectionState.released) return;
+  state.connectionState |= ReservedConnectionState.closed;
+  state.connectionState &= ~ReservedConnectionState.acceptQueries;
+  if (pool.detachConnectionCloseHandler) {
+    pool.detachConnectionCloseHandler(pooledConnection, reservation.onClose!);
+  }
+  releaseReservation(reservation);
 }
 
 function adapterFromOptions(options: Bun.SQL.__internal.DefinedOptions) {
@@ -247,19 +296,6 @@ const SQL: typeof Bun.SQL = function SQL(
     }
   }
 
-  function onTransactionDisconnected(this: TransactionState, err: Error) {
-    const reject = this.reject;
-    this.connectionState |= ReservedConnectionState.closed;
-
-    for (const query of this.queries) {
-      query.reject(err);
-    }
-
-    if (err) {
-      return reject(err);
-    }
-  }
-
   const listenable = "listen" in pool ? pool : null;
   function validateChannel(channel: unknown): asserts channel is string {
     if (typeof channel !== "string" || channel.length === 0) {
@@ -338,19 +374,10 @@ const SQL: typeof Bun.SQL = function SQL(
       queries: new Set(),
     };
 
-    function releaseReservation() {
-      if (state.connectionState & ReservedConnectionState.released) return;
-      state.connectionState |= ReservedConnectionState.released;
-      pool.release(pooledConnection);
-    }
-
-    const onDisconnected = onTransactionDisconnected.bind(state);
-    function onClose(err: Error) {
-      onDisconnected(err);
-      releaseReservation();
-    }
+    const reservation: Reservation = { pool, pooledConnection, state, onClose: null };
+    reservation.onClose = onReservedConnectionClosed.bind(reservation);
     if (pooledConnection.onClose) {
-      pooledConnection.onClose(onClose);
+      pooledConnection.onClose(reservation.onClose);
     }
 
     function reserved_sql(strings: string | TemplateStringsArray | SQLHelper<any> | Query<any, any>, ...values: any[]) {
@@ -471,6 +498,7 @@ const SQL: typeof Bun.SQL = function SQL(
         return Promise.$resolve(undefined);
       }
       state.connectionState &= ~ReservedConnectionState.acceptQueries;
+      reservationRegistry!.unregister(state);
       let timeout = options?.timeout;
       if (timeout) {
         timeout = Number(timeout);
@@ -516,11 +544,12 @@ const SQL: typeof Bun.SQL = function SQL(
       // just release the connection back to the pool
       state.connectionState |= ReservedConnectionState.closed;
       state.connectionState &= ~ReservedConnectionState.acceptQueries;
+      reservationRegistry!.unregister(state);
       // Use adapter method to detach connection close handler
       if (pool.detachConnectionCloseHandler) {
-        pool.detachConnectionCloseHandler(pooledConnection, onClose);
+        pool.detachConnectionCloseHandler(pooledConnection, reservation.onClose!);
       }
-      releaseReservation();
+      releaseReservation(reservation);
       return Promise.$resolve(undefined);
     };
     // this dont need to be async dispose only disposable but we keep compatibility with other types of sql functions
@@ -532,6 +561,12 @@ const SQL: typeof Bun.SQL = function SQL(
     reserved_sql.distributed = reserved_sql.beginDistributed;
     reserved_sql.end = reserved_sql.close;
     resolve(reserved_sql);
+    state.reject = null;
+    (reservationRegistry ??= new FinalizationRegistry(onReservationCollected)).register(
+      reserved_sql,
+      reservation,
+      state,
+    );
   }
 
   function onReserveConnectedWithSignal(this: ReserveAbortState, err: Error | null, pooledConnection) {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -924,6 +924,9 @@ const SQL: typeof Bun.SQL = function SQL(
       if (pool.detachConnectionCloseHandler) {
         pool.detachConnectionCloseHandler(pooledConnection, onClose);
       }
+      // transaction_sql's closures keep this whole scope alive while the caller keeps `tx`;
+      // for a reservation the settle callbacks pin the reserved client.
+      state.reject = callback = resolve = reject = null;
       if (!dontRelease) {
         pool.release(pooledConnection);
       }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -40,8 +40,7 @@ interface ReserveAbortState {
   onAbort: (() => void) | null;
 }
 
-/// `_client` is bound so the reserved client stays reachable, and so is not collected and
-/// released by reservationRegistry, until its transaction settles.
+/// `_client` is bound only to keep the client out of reservationRegistry's reach until the transaction settles.
 function settleReservedTransaction(
   reservedTransaction: Set<Promise<void>>,
   finished: { promise: Promise<void>; resolve: () => void },

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -64,9 +64,7 @@ function onTransactionDisconnected(this: TransactionState, err: Error) {
   }
 }
 
-/// The pool side of one reserve(): what the connection's close handler and the
-/// collection callback need. Held by the pooled connection and by
-/// reservationRegistry, so it must not reference the client itself.
+/// Retained by the pooled connection and reservationRegistry: must not reference the client.
 interface Reservation {
   pool: ReturnType<typeof adapterFromOptions>;
   pooledConnection: any;

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -924,8 +924,7 @@ const SQL: typeof Bun.SQL = function SQL(
       if (pool.detachConnectionCloseHandler) {
         pool.detachConnectionCloseHandler(pooledConnection, onClose);
       }
-      // transaction_sql's closures keep this whole scope alive while the caller keeps `tx`;
-      // for a reservation the settle callbacks pin the reserved client.
+      // a kept `tx` keeps this scope alive; resolve/reject pin a reserved client (see settleReservedTransaction)
       state.reject = callback = resolve = reject = null;
       if (!dontRelease) {
         pool.release(pooledConnection);

--- a/test/js/sql/sql-reserve-gc-reclaim.test.ts
+++ b/test/js/sql/sql-reserve-gc-reclaim.test.ts
@@ -154,7 +154,9 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
           servedDuringTransaction = served;
         });
       })();
-      await started.promise;
+      // transaction cannot resolve before the gate opens, so it only wins the
+      // race by rejecting, which surfaces a setup failure instead of a hang.
+      await Promise.race([started.promise, transaction]);
 
       // Nothing but the running transaction references the client now.
       for (let i = 0; i < 10; i++) {

--- a/test/js/sql/sql-reserve-gc-reclaim.test.ts
+++ b/test/js/sql/sql-reserve-gc-reclaim.test.ts
@@ -1,0 +1,120 @@
+// A `sql.reserve()` client dropped without `release()` / `using` kept its pool
+// slot for the rest of the process: the connection's close handler retained
+// the client (through its scope, and through state.reject -> promise ->
+// client), so it was never even collectable. Once every slot leaked this way,
+// every later query hung.
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  // The `{ signal }` variant keeps a live AbortSignal (held by the test) wired
+  // to the reservation, which must not keep the dropped client reachable.
+  test.each([["reserve()", false] as const, ["reserve({ signal })", true] as const])(
+    "a dropped %s client returns its pool slot on GC",
+    async (_name, withSignal) => {
+      await container.ready;
+      // Force-close in the finally so a regression fails the assertion instead
+      // of hanging in the disposer behind the leaked slot.
+      const sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+      const controller = new AbortController();
+      try {
+        // Leak the client inside an inner scope so nothing on this frame
+        // retains it once the inner async function returns.
+        await (async () => {
+          await sql.reserve(withSignal ? { signal: controller.signal } : undefined);
+        })();
+
+        let result: unknown = "pending";
+        const probe = sql`select 42 as v`.then(
+          ([{ v }]) => (result = v),
+          e => (result = e),
+        );
+        // Drive GC until the FinalizationRegistry releases the slot; give up
+        // after a bounded number of sweeps instead of waiting on wall-clock
+        // time.
+        for (let i = 0; i < 50 && result === "pending"; i++) {
+          Bun.gc(true);
+          await Bun.sleep(10);
+        }
+        await Promise.race([probe, Promise.resolve()]);
+        expect(result).toBe(42);
+        expect(controller.signal.aborted).toBe(false);
+      } finally {
+        // timeout: 0 falls through to graceful close today; a small positive
+        // value reaches the forced-close path.
+        await sql.close({ timeout: 0.1 });
+      }
+    },
+  );
+
+  test("collecting a client that was already released does not release its connection again", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+
+    // Observes when the released client is actually collected, so the test
+    // waits for the collection itself rather than for a number of GC passes.
+    let collected = false;
+    const observer = new FinalizationRegistry(() => (collected = true));
+    await (async () => {
+      const client = await sql.reserve();
+      observer.register(client, undefined);
+      client.release();
+    })();
+    // Hold the only connection while the released client is collected. A
+    // second release() would put the connection back in the pool underneath
+    // this reservation and the plain query below would run on it at once.
+    const reserved = await sql.reserve();
+    let served = false;
+    let parked: Promise<{ v: number }[]>;
+    try {
+      for (let i = 0; i < 50 && !collected; i++) {
+        Bun.gc(true);
+        await Bun.sleep(10);
+      }
+      expect(collected).toBe(true);
+
+      parked = sql`select 1 as v`.then(rows => ((served = true), rows));
+      // A wrongly served query would be written to the connection before this
+      // one, so it is answered before this round trip completes.
+      await reserved`select 2 as v`;
+      expect(served).toBe(false);
+    } finally {
+      reserved.release();
+    }
+    expect((await parked)[0].v).toBe(1);
+  });
+
+  // The close handler already returned the slot when the server killed the
+  // connection; collecting the dropped client afterwards must not return it
+  // twice, which would leave the reconnected slot permanently "busy".
+  test("collecting a client whose connection died does not release its slot again", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+    await using admin = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+
+    let collected = false;
+    const observer = new FinalizationRegistry(() => (collected = true));
+    await (async () => {
+      const client = await sql.reserve();
+      observer.register(client, undefined);
+      const [{ pid }] = await client`select pg_backend_pid() as pid`;
+      await admin`select pg_terminate_backend(${pid})`;
+      // Rejects once the client has observed the close.
+      await expect(client`select 1`).rejects.toBeDefined();
+    })();
+
+    for (let i = 0; i < 50 && !collected; i++) {
+      Bun.gc(true);
+      await Bun.sleep(10);
+    }
+    expect(collected).toBe(true);
+
+    // Both need the reconnected slot to be accounted as free.
+    expect((await sql`select 1 as v`)[0].v).toBe(1);
+    using again = await sql.reserve();
+    expect((await again`select 2 as v`)[0].v).toBe(2);
+  });
+});

--- a/test/js/sql/sql-reserve-gc-reclaim.test.ts
+++ b/test/js/sql/sql-reserve-gc-reclaim.test.ts
@@ -41,7 +41,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
         })();
 
         let result: unknown = "pending";
-        const probe = sql`select 42 as v`.then(
+        sql`select 42 as v`.then(
           ([{ v }]) => (result = v),
           e => (result = e),
         );
@@ -50,7 +50,6 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
         for (let i = 0; i < 50 && result === "pending"; i++) {
           await collectOnce();
         }
-        await Promise.race([probe, Promise.resolve()]);
         expect(result).toBe(42);
         expect(controller.signal.aborted).toBe(false);
       } finally {
@@ -177,6 +176,34 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       expect((await parked)[0].v).toBe(3);
     } finally {
       gate.resolve();
+      await sql.close({ timeout: 0.1 });
+    }
+  });
+
+  // close({ timeout }) whose in-flight work drains in time resolves without
+  // closing or releasing anything today, so a client dropped after it is the
+  // same leak as one that was never closed and must still be reclaimed.
+  test("a client dropped after close({ timeout }) drained its work still returns its slot", async () => {
+    await container.ready;
+    const sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+    try {
+      await (async () => {
+        const client = await sql.reserve();
+        const inflight = client`select pg_sleep(0.01)`;
+        await client.close({ timeout: 5 });
+        await inflight;
+      })();
+
+      let result: unknown = "pending";
+      sql`select 4 as v`.then(
+        ([{ v }]) => (result = v),
+        e => (result = e),
+      );
+      for (let i = 0; i < 50 && result === "pending"; i++) {
+        await collectOnce();
+      }
+      expect(result).toBe(4);
+    } finally {
       await sql.close({ timeout: 0.1 });
     }
   });

--- a/test/js/sql/sql-reserve-gc-reclaim.test.ts
+++ b/test/js/sql/sql-reserve-gc-reclaim.test.ts
@@ -209,4 +209,34 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       await sql.close({ timeout: 0.1 });
     }
   });
+
+  // The finished transaction's `tx` object must not keep the dropped client
+  // (and so its slot) alive through the settle callbacks that pin the client
+  // while the transaction runs.
+  test("a tx kept after its reserved begin() finished does not keep the dropped client's slot", async () => {
+    await container.ready;
+    const sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+    try {
+      let escaped: unknown;
+      await (async () => {
+        const client = await sql.reserve();
+        await client.begin(async tx => {
+          escaped = tx;
+          await tx`select 1`;
+        });
+      })();
+
+      let result: unknown = "pending";
+      sql`select 5 as v`.then(
+        ([{ v }]) => (result = v),
+        e => (result = e),
+      );
+      for (let i = 0; i < 50 && result === "pending"; i++) {
+        await collectOnce();
+      }
+      expect({ result, escapedIsFunction: typeof escaped }).toEqual({ result: 5, escapedIsFunction: "function" });
+    } finally {
+      await sql.close({ timeout: 0.1 });
+    }
+  });
 });

--- a/test/js/sql/sql-reserve-gc-reclaim.test.ts
+++ b/test/js/sql/sql-reserve-gc-reclaim.test.ts
@@ -103,7 +103,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       const [{ pid }] = await client`select pg_backend_pid() as pid`;
       await admin`select pg_terminate_backend(${pid})`;
       // Rejects once the client has observed the close.
-      await expect(client`select 1`).rejects.toBeDefined();
+      await expect(client`select 1`).rejects.toBeInstanceOf(Error);
     })();
 
     for (let i = 0; i < 50 && !collected; i++) {
@@ -116,5 +116,55 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     expect((await sql`select 1 as v`)[0].v).toBe(1);
     using again = await sql.reserve();
     expect((await again`select 2 as v`)[0].v).toBe(2);
+  });
+
+  // `client.begin()` returned without the caller holding `client`: the running
+  // transaction must keep the client alive, or collecting it would hand the
+  // connection, with its transaction still open, to the next pool caller.
+  test("a dropped client is not collected while its begin() is running, and is reclaimed after", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
+
+    let collected = false;
+    const observer = new FinalizationRegistry(() => (collected = true));
+    const started = Promise.withResolvers<void>();
+    const gate = Promise.withResolvers<void>();
+    let served = false;
+    let servedDuringTransaction: boolean | null = null;
+    const transaction = (async () => {
+      const client = await sql.reserve();
+      observer.register(client, undefined);
+      return client.begin(async tx => {
+        await tx`select 1`;
+        started.resolve();
+        await gate.promise;
+        // A plain query wrongly served on this connection was written before
+        // this statement, so it has been answered by the time this resolves.
+        await tx`select 2`;
+        servedDuringTransaction = served;
+      });
+    })();
+    await started.promise;
+
+    // Nothing but the running transaction references the client now.
+    for (let i = 0; i < 10; i++) {
+      Bun.gc(true);
+      await Bun.sleep(10);
+    }
+    expect(collected).toBe(false);
+
+    const parked = sql`select 3 as v`.then(rows => ((served = true), rows));
+    gate.resolve();
+    await transaction;
+    expect(servedDuringTransaction).toBe(false);
+
+    // Once the transaction has settled the client is collectable and its
+    // slot comes back, which is what lets the parked query run.
+    for (let i = 0; i < 50 && !served; i++) {
+      Bun.gc(true);
+      await Bun.sleep(10);
+    }
+    expect(collected).toBe(true);
+    expect((await parked)[0].v).toBe(3);
   });
 });

--- a/test/js/sql/sql-reserve-gc-reclaim.test.ts
+++ b/test/js/sql/sql-reserve-gc-reclaim.test.ts
@@ -7,6 +7,19 @@ import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
 
+// One GC pass from a timer callback, resolved one macrotask later so the
+// registry callbacks it queued have run. GC from the awaiting continuation
+// itself can still see the settled work's stale stack slots (conservative
+// scanning) and keep the object alive for a while on release builds.
+function collectOnce(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(() => {
+    Bun.gc(true);
+    setTimeout(resolve, 0);
+  }, 0);
+  return promise;
+}
+
 describeWithContainer("postgres", { image: "postgres_plain" }, container => {
   const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
 
@@ -32,12 +45,10 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
           ([{ v }]) => (result = v),
           e => (result = e),
         );
-        // Drive GC until the FinalizationRegistry releases the slot; give up
-        // after a bounded number of sweeps instead of waiting on wall-clock
-        // time.
+        // Drive GC until the registry releases the slot, with a bounded number
+        // of passes.
         for (let i = 0; i < 50 && result === "pending"; i++) {
-          Bun.gc(true);
-          await Bun.sleep(10);
+          await collectOnce();
         }
         await Promise.race([probe, Promise.resolve()]);
         expect(result).toBe(42);
@@ -71,8 +82,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     let parked: Promise<{ v: number }[]>;
     try {
       for (let i = 0; i < 50 && !collected; i++) {
-        Bun.gc(true);
-        await Bun.sleep(10);
+        await collectOnce();
       }
       expect(collected).toBe(true);
 
@@ -107,8 +117,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     })();
 
     for (let i = 0; i < 50 && !collected; i++) {
-      Bun.gc(true);
-      await Bun.sleep(10);
+      await collectOnce();
     }
     expect(collected).toBe(true);
 
@@ -123,48 +132,52 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
   // connection, with its transaction still open, to the next pool caller.
   test("a dropped client is not collected while its begin() is running, and is reclaimed after", async () => {
     await container.ready;
-    await using sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
-
-    let collected = false;
-    const observer = new FinalizationRegistry(() => (collected = true));
-    const started = Promise.withResolvers<void>();
+    // Force-closed in the finally: on a regression the parked query below
+    // never runs, and a graceful close would wait for it.
+    const sql = new SQL({ url: url(), max: 1, idleTimeout: 5 });
     const gate = Promise.withResolvers<void>();
-    let served = false;
-    let servedDuringTransaction: boolean | null = null;
-    const transaction = (async () => {
-      const client = await sql.reserve();
-      observer.register(client, undefined);
-      return client.begin(async tx => {
-        await tx`select 1`;
-        started.resolve();
-        await gate.promise;
-        // A plain query wrongly served on this connection was written before
-        // this statement, so it has been answered by the time this resolves.
-        await tx`select 2`;
-        servedDuringTransaction = served;
-      });
-    })();
-    await started.promise;
+    try {
+      let collected = false;
+      const observer = new FinalizationRegistry(() => (collected = true));
+      const started = Promise.withResolvers<void>();
+      let served = false;
+      let servedDuringTransaction: boolean | null = null;
+      const transaction = (async () => {
+        const client = await sql.reserve();
+        observer.register(client, undefined);
+        return client.begin(async tx => {
+          await tx`select 1`;
+          started.resolve();
+          await gate.promise;
+          // A plain query wrongly served on this connection was written before
+          // this statement, so it has been answered by the time this resolves.
+          await tx`select 2`;
+          servedDuringTransaction = served;
+        });
+      })();
+      await started.promise;
 
-    // Nothing but the running transaction references the client now.
-    for (let i = 0; i < 10; i++) {
-      Bun.gc(true);
-      await Bun.sleep(10);
+      // Nothing but the running transaction references the client now.
+      for (let i = 0; i < 10; i++) {
+        await collectOnce();
+      }
+      expect(collected).toBe(false);
+
+      const parked = sql`select 3 as v`.then(rows => ((served = true), rows));
+      gate.resolve();
+      await transaction;
+      expect(servedDuringTransaction).toBe(false);
+
+      // Once the transaction has settled the client is collectable and its
+      // slot comes back, which is what lets the parked query run.
+      for (let i = 0; i < 50 && !served; i++) {
+        await collectOnce();
+      }
+      expect({ collected, served }).toEqual({ collected: true, served: true });
+      expect((await parked)[0].v).toBe(3);
+    } finally {
+      gate.resolve();
+      await sql.close({ timeout: 0.1 });
     }
-    expect(collected).toBe(false);
-
-    const parked = sql`select 3 as v`.then(rows => ((served = true), rows));
-    gate.resolve();
-    await transaction;
-    expect(servedDuringTransaction).toBe(false);
-
-    // Once the transaction has settled the client is collectable and its
-    // slot comes back, which is what lets the parked query run.
-    for (let i = 0; i < 50 && !served; i++) {
-      Bun.gc(true);
-      await Bun.sleep(10);
-    }
-    expect(collected).toBe(true);
-    expect((await parked)[0].v).toBe(3);
   });
 });


### PR DESCRIPTION
### Problem
- A `reserve()` client that is dropped without `release()`, `close()` or `using` keeps its pool connection for the rest of the process. With `max: N`, N such drops leave every later query pending forever.
- The client is not even collectable. In `onReserveConnected` (`src/js/bun/sql.ts`) the close handler installed on the pooled connection is a closure over the scope that holds the client (`onClose` / `releaseReservation`, since #33743), and `state.reject` is the rejecter of the `reserve()` promise, whose value is the client. The live connection retains the client both ways.

### Fix
- The pool side of one reservation (pool, pooled connection, `state`, close handler) is one `Reservation` record. `releaseReservation()` takes the record and `onReservedConnectionClosed()` is bound to it, so the connection retains the record and nothing else. `onTransactionDisconnected` moves to module scope unchanged (it only uses `this`). No function is created per reservation apart from the one `bind`.
- `reserve()` sets `state.reject = null` once the promise has resolved.
- `reserve()` registers the client in a `FinalizationRegistry` with the same record as the held value. The callback detaches the close handler and calls `releaseReservation()`, which returns the slot once and only once through the existing `released` bit. So a slot that was already returned by hand, or by the close handler when the connection died, is not returned twice. `release()` unregisters the client. `close()` does not need to: it sets `closed` before it closes the connection, the callback skips a closed or released reservation, and the close handler returns the slot when the close lands. A `close({ timeout })` whose work drains in time currently resolves without closing anything (reported separately), so a client dropped after it is reclaimed like any other.
- Works for `reserve()` and `reserve({ signal })` (#39454): both resolve through `onReserveConnected`.
- A running `client.begin()` pins the client: `runReservedTransaction` binds it into the settle callbacks that `onTransactionConnected` holds until the transaction ends. Without this, a client referenced only by its running transaction was collected and its connection, transaction still open, went back to the pool (found in review, reproduced). The client becomes collectable exactly when the transaction settles. When it settles, `onTransactionConnected`'s `finally` clears `state.reject`, the callback and both settle callbacks: JSC keeps that scope, parameters included, alive for as long as the caller keeps `tx`, so a kept `tx` would otherwise keep the pin. Direct queries are not pinned: releasing with a statement in flight is what `release()` does today, and the statement completes ahead of anything pipelined after it.
- Verified with `test/js/sql/sql-reserve-gc-reclaim.test.ts` (7 tests, postgres container). The two "dropped client returns its slot" tests fail on main's `sql.ts` (`Expected: 42, Received: "pending"`) and pass with the fix. The "already released" test fails if `release()` stops unregistering. The "connection died" test hangs if the collection callback bypasses the `released` bit. The "begin() is running" test fails without the pin (the client is collected mid-transaction) and also checks the slot is reclaimed once the transaction ends. The "drained close({ timeout })" test fails if `close()` unregisters the client. The "tx kept" test fails without the scope clearing. The tests run each GC pass from a timer callback: on release builds a GC run from the awaiting continuation kept seeing stale stack slots from the turn that settled the transaction and did not collect the client for most of a second. Each test waits for the collection itself (a test side `FinalizationRegistry`) or for the query, not for a fixed time.
- Also passing on the same build: `sql-pool-transaction-isolation.test.ts` (#33743, #39598), `sql-reserve-abort.test.ts`, `sql-close-pending-connection.test.ts`, `test/js/bun/test/fake-timers/fake-timers.test.ts`. 82 tests, plus the 32 of the reclaim, isolation and abort files after the pin.

### Not in this PR
- The first revision also bounded the time a caller waits for a pool slot with `connectionTimeout`, using a JS `setTimeout` in the pool. `fake-timers.test.ts` (#37946) asserts that the runtime's own timeouts are not fakeable, and CI failed on it. The native timers are per connection and the pool is JS state, so that bound needs a runtime internal timer that builtins can arm. It is a separate change. The JS side of it is commit 99427b9952 on this PR's history, for reference.

### Background
- `Bun.SQL` keeps up to `max` connections per instance. `reserve()` takes one out of the pool and returns a client bound to it. The connection goes back only through `release()` on that client, or through the close handler when the connection dies (#33743). `ReservedConnectionState.released` records that the slot went back.
- A `FinalizationRegistry` runs a callback some time after a registered object is garbage collected and passes it the held value. If the held value, or anything else alive, references the registered object, the object is never collected and the callback never runs.
- The client's methods are closures over `onReserveConnected`'s scope and reference the client. That cycle is garbage as a whole once nothing outside it points in. The close handler held by the pooled connection was the outside reference.

<details>
<summary>Repro</summary>

```ts
import { SQL } from "bun";
const sql = new SQL(process.env.PGURL!, { max: 1 });
await (async () => {
  await sql.reserve(); // dropped without release()
})();
Bun.gc(true);
await sql`select 1`; // before: pends forever. after: runs once the client is collected.
```
</details>

<details><summary>Rebase notes</summary>

Rebased onto e19faeb527. #33743 had replaced the bound close handler with closures (`releaseReservation`, `onClose`) inside `onReserveConnected` and added the `released` bit. The conflict was resolved by moving that logic into the `Reservation` record described above, and the collection callback now goes through the same `released` bit. The "connection died" test was added for that interaction.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-reserve-gc-reclaim.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/sql/sql-reserve-gc-reclaim.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
48 |         // Drive GC until the registry releases the slot, with a bounded number
49 |         // of passes.
50 |         for (let i = 0; i < 50 && result === "pending"; i++) {
51 |           await collectOnce();
52 |         }
53 |         expect(result).toBe(42);
                            ^
error: expect(received).toBe(expected)

Expected: 42
Received: "pending"

      at <anonymous> (/workspace/bun/test/js/sql/sql-reserve-gc-reclaim.test.ts:53:24)
(fail) postgres > a dropped reserve() client returns its pool slot on GC [2746.86ms]
48 |         // Drive GC until the registry releases the slot, with a bounded number
49 |         // of passes.
50 |         for (let i = 0; i < 50 && result === "pending"; i++) {
51 |           await collectOnce();
52 |         }
53 |         expect(result).toBe(42);
                            ^
error: expect(received
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (cef791cae)

test/js/sql/sql-reserve-gc-reclaim.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > a dropped reserve() client returns its pool slot on GC [10.61ms]
(pass) postgres > a dropped reserve({ signal }) client returns its pool slot on GC [7.15ms]
(pass) postgres > collecting a client that was already released does not release its connection again [8.19ms]
(pass) postgres > collecting a client whose connection died does not release its slot again [11.55ms]
(pass) postgres > a dropped client is not collected while its begin() is running, and is reclaimed after [49.26ms]
(pass) postgres > a client dropped after close({ timeout }) drained its work still returns its slot [19.05ms]
232 |         e => (result = e),
233 |       );
234 |       for (let i = 0; i < 50 && result === "pending"; i++) {
235 |         await collectOnce();
236 |       }
237 |       expect({ result, escapedIsFunction: typeof escaped }).toEqual({ result: 5, escapedIsFunction: "function" });
                                                                  ^
error: expect(received).toEqual(expected)

  {
    "escapedIsFuncti
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-reserve-gc-reclaim.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/sql/sql-reserve-gc-reclaim.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > a dropped reserve() client returns its pool slot on GC [352.64ms]
(pass) postgres > a dropped reserve({ signal }) client returns its pool slot on GC [107.70ms]
(pass) postgres > collecting a client that was already released does not release its connection again [103.39ms]
(pass) postgres > collecting a client whose connection died does not release its slot again [137.97ms]
(pass) postgres > a dropped client is not collected while its begin() is running, and is reclaimed after [658.56ms]
(pass) postgres > a client dropped after close({ timeout }) drained its work still returns its slot [154.75ms]
(pass) postgres > a tx kept after its reserved begin() finished does not keep the dropped client's slot [139.07ms]

 7 pass
 0 fail
 17 expect() calls
Ran 7 tests across 1 file. [4.50s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 664ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/38] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/38] gen cpp.rs (cppbind)
[3/38] gen JS modules (bundle-modules)
Preprocess modules (7832ms)
Bundle modules (47ms)
Postprocesss modules (208ms)
Bundle Functions (611ms)
Generate Code (36ms)

[8.75s] Bundled "src/js" for production
  2629 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[3/29] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/bun/sql.ts                          | 102 ++++++++----
 test/js/sql/sql-reserve-gc-reclaim.test.ts | 242 +++++++++++++++++++++++++++++
 2 files changed, 312 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 8 passed · 2 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/bun/sql.ts                              18     31      0
test/js/sql/sql-reserve-gc-reclaim.test.ts      8     14      0
```

</details>

<!-- robobun:evidence:end -->