### PR TITLE
node:module: align SourceMap.findOrigin/findEntry/payload with Node.js

### DIFF
--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1082,9 +1082,27 @@ extern "C" JSC::EncodedJSValue Bun__createNodeModuleSourceMapOriginObject(
     return JSValue::encode(object);
 }
 
+static JSC::JSArray* shallowCopyJSArray(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& throwScope, JSC::JSArray* array)
+{
+    JSC::JSArray* copy = array->fastSlice(globalObject, array, 0, array->length());
+    if (copy) {
+        return copy;
+    }
+
+    copy = JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList());
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
+    for (unsigned i = 0, length = array->length(); i < length; i++) {
+        JSC::JSValue element = array->getIndex(globalObject, i);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
+        copy->putDirectIndex(globalObject, i, element);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
+    }
+    return copy;
+}
+
 // Shallow clone matching Node's `cloneSourceMapV3`: `{ ...payload }` with a
-// fresh copy of the `sources` array so callers cannot alias or mutate the
-// stored map through `SourceMap.prototype.payload`.
+// fresh slice of every own-enumerable array-valued property so callers cannot
+// alias or mutate the stored map through `SourceMap.prototype.payload`.
 extern "C" JSC::EncodedJSValue Bun__cloneSourceMapV3Payload(
     JSC::JSGlobalObject* globalObject,
     JSC::EncodedJSValue encodedPayload)
@@ -1102,21 +1120,21 @@ extern "C" JSC::EncodedJSValue Bun__cloneSourceMapV3Payload(
     JSC::objectAssignGeneric(globalObject, vm, target, source);
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    JSC::JSValue sources = target->getIfPropertyExists(globalObject, Identifier::fromString(vm, "sources"_s));
+    PropertyNameArrayBuilder properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+    target->getOwnPropertyNames(target, globalObject, properties, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(throwScope, {});
-    if (auto* sourcesArray = sources.isCell() ? dynamicDowncast<JSC::JSArray>(sources) : nullptr) {
-        JSC::JSArray* copy = sourcesArray->fastSlice(globalObject, sourcesArray, 0, sourcesArray->length());
-        if (!copy) {
-            copy = JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList());
-            RETURN_IF_EXCEPTION(throwScope, {});
-            for (unsigned i = 0, length = sourcesArray->length(); i < length; i++) {
-                JSC::JSValue element = sourcesArray->getIndex(globalObject, i);
-                RETURN_IF_EXCEPTION(throwScope, {});
-                copy->putDirectIndex(globalObject, i, element);
-                RETURN_IF_EXCEPTION(throwScope, {});
-            }
+    for (const auto& propertyName : properties) {
+        JSC::JSValue value = target->getDirect(vm, propertyName);
+        if (!value || !value.isCell()) {
+            continue;
         }
-        target->putDirect(vm, Identifier::fromString(vm, "sources"_s), copy);
+        auto* array = dynamicDowncast<JSC::JSArray>(value);
+        if (!array) {
+            continue;
+        }
+        JSC::JSArray* copy = shallowCopyJSArray(globalObject, throwScope, array);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        target->putDirect(vm, propertyName, copy);
     }
 
     return JSValue::encode(target);
@@ -1130,24 +1148,13 @@ extern "C" JSC::EncodedJSValue Bun__shallowCopyJSArray(
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     JSC::JSValue value = JSC::JSValue::decode(encodedArray);
-    auto* array = value.isCell() ? dynamicDowncast<JSC::JSArray>(value) : nullptr;
+    auto* array = value && value.isCell() ? dynamicDowncast<JSC::JSArray>(value) : nullptr;
     if (!array) [[unlikely]] {
         return JSValue::encode(JSC::jsUndefined());
     }
 
-    JSC::JSArray* copy = array->fastSlice(globalObject, array, 0, array->length());
-    if (copy) {
-        return JSValue::encode(copy);
-    }
-
-    copy = JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList());
+    JSC::JSArray* copy = shallowCopyJSArray(globalObject, throwScope, array);
     RETURN_IF_EXCEPTION(throwScope, {});
-    for (unsigned i = 0, length = array->length(); i < length; i++) {
-        JSC::JSValue element = array->getIndex(globalObject, i);
-        RETURN_IF_EXCEPTION(throwScope, {});
-        copy->putDirectIndex(globalObject, i, element);
-        RETURN_IF_EXCEPTION(throwScope, {});
-    }
     return JSValue::encode(copy);
 }
 

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -12,6 +12,7 @@
 #include <JavaScriptCore/CallData.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/IteratorOperations.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JSCommonJSExtensions.h"
@@ -1054,11 +1055,11 @@ static JSC::Structure* createNodeModuleSourceMapOriginStructure(JSC::VM& vm, JSC
 
     structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->name, 0, offset);
     RELEASE_ASSERT(offset == 0);
-    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "line"), 0, offset);
-    RELEASE_ASSERT(offset == 1);
-    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "column"), 0, offset);
-    RELEASE_ASSERT(offset == 2);
     structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "fileName"), 0, offset);
+    RELEASE_ASSERT(offset == 1);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "lineNumber"), 0, offset);
+    RELEASE_ASSERT(offset == 2);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "columnNumber"), 0, offset);
     RELEASE_ASSERT(offset == 3);
 
     return structure;
