### PR TITLE
Bun.serve: validate type of `development` option

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -474,14 +474,16 @@ impl JSGlobalObject {
 
     /// `validators.throwErrInvalidArgType` —
     /// `The "<name>" property must be of type <expected>, got <actual>`
-    /// where `<actual>` is the JS `typeof` (or `"array"` for arrays).
+    /// where `<actual>` is the JS `typeof` (or `"array"`/`"null"` for arrays/null).
     pub fn throw_invalid_property_type(
         &self,
         name: impl AsRef<[u8]>,
         expected_type: &str,
         value: JSValue,
     ) -> JsError {
-        let actual_type = if value.js_type().is_array() {
+        let actual_type = if value.is_null() {
+            bun_core::ZigString::static_(b"null")
+        } else if value.js_type().is_array() {
             bun_core::ZigString::static_(b"array")
         } else {
             value.js_type_string(self).get_zig_string(self)

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -474,16 +474,14 @@ impl JSGlobalObject {
 
     /// `validators.throwErrInvalidArgType` —
     /// `The "<name>" property must be of type <expected>, got <actual>`
-    /// where `<actual>` is the JS `typeof` (or `"array"`/`"null"` for arrays/null).
+    /// where `<actual>` is the JS `typeof` (or `"array"` for arrays).
     pub fn throw_invalid_property_type(
         &self,
         name: impl AsRef<[u8]>,
         expected_type: &str,
         value: JSValue,
     ) -> JsError {
-        let actual_type = if value.is_null() {
-            bun_core::ZigString::static_(b"null")
-        } else if value.js_type().is_array() {
+        let actual_type = if value.js_type().is_array() {
             bun_core::ZigString::static_(b"array")
         } else {
             value.js_type_string(self).get_zig_string(self)

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -771,7 +771,7 @@ impl ServerConfig {
         }
 
         // "development" impacts other settings like bake.
-        if let Some(dev) = arg.get(global, "development")? {
+        if let Some(dev) = arg.get(global, "development")?.filter(|v| !v.is_null()) {
             if dev.is_object() {
                 if let Some(hmr) = dev.get_boolean_strict(global, "hmr")? {
                     args.development = if !hmr {
@@ -798,7 +798,7 @@ impl ServerConfig {
                 } else {
                     DevelopmentOption::Production
                 };
-            } else if !dev.is_null() {
+            } else {
                 return Err(global.throw_invalid_property_type(
                     "development",
                     "boolean or object",

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -799,9 +799,11 @@ impl ServerConfig {
                     DevelopmentOption::Production
                 };
             } else if !dev.is_null() {
-                return Err(
-                    global.throw_invalid_property_type("development", "boolean or object", dev)
-                );
+                return Err(global.throw_invalid_property_type(
+                    "development",
+                    "boolean or object",
+                    dev,
+                ));
             }
             args.reuse_port = args.development == DevelopmentOption::Production;
         }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -771,7 +771,7 @@ impl ServerConfig {
         }
 
         // "development" impacts other settings like bake.
-        if let Some(dev) = arg.get(global, "development")?.filter(|v| !v.is_null()) {
+        if let Some(dev) = arg.get(global, "development")? {
             if dev.is_object() {
                 if let Some(hmr) = dev.get_boolean_strict(global, "hmr")? {
                     args.development = if !hmr {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -792,12 +792,16 @@ impl ServerConfig {
                 {
                     args.enable_chrome_devtools_automatic_workspace_folders = v;
                 }
-            } else {
-                args.development = if dev.to_boolean() {
+            } else if dev.is_boolean() {
+                args.development = if dev.as_boolean() {
                     DevelopmentOption::Development
                 } else {
                     DevelopmentOption::Production
                 };
+            } else if !dev.is_null() {
+                return Err(
+                    global.throw_invalid_property_type("development", "boolean or object", dev)
+                );
             }
             args.reuse_port = args.development == DevelopmentOption::Production;
         }

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -262,45 +262,39 @@ describe("Bun.serve development options", () => {
     server.stop();
   });
 
-  test.each(["false", "0", "true", "", 0, 1])(
-    "non-boolean development: %p must be rejected, not coerced",
-    value => {
-      // "false"/"0" are truthy under ToBoolean. Accepting them silently would
-      // flip on development mode (and its error page) for a server the caller
-      // configured as production via an env-var string.
-      expect(() =>
-        serve({
-          port: 0,
-          // @ts-expect-error - Testing runtime validation
-          development: value,
-          fetch() {
-            return new Response("ok");
-          },
-        }),
-      ).toThrow(
-        expect.objectContaining({
-          code: "ERR_INVALID_ARG_TYPE",
-          message: expect.stringContaining('"development"'),
-        }),
-      );
-    },
-  );
-
-  test.each([true, false, undefined, null, { hmr: false }])(
-    "valid development: %p is accepted",
-    value => {
-      using server = serve({
+  test.each(["false", "0", "true", "", 0, 1])("non-boolean development: %p must be rejected, not coerced", value => {
+    // "false"/"0" are truthy under ToBoolean. Accepting them silently would
+    // flip on development mode (and its error page) for a server the caller
+    // configured as production via an env-var string.
+    expect(() =>
+      serve({
         port: 0,
-        // @ts-expect-error - null is runtime-tolerated but not in the type
+        // @ts-expect-error - Testing runtime validation
         development: value,
         fetch() {
           return new Response("ok");
         },
-      });
-      expect(typeof server.development).toBe("boolean");
-      server.stop();
-    },
-  );
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: expect.stringContaining('"development"'),
+      }),
+    );
+  });
+
+  test.each([true, false, undefined, null, { hmr: false }])("valid development: %p is accepted", value => {
+    using server = serve({
+      port: 0,
+      // @ts-expect-error - null is runtime-tolerated but not in the type
+      development: value,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+    expect(typeof server.development).toBe("boolean");
+    server.stop();
+  });
 });
 
 describe("Bun.serve static routes", () => {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -261,6 +261,46 @@ describe("Bun.serve development options", () => {
     expect(server.development).toBe(false);
     server.stop();
   });
+
+  test.each(["false", "0", "true", "", 0, 1])(
+    "non-boolean development: %p must be rejected, not coerced",
+    value => {
+      // "false"/"0" are truthy under ToBoolean. Accepting them silently would
+      // flip on development mode (and its error page) for a server the caller
+      // configured as production via an env-var string.
+      expect(() =>
+        serve({
+          port: 0,
+          // @ts-expect-error - Testing runtime validation
+          development: value,
+          fetch() {
+            return new Response("ok");
+          },
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+          message: expect.stringContaining('"development"'),
+        }),
+      );
+    },
+  );
+
+  test.each([true, false, undefined, null, { hmr: false }])(
+    "valid development: %p is accepted",
+    value => {
+      using server = serve({
+        port: 0,
+        // @ts-expect-error - null is runtime-tolerated but not in the type
+        development: value,
+        fetch() {
+          return new Response("ok");
+        },
+      });
+      expect(typeof server.development).toBe("boolean");
+      server.stop();
+    },
+  );
 });
 
 describe("Bun.serve static routes", () => {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -262,7 +262,7 @@ describe("Bun.serve development options", () => {
     server.stop();
   });
 
-  test.each(["false", "0", "true", "", 0, 1])("non-boolean development: %p must be rejected, not coerced", value => {
+  test.each(["false", "0", "true", "", 0, 1, null])("non-boolean development: %p must be rejected, not coerced", value => {
     // "false"/"0" are truthy under ToBoolean. Accepting them silently would
     // flip on development mode (and its error page) for a server the caller
     // configured as production via an env-var string.
@@ -283,16 +283,19 @@ describe("Bun.serve development options", () => {
     );
   });
 
-  test.each([true, false, undefined, null, { hmr: false }])("valid development: %p is accepted", value => {
+  test.each([
+    [true, true],
+    [false, false],
+    [{ hmr: false }, true],
+  ])("valid development: %p is accepted", (value, expected) => {
     using server = serve({
       port: 0,
-      // @ts-expect-error - null is runtime-tolerated but not in the type
       development: value,
       fetch() {
         return new Response("ok");
       },
     });
-    expect(typeof server.development).toBe("boolean");
+    expect(server.development).toBe(expected);
     server.stop();
   });
 });

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -262,26 +262,29 @@ describe("Bun.serve development options", () => {
     server.stop();
   });
 
-  test.each(["false", "0", "true", "", 0, 1, null])("non-boolean development: %p must be rejected, not coerced", value => {
-    // "false"/"0" are truthy under ToBoolean. Accepting them silently would
-    // flip on development mode (and its error page) for a server the caller
-    // configured as production via an env-var string.
-    expect(() =>
-      serve({
-        port: 0,
-        // @ts-expect-error - Testing runtime validation
-        development: value,
-        fetch() {
-          return new Response("ok");
-        },
-      }),
-    ).toThrow(
-      expect.objectContaining({
-        code: "ERR_INVALID_ARG_TYPE",
-        message: expect.stringContaining('"development"'),
-      }),
-    );
-  });
+  test.each(["false", "0", "true", "", 0, 1, null])(
+    "non-boolean development: %p must be rejected, not coerced",
+    value => {
+      // "false"/"0" are truthy under ToBoolean. Accepting them silently would
+      // flip on development mode (and its error page) for a server the caller
+      // configured as production via an env-var string.
+      expect(() =>
+        serve({
+          port: 0,
+          // @ts-expect-error - Testing runtime validation
+          development: value,
+          fetch() {
+            return new Response("ok");
+          },
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+          message: expect.stringContaining('"development"'),
+        }),
+      );
+    },
+  );
 
   test.each([
     [true, true],


### PR DESCRIPTION
Passing a string to the `development` option was being accepted via JS ToBoolean coercion, so `"false"` and `"0"` (both truthy) silently turned **on** development mode. In development mode, `Bun.serve` renders unhandled errors as an HTML page whose embedded payload carries the thrown exception message and stack to the in-browser overlay. A server configured with `development: process.env.DEVELOPMENT` where the env var holds the string `"false"` would serve that page to remote clients, and `NODE_ENV=production` does not override an explicit option.

## Repro

```js
const server = Bun.serve({
  port: 0,
  development: "false",
  fetch() { throw new Error("db_password=hunter2"); },
});
console.log(server.development); // true  (bug)
const body = await (await fetch(server.url)).text();
console.log(body.length);        // ~66 KB dev error page containing the message
```

## Cause

`ServerConfig::from_js` read the non-object branch with `dev.to_boolean()` (JS truthiness). The sibling `idleTimeout` option already validates its type and throws `ERR_INVALID_ARG_TYPE` for a string.

## Fix

Accept a boolean or an object (for the `{hmr, console, ...}` shape) and throw `ERR_INVALID_ARG_TYPE` for anything else (string, number, null):

```
TypeError: The "development" property must be of type boolean or object, got string
 code: "ERR_INVALID_ARG_TYPE"
```

`null` is rejected rather than treated as "unset" because the previous coercion mapped it to Production; silently remapping it to the env-derived default would be the same failure mode in the other direction.

## Verification

`test/js/bun/http/bun-serve-args.test.ts` gains a `test.each` over `"false"`, `"0"`, `"true"`, `""`, `0`, `1`, `null` asserting they now throw, plus a `test.each` over `true`, `false`, `{ hmr: false }` asserting the exact `server.development` result. The rejection cases fail on the unpatched build (server is created with `development: true`) and pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-args.test.ts

<!-- robobun:evidence:end -->