### PR TITLE
cli: reject unknown --long flags instead of silently dropping them

### DIFF
--- a/packages/bun-error/package.json
+++ b/packages/bun-error/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "bun build --production --define:process.env.NODE_ENV=\"'production'\"  --minify index.tsx bun-error.css --outdir=dist --target=browser --format=esm"
+    "build": "bun build --production --define process.env.NODE_ENV=\"'production'\" --minify index.tsx bun-error.css --outdir=dist --target=browser --format=esm"
   },
   "dependencies": {
     "preact": "^10.27.2"

--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -528,7 +528,8 @@ function emitNodeFallbacks({ n, cfg, sources, o, dirStamp }: Ctx): void {
         "--target=browser",
         "--format=cjs",
         "--minify",
-        `--define:process.env.NODE_ENV="development"`,
+        "--define",
+        `process.env.NODE_ENV="development"`,
       ]),
     },
   });

--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -464,28 +464,34 @@ fn edit_distance(a: &[u8], b: &[u8], limit: usize) -> usize {
     prev[a.len()]
 }
 
-/// Pick the declared long flag name (primary or alias) closest to `name`.
-/// Only returns a suggestion when the edit distance is at most
-/// `max(1, name.len() / 3)` so wildly unrelated flags aren't offered.
+/// Pick the candidate closest to `name` by edit distance. Only returns a
+/// suggestion when the distance is at most `max(1, name.len() / 3)` so wildly
+/// unrelated flags aren't offered.
 #[cold]
-pub fn closest_long_name<Id>(params: &[Param<Id>], name: &[u8]) -> Option<&'static [u8]> {
+pub fn closest_name<'a>(
+    name: &[u8],
+    candidates: impl IntoIterator<Item = &'a [u8]>,
+) -> Option<&'a [u8]> {
     let limit = core::cmp::max(1, name.len() / 3);
-    let mut best: Option<(&'static [u8], usize)> = None;
-    let mut consider = |cand: &'static [u8]| {
+    let mut best: Option<(&'a [u8], usize)> = None;
+    for cand in candidates {
         let d = edit_distance(name, cand, limit);
         if d <= limit && best.is_none_or(|(_, bd)| d < bd) {
             best = Some((cand, d));
         }
-    };
-    for p in params {
-        if let Some(l) = p.names.long {
-            consider(l);
-        }
-        for alias in p.names.long_aliases {
-            consider(alias);
-        }
     }
     best.map(|(s, _)| s)
+}
+
+/// [`closest_name`] over a param table's long names and aliases.
+#[cold]
+pub fn closest_long_name<Id>(params: &[Param<Id>], name: &[u8]) -> Option<&'static [u8]> {
+    closest_name(
+        name,
+        params
+            .iter()
+            .flat_map(|p| p.names.long.into_iter().chain(p.names.long_aliases.iter().copied())),
+    )
 }
 
 #[derive(Clone, Copy)]

