### PR TITLE
fetch: map request cache mode to Cache-Control/Pragma on the wire

### DIFF
--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1451,6 +1451,15 @@ impl Request {
             bail!(Err(JsError::Thrown));
         }
 
+        // https://fetch.spec.whatwg.org/#dom-request step 31
+        if req.flags.cache == FetchCacheMode::OnlyIfCached
+            && req.flags.mode != FetchRequestMode::SameOrigin
+        {
+            bail!(Err(global_this.throw_type_error(format_args!(
+                "'only-if-cached' can be set only with 'same-origin' mode"
+            ))));
+        }
+
         if req.url.get().is_empty() {
             bail!(Err(global_this.throw(format_args!(
                 "Failed to construct 'Request': url is required."

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -51,6 +51,8 @@ use crate::webcore::jsc::{
 use bun_core::{String as BunString, Tag as BunStringTag, ZigStringSlice};
 use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
+use bun_http_types::FetchCacheMode::FetchCacheMode;
+use bun_http_types::FetchRequestMode::FetchRequestMode;
 use bun_http_types::Method::Method;
 use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _};
 use bun_paths::{self, PathBuffer};
@@ -932,6 +934,86 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         return Ok(JSValue::ZERO);
     }
 
+    // cache: "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached"
+    let cache_mode: FetchCacheMode = 'extract_cache_mode: {
+        let mut cache_mode = FetchCacheMode::Default;
+        if let Some(req) = request_mut!() {
+            cache_mode = req.flags.cache;
+        }
+
+        let objects_to_try = [
+            options_object.unwrap_or(JSValue::ZERO),
+            request_init_object.unwrap_or(JSValue::ZERO),
+        ];
+
+        for obj in objects_to_try {
+            if !obj.is_empty() {
+                match obj.get_optional_enum::<FetchCacheMode>(global_this, "cache") {
+                    Err(_) => {
+                        return Ok(JSValue::ZERO);
+                    }
+                    Ok(Some(cache_value)) => {
+                        break 'extract_cache_mode cache_value;
+                    }
+                    Ok(None) => {}
+                }
+            }
+        }
+
+        break 'extract_cache_mode cache_mode;
+    };
+
+    if global_this.has_exception() {
+        return Ok(JSValue::ZERO);
+    }
+
+    // mode: "same-origin" | "no-cors" | "cors" | "navigate"
+    let request_mode: FetchRequestMode = 'extract_request_mode: {
+        let mut request_mode = FetchRequestMode::Cors;
+        if let Some(req) = request_mut!() {
+            request_mode = req.flags.mode;
+        }
+
+        let objects_to_try = [
+            options_object.unwrap_or(JSValue::ZERO),
+            request_init_object.unwrap_or(JSValue::ZERO),
+        ];
+
+        for obj in objects_to_try {
+            if !obj.is_empty() {
+                match obj.get_optional_enum::<FetchRequestMode>(global_this, "mode") {
+                    Err(_) => {
+                        return Ok(JSValue::ZERO);
+                    }
+                    Ok(Some(mode_value)) => {
+                        break 'extract_request_mode mode_value;
+                    }
+                    Ok(None) => {}
+                }
+            }
+        }
+
+        break 'extract_request_mode request_mode;
+    };
+
+    if global_this.has_exception() {
+        return Ok(JSValue::ZERO);
+    }
+
+    // https://fetch.spec.whatwg.org/#dom-request step 31 — fetch_impl parses init
+    // directly rather than constructing a Request, so replicate the check here.
+    if cache_mode == FetchCacheMode::OnlyIfCached && request_mode != FetchRequestMode::SameOrigin {
+        let err = global_this.create_type_error_instance(format_args!(
+            "'only-if-cached' can be set only with 'same-origin' mode"
+        ));
+        return Ok(
+            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global_this,
+                err,
+            ),
+        );
+    }
+
     // keepalive: boolean | undefined;
     disable_keepalive = 'extract_disable_keepalive: {
         let objects_to_try = [
@@ -1643,6 +1725,44 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             None,
             any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),
         ));
