### PR TITLE
Bun.serve: borrow large ArrayBuffer Response bodies instead of cloning per-request

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -135,6 +135,12 @@ unsafe extern "C" {
     safe fn JSC__ArrayBuffer__deref(self_: &JSCArrayBuffer);
     // safe: by-value `JSValue`; no-op for non-buffer values.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
+    // safe: by-value `JSValue`; returns the non-JS-cell `JSC::ArrayBuffer*`
+    // (or null when unsuitable for borrowing). See `pinned_store_allocator`.
+    safe fn Bun__ArrayBuffer__retainPinnedStore(v: JSValue) -> *mut JSCArrayBuffer;
+    // safe: `JSCArrayBuffer` is an `opaque_ffi!` ZST handle; releases exactly
+    // the pin + ref taken by `retainPinnedStore`.
+    safe fn Bun__ArrayBuffer__releasePinnedStore(buf: &JSCArrayBuffer);
 }
 
 impl JSValue {
@@ -142,6 +148,53 @@ impl JSValue {
     /// [`JSValue::as_pinned_arraybuffer`] or a pinning collector.
     pub fn unpin_array_buffer(self) {
         JSC__JSValue__unpinArrayBuffer(self);
+    }
+}
+
+/// A [`StdAllocator`] vtable whose context is a native `JSC::ArrayBuffer*`
+/// that has been `ref()`ed + `pin()`ed. `free` releases both; `alloc` /
+/// `resize` / `remap` are absent because the backing bytes belong to JSC and
+/// are never grown through this allocator.
+///
+/// Used by `Body::Value::from_js` so `new Response(arrayBuffer)` can borrow
+/// the buffer instead of `.to_vec()`ing it into a private per-request copy.
+/// The release path touches only the native `ArrayBuffer` (not a `JSCell`),
+/// so it is safe to run from a GC-sweep finalizer.
+pub mod pinned_store_allocator {
+    use super::{
+        Bun__ArrayBuffer__releasePinnedStore, Bun__ArrayBuffer__retainPinnedStore, JSCArrayBuffer,
+        JSValue,
+    };
+    use bun_alloc::{Alignment, AllocatorVTable, StdAllocator};
+    use core::ffi::c_void;
+
+    unsafe fn free(ctx: *mut c_void, _buf: &mut [u8], _: Alignment, _: usize) {
+        Bun__ArrayBuffer__releasePinnedStore(JSCArrayBuffer::opaque_ref(
+            ctx.cast::<JSCArrayBuffer>(),
+        ));
+    }
+
+    static VTABLE: &AllocatorVTable = &AllocatorVTable::free_only(free);
+
+    /// Retain `value`'s backing `JSC::ArrayBuffer` (pin + native ref) and
+    /// return an allocator whose `free` releases exactly that pin + ref.
+    /// `None` when `value` has no ArrayBuffer impl or the buffer is
+    /// resizable/growable (a shrink would invalidate borrowed storage).
+    #[inline]
+    pub fn retain(value: JSValue) -> Option<StdAllocator> {
+        let buf = Bun__ArrayBuffer__retainPinnedStore(value);
+        if buf.is_null() {
+            return None;
+        }
+        Some(StdAllocator {
+            ptr: buf.cast::<c_void>(),
+            vtable: VTABLE,
+        })
+    }
+
+    #[inline]
+    pub fn is_instance(alloc: &StdAllocator) -> bool {
+        core::ptr::eq(alloc.vtable, VTABLE)
     }
 }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -135,9 +135,13 @@ unsafe extern "C" {
     safe fn JSC__ArrayBuffer__deref(self_: &JSCArrayBuffer);
     // safe: by-value `JSValue`; no-op for non-buffer values.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
-    // safe: by-value `JSValue`; returns the non-JS-cell `JSC::ArrayBuffer*`
-    // (or null when unsuitable for borrowing). See `pinned_store_allocator`.
-    safe fn Bun__ArrayBuffer__retainPinnedStore(v: JSValue) -> *mut JSCArrayBuffer;
+    // safe: by-value `JSValue` plus raw out-params the C++ only writes on a
+    // non-null return; see `pinned_store_allocator`.
+    safe fn Bun__ArrayBuffer__retainPinnedStore(
+        v: JSValue,
+        out_ptr: &mut *const u8,
+        out_len: &mut usize,
+    ) -> *mut JSCArrayBuffer;
     // safe: `JSCArrayBuffer` is an `opaque_ffi!` ZST handle; releases exactly
     // the pin + ref taken by `retainPinnedStore`.
     safe fn Bun__ArrayBuffer__releasePinnedStore(buf: &JSCArrayBuffer);
@@ -177,19 +181,25 @@ pub mod pinned_store_allocator {
     static VTABLE: &AllocatorVTable = &AllocatorVTable::free_only(free);
 
     /// Retain `value`'s backing `JSC::ArrayBuffer` (pin + native ref) and
-    /// return an allocator whose `free` releases exactly that pin + ref.
-    /// `None` when `value` has no ArrayBuffer impl or the buffer is
-    /// resizable/growable (a shrink would invalidate borrowed storage).
+    /// return the view's byte range plus an allocator whose `free` releases
+    /// exactly that pin + ref. `None` when `value` has no ArrayBuffer impl or
+    /// the buffer is resizable/growable/shared.
     #[inline]
-    pub fn retain(value: JSValue) -> Option<StdAllocator> {
-        let buf = Bun__ArrayBuffer__retainPinnedStore(value);
+    pub fn retain(value: JSValue) -> Option<(*const u8, usize, StdAllocator)> {
+        let mut ptr: *const u8 = core::ptr::null();
+        let mut len: usize = 0;
+        let buf = Bun__ArrayBuffer__retainPinnedStore(value, &mut ptr, &mut len);
         if buf.is_null() {
             return None;
         }
-        Some(StdAllocator {
-            ptr: buf.cast::<c_void>(),
-            vtable: VTABLE,
-        })
+        Some((
+            ptr,
+            len,
+            StdAllocator {
+                ptr: buf.cast::<c_void>(),
+                vtable: VTABLE,
+            },
+        ))
     }
 
     #[inline]

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3185,21 +3185,41 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
     }
 }
 
-// Retain `v`'s backing JSC::ArrayBuffer natively (ref() + pin()) and return
-// it, so a Blob `Store::Bytes` can borrow its storage without touching the JS
-// cell on release. Returns null for resizable/growable buffers (a shrink
-// would invalidate the borrowed (ptr, len)), SharedArrayBuffers (other agents
-// may write the same storage concurrently, and Bytes::slice() yields &[u8]),
-// or when `v` has no ArrayBuffer impl. Must be called on the JS thread that
-// owns `v`.
-CPP_DECL JSC::ArrayBuffer* Bun__ArrayBuffer__retainPinnedStore(JSC::EncodedJSValue v)
+// Retain `v`'s backing JSC::ArrayBuffer natively (ref() + pin()) and write
+// the view's byte range out, so a Blob `Store::Bytes` can borrow its storage
+// without touching the JS cell on release. `vector()`/`data()` is read AFTER
+// `possiblySharedBuffer()` materializes (see the same ordering discipline in
+// `JSC__JSValue__borrowBytesForOffThread` below). Returns null for
+// resizable/growable buffers (a shrink would invalidate the borrowed
+// (ptr, len)), SharedArrayBuffers (other agents may write the same storage
+// concurrently, and Bytes::slice() yields &[u8]), or when `v` has no
+// ArrayBuffer impl. Must be called on the JS thread that owns `v`.
+CPP_DECL JSC::ArrayBuffer* Bun__ArrayBuffer__retainPinnedStore(JSC::EncodedJSValue v, const uint8_t** out_ptr, size_t* out_len)
 {
-    auto* buf = arrayBufferImpl(JSC::JSValue::decode(v));
-    if (!buf || buf->isResizableOrGrowableShared() || buf->isShared())
-        return nullptr;
-    buf->pin();
-    buf->ref();
-    return buf;
+    auto value = JSC::JSValue::decode(v);
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
+        if (view->isDetached())
+            return nullptr;
+        auto* buf = view->possiblySharedBuffer();
+        if (!buf || buf->isResizableOrGrowableShared() || buf->isShared())
+            return nullptr;
+        buf->pin();
+        buf->ref();
+        *out_ptr = static_cast<const uint8_t*>(view->vector());
+        *out_len = view->byteLength();
+        return buf;
+    }
+    if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
+        auto* buf = jb->impl();
+        if (!buf || buf->isDetached() || buf->isResizableOrGrowableShared() || buf->isShared())
+            return nullptr;
+        buf->pin();
+        buf->ref();
+        *out_ptr = static_cast<const uint8_t*>(buf->data());
+        *out_len = buf->byteLength();
+        return buf;
+    }
+    return nullptr;
 }
 // Release the pin + ref taken by `retainPinnedStore`. Only dereferences the
 // native ArrayBuffer (not a JSCell), so it is safe to call from a finalizer

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3185,6 +3185,31 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
     }
 }
 
+// Retain `v`'s backing JSC::ArrayBuffer natively (ref() + pin()) and return
+// it, so a Blob `Store::Bytes` can borrow its storage without touching the JS
+// cell on release. Returns null for resizable/growable buffers (a shrink
+// would invalidate the borrowed (ptr, len)) or when `v` has no ArrayBuffer
+// impl. Must be called on the JS thread that owns `v`.
+CPP_DECL JSC::ArrayBuffer* Bun__ArrayBuffer__retainPinnedStore(JSC::EncodedJSValue v)
+{
+    auto* buf = arrayBufferImpl(JSC::JSValue::decode(v));
+    if (!buf || buf->isResizableOrGrowableShared())
+        return nullptr;
+    if (!buf->isShared())
+        buf->pin();
+    buf->ref();
+    return buf;
+}
+// Release the pin + ref taken by `retainPinnedStore`. Only dereferences the
+// native ArrayBuffer (not a JSCell), so it is safe to call from a finalizer
+// during the GC sweep that collects the holder.
+CPP_DECL void Bun__ArrayBuffer__releasePinnedStore(JSC::ArrayBuffer* buf)
+{
+    if (!buf->isShared())
+        buf->unpin();
+    buf->deref();
+}
+
 // Borrow `v`'s byte storage for off-thread reading. Splits out only the
 // `FastTypedArray` case from `pinArrayBuffer`, because that's the one mode
 // where `possiblySharedBuffer()` actually COPIES data

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3188,15 +3188,16 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
 // Retain `v`'s backing JSC::ArrayBuffer natively (ref() + pin()) and return
 // it, so a Blob `Store::Bytes` can borrow its storage without touching the JS
 // cell on release. Returns null for resizable/growable buffers (a shrink