@@ -1067,18 +1068,87 @@ static JSC::Structure* createNodeModuleSourceMapOriginStructure(JSC::VM& vm, JSC
 extern "C" JSC::EncodedJSValue Bun__createNodeModuleSourceMapOriginObject(
     JSC::JSGlobalObject* globalObject,
     JSC::EncodedJSValue encodedName,
+    JSC::EncodedJSValue encodedSource,
     JSC::EncodedJSValue encodedLine,
-    JSC::EncodedJSValue encodedColumn,
-    JSC::EncodedJSValue encodedSource)
+    JSC::EncodedJSValue encodedColumn)
 {
     auto& vm = globalObject->vm();
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
     JSObject* object = JSC::constructEmptyObject(vm, zigGlobalObject->m_nodeModuleSourceMapOriginStructure.getInitializedOnMainThread(zigGlobalObject));
     object->putDirectOffset(vm, 0, JSC::JSValue::decode(encodedName));
-    object->putDirectOffset(vm, 1, JSC::JSValue::decode(encodedLine));
-    object->putDirectOffset(vm, 2, JSC::JSValue::decode(encodedColumn));
-    object->putDirectOffset(vm, 3, JSC::JSValue::decode(encodedSource));
+    object->putDirectOffset(vm, 1, JSC::JSValue::decode(encodedSource));
+    object->putDirectOffset(vm, 2, JSC::JSValue::decode(encodedLine));
+    object->putDirectOffset(vm, 3, JSC::JSValue::decode(encodedColumn));
     return JSValue::encode(object);
+}
+
+// Shallow clone matching Node's `cloneSourceMapV3`: `{ ...payload }` with a
+// fresh copy of the `sources` array so callers cannot alias or mutate the
+// stored map through `SourceMap.prototype.payload`.
+extern "C" JSC::EncodedJSValue Bun__cloneSourceMapV3Payload(
+    JSC::JSGlobalObject* globalObject,
+    JSC::EncodedJSValue encodedPayload)
+{
+    auto& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSValue payload = JSC::JSValue::decode(encodedPayload);
+    JSC::JSObject* source = payload.getObject();
+    if (!source) [[unlikely]] {
+        return JSValue::encode(payload);
+    }
+
+    JSC::JSObject* target = JSC::constructEmptyObject(globalObject);
+    JSC::objectAssignGeneric(globalObject, vm, target, source);
+    RETURN_IF_EXCEPTION(throwScope, {});
+
+    JSC::JSValue sources = target->getIfPropertyExists(globalObject, Identifier::fromString(vm, "sources"_s));
+    RETURN_IF_EXCEPTION(throwScope, {});
+    if (auto* sourcesArray = sources.isCell() ? dynamicDowncast<JSC::JSArray>(sources) : nullptr) {
+        JSC::JSArray* copy = sourcesArray->fastSlice(globalObject, sourcesArray, 0, sourcesArray->length());
+        if (!copy) {
+            copy = JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList());
+            RETURN_IF_EXCEPTION(throwScope, {});
+            for (unsigned i = 0, length = sourcesArray->length(); i < length; i++) {
+                JSC::JSValue element = sourcesArray->getIndex(globalObject, i);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                copy->putDirectIndex(globalObject, i, element);
+                RETURN_IF_EXCEPTION(throwScope, {});
+            }
+        }
+        target->putDirect(vm, Identifier::fromString(vm, "sources"_s), copy);
+    }
+
+    return JSValue::encode(target);
+}
+
+extern "C" JSC::EncodedJSValue Bun__shallowCopyJSArray(
+    JSC::JSGlobalObject* globalObject,
+    JSC::EncodedJSValue encodedArray)
+{
+    auto& vm = globalObject->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSValue value = JSC::JSValue::decode(encodedArray);
+    auto* array = value.isCell() ? dynamicDowncast<JSC::JSArray>(value) : nullptr;
+    if (!array) [[unlikely]] {
+        return JSValue::encode(JSC::jsUndefined());
+    }
+
+    JSC::JSArray* copy = array->fastSlice(globalObject, array, 0, array->length());
+    if (copy) {
+        return JSValue::encode(copy);
+    }
+
+    copy = JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList());
+    RETURN_IF_EXCEPTION(throwScope, {});
+    for (unsigned i = 0, length = array->length(); i < length; i++) {
+        JSC::JSValue element = array->getIndex(globalObject, i);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        copy->putDirectIndex(globalObject, i, element);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+    return JSValue::encode(copy);
 }
 
 void addNodeModuleConstructorProperties(JSC::VM& vm,

--- a/src/runtime/api/sourcemap.classes.ts
+++ b/src/runtime/api/sourcemap.classes.ts
@@ -16,13 +16,14 @@ export default [
       },
       payload: {
         getter: "getPayload",
-        cache: true,
+        this: true,
       },
       lineLengths: {
         getter: "getLineLengths",
-        cache: true,
+        this: true,
       },
     },
+    values: ["storedPayload", "storedLineLengths"],
     finalize: true,
     construct: true,
     constructNeedsThis: true,

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -626,6 +626,30 @@ impl InternalSourceMap {
         }
         Some(best.to_mapping())
     }