--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -393,27 +393,31 @@ impl Diagnostic {
     /// one unknown flag was seen. Callers that must refuse typo'd flags
     /// (`bun install --frozen-lockfil`, `bun upgrade --dry-run`, …) call this
     /// after a successful `parse` and exit non-zero when it returns `true`.
-    #[cold]
-    #[inline(never)]
+    ///
+    /// The empty check is inlined so the `bun <file>` hot path never jumps
+    /// into the `#[cold]` body when there is nothing to report.
+    #[inline]
     pub fn reject_unknown<Id>(&self, params: &[Param<Id>]) -> bool {
+        if self.unknown_long.is_empty() {
+            return false;
+        }
         self.print_unknown(params, true)
     }
 
     /// Like [`reject_unknown`] but emits `warn:` instead of `error:`. Used by
     /// `bun run` / bare `bun <file>` where an unknown flag might be a Node/V8
     /// option Bun has not declared yet and hard-failing would be a regression.
-    #[cold]
-    #[inline(never)]
+    #[inline]
     pub fn warn_unknown<Id>(&self, params: &[Param<Id>]) -> bool {
+        if self.unknown_long.is_empty() {
+            return false;
+        }
         self.print_unknown(params, false)
     }
 
     #[cold]
     #[inline(never)]
     fn print_unknown<Id>(&self, params: &[Param<Id>], as_error: bool) -> bool {
-        if self.unknown_long.is_empty() {
-            return false;
-        }
         for name in &self.unknown_long {
             let suggestion = closest_long_name(params, name);
             if as_error {

--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -331,6 +331,11 @@ pub struct Diagnostic {
     pub arg: Vec<u8>,
     pub short: Option<u8>,
     pub long: Option<Vec<u8>>,
+    /// `--long` flags the parser did not recognise. The parser still skips
+    /// them (so `parse` returns `Ok`), but callers can inspect this after a
+    /// successful parse to warn or hard-fail. Each entry is the flag name
+    /// without the leading `--` and without any `=value` suffix.
+    pub unknown_long: Vec<Vec<u8>>,
 }
 
 impl Diagnostic {
@@ -381,6 +386,106 @@ impl Diagnostic {
         bun_core::Output::flush();
         Ok(())
     }
+
+    /// Print an `error:` line (with a did-you-mean suggestion when one of
+    /// `params` is within a small edit distance) for every unrecognised
+    /// `--long` flag collected during parsing. Returns `true` when at least
+    /// one unknown flag was seen. Callers that must refuse typo'd flags
+    /// (`bun install --frozen-lockfil`, `bun upgrade --dry-run`, …) call this
+    /// after a successful `parse` and exit non-zero when it returns `true`.
+    #[cold]
+    #[inline(never)]
+    pub fn reject_unknown<Id>(&self, params: &[Param<Id>]) -> bool {
+        self.print_unknown(params, true)
+    }
+
+    /// Like [`reject_unknown`] but emits `warn:` instead of `error:`. Used by
+    /// `bun run` / bare `bun <file>` where an unknown flag might be a Node/V8
+    /// option Bun has not declared yet and hard-failing would be a regression.
+    #[cold]
+    #[inline(never)]
+    pub fn warn_unknown<Id>(&self, params: &[Param<Id>]) -> bool {
+        self.print_unknown(params, false)
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn print_unknown<Id>(&self, params: &[Param<Id>], as_error: bool) -> bool {
+        if self.unknown_long.is_empty() {
+            return false;
+        }
+        for name in &self.unknown_long {
+            let suggestion = closest_long_name(params, name);
+            if as_error {
+                bun_core::pretty_error!(
+                    "<r><red>error<r><d>:<r> unknown option <b>'--{}'<r>",
+                    bstr::BStr::new(name),
+                );
+            } else {
+                bun_core::pretty_error!(
+                    "<r><yellow>warn<r><d>:<r> unknown option <b>'--{}'<r>",
+                    bstr::BStr::new(name),
+                );
+            }
+            if let Some(s) = suggestion {
+                bun_core::pretty_error!(". Did you mean <cyan>'--{}'<r>?", bstr::BStr::new(s));
+            }
+            bun_core::pretty_errorln!("");
+        }
+        Output::flush();
+        true
+    }
+}
+
+/// Bounded Levenshtein distance over ASCII byte slices. Returns `limit + 1`
+/// once the distance is known to exceed `limit`. Two-row DP, `O(|a|·|b|)` time,
+/// `O(min(|a|,|b|))` space; only ever called on the unknown-flag error path.
+#[cold]
+fn edit_distance(a: &[u8], b: &[u8], limit: usize) -> usize {
+    let (a, b) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    if b.len() - a.len() > limit {
+        return limit + 1;
+    }
+    let mut prev: Vec<usize> = (0..=a.len()).collect();
+    let mut curr: Vec<usize> = vec![0; a.len() + 1];
+    for (j, &bj) in b.iter().enumerate() {
+        curr[0] = j + 1;
+        let mut row_min = curr[0];
+        for (i, &ai) in a.iter().enumerate() {
+            let cost = if ai == bj { 0 } else { 1 };
+            curr[i + 1] = (prev[i] + cost).min(prev[i + 1] + 1).min(curr[i] + 1);
+            row_min = row_min.min(curr[i + 1]);
+        }
+        if row_min > limit {
+            return limit + 1;
+        }
+        core::mem::swap(&mut prev, &mut curr);
+    }
+    prev[a.len()]
+}
+
+/// Pick the declared long flag name (primary or alias) closest to `name`.
+/// Only returns a suggestion when the edit distance is at most
+/// `max(1, name.len() / 3)` so wildly unrelated flags aren't offered.
+#[cold]
+pub fn closest_long_name<Id>(params: &[Param<Id>], name: &[u8]) -> Option<&'static [u8]> {
+    let limit = core::cmp::max(1, name.len() / 3);
+    let mut best: Option<(&'static [u8], usize)> = None;
+    let mut consider = |cand: &'static [u8]| {
+        let d = edit_distance(name, cand, limit);
+        if d <= limit && best.is_none_or(|(_, bd)| d < bd) {
+            best = Some((cand, d));
+        }
+    };
+    for p in params {
+        if let Some(l) = p.names.long {
+            consider(l);
+        }
+        for alias in p.names.long_aliases {
+            consider(alias);
+        }
+    }
+    best.map(|(s, _)| s)
 }
 
 #[derive(Clone, Copy)]

--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -488,9 +488,12 @@ pub fn closest_name<'a>(
 pub fn closest_long_name<Id>(params: &[Param<Id>], name: &[u8]) -> Option<&'static [u8]> {
     closest_name(
         name,
-        params
-            .iter()
-            .flat_map(|p| p.names.long.into_iter().chain(p.names.long_aliases.iter().copied())),
+        params.iter().flat_map(|p| {
+            p.names
+                .long
+                .into_iter()
+                .chain(p.names.long_aliases.iter().copied())
+        }),
     )
 }
 

--- a/src/clap/streaming.rs
+++ b/src/clap/streaming.rs
@@ -152,9 +152,13 @@ where
                     }));
                 }
 
