### PR TITLE
bunfig: error on wrong-typed [install] keys instead of silently ignoring

### DIFF
--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -1301,9 +1301,8 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(exact) = install_obj.get(b"exact") {
-            if let Some(v) = exact.as_bool() {
-                install.exact = Some(v);
-            }
+            self.expect(&exact, ExprTag::EBoolean)?;
+            install.exact = Some(exact.as_bool().expect("infallible: type checked"));
         }
 
         if let Some(registry) = install_obj.get(b"registry") {
@@ -1332,29 +1331,30 @@ impl<'a> Parser<'a> {
             install.scoped = Some(registry_map);
         }
 
-        if let Some(v) = install_obj.get(b"dryRun").and_then(|e| e.as_bool()) {
-            install.dry_run = Some(v);
+        if let Some(expr) = install_obj.get(b"dryRun") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.dry_run = Some(expr.as_bool().expect("infallible: type checked"));
         }
-        if let Some(v) = install_obj.get(b"production").and_then(|e| e.as_bool()) {
-            install.production = Some(v);
+        if let Some(expr) = install_obj.get(b"production") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.production = Some(expr.as_bool().expect("infallible: type checked"));
         }
-        if let Some(v) = install_obj.get(b"frozenLockfile").and_then(|e| e.as_bool()) {
-            install.frozen_lockfile = Some(v);
+        if let Some(expr) = install_obj.get(b"frozenLockfile") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.frozen_lockfile = Some(expr.as_bool().expect("infallible: type checked"));
         }
-        if let Some(v) = install_obj
-            .get(b"saveTextLockfile")
-            .and_then(|e| e.as_bool())
-        {
-            install.save_text_lockfile = Some(v);
+        if let Some(expr) = install_obj.get(b"saveTextLockfile") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.save_text_lockfile = Some(expr.as_bool().expect("infallible: type checked"));
         }
         if let Some(jobs) = install_obj.get(b"concurrentScripts") {
-            if let Some(n) = jobs.as_number() {
-                let n = num_to_u32(n);
-                install.concurrent_scripts = if n == 0 { None } else { Some(n) };
-            }
+            self.expect(&jobs, ExprTag::ENumber)?;
+            let n = num_to_u32(jobs.as_number().expect("infallible: type checked"));
+            install.concurrent_scripts = if n == 0 { None } else { Some(n) };
         }
-        if let Some(v) = install_obj.get(b"ignoreScripts").and_then(|e| e.as_bool()) {
-            install.ignore_scripts = Some(v);
+        if let Some(expr) = install_obj.get(b"ignoreScripts") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.ignore_scripts = Some(expr.as_bool().expect("infallible: type checked"));
         }
         if let Some(node_linker_expr) = install_obj.get(b"linker") {
             self.expect_string(&node_linker_expr)?;
@@ -1368,8 +1368,9 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        if let Some(v) = install_obj.get(b"globalStore").and_then(|e| e.as_bool()) {
-            install.global_store = Some(v);
+        if let Some(expr) = install_obj.get(b"globalStore") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.global_store = Some(expr.as_bool().expect("infallible: type checked"));
         }
 
         if let Some(lockfile_expr) = install_obj.get(b"lockfile") {
@@ -1387,43 +1388,55 @@ impl<'a> Parser<'a> {
                     }
                 }
             }
-            if let Some(v) = lockfile_expr.get(b"save").and_then(|e| e.as_bool()) {
-                install.save_lockfile = Some(v);
+            if let Some(expr) = lockfile_expr.get(b"save") {
+                self.expect(&expr, ExprTag::EBoolean)?;
+                install.save_lockfile = Some(expr.as_bool().expect("infallible: type checked"));
             }
-            if let Some(v) = lockfile_expr
-                .get(b"path")
-                .and_then(|e| e.as_string(self.bump))
-            {
-                install.lockfile_path = Some(v.into());
+            if let Some(expr) = lockfile_expr.get(b"path") {
+                self.expect_string(&expr)?;
+                install.lockfile_path = Some(
+                    expr.as_string(self.bump)
+                        .expect("infallible: type checked")
+                        .into(),
+                );
             }
-            if let Some(v) = lockfile_expr
-                .get(b"savePath")
-                .and_then(|e| e.as_string(self.bump))
-            {
-                install.save_lockfile_path = Some(v.into());
+            if let Some(expr) = lockfile_expr.get(b"savePath") {
+                self.expect_string(&expr)?;
+                install.save_lockfile_path = Some(
+                    expr.as_string(self.bump)
+                        .expect("infallible: type checked")
+                        .into(),
+                );
             }
         }
 
-        if let Some(v) = install_obj.get(b"optional").and_then(|e| e.as_bool()) {
-            install.save_optional = Some(v);
+        if let Some(expr) = install_obj.get(b"optional") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.save_optional = Some(expr.as_bool().expect("infallible: type checked"));
         }
-        if let Some(v) = install_obj.get(b"peer").and_then(|e| e.as_bool()) {
-            install.save_peer = Some(v);
+        if let Some(expr) = install_obj.get(b"peer") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.save_peer = Some(expr.as_bool().expect("infallible: type checked"));
         }
-        if let Some(v) = install_obj.get(b"dev").and_then(|e| e.as_bool()) {
-            install.save_dev = Some(v);
+        if let Some(expr) = install_obj.get(b"dev") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.save_dev = Some(expr.as_bool().expect("infallible: type checked"));
         }
-        if let Some(v) = install_obj
-            .get(b"globalDir")
-            .and_then(|e| e.as_string(self.bump))
-        {
-            install.global_dir = Some(v.into());
+        if let Some(expr) = install_obj.get(b"globalDir") {
+            self.expect_string(&expr)?;
+            install.global_dir = Some(
+                expr.as_string(self.bump)
+                    .expect("infallible: type checked")
+                    .into(),
+            );
         }
-        if let Some(v) = install_obj
-            .get(b"globalBinDir")
-            .and_then(|e| e.as_string(self.bump))
-        {
-            install.global_bin_dir = Some(v.into());
+        if let Some(expr) = install_obj.get(b"globalBinDir") {
+            self.expect_string(&expr)?;
+            install.global_bin_dir = Some(
+                expr.as_string(self.bump)
+                    .expect("infallible: type checked")
+                    .into(),
+            );
         }
 
         if let Some(cache) = install_obj.get(b"cache") {
@@ -1440,24 +1453,32 @@ impl<'a> Parser<'a> {
                     break 'load;
                 }
                 if let ExprData::EObject(_) = cache.data {
-                    if let Some(v) = cache.get(b"disable").and_then(|e| e.as_bool()) {
-                        install.disable_cache = Some(v);
+                    if let Some(expr) = cache.get(b"disable") {
+                        self.expect(&expr, ExprTag::EBoolean)?;
+                        install.disable_cache =
+                            Some(expr.as_bool().expect("infallible: type checked"));
                     }
-                    if let Some(v) = cache.get(b"disableManifest").and_then(|e| e.as_bool()) {
-                        install.disable_manifest_cache = Some(v);
+                    if let Some(expr) = cache.get(b"disableManifest") {
+                        self.expect(&expr, ExprTag::EBoolean)?;
+                        install.disable_manifest_cache =
+                            Some(expr.as_bool().expect("infallible: type checked"));
                     }
-                    if let Some(v) = cache.get(b"dir").and_then(|e| e.as_string(self.bump)) {
-                        install.cache_directory = Some(v.into());
+                    if let Some(expr) = cache.get(b"dir") {
+                        self.expect_string(&expr)?;
+                        install.cache_directory = Some(
+                            expr.as_string(self.bump)
+                                .expect("infallible: type checked")
+                                .into(),
+                        );
                     }
                 }
             }
         }
 
-        if let Some(v) = install_obj
-            .get(b"linkWorkspacePackages")
-            .and_then(|e| e.as_bool())
-        {
-            install.link_workspace_packages = Some(v);
+        if let Some(expr) = install_obj.get(b"linkWorkspacePackages") {
+            self.expect(&expr, ExprTag::EBoolean)?;
+            install.link_workspace_packages =
+                Some(expr.as_bool().expect("infallible: type checked"));
         }
 
         if let Some(security_obj) = install_obj.get(b"security") {

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -195,6 +195,19 @@ impl<'a> Parser<'a> {
         }
     }
 
+    pub(crate) fn expect_bool(&mut self, expr: &Expr) -> crate::Result<bool> {
+        self.expect(expr, ExprTag::EBoolean)?;
+        Ok(expr.as_bool().expect("infallible: type checked"))
+    }
+
+    pub(crate) fn expect_owned_string(&mut self, expr: &Expr) -> crate::Result<Box<[u8]>> {
+        self.expect_string(expr)?;
+        Ok(expr
+            .as_string(self.bump)
+            .expect("infallible: type checked")
+            .into())
+    }
+
     fn apply_coverage_reporter_item(&mut self, item: &Expr) -> crate::Result<()> {
         let item_str = item.as_string(self.bump).unwrap_or(b"");
         if item_str == b"text" {
@@ -1301,8 +1314,7 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(exact) = install_obj.get(b"exact") {
-            self.expect(&exact, ExprTag::EBoolean)?;
-            install.exact = Some(exact.as_bool().expect("infallible: type checked"));
+            install.exact = Some(self.expect_bool(&exact)?);
         }
 
         if let Some(registry) = install_obj.get(b"registry") {
@@ -1332,29 +1344,31 @@ impl<'a> Parser<'a> {
         }
 
         if let Some(expr) = install_obj.get(b"dryRun") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.dry_run = Some(expr.as_bool().expect("infallible: type checked"));
+            install.dry_run = Some(self.expect_bool(&expr)?);
         }
         if let Some(expr) = install_obj.get(b"production") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.production = Some(expr.as_bool().expect("infallible: type checked"));
+            install.production = Some(self.expect_bool(&expr)?);
         }
         if let Some(expr) = install_obj.get(b"frozenLockfile") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.frozen_lockfile = Some(expr.as_bool().expect("infallible: type checked"));
+            install.frozen_lockfile = Some(self.expect_bool(&expr)?);
         }
         if let Some(expr) = install_obj.get(b"saveTextLockfile") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.save_text_lockfile = Some(expr.as_bool().expect("infallible: type checked"));
+            install.save_text_lockfile = Some(self.expect_bool(&expr)?);
         }
         if let Some(jobs) = install_obj.get(b"concurrentScripts") {
             self.expect(&jobs, ExprTag::ENumber)?;
-            let n = num_to_u32(jobs.as_number().expect("infallible: type checked"));
+            let value = jobs.as_number().expect("infallible: type checked");
+            if !value.is_finite() || value < 0.0 {
+                self.add_error(
+                    jobs.loc,
+                    b"Expected a non-negative finite number for concurrentScripts",
+                )?;
+            }
+            let n = num_to_u32(value);
             install.concurrent_scripts = if n == 0 { None } else { Some(n) };
         }
         if let Some(expr) = install_obj.get(b"ignoreScripts") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.ignore_scripts = Some(expr.as_bool().expect("infallible: type checked"));
+            install.ignore_scripts = Some(self.expect_bool(&expr)?);
         }
         if let Some(node_linker_expr) = install_obj.get(b"linker") {
             self.expect_string(&node_linker_expr)?;
@@ -1369,11 +1383,11 @@ impl<'a> Parser<'a> {
             }
         }
         if let Some(expr) = install_obj.get(b"globalStore") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.global_store = Some(expr.as_bool().expect("infallible: type checked"));
+            install.global_store = Some(self.expect_bool(&expr)?);
         }
 
         if let Some(lockfile_expr) = install_obj.get(b"lockfile") {
+            self.expect(&lockfile_expr, ExprTag::EObject)?;
             if let Some(lockfile) = lockfile_expr.get(b"print") {
                 self.expect_string(&lockfile)?;
                 if let Some(value) = lockfile.as_string(self.bump) {
@@ -1389,96 +1403,70 @@ impl<'a> Parser<'a> {
                 }
             }
             if let Some(expr) = lockfile_expr.get(b"save") {
-                self.expect(&expr, ExprTag::EBoolean)?;
-                install.save_lockfile = Some(expr.as_bool().expect("infallible: type checked"));
+                install.save_lockfile = Some(self.expect_bool(&expr)?);
             }
             if let Some(expr) = lockfile_expr.get(b"path") {
-                self.expect_string(&expr)?;
-                install.lockfile_path = Some(
-                    expr.as_string(self.bump)
-                        .expect("infallible: type checked")
-                        .into(),
-                );
+                install.lockfile_path = Some(self.expect_owned_string(&expr)?);
             }
             if let Some(expr) = lockfile_expr.get(b"savePath") {
-                self.expect_string(&expr)?;
-                install.save_lockfile_path = Some(
-                    expr.as_string(self.bump)
-                        .expect("infallible: type checked")
-                        .into(),
-                );
+                install.save_lockfile_path = Some(self.expect_owned_string(&expr)?);
             }
         }
 
         if let Some(expr) = install_obj.get(b"optional") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.save_optional = Some(expr.as_bool().expect("infallible: type checked"));
+            install.save_optional = Some(self.expect_bool(&expr)?);
         }
         if let Some(expr) = install_obj.get(b"peer") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.save_peer = Some(expr.as_bool().expect("infallible: type checked"));
+            install.save_peer = Some(self.expect_bool(&expr)?);
         }
         if let Some(expr) = install_obj.get(b"dev") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.save_dev = Some(expr.as_bool().expect("infallible: type checked"));
+            install.save_dev = Some(self.expect_bool(&expr)?);
         }
         if let Some(expr) = install_obj.get(b"globalDir") {
-            self.expect_string(&expr)?;
-            install.global_dir = Some(
-                expr.as_string(self.bump)
-                    .expect("infallible: type checked")
-                    .into(),
-            );
+            install.global_dir = Some(self.expect_owned_string(&expr)?);
         }
         if let Some(expr) = install_obj.get(b"globalBinDir") {
-            self.expect_string(&expr)?;
-            install.global_bin_dir = Some(
-                expr.as_string(self.bump)
-                    .expect("infallible: type checked")
-                    .into(),
-            );
+            install.global_bin_dir = Some(self.expect_owned_string(&expr)?);
         }
 
         if let Some(cache) = install_obj.get(b"cache") {
-            'load: {
-                if let Some(value) = cache.as_bool() {
-                    if !value {
+            match &cache.data {
+                ExprData::EBoolean(b) => {
+                    if !b.value {
                         install.disable_cache = Some(true);
                         install.disable_manifest_cache = Some(true);
                     }
-                    break 'load;
                 }
-                if let Some(value) = cache.as_string(self.bump) {
-                    install.cache_directory = Some(value.into());
-                    break 'load;
+                ExprData::EString(_) => {
+                    install.cache_directory = Some(
+                        cache
+                            .as_string(self.bump)
+                            .expect("infallible: variant checked")
+                            .into(),
+                    );
                 }
-                if let ExprData::EObject(_) = cache.data {
+                ExprData::EObject(_) => {
                     if let Some(expr) = cache.get(b"disable") {
-                        self.expect(&expr, ExprTag::EBoolean)?;
-                        install.disable_cache =
-                            Some(expr.as_bool().expect("infallible: type checked"));
+                        install.disable_cache = Some(self.expect_bool(&expr)?);
                     }
                     if let Some(expr) = cache.get(b"disableManifest") {
-                        self.expect(&expr, ExprTag::EBoolean)?;
-                        install.disable_manifest_cache =
-                            Some(expr.as_bool().expect("infallible: type checked"));
+                        install.disable_manifest_cache = Some(self.expect_bool(&expr)?);
                     }
                     if let Some(expr) = cache.get(b"dir") {
-                        self.expect_string(&expr)?;
-                        install.cache_directory = Some(
-                            expr.as_string(self.bump)
-                                .expect("infallible: type checked")
-                                .into(),
-                        );
+                        install.cache_directory = Some(self.expect_owned_string(&expr)?);
                     }
+                }
+                _ => {
+                    self.add_error(
+                        cache.loc,
+                        b"Expected cache to be a boolean, string, or object",
+                    )?;
                 }
             }
         }
 
         if let Some(expr) = install_obj.get(b"linkWorkspacePackages") {
-            self.expect(&expr, ExprTag::EBoolean)?;
-            install.link_workspace_packages =
-                Some(expr.as_bool().expect("infallible: type checked"));
+            install.link_workspace_packages = Some(self.expect_bool(&expr)?);
         }
 
         if let Some(security_obj) = install_obj.get(b"security") {

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -8,6 +8,28 @@ describe.concurrent("bunfig.toml type-mismatch error messages", () => {
     [`telemetry = "no"`, "expected boolean but received string"],
     [`define = 3`, "expected object but received number"],
     [`[serve]\nport = "abc"`, "expected number but received string"],
+    // [install] booleans must hard-error on wrong type, not silently drop the
+    // guard (frozenLockfile = "true" previously left the lockfile unfrozen).
+    [`[install]\nfrozenLockfile = "true"`, "expected boolean but received string"],
+    [`[install]\nignoreScripts = "true"`, "expected boolean but received string"],
+    [`[install]\nproduction = "true"`, "expected boolean but received string"],
+    [`[install]\ndryRun = "true"`, "expected boolean but received string"],
+    [`[install]\nsaveTextLockfile = "true"`, "expected boolean but received string"],
+    [`[install]\nexact = "true"`, "expected boolean but received string"],
+    [`[install]\noptional = "false"`, "expected boolean but received string"],
+    [`[install]\npeer = "false"`, "expected boolean but received string"],
+    [`[install]\ndev = "false"`, "expected boolean but received string"],
+    [`[install]\nglobalStore = "true"`, "expected boolean but received string"],
+    [`[install]\nlinkWorkspacePackages = "true"`, "expected boolean but received string"],
+    [`[install]\nconcurrentScripts = "4"`, "expected number but received string"],
+    [`[install]\nglobalDir = true`, "expected string but received boolean"],
+    [`[install]\nglobalBinDir = true`, "expected string but received boolean"],
+    [`[install.lockfile]\nsave = "true"`, "expected boolean but received string"],
+    [`[install.lockfile]\npath = true`, "expected string but received boolean"],
+    [`[install.lockfile]\nsavePath = true`, "expected string but received boolean"],
+    [`[install.cache]\ndisable = "true"`, "expected boolean but received string"],
+    [`[install.cache]\ndisableManifest = "true"`, "expected boolean but received string"],
+    [`[install.cache]\ndir = true`, "expected string but received boolean"],
   ];
 
   test.each(cases)("%s -> %s", async (config, expected) => {
@@ -28,5 +50,36 @@ describe.concurrent("bunfig.toml type-mismatch error messages", () => {
     expect(stderr).not.toMatch(/\be_(string|boolean|number|object|array|null)\b/);
     expect(stdout).toBe("");
     expect(exitCode).not.toBe(0);
+  });
+});
+
+describe.concurrent("bunfig.toml [install] correctly-typed values still accepted", () => {
+  const cases: string[] = [
+    `[install]\nfrozenLockfile = true`,
+    `[install]\nignoreScripts = true`,
+    `[install]\nproduction = true`,
+    `[install]\nexact = true\ndev = false\noptional = false\npeer = false`,
+    `[install]\nsaveTextLockfile = true\ndryRun = true\nglobalStore = true\nlinkWorkspacePackages = true`,
+    `[install]\nconcurrentScripts = 4\nglobalDir = "/tmp"\nglobalBinDir = "/tmp"`,
+    `[install.lockfile]\nsave = true\npath = "bun.lock"\nsavePath = "bun.lock"`,
+    `[install.cache]\ndisable = true\ndisableManifest = true\ndir = "/tmp"`,
+  ];
+
+  test.each(cases)("%s", async config => {
+    using dir = tempDir("bunfig-install-valid", {
+      "bunfig.toml": config + "\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "console.log('ok')"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/config/bunfig/bunfig-errors.test.ts
+++ b/test/config/bunfig/bunfig-errors.test.ts
@@ -22,8 +22,11 @@ describe.concurrent("bunfig.toml type-mismatch error messages", () => {
     [`[install]\nglobalStore = "true"`, "expected boolean but received string"],
     [`[install]\nlinkWorkspacePackages = "true"`, "expected boolean but received string"],
     [`[install]\nconcurrentScripts = "4"`, "expected number but received string"],
+    [`[install]\nconcurrentScripts = -1`, "Expected a non-negative finite number for concurrentScripts"],
     [`[install]\nglobalDir = true`, "expected string but received boolean"],
     [`[install]\nglobalBinDir = true`, "expected string but received boolean"],
+    [`[install]\nlockfile = 5`, "expected object but received number"],
+    [`[install]\ncache = 5`, "Expected cache to be a boolean, string, or object"],
     [`[install.lockfile]\nsave = "true"`, "expected boolean but received string"],
     [`[install.lockfile]\npath = true`, "expected string but received boolean"],
     [`[install.lockfile]\nsavePath = true`, "expected string but received boolean"],
@@ -63,6 +66,8 @@ describe.concurrent("bunfig.toml [install] correctly-typed values still accepted
     `[install]\nconcurrentScripts = 4\nglobalDir = "/tmp"\nglobalBinDir = "/tmp"`,
     `[install.lockfile]\nsave = true\npath = "bun.lock"\nsavePath = "bun.lock"`,
     `[install.cache]\ndisable = true\ndisableManifest = true\ndir = "/tmp"`,
+    `[install]\ncache = false`,
+    `[install]\ncache = "/tmp"`,
   ];
 
   test.each(cases)("%s", async config => {


### PR DESCRIPTION
## Problem

`[install]` booleans in bunfig.toml are read with `.and_then(|e| e.as_bool())`, which returns `None` on a type mismatch, indistinguishable from the key being absent. So a quoted string silently disables the guard with no warning:

```toml
[install]
frozenLockfile = "true"   # lockfile is NOT frozen, install rewrites it
ignoreScripts = "true"    # postinstall RUNS
production = "true"       # devDependencies INSTALLED
```

Meanwhile top-level keys and the `[test]`/`[run]` sections already hard-error on the same mistake (`smol = "yes"` → `error: expected boolean but received string`), so the security-relevant `[install]` flags were the inconsistent outlier. The quoted `"true"` is the natural mistake for anyone bringing these settings over from env-var or CLI conventions.

## Repro

```sh
printf '{"name":"g"}' > package.json
printf '[install]\nfrozenLockfile = "true"\n' > bunfig.toml
bun install      # rc=0, no error
```

## Fix

Route every `[install]` scalar through `self.expect(&expr, ExprTag::...)` / `self.expect_string(&expr)` before reading, matching the pattern already used for `smol`, `telemetry`, `[test].coverage`, `[run].silent`, etc. Keys now covered:

- booleans: `exact`, `dryRun`, `production`, `frozenLockfile`, `saveTextLockfile`, `ignoreScripts`, `globalStore`, `optional`, `peer`, `dev`, `linkWorkspacePackages`, `lockfile.save`, `cache.disable`, `cache.disableManifest`
- number: `concurrentScripts`
- strings: `globalDir`, `globalBinDir`, `lockfile.path`, `lockfile.savePath`, `cache.dir`

A wrong type now produces `error: expected boolean but received string` (or the corresponding number/string message) and a non-zero exit. Correctly-typed values are unaffected.

## Verification

Extended `test/config/bunfig/bunfig-errors.test.ts` with 20 wrong-type `[install]` cases (all fail before this change, rc=0 with empty stderr) and 8 correctly-typed cases that continue to load cleanly. 33/33 pass on the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 23 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/config/bunfig/bunfig-errors.test.ts
bun test v1.4.0 (ba55e9872)

test/config/bunfig/bunfig-errors.test.ts:
(pass) bunfig.toml type-mismatch error messages > smol = "yes" -> expected boolean but received string [172.31ms]
(pass) bunfig.toml type-mismatch error messages > logLevel = 3 -> expected string but received number [144.23ms]
(pass) bunfig.toml type-mismatch error messages > telemetry = "no" -> expected boolean but received string [151.94ms]
(pass) bunfig.toml type-mismatch error messages > [serve]
port = "abc" -> expected number but received string [147.47ms]
(pass) bunfig.toml type-mismatch error messages > define = 3 -> expected object but received number [174.12ms]
47 |       stderr: "pipe",
48 |     });
49 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
50 | 
51 |     const errorLine = stderr.split("\n").find(l => l.startsWith("error:")) ?? stderr;
52 |     expect(errorLine).toBe(`error: ${expected}`);
                           ^
error: expect(received)
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ba55e9872)

test/config/bunfig/bunfig-errors.test.ts:
(pass) bunfig.toml type-mismatch error messages > smol = "yes" -> expected boolean but received string [17.24ms]
(pass) bunfig.toml type-mismatch error messages > logLevel = 3 -> expected string but received number [15.88ms]
(pass) bunfig.toml type-mismatch error messages > telemetry = "no" -> expected boolean but received string [24.53ms]
(pass) bunfig.toml type-mismatch error messages > define = 3 -> expected object but received number [25.10ms]
(pass) bunfig.toml type-mismatch error messages > [serve]
port = "abc" -> expected number but received string [25.41ms]
(pass) bunfig.toml type-mismatch error messages > [install]
frozenLockfile = "true" -> expected boolean but received string [25.44ms]
(pass) bunfig.toml type-mismatch error messages > [install]
ignoreScripts = "true" -> expected boolean but received string [25.72ms]
(pass) bunfig.toml type-mismatch error messages > [install]
production = "true" -> expected boolean but received string [26.01ms]
(pass) bunfig.toml type-mismatch error messages > [install]
dryRun = "true" -> expected boolean but received string [26.29ms]
(pass) bu
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/config/bunfig/bunfig-errors.test.ts
bun test v1.4.0 (ba55e9872)

test/config/bunfig/bunfig-errors.test.ts:
(pass) bunfig.toml type-mismatch error messages > logLevel = 3 -> expected string but received number [144.68ms]
(pass) bunfig.toml type-mismatch error messages > telemetry = "no" -> expected boolean but received string [185.80ms]
(pass) bunfig.toml type-mismatch error messages > define = 3 -> expected object but received number [205.40ms]
(pass) bunfig.toml type-mismatch error messages > [serve]
port = "abc" -> expected number but received string [209.18ms]
(pass) bunfig.toml type-mismatch error messages > smol = "yes" -> expected boolean but received string [289.69ms]
(pass) bunfig.toml type-mismatch error messages > [install]
frozenLockfile = "true" -> expected boolean but received string [184.72ms]
(pass) bunfig.toml type-mismatch error messages > [install]
production = "true" -> expected boolean but received string [124.53ms]
(pass) bunfig.toml type-mismatch error messages > [install]
ignoreScripts = "true" -> expected b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1022ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bunfig/bunfig.rs                     | 145 ++++++++++++++++---------------
 test/config/bunfig/bunfig-errors.test.ts |  58 +++++++++++++
 2 files changed, 135 insertions(+), 68 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/bunfig/bunfig.rs                          8     11      0
test/config/bunfig/bunfig-errors.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->