### PR TITLE
node:test: stop inheriting bun:test's per-test timeout

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1919,7 +1919,7 @@ function before(arg0: unknown, arg1: unknown) {
       () => done(),
       err => done(err ?? new Error("before hook failed")),
     );
-  });
+  }, kBunTestNoTimeout);
 }
 
 function after(arg0: unknown, arg1: unknown) {
@@ -1935,7 +1935,7 @@ function after(arg0: unknown, arg1: unknown) {
       () => done(),
       err => done(err ?? new Error("after hook failed")),
     );
-  });
+  }, kBunTestNoTimeout);
 }
 
 function beforeEach(arg0: unknown, arg1: unknown) {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1689,12 +1689,9 @@ function bunTest() {
   return jest(Bun.main);
 }
 
-// The node-style timeout is enforced entirely by executeTestNode (so a tiny
-// timeout with a synchronous body still passes, like Node). bun:test's own
-// watchdog measures the whole (done) => {} wrapper, so letting it fire would
-// (a) apply bun's 5s default to node:test files that, per Node, have no
-// default timeout, and (b) blame a "done callback" the user never wrote.
-// Disable it unconditionally; Infinity saturates to u32::MAX on the native side.
+// executeTestNode/runHook enforce the node-style timeout; bun:test's watchdog
+// would impose its 5s default (Node has none) and blame the wrapper's `done`.
+// Infinity saturates to u32::MAX on the native side.
 const kBunTestNoTimeout = { timeout: Infinity };
 
 function currentCollectionParent(): TestNode {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -30,8 +30,6 @@ const realClearTimeout = clearTimeout;
 const kDefaultOptions = kEmptyObject;
 // Matches Node's internal/timers TIMEOUT_MAX.
 const kTimeoutMax = 2 ** 31 - 1;
-// Matches bun:test's default per-test timeout.
-const kBunTestDefaultTimeoutMs = 5_000;
 const kJoinSeparator = " > ";
 
 function run() {
@@ -1691,23 +1689,13 @@ function bunTest() {
   return jest(Bun.main);
 }
 
-function bunTestOptions(options: TestOptions) {
-  // The node-style timeout is enforced by executeTestNode itself so that a
-  // tiny timeout (e.g. 1ms) with a synchronous body still passes like in Node.
-  // bun:test's own watchdog measures the whole wrapper, so it is only told
-  // about timeouts that extend past its 5s default.
-  const { timeout } = options;
-  if (timeout === Infinity) {
-    // Node's "no timeout" must override bun:test's default (bun saturates it).
-    return { timeout };
-  }
-  if (typeof timeout === "number" && Number.isFinite(timeout)) {
-    // Keep bun:test's watchdog at or above both the node-style timeout and
-    // bun's default so a lower `--timeout` cannot cut a node timeout short.
-    return { timeout: Math.max(timeout, kBunTestDefaultTimeoutMs) };
-  }
-  return undefined;
-}
+// The node-style timeout is enforced entirely by executeTestNode (so a tiny
+// timeout with a synchronous body still passes, like Node). bun:test's own
+// watchdog measures the whole (done) => {} wrapper, so letting it fire would
+// (a) apply bun's 5s default to node:test files that, per Node, have no
+// default timeout, and (b) blame a "done callback" the user never wrote.
+// Disable it unconditionally; Infinity saturates to u32::MAX on the native side.
+const kBunTestNoTimeout = { timeout: Infinity };
 
 function currentCollectionParent(): TestNode {
   const node = currentNode();
@@ -1776,7 +1764,6 @@ function addTest(
   node.ownTags = ownTags;
 
   const { test } = bunTest();
-  const passOptions = bunTestOptions(options);
 
   const effectiveMode = mode ?? (options.todo ? "todo" : options.skip ? "skip" : undefined);
 
@@ -1784,23 +1771,14 @@ function addTest(
     const register = effectiveMode === "todo" ? test.todo : test.skip;
     // Node runs todo bodies; bun:test only does so under --todo.
     const body = effectiveMode === "todo" ? createTopLevelTestRunner(node, fn, true) : kDefaultFunction;
-    if (passOptions !== undefined) {
-      register(name, body, passOptions);
-    } else {
-      register(name, body);
-    }
+    register(name, body, kBunTestNoTimeout);
     return Promise.resolve(undefined);
   }
 
   // Node's `only` (the option and the test.only()/describe.only() spellings)
   // is a no-op unless --test-only is passed, so it registers an ordinary
   // test/suite; bun:test's only() would skip siblings and is rejected in CI.
-  const runner = createTopLevelTestRunner(node, fn);
-  if (passOptions !== undefined) {
-    test(name, runner, passOptions);
-  } else {
-    test(name, runner);
-  }
+  test(name, createTopLevelTestRunner(node, fn), kBunTestNoTimeout);
 
   // Resolved eagerly rather than when the runner settles: bun:test never invokes
   // the runner for a test `--test-name-pattern` filters out, so a deferred tied
@@ -1868,17 +1846,12 @@ function addSuite(
   };
 
   const effectiveMode = mode ?? (options.todo ? "todo" : options.skip ? "skip" : undefined);
-  const passOptions = bunTestOptions(options);
 
   let register: Function = describe;
   if (effectiveMode === "skip") register = describe.skip;
   else if (effectiveMode === "todo") register = describe.todo;
 
-  if (passOptions !== undefined) {
-    register(name, wrapped, passOptions);
-  } else {
-    register(name, wrapped);
-  }
+  register(name, wrapped, kBunTestNoTimeout);
   return Promise.resolve(undefined);
 }
 

--- a/test/js/node/test_runner/fixtures/25-no-default-timeout.js
+++ b/test/js/node/test_runner/fixtures/25-no-default-timeout.js
@@ -1,0 +1,19 @@
+// node-test.test.ts runs this with `--timeout 200`: Node's test runner has no
+// per-test timeout by default, so an async body that outlives bun:test's
+// runner default must still pass, and a short explicit timeout must still be
+// the one that fails (with Node's message, not bun:test's done-callback hint).
+const { test, describe } = require("node:test");
+
+test("no explicit timeout outlives the runner default", async () => {
+  await new Promise(resolve => setTimeout(resolve, 400));
+});
+
+describe("suite with no explicit timeout", () => {
+  test("also outlives the runner default", async () => {
+    await new Promise(resolve => setTimeout(resolve, 400));
+  });
+});
+
+test("explicit timeout still fails with Node's message", { timeout: 50 }, async () => {
+  await new Promise(resolve => setTimeout(resolve, 400));
+});

--- a/test/js/node/test_runner/fixtures/25-no-default-timeout.js
+++ b/test/js/node/test_runner/fixtures/25-no-default-timeout.js
@@ -1,8 +1,16 @@
 // node-test.test.ts runs this with `--timeout 200`: Node's test runner has no
-// per-test timeout by default, so an async body that outlives bun:test's
+// per-test timeout by default, so an async body or hook that outlives bun:test's
 // runner default must still pass, and a short explicit timeout must still be
 // the one that fails (with Node's message, not bun:test's done-callback hint).
-const { test, describe } = require("node:test");
+const { test, describe, before, after } = require("node:test");
+
+before(async () => {
+  await new Promise(resolve => setTimeout(resolve, 400));
+});
+
+after(async () => {
+  await new Promise(resolve => setTimeout(resolve, 400));
+});
 
 test("no explicit timeout outlives the runner default", async () => {
   await new Promise(resolve => setTimeout(resolve, 400));

--- a/test/js/node/test_runner/fixtures/25-no-default-timeout.js
+++ b/test/js/node/test_runner/fixtures/25-no-default-timeout.js
@@ -1,27 +1,22 @@
-// node-test.test.ts runs this with `--timeout 200`: Node's test runner has no
-// per-test timeout by default, so an async body or hook that outlives bun:test's
-// runner default must still pass, and a short explicit timeout must still be
-// the one that fails (with Node's message, not bun:test's done-callback hint).
-const { test, describe, before, after } = require("node:test");
+// Run with `--timeout 100`: Node has no default per-test timeout, so bodies and
+// before/after hooks with none set must outlive bun:test's default, and an
+// explicit timeout must fail with Node's message (no done-callback hint).
+const { test, before, after } = require("node:test");
 
 before(async () => {
-  await new Promise(resolve => setTimeout(resolve, 400));
+  await new Promise(resolve => setTimeout(resolve, 250));
+  console.log("BEFORE_RAN");
 });
 
 after(async () => {
-  await new Promise(resolve => setTimeout(resolve, 400));
+  await new Promise(resolve => setTimeout(resolve, 250));
+  console.log("AFTER_RAN");
 });
 
 test("no explicit timeout outlives the runner default", async () => {
-  await new Promise(resolve => setTimeout(resolve, 400));
-});
-
-describe("suite with no explicit timeout", () => {
-  test("also outlives the runner default", async () => {
-    await new Promise(resolve => setTimeout(resolve, 400));
-  });
+  await new Promise(resolve => setTimeout(resolve, 250));
 });
 
 test("explicit timeout still fails with Node's message", { timeout: 50 }, async () => {
-  await new Promise(resolve => setTimeout(resolve, 400));
+  await new Promise(resolve => setTimeout(resolve, 250));
 });

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -126,6 +126,18 @@ describe("node:test", () => {
     });
   });
 
+  test("should not apply bun:test's per-test timeout to node:test bodies with no explicit timeout", async () => {
+    // Node's runner has no default per-test timeout; the shim's (done) => {}
+    // wrapper used to inherit bun:test's default and then blame a done callback
+    // the user never wrote. --timeout 200 stands in for the 5s default.
+    const { exitCode, stderr } = await runTests(["25-no-default-timeout.js"], {}, ["--timeout", "200"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("1 fail");
+    expect(stderr).toContain("test timed out after 50ms");
+    expect(stderr).not.toContain("done callback");
+    expect(exitCode).toBe(1);
+  });
+
   test("should not leak file-level beforeEach hooks across files in one process", async () => {
     const { exitCode, stderr } = await runTests(["14-root-hooks-a.js", "14-root-hooks-b.js"]);
     expect(stderr).toContain("4 pass");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -129,9 +129,11 @@ describe("node:test", () => {
   test("should not apply bun:test's per-test timeout to node:test bodies with no explicit timeout", async () => {
     // Node's runner has no default per-test timeout; the shim's (done) => {}
     // wrapper used to inherit bun:test's default and then blame a done callback
-    // the user never wrote. --timeout 200 stands in for the 5s default.
-    const { exitCode, stderr } = await runTests(["25-no-default-timeout.js"], {}, ["--timeout", "200"]);
-    expect(stderr).toContain("2 pass");
+    // the user never wrote. --timeout 100 stands in for the 5s default.
+    const { exitCode, stdout, stderr } = await runTests(["25-no-default-timeout.js"], {}, ["--timeout", "100"]);
+    expect(stdout).toContain("BEFORE_RAN");
+    expect(stdout).toContain("AFTER_RAN");
+    expect(stderr).toContain("1 pass");
     expect(stderr).toContain("1 fail");
     expect(stderr).toContain("test timed out after 50ms");
     expect(stderr).not.toContain("done callback");


### PR DESCRIPTION
## Problem

Under `bun test`, a `node:test` file whose body takes longer than 5 s fails even though `node --test` has no per-test timeout by default, and the failure text blames a `done` callback the user never wrote:

```js
// slow.test.mjs
import { test } from "node:test";
test("legitimately slow (6.5 s)", async () => {
  await new Promise(r => setTimeout(r, 6500));
});
test("after slow", () => {});
```

```
(fail) legitimately slow (6.5 s) [5000ms]
  ^ this test timed out after 5000ms, before its done callback was called.
    If a done callback was not intended, remove the last parameter from the test callback function
```

`node --test slow.test.mjs` passes both.

## Cause

`src/js/node/test.ts` registers each node:test with bun:test via a one-parameter `(done) => { ... }` wrapper. `bunTestOptions` only forwarded an explicit `{timeout}` to bun:test; when the user specified none (Node's default is `Infinity`), it returned `undefined`, so bun:test applied its own 5 s default (or `--timeout`). When that watchdog fired it saw the wrapper's `done` parameter and emitted the done-callback hint.

## Fix

`executeTestNode` already enforces the node-style timeout itself (matching Node's sync-body-still-passes semantics). Hand bun:test `{ timeout: Infinity }` unconditionally so its watchdog never fires on the wrapper; Node's own timer remains the only one. This also removes the race between the two timers when a user did set a finite timeout equal to or above 5 s.

## Verification

New fixture `test/js/node/test_runner/fixtures/25-no-default-timeout.js` run with `--timeout 200` (standing in for the 5 s default so the test stays fast):

```
$ USE_SYSTEM_BUN=1 bun test node-test.test.ts -t "should not apply bun:test's per-test timeout"
(fail) ...  # 0 pass / 3 fail, "done callback" on every line

$ bun bd test node-test.test.ts -t "should not apply bun:test's per-test timeout"
(pass) ...  # 2 pass / 1 fail, failure carries Node's "test timed out after 50ms"
```

All 41 tests in `test/js/node/test_runner/node-test.test.ts` pass.

Fixes #27422

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (7d5912a4d)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [3013.89ms]
(pass) node:test > should run hooks in the right order [3120.34ms]
(pass) node:test > should run tests with different variations [2567.44ms]
(pass) node:test > should run async tests [2529.89ms]
(pass) node:test > should run all tests from multiple files [3779.38ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2636.33ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2627.41ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2798.13ms]
(pass) node:test > should support done callbacks in tests and hooks [2563.48ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2736.06ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (7d5912a4d)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [49.39ms]
(pass) node:test > should run hooks in the right order [64.87ms]
(pass) node:test > should run tests with different variations [45.04ms]
(pass) node:test > should run async tests [45.67ms]
(pass) node:test > should run all tests from multiple files [70.63ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [46.66ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [48.10ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [56.60ms]
(pass) node:test > should support done callbacks in tests and hooks [46.00ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [48.43ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurrent too [50.91ms]
(pass) node:test > should run todo bodies under --todo instead of registering an empty function [44.91ms]
(pass) node:test > should forward Infinity and finite timeouts s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (7d5912a4d)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [2973.10ms]
(pass) node:test > should run hooks in the right order [3115.88ms]
(pass) node:test > should run tests with different variations [2562.32ms]
(pass) node:test > should run async tests [2515.32ms]
(pass) node:test > should run all tests from multiple files [3774.83ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2632.26ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2651.54ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2773.72ms]
(pass) node:test > should support done callbacks in tests and hooks [2532.81ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2727.22ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 714ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7501ms)
Bundle modules (52ms)
Postprocesss modules (178ms)
Bundle Functions (658ms)
Generate Code (21ms)

[8.42s] Bundled "src/js" for production
  2040 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (7d5912a4d)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [48.30ms]
(pass) node:test > should run hooks in the right order [69.78ms]
(pass) node:test > should run tests with different variations [45.80ms]
(pass) node:test > should run async tests [47.55ms]
(pass) node:test > should run all tests from multiple files [69.63ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [45.80ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [45.41ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [48.71ms]
(pass
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/test.ts                                | 48 ++++------------------
 .../test_runner/fixtures/25-no-default-timeout.js  | 22 ++++++++++
 test/js/node/test_runner/node-test.test.ts         | 14 +++++++
 3 files changed, 45 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/test.ts                                           5      8      0
…t/js/node/test_runner/fixtures/25-no-default-timeout.js      1      4      0
test/js/node/test_runner/node-test.test.ts                    5      3      0
```

</details>

<!-- robobun:evidence:end -->