### PR TITLE
WebSocket client: re-arm the opening-handshake timeout after TCP connect

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -55,11 +55,8 @@ new!(pub BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS: unsigned, "BUN_CONFIG_DNS_TIME_TO_
 // handshake through the response body. 0 disables. See `src/http/lib.rs`.
 new!(pub BUN_CONFIG_HTTP_IDLE_TIMEOUT: unsigned, "BUN_CONFIG_HTTP_IDLE_TIMEOUT", { default: 300 });
 // Opening-handshake timeout for the `new WebSocket()` client, in seconds.
-// Armed on the connecting socket and re-armed when the TCP connection opens;
-// if the server accepts the TCP connection but never answers the upgrade, the
-// WebSocket errors after this many seconds instead of sitting in `CONNECTING`
-// forever. 0 disables. uSockets' sweep granularity is 4 s, so very small
-// values round up.
+// A peer that accepts the TCP connection but never answers the upgrade fails
+// with error + close(1006). 0 disables; uSockets' 4 s sweep rounds small values up.
 new!(pub BUN_CONFIG_WS_HANDSHAKE_TIMEOUT: unsigned, "BUN_CONFIG_WS_HANDSHAKE_TIMEOUT", { default: 120 });
 new!(pub BUN_CRASH_REPORT_URL: string, "BUN_CRASH_REPORT_URL", {});
 new!(pub BUN_DEBUG: string, "BUN_DEBUG", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -54,6 +54,13 @@ new!(pub BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS: unsigned, "BUN_CONFIG_DNS_TIME_TO_
 // if it fires the request fails with `error.Timeout`. Covers the TLS
 // handshake through the response body. 0 disables. See `src/http/lib.rs`.
 new!(pub BUN_CONFIG_HTTP_IDLE_TIMEOUT: unsigned, "BUN_CONFIG_HTTP_IDLE_TIMEOUT", { default: 300 });
+// Opening-handshake timeout for the `new WebSocket()` client, in seconds.
+// Armed on the connecting socket and re-armed when the TCP connection opens;
+// if the server accepts the TCP connection but never answers the upgrade, the
+// WebSocket errors after this many seconds instead of sitting in `CONNECTING`
+// forever. 0 disables. uSockets' sweep granularity is 4 s, so very small
+// values round up.
+new!(pub BUN_CONFIG_WS_HANDSHAKE_TIMEOUT: unsigned, "BUN_CONFIG_WS_HANDSHAKE_TIMEOUT", { default: 120 });
 new!(pub BUN_CRASH_REPORT_URL: string, "BUN_CRASH_REPORT_URL", {});
 new!(pub BUN_DEBUG: string, "BUN_DEBUG", {});
 new!(pub BUN_DEBUG_ALL: boolean, "BUN_DEBUG_ALL", {});

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -54,6 +54,17 @@ use bun_http::ssl_config::SSLConfig;
 bun_core::define_scoped_log!(log, WebSocketUpgradeClient, visible);
 bun_core::declare_scope!(alloc, hidden);
 
+/// Opening-handshake timeout in seconds. Armed on the connecting socket and
+/// re-armed in `handle_open` (uSockets clears the socket timeout when a
+/// SEMI_SOCKET transitions to open). 0 disables.
+#[inline]
+fn handshake_timeout_seconds() -> core::ffi::c_uint {
+    bun_core::env_var::BUN_CONFIG_WS_HANDSHAKE_TIMEOUT
+        .get()
+        .unwrap_or(120)
+        .min(u64::from(core::ffi::c_uint::MAX)) as core::ffi::c_uint
+}
+
 /// Local `VirtualMachine → EventLoopCtx` adapter for `KeepAlive::{ref,unref}`.
 /// Forwards to the canonical fully-populated vtable in `bun_jsc`.
 ///
@@ -498,7 +509,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         }
                     }
 
-                    client_ref.tcp.timeout(120);
+                    client_ref.tcp.timeout(handshake_timeout_seconds());
                     client_ref.state = State::Reading;
                     // +1 for cpp_websocket
                     client_ref.ref_();
@@ -546,7 +557,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     }
                 }
 
-                out.tcp.timeout(120);
+                out.tcp.timeout(handshake_timeout_seconds());
                 out.state = State::Reading;
                 // +1 for cpp_websocket
                 out.ref_();
@@ -798,6 +809,13 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // SAFETY: short-lived `&mut` for setup; ends before any reentrant call.
         let me = unsafe { &mut *this.as_ptr() };
         me.tcp = socket;
