### PR TITLE
child_process: run the requested module when fork() is called inside a compiled executable

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -141,6 +141,10 @@ new!(pub JENKINS_URL: string, "JENKINS_URL", {});
 new!(pub MI_VERBOSE: boolean, "MI_VERBOSE", { default: false });
 new!(pub NO_COLOR: boolean, "NO_COLOR", { default: false });
 new!(pub NODE_CHANNEL_FD: string, "NODE_CHANNEL_FD", {});
+// Set by child_process.fork() when the parent is a compiled executable so the
+// spawned copy of the binary runs the requested module instead of the baked
+// entry point. Consumed and unset in `boot_standalone`.
+new!(pub BUN_INTERNAL_FORK_ENTRY: string, "BUN_INTERNAL_FORK_ENTRY", {});
 // A string, not a boolean: node suppresses warnings only when the value is
 // exactly "1" (lib/internal/process/pre_execution.js).
 new!(pub NODE_NO_WARNINGS: string, "NODE_NO_WARNINGS", {});

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -770,7 +770,8 @@ function fork(modulePath, args = [], options) {
     validateObject(options, "options");
   }
   options = { __proto__: null, ...options, shell: false };
-  options.execPath = options.execPath || process.execPath;
+  const userExecPath = options.execPath;
+  options.execPath = userExecPath || process.execPath;
   validateArgumentNullCheck(options.execPath, "options.execPath");
 
   // Prepare arguments for fork:
@@ -785,6 +786,17 @@ function fork(modulePath, args = [], options) {
       execArgv = ArrayPrototypeSlice.$call(execArgv);
       ArrayPrototypeSplice.$call(execArgv, index - 1, 2);
     }
+  }
+
+  // Inside a compiled executable, process.execPath is this binary and it
+  // always boots its embedded main entry. Tell the child which embedded
+  // module to run instead so fork()/cluster.fork() don't re-execute main.
+  if (Bun.isStandaloneExecutable && (!userExecPath || userExecPath === process.execPath)) {
+    const modulePathStr = typeof modulePath === "string" ? modulePath : Buffer.from(modulePath).toString("utf8");
+    options.env = {
+      ...(options.env || process.env),
+      BUN_INTERNAL_FORK_ENTRY: modulePathStr,
+    };
   }
 
   args = [...execArgv, modulePath, ...args];

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -788,19 +788,21 @@ function fork(modulePath, args = [], options) {
     }
   }
 
+  args = [...execArgv, modulePath, ...args];
+
   // Inside a compiled executable, process.execPath is this binary and it
   // always boots its embedded main entry. Tell the child which embedded
   // module to run instead so fork()/cluster.fork() don't re-execute main.
+  // The execArgv count is prefixed so the child knows exactly where
+  // modulePath sits in its argv without a byte-equality scan.
   if (Bun.isStandaloneExecutable && (!userExecPath || userExecPath === process.execPath)) {
     const modulePathStr = typeof modulePath === "string" ? modulePath : Buffer.from(modulePath).toString("utf8");
     options.env = {
       __proto__: null,
       ...(options.env || process.env),
-      BUN_INTERNAL_FORK_ENTRY: modulePathStr,
+      BUN_INTERNAL_FORK_ENTRY: execArgv.length + ":" + modulePathStr,
     };
   }