-// would invalidate the borrowed (ptr, len)) or when `v` has no ArrayBuffer
-// impl. Must be called on the JS thread that owns `v`.
+// would invalidate the borrowed (ptr, len)), SharedArrayBuffers (other agents
+// may write the same storage concurrently, and Bytes::slice() yields &[u8]),
+// or when `v` has no ArrayBuffer impl. Must be called on the JS thread that
+// owns `v`.
 CPP_DECL JSC::ArrayBuffer* Bun__ArrayBuffer__retainPinnedStore(JSC::EncodedJSValue v)
 {
     auto* buf = arrayBufferImpl(JSC::JSValue::decode(v));
-    if (!buf || buf->isResizableOrGrowableShared())
+    if (!buf || buf->isResizableOrGrowableShared() || buf->isShared())
         return nullptr;
-    if (!buf->isShared())
-        buf->pin();
+    buf->pin();
     buf->ref();
     return buf;
 }
@@ -3205,8 +3206,7 @@ CPP_DECL JSC::ArrayBuffer* Bun__ArrayBuffer__retainPinnedStore(JSC::EncodedJSVal
 // during the GC sweep that collects the holder.
 CPP_DECL void Bun__ArrayBuffer__releasePinnedStore(JSC::ArrayBuffer* buf)
 {
-    if (!buf->isShared())
-        buf->unpin();
+    buf->unpin();
     buf->deref();
 }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -893,8 +893,7 @@ pub mod store {
         /// backing buffer is resizable/growable, a `SharedArrayBuffer`, or
         /// otherwise unsuitable for borrowing.
         pub fn init_pinned_array_buffer(value: JSValue) -> Option<StoreRef> {
-            let (ptr, len, allocator) =
-                crate::array_buffer::pinned_store_allocator::retain(value)?;
+            let (ptr, len, allocator) = crate::array_buffer::pinned_store_allocator::retain(value)?;
             let len = len as SizeType;
             // SAFETY: `ptr[..len]` is the view's slice of the live
             // `JSC::ArrayBuffer` contents, read after materialization by

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -885,6 +885,30 @@ pub mod store {
             }))
         }
 
+        /// Borrow the storage of the `JSC::ArrayBuffer` behind `buffer` as a
+        /// `Store::Bytes` without copying. The native `ArrayBuffer` is
+        /// `ref()`ed and `pin()`ed so its contents stay attached for the
+        /// store's lifetime; the store's `Drop` releases both via
+        /// [`array_buffer::pinned_store_allocator`]. Returns `None` when the
+        /// backing buffer is resizable/growable or otherwise unsuitable for
+        /// borrowing.
+        pub fn init_pinned_array_buffer(buffer: &crate::ArrayBuffer) -> Option<StoreRef> {
+            debug_assert!(!buffer.ptr.is_null());
+            let allocator = crate::array_buffer::pinned_store_allocator::retain(buffer.value)?;
+            let len = buffer.byte_len as SizeType;
+            // SAFETY: `ptr[..byte_len]` is the view's slice of the live
+            // `JSC::ArrayBuffer` contents; the native ref keeps the
+            // allocation alive and the pin keeps it attached, so the region
+            // stays valid until the allocator's `free` releases both.
+            let bytes = unsafe { Bytes::from_raw_parts(buffer.ptr, len, len, allocator) };
+            Some(StoreRef::from(Store::new(Store {
+                data: Data::Bytes(bytes),
+                mime_type: bun_http_types::MimeType::NONE,
+                ref_count: bun_ptr::ThreadSafeRefCount::init(),
+                is_all_ascii: None,
+            })))
+        }
+
         pub fn get_path(&self) -> Option<&[u8]> {
             match &self.data {
                 Data::Bytes(bytes) => {
@@ -920,6 +944,20 @@ pub mod store {
             match &self.data {
                 Data::Bytes(b) => b.len(),
                 Data::File(_) | Data::S3(_) => MAX_SIZE,
+            }
+        }
+
+        /// Whether this store's `Bytes` borrow a user-visible JS ArrayBuffer
+        /// (see [`init_pinned_array_buffer`]). Such bytes must not be handed
+        /// to JSC as external-string or external-ArrayBuffer backing: JS can
+        /// mutate the source buffer, and strings must be immutable.
+        #[inline]
+        pub fn bytes_borrow_js_array_buffer(&self) -> bool {
+            match &self.data {
+                Data::Bytes(bytes) => {
+                    crate::array_buffer::pinned_store_allocator::is_instance(&bytes.allocator)
+                }
+                _ => false,
             }
         }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -885,22 +885,23 @@ pub mod store {
             }))
         }
 
-        /// Borrow the storage of the `JSC::ArrayBuffer` behind `buffer` as a
+        /// Borrow the storage of the `JSC::ArrayBuffer` behind `value` as a
         /// `Store::Bytes` without copying. The native `ArrayBuffer` is
         /// `ref()`ed and `pin()`ed so its contents stay attached for the
         /// store's lifetime; the store's `Drop` releases both via
         /// [`array_buffer::pinned_store_allocator`]. Returns `None` when the
         /// backing buffer is resizable/growable, a `SharedArrayBuffer`, or
         /// otherwise unsuitable for borrowing.
