### PR TITLE
test(socket.io): drop 200ms guard timers in connection-state-recovery

### DIFF
--- a/test/js/third_party/socket.io/socket.io-connection-state-recovery.test.ts
+++ b/test/js/third_party/socket.io/socket.io-connection-state-recovery.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { createServer, Server as HttpServer } from "http";
 import { Server, Socket } from "socket.io";
 import { Adapter } from "socket.io-adapter";
-import { eioHandshake, eioPoll, eioPush, fail, success, waitFor } from "./support/util.ts";
+import { eioHandshake, eioPoll, eioPush, waitFor } from "./support/util.ts";
 
 async function init(httpServer: HttpServer, io: Server) {
   // Engine.IO handshake
@@ -35,140 +35,121 @@ async function init(httpServer: HttpServer, io: Server) {
   return [handshake.sid, handshake.pid, offset];
 }
 
+// These tests exercise the Engine.IO HTTP long-polling transport directly via
+// supertest (8 sequential round trips in the heaviest case). They await the
+// protocol events themselves; the test runner's own timeout bounds hangs.
 describe("connection state recovery", () => {
-  it("should restore session and missed packets", done => {
+  it("should restore session and missed packets", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer, {
       connectionStateRecovery: {},
     });
 
-    const timeout = setTimeout(() => {
-      fail(done, io, new Error("timeout"));
-    }, 200);
+    try {
+      let serverSocket: Socket | undefined;
 
-    let serverSocket: Socket | undefined;
+      io.once("connection", socket => {
+        socket.join("room1");
+        serverSocket = socket;
+      });
 
-    io.once("connection", socket => {
-      socket.join("room1");
-      serverSocket = socket;
-    });
+      const [sid, pid, offset] = await init(httpServer, io);
 
-    (async () => {
-      try {
-        const [sid, pid, offset] = await init(httpServer, io);
+      io.emit("hello1"); // broadcast
+      io.to("room1").emit("hello2"); // broadcast to room
+      serverSocket?.emit("hello3"); // direct message
 
-        io.emit("hello1"); // broadcast
-        io.to("room1").emit("hello2"); // broadcast to room
-        serverSocket?.emit("hello3"); // direct message
+      const newSid = await eioHandshake(httpServer);
+      await eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`);
 
-        const newSid = await eioHandshake(httpServer);
-        await eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`);
+      const payload = await eioPoll(httpServer, newSid);
 
-        const payload = await eioPoll(httpServer, newSid);
-        clearTimeout(timeout);
+      const packets = payload.split("\x1e");
 
-        const packets = payload.split("\x1e");
+      expect(packets.length).toBe(4);
 
-        expect(packets.length).toBe(4);
-
-        // note: EVENT packets are received before the CONNECT packet, which is a bit weird
-        // see also: https://github.com/socketio/socket.io-deno/commit/518f534e1c205b746b1cb21fe76b187dabc96f34
-        expect(packets[0].startsWith('42["hello1"')).toBe(true);
-        expect(packets[1].startsWith('42["hello2"')).toBe(true);
-        expect(packets[2].startsWith('42["hello3"')).toBe(true);
-        expect(packets[3]).toBe(`40{"sid":"${sid}","pid":"${pid}"}`);
-        success(done, io);
-      } catch (err) {
-        fail(done, io, err);
-      }
-    })();
+      // note: EVENT packets are received before the CONNECT packet, which is a bit weird
+      // see also: https://github.com/socketio/socket.io-deno/commit/518f534e1c205b746b1cb21fe76b187dabc96f34
+      expect(packets[0].startsWith('42["hello1"')).toBe(true);
+      expect(packets[1].startsWith('42["hello2"')).toBe(true);
+      expect(packets[2].startsWith('42["hello3"')).toBe(true);
+      expect(packets[3]).toBe(`40{"sid":"${sid}","pid":"${pid}"}`);
+    } finally {
+      io.close();
+    }
   });
 
-  it("should restore rooms and data attributes", done => {
+  it("should restore rooms and data attributes", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer, {
       connectionStateRecovery: {},
     });
 
-    const timeout = setTimeout(() => {
-      fail(done, io, new Error("timeout"));
-    }, 200);
+    try {
+      io.once("connection", socket => {
+        expect(socket.recovered).toBe(false);
 
-    io.once("connection", socket => {
-      expect(socket.recovered).toBe(false);
+        socket.join("room1");
+        socket.join("room2");
+        socket.data.foo = "bar";
+      });
 
-      socket.join("room1");
-      socket.join("room2");
-      socket.data.foo = "bar";
-    });
-    (async () => {
-      try {
-        const [sid, pid, offset] = await init(httpServer, io);
+      const [sid, pid, offset] = await init(httpServer, io);
 
-        const newSid = await eioHandshake(httpServer);
+      const newSid = await eioHandshake(httpServer);
 
-        const [socket] = await Promise.all([
-          waitFor<Socket>(io, "connection"),
-          eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`),
-        ]);
+      const [socket] = await Promise.all([
+        waitFor<Socket>(io, "connection"),
+        eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`),
+      ]);
 
-        clearTimeout(timeout);
-        expect(socket.id).toBe(sid);
-        expect(socket.recovered).toBe(true);
+      expect(socket.id).toBe(sid);
+      expect(socket.recovered).toBe(true);
 
-        expect(socket.rooms.has(socket.id)).toBe(true);
-        expect(socket.rooms.has("room1")).toBe(true);
-        expect(socket.rooms.has("room2")).toBe(true);
+      expect(socket.rooms.has(socket.id)).toBe(true);
+      expect(socket.rooms.has("room1")).toBe(true);
+      expect(socket.rooms.has("room2")).toBe(true);
 
-        expect(socket.data.foo).toBe("bar");
+      expect(socket.data.foo).toBe("bar");
 
-        await eioPoll(httpServer, newSid); // drain buffer
-        success(done, io);
-      } catch (err) {
-        fail(done, io, err);
-      }
-    })();
+      await eioPoll(httpServer, newSid); // drain buffer
+    } finally {
+      io.close();
+    }
   });
 
-  it("should not run middlewares upon recovery by default", done => {
+  it("should not run middlewares upon recovery by default", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer, {
       connectionStateRecovery: {},
     });
-    const timeout = setTimeout(() => {
-      fail(done, io, new Error("timeout"));
-    }, 200);
 
-    (async () => {
-      try {
-        const [_, pid, offset] = await init(httpServer, io);
+    try {
+      const [_, pid, offset] = await init(httpServer, io);
 
-        io.use((socket, next) => {
-          socket.data.middlewareWasCalled = true;
+      io.use((socket, next) => {
+        socket.data.middlewareWasCalled = true;
 
-          next();
-        });
+        next();
+      });
 
-        const newSid = await eioHandshake(httpServer);
+      const newSid = await eioHandshake(httpServer);
 
-        const [socket] = await Promise.all([
-          waitFor<Socket>(io, "connection"),
-          eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`),
-        ]);
+      const [socket] = await Promise.all([
+        waitFor<Socket>(io, "connection"),
+        eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`),
+      ]);
 
-        clearTimeout(timeout);
-        expect(socket.recovered).toBe(true);
-        expect(socket.data.middlewareWasCalled).toBe(undefined);
+      expect(socket.recovered).toBe(true);
+      expect(socket.data.middlewareWasCalled).toBe(undefined);
 
-        await eioPoll(httpServer, newSid); // drain buffer
-        success(done, io);
-      } catch (err) {
-        fail(done, io, err);
-      }
-    })();
+      await eioPoll(httpServer, newSid); // drain buffer
+    } finally {
+      io.close();
+    }
   });
 
