### PR TITLE
spawn(windows): tear down stdio PipeReader when start_with_current_pipe fails

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -247,6 +247,8 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS, "BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS", {});
     new_feature_flag!(pub BUN_INSTRUMENTS, "BUN_INSTRUMENTS", {});
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
+    // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
+    new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.
     new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1340,7 +1340,8 @@ impl WindowsBufferedReader {
         // a real uv_read_start failure on a freshly-spawned stdio pipe cannot be
         // triggered from JS, so the test exercises the consumer's error path this way.
         #[cfg(debug_assertions)]
-        if bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_PIPE_READER_START.get() {
+        if bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_PIPE_READER_START.get() == Some(true)
+        {
             return sys::Result::Err(sys::Error::from_code(sys::E::INVAL, sys::Tag::open));
         }
         self.start_reading()

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1336,6 +1336,13 @@ impl WindowsBufferedReader {
         self.source.as_mut().unwrap().set_data(self_ptr);
         self.buffer().clear();
         self.flags.remove(WindowsFlags::IS_DONE);
+        // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts:
+        // a real uv_read_start failure on a freshly-spawned stdio pipe cannot be
+        // triggered from JS, so the test exercises the consumer's error path this way.
+        #[cfg(debug_assertions)]
+        if std::env::var("BUN_INTERNAL_FAIL_PIPE_READER_START").as_deref() == Ok("1") {
+            return sys::Result::Err(sys::Error::from_code(sys::E::INVAL, sys::Tag::open));
+        }
         self.start_reading()
     }
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1340,7 +1340,7 @@ impl WindowsBufferedReader {
         // a real uv_read_start failure on a freshly-spawned stdio pipe cannot be
         // triggered from JS, so the test exercises the consumer's error path this way.
         #[cfg(debug_assertions)]
-        if std::env::var("BUN_INTERNAL_FAIL_PIPE_READER_START").as_deref() == Ok("1") {
+        if bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_PIPE_READER_START.get() {
             return sys::Result::Err(sys::Error::from_code(sys::E::INVAL, sys::Tag::open));
         }
         self.start_reading()

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1725,14 +1725,9 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         }
     }
 
-    if let Writable::Buffer(buffer) = subprocess.stdin.get() {
-        if let Err(err) = Writable::buffer_writer_mut(buffer).start() {
-            let _ = subprocess.try_kill(subprocess.kill_signal);
-            let _ = global_this.throw_value(err.to_js(global_this));
-            return Err(JsError::Thrown);
-        }
-    }
-
+    // Start the readers before the Writable::Buffer stdin writer so that if
+    // the writer's start() throws below, both PipeReaders have taken their
+    // start() ref and on_process_exit's later drain is refcount-balanced.
     if let Readable::Pipe(pipe) = subprocess.stdout.get() {
         // Note: pass `subprocess_nn` (the `NonNull<Subprocess<'static>>`
         // captured above) instead of the live `&mut subprocess`, which would
@@ -1753,6 +1748,14 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
             if let Readable::Pipe(pipe) = subprocess.stderr.get() {
                 Readable::pipe_reader_mut(pipe).read_all();
             }
+        }
+    }
+
+    if let Writable::Buffer(buffer) = subprocess.stdin.get() {
+        if let Err(err) = Writable::buffer_writer_mut(buffer).start() {
+            let _ = subprocess.try_kill(subprocess.kill_signal);
+            let _ = global_this.throw_value(err.to_js(global_this));
+            return Err(JsError::Thrown);
         }
     }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1737,13 +1737,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         // Note: pass `subprocess_nn` (the `NonNull<Subprocess<'static>>`
         // captured above) instead of the live `&mut subprocess`, which would
         // alias with the `&mut subprocess.stdout` borrow held by `pipe`.
-        if let Err(err) =
-            Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !IS_SYNC && lazy)
-        {
-            let _ = subprocess.try_kill(subprocess.kill_signal);
-            let _ = global_this.throw_value(err.to_js(global_this));
-            return Err(JsError::Thrown);
-        }
+        Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !IS_SYNC && lazy);
         if (IS_SYNC || !lazy) && matches!(subprocess.stdout.get(), Readable::Pipe(_)) {
             if let Readable::Pipe(pipe) = subprocess.stdout.get() {
                 Readable::pipe_reader_mut(pipe).read_all();
@@ -1753,13 +1747,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
 
     if let Readable::Pipe(pipe) = subprocess.stderr.get() {
         // Note: see stdout arm above — avoid aliased &mut.
-        if let Err(err) =
-            Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !IS_SYNC && lazy)
-        {
-            let _ = subprocess.try_kill(subprocess.kill_signal);
-            let _ = global_this.throw_value(err.to_js(global_this));
-            return Err(JsError::Thrown);
-        }
+        Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !IS_SYNC && lazy);
 
         if (IS_SYNC || !lazy) && matches!(subprocess.stderr.get(), Readable::Pipe(_)) {
             if let Readable::Pipe(pipe) = subprocess.stderr.get() {
@@ -1774,11 +1762,10 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     // JS. Downgrade 'socket-fd' slots from OwnedFd to UnownedFd so
     // finalize_streams (on later GC) skips them and the caller is the sole
     // owner via .stdio[i]. Placed here (not earlier) because the
-    // Writable::init error arm, the has_exception catch-all, the IPC
-    // open-socket failure, and the stdout/stderr Readable::Pipe .start()
-    // error paths all throw after populating stdio_pipes; on those paths
-    // the caller never receives the Subprocess, so the OwnedFd slot must
-    // remain for the GC'd wrapper's finalize_streams to close.
+    // Writable::init error arm, the has_exception catch-all, and the IPC
+    // open-socket failure all throw after populating stdio_pipes; on those
+    // paths the caller never receives the Subprocess, so the OwnedFd slot
+    // must remain for the GC'd wrapper's finalize_streams to close.
     #[cfg(not(windows))]
     if !socket_fd_indices.is_empty() {
         subprocess.stdio_pipes.with_mut(|pipes| {

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -147,7 +147,7 @@ impl PipeReader {
         process: NonNull<Subprocess<'static>>,
         event_loop: NonNull<EventLoop>,
         lazy: bool,
-    ) -> bun_sys::Result<()> {
+    ) {
         self.r#ref();
         self.process = Some(ParentRef::from(process));
         self.event_loop = event_loop.into();
@@ -165,7 +165,7 @@ impl PipeReader {
                 self.reader
                     .flags
                     .remove(bun_io::pipe_reader::WindowsFlags::IS_DONE);
-                return bun_sys::Result::Ok(());
+                return;
             }
             // Hold one more ref so `self` survives the on_reader_error() teardown
             // below long enough to return; matches the POSIX keepalive.
@@ -184,7 +184,6 @@ impl PipeReader {
                 // and on_process_exit's later drain then double-derefs them.
                 self.on_reader_error(err);
             }
-            return bun_sys::Result::Ok(());
         }
 
         #[cfg(not(windows))]
@@ -194,7 +193,7 @@ impl PipeReader {
                 // pipe buffer provides backpressure and the child blocks.
                 self.reader.flags.insert(PosixFlags::IS_PAUSED);
             }
-            // PosixBufferedReader.start() always returns .result, but if poll
+            // PosixBufferedReader.start() always returns Ok(()); if poll
             // registration fails it synchronously invokes onReaderError() first,
             // which drops both the Readable.pipe ref (via onCloseIO) and the ref we
             // just took above. Hold one more ref so `this` survives long enough to
@@ -205,29 +204,22 @@ impl PipeReader {
             // outlives the guard's drop on return.
             let _keepalive = unsafe { ScopedRef::new(std::ptr::from_mut::<PipeReader>(self)) };
 
-            match self.reader.start(self.stdio_result.unwrap(), true) {
-                bun_sys::Result::Err(err) => {
-                    return bun_sys::Result::Err(err);
-                }
-                bun_sys::Result::Ok(()) => {
-                    #[cfg(unix)]
-                    {
-                        if matches!(self.state, State::Err(_)) {
-                            // onReaderError already ran; `_keepalive`'s Drop on return
-                            // will drop the last ref and deinit() closes the handle.
-                            return bun_sys::Result::Ok(());
-                        }
-                        if let Some(poll) = self.reader.handle.get_poll() {
-                            poll.set_flag(FilePollFlag::Socket);
-                            poll.set_flag(FilePollFlag::Nonblocking);
-                        }
-                        self.reader.flags.insert(
-                            PosixFlags::SOCKET | PosixFlags::NONBLOCKING | PosixFlags::POLLABLE,
-                        );
-                    }
+            let _ = self.reader.start(self.stdio_result.unwrap(), true);
 
-                    return bun_sys::Result::Ok(());
+            #[cfg(unix)]
+            {
+                if matches!(self.state, State::Err(_)) {
+                    // onReaderError already ran; `_keepalive`'s Drop on return
+                    // will drop the last ref and deinit() closes the handle.
+                    return;
                 }
+                if let Some(poll) = self.reader.handle.get_poll() {
+                    poll.set_flag(FilePollFlag::Socket);
+                    poll.set_flag(FilePollFlag::Nonblocking);
+                }
+                self.reader
+                    .flags
+                    .insert(PosixFlags::SOCKET | PosixFlags::NONBLOCKING | PosixFlags::POLLABLE);
             }
         }
     }

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -10,7 +10,6 @@ use bun_io::max_buf::MaxBuf;
 use bun_io::pipe_reader::PosixFlags;
 use bun_jsc::event_loop::EventLoop;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, MarkedArrayBuffer};
-#[cfg(not(windows))]
 use bun_ptr::ScopedRef;
 use bun_ptr::{IntrusiveRc, ParentRef, RefCount};
 use bun_sys;
@@ -168,7 +167,24 @@ impl PipeReader {
                     .remove(bun_io::pipe_reader::WindowsFlags::IS_DONE);
                 return bun_sys::Result::Ok(());
             }
-            return self.reader.start_with_current_pipe();
+            // Hold one more ref so `self` survives the on_reader_error() teardown
+            // below long enough to return; matches the POSIX keepalive.
+            //
+            // SAFETY: `self` is live; ScopedRef bumps the intrusive refcount and
+            // derefs on Drop. The deref may free `*self`, but no borrow of `self`
+            // outlives the guard's drop on return.
+            let _keepalive = unsafe { ScopedRef::new(std::ptr::from_mut::<PipeReader>(self)) };
+            if let bun_sys::Result::Err(err) = self.reader.start_with_current_pipe() {
+                // Route through the same teardown as a read-callback error
+                // (matches POSIX's register_poll failure path): state=Err,
+                // detach from the Subprocess via on_close_io, release the
+                // start() ref, and let the caller proceed to the sibling pipe.
+                // Returning Err would have the caller throw after try_kill
+                // without unwinding this pipe or the never-started sibling,
+                // and on_process_exit's later drain then double-derefs them.
+                self.on_reader_error(err);
+            }
+            return bun_sys::Result::Ok(());
         }
 
         #[cfg(not(windows))]

--- a/test/js/bun/spawn/spawn-pipe-start-error.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-start-error.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isWindows } from "harness";
+
+// On Windows, when the initial uv_read_start on a subprocess stdout/stderr
+// pipe fails (observed from libuv as UV_EINVAL after a bad FileAccessInformation
+// query on the pipe handle), SubprocessPipeReader::start() returned the Err
+// straight from start_with_current_pipe(). The caller in the spawn bindings
+// then threw and returned without tearing down either pipe: stdout still had
+// the extra ref from the top of start(), and stderr had never been start()ed
+// at all (refcount 1, process backref set, live uv.Pipe source).
+//
+// When the killed child's exit callback later fired, on_process_exit resumed
+// reads on both pipes; the EOF that arrived on the unstarted stderr reached
+// on_reader_done, whose trailing deref assumes the matching start() ref exists,
+// so it dereferenced a freed PipeReader. Debug builds hit the RefCount
+// MAGIC_VALID assert; release builds wrote through freed memory, which in
+// practice manifested as a process stuck idle with no error and no exit.
+//
+// The fix routes the start_with_current_pipe() error through on_reader_error
+// (matching what POSIX already does for register_poll failure), so the pipe is
+// torn down and detached from the Subprocess before the exit callback runs.
+//
+// Triggering a real uv_read_start failure on a freshly-spawned stdio pipe is
+// not possible from JS, so this uses a debug-only fault-injection env var.
+
+test.skipIf(!isWindows || !isDebug)(
+  "spawn: a failed stdio pipe start is torn down instead of leaving a dangling sibling reader (windows)",
+  async () => {
+    const fixture = `
+try {
+  const p = Bun.spawn({
+    cmd: [process.execPath, "-e", "1"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, BUN_INTERNAL_FAIL_PIPE_READER_START: undefined },
+  });
+  await p.exited;
+  process.stderr.write("OK\\n");
+} catch (e) {
+  // Before the fix the spawn threw here; printing lets the assertion below
+  // name the exact error code when the post-throw crash is the real failure.
+  process.stderr.write("THREW " + (e?.code ?? e?.message) + "\\n");
+}
+`;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: {
+        ...bunEnv,
+        // The injection point sits in start_with_current_pipe(), which is the
+        // first call the non-lazy Windows start() path makes on the stdout pipe.
+        BUN_INTERNAL_FAIL_PIPE_READER_START: "1",
+      },
+      stdout: "inherit",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    // Without the fix stderr is "THREW EINVAL" followed by the RefCount
+    // MAGIC_VALID debug panic, and exitCode is the debug crash handler's.
+    expect(stderr.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
## Problem

On Windows, when the initial `uv_read_start` on a `Bun.spawn` stdout/stderr pipe fails (observed from libuv as `UV_EINVAL` after a bad `FileAccessInformation` query on the pipe handle), the process hangs idle: the event loop is parked in `GetQueuedCompletionStatusEx`, no error surfaces, and the code awaiting the child's output/exit has nothing to wake it.

## Cause

`SubprocessPipeReader::start()` on Windows returned the `Err` straight from `start_with_current_pipe()`. The spawn bindings then threw and returned without tearing down either pipe:

- stdout still carried the extra ref from the top of `start()` (`self.r#ref()` with no matching deref on the Windows `Err` path);
- stderr had never been `start()`ed at all: refcount 1, `process` backref set, live `uv.Pipe` source.

The process had already been `watch()`ed and is `try_kill`ed before the throw. When the killed child's exit callback fires, `on_process_exit` resumes reads on both still-`Readable::Pipe` slots via `reader.unpause(); reader.read();`. The EOF that arrives on the never-started stderr reaches `on_reader_done`, whose trailing `PipeReader::deref(self)` assumes the matching `start()` ref exists, so it dereferences a PipeReader that `on_close_io`'s own deref just freed.

Debug builds hit:

```
panic: assertion failed: self.magic == MAGIC_VALID
```

Release builds write through the freed refcount, which in practice manifested as a process stuck idle with no error and no exit.

POSIX already handles this correctly: `PosixBufferedReader::start()` never returns `Err`; a `register_poll` failure is routed through `on_reader_error` synchronously, which sets `state = Err`, detaches from the Subprocess via `on_close_io`, and releases the `start()` ref. The Windows path diverged.

## Fix

Route the Windows `start_with_current_pipe()` error through `on_reader_error` (same as POSIX's `register_poll` failure path), under a `ScopedRef` keepalive so `self` survives the teardown long enough to return. `start()` now returns `()` on both platforms; the caller proceeds to start the sibling pipe instead of throwing mid-setup, and the failed slot is `Readable::Ignore` by the time `on_process_exit` runs.

The two reader `.start()` calls are also moved ahead of the `Writable::Buffer` stdin writer's `.start()`, so the remaining POSIX-only throw path there fires after both readers have taken their `start()` ref.

Dead code removed alongside the fix: `SubprocessPipeReader::start()`'s return type is now `()` (it was already infallible on POSIX), the `if let Err { try_kill; throw }` arms at its two call sites in `js_bun_spawn_bindings.rs` are gone, the internal `Err` match arm in the POSIX branch is gone, and the comment listing "the stdout/stderr Readable::Pipe .start() error paths" among the throwing paths is updated.

## Verification

`test/js/bun/spawn/spawn-pipe-start-error.test.ts` exercises the error path via a debug-only fault-injection env var in `start_with_current_pipe` (a real `uv_read_start` failure on a freshly-spawned stdio pipe cannot be triggered from JS). On a Windows debug build:

<details><summary>without the fix</summary>

```
threw: EINVAL
script tail
panic: assertion failed: self.magic == MAGIC_VALID
```
(exit = debug crash handler)

</details>

<details><summary>with the fix</summary>

```
OK
```
(exit 0)

</details>

`test/js/bun/spawn/spawn.test.ts` passes 118/118 on Windows and the child_process suite passes 38/38 on Windows.

Note on the fail-before gate: the fault-injection hook lives in `src/io/PipeReader.rs`, so the gate's `git stash -- src/` removes it along with the fix; without the hook the test spawns a healthy child and passes. The fail-before above was captured by reverting only `SubprocessPipeReader.rs` to `origin/main` with the hook in place.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-pipe-start-error.test.ts

<!-- robobun:evidence:end -->