### PR TITLE
Bun.serve: evaluate If-Match / If-Unmodified-Since on static and file routes

### DIFF
--- a/src/http_types/ETag.rs
+++ b/src/http_types/ETag.rs
@@ -107,6 +107,33 @@ fn split_entity_tags(list: &[u8]) -> EntityTagSplit<'_> {
     }
 }
 
+/// RFC 9110 §13.1.1: evaluate `If-Match` using the strong comparison
+/// (§8.8.3.2: both not weak and opaque-tags byte-equal). `*` is true for any
+/// current representation. Returns `true` when the condition holds (continue);
+/// `false` means respond 412.
+pub fn if_match(
+    // Stored `ETag` header, `None` when the representation has none.
+    etag: Option<&[u8]>,
+    // `If-Match` header
+    if_match: &[u8],
+) -> bool {
+    if strings::trim(if_match, b" \t") == b"*" {
+        return true;
+    }
+    let Some(etag) = etag else { return false };
+    let ours = parse(etag);
+    if ours.is_weak {
+        return false;
+    }
+    for tag_str in split_entity_tags(if_match) {
+        let parsed = parse(tag_str);
+        if !parsed.is_weak && parsed.tag == ours.tag {
+            return true;
+        }
+    }
+    false
+}
+
 pub fn if_none_match(
     // "ETag" header
     etag: &[u8],

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -449,10 +449,33 @@ impl FileRoute {
         };
 
         let status_code: u16 = 'brk: {
-            // RFC 9110 §13.2.2: conditional preconditions are evaluated before
-            // Range. If-None-Match is evaluated first; when present it suppresses
-            // If-Modified-Since regardless of outcome (step 3 vs step 4). Both
-            // only apply to GET/HEAD for 304 purposes.
+            // RFC 9110 §13.2.2: preconditions evaluate before Range, in order:
+            // (1) If-Match, else (2) If-Unmodified-Since; then (3) If-None-Match,
+            // else (4) If-Modified-Since. Steps 1/2 yield 412 on failure and must
+            // run before steps 3/4 can yield 304.
+            if (method == Method::HEAD || method == Method::GET) && this.status_code == 200 {
+                // Step 1: If-Match (strong comparison).
+                if let Some(im) = req.header(b"if-match").filter(|v| !v.is_empty()) {
+                    let etag = this.headers.get(b"etag").filter(|v| !v.is_empty());
+                    if !ETag::if_match(etag, im) {
+                        break 'brk 412;
+                    }
+                // Step 2: If-Unmodified-Since (only when If-Match is absent).
+                } else if let Some(ius) = req
+                    .header(b"if-unmodified-since")
+                    .and_then(crate::jsc_hooks::parse_http_date)
+                {
+                    let Ok(lmd) = this.last_modified_date() else {
+                        return;
+                    };
+                    if let Some(lm) = lmd {
+                        if lm / 1000 > ius / 1000 {
+                            break 'brk 412;
+                        }
+                    }
+                }
+            }
+
             if method == Method::HEAD || method == Method::GET {
                 if let Some(inm) = req.header(b"if-none-match").filter(|v| !v.is_empty()) {
                     if this.status_code == 200 {
@@ -509,6 +532,10 @@ impl FileRoute {
         // null-body status must never start it; 307/308 routes skip it too.
         if HTTPStatusText::is_null_body(status_code) || matches!(status_code, 307 | 308) {
             resp.end_without_body(resp.should_close_connection());
+            return;
+        }
+        if status_code == 412 {
+            resp.end(b"", resp.should_close_connection());
             return;
         }
 

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -268,7 +268,7 @@ impl StaticRoute {
         unsafe {
             // Evaluate conditional request preconditions for HEAD with 200 status
             if (*this).status_code == 200 {
-                if Self::render_304_if_not_modified(this, &mut req, resp) {
+                if Self::render_precondition(this, &mut req, resp) {
                     return;
                 }
             }
@@ -335,7 +335,7 @@ impl StaticRoute {
         unsafe {
             // Evaluate conditional request preconditions for GET with 200 status
             if (*this).status_code == 200 {
-                if Self::render_304_if_not_modified(this, &mut req, resp) {
+                if Self::render_precondition(this, &mut req, resp) {
                     return;
                 }
             }
@@ -535,37 +535,59 @@ impl StaticRoute {
         }
     }
 
+    /// RFC 9110 §13.2.2 precondition evaluation. Writes a 412 or 304 response
+    /// and returns `true` when a precondition short-circuits the request.
+    ///
     /// # Safety
     /// See [`on_head_request`]. May free `*this` via `on_response_complete` when it
     /// returns `true`.
-    unsafe fn render_304_if_not_modified(
+    unsafe fn render_precondition(
         this: *mut Self,
         req: &mut AnyRequest,
         resp: AnyResponse,
     ) -> bool {
         // SAFETY: caller contract.
         unsafe {
-            // RFC 9110 §13.2.2: If-None-Match takes precedence; If-Modified-Since
-            // is evaluated only when If-None-Match is absent.
+            let etag = (*this).headers.get(b"etag").filter(|v| !v.is_empty());
+            let last_modified = (*this)
+                .headers
+                .get(b"last-modified")
+                .and_then(crate::jsc_hooks::parse_http_date);
+
+            // Step 1: If-Match (strong comparison); step 2: If-Unmodified-Since
+            // (only when If-Match is absent).
+            let precondition_failed =
+                if let Some(im) = req.header(b"if-match").filter(|v| !v.is_empty()) {
+                    !ETag::if_match(etag, im)
+                } else if let Some(ius) = req
+                    .header(b"if-unmodified-since")
+                    .and_then(crate::jsc_hooks::parse_http_date)
+                {
+                    matches!(last_modified, Some(lm) if lm / 1000 > ius / 1000)
+                } else {
+                    false
+                };
+            if precondition_failed {
+                return Self::render_bodiless(this, req, resp, 412);
+            }
+
+            // Step 3: If-None-Match (weak comparison). Presence suppresses step 4.
             let not_modified = if let Some(if_none_match) = req.header(b"if-none-match") {
-                match (*this).headers.get(b"etag") {
-                    Some(etag) if !if_none_match.is_empty() && !etag.is_empty() => {
+                match etag {
+                    Some(etag) if !if_none_match.is_empty() => {
                         ETag::if_none_match(etag, if_none_match)
                     }
                     _ => false,
                 }
+            // Step 4: If-Modified-Since (only when If-None-Match is absent).
             } else if let Some(ims) = req
                 .header(b"if-modified-since")
                 .and_then(crate::jsc_hooks::parse_http_date)
             {
                 // §13.1.3: 304 when Last-Modified <= If-Modified-Since. HTTP-date
                 // is second-granular, so compare at second precision.
-                match (*this)
-                    .headers
-                    .get(b"last-modified")
-                    .and_then(crate::jsc_hooks::parse_http_date)
-                {
-                    Some(last_modified) => last_modified / 1000 <= ims / 1000,
+                match last_modified {
+                    Some(lm) => lm / 1000 <= ims / 1000,
                     None => false,
                 }
             } else {
@@ -576,15 +598,31 @@ impl StaticRoute {
                 return false;
             }
 
-            // Return 304 Not Modified
+            Self::render_bodiless(this, req, resp, 304)
+        }
+    }
+
+    /// # Safety
+    /// See [`on_head_request`]. Frees `*this` via `on_response_complete`.
+    unsafe fn render_bodiless(
+        this: *mut Self,
+        req: &mut AnyRequest,
+        resp: AnyResponse,
+        status: u16,
+    ) -> bool {
+        // SAFETY: caller contract.
+        unsafe {
             req.set_yield(false);
             (*this).ref_();
             if let Some(mut server) = (*this).server.get() {
                 server.on_pending_request();
                 resp.timeout(server.config().idle_timeout);
             }
-            (*this).do_write_status(304, resp);
+            (*this).do_write_status(status, resp);
             (*this).do_write_headers(resp);
+            if !HTTPStatusText::is_null_body(status) {
+                resp.write_header_int(b"Content-Length", 0);
+            }
             resp.end_without_body(resp.should_close_connection());
             Self::on_response_complete(this, resp);
             true

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -549,10 +549,14 @@ impl StaticRoute {
         // SAFETY: caller contract.
         unsafe {
             let etag = (*this).headers.get(b"etag").filter(|v| !v.is_empty());
-            let last_modified = (*this)
-                .headers
-                .get(b"last-modified")
-                .and_then(crate::jsc_hooks::parse_http_date);
+            // Deferred: `parse_http_date` allocates + calls into WTF; only run it
+            // when the client actually sent a date-based conditional header.
+            let last_modified = || {
+                (*this)
+                    .headers
+                    .get(b"last-modified")
+                    .and_then(crate::jsc_hooks::parse_http_date)
+            };
 
             // Step 1: If-Match (strong comparison); step 2: If-Unmodified-Since
             // (only when If-Match is absent).
@@ -563,7 +567,7 @@ impl StaticRoute {
                     .header(b"if-unmodified-since")
                     .and_then(crate::jsc_hooks::parse_http_date)
                 {
-                    matches!(last_modified, Some(lm) if lm / 1000 > ius / 1000)
+                    matches!(last_modified(), Some(lm) if lm / 1000 > ius / 1000)
                 } else {
                     false
                 };
@@ -586,7 +590,7 @@ impl StaticRoute {
             {
                 // §13.1.3: 304 when Last-Modified <= If-Modified-Since. HTTP-date
                 // is second-granular, so compare at second precision.
-                match last_modified {
+                match last_modified() {
                     Some(lm) => lm / 1000 <= ims / 1000,
                     None => false,
                 }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -469,6 +469,98 @@ describe("Bun.file in serve routes", () => {
       expect(await res.text()).toBe("Hello, World!");
     });
 
+    // RFC 9110 §13.2.2 steps 1–2: If-Match / If-Unmodified-Since evaluate
+    // first and short-circuit with 412 before If-None-Match / If-Modified-Since.
+    describe.each(["GET", "HEAD"])("If-Match / If-Unmodified-Since (%s)", method => {
+      it("If-Match: non-matching tag on a file route with ETag → 412", async () => {
+        const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+          method,
+          headers: { "If-Match": '"zz"' },
+        });
+        expect(res.status).toBe(412);
+        expect(await res.text()).toBe("");
+      });
+
+      it("If-Match: matching tag on a file route with ETag → 200", async () => {
+        const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+          method,
+          headers: { "If-Match": '"custom-etag"' },
+        });
+        expect(res.status).toBe(200);
+        if (method === "GET") expect(await res.text()).toBe("Hello, World!");
+      });
+
+      it("If-Match: * on a file route without a stored ETag → 200", async () => {
+        const res = await fetch(new URL(`/hello-blob.txt`, server.url), {
+          method,
+          headers: { "If-Match": "*" },
+        });
+        expect(res.status).toBe(200);
+      });
+
+      it("If-Match: tag list on a file route without a stored ETag → 412", async () => {
+        const res = await fetch(new URL(`/hello-blob.txt`, server.url), {
+          method,
+          headers: { "If-Match": '"anything"' },
+        });
+        expect(res.status).toBe(412);
+        expect(await res.text()).toBe("");
+      });
+
+      it('If-Match: W/"custom-etag" uses strong compare → 412', async () => {
+        const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+          method,
+          headers: { "If-Match": 'W/"custom-etag"' },
+        });
+        expect(res.status).toBe(412);
+      });
+
+      it("If-Unmodified-Since earlier than mtime → 412", async () => {
+        const res = await fetch(new URL(`/hello-blob.txt`, server.url), {
+          method,
+          headers: { "If-Unmodified-Since": "Mon, 01 Jan 2001 00:00:00 GMT" },
+        });
+        expect(res.status).toBe(412);
+        expect(await res.text()).toBe("");
+      });
+
+      it("If-Unmodified-Since at or after mtime → 200", async () => {
+        const lm = (await fetch(new URL(`/hello-blob.txt`, server.url))).headers.get("Last-Modified");
+        expect(lm).not.toBeEmpty();
+        const res = await fetch(new URL(`/hello-blob.txt`, server.url), {
+          method,
+          headers: { "If-Unmodified-Since": lm! },
+        });
+        expect(res.status).toBe(200);
+      });
+
+      it("If-Match failure + If-None-Match match → 412 (not 304)", async () => {
+        const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+          method,
+          headers: { "If-Match": '"zz"', "If-None-Match": '"custom-etag"' },
+        });
+        expect(res.status).toBe(412);
+      });
+
+      it("If-Match failure + Range → 412 (no Content-Range)", async () => {
+        const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+          method,
+          headers: { "If-Match": '"zz"', "Range": "bytes=0-3" },
+        });
+        expect(res.status).toBe(412);
+        expect(res.headers.get("content-range")).toBeNull();
+        expect(await res.text()).toBe("");
+      });
+
+      it("If-Match present suppresses If-Unmodified-Since", async () => {
+        const res = await fetch(new URL(`/with-etag.txt`, server.url), {
+          method,
+          headers: { "If-Match": '"custom-etag"', "If-Unmodified-Since": "Mon, 01 Jan 2001 00:00:00 GMT" },
+        });
+        expect(res.status).toBe(200);
+      });
+    });
+
     it.todo("handles ETag", async () => {
       const res1 = await fetch(new URL(`/hello.txt`, server.url));
       const etag = res1.headers.get("ETag");

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -252,3 +252,96 @@ describe("static route Date header", () => {
     expect(dates[0]).not.toContain(pinned);
   });
 });
+
+// RFC 9110 §13.2.2: preconditions evaluate in order (1) If-Match, else
+// (2) If-Unmodified-Since; then (3) If-None-Match, else (4) If-Modified-Since.
+// Steps 1/2 must short-circuit with 412 before steps 3/4 can yield 304.
+describe("static route preconditions (RFC 9110 §13.2.2)", () => {
+  const LM = "Wed, 21 Oct 2015 07:28:00 GMT";
+  const EARLIER = "Mon, 01 Jan 2001 00:00:00 GMT";
+  const LATER = "Sat, 01 Jan 2028 00:00:00 GMT";
+  let server: Server;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      routes: {
+        "/s": new Response("static-body", { headers: { etag: '"s1"', "last-modified": LM } }),
+        "/weak": new Response("static-body", { headers: { etag: 'W/"w1"', "last-modified": LM } }),
+      },
+      fetch: () => new Response("nf", { status: 404 }),
+    });
+  });
+  afterAll(() => server.stop(true));
+
+  const get = (path: string, headers: Record<string, string>, method = "GET") =>
+    fetch(new URL(path, server.url), { method, headers }).then(async r => ({
+      status: r.status,
+      body: await r.text(),
+      etag: r.headers.get("etag"),
+    }));
+
+  describe.each(["GET", "HEAD"])("%s", method => {
+    it("If-Match: non-matching tag → 412", async () => {
+      expect(await get("/s", { "If-Match": '"zz"' }, method)).toEqual({ status: 412, body: "", etag: '"s1"' });
+    });
+
+    it("If-Match: matching strong tag → 200", async () => {
+      const r = await get("/s", { "If-Match": '"s1"' }, method);
+      expect(r.status).toBe(200);
+      if (method === "GET") expect(r.body).toBe("static-body");
+    });
+
+    it("If-Match: list with one matching tag → 200", async () => {
+      expect((await get("/s", { "If-Match": '"a", "s1", "b"' }, method)).status).toBe(200);
+    });
+
+    it("If-Match: * → 200", async () => {
+      expect((await get("/s", { "If-Match": "*" }, method)).status).toBe(200);
+    });
+
+    it('If-Match: W/"s1" uses strong compare → 412', async () => {
+      // §8.8.3.2 strong comparison: a weak client tag never matches.
+      expect((await get("/s", { "If-Match": 'W/"s1"' }, method)).status).toBe(412);
+    });
+
+    it("If-Match against a weak stored ETag → 412 (strong compare)", async () => {
+      expect((await get("/weak", { "If-Match": '"w1"' }, method)).status).toBe(412);
+    });
+
+    it("If-Unmodified-Since earlier than Last-Modified → 412", async () => {
+      expect(await get("/s", { "If-Unmodified-Since": EARLIER }, method)).toEqual({
+        status: 412,
+        body: "",
+        etag: '"s1"',
+      });
+    });
+
+    it("If-Unmodified-Since equal to Last-Modified → 200", async () => {
+      expect((await get("/s", { "If-Unmodified-Since": LM }, method)).status).toBe(200);
+    });
+
+    it("If-Unmodified-Since later than Last-Modified → 200", async () => {
+      expect((await get("/s", { "If-Unmodified-Since": LATER }, method)).status).toBe(200);
+    });
+
+    it("If-Match failure + matching If-None-Match → 412 (not 304)", async () => {
+      // Step 1 fails: 412 is mandatory; step 3 must not run.
+      expect((await get("/s", { "If-Match": '"zz"', "If-None-Match": '"s1"' }, method)).status).toBe(412);
+    });
+
+    it("If-Unmodified-Since failure + matching If-None-Match → 412 (not 304)", async () => {
+      expect((await get("/s", { "If-Unmodified-Since": EARLIER, "If-None-Match": '"s1"' }, method)).status).toBe(412);
+    });
+
+    it("If-Match present suppresses If-Unmodified-Since", async () => {
+      // Step 2 only runs when If-Match is absent: a passing If-Match with a
+      // failing IUS still yields 200.
+      expect((await get("/s", { "If-Match": '"s1"', "If-Unmodified-Since": EARLIER }, method)).status).toBe(200);
+    });
+
+    it("If-Match pass then If-None-Match match → 304", async () => {
+      expect((await get("/s", { "If-Match": '"s1"', "If-None-Match": '"s1"' }, method)).status).toBe(304);
+    });
+  });
+});


### PR DESCRIPTION
## What

`Bun.serve` static `Response` routes and `Bun.file()` routes never evaluated `If-Match` (RFC 9110 §13.1.1) or `If-Unmodified-Since` (§13.1.4), so a 412 was impossible. Because §13.2.2 orders those two ahead of `If-None-Match` / `If-Modified-Since`, a failing `If-Match` combined with a matching `If-None-Match` wrongly produced `304` instead of the required `412`.

## Repro

```js
const server = Bun.serve({
  port: 0,
  routes: {
    "/s": new Response("body", { headers: { etag: '"s1"', "last-modified": "Wed, 21 Oct 2015 07:28:00 GMT" } }),
  },
  fetch: () => new Response("nf", { status: 404 }),
});
const r = await fetch(`${server.url}s`, { headers: { "If-Match": '"zz"', "If-None-Match": '"s1"' } });
console.log(r.status); // before: 304, after: 412
```

## Cause

`StaticRoute::render_304_if_not_modified` and the precondition block in `FileRoute::on` implemented only steps 3 and 4 of the §13.2.2 evaluation order (INM then IMS). Steps 1 and 2 were absent; `grep -rn 'if-match|if-unmodified' src/runtime/server/` had zero hits.

## Fix

- `src/http_types/ETag.rs`: add `if_match()` using the strong comparison (§8.8.3.2: both tags not weak, opaque-tags byte-equal). `*` is true for any current representation; a tag list against no stored ETag is false.
- `src/runtime/server/StaticRoute.rs`: rename `render_304_if_not_modified` to `render_precondition` and evaluate step 1 (`If-Match`) then step 2 (`If-Unmodified-Since`, only when `If-Match` is absent) ahead of the existing INM/IMS block. On failure write `412 Precondition Failed` with the validator headers and `Content-Length: 0`.
- `src/runtime/server/FileRoute.rs`: same evaluation ahead of the existing INM/IMS block; `412` ends with an empty body before Range handling so no `Content-Range` leaks.

## Verification

New tests in `bun-serve-static.test.ts` and `bun-serve-file.test.ts` cover, for GET and HEAD:
- `If-Match`: non-matching tag (412), matching tag (200), list (200), `*` (200), `W/"x"` against strong stored tag (412), strong tag against weak stored tag (412), tag against no stored ETag (412)
- `If-Unmodified-Since`: earlier than LM (412), equal (200), later (200)
- Ordering: `If-Match` failure + `If-None-Match` match (412, not 304); IUS failure + INM match (412); `If-Match` presence suppresses IUS; `If-Match` pass then INM match still 304; `If-Match` failure + `Range` (412, no `Content-Range`)

```
bun bd test test/js/bun/http/bun-serve-static.test.ts test/js/bun/http/bun-serve-file.test.ts
# 149 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts test/js/bun/http/bun-serve-static.test.ts

<!-- robobun:evidence:end -->