-        pub fn init_pinned_array_buffer(buffer: &crate::ArrayBuffer) -> Option<StoreRef> {
-            debug_assert!(!buffer.ptr.is_null());
-            let allocator = crate::array_buffer::pinned_store_allocator::retain(buffer.value)?;
-            let len = buffer.byte_len as SizeType;
-            // SAFETY: `ptr[..byte_len]` is the view's slice of the live
-            // `JSC::ArrayBuffer` contents; the native ref keeps the
-            // allocation alive and the pin keeps it attached, so the region
-            // stays valid until the allocator's `free` releases both.
-            let bytes = unsafe { Bytes::from_raw_parts(buffer.ptr, len, len, allocator) };
+        pub fn init_pinned_array_buffer(value: JSValue) -> Option<StoreRef> {
+            let (ptr, len, allocator) =
+                crate::array_buffer::pinned_store_allocator::retain(value)?;
+            let len = len as SizeType;
+            // SAFETY: `ptr[..len]` is the view's slice of the live
+            // `JSC::ArrayBuffer` contents, read after materialization by
+            // `retainPinnedStore`; the native ref keeps the allocation alive
+            // and the pin keeps it attached, so the region stays valid until
+            // the allocator's `free` releases both.
+            let bytes = unsafe { Bytes::from_raw_parts(ptr.cast_mut(), len, len, allocator) };
             Some(StoreRef::from(Store::new(Store {
                 data: Data::Bytes(bytes),
                 mime_type: bun_http_types::MimeType::NONE,

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -890,8 +890,8 @@ pub mod store {
         /// `ref()`ed and `pin()`ed so its contents stay attached for the
         /// store's lifetime; the store's `Drop` releases both via
         /// [`array_buffer::pinned_store_allocator`]. Returns `None` when the
-        /// backing buffer is resizable/growable or otherwise unsuitable for
-        /// borrowing.
+        /// backing buffer is resizable/growable, a `SharedArrayBuffer`, or
+        /// otherwise unsuitable for borrowing.
         pub fn init_pinned_array_buffer(buffer: &crate::ArrayBuffer) -> Option<StoreRef> {
             debug_assert!(!buffer.ptr.is_null());
             let allocator = crate::array_buffer::pinned_store_allocator::retain(buffer.value)?;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3117,7 +3117,7 @@ where
             // .InlineBlob,
             Body::Value::WTFStringImpl(_) | Body::Value::InternalBlob(_) | Body::Value::Blob(_) => {
                 // toBlobIfPossible checks for WTFString needing a conversion.
-                this.blob = value.use_as_any_blob_allow_non_utf8_string();
+                this.blob = value.use_as_any_blob_for_render();
                 this.render_with_blob_from_body_value();
                 return;
             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2585,6 +2585,12 @@ impl BlobExt for Blob {
         // we can update the store's is_all_ascii flag
         if self.size.get() > 0 && self.offset.get() == 0 {
             if let Some(store_ref) = self.store() {
+                // A borrowed-ArrayBuffer store's bytes are user-mutable, so
+                // this cache would go stale; a cloned Response sharing the
+                // StoreRef would then skip the UTF-8 scan and mis-decode.
+                if store_ref.bytes_borrow_js_array_buffer() {
+                    return;
+                }
                 let store = store_ref.as_ptr();
                 // SAFETY: `store` is live (we hold a `StoreRef`); single-threaded
                 // JS execution means no concurrent &Store borrow is outstanding.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2693,6 +2693,22 @@ impl BlobExt for Blob {
             }
         }
 
+        // The external-string arms below hand `buf` to JSC as the StringImpl's
+        // character storage. When the Store borrows a user-visible JS
+        // ArrayBuffer (the `new Response(arrayBuffer)` path), that would make
+        // the string alias memory JS can mutate; copy instead.
+        if LIFETIME != Lifetime::Temporary
+            && self
+                .store()
+                .is_some_and(|s| s.bytes_borrow_js_array_buffer())
+        {
+            let out = OwnedString::new(BunString::clone_latin1(buf));
+            if LIFETIME == Lifetime::Transfer {
+                self.detach();
+            }
+            return out.to_js(global);
+        }
+
         match LIFETIME {
             // strings are immutable
             // we don't need to clone
@@ -3058,7 +3074,16 @@ impl BlobExt for Blob {
                 {
                     return Err(global.throw_out_of_memory());
                 }
-                let store = self.store().expect("infallible: store present").clone();
+                let store = self.store().expect("infallible: store present");
+                if store.bytes_borrow_js_array_buffer() {
+                    // SAFETY: same `buf` contract as the caller; the `Clone` arm only reads it.
+                    return unsafe {
+                        self.to_array_buffer_view_with_bytes::<{ Lifetime::Clone }, TYPED_ARRAY_VIEW>(
+                            global, buf,
+                        )
+                    };
+                }
+                let store = store.clone();
                 // SAFETY: `from_bytes` only records ptr+len into the FFI struct; the
                 // pointer is then handed to JSC as an external buffer backing whose
                 // lifetime is the cloned `store` ref above (the deallocator releases
@@ -3073,7 +3098,10 @@ impl BlobExt for Blob {
                 }
             }
             Lifetime::Transfer => {
-                if self.store().is_some_and(|s| !s.has_one_ref()) {
+                if self
+                    .store()
+                    .is_some_and(|s| !s.has_one_ref() || s.bytes_borrow_js_array_buffer())
+                {
                     // SAFETY: same `buf` contract as the caller; the `Clone` arm only reads it.
                     let copied = unsafe {
                         self.to_array_buffer_view_with_bytes::<{ Lifetime::Clone }, TYPED_ARRAY_VIEW>(

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1637,6 +1637,16 @@ impl Value {
         }
 
         if let Value::Blob(b) = self {
+            // `dupe_with_content_type` shares the StoreRef. Snapshot a
+            // borrowed JS ArrayBuffer so the clone (a second Response, or a
+            // Request built via `new Request(url, response)`) never carries
+            // the pin outside this body.
+            if b.store().is_some_and(|s| s.bytes_borrow_js_array_buffer()) {
+                return Ok(Value::Blob(Blob::init(
+                    b.shared_view().to_vec(),
+                    global_this,
+                )));
+            }
             return Ok(Value::Blob(b.dupe_with_content_type(false)));
         }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -743,7 +743,7 @@ impl Value {
             Value::InternalBlob(b) => b.memory_cost(),
             Value::WTFStringImpl(s) => wtf_impl(s).memory_cost(),
             Value::Locked(l) => l.size_hint() as usize,
-            Value::Blob(b) => b.size.get() as usize,
+            Value::Blob(b) => b.shared_view().len(),
             // Value::InlineBlob(b) => b.slice_const().len(),
             _ => 0,
         }
@@ -754,11 +754,12 @@ impl Value {
             Value::InternalBlob(b) => b.slice_const().len(),
             Value::WTFStringImpl(s) => wtf_impl(s).byte_slice().len(),
             Value::Locked(l) => l.size_hint() as usize,
-            // A borrowed-ArrayBuffer store's bytes are already reported by
-            // the source ArrayBuffer, so this double-counts them, but the
-            // heap-snapshot and GC estimate should reflect that the body
-            // retains body-sized storage.
-            Value::Blob(b) => b.size.get() as usize,
+            // `shared_view` is empty for file/S3 stores (whose `size` is
+            // `MAX_SIZE` until stat'd) so only bytes-backed stores are
+            // reported. A borrowed-ArrayBuffer store's bytes are already
+            // reported by the source ArrayBuffer; the heap-snapshot and GC
+            // estimate should still reflect that the body retains them.
+            Value::Blob(b) => b.shared_view().len(),
             // Value::InlineBlob(b) => b.slice_const().len(),
             _ => 0,
         }
@@ -880,10 +881,11 @@ impl Value {
     /// `BORROW_ARRAY_BUFFER`: when true, an ArrayBuffer/view body at or above
     /// [`ARRAY_BUFFER_BORROW_THRESHOLD`] is wrapped in a `Blob` that borrows
     /// the live storage instead of `.to_vec()`ing it. Only the `Response`
-    /// constructor takes this path (via [`body::extract`]); `Request` and
-    /// outbound `fetch()` keep the spec snapshot semantics so mutating a
-    /// buffer after handing it to `fetch()` cannot change what goes on the
-    /// wire.
+    /// constructor takes this path (via [`body::extract_for_response`]);
+    /// `Request`, outbound `fetch()`, and `HTMLRewriter.transform()` keep the
+    /// spec snapshot semantics so mutating a buffer after handing it to
+    /// `fetch()` cannot change what goes on the wire, and a rewriter handler
+    /// cannot mutate its own source mid-parse.
     pub fn from_js_maybe_borrow<const BORROW_ARRAY_BUFFER: bool>(
         global_this: &JSGlobalObject,
         value: JSValue,
@@ -923,10 +925,9 @@ impl Value {
                 // backpressure that per-connection copy is held until the
                 // socket drains, so N slow clients x an M-byte body costs
                 // N*M bytes of RSS. `init_pinned_array_buffer` rejects
-                // resizable/growable buffers (a shrink would invalidate the
-                // stored `(ptr, len)`).
+                // resizable/growable and shared buffers.
                 if BORROW_ARRAY_BUFFER && bytes.len() >= Self::ARRAY_BUFFER_BORROW_THRESHOLD {
-                    if let Some(store) = blob::Store::init_pinned_array_buffer(&buffer) {
+                    if let Some(store) = blob::Store::init_pinned_array_buffer(value) {
                         return Ok(Value::Blob(Blob::init_with_store(store, global_this)));
                     }
                 }
@@ -1625,6 +1626,19 @@ type ArrayBufferJSSink = sink::JSSink<ArrayBufferSink>;
 
 // https://github.com/WebKit/webkit/blob/main/Source/WebCore/Modules/fetch/FetchBody.cpp#L45
 pub(crate) fn extract(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Body> {
+    let body_value = Value::from_js(global_this, value)?;
+    if let Value::Blob(b) = &body_value {
+        debug_assert!(!b.is_heap_allocated()); // owned by Body
+    }
+    Ok(Body::new(body_value))
+}
+
+/// `extract` with the large-ArrayBuffer borrow path enabled (see
+/// [`Value::from_js_maybe_borrow`]). The `Response` constructor is the sole
+/// caller: it is the only body-init surface where the borrow is useful
+/// (`Bun.serve` slices the Store directly) and where a handler mutating the
+/// source buffer mid-consume is not a hazard.
+pub(crate) fn extract_for_response(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Body> {
     let body_value = Value::from_js_maybe_borrow::<true>(global_this, value)?;
     if let Value::Blob(b) = &body_value {
         debug_assert!(!b.is_heap_allocated()); // owned by Body

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1251,9 +1251,29 @@ impl Value {
         }
     }
 
+    /// Move the `Value::Blob` payload into an `AnyBlob`, snapshotting a
+    /// borrowed JS ArrayBuffer into owned storage so the pin cannot escape
+    /// the Body. Consumers that may re-enter user JS while holding
+    /// `.slice()` (HTMLRewriter, `ValueBufferer`, outbound fetch) go through
+    /// this; `RequestContext`'s send path uses [`use_as_any_blob_for_render`]
+    /// to keep the borrow.
+    #[inline]
+    fn take_blob_snapshot_if_borrowed(b: &mut Blob) -> AnyBlob {
+        let b = core::mem::take(b);
+        if b.store().is_some_and(|s| s.bytes_borrow_js_array_buffer()) {
+            let owned = InternalBlob {
+                bytes: b.shared_view().to_vec(),
+                was_string: false,
+            };
+            b.detach();
+            return AnyBlob::InternalBlob(owned);
+        }
+        AnyBlob::Blob(b)
+    }
+
     pub fn try_use_as_any_blob(&mut self) -> Option<AnyBlob> {
         let any_blob: AnyBlob = match self {
-            Value::Blob(b) => AnyBlob::Blob(core::mem::take(b)),
+            Value::Blob(b) => Self::take_blob_snapshot_if_borrowed(b),
             Value::InternalBlob(b) => AnyBlob::InternalBlob(core::mem::take(b)),
             Value::WTFStringImpl(str) => {
                 if wtf_impl(str).can_use_as_utf8() {
@@ -1284,7 +1304,7 @@ impl Value {
         // emptied/residual variant (no-op for taken Blob/InternalBlob, releases
         // the +1 for the UTF-8-converted WTFStringImpl arm, deinit for Locked).
         let any_blob: AnyBlob = match self {
-            Value::Blob(b) => AnyBlob::Blob(core::mem::take(b)),
+            Value::Blob(b) => Self::take_blob_snapshot_if_borrowed(b),
             Value::InternalBlob(b) => AnyBlob::InternalBlob(core::mem::take(b)),
             Value::WTFStringImpl(str) => 'brk: {
                 let str = *str;
@@ -1318,7 +1338,7 @@ impl Value {
         let was_null = matches!(self, Value::Null);
         // see `use_as_any_blob` — match by `&mut` to avoid E0509.
         let any_blob: AnyBlob = match self {
-            Value::Blob(b) => AnyBlob::Blob(core::mem::take(b)),
+            Value::Blob(b) => Self::take_blob_snapshot_if_borrowed(b),
             Value::InternalBlob(b) => AnyBlob::InternalBlob(core::mem::take(b)),
             Value::WTFStringImpl(s) => {
                 let s = *s;
@@ -1333,6 +1353,29 @@ impl Value {
             _ => AnyBlob::Blob(Blob::default()),
         };
 
+        *self = if was_null { Value::Null } else { Value::Used };
+        any_blob
+    }
+
+    /// `use_as_any_blob_allow_non_utf8_string` without the borrowed-store
+    /// snapshot: the `Bun.serve` send path (`RequestContext::do_render_with_
+    /// body`) is the sole caller, since it never re-enters user JS while the
+    /// `AnyBlob.slice()` is live and its lifetime is single-thread-only.
+    pub fn use_as_any_blob_for_render(&mut self) -> AnyBlob {
+        let was_null = matches!(self, Value::Null);
+        let any_blob: AnyBlob = match self {
+            Value::Blob(b) => AnyBlob::Blob(core::mem::take(b)),
+            Value::InternalBlob(b) => AnyBlob::InternalBlob(core::mem::take(b)),
+            Value::WTFStringImpl(s) => {
+                let s = *s;
+                let _ = core::mem::ManuallyDrop::new(core::mem::replace(self, Value::Used));
+                AnyBlob::WTFStringImpl(s)
+            }
+            Value::Locked(l) => l
+                .to_any_blob_allow_promise()
+                .unwrap_or(AnyBlob::Blob(Blob::default())),
+            _ => AnyBlob::Blob(Blob::default()),
+        };
         *self = if was_null { Value::Null } else { Value::Used };
         any_blob
     }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -678,11 +678,12 @@ impl Value {
 }
 
 impl Value {
-    /// `new Response(arrayBuffer)` / `new Request(url, { body: arrayBuffer })`
-    /// borrows the buffer above this size; below it the copy is cheap and the
-    /// spec snapshot semantics are preserved exactly. Matches the uWS cork
-    /// buffer (`LoopData::CORK_BUFFER_SIZE`): a body that fits the cork buffer
-    /// is memcpy'd on the send path anyway.
+    /// `new Response(arrayBuffer)` borrows the buffer above this size (see
+    /// [`from_js_maybe_borrow`]). Below it the copy is cheap and the spec
+    /// snapshot semantics are preserved exactly; `new Request` and outbound
+    /// `fetch()` always copy. Matches the uWS cork buffer
+    /// (`LoopData::CORK_BUFFER_SIZE`): a body that fits the cork buffer is
+    /// memcpy'd on the send path anyway.
     pub const ARRAY_BUFFER_BORROW_THRESHOLD: usize = 16 * 1024;
 
     // We may not have all the data yet
@@ -742,6 +743,7 @@ impl Value {
             Value::InternalBlob(b) => b.memory_cost(),
             Value::WTFStringImpl(s) => wtf_impl(s).memory_cost(),
             Value::Locked(l) => l.size_hint() as usize,
+            Value::Blob(b) => b.size.get() as usize,
             // Value::InlineBlob(b) => b.slice_const().len(),
             _ => 0,
         }
@@ -752,6 +754,11 @@ impl Value {
             Value::InternalBlob(b) => b.slice_const().len(),
             Value::WTFStringImpl(s) => wtf_impl(s).byte_slice().len(),
             Value::Locked(l) => l.size_hint() as usize,
+            // A borrowed-ArrayBuffer store's bytes are already reported by
+            // the source ArrayBuffer, so this double-counts them, but the
+            // heap-snapshot and GC estimate should reflect that the body
+            // retains body-sized storage.
+            Value::Blob(b) => b.size.get() as usize,
             // Value::InlineBlob(b) => b.slice_const().len(),
             _ => 0,
         }
@@ -867,6 +874,20 @@ impl Value {
     }
 
     pub fn from_js(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Value> {
+        Self::from_js_maybe_borrow::<false>(global_this, value)
+    }
+
+    /// `BORROW_ARRAY_BUFFER`: when true, an ArrayBuffer/view body at or above
+    /// [`ARRAY_BUFFER_BORROW_THRESHOLD`] is wrapped in a `Blob` that borrows
+    /// the live storage instead of `.to_vec()`ing it. Only the `Response`
+    /// constructor takes this path (via [`body::extract`]); `Request` and
+    /// outbound `fetch()` keep the spec snapshot semantics so mutating a
+    /// buffer after handing it to `fetch()` cannot change what goes on the
+    /// wire.
+    pub fn from_js_maybe_borrow<const BORROW_ARRAY_BUFFER: bool>(
+        global_this: &JSGlobalObject,
+        value: JSValue,
+    ) -> JsResult<Value> {
         value.ensure_still_alive();
 
         if value.is_empty_or_undefined_or_null() {
@@ -896,14 +917,15 @@ impl Value {
                 }
 
                 // Above the cork-buffer size, borrow the ArrayBuffer's storage
-                // instead of `.to_vec()`ing it. A fetch handler that returns
-                // `new Response(sharedBuffer)` otherwise pays one body-sized
-                // memcpy + allocation per request, and under backpressure
-                // that per-connection copy is held until the socket drains,
-                // so N slow clients x an M-byte body costs N*M bytes of RSS.
-                // `init_pinned_array_buffer` rejects resizable/growable
-                // buffers (a shrink would invalidate the stored `(ptr, len)`).
-                if bytes.len() >= Self::ARRAY_BUFFER_BORROW_THRESHOLD {
+                // instead of `.to_vec()`ing it. A `Bun.serve` fetch handler
+                // that returns `new Response(sharedBuffer)` otherwise pays one
+                // body-sized memcpy + allocation per request, and under
+                // backpressure that per-connection copy is held until the
+                // socket drains, so N slow clients x an M-byte body costs
+                // N*M bytes of RSS. `init_pinned_array_buffer` rejects
+                // resizable/growable buffers (a shrink would invalidate the
+                // stored `(ptr, len)`).
+                if BORROW_ARRAY_BUFFER && bytes.len() >= Self::ARRAY_BUFFER_BORROW_THRESHOLD {
                     if let Some(store) = blob::Store::init_pinned_array_buffer(&buffer) {
                         return Ok(Value::Blob(Blob::init_with_store(store, global_this)));
                     }
@@ -1603,7 +1625,7 @@ type ArrayBufferJSSink = sink::JSSink<ArrayBufferSink>;
 
 // https://github.com/WebKit/webkit/blob/main/Source/WebCore/Modules/fetch/FetchBody.cpp#L45
 pub(crate) fn extract(global_this: &JSGlobalObject, value: JSValue) -> JsResult<Body> {
-    let body_value = Value::from_js(global_this, value)?;
+    let body_value = Value::from_js_maybe_borrow::<true>(global_this, value)?;
     if let Value::Blob(b) = &body_value {
         debug_assert!(!b.is_heap_allocated()); // owned by Body
     }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1163,6 +1163,20 @@ impl Value {
                 let new_blob = core::mem::take(b);
                 *self = Value::Used;
                 debug_assert!(!new_blob.is_heap_allocated()); // owned by Body
+                // Snapshot a borrowed JS ArrayBuffer into owned storage so the
+                // returned Blob is immutable and its Store never carries the
+                // non-atomic `JSC::ArrayBuffer` ref/pin off this thread
+                // (e.g. via `URL.createObjectURL` + cross-Worker revoke).
+                if new_blob
+                    .store()
+                    .is_some_and(|s| s.bytes_borrow_js_array_buffer())
+                {
+                    // SAFETY: VirtualMachine::get() returns the live per-thread VM.
+                    let global = VirtualMachine::get().global();
+                    let owned = Blob::init(new_blob.shared_view().to_vec(), global);
+                    new_blob.detach();
+                    return owned;
+                }
                 new_blob
             }
             Value::InternalBlob(ib) => {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -678,6 +678,13 @@ impl Value {
 }
 
 impl Value {
+    /// `new Response(arrayBuffer)` / `new Request(url, { body: arrayBuffer })`
+    /// borrows the buffer above this size; below it the copy is cheap and the
+    /// spec snapshot semantics are preserved exactly. Matches the uWS cork
+    /// buffer (`LoopData::CORK_BUFFER_SIZE`): a body that fits the cork buffer
+    /// is memcpy'd on the send path anyway.
+    pub const ARRAY_BUFFER_BORROW_THRESHOLD: usize = 16 * 1024;
+
     // We may not have all the data yet
     // So we can't know for sure if it's empty or not
     // We CAN know that it is definitely empty.
@@ -886,6 +893,20 @@ impl Value {
 
                 if bytes.is_empty() {
                     return Ok(Value::Empty);
+                }
+
+                // Above the cork-buffer size, borrow the ArrayBuffer's storage
+                // instead of `.to_vec()`ing it. A fetch handler that returns
+                // `new Response(sharedBuffer)` otherwise pays one body-sized
+                // memcpy + allocation per request, and under backpressure
+                // that per-connection copy is held until the socket drains,
+                // so N slow clients x an M-byte body costs N*M bytes of RSS.
+                // `init_pinned_array_buffer` rejects resizable/growable
+                // buffers (a shrink would invalidate the stored `(ptr, len)`).
+                if bytes.len() >= Self::ARRAY_BUFFER_BORROW_THRESHOLD {
+                    if let Some(store) = blob::Store::init_pinned_array_buffer(&buffer) {
+                        return Ok(Value::Blob(Blob::init_with_store(store, global_this)));
+                    }
                 }
 
                 // The global allocator aborts on OOM, so a "Failed to clone

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1239,8 +1239,7 @@ impl Response {
             if arguments[0].is_undefined_or_null() {
                 break 'brk Body::new(BodyValue::Null);
             }
-            // `Body::extract` is a free fn re-exported as `body::extract`.
-            super::body::extract(global_this, arguments[0])?
+            super::body::extract_for_response(global_this, arguments[0])?
         };
         // `Body` has NO `Drop`; arm a guard so the
         // error returns below release the extracted body payload.

--- a/test/js/bun/http/serve-buffer-body-backpressure-fixture.ts
+++ b/test/js/bun/http/serve-buffer-body-backpressure-fixture.ts
@@ -1,0 +1,30 @@
+// Server fixture for serve-buffer-body-backpressure.test.ts.
+// Returns a large shared buffer from the fetch handler and from a static
+// route so the test can compare the per-connection memory cost of each path.
+
+const bodyMB = Number(process.argv[2] ?? 16);
+const buf = new Uint8Array(bodyMB * 1024 * 1024).fill(65);
+
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  idleTimeout: 0,
+  routes: {
+    "/static": new Response(buf),
+    "/rss": () => new Response(String(process.memoryUsage.rss())),
+  },
+  fetch() {
+    return new Response(buf);
+  },
+});
+
+console.log(JSON.stringify({ port: server.port }));
+
+process.on("message", msg => {
+  if (msg === "rss") {
+    Bun.gc(true);
+    process.send?.({ rss: process.memoryUsage.rss() });
+  }
+});
+
+setInterval(() => {}, 1 << 30);

--- a/test/js/bun/http/serve-buffer-body-backpressure-fixture.ts
+++ b/test/js/bun/http/serve-buffer-body-backpressure-fixture.ts
@@ -11,7 +11,6 @@ const server = Bun.serve({
   idleTimeout: 0,
   routes: {
     "/static": new Response(buf),
-    "/rss": () => new Response(String(process.memoryUsage.rss())),
   },
   fetch() {
     return new Response(buf);

--- a/test/js/bun/http/serve-buffer-body-backpressure.test.ts
+++ b/test/js/bun/http/serve-buffer-body-backpressure.test.ts
@@ -1,0 +1,121 @@
+// A fetch handler that returns `new Response(sharedBuffer)` should not hold a
+// private copy of the body per in-flight connection. With N stalled clients
+// and an M-MB body, peak RSS used to grow by N*M MB (the body was .to_vec()'d
+// at Response construction). The static-route path already served the same
+// buffer at ~0 MB/conn; the fetch handler now does too.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import net from "node:net";
+import path from "node:path";
+
+const bodyMB = 16;
+const clients = 24;
+
+async function spawnServer() {
+  const { promise, resolve, reject } = Promise.withResolvers<number>();
+  const proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "serve-buffer-body-backpressure-fixture.ts"), String(bodyMB)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+    ipc(message) {
+      if (typeof message?.rss === "number") rssWaiters.shift()?.(message.rss);
+    },
+  });
+  const rssWaiters: ((n: number) => void)[] = [];
+  const rss = () =>
+    new Promise<number>(r => {
+      rssWaiters.push(r);
+      proc.send("rss");
+    });
+  (async () => {
+    let acc = "";
+    for await (const chunk of proc.stdout) {
+      acc += new TextDecoder().decode(chunk);
+      const m = acc.match(/"port":(\d+)/);
+      if (m) return resolve(Number(m[1]));
+    }
+    reject(new Error("server fixture exited without printing a port: " + acc));
+  })();
+  const port = await promise;
+  return { proc, port, rss };
+}
+
+async function measure(pathname: string) {
+  const { proc, port, rss } = await spawnServer();
+  try {
+    // Let the allocator settle after the startup burst.
+    await rss();
+    const before = await rss();
+
+    const socks: net.Socket[] = [];
+    let connected = 0;
+    const allUp = Promise.withResolvers<void>();
+    for (let i = 0; i < clients; i++) {
+      const s = net.connect(port, "127.0.0.1");
+      socks.push(s);
+      s.on("connect", () => {
+        s.write(`GET ${pathname} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+        s.pause();
+        if (++connected === clients) allUp.resolve();
+      });
+      s.on("error", () => {});
+    }
+    await allUp.promise;
+
+    // Poll until the server has responded to every request (pending body
+    // bytes are held on the server side) and RSS has stabilised.
+    let peak = before;
+    let last = -1;
+    for (let i = 0; i < 40; i++) {
+      const r = await rss();
+      peak = Math.max(peak, r);
+      if (Math.abs(r - last) < 1024 * 1024 && i >= 4) break;
+      last = r;
+      await Bun.sleep(50);
+    }
+
+    for (const s of socks) s.destroy();
+    return (peak - before) / (1024 * 1024);
+  } finally {
+    proc.kill(9);
+    await proc.exited;
+  }
+}
+
+test("Bun.serve: fetch handler returning new Response(buffer) does not copy the body per connection under backpressure", async () => {
+  const deltaMB = await measure("/via-fetch");
+  console.log(`fetch-handler: ${clients} stalled clients x ${bodyMB} MB body -> +${deltaMB.toFixed(1)} MB`);
+
+  // Before: one body-sized Vec per connection => clients * bodyMB MB (384 MB here).
+  // After: the shared ArrayBuffer is referenced, not cloned, so the delta is
+  // bounded by socket buffers + request-context overhead. Allow generous slack
+  // under ASAN/debug. The unfixed build exceeds this by more than an order of
+  // magnitude.
+  const bound = (isASAN || isDebug ? 3 : 1.5) * clients;
+  expect(deltaMB).toBeLessThan(bound);
+});
+
+test("Bun.serve: static route with a buffered Response does not copy the body per connection under backpressure", async () => {
+  const deltaMB = await measure("/static");
+  console.log(`static-route: ${clients} stalled clients x ${bodyMB} MB body -> +${deltaMB.toFixed(1)} MB`);
+
+  const bound = (isASAN || isDebug ? 3 : 1.5) * clients;
+  expect(deltaMB).toBeLessThan(bound);
+});
+
+test("Bun.serve: a fetch handler returning new Response(buffer) delivers the full body", async () => {
+  const { proc, port } = await spawnServer();
+  try {
+    const hash = Bun.hash(new Uint8Array(bodyMB * 1024 * 1024).fill(65));
+    const res = await fetch(`http://127.0.0.1:${port}/via-fetch`);
+    const got = await res.bytes();
+    expect(got.byteLength).toBe(bodyMB * 1024 * 1024);
+    expect(Bun.hash(got)).toBe(hash);
+  } finally {
+    proc.kill(9);
+    await proc.exited;
+  }
+});

--- a/test/js/bun/http/serve-buffer-body-backpressure.test.ts
+++ b/test/js/bun/http/serve-buffer-body-backpressure.test.ts
@@ -21,15 +21,21 @@ async function spawnServer() {
     stderr: "inherit",
     stdin: "ignore",
     ipc(message) {
-      if (typeof message?.rss === "number") rssWaiters.shift()?.(message.rss);
+      if (typeof message?.rss === "number") rssWaiters.shift()?.resolve(message.rss);
     },
   });
-  const rssWaiters: ((n: number) => void)[] = [];
-  const rss = () =>
-    new Promise<number>(r => {
-      rssWaiters.push(r);
-      proc.send("rss");
-    });
+  const rssWaiters: PromiseWithResolvers<number>[] = [];
+  const exitErr = proc.exited.then(code => new Error(`server fixture exited (${code})`));
+  exitErr.then(err => {
+    reject(err);
+    for (const w of rssWaiters.splice(0)) w.reject(err);
+  });
+  const rss = () => {
+    const w = Promise.withResolvers<number>();
+    rssWaiters.push(w);
+    proc.send("rss");
+    return w.promise;
+  };
   (async () => {
     let acc = "";
     for await (const chunk of proc.stdout) {
@@ -40,11 +46,11 @@ async function spawnServer() {
     reject(new Error("server fixture exited without printing a port: " + acc));
   })();
   const port = await promise;
-  return { proc, port, rss };
+  return { proc, port, rss, exitErr };
 }
 
 async function measure(pathname: string) {
-  const { proc, port, rss } = await spawnServer();
+  const { proc, port, rss, exitErr } = await spawnServer();
   try {
     // Let the allocator settle after the startup burst.
     await rss();
@@ -61,9 +67,14 @@ async function measure(pathname: string) {
         s.pause();
         if (++connected === clients) allUp.resolve();
       });
-      s.on("error", () => {});
+      s.on("error", err => allUp.reject(err));
     }
-    await allUp.promise;
+    await Promise.race([
+      allUp.promise,
+      exitErr.then(err => {
+        throw err;
+      }),
+    ]);
 
     // Poll until the server has responded to every request (pending body
     // bytes are held on the server side) and RSS has stabilised.

--- a/test/js/bun/util/heap-snapshot.test.ts
+++ b/test/js/bun/util/heap-snapshot.test.ts
@@ -31,8 +31,11 @@ describe("Native types report their size correctly", () => {
   });
 
   it("Request", () => {
+    // A string body is owned by the Request (ArrayBuffer bodies above the
+    // borrow threshold are referenced, not copied, so their bytes are
+    // attributed to the ArrayBuffer in the heap snapshot instead).
     var request = new Request("https://example.com", {
-      body: Buffer.alloc(1024 * 1024 * 2, "yoo"),
+      body: Buffer.alloc(1024 * 1024 * 2, "yoo").toString(),
     });
     globalThis.request = request;
 
@@ -48,7 +51,7 @@ describe("Native types report their size correctly", () => {
   });
 
   it("Response", () => {
-    var response = new Response(Buffer.alloc(1024 * 1024 * 4, "yoo"), {
+    var response = new Response(Buffer.alloc(1024 * 1024 * 4, "yoo").toString(), {
       headers: {
         "Content-Type": "text/plain",
       },

--- a/test/js/bun/util/heap-snapshot.test.ts
+++ b/test/js/bun/util/heap-snapshot.test.ts
@@ -31,11 +31,8 @@ describe("Native types report their size correctly", () => {
   });
 
   it("Request", () => {
-    // A string body is owned by the Request (ArrayBuffer bodies above the
-    // borrow threshold are referenced, not copied, so their bytes are
-    // attributed to the ArrayBuffer in the heap snapshot instead).
     var request = new Request("https://example.com", {
-      body: Buffer.alloc(1024 * 1024 * 2, "yoo").toString(),
+      body: Buffer.alloc(1024 * 1024 * 2, "yoo"),
     });
     globalThis.request = request;
 
@@ -51,7 +48,7 @@ describe("Native types report their size correctly", () => {
   });
 
   it("Response", () => {
-    var response = new Response(Buffer.alloc(1024 * 1024 * 4, "yoo").toString(), {
+    var response = new Response(Buffer.alloc(1024 * 1024 * 4, "yoo"), {
       headers: {
         "Content-Type": "text/plain",
       },

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -819,21 +819,29 @@ describe("constructing a Response from a large ArrayBuffer borrows the storage",
     expect(out[N - 1]).toBe(0x61);
   });
 
-  test("text() on a clone re-scans the borrow after the source is mutated", async () => {
-    // r1 and r2 share the same borrowed Store; r1.text() must not cache an
-    // ASCII verdict on the shared Store that r2.text() would trust after
-    // the source bytes have changed.
+  test("Response.clone() snapshots the borrow (the clone never shares the pinned Store)", async () => {
     const buf = new Uint8Array(N).fill(0x61);
     const r1 = new Response(buf);
     const r2 = r1.clone();
-    expect((await r1.text())[0]).toBe("a");
-    for (let i = 0; i < N; i += 2) {
-      buf[i] = 0xc3;
-      buf[i + 1] = 0xa9;
-    }
-    const t2 = await r2.text();
-    expect(t2.length).toBe(N / 2);
-    expect(t2[0]).toBe("é");
+    buf.fill(0x62);
+    // r1 still borrows (sees the mutation); r2 snapshotted at clone time.
+    expect((await r1.bytes())[0]).toBe(0x62);
+    expect((await r2.bytes())[0]).toBe(0x61);
+  });
+
+  test("new Request(url, Response) snapshots the borrow", async () => {
+    const buf = new Uint8Array(N).fill(0x61);
+    const res = new Response(buf);
+    const req = new Request("http://example.com/", res);
+    buf.fill(0x62);
+    const out = await req.bytes();
+    expect(out[0]).toBe(0x61);
+    // The Request does not hold a pin; transfer() detaches with the Response
+    // also consumed.
+    await res.bytes();
+    const moved = buf.buffer.transfer();
+    expect(buf.buffer.byteLength).toBe(0);
+    expect(moved.byteLength).toBe(N);
   });
 
   describe("Response", () => {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -749,111 +749,142 @@ describe.concurrent("string body consumption does not leak", () => {
   }
 });
 
-describe("constructing a body from a large ArrayBuffer borrows the storage", () => {
-  // Bodies from ArrayBuffers/views above the cork-buffer threshold wrap the
-  // JSC ArrayBuffer instead of cloning it. The borrow is exposed via a pin
-  // on the backing buffer: transfer() copies instead of detaching for its
-  // duration, and is released once the body has been consumed.
+describe("constructing a Response from a large ArrayBuffer borrows the storage", () => {
+  // Response bodies from ArrayBuffers/views above the cork-buffer threshold
+  // wrap the JSC ArrayBuffer instead of cloning it (so a Bun.serve fetch
+  // handler returning `new Response(sharedBuffer)` does not pay a per-request
+  // body-sized copy). Request and outbound fetch() keep the spec snapshot
+  // semantics and always copy. The borrow is exposed via a pin on the backing
+  // buffer: transfer() copies instead of detaching for its duration, released
+  // once the body has been consumed.
   const N = 64 * 1024;
+  const SMALL = 4 * 1024;
 
-  for (const { body: BodyType, fn } of bodyTypes) {
-    describe(BodyType.name, () => {
-      for (const method of ["arrayBuffer", "bytes", "text"] as const) {
-        test(`${method}() releases the borrow and returns a distinct buffer`, async () => {
-          const buf = new Uint8Array(N).fill(0x61);
-          const body = fn(buf);
-          const out: any = await (body as any)[method]();
-          // A subsequent mutation of the source must not be visible in the
-          // materialised body.
-          buf.fill(0x62);
-          if (method === "arrayBuffer") {
-            expect(out.byteLength).toBe(N);
-            expect(new Uint8Array(out)[0]).toBe(0x61);
-          } else if (method === "bytes") {
-            expect(out.byteLength).toBe(N);
-            expect(out[0]).toBe(0x61);
-          } else {
-            expect(out.length).toBe(N);
-            expect(out[0]).toBe("a");
-          }
-          // The body is consumed: the pin on `buf.buffer` is gone, so
-          // transfer() detaches again.
-          const moved = buf.buffer.transfer();
-          expect(buf.buffer.byteLength).toBe(0);
-          expect(moved.byteLength).toBe(N);
-        });
-      }
+  test("Request snapshots BufferSource bodies (mutate-before-consume not visible)", async () => {
+    const buf = new Uint8Array(N).fill(0x61);
+    const req = new Request("http://example.com/", { method: "POST", body: buf });
+    buf.fill(0x62);
+    const out = await req.bytes();
+    expect(out[0]).toBe(0x61);
+    expect(out[out.byteLength - 1]).toBe(0x61);
+    // No pin was taken; transfer() detaches.
+    const moved = buf.buffer.transfer();
+    expect(buf.buffer.byteLength).toBe(0);
+    expect(moved.byteLength).toBe(N);
+  });
 
-      test("blob() snapshots the borrow into an owned Store", async () => {
+  test("Response borrows BufferSource bodies above the threshold (mutate-before-consume is visible)", async () => {
+    const buf = new Uint8Array(N).fill(0x61);
+    const res = new Response(buf);
+    buf.fill(0x62);
+    expect((await res.bytes())[0]).toBe(0x62);
+  });
+
+  test("Response snapshots BufferSource bodies below the threshold", async () => {
+    const buf = new Uint8Array(SMALL).fill(0x61);
+    const res = new Response(buf);
+    buf.fill(0x62);
+    expect((await res.bytes())[0]).toBe(0x61);
+  });
+
+  describe("Response", () => {
+    const fn = (body: BodyInit) => new Response(body);
+
+    for (const method of ["arrayBuffer", "bytes", "text"] as const) {
+      test(`${method}() releases the borrow and returns a distinct buffer`, async () => {
         const buf = new Uint8Array(N).fill(0x61);
-        const blob = await fn(buf).blob();
-        // `.blob()` copies out of the borrowed ArrayBuffer so the returned
-        // Blob is immutable and its Store cannot carry the pin off-thread.
+        const body = fn(buf);
+        const out: any = await (body as any)[method]();
+        // A subsequent mutation of the source must not be visible in the
+        // materialised body.
         buf.fill(0x62);
-        const out = new Uint8Array(await blob.arrayBuffer());
-        expect(out.byteLength).toBe(N);
-        expect(out[0]).toBe(0x61);
-        // The borrow was released when `.blob()` snapshotted; `transfer()`
-        // detaches again with the Blob still live.
+        if (method === "arrayBuffer") {
+          expect(out.byteLength).toBe(N);
+          expect(new Uint8Array(out)[0]).toBe(0x61);
+        } else if (method === "bytes") {
+          expect(out.byteLength).toBe(N);
+          expect(out[0]).toBe(0x61);
+        } else {
+          expect(out.length).toBe(N);
+          expect(out[0]).toBe("a");
+        }
+        // The body is consumed: the pin on `buf.buffer` is gone, so
+        // transfer() detaches again.
         const moved = buf.buffer.transfer();
         expect(buf.buffer.byteLength).toBe(0);
         expect(moved.byteLength).toBe(N);
-        expect((await blob.bytes())[0]).toBe(0x61);
       });
+    }
 
-      test("transfer() copies while the body holds the borrow, detaches after", async () => {
-        const buf = new Uint8Array(N).fill(0x61);
-        const body = fn(buf);
-        const moved = buf.buffer.transfer();
-        expect(moved.byteLength).toBe(N);
-        // Pinned: transfer() left the source attached (copy-instead-of-detach).
-        expect(buf.buffer.byteLength).toBe(N);
-        // The body still reads the original contents.
-        const out = await body.bytes();
-        expect(out.byteLength).toBe(N);
-        expect(out[0]).toBe(0x61);
-        // Consuming the body released the pin; transfer() now detaches.
-        const moved2 = buf.buffer.transfer();
-        expect(buf.buffer.byteLength).toBe(0);
-        expect(moved2.byteLength).toBe(N);
-      });
-
-      test("view offset/length are respected", async () => {
-        const raw = new Uint8Array(N);
-        for (let i = 0; i < N; i++) raw[i] = i & 0xff;
-        const view = new Uint8Array(raw.buffer, 17, N - 64);
-        const out = await fn(view).bytes();
-        expect(out.byteLength).toBe(N - 64);
-        expect(out[0]).toBe(17);
-        expect(out[out.byteLength - 1]).toBe((17 + N - 64 - 1) & 0xff);
-      });
-
-      test("resizable ArrayBuffer bodies snapshot at construction", async () => {
-        // @ts-ignore: maxByteLength is a recent option
-        const ab = new ArrayBuffer(N, { maxByteLength: N * 2 });
-        new Uint8Array(ab).fill(0x61);
-        const body = fn(new Uint8Array(ab));
-        // Borrow path rejects resizable; a subsequent resize must not affect
-        // the body.
-        // @ts-ignore
-        ab.resize(N / 2);
-        const out = await body.bytes();
-        expect(out.byteLength).toBe(N);
-        expect(out[out.byteLength - 1]).toBe(0x61);
-      });
-
-      test("GC of the source ArrayBuffer does not free the borrowed body", async () => {
-        let buf: Uint8Array | undefined = new Uint8Array(N).fill(0x61);
-        const body = fn(buf);
-        buf = undefined;
-        Bun.gc(true);
-        const out = await body.bytes();
-        expect(out.byteLength).toBe(N);
-        expect(out[0]).toBe(0x61);
-        expect(out[out.byteLength - 1]).toBe(0x61);
-      });
+    test("blob() snapshots the borrow into an owned Store", async () => {
+      const buf = new Uint8Array(N).fill(0x61);
+      const blob = await fn(buf).blob();
+      // `.blob()` copies out of the borrowed ArrayBuffer so the returned
+      // Blob is immutable and its Store cannot carry the pin off-thread.
+      buf.fill(0x62);
+      const out = new Uint8Array(await blob.arrayBuffer());
+      expect(out.byteLength).toBe(N);
+      expect(out[0]).toBe(0x61);
+      // The borrow was released when `.blob()` snapshotted; `transfer()`
+      // detaches again with the Blob still live.
+      const moved = buf.buffer.transfer();
+      expect(buf.buffer.byteLength).toBe(0);
+      expect(moved.byteLength).toBe(N);
+      expect((await blob.bytes())[0]).toBe(0x61);
     });
-  }
+
+    test("transfer() copies while the body holds the borrow, detaches after", async () => {
+      const buf = new Uint8Array(N).fill(0x61);
+      const body = fn(buf);
+      const moved = buf.buffer.transfer();
+      expect(moved.byteLength).toBe(N);
+      // Pinned: transfer() left the source attached (copy-instead-of-detach).
+      expect(buf.buffer.byteLength).toBe(N);
+      // The body still reads the original contents.
+      const out = await body.bytes();
+      expect(out.byteLength).toBe(N);
+      expect(out[0]).toBe(0x61);
+      // Consuming the body released the pin; transfer() now detaches.
+      const moved2 = buf.buffer.transfer();
+      expect(buf.buffer.byteLength).toBe(0);
+      expect(moved2.byteLength).toBe(N);
+    });
+
+    test("view offset/length are respected", async () => {
+      const raw = new Uint8Array(N);
+      for (let i = 0; i < N; i++) raw[i] = i & 0xff;
+      const view = new Uint8Array(raw.buffer, 17, N - 64);
+      const out = await fn(view).bytes();
+      expect(out.byteLength).toBe(N - 64);
+      expect(out[0]).toBe(17);
+      expect(out[out.byteLength - 1]).toBe((17 + N - 64 - 1) & 0xff);
+    });
+
+    test("resizable ArrayBuffer bodies snapshot at construction", async () => {
+      // @ts-ignore: maxByteLength is a recent option
+      const ab = new ArrayBuffer(N, { maxByteLength: N * 2 });
+      new Uint8Array(ab).fill(0x61);
+      const body = fn(new Uint8Array(ab));
+      // Borrow path rejects resizable; a subsequent resize must not affect
+      // the body.
+      // @ts-ignore
+      ab.resize(N / 2);
+      const out = await body.bytes();
+      expect(out.byteLength).toBe(N);
+      expect(out[out.byteLength - 1]).toBe(0x61);
+    });
+
+    test("GC of the source ArrayBuffer does not free the borrowed body", async () => {
+      let buf: Uint8Array | undefined = new Uint8Array(N).fill(0x61);
+      const body = fn(buf);
+      buf = undefined;
+      Bun.gc(true);
+      const out = await body.bytes();
+      expect(out.byteLength).toBe(N);
+      expect(out[0]).toBe(0x61);
+      expect(out[out.byteLength - 1]).toBe(0x61);
+    });
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/6860

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -797,6 +797,23 @@ describe("constructing a Response from a large ArrayBuffer borrows the storage",
     expect(out[0]).toBe(0x61);
   });
 
+  test("text() on a clone re-scans the borrow after the source is mutated", async () => {
+    // r1 and r2 share the same borrowed Store; r1.text() must not cache an
+    // ASCII verdict on the shared Store that r2.text() would trust after
+    // the source bytes have changed.
+    const buf = new Uint8Array(N).fill(0x61);
+    const r1 = new Response(buf);
+    const r2 = r1.clone();
+    expect((await r1.text())[0]).toBe("a");
+    for (let i = 0; i < N; i += 2) {
+      buf[i] = 0xc3;
+      buf[i + 1] = 0xa9;
+    }
+    const t2 = await r2.text();
+    expect(t2.length).toBe(N / 2);
+    expect(t2[0]).toBe("é");
+  });
+
   describe("Response", () => {
     const fn = (body: BodyInit) => new Response(body);
 

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -749,6 +749,108 @@ describe.concurrent("string body consumption does not leak", () => {
   }
 });
 
+describe("constructing a body from a large ArrayBuffer borrows the storage", () => {
+  // Bodies from ArrayBuffers/views above the cork-buffer threshold wrap the
+  // JSC ArrayBuffer instead of cloning it. The borrow is exposed via a pin
+  // on the backing buffer: transfer() copies instead of detaching for its
+  // duration, and is released once the body has been consumed.
+  const N = 64 * 1024;
+
+  for (const { body: BodyType, fn } of bodyTypes) {
+    describe(BodyType.name, () => {
+      for (const method of ["arrayBuffer", "bytes", "text"] as const) {
+        test(`${method}() releases the borrow and returns a distinct buffer`, async () => {
+          const buf = new Uint8Array(N).fill(0x61);
+          const body = fn(buf);
+          const out: any = await (body as any)[method]();
+          // A subsequent mutation of the source must not be visible in the
+          // materialised body.
+          buf.fill(0x62);
+          if (method === "arrayBuffer") {
+            expect(out.byteLength).toBe(N);
+            expect(new Uint8Array(out)[0]).toBe(0x61);
+          } else if (method === "bytes") {
+            expect(out.byteLength).toBe(N);
+            expect(out[0]).toBe(0x61);
+          } else {
+            expect(out.length).toBe(N);
+            expect(out[0]).toBe("a");
+          }
+          // The body is consumed: the pin on `buf.buffer` is gone, so
+          // transfer() detaches again.
+          const moved = buf.buffer.transfer();
+          expect(buf.buffer.byteLength).toBe(0);
+          expect(moved.byteLength).toBe(N);
+        });
+      }
+
+      test("blob() readers return distinct buffers", async () => {
+        const buf = new Uint8Array(N).fill(0x61);
+        const blob = await fn(buf).blob();
+        // The body's borrow moved into the returned Blob; materialising it
+        // snapshots into a distinct buffer unaffected by later mutation.
+        const out = new Uint8Array(await blob.arrayBuffer());
+        buf.fill(0x62);
+        expect(out.byteLength).toBe(N);
+        expect(out[0]).toBe(0x61);
+        expect(await blob.text()).toHaveLength(N);
+      });
+
+      test("transfer() copies while the body holds the borrow, detaches after", async () => {
+        const buf = new Uint8Array(N).fill(0x61);
+        const body = fn(buf);
+        const moved = buf.buffer.transfer();
+        expect(moved.byteLength).toBe(N);
+        // Pinned: transfer() left the source attached (copy-instead-of-detach).
+        expect(buf.buffer.byteLength).toBe(N);
+        // The body still reads the original contents.
+        const out = await body.bytes();
+        expect(out.byteLength).toBe(N);
+        expect(out[0]).toBe(0x61);
+        // Consuming the body released the pin; transfer() now detaches.
+        const moved2 = buf.buffer.transfer();
+        expect(buf.buffer.byteLength).toBe(0);
+        expect(moved2.byteLength).toBe(N);
+      });
+
+      test("view offset/length are respected", async () => {
+        const raw = new Uint8Array(N);
+        for (let i = 0; i < N; i++) raw[i] = i & 0xff;
+        const view = new Uint8Array(raw.buffer, 17, N - 64);
+        const out = await fn(view).bytes();
+        expect(out.byteLength).toBe(N - 64);
+        expect(out[0]).toBe(17);
+        expect(out[out.byteLength - 1]).toBe((17 + N - 64 - 1) & 0xff);
+      });
+
+      test("resizable ArrayBuffer bodies snapshot at construction", async () => {
+        // @ts-ignore: maxByteLength is a recent option
+        const ab = new ArrayBuffer(N, { maxByteLength: N * 2 });
+        new Uint8Array(ab).fill(0x61);
+        const body = fn(new Uint8Array(ab));
+        // Borrow path rejects resizable; a subsequent resize must not affect
+        // the body.
+        // @ts-ignore
+        ab.resize(N / 2);
+        const out = await body.bytes();
+        expect(out.byteLength).toBe(N);
+        expect(out[out.byteLength - 1]).toBe(0x61);
+      });
+
+      test("GC of the source ArrayBuffer does not free the borrowed body", async () => {
+        let buf: Uint8Array | undefined = new Uint8Array(N).fill(0x61);
+        const body = fn(buf);
+        buf = undefined;
+        Bun.gc(true);
+        const out = await body.bytes();
+        expect(out.byteLength).toBe(N);
+        expect(out[0]).toBe(0x61);
+        expect(out[out.byteLength - 1]).toBe(0x61);
+      });
+    });
+  }
+});
+
 // https://github.com/oven-sh/bun/issues/6860
 describe("constructing a body from an unusable ReadableStream", () => {
   const bytes = () =>

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -784,16 +784,21 @@ describe("constructing a body from a large ArrayBuffer borrows the storage", () 
         });
       }
 
-      test("blob() readers return distinct buffers", async () => {
+      test("blob() snapshots the borrow into an owned Store", async () => {
         const buf = new Uint8Array(N).fill(0x61);
         const blob = await fn(buf).blob();
-        // The body's borrow moved into the returned Blob; materialising it
-        // snapshots into a distinct buffer unaffected by later mutation.
-        const out = new Uint8Array(await blob.arrayBuffer());
+        // `.blob()` copies out of the borrowed ArrayBuffer so the returned
+        // Blob is immutable and its Store cannot carry the pin off-thread.
         buf.fill(0x62);
+        const out = new Uint8Array(await blob.arrayBuffer());
         expect(out.byteLength).toBe(N);
         expect(out[0]).toBe(0x61);
-        expect(await blob.text()).toHaveLength(N);
+        // The borrow was released when `.blob()` snapshotted; `transfer()`
+        // detaches again with the Blob still live.
+        const moved = buf.buffer.transfer();
+        expect(buf.buffer.byteLength).toBe(0);
+        expect(moved.byteLength).toBe(N);
+        expect((await blob.bytes())[0]).toBe(0x61);
       });
 
       test("transfer() copies while the body holds the borrow, detaches after", async () => {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -797,6 +797,28 @@ describe("constructing a Response from a large ArrayBuffer borrows the storage",
     expect(out[0]).toBe(0x61);
   });
 
+  test("HTMLRewriter.transform(Response) snapshots the borrowed body before parsing", async () => {
+    // lol-html invokes user handlers mid-chunk; a handler must not be able to
+    // mutate the bytes the parser is still iterating.
+    const buf = new Uint8Array(N).fill(0x61);
+    buf.set(new TextEncoder().encode("<p>x</p><p>x</p>"), 0);
+    let hits = 0;
+    const out = await new HTMLRewriter()
+      .on("p", {
+        element() {
+          hits++;
+          buf.fill(0);
+        },
+      })
+      .transform(new Response(buf))
+      .bytes();
+    // Both <p> elements were parsed from the snapshot; the handler's mutation
+    // of the source buffer did not affect the second one.
+    expect(hits).toBe(2);
+    expect(out.byteLength).toBe(N);
+    expect(out[N - 1]).toBe(0x61);
+  });
+
   test("text() on a clone re-scans the borrow after the source is mutated", async () => {
     // r1 and r2 share the same borrowed Store; r1.text() must not cache an
     // ASCII verdict on the shared Store that r2.text() would trust after

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -787,6 +787,16 @@ describe("constructing a Response from a large ArrayBuffer borrows the storage",
     expect((await res.bytes())[0]).toBe(0x61);
   });
 
+  test("Response snapshots SharedArrayBuffer bodies (mutate-before-consume not visible)", async () => {
+    const sab = new SharedArrayBuffer(N);
+    const view = new Uint8Array(sab).fill(0x61);
+    const res = new Response(view);
+    view.fill(0x62);
+    const out = await res.bytes();
+    expect(out.byteLength).toBe(N);
+    expect(out[0]).toBe(0x61);
+  });
+
   describe("Response", () => {
     const fn = (body: BodyInit) => new Response(body);
 


### PR DESCRIPTION
A `Bun.serve` fetch handler that returns `new Response(sharedBuffer)` cloned the buffer once per request: `Body::Value::from_js` did `bytes.to_vec()` for every ArrayBuffer/view body, and under backpressure that per-request `Vec<u8>` sat in `RequestContext.blob` until the socket drained. N stalled clients times an M-byte body cost N*M bytes of RSS, plus the synchronous memcpy burst stalled the event loop. The static-route path already served the same buffer at ~0 MB/conn because the `Response` is constructed once and every request slices one shared `Store`.

## Repro

```js
const buf = new Uint8Array(16 * 1024 * 1024).fill(65);
Bun.serve({ port: 0, fetch() { return new Response(buf); } });
// open 24 TCP connections, send the request line, pause() each socket
```

24 stalled clients x 16 MB -> **+384.0 MB** RSS (exactly 16.0 MB/client), reaped only when `idleTimeout` fires.

## Fix

For ArrayBuffer/view bodies at or above the uWS cork-buffer size (16 KB), the `Response` constructor (`body::extract_for_response`) wraps the input in a `Blob` `Store` whose `Bytes` borrow the `JSC::ArrayBuffer` storage directly instead of `.to_vec()`ing it. `new Request(url, {body})`, outbound `fetch()`, and `HTMLRewriter.transform(arrayBuffer)` keep the spec snapshot copy via `Value::from_js` / `body::extract`, so mutating a buffer after handing it to `fetch()` cannot change what goes on the wire. The native `ArrayBuffer` is `ref()`ed + `pin()`ed via a new `StdAllocator` vtable (`pinned_store_allocator`), following the `StringImplAllocator` / `LinuxMemFdAllocator` pattern:

- `Bun__ArrayBuffer__retainPinnedStore(JSValue, out_ptr, out_len)` materializes via `possiblySharedBuffer()`, then reads `vector()`/`data()` and writes the view range, returning the `JSC::ArrayBuffer*` after `ref()`+`pin()`. Returns null for resizable/growable buffers (a shrink would invalidate the borrowed `(ptr, len)`) and `SharedArrayBuffer` (other agents may write the storage concurrently).
- `Bun__ArrayBuffer__releasePinnedStore(ArrayBuffer*)` is the allocator's `free`; it touches only the native `ArrayBuffer` (not a `JSCell`), so it is safe from the GC-sweep finalizer that drops the holder.

The borrow is confined to `Body::Value` and `RequestContext.blob`: the `Bun.serve` send path moves it out via a new `use_as_any_blob_for_render()` (`render_bytes()` / `on_writable_bytes()` slice it directly and never re-enter user JS while the slice is live). Every other accessor snapshots on the way out:

- `try_use_as_any_blob` / `use_as_any_blob` / `use_as_any_blob_allow_non_utf8_string` share a `take_blob_snapshot_if_borrowed` helper that copies a borrowed store into an owned `InternalBlob`, so `HTMLRewriter.transform(new Response(buf))`, `ValueBufferer`, `wasm_streaming`, `Bun.spawn` stdio, shell piping, and the body readers all see a snapshot.
- `Body::Value::use_()` copies into an owned `Store` so `.blob()` returns an immutable Blob and the pin cannot reach `ObjectURLRegistry` (whose cross-Worker `revoke()` would otherwise drop the non-atomic `JSC::ArrayBuffer` ref/pin on a foreign thread).
- `to_string_with_bytes` / `to_array_buffer_view_with_bytes` fall through to a real copy when the `Store` carries this allocator, so `.text()` / `.bytes()` / `.arrayBuffer()` return distinct buffers and release the borrow.
- `Blob::set_is_ascii_flag` skips the store-level `is_all_ascii` cache write for borrowed stores, so a cloned `Response` sharing the `StoreRef` re-scans after the source is mutated.

`Body::Value::{memory_cost, estimated_size}` gain a `Value::Blob` arm that reports `shared_view().len()` (0 for file/S3 stores) so the heap snapshot attributes an in-memory Blob body's size to its holder.

While a `Response` holds the borrow, `transfer()` on the source buffer copies instead of detaching (the existing `pin()` semantics); the pin is released when the body is consumed or dropped. Mutating the source buffer before the `Response` body is consumed is visible (the borrow is the point); below the 16 KB threshold and for `Request`/outbound `fetch()` the spec snapshot semantics are unchanged.

## Result

24 stalled clients x 16 MB body, debug+ASAN:

| path | before | after |
| --- | --- | --- |
| fetch handler `new Response(buf)` | +384.0 MB | +1.0 MB |
| static route | +1.0 MB | +1.0 MB |

## Tests

`test/js/bun/http/serve-buffer-body-backpressure.test.ts`
- fetch handler and static route: peak RSS delta per stalled connection stays bounded well below one body size
- full-body delivery is byte-exact

`test/js/web/fetch/body.test.ts` (new `constructing a Response from a large ArrayBuffer` block)
- `Request` snapshots BufferSource bodies (mutate-before-consume not visible); `Response` above the threshold borrows (mutate-before-consume is visible); `Response` below the threshold snapshots; `SharedArrayBuffer` snapshots
- `HTMLRewriter.transform(new Response(buf))` parses a snapshot: an `element()` handler that zero-fills `buf` still sees both tags and the output tail is unchanged
- `.text()` on a clone re-scans after the source is mutated (no stale ASCII verdict)
- `.arrayBuffer()` / `.bytes()` / `.text()` return buffers unaffected by later source mutation and release the borrow (subsequent `transfer()` detaches)
- `.blob()` snapshots the borrow into an owned Store; the returned Blob is unaffected by later source mutation and `transfer()` detaches with it still live
- `transfer()` copies while the body holds the borrow, detaches after
- view offset/length are respected
- resizable `ArrayBuffer` bodies snapshot at construction (copy path)
- GC of the source `ArrayBuffer` does not free the borrowed body

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-buffer-body-backpressure.test.ts test/js/web/fetch/body.test.ts
bun test v1.4.0 (13db11d80)

test/js/bun/http/serve-buffer-body-backpressure.test.ts:
fetch-handler: 24 stalled clients x 16 MB body -> +385.1 MB
104 |   // After: the shared ArrayBuffer is referenced, not cloned, so the delta is
105 |   // bounded by socket buffers + request-context overhead. Allow generous slack
106 |   // under ASAN/debug. The unfixed build exceeds this by more than an order of
107 |   // magnitude.
108 |   const bound = (isASAN || isDebug ? 3 : 1.5) * clients;
109 |   expect(deltaMB).toBeLessThan(bound);
                        ^
error: expect(received).toBeLessThan(expected)

Expected: < 72
Received: 385.05859375

      at <anonymous> (/workspace/bun/test/js/bun/http/serve-buffer-body-backpressure.test.ts:109:19)
(fail) Bun.serve: fetch handler returning new Response(buffer) does not copy the body per connection under backpressure [1641.75ms]
static-route: 24 stalled clients x 16 MB body -> +0.0 MB
(pass) Bun.serve: static route
... (truncated)

release without fix: 2 failed, 4 skipped
bun test v1.4.0-canary.1 (19cc36a42)

test/js/bun/http/serve-buffer-body-backpressure.test.ts:
fetch-handler: 24 stalled clients x 16 MB body -> +1.0 MB
(pass) Bun.serve: fetch handler returning new Response(buffer) does not copy the body per connection under backpressure [286.52ms]
static-route: 24 stalled clients x 16 MB body -> +0.0 MB
(pass) Bun.serve: static route with a buffered Response does not copy the body per connection under backpressure [266.73ms]
(pass) Bun.serve: a fetch handler returning new Response(buffer) delivers the full body [67.72ms]

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [0.09ms]
(pass) Request > constructor > null [0.03ms]
(pass) Request > constructor > string > "" [0.11ms]
(pass) Request > constructor > string > "Hello world" [0.02ms]
(pass) Request > constructor > string > "🫠" [0.01ms]
(pass) Request > constructor > string > "⁉️"
(pass) Request > constructor > ArrayBuffer > empty buffer [0.16ms]
(pass) Request > constructor > ArrayBuffer > small buffer [0.12ms]
(pass) Request > constructor > ArrayBuffer > large buffer [1.22ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [0.04ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-buffer-body-backpressure.test.ts test/js/web/fetch/body.test.ts
bun test v1.4.0 (13db11d80)

test/js/bun/http/serve-buffer-body-backpressure.test.ts:
fetch-handler: 24 stalled clients x 16 MB body -> +2.0 MB
(pass) Bun.serve: fetch handler returning new Response(buffer) does not copy the body per connection under backpressure [1460.39ms]
static-route: 24 stalled clients x 16 MB body -> +1.0 MB
(pass) Bun.serve: static route with a buffered Response does not copy the body per connection under backpressure [1042.46ms]
(pass) Bun.serve: a fetch handler returning new Response(buffer) delivers the full body [836.18ms]

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [5.13ms]
(pass) Request > constructor > null [3.13ms]
(pass) Request > constructor > string > "" [6.34ms]
(pass) Request > constructor > string > "Hello world" [1.74ms]
(pass) Request > constructor > string > "🫠" [1.30ms]
(pass) Request > constructor > string > "⁉️" [1.07ms]
(pass) Request > constructor > ArrayBuffer > empty
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 713ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen cpp.rs (cppbind)
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[2/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/array_buffer.rs                            |  63 +++++++
 src/jsc/bindings/bindings.cpp                      |  45 +++++
 src/jsc/webcore_types.rs                           |  38 ++++
 src/runtime/server/RequestContext.rs               |   2 +-
 src/runtime/webcore/Blob.rs                        |  38 +++-
 src/runtime/webcore/Body.rs                        | 130 +++++++++++++-
 src/runtime/webcore/Response.rs                    |   3 +-
 .../http/serve-buffer-body-backpressure-fixture.ts |  29 +++
 .../http/serve-buffer-body-backpressure.test.ts    | 132 ++++++++++++++
 test/js/web/fetch/body.test.ts                     | 195 +++++++++++++++++++++
 10 files changed, 667 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 7 passed · 1 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/array_buffer.rs                                       6      6      0
src/jsc/bindings/bindings.cpp                                 3      4      0
src/jsc/webcore_types.rs                                      6      6      0
src/runtime/server/RequestContext.rs                          5      1      0
src/runtime/webcore/Blob.rs                                   5      3      0
src/runtime/webcore/Body.rs                                  19     20      0
src/runtime/webcore/Response.rs                               1      1      0
…t/js/bun/http/serve-buffer-body-backpressure-fixture.ts      0      2      0
test/js/bun/http/serve-buffer-body-backpressure.test.ts       0      8      0
test/js/web/fetch/body.test.ts                                8     11      0
```

</details>

<!-- robobun:evidence:end -->