### PR TITLE
sql(mysql): bound packet-body reads to the enclosing packet's payload length

### DIFF
--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -1,4 +1,0 @@
-export default {
-  kArmHandshakeTimeout: Symbol("kArmHandshakeTimeout"),
-  kVerifyError: Symbol("kVerifyError"),
-};

--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -1,0 +1,7 @@
+export default {
+  kArmHandshakeTimeout: Symbol("kArmHandshakeTimeout"),
+  // Internal handshake-settled signal: server-side sockets emit no user
+  // 'secureConnect' (node parity), so internal deferrals park on this instead.
+  kSecureConnectDone: Symbol("kSecureConnectDone"),
+  kVerifyError: Symbol("kVerifyError"),
+};

--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -1,7 +1,4 @@
 export default {
   kArmHandshakeTimeout: Symbol("kArmHandshakeTimeout"),
-  // Internal handshake-settled signal: server-side sockets emit no user
-  // 'secureConnect' (node parity), so internal deferrals park on this instead.
-  kSecureConnectDone: Symbol("kSecureConnectDone"),
   kVerifyError: Symbol("kVerifyError"),
 };

--- a/src/sql/mysql/protocol/AnyMySQLError.rs
+++ b/src/sql/mysql/protocol/AnyMySQLError.rs
@@ -42,6 +42,7 @@ pub enum Error {
     InvalidEOFPacket,
     InvalidErrorPacket,
     UnexpectedPacket,
+    MalformedPacket,
     ShortRead,
     UnknownError,
     InvalidState,

--- a/src/sql/mysql/protocol/NewReader.rs
+++ b/src/sql/mysql/protocol/NewReader.rs
@@ -11,7 +11,6 @@ pub trait ReaderContext: Copy {
     fn skip(self, count: isize);
     fn ensure_capacity(self, count: usize) -> bool;
     fn read(self, count: usize) -> Result<Data, AnyMySQLError>;
-    fn read_z(self) -> Result<Data, AnyMySQLError>;
     fn set_offset_from_start(self, offset: usize);
     /// Bytes from the current offset to the end of the framed packet body, or
     /// `usize::MAX` when no packet is framed (header decoding).
@@ -66,14 +65,17 @@ impl<C: ReaderContext> NewReader<C> {
     }
 
     pub fn read_z(self) -> Result<Data, AnyMySQLError> {
-        if bun_core::strings::index_of_char(self.peek(), 0).is_none() {
-            return Err(if self.wrapped.packet_remaining() == usize::MAX {
-                AnyMySQLError::ShortRead
-            } else {
-                AnyMySQLError::MalformedPacket
-            });
+        match bun_core::strings::index_of_char(self.peek(), 0) {
+            Some(zero) => {
+                let data = self.wrapped.read(zero as usize)?;
+                self.wrapped.skip(1);
+                Ok(data)
+            }
+            None if self.wrapped.packet_remaining() == usize::MAX => {
+                Err(AnyMySQLError::ShortRead)
+            }
+            None => Err(AnyMySQLError::MalformedPacket),
         }
-        self.wrapped.read_z()
     }
 
     pub fn byte(self) -> Result<u8, AnyMySQLError> {

--- a/src/sql/mysql/protocol/NewReader.rs
+++ b/src/sql/mysql/protocol/NewReader.rs
@@ -71,9 +71,7 @@ impl<C: ReaderContext> NewReader<C> {
                 self.wrapped.skip(1);
                 Ok(data)
             }
-            None if self.wrapped.packet_remaining() == usize::MAX => {
-                Err(AnyMySQLError::ShortRead)
-            }
+            None if self.wrapped.packet_remaining() == usize::MAX => Err(AnyMySQLError::ShortRead),
             None => Err(AnyMySQLError::MalformedPacket),
         }
     }

--- a/src/sql/mysql/protocol/NewReader.rs
+++ b/src/sql/mysql/protocol/NewReader.rs
@@ -13,6 +13,11 @@ pub trait ReaderContext: Copy {
     fn read(self, count: usize) -> Result<Data, AnyMySQLError>;
     fn read_z(self) -> Result<Data, AnyMySQLError>;
     fn set_offset_from_start(self, offset: usize);
+    /// Bytes from the current offset to the end of the framed packet body, or
+    /// `usize::MAX` when no packet is framed (header decoding).
+    fn packet_remaining(&self) -> usize;
+    fn set_packet_limit_from_start(self, packet_length: usize);
+    fn clear_packet_limit(self);
 }
 
 #[derive(Clone, Copy)]
@@ -29,7 +34,23 @@ impl<C: ReaderContext> NewReader<C> {
         self.wrapped.set_offset_from_start(offset);
     }
 
+    pub fn set_packet_limit_from_start(self, packet_length: usize) {
+        self.wrapped.set_packet_limit_from_start(packet_length);
+    }
+
+    pub fn clear_packet_limit(self) {
+        self.wrapped.clear_packet_limit();
+    }
+
+    /// Every MySQL packet's body is bounded by the Int<3> payload_length in its
+    /// header. The dispatch loop buffers the whole packet before decoding it,
+    /// so a body read that still comes up short has overrun the packet, and the
+    /// bytes it would return belong to the next packet's framing: that is a
+    /// malformed packet, never "wait for more socket data".
     pub fn read(self, count: usize) -> Result<Data, AnyMySQLError> {
+        if count > self.wrapped.packet_remaining() {
+            return Err(AnyMySQLError::MalformedPacket);
+        }
         self.wrapped.read(count)
     }
 
@@ -39,10 +60,19 @@ impl<C: ReaderContext> NewReader<C> {
     }
 
     pub fn peek(&self) -> &[u8] {
-        self.wrapped.peek()
+        let limit = self.wrapped.packet_remaining();
+        let full = self.wrapped.peek();
+        &full[..full.len().min(limit)]
     }
 
     pub fn read_z(self) -> Result<Data, AnyMySQLError> {
+        if bun_core::strings::index_of_char(self.peek(), 0).is_none() {
+            return Err(if self.wrapped.packet_remaining() == usize::MAX {
+                AnyMySQLError::ShortRead
+            } else {
+                AnyMySQLError::MalformedPacket
+            });
+        }
         self.wrapped.read_z()
     }
 

--- a/src/sql/mysql/protocol/NewReader.rs
+++ b/src/sql/mysql/protocol/NewReader.rs
@@ -41,11 +41,8 @@ impl<C: ReaderContext> NewReader<C> {
         self.wrapped.clear_packet_limit();
     }
 
-    /// Every MySQL packet's body is bounded by the Int<3> payload_length in its
-    /// header. The dispatch loop buffers the whole packet before decoding it,
-    /// so a body read that still comes up short has overrun the packet, and the
-    /// bytes it would return belong to the next packet's framing: that is a
-    /// malformed packet, never "wait for more socket data".
+    /// The dispatch loop buffers the whole packet before decoding, so a body
+    /// read past `packet_remaining` is a malformed packet, never `ShortRead`.
     pub fn read(self, count: usize) -> Result<Data, AnyMySQLError> {
         if count > self.wrapped.packet_remaining() {
             return Err(AnyMySQLError::MalformedPacket);

--- a/src/sql/mysql/protocol/StackReader.rs
+++ b/src/sql/mysql/protocol/StackReader.rs
@@ -37,4 +37,13 @@ impl<'a> ReaderContext for StackReader<'a> {
     fn set_offset_from_start(self, offset: usize) {
         StackReader::set_offset_from_start(&self, offset)
     }
+    fn packet_remaining(&self) -> usize {
+        StackReader::packet_remaining(self)
+    }
+    fn set_packet_limit_from_start(self, packet_length: usize) {
+        StackReader::set_packet_end_from_start(&self, packet_length)
+    }
+    fn clear_packet_limit(self) {
+        StackReader::clear_packet_end(&self)
+    }
 }

--- a/src/sql/mysql/protocol/StackReader.rs
+++ b/src/sql/mysql/protocol/StackReader.rs
@@ -31,9 +31,6 @@ impl<'a> ReaderContext for StackReader<'a> {
     fn read(self, count: usize) -> Result<Data, AnyMySQLError> {
         StackReader::read(&self, count)
     }
-    fn read_z(self) -> Result<Data, AnyMySQLError> {
-        StackReader::read_z(&self)
-    }
     fn set_offset_from_start(self, offset: usize) {
         StackReader::set_offset_from_start(&self, offset)
     }

--- a/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
+++ b/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
@@ -29,12 +29,13 @@ impl StmtPrepareOKPacket {
             return Err(AnyMySQLError::InvalidPrepareOKPacket);
         }
         self.num_columns = reader.int::<u16>()?;
-        self.num_params = reader.int::<u16>()?;
-        // Both counts size a Vec<ColumnDefinition41> and how many follow-up
-        // packets the client waits for; MySQL's MAX_FIELDS is 4096.
-        if self.num_columns > 4096 || self.num_params > 4096 {
+        // num_columns sizes a Vec<ColumnDefinition41> and how many follow-up
+        // packets the client waits for; MySQL's MAX_FIELDS is 4096. num_params
+        // is already bounded by its u16 wire type (ER_PS_MANY_PARAM at 65535).
+        if self.num_columns > 4096 {
             return Err(AnyMySQLError::InvalidPrepareOKPacket);
         }
+        self.num_params = reader.int::<u16>()?;
         let _ = reader.int::<u8>()?; // reserved_1
         if self.packet_length >= 12 {
             self.warning_count = reader.int::<u16>()?;

--- a/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
+++ b/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
@@ -30,11 +30,8 @@ impl StmtPrepareOKPacket {
         }
         self.num_columns = reader.int::<u16>()?;
         self.num_params = reader.int::<u16>()?;
-        // Both counts drive allocation of a Vec<ColumnDefinition41>
-        // (~256 bytes each) and how many follow-up packets the client will
-        // wait for. MySQL hard-caps a result set at 4096 columns (MAX_FIELDS),
-        // so a larger count is a hostile 12-byte packet trying to make us
-        // commit megabytes and then wedge waiting for packets that never come.
+        // Both counts size a Vec<ColumnDefinition41> and how many follow-up
+        // packets the client waits for; MySQL's MAX_FIELDS is 4096.
         if self.num_columns > 4096 || self.num_params > 4096 {
             return Err(AnyMySQLError::InvalidPrepareOKPacket);
         }

--- a/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
+++ b/src/sql/mysql/protocol/StmtPrepareOKPacket.rs
@@ -30,6 +30,14 @@ impl StmtPrepareOKPacket {
         }
         self.num_columns = reader.int::<u16>()?;
         self.num_params = reader.int::<u16>()?;
+        // Both counts drive allocation of a Vec<ColumnDefinition41>
+        // (~256 bytes each) and how many follow-up packets the client will
+        // wait for. MySQL hard-caps a result set at 4096 columns (MAX_FIELDS),
+        // so a larger count is a hostile 12-byte packet trying to make us
+        // commit megabytes and then wedge waiting for packets that never come.
+        if self.num_columns > 4096 || self.num_params > 4096 {
+            return Err(AnyMySQLError::InvalidPrepareOKPacket);
+        }
         let _ = reader.int::<u8>()?; // reserved_1
         if self.packet_length >= 12 {
             self.warning_count = reader.int::<u16>()?;

--- a/src/sql/shared/StackReader.rs
+++ b/src/sql/shared/StackReader.rs
@@ -77,7 +77,11 @@ impl<'a> StackReader<'a> {
     }
 
     pub fn packet_remaining(&self) -> usize {
-        self.packet_end.get().saturating_sub(self.offset.get())
+        let end = self.packet_end.get();
+        if end == usize::MAX {
+            return usize::MAX;
+        }
+        end.saturating_sub(self.offset.get())
     }
 
     pub fn set_offset_from_start(&self, offset: usize) {

--- a/src/sql/shared/StackReader.rs
+++ b/src/sql/shared/StackReader.rs
@@ -40,6 +40,11 @@ pub struct StackReader<'a> {
     pub buffer: &'a [u8],
     pub offset: &'a Cell<usize>,
     pub message_start: &'a Cell<usize>,
+    /// Absolute offset one past the current packet's last body byte; reads at
+    /// or past it are a protocol error, not a short read. `usize::MAX` means
+    /// "no packet framed yet" (header decode, or a protocol that tracks its
+    /// own message lengths like Postgres).
+    pub packet_end: &'a Cell<usize>,
 }
 
 impl<'a> StackReader<'a> {
@@ -47,16 +52,32 @@ impl<'a> StackReader<'a> {
         buffer: &'a [u8],
         offset: impl IntoCursor<'a>,
         message_start: impl IntoCursor<'a>,
+        packet_end: impl IntoCursor<'a>,
     ) -> R {
         R::wrap(StackReader {
             buffer,
             offset: offset.into_cursor(),
             message_start: message_start.into_cursor(),
+            packet_end: packet_end.into_cursor(),
         })
     }
 
     pub fn mark_message_start(&self) {
         self.message_start.set(self.offset.get());
+        self.packet_end.set(usize::MAX);
+    }
+
+    pub fn set_packet_end_from_start(&self, packet_length: usize) {
+        self.packet_end
+            .set(self.message_start.get().saturating_add(packet_length));
+    }
+
+    pub fn clear_packet_end(&self) {
+        self.packet_end.set(usize::MAX);
+    }
+
+    pub fn packet_remaining(&self) -> usize {
+        self.packet_end.get().saturating_sub(self.offset.get())
     }
 
     pub fn set_offset_from_start(&self, offset: usize) {

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1744,17 +1744,6 @@ impl ReaderContext for Reader {
         self.skip(isize::try_from(count).expect("int cast"));
         Ok(Data::Temporary(slice))
     }
-
-    fn read_z(self) -> Result<Data, AnyMySQLError> {
-        let remaining = self.read_buffer().remaining();
-        if let Some(zero) = bun_core::strings::index_of_char(remaining, 0) {
-            let slice = bun_ptr::RawSlice::new(&remaining[0..zero as usize]);
-            self.skip(isize::try_from(zero + 1).expect("int cast"));
-            return Ok(Data::Temporary(slice));
-        }
-
-        Err(AnyMySQLError::ShortRead)
-    }
 }
 
 // Canonical type lives in `bun_sql::mysql`; re-export so this module's

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -55,6 +55,7 @@ pub struct MySQLConnection {
     write_buffer: OffsetByteList,
     read_buffer: OffsetByteList,
     last_message_start: u32,
+    packet_end: u32,
     sequence_id: u8,
 
     // TODO: move it to JSMySQLConnection
@@ -98,6 +99,7 @@ impl Default for MySQLConnection {
             write_buffer: OffsetByteList::default(),
             read_buffer: OffsetByteList::default(),
             last_message_start: 0,
+            packet_end: u32::MAX,
             sequence_id: 0,
             queue: MySQLRequestQueue::init(),
             statements: PreparedStatementsMap::default(),
@@ -488,7 +490,8 @@ impl MySQLConnection {
             // so the post-error read of `offset`/`consumed` doesn't conflict.
             let consumed = core::cell::Cell::new(0usize);
             let offset = core::cell::Cell::new(0usize);
-            let reader = StackReader::init(data, &consumed, &offset);
+            let packet_end = core::cell::Cell::new(usize::MAX);
+            let reader = StackReader::init(data, &consumed, &offset, &packet_end);
             match self.process_packets(reader) {
                 Ok(()) => {}
                 Err(err) => {
@@ -583,6 +586,10 @@ impl MySQLConnection {
             reader
                 .ensure_capacity(packet_length)
                 .map_err(|_| AnyMySQLError::ShortRead)?;
+            // The full packet is now buffered; bound every body read to it so a
+            // server-controlled lenenc length can't pull bytes from the next
+            // packet (silent corruption) or return ShortRead (permanent wedge).
+            reader.set_packet_limit_from_start(packet_length);
             // `NewReader<C>: Copy` so the scopeguard captures by copy; the inner
             // `C` writes through a raw pointer so the offset update still lands.
             // Always skip the full packet, we dont care about padding or unread bytes.
@@ -605,6 +612,10 @@ impl MySQLConnection {
                     // reject them instead of feeding them to the auth/command handlers.
                     if self.tls_status == TLSStatus::MessageSent {
                         reader.set_offset_from_start(packet_length);
+                        // This check is explicitly looking for bytes buffered
+                        // AFTER the handshake packet, so drop the per-packet
+                        // window before peeking.
+                        reader.clear_packet_limit();
                         if !reader.peek().is_empty() {
                             return Err(AnyMySQLError::UnexpectedPacket);
                         }
@@ -1656,15 +1667,41 @@ impl Reader {
         // through `&mut self` while the reader is live.
         unsafe { &mut *core::ptr::addr_of_mut!((*self.connection).last_message_start) }
     }
+
+    #[inline]
+    #[allow(clippy::mut_from_ref)]
+    fn packet_end(&self) -> &mut u32 {
+        // SAFETY: same justification as `read_buffer()` / `last_message_start()`.
+        unsafe { &mut *core::ptr::addr_of_mut!((*self.connection).packet_end) }
+    }
 }
 
 impl ReaderContext for Reader {
     fn mark_message_start(self) {
         *self.last_message_start() = self.read_buffer().head;
+        *self.packet_end() = u32::MAX;
     }
 
     fn set_offset_from_start(self, offset: usize) {
         self.read_buffer().head = *self.last_message_start() + (offset as u32);
+    }
+
+    fn packet_remaining(&self) -> usize {
+        let end = *self.packet_end();
+        if end == u32::MAX {
+            return usize::MAX;
+        }
+        end.saturating_sub(self.read_buffer().head) as usize
+    }
+
+    fn set_packet_limit_from_start(self, packet_length: usize) {
+        // packet_length = PacketHeader::SIZE + a 24-bit body length, so the sum
+        // always fits in u32.
+        *self.packet_end() = *self.last_message_start() + packet_length as u32;
+    }
+
+    fn clear_packet_limit(self) {
+        *self.packet_end() = u32::MAX;
     }
 
     fn peek(&self) -> &[u8] {

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -586,9 +586,7 @@ impl MySQLConnection {
             reader
                 .ensure_capacity(packet_length)
                 .map_err(|_| AnyMySQLError::ShortRead)?;
-            // The full packet is now buffered; bound every body read to it so a
-            // server-controlled lenenc length can't pull bytes from the next
-            // packet (silent corruption) or return ShortRead (permanent wedge).
+            // Bound every body read to the now-fully-buffered packet.
             reader.set_packet_limit_from_start(packet_length);
             // `NewReader<C>: Copy` so the scopeguard captures by copy; the inner
             // `C` writes through a raw pointer so the offset update still lands.
@@ -612,9 +610,7 @@ impl MySQLConnection {
                     // reject them instead of feeding them to the auth/command handlers.
                     if self.tls_status == TLSStatus::MessageSent {
                         reader.set_offset_from_start(packet_length);
-                        // This check is explicitly looking for bytes buffered
-                        // AFTER the handshake packet, so drop the per-packet
-                        // window before peeking.
+                        // Peeking past this packet, so drop its window.
                         reader.clear_packet_limit();
                         if !reader.peek().is_empty() {
                             return Err(AnyMySQLError::UnexpectedPacket);
@@ -1695,8 +1691,6 @@ impl ReaderContext for Reader {
     }
 
     fn set_packet_limit_from_start(self, packet_length: usize) {
-        // packet_length = PacketHeader::SIZE + a 24-bit body length, so the sum
-        // always fits in u32.
         *self.packet_end() = *self.last_message_start() + packet_length as u32;
     }
 

--- a/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
+++ b/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
@@ -107,6 +107,7 @@ pub(crate) fn mysql_error_to_js(
         "InvalidEOFPacket" => b"ERR_MYSQL_INVALID_EOF_PACKET",
         "InvalidErrorPacket" => b"ERR_MYSQL_INVALID_ERROR_PACKET",
         "UnexpectedPacket" => b"ERR_MYSQL_UNEXPECTED_PACKET",
+        "MalformedPacket" => b"ERR_MYSQL_MALFORMED_PACKET",
         "ConnectionTimedOut" => b"ERR_MYSQL_CONNECTION_TIMEOUT",
         "IdleTimeout" => b"ERR_MYSQL_IDLE_TIMEOUT",
         "LifetimeTimeout" => b"ERR_MYSQL_LIFETIME_TIMEOUT",

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -984,7 +984,9 @@ impl PostgresSQLConnection {
         if self.read_buffer.get().remaining().is_empty() {
             let mut consumed: usize = 0;
             let mut offset: usize = 0;
-            let reader = protocol::StackReader::init(data, &mut consumed, &mut offset);
+            let mut packet_end: usize = usize::MAX;
+            let reader =
+                protocol::StackReader::init(data, &mut consumed, &mut offset, &mut packet_end);
             match PostgresRequest::on_data(self, reader) {
                 Ok(()) => {}
                 Err(err) => {

--- a/test/js/sql/sql-mysql-auth-short-nonce.test.ts
+++ b/test/js/sql/sql-mysql-auth-short-nonce.test.ts
@@ -99,7 +99,10 @@ test("MySQL: an AuthSwitchRequest frame declaring a zero-length payload is rejec
       e => ({ code: e?.code ?? String(e) }),
     );
 
-    expect(err).toEqual({ code: "ERR_MYSQL_INVALID_AUTH_SWITCH_REQUEST" });
+    // A zero-length body leaves no byte for handle_auth's first-byte dispatch
+    // read, so the per-packet bound rejects it before the AuthSwitch-specific
+    // packet_size check is reached.
+    expect(err).toEqual({ code: "ERR_MYSQL_MALFORMED_PACKET" });
   } finally {
     await new Promise<void>(r => server.close(() => r()));
   }

--- a/test/js/sql/sql-mysql-packet-overrun.test.ts
+++ b/test/js/sql/sql-mysql-packet-overrun.test.ts
@@ -193,7 +193,10 @@ test("mysql: a lenenc overrun on the buffered-reader path is rejected, not serve
         if (payload[0] !== 0x03 /* COM_QUERY */ || answered) return;
         answered = true;
         socket.write(full.subarray(0, split));
-        setImmediate(() => socket.write(full.subarray(split)));
+        // Yield twice so the first write reaches the client's on_data before
+        // the second is sent (immediates run before I/O polling, so a single
+        // setImmediate would let both chunks coalesce into one client read).
+        setImmediate(() => setImmediate(() => socket.write(full.subarray(split))));
       });
     });
     socket.on("error", () => {});

--- a/test/js/sql/sql-mysql-packet-overrun.test.ts
+++ b/test/js/sql/sql-mysql-packet-overrun.test.ts
@@ -1,0 +1,231 @@
+// Fault-injection test: requires a server that refuses / drops / sends malformed
+// frames, which a healthy container will not do on demand. DO NOT COPY THIS
+// PATTERN — anything a real server can produce belongs in describeWithContainer.
+// All wire-protocol bytes come from test/js/sql/wire-frames.ts; do not inline
+// Buffer.alloc frame construction here.
+//
+// Every MySQL packet carries an Int<3> payload length in its header. The body
+// decoders (result-set rows, column definitions, OK packets) then read
+// length-encoded fields whose claimed sizes are themselves server-controlled.
+// A lenenc length that exceeds the enclosing packet's payload_length is a
+// malformed packet (mysql2: "Malformed packet"), and a decoder that trusts the
+// inner lenenc over the outer packet boundary either (a) reads the next,
+// already-buffered packet's header/body bytes and returns them as column data,
+// or (b) returns ShortRead when no next packet is buffered, which the dispatch
+// loop treats as "wait for more socket data" so the query and everything queued
+// behind it pend forever. Both must reject with ERR_MYSQL_MALFORMED_PACKET.
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import {
+  listeningServer,
+  mysqlColumnDefinition,
+  mysqlHandshakeV10,
+  mysqlLenencInt,
+  mysqlOkPacket,
+  mysqlRawPacket,
+  mysqlReadPackets,
+  mysqlTextResultSetRow,
+} from "./wire-frames";
+
+const MYSQL_TYPE_VAR_STRING = 0xfd;
+
+// One mock MySQL server for the whole file: completes the handshake, OKs the
+// client's HandshakeResponse41, then replies to the first COM_QUERY with
+// whatever `nextReply` holds and ignores later queries. Leaving the socket open
+// after replying is deliberate: a ShortRead-wedged client only fails if the
+// socket closes, so closing here would mask the wedge face.
+let nextReply!: Buffer;
+const sockets = new Set<import("node:net").Socket>();
+const mock = await listeningServer(socket => {
+  sockets.add(socket);
+  socket.on("close", () => sockets.delete(socket));
+  const reply = nextReply;
+  let buffered = Buffer.alloc(0);
+  let authed = false;
+  let answered = false;
+  socket.write(mysqlHandshakeV10());
+  socket.on("data", chunk => {
+    buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (_seq, payload) => {
+      if (!authed) {
+        authed = true;
+        socket.write(mysqlOkPacket(2));
+        return;
+      }
+      if (payload[0] !== 0x03 /* COM_QUERY */) return;
+      if (answered) return;
+      answered = true;
+      socket.write(reply);
+    });
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => {
+  for (const s of sockets) s.destroy();
+  return new Promise<void>(r => mock.server.close(() => r()));
+});
+
+type Outcome = { ok: unknown[] } | { err: string };
+
+async function run(reply: Buffer): Promise<Outcome> {
+  nextReply = reply;
+  const sql = new SQL({
+    adapter: "mysql",
+    hostname: "127.0.0.1",
+    port: mock.port,
+    username: "u",
+    password: "",
+    database: "d",
+    tls: false,
+    max: 1,
+  });
+  try {
+    return await sql
+      .unsafe("select x")
+      .simple()
+      .then(
+        rows => ({ ok: (rows as unknown as { x: unknown }[]).map(r => r.x) }),
+        e => ({ err: e?.code ?? String(e) }),
+      );
+  } finally {
+    await sql.close({ timeout: 0 }).catch(() => {});
+  }
+}
+
+// A single VAR_STRING column "x" so the row-decoding branch is reached.
+const oneColumnHeader = Buffer.concat([
+  mysqlRawPacket(1, mysqlLenencInt(1)),
+  mysqlColumnDefinition(2, { name: "x", type: MYSQL_TYPE_VAR_STRING }),
+]);
+
+// --- (b) wedge: lenenc claims bytes that never arrive -----------------------
+
+const wedgeCases: { name: string; reply: Buffer }[] = [
+  {
+    // Row body is [0xfc, 0x2c, 0x01, 'a', 'b', 'c'] — a lenenc-string claiming
+    // 300 bytes but supplying 3. With no per-packet bound the decoder returns
+    // ShortRead and the dispatch loop waits forever for bytes that never come.
+    name: "text-protocol row whose lenenc field overruns the packet",
+    reply: Buffer.concat([
+      oneColumnHeader,
+      mysqlRawPacket(3, Buffer.concat([Buffer.from([0xfc, 0x2c, 0x01]), Buffer.from("abc")])),
+    ]),
+  },
+  {
+    // ColumnDefinition41's first field is string<lenenc> catalog. Claim 300
+    // bytes in a packet that only has 3 so the overrun fires during column
+    // definition decoding (before any rows).
+    name: "column definition whose lenenc catalog overruns the packet",
+    reply: Buffer.concat([
+      mysqlRawPacket(1, mysqlLenencInt(1)),
+      mysqlRawPacket(2, Buffer.concat([Buffer.from([0xfc, 0x2c, 0x01]), Buffer.from("def")])),
+    ]),
+  },
+];
+
+test.each(wedgeCases)("mysql: $name fails the query instead of wedging", async ({ reply }) => {
+  // Pre-fix this test times out: the query never settles.
+  expect(await run(reply)).toEqual({ err: "ERR_MYSQL_MALFORMED_PACKET" });
+});
+
+// --- (a) leak: overrun reads into the NEXT packet's bytes -------------------
+
+test("mysql: a lenenc field overrunning into an already-buffered next packet is rejected, not served as data", async () => {
+  // Row packet body is [0x08] — a lenenc-string claiming 8 bytes but supplying 0.
+  // The next row packet and the 0xFE terminator are sent in the same write, so
+  // an unbounded decoder reads the following packet's header/body bytes as this
+  // row's column value and still finds a terminator, returning a phantom row
+  // whose bytes are protocol framing. With the per-packet bound the row packet
+  // is rejected before any next-packet bytes are touched.
+  const got = await run(
+    Buffer.concat([
+      oneColumnHeader,
+      mysqlRawPacket(3, Buffer.from([0x08])),
+      mysqlTextResultSetRow(4, ["real"]),
+      mysqlOkPacket(5, 0xfe),
+    ]),
+  );
+  expect(got).toEqual({ err: "ERR_MYSQL_MALFORMED_PACKET" });
+});
+
+test("mysql: a zero-length row packet is rejected, not decoded from the next packet's header", async () => {
+  // A length-0 row packet has no lenenc byte at all; an unbounded peek() reads
+  // the following packet's header byte as the lenenc prefix. Here that byte is
+  // 0x05 (the next packet's payload_length low byte), so the unbounded decoder
+  // reads 5 "data" bytes out of the NEXT packet's framing and body.
+  const got = await run(
+    Buffer.concat([
+      oneColumnHeader,
+      mysqlRawPacket(3, Buffer.alloc(0)),
+      mysqlTextResultSetRow(4, ["real"]),
+      mysqlOkPacket(5, 0xfe),
+    ]),
+  );
+  expect(got).toEqual({ err: "ERR_MYSQL_MALFORMED_PACKET" });
+});
+
+// --- buffered-reader path: a packet split across two reads ------------------
+
+test("mysql: a lenenc overrun on the buffered-reader path is rejected, not served as data", async () => {
+  // Splitting the reply mid-row forces the first chunk into the connection's
+  // read_buffer (ShortRead on packet 3), so the second chunk is decoded via the
+  // buffered `Reader` impl of the per-packet bound instead of the fast-path
+  // `StackReader`. Both impls must enforce the same limit.
+  const full = Buffer.concat([
+    oneColumnHeader,
+    mysqlRawPacket(3, Buffer.from([0x08])),
+    mysqlTextResultSetRow(4, ["real"]),
+    mysqlOkPacket(5, 0xfe),
+  ]);
+  // Split inside packet 3's body so its header is buffered but its body is not.
+  const split = oneColumnHeader.length + 4;
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let answered = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (_seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(2));
+          return;
+        }
+        if (payload[0] !== 0x03 /* COM_QUERY */ || answered) return;
+        answered = true;
+        socket.write(full.subarray(0, split));
+        setImmediate(() => socket.write(full.subarray(split)));
+      });
+    });
+    socket.on("error", () => {});
+  });
+  const sql = new SQL({
+    adapter: "mysql",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    password: "",
+    database: "d",
+    tls: false,
+    max: 1,
+  });
+  try {
+    const got = await sql
+      .unsafe("select x")
+      .simple()
+      .then(
+        rows => ({ ok: (rows as unknown as { x: unknown }[]).map(r => r.x) }),
+        e => ({ err: e?.code ?? String(e) }),
+      );
+    expect(got).toEqual({ err: "ERR_MYSQL_MALFORMED_PACKET" });
+  } finally {
+    await sql.close({ timeout: 0 }).catch(() => {});
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+// --- boundary: a value that exactly fills the packet still decodes ---------
+
+test("mysql: a row whose single field exactly fills the packet still decodes", async () => {
+  const got = await run(Buffer.concat([oneColumnHeader, mysqlTextResultSetRow(3, ["ab"]), mysqlOkPacket(4, 0xfe)]));
+  expect(got).toEqual({ ok: ["ab"] });
+});

--- a/test/js/sql/sql-mysql-packet-overrun.test.ts
+++ b/test/js/sql/sql-mysql-packet-overrun.test.ts
@@ -312,13 +312,11 @@ test("mysql: a prepare-OK claiming 60000 columns is rejected instead of allocati
   // num_columns is server-controlled and drives both the ColumnDefinition41
   // Vec allocation and how many follow-up packets the client waits for.
   // MySQL caps a result set at 4096 columns (MAX_FIELDS); a prepare-OK
-  // claiming more is a hostile 12-byte packet.
+  // claiming more is a hostile 12-byte packet. num_params is NOT capped:
+  // MySQL accepts up to 65535 placeholders (ER_PS_MANY_PARAM fires only at
+  // the u16 boundary), and large IN-lists / bulk inserts legitimately exceed
+  // 4096.
   const got = await runPrepared({ prepareReply: mysqlStmtPrepareOk(1, 1, 60000, 0) });
-  expect(got).toEqual({ err: "ERR_MYSQL_INVALID_PREPARE_OK_PACKET" });
-});
-
-test("mysql: a prepare-OK claiming 60000 params is rejected instead of allocating and waiting forever", async () => {
-  const got = await runPrepared({ prepareReply: mysqlStmtPrepareOk(1, 1, 0, 60000) });
   expect(got).toEqual({ err: "ERR_MYSQL_INVALID_PREPARE_OK_PACKET" });
 });
 

--- a/test/js/sql/sql-mysql-packet-overrun.test.ts
+++ b/test/js/sql/sql-mysql-packet-overrun.test.ts
@@ -24,10 +24,16 @@ import {
   mysqlOkPacket,
   mysqlRawPacket,
   mysqlReadPackets,
+  mysqlStmtPrepareOk,
   mysqlTextResultSetRow,
 } from "./wire-frames";
 
+const MYSQL_TYPE_LONG = 0x03;
+const MYSQL_TYPE_LONGLONG = 0x08;
 const MYSQL_TYPE_VAR_STRING = 0xfd;
+const COM_QUERY = 0x03;
+const COM_STMT_PREPARE = 0x16;
+const COM_STMT_EXECUTE = 0x17;
 
 // One mock MySQL server for the whole file: completes the handshake, OKs the
 // client's HandshakeResponse41, then replies to the first COM_QUERY with
@@ -51,7 +57,7 @@ const mock = await listeningServer(socket => {
         socket.write(mysqlOkPacket(2));
         return;
       }
-      if (payload[0] !== 0x03 /* COM_QUERY */) return;
+      if (payload[0] !== COM_QUERY) return;
       if (answered) return;
       answered = true;
       socket.write(reply);
@@ -190,7 +196,7 @@ test("mysql: a lenenc overrun on the buffered-reader path is rejected, not serve
           socket.write(mysqlOkPacket(2));
           return;
         }
-        if (payload[0] !== 0x03 /* COM_QUERY */ || answered) return;
+        if (payload[0] !== COM_QUERY || answered) return;
         answered = true;
         socket.write(full.subarray(0, split));
         // Yield twice so the first write reaches the client's on_data before
@@ -226,9 +232,119 @@ test("mysql: a lenenc overrun on the buffered-reader path is rejected, not serve
   }
 });
 
+// --- prepared-statement path (binary rows + prepare-OK metadata) ------------
+
+// Mock server for the prepared-statement path: authenticates, answers
+// COM_STMT_PREPARE with `prepareReply`, answers COM_STMT_EXECUTE with
+// `executeReply` (if given), and otherwise goes silent so a wedge shows as a
+// test timeout. Returns the caught error code / row objects.
+async function runPrepared(opts: { prepareReply: Buffer; executeReply?: Buffer }): Promise<Outcome> {
+  const { server, port } = await listeningServer(socket => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (_seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(2));
+          return;
+        }
+        if (payload[0] === COM_STMT_PREPARE) socket.write(opts.prepareReply);
+        else if (payload[0] === COM_STMT_EXECUTE && opts.executeReply) socket.write(opts.executeReply);
+      });
+    });
+    socket.on("error", () => {});
+  });
+  const sql = new SQL({
+    adapter: "mysql",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    password: "",
+    database: "d",
+    tls: false,
+    max: 1,
+  });
+  try {
+    return await sql`select a, b, c from t`.then(
+      rows => ({ ok: rows as unknown[] }),
+      e => ({ err: e?.code ?? String(e) }),
+    );
+  } finally {
+    await sql.close({ timeout: 0 }).catch(() => {});
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}
+
+// Three fixed-width binary-protocol columns so the row decoder has bytes to
+// consume past the header: LONG (4 bytes), LONGLONG (8 bytes), VAR_STRING
+// (lenenc). Shared by the prepare response and the execute result-set header.
+const threeColDefs = (startSeq: number) =>
+  Buffer.concat([
+    mysqlColumnDefinition(startSeq, { name: "a", type: MYSQL_TYPE_LONG }),
+    mysqlColumnDefinition(startSeq + 1, { name: "b", type: MYSQL_TYPE_LONGLONG }),
+    mysqlColumnDefinition(startSeq + 2, { name: "c", type: MYSQL_TYPE_VAR_STRING }),
+  ]);
+
+test("mysql: a binary-protocol row truncated to its 0x00 header is rejected, not decoded from the next packet", async () => {
+  // The binary row packet body is [0x00]: the row header byte and nothing else,
+  // so the null-bitmap and the three fixed-width cells lie past the packet
+  // boundary. An unbounded decoder reads them out of the OK terminator's
+  // framing bytes and returns garbage column values (b == the terminator's
+  // header bytes reinterpreted as an i64). The per-packet bound rejects the
+  // row at the null-bitmap read, before any next-packet bytes are touched.
+  const got = await runPrepared({
+    prepareReply: Buffer.concat([mysqlStmtPrepareOk(1, 1, 3, 0), threeColDefs(2)]),
+    executeReply: Buffer.concat([
+      mysqlRawPacket(1, mysqlLenencInt(3)),
+      threeColDefs(2),
+      mysqlRawPacket(5, Buffer.from([0x00])),
+      mysqlOkPacket(6, 0xfe),
+    ]),
+  });
+  expect(got).toEqual({ err: "ERR_MYSQL_MALFORMED_PACKET" });
+});
+
+test("mysql: a prepare-OK claiming 60000 columns is rejected instead of allocating and waiting forever", async () => {
+  // num_columns is server-controlled and drives both the ColumnDefinition41
+  // Vec allocation and how many follow-up packets the client waits for.
+  // MySQL caps a result set at 4096 columns (MAX_FIELDS); a prepare-OK
+  // claiming more is a hostile 12-byte packet.
+  const got = await runPrepared({ prepareReply: mysqlStmtPrepareOk(1, 1, 60000, 0) });
+  expect(got).toEqual({ err: "ERR_MYSQL_INVALID_PREPARE_OK_PACKET" });
+});
+
+test("mysql: a prepare-OK claiming 60000 params is rejected instead of allocating and waiting forever", async () => {
+  const got = await runPrepared({ prepareReply: mysqlStmtPrepareOk(1, 1, 0, 60000) });
+  expect(got).toEqual({ err: "ERR_MYSQL_INVALID_PREPARE_OK_PACKET" });
+});
+
 // --- boundary: a value that exactly fills the packet still decodes ---------
 
 test("mysql: a row whose single field exactly fills the packet still decodes", async () => {
   const got = await run(Buffer.concat([oneColumnHeader, mysqlTextResultSetRow(3, ["ab"]), mysqlOkPacket(4, 0xfe)]));
   expect(got).toEqual({ ok: ["ab"] });
+});
+
+test("mysql: a well-formed binary-protocol row that exactly fills the packet still decodes", async () => {
+  // Binary row body: Int<1>(0x00) header, null-bitmap (1 byte, bit 2 set so
+  // column c is NULL), Int<4> for LONG a=7, Int<8> for LONGLONG b=9.
+  const body = Buffer.alloc(14);
+  body[0] = 0x00;
+  body[1] = 1 << (2 + 2); // null-bitmap: column index 2 is NULL (offset +2 reserved bits)
+  body.writeInt32LE(7, 2);
+  body.writeBigInt64LE(9n, 6);
+  const got = await runPrepared({
+    prepareReply: Buffer.concat([mysqlStmtPrepareOk(1, 1, 3, 0), threeColDefs(2)]),
+    executeReply: Buffer.concat([
+      mysqlRawPacket(1, mysqlLenencInt(3)),
+      threeColDefs(2),
+      mysqlRawPacket(5, body),
+      mysqlOkPacket(6, 0xfe),
+    ]),
+  });
+  expect(got).toEqual({ ok: [{ a: 7, b: 9, c: null }] });
 });


### PR DESCRIPTION
## Repro

A mock server that answers a `COM_QUERY` with a single-column result set whose row packet's lenenc field claims more bytes than the packet holds:

```js
// Row packet body is [0x08] (claims 8 bytes, supplies 0), followed by a
// well-formed row and terminator in the same write:
await sql.unsafe("select x").simple();
// before: [{x: '\x05\x00\x00\x04\x04rea'}, {x: 'real'}]  <- phantom row of framing bytes
// after:  MySQLError: MalformedPacket (ERR_MYSQL_MALFORMED_PACKET)
```

The binary-protocol face: a `COM_STMT_EXECUTE` row packet holding only the `0x00` header byte, with three declared columns (LONG, LONGLONG, VAR_STRING):

```js
// before: [{a: null, b: "562954215227392", c: ""}]  <- b is the OK terminator's header bytes as an i64
// after:  MySQLError: MalformedPacket
```

And when the overrunning row is the last thing the server sends, the query and everything queued behind it never settle. All of these reproduce deterministically on release and debug builds with no sanitizer involvement.

## Cause

`NewReader` read row fields, column-definition strings, and OK-packet metadata straight off the receive stream with no per-packet window. `process_packets` decodes each packet's Int<3> payload length and `ensure_capacity`s the full packet before dispatching, but the reader's `peek`/`read`/`read_z` checked only the receive-buffer end, never the packet boundary. A server-controlled lenenc length that exceeded the enclosing packet's `payload_length` therefore had two faces from the same byte: when the next packet was already buffered, the read returned its header/body bytes as column data and the query resolved with a phantom row; when nothing else was buffered, `read()` returned `ShortRead`, which the dispatch loop treats as "wait for more socket data", so the query and everything behind it pended forever. The same applies to the binary-protocol row decoder's null-bitmap and fixed-width cell reads.

Separately, `StmtPrepareOKPacket`'s `num_columns`/`num_params` (server-controlled u16) were used uncapped to size the `ColumnDefinition41` vectors and to decide how many follow-up packets to wait for, so a hostile 12-byte prepare-OK claiming 60000 columns allocated ~15 MB and then wedged waiting for packets that never arrive.

This is the MySQL analogue of the Postgres DataRow/RowDescription overrun handling, on a separate code path and with the corruption face.

## Fix

Give `ReaderContext` a per-packet limit: `process_packets` sets it right after decoding the header (where the full packet is known to be buffered) and `mark_message_start` clears it at the top of each iteration. `NewReader::peek` now returns only bytes inside the current packet, and `NewReader::read`/`read_z` reject a read that would cross the limit with the new `MalformedPacket` error (`ERR_MYSQL_MALFORMED_PACKET`) instead of returning another packet's framing bytes or `ShortRead`. Both reader implementations carry the limit: the fast-path `StackReader` via a new `packet_end` cursor on the shared struct, and the buffered `Reader` via a `packet_end` field on `MySQLConnection`. Every body decoder (text rows, binary rows, column definitions, OK/EOF/error packets, handshake) goes through `NewReader`, so the bound covers them all.

`StmtPrepareOKPacket::decode_internal` now rejects `num_columns` above 4096 (MySQL's `MAX_FIELDS`), matching the existing result-set `field_count` cap.

The TLS plaintext-injection check in `process_packets` deliberately looks past the handshake packet, so it clears the limit before peeking.

One existing assertion changed: a zero-length `AuthSwitchRequest` payload now rejects at the per-packet bound (`ERR_MYSQL_MALFORMED_PACKET`) before the AuthSwitch-specific `packet_size` check is reached. The test's intent (the packet is rejected) is unchanged.

## Verification

`test/js/sql/sql-mysql-packet-overrun.test.ts` drives a mock MySQL server so it runs without Docker. Nine cases:

- two wedge cases (text-protocol row and `ColumnDefinition41` catalog overrunning the packet) that time out on an unfixed build;
- two text-protocol leak cases (a row claiming 8 bytes with 0 supplied, and a zero-length row packet) that return phantom rows built from the next packet's header bytes on an unfixed build;
- a buffered-reader case that splits the reply across two writes so the second chunk decodes via the buffered `Reader` impl;
- a binary-protocol leak case where a row truncated to its `0x00` header returns the next packet's framing bytes as column values on an unfixed build;
- a prepare-OK case claiming 60000 columns that wedges on an unfixed build and now rejects with `ERR_MYSQL_INVALID_PREPARE_OK_PACKET`;
- two boundary cases (text and binary) where the single field exactly fills the packet, which still decode.

Seven of the nine fail on an unfixed build; the two boundary cases are the guard that well-formed packets are unaffected. The existing MySQL and Postgres wire-frame tests (TLS plaintext injection, auth short nonce, prepare-OK zero statement id, datarow overrun, invalid message length) continue to pass.
