### PR TITLE
test(tls): dial bound IP in 'SNICallback matches bind hostname' (host-dependent ECONNREFUSED)

### DIFF
--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1099,9 +1099,13 @@ it("SNICallback runs even when the requested servername matches the bind hostnam
   });
   server.listen(0, "localhost");
   await once(server, "listening");
-  const port = (server.address() as AddressInfo).port;
-  // host: "localhost" defaults servername to "localhost" - the bind hostname.
-  const client = connect({ port, host: "localhost", rejectUnauthorized: false });
+  const { address, port } = server.address() as AddressInfo;
+  // Dial the bound IP directly: on a host with ::1 in /etc/hosts but no
+  // non-loopback IPv6, listen("localhost") binds ::1 while connect("localhost")
+  // resolves under ADDRCONFIG and only sees 127.0.0.1 (matches Node), so a
+  // hostname connect would ECONNREFUSED. The SNI servername is what must match
+  // the bind hostname, not the dial target.
+  const client = connect({ port, host: address, servername: "localhost", rejectUnauthorized: false });
   await once(client, "secureConnect");
   expect(sniCalls).toBe(1);
   // The peer certificate must be the SNICallback's RSA cert, not COMMON_CERT.


### PR DESCRIPTION
## What

The test \`SNICallback runs even when the requested servername matches the bind hostname\` in \`test/js/node/tls/node-tls-server.test.ts\` fails on hosts where \`/etc/hosts\` maps \`localhost\` to both \`127.0.0.1\` and \`::1\` but only loopback IPv6 is configured (no non-loopback IPv6 address):

\`\`\`
error: connect ECONNREFUSED 127.0.0.1:39971
\`\`\`

## Why this happens (and why it is not a \`node:net\` bug)

- \`server.listen(0, "localhost")\` resolves \`localhost\` **without** \`AI_ADDRCONFIG\` and binds the first result, which is \`::1\`.
- \`net.connect({host: "localhost"})\` resolves **with** \`AI_ADDRCONFIG\` (added by \`lookupAndConnect\` when no family is forced). On a host with only loopback IPv6, \`AI_ADDRCONFIG\` filters \`::1\`, so the lookup returns only \`127.0.0.1\` and the connect refuses.

Node 26.3.0 behaves identically:

\`\`\`
$ node -e 'const net=require("net");const s=net.createServer();s.listen(0,"localhost",()=>{console.log(s.address());const c=net.connect({port:s.address().port,host:"localhost"});c.on("connect",()=>{console.log("ok");c.end();s.close();});c.on("error",e=>{console.log("err",e.message);s.close();});});'
{ address: '::1', family: 'IPv6', port: 38151 }
err connect ECONNREFUSED 127.0.0.1:38151
\`\`\`

So Bun already matches Node here; there is no runtime change to make.

## Fix

The test's purpose is that the client's **SNI servername** equals the server's **bind hostname** (\`"localhost"\`), which Listener pre-registers in the static SNI tree, so that a regression where the tree shadows the user \`SNICallback\` would be caught. The transport dial target does not need to be the name \`"localhost"\`.

Dial \`server.address().address\` (whatever IP the listener actually bound) and pass \`servername: "localhost"\` explicitly. The SNI invariant is preserved; the connect no longer depends on the host's \`AI_ADDRCONFIG\` interaction with \`/etc/hosts\`.

## Verification

Before (on a host with \`::1 localhost\` in \`/etc/hosts\` and no global IPv6):
\`\`\`
(fail) SNICallback runs even when the requested servername matches the bind hostname
  error: connect ECONNREFUSED 127.0.0.1:39971
\`\`\`

After:
\`\`\`
 41 pass
 0 fail
\`\`\`

Test-only change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/tls/node-tls-server.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/tls/node-tls-server.test.ts
bun test v1.4.0 (c9a6c6a87)

test/js/node/tls/node-tls-server.test.ts:
(pass) tls.createServer listen > should throw when no port or path when using options [78.23ms]
(pass) tls.createServer listen > should listen on IPv6 by default [145.81ms]
(pass) tls.createServer listen > should listen on IPv4 [36.67ms]
(pass) tls.createServer listen > should call listening [20.11ms]
(pass) tls.createServer listen > should listen on localhost [23.96ms]
(pass) tls.createServer listen > should listen on localhost [22.20ms]
(pass) tls.createServer listen > should listen without port or host [20.90ms]
(pass) tls.createServer listen > should listen on unix domain socket [22.47ms]
(pass) tls.createServer listen > should not listen with wrong password [38.67ms]
(pass) tls.createServer listen > should reject passphrase longer than PEM_BUFSIZE without crashing [18.13ms]
(pass) tls.createServer listen > should not listen without cert [16.23ms]
(pass) tls.createServer listen > should not listen without password [17.25ms]
(pass) tls.createServer > should work with getCertificate [467.73ms]
(pass) tls.createServer events > should receive data [149.65ms]
(pass) tls.createServer events > should call end [87.55ms]
(pass) tls.createServer events > should call close [20.88ms]
(pass) tls.createServer events > should call connection and drop [75.46ms]
(pass) tls.createServer events > should error on an invalid port [16.79ms]
(pass) tls.createServer events > should call abort with signal [21.97ms]
(pass) tls.createServer events > should echo data [31.97ms]
(pass) tls.rootCertificates should exists [16.96ms]
(pass) connectionListener should emit the right amount of times, and with alpnProtocol available [1640.99ms]
(pass) destroying the socket from inside SNICallback or ALPNCallback does not crash the process [300.06ms]
(pass) leaves socket.authorized false unless a clie
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/tls/node-tls-server.test.ts | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/node/tls/node-tls-server.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->