### PR TITLE
upgrade: require a release-asset sha256 and verify canary downloads

### DIFF
--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -182,6 +182,7 @@ impl UpgradeCommand {
         refresher: Option<&mut Progress::Progress>,
         mut progress: Option<&mut Progress::Node>,
         use_profile: bool,
+        use_canary: bool,
     ) -> crate::Result<Option<Version>> {
         let mut headers_buf: Vec<u8> = Self::DEFAULT_GITHUB_HEADERS.to_vec();
 
@@ -212,8 +213,13 @@ impl UpgradeCommand {
         let url_buf: &'static mut Vec<u8> = crate::cli::cli_arena().alloc(Vec::new());
         write!(
             url_buf,
-            "https://{}/repos/Jarred-Sumner/bun-releases-for-updater/releases/latest",
+            "https://{}{}",
             bstr::BStr::new(github_api_domain),
+            if use_canary {
+                "/repos/oven-sh/bun/releases/tags/canary"
+            } else {
+                "/repos/Jarred-Sumner/bun-releases-for-updater/releases/latest"
+            },
         )
         .expect("oom");
         let api_url = URL::parse(&url_buf[..]);
@@ -562,7 +568,7 @@ impl UpgradeCommand {
 
         let use_profile = argv_contains(b"--profile");
 
-        let mut version: Version = if !use_canary {
+        let mut version: Version = {
             // `Progress::start` returns `&mut Node` borrowing `refresher`;
             // leak the Progress and use raw pointers so we can pass both
             // `&mut refresher` and `&mut progress` to `get_latest_version`.
@@ -581,6 +587,7 @@ impl UpgradeCommand {
                 // SAFETY: progress points into the same leaked allocation (see above).
                 Some(unsafe { &mut *progress }),
                 use_profile,
+                use_canary,
             )?
             else {
                 return Ok(());
@@ -591,16 +598,6 @@ impl UpgradeCommand {
             // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
             unsafe { (*refresher).refresh() };
 
-            if !Environment::IS_CANARY {
-                if version.name().is_some() && version.is_current() {
-                    bun_core::pretty_errorln!(
-                        "<r><green>Congrats!<r> You're already on the latest version of Bun <d>(which is v{})<r>",
-                        bstr::BStr::new(&version.name().unwrap())
-                    );
-                    Global::exit(0);
-                }
-            }
-
             if version.name().is_none() {
                 bun_core::pretty_errorln!(
                     "<r><red>error:<r> Bun versions are currently unavailable (the latest version name didn't match the expected format)"
@@ -608,36 +605,41 @@ impl UpgradeCommand {
                 Global::exit(1);
             }
 
-            if !Environment::IS_CANARY {
-                bun_core::pretty_errorln!(
-                    "<r><b>Bun <cyan>v{}<r> is out<r>! You're on <blue>v{}<r>\n",
-                    bstr::BStr::new(&version.name().unwrap()),
-                    Global::package_json_version
-                );
-            } else {
-                bun_core::pretty_errorln!(
-                    "<r><b>Downgrading from Bun <blue>{}-canary<r> to Bun <cyan>v{}<r><r>\n",
-                    Global::package_json_version,
-                    bstr::BStr::new(&version.name().unwrap())
-                );
+            if !use_canary {
+                if !Environment::IS_CANARY {
+                    if version.is_current() {
+                        bun_core::pretty_errorln!(
+                            "<r><green>Congrats!<r> You're already on the latest version of Bun <d>(which is v{})<r>",
+                            bstr::BStr::new(&version.name().unwrap())
+                        );
+                        Global::exit(0);
+                    }
+
+                    bun_core::pretty_errorln!(
+                        "<r><b>Bun <cyan>v{}<r> is out<r>! You're on <blue>v{}<r>\n",
+                        bstr::BStr::new(&version.name().unwrap()),
+                        Global::package_json_version
+                    );
+                } else {
+                    bun_core::pretty_errorln!(
+                        "<r><b>Downgrading from Bun <blue>{}-canary<r> to Bun <cyan>v{}<r><r>\n",
+                        Global::package_json_version,
+                        bstr::BStr::new(&version.name().unwrap())
+                    );
+                }
+                Output::flush();
             }
-            Output::flush();
 
             version
-        } else {
-            Version {
-                tag: b"canary"[..].into(),
-                zip_url: const_format::concatcp!(
-                    "https://github.com/oven-sh/bun/releases/download/canary/",
-                    Version::ZIP_FILENAME
-                )
-                .as_bytes()
-                .into(),
-                size: 0,
-                buf: MutableString::init_empty(),
-                digest: Integrity::default(),
-            }
         };
+
+        if !version.digest.tag.is_supported() {
+            bun_core::pretty_errorln!(
+                "<r><red>error:<r> The GitHub API did not return a sha256 checksum for the {} release asset. Refusing to download an unverifiable archive.\n<r>note: run <b>bun upgrade<r> again in a moment; GitHub computes asset checksums shortly after upload",
+                if use_canary { "canary" } else { "latest" },
+            );
+            Global::exit(1);
+        }
 
         let zip_url_bytes = core::mem::take(&mut version.zip_url);
         let zip_url = URL::parse(&zip_url_bytes);
@@ -709,7 +711,7 @@ impl UpgradeCommand {
                 Global::exit(1);
             }
 
-            if version.digest.tag.is_supported() && !version.digest.verify(bytes) {
+            if !version.digest.verify(bytes) {
                 bun_core::pretty_errorln!(
                     "<r><red>error:<r> The file downloaded from {} did not match the checksum reported by the GitHub API for this release.\n<r>note: run <b>bun upgrade<r> again to retry the download",
                     bstr::BStr::new(&zip_url_bytes)

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -464,6 +464,19 @@ impl UpgradeCommand {
         if !SILENT {
             progress.expect("infallible: progress active").end();
             refresher.expect("infallible: progress active").refresh();
+
+            if use_canary {
+                bun_core::pretty_errorln!(
+                    "<r><red>error:<r> Canary builds are not available for this platform yet\n\n   Release: <cyan>https://github.com/oven-sh/bun/releases/tag/canary<r>\n  Filename: <b>{}<r>\n",
+                    if use_profile {
+                        Version::PROFILE_ZIP_FILENAME
+                    } else {
+                        Version::ZIP_FILENAME
+                    }
+                );
+                Global::exit(1);
+            }
+
             if let Some(name) = version.name() {
                 bun_core::pretty_errorln!(
                     "Bun v{} is out, but not for this platform ({}) yet.",

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -344,23 +344,21 @@ it("verifies the downloaded release archive against the digest reported by the r
   expect(matched.exitCode).toBe(1);
 });
 
-describe.each(["--stable", "--canary"] as const)("%s", flag => {
+describe.concurrent.each(["--stable", "--canary"] as const)("%s", flag => {
   const tagName = flag === "--canary" ? "canary" : "bun-v9.9.9";
   const archiveBody = "this is not a real zip archive";
 
-  it("refuses to download when the release asset has no checksum", async () => {
-    // An asset with a `digest` that is absent, null, or malformed must be
-    // treated as unverifiable: no download, no install, no execution.
-    for (const digest of [undefined, null, "", "sha256:not-hex", "md5:" + Buffer.alloc(16).toString("hex")]) {
+  // An asset with a `digest` that is absent, null, or malformed must be
+  // treated as unverifiable: no download, no install, no execution.
+  it.each([undefined, null, "", "sha256:not-hex", "md5:" + Buffer.alloc(16).toString("hex")])(
+    "refuses to download when the release asset digest is %p",
+    async digest => {
       const result = await runUpgrade({ tagName, archiveBody, digest, flag });
-      expect({ digest, stderr: result.stderr }).toEqual({
-        digest,
-        stderr: expect.stringContaining("did not return a sha256 checksum"),
-      });
+      expect(result.stderr).toContain("did not return a sha256 checksum");
       expect(result.downloaded).toBe(false);
       expect(result.exitCode).toBe(1);
-    }
-  });
+    },
+  );
 
   it("refuses to install when the downloaded archive does not match the checksum", async () => {
     const wrongDigest = `sha256:${Buffer.alloc(32, 0xab).toString("hex")}`;

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -2,12 +2,30 @@ import { spawn } from "bun";
 import { upgrade_test_helpers } from "bun:internal-for-testing";
 import { describe, expect, it, setDefaultTimeout } from "bun:test";
 import { bunExe, bunEnv as env, tempDir, tls, tmpdirSync } from "harness";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { copyFile } from "node:fs/promises";
 import { basename, join } from "path";
 const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
 
 setDefaultTimeout(1000 * 60 * 5);
+
+// Cover every platform/arch/abi/cpu combination so the asset list matches
+// whichever target this test runs on. Non-matching names are ignored.
+const assetNames: string[] = [];
+for (const os of ["windows", "linux", "darwin"]) {
+  for (const arch of ["x64", "aarch64"]) {
+    for (const abi of ["", "-musl", "-android"]) {
+      for (const cpu of ["", "-baseline"]) {
+        assetNames.push(`bun-${os}-${arch}${abi}${cpu}.zip`);
+        assetNames.push(`bun-${os}-${arch}${abi}${cpu}-profile.zip`);
+      }
+    }
+  }
+}
+
+function sha256Hex(body: string) {
+  return new Bun.CryptoHasher("sha256").update(body).digest("hex");
+}
 
 describe.concurrent(() => {
   it("two invalid arguments, should display error message and suggest command", async () => {
@@ -99,70 +117,27 @@ describe.concurrent(() => {
   });
 
   it("zero arguments, should succeed", async () => {
-    const tagName = bunExe().includes("-debug") ? "canary" : `bun-v${Bun.version}`;
+    const archiveBody = "this is not a real zip archive";
+    const digest = `sha256:${sha256Hex(archiveBody)}`;
     using server = Bun.serve({
       tls: tls,
       port: 0,
-      async fetch() {
+      async fetch(req) {
+        const { pathname } = new URL(req.url);
+        if (pathname.startsWith("/releases/")) {
+          return new Response(archiveBody);
+        }
+        const tagName = pathname.endsWith("/canary") ? "canary" : `bun-v${Bun.version}`;
         return new Response(
           JSON.stringify({
             "tag_name": tagName,
-            "assets": [
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-windows-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-windows-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-linux-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-linux-aarch64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-x64-baseline.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-x64-baseline.zip`,
-              },
-              {
-                "url": "foo",
-                "content_type": "application/zip",
-                "name": "bun-darwin-aarch64.zip",
-                "browser_download_url": `https://pub-5e11e972747a44bf9aaf9394f185a982.r2.dev/releases/${tagName}/bun-darwin-aarch64.zip`,
-              },
-            ],
+            "assets": assetNames.map(name => ({
+              "url": "foo",
+              "content_type": "application/zip",
+              "name": name,
+              "digest": digest,
+              "browser_download_url": `https://${server.hostname}:${server.port}/releases/${tagName}/${name}`,
+            })),
           }),
         );
       },
@@ -185,17 +160,21 @@ describe.concurrent(() => {
         ...env,
         NODE_TLS_REJECT_UNAUTHORIZED: "0",
         GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+        ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
       },
     });
 
     closeTempDirHandle();
 
-    // Should not contain error message
-    expect(await proc.stderr.text()).not.toContain("error:");
-    // Reap the subprocess: stderr can close before the child exits, and an
-    // unreaped child is force-killed by the test runner at test end without
-    // draining the Subprocess refcount — LSan then flags it as a leak.
-    await proc.exited;
+    const [stderr] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // Should not fail argument parsing, the integrity gate, or the staging-dir
+    // writes (the Windows FILE_SHARE_DELETE case above); the run proceeds into
+    // unpacking, where the bogus archive is rejected.
+    expect(stderr).not.toContain("error: This command updates Bun itself");
+    expect(stderr).not.toContain("did not return a sha256 checksum");
+    expect(stderr).not.toContain("did not match the checksum");
+    expect(stderr).not.toContain("temporary directory");
+    expect(stderr).not.toContain("temp file");
   });
 });
 
@@ -213,18 +192,10 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
   });
   const stagingRootPath = String(stagingRoot);
 
-  // Cover every platform/arch/abi/cpu combination so the asset list matches
-  // whichever target this test runs on. Non-matching names are ignored.
-  const assetNames: string[] = [];
-  for (const os of ["windows", "linux", "darwin"]) {
-    for (const arch of ["x64", "aarch64"]) {
-      for (const abi of ["", "-musl"]) {
-        for (const cpu of ["", "-baseline"]) {
-          assetNames.push(`bun-${os}-${arch}${abi}${cpu}.zip`);
-        }
-      }
-    }
-  }
+  // The downloaded artifact only needs to be non-empty so the upgrade
+  // reaches the staging step; it is expected to fail when unpacking.
+  const archiveBody = "this is not a real zip archive";
+  const digest = `sha256:${sha256Hex(archiveBody)}`;
 
   using server = Bun.serve({
     tls: tls,
@@ -232,9 +203,7 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
     async fetch(req) {
       const { pathname } = new URL(req.url);
       if (pathname.startsWith("/releases/")) {
-        // The downloaded artifact only needs to be non-empty so the upgrade
-        // reaches the staging step; it is expected to fail when unpacking.
-        return new Response("this is not a real zip archive");
+        return new Response(archiveBody);
       }
       return new Response(
         JSON.stringify({
@@ -243,6 +212,7 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
             "url": "foo",
             "content_type": "application/zip",
             "name": name,
+            "digest": digest,
             "browser_download_url": `https://${server.hostname}:${server.port}/releases/${tagName}/${name}`,
           })),
         }),
@@ -295,74 +265,121 @@ it("recreates the staging directory in the temp dir instead of reusing a pre-exi
   expect(exitCode).toBe(1);
 });
 
+async function runUpgrade({
+  tagName,
+  archiveBody,
+  digest,
+  flag,
+  extraEnv = {},
+}: {
+  tagName: string;
+  archiveBody: string;
+  digest: string | null | undefined;
+  flag: "--stable" | "--canary";
+  extraEnv?: Record<string, string>;
+}) {
+  let downloaded = false;
+  using server = Bun.serve({
+    tls: tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (pathname.startsWith("/releases/")) {
+        downloaded = true;
+        return new Response(archiveBody);
+      }
+      const asset: Record<string, unknown> = {
+        "url": "foo",
+        "content_type": "application/zip",
+      };
+      if (digest !== undefined) asset.digest = digest;
+      return new Response(
+        JSON.stringify({
+          "tag_name": tagName,
+          "assets": assetNames.map(name => ({
+            ...asset,
+            "name": name,
+            "browser_download_url": `https://${server.hostname}:${server.port}/releases/${tagName}/${name}`,
+          })),
+        }),
+      );
+    },
+  });
+
+  const cwd = tmpdirSync();
+  const execPath = join(cwd, basename(bunExe()));
+  await copyFile(bunExe(), execPath);
+
+  await using proc = Bun.spawn({
+    cmd: [execPath, "upgrade", flag],
+    cwd,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      ...extraEnv,
+    },
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  return { stderr, exitCode, downloaded, execPath };
+}
+
 it("verifies the downloaded release archive against the digest reported by the release asset", async () => {
   const archiveBody = "this is not a real zip archive";
-  const correctDigest = `sha256:${new Bun.CryptoHasher("sha256").update(archiveBody).digest("hex")}`;
+  const correctDigest = `sha256:${sha256Hex(archiveBody)}`;
   const wrongDigest = `sha256:${Buffer.alloc(32, 0xab).toString("hex")}`;
 
-  const assetNames: string[] = [];
-  for (const os of ["windows", "linux", "darwin"]) {
-    for (const arch of ["x64", "aarch64"]) {
-      for (const abi of ["", "-musl"]) {
-        for (const cpu of ["", "-baseline"]) {
-          assetNames.push(`bun-${os}-${arch}${abi}${cpu}.zip`);
-        }
-      }
-    }
-  }
-
-  const runUpgrade = async (tagName: string, digest: string) => {
-    using server = Bun.serve({
-      tls: tls,
-      port: 0,
-      async fetch(req) {
-        const { pathname } = new URL(req.url);
-        if (pathname.startsWith("/releases/")) {
-          return new Response(archiveBody);
-        }
-        return new Response(
-          JSON.stringify({
-            "tag_name": tagName,
-            "assets": assetNames.map(name => ({
-              "url": "foo",
-              "content_type": "application/zip",
-              "name": name,
-              "digest": digest,
-              "browser_download_url": `https://${server.hostname}:${server.port}/releases/${tagName}/${name}`,
-            })),
-          }),
-        );
-      },
-    });
-
-    const cwd = tmpdirSync();
-    const execPath = join(cwd, basename(bunExe()));
-    await copyFile(bunExe(), execPath);
-
-    await using proc = Bun.spawn({
-      cmd: [execPath, "upgrade", "--stable"],
-      cwd,
-      stdout: null,
-      stdin: "pipe",
-      stderr: "pipe",
-      env: {
-        ...env,
-        NODE_TLS_REJECT_UNAUTHORIZED: "0",
-        GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
-        ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
-      },
-    });
-
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { stderr, exitCode };
-  };
-
-  const mismatched = await runUpgrade("bun-v9.9.7", wrongDigest);
+  const mismatched = await runUpgrade({ tagName: "bun-v9.9.7", archiveBody, digest: wrongDigest, flag: "--stable" });
   expect(mismatched.stderr).toContain("did not match the checksum reported by the GitHub API for this release");
   expect(mismatched.exitCode).toBe(1);
 
-  const matched = await runUpgrade("bun-v9.9.8", correctDigest);
+  const matched = await runUpgrade({ tagName: "bun-v9.9.8", archiveBody, digest: correctDigest, flag: "--stable" });
   expect(matched.stderr).toContain("9.9.8");
   expect(matched.stderr).not.toContain("did not match the checksum reported by the GitHub API for this release");
   expect(matched.exitCode).toBe(1);
+});
+
+describe.each(["--stable", "--canary"] as const)("%s", flag => {
+  const tagName = flag === "--canary" ? "canary" : "bun-v9.9.9";
+  const archiveBody = "this is not a real zip archive";
+
+  it("refuses to download when the release asset has no checksum", async () => {
+    // An asset with a `digest` that is absent, null, or malformed must be
+    // treated as unverifiable: no download, no install, no execution.
+    for (const digest of [undefined, null, "", "sha256:not-hex", "md5:" + Buffer.alloc(16).toString("hex")]) {
+      const result = await runUpgrade({ tagName, archiveBody, digest, flag });
+      expect({ digest, stderr: result.stderr }).toEqual({
+        digest,
+        stderr: expect.stringContaining("did not return a sha256 checksum"),
+      });
+      expect(result.downloaded).toBe(false);
+      expect(result.exitCode).toBe(1);
+    }
+  });
+
+  it("refuses to install when the downloaded archive does not match the checksum", async () => {
+    const wrongDigest = `sha256:${Buffer.alloc(32, 0xab).toString("hex")}`;
+    using stagingRoot = tempDir("bun-upgrade-integrity", {});
+    const result = await runUpgrade({
+      tagName,
+      archiveBody,
+      digest: wrongDigest,
+      flag,
+      extraEnv: { BUN_TMPDIR: String(stagingRoot) },
+    });
+    expect(result.stderr).toContain("did not match the checksum reported by the GitHub API for this release");
+    expect(result.downloaded).toBe(true);
+    // The archive is rejected before it is written to the staging directory,
+    // so nothing from the download touches disk and nothing is executed.
+    expect(existsSync(String(stagingRoot))).toBe(true);
+    expect(readdirSync(String(stagingRoot))).toEqual([]);
+    // The installed binary must be untouched.
+    expect(statSync(result.execPath).size).toBe(statSync(bunExe()).size);
+    expect(result.exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
## Problem

`bun upgrade` only checked the downloaded archive's sha256 when the GitHub release-asset JSON happened to include a `digest` field. When the field was absent, null, or unparseable, the check was silently skipped: the archive was unzipped and executed (the `--version` probe and the `completions` refresh) without any integrity verification.

The canary path was worse: it built a `Version` with a hardcoded `github.com/.../canary/...` URL and `Integrity::default()`, never querying the release API at all, so `bun upgrade --canary` (and every canary build's default self-update) was never checksummed.

Reproducing the no-digest case with a loopback fake API via `GITHUB_API_DOMAIN`:

```
mode=nodigest     rc=0  binary=REPLACED  payload-executions=2
```

The archive was installed and executed twice even though no checksum was ever compared.

## Fix

`get_latest_version` now serves both channels: it queries `/repos/oven-sh/bun/releases/tags/canary` for canary and the existing updater repo for stable, so the canary asset's `digest` is fetched from the same source as stable. The hardcoded no-digest canary `Version` is gone.

Before the download starts, a missing or unparseable `digest` is a hard error:

```
error: The GitHub API did not return a sha256 checksum for the <channel> release asset. Refusing to download an unverifiable archive.
note: run bun upgrade again in a moment; GitHub computes asset checksums shortly after upload
```

After download, the existing mismatch check is now unconditional (the `is_supported()` guard is removed), so a payload that does not match the API-reported sha256 is rejected before it touches disk.

## Tests

`test/cli/install/bun-upgrade.test.ts` gains a `describe.each(["--stable", "--canary"])` block covering both channels:

- `digest` absent / `null` / empty / `sha256:not-hex` / unsupported algorithm: upgrade refuses with the new error and the archive endpoint is never hit.
- wrong `digest`: upgrade refuses with the existing mismatch error, nothing is written into `BUN_TMPDIR`, and the target binary is byte-identical.

Without the `src/` change the new `--canary` cases download the real canary from github.com and print "Upgraded", and the `--stable` no-digest case proceeds to unzip; with the change all 12 tests in the file pass.

The pre-existing "zero arguments" test is now hermetic (it previously fetched the real canary archive over the network) and the staging-directory test now supplies a matching digest so it still reaches the staging step.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-upgrade.test.ts

<!-- robobun:evidence:end -->

Fixes #11482
