### PR TITLE
undici: wire ProxyAgent/setGlobalDispatcher/{dispatcher} to native fetch proxy

### DIFF
--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -4,7 +4,7 @@ const { _ReadableFromWeb: ReadableFromWeb } = require("internal/webstreams_adapt
 const ObjectCreate = Object.create;
 const kEmptyObject = ObjectCreate(null);
 
-var fetch = Bun.fetch;
+const nativeFetch = Bun.fetch;
 const bindings = $cpp("Undici.cpp", "createUndiciInternalBinding");
 const Response = bindings[0];
 const Request = bindings[1];
@@ -31,6 +31,61 @@ class FileReader extends EventTarget {
 
 function notImplemented() {
   throw new Error("This function is not yet implemented in Bun");
+}
+
+// Proxying is the only dispatcher behaviour implemented: ProxyAgent returns a
+// value for native fetch's `proxy` option here, every other dispatcher returns
+// undefined and the request reaches native fetch (and its *_PROXY env) unchanged.
+const kProxyFor = Symbol("kProxyFor");
+
+function resolveProxy(dispatcher) {
+  if (dispatcher == null) dispatcher = getGlobalDispatcher();
+  if (dispatcher != null && typeof dispatcher[kProxyFor] === "function") {
+    return dispatcher[kProxyFor]();
+  }
+  return undefined;
+}
+
+function fetch(input, init = undefined) {
+  try {
+    const proxy = resolveProxy(init?.dispatcher);
+    // An explicit proxy wins, and a unix socket request cannot go through a proxy.
+    if (proxy === undefined || (init != null && (init.proxy !== undefined || init.unix != null))) {
+      return nativeFetch(input, init);
+    }
+    if (init == null) return nativeFetch(input, { proxy });
+    // A Request as init cannot be spread (its fields are prototype getters);
+    // fold it into the input instead so the proxy can be passed alongside.
+    if (init instanceof Request) return nativeFetch(new Request(input, init), { proxy });
+    return nativeFetch(input, { ...init, proxy });
+  } catch (e) {
+    return Promise.$reject(e);
+  }
+}
+fetch.preconnect = nativeFetch.preconnect;
+
+// Mirrors upstream util.parseURL for the UrlObject forms of request().
+function urlFromUrlObject(obj) {
+  let origin = obj.origin;
+  if (origin == null) {
+    const protocol = obj.protocol ?? "";
+    const port = obj.port ?? (protocol === "https:" ? 443 : 80);
+    origin = `${protocol}//${obj.hostname ?? ""}:${port}`;
+  } else {
+    origin = String(origin);
+  }
+  let path = obj.path ?? `${obj.pathname ?? ""}${obj.search ?? ""}`;
+  path = String(path);
+  if (origin.endsWith("/")) origin = origin.slice(0, -1);
+  if (path && path[0] !== "/") path = "/" + path;
+  try {
+    return new URL(origin + path);
+  } catch (cause) {
+    throw new InvalidArgumentError(
+      `Invalid URL ${JSON.stringify(origin + path)}: a UrlObject needs an origin, or a protocol and hostname`,
+      { cause },
+    );
+  }
 }
 
 /**
@@ -170,7 +225,7 @@ async function request(
     throwOnError = false,
     body: inputBody,
     maxRedirections,
-    // dispatcher,
+    dispatcher,
   } = options;
 
   // TODO: More validations
@@ -179,8 +234,7 @@ async function request(
     if (query) url = new URL(url);
   } else if (typeof url === "object" && url !== null) {
     if (!(url instanceof URL)) {
-      // TODO: Parse undici UrlObject
-      throw new Error("not implemented");
+      url = urlFromUrlObject(url);
     }
   } else throw new TypeError("url must be a string, URL, or UrlObject");
 
@@ -204,9 +258,10 @@ async function request(
   }
 
   const followRedirects = maxRedirections != null && maxRedirections > 0;
+  const proxy = resolveProxy(dispatcher);
 
   /** @type {Response} */
-  const resp = await fetch(url, {
+  const resp = await nativeFetch(url, {
     signal,
     mode: "cors",
     method,
@@ -215,6 +270,7 @@ async function request(
     redirect: followRedirects ? "follow" : "manual",
     maxRedirects: followRedirects ? maxRedirections : undefined,
     keepalive: !reset,
+    proxy,
   });
 
   const { status: statusCode, headers, trailers } = resp;
@@ -254,33 +310,162 @@ class MockAgent {
 
 function mockErrors() {}
 
-class Dispatcher extends EventEmitter {}
-class Agent extends Dispatcher {}
-class Pool extends Dispatcher {
-  request() {}
-}
-class BalancedPool extends Dispatcher {}
-class Client extends Dispatcher {
-  request() {}
-}
+class Dispatcher extends EventEmitter {
+  #closed = false;
+  #destroyed = false;
 
-class DispatcherBase extends EventEmitter {}
+  dispatch() {
+    notImplemented();
+  }
 
-class ProxyAgent extends DispatcherBase {
-  constructor() {
-    super();
+  // `options` is both the UrlObject ({ origin, path }) and the request options.
+  request(options, callback) {
+    const p = request(options, { ...options, dispatcher: this });
+    if (typeof callback === "function") {
+      p.$then(
+        data => callback(null, data),
+        err => callback(err, null),
+      );
+      return;
+    }
+    return p;
+  }
+
+  close(callback) {
+    this.#closed = true;
+    if (typeof callback === "function") {
+      queueMicrotask(callback);
+      return;
+    }
+    return Promise.$resolve();
+  }
+
+  destroy(err, callback) {
+    this.#destroyed = true;
+    if (typeof err === "function") {
+      callback = err;
+    }
+    if (typeof callback === "function") {
+      queueMicrotask(callback);
+      return;
+    }
+    return Promise.$resolve();
+  }
+
+  get closed() {
+    return this.#closed;
+  }
+
+  get destroyed() {
+    return this.#destroyed;
+  }
+
+  [kProxyFor]() {
+    return undefined;
   }
 }
 
-class EnvHttpProxyAgent extends DispatcherBase {
-  constructor() {
+class Agent extends Dispatcher {}
+class BalancedPool extends Dispatcher {}
+
+// Shared by Client and Pool, which are siblings upstream (a Pool is not a Client).
+class OriginDispatcher extends Dispatcher {
+  #origin;
+
+  constructor(origin, _options) {
     super();
+    if (!origin || (typeof origin !== "string" && !(origin instanceof URL))) {
+      throw new InvalidArgumentError("Invalid URL: origin must be a non-empty string or URL");
+    }
+    try {
+      this.#origin = new URL(origin).origin;
+    } catch (cause) {
+      throw new InvalidArgumentError(`Invalid URL: ${JSON.stringify(String(origin))}`, { cause });
+    }
+  }
+
+  request(options, callback) {
+    if (options != null && typeof options === "object" && !(options instanceof URL)) {
+      options = { ...options, origin: this.#origin };
+    }
+    return super.request(options, callback);
+  }
+}
+
+class Client extends OriginDispatcher {}
+class Pool extends OriginDispatcher {}
+
+class ProxyAgent extends Dispatcher {
+  #proxy;
+
+  constructor(opts) {
+    super();
+    if (typeof opts === "string" || opts instanceof URL) {
+      opts = { uri: opts };
+    }
+    if (opts == null || typeof opts !== "object") {
+      throw new InvalidArgumentError("Proxy uri is mandatory");
+    }
+    const { uri, token, auth } = opts;
+    if (!uri || (typeof uri !== "string" && !(uri instanceof URL))) {
+      throw new InvalidArgumentError("Proxy uri is mandatory");
+    }
+    if (token != null && auth != null) {
+      throw new InvalidArgumentError("opts.auth cannot be used in combination with opts.token");
+    }
+    if (token != null && typeof token !== "string") {
+      throw new InvalidArgumentError("opts.token must be a string");
+    }
+    if (auth != null && typeof auth !== "string") {
+      throw new InvalidArgumentError("opts.auth must be a string");
+    }
+    const headers = opts.headers != null ? { ...opts.headers } : {};
+    if (token != null) {
+      headers["proxy-authorization"] = token;
+    } else if (auth != null) {
+      headers["proxy-authorization"] = `Basic ${auth}`;
+    }
+    this.#proxy = Object.keys(headers).length > 0 ? { url: String(uri), headers } : String(uri);
+  }
+
+  [kProxyFor]() {
+    return this.#proxy;
+  }
+}
+
+// Native fetch applies the *_PROXY env itself (per redirect hop), so this
+// inherits the undefined kProxyFor; the per-instance overrides are unsupported.
+class EnvHttpProxyAgent extends Dispatcher {
+  constructor(opts) {
+    super();
+    if (opts != null && (opts.httpProxy != null || opts.httpsProxy != null || opts.noProxy != null)) {
+      throw new Error(
+        "EnvHttpProxyAgent's httpProxy/httpsProxy/noProxy options are not implemented in Bun; " +
+          "set the HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables or use ProxyAgent",
+      );
+    }
   }
 }
 
 class RetryAgent extends Dispatcher {
-  constructor() {
+  #inner;
+
+  constructor(dispatcher, _options) {
     super();
+    if (dispatcher == null || typeof dispatcher !== "object") {
+      throw new InvalidArgumentError("RetryAgent requires the dispatcher to wrap as its first argument");
+    }
+    this.#inner = dispatcher;
+  }
+
+  request(options, callback) {
+    const inner = this.#inner;
+    if (typeof inner.request === "function") return inner.request(options, callback);
+    return super.request(options, callback);
+  }
+
+  [kProxyFor]() {
+    return this.#inner[kProxyFor]?.();
   }
 }
 
@@ -316,7 +501,14 @@ class BodyTimeoutError extends UndiciError {}
 class RequestContentLengthMismatchError extends UndiciError {}
 class ConnectTimeoutError extends UndiciError {}
 class ResponseStatusCodeError extends UndiciError {}
-class InvalidArgumentError extends UndiciError {}
+// The one error this module throws itself; upstream's name/code so callers can branch on them.
+class InvalidArgumentError extends UndiciError {
+  constructor(message, options) {
+    super(message, options);
+    this.name = "InvalidArgumentError";
+    this.code = "UND_ERR_INVALID_ARG";
+  }
+}
 class InvalidReturnValueError extends UndiciError {}
 class RequestAbortedError extends AbortError {}
 class ClientDestroyedError extends UndiciError {}
@@ -402,13 +594,12 @@ function serializeAMimeType() {
 
 let globalDispatcher;
 
-// Add missing dispatcher functions
 function setGlobalDispatcher(dispatcher) {
   globalDispatcher = dispatcher;
 }
 
 function getGlobalDispatcher() {
-  return (globalDispatcher ??= new Dispatcher());
+  return (globalDispatcher ??= new Agent());
 }
 
 // Add missing origin functions

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,6 +1,24 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { once } from "node:events";
+import net from "node:net";
+import { join } from "node:path";
 import { Readable } from "node:stream";
-import { request, fetch as undiciFetch } from "undici";
+import {
+  Agent,
+  Client,
+  Dispatcher,
+  EnvHttpProxyAgent,
+  errors,
+  getGlobalDispatcher,
+  MockAgent,
+  Pool,
+  ProxyAgent,
+  request,
+  RetryAgent,
+  setGlobalDispatcher,
+  fetch as undiciFetch,
+} from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -95,14 +113,6 @@ describe("undici", () => {
       const json = (await body.json()) as { url: string };
       expect(json.url).toBe(`${hostUrl}/get`);
     });
-
-    // it("should accept an undici UrlObject", async () => {
-    //   // @ts-ignore
-    //   const { body } = await request({ protocol: "https:", hostname: host, path: "/get" });
-    //   expect(body).toBeDefined();
-    //   const json = (await body.json()) as { url: string };
-    //   expect(json.url).toBe(`${hostUrl}/get`);
-    // });
 
     it("should prevent body from being attached to GET or HEAD requests", async () => {
       try {
@@ -265,5 +275,462 @@ describe("undici.request maxRedirections", () => {
     } finally {
       server.stop(true);
     }
+  });
+});
+
+// A minimal HTTP proxy that records every request it sees. Supports both
+// absolute-form requests (http:// targets) and CONNECT (tunneled targets).
+async function recordingProxy() {
+  const seen: string[] = [];
+  const seenHeaders: Record<string, string>[] = [];
+  const server = net.createServer(socket => {
+    socket.once("data", data => {
+      const [line, ...rest] = data.toString("latin1").split("\r\n");
+      seen.push(line);
+      const headers: Record<string, string> = {};
+      for (const h of rest) {
+        const i = h.indexOf(":");
+        if (i > 0) headers[h.slice(0, i).toLowerCase()] = h.slice(i + 1).trim();
+      }
+      seenHeaders.push(headers);
+      const [method, target] = line.split(" ");
+      if (method === "CONNECT") {
+        const [host, port] = target.split(":");
+        const upstream = net.connect({ host, port: Number(port) }, () => {
+          socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          upstream.pipe(socket);
+          socket.pipe(upstream);
+        });
+        upstream.on("error", () => socket.destroy());
+        socket.on("error", () => upstream.destroy());
+        socket.on("close", () => upstream.end());
+      } else {
+        const body = "PROXIED";
+        socket.end(`HTTP/1.1 200 OK\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n${body}`);
+      }
+    });
+    socket.on("error", () => {});
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const addr = server.address() as net.AddressInfo;
+  return {
+    seen,
+    seenHeaders,
+    url: `http://127.0.0.1:${addr.port}`,
+    [Symbol.asyncDispose]: () => new Promise<void>(r => server.close(() => r())),
+  };
+}
+
+function recordingOrigin() {
+  const seen: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch: req => {
+      seen.push(new URL(req.url).pathname);
+      return new Response("ORIGIN");
+    },
+  });
+  return { seen, url: `http://127.0.0.1:${server.port}`, [Symbol.asyncDispose]: () => server.stop(true) };
+}
+
+describe("undici ProxyAgent / dispatcher", () => {
+  // These tests call undici.fetch()/request() in-process against loopback
+  // servers; an ambient HTTP_PROXY/NO_PROXY would change the routing. Clear
+  // them for this block (assign "" rather than delete so native sees it).
+  const savedProxyEnv: Record<string, string | undefined> = {};
+  const PROXY_ENV_KEYS = ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"];
+  beforeAll(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      savedProxyEnv[key] = process.env[key];
+      process.env[key] = "";
+    }
+  });
+  afterAll(() => {
+    for (const key of PROXY_ENV_KEYS) {
+      if (savedProxyEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedProxyEnv[key];
+    }
+  });
+
+  it("fetch keeps the shape of the native function", () => {
+    // init is optional, as in the Fetch IDL and upstream undici.
+    expect(undiciFetch.length).toBe(1);
+    expect(undiciFetch.preconnect).toBe(Bun.fetch.preconnect);
+  });
+
+  it("fetch({dispatcher: ProxyAgent}) goes through the proxy, not to the origin", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const agent = new ProxyAgent(proxy.url);
+    const res = await undiciFetch(`${origin.url}/via-dispatcher`, { dispatcher: agent });
+    expect(await res.text()).toBe("PROXIED");
+
+    expect(proxy.seen).toEqual([`GET ${origin.url}/via-dispatcher HTTP/1.1`]);
+    expect(origin.seen).toEqual([]);
+    await agent.close();
+  });
+
+  it("fetch(Request, {dispatcher: ProxyAgent}) goes through the proxy", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const res = await undiciFetch(new Request(`${origin.url}/request-object`), {
+      dispatcher: new ProxyAgent(proxy.url),
+    });
+    expect(await res.text()).toBe("PROXIED");
+    expect(proxy.seen).toEqual([`GET ${origin.url}/request-object HTTP/1.1`]);
+    expect(origin.seen).toEqual([]);
+  });
+
+  it("fetch(url, Request) as init still goes through a global ProxyAgent and keeps the Request's fields", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const init = new Request("http://ignored.invalid/", {
+      method: "POST",
+      headers: { "x-from-init": "yes" },
+      body: "b",
+    });
+    const previous = getGlobalDispatcher();
+    try {
+      setGlobalDispatcher(new ProxyAgent(proxy.url));
+      const res = await undiciFetch(`${origin.url}/request-as-init`, init);
+      expect(await res.text()).toBe("PROXIED");
+    } finally {
+      setGlobalDispatcher(previous);
+    }
+
+    expect(proxy.seen).toEqual([`POST ${origin.url}/request-as-init HTTP/1.1`]);
+    expect(proxy.seenHeaders[0]["x-from-init"]).toBe("yes");
+    expect(origin.seen).toEqual([]);
+  });
+
+  it("request({dispatcher: ProxyAgent}) goes through the proxy and sends token as proxy-authorization", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const agent = new ProxyAgent({ uri: proxy.url, token: "Bearer secret-token" });
+    const { statusCode, body } = await request(`${origin.url}/req`, { dispatcher: agent });
+    expect(statusCode).toBe(200);
+    expect(await body!.text()).toBe("PROXIED");
+
+    expect(proxy.seen).toEqual([`GET ${origin.url}/req HTTP/1.1`]);
+    expect(proxy.seenHeaders[0]["proxy-authorization"]).toBe("Bearer secret-token");
+    expect(origin.seen).toEqual([]);
+  });
+
+  it("ProxyAgent opts.headers are sent to the proxy", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const agent = new ProxyAgent({
+      uri: proxy.url,
+      headers: { "x-proxy-tenant": "acme" },
+      auth: Buffer.from("user:pass").toString("base64"),
+    });
+    await (await undiciFetch(`${origin.url}/headers`, { dispatcher: agent })).text();
+
+    expect(proxy.seenHeaders[0]["x-proxy-tenant"]).toBe("acme");
+    expect(proxy.seenHeaders[0]["proxy-authorization"]).toBe(`Basic ${Buffer.from("user:pass").toString("base64")}`);
+    expect(origin.seen).toEqual([]);
+  });
+
+  it("setGlobalDispatcher(ProxyAgent) applies to fetch and request without an explicit dispatcher", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const previous = getGlobalDispatcher();
+    try {
+      setGlobalDispatcher(new ProxyAgent(proxy.url));
+      await (await undiciFetch(`${origin.url}/global-fetch`)).text();
+      await (await request(`${origin.url}/global-request`)).body!.text();
+    } finally {
+      setGlobalDispatcher(previous);
+    }
+
+    expect(proxy.seen).toEqual([
+      `GET ${origin.url}/global-fetch HTTP/1.1`,
+      `GET ${origin.url}/global-request HTTP/1.1`,
+    ]);
+    expect(origin.seen).toEqual([]);
+  });
+
+  it("an explicit non-proxy dispatcher overrides a global ProxyAgent", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const previous = getGlobalDispatcher();
+    try {
+      setGlobalDispatcher(new ProxyAgent(proxy.url));
+      const res = await undiciFetch(`${origin.url}/explicit-agent`, { dispatcher: new Agent() });
+      expect(await res.text()).toBe("ORIGIN");
+    } finally {
+      setGlobalDispatcher(previous);
+    }
+
+    expect(origin.seen).toEqual(["/explicit-agent"]);
+    expect(proxy.seen).toEqual([]);
+  });
+
+  it("a unix socket request ignores a global ProxyAgent instead of failing the proxy/unix conflict", async () => {
+    await using proxy = await recordingProxy();
+    using dir = tempDir("undici-unix", {});
+    const unix = join(String(dir), "s.sock");
+    const seen: string[] = [];
+    await using origin = Bun.serve({
+      unix,
+      fetch: req => {
+        seen.push(new URL(req.url).pathname);
+        return new Response("UNIX");
+      },
+    });
+
+    const previous = getGlobalDispatcher();
+    try {
+      setGlobalDispatcher(new ProxyAgent(proxy.url));
+      const res = await undiciFetch("http://localhost/over-unix", { unix });
+      expect(await res.text()).toBe("UNIX");
+    } finally {
+      setGlobalDispatcher(previous);
+    }
+
+    expect(seen).toEqual(["/over-unix"]);
+    expect(proxy.seen).toEqual([]);
+  });
+
+  it("setGlobalDispatcher accepts dispatchers without proxy support (MockAgent) and requests go direct", async () => {
+    await using origin = recordingOrigin();
+
+    const previous = getGlobalDispatcher();
+    try {
+      setGlobalDispatcher(new MockAgent());
+      const res = await undiciFetch(`${origin.url}/mock-agent`);
+      expect(await res.text()).toBe("ORIGIN");
+    } finally {
+      setGlobalDispatcher(previous);
+    }
+
+    expect(origin.seen).toEqual(["/mock-agent"]);
+  });
+
+  it("RetryAgent wrapping a ProxyAgent goes through the proxy", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const res = await undiciFetch(`${origin.url}/retry`, { dispatcher: new RetryAgent(new ProxyAgent(proxy.url)) });
+    expect(await res.text()).toBe("PROXIED");
+    expect(proxy.seen).toEqual([`GET ${origin.url}/retry HTTP/1.1`]);
+    expect(origin.seen).toEqual([]);
+  });
+
+  it("proxyAgent.request({origin, path}) goes through the proxy", async () => {
+    await using origin = recordingOrigin();
+    await using proxy = await recordingProxy();
+
+    const { body } = await new ProxyAgent(proxy.url).request({ origin: origin.url, path: "/self", method: "GET" });
+    expect(await body!.text()).toBe("PROXIED");
+    expect(proxy.seen).toEqual([`GET ${origin.url}/self HTTP/1.1`]);
+    expect(origin.seen).toEqual([]);
+  });
+
+  it("ProxyAgent rejects a missing or empty uri", () => {
+    for (const arg of [undefined, {}, 123, "", { uri: "" }]) {
+      expect(() => new (ProxyAgent as any)(arg)).toThrow("Proxy uri is mandatory");
+    }
+  });
+
+  it("ProxyAgent rejects credentials it would otherwise drop", () => {
+    const uri = "http://127.0.0.1:1";
+    expect(() => new (ProxyAgent as any)({ uri, token: Buffer.from("t") })).toThrow(errors.InvalidArgumentError);
+    expect(() => new (ProxyAgent as any)({ uri, auth: 123 })).toThrow(errors.InvalidArgumentError);
+    expect(() => new ProxyAgent({ uri, token: "t", auth: "a" })).toThrow(errors.InvalidArgumentError);
+  });
+
+  it("RetryAgent requires a dispatcher to wrap", () => {
+    expect(() => new (RetryAgent as any)()).toThrow(errors.InvalidArgumentError);
+    expect(() => new (RetryAgent as any)(null)).toThrow(errors.InvalidArgumentError);
+    expect(() => new RetryAgent(new Agent())).not.toThrow();
+  });
+
+  it("Client and Pool reject a missing, empty or unparsable origin, and stay siblings", () => {
+    for (const Ctor of [Client, Pool]) {
+      for (const arg of [undefined, null, "", 123, "not a url"]) {
+        expect(() => new (Ctor as any)(arg)).toThrow(errors.InvalidArgumentError);
+      }
+    }
+    const pool = new Pool("http://127.0.0.1:1");
+    expect(pool).toBeInstanceOf(Dispatcher);
+    expect(pool).not.toBeInstanceOf(Client);
+    expect(new Client("http://127.0.0.1:1")).not.toBeInstanceOf(Pool);
+    expect(pool.constructor.name).toBe("Pool");
+  });
+
+  it("EnvHttpProxyAgent() re-evaluates NO_PROXY per redirect hop", async () => {
+    // The routing here is native's; this pins that a global EnvHttpProxyAgent
+    // stays out of its way: hop 1 (NO_PROXY host) goes direct, hop 2 (not
+    // exempt) must reach the proxy, which answers itself.
+    await using proxy = await recordingProxy();
+    const hop1Seen: string[] = [];
+    await using exempt = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => {
+        hop1Seen.push(new URL(req.url).pathname);
+        return Response.redirect("http://127.0.0.2:9/hop2", 302);
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { EnvHttpProxyAgent, fetch, setGlobalDispatcher } = require("undici");
+         setGlobalDispatcher(new EnvHttpProxyAgent());
+         console.log(await (await fetch(process.argv[1])).text());`,
+        `http://127.0.0.1:${exempt.port}/hop1`,
+      ],
+      env: { ...bunEnv, HTTP_PROXY: proxy.url, http_proxy: proxy.url, NO_PROXY: "127.0.0.1", no_proxy: "127.0.0.1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("PROXIED");
+    expect(exitCode).toBe(0);
+
+    expect(hop1Seen).toEqual(["/hop1"]);
+    expect(proxy.seen).toEqual(["GET http://127.0.0.2:9/hop2 HTTP/1.1"]);
+  });
+
+  it("EnvHttpProxyAgent rejects per-instance overrides instead of ignoring them", () => {
+    expect(() => new EnvHttpProxyAgent()).not.toThrow();
+    expect(() => new EnvHttpProxyAgent({})).not.toThrow();
+    expect(() => new EnvHttpProxyAgent({ httpProxy: "http://127.0.0.1:1" })).toThrow("not implemented");
+    expect(() => new EnvHttpProxyAgent({ httpsProxy: "http://127.0.0.1:1" })).toThrow("not implemented");
+    expect(() => new EnvHttpProxyAgent({ noProxy: "example.com" })).toThrow("not implemented");
+  });
+});
+
+describe("undici.request UrlObject", () => {
+  it("accepts {origin, path} and {protocol, hostname, port, path}", async () => {
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: req => {
+        const url = new URL(req.url);
+        return Response.json({ path: url.pathname + url.search });
+      },
+    });
+    const base = { hostname: "127.0.0.1", port: origin.port };
+
+    const r1 = await request({ origin: `http://127.0.0.1:${origin.port}`, path: "/origin-path" } as any);
+    expect(await r1.body!.json()).toEqual({ path: "/origin-path" });
+
+    // Trailing slash on origin (always present on URL#href) and a missing
+    // leading slash on path must not produce `//x` or `hostx`.
+    const r2 = await request({ origin: `http://127.0.0.1:${origin.port}/`, path: "no-leading-slash" } as any);
+    expect(await r2.body!.json()).toEqual({ path: "/no-leading-slash" });
+
+    const r3 = await request({ protocol: "http:", ...base, path: "/proto-host-port" } as any);
+    expect(await r3.body!.json()).toEqual({ path: "/proto-host-port" });
+
+    const r4 = await request({ protocol: "http:", ...base, pathname: "/pn", search: "?a=1" } as any);
+    expect(await r4.body!.json()).toEqual({ path: "/pn?a=1" });
+  });
+
+  it("rejects a UrlObject that does not form a URL with InvalidArgumentError naming it", async () => {
+    const err = await request({ path: "/no-origin" } as any).then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(errors.InvalidArgumentError);
+    expect({ name: err.name, code: err.code }).toEqual({ name: "InvalidArgumentError", code: "UND_ERR_INVALID_ARG" });
+    expect(err.message).toContain('"//:80/no-origin"');
+  });
+});
+
+describe("undici Client / Pool / Dispatcher.request (#14498, #21944)", () => {
+  it("Client and Pool bind to their constructor origin", async () => {
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: async req =>
+        Response.json({
+          method: req.method,
+          path: new URL(req.url).pathname,
+          body: Buffer.from(await req.arrayBuffer()).toString("hex"),
+        }),
+    });
+    const originUrl = `http://127.0.0.1:${origin.port}`;
+    const hex = (s: string | Buffer) => Buffer.from(s).toString("hex");
+
+    const client = new Client(originUrl);
+    const r1 = await client.request({ path: "/from-client", method: "GET" });
+    expect(r1.statusCode).toBe(200);
+    expect(await r1.body!.json()).toEqual({ method: "GET", path: "/from-client", body: "" });
+
+    // URL#href carries a trailing slash; must not turn into `//from-pool`.
+    const pool = new Pool(new URL(originUrl));
+    const r2 = await pool.request({ path: "/from-pool", method: "GET" });
+    expect(await r2.body!.json()).toEqual({ method: "GET", path: "/from-pool", body: "" });
+
+    // options.origin does not redirect a Client away from its bound origin.
+    const r3 = await client.request({ origin: "http://127.0.0.1:1", path: "/bound", method: "GET" } as any);
+    expect(await r3.body!.json()).toEqual({ method: "GET", path: "/bound", body: "" });
+
+    // Readable bodies: string chunks, and binary chunks that are not valid UTF-8.
+    const r4 = await client.request({ path: "/post", method: "POST", body: Readable.from(["hello ", "world"]) });
+    expect(await r4.body!.json()).toEqual({ method: "POST", path: "/post", body: hex("hello world") });
+    const bin = Buffer.from([0x00, 0xff, 0xfe, 0x80, 0xc3]);
+    const r5 = await client.request({ path: "/post-bin", method: "POST", body: Readable.from([bin]) });
+    expect(await r5.body!.json()).toEqual({ method: "POST", path: "/post-bin", body: hex(bin) });
+
+    // RetryAgent forwards request() to the dispatcher it wraps, so it keeps
+    // the Client's origin.
+    const r6 = await new RetryAgent(client).request({ path: "/via-retry", method: "GET" });
+    expect(await r6.body!.json()).toEqual({ method: "GET", path: "/via-retry", body: "" });
+
+    await expect(client.close()).resolves.toBeUndefined();
+    await expect(pool.destroy()).resolves.toBeUndefined();
+  });
+
+  it("Agent.request({origin, path}) and close()/destroy() work", async () => {
+    await using origin = Bun.serve({
+      port: 0,
+      fetch: req => Response.json({ path: new URL(req.url).pathname }),
+    });
+
+    const originUrl = (s: { port: number }) => `http://127.0.0.1:${s.port}`;
+    const agent = new Agent();
+    const res = await agent.request({ origin: new URL(originUrl(origin)), path: "/agent", method: "GET" });
+    expect(await res.body!.json()).toEqual({ path: "/agent" });
+
+    // Callback form: (null, data) on success, (err, null) on failure.
+    const ok = Promise.withResolvers<[unknown, any]>();
+    expect(agent.request({ origin: originUrl(origin), path: "/cb", method: "GET" }, (e, d) => ok.resolve([e, d]))).toBe(
+      undefined,
+    );
+    const [okErr, okData] = await ok.promise;
+    expect(okErr).toBeNull();
+    expect(await okData.body.json()).toEqual({ path: "/cb" });
+
+    const failed = Promise.withResolvers<[unknown, unknown]>();
+    agent.request({ origin: originUrl(origin), path: "/cb", method: "GET", body: "x" }, (e, d) =>
+      failed.resolve([e, d]),
+    );
+    const [failErr, failData] = await failed.promise;
+    expect((failErr as Error).message).toBe("Body not allowed for GET or HEAD requests");
+    expect(failData).toBeNull();
+
+    expect({ closed: agent.closed, destroyed: agent.destroyed }).toEqual({ closed: false, destroyed: false });
+    await expect(agent.close()).resolves.toBeUndefined();
+    expect({ closed: agent.closed, destroyed: agent.destroyed }).toEqual({ closed: true, destroyed: false });
+
+    const other = new Agent();
+    await expect(other.destroy()).resolves.toBeUndefined();
+    expect(other.destroyed).toBe(true);
+
+    const { promise, resolve } = Promise.withResolvers<void>();
+    new Agent().close(resolve);
+    await promise;
   });
 });


### PR DESCRIPTION
### Problem

- The builtin `undici` module exported `ProxyAgent` as an empty class, and `undici.fetch` / `undici.request` ignored the `dispatcher` option and `setGlobalDispatcher()`. Code that pinned egress to a proxy the documented undici way connected directly to the origin and got a normal 200, with no error or warning:

  ```js
  import { ProxyAgent, fetch, setGlobalDispatcher } from "undici";
  await fetch(url, { dispatcher: new ProxyAgent(proxy) });   // went direct
  setGlobalDispatcher(new ProxyAgent(proxy)); await fetch(url); // went direct
  ```

- `undici` is aliased to this builtin even when the npm package is installed, so users could not work around it by installing undici.
- Related: `Agent#close()` did not exist (#14498) and `Client#request()` / `Pool#request()` were empty stubs returning `undefined` (#21944).

### Fix

- `ProxyAgent` stores its proxy (`uri`, plus `headers` / `token` / `auth` as headers sent to the proxy) and exposes it through an internal symbol. `undici.fetch` and `undici.request` read that from the explicit `dispatcher` option, or from the global dispatcher when none is passed, and pass it as native fetch's existing `proxy` option. `RetryAgent` forwards to the dispatcher it wraps. Bun's `fetch(url, Request)` form is folded into one `Request` so the proxy still applies. `ProxyAgent` rejects an empty `uri` and non-string `token` / `auth`, and `RetryAgent` rejects a missing dispatcher, instead of silently dropping them.
- This is the only dispatcher behaviour implemented. Every other dispatcher (`Agent`, `EnvHttpProxyAgent`, `MockAgent`, subclasses overriding `dispatch()`, ...) leaves the request unchanged and it goes to native fetch, which applies `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` itself, re-evaluated per redirect hop. So `new EnvHttpProxyAgent()` works by deferring to that; its per-instance `httpProxy` / `httpsProxy` / `noProxy` overrides (and `ProxyAgent`'s `requestTls` / `proxyTls`) are not supported, and the `EnvHttpProxyAgent` ones throw rather than being silently ignored. `Dispatcher#dispatch()` itself still throws not implemented, like `stream` / `pipeline` / `connect` already do.
- `Dispatcher` gains `request(urlObject)`, `close()` and `destroy()`; `Client` / `Pool` store their constructor origin so `client.request({ path })` works. `request()` now accepts an undici UrlObject (`{ origin, path }` or `{ protocol, hostname, port, pathname, search }`), following upstream's `parseURL`. `RetryAgent#request()` forwards to the dispatcher it wraps.
- No native code is changed. Verified with `test/js/first_party/undici/undici.test.ts`: a loopback recording proxy plus a recording origin assert which one received each request for `fetch`, `fetch(Request)`, `request`, the global dispatcher, `RetryAgent`, `agent.request()`, an explicit `Agent` overriding a global `ProxyAgent`, `MockAgent` as the global, `ProxyAgent` headers / token / auth, and `EnvHttpProxyAgent` under `HTTP_PROXY` + `NO_PROXY` including a redirect from an exempt host to a proxied one (subprocess, since native reads the env). On main 17 of the 35 tests fail; with this change all pass.

### Background

- A **dispatcher** is undici's pluggable transport object: `fetch(url, { dispatcher })` or `setGlobalDispatcher(d)` routes the request through `d.dispatch()`. `ProxyAgent` is the dispatcher that sends everything via an HTTP proxy; `EnvHttpProxyAgent` picks a proxy from the `*_PROXY` environment variables. Bun's builtin does not have a dispatch pipeline; this PR maps the one dispatcher property that matters for routing (which proxy) onto the `proxy` option Bun's native `fetch` already has.
- A **UrlObject** is upstream undici's alternative to a URL string: `request({ origin, path })` or `client.request({ path })`, where `Client` supplies the origin.

Fixes #4474
Fixes #14498
Fixes #21944

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 12 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 17 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [69.81ms]
(pass) undici > request > should error when body has already been consumed [16.78ms]
(pass) undici > request > should make a POST request when provided a body and POST method [10.68ms]
(pass) undici > request > should stream a node:stream Readable body [260.68ms]
(pass) undici > request > should accept a URL class object [10.41ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [11.18ms]
(pass) undici > request > a 204 has no body [51.10ms]
(pass) undici > request > the response to a HEAD request has no body [19.60ms]
(pass) undici > request > should allow a query string to be passed [20.03ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [16.39ms]
(pass) undici > request > should allow us to abort the request with a signal [532.51ms]
(pass) undici > req
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (3f6299c07)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [4.06ms]
(pass) undici > request > should error when body has already been consumed [0.37ms]
(pass) undici > request > should make a POST request when provided a body and POST method [0.25ms]
(pass) undici > request > should stream a node:stream Readable body [4.43ms]
(pass) undici > request > should accept a URL class object [0.24ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [0.18ms]
(pass) undici > request > a 204 has no body [1.06ms]
(pass) undici > request > the response to a HEAD request has no body [0.46ms]
(pass) undici > request > should allow a query string to be passed [0.48ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [0.35ms]
(pass) undici > request > should allow us to abort the request with a signal [500.94ms]
(pass) undici > request > should properly append headers to the request [0.68ms]
(pass) undici.request maxRedirections > does not follow more redirects than maxRedirections allows [2.13ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [85.79ms]
(pass) undici > request > should error when body has already been consumed [19.06ms]
(pass) undici > request > should make a POST request when provided a body and POST method [19.56ms]
(pass) undici > request > should stream a node:stream Readable body [253.66ms]
(pass) undici > request > should accept a URL class object [11.23ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [11.89ms]
(pass) undici > request > a 204 has no body [56.88ms]
(pass) undici > request > the response to a HEAD request has no body [20.84ms]
(pass) undici > request > should allow a query string to be passed [19.68ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [16.57ms]
(pass) undici > request > should allow us to abort the request with a signal [533.81ms]
(pass) undici > req
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 649ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (7874ms)
Bundle modules (51ms)
Postprocesss modules (48ms)
Bundle Functions (705ms)
Generate Code (19ms)

[8.71s] Bundled "src/js" for production
  2629 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[3/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/undici.js               | 231 ++++++++++++--
 test/js/first_party/undici/undici.test.ts | 485 +++++++++++++++++++++++++++++-
 2 files changed, 687 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 14 passed · 0 rejected · iteration 12

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/thirdparty/undici.js                   33     54      0
test/js/first_party/undici/undici.test.ts     22     31      0
```

</details>

<!-- robobun:evidence:end -->

<details><summary>Notes</summary>

Rebases. Two changes landed on main while this was under review and touched both files; each time the branch was squashed onto main with main's hunks kept as is:

- #39778: `BodyReadable` accepts a null body and `request()` always constructs one (plus a 204 / HEAD test).
- #39917: the `Readable` request-body block in `request()` is deleted and the body is handed to fetch, which streams it (plus a streaming test). That supersedes this PR's earlier byte-concatenating version of the same block, which is dropped; the Client / Pool tests here still post string and binary `Readable` bodies through that path.

The rest of the diff is unchanged from the version alii reviewed. The review history (a native `proxy: ""` attempt, a JS-side `EnvHttpProxyAgent` matcher) is in the threads; neither is in the final diff.
</details>