+    }
+
+    // https://fetch.spec.whatwg.org/#http-network-or-cache-fetch steps 15-17.
+    // Bun has no local HTTP cache, but the cache mode is still observable on the
+    // wire (shared caches / CDNs read Cache-Control and Pragma).
+    {
+        let mut effective_cache_mode = cache_mode;
+        if effective_cache_mode == FetchCacheMode::Default
+            && let Some(h) = headers.as_ref()
+            && (h.get(b"if-modified-since").is_some()
+                || h.get(b"if-none-match").is_some()
+                || h.get(b"if-unmodified-since").is_some()
+                || h.get(b"if-match").is_some()
+                || h.get(b"if-range").is_some())
+        {
+            effective_cache_mode = FetchCacheMode::NoStore;
+        }
+
+        match effective_cache_mode {
+            FetchCacheMode::NoCache => {
+                let h = headers.get_or_insert_default();
+                if h.get(b"cache-control").is_none() {
+                    h.append(b"Cache-Control", b"max-age=0");
+                }
+            }
+            FetchCacheMode::NoStore | FetchCacheMode::Reload => {
+                let h = headers.get_or_insert_default();
+                if h.get(b"pragma").is_none() {
+                    h.append(b"Pragma", b"no-cache");
+                }
+                if h.get(b"cache-control").is_none() {
+                    h.append(b"Cache-Control", b"no-cache");
+                }
+            }
+            FetchCacheMode::Default
+            | FetchCacheMode::ForceCache
+            | FetchCacheMode::OnlyIfCached => {}
+        }
     }
 
     // `body` is mutated in place for the sendfile/readfile paths and then

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -573,6 +573,88 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         );
     }
 
