### PR TITLE
node:zlib: block worker shutdown on in-flight async compression (UAF)

### DIFF
--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -10,7 +10,7 @@
 //! poll deadline). See PORTING.md §Dispatch.
 
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicI32, AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicI32, AtomicPtr, AtomicU32, Ordering};
 
 use bun_io::{self as Async, Waker};
 use bun_uws as uws;
@@ -89,6 +89,15 @@ pub struct EventLoop {
 
     pub entered_event_loop_count: isize,
     pub concurrent_ref: AtomicI32,
+    /// Count of `WorkPool` jobs scheduled from this VM's JS thread whose
+    /// pool-thread callback has not yet finished its last access to this
+    /// `EventLoop` (typically `enqueue_task_concurrent`). `WebWorker::shutdown`
+    /// spins on this reaching zero before freeing the JSC heap and the
+    /// `VirtualMachine` box that this `EventLoop` is a field of; without that
+    /// barrier the pool thread's `do_work()` (JSC-heap input/output buffers)
+    /// and completion post are both use-after-free. Bracket with
+    /// [`Self::work_pool_task_ref`] / [`Self::work_pool_task_unref`].
+    pub work_pool_pending: AtomicU32,
     /// Atomic nullable pointer to the next-due `WTFTimer`.
     ///
     /// Note (§Dispatch): payload is `*mut ()` — the real
@@ -129,6 +138,7 @@ impl Default for EventLoop {
             uws_loop: (),
             entered_event_loop_count: 0,
             concurrent_ref: AtomicI32::new(0),
+            work_pool_pending: AtomicU32::new(0),
             imminent_gc_timer: AtomicPtr::new(core::ptr::null_mut()),
             #[cfg(unix)]
             signal_handler: None,
@@ -1003,6 +1013,38 @@ impl EventLoop {
         }
         self.concurrent_tasks.push(task);
         self.wakeup();
+    }
+
+    /// JS-thread: call immediately before `WorkPool::schedule` for a task whose
+    /// pool-thread callback will dereference this `EventLoop` / the owning
+    /// `VirtualMachine` / the JSC heap (e.g. to post a completion via
+    /// [`Self::enqueue_task_concurrent`]). Paired with
+    /// [`Self::work_pool_task_unref`] on the pool thread; see
+    /// [`Self::work_pool_pending`].
+    #[inline]
+    pub fn work_pool_task_ref(&self) {
+        self.work_pool_pending.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Pool-thread: call as the last `EventLoop`/VM access in the `WorkPool`
+    /// callback (after [`Self::enqueue_task_concurrent`]). The `Release` store
+    /// pairs with [`Self::wait_for_pending_work_pool_tasks`]'s `Acquire` load
+    /// so `WebWorker::shutdown` cannot observe zero until every prior access
+    /// is visible, making the subsequent VM dealloc safe.
+    #[inline]
+    pub fn work_pool_task_unref(&self) {
+        self.work_pool_pending.fetch_sub(1, Ordering::Release);
+    }
+
+    /// Worker-thread shutdown barrier. Spins (yielding) until every
+    /// outstanding [`Self::work_pool_task_ref`] has been matched by
+    /// [`Self::work_pool_task_unref`]. Each pending task is one bounded
+    /// compression/IO step, so the wait is bounded; `terminate()` already runs
+    /// user exit handlers here, so this is not a new latency cliff.
+    pub fn wait_for_pending_work_pool_tasks(&self) {
+        while self.work_pool_pending.load(Ordering::Acquire) > 0 {
+            std::thread::yield_now();
+        }
     }
 
     pub fn ref_concurrently(&self) {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1312,6 +1312,14 @@ impl WebWorker {
             // or observes m_isShuttingDown under m_lock and drops. Idempotent;
             // teardownJSCVM sets it again.
             Bun__JSCTaskScheduler__markShuttingDown(vm.global());
+            // Wait for in-flight WorkPool jobs scheduled from this VM
+            // (node:zlib async compression today; see `work_pool_pending`).
+            // The pool-thread callback reads this VM's `EventLoop` and the
+            // JSC-heap-backed input/output buffers; both are freed below
+            // (teardownJSCVM / step-5 dealloc). Runs before the drain so the
+            // completion each job posts is reclaimed by
+            // `release_queued_tasks_for_shutdown`.
+            vm.event_loop_shared().wait_for_pending_work_pool_tasks();
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when
             // terminate() lands, and any Worker dispatchExit close task from a

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1317,8 +1317,8 @@ impl WebWorker {
             // The pool-thread callback reads this VM's `EventLoop` and the
             // JSC-heap-backed input/output buffers; both are freed below
             // (teardownJSCVM / step-5 dealloc). Runs before the drain so the
-            // completion each job posts is reclaimed by
-            // `release_queued_tasks_for_shutdown`.
+            // completion each job posts is released by the matching
+            // `__bun_release_task_at_shutdown` arm while JSC is still live.
             vm.event_loop_shared().wait_for_pending_work_pool_tasks();
             // Reclaim queued CppTasks (the per-worker stdio/messaging
             // MessagePort drain tasks that can be in self.tasks mid-tick when

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1213,6 +1213,32 @@ pub(crate) fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool
             unsafe { Bun__deleteDeferredWorkTask(task.ptr.cast::<JSCDeferredWorkTask>()) };
             true
         }
+        // Async `node:zlib` write completion that reached the queue after the
+        // worker's last tick (the `work_pool_pending` barrier guarantees the
+        // post lands before this drain). Release `write()`'s acquisitions
+        // (Strong handle, pinned buffers, poll_ref, +1 ref) without calling
+        // the JS write/error callbacks; JSC is still live here.
+        task_tag::NativeZlib | task_tag::NativeBrotli | task_tag::NativeZstd => {
+            macro_rules! release_compression {
+                ($T:ty) => {
+                    // SAFETY: tag identifies pointee; live m_ctx payload kept
+                    // alive by `write()`'s `ref_()`.
+                    unsafe {
+                        node_zlib_binding::CompressionStream::<$T>::release_unrun(
+                            task.ptr.cast::<$T>(),
+                        )
+                    }
+                };
+            }
+            match task.tag {
+                task_tag::NativeZlib => release_compression!(NativeZlib),
+                task_tag::NativeBrotli => release_compression!(NativeBrotli),
+                task_tag::NativeZstd => release_compression!(NativeZstd),
+                // SAFETY: outer arm guard proves one of the three tags matched.
+                _ => unsafe { core::hint::unreachable_unchecked() },
+            }
+            true
+        }
         // Same reclaim `drop_concurrent_cpp_tasks` performs, but for tasks
         // that were already batch-moved into `self.tasks`. Must run before
         // JSC teardown: a Worker `dispatchExit` lambda's `~Ref<Worker>` walks

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -449,6 +449,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             callback: Self::async_job_run_task,
         });
         this.poll_ref().with_mut(|p| p.ref_(vm));
+        // Hold the worker-shutdown barrier open until the pool thread has
+        // finished `do_work()` and posted the completion; matched by
+        // `work_pool_task_unref()` at the end of `async_job_run`.
+        vm.event_loop_shared().work_pool_task_ref();
         WorkPool::schedule(this.task().as_ptr());
 
         Ok(JSValue::UNDEFINED)
@@ -487,10 +491,18 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         // `enqueue_task_concurrent` body only touches the lock-free
         // `concurrent_tasks` queue (thread-safe). `this` is the heap-allocated
         // `m_ctx` payload — the matching `ref()` in `write()` keeps it alive
-        // until `run_from_js_thread` runs and calls `deref()`.
+        // until `run_from_js_thread` runs and calls `deref()`. Liveness of the
+        // VM across a worker terminate is guaranteed by the
+        // `work_pool_task_ref()` taken in `write()`: `WebWorker::shutdown`
+        // blocks on that count reaching zero before freeing the JSC heap or
+        // the VM box, so `global_this`, `vm` and `event_loop` are all still
+        // valid here.
         unsafe {
             (*vm.event_loop()).enqueue_task_concurrent(ConcurrentTask::create(Task::init(this)));
         }
+        // Last VM access; pairs with `work_pool_task_ref()` in `write()` and
+        // releases `WebWorker::shutdown`'s barrier.
+        vm.event_loop_shared().work_pool_task_unref();
     }
 
     /// Dispatched from `dispatch.rs` when the worker-thread `do_work()` posts

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -584,6 +584,44 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         unsafe { T::deref(this_ptr) };
     }
 
