### PR TITLE
tls: complete the handshake when pauseOnConnect is set on the server

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1027,10 +1027,9 @@ function onconnection(err, clientHandle) {
   _socket._server = self;
 
   if (pauseOnConnect) {
-    // For TLS, only pause the JS stream: the native handle must keep reading so
-    // the TLS engine sees the handshake and FIN/close_notify; ServerHandlers.data
-    // applies backpressure at the highWaterMark and the paused Duplex buffers
-    // decrypted bytes until the user resume()s.
+    // For TLS, only pause the JS stream: the native handle keeps reading so the
+    // TLS engine sees the handshake and FIN; ServerHandlers.data buffers decrypted
+    // bytes into the paused Duplex and applies backpressure at highWaterMark.
     if (isTLS) Duplex.prototype.pause.$call(_socket);
     else _socket.pause();
   }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -871,6 +871,13 @@ const ServerHandlers: SocketHandler<NetSocket> = {
         self.authorized = true;
       }
     }
+    const pauseOnConnect = server?.pauseOnConnect;
+    if (pauseOnConnect) {
+      // onconnection left the native handle reading so the handshake could
+      // proceed; pause it now, before emitting, so the handler sees the socket
+      // paused and a handler that resume()s is not stomped afterwards.
+      self.pause();
+    }
     if (server) {
       const connectionListener = server[bunSocketServerOptions]?.connectionListener;
       if (typeof connectionListener === "function") {
@@ -881,9 +888,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     // after secureConnection event we emmit secure and secureConnect
     self.emit("secure", self);
     self.emit("secureConnect", verifyError);
-    if (server?.pauseOnConnect) {
-      self.pause();
-    } else {
+    if (!pauseOnConnect) {
       self.resume();
     }
   },
@@ -1027,7 +1032,11 @@ function onconnection(err, clientHandle) {
   _socket._server = self;
 
   if (pauseOnConnect) {
-    _socket.pause();
+    // For TLS, only pause the JS stream: the native handle must keep reading so
+    // the TLS engine sees the ClientHello. ServerHandlers.handshake pauses the
+    // handle once the handshake has settled (before emitting secureConnection).
+    if (isTLS) Duplex.prototype.pause.$call(_socket);
+    else _socket.pause();
   }
 
   if (typeof connectionListener === "function") {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -871,13 +871,6 @@ const ServerHandlers: SocketHandler<NetSocket> = {
         self.authorized = true;
       }
     }
-    const pauseOnConnect = server?.pauseOnConnect;
-    if (pauseOnConnect) {
-      // onconnection left the native handle reading so the handshake could
-      // proceed; pause it now, before emitting, so the handler sees the socket
-      // paused and a handler that resume()s is not stomped afterwards.
-      self.pause();
-    }
     if (server) {
       const connectionListener = server[bunSocketServerOptions]?.connectionListener;
       if (typeof connectionListener === "function") {
@@ -888,7 +881,9 @@ const ServerHandlers: SocketHandler<NetSocket> = {
     // after secureConnection event we emmit secure and secureConnect
     self.emit("secure", self);
     self.emit("secureConnect", verifyError);
-    if (!pauseOnConnect) {
+    // onconnection already Duplex-paused for pauseOnConnect (native reads stay on
+    // so FIN/close_notify still arrive; ServerHandlers.data applies backpressure).
+    if (!server?.pauseOnConnect) {
       self.resume();
     }
   },
@@ -1033,8 +1028,9 @@ function onconnection(err, clientHandle) {
 
   if (pauseOnConnect) {
     // For TLS, only pause the JS stream: the native handle must keep reading so
-    // the TLS engine sees the ClientHello. ServerHandlers.handshake pauses the
-    // handle once the handshake has settled (before emitting secureConnection).
+    // the TLS engine sees the handshake and FIN/close_notify; ServerHandlers.data
+    // applies backpressure at the highWaterMark and the paused Duplex buffers
+    // decrypted bytes until the user resume()s.
     if (isTLS) Duplex.prototype.pause.$call(_socket);
     else _socket.pause();
   }

--- a/test/js/node/test/parallel/test-tls-server-parent-constructor-options.js
+++ b/test/js/node/test/parallel/test-tls-server-parent-constructor-options.js
@@ -1,0 +1,68 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Test that `tls.Server` constructor options are passed to the parent
+// constructor.
+
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const tls = require('tls');
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+};
+
+{
+  const server = tls.createServer(options, common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, false);
+    assert.strictEqual(socket.isPaused(), false);
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, false);
+  assert.strictEqual(server.pauseOnConnect, false);
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false
+    }, common.mustCall(() => {
+      socket.end();
+    }));
+
+    socket.on('close', () => {
+      server.close();
+    });
+  }));
+}
+
+{
+  const server = tls.createServer({
+    allowHalfOpen: true,
+    pauseOnConnect: true,
+    ...options
+  }, common.mustCall((socket) => {
+    assert.strictEqual(socket.allowHalfOpen, true);
+    assert.strictEqual(socket.isPaused(), true);
+    socket.on('end', socket.end);
+  }));
+
+  assert.strictEqual(server.allowHalfOpen, true);
+  assert.strictEqual(server.pauseOnConnect, true);
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false
+    }, common.mustCall(() => {
+      socket.end();
+    }));
+
+    socket.on('close', () => {
+      server.close();
+    });
+  }));
+}

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1099,9 +1099,11 @@ it("SNICallback runs even when the requested servername matches the bind hostnam
   });
   server.listen(0, "localhost");
   await once(server, "listening");
