### PR TITLE
inspector: honor --inspect flags on compiled executables

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3287,8 +3287,6 @@ pub struct Options {
     // forward-dep crate; callers pass it as the resolver's trait object so
     // both VM and resolver can hold it without the cycle.
     pub graph: Option<&'static dyn bun_resolver::StandaloneModuleGraph>,
-    /// Forwarded to [`InitOptions::debugger`] so `configure_debugger` sees the
-    /// CLI `--inspect*` flag on the standalone-executable path.
     pub debugger: bun_options_types::context::Debugger,
     pub is_main_thread: bool,
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4063,6 +4063,7 @@ impl VirtualMachine {
         let vm = Self::init(init_opts)?;
         // SAFETY: `vm` is the unique live VM on this thread.
         let vm_ref = unsafe { &mut *vm };
+        vm_ref.dns_result_order = opts.dns_result_order;
         vm_ref.transpiler.resolver.standalone_module_graph = Some(graph);
         vm_ref.install_bytecode_string_table(graph);
         // Avoid reading from tsconfig.json & package.json when in standalone mode

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3287,10 +3287,9 @@ pub struct Options {
     // forward-dep crate; callers pass it as the resolver's trait object so
     // both VM and resolver can hold it without the cycle.
     pub graph: Option<&'static dyn bun_resolver::StandaloneModuleGraph>,
-    // Note: debugger
-    // configuration is plumbed through `RuntimeHooks::ensure_debugger` (the
-    // CLI option struct lives in `bun_cli`, a forward dep). See
-    // `runtime/jsc_hooks.rs` for the `configureDebugger` call site.
+    /// Forwarded to [`InitOptions::debugger`] so `configure_debugger` sees the
+    /// CLI `--inspect*` flag on the standalone-executable path.
+    pub debugger: bun_options_types::context::Debugger,
     pub is_main_thread: bool,
 }
 
@@ -4054,6 +4053,7 @@ impl VirtualMachine {
             graph: Some(graph),
             log: opts.log,
             env_loader: opts.env_loader,
+            debugger: opts.debugger,
             smol: opts.smol,
             mini_mode: opts.smol,
             eval_mode: false,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1156,6 +1156,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             args: ctx.args.clone(),
             graph: Some(graph_dyn),
             is_main_thread: true,
+            debugger: ::core::mem::take(&mut ctx.runtime_options.debugger),
             smol: ctx.runtime_options.smol,
             // `Options::dns_result_order` is `u8` until the
             // b2-cycle widens it to `bun_dns::Order`; the enum is

--- a/test/cli/env/bun-options.test.ts
+++ b/test/cli/env/bun-options.test.ts
@@ -116,6 +116,27 @@ describe("BUN_OPTIONS environment variable", () => {
     expect(cpuProfiles.length).toBeGreaterThanOrEqual(1);
   }, 60_000);
 
+  test("--dns-result-order is honored (standalone executable)", () => {
+    using dir = tempDir("bun-options-dns-order-compile", {
+      "entry.ts": `console.log(require("dns").getDefaultResultOrder());`,
+    });
+
+    const exePath = String(dir) + "/app";
+    const build = spawnSync({
+      cmd: [bunExe(), "build", "--compile", String(dir) + "/entry.ts", "--outfile", exePath],
+      env: bunEnv,
+    });
+    expect(build.exitCode).toBe(0);
+
+    const result = spawnSync({
+      cmd: [exePath],
+      env: { ...bunEnv, BUN_OPTIONS: "--dns-result-order=ipv4first" },
+    });
+
+    expect(result.stdout.toString().trim()).toBe("ipv4first");
+    expect(result.exitCode).toBe(0);
+  }, 60_000);
+
   test("empty BUN_OPTIONS - should work normally", () => {
     const result = spawnSync({
       cmd: [bunExe(), "--print='NORMAL'"],

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -359,31 +359,39 @@ describe("standalone executable", () => {
         stdout: "ignore",
         stderr: "pipe",
       });
+      try {
+        const { url, stderr } = await readInspectorUrl(compiledInspectee);
+        if (!url) {
+          throw new Error("Inspector never started; stderr: " + JSON.stringify(stderr));
+        }
+        expect({ protocol: url.protocol, hostname: url.hostname }).toEqual({
+          protocol: "ws:",
+          hostname: "127.0.0.1",
+        });
 
-      const { url, stderr } = await readInspectorUrl(compiledInspectee);
-      if (!url) {
-        throw new Error("Inspector never started; stderr: " + JSON.stringify(stderr));
+        const webSocket = new WebSocket(url);
+        await new Promise<void>((resolve, reject) => {
+          webSocket.addEventListener("open", () => resolve());
+          webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+          webSocket.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
+        });
+        webSocket.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
+        const reply = await new Promise((resolve, reject) => {
+          webSocket.addEventListener("message", ({ data }) => resolve(JSON.parse(data.toString())));
+          webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+          webSocket.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
+        });
+        expect(reply).toMatchObject({
+          id: 1,
+          result: { result: { type: "number", value: 2 } },
+        });
+        webSocket.close();
+      } finally {
+        // The exe must stop before `dir` is disposed (Windows cannot remove a
+        // directory while an executable inside it is still running).
+        compiledInspectee.kill();
+        await compiledInspectee.exited;
       }
-      expect({ protocol: url.protocol, hostname: url.hostname }).toEqual({
-        protocol: "ws:",
-        hostname: "127.0.0.1",
-      });
-
-      const webSocket = new WebSocket(url);
-      await new Promise<void>((resolve, reject) => {
-        webSocket.addEventListener("open", () => resolve());
-        webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
-        webSocket.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
-      });
-      webSocket.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
-      const reply = await new Promise(resolve => {
-        webSocket.addEventListener("message", ({ data }) => resolve(JSON.parse(data.toString())));
-      });
-      expect(reply).toMatchObject({
-        id: 1,
-        result: { result: { type: "number", value: 2 } },
-      });
-      webSocket.close();
     }, 60_000);
   }
 
@@ -400,21 +408,25 @@ describe("standalone executable", () => {
       stdout: "ignore",
       stderr: "pipe",
     });
+    try {
+      const { url, stderr } = await readInspectorUrl(compiledInspectee);
+      if (!url) {
+        throw new Error("Inspector never started; stderr: " + JSON.stringify(stderr));
+      }
+      // The script body must not have run before a debugger connects.
+      expect(stderr).not.toContain("ran");
+      expect(compiledInspectee.exitCode).toBeNull();
 
-    const { url, stderr } = await readInspectorUrl(compiledInspectee);
-    if (!url) {
-      throw new Error("Inspector never started; stderr: " + JSON.stringify(stderr));
+      const webSocket = new WebSocket(url);
+      await new Promise<void>((resolve, reject) => {
+        webSocket.addEventListener("open", () => resolve());
+        webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+      });
+      webSocket.close();
+    } finally {
+      compiledInspectee.kill();
+      await compiledInspectee.exited;
     }
-    // The script body must not have run before a debugger connects.
-    expect(stderr).not.toContain("ran");
-    expect(compiledInspectee.exitCode).toBeNull();
-
-    const webSocket = new WebSocket(url);
-    await new Promise<void>((resolve, reject) => {
-      webSocket.addEventListener("open", () => resolve());
-      webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
-    });
-    webSocket.close();
   }, 60_000);
 });
 

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isPosix, randomPort, tempDir } from "harness";
+import { bunEnv, bunExe, isPosix, isWindows, randomPort, tempDir } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -298,6 +298,124 @@ describe("websocket", () => {
   afterEach(() => {
     inspectee?.kill();
   });
+});
+
+describe("standalone executable", () => {
+  let compiledInspectee: Subprocess | undefined;
+
+  afterEach(() => {
+    compiledInspectee?.kill();
+  });
+
+  async function readInspectorUrl(proc: Subprocess): Promise<{ url: URL | undefined; stderr: string }> {
+    let url: URL | undefined;
+    let stderr = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr as ReadableStream) {
+      stderr += decoder.decode(chunk);
+      for (const line of stderr.split("\n")) {
+        try {
+          const candidate = new URL(line.trim());
+          if (candidate.protocol.includes("ws")) {
+            url = candidate;
+          }
+        } catch {}
+      }
+      if (url) break;
+    }
+    return { url, stderr };
+  }
+
+  async function compile(dir: string, extraArgs: string[] = []): Promise<string> {
+    const exePath = join(dir, isWindows ? "app.exe" : "app");
+    await using build = spawn({
+      cmd: [bunExe(), "build", "--compile", join(dir, "entry.ts"), "--outfile", exePath, ...extraArgs],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    if (buildExit !== 0) throw new Error("compile failed: " + buildErr);
+    return exePath;
+  }
+
+  // Keep the process alive long enough for the (concurrently-started)
+  // debugger thread to print its banner; bounded so the fail-before case
+  // does not hang until the test timeout.
+  const entry = `setTimeout(() => {}, 15_000);`;
+
+  for (const { name, env, compileArgs } of [
+    { name: "BUN_OPTIONS=--inspect", env: { BUN_OPTIONS: "--inspect=127.0.0.1:0" }, compileArgs: [] },
+    { name: "--compile-exec-argv=--inspect", env: {}, compileArgs: ["--compile-exec-argv=--inspect=127.0.0.1:0"] },
+  ]) {
+    test(`${name} opens the inspector`, async () => {
+      using dir = tempDir("inspect-compile", { "entry.ts": entry });
+      const exePath = await compile(String(dir), compileArgs);
+
+      compiledInspectee = spawn({
+        cmd: [exePath],
+        env: { ...bunEnv, ...env },
+        cwd: String(dir),
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+
+      const { url, stderr } = await readInspectorUrl(compiledInspectee);
+      if (!url) {
+        throw new Error("Inspector never started; stderr: " + JSON.stringify(stderr));
+      }
+      expect({ protocol: url.protocol, hostname: url.hostname }).toEqual({
+        protocol: "ws:",
+        hostname: "127.0.0.1",
+      });
+
+      const webSocket = new WebSocket(url);
+      await new Promise<void>((resolve, reject) => {
+        webSocket.addEventListener("open", () => resolve());
+        webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+        webSocket.addEventListener("close", cause => reject(new Error("WebSocket closed", { cause })));
+      });
+      webSocket.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
+      const reply = await new Promise(resolve => {
+        webSocket.addEventListener("message", ({ data }) => resolve(JSON.parse(data.toString())));
+      });
+      expect(reply).toMatchObject({
+        id: 1,
+        result: { result: { type: "number", value: 2 } },
+      });
+      webSocket.close();
+    }, 60_000);
+  }
+
+  test("BUN_OPTIONS=--inspect-wait blocks until a debugger connects", async () => {
+    using dir = tempDir("inspect-compile-wait", {
+      "entry.ts": `console.error("ran");`,
+    });
+    const exePath = await compile(String(dir));
+
+    compiledInspectee = spawn({
+      cmd: [exePath],
+      env: { ...bunEnv, BUN_OPTIONS: "--inspect-wait=127.0.0.1:0" },
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+
+    const { url, stderr } = await readInspectorUrl(compiledInspectee);
+    if (!url) {
+      throw new Error("Inspector never started; stderr: " + JSON.stringify(stderr));
+    }
+    // The script body must not have run before a debugger connects.
+    expect(stderr).not.toContain("ran");
+    expect(compiledInspectee.exitCode).toBeNull();
+
+    const webSocket = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      webSocket.addEventListener("open", () => resolve());
+      webSocket.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+    });
+    webSocket.close();
+  }, 60_000);
 });
 
 describe("http metadata endpoint", () => {


### PR DESCRIPTION
## Repro

```sh
D=$(mktemp -d); cd $D
printf 'await Bun.sleep(700);\nconsole.log("execArgv=" + JSON.stringify(process.execArgv));\n' > l.ts
bun build --compile l.ts --outfile app
BUN_OPTIONS="--inspect=127.0.0.1:0" ./app
# execArgv=["--inspect=127.0.0.1:0"] but no "Bun Inspector" banner, no listener
```

`bun run l.ts` with the same `BUN_OPTIONS` opens the inspector. `--compile-exec-argv=--inspect=...` is dropped the same way, and `--inspect-wait` does not wait.

## Cause

`RunCommand::boot_standalone` builds the VM via `VirtualMachine::init_with_module_graph(Options { .. })`, but `Options` had no `debugger` field, so `init_with_module_graph` always passed `InitOptions { debugger: Default::default(), .. }` and `configure_debugger` saw `Debugger::Unspecified`. The CLI flag made it as far as `ctx.runtime_options.debugger` (hence `process.execArgv`) and was then dropped. Only the `BUN_INSPECT` env var, read directly inside `configure_debugger`, could start the inspector on a compiled binary.

`RunCommand::boot` (the `bun run` path) already calls `VirtualMachine::init(InitOptions { debugger: take(&mut ctx.runtime_options.debugger), .. })`, so the two boot paths had diverged.

## Fix

Add `debugger: bun_options_types::context::Debugger` to `virtual_machine::Options`, forward it in `init_with_module_graph`, and populate it from `ctx.runtime_options.debugger` in `boot_standalone`, matching `boot`. The stale comment claiming the type lived in a forward-dep crate is removed (`InitOptions` already uses it).

`init_worker` / `init_bake` keep using `..Default::default()` and remain unchanged.

## Tests

New `standalone executable` describe in `test/cli/inspect/inspect.test.ts`:
- `BUN_OPTIONS=--inspect=127.0.0.1:0` on a compiled exe prints the banner and accepts a WebSocket that can `Runtime.evaluate`
- `--compile-exec-argv=--inspect=127.0.0.1:0` does the same
- `BUN_OPTIONS=--inspect-wait=127.0.0.1:0` blocks the script body until a client connects

All three fail on main ("Inspector never started"; `--inspect-wait` runs the body immediately) and pass with this change.

Not addressed here: a compile-time opt-out so a shipped binary can refuse `BUN_INSPECT`-driven debugging. That is a separate hardening feature.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/inspect/inspect.test.ts

<!-- robobun:evidence:end -->

Fixes #20253