-
-  args = [...execArgv, modulePath, ...args];
 
   if (typeof options.stdio === "string") {
     options.stdio = stdioStringToArray(options.stdio, "ipc");

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -794,6 +794,7 @@ function fork(modulePath, args = [], options) {
   if (Bun.isStandaloneExecutable && (!userExecPath || userExecPath === process.execPath)) {
     const modulePathStr = typeof modulePath === "string" ? modulePath : Buffer.from(modulePath).toString("utf8");
     options.env = {
+      __proto__: null,
       ...(options.env || process.env),
       BUN_INTERNAL_FORK_ENTRY: modulePathStr,
     };

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3201,6 +3201,14 @@ impl VirtualMachine {
             self.transpiler_store.enabled = false;
         }
 
+        // Consumed by `boot_standalone` before this runs; scrub it from
+        // `process.env` so grandchildren spawned with default env don't
+        // inherit a stale fork target. On Windows `std::env::remove_var`
+        // doesn't touch the WTF-8 snapshot the env loader reads.
+        if let Some(idx) = map.map.get_index(b"BUN_INTERNAL_FORK_ENTRY") {
+            map.map.swap_remove_at(idx);
+        }
+
         if let Some(idx) = map.map.get_index(b"NODE_CHANNEL_FD") {
             let (_, kv) = map.map.swap_remove_at(idx);
             let fd_s = kv.value;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1633,72 +1633,8 @@ unsafe fn resolve_entry_point_specifier<'s>(
 ) -> Option<&'s [u8]> {
     // SAFETY: per fn contract; read-only field.
     if let Some(graph) = unsafe { (*parent).standalone_module_graph } {
-        if graph.find(str).is_some() {
-            return Some(str);
-        }
-
-        // Since `bun build --compile` renames files to `.js` by default, we
-        // need to do the reverse of our file extension mapping.
-        //
-        //   new Worker("./foo")     -> new Worker("./foo.js")
-        //   new Worker("./foo.ts")  -> new Worker("./foo.js")
-        //   new Worker("./foo.jsx") -> new Worker("./foo.js")
-        //   new Worker("./foo.mjs") -> new Worker("./foo.js")
-        //   new Worker("./foo.mts") -> new Worker("./foo.js")
-        //   new Worker("./foo.cjs") -> new Worker("./foo.js")
-        //   new Worker("./foo.cts") -> new Worker("./foo.js")
-        //   new Worker("./foo.tsx") -> new Worker("./foo.js")
-        //
-        if str.starts_with(b"./") || str.starts_with(b"../") {
-            'try_from_extension: {
-                let mut pathbuf = bun_paths::path_buffer_pool::get();
-                let base_path = graph.base_public_path_with_default_suffix();
-                let base = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Loose>(
-                    base_path,
-                    &mut pathbuf[..],
-                    &[str],
-                );
-                let base_len = base.len();
-                let extname_len = bun_paths::extension(base).len();
-                // `extname` cannot be held as a sub-slice of `pathbuf` while
-                // writing into `pathbuf` — compare
-                // by re-slicing after dropping the mutable borrow.
-                let extname = &pathbuf[base_len - extname_len..base_len];
-
-                // ./foo -> ./foo.js
-                if extname.is_empty() {
-                    pathbuf[base_len..base_len + 3].copy_from_slice(b".js");
-                    if let Some(js_file) = graph.find(&pathbuf[0..base_len + 3]) {
-                        return Some(js_file);
-                    }
-                    break 'try_from_extension;
-                }
-
-                // ./foo.ts -> ./foo.js
-                if extname == b".ts" {
-                    pathbuf[base_len - 3..base_len].copy_from_slice(b".js");
-                    if let Some(js_file) = graph.find(&pathbuf[0..base_len]) {
-                        return Some(js_file);
-                    }
-                    break 'try_from_extension;
-                }
-
-                if extname.len() == 4 {
-                    const EXTS: [&[u8]; 6] = [b".tsx", b".jsx", b".mjs", b".mts", b".cts", b".cjs"];
-                    for ext in EXTS {
-                        if extname == ext {
-                            let js_len = b".js".len();
-                            pathbuf[base_len - ext.len()..base_len - ext.len() + js_len]
-                                .copy_from_slice(b".js");
-                            let as_js = &pathbuf[0..base_len - ext.len() + js_len];
-                            if let Some(js_file) = graph.find(as_js) {
-                                return Some(js_file);
-                            }
-                            break 'try_from_extension;
-                        }
-                    }
-                }
-            }
+        if let Some(name) = graph.resolve_embedded_entry(str) {
+            return Some(name);
         }
     }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1633,8 +1633,13 @@ unsafe fn resolve_entry_point_specifier<'s>(
 ) -> Option<&'s [u8]> {
     // SAFETY: per fn contract; read-only field.
     if let Some(graph) = unsafe { (*parent).standalone_module_graph } {
-        if let Some(name) = graph.resolve_embedded_entry(str) {
+        if let Some(name) = graph.find(str) {
             return Some(name);
+        }
+        if str.starts_with(b"./") || str.starts_with(b"../") {
+            if let Some(name) = graph.resolve_embedded_entry(str) {
+                return Some(name);
+            }
         }
     }
 

--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -57,7 +57,10 @@ pub trait StandaloneModuleGraph: Send + Sync {
         } else if ext == b".ts" {
             buf[joined_len - 3..joined_len].copy_from_slice(b".js");
             joined_len
-        } else if matches!(ext, b".tsx" | b".jsx" | b".mjs" | b".mts" | b".cts" | b".cjs") {
+        } else if matches!(
+            ext,
+            b".tsx" | b".jsx" | b".mjs" | b".mts" | b".cts" | b".cjs"
+        ) {
             let base = joined_len - ext.len();
             buf[base..base + 3].copy_from_slice(b".js");
             base + 3

--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -27,4 +27,43 @@ pub trait StandaloneModuleGraph: Send + Sync {
     /// so `process.execArgv` (lower-tier `bun_jsc` callers holding only the
     /// trait object) can read it without downcasting to the concrete graph.
     fn compile_exec_argv(&self) -> &[u8];
+
+    /// Resolve a `new Worker(path)` / `child_process.fork(path)` specifier to
+    /// its embedded canonical name. `bun build --compile` renames sources to
+    /// `.js` in the graph, so this joins `specifier` against the virtual root
+    /// and probes `.ts` / `.tsx` / `.jsx` / `.mjs` / `.mts` / `.cts` / `.cjs`
+    /// (and extensionless) as `.js`. Returns `None` when nothing matched.
+    fn resolve_embedded_entry(&self, specifier: &[u8]) -> Option<&[u8]> {
+        if let Some(name) = self.find(specifier) {
+            return Some(name);
+        }
+
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let joined = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Loose>(
+            self.base_public_path_with_default_suffix(),
+            &mut buf[..],
+            &[specifier],
+        );
+        let joined_len = joined.len();
+        if let Some(name) = self.find(&buf[..joined_len]) {
+            return Some(name);
+        }
+
+        let ext_len = bun_paths::extension(&buf[..joined_len]).len();
+        let ext = &buf[joined_len - ext_len..joined_len];
+        let probe_len = if ext.is_empty() {
+            buf[joined_len..joined_len + 3].copy_from_slice(b".js");
+            joined_len + 3
+        } else if ext == b".ts" {
+            buf[joined_len - 3..joined_len].copy_from_slice(b".js");
+            joined_len
+        } else if matches!(ext, b".tsx" | b".jsx" | b".mjs" | b".mts" | b".cts" | b".cjs") {
+            let base = joined_len - ext.len();
+            buf[base..base + 3].copy_from_slice(b".js");
+            base + 3
+        } else {
+            return None;
+        };
+        self.find(&buf[..probe_len])
+    }
 }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1400,15 +1400,65 @@ pub mod command {
             ctx.debug.global_cache = GlobalCache::disable;
         }
 
+        let (entry_name, passthrough_start) = match resolve_standalone_fork_entry(graph) {
+            Some((entry, module_argv_idx)) => (entry, module_argv_idx + 1),
+            None => (
+                graph.entry_point().name.to_vec().into_boxed_slice(),
+                offset_for_passthrough,
+            ),
+        };
+
         ctx.passthrough = bun::argv()
             .iter()
-            .skip(offset_for_passthrough)
+            .skip(passthrough_start)
             .map(|a| a.to_vec().into_boxed_slice())
             .collect();
 
-        let entry_name = graph.entry_point().name.to_vec().into_boxed_slice();
         super::run_command::RunCommand::boot_standalone(ctx, entry_name, graph)?;
         Ok(())
+    }
+
+    /// `child_process.fork()` inside a compiled executable spawns this same
+    /// binary with `BUN_INTERNAL_FORK_ENTRY` naming the module to run in place
+    /// of the baked entry point. Returns the resolved entry path and the argv
+    /// index of the module-path argument so everything after it becomes
+    /// `process.argv[2..]`.
+    #[cold]
+    fn resolve_standalone_fork_entry(
+        graph: &mut bun_standalone_graph::Graph,
+    ) -> Option<(Box<[u8]>, usize)> {
+        let raw = bun_core::env_var::BUN_INTERNAL_FORK_ENTRY::get()?;
+        if raw.is_empty() {
+            return None;
+        }
+        let module_path = raw.to_vec();
+        // SAFETY: single-threaded startup, before `bun_jsc::initialize`.
+        unsafe { std::env::remove_var("BUN_INTERNAL_FORK_ENTRY") };
+
+        let argv = bun::argv();
+        let idx = argv
+            .iter()
+            .skip(1)
+            .position(|a| a == module_path.as_slice())
+            .map(|i| i + 1)
+            .unwrap_or(argv.len());
+
+        let entry = graph.resolve_fork_entry(&module_path).unwrap_or_else(|| {
+            let mut cwd_buf = bun_paths::PathBuffer::uninit();
+            let cwd = bun_core::getcwd(&mut cwd_buf)
+                .map(|z| z.as_bytes())
+                .unwrap_or(b".");
+            let mut out = bun_paths::path_buffer_pool::get();
+            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+                cwd,
+                &mut out[..],
+                &[&module_path],
+            )
+            .to_vec()
+            .into_boxed_slice()
+        });
+
+        Some((entry, idx))
     }
 
     /// `bun [run] <script>` / `bun --version` / bare `bun`. The dominant tag

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1400,13 +1400,14 @@ pub mod command {
             ctx.debug.global_cache = GlobalCache::disable;
         }
 
-        let (entry_name, passthrough_start) = match resolve_standalone_fork_entry(graph) {
-            Some((entry, module_argv_idx)) => (entry, module_argv_idx + 1),
-            None => (
-                graph.entry_point().name.to_vec().into_boxed_slice(),
-                offset_for_passthrough,
-            ),
-        };
+        let (entry_name, passthrough_start) =
+            match resolve_standalone_fork_entry(graph, offset_for_passthrough) {
+                Some((entry, module_argv_idx)) => (entry, module_argv_idx + 1),
+                None => (
+                    graph.entry_point().name.to_vec().into_boxed_slice(),
+                    offset_for_passthrough,
+                ),
+            };
 
         ctx.passthrough = bun::argv()
             .iter()
@@ -1426,6 +1427,7 @@ pub mod command {
     #[cold]
     fn resolve_standalone_fork_entry(
         graph: &bun_standalone_graph::Graph,
+        offset_for_passthrough: usize,
     ) -> Option<(Box<[u8]>, usize)> {
         use bun_resolver::StandaloneModuleGraph as _;
 
@@ -1437,12 +1439,15 @@ pub mod command {
         // SAFETY: single-threaded startup, before `bun_jsc::initialize`.
         unsafe { std::env::remove_var("BUN_INTERNAL_FORK_ENTRY") };
 
+        // argv() has compile_exec_argv / BUN_OPTIONS tokens spliced at index 1;
+        // `offset_for_passthrough` is the first OS-passed arg slot, so start
+        // the scan there to avoid matching a spliced flag value.
         let argv = bun::argv();
         let idx = argv
             .iter()
-            .skip(1)
+            .skip(offset_for_passthrough)
             .position(|a| a == module_path.as_slice())
-            .map(|i| i + 1)
+            .map(|i| i + offset_for_passthrough)
             .unwrap_or(argv.len());
 
         let entry = match graph.resolve_embedded_entry(&module_path) {

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1435,22 +1435,27 @@ pub mod command {
         if raw.is_empty() {
             return None;
         }
-        let module_path = raw.to_vec();
         // SAFETY: single-threaded startup, before `bun_jsc::initialize`.
         unsafe { std::env::remove_var("BUN_INTERNAL_FORK_ENTRY") };
 
-        // argv() has compile_exec_argv / BUN_OPTIONS tokens spliced at index 1;
-        // `offset_for_passthrough` is the first OS-passed arg slot, so start
-        // the scan there to avoid matching a spliced flag value.
-        let argv = bun::argv();
-        let idx = argv
-            .iter()
-            .skip(offset_for_passthrough)
-            .position(|a| a == module_path.as_slice())
-            .map(|i| i + offset_for_passthrough)
-            .unwrap_or(argv.len());
+        // fork() writes "<execArgv.length>:<modulePath>" so modulePath sits at
+        // offset_for_passthrough + execArgv_len in argv(); no value scan
+        // needed. `offset_for_passthrough` already accounts for
+        // compile_exec_argv / BUN_OPTIONS tokens spliced at index 1.
+        let digits = raw.iter().take_while(|b| b.is_ascii_digit()).count();
+        let (exec_argv_len, module_path) = match raw.get(digits) {
+            Some(b':') if digits > 0 => (
+                bun_core::parse_int::<usize>(&raw[..digits], 10).unwrap_or(0),
+                &raw[digits + 1..],
+            ),
+            _ => (0, raw),
+        };
+        if module_path.is_empty() {
+            return None;
+        }
+        let idx = (offset_for_passthrough + exec_argv_len).min(bun::argv().len());
 
-        let entry = match graph.resolve_embedded_entry(&module_path) {
+        let entry = match graph.resolve_embedded_entry(module_path) {
             Some(name) => name.to_vec().into_boxed_slice(),
             None => {
                 let mut cwd_buf = bun_paths::PathBuffer::uninit();
@@ -1461,7 +1466,7 @@ pub mod command {
                 bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
                     cwd,
                     &mut out[..],
-                    &[&module_path],
+                    &[module_path],
                 )
                 .to_vec()
                 .into_boxed_slice()

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1425,8 +1425,10 @@ pub mod command {
     /// `process.argv[2..]`.
     #[cold]
     fn resolve_standalone_fork_entry(
-        graph: &mut bun_standalone_graph::Graph,
+        graph: &bun_standalone_graph::Graph,
     ) -> Option<(Box<[u8]>, usize)> {
+        use bun_resolver::StandaloneModuleGraph as _;
+
         let raw = bun_core::env_var::BUN_INTERNAL_FORK_ENTRY::get()?;
         if raw.is_empty() {
             return None;
@@ -1443,20 +1445,23 @@ pub mod command {
             .map(|i| i + 1)
             .unwrap_or(argv.len());
 
-        let entry = graph.resolve_fork_entry(&module_path).unwrap_or_else(|| {
-            let mut cwd_buf = bun_paths::PathBuffer::uninit();
-            let cwd = bun_core::getcwd(&mut cwd_buf)
-                .map(|z| z.as_bytes())
-                .unwrap_or(b".");
-            let mut out = bun_paths::path_buffer_pool::get();
-            bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
-                cwd,
-                &mut out[..],
-                &[&module_path],
-            )
-            .to_vec()
-            .into_boxed_slice()
-        });
+        let entry = match graph.resolve_embedded_entry(&module_path) {
+            Some(name) => name.to_vec().into_boxed_slice(),
+            None => {
+                let mut cwd_buf = bun_paths::PathBuffer::uninit();
+                let cwd = bun_core::getcwd(&mut cwd_buf)
+                    .map(|z| z.as_bytes())
+                    .unwrap_or(b".");
+                let mut out = bun_paths::path_buffer_pool::get();
+                bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
+                    cwd,
+                    &mut out[..],
+                    &[&module_path],
+                )
+                .to_vec()
+                .into_boxed_slice()
+            }
+        };
 
         Some((entry, idx))
     }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -177,50 +177,6 @@ impl StandaloneModuleGraph {
             self.files.get_mut(name)
         }
     }
-
-    /// Resolve a module path passed to `child_process.fork()` inside a
-    /// compiled executable to its embedded canonical name. Relative paths are
-    /// joined against the virtual root and extensions are remapped to `.js`
-    /// the same way `new Worker(path)` is resolved (see
-    /// `web_worker.rs::resolve_entry_point_specifier`). Returns `None` when
-    /// the module is not embedded.
-    pub fn resolve_fork_entry(&mut self, specifier: &[u8]) -> Option<Box<[u8]>> {
-        if let Some(file) = self.find(specifier) {
-            return Some(file.name.to_vec().into_boxed_slice());
-        }
-
-        let mut buf = bun_paths::path_buffer_pool::get();
-        let joined = path::resolve_path::join_abs_string_buf::<bun_paths::platform::Loose>(
-            BASE_PUBLIC_PATH_WITH_DEFAULT_SUFFIX.as_bytes(),
-            &mut buf[..],
-            &[specifier],
-        );
-        let joined_len = joined.len();
-        if let Some(file) = self.find(&buf[..joined_len]) {
-            return Some(file.name.to_vec().into_boxed_slice());
-        }
-
-        let ext_len = bun_paths::extension(&buf[..joined_len]).len();
-        let ext = &buf[joined_len - ext_len..joined_len];
-        let probe_len = if ext.is_empty() {
-            buf[joined_len..joined_len + 3].copy_from_slice(b".js");
-            joined_len + 3
-        } else if ext == b".ts" {
-            buf[joined_len - 3..joined_len].copy_from_slice(b".js");
-            joined_len
-        } else if matches!(
-            ext,
-            b".tsx" | b".jsx" | b".mjs" | b".mts" | b".cts" | b".cjs"
-        ) {
-            let base = joined_len - ext.len();
-            buf[base..base + 3].copy_from_slice(b".js");
-            base + 3
-        } else {
-            return None;
-        };
-        self.find(&buf[..probe_len])
-            .map(|f| f.name.to_vec().into_boxed_slice())
-    }
 }
 
 // SAFETY: the graph is the process-global INSTANCE singleton (set once at

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -177,6 +177,47 @@ impl StandaloneModuleGraph {
             self.files.get_mut(name)
         }
     }
+
+    /// Resolve a module path passed to `child_process.fork()` inside a
+    /// compiled executable to its embedded canonical name. Relative paths are
+    /// joined against the virtual root and extensions are remapped to `.js`
+    /// the same way `new Worker(path)` is resolved (see
+    /// `web_worker.rs::resolve_entry_point_specifier`). Returns `None` when
+    /// the module is not embedded.
+    pub fn resolve_fork_entry(&mut self, specifier: &[u8]) -> Option<Box<[u8]>> {
+        if let Some(file) = self.find(specifier) {
+            return Some(file.name.to_vec().into_boxed_slice());
+        }
+
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let joined = path::resolve_path::join_abs_string_buf::<bun_paths::platform::Loose>(
+            BASE_PUBLIC_PATH_WITH_DEFAULT_SUFFIX.as_bytes(),
+            &mut buf[..],
+            &[specifier],
+        );
+        let joined_len = joined.len();
+        if let Some(file) = self.find(&buf[..joined_len]) {
+            return Some(file.name.to_vec().into_boxed_slice());
+        }
+
+        let ext_len = bun_paths::extension(&buf[..joined_len]).len();
+        let ext = &buf[joined_len - ext_len..joined_len];
+        let probe_len = if ext.is_empty() {
+            buf[joined_len..joined_len + 3].copy_from_slice(b".js");
+            joined_len + 3
+        } else if ext == b".ts" {
+            buf[joined_len - 3..joined_len].copy_from_slice(b".js");
+            joined_len
+        } else if matches!(ext, b".tsx" | b".jsx" | b".mjs" | b".mts" | b".cts" | b".cjs") {
+            let base = joined_len - ext.len();
+            buf[base..base + 3].copy_from_slice(b".js");
+            base + 3
+        } else {
+            return None;
+        };
+        self.find(&buf[..probe_len])
+            .map(|f| f.name.to_vec().into_boxed_slice())
+    }
 }
 
 // SAFETY: the graph is the process-global INSTANCE singleton (set once at

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -208,7 +208,10 @@ impl StandaloneModuleGraph {
         } else if ext == b".ts" {
             buf[joined_len - 3..joined_len].copy_from_slice(b".js");
             joined_len
-        } else if matches!(ext, b".tsx" | b".jsx" | b".mjs" | b".mts" | b".cts" | b".cjs") {
+        } else if matches!(
+            ext,
+            b".tsx" | b".jsx" | b".mjs" | b".mts" | b".cts" | b".cjs"
+        ) {
             let base = joined_len - ext.len();
             buf[base..base + 3].copy_from_slice(b".js");
             base + 3

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -411,7 +411,7 @@ describe("bundler", () => {
       `,
     },
     outfile: "dist/out",
-    run: { stdout: 'primary got worker argv=[]', file: "dist/out", setCwd: true },
+    run: { stdout: "primary got worker argv=[]", file: "dist/out", setCwd: true },
   });
   itBundled("compile/WorkerRelativePathTSExtensionBytecode", {
     backend: "cli",

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -355,6 +355,64 @@ describe("bundler", () => {
     outfile: "dist/out",
     run: { stdout: "Hello, world!\nWorker loaded!\n", file: "dist/out", setCwd: true },
   });
+  itBundled("compile/ChildProcessForkEmbedded", {
+    backend: "cli",
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import { fork } from "child_process";
+        import { rmSync } from "fs";
+        if (process.env.__FORK_DEPTH) {
+          console.log("MAIN-REENTERED argv=" + JSON.stringify(process.argv.slice(2)));
+          process.exit(7);
+        }
+        rmSync("./job.mjs", { force: true });
+        const child = fork("./job.mjs", ["hello"], {
+          silent: true,
+          env: { ...process.env, __FORK_DEPTH: "1" },
+        });
+        let out = "";
+        child.stdout.on("data", d => (out += d));
+        child.on("message", m => console.log("ipc=" + m));
+        child.on("exit", code => {
+          console.log(out.trim());
+          process.exit(code ?? 1);
+        });
+      `,
+      "/job.mjs": /* js */ `
+        process.send("pong");
+        console.log("forked " + process.argv[2] + " leaked=" + ("BUN_INTERNAL_FORK_ENTRY" in process.env));
+      `,
+    },
+    entryPointsRaw: ["./entry.ts", "./job.mjs"],
+    outfile: "dist/out",
+    run: { stdout: "ipc=pong\nforked hello leaked=false", file: "dist/out", setCwd: true },
+  });
+  itBundled("compile/ClusterFork", {
+    backend: "cli",
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import cluster from "cluster";
+        if (cluster.isPrimary) {
+          if (process.env.__FORK_DEPTH) {
+            console.log("MAIN-REENTERED-AS-PRIMARY");
+            process.exit(7);
+          }
+          const worker = cluster.fork({ __FORK_DEPTH: "1" });
+          worker.on("message", m => {
+            console.log("primary got " + m);
+            worker.kill();
+          });
+          worker.on("exit", () => process.exit(0));
+        } else {
+          process.send("worker argv=" + JSON.stringify(process.argv.slice(2)));
+        }
+      `,
+    },
+    outfile: "dist/out",
+    run: { stdout: 'primary got worker argv=[]', file: "dist/out", setCwd: true },
+  });
   itBundled("compile/WorkerRelativePathTSExtensionBytecode", {
     backend: "cli",
     compile: true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -372,9 +372,11 @@ describe("bundler", () => {
           env: { ...process.env, __FORK_DEPTH: "1" },
         });
         let out = "";
+        let ipc;
         child.stdout.on("data", d => (out += d));
-        child.on("message", m => console.log("ipc=" + m));
-        child.on("exit", code => {
+        child.on("message", m => (ipc = m));
+        child.on("close", code => {
+          console.log("ipc=" + ipc);
           console.log(out.trim());
           process.exit(code ?? 1);
         });


### PR DESCRIPTION
## Problem

Inside a `bun build --compile` binary, `child_process.fork(\"./job.mjs\")` spawns `process.execPath` (the compiled binary itself). A standalone executable always booted its embedded main entry point, so `./job.mjs` was demoted to `process.argv[2]` and the forked module never ran. Unguarded, the child re-executed the parent program, which forked again: an exponential self-respawn storm. `cluster.fork()` hit the same path and leaked the module path into the worker's `process.argv`.

## Repro

```sh
cat > main.ts <<'TS'
if (process.env.__DEPTH) { console.log(\"SPAWNED-AS-MAIN depth=\" + process.env.__DEPTH + \" argv=\" + JSON.stringify(process.argv)); process.exit(7); }
import { fork } from \"child_process\";
const p = fork(\"./job.mjs\", [\"a1\"], { silent: true, env: { ...process.env, __DEPTH: \"1\" } });
let out = \"\"; p.stdout?.on(\"data\", d => out += d);
p.on(\"exit\", c => { console.log(\"PARENT: child exit=\" + c + \" out=\" + JSON.stringify(out.trim())); process.exit(0); });
TS
cat > job.mjs <<'JS'
console.log(\"job.mjs RAN args=\" + JSON.stringify(process.argv.slice(2))); process.exit(0);
JS
bun build --compile main.ts job.mjs --outfile app && ./app
```

Before: `PARENT: child exit=7 out=\"SPAWNED-AS-MAIN depth=1 argv=[\\\"bun\\\",\\\"/\$bunfs/root/app\\\",\\\"./job.mjs\\\",\\\"a1\\\"]\"`
After: `PARENT: child exit=0 out=\"job.mjs RAN args=[\\\"a1\\\"]\"`

## Cause

`boot_standalone` in `src/runtime/cli/mod.rs` hard-codes `graph.entry_point()` as the module to run and puts all of `argv[1..]` into `ctx.passthrough`. There was no mechanism for a compiled binary to be told \"run this other embedded module instead\". `new Worker(path)` already had graph-aware resolution, but `fork()` spawns a fresh process so that path never applied.

## Fix

When `fork()` runs inside a standalone executable and is spawning itself, it sets `BUN_INTERNAL_FORK_ENTRY=<modulePath>` in the child's environment. The child's `boot_standalone` reads and unsets it, resolves it against the embedded module graph using the same extension remapping `new Worker(path)` uses (`./job.mjs` -> `/\$bunfs/root/job.js`), and boots that module instead of the baked entry point. Everything in argv after the module path becomes `process.argv[2..]`. If the module is not embedded, the path is resolved against cwd so on-disk scripts still work; a missing module surfaces as a normal \"Module not found\" error.

`cluster.fork()` goes through the same `child_process.fork()`, so cluster workers now boot with a clean `process.argv` too.

## Verification

```
bun bd test test/bundler/bundler_compile.test.ts -t \"ChildProcessForkEmbedded|ClusterFork\"
```

Both new tests fail on the released binary (`MAIN-REENTERED argv=[\"./job.mjs\",\"hello\"]` / `argv=[\"/\$bunfs/root/out\"]`) and pass with this change. `compile-argv.test.ts`, the existing `compile/Worker*` tests, `test/js/node/cluster.test.ts`, and the Node-ported `test-child-process-fork-*` suite continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->