-  const port = (server.address() as AddressInfo).port;
-  // host: "localhost" defaults servername to "localhost" - the bind hostname.
-  const client = connect({ port, host: "localhost", rejectUnauthorized: false });
+  const { port, address } = server.address() as AddressInfo;
+  // Connect to the address the server actually bound (localhost may resolve to
+  // ::1 for the bind but 127.0.0.1 for the connect on a dual-stack host);
+  // servername: "localhost" still delivers the bind hostname via SNI.
+  const client = connect({ port, host: address, servername: "localhost", rejectUnauthorized: false });
   await once(client, "secureConnect");
   expect(sniCalls).toBe(1);
   // The peer certificate must be the SNICallback's RSA cert, not COMMON_CERT.

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1333,10 +1333,10 @@ describe("tls.createServer pauseOnConnect", () => {
         got += d;
       });
       cli.write("hello");
-      // Barrier: a round-trip the other way proves the client's write has
-      // traversed the event loop on the server side while still paused.
-      srv.write("ack");
-      await once(cli, "data");
+      // Wait for the bytes to land in the paused Duplex's buffer (proving they
+      // reached the server without a 'data' event). Polling avoids the ordering
+      // assumption a reverse round-trip barrier would rely on.
+      while (srv.readableLength < 5) await new Promise(r => setImmediate(r));
       expect({ got, flowing: srv.readableFlowing, readableLength: srv.readableLength }).toEqual({
         got: "",
         flowing: false,

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1303,3 +1303,73 @@ it("tls.connect honors secureOptions when negotiating the protocol version", asy
   }
   await once(server, "close");
 });
