### PR TITLE
cli: gate bun init / update -i prompts on stdin isatty

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -243,6 +243,9 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS, "BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS", {});
     new_feature_flag!(pub BUN_INSTRUMENTS, "BUN_INSTRUMENTS", {});
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
+    // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
+    // tests can drive the multi-select by writing keystrokes to a pipe.
+    new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN, "BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT, "BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT", {});
     new_feature_flag!(pub BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF, "BUN_INTERNAL_SUPPRESS_CRASH_ON_PROCESS_KILL_SELF", {});

--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -362,6 +362,13 @@ impl InitCommand {
             }
         }
 
+        // The template picker reads single keystrokes from raw-mode stdin; on a
+        // pipe (CI, `spawn(...,{stdio:'pipe'})`, `foo | bun init`) that blocks
+        // forever. npm init falls back to defaults when stdin is not a TTY.
+        if !auto_yes && !Output::is_stdin_tty() {
+            auto_yes = true;
+        }
+
         if let Some(ifdir) = initialize_in_folder {
             if let Err(err) = bun_sys::Dir::cwd().make_path(ifdir) {
                 bun_core::pretty_errorln!(

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -250,6 +250,27 @@ impl UpdateInteractiveCommand {
         );
         Output::flush();
 
+        // The multi-select reads single keystrokes from raw-mode stdin. On a
+        // pipe (CI, spawn with stdio:'pipe') that either blocks forever or
+        // silently selects nothing on EOF while spraying cursor-control
+        // escapes into a non-TTY log. Refuse early, before resolving
+        // manifests. Tests that drive the UI via piped keystrokes set
+        // BUN_INTERNAL_INTERACTIVE_ASSUME_TTY=1 to bypass this.
+        if !Output::is_stdin_tty()
+            && !bun_core::env_var::feature_flag::BUN_INTERNAL_INTERACTIVE_ASSUME_TTY
+                .get()
+                .unwrap_or(false)
+        {
+            bun_core::pretty_errorln!(
+                "<r><red>error<r>: <b>bun update --interactive<r> requires an interactive terminal."
+            );
+            bun_core::pretty_errorln!(
+                "Use <cyan>bun update<r> to update non-interactively, or <cyan>bun outdated<r> to list available updates."
+            );
+            Output::flush();
+            Global::exit(1);
+        }
+
         let cli = CommandLineArguments::parse(Subcommand::Update)?;
         let silent = cli.silent;
 

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -264,7 +264,7 @@ impl UpdateInteractiveCommand {
             bun_core::pretty_errorln!(
                 "<r><red>error<r>: <b>bun update --interactive<r> requires an interactive terminal."
             );
-            bun_core::pretty_errorln!(
+            bun_core::note!(
                 "Use <cyan>bun update<r> to update non-interactively, or <cyan>bun outdated<r> to list available updates."
             );
             Output::flush();

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -99,6 +99,33 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
   }, 30_000);
 
+  test("bun init falls back to --yes when stdin is not a TTY", async () => {
+    const temp = tempDirWithFiles("bun-init-no-tty", {});
+
+    // stdin is a pipe we never write to. Previously this hung at the template
+    // menu waiting for a keystroke that never arrives.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "init"],
+      cwd: temp,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: initEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // No interactive menu rendered: no "Select a project template" prompt and
+    // no cursor-control escapes leaked into piped stdout.
+    expect(stdout).not.toContain("Select a project template");
+    expect(stdout).not.toContain("\x1b[");
+    expect(stderr).not.toContain("\x1b[");
+    expect(exitCode).toBe(0);
+
+    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+  }, 30_000);
+
   test("bun init in folder", async () => {
     const temp = tempDirWithFiles("bun-init-in-folder", {
       "mydir": {
@@ -208,10 +235,9 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
       env: initEnv,
     });
     expect(await exited2).toBe(0);
-    expect(await stderr.text()).toMatchInlineSnapshot(`
-    "note: package.json already exists, configuring existing project
-    "
-  `);
+    // stdin is "ignore" (not a TTY), so this run behaves like `-y` and the
+    // "package.json already exists" note is suppressed just as it is for `-y`.
+    expect(await stderr.text()).toMatchInlineSnapshot(`""`);
     expect(await exited2).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
     expect(readdirSync(path.join(temp, "mydir")).sort()).toMatchInlineSnapshot(`

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -63,42 +63,6 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
   }, 30_000);
 
-  test("bun init with piped cli", async () => {
-    const temp = tempDirWithFiles("bun-init-with-piped-cli", {});
-
-    const { exited } = Bun.spawn({
-      cmd: [bunExe(), "init"],
-      cwd: temp,
-      stdio: [new Blob(["\n\n\n\n\n\n\n\n\n\n\n\n"]), "inherit", "inherit"],
-      env: initEnv,
-    });
-
-    expect(await exited).toBe(0);
-
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
-    expect(pkg).toEqual({
-      "name": path.basename(temp).toLowerCase().replaceAll(" ", "-"),
-      "module": "index.ts",
-      "private": true,
-      "type": "module",
-      "devDependencies": {
-        "@types/bun": "latest",
-      },
-      "peerDependencies": {
-        "typescript": "^6",
-      },
-    });
-    const readme = fs.readFileSync(path.join(temp, "README.md"), "utf8");
-    expect(readme).toStartWith("# " + path.basename(temp).toLowerCase().replaceAll(" ", "-") + "\n");
-    expect(readme).toInclude("v" + Bun.version.replaceAll("-debug", ""));
-    expect(readme).toInclude("index.ts");
-
-    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
-  }, 30_000);
-
   test("bun init falls back to --yes when stdin is not a TTY", async () => {
     const temp = tempDirWithFiles("bun-init-no-tty", {});
 

--- a/test/cli/update_interactive_install.test.ts
+++ b/test/cli/update_interactive_install.test.ts
@@ -200,4 +200,54 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
       throw err;
     }
   });
+
+  test("refuses to prompt when stdin is not a TTY", async () => {
+    using dir = tempDir("update-interactive-no-tty", {
+      "package.json": JSON.stringify({
+        name: "test-project",
+        version: "1.0.0",
+        dependencies: { "is-even": "0.1.0" },
+      }),
+    });
+
+    const env = {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+      // Drop the harness bypass so the real isatty gate is exercised.
+      BUN_INTERNAL_INTERACTIVE_ASSUME_TTY: undefined,
+    };
+
+    await using installProc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await installProc.exited;
+
+    // stdin is a pipe we never write to. Previously this hung at the menu.
+    await using updateProc = Bun.spawn({
+      cmd: [bunExe(), "update", "--interactive"],
+      cwd: String(dir),
+      env,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      updateProc.stdout.text(),
+      updateProc.stderr.text(),
+      updateProc.exited,
+    ]);
+
+    expect(stderr).toContain("requires an interactive terminal");
+    // No cursor-control escapes leaked into piped output.
+    expect(stdout).not.toContain("\x1b[");
+    expect(exitCode).toBe(1);
+
+    // package.json untouched
+    const pkg = JSON.parse(readFileSync(join(String(dir), "package.json"), "utf8"));
+    expect(pkg.dependencies["is-even"]).toBe("0.1.0");
+  });
 });

--- a/test/cli/update_interactive_install.test.ts
+++ b/test/cli/update_interactive_install.test.ts
@@ -210,27 +210,16 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
       }),
     });
 
-    const env = {
-      ...bunEnv,
-      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
-      // Drop the harness bypass so the real isatty gate is exercised.
-      BUN_INTERNAL_INTERACTIVE_ASSUME_TTY: undefined,
-    };
-
-    await using installProc = Bun.spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    await installProc.exited;
-
-    // stdin is a pipe we never write to. Previously this hung at the menu.
+    // stdin is a pipe we never write to. Previously this reached the menu and
+    // blocked on read(); now the gate fires before any manifest resolution.
     await using updateProc = Bun.spawn({
       cmd: [bunExe(), "update", "--interactive"],
       cwd: String(dir),
-      env,
+      env: {
+        ...bunEnv,
+        // Drop the harness bypass so the real isatty gate is exercised.
+        BUN_INTERNAL_INTERACTIVE_ASSUME_TTY: undefined,
+      },
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -74,6 +74,9 @@ export const bunEnv: NodeJS.Dict<string> = {
   CI: "1",
   BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
   BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+  // Tests drive `bun update --interactive` by writing keystrokes to a pipe;
+  // the real command refuses on non-TTY stdin. Bypass that gate under test.
+  BUN_INTERNAL_INTERACTIVE_ASSUME_TTY: "1",
   BUN_GARBAGE_COLLECTOR_LEVEL: process.env.BUN_GARBAGE_COLLECTOR_LEVEL || "0",
   BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE: "1",
   BUN_DEBUG_linkerctx: "0",


### PR DESCRIPTION
## Problem

`bun init` and `bun update --interactive` render a raw-mode select menu that does a blocking single-byte read on stdin with no `isatty(0)` check. In any context where stdin is a pipe rather than a terminal (CI runners, `spawn(..., {stdio: 'pipe'})`, `something | bun init`):

```
$ (sleep 30) | timeout 8 bun init;              echo rc=$?   # rc=124, hung at menu
$ (sleep 30) | CI=true timeout 8 bun init;      echo rc=$?   # rc=124, CI=true ignored
$ bun init </dev/null | cat -v
? Select a project template - Press return to submit.
       Blank^[[0K
    React^[[0K
    Library^[[0K
^[[0J^[[4A^[[0J...                                           # auto-selected, ANSI into pipe
$ (sleep 30) | timeout 8 bun update -i;         echo rc=$?   # rc=124, hung at menu
```

`CI=true` is ignored, and on EOF stdin the menu auto-selects the first option while writing cursor-control escapes (`\x1b[?25l`, `\x1b[nA`, `\x1b[0J`, `\x1b[0K`) into non-TTY stdout.

## Fix

- **`bun init`**: when stdin is not a TTY, behave as if `-y` was passed (npm init parity). The template picker is never entered, so no hang and no escape sequences.
- **`bun update --interactive`**: when stdin is not a TTY, refuse early (before resolving manifests) with a message pointing at `bun update` / `bun outdated`. The user explicitly asked for a mode that cannot work without a terminal.

Tests that drive the `update -i` multi-select by writing keystrokes to a pipe set `BUN_INTERNAL_INTERACTIVE_ASSUME_TTY=1` (added to the harness `bunEnv`) to bypass the gate.

The SIGINT-leaves-cursor-hidden face of this report is covered separately by #30891.

## Verification

```
# before: both hang (timeout); after: both return immediately
bun bd test test/cli/init/init.test.ts -t "falls back to --yes"
bun bd test test/cli/update_interactive_install.test.ts -t "refuses to prompt"
```

All existing `init` / `update_interactive_*` / regression tests pass unchanged except `bun init twice`, whose stderr snapshot drops the "package.json already exists" note (non-TTY stdin now matches `-y`, which already suppressed that note).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/init/init.test.ts

<!-- robobun:evidence:end -->