+    // cache: "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached"
+    // Extracted before the data: early return so the step-31 TypeError below is
+    // consistent with `new Request()` regardless of scheme.
+    let cache_mode: FetchCacheMode = 'extract_cache_mode: {
+        let mut cache_mode = FetchCacheMode::Default;
+        if let Some(req) = request_mut!() {
+            cache_mode = req.flags.cache;
+        }
+
+        let objects_to_try = [
+            options_object.unwrap_or(JSValue::ZERO),
+            request_init_object.unwrap_or(JSValue::ZERO),
+        ];
+
+        for obj in objects_to_try {
+            if !obj.is_empty() {
+                match obj.get_optional_enum::<FetchCacheMode>(global_this, "cache") {
+                    Err(_) => {
+                        return Ok(JSValue::ZERO);
+                    }
+                    Ok(Some(cache_value)) => {
+                        break 'extract_cache_mode cache_value;
+                    }
+                    Ok(None) => {}
+                }
+            }
+        }
+
+        break 'extract_cache_mode cache_mode;
+    };
+
+    if global_this.has_exception() {
+        return Ok(JSValue::ZERO);
+    }
+
+    // mode: "same-origin" | "no-cors" | "cors" | "navigate"
+    let request_mode: FetchRequestMode = 'extract_request_mode: {
+        let mut request_mode = FetchRequestMode::Cors;
+        if let Some(req) = request_mut!() {
+            request_mode = req.flags.mode;
+        }
+
+        let objects_to_try = [
+            options_object.unwrap_or(JSValue::ZERO),
+            request_init_object.unwrap_or(JSValue::ZERO),
+        ];
+
+        for obj in objects_to_try {
+            if !obj.is_empty() {
+                match obj.get_optional_enum::<FetchRequestMode>(global_this, "mode") {
+                    Err(_) => {
+                        return Ok(JSValue::ZERO);
+                    }
+                    Ok(Some(mode_value)) => {
+                        break 'extract_request_mode mode_value;
+                    }
+                    Ok(None) => {}
+                }
+            }
+        }
+
+        break 'extract_request_mode request_mode;
+    };
+
+    if global_this.has_exception() {
+        return Ok(JSValue::ZERO);
+    }
+
+    // https://fetch.spec.whatwg.org/#dom-request step 31 — fetch_impl parses init
+    // directly rather than constructing a Request, so replicate the check here.
+    if cache_mode == FetchCacheMode::OnlyIfCached && request_mode != FetchRequestMode::SameOrigin {
+        let err = global_this.create_type_error_instance(format_args!(
+            "'only-if-cached' can be set only with 'same-origin' mode"
+        ));
+        return Ok(
+            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global_this,
+                err,
+            ),
+        );
+    }
+
     if url_str.has_prefix_comptime(b"data:") {
         let url_slice = url_str.to_utf8_without_ref();
         // `defer url_slice.deinit()` → Drop.
@@ -932,86 +1014,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     if global_this.has_exception() {
         return Ok(JSValue::ZERO);
-    }
-
-    // cache: "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached"
-    let cache_mode: FetchCacheMode = 'extract_cache_mode: {
-        let mut cache_mode = FetchCacheMode::Default;
-        if let Some(req) = request_mut!() {
-            cache_mode = req.flags.cache;
-        }
-
-        let objects_to_try = [
-            options_object.unwrap_or(JSValue::ZERO),
-            request_init_object.unwrap_or(JSValue::ZERO),
-        ];
-
-        for obj in objects_to_try {
-            if !obj.is_empty() {
-                match obj.get_optional_enum::<FetchCacheMode>(global_this, "cache") {
-                    Err(_) => {
-                        return Ok(JSValue::ZERO);
-                    }
-                    Ok(Some(cache_value)) => {
-                        break 'extract_cache_mode cache_value;
-                    }
-                    Ok(None) => {}
-                }
-            }
-        }
-
-        break 'extract_cache_mode cache_mode;
-    };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
-    // mode: "same-origin" | "no-cors" | "cors" | "navigate"
-    let request_mode: FetchRequestMode = 'extract_request_mode: {
-        let mut request_mode = FetchRequestMode::Cors;
-        if let Some(req) = request_mut!() {
-            request_mode = req.flags.mode;
-        }
-
-        let objects_to_try = [
-            options_object.unwrap_or(JSValue::ZERO),
-            request_init_object.unwrap_or(JSValue::ZERO),
-        ];
-
-        for obj in objects_to_try {
-            if !obj.is_empty() {
-                match obj.get_optional_enum::<FetchRequestMode>(global_this, "mode") {
-                    Err(_) => {
-                        return Ok(JSValue::ZERO);
-                    }
-                    Ok(Some(mode_value)) => {
-                        break 'extract_request_mode mode_value;
-                    }
-                    Ok(None) => {}
-                }
-            }
-        }
-
-        break 'extract_request_mode request_mode;
-    };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
-    // https://fetch.spec.whatwg.org/#dom-request step 31 — fetch_impl parses init
-    // directly rather than constructing a Request, so replicate the check here.
-    if cache_mode == FetchCacheMode::OnlyIfCached && request_mode != FetchRequestMode::SameOrigin {
-        let err = global_this.create_type_error_instance(format_args!(
-            "'only-if-cached' can be set only with 'same-origin' mode"
-        ));
-        return Ok(
-            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
-                global_this,
-                err,
-            ),
-        );
     }
 
     // keepalive: boolean | undefined;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1759,9 +1759,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     h.append(b"Cache-Control", b"no-cache");
                 }
             }
-            FetchCacheMode::Default
-            | FetchCacheMode::ForceCache
-            | FetchCacheMode::OnlyIfCached => {}
+            FetchCacheMode::Default | FetchCacheMode::ForceCache | FetchCacheMode::OnlyIfCached => {
+            }
         }
     }
 

--- a/test/js/web/fetch/fetch-cache-mode.test.ts
+++ b/test/js/web/fetch/fetch-cache-mode.test.ts
@@ -121,4 +121,11 @@ describe("cache: only-if-cached", () => {
     await expect(fetch("http://127.0.0.1:1/", { cache: "only-if-cached" })).rejects.toThrow(TypeError);
     await expect(fetch("http://127.0.0.1:1/", { cache: "only-if-cached", mode: "cors" })).rejects.toThrow(TypeError);
   });
+
+  test("fetch() rejects for data: URLs too", async () => {
+    await expect(fetch("data:text/plain,hi", { cache: "only-if-cached" })).rejects.toThrow(TypeError);
+    expect(await (await fetch("data:text/plain,hi", { cache: "only-if-cached", mode: "same-origin" })).text()).toBe(
+      "hi",
+    );
+  });
 });

