### PR TITLE
worker: fence async crypto (AnyTaskJob) completions against terminate() freeing the VM

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1553,6 +1553,11 @@ impl VirtualMachine {
             // drain below) or observes the flag under m_lock and drops.
             // destructOnExit sets it again (idempotently).
             Bun__JSCTaskScheduler__markShuttingDown(self.global());
+            // Same mirror for work-pool `AnyTaskJob`s (see web_worker.rs
+            // shutdown()): wait out any in-flight `ctx.run()` (which may be
+            // writing into a JSC `ArrayBuffer`) before `destructOnExit` frees
+            // the JSC heap.
+            self.any_task_gate().close();
 
             // Every worker has now posted its close task to our concurrent
             // queue (OUTSTANDING is decremented after dispatchExit). Drop

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -273,6 +273,10 @@ pub struct VirtualMachine {
     pub macro_event_loop: EventLoop,
     pub regular_event_loop: EventLoop,
     pub event_loop: *mut EventLoop, // BORROW_FIELD — points at sibling regular_event_loop/macro_event_loop
+    /// See [`crate::any_task_job::AnyTaskGate`]. `Option` only so the field is
+    /// zero-valid for `init()`'s `alloc_zeroed`; written there, always `Some`
+    /// until `destroy()`.
+    pub any_task_gate: Option<std::sync::Arc<crate::any_task_job::AnyTaskGate>>,
 
     pub ref_strings: crate::ref_string::Map,
     pub ref_strings_mutex: bun_threading::Mutex,
@@ -738,6 +742,16 @@ impl VirtualMachine {
     pub fn event_loop_shared(&self) -> &EventLoop {
         // SAFETY: see `event_loop_mut`.
         unsafe { &*self.event_loop }
+    }
+
+    /// See [`crate::any_task_job::AnyTaskGate`]. Always `Some` between
+    /// `init()` and `destroy()`.
+    #[inline]
+    pub fn any_task_gate(&self) -> &std::sync::Arc<crate::any_task_job::AnyTaskGate> {
+        debug_assert!(self.any_task_gate.is_some());
+        // SAFETY: written in `init()`, taken in `destroy()`; every caller is
+        // between the two.
+        unsafe { self.any_task_gate.as_ref().unwrap_unchecked() }
     }
 
     /// Alias for [`Self::event_loop_mut`]. Kept for callers migrated on the
@@ -2114,6 +2128,7 @@ impl VirtualMachine {
             (*regular).virtual_machine = NonNull::new(vm);
             let _ = (*regular).tasks.ensure_unused_capacity(64);
             addr_of_mut!((*vm).event_loop).write(regular);
+            addr_of_mut!((*vm).any_task_gate).write(Some(crate::any_task_job::AnyTaskGate::new()));
 
             // `source_mappings.map` is a sibling-field backref onto
             // `saved_source_map_table`.
@@ -4420,6 +4435,11 @@ impl VirtualMachine {
         // time and `load_preloads` clears the boxes but keeps the Vec buffer,
         // so reclaim it here or every Worker leaks it.
         drop(core::mem::take(&mut self.preload));
+
+        // Release this VM's `AnyTaskGate` ref; the gate itself is freed once
+        // every in-flight pool-thread job that observed the close has dropped
+        // its clone.
+        drop(self.any_task_gate.take());
 
         // SAFETY: this VM is raw-`dealloc`'d (no field `Drop` runs), so
         // `transpiler` is never auto-dropped after `deinit` clears its fields.

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -9,13 +9,69 @@
 
 use core::ffi::c_void;
 use core::ptr::NonNull;
+use std::sync::Arc;
 
 use bun_event_loop::AnyTask::AnyTask;
 use bun_io::KeepAlive;
+use bun_threading::RwLock;
 use bun_threading::work_pool::{IntrusiveWorkTask as _, Task as WorkPoolTask, WorkPool};
 
-use crate::event_loop::ConcurrentTask;
+use crate::event_loop::{ConcurrentTask, ConcurrentTaskItem, EventLoop};
 use crate::{JSGlobalObject, JsResult, VirtualMachineRef as VirtualMachine};
+
+/// Close-once fence between a VM and every [`AnyTaskJob`] it schedules, so a
+/// pool-thread completion that lands after `worker.terminate()` frees the VM
+/// observes the free instead of pushing into the freed event loop.
+///
+/// Each VM owns one `Arc` clone; each in-flight job holds another (so the gate
+/// itself outlives both). The pool-thread completion takes a read lock across
+/// its `enqueue_task_concurrent` push. [`crate::web_worker::WebWorker`]'s
+/// shutdown calls [`Self::close`] before draining the concurrent queue and
+/// deallocating the VM: taking the write lock waits out every in-flight reader
+/// (so their push is visible to the drain), and once `closed` is set any later
+/// completion returns without touching the VM. Same fence-then-drain shape as
+/// `ScriptExecutionContext::markTerminating` for the C++ `postTaskTo` path.
+pub struct AnyTaskGate {
+    closed: RwLock<bool>,
+}
+
+impl AnyTaskGate {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            closed: RwLock::new(false),
+        })
+    }
+
+    /// Mark the owning VM as going away. Takes the write lock, so it returns
+    /// only after every concurrent [`Self::enqueue`] reader has released.
+    pub fn close(&self) {
+        *self.closed.write() = true;
+    }
+
+    /// Push `task` onto `event_loop` if the gate is still open. The read lock
+    /// held across the push orders it before [`Self::close`] returns. Returns
+    /// `false` (caller retains `task`) when closed.
+    ///
+    /// # Safety
+    /// `event_loop` must be the `EventLoop` of the VM that owns this gate, and
+    /// [`Self::close`] must be called on it before that VM is freed.
+    unsafe fn enqueue(
+        &self,
+        event_loop: *const EventLoop,
+        task: NonNull<ConcurrentTaskItem>,
+    ) -> bool {
+        let guard = self.closed.read();
+        if *guard {
+            return false;
+        }
+        // SAFETY: caller contract — gate open ⇒ `close()` hasn't returned ⇒
+        // worker shutdown hasn't progressed past it ⇒ the VM (and its embedded
+        // event loop) is still live.
+        unsafe { (*event_loop).enqueue_task_concurrent(task) };
+        drop(guard);
+        true
+    }
+}
 
 /// Per-job payload trait. Implementors own the off-thread work body and the
 /// JS-thread completion; the surrounding heap/queue/keep-alive plumbing is
@@ -49,6 +105,13 @@ pub trait AnyTaskJobCtx: Sized {
 /// e.g. a `JSPromiseStrong` field after scheduling.
 pub struct AnyTaskJob<C> {
     vm: bun_ptr::BackRef<VirtualMachine>,
+    /// Snapshot of `vm.global` / `vm.event_loop()` at `create` time, plus the
+    /// VM's gate, so the pool-thread [`Self::run_task`] never reads a field of
+    /// `vm` (which may be a worker freed by terminate() while the task ran).
+    /// `vm` itself is only dereferenced on the JS thread ([`Self::run_from_js`]).
+    gate: Arc<AnyTaskGate>,
+    global: *mut JSGlobalObject,
+    event_loop: *const EventLoop,
     task: WorkPoolTask,
     any_task: AnyTask,
     poll: KeepAlive,
@@ -72,9 +135,13 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
     /// (running `Drop for C`). The returned pointer is owned by the caller
     /// until handed to [`Self::schedule`].
     pub fn create(global: &JSGlobalObject, ctx: C) -> JsResult<*mut Self> {
-        let vm = bun_ptr::BackRef::new(global.bun_vm());
+        let vm_ref = global.bun_vm();
+        let vm = bun_ptr::BackRef::new(vm_ref);
         let job = bun_core::heap::into_raw(Box::new(Self {
             vm,
+            gate: Arc::clone(vm_ref.any_task_gate()),
+            global: core::ptr::from_ref(global).cast_mut(),
+            event_loop: vm_ref.event_loop(),
             task: WorkPoolTask {
                 node: Default::default(),
                 callback: Self::run_task,
@@ -137,14 +204,41 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
     fn run_task(task: *mut WorkPoolTask) {
         // SAFETY: only reachable via the `WorkPoolTask::callback` slot wired
         // in `create`; `task` points to `Self.task` and the job is live until
-        // `run_from_js` reclaims it.
-        let job = unsafe { &mut *Self::from_task_ptr(task) };
-        let vm = job.vm;
-        job.ctx.run(vm.global);
-        // `ConcurrentTask::create` heap-allocates a fresh task; the queue takes
-        // ownership of it.
-        vm.event_loop_shared()
-            .enqueue_task_concurrent(ConcurrentTask::create(job.any_task.task()));
+        // `run_from_js` reclaims it (or is leaked below).
+        let this = unsafe { Self::from_task_ptr(task) };
+        let enqueued = {
+            // SAFETY: as above; exclusively owned on this thread until enqueue.
+            let job = unsafe { &mut *this };
+            job.ctx.run(job.global);
+            // `ConcurrentTask::create` heap-allocates a fresh node; the queue
+            // takes ownership of it when the push succeeds.
+            let node = ConcurrentTask::create(job.any_task.task());
+            // SAFETY: `job.event_loop` is the owning VM's loop; worker shutdown
+            // closes the gate before freeing it (see `AnyTaskGate`).
+            if unsafe { job.gate.enqueue(job.event_loop, node) } {
+                true
+            } else {
+                // SAFETY: `node` came from `ConcurrentTask::create`
+                // (heap-owned) and was not handed to the queue.
+                unsafe { bun_core::heap::destroy(node.as_ptr()) };
+                false
+            }
+        };
+        if enqueued {
+            return;
+        }
+        // VM is gone (worker terminated mid-run). Drop our gate ref so the
+        // shared `Arc` can release once every in-flight job has observed the
+        // close.
+        // SAFETY: `this` is the sole owner (the `&mut` above has ended);
+        // `gate` was written in `create` and is never read again past this
+        // point (the box is leaked below).
+        unsafe { core::ptr::drop_in_place(core::ptr::addr_of_mut!((*this).gate)) };
+        // The remainder of the box (`poll`, `ctx`) is intentionally leaked:
+        // `ctx` holds `Strong` JSC handles into the dead VM's heap and
+        // `poll.unref` would touch the freed event loop. This matches the fate
+        // of tasks already queued on a terminated worker's never-drained
+        // concurrent queue.
     }
 
     /// `AnyTask` callback — runs ON the JS thread. Reclaims the heap

--- a/src/jsc/any_task_job.rs
+++ b/src/jsc/any_task_job.rs
@@ -16,21 +16,27 @@ use bun_io::KeepAlive;
 use bun_threading::RwLock;
 use bun_threading::work_pool::{IntrusiveWorkTask as _, Task as WorkPoolTask, WorkPool};
 
-use crate::event_loop::{ConcurrentTask, ConcurrentTaskItem, EventLoop};
+use crate::event_loop::ConcurrentTask;
 use crate::{JSGlobalObject, JsResult, VirtualMachineRef as VirtualMachine};
 
-/// Close-once fence between a VM and every [`AnyTaskJob`] it schedules, so a
-/// pool-thread completion that lands after `worker.terminate()` frees the VM
-/// observes the free instead of pushing into the freed event loop.
+/// Close-once fence between a VM and every [`AnyTaskJob`] it schedules, so the
+/// pool-thread work body and completion either run entirely before
+/// `worker.terminate()` tears the VM down, or not at all.
 ///
 /// Each VM owns one `Arc` clone; each in-flight job holds another (so the gate
-/// itself outlives both). The pool-thread completion takes a read lock across
-/// its `enqueue_task_concurrent` push. [`crate::web_worker::WebWorker`]'s
-/// shutdown calls [`Self::close`] before draining the concurrent queue and
-/// deallocating the VM: taking the write lock waits out every in-flight reader
-/// (so their push is visible to the drain), and once `closed` is set any later
-/// completion returns without touching the VM. Same fence-then-drain shape as
+/// itself outlives both). The pool thread runs `ctx.run()` and the
+/// `enqueue_task_concurrent` push under a read lock: several ctxs read inputs
+/// from (and `Scrypt` writes its output into) JSC-heap-backed `ArrayBuffer`s,
+/// and the enqueue itself dereferences the embedded `EventLoop`, so both must
+/// be ordered before JSC-heap teardown and the VM free.
+///
+/// [`crate::web_worker::WebWorker`]'s shutdown calls [`Self::close`] before
+/// draining the concurrent queue, before JSC teardown, and before deallocating
+/// the VM. Taking the write lock waits out every in-flight reader (so the KDF
+/// finishes and its push is visible to the drain), and once `closed` is set
+/// any later pool task skips its body entirely. Same fence-then-drain shape as
 /// `ScriptExecutionContext::markTerminating` for the C++ `postTaskTo` path.
+/// Matches Node's behaviour of draining in-flight libuv work on env teardown.
 pub struct AnyTaskGate {
     closed: RwLock<bool>,
 }
@@ -43,31 +49,20 @@ impl AnyTaskGate {
     }
 
     /// Mark the owning VM as going away. Takes the write lock, so it returns
-    /// only after every concurrent [`Self::enqueue`] reader has released.
+    /// only after every concurrent [`Self::run_gated`] reader has released.
     pub fn close(&self) {
         *self.closed.write() = true;
     }
 
-    /// Push `task` onto `event_loop` if the gate is still open. The read lock
-    /// held across the push orders it before [`Self::close`] returns. Returns
-    /// `false` (caller retains `task`) when closed.
-    ///
-    /// # Safety
-    /// `event_loop` must be the `EventLoop` of the VM that owns this gate, and
-    /// [`Self::close`] must be called on it before that VM is freed.
-    unsafe fn enqueue(
-        &self,
-        event_loop: *const EventLoop,
-        task: NonNull<ConcurrentTaskItem>,
-    ) -> bool {
+    /// Run `body` under a read lock if the gate is open, else skip it. The
+    /// lock held across `body` orders it entirely before [`Self::close`]
+    /// returns. Returns `false` when closed (body not run).
+    fn run_gated(&self, body: impl FnOnce()) -> bool {
         let guard = self.closed.read();
         if *guard {
             return false;
         }
-        // SAFETY: caller contract — gate open ⇒ `close()` hasn't returned ⇒
-        // worker shutdown hasn't progressed past it ⇒ the VM (and its embedded
-        // event loop) is still live.
-        unsafe { (*event_loop).enqueue_task_concurrent(task) };
+        body();
         drop(guard);
         true
     }
@@ -105,13 +100,10 @@ pub trait AnyTaskJobCtx: Sized {
 /// e.g. a `JSPromiseStrong` field after scheduling.
 pub struct AnyTaskJob<C> {
     vm: bun_ptr::BackRef<VirtualMachine>,
-    /// Snapshot of `vm.global` / `vm.event_loop()` at `create` time, plus the
-    /// VM's gate, so the pool-thread [`Self::run_task`] never reads a field of
-    /// `vm` (which may be a worker freed by terminate() while the task ran).
-    /// `vm` itself is only dereferenced on the JS thread ([`Self::run_from_js`]).
+    /// The pool-thread [`Self::run_task`] only dereferences `vm` (and the
+    /// JSC-heap buffers `ctx` borrows) under this gate's read lock, so a
+    /// worker VM freed by terminate() is never touched. See [`AnyTaskGate`].
     gate: Arc<AnyTaskGate>,
-    global: *mut JSGlobalObject,
-    event_loop: *const EventLoop,
     task: WorkPoolTask,
     any_task: AnyTask,
     poll: KeepAlive,
@@ -140,8 +132,6 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         let job = bun_core::heap::into_raw(Box::new(Self {
             vm,
             gate: Arc::clone(vm_ref.any_task_gate()),
-            global: core::ptr::from_ref(global).cast_mut(),
-            event_loop: vm_ref.event_loop(),
             task: WorkPoolTask {
                 node: Default::default(),
                 callback: Self::run_task,
@@ -206,31 +196,31 @@ impl<C: AnyTaskJobCtx> AnyTaskJob<C> {
         // in `create`; `task` points to `Self.task` and the job is live until
         // `run_from_js` reclaims it (or is leaked below).
         let this = unsafe { Self::from_task_ptr(task) };
-        let enqueued = {
-            // SAFETY: as above; exclusively owned on this thread until enqueue.
+        // SAFETY: `gate` was written in `create`; this thread exclusively owns
+        // `*this` until the enqueue below hands it to the JS thread. Cloned so
+        // the read lock can be held while `this` is reborrowed `&mut` inside.
+        let gate = Arc::clone(unsafe { &(*this).gate });
+        let ran = gate.run_gated(|| {
+            // SAFETY: gate open ⇒ worker shutdown hasn't passed `close()` ⇒
+            // the owning VM, its JSC heap (which `ctx.run` may read/write via
+            // `ArrayBuffer`-backed inputs/outputs), and its embedded event
+            // loop are all still live.
             let job = unsafe { &mut *this };
-            job.ctx.run(job.global);
-            // `ConcurrentTask::create` heap-allocates a fresh node; the queue
-            // takes ownership of it when the push succeeds.
-            let node = ConcurrentTask::create(job.any_task.task());
-            // SAFETY: `job.event_loop` is the owning VM's loop; worker shutdown
-            // closes the gate before freeing it (see `AnyTaskGate`).
-            if unsafe { job.gate.enqueue(job.event_loop, node) } {
-                true
-            } else {
-                // SAFETY: `node` came from `ConcurrentTask::create`
-                // (heap-owned) and was not handed to the queue.
-                unsafe { bun_core::heap::destroy(node.as_ptr()) };
-                false
-            }
-        };
-        if enqueued {
+            let vm = job.vm;
+            job.ctx.run(vm.global);
+            // `ConcurrentTask::create` heap-allocates; the queue takes
+            // ownership.
+            vm.event_loop_shared()
+                .enqueue_task_concurrent(ConcurrentTask::create(job.any_task.task()));
+        });
+        drop(gate);
+        if ran {
             return;
         }
-        // VM is gone (worker terminated mid-run). Drop our gate ref so the
-        // shared `Arc` can release once every in-flight job has observed the
-        // close.
-        // SAFETY: `this` is the sole owner (the `&mut` above has ended);
+        // Gate closed (worker terminated before this task was picked up). Drop
+        // our gate ref so the shared `Arc` can release once every scheduled
+        // job has observed the close.
+        // SAFETY: `this` is the sole owner (`run_gated` did not touch it);
         // `gate` was written in `create` and is never read again past this
         // point (the box is leaked below).
         unsafe { core::ptr::drop_in_place(core::ptr::addr_of_mut!((*this).gate)) };

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1312,6 +1312,12 @@ impl WebWorker {
             // or observes m_isShuttingDown under m_lock and drops. Idempotent;
             // teardownJSCVM sets it again.
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
+            // Same fence for work-pool completions (`AnyTaskJob`: node:crypto
+            // KDFs, Bun.secrets, Bun.zstd*). `close()`'s write lock waits out
+            // any pool-thread `enqueue_task_concurrent` reader so the push is
+            // visible to the drain below; completions landing after this
+            // observe `closed` and never dereference `vm` (which step 5 frees).
+            vm.any_task_gate().close();
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when
             // terminate() lands, and any Worker dispatchExit close task from a

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1312,11 +1312,12 @@ impl WebWorker {
             // or observes m_isShuttingDown under m_lock and drops. Idempotent;
             // teardownJSCVM sets it again.
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
-            // Same fence for work-pool completions (`AnyTaskJob`: node:crypto
-            // KDFs, Bun.secrets, Bun.zstd*). `close()`'s write lock waits out
-            // any pool-thread `enqueue_task_concurrent` reader so the push is
-            // visible to the drain below; completions landing after this
-            // observe `closed` and never dereference `vm` (which step 5 frees).
+            // Same fence for work-pool jobs (`AnyTaskJob`: node:crypto KDFs/
+            // HKDF/primes/keypairs/sign, Bun.secrets, Bun.zstd*). `close()`'s
+            // write lock waits out every pool thread that is inside
+            // `ctx.run()` or the enqueue (both touch the JSC heap / `vm`), so
+            // they finish before teardownJSCVM and step 5's free; a job the
+            // pool picks up after this observes `closed` and skips its body.
             vm.any_task_gate().close();
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -218,7 +218,14 @@ test(
         console.log("ok");
       `,
       ],
-      env: bunEnv,
+      // A job still on the pool at close() is leaked by design (its ctx holds
+      // Strong handles into the dead VM's JSC heap), and any job that raced
+      // into concurrent_tasks before close() ends up requeued into
+      // EventLoop.tasks, whose buffer becomes unreachable when the worker VM
+      // is raw-dealloc'd. Both are bounded per terminated worker; opt this
+      // subprocess out of LSan so that stranded-task accounting isn't asserted
+      // as a regression.
+      env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -176,3 +176,55 @@ test.skipIf(!isASAN)(
   },
   timeout,
 );
+
+// Regression: AnyTaskJob::run_task (work-pool thread) read vm.global and
+// vm.event_loop_shared() to enqueue the completion; when the owning VM was a
+// worker freed by terminate() while a long KDF (scrypt/pbkdf2) was running,
+// both reads were a heap-use-after-free in VirtualMachine (freed by
+// WebWorker::shutdown). Release builds segfaulted; ASAN reported the UAF on a
+// "Bun Pool" thread.
+test(
+  "terminate() while async crypto.scrypt()/pbkdf2() are running on the work pool does not UAF the worker VM",
+  async () => {
+    // Long KDF iterations make the terminate window huge, so one round per
+    // worker is enough for ASAN to catch the UAF; release builds segfaulted
+    // within a few rounds on the unfixed path.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const src =
+          'const { parentPort } = require("node:worker_threads");' +
+          'const crypto = require("node:crypto");' +
+          'const { promisify } = require("node:util");' +
+          'const scrypt = promisify(crypto.scrypt), pbkdf2 = promisify(crypto.pbkdf2);' +
+          'const lanes = (n, f) => { for (let i = 0; i < n; i++) (async () => { for (;;) { try { await f(); } catch {} } })(); };' +
+          'lanes(3, () => scrypt("pw", "salt", 64, { N: 1 << 14, r: 8, p: 1, maxmem: 128 << 20 }));' +
+          'lanes(3, () => pbkdf2("pw", "salt", 200000, 64, "sha512"));' +
+          'parentPort.postMessage("up");';
+        for (let r = 0; r < ${rounds}; r++) {
+          const w = new Worker(src, { eval: true });
+          // Wait until the KDF lanes are scheduled on the work pool.
+          await new Promise((res, rej) => {
+            w.once("message", res);
+            w.once("error", rej);
+          });
+          // Terminate with the KDFs in flight; their pool-thread completion
+          // must not touch the freed VM.
+          await w.terminate();
+        }
+        console.log("ok");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  },
+  timeout,
+);


### PR DESCRIPTION
## What

`worker.terminate()` while an async `crypto.scrypt()` / `crypto.pbkdf2()` (or any other `AnyTaskJob`: HKDF, prime gen, key-pair gen, sign, DH, `Bun.secrets`, `Bun.zstd*`) is running on the work pool freed the worker's `VirtualMachine` and its JSC heap while the pool thread was still touching both:

- `AnyTaskJob::run_task` read `vm.global` and `vm.event_loop_shared()` off a raw backref when posting its completion
- `ctx.run()` itself reads inputs from JSC-backed `ArrayBuffer`s (`StringOrBuffer` password/salt) and, for `Scrypt`, writes its derived key into a JSC `ArrayBuffer` allocated in `init()`

`WebWorker::shutdown` frees the JSC heap (`teardownJSCVM`) and then the VM storage, so a pool thread still inside BoringSSL's scrypt wrote its output into freed memory. The next worker to reuse that allocation saw the corruption as a garbage `ArrayAllocationProfile` in `llint_op_new_array` (aarch64 release lanes), or the completion enqueue read the freed `EventLoop` directly:

```
heap-use-after-free  READ of size 8  thread T15 (Bun Pool 2)
  #0 event_loop_shared                                    src/jsc/VirtualMachine.rs:740
  #1 AnyTaskJob<crypto::CallbackCtx<Scrypt>>::run_task    src/jsc/any_task_job.rs:146
freed by thread (Worker):  WebWorker::shutdown  src/jsc/web_worker.rs:1390
```

## Fix

A per-VM `Arc<RwLock<bool>>` gate. `AnyTaskJob::create` clones it; `run_task` runs `ctx.run()` and the `enqueue_task_concurrent` push under a read lock. `WebWorker::shutdown` closes the gate (write lock) right next to the existing `ScriptExecutionContext::markTerminating` / `JSCTaskScheduler::markShuttingDown` fences, before draining the concurrent queue, before JSC teardown, and before deallocating the VM. The write lock waits out every in-flight reader so the work body finishes and its push is visible to the drain; a job the pool picks up after `close()` observes it and skips its body entirely (matching Node's behaviour of draining in-flight libuv work on env teardown).

Skipped jobs intentionally leak their `ctx` (it holds `Strong` JSC handles into the dead VM's heap, and `poll.unref` would touch the freed event loop). This matches the fate of tasks already queued on a terminated worker's never-drained concurrent queue. The gate `Arc` itself is released on both paths so it does not accumulate.

## Scope

This is the focused `AnyTaskJob` slice of #32071 / #34154 (which cover the full cross-thread producer class). The other producers (`FetchTasklet`, `WorkTask`, `ConcurrentPromiseTask`, `AsyncFSTask`, napi, watchers) still have the analogous defect and stay with those PRs; this change keeps the diff small so the crypto segfault can land independently. The `AnyTaskGate` introduced here is reusable by those call sites if the wider change is further delayed.

## Verification

New test in `test/js/web/workers/worker-terminate-lifetime.test.ts`:

- fail-before (`USE_SYSTEM_BUN=1`): segfault at `0xFFFFFFFF00000000`, "multiple threads are crashing"
- fail-after (`bun bd`, ASAN): passes
- fail-after (release x64, 12-round original repro): 12/12 clean

Existing `test/js/node/crypto/{pbkdf2,scrypt,hkdf-callback-null}.test.ts` and `node-crypto.test.js` (202 tests, covers the `extern_crypto_job!` set) all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->