### PR TITLE
url: throw ERR_INVALID_TUPLE from new URLSearchParams() for non-pair sequence entries

### DIFF
--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -151,6 +151,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_RETURN_VALUE", TypeError],
   ["ERR_INVALID_STATE", Error, undefined, TypeError, RangeError],
   ["ERR_INVALID_THIS", TypeError],
+  ["ERR_INVALID_TUPLE", TypeError],
   ["ERR_INVALID_URI", URIError],
   ["ERR_INVALID_URL_SCHEME", TypeError],
   ["ERR_INVALID_URL", TypeError],

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -36,6 +36,7 @@
 #include "JSDOMConvertStrings.h"
 #include "JSDOMConvertUnion.h"
 #include "JSDOMExceptionHandling.h"
+#include "ErrorCode.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMIterator.h"
@@ -126,8 +127,8 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSURLSearchParamsDOMCons
     auto init = argument0.value().isUndefined() ? emptyString() : convert<IDLUnion<IDLSequence<IDLSequence<IDLUSVString>>, IDLRecord<IDLUSVString, IDLUSVString>, IDLUSVString>>(*lexicalGlobalObject, argument0.value());
     RETURN_IF_EXCEPTION(throwScope, {});
     auto object = URLSearchParams::create(WTF::move(init));
-    if constexpr (IsExceptionOr<decltype(object)>)
-        RETURN_IF_EXCEPTION(throwScope, {});
+    if (object.hasException()) [[unlikely]]
+        return Bun::throwError(lexicalGlobalObject, throwScope, Bun::ErrorCode::ERR_INVALID_TUPLE, "Each query pair must be an iterable [name, value] tuple"_s);
     static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);
     auto jsValue = toJSNewlyCreated<IDLInterface<URLSearchParams>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(object));
     if constexpr (IsExceptionOr<decltype(object)>)

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -258,6 +258,31 @@ describe("url", () => {
     expect(params.get("second")).toBe("replaced");
     expect(params.get("third")).toBeNull();
   });
+
+  it("URLSearchParams throws ERR_INVALID_TUPLE for non-pair sequence entries", () => {
+    const capture = (fn: () => void) => {
+      let err: any;
+      try {
+        fn();
+      } catch (e) {
+        err = e;
+      }
+      return err;
+    };
+
+    for (const init of [[[1]], [[]], [["a", "b", "c"]], [["a", "b"], ["c"]]] as any[]) {
+      const e = capture(() => new URLSearchParams(init));
+      expect(e).toBeInstanceOf(TypeError);
+      expect({ name: e.name, code: e.code, message: e.message }).toEqual({
+        name: "TypeError",
+        code: "ERR_INVALID_TUPLE",
+        message: "Each query pair must be an iterable [name, value] tuple",
+      });
+    }
+
+    // valid pair still works
+    expect(new URLSearchParams([["a", "b"]]).toString()).toBe("a=b");
+  });
 });
 
 describe("url.searchParams lazy href sync", () => {


### PR DESCRIPTION
## What does this PR do?

`new URLSearchParams(init)` where `init` is a sequence containing an entry whose length is not 2 previously threw a bare `TypeError` with message `"Type error"` and no `.code` property. Node throws a `TypeError` with `code: "ERR_INVALID_TUPLE"` and message `"Each query pair must be an iterable [name, value] tuple"`.

### Repro

```js
try { new URLSearchParams([[1]]) } catch (e) { console.log(e.code, e.message) }
```

| | before | after / node |
|-|-|-|
| `.code` | `undefined` | `"ERR_INVALID_TUPLE"` |
| `.message` | `"Type error"` | `"Each query pair must be an iterable [name, value] tuple"` |
| `instanceof TypeError` | `true` | `true` |

### Fix

`URLSearchParams::create` returns `ExceptionOr<...>` and only rejects in one case: an inner sequence whose length is not 2. The constructor wrapper now checks `hasException()` on that result and throws the Node-compatible `ERR_INVALID_TUPLE` instead of propagating the message-less WebCore `TypeError`. Adds `ERR_INVALID_TUPLE` to the error-code table as a `TypeError`.

### Not covered here

Node also throws `ERR_INVALID_TUPLE` when an inner entry is not iterable at all (`new URLSearchParams([1])`, `[null]`, `[{}]`). In Bun that rejection happens inside the IDL sequence-of-sequences converter, before `URLSearchParams::create` runs, and the same converter call can also surface user-thrown exceptions from `toString()` or iterator traps that must propagate unchanged. Mapping that path correctly means replacing the `convert<IDLUnion<...>>` call with a hand-rolled iterability check per inner entry; that is a larger constructor rewrite and is left for a follow-up. Those inputs still throw a `TypeError` today.

### Verification

```sh
bun bd test test/js/web/url/url.test.ts -t ERR_INVALID_TUPLE
```

Fails against main (`code: undefined`, `message: "Type error"`), passes with the change. Existing `test/js/web/url/url.test.ts`, `test/js/deno/url/urlsearchparams.test.ts`, and `test-whatwg-url-custom-searchparams.js` continue to pass.