### PR TITLE
node:test: start a subtest's body synchronously at the t.test() call

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1456,7 +1456,16 @@ function appendSubtestStep(owner: TestNode, step: () => Promise<void>): Promise<
   let link: Promise<void>;
   if (owner.subtestChainIdle) {
     owner.subtestChainIdle = false;
+    // Publish a pending tail before starting inline so a reentrant call on
+    // this owner during step()'s synchronous prefix (the body using the
+    // parent's captured `t`) chains behind the in-flight step instead of the
+    // stale resolved tail.
+    const gate = Promise.withResolvers<void>();
+    owner.subtestChain = gate.promise;
     link = step();
+    gate.resolve(link);
+    // A reentrant call moved the tail past the gate; keep it.
+    if (owner.subtestChain !== gate.promise) return link;
   } else {
     link = owner.subtestChain.then(step);
   }

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -842,6 +842,10 @@ class TestNode {
   // Inline subtests are serialized through this chain. `concurrency` is
   // validated for Node-compat error codes but subtests always run serially.
   subtestChain: Promise<void> = Promise.resolve();
+  // True when no subtest step is in flight on the chain; appendSubtestStep()
+  // starts the next step inline (Node starts a subtest's body synchronously
+  // at the t.test() call when the parent has a free concurrency slot).
+  subtestChainIdle = true;
   failedSubtests = 0;
   firstSubtestError: unknown = undefined;
   // First failure from a before hook created while this test was running.
@@ -1444,10 +1448,29 @@ function runBeforeHookOnce(hook: Hook, owner: TestNode, arg: unknown): Promise<v
   return (hook.result ??= runHook(hook, owner, arg));
 }
 