--- a/test/js/web/fetch/fetch-cache-mode.test.ts
+++ b/test/js/web/fetch/fetch-cache-mode.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+// https://fetch.spec.whatwg.org/#http-network-or-cache-fetch steps 15-17:
+// the request's `cache` mode must reach the wire as Cache-Control / Pragma
+// headers so shared caches (CDNs, proxies) along the path observe it.
+describe("fetch() cache mode", () => {
+  describe.each(["init", "Request"] as const)("via %s", kind => {
+    const opts = (url: string, init: RequestInit) => (kind === "init" ? [url, init] : [new Request(url, init)]);
+
+    test.each([
+      ["no-store", "no-cache", "no-cache"],
+      ["reload", "no-cache", "no-cache"],
+    ] as const)("cache: %s sends Pragma/Cache-Control: no-cache", async (cache, cc, pragma) => {
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
+      });
+      const args = opts(server.url.href, { cache }) as [any, any?];
+      const h = (await (await fetch(...args)).json()) as Record<string, string>;
+      expect({ "cache-control": h["cache-control"], "pragma": h["pragma"] }).toEqual({
+        "cache-control": cc,
+        "pragma": pragma,
+      });
+    });
+
+    test("cache: no-cache sends Cache-Control: max-age=0", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
+      });
+      const args = opts(server.url.href, { cache: "no-cache" }) as [any, any?];
+      const h = (await (await fetch(...args)).json()) as Record<string, string>;
+      expect(h["cache-control"]).toBe("max-age=0");
+      expect(h["pragma"]).toBeUndefined();
+    });
+
+    test.each(["default", "force-cache"] as const)("cache: %s sends no cache headers", async cache => {
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
+      });
+      const args = opts(server.url.href, { cache }) as [any, any?];
+      const h = (await (await fetch(...args)).json()) as Record<string, string>;
+      expect(h["cache-control"]).toBeUndefined();
+      expect(h["pragma"]).toBeUndefined();
+    });
+  });
+
+  test("explicit Cache-Control/Pragma are not overwritten", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
+    });
+    const h = (await (
+      await fetch(server.url, {
+        cache: "no-store",
+        headers: { "Cache-Control": "max-age=123", "Pragma": "custom" },
+      })
+    ).json()) as Record<string, string>;
+    expect({ "cache-control": h["cache-control"], "pragma": h["pragma"] }).toEqual({
+      "cache-control": "max-age=123",
+      "pragma": "custom",
+    });
+  });
+
+  test("conditional header with default cache mode sends no-cache", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
+    });
+    const h = (await (
+      await fetch(server.url, { headers: { "If-None-Match": '"abc"' } })
+    ).json()) as Record<string, string>;
+    expect({
+      "cache-control": h["cache-control"],
+      "pragma": h["pragma"],
+      "if-none-match": h["if-none-match"],
+    }).toEqual({
+      "cache-control": "no-cache",
+      "pragma": "no-cache",
+      "if-none-match": '"abc"',
+    });
+  });
+
+  test("init overrides Request cache mode", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
+    });
+    const req = new Request(server.url, { cache: "no-cache" });
+    const h = (await (await fetch(req, { cache: "no-store" })).json()) as Record<string, string>;
+    expect({ "cache-control": h["cache-control"], "pragma": h["pragma"] }).toEqual({
+      "cache-control": "no-cache",
+      "pragma": "no-cache",
+    });
+  });
+});
+
+describe("cache: only-if-cached", () => {
+  test("new Request() throws TypeError unless mode is same-origin", () => {
+    expect(() => new Request("http://example.com/", { cache: "only-if-cached" })).toThrow(TypeError);
+    expect(() => new Request("http://example.com/", { cache: "only-if-cached", mode: "cors" })).toThrow(TypeError);
+    expect(() => new Request("http://example.com/", { cache: "only-if-cached", mode: "no-cors" })).toThrow(TypeError);
+    expect(() => new Request("http://example.com/", { cache: "only-if-cached", mode: "same-origin" })).not.toThrow();
+  });
+
+  test("new Request(request) inherits and still validates", () => {
+    const ok = new Request("http://example.com/", { cache: "only-if-cached", mode: "same-origin" });
+    expect(() => new Request(ok, { mode: "cors" })).toThrow(TypeError);
+    expect(() => new Request(ok)).not.toThrow();
+  });
+
+  test("fetch() rejects with TypeError unless mode is same-origin", async () => {
+    await expect(fetch("http://127.0.0.1:1/", { cache: "only-if-cached" })).rejects.toThrow(TypeError);
+    await expect(fetch("http://127.0.0.1:1/", { cache: "only-if-cached", mode: "cors" })).rejects.toThrow(TypeError);
+  });
+});

