### PR TITLE
runtime: make CSS default export {} to match bun build

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3390,6 +3390,18 @@ fn transpile_source_code_inner(
             // SAFETY: null-checked above; `global_object` is the live per-thread
             // `JSGlobalObject` for the FFI call.
             let global = unsafe { &*global_object };
+            // CSS imports have no runtime value; the bundler emits `{}` for the
+            // JS stub of a CSS entry (esbuild parity), so match that here instead
+            // of leaking the file path as the default export.
+            if matches!(loader, L::Css) {
+                return Ok(OwnedResolvedSource::from(ResolvedSource {
+                    jsvalue_for_export: JSValue::create_empty_object(global, 0),
+                    specifier: input_specifier.dupe_ref(),
+                    source_url: create_if_different(input_specifier, path.text),
+                    tag: ResolvedSourceTag::ExportDefaultObject,
+                    ..Default::default()
+                }));
+            }
             // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
             let value = if !unsafe { &*jsc_vm }.origin.is_empty() {
                 // Rewrite `specifier` against `vm.origin` so

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3390,9 +3390,11 @@ fn transpile_source_code_inner(
             // SAFETY: null-checked above; `global_object` is the live per-thread
             // `JSGlobalObject` for the FFI call.
             let global = unsafe { &*global_object };
-            // CSS imports have no runtime value; the bundler emits `{}` for the
-            // JS stub of a CSS entry (esbuild parity), so match that here instead
-            // of leaking the file path as the default export.
+            // The bundler emits `{}` as the JS stub for a plain CSS import
+            // (esbuild parity); match that here instead of leaking the file path
+            // as the default export. `.module.css` still diverges: the bundler
+            // emits a class-name map there, runtime CSS-module scoping is not
+            // implemented.
             if matches!(loader, L::Css) {
                 return Ok(OwnedResolvedSource::from(ResolvedSource {
                     jsvalue_for_export: JSValue::create_empty_object(global, 0),

--- a/test/js/bun/css/css-loader.test.ts
+++ b/test/js/bun/css/css-loader.test.ts
@@ -3,7 +3,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 // The default export of a CSS import is an empty object (esbuild parity), and
 // `bun run` and `bun build --target=bun` agree on that shape.
-describe("css loader default export", () => {
+describe.concurrent("css loader default export", () => {
   const entry = `import c from "./s.css";\nprocess.stdout.write(typeof c + " " + JSON.stringify(c));\n`;
 
   test("bun run", async () => {

--- a/test/js/bun/css/css-loader.test.ts
+++ b/test/js/bun/css/css-loader.test.ts
@@ -1,0 +1,52 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// The default export of a CSS import is an empty object (esbuild parity), and
+// `bun run` and `bun build --target=bun` agree on that shape.
+describe("css loader default export", () => {
+  const entry = `import c from "./s.css";\nprocess.stdout.write(typeof c + " " + JSON.stringify(c));\n`;
+
+  test("bun run", async () => {
+    using dir = tempDir("css-loader-run", {
+      "s.css": ".c { color: red }",
+      "e.ts": entry,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "e.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("object {}");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun build --target=bun then run matches bun run", async () => {
+    using dir = tempDir("css-loader-build", {
+      "s.css": ".c { color: red }",
+      "e.ts": entry,
+    });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "e.ts", "--target=bun", "--outdir=out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [, buildErr, buildCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildErr).toBe("");
+    expect(buildCode).toBe(0);
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "out/e.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("object {}");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/css/css-loader.test.ts
+++ b/test/js/bun/css/css-loader.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-// The default export of a CSS import is an empty object (esbuild parity), and
-// `bun run` and `bun build --target=bun` agree on that shape.
+// The default export of a plain .css import is an empty object (esbuild
+// parity), and `bun run` and `bun build --target=bun` agree on that shape.
 describe.concurrent("css loader default export", () => {
   const entry = `import c from "./s.css";\nprocess.stdout.write(typeof c + " " + JSON.stringify(c));\n`;
 

--- a/test/js/bun/css/css-loader.test.ts
+++ b/test/js/bun/css/css-loader.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // The default export of a CSS import is an empty object (esbuild parity), and

--- a/test/js/bun/resolve/import-empty.test.js
+++ b/test/js/bun/resolve/import-empty.test.js
@@ -23,9 +23,9 @@ it("importing empty file with type file returns it path", async () => {
 
 // MARK: - web imports
 
-it("importing empty css file returns its path", async () => {
+it("importing empty css file returns an empty object", async () => {
   const empty_file_css = (await import("./empty-file", { with: { type: "css" } })).default;
-  expect(empty_file_css).toEqual(empty_file_path);
+  expect(empty_file_css).toEqual({});
 });
 
 it("importing empty html file returns HTMLBundle with its path", async () => {


### PR DESCRIPTION
## Repro

```sh
printf '.c{}' > s.css
printf 'import c from "./s.css";console.log(typeof c, JSON.stringify(c))' > e.ts
bun run e.ts
# before: string "/abs/path/s.css"
bun build e.ts --target=bun --outdir=o && (cd o && bun e.js)
# object {}
```

`bun run` and the artifact produced by `bun build --target=bun` disagreed on the default export of a plain `.css` import: the runtime returned the absolute file path as a string, the bundler emits `var s_default = {}`.

## Cause

`transpile_source_code_inner` in `src/runtime/jsc_hooks.rs` has no `Loader::Css` match arm, so `.css` falls through to the `_` catch-all (the file loader) which exports `path.text` as a string. The bundler's `ParseTask` builds an empty-object lazy export for the JS stub of a CSS entry, matching esbuild.

## Fix

Return an empty object for the css loader in the fallback arm, after the existing auto-watch registration so `--hot` keeps picking up `.css` edits. `require`, dynamic `import()`, and Worker imports all go through the same path and now agree with the bundled output.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/css/css-loader.test.ts
(fail) css loader default export > bun run
  Expected: "object {}"
  Received: "string \"/tmp/.../s.css\""
(pass) css loader default export > bun build --target=bun then run matches bun run

$ bun bd test test/js/bun/css/css-loader.test.ts
(pass) css loader default export > bun run
(pass) css loader default export > bun build --target=bun then run matches bun run
```

The existing `should hot reload when hot-file-loader.css is overwritten` test still passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css-loader.test.ts test/js/bun/resolve/import-empty.test.js
bun test v1.4.0 (786f6da16)

test/js/bun/resolve/import-empty.test.js:
(pass) importing empty text file returns empty string [27.98ms]
(pass) importing empty file with type file returns it path [6.51ms]
23 | 
24 | // MARK: - web imports
25 | 
26 | it("importing empty css file returns an empty object", async () => {
27 |   const empty_file_css = (await import("./empty-file", { with: { type: "css" } })).default;
28 |   expect(empty_file_css).toEqual({});
                              ^
error: expect(received).toEqual(expected)

Expected: {}
Received: "/workspace/bun/test/js/bun/resolve/empty-file"

      at <anonymous> (/workspace/bun/test/js/bun/resolve/import-empty.test.js:28:26)
(fail) importing empty css file returns an empty object [8.39ms]
(pass) importing empty html file returns HTMLBundle with its path [5.97ms]
(pass) importing empty js like file returns empty module [25.49ms]
(pass) importing empty json file throws JSON Parse error [9.99ms]
(pass) import
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (9ea153ae0)

test/js/bun/resolve/import-empty.test.js:
(pass) importing empty text file returns empty string [0.88ms]
(pass) importing empty file with type file returns it path [0.13ms]
(pass) importing empty css file returns an empty object [0.08ms]
(pass) importing empty html file returns HTMLBundle with its path [0.08ms]
(pass) importing empty js like file returns empty module [0.57ms]
(pass) importing empty json file throws JSON Parse error [0.25ms]
(pass) importing empty jsonc/toml file returns module with empty object as default export [0.25ms]
(pass) importing empty file returns module with path as default export [0.16ms]
(pass) importing empty sqlite files returns database object [0.66ms]

test/js/bun/css/css-loader.test.ts:
(pass) css loader default export > bun run [25.46ms]
(pass) css loader default export > bun build --target=bun then run matches bun run [32.04ms]

 11 pass
 0 fail
 31 expect() calls
Ran 11 tests across 2 files. [204.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css-loader.test.ts test/js/bun/resolve/import-empty.test.js
bun test v1.4.0 (786f6da16)

test/js/bun/resolve/import-empty.test.js:
(pass) importing empty text file returns empty string [25.06ms]
(pass) importing empty file with type file returns it path [5.72ms]
(pass) importing empty css file returns an empty object [5.57ms]
(pass) importing empty html file returns HTMLBundle with its path [5.51ms]
(pass) importing empty js like file returns empty module [58.47ms]
(pass) importing empty json file throws JSON Parse error [10.71ms]
(pass) importing empty jsonc/toml file returns module with empty object as default export [13.15ms]
(pass) importing empty file returns module with path as default export [11.85ms]
(pass) importing empty sqlite files returns database object [25.95ms]

test/js/bun/css/css-loader.test.ts:
(pass) css loader default export > bun run [1258.94ms]
(pass) css loader default export > bun build --target=bun then run matches bun run [1482.41ms]

 11 pass
 0 fail
 31 expect() calls
Ran 11 tests across 2 f
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 628ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/jsc_hooks.rs                 | 14 +++++++++
 test/js/bun/css/css-loader.test.ts       | 52 ++++++++++++++++++++++++++++++++
 test/js/bun/resolve/import-empty.test.js |  4 +--
 3 files changed, 68 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/runtime/jsc_hooks.rs                      4      2      0
test/js/bun/css/css-loader.test.ts            1      3      0
test/js/bun/resolve/import-empty.test.js      1      1      0
```

</details>

<!-- robobun:evidence:end -->