+    /// Shutdown-drain counterpart of [`Self::run_from_js_thread`]: releases the
+    /// resources `write()` acquired (Strong `this_value`, pinned input/output
+    /// buffers, `poll_ref`, the `ref_()` +1) without invoking JS callbacks.
+    /// Called from `__bun_release_task_at_shutdown` for a completion that
+    /// reached the queue after the worker thread stopped ticking. Runs on the
+    /// worker's JS thread with the JSC heap and VM still live (before
+    /// `teardownJSCVM`).
+    ///
+    /// SAFETY: same contract as [`Self::run_from_js_thread`].
+    pub(crate) unsafe fn release_unrun(this_ptr: *mut T) {
+        let this = ParentRef::from(NonNull::new(this_ptr).expect("release_unrun: this"));
+        let global: &JSGlobalObject = this.global_this();
+        let vm = global.bun_vm();
+
+        this.write_in_progress().set(false);
+
+        if let Some(this_value) = this.this_value().with_mut(|v| v.try_swap()) {
+            for pinned in [
+                T::pending_input_get_cached(this_value),
+                T::pending_output_get_cached(this_value),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                if pinned.is_cell() {
+                    if let Some(buf) = pinned.as_array_buffer(global) {
+                        buf.unpin();
+                    }
+                }
+            }
+        }
+
+        this.poll_ref().with_mut(|p| p.unref(vm));
+        // SAFETY: matching `ref_()` in `write()`; `this_ptr` is the heap payload
+        // and is not accessed after this call.
+        unsafe { T::deref(this_ptr) };
+    }
+
     pub(crate) fn write_sync(
         this: &T,
         global_this: &JSGlobalObject,

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 
 // Regression test for a heap-use-after-free when a Worker is terminated
@@ -14,15 +14,13 @@ import { bunEnv, bunExe, isASAN } from "harness";
 //
 // Keeping several codecs in flight at once makes the do_work() window wide
 // enough that terminate() reliably lands inside it.
-test(
-  "worker.terminate() during in-flight node:zlib async compression does not UAF",
-  async () => {
-    // ASAN poisons the freed VM immediately; a couple of rounds are enough.
-    // Release builds need the freed page to be reused/unmapped, which takes a
-    // few more.
-    const ROUNDS = isASAN ? 4 : 10;
+test("worker.terminate() during in-flight node:zlib async compression does not UAF", async () => {
+  // ASAN poisons the freed VM immediately; a couple of rounds are enough.
+  // Release builds need the freed page to be reused/unmapped, which takes a
+  // few more.
+  const ROUNDS = isASAN ? 4 : 10;
 
-    const script = /* js */ `
+  const script = /* js */ `
       const { Worker } = require("node:worker_threads");
       const src = \`
         const { parentPort } = require("node:worker_threads");
@@ -55,23 +53,17 @@ test(
       });
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).not.toContain("heap-use-after-free");
-    expect(stderr).not.toContain("AddressSanitizer");
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
-  },
-  // Per-test override: each round starts a Worker under ASAN and compresses a
-  // 16 MiB buffer; the default 5s is too short for that even once.
-  60_000,
-);
+  expect(stderr).not.toContain("heap-use-after-free");
+  expect(stderr).not.toContain("AddressSanitizer");
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+}, // Per-test override: each round starts a Worker under ASAN and compresses a
+// 16 MiB buffer; the default 5s is too short for that even once.
+60_000);

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -64,6 +64,5 @@ test("worker.terminate() during in-flight node:zlib async compression does not U
   expect(stderr).not.toContain("heap-use-after-free");
   expect(stderr).not.toContain("AddressSanitizer");
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
-}, // Per-test override: each round starts a Worker under ASAN and compresses a
-// 16 MiB buffer; the default 5s is too short for that even once.
+}, // 16 MiB buffer; the default 5s is too short for that even once. // Per-test override: each round starts a Worker under ASAN and compresses a
 60_000);

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+
+// Regression test for a heap-use-after-free when a Worker is terminated
+// while async node:zlib operations (gzip/brotliCompress/deflate) are running
+// on the thread pool. The pool-thread completion callback dereferenced the
+// worker's VirtualMachine/EventLoop after WebWorker::shutdown had already
+// freed it:
+//
+//   heap-use-after-free  READ of size 8  thread T16 (Bun Pool 2)
+//     #0 event_loop                       src/jsc/VirtualMachine.rs
+//     #1 async_job_run<NativeBrotli>      src/runtime/node/node_zlib_binding.rs
+//   freed by thread (Worker): WebWorker::shutdown  src/jsc/web_worker.rs
+//
+// Keeping several codecs in flight at once makes the do_work() window wide
+// enough that terminate() reliably lands inside it.
+test(
+  "worker.terminate() during in-flight node:zlib async compression does not UAF",
+  async () => {
+    // ASAN poisons the freed VM immediately; a couple of rounds are enough.
+    // Release builds need the freed page to be reused/unmapped, which takes a
+    // few more.
+    const ROUNDS = isASAN ? 4 : 10;
+
+    const script = /* js */ `
+      const { Worker } = require("node:worker_threads");
+      const src = \`
+        const { parentPort } = require("node:worker_threads");
+        const zlib = require("node:zlib");
+        const { promisify } = require("node:util");
+        const gz = promisify(zlib.gzip);
+        const br = promisify(zlib.brotliCompress);
+        const df = promisify(zlib.deflate);
+        const big = Buffer.alloc(16 << 20, 0x61);
+        const lanes = (n, f) => {
+          for (let i = 0; i < n; i++)
+            (async () => { for (;;) { try { await f(); } catch {} } })();
+        };
+        lanes(2, () => gz(big));
+        lanes(1, () => br(big.subarray(0, 4 << 20)));
+        lanes(2, () => df(big.subarray(0, 10 << 20)));
+        parentPort.postMessage("up");
+      \`;
+      (async () => {
+        for (let r = 0; r < ${ROUNDS}; r++) {
+          const w = new Worker(src, { eval: true });
+          await new Promise(res => w.once("message", res));
+          await Bun.sleep(60 + (r * 41) % 220);
+          await w.terminate();
+        }
+        console.log("ok");
+      })().catch(e => {
+        console.error(e);
+        process.exit(1);
+      });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).not.toContain("heap-use-after-free");
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+  },
+  // Per-test override: each round starts a Worker under ASAN and compresses a
+  // 16 MiB buffer; the default 5s is too short for that even once.
+  60_000,
+);

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -53,6 +53,6 @@ test("worker.terminate() during in-flight node:zlib async compression does not U
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("heap-use-after-free");
-  expect(stderr).not.toContain("AddressSanitizer");
+  expect(stderr).not.toContain("ERROR: AddressSanitizer");
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
 }, 30_000);

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -64,5 +64,4 @@ test("worker.terminate() during in-flight node:zlib async compression does not U
   expect(stderr).not.toContain("heap-use-after-free");
   expect(stderr).not.toContain("AddressSanitizer");
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
-}, // 16 MiB buffer; the default 5s is too short for that even once. // Per-test override: each round starts a Worker under ASAN and compresses a
-60_000);
+}, 60_000); // 16 MiB buffer; the default 5s is too short for that even once. // Per-test override: each round starts a Worker under ASAN and compresses a

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 
 // worker.terminate() while async node:zlib compression is in flight on the

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -1,57 +1,48 @@
-import { expect, test } from "bun:test";
+import { test, expect } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 
-// Regression test for a heap-use-after-free when a Worker is terminated
-// while async node:zlib operations (gzip/brotliCompress/deflate) are running
-// on the thread pool. The pool-thread completion callback dereferenced the
-// worker's VirtualMachine/EventLoop after WebWorker::shutdown had already
-// freed it:
-//
-//   heap-use-after-free  READ of size 8  thread T16 (Bun Pool 2)
-//     #0 event_loop                       src/jsc/VirtualMachine.rs
-//     #1 async_job_run<NativeBrotli>      src/runtime/node/node_zlib_binding.rs
-//   freed by thread (Worker): WebWorker::shutdown  src/jsc/web_worker.rs
-//
-// Keeping several codecs in flight at once makes the do_work() window wide
-// enough that terminate() reliably lands inside it.
+// worker.terminate() while async node:zlib compression is in flight on the
+// thread pool must not dereference the worker's freed VM/EventLoop from the
+// pool-thread completion. Mixed gzip/brotli/deflate lanes keep do_work() busy
+// so terminate reliably lands mid-compression.
 test("worker.terminate() during in-flight node:zlib async compression does not UAF", async () => {
-  // ASAN poisons the freed VM immediately; a couple of rounds are enough.
-  // Release builds need the freed page to be reused/unmapped, which takes a
-  // few more.
   const ROUNDS = isASAN ? 4 : 10;
 
   const script = /* js */ `
-      const { Worker } = require("node:worker_threads");
-      const src = \`
-        const { parentPort } = require("node:worker_threads");
-        const zlib = require("node:zlib");
-        const { promisify } = require("node:util");
-        const gz = promisify(zlib.gzip);
-        const br = promisify(zlib.brotliCompress);
-        const df = promisify(zlib.deflate);
-        const big = Buffer.alloc(16 << 20, 0x61);
-        const lanes = (n, f) => {
-          for (let i = 0; i < n; i++)
-            (async () => { for (;;) { try { await f(); } catch {} } })();
-        };
-        lanes(2, () => gz(big));
-        lanes(1, () => br(big.subarray(0, 4 << 20)));
-        lanes(2, () => df(big.subarray(0, 10 << 20)));
-        parentPort.postMessage("up");
-      \`;
-      (async () => {
-        for (let r = 0; r < ${ROUNDS}; r++) {
-          const w = new Worker(src, { eval: true });
-          await new Promise(res => w.once("message", res));
-          await Bun.sleep(60 + (r * 41) % 220);
-          await w.terminate();
-        }
-        console.log("ok");
-      })().catch(e => {
-        console.error(e);
-        process.exit(1);
-      });
-    `;
+    const { Worker } = require("node:worker_threads");
+    const src = \`
+      const { parentPort } = require("node:worker_threads");
+      const zlib = require("node:zlib");
+      const { promisify } = require("node:util");
+      const gz = promisify(zlib.gzip);
+      const br = promisify(zlib.brotliCompress);
+      const df = promisify(zlib.deflate);
+      const big = Buffer.alloc(16 << 20, 0x61);
+      const lanes = (n, f) => {
+        for (let i = 0; i < n; i++)
+          (async () => { for (;;) { try { await f(); } catch {} } })();
+      };
+      lanes(2, () => gz(big));
+      lanes(1, () => br(big.subarray(0, 4 << 20)));
+      lanes(2, () => df(big.subarray(0, 10 << 20)));
+      parentPort.postMessage("up");
+    \`;
+    (async () => {
+      for (let r = 0; r < ${ROUNDS}; r++) {
+        const w = new Worker(src, { eval: true });
+        await new Promise((resolve, reject) => {
+          w.once("message", resolve);
+          w.once("error", reject);
+          w.once("exit", code => reject(new Error("worker exited " + code + " before ready")));
+        });
+        await w.terminate();
+      }
+      console.log("ok");
+    })().catch(e => {
+      console.error(e);
+      process.exit(1);
+    });
+  `;
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
@@ -64,4 +55,4 @@ test("worker.terminate() during in-flight node:zlib async compression does not U
   expect(stderr).not.toContain("heap-use-after-free");
   expect(stderr).not.toContain("AddressSanitizer");
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
-}, 60_000); // 16 MiB buffer; the default 5s is too short for that even once. // Per-test override: each round starts a Worker under ASAN and compresses a
+}, 30_000);

--- a/test/js/node/zlib/zlib-worker-terminate.test.ts
+++ b/test/js/node/zlib/zlib-worker-terminate.test.ts
@@ -3,8 +3,8 @@ import { bunEnv, bunExe, isASAN } from "harness";
 
 // worker.terminate() while async node:zlib compression is in flight on the
 // thread pool must not dereference the worker's freed VM/EventLoop from the
-// pool-thread completion. Mixed gzip/brotli/deflate lanes keep do_work() busy
-// so terminate reliably lands mid-compression.
+// pool-thread completion. One lane per Native* tag (zlib/brotli/zstd) keeps
+// do_work() busy so terminate reliably lands mid-compression.
 test("worker.terminate() during in-flight node:zlib async compression does not UAF", async () => {
   const ROUNDS = isASAN ? 4 : 10;
 
@@ -17,6 +17,7 @@ test("worker.terminate() during in-flight node:zlib async compression does not U
       const gz = promisify(zlib.gzip);
       const br = promisify(zlib.brotliCompress);
       const df = promisify(zlib.deflate);
+      const zs = promisify(zlib.zstdCompress);
       const big = Buffer.alloc(16 << 20, 0x61);
       const lanes = (n, f) => {
         for (let i = 0; i < n; i++)
@@ -25,6 +26,7 @@ test("worker.terminate() during in-flight node:zlib async compression does not U
       lanes(2, () => gz(big));
       lanes(1, () => br(big.subarray(0, 4 << 20)));
       lanes(2, () => df(big.subarray(0, 10 << 20)));
+      lanes(1, () => zs(big.subarray(0, 4 << 20)));
       parentPort.postMessage("up");
     \`;
     (async () => {
@@ -55,4 +57,7 @@ test("worker.terminate() during in-flight node:zlib async compression does not U
   expect(stderr).not.toContain("heap-use-after-free");
   expect(stderr).not.toContain("ERROR: AddressSanitizer");
   expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ok", exitCode: 0 });
+  // Worker startup under debug+ASAN is ~1.8s on its own; 4 rounds cannot fit
+  // the 5s default. Shrinking the buffers to fit loses the race window (0/3
+  // repro on the unfixed build at 4 MiB), so the workload stays as-is.
 }, 30_000);


### PR DESCRIPTION
## Problem

`worker.terminate()` while an async `node:zlib` operation (`gzip` / `brotliCompress` / `deflate` / `zstd`) is running on the thread pool crashes with a cross-thread heap-use-after-free:

```
heap-use-after-free  READ of size 8  thread T16 (Bun Pool 2)
  #0 VirtualMachine::event_loop                 src/jsc/VirtualMachine.rs:716
  #1 CompressionStream<NativeBrotli>::async_job_run
                                                src/runtime/node/node_zlib_binding.rs:492
freed by thread (Worker): WebWorker::shutdown   src/jsc/web_worker.rs:1390
```

The pool-thread completion callback walks `global_this -> bun_vm_concurrently() -> event_loop()` to post its result after `WebWorker::shutdown` has already raw-`dealloc`'d the `VirtualMachine` box (the `EventLoop` is a value field of it). `do_work()` itself also reads/writes the pinned JSC-heap input/output buffers that `teardownJSCVM` frees. Under a release build this is a plain SIGSEGV.

Worker `process.exit()` and an uncaught throw take the same shutdown path and hit the same race.

## Fix

Add a small shutdown barrier on `EventLoop`:

- `work_pool_pending: AtomicU32` counts WorkPool jobs scheduled from this VM's JS thread whose pool-thread callback has not yet made its last `EventLoop`/VM access.
- `CompressionStream::write()` calls `work_pool_task_ref()` immediately before `WorkPool::schedule`; `async_job_run` calls `work_pool_task_unref()` (Release) as its final VM access, after `enqueue_task_concurrent`.
- `WebWorker::shutdown` spins on `work_pool_pending == 0` (Acquire) after stopping the cross-thread CppTask posters and before `release_queued_tasks_for_shutdown` / `teardownJSCVM` / the VM `dealloc`. The Release/Acquire pair guarantees the VM box and JSC heap are live for the pool thread's whole callback, and the completion each job posts is then reclaimed by the existing drain.

Each pending job is one bounded compression step, so `terminate()` latency is bounded by the slowest in-flight chunk (the same model Node's `uv_run` drain gives).

## Scope

This is a targeted fix for the `node:zlib` site only. #34154 is the general `ShutdownGate` that covers every WorkPool/HTTP-thread producer (fetch, S3, `node:fs` async, dns, napi, crypto, bundler, ...); the counter here is the minimal subset of that design and will be subsumed when it lands. #32073 tracks the generation-token follow-up.

## Test

`test/js/node/zlib/zlib-worker-terminate.test.ts` spawns a worker that keeps 5 lanes of gzip/brotli/deflate in flight and terminates it mid-compression, 4 rounds under ASAN / 10 otherwise.

<details>
<summary>Fail-before / pass-after</summary>

```
# without src/ changes (bun bd, ASAN)
error: expect(received).not.toContain(expected)
Expected to not contain: "heap-use-after-free"
  #1 async_job_run<NativeBrotli> src/runtime/node/node_zlib_binding.rs:492
  freed by WebWorker::shutdown   src/jsc/web_worker.rs:1390

# with src/ changes
(pass) worker.terminate() during in-flight node:zlib async compression does not UAF [11039ms]
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib-worker-terminate.test.ts
bun test v1.4.0 (12f4d3972)

test/js/node/zlib/zlib-worker-terminate.test.ts:
52 |     stdout: "pipe",
53 |     stderr: "pipe",
54 |   });
55 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
56 | 
57 |   expect(stderr).not.toContain("heap-use-after-free");
                          ^
error: expect(received).not.toContain(expected)

Expected to not contain: "heap-use-after-free"
Received: "=================================================================\n==126269==ERROR: AddressSanitizer: heap-use-after-free on address 0x74afe687b4b8 at pc 0x00000c72d56d bp 0x71df499ee9f0 sp 0x71df499ee9e8\nREAD of size 8 at 0x74afe687b4b8 thread T7 (Bun Pool 2)\n    #0 0x00000c72d56c in <bun_jsc::virtual_machine::VirtualMachine>::event_loop /workspace/bun/src/jsc/VirtualMachine.rs:716:9\n    #1 0x00000c72d56c in <bun_runtime::node::node_zlib_binding::CompressionStream<bun_runtime::node::native_brotli_impl::_impl::NativeBrotli>>::async_job_ru
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a157772e8)

test/js/node/zlib/zlib-worker-terminate.test.ts:
(pass) worker.terminate() during in-flight node:zlib async compression does not UAF [1082.89ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [1266.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/zlib/zlib-worker-terminate.test.ts
bun test v1.4.0 (12f4d3972)

test/js/node/zlib/zlib-worker-terminate.test.ts:
(pass) worker.terminate() during in-flight node:zlib async compression does not UAF [11080.79ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [13.20s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 754ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/event_loop.rs                           | 44 ++++++++++++++++-
 src/jsc/web_worker.rs                           |  8 ++++
 src/runtime/dispatch.rs                         | 26 ++++++++++
 src/runtime/node/node_zlib_binding.rs           | 52 +++++++++++++++++++-
 test/js/node/zlib/zlib-worker-terminate.test.ts | 63 +++++++++++++++++++++++++
 5 files changed, 191 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/event_loop.rs                                5      4      0
src/jsc/web_worker.rs                                3      3      0
src/runtime/dispatch.rs                              3      1      0
src/runtime/node/node_zlib_binding.rs                5      3      0
test/js/node/zlib/zlib-worker-terminate.test.ts      2      8      0
```

</details>

<!-- robobun:evidence:end -->