### PR TITLE
resolver: search Node's legacy global folders and populate Module.globalPaths

### DIFF
--- a/src/js/builtins/NodeModuleObject.ts
+++ b/src/js/builtins/NodeModuleObject.ts
@@ -1,5 +1,6 @@
-// Implementation for `require('node:module')._initPaths`. Exists only as a
-// compatibility stub. Calling this does not affect the actual CommonJS loader.
+// Implementation for `require('node:module')._initPaths`. The resolver reads
+// NODE_PATH / HOME / execPath itself on each resolve, so calling this only
+// refreshes the `Module.globalPaths` introspection array.
 export function _initPaths() {
   const homeDir = process.platform === "win32" ? process.env.USERPROFILE : Bun.env.HOME;
   const nodePath = process.platform === "win32" ? process.env.NODE_PATH : Bun.env.NODE_PATH;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -513,6 +513,22 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveLookupPaths,
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(resolveLookupPaths(globalObject, request, parent)));
 }
 
+static void appendGlobalPaths(JSC::JSGlobalObject* globalObject, JSC::JSArray* array, JSC::ThrowScope& scope)
+{
+    JSValue globalPaths = JSValue::decode(Resolver__globalPathsJSValue(globalObject));
+    RETURN_IF_EXCEPTION(scope, );
+    auto* globalPathsArray = dynamicDowncast<JSArray>(globalPaths);
+    if (!globalPathsArray) [[unlikely]]
+        return;
+    auto len = globalPathsArray->length();
+    for (size_t i = 0; i < len; i++) {
+        auto path = globalPathsArray->getIndex(globalObject, i);
+        RETURN_IF_EXCEPTION(scope, );
+        array->push(globalObject, path);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+}
+
 JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String request, PathResolveModule parent)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -526,26 +542,34 @@ JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String reques
             true
 #endif
             )) {
+        JSArray* array;
         if (parent.paths) {
-            auto array = JSC::constructArray(globalObject, (ArrayAllocationProfile*)nullptr, nullptr, 0);
+            array = JSC::constructArray(globalObject, (ArrayAllocationProfile*)nullptr, nullptr, 0);
             RETURN_IF_EXCEPTION(scope, {});
             auto len = parent.paths->length();
             for (size_t i = 0; i < len; i++) {
                 auto path = parent.paths->getIndex(globalObject, i);
+                RETURN_IF_EXCEPTION(scope, {});
                 array->push(globalObject, path);
+                RETURN_IF_EXCEPTION(scope, {});
             }
-            RELEASE_AND_RETURN(scope, array);
         } else if (parent.pathsArrayLazy && parent.filename) {
             auto filenameValue = parent.filename->value(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             auto filename = Bun::toString(filenameValue);
             auto paths = JSValue::decode(Resolver__nodeModulePathsJSValue(filename, globalObject, true));
-            RELEASE_AND_RETURN(scope, paths);
-        } else {
-            auto array = JSC::constructEmptyArray(globalObject, nullptr, 0);
             RETURN_IF_EXCEPTION(scope, {});
-            RELEASE_AND_RETURN(scope, array);
+            array = dynamicDowncast<JSArray>(paths);
+            if (!array) [[unlikely]] {
+                RELEASE_AND_RETURN(scope, paths);
+            }
+        } else {
+            array = JSC::constructEmptyArray(globalObject, nullptr, 0);
+            RETURN_IF_EXCEPTION(scope, {});
         }
+        appendGlobalPaths(globalObject, array, scope);
+        RETURN_IF_EXCEPTION(scope, {});
+        RELEASE_AND_RETURN(scope, array);
     }
 
     JSValue dirname;
@@ -692,9 +716,7 @@ static JSValue getConstantsObject(VM& vm, JSObject* moduleObject)
 
 static JSValue getGlobalPathsObject(VM& vm, JSObject* moduleObject)
 {
-    return JSC::constructEmptyArray(
-        moduleObject->globalObject(),
-        static_cast<ArrayAllocationProfile*>(nullptr), 0);
+    return JSValue::decode(Resolver__globalPathsJSValue(moduleObject->globalObject()));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionSetCJSWrapperItem, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/modules/NodeModuleModule.h
+++ b/src/jsc/modules/NodeModuleModule.h
@@ -22,6 +22,7 @@ JSC::JSValue createStreamIterEnabledFlag(Zig::GlobalObject*);
 void addNodeModuleConstructorProperties(JSC::VM &vm, Zig::GlobalObject *globalObject);
 
 extern "C" JSC::EncodedJSValue Resolver__nodeModulePathsJSValue(BunString specifier, JSC::JSGlobalObject*, bool use_dirname);
+extern "C" JSC::EncodedJSValue Resolver__globalPathsJSValue(JSC::JSGlobalObject*);
 extern "C" bool ModuleLoader__isBuiltin(const char* data, size_t len);
 
 struct PathResolveModule {

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -32,6 +32,63 @@ pub(crate) extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObje
     node_module_paths_js_value(in_str, global, false)
 }
 
+/// Node.js "global folders" list for `Module.globalPaths` /
+/// `Module._resolveLookupPaths`: the NODE_PATH entries followed by
+/// `$HOME/.node_modules`, `$HOME/.node_libraries` and `$PREFIX/lib/node`.
+/// https://nodejs.org/api/modules.html#loading-from-the-global-folders
+#[unsafe(export_name = "Resolver__globalPathsJSValue")]
+pub(crate) extern "C" fn global_paths_js_value(global: &JSGlobalObject) -> JSValue {
+    crate::mark_binding!();
+    let mut list: Vec<OwnedString> = Vec::new();
+    let env = global.bun_vm().env_loader_opt();
+
+    if let Some(node_path) = env.and_then(|e| e.get(b"NODE_PATH")) {
+        let delim = if cfg!(windows) { b';' } else { b':' };
+        for entry in node_path.split(|&b| b == delim).filter(|s| !s.is_empty()) {
+            list.push(OwnedString::new(BunString::clone_utf8(entry)));
+        }
+    }
+
+    let home_key = bun_core::env_var::HOME.key().as_bytes();
+    if let Some(home) = env.and_then(|e| e.get(home_key)).filter(|h| !h.is_empty()) {
+        let home = strip_trailing_sep(home);
+        for suffix in [".node_modules", ".node_libraries"] {
+            list.push(OwnedString::new(BunString::create_format(format_args!(
+                "{}{}{}",
+                BStr::new(home),
+                SEP_STR,
+                suffix,
+            ))));
+        }
+    }
+
+    if let Ok(exe) = bun_core::self_exe_path() {
+        let bin = resolve_path::dirname::<bun_paths::platform::Auto>(exe.as_bytes());
+        let prefix = if cfg!(windows) {
+            bin
+        } else {
+            resolve_path::dirname::<bun_paths::platform::Auto>(bin)
+        };
+        let prefix = strip_trailing_sep(prefix);
+        list.push(OwnedString::new(BunString::create_format(format_args!(
+            "{}{sep}lib{sep}node",
+            BStr::new(prefix),
+            sep = SEP_STR,
+        ))));
+    }
+
+    OwnedString::as_raw_slice(&list)
+        .to_js_array(global)
+        .unwrap_or(JSValue::ZERO)
+}
+
+fn strip_trailing_sep(mut p: &[u8]) -> &[u8] {
+    while p.len() > 1 && Platform::AUTO.is_separator(p[p.len() - 1]) {
+        p = &p[..p.len() - 1];
+    }
+    p
+}
+
 // C++ callers pass `in_str` by value without transferring a ref:
 // `bun_core::String` is `Copy` with no `Drop` impl, so receiving it by value
 // never releases the caller's ref.

--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -32,9 +32,8 @@ pub(crate) extern "C" fn Resolver__propForRequireMainPaths(global: &JSGlobalObje
     node_module_paths_js_value(in_str, global, false)
 }
 
-/// Node.js "global folders" list for `Module.globalPaths` /
-/// `Module._resolveLookupPaths`: the NODE_PATH entries followed by
-/// `$HOME/.node_modules`, `$HOME/.node_libraries` and `$PREFIX/lib/node`.
+/// `Module.globalPaths` / `_resolveLookupPaths` global folders: NODE_PATH
+/// entries, then `$HOME/.node_modules`, `$HOME/.node_libraries`, `$PREFIX/lib/node`.
 /// https://nodejs.org/api/modules.html#loading-from-the-global-folders
 #[unsafe(export_name = "Resolver__globalPathsJSValue")]
 pub(crate) extern "C" fn global_paths_js_value(global: &JSGlobalObject) -> JSValue {
@@ -83,7 +82,7 @@ pub(crate) extern "C" fn global_paths_js_value(global: &JSGlobalObject) -> JSVal
 }
 
 fn strip_trailing_sep(mut p: &[u8]) -> &[u8] {
-    while p.len() > 1 && Platform::AUTO.is_separator(p[p.len() - 1]) {
+    while !p.is_empty() && Platform::AUTO.is_separator(p[p.len() - 1]) {
         p = &p[..p.len() - 1];
     }
     p

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2864,6 +2864,53 @@ impl<'a> Resolver<'a> {
             }
         }
 
+        // try resolve from the legacy "global folders": $HOME/.node_modules,
+        // $HOME/.node_libraries and $PREFIX/lib/node, in that order.
+        // https://nodejs.org/api/modules.html#loading-from-the-global-folders
+        {
+            let home_key = bun_core::env_var::HOME.key().as_bytes();
+            let home = self
+                .env_loader()
+                .and_then(|env| env.get(home_key))
+                .filter(|h| !h.is_empty());
+            let exe = bun_core::self_exe_path().ok().map(|z| z.as_bytes());
+            for (base, suffix) in [
+                (home, b".node_modules" as &[u8]),
+                (home, b".node_libraries"),
+                (
+                    exe,
+                    if cfg!(windows) {
+                        b"../lib/node"
+                    } else {
+                        b"../../lib/node"
+                    },
+                ),
+            ] {
+                let Some(base) = base else { continue };
+                let Some(abs_path) = self
+                    .fs_ref()
+                    .abs_buf_checked(&[base, suffix, import_path], bufs!(node_modules_check))
+                else {
+                    continue;
+                };
+                if let Some(debug) = self.debug_logs.as_mut() {
+                    debug.add_note_fmt(format_args!(
+                        "Checking for a package in the global folder \"{}\"",
+                        bstr::BStr::new(abs_path)
+                    ));
+                }
+                if self
+                    .load_as_file_or_directory(abs_path, kind, out)
+                    .is_success()
+                {
+                    if let Some(d) = self.debug_logs.as_mut() {
+                        d.decrease_indent();
+                    }
+                    return MatchStatus::Success;
+                }
+            }
+        }
+
         dir_info = source_dir_info;
 
         // this is the magic!

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2843,6 +2843,7 @@ impl<'a> Resolver<'a> {
                 let Some(abs_path) = self
                     .fs_ref()
                     .abs_buf_checked(&[path, import_path], bufs!(node_modules_check))
+                    .filter(|p| bun_paths::is_absolute(p))
                 else {
                     continue;
                 };
@@ -2887,9 +2888,13 @@ impl<'a> Resolver<'a> {
                 ),
             ] {
                 let Some(base) = base else { continue };
+                // Loose-mode join treats a Windows `C:\...` import_path as
+                // absolute even on posix and discards the base; skip probes
+                // whose result is not native-absolute (dir_info asserts it).
                 let Some(abs_path) = self
                     .fs_ref()
                     .abs_buf_checked(&[base, suffix, import_path], bufs!(node_modules_check))
+                    .filter(|p| bun_paths::is_absolute(p))
                 else {
                     continue;
                 };

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -413,34 +413,34 @@ describe("NODE_PATH test", () => {
 describe("global folders resolution", () => {
   const homeVar = isWindows ? "USERPROFILE" : "HOME";
 
-  const prepare = () => {
-    const dir = tempDirWithFiles("global-folders", {
-      "home/.node_modules/gp-from-nm/index.js": "module.exports = 'FROM_HOME_NODE_MODULES';",
-      "home/.node_libraries/gp-from-lib/index.js": "module.exports = 'FROM_HOME_NODE_LIBRARIES';",
-      "home/.node_modules/gp-both/index.js": "module.exports = 'NM_WINS';",
-      "home/.node_libraries/gp-both/index.js": "module.exports = 'LIB_LOSES';",
-      "np/gp-from-np/index.js": "module.exports = 'FROM_NODE_PATH';",
-      "np/gp-from-nm/index.js": "module.exports = 'NODE_PATH_WINS';",
-      "proj/package.json": JSON.stringify({ name: "proj", type: "commonjs" }),
-      "proj/node_modules/gp-local/index.js": "module.exports = 'LOCAL_WINS';",
-      "home/.node_modules/gp-local/index.js": "module.exports = 'GLOBAL_LOSES';",
-      "proj/app.js": `
-        const M = require("node:module");
-        let result = {};
-        for (const name of ["gp-from-nm", "gp-from-lib", "gp-both", "gp-from-np", "gp-local"]) {
-          try { result[name] = require(name); } catch (e) { result[name] = "THREW:" + e.code; }
-        }
-        result.globalPaths = M.globalPaths;
-        result.resolvePaths = require.resolve.paths("gp-from-nm");
-        result.lookupPaths = M._resolveLookupPaths("gp-from-nm", module);
-        console.log(JSON.stringify(result));
-      `,
-    });
-    return { dir, home: joinP(dir, "home"), proj: joinP(dir, "proj"), np: joinP(dir, "np") };
+  const fixture = {
+    "home/.node_modules/gp-from-nm/index.js": "module.exports = 'FROM_HOME_NODE_MODULES';",
+    "home/.node_libraries/gp-from-lib/index.js": "module.exports = 'FROM_HOME_NODE_LIBRARIES';",
+    "home/.node_modules/gp-both/index.js": "module.exports = 'NM_WINS';",
+    "home/.node_libraries/gp-both/index.js": "module.exports = 'LIB_LOSES';",
+    "np/gp-from-np/index.js": "module.exports = 'FROM_NODE_PATH';",
+    "np/gp-from-nm/index.js": "module.exports = 'NODE_PATH_WINS';",
+    "proj/package.json": JSON.stringify({ name: "proj", type: "commonjs" }),
+    "proj/node_modules/gp-local/index.js": "module.exports = 'LOCAL_WINS';",
+    "home/.node_modules/gp-local/index.js": "module.exports = 'GLOBAL_LOSES';",
+    "proj/app.js": `
+      const M = require("node:module");
+      let result = {};
+      for (const name of ["gp-from-nm", "gp-from-lib", "gp-both", "gp-from-np", "gp-local"]) {
+        try { result[name] = require(name); } catch (e) { result[name] = "THREW:" + e.code; }
+      }
+      result.globalPaths = M.globalPaths;
+      result.resolvePaths = require.resolve.paths("gp-from-nm");
+      result.lookupPaths = M._resolveLookupPaths("gp-from-nm", module);
+      console.log(JSON.stringify(result));
+    `,
   };
 
   it("resolves bare specifiers from $HOME/.node_modules and $HOME/.node_libraries", () => {
-    const { home, proj, np } = prepare();
+    using dir = tempDir("global-folders", fixture);
+    const home = joinP(String(dir), "home");
+    const proj = joinP(String(dir), "proj");
+    const np = joinP(String(dir), "np");
     const { exitCode, stdout, stderr } = Bun.spawnSync({
       cmd: [bunExe(), "--no-install", "app.js"],
       env: { ...bunEnv, [homeVar]: home, NODE_PATH: np },
@@ -481,7 +481,9 @@ describe("global folders resolution", () => {
   });
 
   it("resolves from $HOME/.node_modules when NODE_PATH is unset", () => {
-    const { home, proj } = prepare();
+    using dir = tempDir("global-folders", fixture);
+    const home = joinP(String(dir), "home");
+    const proj = joinP(String(dir), "proj");
     const { exitCode, stdout, stderr } = Bun.spawnSync({
       cmd: [bunExe(), "--no-install", "app.js"],
       env: { ...bunEnv, [homeVar]: home, NODE_PATH: "" },
@@ -497,7 +499,8 @@ describe("global folders resolution", () => {
   });
 
   it("returns MODULE_NOT_FOUND when HOME is unset and no global folder matches", () => {
-    const { proj } = prepare();
+    using dir = tempDir("global-folders", fixture);
+    const proj = joinP(String(dir), "proj");
     const env = { ...bunEnv, NODE_PATH: "" };
     delete env[homeVar];
     const { exitCode, stdout } = Bun.spawnSync({

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -412,6 +412,9 @@ describe("NODE_PATH test", () => {
 // https://nodejs.org/api/modules.html#loading-from-the-global-folders
 describe("global folders resolution", () => {
   const homeVar = isWindows ? "USERPROFILE" : "HOME";
+  // The runtime emits native-separator paths; normalize to forward slashes so the
+  // same `joinP` expectations hold on every platform.
+  const norm = (arr: string[]) => arr.map(p => p.replaceAll("\\", "/"));
 
   const fixture = {
     "home/.node_modules/gp-from-nm/index.js": "module.exports = 'FROM_HOME_NODE_MODULES';",
@@ -443,8 +446,8 @@ describe("global folders resolution", () => {
     const np = joinP(String(dir), "np");
     const { exitCode, stdout, stderr } = Bun.spawnSync({
       cmd: [bunExe(), "--no-install", "app.js"],
-      env: { ...bunEnv, [homeVar]: home, NODE_PATH: np },
-      cwd: proj,
+      env: { ...bunEnv, [homeVar]: join(String(dir), "home"), NODE_PATH: join(String(dir), "np") },
+      cwd: join(String(dir), "proj"),
     });
     const out = stdout.toString().trim();
     expect(stderr.toString()).toBe("");
@@ -458,20 +461,21 @@ describe("global folders resolution", () => {
     expect(result["gp-local"]).toBe("LOCAL_WINS"); // local node_modules before global folders
 
     // Module.globalPaths is populated
-    expect(result.globalPaths).toContain(np);
-    expect(result.globalPaths).toContain(joinP(home, ".node_modules"));
-    expect(result.globalPaths).toContain(joinP(home, ".node_libraries"));
+    const globalPaths = norm(result.globalPaths);
+    expect(globalPaths).toContain(np);
+    expect(globalPaths).toContain(joinP(home, ".node_modules"));
+    expect(globalPaths).toContain(joinP(home, ".node_libraries"));
     // Node orders globalPaths as [...NODE_PATH, .node_modules, .node_libraries, $PREFIX/lib/node]
-    expect(result.globalPaths.indexOf(np)).toBeLessThan(result.globalPaths.indexOf(joinP(home, ".node_modules")));
-    expect(result.globalPaths.indexOf(joinP(home, ".node_modules"))).toBeLessThan(
-      result.globalPaths.indexOf(joinP(home, ".node_libraries")),
+    expect(globalPaths.indexOf(np)).toBeLessThan(globalPaths.indexOf(joinP(home, ".node_modules")));
+    expect(globalPaths.indexOf(joinP(home, ".node_modules"))).toBeLessThan(
+      globalPaths.indexOf(joinP(home, ".node_libraries")),
     );
     // $PREFIX/lib/node is the last entry
-    expect(result.globalPaths[result.globalPaths.length - 1]).toEndWith(joinP("lib", "node"));
+    expect(globalPaths[globalPaths.length - 1]).toEndWith("lib/node");
 
     // require.resolve.paths() and Module._resolveLookupPaths() append the global folders
     // after the per-directory node_modules entries.
-    for (const paths of [result.resolvePaths, result.lookupPaths]) {
+    for (const paths of [norm(result.resolvePaths), norm(result.lookupPaths)]) {
       expect(paths).toContain(joinP(proj, "node_modules"));
       expect(paths).toContain(joinP(home, ".node_modules"));
       expect(paths).toContain(joinP(home, ".node_libraries"));
@@ -483,38 +487,37 @@ describe("global folders resolution", () => {
   it("resolves from $HOME/.node_modules when NODE_PATH is unset", () => {
     using dir = tempDir("global-folders", fixture);
     const home = joinP(String(dir), "home");
-    const proj = joinP(String(dir), "proj");
     const { exitCode, stdout, stderr } = Bun.spawnSync({
       cmd: [bunExe(), "--no-install", "app.js"],
-      env: { ...bunEnv, [homeVar]: home, NODE_PATH: "" },
-      cwd: proj,
+      env: { ...bunEnv, [homeVar]: join(String(dir), "home"), NODE_PATH: "" },
+      cwd: join(String(dir), "proj"),
     });
     expect(stderr.toString()).toBe("");
     const result = JSON.parse(stdout.toString().trim());
     expect(result["gp-from-nm"]).toBe("FROM_HOME_NODE_MODULES");
     expect(result["gp-from-lib"]).toBe("FROM_HOME_NODE_LIBRARIES");
     expect(result["gp-from-np"]).toBe("THREW:MODULE_NOT_FOUND");
-    expect(result.globalPaths).toContain(joinP(home, ".node_modules"));
+    expect(norm(result.globalPaths)).toContain(joinP(home, ".node_modules"));
     expect(exitCode).toBe(0);
   });
 
   it("returns MODULE_NOT_FOUND when HOME is unset and no global folder matches", () => {
     using dir = tempDir("global-folders", fixture);
-    const proj = joinP(String(dir), "proj");
     const env = { ...bunEnv, NODE_PATH: "" };
     delete env[homeVar];
     const { exitCode, stdout } = Bun.spawnSync({
       cmd: [bunExe(), "--no-install", "app.js"],
       env,
-      cwd: proj,
+      cwd: join(String(dir), "proj"),
     });
     const result = JSON.parse(stdout.toString().trim());
     expect(result["gp-from-nm"]).toBe("THREW:MODULE_NOT_FOUND");
     expect(result["gp-from-lib"]).toBe("THREW:MODULE_NOT_FOUND");
     expect(result["gp-local"]).toBe("LOCAL_WINS");
     // globalPaths still has $PREFIX/lib/node even without HOME
-    expect(result.globalPaths.length).toBeGreaterThanOrEqual(1);
-    expect(result.globalPaths[result.globalPaths.length - 1]).toEndWith(joinP("lib", "node"));
+    const globalPaths = norm(result.globalPaths);
+    expect(globalPaths.length).toBeGreaterThanOrEqual(1);
+    expect(globalPaths[globalPaths.length - 1]).toEndWith("lib/node");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -409,6 +409,113 @@ describe("NODE_PATH test", () => {
   });
 });
 
+// https://nodejs.org/api/modules.html#loading-from-the-global-folders
+describe("global folders resolution", () => {
+  const homeVar = isWindows ? "USERPROFILE" : "HOME";
+
+  const prepare = () => {
+    const dir = tempDirWithFiles("global-folders", {
+      "home/.node_modules/gp-from-nm/index.js": "module.exports = 'FROM_HOME_NODE_MODULES';",
+      "home/.node_libraries/gp-from-lib/index.js": "module.exports = 'FROM_HOME_NODE_LIBRARIES';",
+      "home/.node_modules/gp-both/index.js": "module.exports = 'NM_WINS';",
+      "home/.node_libraries/gp-both/index.js": "module.exports = 'LIB_LOSES';",
+      "np/gp-from-np/index.js": "module.exports = 'FROM_NODE_PATH';",
+      "np/gp-from-nm/index.js": "module.exports = 'NODE_PATH_WINS';",
+      "proj/package.json": JSON.stringify({ name: "proj", type: "commonjs" }),
+      "proj/node_modules/gp-local/index.js": "module.exports = 'LOCAL_WINS';",
+      "home/.node_modules/gp-local/index.js": "module.exports = 'GLOBAL_LOSES';",
+      "proj/app.js": `
+        const M = require("node:module");
+        let result = {};
+        for (const name of ["gp-from-nm", "gp-from-lib", "gp-both", "gp-from-np", "gp-local"]) {
+          try { result[name] = require(name); } catch (e) { result[name] = "THREW:" + e.code; }
+        }
+        result.globalPaths = M.globalPaths;
+        result.resolvePaths = require.resolve.paths("gp-from-nm");
+        result.lookupPaths = M._resolveLookupPaths("gp-from-nm", module);
+        console.log(JSON.stringify(result));
+      `,
+    });
+    return { dir, home: joinP(dir, "home"), proj: joinP(dir, "proj"), np: joinP(dir, "np") };
+  };
+
+  it("resolves bare specifiers from $HOME/.node_modules and $HOME/.node_libraries", () => {
+    const { home, proj, np } = prepare();
+    const { exitCode, stdout, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "--no-install", "app.js"],
+      env: { ...bunEnv, [homeVar]: home, NODE_PATH: np },
+      cwd: proj,
+    });
+    const out = stdout.toString().trim();
+    expect(stderr.toString()).toBe("");
+    const result = JSON.parse(out);
+
+    // require() resolution
+    expect(result["gp-from-nm"]).toBe("NODE_PATH_WINS"); // NODE_PATH before $HOME/.node_modules
+    expect(result["gp-from-lib"]).toBe("FROM_HOME_NODE_LIBRARIES");
+    expect(result["gp-both"]).toBe("NM_WINS"); // .node_modules before .node_libraries
+    expect(result["gp-from-np"]).toBe("FROM_NODE_PATH");
+    expect(result["gp-local"]).toBe("LOCAL_WINS"); // local node_modules before global folders
+
+    // Module.globalPaths is populated
+    expect(result.globalPaths).toContain(np);
+    expect(result.globalPaths).toContain(joinP(home, ".node_modules"));
+    expect(result.globalPaths).toContain(joinP(home, ".node_libraries"));
+    // Node orders globalPaths as [...NODE_PATH, .node_modules, .node_libraries, $PREFIX/lib/node]
+    expect(result.globalPaths.indexOf(np)).toBeLessThan(result.globalPaths.indexOf(joinP(home, ".node_modules")));
+    expect(result.globalPaths.indexOf(joinP(home, ".node_modules"))).toBeLessThan(
+      result.globalPaths.indexOf(joinP(home, ".node_libraries")),
+    );
+    // $PREFIX/lib/node is the last entry
+    expect(result.globalPaths[result.globalPaths.length - 1]).toEndWith(joinP("lib", "node"));
+
+    // require.resolve.paths() and Module._resolveLookupPaths() append the global folders
+    // after the per-directory node_modules entries.
+    for (const paths of [result.resolvePaths, result.lookupPaths]) {
+      expect(paths).toContain(joinP(proj, "node_modules"));
+      expect(paths).toContain(joinP(home, ".node_modules"));
+      expect(paths).toContain(joinP(home, ".node_libraries"));
+      expect(paths.indexOf(joinP(proj, "node_modules"))).toBeLessThan(paths.indexOf(joinP(home, ".node_modules")));
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  it("resolves from $HOME/.node_modules when NODE_PATH is unset", () => {
+    const { home, proj } = prepare();
+    const { exitCode, stdout, stderr } = Bun.spawnSync({
+      cmd: [bunExe(), "--no-install", "app.js"],
+      env: { ...bunEnv, [homeVar]: home, NODE_PATH: "" },
+      cwd: proj,
+    });
+    expect(stderr.toString()).toBe("");
+    const result = JSON.parse(stdout.toString().trim());
+    expect(result["gp-from-nm"]).toBe("FROM_HOME_NODE_MODULES");
+    expect(result["gp-from-lib"]).toBe("FROM_HOME_NODE_LIBRARIES");
+    expect(result["gp-from-np"]).toBe("THREW:MODULE_NOT_FOUND");
+    expect(result.globalPaths).toContain(joinP(home, ".node_modules"));
+    expect(exitCode).toBe(0);
+  });
+
+  it("returns MODULE_NOT_FOUND when HOME is unset and no global folder matches", () => {
+    const { proj } = prepare();
+    const env = { ...bunEnv, NODE_PATH: "" };
+    delete env[homeVar];
+    const { exitCode, stdout } = Bun.spawnSync({
+      cmd: [bunExe(), "--no-install", "app.js"],
+      env,
+      cwd: proj,
+    });
+    const result = JSON.parse(stdout.toString().trim());
+    expect(result["gp-from-nm"]).toBe("THREW:MODULE_NOT_FOUND");
+    expect(result["gp-from-lib"]).toBe("THREW:MODULE_NOT_FOUND");
+    expect(result["gp-local"]).toBe("LOCAL_WINS");
+    // globalPaths still has $PREFIX/lib/node even without HOME
+    expect(result.globalPaths.length).toBeGreaterThanOrEqual(1);
+    expect(result.globalPaths[result.globalPaths.length - 1]).toEndWith(joinP("lib", "node"));
+    expect(exitCode).toBe(0);
+  });
+});
+
 it("can resolve with source directories that do not exist", () => {
   // In Nuxt/Vite, the following call happens:
   // `require("module").createRequire("file:///Users/clo/my-nuxt-app/@vue/server-renderer")("vue")`

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -249,11 +249,12 @@ describe.concurrent("node-module-module", () => {
   });
 
   test("Module._resolveLookupPaths", () => {
-    expect(Module._resolveLookupPaths("foo")).toEqual([]);
+    const globalPaths = Module.globalPaths;
+    expect(Module._resolveLookupPaths("foo")).toEqual([...globalPaths]);
     expect(Module._resolveLookupPaths("./bar", { id: "1", filename: "/baz/abc" })).toEqual(["/baz"]);
     expect(Module._resolveLookupPaths("./bar", {})).toEqual(["."]);
     expect(Module._resolveLookupPaths("./bar", { paths: ["a"] })).toEqual(["."]);
-    expect(Module._resolveLookupPaths("bar", { paths: ["a"] })).toEqual(["a"]);
+    expect(Module._resolveLookupPaths("bar", { paths: ["a"] })).toEqual(["a", ...globalPaths]);
   });
 
   test("Module.findSourceMap doesn't throw", () => {


### PR DESCRIPTION
Node's CJS loader, after walking up `node_modules` and `NODE_PATH`, also searches `$HOME/.node_modules`, `$HOME/.node_libraries` and `$PREFIX/lib/node` ([docs](https://nodejs.org/api/modules.html#loading-from-the-global-folders)). Bun honoured `NODE_PATH` but skipped these three.

## Repro

```js
import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
import { tmpdir } from 'node:os'; import { join } from 'node:path'; import { spawnSync } from 'node:child_process';
const home = mkdtempSync(join(tmpdir(), 'gp-'));
mkdirSync(join(home, '.node_modules', 'gpmarker-nm'), { recursive: true });
writeFileSync(join(home, '.node_modules', 'gpmarker-nm', 'index.js'), 'module.exports = "FROM_HOME_NODE_MODULES";');
const proj = join(home, 'proj'); mkdirSync(proj);
writeFileSync(join(proj, 'package.json'), '{"type":"commonjs"}');
writeFileSync(join(proj, 'app.js'), `let v; try { v = require('gpmarker-nm'); } catch (e) { v = 'THREW:' + e.code; }
console.log(JSON.stringify({ v, globalPaths: require('node:module').globalPaths.length, inPaths: JSON.stringify(require.resolve.paths('gpmarker-nm')).includes('.node_modules') }));`);
const args = typeof Bun !== 'undefined' ? ['--no-install', 'app.js'] : ['app.js'];
const r = JSON.parse(spawnSync(process.execPath, args, { cwd: proj, env: { ...process.env, HOME: home, NODE_PATH: '' }, encoding: 'utf8' }).stdout.trim());
console.log(JSON.stringify(r));
if (r.v !== 'FROM_HOME_NODE_MODULES' || !r.globalPaths || !r.inPaths) { console.log('BUG global folders not searched'); process.exit(1); }
console.log('ok');
```

Node prints `{"v":"FROM_HOME_NODE_MODULES","globalPaths":3,"inPaths":true}`, Bun printed `{"v":"THREW:MODULE_NOT_FOUND","globalPaths":0,"inPaths":false}`. With auto-install on, the bare name was masked by Bun silently installing the npm package of that name instead of loading the user's copy from `$HOME/.node_modules`.

## Cause

- `getGlobalPathsObject` in `NodeModuleModule.cpp` returned a hard-coded empty array, so `Module.globalPaths` was always `[]`.
- `resolveLookupPaths` (used by `require.resolve.paths` and `Module._resolveLookupPaths`) copied `parent.paths` but never appended the global folders for bare specifiers.
- `load_node_modules` in `resolver.rs` probed `NODE_PATH` entries but never probed `$HOME/.node_modules`, `$HOME/.node_libraries` or `$PREFIX/lib/node`.

## Fix

- Add a `Resolver__globalPathsJSValue` export in `resolver_jsc.rs` that builds the full list (`NODE_PATH` entries, then `$HOME/.node_modules`, `$HOME/.node_libraries`, `$PREFIX/lib/node`) from the dotenv loader and `self_exe_path`, matching Node's `Module._initPaths` ordering.
- `getGlobalPathsObject` now calls that helper, so `Module.globalPaths` is populated on first access.
- `resolveLookupPaths` appends the global paths after `parent.paths` for bare specifiers, so `require.resolve.paths('pkg')` and `Module._resolveLookupPaths('pkg', module)` match Node.
- `load_node_modules` probes the three global folders right after the `NODE_PATH` loop, using the same `load_as_file_or_directory` path.

## Verification

New tests in `test/js/bun/resolve/resolve.test.ts` cover resolution from `$HOME/.node_modules` and `$HOME/.node_libraries`, precedence (local `node_modules` > `NODE_PATH` > `$HOME/.node_modules` > `$HOME/.node_libraries`), the contents and ordering of `Module.globalPaths`, and that `require.resolve.paths` / `_resolveLookupPaths` append them for bare specifiers. The existing `Module._resolveLookupPaths` assertions in `test/js/node/module/node-module-module.test.js` are updated to expect the appended global paths (matching Node). The vendored `test-module-globalpaths-nodepath.js` still passes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->