+        // `us_internal_socket_after_open` clears the socket timeout when the
+        // SEMI_SOCKET becomes a full socket, so the `timeout()` set in
+        // `connect()` only covered the TCP connect. Re-arm here so a peer that
+        // accepts the TCP connection but never answers the upgrade (or never
+        // completes the TLS handshake) eventually fails instead of sitting in
+        // `CONNECTING` forever.
+        socket.timeout(handshake_timeout_seconds());
 
         debug_assert!(!me.input_body_buf.is_empty());
         debug_assert!(me.to_send_len == 0);

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -54,15 +54,16 @@ use bun_http::ssl_config::SSLConfig;
 bun_core::define_scoped_log!(log, WebSocketUpgradeClient, visible);
 bun_core::declare_scope!(alloc, hidden);
 
-/// Opening-handshake timeout in seconds. Armed on the connecting socket and
-/// re-armed in `handle_open` (uSockets clears the socket timeout when a
-/// SEMI_SOCKET transitions to open). 0 disables.
+/// Opening-handshake timeout in seconds, normalised for uSockets' timer
+/// wheel (short-timeout counter wraps at 240 ticks; `set_timeout` routes
+/// larger values onto the minute-granularity long timer). 0 disables.
 #[inline]
 fn handshake_timeout_seconds() -> core::ffi::c_uint {
-    bun_core::env_var::BUN_CONFIG_WS_HANDSHAKE_TIMEOUT
-        .get()
-        .unwrap_or(120)
-        .min(u64::from(core::ffi::c_uint::MAX)) as core::ffi::c_uint
+    bun_http::normalize_idle_timeout_seconds(
+        bun_core::env_var::BUN_CONFIG_WS_HANDSHAKE_TIMEOUT
+            .get()
+            .unwrap_or(120),
+    )
 }
 
 /// Local `VirtualMachine → EventLoopCtx` adapter for `KeepAlive::{ref,unref}`.
@@ -509,7 +510,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                         }
                     }
 
-                    client_ref.tcp.timeout(handshake_timeout_seconds());
+                    client_ref.tcp.set_timeout(handshake_timeout_seconds());
                     client_ref.state = State::Reading;
                     // +1 for cpp_websocket
                     client_ref.ref_();
@@ -557,7 +558,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                     }
                 }
 
-                out.tcp.timeout(handshake_timeout_seconds());
+                out.tcp.set_timeout(handshake_timeout_seconds());
                 out.state = State::Reading;
                 // +1 for cpp_websocket
                 out.ref_();
@@ -809,13 +810,10 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // SAFETY: short-lived `&mut` for setup; ends before any reentrant call.
         let me = unsafe { &mut *this.as_ptr() };
         me.tcp = socket;
-        // `us_internal_socket_after_open` clears the socket timeout when the
-        // SEMI_SOCKET becomes a full socket, so the `timeout()` set in
-        // `connect()` only covered the TCP connect. Re-arm here so a peer that
-        // accepts the TCP connection but never answers the upgrade (or never
-        // completes the TLS handshake) eventually fails instead of sitting in
-        // `CONNECTING` forever.
-        socket.timeout(handshake_timeout_seconds());
+        // `us_internal_socket_after_open` zeroes the socket timeout when the
+        // SEMI_SOCKET opens, so the value `connect()` armed only covered the
+        // TCP connect. Re-arm so an accept-but-never-answer peer times out.
+        socket.set_timeout(handshake_timeout_seconds());
 
         debug_assert!(!me.input_body_buf.is_empty());
         debug_assert!(me.to_send_len == 0);
