### PR TITLE
worker: don't enqueue work-pool completions into a terminated worker's freed EventLoop

### DIFF
--- a/src/jsc/ConcurrentPromiseTask.rs
+++ b/src/jsc/ConcurrentPromiseTask.rs
@@ -58,7 +58,9 @@ impl<Context: ConcurrentPromiseTaskContext> Taskable for ConcurrentPromiseTask<'
 
 impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Context> {
     pub fn create_on_js_thread(global_this: &'a JSGlobalObject, value: Box<Context>) -> Box<Self> {
-        let event_loop = VirtualMachine::get().event_loop_shared().concurrent_handle();
+        let event_loop = VirtualMachine::get()
+            .event_loop_shared()
+            .concurrent_handle();
         let mut this = Box::new(Self {
             event_loop,
             ctx: value,

--- a/src/jsc/ConcurrentPromiseTask.rs
+++ b/src/jsc/ConcurrentPromiseTask.rs
@@ -2,11 +2,10 @@ use bun_event_loop::ConcurrentTask::{AutoDeinit, ConcurrentTask, TaskTag, Taskab
 use bun_io::{self as Async, KeepAlive};
 use bun_threading::{IntrusiveWorkTask as _, WorkPoolTask, work_pool::WorkPool};
 
-use crate::event_loop::EventLoop;
+use crate::event_loop::{EventLoop, LoopHandle};
 use crate::js_promise::{JSPromise, Strong as JSPromiseStrong};
 use crate::virtual_machine::VirtualMachine;
 use crate::{JSGlobalObject, JsTerminated};
-use bun_ptr::BackRef;
 
 /// The `Context` type parameter for [`ConcurrentPromiseTask`] must implement this trait:
 /// - `run(&mut self)` — performs the work on the thread pool
@@ -31,9 +30,11 @@ pub struct ConcurrentPromiseTask<'a, Context: ConcurrentPromiseTaskContext> {
     // Owned here so dropping the task frees the context.
     pub ctx: Box<Context>,
     pub task: WorkPoolTask,
-    /// BACKREF — captured from the JS-thread VM at create time; the VM (and its
-    /// `EventLoop`) outlives every task scheduled on it.
-    pub event_loop: BackRef<EventLoop>,
+    /// Captured from the JS-thread VM at create time. A handle (not a
+    /// reference): the owning worker VM can be freed by terminate() while
+    /// this task sits in the pool, so `on_finish` must go through the
+    /// registry-checked enqueue.
+    pub event_loop: LoopHandle,
     pub promise: JSPromiseStrong,
     pub global_this: &'a JSGlobalObject,
     pub concurrent_task: ConcurrentTask,
@@ -57,9 +58,7 @@ impl<Context: ConcurrentPromiseTaskContext> Taskable for ConcurrentPromiseTask<'
 
 impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Context> {
     pub fn create_on_js_thread(global_this: &'a JSGlobalObject, value: Box<Context>) -> Box<Self> {
-        // `VirtualMachine::get()` returns the JS-thread singleton; the VM and
-        // its `EventLoop` outlive every task scheduled on it.
-        let event_loop = BackRef::new(VirtualMachine::get().as_mut().event_loop_shared());
+        let event_loop = VirtualMachine::get().event_loop_shared().concurrent_handle();
         let mut this = Box::new(Self {
             event_loop,
             ctx: value,
@@ -116,7 +115,9 @@ impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Contex
         );
         // `task` is the live `concurrent_task` field of the heap-allocated
         // job; the queue takes ownership of its intrusive `next` link.
-        event_loop.enqueue_task_concurrent(task);
+        // `event_loop` may denote a worker VM's loop freed by terminate()
+        // while the pool task ran.
+        let _ = EventLoop::try_enqueue_task_concurrent(event_loop, task);
     }
 
     /// Frees the heap allocation backing this task.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -456,6 +456,105 @@ impl VMHolder {
     }
 }
 
+/// Process-global registry of `EventLoop` addresses that cross-thread
+/// producers may still enqueue to.
+///
+/// Worker `VirtualMachine`s (and the `EventLoop`s embedded in them) are freed
+/// by `WebWorker::shutdown()` while producers on the work pool still hold the
+/// loop address captured when the work was scheduled. A push after the free
+/// corrupts reused heap memory; see
+/// [`crate::event_loop::EventLoop::try_enqueue_task_concurrent`].
+///
+/// This is the Rust-side analogue of the fence the C++ `postTaskTo` path
+/// already has (`allScriptExecutionContextsMap` + its lock): teardown removes
+/// the VM's loops from the registry under the same lock producers take to
+/// enqueue, so a producer either observes the loop live (and teardown then
+/// waits for the lock before freeing) or drops the task.
+///
+/// Addresses are stored as `usize`; the registry never dereferences them.
+/// Each registration carries a process-unique generation so a stale producer
+/// cannot be fooled by a new VM allocated at a dead VM's address.
+///
+/// Lock ordering: this lock is a leaf. The critical sections only touch the
+/// target's MPSC queue (wait-free push) and `wakeup()` (a syscall); they take
+/// no other locks.
+pub(crate) mod live_loop_registry {
+    use super::{MAIN_THREAD_VM, VirtualMachine};
+    use bun_threading::Guarded;
+    use core::sync::atomic::{AtomicU64, Ordering};
+
+    #[derive(Copy, Clone, Eq, PartialEq)]
+    pub(crate) struct Entry {
+        /// Owning VM; key for [`unregister_vm`]. Never dereferenced.
+        vm: usize,
+        pub(crate) addr: usize,
+        pub(crate) generation: u64,
+    }
+
+    pub(crate) static REGISTRY: Guarded<Vec<Entry>> = Guarded::new(Vec::new());
+
+    /// Starts at 1 so generation 0 (zero-initialised/placeholder handles)
+    /// matches nothing.
+    static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+    /// Register `vm`'s embedded event loops. Called as the final step of
+    /// `VirtualMachine::init()`, after both loops have been written. Stamps
+    /// each loop's `live_generation` so [`EventLoop::concurrent_handle`] can
+    /// build a handle without the lock.
+    pub(crate) fn register_vm(vm: *mut VirtualMachine) {
+        let generation = NEXT_GENERATION.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: `vm` is the freshly-initialised allocation; `init()` has
+        // exclusive access at this point.
+        let (regular, macro_) = unsafe {
+            (*vm).regular_event_loop.live_generation = generation;
+            (*vm).macro_event_loop.live_generation = generation;
+            (
+                core::ptr::addr_of!((*vm).regular_event_loop) as usize,
+                core::ptr::addr_of!((*vm).macro_event_loop) as usize,
+            )
+        };
+        let mut reg = REGISTRY.lock();
+        reg.push(Entry {
+            vm: vm as usize,
+            addr: regular,
+            generation,
+        });
+        reg.push(Entry {
+            vm: vm as usize,
+            addr: macro_,
+            generation,
+        });
+    }
+
+    /// Remove every entry for `vm`. Called from `WebWorker::shutdown()` before
+    /// anything the VM owns is freed; once this returns, no producer can be
+    /// inside a checked enqueue targeting `vm` (they would have to hold the
+    /// same lock).
+    pub(crate) fn unregister_vm(vm: *mut VirtualMachine) {
+        REGISTRY.lock().retain(|e| e.vm != vm as usize);
+    }
+
+    /// `true` iff `addr` is one of the immortal main-thread VM's embedded
+    /// loops. Lock-free: the main VM allocation is never freed, so a worker
+    /// loop can never occupy an address inside it, and an address match
+    /// proves liveness without the registry.
+    pub(crate) fn is_main_vm_loop(addr: usize) -> bool {
+        let main = MAIN_THREAD_VM.load(Ordering::Acquire);
+        if main.is_null() {
+            return false;
+        }
+        // SAFETY: `main` points at the live, never-freed main-thread VM
+        // allocation; `addr_of!` only projects field addresses (no read).
+        let (regular, macro_) = unsafe {
+            (
+                core::ptr::addr_of!((*main).regular_event_loop) as usize,
+                core::ptr::addr_of!((*main).macro_event_loop) as usize,
+            )
+        };
+        addr == regular || addr == macro_
+    }
+}
+
 #[thread_local]
 pub static IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE: Cell<bool> = Cell::new(false);
 #[thread_local]
@@ -1113,7 +1212,12 @@ impl VirtualMachine {
     pub fn enable_macro_mode(&mut self) {
         if !self.has_enabled_macro_mode {
             self.has_enabled_macro_mode = true;
+            // `EventLoop::default()` zeroes `live_generation`; the macro
+            // loop's address is still the one `register_vm` stamped, so
+            // restore its generation so `concurrent_handle()` stays valid.
+            let generation = self.macro_event_loop.live_generation;
             self.macro_event_loop = EventLoop::default();
+            self.macro_event_loop.live_generation = generation;
             self.macro_event_loop.virtual_machine = NonNull::new(std::ptr::from_mut(self));
             self.macro_event_loop.global = NonNull::new(self.global);
             self.macro_event_loop.concurrent_tasks = Default::default();
@@ -2199,6 +2303,11 @@ impl VirtualMachine {
             // SAFETY: written once during init.
             IS_SMOL_MODE.store(true, core::sync::atomic::Ordering::Relaxed);
         }
+
+        // Publish both embedded event loops to the live-loop registry so
+        // checked cross-thread producers (`try_enqueue_task_concurrent`) can
+        // verify liveness. Last step: the loops are fully written above.
+        live_loop_registry::register_vm(vm);
 
         Ok(vm)
     }

--- a/src/jsc/WorkTask.rs
+++ b/src/jsc/WorkTask.rs
@@ -4,7 +4,7 @@ use bun_threading::{IntrusiveWorkTask as _, WorkPoolTask, work_pool::WorkPool};
 
 use crate::JSGlobalObject;
 use crate::debugger::AsyncTaskTracker;
-use crate::event_loop::EventLoop;
+use crate::event_loop::{EventLoop, LoopHandle};
 use bun_ptr::BackRef;
 
 /// A generic task that runs work on a thread pool and executes a callback on the main JavaScript thread.
@@ -34,9 +34,11 @@ pub trait WorkTaskContext: Sized {
 pub struct WorkTask<Context: WorkTaskContext> {
     pub ctx: *mut Context,
     pub task: WorkPoolTask,
-    /// BACKREF — captured from the JS-thread VM at create time; the VM (and its
-    /// `EventLoop`) outlives every task scheduled on it.
-    pub event_loop: BackRef<EventLoop>,
+    /// Captured from the JS-thread VM at create time. A handle (not a
+    /// reference): the owning worker VM can be freed by terminate() while
+    /// this task sits in the pool, so `on_finish` must go through the
+    /// registry-checked enqueue.
+    pub event_loop: LoopHandle,
     // allocator field dropped — global mimalloc (see PORTING.md §Allocators)
     pub global_this: BackRef<JSGlobalObject>,
     pub concurrent_task: ConcurrentTask,
@@ -61,7 +63,7 @@ impl<Context: WorkTaskContext> Taskable for WorkTask<Context> {
 impl<Context: WorkTaskContext> WorkTask<Context> {
     pub fn create_on_js_thread(global_this: &JSGlobalObject, value: *mut Context) -> *mut Self {
         let vm = global_this.bun_vm().as_mut();
-        let event_loop = BackRef::new(vm.event_loop_shared());
+        let event_loop = vm.event_loop_shared().concurrent_handle();
         let mut this = Box::new(Self {
             event_loop,
             ctx: value,
@@ -136,7 +138,9 @@ impl<Context: WorkTaskContext> WorkTask<Context> {
                 .from(this_ptr, AutoDeinit::ManualDeinit),
         );
         // `task` is the inline `concurrent_task` field of the live
-        // heap-allocated `*this`; `event_loop` is the JS-thread loop stored at init.
-        event_loop.enqueue_task_concurrent(task);
+        // heap-allocated `*this`; `event_loop` was captured at init and may
+        // denote a worker VM's loop freed by terminate() while the pool task
+        // ran.
+        let _ = EventLoop::try_enqueue_task_concurrent(event_loop, task);
     }
 }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -106,6 +106,11 @@ pub struct EventLoop {
     pub signal_handler: Option<bun_ptr::BackRef<PosixSignalHandle>>,
     #[cfg(not(unix))]
     pub signal_handler: (),
+
+    /// Registration generation from [`crate::virtual_machine::live_loop_registry`],
+    /// stamped at registration time; 0 = not stamped. Read on the owning
+    /// thread only, by [`EventLoop::concurrent_handle`].
+    pub(crate) live_generation: u64,
 }
 
 impl Default for EventLoop {
@@ -134,8 +139,24 @@ impl Default for EventLoop {
             signal_handler: None,
             #[cfg(not(unix))]
             signal_handler: (),
+            live_generation: 0,
         }
     }
+}
+
+/// Schedule-time identity of a specific [`EventLoop`] for cross-thread
+/// producers that deliver a completion from the work pool (or another thread)
+/// through [`EventLoop::try_enqueue_task_concurrent`].
+///
+/// Plain data (`Copy`, `Send`, `Sync`): holding one neither keeps the loop
+/// alive nor permits dereferencing it. The address alone cannot distinguish a
+/// live loop from a new worker VM reusing a dead worker's allocation; the
+/// generation (minted per registration in
+/// [`crate::virtual_machine::live_loop_registry`], never reused) can.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct LoopHandle {
+    addr: usize,
+    generation: u64,
 }
 
 mod drain_result {
@@ -1003,6 +1024,61 @@ impl EventLoop {
         }
         self.concurrent_tasks.push(task);
         self.wakeup();
+    }
+
+    /// Schedule-time [`LoopHandle`] for this loop, for producers that deliver
+    /// a completion from another thread through
+    /// [`EventLoop::try_enqueue_task_concurrent`]. Call on the owning thread.
+    #[inline]
+    pub fn concurrent_handle(&self) -> LoopHandle {
+        LoopHandle {
+            addr: core::ptr::from_ref(self) as usize,
+            generation: self.live_generation,
+        }
+    }
+
+    /// Cross-thread enqueue that tolerates the target event loop (and the
+    /// worker VM embedding it) having been freed by `WebWorker::shutdown()`
+    /// while the producer ran. For producers that captured a [`LoopHandle`]
+    /// at schedule time instead of a `&EventLoop`.
+    ///
+    /// Returns `false` when the loop is gone, including when a new loop
+    /// reuses the dead loop's address (the generation comparison catches
+    /// that). On `false` the task node is freed if `auto_delete`; the payload
+    /// is leaked (same as a task left undrained in a terminated worker's
+    /// queue, since its tag-specific teardown can only run on the JS thread).
+    pub fn try_enqueue_task_concurrent(
+        handle: LoopHandle,
+        task: core::ptr::NonNull<ConcurrentTaskItem>,
+    ) -> bool {
+        use crate::virtual_machine::live_loop_registry;
+        // Fast path: loops embedded in the main-thread VM are never freed.
+        if live_loop_registry::is_main_vm_loop(handle.addr) {
+            // SAFETY: main-thread VM loop, never freed; `enqueue_task_concurrent`
+            // takes `&self` and is thread-safe.
+            unsafe { (*(handle.addr as *const EventLoop)).enqueue_task_concurrent(task) };
+            return true;
+        }
+        let reg = live_loop_registry::REGISTRY.lock();
+        if !reg
+            .iter()
+            .any(|e| e.addr == handle.addr && e.generation == handle.generation)
+        {
+            drop(reg);
+            // SAFETY: the task was built for this enqueue and never linked
+            // into any queue; the producer still owns it.
+            unsafe {
+                if task.as_ref().auto_delete() {
+                    drop(bun_core::heap::take(task.as_ptr()));
+                }
+            }
+            return false;
+        }
+        // SAFETY: the loop is registered-live, and unregistration (which
+        // happens-before any free in `WebWorker::shutdown`) takes the same
+        // lock we hold.
+        unsafe { (*(handle.addr as *const EventLoop)).enqueue_task_concurrent(task) };
+        true
     }
 
     pub fn ref_concurrently(&self) {

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1240,6 +1240,15 @@ impl WebWorker {
         // vm_lock held; this is the unpublish point.
         let vm_ptr = self.vm.replace(core::ptr::null_mut());
         self.vm_lock.unlock();
+        // Unregister from the live-loop registry so checked cross-thread
+        // producers (the work pool via `try_enqueue_task_concurrent`) observe
+        // the loop as gone instead of pushing into memory freed in step 5.
+        // Must precede every free below; a producer inside a checked enqueue
+        // holds the registry lock, so returning from this call also means no
+        // such producer is still touching the VM.
+        if !vm_ptr.is_null() {
+            crate::virtual_machine::live_loop_registry::unregister_vm(vm_ptr);
+        }
         let mut loop_: Option<*mut bun_uws::Loop> = None;
         if !vm_ptr.is_null() {
             // SAFETY: vm_ptr was published under vm_lock; sole owner now.

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -209,7 +209,11 @@ test(
         console.log("ok");
       `,
       ],
-      env: bunEnv,
+      // A completion that races terminate() is dropped and its task box
+      // (holding a JSPromiseStrong into the dead VM) is intentionally leaked,
+      // same as tasks left undrained in a terminated worker's queue; LSAN
+      // would flag that as a failure.
+      env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -176,3 +176,48 @@ test.skipIf(!isASAN)(
   },
   timeout,
 );
+
+// Regression: ConcurrentPromiseTask<TransformTask>::on_finish (work pool
+// thread) held a raw &EventLoop captured at schedule time and pushed the
+// completion into it after WebWorker::shutdown() had freed the worker's VM
+// allocation (which embeds the EventLoop). ASAN heap-use-after-free in
+// EventLoop::enqueue_task_concurrent; stock release segfault.
+test(
+  "terminate() while Bun.Transpiler.transform() is in flight on the work pool does not UAF",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        // Large-ish source so a single transform stays on the pool long
+        // enough for terminate() to land mid-work.
+        const body = [
+          'const { parentPort } = require("node:worker_threads");',
+          'const tr = new Bun.Transpiler({ loader: "tsx" });',
+          'const code = Array.from({ length: 8000 }, (_, i) => "export const v" + i + " = (x: number): number => x * " + i + ";").join(" ");',
+          'for (let i = 0; i < 4; i++) (async () => { for (;;) { try { await tr.transform(code, "tsx"); } catch { await Bun.sleep(1); } } })();',
+          'parentPort.postMessage("up");',
+        ].join("\\n");
+        for (let r = 0; r < ${slow ? 4 : 8}; r++) {
+          const w = new Worker(body, { eval: true });
+          await new Promise(res => w.once("message", res));
+          await Bun.sleep(30 + (r * 37) % 120);
+          await w.terminate();
+        }
+        console.log("ok");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);


### PR DESCRIPTION
### Crash

`worker.terminate()` while `Bun.Transpiler.transform()` (or any `ConcurrentPromiseTask` / `WorkTask` consumer) is in flight on the work pool: the pool thread posts the completion into the worker's `EventLoop` after `WebWorker::shutdown()` has freed the `VirtualMachine` allocation that embeds it.

```
heap-use-after-free  READ of size 8  thread T12 (Bun Pool 0)
  #0 EventLoop::vm_ref                  src/jsc/event_loop.rs:1044
  #1 EventLoop::enqueue_task_concurrent src/jsc/event_loop.rs:1000
  #2 ConcurrentPromiseTask<TransformTask>::on_finish  src/jsc/ConcurrentPromiseTask.rs:119
  #3 ThreadPool Thread::run
freed by thread T10 (Worker):
     WebWorker::shutdown                src/jsc/web_worker.rs
```

Release builds SIGSEGV; worker `process.exit()` and uncaught throw are equal triggers.

### Repro

```js
const { Worker } = require("node:worker_threads");
const src = [
  'const { parentPort } = require("node:worker_threads");',
  'const tr = new Bun.Transpiler({ loader: "tsx" });',
  'const code = Array.from({ length: 20000 }, (_, i) => "export const v" + i + " = (x: number): number => x * " + i + ";").join(" ");',
  'for (let i = 0; i < 4; i++) (async () => { for (;;) { try { await tr.transform(code, "tsx"); } catch { await Bun.sleep(1); } } })();',
  'parentPort.postMessage("up");',
].join("\n");
for (let r = 0; r < 12; r++) {
  const w = new Worker(src, { eval: true });
  await new Promise(res => w.once("message", res));
  await Bun.sleep(60 + (r * 41) % 220);
  await w.terminate();
}
```

### Cause

`ConcurrentPromiseTask` / `WorkTask` stored a `BackRef<EventLoop>` captured at create time and `on_finish` dereferenced it unconditionally from the pool thread. The field comment claimed "the VM (and its EventLoop) outlives every task scheduled on it"; that is wrong for workers. `enqueue_task_concurrent` had only a debug assert.

### Fix

- `live_loop_registry` (a `Guarded<Vec>`) in `VirtualMachine.rs`: `register_vm` stamps both embedded event loops with a process-unique generation and publishes `(vm, loop_addr, generation)` as the final step of `VirtualMachine::init()`; `unregister_vm` removes the entries under the same lock as the first step of `WebWorker::shutdown()`, before any free.
- `LoopHandle` (`(addr, generation)`, plain data) and `EventLoop::concurrent_handle()` / `EventLoop::try_enqueue_task_concurrent()` in `event_loop.rs`. The checked enqueue takes the registry lock, verifies the `(addr, generation)` pair, and only then dereferences; main-thread VM loops take a lock-free fast path (their allocation is never freed, so a worker loop can never occupy an address inside it).
- `ConcurrentPromiseTask` / `WorkTask` carry a `LoopHandle` instead of `BackRef<EventLoop>` and post through `try_enqueue_task_concurrent`. A completion that races shutdown is dropped (the task box leaks, same as tasks left undrained in a terminated worker's queue today).

This is the minimal slice of #32071 covering the work-pool producers; the registry is the same shape so the remaining producers there can rebase on top.

### Verification

- `bun bd test test/js/web/workers/worker-terminate-lifetime.test.ts -t "Bun.Transpiler.transform"` passes
- With `src/` stashed: ASAN heap-use-after-free at `EventLoop::vm_ref` (fail-before)
- `transpiler.test.js` (182 pass), `glob/scan.test.ts` (194 pass), `workers/worker.test.ts` (25 pass) unchanged

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->