+
+    /// Matches the semantics of `Mapping.List.find_closest`: returns the last
+    /// mapping with generated position `<= (line, column)` regardless of
+    /// whether the generated line matches. Inputs are signed 0-based offsets.
+    pub fn find_closest(self, line: i32, column: i32) -> Option<Mapping> {
+        let sync_idx = self.locate_window(line, column)?;
+
+        let mut state = State::default();
+        let mut reader = WindowReader::DANGLING;
+        self.seed_window(sync_idx, &mut state, &mut reader);
+
+        let mut best = state;
+        while !reader.done() {
+            let mut nxt = state;
+            reader.next(&mut nxt);
+            if !nxt.less_or_equal(line, column) {
+                break;
+            }
+            best = nxt;
+            state = nxt;
+        }
+
+        Some(best.to_mapping())
+    }
 }
 
 /// Stateful forward cursor. `move_to` is cheap when successive targets are

--- a/src/sourcemap/Mapping.rs
+++ b/src/sourcemap/Mapping.rs
@@ -187,6 +187,49 @@ impl List {
         None
     }
 
+    fn find_closest_index(
+        line_column_offsets: &[LineColumnOffset],
+        line: i32,
+        column: i32,
+    ) -> Option<usize> {
+        let mut count = line_column_offsets.len();
+        let mut index: usize = 0;
+        while count > 0 {
+            let step = count / 2;
+            let i: usize = index + step;
+            let mapping = line_column_offsets[i];
+            if mapping.lines.zero_based() < line
+                || (mapping.lines.zero_based() == line && mapping.columns.zero_based() <= column)
+            {
+                index = i + 1;
+                count = count.saturating_sub(step + 1);
+            } else {
+                count = step;
+            }
+        }
+
+        if index == 0 {
+            return None;
+        }
+        Some(index - 1)
+    }
+
+    /// Closest mapping whose generated position is `<= (line, column)`, regardless of
+    /// whether the generated line matches. Returns `None` only when `(line, column)` is
+    /// before the first mapping or the list is empty. Inputs are signed 0-based offsets
+    /// (Node.js `SourceMap.prototype.findEntry` accepts negative values).
+    pub fn find_closest(&self, line: i32, column: i32) -> Option<Mapping> {
+        match &self.r#impl {
+            ListValue::WithoutNames(list) => {
+                Self::find_closest_index(list.items_generated(), line, column)
+                    .map(|i| list.get(i).to_named())
+            }
+            ListValue::WithNames(list) => {
+                Self::find_closest_index(list.items_generated(), line, column).map(|i| *list.get(i))
+            }
+        }
+    }
+
     pub fn sort(&mut self) {
         // `MultiArrayList::sort(&mut self, ctx)` swaps the `generated` column
         // in place, so the comparator cannot hold a `&[LineColumnOffset]` over

--- a/src/sourcemap/ParsedSourceMap.rs
+++ b/src/sourcemap/ParsedSourceMap.rs
@@ -261,13 +261,7 @@ impl ParsedSourceMap {
     /// and may be negative.
     pub fn find_closest_mapping(&self, line: i32, column: i32) -> Option<Mapping> {
         if let Some(ism) = &self.internal {
-            if line < 0 {
-                return None;
-            }
-            return ism.find(
-                Ordinal::from_zero_based(line),
-                Ordinal::from_zero_based(column.max(0)),
-            );
+            return ism.find_closest(line, column);
         }
         self.mappings.find_closest(line, column)
     }

--- a/src/sourcemap/ParsedSourceMap.rs
+++ b/src/sourcemap/ParsedSourceMap.rs
@@ -255,6 +255,23 @@ impl ParsedSourceMap {
         self.mappings.find(line, column)
     }
 
+    /// Like [`Self::find_mapping`] but returns the closest preceding mapping even
+    /// when its generated line differs from `line`. Matches Node.js's
+    /// `SourceMap.prototype.findEntry` semantics. Inputs are signed 0-based offsets
+    /// and may be negative.
+    pub fn find_closest_mapping(&self, line: i32, column: i32) -> Option<Mapping> {
+        if let Some(ism) = &self.internal {
+            if line < 0 {
+                return None;
+            }
+            return ism.find(
+                Ordinal::from_zero_based(line),
+                Ordinal::from_zero_based(column.max(0)),
+            );
+        }
+        self.mappings.find_closest(line, column)
+    }
+
     pub fn internal_cursor(&self) -> Option<crate::internal_source_map::Cursor> {
         self.internal.as_ref().map(|ism| ism.cursor())
     }

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -7,7 +7,7 @@ use bstr::BStr;
 
 use bun_core::{self as bstring, strings};
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, bun_string_jsc};
-use bun_sourcemap::{Mapping, Ordinal, ParseResult, ParsedSourceMap, mapping};
+use bun_sourcemap::{Mapping, ParseResult, ParsedSourceMap, mapping};
 
 // generate-classes.ts does not emit Rust accessors yet, so the
 // `to_js`/cached-setter helpers below forward to the codegen-emitted C++
@@ -176,11 +176,14 @@ impl JSSourceMap {
             names: names.into_boxed_slice(),
         });
 