+
+describe("tls.createServer pauseOnConnect", () => {
+  it("completes the TLS handshake and delivers the socket paused", async () => {
+    const server: Server = createServer({ ...COMMON_CERT, pauseOnConnect: true });
+    const accepted = Promise.withResolvers<{ paused: boolean; flowing: boolean | null; socket: TLSSocket }>();
+    server.on("secureConnection", s => {
+      accepted.resolve({ paused: s.isPaused(), flowing: s.readableFlowing, socket: s });
+    });
+    server.on("tlsClientError", accepted.reject);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    let cli: TLSSocket | undefined;
+    let srv: TLSSocket | undefined;
+    try {
+      const port = (server.address() as AddressInfo).port;
+      cli = connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+      // Before the fix this hung: onconnection paused the native handle, so the
+      // TLS engine never saw the ClientHello.
+      await once(cli, "secureConnect");
+      const { paused, flowing, socket } = await accepted.promise;
+      srv = socket;
+      expect({ paused, flowing }).toEqual({ paused: true, flowing: false });
+
+      let got = "";
+      srv.on("data", d => (got += d));
+      cli.write("hello");
+      const dataP = once(srv, "data");
+      srv.resume();
+      await dataP;
+      expect(got).toBe("hello");
+    } finally {
+      cli?.destroy();
+      srv?.destroy();
+      server.close();
+    }
+    await once(server, "close");
+  });
+
+  it("honors resume() made inside the secureConnection handler", async () => {
+    const server: Server = createServer({ ...COMMON_CERT, pauseOnConnect: true });
+    const accepted = Promise.withResolvers<TLSSocket>();
+    server.on("secureConnection", s => {
+      s.resume();
+      accepted.resolve(s);
+    });
+    server.on("tlsClientError", accepted.reject);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    let cli: TLSSocket | undefined;
+    let srv: TLSSocket | undefined;
+    try {
+      const port = (server.address() as AddressInfo).port;
+      cli = connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+      await once(cli, "secureConnect");
+      srv = await accepted.promise;
+      expect({ paused: srv.isPaused(), flowing: srv.readableFlowing }).toEqual({ paused: false, flowing: true });
+
+      let got = "";
+      srv.on("data", d => (got += d));
+      cli.write("hello");
+      await once(srv, "data");
+      expect(got).toBe("hello");
+    } finally {
+      cli?.destroy();
+      srv?.destroy();
+      server.close();
+    }
+    await once(server, "close");
+  });
+});

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1327,8 +1327,22 @@ describe("tls.createServer pauseOnConnect", () => {
       expect({ paused, flowing }).toEqual({ paused: true, flowing: false });
 
       let got = "";
-      srv.on("data", d => (got += d));
+      let stopped = true;
+      srv.on("data", d => {
+        if (stopped) throw new Error("data event fired while paused");
+        got += d;
+      });
       cli.write("hello");
+      // Barrier: a round-trip the other way proves the client's write has
+      // traversed the event loop on the server side while still paused.
+      srv.write("ack");
+      await once(cli, "data");
+      expect({ got, flowing: srv.readableFlowing, readableLength: srv.readableLength }).toEqual({
+        got: "",
+        flowing: false,
+        readableLength: 5,
+      });
+      stopped = false;
       const dataP = once(srv, "data");
       srv.resume();
       await dataP;

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1327,11 +1327,7 @@ describe("tls.createServer pauseOnConnect", () => {
       expect({ paused, flowing }).toEqual({ paused: true, flowing: false });
 
       let got = "";
-      let stopped = true;
-      srv.on("data", d => {
-        if (stopped) throw new Error("data event fired while paused");
-        got += d;
-      });
+      srv.on("data", d => (got += d));
       cli.write("hello");
       // Wait for the bytes to land in the paused Duplex's buffer (proving they
       // reached the server without a 'data' event). Polling avoids the ordering
@@ -1342,7 +1338,6 @@ describe("tls.createServer pauseOnConnect", () => {
         flowing: false,
         readableLength: 5,
       });
-      stopped = false;
       const dataP = once(srv, "data");
       srv.resume();
       await dataP;


### PR DESCRIPTION
## What

`tls.createServer({ pauseOnConnect: true })` never emitted `'secureConnection'` and the client never saw `'secureConnect'`. The handshake hung forever. Node completes the handshake and delivers the socket paused.

## Repro

```js
import tls from 'node:tls'; import fs from 'node:fs'; import { once } from 'node:events';
const server = tls.createServer({
  pauseOnConnect: true,
  key: fs.readFileSync('agent1-key.pem'),
  cert: fs.readFileSync('agent1-cert.pem'),
});
server.on('secureConnection', s => console.log('secureConnection isPaused=' + s.isPaused()));
await once(server.listen(0, '127.0.0.1'), 'listening');
const cli = tls.connect({ port: server.address().port, rejectUnauthorized: false });
await once(cli, 'secureConnect'); // hangs in bun, completes in node
```

## Cause

`onconnection` in `src/js/node/net.ts` called `_socket.pause()` for `pauseOnConnect`. `Socket.prototype.pause()` calls `this._handle.pause()`, which stops native reads, so the TLS engine never saw the ClientHello and `ServerHandlers.handshake` never fired.

In Node, `pauseOnConnect` sets `readableFlowing = false` on the TLSSocket via `pauseOnCreate`, but TLSWrap keeps reading the underlying socket internally so the handshake (and FIN/close_notify) proceed; only the decrypted output stream is paused.

## Fix

For a TLS accepted socket, `onconnection` now pauses only the Duplex (`Duplex.prototype.pause`), leaving the native handle reading. The TLS engine sees the handshake and FIN; `ServerHandlers.data` pushes decrypted bytes into the paused Duplex buffer (no `'data'` events fire) and applies native backpressure at the highWaterMark. `ServerHandlers.handshake` no longer re-pauses after emit; it only skips the post-emit `resume()` when `pauseOnConnect` is set, so:

- the `'secureConnection'` handler sees `isPaused() === true` / `readableFlowing === false` (matches Node)
- a handler that calls `resume()` is honored, not re-paused afterwards (matches Node)
- `'end'` still fires on a paused socket when the peer closes (matches Node; Node's `test-tls-server-parent-constructor-options.js` relies on this)

Plain TCP (`net.createServer({ pauseOnConnect: true })`) is unchanged.

## Verification

```
bun bd test test/js/node/tls/node-tls-server.test.ts -t pauseOnConnect
bun bd test/js/node/test/parallel/test-tls-server-parent-constructor-options.js
```

All three tests hang/time out on main and pass with this change. The first custom test includes a round-trip barrier proving no `'data'` event fires while paused and the bytes are buffered (`readableLength === 5`), matching Node.

## Not covered

`Socket.prototype.pause()` on a TLS socket still stops native reads entirely, so user code that calls `s.pause()` before the handshake (e.g. inside a TLS server's `'connection'` handler, which in Bun delivers the TLSSocket rather than Node's raw net.Socket) still stalls it. Fixing that uniformly means either gating `_handle.pause()` on `secureConnecting` in `Socket.prototype.pause`, or deferring the poll change in the native layer until the TLS handshake is finished. #32630 also fixes only the `pauseOnConnect` option at the JS layer; the broader native-level change is out of scope here.

Related: #35108 covers the separate case of `pause()` made inside the handler with `pauseOnConnect: false`. #32630 subsumes this PR if that lands first.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-server.test.ts
bun test v1.4.0 (60449f362)

test/js/node/tls/node-tls-server.test.ts:
(pass) tls.createServer listen > should throw when no port or path when using options [85.58ms]
(pass) tls.createServer listen > should listen on IPv6 by default [153.85ms]
(pass) tls.createServer listen > should listen on IPv4 [29.85ms]
(pass) tls.createServer listen > should call listening [20.30ms]
(pass) tls.createServer listen > should listen on localhost [23.48ms]
(pass) tls.createServer listen > should listen on localhost [22.66ms]
(pass) tls.createServer listen > should listen without port or host [21.42ms]
(pass) tls.createServer listen > should listen on unix domain socket [21.45ms]
(pass) tls.createServer listen > should not listen with wrong password [37.94ms]
(pass) tls.createServer listen > should reject passphrase longer than PEM_BUFSIZE without crashing [19.34ms]
(pass) tls.createServer listen > should not listen without cert [17.28ms]
(pass) tls.createServer listen > should not listen without password [23.90m
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (09dee02d3)

test/js/node/tls/node-tls-server.test.ts:
(pass) tls.createServer listen > should throw when no port or path when using options [2.48ms]
(pass) tls.createServer listen > should listen on IPv6 by default [3.54ms]
(pass) tls.createServer listen > should listen on IPv4 [1.41ms]
(pass) tls.createServer listen > should call listening [1.38ms]
(pass) tls.createServer listen > should listen on localhost [1.41ms]
(pass) tls.createServer listen > should listen on localhost [1.39ms]
(pass) tls.createServer listen > should listen without port or host [1.37ms]
(pass) tls.createServer listen > should listen on unix domain socket [1.61ms]
(pass) tls.createServer listen > should not listen with wrong password [1.60ms]
(pass) tls.createServer listen > should reject passphrase longer than PEM_BUFSIZE without crashing [2.50ms]
(pass) tls.createServer listen > should not listen without cert [1.24ms]
(pass) tls.createServer listen > should not listen without password [1.26ms]
(pass) tls.createServer > should work with getCertificate [18.92ms]
(pass) tls.createServer events > should receive data [3.91ms]
(pass) tls.createServer events > should call 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-server.test.ts
bun test v1.4.0 (60449f362)

test/js/node/tls/node-tls-server.test.ts:
(pass) tls.createServer listen > should throw when no port or path when using options [82.59ms]
(pass) tls.createServer listen > should listen on IPv6 by default [145.90ms]
(pass) tls.createServer listen > should listen on IPv4 [28.11ms]
(pass) tls.createServer listen > should call listening [20.73ms]
(pass) tls.createServer listen > should listen on localhost [24.02ms]
(pass) tls.createServer listen > should listen on localhost [23.88ms]
(pass) tls.createServer listen > should listen without port or host [22.46ms]
(pass) tls.createServer listen > should listen on unix domain socket [23.97ms]
(pass) tls.createServer listen > should not listen with wrong password [40.28ms]
(pass) tls.createServer listen > should reject passphrase longer than PEM_BUFSIZE without crashing [19.77ms]
(pass) tls.createServer listen > should not listen without cert [19.75ms]
(pass) tls.createServer listen > should not listen without password [20.18m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 727ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7800ms)
Bundle modules (319ms)
Postprocesss modules (482ms)
Bundle Functions (1045ms)
Generate Code (15ms)

[9.68s] Bundled "src/js" for production
  2040 kb
  165 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                                 | 12 ++-
 .../test-tls-server-parent-constructor-options.js  | 68 +++++++++++++++++
 test/js/node/tls/node-tls-server.test.ts           | 87 +++++++++++++++++++++-
 3 files changed, 160 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/net.ts                                           11     10      0
…/parallel/test-tls-server-parent-constructor-options.js      0      1      0
test/js/node/tls/node-tls-server.test.ts                      7      6      0
```

</details>

<!-- robobun:evidence:end -->