### PR TITLE
http: compare URL scheme case-insensitively for proxy and redirect Location

### DIFF
--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -566,10 +566,7 @@ impl HttpThread {
                 client.set_custom_ssl_ctx(ctx_nn);
                 // Keepalive is now supported for custom SSL contexts
                 let result = if let Some(url) = client.http_proxy.clone() {
-                    if url.protocol.is_empty()
-                        || url.protocol == b"https"
-                        || url.protocol == b"http"
-                    {
+                    if url.protocol.is_empty() || url.has_http_like_protocol() {
                         custom_context.connect(client, url.hostname, url.get_port_auto())
                     } else {
                         return Err(crate::Error::UnsupportedProxyProtocol);
@@ -585,7 +582,7 @@ impl HttpThread {
         if let Some(url) = client.http_proxy.clone() {
             if !url.href.is_empty() {
                 // https://github.com/oven-sh/bun/issues/11343
-                if url.protocol.is_empty() || url.protocol == b"https" || url.protocol == b"http" {
+                if url.protocol.is_empty() || url.has_http_like_protocol() {
                     return self.context::<IS_SSL>().connect(
                         client,
                         url.hostname,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -5219,8 +5219,18 @@ impl<'a> HTTPClient<'a> {
                                 } else {
                                     &location[0..i]
                                 };
-                                let is_http = protocol_name == b"http";
-                                if is_http || protocol_name == b"https" {
+                                let is_http = strings::eql_case_insensitive_ascii(
+                                    protocol_name,
+                                    b"http",
+                                    true,
+                                );
+                                if is_http
+                                    || strings::eql_case_insensitive_ascii(
+                                        protocol_name,
+                                        b"https",
+                                        true,
+                                    )
+                                {
                                 } else {
                                     return Err(crate::Error::UnsupportedRedirectProtocol);
                                 }
@@ -5293,7 +5303,11 @@ impl<'a> HTTPClient<'a> {
                                     return Err(crate::Error::RedirectURLTooLong);
                                 }
 
-                                let is_http = protocol_name == b"http";
+                                let is_http = strings::eql_case_insensitive_ascii(
+                                    protocol_name,
+                                    b"http",
+                                    true,
+                                );
 
                                 if is_http {
                                     string_builder.count(b"http:");

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -310,7 +310,7 @@ impl<'a> URL<'a> {
     }
 
     pub fn is_file(&self) -> bool {
-        self.protocol == b"file"
+        strings::eql_case_insensitive_ascii(self.protocol, b"file", true)
     }
 
     /// host + path without the ending slash, protocol, searchParams and hash
@@ -377,17 +377,19 @@ impl<'a> URL<'a> {
         b"http"
     }
 
+    // RFC 3986 §3.1: the scheme is case-insensitive. `URL::parse` borrows
+    // `protocol` from the input without normalizing, so compare accordingly.
     #[inline]
     pub fn is_https(&self) -> bool {
-        self.protocol == b"https"
+        strings::eql_case_insensitive_ascii(self.protocol, b"https", true)
     }
     #[inline]
     pub fn is_s3(&self) -> bool {
-        self.protocol == b"s3"
+        strings::eql_case_insensitive_ascii(self.protocol, b"s3", true)
     }
     #[inline]
     pub fn is_http(&self) -> bool {
-        self.protocol == b"http"
+        strings::eql_case_insensitive_ascii(self.protocol, b"http", true)
     }
 
     pub fn display_hostname(&self) -> &[u8] {
@@ -445,7 +447,7 @@ impl<'a> URL<'a> {
     }
 
     pub fn has_http_like_protocol(&self) -> bool {
-        self.protocol == b"http" || self.protocol == b"https"
+        self.is_http() || self.is_https()
     }
 
     pub fn get_port(&self) -> Option<u16> {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -2155,3 +2155,90 @@ test("non-200 CONNECT response from proxy is surfaced and its Location header is
     await once(proxy, "close");
   }
 });
+
+// RFC 3986 §3.1: the URL scheme is case-insensitive. The explicit
+// `fetch(url, { proxy })` option goes through the WHATWG URL parser, which
+// lowercases the scheme; the http_proxy / HTTP_PROXY environment variables go
+// through bun_url::URL::parse, which borrows the scheme as-is. Before the fix,
+// `http_proxy=HTTP://host:port` failed every request with
+// UnsupportedProxyProtocol while the identical string via `{ proxy }` worked.
+// curl and Node's undici EnvHttpProxyAgent both accept the uppercase form.
+describe("http_proxy env var scheme is case-insensitive", () => {
+  const cases = [
+    ["http_proxy", "HTTP"],
+    ["HTTP_PROXY", "Http"],
+    ["http_proxy", "hTtP"],
+  ] as const;
+
+  test.concurrent.each(cases)("%s=%s://... is accepted", async (envKey, scheme) => {
+    using origin = Bun.serve({ port: 0, fetch: () => new Response("origin") });
+    const proxy = net.createServer(clientSocket => {
+      clientSocket.on("error", () => {});
+      clientSocket.once("data", data => {
+        const body = "PROXIED " + data.toString("latin1").split("\r\n")[0];
+        clientSocket.end(`HTTP/1.1 200 OK\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n${body}`);
+      });
+    });
+    proxy.listen(0, "127.0.0.1");
+    await once(proxy, "listening");
+    const proxyPort = (proxy.address() as net.AddressInfo).port;
+
+    try {
+      const targetUrl = `http://127.0.0.1:${origin.port}/x`;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const r = await fetch(${JSON.stringify(targetUrl)}, { keepalive: false }); console.log(r.status, await r.text());`,
+        ],
+        env: {
+          ...bunEnv,
+          NO_PROXY: undefined,
+          no_proxy: undefined,
+          HTTP_PROXY: undefined,
+          http_proxy: undefined,
+          HTTPS_PROXY: undefined,
+          https_proxy: undefined,
+          [envKey]: `${scheme}://127.0.0.1:${proxyPort}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe(`200 PROXIED GET ${targetUrl} HTTP/1.1`);
+      expect(exitCode).toBe(0);
+    } finally {
+      proxy.close();
+      await once(proxy, "close");
+    }
+  });
+
+  // An unrecognized scheme must still be rejected loudly instead of silently
+  // going direct.
+  test.concurrent("socks5:// is still rejected with UnsupportedProxyProtocol", async () => {
+    using origin = Bun.serve({ port: 0, fetch: () => new Response("origin") });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `try { await fetch(${JSON.stringify(`http://127.0.0.1:${origin.port}/x`)}); console.log("OK"); } catch (e) { console.log("ERR", e?.code ?? e?.name); }`,
+      ],
+      env: {
+        ...bunEnv,
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: "socks5://127.0.0.1:1",
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("ERR UnsupportedProxyProtocol");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -282,3 +282,49 @@ it("fetch() does not leak intermediate redirect URLs in multi-hop chains", async
   // page retention inflate RSS even with no leak, so widen the threshold.
   expect(secondHalfMiB).toBeLessThan(isASAN ? 400 : 12);
 }, 60_000);
+
+// RFC 3986 §3.1: the URL scheme is case-insensitive. The Location header is
+// taken from the response verbatim and its scheme sliced out before WHATWG
+// normalization runs, so the http/https check has to compare case-insensitively
+// or `Location: HTTPS://host/...` is rejected with UnsupportedRedirectProtocol.
+describe("fetch() follows a redirect whose Location scheme is not lowercase", () => {
+  it.concurrent.each(["HTTP", "Http", "hTtP"])("Location: %s://...", async scheme => {
+    await using final = Bun.serve({
+      port: 0,
+      fetch: () => new Response("FINAL"),
+    });
+
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer(socket => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+      socket.on("error", () => {});
+      socket.once("data", () => {
+        socket.end(
+          `HTTP/1.1 302 Found\r\nLocation: ${scheme}://127.0.0.1:${final.port}/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`,
+        );
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as net.AddressInfo;
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/start`);
+      expect({
+        status: res.status,
+        redirected: res.redirected,
+        url: res.url,
+        body: await res.text(),
+      }).toEqual({
+        status: 200,
+        redirected: true,
+        url: `http://127.0.0.1:${final.port}/final`,
+        body: "FINAL",
+      });
+    } finally {
+      for (const s of sockets) s.destroy();
+      server.close();
+      await once(server, "close");
+    }
+  });
+});


### PR DESCRIPTION
## What

`http_proxy=HTTP://host:port` (or any scheme not spelled in lowercase) rejected every request through `fetch` and `bun install` with `UnsupportedProxyProtocol`, while the same string passed via `fetch(url, { proxy: "HTTP://..." })` worked. Similarly, a server responding with `Location: HTTPS://host/...` failed the redirect with `UnsupportedRedirectProtocol`.

## Why

RFC 3986 section 3.1 defines the URL scheme as case-insensitive, and both curl and undici's `EnvHttpProxyAgent` accept the uppercase form. The `{ proxy }` option path goes through the WHATWG URL parser, which lowercases the scheme; the `http_proxy` / `HTTPS_PROXY` environment variables are parsed by `bun_url::URL::parse`, which is a borrowing parser and keeps `protocol` as a raw slice of the input. The proxy protocol check in `HTTPThread` and the `is_http()`/`is_https()` helpers compared those bytes exactly. The redirect follower slices the scheme out of the raw `Location` header bytes before WHATWG normalization runs and compared the same way.

## Fix

- `bun_url::URL::is_http`, `is_https`, `is_s3`, `is_file`, and `has_http_like_protocol` now compare ASCII case-insensitively.
- The two inline scheme checks in `HTTPThread` go through `has_http_like_protocol()`.
- The two `Location` scheme comparisons in the redirect follower go through `strings::eql_case_insensitive_ascii`.

This also fixes `get_port_auto()` defaulting `HTTPS://proxy` (no explicit port) to 80 instead of 443, and `HTTPClient::is_https()` picking the plaintext context for an `HTTPS://` proxy.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/http/proxy.test.ts -t "http_proxy env var scheme"
(fail) http_proxy=HTTP://... is accepted
  error: UnsupportedProxyProtocol fetching "http://127.0.0.1:.../x"
 1 pass / 3 fail

$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-redirect.test.ts -t "Location scheme"
(fail) Location: HTTP://...
  error: UnsupportedRedirectProtocol fetching "http://127.0.0.1:.../start"
 0 pass / 3 fail

$ bun bd test test/js/bun/http/proxy.test.ts -t "http_proxy env var scheme"
 4 pass / 0 fail
$ bun bd test test/js/web/fetch/fetch-redirect.test.ts -t "Location scheme"
 3 pass / 0 fail
```

Full `proxy.test.ts` (62 tests) and `fetch-redirect.test.ts` (15 tests) pass.

Related: #16182 (this covers scheme case only; full WHATWG normalization of the proxy env URL is still open)

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy.test.ts test/js/web/fetch/fetch-redirect.test.ts
bun test v1.4.0 (c50a91c20)

test/js/bun/http/proxy.test.ts:
(pass) GET non-TLS proxy -> non-TLS body type undefined [853.99ms]
(pass) POST non-TLS proxy -> non-TLS body type string [836.44ms]
(pass) GET TLS proxy -> non-TLS body type undefined [985.30ms]
(pass) GET non-TLS proxy -> TLS body type undefined [1142.59ms]
(pass) POST non-TLS proxy -> TLS body type string [1177.59ms]
(pass) POST TLS proxy -> non-TLS body type string [525.95ms]
(pass) GET TLS proxy -> TLS body type undefined [752.01ms]
(pass) POST TLS proxy -> TLS body type string [769.62ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [937.61ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [1119.27ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [1255.51ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [1104.45ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12
... (truncated)

release without fix: 3 failed, 1 skipped
bun test v1.4.0-canary.1 (6930da6d6)

test/js/bun/http/proxy.test.ts:
(pass) POST non-TLS proxy -> non-TLS body type string [33.08ms]
(pass) GET non-TLS proxy -> non-TLS body type undefined [33.34ms]
(pass) POST TLS proxy -> non-TLS body type string [38.45ms]
(pass) GET TLS proxy -> non-TLS body type undefined [38.48ms]
(pass) POST non-TLS proxy -> TLS body type string [41.92ms]
(pass) GET non-TLS proxy -> TLS body type undefined [44.32ms]
(pass) GET TLS proxy -> TLS body type undefined [49.48ms]
(pass) POST TLS proxy -> TLS body type string [49.48ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [52.35ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [53.21ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [56.46ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [58.78ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [650.88ms]
(pass) proxy can handle redirects with TLS server > with chunked body #12007 [649.97ms]
(pass) non-TLS origin redirect through HTTPS proxy forwards every hop through the proxy [8.02ms]
(pass) unsupp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/proxy.test.ts test/js/web/fetch/fetch-redirect.test.ts
bun test v1.4.0 (c50a91c20)

test/js/bun/http/proxy.test.ts:
(pass) GET non-TLS proxy -> non-TLS body type undefined [759.01ms]
(pass) POST non-TLS proxy -> non-TLS body type string [742.07ms]
(pass) GET TLS proxy -> non-TLS body type undefined [934.80ms]
(pass) GET non-TLS proxy -> TLS body type undefined [995.92ms]
(pass) POST non-TLS proxy -> TLS body type string [1016.42ms]
(pass) POST TLS proxy -> non-TLS body type string [401.94ms]
(pass) GET TLS proxy -> TLS body type undefined [650.76ms]
(pass) POST TLS proxy -> TLS body type string [572.68ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [817.57ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [923.98ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [1008.17ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [949.15ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 695ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/HTTPThread.rs                   |  7 +--
 src/http/lib.rs                          | 20 ++++++--
 src/url/lib.rs                           | 12 +++--
 test/js/bun/http/proxy.test.ts           | 87 ++++++++++++++++++++++++++++++++
 test/js/web/fetch/fetch-redirect.test.ts | 46 +++++++++++++++++
 5 files changed, 159 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/http/HTTPThread.rs                        1      2      0
src/http/lib.rs                               3      2      0
src/url/lib.rs                                3      3      0
test/js/bun/http/proxy.test.ts                1      1      0
test/js/web/fetch/fetch-redirect.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->