### PR TITLE
sql: reject sql.begin() when COMMIT is answered with the ROLLBACK tag

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1097,10 +1097,11 @@ try {
 
 ### Transaction Errors
 
-| Transaction Errors                       | Description                           |
-| ---------------------------------------- | ------------------------------------- |
-| `ERR_POSTGRES_UNSAFE_TRANSACTION`        | Unsafe transaction operation detected |
-| `ERR_POSTGRES_INVALID_TRANSACTION_STATE` | Invalid transaction state             |
+| Transaction Errors                       | Description                                                                                               |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `ERR_POSTGRES_UNSAFE_TRANSACTION`        | Unsafe transaction operation detected                                                                     |
+| `ERR_POSTGRES_INVALID_TRANSACTION_STATE` | Invalid transaction state                                                                                 |
+| `ERR_POSTGRES_COMMIT_ROLLED_BACK`        | `COMMIT` was answered with `ROLLBACK` because the transaction was already aborted; nothing was committed |
 
 </Accordion>
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1097,10 +1097,10 @@ try {
 
 ### Transaction Errors
 
-| Transaction Errors                       | Description                                                                                               |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `ERR_POSTGRES_UNSAFE_TRANSACTION`        | Unsafe transaction operation detected                                                                     |
-| `ERR_POSTGRES_INVALID_TRANSACTION_STATE` | Invalid transaction state                                                                                 |
+| Transaction Errors                       | Description                                                                                              |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `ERR_POSTGRES_UNSAFE_TRANSACTION`        | Unsafe transaction operation detected                                                                    |
+| `ERR_POSTGRES_INVALID_TRANSACTION_STATE` | Invalid transaction state                                                                                |
 | `ERR_POSTGRES_COMMIT_ROLLED_BACK`        | `COMMIT` was answered with `ROLLBACK` because the transaction was already aborted; nothing was committed |
 
 </Accordion>

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -766,7 +766,17 @@ const SQL: typeof Bun.SQL = function SQL(
       if (BEFORE_COMMIT_OR_ROLLBACK_COMMAND) {
         await run_internal_transaction_sql(BEFORE_COMMIT_OR_ROLLBACK_COMMAND);
       }
-      await run_internal_transaction_sql(COMMIT_COMMAND);
+      const commit_result = await run_internal_transaction_sql(COMMIT_COMMAND);
+      // PostgreSQL answers COMMIT on an aborted transaction with a
+      // CommandComplete tag of "ROLLBACK" (the session is already in the
+      // failed-transaction state, so nothing was committed). Surfacing that
+      // as a resolved begin() would report a rolled-back transaction as
+      // success.
+      if (commit_result?.command === "ROLLBACK") {
+        throw new PostgresError("COMMIT was rolled back by the server because the transaction was already aborted", {
+          code: "ERR_POSTGRES_COMMIT_ROLLED_BACK",
+        });
+      }
       return resolve(transaction_result);
     } catch (err) {
       try {

--- a/test/js/sql/sql-begin-commit-rolled-back.test.ts
+++ b/test/js/sql/sql-begin-commit-rolled-back.test.ts
@@ -1,0 +1,50 @@
+// When a statement inside a PostgreSQL transaction fails, the session enters
+// the failed-transaction state (25P02) and COMMIT is answered with the
+// CommandComplete tag "ROLLBACK", not "COMMIT": nothing was committed.
+// sql.begin() must not resolve that as a successful transaction; the caller
+// would otherwise believe their writes landed when the server rolled them
+// back.
+//
+// This test reaches the failed-transaction state by swallowing an error inside
+// the begin() callback, so the callback returns normally and begin() sends
+// COMMIT.
+import { SQL, randomUUIDv7 } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const url = () => `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+
+  test("sql.begin() rejects when COMMIT is answered with the ROLLBACK tag", async () => {
+    await container.ready;
+    await using sql = new SQL({ url: url(), max: 1 });
+
+    const table = `t_commit_rb_${randomUUIDv7("hex").slice(-12)}`;
+    await sql.unsafe(`CREATE TABLE ${table} (a int)`);
+    try {
+      const result = await sql
+        .begin(async tx => {
+          await tx.unsafe(`INSERT INTO ${table} VALUES (1)`);
+          // Put the session into the failed-transaction state, but swallow
+          // the error so the callback returns normally and begin() proceeds
+          // to COMMIT.
+          await tx.unsafe(`SELECT * FROM does_not_exist_${randomUUIDv7("hex").slice(-12)}`).catch(() => {});
+          return "ok";
+        })
+        .then(
+          v => ({ resolved: v }),
+          e => ({ rejected: e }),
+        );
+
+      expect(result).toEqual({
+        rejected: expect.objectContaining({ code: "ERR_POSTGRES_COMMIT_ROLLED_BACK" }),
+      });
+
+      // Nothing was committed.
+      const rows = await sql.unsafe(`SELECT a FROM ${table}`);
+      expect(rows).toEqual([]);
+    } finally {
+      await sql.unsafe(`DROP TABLE IF EXISTS ${table}`);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

When a statement inside a PostgreSQL transaction fails, the session enters the failed-transaction state (`25P02`) and a subsequent `COMMIT` is answered with `CommandComplete('ROLLBACK')`, not `'COMMIT'`: nothing was committed. `sql.begin()` ignored the returned command tag and resolved with the callback's return value, so a caller that swallowed an error inside the callback saw `begin()` resolve for a transaction the server rolled back:

```js
await sql.begin(async tx => {
  await tx`INSERT INTO t VALUES (1)`;
  await tx`SELECT * FROM nope`.catch(() => {});   // swallows 42P01, tx now aborted
  return 'ok';
});
// resolved 'ok', but t is empty
```

## Fix

Check the `COMMIT` result's `.command` tag and reject `begin()` with `ERR_POSTGRES_COMMIT_ROLLED_BACK` when it reads `'ROLLBACK'`. MySQL and SQLite never answer COMMIT with a ROLLBACK tag, so the check is a no-op there.

## Verification

`test/js/sql/sql-begin-commit-rolled-back.test.ts` runs the scenario above against a real Postgres: on main `begin()` resolves `'ok'` with an empty table; with this change it rejects with `ERR_POSTGRES_COMMIT_ROLLED_BACK` and the table is still empty.