### PR TITLE
sql(postgres): decode 'infinity'::date/timestamp to the Number ±Infinity

### DIFF
--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -171,6 +171,13 @@ static JSC::JSValue toJS(JSC::VM& vm, JSC::JSGlobalObject* globalObject, DataCel
         break;
     case DataCellTag::DateWithTimeZone:
     case DataCellTag::Date: {
+        // Postgres 'infinity'::date / '-infinity'::timestamp arrive here as
+        // ±Infinity. DateInstance::create applies timeClip, which maps every
+        // non-finite input to NaN and loses the sign. Return the Number
+        // ±Infinity instead, matching node-postgres (pg-types / postgres-date).
+        if (std::isinf(cell.value.date)) {
+            return jsDoubleNumber(cell.value.date);
+        }
         return JSC::DateInstance::create(vm, globalObject->dateStructure(), cell.value.date);
         break;
     }

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -313,11 +313,15 @@ fn parse_array(
                         continue;
                     }
                     if array_type == types::Tag::date_array {
-                        let mut str = BunString::init(element);
-                        array.push(SQLDataCell::date(
-                            crate::jsc::bun_string_jsc::parse_date(&mut str, global_object)
-                                .map_err(crate::jsc::js_error_to_postgres)?,
-                        ));
+                        let ms = match crate::postgres::types::date::parse_infinity(element) {
+                            Some(inf) => inf,
+                            None => {
+                                let mut str = BunString::init(element);
+                                crate::jsc::bun_string_jsc::parse_date(&mut str, global_object)
+                                    .map_err(crate::jsc::js_error_to_postgres)?
+                            }
+                        };
+                        array.push(SQLDataCell::date(ms));
                     } else {
                         // the only escape sequency possible here is \b
                         if element == b"\\b" {
@@ -827,6 +831,9 @@ pub(crate) fn from_bytes(
             } else {
                 if bun_core::strings::eql_case_insensitive_ascii(bytes, b"NULL", true) {
                     return Ok(SQLDataCell::null());
+                }
+                if let Some(inf) = crate::postgres::types::date::parse_infinity(bytes) {
+                    return Ok(SQLDataCell::date(inf));
                 }
                 // `timestamp` (without time zone) text carries no offset, so
                 // decode its components as UTC to match the binary path. `date`

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -9,8 +9,32 @@ const US_PER_MS: i64 = 1000;
 pub fn from_binary(bytes: &[u8]) -> f64 {
     let microseconds =
         i64::from_be_bytes(bytes[0..8].try_into().expect("infallible: size matches"));
+    // Postgres src/include/datatype/timestamp.h: DT_NOEND / DT_NOBEGIN are the
+    // i64 endpoints. Return ±Infinity so the JS side can surface the value as a
+    // Number (see SQLClient.cpp toJS Date case); without this the arithmetic
+    // below yields ~9.224e15 ms, past JS Date's ±8.64e15 range, and timeClip
+    // collapses both signs to NaN.
+    if microseconds == i64::MAX {
+        return f64::INFINITY;
+    }
+    if microseconds == i64::MIN {
+        return f64::NEG_INFINITY;
+    }
     let double_microseconds: f64 = microseconds as f64;
     (double_microseconds / US_PER_MS as f64) + POSTGRES_EPOCH_DATE as f64
+}
+
+/// `'infinity'` / `'-infinity'` as Postgres emits them for date / timestamp /
+/// timestamptz in text format. Returns `Some(±f64::INFINITY)` for those two
+/// spellings (case-insensitive), `None` otherwise.
+pub fn parse_infinity(bytes: &[u8]) -> Option<f64> {
+    if bun_core::strings::eql_case_insensitive_ascii(bytes, b"infinity", true) {
+        return Some(f64::INFINITY);
+    }
+    if bun_core::strings::eql_case_insensitive_ascii(bytes, b"-infinity", true) {
+        return Some(f64::NEG_INFINITY);
+    }
+    None
 }
 
 /// Decode a Postgres `timestamp` (WITHOUT TIME ZONE) text value as UTC, so the

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -75,6 +75,15 @@ pub fn from_js(global_object: &JSGlobalObject, value: JSValue) -> JsResult<i64> 
         return Ok(0);
     };
 
+    // Round-trip the ±Infinity the decoder produces back to DT_NOEND /
+    // DT_NOBEGIN; otherwise `f64::INFINITY as i64` saturates to i64::MAX and
+    // the subtract/multiply below overflows.
+    if double_value == f64::INFINITY {
+        return Ok(i64::MAX);
+    }
+    if double_value == f64::NEG_INFINITY {
+        return Ok(i64::MIN);
+    }
     let unix_timestamp: i64 = double_value as i64;
     Ok((unix_timestamp - POSTGRES_EPOCH_DATE) * US_PER_MS)
 }

--- a/test/js/sql/postgres-infinity-date.test.ts
+++ b/test/js/sql/postgres-infinity-date.test.ts
@@ -1,0 +1,194 @@
+// Postgres `'infinity'::date` / `'-infinity'::timestamp` must decode to the JS
+// Number ±Infinity, not `Invalid Date`. An Invalid Date's getTime() is NaN, so
+// the sign (and the fact that the value is infinity at all, as opposed to a
+// parse failure) is lost. node-postgres (via postgres-date) returns ±Infinity
+// for these values; this test pins the same behaviour on every decode path:
+//   - scalar text (simple query)
+//   - scalar binary (extended protocol, timestamp/timestamptz only)
+//   - array text ({infinity,-infinity}::date[] etc.)
+//
+// Driven by a scripted v3 backend so the exact wire bytes each path sees are
+// deterministic. A finite value is included in every case to show that Date
+// decoding for ordinary values is unaffected.
+
+import { SQL } from "bun";
+import { afterAll, expect, test } from "bun:test";
+import {
+  listeningServer,
+  pgAuthenticationOk,
+  pgBindComplete,
+  pgCommandComplete,
+  pgDataRow,
+  pgParameterDescription,
+  pgParseComplete,
+  pgReadFrontendMessages,
+  pgReadyForQuery,
+  pgRowDescription,
+  type PgRowDescriptionColumn,
+} from "./wire-frames";
+
+const OID = {
+  date: 1082,
+  timestamp: 1114,
+  timestamptz: 1184,
+  date_array: 1182,
+  timestamp_array: 1115,
+  timestamptz_array: 1185,
+} as const;
+
+// Postgres src/include/datatype/timestamp.h: DT_NOBEGIN / DT_NOEND are
+// PG_INT64_MIN / PG_INT64_MAX on the wire for timestamp / timestamptz.
+const PG_INT64_MAX = 0x7fffffffffffffffn;
+const PG_INT64_MIN = -0x8000000000000000n;
+
+function be64(n: bigint): Buffer {
+  const b = Buffer.alloc(8);
+  b.writeBigInt64BE(n, 0);
+  return b;
+}
+
+// --- scripted backends -----------------------------------------------------
+
+// Simple-query backend: serves one RowDescription + one DataRow, latched per
+// test via `simpleReply`.
+let simpleReply!: { cols: PgRowDescriptionColumn[]; row: (Buffer | null)[] };
+const simple = await listeningServer(socket => {
+  let startup = true;
+  socket.on("data", data => {
+    if (startup) {
+      startup = false;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+      return;
+    }
+    if (data[0] !== 0x51 /* 'Q' */) return;
+    socket.write(
+      Buffer.concat([
+        pgRowDescription(simpleReply.cols),
+        pgDataRow(simpleReply.row),
+        pgCommandComplete("SELECT 1"),
+        pgReadyForQuery(),
+      ]),
+    );
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => simple.server.close(() => r())));
+
+async function runSimple(cols: PgRowDescriptionColumn[], row: (Buffer | null)[]): Promise<any> {
+  simpleReply = { cols, row };
+  const sql = new SQL({ url: `postgres://u@127.0.0.1:${simple.port}/db`, max: 1, connectionTimeout: 2 });
+  try {
+    const [r]: any = await sql`select 1`.simple();
+    return r;
+  } finally {
+    await sql.close({ timeout: 0 }).catch(() => {});
+  }
+}
+
+// Extended-protocol backend: answers Parse with the latched RowDescription,
+// answers Bind with the latched DataRow. The client requests binary result
+// format for timestamp/timestamptz, so the DataRow here carries DT_NOEND /
+// DT_NOBEGIN as raw i64.
+let extReply!: { cols: PgRowDescriptionColumn[]; row: (Buffer | null)[] };
+const extended = await listeningServer(socket => {
+  const reply = () => extReply;
+  let pending = Buffer.alloc(0);
+  let sawStartup = false;
+  socket.on("data", chunk => {
+    pending = Buffer.concat([pending, chunk]);
+    if (!sawStartup) {
+      if (pending.length < 4) return;
+      const len = pending.readInt32BE(0);
+      if (pending.length < len) return;
+      pending = pending.subarray(len);
+      sawStartup = true;
+      socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+    }
+    pending = pgReadFrontendMessages(pending, type => {
+      if (type === 0x50 /* Parse */) {
+        socket.write(
+          Buffer.concat([pgParseComplete(), pgParameterDescription([]), pgRowDescription(reply().cols), pgReadyForQuery()]),
+        );
+      } else if (type === 0x42 /* Bind */) {
+        socket.write(
+          Buffer.concat([pgBindComplete(), pgDataRow(reply().row), pgCommandComplete("SELECT 1"), pgReadyForQuery()]),
+        );
+      }
+    });
+  });
+  socket.on("error", () => {});
+});
+afterAll(() => new Promise<void>(r => extended.server.close(() => r())));
+
+async function runExtended(cols: PgRowDescriptionColumn[], row: (Buffer | null)[]): Promise<any> {
+  extReply = { cols, row };
+  const sql = new SQL({
+    adapter: "postgres",
+    hostname: "127.0.0.1",
+    port: extended.port,
+    username: "u",
+    database: "db",
+    tls: false,
+    max: 1,
+    prepare: true,
+    connectionTimeout: 2,
+  });
+  try {
+    const [r]: any = await sql`select 1`;
+    return r;
+  } finally {
+    await sql.close({ timeout: 0 }).catch(() => {});
+  }
+}
+
+// --- scalar text path ------------------------------------------------------
+
+test.each(["date", "timestamp", "timestamptz"] as const)("scalar %s text 'infinity'/'-infinity' → ±Infinity", async t => {
+  const row = await runSimple(
+    [
+      { name: "pos", typeOid: OID[t] },
+      { name: "neg", typeOid: OID[t] },
+      { name: "fin", typeOid: OID[t] },
+    ],
+    [Buffer.from("infinity"), Buffer.from("-infinity"), Buffer.from(t === "date" ? "2000-01-02" : "2000-01-02 00:00:00+00")],
+  );
+  expect(row.pos).toBe(Infinity);
+  expect(row.neg).toBe(-Infinity);
+  expect(row.fin).toBeInstanceOf(Date);
+  expect((row.fin as Date).getTime()).toBe(Date.UTC(2000, 0, 2));
+});
+
+// --- scalar binary path (timestamp / timestamptz) --------------------------
+
+test.each(["timestamp", "timestamptz"] as const)("scalar %s binary DT_NOEND/DT_NOBEGIN → ±Infinity", async t => {
+  const row = await runExtended(
+    [
+      { name: "pos", typeOid: OID[t], format: 1 },
+      { name: "neg", typeOid: OID[t], format: 1 },
+      { name: "fin", typeOid: OID[t], format: 1 },
+    ],
+    // 86_400_000_000 µs past 2000-01-01 == 2000-01-02 UTC
+    [be64(PG_INT64_MAX), be64(PG_INT64_MIN), be64(86_400_000_000n)],
+  );
+  expect(row.pos).toBe(Infinity);
+  expect(row.neg).toBe(-Infinity);
+  expect(row.fin).toBeInstanceOf(Date);
+  expect((row.fin as Date).getTime()).toBe(Date.UTC(2000, 0, 2));
+});
+
+// --- array text path -------------------------------------------------------
+
+test.each(["date_array", "timestamp_array", "timestamptz_array"] as const)(
+  "%s text {infinity,-infinity,<finite>} → [Infinity, -Infinity, Date]",
+  async t => {
+    const fin = t === "date_array" ? "2000-01-02" : '"2000-01-02 00:00:00+00"';
+    const row = await runSimple(
+      [{ name: "a", typeOid: OID[t] }],
+      [Buffer.from(`{infinity,-infinity,${fin}}`)],
+    );
+    expect(row.a[0]).toBe(Infinity);
+    expect(row.a[1]).toBe(-Infinity);
+    expect(row.a[2]).toBeInstanceOf(Date);
+    expect((row.a[2] as Date).getTime()).toBe(Date.UTC(2000, 0, 2));
+  },
+);

--- a/test/js/sql/postgres-infinity-date.test.ts
+++ b/test/js/sql/postgres-infinity-date.test.ts
@@ -107,7 +107,12 @@ const extended = await listeningServer(socket => {
     pending = pgReadFrontendMessages(pending, type => {
       if (type === 0x50 /* Parse */) {
         socket.write(
-          Buffer.concat([pgParseComplete(), pgParameterDescription([]), pgRowDescription(reply().cols), pgReadyForQuery()]),
+          Buffer.concat([
+            pgParseComplete(),
+            pgParameterDescription([]),
+            pgRowDescription(reply().cols),
+            pgReadyForQuery(),
+          ]),
         );
       } else if (type === 0x42 /* Bind */) {
         socket.write(
@@ -143,20 +148,27 @@ async function runExtended(cols: PgRowDescriptionColumn[], row: (Buffer | null)[
 
 // --- scalar text path ------------------------------------------------------
 
-test.each(["date", "timestamp", "timestamptz"] as const)("scalar %s text 'infinity'/'-infinity' → ±Infinity", async t => {
-  const row = await runSimple(
-    [
-      { name: "pos", typeOid: OID[t] },
-      { name: "neg", typeOid: OID[t] },
-      { name: "fin", typeOid: OID[t] },
-    ],
-    [Buffer.from("infinity"), Buffer.from("-infinity"), Buffer.from(t === "date" ? "2000-01-02" : "2000-01-02 00:00:00+00")],
-  );
-  expect(row.pos).toBe(Infinity);
-  expect(row.neg).toBe(-Infinity);
-  expect(row.fin).toBeInstanceOf(Date);
-  expect((row.fin as Date).getTime()).toBe(Date.UTC(2000, 0, 2));
-});
+test.each(["date", "timestamp", "timestamptz"] as const)(
+  "scalar %s text 'infinity'/'-infinity' → ±Infinity",
+  async t => {
+    const row = await runSimple(
+      [
+        { name: "pos", typeOid: OID[t] },
+        { name: "neg", typeOid: OID[t] },
+        { name: "fin", typeOid: OID[t] },
+      ],
+      [
+        Buffer.from("infinity"),
+        Buffer.from("-infinity"),
+        Buffer.from(t === "date" ? "2000-01-02" : "2000-01-02 00:00:00+00"),
+      ],
+    );
+    expect(row.pos).toBe(Infinity);
+    expect(row.neg).toBe(-Infinity);
+    expect(row.fin).toBeInstanceOf(Date);
+    expect((row.fin as Date).getTime()).toBe(Date.UTC(2000, 0, 2));
+  },
+);
 
 // --- scalar binary path (timestamp / timestamptz) --------------------------
 
@@ -182,10 +194,7 @@ test.each(["date_array", "timestamp_array", "timestamptz_array"] as const)(
   "%s text {infinity,-infinity,<finite>} → [Infinity, -Infinity, Date]",
   async t => {
     const fin = t === "date_array" ? "2000-01-02" : '"2000-01-02 00:00:00+00"';
-    const row = await runSimple(
-      [{ name: "a", typeOid: OID[t] }],
-      [Buffer.from(`{infinity,-infinity,${fin}}`)],
-    );
+    const row = await runSimple([{ name: "a", typeOid: OID[t] }], [Buffer.from(`{infinity,-infinity,${fin}}`)]);
     expect(row.a[0]).toBe(Infinity);
     expect(row.a[1]).toBe(-Infinity);
     expect(row.a[2]).toBeInstanceOf(Date);

--- a/test/js/sql/postgres-infinity-date.test.ts
+++ b/test/js/sql/postgres-infinity-date.test.ts
@@ -47,6 +47,25 @@ function be64(n: bigint): Buffer {
   return b;
 }
 
+function readBindParameters(body: Buffer): Buffer[] {
+  // PostgreSQL FE/BE §55.7 Bind: String(portal) String(stmt) Int16(nFmt)
+  // Int16[nFmt] Int16(nParams) (Int32 len, Byte[len])[nParams] ...
+  let o = body.indexOf(0) + 1;
+  o = body.indexOf(0, o) + 1;
+  const nFmt = body.readInt16BE(o);
+  o += 2 + 2 * nFmt;
+  const nParams = body.readInt16BE(o);
+  o += 2;
+  const out: Buffer[] = [];
+  for (let i = 0; i < nParams; i++) {
+    const len = body.readInt32BE(o);
+    o += 4;
+    out.push(len < 0 ? Buffer.alloc(0) : body.subarray(o, o + len));
+    if (len > 0) o += len;
+  }
+  return out;
+}
+
 // --- scripted backends -----------------------------------------------------
 
 // Simple-query backend: serves one RowDescription + one DataRow, latched per
@@ -201,3 +220,69 @@ test.each(["date_array", "timestamp_array", "timestamptz_array"] as const)(
     expect((row.a[2] as Date).getTime()).toBe(Date.UTC(2000, 0, 2));
   },
 );
+
+// --- encode (bind) path ----------------------------------------------------
+// Binding the ±Infinity the decoder produces back to a timestamp / timestamptz
+// parameter must write DT_NOEND / DT_NOBEGIN on the wire. Before the matching
+// from_js fix, `f64::INFINITY as i64` saturated to i64::MAX and the
+// (ms - epoch) * 1000 arithmetic overflowed: debug panicked, release wrapped
+// to a garbage i64.
+
+test.each(["timestamp", "timestamptz"] as const)("binding ±Infinity to %s writes DT_NOEND / DT_NOBEGIN", async t => {
+  let sent: Buffer[] | undefined;
+  const { port, server } = await listeningServer(socket => {
+    let pending = Buffer.alloc(0);
+    let sawStartup = false;
+    socket.on("data", chunk => {
+      pending = Buffer.concat([pending, chunk]);
+      if (!sawStartup) {
+        if (pending.length < 4) return;
+        const len = pending.readInt32BE(0);
+        if (pending.length < len) return;
+        pending = pending.subarray(len);
+        sawStartup = true;
+        socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+      }
+      pending = pgReadFrontendMessages(pending, (type, body) => {
+        if (type === 0x50 /* Parse */) {
+          socket.write(
+            Buffer.concat([
+              pgParseComplete(),
+              pgParameterDescription([OID[t], OID[t], OID[t]]),
+              pgRowDescription([{ name: "x", typeOid: 25 }]),
+              pgReadyForQuery(),
+            ]),
+          );
+        } else if (type === 0x42 /* Bind */) {
+          sent = readBindParameters(body);
+          socket.write(
+            Buffer.concat([pgBindComplete(), pgDataRow([Buffer.from("ok")]), pgCommandComplete("SELECT 1"), pgReadyForQuery()]),
+          );
+        }
+      });
+    });
+    socket.on("error", () => {});
+  });
+  try {
+    const sql = new SQL({
+      adapter: "postgres",
+      hostname: "127.0.0.1",
+      port,
+      username: "u",
+      database: "db",
+      tls: false,
+      max: 1,
+      prepare: true,
+      connectionTimeout: 2,
+    });
+    try {
+      await sql`select ${Infinity}, ${-Infinity}, ${new Date(Date.UTC(2000, 0, 2))}`;
+    } finally {
+      await sql.close({ timeout: 0 }).catch(() => {});
+    }
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+  expect(sent).toBeDefined();
+  expect(sent!.map(b => b.readBigInt64BE(0))).toEqual([PG_INT64_MAX, PG_INT64_MIN, 86_400_000_000n]);
+});

--- a/test/js/sql/postgres-infinity-date.test.ts
+++ b/test/js/sql/postgres-infinity-date.test.ts
@@ -256,7 +256,12 @@ test.each(["timestamp", "timestamptz"] as const)("binding ±Infinity to %s write
         } else if (type === 0x42 /* Bind */) {
           sent = readBindParameters(body);
           socket.write(
-            Buffer.concat([pgBindComplete(), pgDataRow([Buffer.from("ok")]), pgCommandComplete("SELECT 1"), pgReadyForQuery()]),
+            Buffer.concat([
+              pgBindComplete(),
+              pgDataRow([Buffer.from("ok")]),
+              pgCommandComplete("SELECT 1"),
+              pgReadyForQuery(),
+            ]),
           );
         }
       });

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -9293,8 +9293,8 @@ CREATE TABLE ${table_name} (
       `;
 
         const values = result[0].special_dates;
-        expect(values[0].toString()).toBe("Invalid Date");
-        expect(values[1].toString()).toBe("Invalid Date");
+        expect(values[0]).toBe(Infinity);
+        expect(values[1]).toBe(-Infinity);
         // Skip testing today/yesterday/tomorrow as they depend on current date
       });
 
@@ -9714,8 +9714,8 @@ CREATE TABLE ${table_name} (
         ]::timestamp[] as special_timestamps
       `;
 
-        expect(result[0].special_timestamps[0].toString()).toBe("Invalid Date");
-        expect(result[0].special_timestamps[1].toString()).toBe("Invalid Date");
+        expect(result[0].special_timestamps[0]).toBe(Infinity);
+        expect(result[0].special_timestamps[1]).toBe(-Infinity);
         expect(result[0].special_timestamps[2].toISOString()).toBe("1970-01-01T00:00:00.000Z");
       });
 
@@ -9917,8 +9917,8 @@ CREATE TABLE ${table_name} (
         ]::timestamptz[] as special_timestamps
       `;
 
-        expect(result[0].special_timestamps[0].toString()).toBe("Invalid Date");
-        expect(result[0].special_timestamps[1].toString()).toBe("Invalid Date");
+        expect(result[0].special_timestamps[0]).toBe(Infinity);
+        expect(result[0].special_timestamps[1]).toBe(-Infinity);
         expect(result[0].special_timestamps[2].toISOString()).toBe("1970-01-01T00:00:00.000Z");
       });
 

--- a/test/regression/issue/21311.test.ts
+++ b/test/regression/issue/21311.test.ts
@@ -96,8 +96,7 @@ describeWithContainer(
       allQueryResults.forEach((row, i) => {
         expect(row.should_be_null).toBeNumber();
         if (row.should_be_null) {
-          expect(row.date).toBeDefined();
-          expect(row.date?.getTime()).toBeNaN();
+          expect(row.date).toBe(Infinity);
         } else {
           expect(row.date).toBeNull();
         }


### PR DESCRIPTION
## Problem

Postgres represents unbounded dates and timestamps as the special values `'infinity'` / `'-infinity'`. On every decode path Bun returned them as `Invalid Date` (a `Date` whose `getTime()` is `NaN`):

```js
await sql`select 'infinity'::date as a, '-infinity'::date as b`
// [{ a: Invalid Date, b: Invalid Date }]   sign lost, indistinguishable from a parse failure
```

That is data loss: `+infinity`, `-infinity`, and a genuinely unparseable value all collapse to the same `NaN`, so user code cannot tell whether a row means "no upper bound" or "no lower bound".

## Cause

Three independent paths, all ending at the same NaN:

- **scalar text** (`date` always, `timestamp`/`timestamptz` on `.simple()`): routed through JS `Date.parse('infinity')` → `NaN`.
- **scalar binary** (`timestamp`/`timestamptz` on the extended protocol): Postgres sends `PG_INT64_MAX` / `PG_INT64_MIN` (`DT_NOEND` / `DT_NOBEGIN`). `from_binary` does `i64::MAX as f64 / 1000 + 946684800000` ≈ 9.224e15 ms, past JS Date's ±8.64e15 range, and `DateInstance::create`'s `timeClip` maps it to `NaN`.
- **array text** (`{infinity,-infinity}::timestamp[]`): the parser already produced `SQLDataCell::date(f64::INFINITY)`, but `SQLClient.cpp` hands that to `DateInstance::create`, whose `timeClip` maps every non-finite input to `NaN`. So the existing code that tried to preserve ±Infinity never took effect.

## Fix

Return the JS Number `±Infinity` for these values, matching node-postgres (`pg-types` via `postgres-date`, for oids 1082/1114/1184). `postgres.js` does not special-case this and returns `Invalid Date`, but that loses information; node-postgres' behaviour is the one that round-trips.

- `types/date.rs` `from_binary`: recognise `i64::MAX` / `i64::MIN` and return `±f64::INFINITY`.
- `types/date.rs` `parse_infinity`: shared helper for the `infinity` / `-infinity` text spellings.
- `types/date.rs` `from_js`: map `±Infinity` back to `i64::MAX` / `i64::MIN` so the encode/decode pair is symmetric and the `(ms - epoch) * 1000` arithmetic never overflows on the value the decoder now produces.
- `DataCell.rs`: check `parse_infinity` before `Date.parse` on the scalar text path and the unquoted-`date[]` array path (the `timestamp[]`/`timestamptz[]` array path already produced `date(±INFINITY)`).
- `SQLClient.cpp` `toJS`: when the Date cell carries ±Infinity, return `jsDoubleNumber(±Infinity)` instead of a `timeClip`'d `DateInstance`.

Finite dates are unchanged and remain `Date` instances. MySQL shares the `toJS` path but never produces ±Infinity there (zero DATETIME is `NaN`, which `std::isinf` is false for).

This is a behaviour change (the result type for these two values changes from `Date` to `number`), but the previous value was unusable: `.toISOString()` throws on it, `.getTime()` is `NaN`, and the sign is gone.

## Verification

`test/js/sql/postgres-infinity-date.test.ts` drives a scripted v3 backend and covers every path:

- scalar text: `date` / `timestamp` / `timestamptz`
- scalar binary: `timestamp` / `timestamptz` (`PG_INT64_MAX` / `PG_INT64_MIN` on the wire)
- array text: `date[]` / `timestamp[]` / `timestamptz[]`
- bind: `±Infinity` bound to a `timestamp` / `timestamptz` parameter writes `PG_INT64_MAX` / `PG_INT64_MIN` in the `Bind` body

Each case asserts `±Infinity` for the special values and a `Date` instance for an adjacent finite value. All ten fail on main; all pass here. The three `sql.test.ts` array tests and `test/regression/issue/21311.test.ts` that pinned the old `Invalid Date` behaviour are updated. `sql-postgres-datetime-roundtrip.test.ts`, `postgres-datarow-overrun.test.ts`, `postgres-binary-float-nan-box.test.ts`, and `wire-frames.test.ts` are unchanged and pass.

Follows on from the note at the bottom of #35112.