-  it("should run middlewares even upon recovery", done => {
+  it("should run middlewares even upon recovery", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer, {
       connectionStateRecovery: {
@@ -176,120 +157,94 @@ describe("connection state recovery", () => {
       },
     });
 
-    const timeout = setTimeout(() => {
-      fail(done, io, new Error("timeout"));
-    }, 200);
+    try {
+      const [_, pid, offset] = await init(httpServer, io);
 
-    (async () => {
-      try {
-        const [_, pid, offset] = await init(httpServer, io);
+      io.use((socket, next) => {
+        socket.data.middlewareWasCalled = true;
 
-        io.use((socket, next) => {
-          socket.data.middlewareWasCalled = true;
+        next();
+      });
 
-          next();
-        });
+      const newSid = await eioHandshake(httpServer);
 
-        const newSid = await eioHandshake(httpServer);
+      const [socket] = await Promise.all([
+        waitFor<Socket>(io, "connection"),
+        eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`),
+      ]);
 
-        const [socket] = await Promise.all([
-          waitFor<Socket>(io, "connection"),
-          eioPush(httpServer, newSid, `40{"pid":"${pid}","offset":"${offset}"}`),
-        ]);
+      expect(socket.recovered).toBe(true);
+      expect(socket.data.middlewareWasCalled).toBe(true);
 
-        clearTimeout(timeout);
-
-        expect(socket.recovered).toBe(true);
-        expect(socket.data.middlewareWasCalled).toBe(true);
-
-        await eioPoll(httpServer, newSid); // drain buffer
-        success(done, io);
-      } catch (err) {
-        fail(done, io, err);
-      }
-    })();
+      await eioPoll(httpServer, newSid); // drain buffer
+    } finally {
+      io.close();
+    }
   });
 
-  it("should fail to restore an unknown session", done => {
+  it("should fail to restore an unknown session", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer, {
       connectionStateRecovery: {},
     });
 
-    const timeout = setTimeout(() => {
-      fail(done, io, new Error("timeout"));
-    }, 200);
+    try {
+      // Engine.IO handshake
+      const sid = await eioHandshake(httpServer);
 
-    (async () => {
-      try {
-        // Engine.IO handshake
-        const sid = await eioHandshake(httpServer);
+      // Socket.IO handshake
+      await eioPush(httpServer, sid, '40{"pid":"foo","offset":"bar"}');
 
-        // Socket.IO handshake
-        await eioPush(httpServer, sid, '40{"pid":"foo","offset":"bar"}');
+      const handshakeBody = await eioPoll(httpServer, sid);
 
-        const handshakeBody = await eioPoll(httpServer, sid);
+      expect(handshakeBody.startsWith("40")).toBe(true);
 
-        clearTimeout(timeout);
+      const handshake = JSON.parse(handshakeBody.substring(2));
 
-        expect(handshakeBody.startsWith("40")).toBe(true);
-
-        const handshake = JSON.parse(handshakeBody.substring(2));
-
-        expect(handshake.sid).not.toBe("foo");
-        expect(handshake.pid).not.toBe("bar");
-
-        success(done, io);
-      } catch (err) {
-        fail(done, io, err);
-      }
-    })();
+      expect(handshake.sid).not.toBe("foo");
+      expect(handshake.pid).not.toBe("bar");
+    } finally {
+      io.close();
+    }
   });
 
-  it("should be disabled by default", done => {
+  it("should be disabled by default", async () => {
     const httpServer = createServer().listen(0);
     const io = new Server(httpServer);
-    const timeout = setTimeout(() => {
-      fail(done, io, new Error("timeout"));
-    }, 200);
 
-    (async () => {
-      try {
-        // Engine.IO handshake
-        const sid = await eioHandshake(httpServer);
+    try {
+      // Engine.IO handshake
+      const sid = await eioHandshake(httpServer);
 
-        // Socket.IO handshake
-        await eioPush(httpServer, sid, "40");
+      // Socket.IO handshake
+      await eioPush(httpServer, sid, "40");
 
-        const handshakeBody = await eioPoll(httpServer, sid);
+      const handshakeBody = await eioPoll(httpServer, sid);
 
-        clearTimeout(timeout);
-        expect(handshakeBody.startsWith("40")).toBe(true);
+      expect(handshakeBody.startsWith("40")).toBe(true);
 
-        const handshake = JSON.parse(handshakeBody.substring(2));
+      const handshake = JSON.parse(handshakeBody.substring(2));
 
-        expect(handshake.sid).not.toBe(undefined);
-        expect(handshake.pid).toBe(undefined);
-
-        success(done, io);
-      } catch (err) {
-        fail(done, io, err);
-      }
-    })();
+      expect(handshake.sid).not.toBe(undefined);
+      expect(handshake.pid).toBe(undefined);
+    } finally {
+      io.close();
+    }
   });
 
-  it("should not call adapter#persistSession or adapter#restoreSession if disabled", done => {
+  it("should not call adapter#persistSession or adapter#restoreSession if disabled", async () => {
     const httpServer = createServer().listen(0);
 
     let io: Server;
+    let called = "";
     class DummyAdapter extends Adapter {
       override persistSession() {
-        fail(done, io, new Error("should not happen"));
+        called = "persistSession";
         return Promise.reject("should not happen");
       }
 
       override restoreSession() {
-        fail(done, io, new Error("should not happen"));
+        called = "restoreSession";
         return Promise.reject("should not happen");
       }
     }
@@ -297,23 +252,18 @@ describe("connection state recovery", () => {
     io = new Server(httpServer, {
       adapter: DummyAdapter,
     });
-    const timeout = setTimeout(() => {
-      fail(done, io, new Error("timeout"));
-    }, 200);
 
-    (async () => {
-      try {
-        // Engine.IO handshake
-        const sid = await eioHandshake(httpServer);
+    try {
+      // Engine.IO handshake
+      const sid = await eioHandshake(httpServer);
 
-        await eioPush(httpServer, sid, '40{"pid":"foo","offset":"bar"}');
-        await eioPoll(httpServer, sid);
-        await eioPush(httpServer, sid, "1");
-        clearTimeout(timeout);
-        success(done, io);
-      } catch (err) {
-        fail(done, io, err);
-      }
-    })();
+      await eioPush(httpServer, sid, '40{"pid":"foo","offset":"bar"}');
+      await eioPoll(httpServer, sid);
+      await eioPush(httpServer, sid, "1");
+
+      expect(called).toBe("");
+    } finally {
+      io.close();
+    }
   });
 });


### PR DESCRIPTION
Fixes `test/js/third_party/socket.io/socket.io-connection-state-recovery.test.ts` going red on the debian-13 x64-asan lane.

## Failure

```
error: timeout
      at <anonymous> (test/js/third_party/socket.io/socket.io-connection-state-recovery.test.ts:46:26)
✗ connection state recovery > should restore session and missed packets [219.96ms]
```

Seen on builds [77055](https://buildkite.com/bun/bun/builds/77055) (219.84ms) and [77789](https://buildkite.com/bun/bun/builds/77789) (219.96ms), both debian-13 x64-asan.

## Cause

Each test in this file carries a `setTimeout(() => fail(...), 200)` guard that was added when the suite was ported from upstream socket.io in fe74c948cd. The [upstream test](https://github.com/socketio/socket.io/blob/main/packages/socket.io/test/connection-state-recovery.ts) has no such timers.

These tests drive the Engine.IO long-polling transport by hand via supertest: the first test performs 8 sequential HTTP round trips. On release that is ~50ms; on release+ASAN it is ~220ms. #34782 moved the x64-asan build lane from amazonlinux-2023 to debian-13 on Jul 21, and the failures started immediately after, with the work landing just past the 200ms guard every time.

The guard is not a behavioral assertion. It races real work against a wall clock and turns a slow-but-correct run into a failure. The test runner already applies its own per-test timeout (90s, tripled under ASAN in CI).

## Fix

Drop the guard timers and align with the upstream structure: plain `async` tests that await the protocol events, with `io.close()` in a `finally` block so the server is always released. Every assertion is preserved; the same code paths are exercised.

## Verification

```
# before, bun bd (debug+asan), 5 runs: 0 pass / 7 fail every time
# after, bun bd (debug+asan), 5 runs:
7 pass / 0 fail (×5)

# release bun, 3 runs:
7 pass / 0 fail (×3)
```

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/third_party/socket.io/socket.io-connection-state-recovery.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/third_party/socket.io/socket.io-connection-state-recovery.test.ts
bun test v1.4.0 (70a1c0502)

test/js/third_party/socket.io/socket.io-connection-state-recovery.test.ts:
(pass) connection state recovery > should restore session and missed packets [2559.28ms]
(pass) connection state recovery > should restore rooms and data attributes [1087.52ms]
(pass) connection state recovery > should not run middlewares upon recovery by default [1125.18ms]
(pass) connection state recovery > should run middlewares even upon recovery [1000.73ms]
(pass) connection state recovery > should fail to restore an unknown session [421.80ms]
(pass) connection state recovery > should be disabled by default [434.45ms]
(pass) connection state recovery > should not call adapter#persistSession or adapter#restoreSession if disabled [405.80ms]

 7 pass
 0 fail
 43 expect() calls
Ran 7 tests across 1 file. [14.50s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../socket.io-connection-state-recovery.test.ts    | 318 +++++++++------------
 1 file changed, 134 insertions(+), 184 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…y/socket.io/socket.io-connection-state-recovery.test.ts      2      3      0
```

</details>

**self-review** · no surviving concerns

25 concerns were raised and did not survive verification.

**root cause** · written by the author bot

The test wrapped its async work in a hardcoded 200ms setTimeout guard that was not a behavioral assertion, and on slow ASAN builds the real protocol steps outran that window, so the guard fired and failed the test even though the code under test behaved correctly. The fix removes the wall-clock guards entirely and converts each test to a plain async function that awaits the protocol steps directly, with server cleanup moved into a try/finally block. Hangs are now bounded by the test runner's per-test timeout rather than an arbitrary 200ms race, and all original assertions are preserved.

<!-- robobun:evidence:end -->