@@ -1599,7 +1597,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
                 // SAFETY: short-lived read; `this` is live per caller contract.
                 let has_ws = unsafe { (*this).outgoing_websocket.is_some() };
                 if !tcp.is_closed() && has_ws {
-                    tcp.timeout(0);
+                    tcp.set_timeout(0);
                     log!("onDidConnect (tunnel mode)");
 
                     // Release the ref that paired with C++'s m_upgradeClient: C++
@@ -1657,7 +1655,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // SAFETY: short-lived read; `this` is live per caller contract.
         let has_ws = unsafe { (*this).outgoing_websocket.is_some() };
         if !tcp.is_closed() && has_ws {
-            tcp.timeout(0);
+            tcp.set_timeout(0);
             log!("onDidConnect");
 
             // SAFETY: short-lived `&mut` for the field take/detach; ends before

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1751,12 +1751,9 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::timeout: {
-        // The opening handshake timed out before the server answered the
-        // upgrade. Per the WHATWG "fail the WebSocket connection" algorithm
-        // a failure during CONNECTING fires an error event followed by
-        // close(1006). didReceiveClose only dispatches the error event when
-        // the state was CONNECTING, so this is a no-op for a post-open
-        // timeout (which is not currently armed anywhere).
+        // Opening-handshake timeout: per WHATWG "fail the WebSocket connection"
+        // fire error + close(1006). didReceiveClose gates the error event on
+        // wasConnecting, so a (currently unreachable) post-open timeout only closes.
         didReceiveClose(CleanStatus::NotClean, 1006, "Timeout"_s, true);
         break;
     }

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1751,7 +1751,13 @@ void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
         break;
     }
     case Bun::WebSocketErrorCode::timeout: {
-        didReceiveClose(CleanStatus::Clean, 1013, "Timeout"_s);
+        // The opening handshake timed out before the server answered the
+        // upgrade. Per the WHATWG "fail the WebSocket connection" algorithm
+        // a failure during CONNECTING fires an error event followed by
+        // close(1006). didReceiveClose only dispatches the error event when
+        // the state was CONNECTING, so this is a no-op for a post-open
+        // timeout (which is not currently armed anywhere).
+        didReceiveClose(CleanStatus::NotClean, 1006, "Timeout"_s, true);
         break;
     }
     case Bun::WebSocketErrorCode::closed: {

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -37,7 +37,7 @@ describe("WebSocket upgrade", () => {
 
   test("should send correct upgrade headers", async () => {
     const server = serve({
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: 0,
       fetch(request, server) {
         expect(server.upgrade(request)).toBeTrue();
@@ -46,7 +46,7 @@ describe("WebSocket upgrade", () => {
         expect(headers.get("upgrade")).toBe("websocket");
         expect(headers.get("sec-websocket-version")).toBe("13");
         expect(headers.get("sec-websocket-key")).toBeString();
-        expect(headers.get("host")).toBe(`localhost:${server.port}`);
+        expect(headers.get("host")).toBe(`127.0.0.1:${server.port}`);
         return;
         // FIXME: types gets annoyed if this is not here
         return new Response();
@@ -61,7 +61,7 @@ describe("WebSocket upgrade", () => {
       },
     });
     await new Promise((resolve, reject) => {
-      const ws = new WebSocket(`ws://localhost:${server.port}/`);
+      const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`);
       ws.addEventListener("open", resolve);
       ws.addEventListener("error", reject);
       ws.addEventListener("close", reject);

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -1,7 +1,44 @@
 import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 describe("WebSocket upgrade", () => {
+  // https://github.com/oven-sh/bun/issues/2896
+  // A server that accepts the TCP connection but never answers the upgrade
+  // used to leave the WebSocket in CONNECTING forever: the handshake timeout
+  // was armed on the connecting socket, but usockets clears it when the
+  // socket opens and handle_open never re-armed it. With
+  // BUN_CONFIG_WS_HANDSHAKE_TIMEOUT=1 (usockets sweeps every 4 s, so the
+  // effective delay is ~4-8 s) the WebSocket should error and close.
+  test("fails the handshake when the server never responds", async () => {
+    const script = `
+      const net = require("node:net");
+      const srv = net.createServer(() => {});
+      srv.listen(0, "127.0.0.1", () => {
+        const port = srv.address().port;
+        const ws = new WebSocket("ws://127.0.0.1:" + port + "/");
+        const events = [];
+        ws.onopen = () => events.push("open");
+        ws.onerror = () => events.push("error");
+        ws.onclose = (e) => {
+          events.push("close:" + e.code);
+          console.log(JSON.stringify(events));
+          srv.close();
+        };
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_CONFIG_WS_HANDSHAKE_TIMEOUT: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual(["error", "close:1006"]);
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
   test("should send correct upgrade headers", async () => {
     const server = serve({
       hostname: "localhost",

--- a/test/js/web/websocket/websocket-upgrade.test.ts
+++ b/test/js/web/websocket/websocket-upgrade.test.ts
@@ -4,12 +4,8 @@ import { bunEnv, bunExe } from "harness";
 
 describe("WebSocket upgrade", () => {
   // https://github.com/oven-sh/bun/issues/2896
-  // A server that accepts the TCP connection but never answers the upgrade
-  // used to leave the WebSocket in CONNECTING forever: the handshake timeout
-  // was armed on the connecting socket, but usockets clears it when the
-  // socket opens and handle_open never re-armed it. With
-  // BUN_CONFIG_WS_HANDSHAKE_TIMEOUT=1 (usockets sweeps every 4 s, so the
-  // effective delay is ~4-8 s) the WebSocket should error and close.
+  // BUN_CONFIG_WS_HANDSHAKE_TIMEOUT=1: uSockets sweeps every 4 s, so the
+  // effective delay is ~4-8 s, hence the 30 s test budget.
   test("fails the handshake when the server never responds", async () => {
     const script = `
       const net = require("node:net");


### PR DESCRIPTION


### What

`new WebSocket()` against a server that accepts the TCP connection but never answers the upgrade sat in `CONNECTING` forever. No `error`, no `close`, `readyState === 0` at 300 s / 420 s / 900 s. On the same origin `fetch()` errors at ~300 s (the HTTP idle timeout) and Node's built-in WebSocket errors at ~300 s.

### Repro

```js
import net from "node:net";
const srv = net.createServer(() => {}); // accept, never respond
await new Promise(r => srv.listen(0, "127.0.0.1", r));
const ws = new WebSocket(`ws://127.0.0.1:${srv.address().port}/`);
ws.onerror = () => console.log("error");
ws.onclose = e => console.log("close", e.code);
// before: nothing ever fires
```

### Cause

`HTTPClient::connect()` arms `tcp.timeout(120)` on the just-created socket, but that socket is still a `SEMI_SOCKET` waiting for the TCP connect. When it connects, `us_internal_socket_after_open()` [clears the socket timeout](https://github.com/oven-sh/bun/blob/47597ab2c9/packages/bun-usockets/src/context.c#L797) before dispatching `on_open`, and `handle_open` never re-arms it. So the 120 s intent only ever covered the TCP connect phase; once the peer accepted, the upgrade wait had no timeout at all.

### Fix

- `handle_open` re-arms the socket timeout so it covers the upgrade response wait (and the TLS handshake for `wss://`).
- The value is read from `BUN_CONFIG_WS_HANDSHAKE_TIMEOUT` (default 120 s, same as the previous hardcoded constant) so the test can exercise the path without waiting two minutes; uSockets' sweep granularity is 4 s so `=1` fires in ~4-8 s.
- `WebSocketErrorCode::timeout` now maps to `error` + `close(1006)` like the other `CONNECTING`-phase failures, matching the WHATWG "fail the WebSocket connection" steps and Node. The previous `(Clean, 1013)` mapping was dead code: nothing arms a timeout on an established client socket, so no observable behaviour changes for open connections.

### Verification

New test in `test/js/web/websocket/websocket-upgrade.test.ts` spawns a child with `BUN_CONFIG_WS_HANDSHAKE_TIMEOUT=1`, points a WebSocket at a `net.createServer(() => {})` that accepts and never answers, and asserts `["error", "close:1006"]`.

```
=== FAIL-BEFORE (USE_SYSTEM_BUN=1) ===
(fail) WebSocket upgrade > fails the handshake when the server never responds [30000.49ms]
  ^ this test timed out after 30000ms.

=== PASS-AFTER (bun bd) ===
(pass) WebSocket upgrade > fails the handshake when the server never responds [5208.71ms]
```

`test/js/web/websocket/websocket-client.test.ts` (34 pass), `websocket-close-connecting.test.ts`, `websocket-unix.test.ts`, `error-event.test.ts` all pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-upgrade.test.ts
bun test v1.4.0 (8c0bc28b3)

test/js/web/websocket/websocket-upgrade.test.ts:
killed 1 dangling process
(fail) WebSocket upgrade > fails the handshake when the server never responds [30006.58ms]
  ^ this test timed out after 30000ms.

# Unhandled error between tests
-------------------------------
29 |       stdout: "pipe",
30 |       stderr: "pipe",
31 |     });
32 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
33 |     expect(stderr).toBe("");
34 |     expect(JSON.parse(stdout.trim())).toEqual(["error", "close:1006"]);
                     ^
SyntaxError: JSON Parse error: Unexpected EOF
      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-upgrade.test.ts:34:17)
-------------------------------

(pass) WebSocket upgrade > should send correct upgrade headers [49.56ms]

 1 pass
 1 fail
 1 error
 3 expect() calls
Ran 2 tests across 1 file. [32.34s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (d1119b2fd)

test/js/web/websocket/websocket-upgrade.test.ts:
(pass) WebSocket upgrade > fails the handshake when the server never responds [4030.40ms]
(pass) WebSocket upgrade > should send correct upgrade headers [1.71ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [4.18s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-upgrade.test.ts
bun test v1.4.0 (8c0bc28b3)

test/js/web/websocket/websocket-upgrade.test.ts:
(pass) WebSocket upgrade > fails the handshake when the server never responds [5239.75ms]
(pass) WebSocket upgrade > should send correct upgrade headers [35.36ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [7.35s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 766ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                            |  4 +++
 .../websocket_client/WebSocketUpgradeClient.rs     | 24 ++++++++++---
 src/jsc/bindings/webcore/WebSocket.cpp             |  5 ++-
 test/js/web/websocket/websocket-upgrade.test.ts    | 39 ++++++++++++++++++++--
 4 files changed, 64 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/bun_core/env_var.rs                                      4      6      0
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs      5     13      0
src/jsc/bindings/webcore/WebSocket.cpp                       3      4      0
test/js/web/websocket/websocket-upgrade.test.ts              3      3      0
```

</details>

<!-- robobun:evidence:end -->