-        if !payload_arg.is_empty() {
-            Self::payload_set_cached(this_value, global, payload_arg);
+        // Node stores a private clone of the caller's payload so later
+        // mutations to the argument cannot change what `sm.payload` reports.
+        let payload_clone = clone_source_map_payload(global, payload_arg)?;
+        if !payload_clone.is_empty() {
+            Self::stored_payload_set_cached(this_value, global, payload_clone);
         }
         if !line_lengths.is_empty() {
-            Self::line_lengths_set_cached(this_value, global, line_lengths);
+            Self::stored_line_lengths_set_cached(this_value, global, line_lengths);
         }
 
         Ok(source_map)
@@ -203,18 +206,36 @@ impl JSSourceMap {
         }
     }
     #[inline]
-    fn payload_set_cached(this_value: JSValue, global: &JSGlobalObject, value: JSValue) {
+    fn stored_payload_set_cached(this_value: JSValue, global: &JSGlobalObject, value: JSValue) {
         // SAFETY: `global` is live; `this_value` is the freshly-constructed wrapper.
         unsafe {
-            SourceMapPrototype__payloadSetCachedValue(this_value, global.as_mut_ptr(), value)
+            SourceMapPrototype__storedPayloadSetCachedValue(this_value, global.as_mut_ptr(), value)
         };
     }
     #[inline]
-    fn line_lengths_set_cached(this_value: JSValue, global: &JSGlobalObject, value: JSValue) {
+    fn stored_payload_get_cached(this_value: JSValue) -> JSValue {
+        // SAFETY: `this_value` is the live wrapper; the slot is a WriteBarrier read.
+        unsafe { SourceMapPrototype__storedPayloadGetCachedValue(this_value) }
+    }
+    #[inline]
+    fn stored_line_lengths_set_cached(
+        this_value: JSValue,
+        global: &JSGlobalObject,
+        value: JSValue,
+    ) {
         // SAFETY: `global` is live; `this_value` is the freshly-constructed wrapper.
         unsafe {
-            SourceMapPrototype__lineLengthsSetCachedValue(this_value, global.as_mut_ptr(), value)
+            SourceMapPrototype__storedLineLengthsSetCachedValue(
+                this_value,
+                global.as_mut_ptr(),
+                value,
+            )
         };
+    }
+    #[inline]
+    fn stored_line_lengths_get_cached(this_value: JSValue) -> JSValue {
+        // SAFETY: `this_value` is the live wrapper; the slot is a WriteBarrier read.
+        unsafe { SourceMapPrototype__storedLineLengthsGetCachedValue(this_value) }
     }
 
     pub fn memory_cost(&self) -> usize {
@@ -227,14 +248,24 @@ impl JSSourceMap {
         self.memory_cost()
     }
 
-    // The cached value should handle this.
-    pub fn get_payload(&self, _global: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(JSValue::UNDEFINED)
+    pub fn get_payload(&self, this_value: JSValue, global: &JSGlobalObject) -> JsResult<JSValue> {
+        let stored = Self::stored_payload_get_cached(this_value);
+        if stored.is_empty() {
+            return Ok(JSValue::UNDEFINED);
+        }
+        clone_source_map_payload(global, stored)
     }
 
-    // The cached value should handle this.
-    pub fn get_line_lengths(&self, _global: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(JSValue::UNDEFINED)
+    pub fn get_line_lengths(
+        &self,
+        this_value: JSValue,
+        global: &JSGlobalObject,
+    ) -> JsResult<JSValue> {
+        let stored = Self::stored_line_lengths_get_cached(this_value);
+        if stored.is_empty() {
+            return Ok(JSValue::UNDEFINED);
+        }
+        shallow_copy_array(global, stored)
     }
 
     fn mapping_name_to_js(&self, global: &JSGlobalObject, mapping: &Mapping) -> JsResult<JSValue> {
@@ -266,14 +297,24 @@ impl JSSourceMap {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
+        // Node documents `findOrigin` in Error-stack units: both inputs and the
+        // returned `lineNumber`/`columnNumber` are 1-based. It delegates to
+        // `findEntry(line - 1, column - 1)` and then offsets the original
+        // position by the distance from the matched generated position, so a
+        // lookup mid-range interpolates within the original span.
         let [line_number, column_number] = get_line_column(global, frame)?;
 
-        let Some(mapping) = this.sourcemap.find_mapping(
-            Ordinal::from_zero_based(line_number),
-            Ordinal::from_zero_based(column_number),
-        ) else {
+        let Some(mapping) = this
+            .sourcemap
+            .find_closest_mapping(line_number.wrapping_sub(1), column_number.wrapping_sub(1))
+        else {
             return Ok(JSValue::create_empty_object(global, 0));
         };
+        if mapping.source_index < 0 {
+            return Ok(JSValue::create_empty_object(global, 0));
+        }
+        let line_offset = line_number.wrapping_sub(mapping.generated.lines.zero_based());
+        let column_offset = column_number.wrapping_sub(mapping.generated.columns.zero_based());
         let name = this.mapping_name_to_js(global, &mapping)?;
         let source = this.source_name_to_js(global, &mapping)?;
         // SAFETY: C++ FFI; arguments are valid JSValues and a live JSGlobalObject.
@@ -283,9 +324,9 @@ impl JSSourceMap {
             Bun__createNodeModuleSourceMapOriginObject(
                 global.as_mut_ptr(),
                 name,
-                JSValue::js_number(mapping.original.lines.zero_based() as f64),
-                JSValue::js_number(mapping.original.columns.zero_based() as f64),
                 source,
+                JSValue::js_number((mapping.original.lines.zero_based() + line_offset) as f64),
+                JSValue::js_number((mapping.original.columns.zero_based() + column_offset) as f64),
             )
         })
     }
@@ -297,10 +338,10 @@ impl JSSourceMap {
     ) -> JsResult<JSValue> {
         let [line_number, column_number] = get_line_column(global, frame)?;
 
-        let Some(mapping) = this.sourcemap.find_mapping(
-            Ordinal::from_zero_based(line_number),
-            Ordinal::from_zero_based(column_number),
-        ) else {
+        let Some(mapping) = this
+            .sourcemap
+            .find_closest_mapping(line_number, column_number)
+        else {
             return Ok(JSValue::create_empty_object(global, 0));
         };
 
@@ -334,6 +375,20 @@ fn get_line_column(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<[i32;
     ])
 }
 
+fn clone_source_map_payload(global: &JSGlobalObject, payload: JSValue) -> JsResult<JSValue> {
+    // SAFETY: C++ FFI; `global` is live and `payload` is a valid JSValue.
+    bun_jsc::call_zero_is_throw(global, || unsafe {
+        Bun__cloneSourceMapV3Payload(global.as_mut_ptr(), payload)
+    })
+}
+
+fn shallow_copy_array(global: &JSGlobalObject, array: JSValue) -> JsResult<JSValue> {
+    // SAFETY: C++ FFI; `global` is live and `array` is a valid JSValue.
+    bun_jsc::call_zero_is_throw(global, || unsafe {
+        Bun__shallowCopyJSArray(global.as_mut_ptr(), array)
+    })
+}
+
 // Codegen-emitted helpers (`SourceMap__create`, `*SetCachedValue`) are defined
 // in ZigGeneratedClasses.cpp with `extern JSC_CALLCONV` (= `"C" SYSV_ABI` on
 // Windows-x64), so they must be imported via `jsc_abi_extern!` to get the
@@ -345,29 +400,31 @@ bun_jsc::jsc_abi_extern! {
     // the extern FFI-safe — `JSSourceMap` itself has Rust-only field layout.
     fn SourceMap__create(globalObject: *mut JSGlobalObject, ctx: *mut ()) -> JSValue;
 
-    // Codegen-emitted cached-value setters; names match generated_classes.ts output.
-    fn SourceMapPrototype__payloadSetCachedValue(
+    // Codegen-emitted cached-value slots; names match generated_classes.ts output.
+    fn SourceMapPrototype__storedPayloadSetCachedValue(
         thisValue: JSValue,
         globalObject: *mut JSGlobalObject,
         value: JSValue,
     );
-    fn SourceMapPrototype__lineLengthsSetCachedValue(
+    fn SourceMapPrototype__storedPayloadGetCachedValue(thisValue: JSValue) -> JSValue;
+    fn SourceMapPrototype__storedLineLengthsSetCachedValue(
         thisValue: JSValue,
         globalObject: *mut JSGlobalObject,
         value: JSValue,
     );
+    fn SourceMapPrototype__storedLineLengthsGetCachedValue(thisValue: JSValue) -> JSValue;
 }
 
-// These two are hand-written in `src/jsc/modules/NodeModuleModule.cpp` as
-// plain `extern "C"` (no `JSC_CALLCONV`/`SYSV_ABI`), so they use the platform
+// These are hand-written in `src/jsc/modules/NodeModuleModule.cpp` as plain
+// `extern "C"` (no `JSC_CALLCONV`/`SYSV_ABI`), so they use the platform
 // default — keep them in a separate `extern "C"` block.
 unsafe extern "C" {
     fn Bun__createNodeModuleSourceMapOriginObject(
         globalObject: *mut JSGlobalObject,
         name: JSValue,
+        source: JSValue,
         line: JSValue,
         column: JSValue,
-        source: JSValue,
     ) -> JSValue;
 
     fn Bun__createNodeModuleSourceMapEntryObject(
@@ -379,4 +436,9 @@ unsafe extern "C" {
         source: JSValue,
         name: JSValue,
     ) -> JSValue;
+
+    fn Bun__cloneSourceMapV3Payload(globalObject: *mut JSGlobalObject, payload: JSValue)
+    -> JSValue;
+
+    fn Bun__shallowCopyJSArray(globalObject: *mut JSGlobalObject, array: JSValue) -> JSValue;
 }

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -313,8 +313,10 @@ impl JSSourceMap {
         if mapping.source_index < 0 {
             return Ok(JSValue::create_empty_object(global, 0));
         }
-        let line_offset = line_number.wrapping_sub(mapping.generated.lines.zero_based());
-        let column_offset = column_number.wrapping_sub(mapping.generated.columns.zero_based());
+        // Node computes these offsets in JS numbers; widen to f64 so an
+        // adversarial 2^31-ish input cannot overflow i32 arithmetic.
+        let line_offset = line_number as f64 - mapping.generated.lines.zero_based() as f64;
+        let column_offset = column_number as f64 - mapping.generated.columns.zero_based() as f64;
         let name = this.mapping_name_to_js(global, &mapping)?;
         let source = this.source_name_to_js(global, &mapping)?;
         // SAFETY: C++ FFI; arguments are valid JSValues and a live JSGlobalObject.
@@ -325,8 +327,8 @@ impl JSSourceMap {
                 global.as_mut_ptr(),
                 name,
                 source,
-                JSValue::js_number((mapping.original.lines.zero_based() + line_offset) as f64),
-                JSValue::js_number((mapping.original.columns.zero_based() + column_offset) as f64),
+                JSValue::js_number(mapping.original.lines.zero_based() as f64 + line_offset),
+                JSValue::js_number(mapping.original.columns.zero_based() as f64 + column_offset),
             )
         })
     }

--- a/test/js/node/module/module-sourcemap.test.js
+++ b/test/js/node/module/module-sourcemap.test.js
@@ -23,5 +23,6 @@ test("Can create SourceMap instance from node:module", () => {
 
   const sourceMap = new SourceMap(payload);
   expect(sourceMap).toBeInstanceOf(SourceMap);
-  expect(sourceMap.payload).toBe(payload);
+  expect(sourceMap.payload).toEqual(payload);
+  expect(sourceMap.payload).not.toBe(payload);
 });

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -35,7 +35,7 @@ test("SourceMap instance has expected methods", () => {
   expect(sourceMap.findEntry.length).toBe(2);
 });
 
-test("SourceMap payload getter", () => {
+test("SourceMap payload getter returns a fresh clone", () => {
   const payload = {
     version: 3,
     sources: ["test.js"],
@@ -43,10 +43,22 @@ test("SourceMap payload getter", () => {
   };
   const sourceMap = new SourceMap(payload);
 
-  expect(sourceMap.payload).toBe(payload);
+  const first = sourceMap.payload;
+  expect(first).toEqual(payload);
+  expect(first).not.toBe(payload);
+  expect(first.sources).not.toBe(payload.sources);
+  expect(sourceMap.payload).not.toBe(first);
+
+  // Mutating the caller's object after construction must not leak through.
+  payload.file = "mutated";
+  expect(sourceMap.payload.file).toBeUndefined();
+
+  // Mutating a returned clone must not leak into later reads.
+  first.version = 99;
+  expect(sourceMap.payload.version).toBe(3);
 });
 
-test("SourceMap lineLengths getter", () => {
+test("SourceMap lineLengths getter returns a fresh copy", () => {
   const payload = {
     version: 3,
     sources: ["test.js"],
@@ -55,7 +67,10 @@ test("SourceMap lineLengths getter", () => {
   const lineLengths = [10, 20, 30];
   const sourceMap = new SourceMap(payload, { lineLengths });
 
-  expect(sourceMap.lineLengths).toBe(lineLengths);
+  const first = sourceMap.lineLengths;
+  expect(first).toEqual([10, 20, 30]);
+  expect(first).not.toBe(lineLengths);
+  expect(sourceMap.lineLengths).not.toBe(first);
 });
 
 test("SourceMap lineLengths undefined when not provided", () => {
@@ -93,16 +108,66 @@ test("SourceMap findOrigin returns origin data", () => {
     sources: ["test.js"],
     mappings: "AAAA",
   });
-  const result = sourceMap.findOrigin(0, 0);
+  // findOrigin takes 1-based Error-stack line/column and returns 1-based
+  // lineNumber/columnNumber.
+  const result = sourceMap.findOrigin(1, 1);
 
   expect(result).toMatchInlineSnapshot(`
     {
-      "column": 0,
+      "columnNumber": 1,
       "fileName": "test.js",
-      "line": 0,
+      "lineNumber": 1,
       "name": undefined,
     }
   `);
+});
+
+test("SourceMap findOrigin is 1-based and findEntry clamps to the closest preceding entry", () => {
+  const payload = {
+    version: 3,
+    file: "out.js",
+    sources: ["a.ts", "b.ts"],
+    names: [],
+    mappings: "AAAA,IACC;AAAC,GCAE",
+  };
+  const sourceMap = new SourceMap(payload);
+
+  // Row/column 0 are before the first 1-based position.
+  expect(sourceMap.findOrigin(1, 0)).toEqual({});
+  expect(sourceMap.findOrigin(0, 0)).toEqual({});
+
+  // findOrigin offsets the original position by the distance from the matched
+  // generated position, so the returned column tracks the input column.
+  expect(sourceMap.findOrigin(2, 5)).toEqual({
+    name: undefined,
+    fileName: "b.ts",
+    lineNumber: 2,
+    columnNumber: 6,
+  });
+
+  // Past the last mapping, findEntry returns the closest preceding entry.
+  expect(sourceMap.findEntry(99, 99)).toEqual({
+    generatedLine: 1,
+    generatedColumn: 3,
+    originalSource: "b.ts",
+    originalLine: 1,
+    originalColumn: 4,
+    name: undefined,
+  });
+
+  // Before the first mapping it stays {}.
+  expect(sourceMap.findEntry(-1, -1)).toEqual({});
+  expect(sourceMap.findEntry(0, -1)).toEqual({});
+
+  // A negative column on a later line still resolves to the preceding line.
+  expect(sourceMap.findEntry(1, -1)).toEqual({
+    generatedLine: 0,
+    generatedColumn: 4,
+    originalSource: "a.ts",
+    originalLine: 1,
+    originalColumn: 1,
+    name: undefined,
+  });
 });
 
 test("SourceMap with names returns name property correctly", () => {

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -39,23 +39,41 @@ test("SourceMap payload getter returns a fresh clone", () => {
   const payload = {
     version: 3,
     sources: ["test.js"],
-    mappings: "AAAA",
+    names: ["fn"],
+    sourcesContent: ["src"],
+    mappings: "AAAAA",
   };
   const sourceMap = new SourceMap(payload);
 
   const first = sourceMap.payload;
   expect(first).toEqual(payload);
   expect(first).not.toBe(payload);
+  // Every array-valued property is sliced, not just sources.
   expect(first.sources).not.toBe(payload.sources);
+  expect(first.names).not.toBe(payload.names);
+  expect(first.sourcesContent).not.toBe(payload.sourcesContent);
   expect(sourceMap.payload).not.toBe(first);
 
-  // Mutating the caller's object after construction must not leak through.
+  // Mutating the caller's object or its arrays after construction must not
+  // leak through.
   payload.file = "mutated";
+  payload.sources.push("leaked");
+  payload.names.push("leaked");
   expect(sourceMap.payload.file).toBeUndefined();
+  expect(sourceMap.payload.sources).toEqual(["test.js"]);
+  expect(sourceMap.payload.names).toEqual(["fn"]);
 
   // Mutating a returned clone must not leak into later reads.
   first.version = 99;
+  first.sources.push("leaked");
   expect(sourceMap.payload.version).toBe(3);
+  expect(sourceMap.payload.sources).toEqual(["test.js"]);
+});
+
+test("SourceMap payload without sources is cloned without crashing", () => {
+  const sourceMap = new SourceMap({ version: 3, mappings: ";;" });
+  expect(sourceMap.payload).toEqual({ version: 3, mappings: ";;" });
+  expect(sourceMap.findEntry(0, 0)).toEqual({});
 });
 
 test("SourceMap lineLengths getter returns a fresh copy", () => {
@@ -71,6 +89,10 @@ test("SourceMap lineLengths getter returns a fresh copy", () => {
   expect(first).toEqual([10, 20, 30]);
   expect(first).not.toBe(lineLengths);
   expect(sourceMap.lineLengths).not.toBe(first);
+
+  // Mutating a returned copy must not leak into later reads.
+  first.push(99);
+  expect(sourceMap.lineLengths).toEqual([10, 20, 30]);
 });
 
 test("SourceMap lineLengths undefined when not provided", () => {


### PR DESCRIPTION
Three documented `module.SourceMap` method contracts diverged from Node.js:

```js
import { SourceMap } from 'node:module';
const payload = { version: 3, sources: ['a.ts','b.ts'], names: [], mappings: 'AAAA,IACC;AAAC,GCAE' };
const sm = new SourceMap(payload);

sm.findOrigin(2, 5);  // bun: {}                                            node: {fileName:'b.ts', lineNumber:2, columnNumber:6}
sm.findOrigin(1, 0);  // bun: {line:1, column:2, fileName:'a.ts'}           node: {}
sm.findEntry(99, 99); // bun: {}                                            node: last mapping
sm.payload === payload; // bun: true                                        node: false (cloned on store and on every get)
```

### Cause

- `findOrigin()` passed its arguments straight to the 0-based lookup and returned 0-based `{line, column}`; Node documents it in Error-stack `file:line:col` units (1-based in and out, keys `lineNumber`/`columnNumber`) and offsets the original position by the distance from the matched generated segment.
- `findEntry()` used `List::find`, which only matches when the preceding mapping is on the same generated line. Node's binary search returns the closest preceding mapping regardless of line and only yields `{}` before the first mapping.
- The `payload` getter was wired as `cache: true` and the constructor stored the caller's object in that slot, so `sm.payload` aliased the argument and mutation stuck. Node stores a shallow clone and re-clones on every access (`lineLengths` had the same aliasing).

### Fix

- `findOrigin` now looks up `(line - 1, column - 1)`, returns `{name, fileName, lineNumber, columnNumber}`, and computes the result from `original + (input - generated)` so mid-span lookups interpolate like Node.
- Added `List::find_closest` / `ParsedSourceMap::find_closest_mapping` (closest preceding entry, signed inputs accepted) and routed `findEntry`/`findOrigin` through it.
- `payload`/`lineLengths` now back onto GC-traced `values` slots; the constructor stores a `{ ...payload, sources: [...sources] }` clone and the getters return a fresh clone each call via new C++ helpers `Bun__cloneSourceMapV3Payload` / `Bun__shallowCopyJSArray`.

### Verification

All the following now match Node v26.3.0 output exactly (including `findOrigin(2,0)` producing a negative column and `findEntry(1,-1)` resolving to the previous line):

```
findOrigin(1,1) -> {fileName:"a.ts",lineNumber:1,columnNumber:1}
findOrigin(1,0) -> {}
findOrigin(2,5) -> {fileName:"b.ts",lineNumber:2,columnNumber:6}
findEntry(99,99) -> {generatedLine:1,generatedColumn:3,originalSource:"b.ts",originalLine:1,originalColumn:4}
findEntry(-1,-1) -> {}
payload === caller -> false
sm.payload.file = 'MUT'; sm.payload.file -> undefined
```

New coverage in `test/js/node/module/sourcemap.test.js`; the two existing tests that asserted the aliasing behavior were updated.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/module-sourcemap.test.js test/js/node/module/sourcemap.test.js
bun test v1.4.0 (5446b8a20)

test/js/node/module/module-sourcemap.test.js:
(pass) SourceMap is available from node:module [10.94ms]
(pass) SourceMap from require('module') works [2.05ms]
22 |   };
23 | 
24 |   const sourceMap = new SourceMap(payload);
25 |   expect(sourceMap).toBeInstanceOf(SourceMap);
26 |   expect(sourceMap.payload).toEqual(payload);
27 |   expect(sourceMap.payload).not.toBe(payload);
                                     ^
error: expect(received).not.toBe(expected)

Expected: not {
  version: 3,
  sources: [ "test.js" ],
  names: [],
  mappings: "AAAA",
}

      at <anonymous> (/workspace/bun/test/js/node/module/module-sourcemap.test.js:27:33)
(fail) Can create SourceMap instance from node:module [6.29ms]

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [7.35ms]
(pass) SourceMap constructor requires payload [3.63ms]
(pass) SourceMap payload must be an object [2.74ms]
(pass) SourceMap instance has expected methods [
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (02eb7ff03)

test/js/node/module/module-sourcemap.test.js:
(pass) SourceMap is available from node:module [0.50ms]
(pass) SourceMap from require('module') works [0.06ms]
(pass) Can create SourceMap instance from node:module [0.11ms]

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [0.04ms]
(pass) SourceMap constructor requires payload [0.12ms]
(pass) SourceMap payload must be an object [0.04ms]
(pass) SourceMap instance has expected methods [0.06ms]
48 |   const first = sourceMap.payload;
49 |   expect(first).toEqual(payload);
50 |   expect(first).not.toBe(payload);
51 |   // Every array-valued property is sliced, not just sources.
52 |   expect(first.sources).not.toBe(payload.sources);
53 |   expect(first.names).not.toBe(payload.names);
                               ^
error: expect(received).not.toBe(expected)

Expected: not [ "fn" ]

      at <anonymous> (/workspace/bun/test/js/node/module/sourcemap.test.js:53:27)
(fail) SourceMap payload getter returns a fresh clone [0.22ms]
============================================================
Bun Canary v1.4.0-canary.1 (02eb7ff03) Linux x64
Linux Kernel v6.17.0 | glibc v2.41
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/module-sourcemap.test.js test/js/node/module/sourcemap.test.js
bun test v1.4.0 (5446b8a20)

test/js/node/module/module-sourcemap.test.js:
(pass) SourceMap is available from node:module [22.38ms]
(pass) SourceMap from require('module') works [3.60ms]
(pass) Can create SourceMap instance from node:module [5.53ms]

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [7.96ms]
(pass) SourceMap constructor requires payload [4.67ms]
(pass) SourceMap payload must be an object [3.01ms]
(pass) SourceMap instance has expected methods [3.64ms]
(pass) SourceMap payload getter returns a fresh clone [7.42ms]
(pass) SourceMap payload without sources is cloned without crashing [2.86ms]
(pass) SourceMap lineLengths getter returns a fresh copy [3.56ms]
(pass) SourceMap lineLengths undefined when not provided [1.98ms]
(pass) SourceMap findEntry returns mapping data [2.99ms]
(pass) SourceMap findOrigin returns origin data [2.86ms]
(pass) SourceMap findOrigin is 1-based and findEntry clamps to the closest preceding entry
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 794ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/26] gen cpp.rs (cppbind)
[3/26] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.cla
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/modules/NodeModuleModule.cpp         |  93 ++++++++++++++++++--
 src/runtime/api/sourcemap.classes.ts         |   5 +-
 src/sourcemap/InternalSourceMap.rs           |  24 ++++++
 src/sourcemap/Mapping.rs                     |  43 ++++++++++
 src/sourcemap/ParsedSourceMap.rs             |  11 +++
 src/sourcemap_jsc/JSSourceMap.rs             | 124 ++++++++++++++++++++-------
 test/js/node/module/module-sourcemap.test.js |   3 +-
 test/js/node/module/sourcemap.test.js        | 103 ++++++++++++++++++++--
 8 files changed, 357 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/modules/NodeModuleModule.cpp              3      6      0
src/runtime/api/sourcemap.classes.ts              1      1      0
src/sourcemap/InternalSourceMap.rs                2      1      0
src/sourcemap/Mapping.rs                          4      3      0
src/sourcemap/ParsedSourceMap.rs                  3      4      0
src/sourcemap_jsc/JSSourceMap.rs                  2     12      0
test/js/node/module/module-sourcemap.test.js      1      1      0
test/js/node/module/sourcemap.test.js             2      2      0
```

</details>

<!-- robobun:evidence:end -->