--- a/test/js/web/fetch/fetch-cache-mode.test.ts
+++ b/test/js/web/fetch/fetch-cache-mode.test.ts
@@ -73,9 +73,10 @@ describe("fetch() cache mode", () => {
       hostname: "127.0.0.1",
       fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
     });
-    const h = (await (
-      await fetch(server.url, { headers: { "If-None-Match": '"abc"' } })
-    ).json()) as Record<string, string>;
+    const h = (await (await fetch(server.url, { headers: { "If-None-Match": '"abc"' } })).json()) as Record<
+      string,
+      string
+    >;
     expect({
       "cache-control": h["cache-control"],
       "pragma": h["pragma"],

--- a/test/regression/issue/2993.test.ts
+++ b/test/regression/issue/2993.test.ts
@@ -4,7 +4,9 @@ test("Request cache option is set correctly", () => {
   const cacheValues = ["default", "no-store", "reload", "no-cache", "force-cache", "only-if-cached"] as const;
 
   for (const cache of cacheValues) {
-    const request = new Request("http://localhost:8080/", { cache });
+    // "only-if-cached" is only valid with mode: "same-origin" (Fetch spec step 31)
+    const mode = cache === "only-if-cached" ? "same-origin" : undefined;
+    const request = new Request("http://localhost:8080/", { cache, mode });
     expect(request.cache).toBe(cache);
   }
 });


### PR DESCRIPTION
## What

`fetch(url, { cache: "no-store" })` (and `"reload"` / `"no-cache"`) was accepted, reflected by `request.cache`, and then ignored: every cache mode produced byte-identical request headers. Per [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch) steps 15-17, the cache mode must reach the wire even when the runtime has no local HTTP cache, because that is how shared caches (CDNs, proxies) along the path are instructed.

```js
const server = Bun.serve({ port: 0,
  fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))) });
const h = await (await fetch(server.url, { cache: "no-store" })).json();
console.log(h["cache-control"], h["pragma"]);
// before: undefined undefined
// after:  no-cache no-cache
server.stop(true);
```

Also, `new Request(url, { cache: "only-if-cached" })` with any mode other than `"same-origin"` was accepted; the spec (Request constructor step 31) requires a `TypeError`.

## Cause

`Request.construct_into` parsed the enum into `flags.cache` and the getter echoed it, but nothing in `fetch_impl` read it: no header append, no validation. `mode` was in the same state (parsed, stored, unread).

## Fix

- `fetch_impl` now extracts `cache` and `mode` the same way it already extracts `redirect`, and applies spec steps 15-17 after header extraction:
  - `no-store` / `reload`: append `Pragma: no-cache` and `Cache-Control: no-cache` (unless already present)
  - `no-cache`: append `Cache-Control: max-age=0` (unless already present)
  - `default` with a conditional header (`If-Modified-Since` / `If-None-Match` / `If-Unmodified-Since` / `If-Match` / `If-Range`) is treated as `no-store`
- `Request.construct_into` and `fetch_impl` both reject `only-if-cached` with a non-`same-origin` mode as a `TypeError` (message matches undici: `'only-if-cached' can be set only with 'same-origin' mode`).
- User-supplied `Cache-Control` / `Pragma` headers are preserved.

## Verification

```
bun bd test test/js/web/fetch/fetch-cache-mode.test.ts test/regression/issue/2993.test.ts
# 23 pass, 0 fail
```

`USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-cache-mode.test.ts` fails 11/16 (wire headers absent, no TypeError), confirming the test exercises the change.

`test/regression/issue/2993.test.ts` was updated to pass `mode: "same-origin"` when constructing a Request with `cache: "only-if-cached"`, which the spec (and now Bun) requires.


Fixes #6723

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-cache-mode.test.ts "test/regression/issue/2993.test.ts"
bun test v1.4.0 (3da0d2e0d)

test/regression/issue/2993.test.ts:
(pass) Request cache option is set correctly [22.20ms]
(pass) Request mode option is set correctly [8.85ms]
(pass) Request cache defaults to 'default' [2.40ms]
(pass) Request mode defaults to 'cors' [2.75ms]
(pass) Request.clone() preserves cache and mode options [3.93ms]
(pass) new Request(request) preserves cache and mode options [3.91ms]
(pass) new Request(request, init) allows overriding cache and mode [5.84ms]

test/js/web/fetch/fetch-cache-mode.test.ts:
16 |         hostname: "127.0.0.1",
17 |         fetch: req => new Response(JSON.stringify(Object.fromEntries(req.headers))),
18 |       });
19 |       const args = opts(server.url.href, { cache }) as [any, any?];
20 |       const h = (await (await fetch(...args)).json()) as Record<string, string>;
21 |       expect({ "cache-control": h["cache-control"], "pragma": h["pragma"] }).toEqual({
                                                  
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9adb27787)

test/regression/issue/2993.test.ts:
(pass) Request cache option is set correctly [0.61ms]
(pass) Request mode option is set correctly [0.10ms]
(pass) Request cache defaults to 'default' [0.03ms]
(pass) Request mode defaults to 'cors' [0.02ms]
(pass) Request.clone() preserves cache and mode options [0.04ms]
(pass) new Request(request) preserves cache and mode options [0.04ms]
(pass) new Request(request, init) allows overriding cache and mode [0.07ms]

test/js/web/fetch/fetch-cache-mode.test.ts:
(pass) fetch() cache mode > via init > cache: no-store sends Pragma/Cache-Control: no-cache [2.18ms]
(pass) fetch() cache mode > via init > cache: reload sends Pragma/Cache-Control: no-cache [1.03ms]
(pass) fetch() cache mode > via init > cache: no-cache sends Cache-Control: max-age=0 [1.07ms]
(pass) fetch() cache mode > via init > cache: default sends no cache headers [1.03ms]
(pass) fetch() cache mode > via init > cache: force-cache sends no cache headers [0.82ms]
(pass) fetch() cache mode > via Request > cache: no-store sends Pragma/Cache-Control: no-cache [0.77ms]
(pass) fetch() cache mode > via Request > cache: reload sends Pragma/Cac
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-cache-mode.test.ts "test/regression/issue/2993.test.ts"
bun test v1.4.0 (3da0d2e0d)

test/regression/issue/2993.test.ts:
(pass) Request cache option is set correctly [12.60ms]
(pass) Request mode option is set correctly [4.92ms]
(pass) Request cache defaults to 'default' [1.52ms]
(pass) Request mode defaults to 'cors' [1.64ms]
(pass) Request.clone() preserves cache and mode options [2.28ms]
(pass) new Request(request) preserves cache and mode options [2.33ms]
(pass) new Request(request, init) allows overriding cache and mode [3.57ms]

test/js/web/fetch/fetch-cache-mode.test.ts:
(pass) fetch() cache mode > via init > cache: no-store sends Pragma/Cache-Control: no-cache [54.53ms]
(pass) fetch() cache mode > via init > cache: reload sends Pragma/Cache-Control: no-cache [18.16ms]
(pass) fetch() cache mode > via init > cache: no-cache sends Cache-Control: max-age=0 [31.24ms]
(pass) fetch() cache mode > via init > cache: default sends no cache headers [29.66ms]
(pass) fetch() cache mode > via init > cache: force-cache
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 754ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Request.rs             |   9 ++
 src/runtime/webcore/fetch.rs               | 121 ++++++++++++++++++++++++++
 test/js/web/fetch/fetch-cache-mode.test.ts | 131 +++++++++++++++++++++++++++++
 test/regression/issue/2993.test.ts         |   4 +-
 4 files changed, 264 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/webcore/Request.rs                  2      1      0
src/runtime/webcore/fetch.rs                    7      6      0
test/js/web/fetch/fetch-cache-mode.test.ts      1      3      0
test/regression/issue/2993.test.ts              1      1      0
```

</details>

<!-- robobun:evidence:end -->