### PR TITLE
node:test: run the callback when the name arg is not a string/function/object

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1182,50 +1182,36 @@ type HookOptions = {
 };
 
 function parseTestArgs(arg0: unknown, arg1: unknown, arg2: unknown) {
-  let name: string;
-  let options: TestOptions;
-  let fn: TestFn;
+  // Node's createSubtest (lib/internal/test_runner/test.js) shifts each
+  // positional only when its declared slot's type does not match, so a
+  // `name` that is neither string nor function nor object still lets
+  // `options`/`fn` flow through from arg1/arg2.
+  let name: unknown = arg0;
+  let options: unknown = arg1;
+  let fn: unknown = arg2;
 
-  if (typeof arg0 === "function") {
-    name = arg0.name || kDefaultName;
-    fn = arg0 as TestFn;
-    if (typeof arg1 === "object") {
-      options = (arg1 ?? kDefaultOptions) as TestOptions;
-    } else {
-      options = kDefaultOptions;
-    }
-  } else if (typeof arg0 === "string") {
-    name = arg0;
-    if (typeof arg1 === "object") {
-      options = (arg1 ?? kDefaultOptions) as TestOptions;
-      if (typeof arg2 === "function") {
-        fn = arg2 as TestFn;
-      } else {
-        fn = kDefaultFunction;
-      }
-    } else if (typeof arg1 === "function") {
-      fn = arg1 as TestFn;
-      options = kDefaultOptions;
-    } else {
-      fn = kDefaultFunction;
-      options = kDefaultOptions;
-    }
-  } else if (typeof arg0 === "object" && arg0 !== null) {
-    options = arg0 as TestOptions;
-    if (typeof arg1 === "function") {
-      fn = arg1 as TestFn;
-      name = fn.name || kDefaultName;
-    } else {
-      fn = kDefaultFunction;
-      name = kDefaultName;
-    }
-  } else {
-    name = kDefaultName;
-    fn = kDefaultFunction;
-    options = kDefaultOptions;
+  if (typeof name === "function") {
+    fn = name;
+  } else if (name !== null && typeof name === "object") {
+    fn = options;
+    options = name;
+  } else if (typeof options === "function") {
+    fn = options;
   }
 
-  return { name, options, fn };
+  if (options === null || typeof options !== "object") {
+    options = kDefaultOptions;
+  }
+  // Resolve the name before defaulting fn so kDefaultFunction's own inferred
+  // .name never surfaces (Node's noop is Function.prototype, whose name is "").
+  if (typeof name !== "string" || name === "") {
+    name = (typeof fn === "function" && (fn as Function).name) || kDefaultName;
+  }
+  if (typeof fn !== "function") {
+    fn = kDefaultFunction;
+  }
+
+  return { name: name as string, options: options as TestOptions, fn: fn as TestFn };
 }
 
 // Shared by test and hook options: Node validates both the same way.

--- a/test/js/node/test_runner/fixtures/25-non-string-name.js
+++ b/test/js/node/test_runner/fixtures/25-non-string-name.js
@@ -1,0 +1,36 @@
+// Node runs the body when the name argument is undefined/null/number/boolean/
+// Symbol, naming the test from fn.name (or <anonymous>). Bun previously dropped
+// the callback for any non-string/non-function/non-object name and registered a
+// body-less always-passing test.
+const { test, describe, it } = require("node:test");
+
+let ran = 0;
+const mark = expectedName => {
+  return function named(t) {
+    ran++;
+    t.assert.equal(t.name, expectedName);
+  };
+};
+
+// No body at all: Node names it <anonymous>, not the internal noop's name.
+test({ skip: false });
+test(undefined, mark("named"));
+test(null, mark("named"));
+test(12345, mark("named"));
+test(true, mark("named"));
+test(Symbol("x"), mark("named"));
+test("", mark("named"));
+// Three-arg form: a non-string name must not stop options/fn from being read.
+test(42, { skip: false }, mark("named"));
+test(null, null, mark("named"));
+
+describe(42, () => {
+  it("child of numeric describe", t => {
+    ran++;
+    t.assert.equal(t.name, "child of numeric describe");
+  });
+});
+
+test("all bodies ran", t => {
+  t.assert.equal(ran, 9);
+});

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,24 +1,36 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 import { join } from "node:path";
 
-describe("node:test", () => {
-  test("should run basic tests", async () => {
-    const { exitCode, stderr } = await runTests(["01-harness.js"]);
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
-  });
+// 01-harness.js alone runs 32 fixture tests in a debug+ASAN subprocess; the
+// 5s default is not enough headroom for the three tests that drive it.
+const heavyFixtureTimeout = isASAN ? 20_000 : 5_000;
 
-  test("should run hooks in the right order", async () => {
-    const { exitCode, stderr } = await runTests(["02-hooks.js"]);
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
-  });
+describe("node:test", () => {
+  test(
+    "should run basic tests",
+    async () => {
+      const { exitCode, stderr } = await runTests(["01-harness.js"]);
+      expect({ exitCode, stderr }).toMatchObject({
+        exitCode: 0,
+        stderr: expect.stringContaining("0 fail"),
+      });
+    },
+    heavyFixtureTimeout,
+  );
+
+  test(
+    "should run hooks in the right order",
+    async () => {
+      const { exitCode, stderr } = await runTests(["02-hooks.js"]);
+      expect({ exitCode, stderr }).toMatchObject({
+        exitCode: 0,
+        stderr: expect.stringContaining("0 fail"),
+      });
+    },
+    heavyFixtureTimeout,
+  );
 
   test("should run tests with different variations", async () => {
     const { exitCode, stderr } = await runTests(["03-test-variations.js"]);
@@ -36,14 +48,18 @@ describe("node:test", () => {
     });
   });
 
-  test("should run all tests from multiple files", async () => {
-    const { exitCode, stderr } = await runTests(["01-harness.js", "02-hooks.js"]);
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      // 32 from 01-harness + 3 from 02-hooks
-      stderr: expect.stringContaining("35 pass"),
-    });
-  });
+  test(
+    "should run all tests from multiple files",
+    async () => {
+      const { exitCode, stderr } = await runTests(["01-harness.js", "02-hooks.js"]);
+      expect({ exitCode, stderr }).toMatchObject({
+        exitCode: 0,
+        // 32 from 01-harness + 3 from 02-hooks
+        stderr: expect.stringContaining("35 pass"),
+      });
+    },
+    heavyFixtureTimeout,
+  );
 
   test("should run test() and describe() called inside another test() as subtests", async () => {
     const { exitCode, stderr } = await runTests(["05-test-in-test.js"]);

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -258,6 +258,21 @@ describe("node:test", () => {
       stderr: expect.stringContaining("0 fail"),
     });
   });
+
+  test("should run the callback when the name arg is undefined/null/number/boolean/Symbol", async () => {
+    // Node's createSubtest only reinterprets a positional when its declared
+    // slot's type matches, so a non-string name still lets options/fn flow
+    // through. Bun previously replaced fn with a noop and registered a
+    // body-less always-passing <anonymous> test.
+    const { exitCode, stderr } = await runTests(["25-non-string-name.js"]);
+    expect(stderr).toContain("11 pass");
+    // The internal default function's inferred name must not leak as a test name.
+    expect(stderr).not.toContain("kDefaultFunction");
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 0,
+      stderr: expect.stringContaining("0 fail"),
+    });
+  });
 });
 
 async function runTests(filenames: string[], env: Record<string, string> = {}, args: string[] = []) {


### PR DESCRIPTION
## Problem

`test()` / `it()` / `describe()` / `suite()` from `node:test` silently dropped the callback when the name argument was neither a string, a function, nor an object (`undefined`, `null`, number, boolean, `Symbol`). The test registered as a body-less always-passing `<anonymous>` entry (for `describe`, an empty suite whose children never registered), so the run went green without executing any of the bodies. Node runs the body in every case.

Realistic triggers: `test(fixture.title, fn)` with a missing title, `for (const n of ids) test(n, fn)`, `describe(pkg.version, ...)`.

## Reproduction

```js
// name-drop.test.mjs
import { test, describe, it } from 'node:test';
import assert from 'node:assert';
test(undefined, () => assert.fail('undef name'));
test(null,      () => assert.fail('null name'));
test(12345,     () => assert.fail('numeric name'));
test(true,      () => assert.fail('boolean name'));
describe(42, () => { it('child', () => assert.fail('describe(42)')); });
test('ctrl-pass', () => {});
```

Node v26.3.0: `tests 6 / pass 1 / fail 5`, exit 1.
Bun (before): `5 pass 0 fail`, exit 0, none of the failing bodies executed.

## Cause

`parseTestArgs`' final `else` branch set `fn = kDefaultFunction` whenever `arg0` was none of string/function/object, discarding `arg1`/`arg2` entirely.

## Fix

Rewrite `parseTestArgs` to mirror Node's `createSubtest` + `Test` constructor (`lib/internal/test_runner/test.js`): shift each positional into `fn`/`options` only when its declared slot's type does not match, then normalise `name` from `fn.name` when it is not a non-empty string. This also fixes `test("", fn)` to report `fn.name` instead of an empty name, matching Node.

## Verification

New fixture `test/js/node/test_runner/fixtures/25-non-string-name.js` covers `undefined` / `null` / number / boolean / `Symbol` / `""` as the name, the three-arg `test(42, {}, fn)` / `test(null, null, fn)` forms, and `describe(42, ...)` with a child. Passes identically under `node --test` and `bun bd test`; fails under the previous `parseTestArgs`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (92e20fad8)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [3193.95ms]
(pass) node:test > should run hooks in the right order [3355.69ms]
(pass) node:test > should run tests with different variations [2738.21ms]
(pass) node:test > should run async tests [2755.92ms]
(pass) node:test > should run all tests from multiple files [4076.84ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [3341.74ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2714.96ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2897.08ms]
(pass) node:test > should support done callbacks in tests and hooks [2704.21ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2891.87ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (92e20fad8)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [50.71ms]
(pass) node:test > should run hooks in the right order [68.48ms]
(pass) node:test > should run tests with different variations [48.38ms]
(pass) node:test > should run async tests [46.85ms]
(pass) node:test > should run all tests from multiple files [74.37ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [53.05ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [70.76ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [52.01ms]
(pass) node:test > should support done callbacks in tests and hooks [47.72ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [53.30ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurrent too [51.50ms]
(pass) node:test > should run todo bodies under --todo instead of registering an empty function [46.22ms]
(pass) node:test > should forward Infinity and finite timeouts s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (92e20fad8)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [3262.15ms]
(pass) node:test > should run hooks in the right order [3339.84ms]
(pass) node:test > should run tests with different variations [2686.74ms]
(pass) node:test > should run async tests [2544.10ms]
(pass) node:test > should run all tests from multiple files [4038.86ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2915.60ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2835.70ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2922.68ms]
(pass) node:test > should support done callbacks in tests and hooks [2710.44ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2920.39ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 892ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (12318ms)
Bundle modules (43ms)
Postprocesss modules (176ms)
Bundle Functions (851ms)
Generate Code (22ms)

[13.43s] Bundled "src/js" for production
  2040 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[build] done
bun test v1.4.0-canary.1 (92e20fad8)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [70.76ms]
(pass) node:test > should run hooks in the right order [92.76ms]
(pass) node:test > should run tests with different variations [69.90ms]
(pass) node:test > should run async tests [65.72ms]
(pass) node:test > should run all tests from multiple files [76.86ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [66.92ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [71.46ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [72.58ms]
(pa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/test.ts                                | 68 ++++++++-----------
 .../test_runner/fixtures/25-non-string-name.js     | 36 ++++++++++
 test/js/node/test_runner/node-test.test.ts         | 79 +++++++++++++++-------
 3 files changed, 118 insertions(+), 65 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js/node/test.ts                                          3      3      0
test/js/node/test_runner/fixtures/25-non-string-name.js      0      2      0
test/js/node/test_runner/node-test.test.ts                   3      3      0
```

</details>

<!-- robobun:evidence:end -->