+// Appends an async step to a node's subtest chain. When nothing is in flight
+// the step is started inline so its synchronous prefix runs before this
+// function returns, matching Node's Test.start() calling run() directly when
+// the parent has a free concurrency slot.
+function appendSubtestStep(owner: TestNode, step: () => Promise<void>): Promise<void> {
+  let link: Promise<void>;
+  if (owner.subtestChainIdle) {
+    owner.subtestChainIdle = false;
+    link = step();
+  } else {
+    link = owner.subtestChain.then(step);
+  }
+  owner.subtestChain = link;
+  link.then(() => {
+    if (owner.subtestChain === link) owner.subtestChainIdle = true;
+  });
+  return link;
+}
+
 // Failures fail the owning test (Node: hook.error -> test.fail) instead of
 // poisoning the subtest chain, so they are reported even when nothing awaits.
 function scheduleImmediateBeforeHook(node: TestNode, hook: Hook, arg: unknown) {
-  node.subtestChain = node.subtestChain.then(async () => {
+  appendSubtestStep(node, async () => {
     try {
       await runBeforeHookOnce(hook, node, arg);
     } catch (err) {
@@ -1456,25 +1479,32 @@ function scheduleImmediateBeforeHook(node: TestNode, hook: Hook, arg: unknown) {
   });
 }
 
-async function runOwnBeforeHooks(node: TestNode) {
+function runOwnBeforeHooks(node: TestNode): Promise<void> | undefined {
   // Node runs suites strictly sequentially, so a subtest is gated on the before
   // hooks of every enclosing inline suite and the owning test, outermost first;
   // runBeforeHookOnce memoizes each, so the racing siblings share one result.
   const owners: TestNode[] = [];
+  let any = false;
   for (let owner: TestNode | undefined = node; owner !== undefined; owner = owner.parent) {
     owners.unshift(owner);
+    if (owner.hooks.before.length > 0) any = true;
     // Stop at the owning collection-phase test/suite: hooks above it were
     // registered through bun:test's own beforeAll and are not run by the shim.
     if (!owner.isExecutionPhase) break;
   }
-  for (const owner of owners) {
-    const { before } = owner.hooks;
-    if (before.length === 0) continue;
-    const arg = owner.isSuite ? owner.getSuiteCtx() : owner.getCtx();
-    for (const hook of before) {
-      await runBeforeHookOnce(hook, owner, arg);
+  // With no hooks return undefined, not a promise: an `await` here would cost
+  // the synchronous start of the subtest body that Node provides.
+  if (!any) return undefined;
+  return (async () => {
+    for (const owner of owners) {
+      const { before } = owner.hooks;
+      if (before.length === 0) continue;
+      const arg = owner.isSuite ? owner.getSuiteCtx() : owner.getCtx();
+      for (const hook of before) {
+        await runBeforeHookOnce(hook, owner, arg);
+      }
     }
-  }
+  })();
 }
 
 async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
@@ -1610,7 +1640,12 @@ function scheduleSubtest(parent: TestNode, child: TestNode, fn: TestFn): Promise
     }
     let failure: unknown;
     try {
-      await runOwnBeforeHooks(parent);
+      // Only await when there are hooks: executeTestNode() is called as the
+      // operand of the next await, so its synchronous prefix (which reaches
+      // the test body when no beforeEach hooks exist) runs before this
+      // function first suspends.
+      const beforeHooks = runOwnBeforeHooks(parent);
+      if (beforeHooks !== undefined) await beforeHooks;
       failure = await executeTestNode(child, fn);
     } catch (err) {
       failure = err;
@@ -1620,8 +1655,7 @@ function scheduleSubtest(parent: TestNode, child: TestNode, fn: TestFn): Promise
       parent.firstSubtestError ??= failure;
     }
   };
-  const result = (parent.subtestChain = parent.subtestChain.then(run));
-  return result.then(() => undefined);
+  return appendSubtestStep(parent, run).then(() => undefined);
 }
 
 function recordSuiteFailure(suite: TestNode, err: unknown) {
@@ -1679,8 +1713,7 @@ function scheduleSuiteSubtest(parent: TestNode, suite: TestNode, build: unknown)
       parent.firstSubtestError ??= suite.firstSubtestError;
     }
   };
-  const result = (parent.subtestChain = parent.subtestChain.then(run));
-  return result.then(() => undefined);
+  return appendSubtestStep(parent, run).then(() => undefined);
 }
 
 // -----------------------------------------------------------------------------
@@ -1837,6 +1870,7 @@ function addSuite(
     // chain through a gate the callback's settlement opens.
     const gate = Promise.withResolvers<void>();
     suite.subtestChain = runningNode.subtestChain.then(() => gate.promise);
+    suite.subtestChainIdle = false;
     // Build the suite eagerly (Node also runs describe callbacks immediately),
     // collecting children onto the suite's own subtest chain.
     let build: unknown;

--- a/test/js/node/test_runner/fixtures/25-subtest-sync-start.js
+++ b/test/js/node/test_runner/fixtures/25-subtest-sync-start.js
@@ -1,0 +1,93 @@
+// Node starts a subtest's body synchronously at the t.test() call when the
+// parent has a free concurrency slot (Test.start() calls run() directly). All
+// assertions pass verbatim on the node v26.3.0 binary.
+const assert = require("node:assert");
+const { test } = require("node:test");
+
+test("a subtest's synchronous body runs before t.test() returns", async t => {
+  let x = 0;
+  const p = t.test("sub", () => {
+    x = 1;
+  });
+  assert.strictEqual(x, 1, "the subtest body must have run at the t.test() call");
+  await p;
+});
+
+test("the synchronous prefix of an async subtest body runs before t.test() returns", async t => {
+  let x = 0;
+  const p = t.test("sub", async () => {
+    x = 1;
+    await 0;
+    x = 2;
+  });
+  assert.strictEqual(x, 1);
+  await p;
+  assert.strictEqual(x, 2);
+});
+
+test("a second subtest in the same tick is queued behind the first", async t => {
+  const order = [];
+  t.test("a", async () => {
+    order.push("a:start");
+    await new Promise(resolve => setImmediate(resolve));
+    order.push("a:end");
+  });
+  t.test("b", () => {
+    order.push("b");
+  });
+  // The first subtest started inline and now occupies the single slot; the
+  // second is deferred until it finishes.
+  assert.deepStrictEqual(order, ["a:start"]);
+  t.after(() => {
+    assert.deepStrictEqual(order, ["a:start", "a:end", "b"]);
+  });
+});
+
+test("awaiting a subtest frees the slot so the next one starts inline", async t => {
+  const order = [];
+  await t.test("a", () => {
+    order.push("a");
+  });
+  assert.deepStrictEqual(order, ["a"]);
+  t.test("b", () => {
+    order.push("b");
+  });
+  assert.deepStrictEqual(order, ["a", "b"]);
+});
+
+test("a subtest of a subtest also starts synchronously", async t => {
+  const order = [];
+  const p = t.test("outer", t2 => {
+    order.push("outer:start");
+    t2.test("inner", () => {
+      order.push("inner");
+    });
+    order.push("outer:end");
+  });
+  assert.deepStrictEqual(order, ["outer:start", "inner", "outer:end"]);
+  await p;
+});
+
+test("a before hook defers the subtest body but runs its own body inline", async t => {
+  const order = [];
+  t.before(() => {
+    order.push("before");
+  });
+  assert.deepStrictEqual(order, ["before"]);
+  const p = t.test("sub", () => {
+    order.push("sub");
+  });
+  assert.deepStrictEqual(order, ["before"]);
+  await p;
+  assert.deepStrictEqual(order, ["before", "sub"]);
+});
+
+test("a done-callback subtest body runs before t.test() returns", async t => {
+  let x = 0;
+  const p = t.test("sub", (_t2, done) => {
+    x = 1;
+    done();
+  });
+  assert.strictEqual(x, 1);
+  await p;
+});

--- a/test/js/node/test_runner/fixtures/25-subtest-sync-start.js
+++ b/test/js/node/test_runner/fixtures/25-subtest-sync-start.js
@@ -91,3 +91,21 @@ test("a done-callback subtest body runs before t.test() returns", async t => {
   assert.strictEqual(x, 1);
   await p;
 });
+
+test("a sibling created on the parent t from inside a subtest body is serialized after it", async t => {
+  const order = [];
+  const pA = t.test("a", async () => {
+    order.push("a:start");
+    // Parent's t, not the subtest context: a sibling of 'a' on the parent.
+    t.test("b", () => {
+      order.push("b");
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    order.push("a:end");
+  });
+  assert.deepStrictEqual(order, ["a:start"]);
+  await pA;
+  t.after(() => {
+    assert.deepStrictEqual(order, ["a:start", "a:end", "b"]);
+  });
+});

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -258,6 +258,15 @@ describe("node:test", () => {
       stderr: expect.stringContaining("0 fail"),
     });
   });
+
+  test("should start a subtest's body synchronously at the t.test() call like node", async () => {
+    const { exitCode, stderr } = await runTests(["25-subtest-sync-start.js"]);
+    expect(stderr).toContain("7 pass");
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 0,
+      stderr: expect.stringContaining("0 fail"),
+    });
+  });
 });
 
 async function runTests(filenames: string[], env: Record<string, string> = {}, args: string[] = []) {

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -261,7 +261,7 @@ describe("node:test", () => {
 
   test("should start a subtest's body synchronously at the t.test() call like node", async () => {
     const { exitCode, stderr } = await runTests(["25-subtest-sync-start.js"]);
-    expect(stderr).toContain("7 pass");
+    expect(stderr).toContain("8 pass");
     expect({ exitCode, stderr }).toMatchObject({
       exitCode: 0,
       stderr: expect.stringContaining("0 fail"),


### PR DESCRIPTION
### What does this PR do?

Bun's `node:test` shim deferred every inline subtest body by at least one microtask, so state a subtest writes synchronously was not visible on the parent's next line. Node starts the body immediately at the `t.test()` call.

```js
import { test } from 'node:test';
import assert from 'node:assert';
test('parent reads state a subtest sets synchronously', async (t) => {
  let x = 0;
  const p = t.test('subtest sets x', () => { x = 1; });
  console.log('LOG:x-after-call=' + x);        // node: 1   bun: 0
  assert.strictEqual(x, 1, 'subtest body should have run at the t.test() call');
  await p;
});
```

Node v26.3.0: `LOG:x-after-call=1`, passes. Bun on `main` (47597ab2c): `LOG:x-after-call=0`, assertion fails.

### Cause

`scheduleSubtest` in `src/js/node/test.ts` always appended via `parent.subtestChain = parent.subtestChain.then(run)`, so `run()` never began until the next microtask. Even if it had, the unconditional `await runOwnBeforeHooks(parent)` (resolved promise, no hooks) would have suspended before `executeTestNode` was reached. Node's `Test.start()` calls `run()` directly when the parent has a free concurrency slot, and `run()` only `await`s a before/beforeEach hook when one exists, so the body's synchronous prefix is reached inline.

### Fix

- `TestNode` gains a `subtestChainIdle` flag.
- `appendSubtestStep(owner, step)` starts `step()` inline when the chain is idle (so its synchronous prefix runs before returning) and chains via `.then()` otherwise; the flag is reset when the tail link settles. `scheduleSubtest`, `scheduleSuiteSubtest`, and `scheduleImmediateBeforeHook` now go through it.
- `runOwnBeforeHooks` returns `undefined` when no enclosing owner has a `before` hook, and `scheduleSubtest` only `await`s it when it returned a promise, so `executeTestNode` is reached as the operand of the first `await` (its own synchronous prefix calls the body).
- An inline suite's seeded chain is marked not idle so its gated children never start ahead of the gate.

The effect matches Node: the first subtest in a tick starts inline, later ones in the same tick queue (the first still occupies the single slot), and awaiting a subtest frees the slot so the next one starts inline again. With a `before`/`beforeEach` hook present, the hook's synchronous body runs inline and the subtest body is deferred by that hook's `await`, also matching Node.

### How did you verify your code works?

New fixture `test/js/node/test_runner/fixtures/25-subtest-sync-start.js` (7 tests covering the cases above) passes verbatim on the Node v26.3.0 binary and now on `bun bd test`. `node-test.test.ts` is 41 pass / 0 fail. Without the `src/` change all 7 cases fail (`0 !== 1` on the first assert).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (f637f2fb8)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [3075.27ms]
(pass) node:test > should run hooks in the right order [3167.69ms]
(pass) node:test > should run tests with different variations [2621.56ms]
(pass) node:test > should run async tests [2555.03ms]
(pass) node:test > should run all tests from multiple files [3836.26ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2668.40ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2668.17ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2795.70ms]
(pass) node:test > should support done callbacks in tests and hooks [2582.81ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2781.42ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (2ebc7ad87)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [48.53ms]
(pass) node:test > should run hooks in the right order [65.10ms]
(pass) node:test > should run tests with different variations [45.85ms]
(pass) node:test > should run async tests [46.70ms]
(pass) node:test > should run all tests from multiple files [69.14ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [47.12ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [48.17ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [49.71ms]
(pass) node:test > should support done callbacks in tests and hooks [46.88ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [49.41ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurrent too [49.35ms]
(pass) node:test > should run todo bodies under --todo instead of registering an empty function [45.97ms]
(pass) node:test > should forward Infinity and finite timeouts s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (f637f2fb8)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [3056.18ms]
(pass) node:test > should run hooks in the right order [3155.39ms]
(pass) node:test > should run tests with different variations [2609.32ms]
(pass) node:test > should run async tests [2536.20ms]
(pass) node:test > should run all tests from multiple files [3772.43ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2614.10ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2619.32ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2792.56ms]
(pass) node:test > should support done callbacks in tests and hooks [2529.60ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2714.88ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 902ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (12189ms)
Bundle modules (155ms)
Postprocesss modules (526ms)
Bundle Functions (1617ms)
Generate Code (42ms)

[14.58s] Bundled "src/js" for production
  2041 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/test.ts                                |  71 ++++++++++---
 .../test_runner/fixtures/25-subtest-sync-start.js  | 111 +++++++++++++++++++++
 test/js/node/test_runner/node-test.test.ts         |   9 ++
 3 files changed, 177 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/test.ts                                           8      8      0
…t/js/node/test_runner/fixtures/25-subtest-sync-start.js      1      4      0
test/js/node/test_runner/node-test.test.ts                    2      2      0
```

</details>

<!-- robobun:evidence:end -->