### PR TITLE
parser: keep nested macro imports as real imports inside the macro runtime

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3581,10 +3581,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<Stmt, crate::Error> {
         let wants_macro =
             Self::ALLOW_MACROS && (path.is_macro || crate::Macro::is_macro_path(path.text));
-        // Inside the macro runtime the visit pass will not evaluate nested macro
-        // calls (see the `is_macro_runtime` gate in visit_expr), so erasing this
-        // import would leave the call site with no binding. Keep it as a regular
-        // import instead so the outer macro can call the inner function at runtime.
+        // visit_expr won't evaluate nested macro calls when `is_macro_runtime` is set,
+        // so erasing this import would leave the call site with no binding. Keep it as
+        // a regular import so the outer macro can call the inner function at runtime.
         let is_macro = wants_macro && !self.options.features.is_macro_runtime;
         if wants_macro
             && self.options.features.is_macro_runtime

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3689,7 +3689,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return Ok(self.s(S::Empty {}, loc));
         }
 
-        let macro_remap = if Self::ALLOW_MACROS {
+        let macro_remap = if Self::ALLOW_MACROS && !self.options.features.is_macro_runtime {
             self.options
                 .macro_context
                 .as_deref()

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3575,12 +3575,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn process_import_statement(
         &mut self,
         stmt_: S::Import,
-        path: ParsedPath<'a>,
+        mut path: ParsedPath<'a>,
         loc: bun_ast::Loc,
         was_originally_bare_import: bool,
     ) -> Result<Stmt, crate::Error> {
-        let is_macro =
+        let wants_macro =
             Self::ALLOW_MACROS && (path.is_macro || crate::Macro::is_macro_path(path.text));
+        // Inside the macro runtime the visit pass will not evaluate nested macro
+        // calls (see the `is_macro_runtime` gate in visit_expr), so erasing this
+        // import would leave the call site with no binding. Keep it as a regular
+        // import instead so the outer macro can call the inner function at runtime.
+        let is_macro = wants_macro && !self.options.features.is_macro_runtime;
+        if wants_macro
+            && self.options.features.is_macro_runtime
+            && crate::Macro::is_macro_path(path.text)
+        {
+            path.text = &path.text[crate::Macro::NAMESPACE_WITH_COLON.len()..];
+        }
         let mut stmt = stmt_;
         if is_macro {
             let id = self.add_import_record(ImportKind::Stmt, path.loc, path.text);

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2164,10 +2164,13 @@ impl<'a> Parser<'a> {
 
         #[cfg(not(target_arch = "wasm32"))]
         if bun_core::feature_flags::RUNTIME_TRANSPILER_CACHE {
+            let is_macro_runtime = p.options.features.is_macro_runtime;
             if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
-                if p.macro_call_count != 0 {
+                if p.macro_call_count != 0 || is_macro_runtime {
                     // disable this for:
                     // - macros
+                    // - macro-runtime transpiles (nested macro imports are kept
+                    //   as regular imports, which must not reach normal-mode reads)
                     cache.input_hash = None;
                 } else {
                     cache.exports_kind = exports_kind;

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -362,7 +362,7 @@ pub mod Runtime {
         pub fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 17] = [
+            let bools: [bool; 18] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -380,6 +380,7 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
+                self.is_macro_runtime,
                 // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
             ];
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -362,7 +362,7 @@ pub mod Runtime {
         pub fn hash_for_runtime_transpiler(&self, hasher: &mut Wyhash) {
             debug_assert!(self.runtime_transpiler_cache.is_some());
 
-            let bools: [bool; 18] = [
+            let bools: [bool; 17] = [
                 self.top_level_await,
                 self.auto_import_jsx,
                 self.allow_runtime,
@@ -380,8 +380,8 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
-                self.is_macro_runtime,
-                // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
+                // .inject_jest_globals and .is_macro_runtime are excluded: both
+                // bail out of the cache entirely (input_hash is cleared).
             ];
 
             // `[bool; N]` is N bytes of 0x00/0x01.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,9 +43,9 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-/// Version 24: `is_macro_runtime` participates in the features hash so a
-/// macro-runtime transpile of a nested-macro module cannot poison the
-/// normal-mode cache entry (#16992).
+/// Version 24: nested `with { type: "macro" }` imports are kept as regular
+/// imports inside the macro runtime (#16992); macro-runtime transpiles no
+/// longer write to the cache.
 const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -43,7 +43,10 @@ bun_core::declare_scope!(cache, visible);
 /// path reinstates the bug for any previously-cached TLA module (#30887).
 /// Version 23: `jsx.runtime`/`jsx.development` participate in the features hash,
 /// and tsconfig `"jsx": "react-jsx"` now emits the production runtime (#4227).
-const EXPECTED_VERSION: u32 = 23;
+/// Version 24: `is_macro_runtime` participates in the features hash so a
+/// macro-runtime transpile of a nested-macro module cannot poison the
+/// normal-mode cache entry (#16992).
+const EXPECTED_VERSION: u32 = 24;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2544,6 +2544,7 @@ fn transpile_source_code_inner(
                     allow_bytecode_cache: true,
                     set_breakpoint_on_first_line,
                     runtime_transpiler_cache: if !disable_transpilying
+                        && !macro_mode
                         && !<RuntimeTranspilerCache as bun_bundler::RuntimeTranspilerCacheExt>::disabled()
                     {
                         Some(&mut cache)

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -242,11 +242,7 @@ describe("nested macro imports", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toMatchObject({
       stdout: expect.stringMatching(/OUTER\(MACRO_7\)\n$/),
       stderr: "",

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -159,6 +159,77 @@ test("object argument with a sparse numeric key", async () => {
   });
 });
 
+describe("nested macro imports", () => {
+  const files = {
+    "inner.ts": `export function stamp() { return "MACRO_" + 7; }\n`,
+    "outer.ts": `
+      import { stamp } from "./inner.ts" with { type: "macro" };
+      export function outer() { return "OUTER(" + stamp() + ")"; }
+      export async function outerAsync() { return "OUTER(" + stamp() + ")"; }
+    `,
+    "outer-prefix.ts": `
+      import { stamp } from "macro:./inner.ts";
+      export function outer() { return "OUTER(" + stamp() + ")"; }
+    `,
+    "use-sync.ts": `
+      import { outer } from "./outer.ts" with { type: "macro" };
+      console.log(outer());
+    `,
+    "use-async.ts": `
+      import { outerAsync } from "./outer.ts" with { type: "macro" };
+      console.log(await outerAsync());
+    `,
+    "use-prefix.ts": `
+      import { outer } from "./outer-prefix.ts" with { type: "macro" };
+      console.log(outer());
+    `,
+  };
+
+  for (const entry of ["use-sync.ts", "use-async.ts", "use-prefix.ts"]) {
+    test.concurrent(`bun run ${entry}`, async () => {
+      using dir = tempDir("macro-nested-run", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", entry],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stdout, stderr, exitCode }).toMatchObject({
+        stdout: expect.stringMatching(/OUTER\(MACRO_7\)\n$/),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  }
+
+  test.concurrent("bun build inlines the nested macro result", async () => {
+    using dir = tempDir("macro-nested-build", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./use-sync.ts", "--outdir", "dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ stderr: "", exitCode: 0 });
+    const out = await Bun.file(path.join(String(dir), "dist", "use-sync.js")).text();
+    expect(out).toContain("OUTER(MACRO_7)");
+    expect(out).not.toContain("stamp");
+    expect(out).not.toContain("inner.ts");
+  });
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -195,11 +195,7 @@ describe("nested macro imports", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout, stderr, exitCode }).toMatchObject({
         stdout: expect.stringMatching(/OUTER\(MACRO_7\)\n$/),
         stderr: "",
@@ -217,11 +213,7 @@ describe("nested macro imports", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toMatchObject({ stderr: "", exitCode: 0 });
     const out = await Bun.file(path.join(String(dir), "dist", "use-sync.js")).text();
     expect(out).toContain("OUTER(MACRO_7)");

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -220,6 +220,39 @@ describe("nested macro imports", () => {
     expect(out).not.toContain("stamp");
     expect(out).not.toContain("inner.ts");
   });
+
+  test.concurrent("bunfig [macros] remap inside the macro runtime", async () => {
+    using dir = tempDir("macro-nested-remap", {
+      "bunfig.toml": `[macros]\nfakepkg = { "stamp" = "fakepkg" }\n`,
+      "node_modules/fakepkg/package.json": `{"name":"fakepkg","main":"index.js"}`,
+      "node_modules/fakepkg/index.js": `export function stamp() { return "MACRO_" + 7; }\n`,
+      "outer.ts": `
+        import { stamp } from "fakepkg";
+        export function outer() { return "OUTER(" + stamp() + ")"; }
+      `,
+      "use.ts": `
+        import { outer } from "./outer.ts" with { type: "macro" };
+        console.log(outer());
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "use.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({
+      stdout: expect.stringMatching(/OUTER\(MACRO_7\)\n$/),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });
 
 describe("--no-macros", () => {


### PR DESCRIPTION
## What

A macro that itself imports another module with `{ type: "macro" }` (or the `macro:` specifier prefix, or via a bunfig `[macros]` remap) throws `ReferenceError` at build time because the nested import is erased but the call site is never inlined.

## Repro

```ts
// inner.ts
export function stamp() { return "MACRO_" + 7; }

// outer.ts
import { stamp } from "./inner.ts" with { type: "macro" };
export function outer() { return "OUTER(" + stamp() + ")"; }

// use.ts
import { outer } from "./outer.ts" with { type: "macro" };
console.log(outer());
```

```
$ bun run use.ts
error: cannot coerce Exception (JSType(0)) to Bun's AST. Please return a simpler type
```

The async variant surfaces the underlying `ReferenceError: stamp is not defined`. Importing `outer.ts` at runtime (not as a macro) works fine because the nested macro is inlined normally.

## Cause

`process_import_statement` in `src/js_parser/p.rs` erases any `with { type: "macro" }` / `macro:` / bunfig-remapped import unconditionally and records the bindings in `p.macro_.refs` for the visit pass to inline. But `visit_expr` only evaluates those calls when `!features.is_macro_runtime`, and loading a module for macro execution sets `is_macro_runtime = true` (via `enable_macro_mode` -> `target = BunMacro`). So the import is gone, the call is never inlined, and the binding is undefined.

## Fix

When `features.is_macro_runtime` is set, treat the nested macro import as a regular import (stripping the `macro:` prefix if present) instead of erasing it, and skip the `macro_remap` lookup. The inner module then loads normally inside the macro VM and its exports are callable when the outer macro runs. The visit-pass gate is unchanged, so there is no re-entrant `MacroContext::call`.

Macro-runtime transpiles also no longer write to the on-disk runtime transpiler cache (`input_hash` is cleared alongside the existing `macro_call_count != 0` bail-out), so a macro-mode transpile of a nested-macro module cannot poison the entry a later normal-mode load reads. Normal-mode entries are still served to macro-mode reads since their output is valid there. `EXPECTED_VERSION` is bumped to 24.

## Tests

Added to `test/bundler/transpiler/macro-test.test.ts`: sync/async `bun run` for the attribute form, the `macro:` prefix form, and a bunfig `[macros]` package-path remap, plus a `bun build` check that the final output contains the fully inlined `OUTER(MACRO_7)` with no reference to `stamp` or `inner.ts`. All five fail on main with `ReferenceError: stamp is not defined` (sync shows the coerce-Exception message) and pass with the fix.

Fixes #16992

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.0 (b395bf8b9)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cfe7395c0)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [1.12ms]
(pass) latin1 string [0.03ms]
(pass) ascii string [0.01ms]
(pass) type coercion [0.06ms]
(pass) escaping [0.16ms]
(pass) utf16 string [0.02ms]
(pass) import aliases [0.03ms]
(pass) default import [0.01ms]
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.07ms]
(pass) object argument with a sparse numeric key [18.15ms]
(pass) nested macro imports > bunfig [macros] remap inside the macro runtime [12.81ms]
(pass) nested macro imports > bun run use-prefix.ts [19.28ms]
(pass) nested macro imports > bun run use-sync.ts [29.65ms]
(pass) nested macro imports > bun build inlines the nested macro result [25.74ms]
(pass) nested macro imports > bun run use-async.ts [31.28ms]
(pass) --no-macros > bun build --no-macros refuses to run macros [5.38ms]
(pass) --no-macros > Bun.build({ macros: false }) refuses to run macros [16.89ms]
(pass) --no-macros > bun build without --no-macros still runs macros [33.34ms]

 19 pass
 0 fail
 89 expect() calls
Ran 19 tests across 1 file. [384.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.0 (b395bf8b9)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 748ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         | 16 +++++-
 src/js_parser/parse/parse_entry.rs         |  5 +-
 src/js_parser/parser.rs                    |  3 +-
 src/jsc/RuntimeTranspilerCache.rs          |  5 +-
 src/runtime/jsc_hooks.rs                   |  1 +
 test/bundler/transpiler/macro-test.test.ts | 92 ++++++++++++++++++++++++++++++
 6 files changed, 116 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              5      4      0
src/js_parser/parse/parse_entry.rs              2      2      0
src/js_parser/parser.rs                         3      3      0
src/jsc/RuntimeTranspilerCache.rs               4      2      0
src/runtime/jsc_hooks.rs                        4      1      0
test/bundler/transpiler/macro-test.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->