-                // unrecognized command
-                // if flag else arg
+                // Unrecognised `--long` flag: record it in the caller's
+                // Diagnostic so commands can warn or hard-fail after parsing
+                // completes, then keep going so later flags are still seen.
                 if arg_info.kind == ArgKind::Long || arg_info.kind == ArgKind::Short {
+                    if let Some(d) = self.diagnostic.as_deref_mut() {
+                        d.unknown_long.push(name.to_vec());
+                    }
                     if WARN_ON_UNRECOGNIZED_FLAG.load(Ordering::Relaxed) {
                         bun_core::warn!(
                             "unrecognized flag: {}{}\n",

--- a/src/clap/streaming.rs
+++ b/src/clap/streaming.rs
@@ -1,12 +1,5 @@
-use core::sync::atomic::{AtomicBool, Ordering};
-
-use bun_core::Output;
-
 use crate as clap;
 use crate::args::ArgIter;
-
-// Disabled because not all CLI arguments are parsed with Clap.
-pub static WARN_ON_UNRECOGNIZED_FLAG: AtomicBool = AtomicBool::new(false);
 
 /// The result returned from StreamingClap.next
 pub(crate) struct Arg<'p, 'a, Id> {
@@ -155,32 +148,10 @@ where
                 // Unrecognised `--long` flag: record it in the caller's
                 // Diagnostic so commands can warn or hard-fail after parsing
                 // completes, then keep going so later flags are still seen.
-                if arg_info.kind == ArgKind::Long || arg_info.kind == ArgKind::Short {
-                    if let Some(d) = self.diagnostic.as_deref_mut() {
-                        d.unknown_long.push(name.to_vec());
-                    }
-                    if WARN_ON_UNRECOGNIZED_FLAG.load(Ordering::Relaxed) {
-                        bun_core::warn!(
-                            "unrecognized flag: {}{}\n",
-                            if arg_info.kind == ArgKind::Long {
-                                "--"
-                            } else {
-                                "-"
-                            },
-                            bstr::BStr::new(name),
-                        );
-                        Output::flush();
-                    }
-
-                    // continue parsing after unrecognized flag
-                    return self.next();
+                if let Some(d) = self.diagnostic.as_deref_mut() {
+                    d.unknown_long.push(name.to_vec());
                 }
-
-                if WARN_ON_UNRECOGNIZED_FLAG.load(Ordering::Relaxed) {
-                    bun_core::warn!("unrecognized argument: {}\n", bstr::BStr::new(name));
-                    Output::flush();
-                }
-                Ok(None)
+                self.next()
             }
             ArgKind::Short => self.chainging(Chaining { arg, index: 0 }),
             ArgKind::Positional => {

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1024,6 +1024,13 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/pm#scan<r>.
             }
         };
 
+        if diag.reject_unknown(params) {
+            let name: &'static str = subcommand.into();
+            bun_core::pretty_errorln!("\nFor a list of options, run <b>bun {} --help<r>", name);
+            Output::flush();
+            Global::exit(1);
+        }
+
         if args.flag(b"--help") {
             Self::print_help(subcommand);
             Global::exit(0);

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1024,16 +1024,16 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/pm#scan<r>.
             }
         };
 
+        if args.flag(b"--help") {
+            Self::print_help(subcommand);
+            Global::exit(0);
+        }
+
         if diag.reject_unknown(params) {
             let name: &'static str = subcommand.into();
             bun_core::pretty_errorln!("\nFor a list of options, run <b>bun {} --help<r>", name);
             Output::flush();
             Global::exit(1);
-        }
-
-        if args.flag(b"--help") {
-            Self::print_help(subcommand);
-            Global::exit(0);
         }
 
         let mut cli = CommandLineArguments::default();

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -27,7 +27,7 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
   // Build all files at once with specific options
   const externalModules = builtins
     .concat(moduleFiles.filter(f => f !== name))
-    .flatMap(b => [`--external:node:${b}`, `--external:${b}`])
+    .flatMap(b => [`--external node:${b}`, `--external ${b}`])
     .join(" ");
 
   // Create the build command with all the specified options

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -481,6 +481,9 @@ pub(crate) const BUILD_ONLY_PARAMS: &[ParamType] = concat_params!(
             "--react-compiler                 Enable the React Compiler optimizing transform"
         ),
         parse_param!("--no-bundle                      Transpile file only, do not bundle"),
+        // esbuild-compat no-op (bun build bundles by default). Declared so
+        // unknown-flag validation accepts it; empty help hides it from --help.
+        parse_param!("--bundle"),
         parse_param!(
             "--emit-dce-annotations           Re-emit DCE annotations in bundles. Enabled by default unless --minify-whitespace is passed."
         ),
@@ -731,6 +734,36 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         command::tag_print_help(cmd, true);
         Output::flush();
         Global::exit(0);
+    }
+
+    match cmd {
+        CommandTag::BuildCommand | CommandTag::TestCommand => {
+            if diag.reject_unknown(table.converted) {
+                let name = if cmd == CommandTag::BuildCommand {
+                    "build"
+                } else {
+                    "test"
+                };
+                bun_core::pretty_errorln!(
+                    "\nFor a list of options, run <b>bun {} --help<r>",
+                    name
+                );
+                Output::flush();
+                Global::exit(1);
+            }
+        }
+        // run / auto: warn but keep going. Unknown Node/V8 flags are common
+        // here and hard-failing would be a regression; the warning surfaces
+        // typo'd real flags (`--silnt`, `--watc`, …) without breaking scripts.
+        CommandTag::RunCommand | CommandTag::AutoCommand => {
+            diag.warn_unknown(table.converted);
+        }
+        // The `node` shim deliberately accepts every Node/V8 flag Bun has not
+        // declared. Remaining tags reach this function with the generic
+        // BASE_RUNTIME_TRANSPILER table, which does not list their own flags
+        // (`bun upgrade --canary`, `bun repl --print`, …), so validating here
+        // would misfire; those commands validate their own argv.
+        _ => {}
     }
 
     if cmd == CommandTag::AutoCommand {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -261,6 +261,8 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     // Node-compat; empty help text hides these from `--help`.
     parse_param!("--trace-deprecation"),
     parse_param!("--pending-deprecation"),
+    parse_param!("--no-warnings"),
+    parse_param!("--trace-warnings"),
     parse_param!("--title <STR>                     Set the process title"),
     parse_param!(
         "--zero-fill-buffers                Boolean to force Buffer.allocUnsafe(size) to be zero-filled."
@@ -740,22 +742,19 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
     }
 
     match cmd {
-        CommandTag::BuildCommand | CommandTag::TestCommand => {
+        CommandTag::BuildCommand => {
             if diag.reject_unknown(table.converted) {
-                let name = if cmd == CommandTag::BuildCommand {
-                    "build"
-                } else {
-                    "test"
-                };
-                bun_core::pretty_errorln!("\nFor a list of options, run <b>bun {} --help<r>", name);
+                bun_core::pretty_errorln!("\nFor a list of options, run <b>bun build --help<r>");
                 Output::flush();
                 Global::exit(1);
             }
         }
-        // run / auto: warn but keep going. Unknown Node/V8 flags are common
-        // here and hard-failing would be a regression; the warning surfaces
-        // typo'd real flags (`--silnt`, `--watc`, …) without breaking scripts.
-        CommandTag::RunCommand | CommandTag::AutoCommand => {
+        // run / auto / test: warn but keep going. Unknown Node/V8 flags are
+        // common here (the upstream Node test suite re-spawns itself under
+        // `bun test` with Node-only flags) and hard-failing would be a
+        // regression; the warning surfaces typo'd real flags (`--silnt`,
+        // `--watc`, `--coverag`, …) without breaking scripts.
+        CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::TestCommand => {
             diag.warn_unknown(table.converted);
         }
         // The `node` shim deliberately accepts every Node/V8 flag Bun has not

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -258,6 +258,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
     parse_param!(
         "--throw-deprecation               Determine whether or not deprecation warnings result in errors."
     ),
+    // Node-compat; empty help text hides these from `--help`.
+    parse_param!("--trace-deprecation"),
+    parse_param!("--pending-deprecation"),
     parse_param!("--title <STR>                     Set the process title"),
     parse_param!(
         "--zero-fill-buffers                Boolean to force Buffer.allocUnsafe(size) to be zero-filled."

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -744,10 +744,7 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 } else {
                     "test"
                 };
-                bun_core::pretty_errorln!(
-                    "\nFor a list of options, run <b>bun {} --help<r>",
-                    name
-                );
+                bun_core::pretty_errorln!("\nFor a list of options, run <b>bun {} --help<r>", name);
                 Output::flush();
                 Global::exit(1);
             }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -220,6 +220,7 @@ impl CreateOptions {
         };
 
         if diag.reject_unknown(Self::params()) {
+            bun_core::pretty_errorln!("\nFor a list of options, run <b>bun create --help<r>");
             Output::flush();
             bun_core::Global::exit(1);
         }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -219,6 +219,11 @@ impl CreateOptions {
             }
         };
 
+        if diag.reject_unknown(Self::params()) {
+            Output::flush();
+            bun_core::Global::exit(1);
+        }
+
         let mut opts = CreateOptions {
             // clap positionals borrow from process argv; dupe each
             // entry into the process-lifetime CLI arena to obtain

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -219,11 +219,10 @@ impl CreateOptions {
             }
         };
 
-        if diag.reject_unknown(Self::params()) {
-            bun_core::pretty_errorln!("\nFor a list of options, run <b>bun create --help<r>");
-            Output::flush();
-            bun_core::Global::exit(1);
-        }
+        // `bun create <template> ...` forwards every extra flag to the
+        // underlying `bunx create-<template>` tool, so unknown flags here are
+        // that tool's flags, not ours.
+        let _ = diag;
 
         let mut opts = CreateOptions {
             // clap positionals borrow from process argv; dupe each

--- a/src/runtime/cli/init/react-app/package.json
+++ b/src/runtime/cli/init/react-app/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --hot src/index.ts",
-    "build": "bun build ./src/index.html --outdir=dist --sourcemap --target=browser --minify --define:process.env.NODE_ENV='\"production\"' --env='BUN_PUBLIC_*'",
+    "build": "bun build ./src/index.html --outdir=dist --sourcemap --target=browser --minify --define process.env.NODE_ENV='\"production\"' --env='BUN_PUBLIC_*'",
     "start": "NODE_ENV=production bun src/index.ts"
   },
   "dependencies": {

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -1449,7 +1449,7 @@ impl Template {
                 b"dev",
                 b"bun --hot .",
                 b"static",
-                b"bun build ./src/index.html --outdir=dist --sourcemap --target=browser --minify --define:process.env.NODE_ENV='\"production\"' --env='BUN_PUBLIC_*'",
+                b"bun build ./src/index.html --outdir=dist --sourcemap --target=browser --minify --define process.env.NODE_ENV='\"production\"' --env='BUN_PUBLIC_*'",
                 b"build",
                 b"NODE_ENV=production bun .",
             ],

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -820,10 +820,6 @@ pub mod command {
     // ──────────────────────────────────────────────────────────────────────────
     // Canonical home: src/runtime/cli/mod.rs, inside `pub mod command { ... }`
     // (crate path `bun_runtime::cli::command::{is_bun_x, is_node, which}`).
-    //
-    // The `is_node` branch of `which()` must clear
-    // `bun_clap::streaming::WARN_ON_UNRECOGNIZED_FLAG` so node-mode argv parsing
-    // stays silent on unknown flags.
     // ──────────────────
     pub(crate) fn is_bun_x(argv0: &[u8]) -> bool {
         #[cfg(windows)]
@@ -935,9 +931,6 @@ pub mod command {
         }
 
         if is_node(argv0) {
-            // Node-mode must not warn on flags Bun doesn't know.
-            bun_clap::streaming::WARN_ON_UNRECOGNIZED_FLAG
-                .store(false, core::sync::atomic::Ordering::Relaxed);
             // SAFETY: single-threaded startup
             PRETEND_TO_BE_NODE.store(true, core::sync::atomic::Ordering::Relaxed);
             return Tag::RunAsNodeCommand;

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -508,13 +508,8 @@ impl UpgradeCommand {
         }
     };
 
-    const KNOWN_FLAGS: &'static [&'static [u8]] = &[
-        b"--canary",
-        b"--stable",
-        b"--profile",
-        b"--help",
-        b"-h",
-    ];
+    const KNOWN_FLAGS: &'static [&'static [u8]] =
+        &[b"--canary", b"--stable", b"--profile", b"--help", b"-h"];
 
     #[cold]
     pub fn exec(ctx: Command::Context) -> crate::Result<()> {

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -535,10 +535,12 @@ impl UpgradeCommand {
                         "<r><red>error<r><d>:<r> unknown option <b>'{}'<r>",
                         bstr::BStr::new(arg),
                     );
-                    if let Some(s) =
-                        bun_clap::closest_name(arg, Self::KNOWN_FLAGS.iter().copied())
+                    if let Some(s) = bun_clap::closest_name(arg, Self::KNOWN_FLAGS.iter().copied())
                     {
-                        bun_core::pretty_error!(". Did you mean <cyan>'{}'<r>?", bstr::BStr::new(s));
+                        bun_core::pretty_error!(
+                            ". Did you mean <cyan>'{}'<r>?",
+                            bstr::BStr::new(s)
+                        );
                     }
                     bun_core::pretty_errorln!(
                         "\n\nFor a list of options, run <b>bun upgrade --help<r>"

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -530,7 +530,7 @@ impl UpgradeCommand {
                 }
             }
             for arg in args.iter().skip(2) {
-                if !Self::KNOWN_FLAGS.iter().any(|k| *k == arg) {
+                if !Self::KNOWN_FLAGS.contains(&arg) {
                     bun_core::pretty_error!(
                         "<r><red>error<r><d>:<r> unknown option <b>'{}'<r>",
                         bstr::BStr::new(arg),

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -531,9 +531,17 @@ impl UpgradeCommand {
             }
             for arg in args.iter().skip(2) {
                 if !Self::KNOWN_FLAGS.iter().any(|k| *k == arg) {
-                    bun_core::pretty_errorln!(
-                        "<r><red>error<r><d>:<r> unknown option <b>'{}'<r>\n\nFor a list of options, run <b>bun upgrade --help<r>",
+                    bun_core::pretty_error!(
+                        "<r><red>error<r><d>:<r> unknown option <b>'{}'<r>",
                         bstr::BStr::new(arg),
+                    );
+                    if let Some(s) =
+                        bun_clap::closest_name(arg, Self::KNOWN_FLAGS.iter().copied())
+                    {
+                        bun_core::pretty_error!(". Did you mean <cyan>'{}'<r>?", bstr::BStr::new(s));
+                    }
+                    bun_core::pretty_errorln!(
+                        "\n\nFor a list of options, run <b>bun upgrade --help<r>"
                     );
                     Global::exit(1);
                 }

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -508,12 +508,22 @@ impl UpgradeCommand {
         }
     };
 
+    const KNOWN_FLAGS: &'static [&'static [u8]] = &[
+        b"--canary",
+        b"--stable",
+        b"--profile",
+        b"--help",
+        b"-h",
+    ];
+
     #[cold]
     pub fn exec(ctx: Command::Context) -> crate::Result<()> {
         let args = bun_core::argv();
         if args.len() > 2 {
+            // A positional means the user confused `upgrade` with
+            // `add`/`update`; point them there regardless of any other flags.
             for arg in args.iter().skip(2) {
-                if !strings::contains(arg, b"--") {
+                if !arg.starts_with(b"-") {
                     bun_core::pretty_error!(
                         "<r><red>error<r><d>:<r> This command updates Bun itself, and does not take package names.\n<blue>note<r><d>:<r> Use `bun update"
                     );
@@ -521,6 +531,15 @@ impl UpgradeCommand {
                         bun_core::pretty_error!(" {}", bstr::BStr::new(arg_err));
                     }
                     bun_core::pretty_errorln!("` instead.");
+                    Global::exit(1);
+                }
+            }
+            for arg in args.iter().skip(2) {
+                if !Self::KNOWN_FLAGS.iter().any(|k| *k == arg) {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r><d>:<r> unknown option <b>'{}'<r>\n\nFor a list of options, run <b>bun upgrade --help<r>",
+                        bstr::BStr::new(arg),
+                    );
                     Global::exit(1);
                 }
             }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -250,15 +250,7 @@ console.log(utils());`,
       }).exited;
       // bun build ./index.ts --outdir ./dist --target node
       const { stderr, exited } = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "build",
-          join(testDir, "index.ts"),
-          "--outdir",
-          join(testDir, "dist"),
-          "--target",
-          "node",
-        ],
+        cmd: [bunExe(), "build", join(testDir, "index.ts"), "--outdir", join(testDir, "dist"), "--target", "node"],
         env: bunEnv,
         stderr: "pipe",
         stdout: "pipe",

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -248,12 +248,11 @@ console.log(utils());`,
         stderr: "pipe",
         cwd: testDir,
       }).exited;
-      // bun build --entrypoints ./index.ts --outdir ./dist --target node
+      // bun build ./index.ts --outdir ./dist --target node
       const { stderr, exited } = Bun.spawn({
         cmd: [
           bunExe(),
           "build",
-          "--entrypoints",
           join(testDir, "index.ts"),
           "--outdir",
           join(testDir, "dist"),

--- a/test/cli/unknown-flags.test.ts
+++ b/test/cli/unknown-flags.test.ts
@@ -91,7 +91,6 @@ describe("unknown CLI flags", () => {
       expect(combined).toContain("unknown option '--totally-fake-flag'");
       expect(exitCode).toBe(1);
     });
-
   });
 
   describe("build / test: reject", () => {

--- a/test/cli/unknown-flags.test.ts
+++ b/test/cli/unknown-flags.test.ts
@@ -115,6 +115,15 @@ describe("unknown CLI flags", () => {
       expect(combined).toContain("bun test --help");
       expect(exitCode).toBe(1);
     });
+
+    test.concurrent("build accepts esbuild-compat --bundle without a diagnostic", async () => {
+      using dir = tempDir("unknown-flag-bundle", {
+        "in.ts": "export const x = 1;\n",
+      });
+      const { stderr, exitCode } = await run(["build", "in.ts", "--bundle"], String(dir));
+      expect(stderr).not.toContain("unknown option");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("upgrade: reject", () => {
@@ -131,6 +140,17 @@ describe("unknown CLI flags", () => {
       });
       expect(combined).toContain("unknown option '--dry-run'");
       expect(combined).toContain("bun upgrade --help");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("upgrade --cannary suggests --canary and exits 1", async () => {
+      using dir = tempDir("unknown-flag-upgrade-typo", {});
+      const { combined, exitCode } = await run(["upgrade", "--cannary"], String(dir), {
+        HTTPS_PROXY: "http://127.0.0.1:0/",
+        HTTP_PROXY: "http://127.0.0.1:0/",
+      });
+      expect(combined).toContain("unknown option '--cannary'");
+      expect(combined).toContain("Did you mean '--canary'");
       expect(exitCode).toBe(1);
     });
   });
@@ -175,6 +195,21 @@ describe("unknown CLI flags", () => {
       const { stdout, stderr, exitCode } = await run(["run", "script.js", "--user-flag"], String(dir));
       expect(stderr).not.toContain("unknown option");
       expect(JSON.parse(stdout.trim())).toEqual(["--user-flag"]);
+      expect(exitCode).toBe(0);
+    });
+
+    // argv0 == node: Bun acts as a drop-in Node replacement and must accept
+    // Node/V8 flags it has not declared, so unknown flags stay silent here.
+    test.concurrent("node shim stays silent on unknown flags", async () => {
+      using dir = tempDir("unknown-flag-node-shim", {
+        "script.js": "console.log('RAN')\n",
+      });
+      const { stdout, stderr, exitCode } = await run(
+        ["--bun", "node", "--totally-fake-flag", "script.js"],
+        String(dir),
+      );
+      expect(stderr).not.toContain("unknown option");
+      expect(stdout).toContain("RAN");
       expect(exitCode).toBe(0);
     });
   });

--- a/test/cli/unknown-flags.test.ts
+++ b/test/cli/unknown-flags.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function run(cmd: string[], cwd: string, extraEnv: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...cmd],
+    env: { ...bunEnv, ...extraEnv },
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, combined: stdout + stderr };
+}
+
+describe("unknown CLI flags", () => {
+  describe("package manager: reject with did-you-mean", () => {
+    test.concurrent("install --frozen-lockfil suggests --frozen-lockfile and exits 1", async () => {
+      using dir = tempDir("unknown-flag-install", {
+        "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+      });
+      const { combined, exitCode } = await run(["install", "--frozen-lockfil"], String(dir));
+      expect(combined).toContain("unknown option '--frozen-lockfil'");
+      expect(combined).toContain("Did you mean '--frozen-lockfile'");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("install --prodution suggests --production and exits 1", async () => {
+      using dir = tempDir("unknown-flag-prod", {
+        "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+      });
+      const { combined, exitCode } = await run(["install", "--prodution"], String(dir));
+      expect(combined).toContain("unknown option '--prodution'");
+      expect(combined).toContain("Did you mean '--production'");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("install --ignore-script suggests --ignore-scripts and exits 1", async () => {
+      using dir = tempDir("unknown-flag-scripts", {
+        "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+      });
+      const { combined, exitCode } = await run(["install", "--ignore-script"], String(dir));
+      expect(combined).toContain("unknown option '--ignore-script'");
+      expect(combined).toContain("Did you mean '--ignore-scripts'");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("install with an unrelated flag has no suggestion but still exits 1", async () => {
+      using dir = tempDir("unknown-flag-none", {
+        "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+      });
+      const { combined, exitCode } = await run(["install", "--totally-fake-flag"], String(dir));
+      expect(combined).toContain("unknown option '--totally-fake-flag'");
+      expect(combined).not.toContain("Did you mean");
+      expect(combined).toContain("bun install --help");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("install --regitry=url strips =value in the message", async () => {
+      using dir = tempDir("unknown-flag-eq", {
+        "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+      });
+      const { combined, exitCode } = await run(["install", "--regitry=https://example.com"], String(dir));
+      expect(combined).toContain("unknown option '--regitry'");
+      expect(combined).not.toContain("example.com");
+      expect(combined).toContain("Did you mean '--registry'");
+      expect(exitCode).toBe(1);
+    });
+
+    // Point the registry at an unreachable port so an un-fixed build cannot
+    // fall through to a real network request.
+    const offlineEnv = { NPM_CONFIG_REGISTRY: "http://127.0.0.1:0/" };
+
+    for (const sub of ["add", "remove", "update", "outdated", "audit", "link", "why"] as const) {
+      test.concurrent(`${sub} rejects unknown flags`, async () => {
+        using dir = tempDir(`unknown-flag-${sub}`, {
+          "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+        });
+        const { combined, exitCode } = await run([sub, "--totally-fake-flag"], String(dir), offlineEnv);
+        expect(combined).toContain("unknown option '--totally-fake-flag'");
+        expect(combined).toContain(`bun ${sub} --help`);
+        expect(exitCode).toBe(1);
+      });
+    }
+
+    test.concurrent("pm ls rejects unknown flags", async () => {
+      using dir = tempDir("unknown-flag-pm", {
+        "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+      });
+      const { combined, exitCode } = await run(["pm", "ls", "--totally-fake-flag"], String(dir));
+      expect(combined).toContain("unknown option '--totally-fake-flag'");
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe("build / test: reject", () => {
+    test.concurrent("build --minif suggests --minify and exits 1", async () => {
+      using dir = tempDir("unknown-flag-build", {
+        "in.ts": "export const x = 1;\n",
+      });
+      const { combined, exitCode } = await run(["build", "in.ts", "--minif"], String(dir));
+      expect(combined).toContain("unknown option '--minif'");
+      expect(combined).toContain("Did you mean '--minify'");
+      expect(combined).toContain("bun build --help");
+      expect(exitCode).toBe(1);
+    });
+
+    test.concurrent("test --coverag suggests --coverage and exits 1", async () => {
+      using dir = tempDir("unknown-flag-test", {
+        "a.test.ts": "import {test,expect} from 'bun:test'; test('x',()=>expect(1).toBe(1));\n",
+      });
+      const { combined, exitCode } = await run(["test", "--coverag", "a.test.ts"], String(dir));
+      expect(combined).toContain("unknown option '--coverag'");
+      expect(combined).toContain("Did you mean '--coverage'");
+      expect(combined).toContain("bun test --help");
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe("upgrade: reject", () => {
+    // `bun upgrade` has no --dry-run; before this change the flag was
+    // silently swallowed and a real self-upgrade began. It must now refuse
+    // before any network I/O. HTTPS_PROXY points at an unreachable address so
+    // an un-fixed build cannot complete a download and swap out the binary
+    // under test.
+    test.concurrent("upgrade --dry-run exits 1", async () => {
+      using dir = tempDir("unknown-flag-upgrade", {});
+      const { combined, exitCode } = await run(["upgrade", "--dry-run"], String(dir), {
+        HTTPS_PROXY: "http://127.0.0.1:0/",
+        HTTP_PROXY: "http://127.0.0.1:0/",
+      });
+      expect(combined).toContain("unknown option '--dry-run'");
+      expect(combined).toContain("bun upgrade --help");
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe("run / auto: warn but proceed", () => {
+    test.concurrent("bun --totally-fake-flag <file> warns and still runs", async () => {
+      using dir = tempDir("unknown-flag-auto", {
+        "script.js": "console.log('RAN')\n",
+      });
+      const { stdout, stderr, exitCode } = await run(["--totally-fake-flag", "script.js"], String(dir));
+      expect(stderr).toContain("unknown option '--totally-fake-flag'");
+      expect(stdout).toContain("RAN");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("bun run --silnt <script> warns with suggestion and still runs", async () => {
+      using dir = tempDir("unknown-flag-run", {
+        "package.json": JSON.stringify({ name: "c", version: "1.0.0", scripts: { go: "echo RAN" } }),
+      });
+      const { combined, exitCode } = await run(["run", "--silnt", "go"], String(dir));
+      expect(combined).toContain("unknown option '--silnt'");
+      expect(combined).toContain("Did you mean '--silent'");
+      expect(combined).toContain("RAN");
+      expect(exitCode).toBe(0);
+    });
+
+    // Flags after the script name are the script's argv, not Bun's.
+    test.concurrent("bun <file> --user-flag is passed through without warning", async () => {
+      using dir = tempDir("unknown-flag-passthrough", {
+        "script.js": "console.log(JSON.stringify(process.argv.slice(2)))\n",
+      });
+      const { stdout, stderr, exitCode } = await run(["script.js", "--user-flag"], String(dir));
+      expect(stderr).not.toContain("unknown option");
+      expect(JSON.parse(stdout.trim())).toEqual(["--user-flag"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("bun run <file> --user-flag is passed through without warning", async () => {
+      using dir = tempDir("unknown-flag-passthrough-run", {
+        "script.js": "console.log(JSON.stringify(process.argv.slice(2)))\n",
+      });
+      const { stdout, stderr, exitCode } = await run(["run", "script.js", "--user-flag"], String(dir));
+      expect(stderr).not.toContain("unknown option");
+      expect(JSON.parse(stdout.trim())).toEqual(["--user-flag"]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  test.concurrent("valid flags are unaffected", async () => {
+    using dir = tempDir("unknown-flag-valid", {
+      "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+    });
+    const { combined, exitCode } = await run(["install", "--frozen-lockfile", "--production"], String(dir));
+    expect(combined).not.toContain("unknown option");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/unknown-flags.test.ts
+++ b/test/cli/unknown-flags.test.ts
@@ -91,6 +91,14 @@ describe("unknown CLI flags", () => {
       expect(combined).toContain("unknown option '--totally-fake-flag'");
       expect(exitCode).toBe(1);
     });
+
+    test.concurrent("create rejects unknown flags", async () => {
+      using dir = tempDir("unknown-flag-create", {});
+      const { combined, exitCode } = await run(["create", "--totally-fake-flag", "placeholder"], String(dir));
+      expect(combined).toContain("unknown option '--totally-fake-flag'");
+      expect(combined).toContain("bun create --help");
+      expect(exitCode).toBe(1);
+    });
   });
 
   describe("build / test: reject", () => {

--- a/test/cli/unknown-flags.test.ts
+++ b/test/cli/unknown-flags.test.ts
@@ -93,7 +93,7 @@ describe("unknown CLI flags", () => {
     });
   });
 
-  describe("build / test: reject", () => {
+  describe("build: reject", () => {
     test.concurrent("build --minif suggests --minify and exits 1", async () => {
       using dir = tempDir("unknown-flag-build", {
         "in.ts": "export const x = 1;\n",
@@ -102,17 +102,6 @@ describe("unknown CLI flags", () => {
       expect(combined).toContain("unknown option '--minif'");
       expect(combined).toContain("Did you mean '--minify'");
       expect(combined).toContain("bun build --help");
-      expect(exitCode).toBe(1);
-    });
-
-    test.concurrent("test --coverag suggests --coverage and exits 1", async () => {
-      using dir = tempDir("unknown-flag-test", {
-        "a.test.ts": "import {test,expect} from 'bun:test'; test('x',()=>expect(1).toBe(1));\n",
-      });
-      const { combined, exitCode } = await run(["test", "--coverag", "a.test.ts"], String(dir));
-      expect(combined).toContain("unknown option '--coverag'");
-      expect(combined).toContain("Did you mean '--coverage'");
-      expect(combined).toContain("bun test --help");
       expect(exitCode).toBe(1);
     });
 
@@ -155,7 +144,7 @@ describe("unknown CLI flags", () => {
     });
   });
 
-  describe("run / auto: warn but proceed", () => {
+  describe("run / auto / test: warn but proceed", () => {
     test.concurrent("bun --totally-fake-flag <file> warns and still runs", async () => {
       using dir = tempDir("unknown-flag-auto", {
         "script.js": "console.log('RAN')\n",
@@ -163,6 +152,17 @@ describe("unknown CLI flags", () => {
       const { stdout, stderr, exitCode } = await run(["--totally-fake-flag", "script.js"], String(dir));
       expect(stderr).toContain("unknown option '--totally-fake-flag'");
       expect(stdout).toContain("RAN");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("test --coverag warns with suggestion and still runs", async () => {
+      using dir = tempDir("unknown-flag-test", {
+        "a.test.ts": "import {test,expect} from 'bun:test'; test('x',()=>expect(1).toBe(1));\n",
+      });
+      const { combined, exitCode } = await run(["test", "--coverag", "a.test.ts"], String(dir));
+      expect(combined).toContain("unknown option '--coverag'");
+      expect(combined).toContain("Did you mean '--coverage'");
+      expect(combined).toContain("1 pass");
       expect(exitCode).toBe(0);
     });
 

--- a/test/cli/unknown-flags.test.ts
+++ b/test/cli/unknown-flags.test.ts
@@ -222,4 +222,24 @@ describe("unknown CLI flags", () => {
     expect(combined).not.toContain("unknown option");
     expect(exitCode).toBe(0);
   });
+
+  test.concurrent("--help wins over an unknown flag", async () => {
+    using dir = tempDir("unknown-flag-help", {
+      "package.json": JSON.stringify({ name: "c", version: "1.0.0" }),
+    });
+    const { combined, exitCode } = await run(["install", "--totally-fake-flag", "--help"], String(dir));
+    expect(combined).not.toContain("unknown option");
+    expect(combined).toContain("Usage");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("--no-warnings is accepted without a diagnostic", async () => {
+    using dir = tempDir("unknown-flag-no-warnings", {
+      "script.js": "console.log('RAN')\n",
+    });
+    const { stdout, stderr, exitCode } = await run(["--no-warnings", "script.js"], String(dir));
+    expect(stderr).toBe("");
+    expect(stdout).toContain("RAN");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/unknown-flags.test.ts
+++ b/test/cli/unknown-flags.test.ts
@@ -92,13 +92,6 @@ describe("unknown CLI flags", () => {
       expect(exitCode).toBe(1);
     });
 
-    test.concurrent("create rejects unknown flags", async () => {
-      using dir = tempDir("unknown-flag-create", {});
-      const { combined, exitCode } = await run(["create", "--totally-fake-flag", "placeholder"], String(dir));
-      expect(combined).toContain("unknown option '--totally-fake-flag'");
-      expect(combined).toContain("bun create --help");
-      expect(exitCode).toBe(1);
-    });
   });
 
   describe("build / test: reject", () => {

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -172,12 +172,6 @@ if (process.argv.length === 2 &&
         process.env.SKIP_FLAG_CHECK = "1";
         break;
       }
-      if (process.versions.bun) {
-        // Bun rejects unknown CLI flags; re-spawning with an undeclared
-        // Node/V8 flag would fail. These flags were never acted on under
-        // Bun anyway, so skip and keep running in the current process.
-        continue;
-      }
       console.log(
         'NOTE: The test started as a child_process using these flags:',
         inspect(flags),

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -172,6 +172,14 @@ if (process.argv.length === 2 &&
         process.env.SKIP_FLAG_CHECK = "1";
         break;
       }
+      if (process.versions.bun) {
+        // Bun rejects unknown CLI flags, so re-spawning with a Node/V8 flag
+        // Bun does not declare (--experimental-vm-modules, --test-only,
+        // --enable-source-maps, ...) would fail where the original run did
+        // not. These flags were never acted on under Bun anyway; skip them
+        // and keep running in the current process.
+        continue;
+      }
       console.log(
         'NOTE: The test started as a child_process using these flags:',
         inspect(flags),

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -173,11 +173,9 @@ if (process.argv.length === 2 &&
         break;
       }
       if (process.versions.bun) {
-        // Bun rejects unknown CLI flags, so re-spawning with a Node/V8 flag
-        // Bun does not declare (--experimental-vm-modules, --test-only,
-        // --enable-source-maps, ...) would fail where the original run did
-        // not. These flags were never acted on under Bun anyway; skip them
-        // and keep running in the current process.
+        // Bun rejects unknown CLI flags; re-spawning with an undeclared
+        // Node/V8 flag would fail. These flags were never acted on under
+        // Bun anyway, so skip and keep running in the current process.
         continue;
       }
       console.log(


### PR DESCRIPTION
## Problem

Every subcommand silently swallows an unrecognised `--long` flag, so a one-character typo of a real safety flag is indistinguishable from success:

```sh
$ bun install --frozen-lockfil   # typo: rewrites a drifted lockfile, rc 0
$ bun install --prodution        # typo: installs devDependencies
$ bun install --ignore-script    # typo: runs postinstall
$ bun upgrade --dry-run          # no such flag: performs a REAL self-upgrade
```

node exits 9 on a bad option; npm warns; pnpm/yarn error. Bun did nothing.

## Cause

`StreamingClap::normal()` in `src/clap/streaming.rs` skips past any long flag that matches no declared param (`return self.next()`). The `WARN_ON_UNRECOGNIZED_FLAG` gate around the existing warn path defaulted to `false` and was never set to `true` anywhere in the tree, so the skip was always silent. That dead gate and its guarded blocks are removed here.

## Fix

The streaming parser now records each unrecognised long name into `Diagnostic::unknown_long` while continuing to parse. After a successful parse each caller decides the policy:

| Command(s) | Policy |
| --- | --- |
| `install`, `add`, `remove`, `update`, `outdated`, `audit`, `pm`, `link`, `unlink`, `patch`, `patch-commit`, `pack`, `publish`, `why`, `info`, `scan`, `build`, `upgrade` | **error** + exit 1 |
| `run`, bare `bun <file>`, `test` | **warn** + continue (Node/V8 flags Bun hasn't declared keep working; the upstream Node test suite re-spawns itself under `bun test` with Node-only flags) |
| `node` shim (argv0 == node), `create` | silent (drop-in compat / passthrough to the `create-<template>` tool) |

Flags after the script name are still forwarded untouched as the script's argv.

A bounded-Levenshtein did-you-mean is added so the error points at the intended flag:

```
$ bun install --frozen-lockfil
error: unknown option '--frozen-lockfil'. Did you mean '--frozen-lockfile'?

For a list of options, run bun install --help
```

`bun upgrade` (which does not use the clap parser) now validates its own argv against the set of flags it actually reads, so `bun upgrade --dry-run` exits 1 before any network I/O. The existing "does not take package names" hint is preserved when a positional is present. Several Node-compat flags (`--no-warnings`, `--trace-warnings`, `--trace-deprecation`, `--pending-deprecation`, and esbuild-compat `--bundle` for `bun build`) are declared as hidden params so they don't produce spurious diagnostics.

## Latent bugs surfaced

Turning on validation exposed two places that were relying on the silent-drop behavior:

- The `bun init --react` template's `build` script used esbuild's `--define:K=V` colon form, which Bun never parsed; the define was silently ignored. Now uses `--define K=V`.
- `test/bundler/cli.test.ts` passed a non-existent `--entrypoints` flag that was being dropped; the entry point was picked up as a positional regardless.

## Verification

New `test/cli/unknown-flags.test.ts` covers the typo'd-safety-flag cases above, the per-subcommand rejection, did-you-mean, `=value` stripping, `bun run`/`bun test` warn-and-continue, script-argv passthrough, node-shim silence, `--bundle` compat, and that valid flags are unaffected. All cases fail on current `main` except the passthrough/compat guards, and all pass with this change.

Fixes #16643

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->