### PR TITLE
bun test: print summary and fail when process.exit() is called mid-run

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3044,6 +3044,14 @@ impl TestCommand {
 
         reporter.write_junit_report_if_needed();
 
+        // Run complete: summary printed, JUnit written. Any `process.exit()`
+        // from here on (watch-idle timers, `'exit'` listeners) is a normal
+        // shutdown-time exit, not a mid-run abort.
+        // SAFETY: single-threaded (JS VM thread).
+        unsafe {
+            REPORTER.write(None);
+        }
+
         if vm.hot_reload == jsc::virtual_machine::HOT_RELOAD_WATCH {
             let vm_ptr: *mut VirtualMachine = vm;
             // SAFETY: `vm_ptr` reborrows the live `&mut VirtualMachine`;
@@ -3064,15 +3072,6 @@ impl TestCommand {
             || reporter.jest.unhandled_errors_between_tests > 0
         {
             vm.exit_handler.exit_code = 1;
-        }
-        // The run is complete: summary printed, exit code computed. Clear
-        // `REPORTER` before firing JS `'exit'` listeners so a handler calling
-        // `process.exit()` (Node's `common.mustCall()` pattern) is handled by
-        // `Bun__Process__exit` as a normal shutdown-time exit rather than a
-        // mid-run abort.
-        // SAFETY: single-threaded (JS VM thread).
-        unsafe {
-            REPORTER.write(None);
         }
         // Run `process.on('exit')` handlers like `bun run` does. Node's test
         // harness verifies mustCall() counts from one, so skipping them made
@@ -3482,6 +3481,9 @@ pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u
         return;
     }
 
+    if Output::is_github_action() {
+        pretty_errorln!("<r>\n::endgroup::\n");
+    }
     pretty_error!(
         "\n<red>error<r><d>:<r> <b>process.exit({})<r> was called during <b>bun test<r>\n",
         requested,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3067,6 +3067,15 @@ impl TestCommand {
         {
             vm.exit_handler.exit_code = 1;
         }
+        // The run is complete: summary printed, exit code computed. Clear
+        // `REPORTER` before firing JS `'exit'` listeners so a handler calling
+        // `process.exit()` (Node's `common.mustCall()` pattern) is handled by
+        // `Bun__Process__exit` as a normal shutdown-time exit rather than a
+        // mid-run abort.
+        // SAFETY: single-threaded (JS VM thread).
+        unsafe {
+            REPORTER.write(None);
+        }
         // Run `process.on('exit')` handlers like `bun run` does. Node's test
         // harness verifies mustCall() counts from one, so skipping them made
         // those assertions silently pass. Must precede the GC-root release
@@ -3089,10 +3098,6 @@ impl TestCommand {
         // no concurrent reader exists on this shutdown path.
         unsafe {
             jest::Jest::RUNNER.write(None);
-        }
-        // SAFETY: same single-thread shutdown path as `RUNNER` above.
-        unsafe {
-            REPORTER.write(None);
         }
         drop(reporter);
         {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3480,13 +3480,20 @@ pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u
         .saturating_sub(reporter.jest.summary.files);
 
     // `process.exit()` during the last file's top-level module evaluation
-    // with no later files queued is the Node test harness re-spawn pattern
-    // (`test/js/node/test/common/index.js` exec-with-Flags then
-    // `process.exit(child.status)`): pass the requested code through
-    // unchanged. `module_load_in_progress` is only set for the synchronous
-    // `load_entry_point_for_test_runner` window; a `describe()` callback
-    // (still `Phase::Collection` but after module load) does not qualify.
-    if not_run == 0 && reporter.jest.module_load_in_progress {
+    // with no later files queued and nothing already failed is the Node test
+    // harness re-spawn pattern (`test/js/node/test/common/index.js`
+    // exec-with-Flags then `process.exit(child.status)`): pass the requested
+    // code through unchanged. `module_load_in_progress` is only set for the
+    // synchronous `load_entry_point_for_test_runner` window; a `describe()`
+    // callback (still `Phase::Collection` but after module load) does not
+    // qualify. `fail`/`unhandled_errors` gate the multi-file case where an
+    // earlier file recorded a failure and the last file's top-level
+    // `process.exit(0)` would otherwise mask it.
+    if not_run == 0
+        && reporter.jest.module_load_in_progress
+        && reporter.jest.summary.fail == 0
+        && reporter.jest.unhandled_errors_between_tests == 0
+    {
         return;
     }
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2249,6 +2249,7 @@ impl TestCommand {
                 // process-lifetime CLI context and `exec()` never returns.
                 test_options: unsafe { bun_ptr::detach_lifetime_ref(&ctx.test_options) },
                 unhandled_errors_between_tests: 0,
+                total_test_files: 0,
                 summary: Summary::default(),
             },
             last_dot: 0,
@@ -2267,6 +2268,10 @@ impl TestCommand {
         // valid for the process lifetime.
         unsafe {
             jest::Jest::RUNNER.write(Some(core::ptr::NonNull::from(&mut reporter.jest)));
+        }
+        // SAFETY: same single-thread / process-lifetime invariant as `RUNNER`.
+        unsafe {
+            REPORTER.write(Some(core::ptr::NonNull::from(&mut *reporter)));
         }
         // `reporter.jest.test_options` is initialised in the struct
         // literal above (lifetime-erased); the post-init assignment is dropped.
@@ -2698,6 +2703,7 @@ impl TestCommand {
                 }
             }
 
+            reporter.jest.total_test_files = test_files.len() as u32;
             if ctx.test_options.parallel > 0 {
                 ran_parallel = ParallelRunner::run_as_coordinator(
                     &mut reporter,
@@ -3076,6 +3082,10 @@ impl TestCommand {
         unsafe {
             jest::Jest::RUNNER.write(None);
         }
+        // SAFETY: same single-thread shutdown path as `RUNNER` above.
+        unsafe {
+            REPORTER.write(None);
+        }
         drop(reporter);
         {
             let vm_ptr: *mut VirtualMachine = vm;
@@ -3416,4 +3426,82 @@ pub(crate) fn handle_top_level_test_error_before_javascript_start(err: &crate::E
         }
     }
     Global::exit(1);
+}
+
+/// JS-VM-thread-only pointer to the boxed `CommandLineReporter` while a
+/// `bun test` run is in progress. Set alongside [`jest::Jest::RUNNER`] in
+/// `TestCommand::exec` and cleared on the same shutdown path.
+static REPORTER: bun_core::RacyCell<Option<core::ptr::NonNull<CommandLineReporter>>> =
+    bun_core::RacyCell::new(None);
+
+/// Called from `Bun__Process__exit` when user code invokes `process.exit()`
+/// on the main thread while `bun test` is running. Prints the summary that
+/// would otherwise be lost and forces a nonzero exit so a test calling
+/// `process.exit(0)` can't make the whole run appear green while later files
+/// are silently never executed.
+pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u8) {
+    // SAFETY: `REPORTER` is only read/written on the JS VM thread.
+    let Some(reporter_ptr) = (unsafe { REPORTER.read() }) else {
+        return;
+    };
+    // Clear first so a re-entrant `process.exit()` from an `'exit'` listener
+    // or JUnit write path below is a no-op instead of double-printing.
+    // SAFETY: single-threaded (JS VM thread); no concurrent reader.
+    unsafe { REPORTER.write(None) };
+    // SAFETY: `REPORTER` was set from `&mut *reporter` in `exec()`, which
+    // owns the `Box<CommandLineReporter>` for the process lifetime. Same
+    // write-provenance raw-ptr escape as `Jest::RUNNER`: ancestor frames hold
+    // a `&mut` but never access it again because `global_exit()` (our caller's
+    // next call) diverges.
+    let reporter = unsafe { &mut *reporter_ptr.as_ptr() };
+
+    // A `--parallel` worker's crash is accounted for by the coordinator
+    // (`Coordinator::reap_worker` → `account_crash`); don't print a summary
+    // to stderr here, it would interleave with the coordinator's output.
+    if reporter.worker_ipc_file_idx.is_some() {
+        return;
+    }
+
+    let started = reporter.jest.summary.files;
+    let total = reporter.jest.total_test_files;
+    let not_run = total.saturating_sub(started);
+
+    pretty_error!(
+        "\n<red>error<r><d>:<r> <b>process.exit({})<r> was called during <b>bun test<r>\n",
+        requested,
+    );
+    if not_run > 0 {
+        pretty_error!(
+            "       <b>{}<r> test file{} {} never reached.\n",
+            not_run,
+            if not_run == 1 { "" } else { "s" },
+            if not_run == 1 { "was" } else { "were" },
+        );
+    }
+    pretty_error!("\n");
+
+    let summary = reporter.jest.summary;
+    if summary.pass > 0 {
+        pretty_error!("<r><green>");
+    }
+    pretty_error!(" {:5>} pass<r>\n", summary.pass);
+    if summary.skip > 0 {
+        pretty_error!(" <r><yellow>{:5>} skip<r>\n", summary.skip);
+    }
+    if summary.todo > 0 {
+        pretty_error!(" <r><magenta>{:5>} todo<r>\n", summary.todo);
+    }
+    if summary.fail > 0 {
+        pretty_error!("<r><red>");
+    } else {
+        pretty_error!("<r><d>");
+    }
+    pretty_error!(" {:5>} fail<r>\n", summary.fail);
+    reporter.print_summary();
+    pretty_error!("\n");
+    Output::flush();
+
+    reporter.write_junit_report_if_needed();
+
+    vm.exit_handler.exit_code = 1;
 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1516,6 +1516,51 @@ impl CommandLineReporter {
             .saturating_add(sequence.expect_call_count);
     }
 
+    /// `pass / skip / filtered out / todo / fail / errors` lines, shared by
+    /// the end-of-run summary in `TestCommand::exec` and the mid-run
+    /// `process.exit()` summary so they never diverge.
+    pub fn print_summary_counts(&self, indent: &str) {
+        let summary = self.jest.summary;
+        if summary.pass > 0 {
+            pretty_error!("<r><green>");
+        }
+        pretty_error!("{}{:5>} pass<r>\n", indent, summary.pass);
+
+        if summary.skip > 0 {
+            pretty_error!("{}<r><yellow>{:5>} skip<r>\n", indent, summary.skip);
+        } else if summary.skipped_because_label > 0 {
+            pretty_error!(
+                "{}<r><d>{:5>} filtered out<r>\n",
+                indent,
+                summary.skipped_because_label
+            );
+        }
+
+        if summary.todo > 0 {
+            pretty_error!("{}<r><magenta>{:5>} todo<r>\n", indent, summary.todo);
+        }
+
+        if summary.fail > 0 {
+            pretty_error!("<r><red>");
+        } else {
+            pretty_error!("<r><d>");
+        }
+        pretty_error!("{}{:5>} fail<r>\n", indent, summary.fail);
+
+        if self.jest.unhandled_errors_between_tests > 0 {
+            pretty_error!(
+                "{}<r><red>{:5>} error{}<r>\n",
+                indent,
+                self.jest.unhandled_errors_between_tests,
+                if self.jest.unhandled_errors_between_tests > 1 {
+                    "s"
+                } else {
+                    ""
+                }
+            );
+        }
+    }
+
     pub fn print_summary(&mut self) {
         let summary_ = self.summary();
         let tests = summary_.fail + summary_.pass + summary_.skip + summary_.todo;
@@ -2927,45 +2972,7 @@ impl TestCommand {
                     pretty_error!("{}<r>--seed={}<r>\n", &indenter, seed);
                 }
 
-                if summary.pass > 0 {
-                    pretty_error!("<r><green>");
-                }
-
-                pretty_error!("{}{:5>} pass<r>\n", &indenter, summary.pass);
-
-                if summary.skip > 0 {
-                    pretty_error!("{}<r><yellow>{:5>} skip<r>\n", &indenter, summary.skip);
-                } else if summary.skipped_because_label > 0 {
-                    pretty_error!(
-                        "{}<r><d>{:5>} filtered out<r>\n",
-                        &indenter,
-                        summary.skipped_because_label
-                    );
-                }
-
-                if summary.todo > 0 {
-                    pretty_error!("{}<r><magenta>{:5>} todo<r>\n", &indenter, summary.todo);
-                }
-
-                if summary.fail > 0 {
-                    pretty_error!("<r><red>");
-                } else {
-                    pretty_error!("<r><d>");
-                }
-
-                pretty_error!("{}{:5>} fail<r>\n", &indenter, summary.fail);
-                if reporter.jest.unhandled_errors_between_tests > 0 {
-                    pretty_error!(
-                        "{}<r><red>{:5>} error{}<r>\n",
-                        &indenter,
-                        reporter.jest.unhandled_errors_between_tests,
-                        if reporter.jest.unhandled_errors_between_tests > 1 {
-                            "s"
-                        } else {
-                            ""
-                        }
-                    );
-                }
+                reporter.print_summary_counts(if indenter.indent { " " } else { "" });
 
                 let mut print_expect_calls = summary.expectations > 0;
                 if reporter.jest.snapshots.total > 0 {
@@ -3462,9 +3469,29 @@ pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u
         return;
     }
 
-    let started = reporter.jest.summary.files;
+    let active_phase = reporter
+        .jest
+        .bun_test_root
+        .active_file
+        .as_deref()
+        .map(|bt| bt.phase);
+    // `summary.files` is bumped after `load_entry_point_for_test_runner`
+    // returns (`TestCommand::run`), so a file still in its module-load /
+    // Collection phase hasn't been counted yet.
+    let started = reporter.jest.summary.files
+        + u32::from(active_phase == Some(bun_test::Phase::Collection));
     let total = reporter.jest.total_test_files;
     let not_run = total.saturating_sub(started);
+
+    // `process.exit()` during the last file's module load with no later
+    // files queued is the Node test harness re-spawn pattern
+    // (`test/js/node/test/common/index.js` exec-with-Flags then
+    // `process.exit(child.status)`): pass the requested code through
+    // unchanged. Anything else (a test body is executing, or later files
+    // would be skipped) is a silent-green hazard.
+    if not_run == 0 && active_phase == Some(bun_test::Phase::Collection) {
+        return;
+    }
 
     pretty_error!(
         "\n<red>error<r><d>:<r> <b>process.exit({})<r> was called during <b>bun test<r>\n",
@@ -3480,23 +3507,7 @@ pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u
     }
     pretty_error!("\n");
 
-    let summary = reporter.jest.summary;
-    if summary.pass > 0 {
-        pretty_error!("<r><green>");
-    }
-    pretty_error!(" {:5>} pass<r>\n", summary.pass);
-    if summary.skip > 0 {
-        pretty_error!(" <r><yellow>{:5>} skip<r>\n", summary.skip);
-    }
-    if summary.todo > 0 {
-        pretty_error!(" <r><magenta>{:5>} todo<r>\n", summary.todo);
-    }
-    if summary.fail > 0 {
-        pretty_error!("<r><red>");
-    } else {
-        pretty_error!("<r><d>");
-    }
-    pretty_error!(" {:5>} fail<r>\n", summary.fail);
+    reporter.print_summary_counts(" ");
     reporter.print_summary();
     pretty_error!("\n");
     Output::flush();

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2295,6 +2295,7 @@ impl TestCommand {
                 test_options: unsafe { bun_ptr::detach_lifetime_ref(&ctx.test_options) },
                 unhandled_errors_between_tests: 0,
                 total_test_files: 0,
+                module_load_in_progress: false,
                 summary: Summary::default(),
             },
             last_dot: 0,
@@ -3300,11 +3301,15 @@ impl TestCommand {
 
             // need to wake up so autoTick() doesn't wait for 16-100ms after loading the entrypoint
             vm.wakeup();
-            let promise = vm.load_entry_point_for_test_runner(file_path)?;
-            // Only count the file once, not once per repeat
+            // Only count the file once, not once per repeat. Bumped before
+            // module load so `on_process_exit_during_tests` sees this file as
+            // started when `process.exit()` is called from top-level.
             if repeat_index == 0 {
                 reporter.summary().files += 1;
             }
+            reporter.jest.module_load_in_progress = true;
+            let promise = vm.load_entry_point_for_test_runner(file_path)?;
+            reporter.jest.module_load_in_progress = false;
 
             // S012: `JSInternalPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
             match jsc::JSInternalPromise::opaque_mut(promise).status() {
@@ -3469,27 +3474,19 @@ pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u
         return;
     }
 
-    let active_phase = reporter
+    let not_run = reporter
         .jest
-        .bun_test_root
-        .active_file
-        .as_deref()
-        .map(|bt| bt.phase);
-    // `summary.files` is bumped after `load_entry_point_for_test_runner`
-    // returns (`TestCommand::run`), so a file still in its module-load /
-    // Collection phase hasn't been counted yet.
-    let started = reporter.jest.summary.files
-        + u32::from(active_phase == Some(bun_test::Phase::Collection));
-    let total = reporter.jest.total_test_files;
-    let not_run = total.saturating_sub(started);
+        .total_test_files
+        .saturating_sub(reporter.jest.summary.files);
 
-    // `process.exit()` during the last file's module load with no later
-    // files queued is the Node test harness re-spawn pattern
+    // `process.exit()` during the last file's top-level module evaluation
+    // with no later files queued is the Node test harness re-spawn pattern
     // (`test/js/node/test/common/index.js` exec-with-Flags then
     // `process.exit(child.status)`): pass the requested code through
-    // unchanged. Anything else (a test body is executing, or later files
-    // would be skipped) is a silent-green hazard.
-    if not_run == 0 && active_phase == Some(bun_test::Phase::Collection) {
+    // unchanged. `module_load_in_progress` is only set for the synchronous
+    // `load_entry_point_for_test_runner` window; a `describe()` callback
+    // (still `Phase::Collection` but after module load) does not qualify.
+    if not_run == 0 && reporter.jest.module_load_in_progress {
         return;
     }
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1516,9 +1516,7 @@ impl CommandLineReporter {
             .saturating_add(sequence.expect_call_count);
     }
 
-    /// `pass / skip / filtered out / todo / fail / errors` lines, shared by
-    /// the end-of-run summary in `TestCommand::exec` and the mid-run
-    /// `process.exit()` summary so they never diverge.
+    /// `pass / skip / filtered out / todo / fail / errors` lines.
     pub fn print_summary_counts(&self, indent: &str) {
         let summary = self.jest.summary;
         if summary.pass > 0 {
@@ -3306,10 +3304,8 @@ impl TestCommand {
 
             // need to wake up so autoTick() doesn't wait for 16-100ms after loading the entrypoint
             vm.wakeup();
-            // Only count the file once, not once per repeat. Bumped before
-            // module load so `on_process_exit_during_tests` sees this file as
-            // started when `process.exit()` is called from top-level.
             if repeat_index == 0 {
+                // Before load: `on_process_exit_during_tests` must see this file as started.
                 reporter.summary().files += 1;
             }
             reporter.jest.module_load_in_progress = true;
@@ -3445,25 +3441,25 @@ pub(crate) fn handle_top_level_test_error_before_javascript_start(err: &crate::E
     Global::exit(1);
 }
 
-/// JS-VM-thread-only pointer to the boxed `CommandLineReporter` while a
-/// `bun test` run is in progress. Set alongside [`jest::Jest::RUNNER`] in
-/// `TestCommand::exec` and cleared on the same shutdown path.
+/// Live `CommandLineReporter` while a `bun test` run is in progress (sibling of [`jest::Jest::RUNNER`]).
 static REPORTER: bun_core::RacyCell<Option<core::ptr::NonNull<CommandLineReporter>>> =
     bun_core::RacyCell::new(None);
 
-/// Called from `Bun__Process__exit` when user code invokes `process.exit()`
-/// on the main thread while `bun test` is running. Prints the summary that
-/// would otherwise be lost and forces a nonzero exit so a test calling
-/// `process.exit(0)` can't make the whole run appear green while later files
-/// are silently never executed.
+/// The Node `common/index.js` re-spawn / `common.skip()` pattern: last file's top-level exit, nothing to hide.
+fn is_last_file_toplevel_exit_with_no_failures(r: &CommandLineReporter, not_run: u32) -> bool {
+    not_run == 0
+        && r.jest.module_load_in_progress
+        && r.jest.summary.fail == 0
+        && r.jest.unhandled_errors_between_tests == 0
+}
+
+/// `Bun__Process__exit` hook: flush the `bun test` summary and force exit 1 so an in-test `process.exit(0)` can't mask later files.
 pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u8) {
     // SAFETY: `REPORTER` is only read/written on the JS VM thread.
     let Some(reporter_ptr) = (unsafe { REPORTER.read() }) else {
         return;
     };
-    // Clear first so a re-entrant `process.exit()` from an `'exit'` listener
-    // or JUnit write path below is a no-op instead of double-printing.
-    // SAFETY: single-threaded (JS VM thread); no concurrent reader.
+    // SAFETY: single-threaded; clear-before-use makes re-entry a no-op.
     unsafe { REPORTER.write(None) };
     // SAFETY: `REPORTER` was set from `&mut *reporter` in `exec()`, which
     // owns the `Box<CommandLineReporter>` for the process lifetime. Same
@@ -3472,10 +3468,8 @@ pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u
     // next call) diverges.
     let reporter = unsafe { &mut *reporter_ptr.as_ptr() };
 
-    // A `--parallel` worker's crash is accounted for by the coordinator
-    // (`Coordinator::reap_worker` → `account_crash`); don't print a summary
-    // to stderr here, it would interleave with the coordinator's output.
     if reporter.worker_ipc_file_idx.is_some() {
+        // `--parallel` coordinator accounts for the crash (`reap_worker` → `account_crash`).
         return;
     }
 
@@ -3484,21 +3478,7 @@ pub(crate) fn on_process_exit_during_tests(vm: &mut VirtualMachine, requested: u
         .total_test_files
         .saturating_sub(reporter.jest.summary.files);
 
-    // `process.exit()` during the last file's top-level module evaluation
-    // with no later files queued and nothing already failed is the Node test
-    // harness re-spawn pattern (`test/js/node/test/common/index.js`
-    // exec-with-Flags then `process.exit(child.status)`): pass the requested
-    // code through unchanged. `module_load_in_progress` is only set for the
-    // synchronous `load_entry_point_for_test_runner` window; a `describe()`
-    // callback (still `Phase::Collection` but after module load) does not
-    // qualify. `fail`/`unhandled_errors` gate the multi-file case where an
-    // earlier file recorded a failure and the last file's top-level
-    // `process.exit(0)` would otherwise mask it.
-    if not_run == 0
-        && reporter.jest.module_load_in_progress
-        && reporter.jest.summary.fail == 0
-        && reporter.jest.unhandled_errors_between_tests == 0
-    {
+    if is_last_file_toplevel_exit_with_no_failures(reporter, not_run) {
         return;
     }
 

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -58,6 +58,11 @@ pub extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         // instead to terminate the worker sooner
         worker.exit();
     } else {
+        // `bun test` runs every file in this process, so an in-test
+        // `process.exit()` would otherwise drop the summary and report the
+        // run green regardless of later files. Flush the summary and force a
+        // nonzero exit before the normal shutdown path.
+        crate::cli::test_command::on_process_exit_during_tests(vm, code);
         vm.on_exit();
         vm.global_exit();
     }

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -58,10 +58,6 @@ pub extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         // instead to terminate the worker sooner
         worker.exit();
     } else {
-        // `bun test` runs every file in this process, so an in-test
-        // `process.exit()` would otherwise drop the summary and report the
-        // run green regardless of later files. Flush the summary and force a
-        // nonzero exit before the normal shutdown path.
         crate::cli::test_command::on_process_exit_during_tests(vm, code);
         vm.on_exit();
         vm.global_exit();

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -144,6 +144,13 @@ pub struct TestRunner<'a> {
     pub filter_regex: Option<core::ptr::NonNull<RegularExpression>>,
 
     pub unhandled_errors_between_tests: u32,
+    /// Total number of test files queued for the serial run, set by
+    /// `test_command` after discovery so [`on_process_exit_during_tests`]
+    /// can report how many files were never reached. `0` in a `--parallel`
+    /// worker (the coordinator owns the file list).
+    ///
+    /// [`on_process_exit_during_tests`]: crate::cli::test_command::on_process_exit_during_tests
+    pub total_test_files: u32,
     pub summary: Summary,
 
     pub bun_test_root: bun_test::BunTestRoot,

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -151,6 +151,12 @@ pub struct TestRunner<'a> {
     ///
     /// [`on_process_exit_during_tests`]: crate::cli::test_command::on_process_exit_during_tests
     pub total_test_files: u32,
+    /// Set for the duration of `load_entry_point_for_test_runner` in
+    /// `TestCommand::run`. Distinguishes a top-level-module `process.exit()`
+    /// (the Node re-spawn pattern) from one inside a `describe()` callback,
+    /// which runs later via `Collection::step` but is still
+    /// `Phase::Collection`.
+    pub module_load_in_progress: bool,
     pub summary: Summary,
 
     pub bun_test_root: bun_test::BunTestRoot,

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -144,18 +144,9 @@ pub struct TestRunner<'a> {
     pub filter_regex: Option<core::ptr::NonNull<RegularExpression>>,
 
     pub unhandled_errors_between_tests: u32,
-    /// Total number of test files queued for the serial run, set by
-    /// `test_command` after discovery so [`on_process_exit_during_tests`]
-    /// can report how many files were never reached. `0` in a `--parallel`
-    /// worker (the coordinator owns the file list).
-    ///
-    /// [`on_process_exit_during_tests`]: crate::cli::test_command::on_process_exit_during_tests
+    /// Serial-run file queue length; see `on_process_exit_during_tests`.
     pub total_test_files: u32,
-    /// Set for the duration of `load_entry_point_for_test_runner` in
-    /// `TestCommand::run`. Distinguishes a top-level-module `process.exit()`
-    /// (the Node re-spawn pattern) from one inside a `describe()` callback,
-    /// which runs later via `Collection::step` but is still
-    /// `Phase::Collection`.
+    /// True while `TestCommand::run` is inside `load_entry_point_for_test_runner`.
     pub module_load_in_progress: bool,
     pub summary: Summary,
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1551,6 +1551,30 @@ describe("bun test", () => {
       expect(exitCode).toBe(1);
     });
 
+    test.concurrent("exits nonzero when called from a describe() body with a later file queued", async () => {
+      using dir = tempDir("bun-test-process-exit-describe", {
+        "a.test.ts": `
+          import { describe } from "bun:test";
+          describe("x", () => { process.exit(0); });
+        `,
+        "b.test.ts": `
+          import { test, expect } from "bun:test";
+          test("would fail", () => { expect(1).toBe(2); });
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("process.exit(0) was called during bun test");
+      expect(stderr).toContain("1 test file was never reached");
+      expect(exitCode).toBe(1);
+    });
+
     test.concurrent("reports the requested code in the message", async () => {
       using dir = tempDir("bun-test-process-exit-code", {
         "only.test.ts": `

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1501,6 +1501,75 @@ describe("bun test", () => {
     expect(stderr).toContain("1 pass");
     expect(exitCode).toBe(1);
   });
+
+  describe("process.exit() inside a test", () => {
+    test.concurrent("exits nonzero with a summary when a later file is never reached", async () => {
+      using dir = tempDir("bun-test-process-exit", {
+        "a-exits.test.ts": `
+          import { test } from "bun:test";
+          test("calls process.exit(0)", () => { process.exit(0); });
+        `,
+        "b-never-runs.test.ts": `
+          import { test, expect } from "bun:test";
+          test("would fail", () => { expect(1).toBe(2); });
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./a-exits.test.ts", "./b-never-runs.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("process.exit(0) was called during bun test");
+      expect(stderr).toContain("1 test file was never reached");
+      expect(stderr).toMatch(/Ran \d+ tests? across \d+ files?/);
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("exits nonzero with a summary for a single file (no remaining files)", async () => {
+      using dir = tempDir("bun-test-process-exit-single", {
+        "only.test.ts": `
+          import { test } from "bun:test";
+          test("ok", () => {});
+          test("calls process.exit(0)", () => { process.exit(0); });
+          test("never runs", () => { throw new Error("unreachable"); });
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./only.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("process.exit(0) was called during bun test");
+      expect(stderr).toContain("1 pass");
+      expect(stderr).not.toContain("never reached");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("reports the requested code in the message", async () => {
+      using dir = tempDir("bun-test-process-exit-code", {
+        "only.test.ts": `
+          import { test } from "bun:test";
+          test("calls process.exit(42)", () => { process.exit(42); });
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./only.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("process.exit(42) was called during bun test");
+      expect(exitCode).toBe(1);
+    });
+  });
 });
 
 function createTest(input?: string | (string | { filename: string; contents: string })[], filename?: string): string {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1594,6 +1594,27 @@ describe("bun test", () => {
       expect(exitCode).toBe(1);
     });
 
+    test.concurrent("does not mask an earlier failure when the last file exits at top level", async () => {
+      using dir = tempDir("bun-test-process-exit-mask", {
+        "a.test.ts": `
+          import { test, expect } from "bun:test";
+          test("fails", () => { expect(1).toBe(2); });
+        `,
+        "b.test.ts": `process.exit(0);`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("process.exit(0) was called during bun test");
+      expect(stderr).toContain("1 fail");
+      expect(exitCode).toBe(1);
+    });
+
     // Node's test/parallel common/index.js re-spawns the current file with
     // `// Flags:` applied and then `process.exit(child.status)` from the
     // parent's module top level. That is the only file in the run and no

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1569,6 +1569,29 @@ describe("bun test", () => {
       expect(stderr).toContain("process.exit(42) was called during bun test");
       expect(exitCode).toBe(1);
     });
+
+    // Node's test/parallel common/index.js re-spawns the current file with
+    // `// Flags:` applied and then `process.exit(child.status)` from the
+    // parent's module top level. That is the only file in the run and no
+    // test body has started, so the requested code must pass through.
+    test.concurrent.each([0, 1] as const)(
+      "passes through top-level process.exit(%p) when it is the only file",
+      async code => {
+        using dir = tempDir("bun-test-process-exit-wrapper", {
+          "wrapper.test.ts": `process.exit(${code});`,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test", "./wrapper.test.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("process.exit");
+        expect(exitCode).toBe(code);
+      },
+    );
   });
 });
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1637,6 +1637,31 @@ describe("bun test", () => {
         expect(exitCode).toBe(code);
       },
     );
+
+    // After all tests finish and the summary is printed, the run is no longer
+    // "mid-run": a process.on('exit') listener calling process.exit() must
+    // behave like it does under `bun run` (honor the requested code, no
+    // mid-run diagnostic, no second summary).
+    test.concurrent("process.exit() from an 'exit' listener is not treated as mid-run", async () => {
+      using dir = tempDir("bun-test-process-exit-listener", {
+        "only.test.ts": `
+          import { test } from "bun:test";
+          process.on("exit", () => process.exit(3));
+          test("a passing test", () => {});
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./only.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("was called during bun test");
+      expect(stderr.match(/\b1 pass\b/g)?.length).toBe(1);
+      expect(exitCode).toBe(3);
+    });
   });
 });
 


### PR DESCRIPTION
## What

`process.exit(0)` called inside any test body (node:test or bun:test) made `bun test` exit 0 immediately with no summary line and no error. Every remaining test and file in the run was silently never executed, so a run whose later file has a real failing test was reported green.

```sh
D=$(mktemp -d); cd "$D"
cat > a-exits.test.mjs <<'JS'
import { test } from 'node:test';
test('A calls process.exit(0)', () => { process.exit(0); });
JS
cat > b-never-runs.test.mjs <<'JS'
import { test } from 'node:test';
import assert from 'node:assert';
test('B fails', () => { assert.fail('B should be red'); });
JS
bun test; echo "rc=$?"
```

Before: prints only the banner, exits 0.

After:
```
a-exits.test.mjs:

error: process.exit(0) was called during bun test
       1 test file was never reached.

 0 pass
 0 fail
Ran 0 tests across 1 file. [...]
rc=1
```

`node --test` isolates each file in its own process, so the exiting file passes and the next file's failure is still reported (exit 1).

## How

`Bun__Process__exit` (`src/runtime/node/node_process.rs`) now calls into `test_command::on_process_exit_during_tests` before the normal `on_exit()` / `global_exit()` shutdown. When a `bun test` reporter is active it prints the pass/fail summary that would otherwise be lost, reports how many test files were never reached, writes the JUnit report, and forces exit code 1.

Two exemptions:

- A `--parallel` worker is left alone: the coordinator already accounts for a worker that dies mid-file as a failure (`Coordinator::reap_worker` -> `account_crash`) and continues with a fresh worker.
- `process.exit()` called at module top level of the last (or only) file in the run passes through unchanged. Node's test harness (`test/js/node/test/common/index.js`) re-spawns the current file with its `// Flags:` applied and then `process.exit(child.status)` from the parent's module top level; no test body has started and no later file is skipped, so that is not a silent-green hazard.

The pass/skip/filtered/todo/fail/errors block is extracted into `CommandLineReporter::print_summary_counts` so the mid-run and end-of-run summaries share one implementation.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->