### PR TITLE
node:tls: rejectUnauthorized: null must not disable certificate verification

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -958,7 +958,7 @@ function onconnection(err, clientHandle) {
   }
   clientHandle[kServerSocket] = handle;
   const options = self[bunSocketServerOptions];
-  const { pauseOnConnect, connectionListener, [kSocketClass]: SClass, requestCert, rejectUnauthorized } = options;
+  const { pauseOnConnect, connectionListener, [kSocketClass]: SClass, requestCert } = options;
   // Propagate the server's half-open/highWaterMark settings to the accepted
   // socket so the Duplex's allowHalfOpen matches what the native layer was
   // configured with in kRealListen; without this, net.createServer({
@@ -971,9 +971,10 @@ function onconnection(err, clientHandle) {
   }) as NetSocket | TLSSocket;
   _socket.isServer = true;
   _socket._requestCert = requestCert;
-  // The raw options object only has rejectUnauthorized when the user passed it explicitly;
-  // fall back to the server's normalized value (defaults to true for tls.Server).
-  _socket._rejectUnauthorized = rejectUnauthorized ?? self._rejectUnauthorized;
+  // tls.Server's setSecureContext has already normalized this via `!== false`,
+  // so read the server field, not the raw option (which may be a falsy
+  // non-boolean like 0 that `??` would let through).
+  _socket._rejectUnauthorized = self._rejectUnauthorized;
 
   _socket[kAttach](clientHandle.localPort, clientHandle);
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1757,9 +1757,11 @@ Socket.prototype.connect = function connect(...args) {
       // Client always request Cert
       this._requestCert = true;
       if (tls) {
-        if (typeof rejectUnauthorized !== "undefined") {
-          this._rejectUnauthorized = rejectUnauthorized;
-          tls.rejectUnauthorized = rejectUnauthorized;
+        if (rejectUnauthorized !== undefined) {
+          // Node normalizes via `!== false` so any non-`false` value (including
+          // `null`) keeps verification on; only an explicit `false` opts out.
+          // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1781
+          this._rejectUnauthorized = tls.rejectUnauthorized = rejectUnauthorized !== false;
         } else {
           this._rejectUnauthorized = tls.rejectUnauthorized;
         }
@@ -2822,9 +2824,8 @@ function internalConnect(self, options, address, port, addressType, localAddress
     self._requestCert = true; // Client always request Cert
     if (tls) {
       const { rejectUnauthorized, session, checkServerIdentity } = options;
-      if (typeof rejectUnauthorized !== "undefined") {
-        self._rejectUnauthorized = rejectUnauthorized;
-        tls.rejectUnauthorized = rejectUnauthorized;
+      if (rejectUnauthorized !== undefined) {
+        self._rejectUnauthorized = tls.rejectUnauthorized = rejectUnauthorized !== false;
       } else {
         self._rejectUnauthorized = tls.rejectUnauthorized;
       }
@@ -2975,9 +2976,8 @@ function internalConnectMultiple(context, canceled?) {
     self._requestCert = true; // Client always request Cert
     if (tls) {
       const { rejectUnauthorized, session, checkServerIdentity } = context.options;
-      if (typeof rejectUnauthorized !== "undefined") {
-        self._rejectUnauthorized = rejectUnauthorized;
-        tls.rejectUnauthorized = rejectUnauthorized;
+      if (rejectUnauthorized !== undefined) {
+        self._rejectUnauthorized = tls.rejectUnauthorized = rejectUnauthorized !== false;
       } else {
         self._rejectUnauthorized = tls.rejectUnauthorized;
       }

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1281,8 +1281,11 @@ function Server(options, secureConnectionListener): void {
 
       const rejectUnauthorized = options.rejectUnauthorized;
 
-      if (typeof rejectUnauthorized !== "undefined") {
-        this._rejectUnauthorized = rejectUnauthorized;
+      if (rejectUnauthorized !== undefined) {
+        // Node normalizes via `!== false` so any non-`false` value (including
+        // `null`) keeps verification on; only an explicit `false` opts out.
+        // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1368
+        this._rejectUnauthorized = rejectUnauthorized !== false;
       } else this._rejectUnauthorized = rejectUnauthorizedDefault();
 
       const ciphers = options.ciphers;

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -765,11 +765,45 @@ describe("rejectUnauthorized fails closed for anything other than an explicit fa
          });`,
       ],
       env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
-      stderr: "ignore",
+      stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout.trim()).toBe("rejected DEPTH_ZERO_SELF_SIGNED_CERT");
-    expect(exitCode).toBe(0);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr carries the one-time NODE_TLS_REJECT_UNAUTHORIZED process warning
+    // (with a stack trace), so it's captured for the failure diff but not
+    // constrained.
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
+      stdout: "rejected DEPTH_ZERO_SELF_SIGNED_CERT",
+      exitCode: 0,
+    });
+  });
+
+  it("server {requestCert: true, rejectUnauthorized: null} rejects an unverified client certificate", async () => {
+    const events: string[] = [];
+    const server = tls.createServer(
+      { cert: COMMON_CERT_.cert, key: COMMON_CERT_.key, requestCert: true, rejectUnauthorized: null as any },
+      s => {
+        events.push(`handler authorized=${s.authorized}`);
+        s.end();
+      },
+    );
+    server.on("tlsClientError", e => events.push(`tlsClientError ${(e as any).code ?? e.message}`));
+    server.on("secureConnection", s => events.push(`secureConnection authorized=${s.authorized}`));
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const c = tls.connect({
+        port: (server.address() as AddressInfo).port,
+        host: "127.0.0.1",
+        cert: COMMON_CERT_.cert,
+        key: COMMON_CERT_.key,
+        rejectUnauthorized: false,
+      });
+      c.on("error", () => {});
+      await once(c, "close");
+    } finally {
+      server.close();
+    }
+    expect(events).toEqual(["tlsClientError DEPTH_ZERO_SELF_SIGNED_CERT"]);
+    expect(server._rejectUnauthorized).toBe(true);
   });
 });
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN } from "harness";
 import https from "https";
@@ -717,6 +717,60 @@ it("a write before 'secureConnect' still reports the handshake's own failure", a
   const [error] = await once(client, "error");
   expect(error.code).toBe("ERR_SSL_NO_SUPPORTED_VERSIONS_ENABLED");
   expect(secureConnect).toBe(false);
+});
+
+describe("rejectUnauthorized fails closed for anything other than an explicit false", () => {
+  let server: tls.Server;
+  let port: number;
+  beforeAll(async () => {
+    server = tls.createServer({ cert: COMMON_CERT_.cert, key: COMMON_CERT_.key }, s => s.end());
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    port = (server.address() as AddressInfo).port;
+  });
+  afterAll(() => server.close());
+
+  const probe = (value: unknown) =>
+    new Promise<string>(resolve => {
+      const s = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: value as any }, () => {
+        resolve(`connected authorized=${s.authorized}`);
+        s.destroy();
+      });
+      s.on("error", e => resolve(`rejected ${(e as any).code}`));
+    });
+
+  // Node normalizes options.rejectUnauthorized via `!== false`, so `null` keeps
+  // verification on and the self-signed peer is rejected. Only an explicit
+  // `false` opts out.
+  it.concurrent.each([
+    ["null", null, "rejected DEPTH_ZERO_SELF_SIGNED_CERT"],
+    ["undefined", undefined, "rejected DEPTH_ZERO_SELF_SIGNED_CERT"],
+    ["true", true, "rejected DEPTH_ZERO_SELF_SIGNED_CERT"],
+    ["false", false, "connected authorized=false"],
+  ] as const)("rejectUnauthorized: %s", async (_label, value, expected) => {
+    expect(await probe(value)).toBe(expected);
+  });
+
+  it("null keeps verification on even under NODE_TLS_REJECT_UNAUTHORIZED=0", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const tls = require("node:tls");
+         const server = tls.createServer(${JSON.stringify({ cert: COMMON_CERT_.cert, key: COMMON_CERT_.key })}, s => s.end());
+         server.listen(0, "127.0.0.1", () => {
+           const s = tls.connect({ port: server.address().port, host: "127.0.0.1", rejectUnauthorized: null }, () => {
+             console.log("connected"); s.destroy(); server.close();
+           });
+           s.on("error", e => { console.log("rejected " + e.code); server.close(); });
+         });`,
+      ],
+      env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+      stderr: "ignore",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.trim()).toBe("rejected DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("https.request reports an impossible version window as a TLS error, not a certificate error", async () => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -777,34 +777,42 @@ describe("rejectUnauthorized fails closed for anything other than an explicit fa
     });
   });
 
-  it("server {requestCert: true, rejectUnauthorized: null} rejects an unverified client certificate", async () => {
-    const events: string[] = [];
-    const server = tls.createServer(
-      { cert: COMMON_CERT_.cert, key: COMMON_CERT_.key, requestCert: true, rejectUnauthorized: null as any },
-      s => {
-        events.push(`handler authorized=${s.authorized}`);
-        s.end();
-      },
-    );
-    server.on("tlsClientError", e => events.push(`tlsClientError ${(e as any).code ?? e.message}`));
-    server.on("secureConnection", s => events.push(`secureConnection authorized=${s.authorized}`));
-    await once(server.listen(0, "127.0.0.1"), "listening");
-    try {
-      const c = tls.connect({
-        port: (server.address() as AddressInfo).port,
-        host: "127.0.0.1",
-        cert: COMMON_CERT_.cert,
-        key: COMMON_CERT_.key,
-        rejectUnauthorized: false,
+  it.each([
+    ["null", null],
+    ["0", 0],
+  ] as const)(
+    "server {requestCert: true, rejectUnauthorized: %s} rejects an unverified client certificate",
+    async (_label, value) => {
+      const events: string[] = [];
+      const server = tls.createServer(
+        { cert: COMMON_CERT_.cert, key: COMMON_CERT_.key, requestCert: true, rejectUnauthorized: value as any },
+        s => {
+          events.push(`handler authorized=${s.authorized}`);
+          s.end();
+        },
+      );
+      server.on("tlsClientError", e => events.push(`tlsClientError ${(e as any).code ?? e.message}`));
+      server.on("secureConnection", s => events.push(`secureConnection authorized=${s.authorized}`));
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      try {
+        const c = tls.connect({
+          port: (server.address() as AddressInfo).port,
+          host: "127.0.0.1",
+          cert: COMMON_CERT_.cert,
+          key: COMMON_CERT_.key,
+          rejectUnauthorized: false,
+        });
+        c.on("error", () => {});
+        await once(c, "close");
+      } finally {
+        server.close();
+      }
+      expect({ events, normalized: (server as any)._rejectUnauthorized }).toEqual({
+        events: ["tlsClientError DEPTH_ZERO_SELF_SIGNED_CERT"],
+        normalized: true,
       });
-      c.on("error", () => {});
-      await once(c, "close");
-    } finally {
-      server.close();
-    }
-    expect(events).toEqual(["tlsClientError DEPTH_ZERO_SELF_SIGNED_CERT"]);
-    expect(server._rejectUnauthorized).toBe(true);
-  });
+    },
+  );
 });
 
 it("https.request reports an impossible version window as a TLS error, not a certificate error", async () => {


### PR DESCRIPTION
## What

`tls.connect({rejectUnauthorized: null})` completed the handshake against a self-signed peer with `authorized=false` and no error: certificate verification was silently off. Node treats every value other than an explicit `false` as "verify" and rejects with `DEPTH_ZERO_SELF_SIGNED_CERT`.

```js
const s = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: null }, () => {
  // bun: reached here with s.authorized === false  (verification OFF)
  // node: never reached; 'error' fires with DEPTH_ZERO_SELF_SIGNED_CERT
});
```

The same pattern on the server side, `tls.createServer({requestCert: true, rejectUnauthorized: null})`, emitted `secureConnection` with `authorized=false` for a client presenting an unverifiable certificate, where Node emits `tlsClientError` and never hands the socket to the application.

Realistic triggers include `rejectUnauthorized: cfg.tls?.rejectUnauthorized ?? null`, a JSON config carrying `"rejectUnauthorized": null`, or an options builder that writes `null` for "unset". Only `node:tls` was affected; `https.request`/`Agent` and `fetch({ tls })` already handled `null` correctly.

## Cause

The three client-connect paths in `src/js/node/net.ts` (`Socket.prototype.connect`, `internalConnect`, `internalConnectMultiple`) and `Server.prototype.setSecureContext` in `src/js/node/tls.ts` stored any non-`undefined` value verbatim:

```js
if (typeof rejectUnauthorized !== "undefined") {
  this._rejectUnauthorized = rejectUnauthorized;        // null stored
```

The client post-handshake verify branch then evaluated `rejectUnauthorized ?? self._rejectUnauthorized` as `null`, so `destroy(verifyError)` never ran. On the server side the accepted socket's `_rejectUnauthorized` resolved to `null ?? null`, so the falsy `if (self._rejectUnauthorized)` skipped `tlsClientError`/destroy.

## Fix

Normalize the stored value with Node's `!== false` rule at all four sites so `_rejectUnauthorized` is always a proper boolean and `null` falls on the verify side:

```js
if (rejectUnauthorized !== undefined) {
  this._rejectUnauthorized = rejectUnauthorized !== false;
```

`onconnection` now reads the accepted socket's `_rejectUnauthorized` from the server's normalized field directly instead of the raw options object. Reading the raw option let a non-nullish falsy value like `0` through `??`, which with `setSecureContext` normalized would have turned a previous listen-time `ERR_INVALID_ARG_TYPE` into a silent fail-open at handshake time.

References: [wrap.js:1781](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1781) (client) and [wrap.js:1368](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1368) (server).

On the client side, non-boolean non-nullish values (`0`, `""`, `NaN`, `"false"`) continue to throw `ERR_INVALID_ARG_TYPE` from the native `SecureContext` construction, which happens before this normalization runs. On the server side they now behave like `true` (reject unverified peers), matching Node.

## Verification

New tests in `test/js/node/tls/node-tls-connect.test.ts`:

- client: `null`/`undefined`/`true` are rejected with `DEPTH_ZERO_SELF_SIGNED_CERT` against a self-signed server, `false` still connects
- subprocess: `null` is rejected even under `NODE_TLS_REJECT_UNAUTHORIZED=0`
- server: `{requestCert: true, rejectUnauthorized: null}` and `{requestCert: true, rejectUnauthorized: 0}` produce `tlsClientError` and never `secureConnection`, and `server._rejectUnauthorized` is `true`

All match Node v26.3.0.

```
# fail-before (main's src/)
(fail) rejectUnauthorized: null                           Received: connected authorized=false
(fail) null keeps verification on under ...=0             Received: connected
(fail) server {requestCert, rejectUnauthorized: null}     Received: [handler authorized=false, secureConnection authorized=false]
(fail) server {requestCert, rejectUnauthorized: 0}        (threw ERR_INVALID_ARG_TYPE at listen)

# pass-after (this branch)
7 pass / 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (bf50b8c94)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.52ms]
(pass) should thow ECONNRESET if FIN is received before handshake [462.86ms]
(pass) should be able to grab the JSStreamSocket constructor [22.75ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [49.86ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [82.68ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.connect 
... (truncated)

release without fix: 1 failed, 18 skipped
bun test v1.4.0-canary.1 (f0b4457b8)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.04ms]
(pass) should thow ECONNRESET if FIN is received before handshake [32.42ms]
(pass) should be able to grab the JSStreamSocket constructor [0.24ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [12.31ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [5.27ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.connect > should timeout
(skip) tls.connect > should be able to transfer data
(skip) tls.connect using duplex proxy > should work with alpnProtocols
(pass) tls.connect using dup
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.0 (bf50b8c94)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.30ms]
(pass) should thow ECONNRESET if FIN is received before handshake [460.56ms]
(pass) should be able to grab the JSStreamSocket constructor [28.34ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [40.66ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [81.10ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.connect 
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 695ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7402ms)
Bundle modules (36ms)
Postprocesss modules (163ms)
Bundle Functions (745ms)
Generate Code (23ms)

[8.39s] Bundled "src/js" for production
  2040 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        | 27 +++++----
 src/js/node/tls.ts                        |  7 ++-
 test/js/node/tls/node-tls-connect.test.ts | 98 ++++++++++++++++++++++++++++++-
 3 files changed, 116 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                             3      3      0
src/js/node/tls.ts                             1      1      0
test/js/node/tls/node-tls-connect.test.ts      5      9      0
```

</details>

<!-- robobun:evidence:end -->