### PR TITLE
error printer: render non-Error cause values

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6009,11 +6009,21 @@ impl VirtualMachine {
                     continue;
                 }
 
+                let kind = value.js_type();
+
                 if field.eql_comptime(b"cause") {
                     saw_cause = true;
+                    // An Error-typed cause always gets a full recursive render
+                    // (stack + its own cause chain), even at depth >= 2 where
+                    // other Error-typed properties fall through to the
+                    // truncated inline path.
+                    if kind == JSType::ErrorInstance {
+                        value.protect();
+                        errors_to_append.push(value);
+                        continue;
+                    }
                 }
 
-                let kind = value.js_type();
                 if kind == JSType::ErrorInstance && !prev_had_errors {
                     value.protect();
                     errors_to_append.push(value);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5924,6 +5924,24 @@ impl VirtualMachine {
             )?;
             let longest_name = iterator.get_longest_property_name().min(10);
             let mut is_first_property = true;
+
+            struct RestoreFmt<'a, 'f> {
+                f: &'a mut crate::console_object::Formatter<'f>,
+                d: bool,
+                q: bool,
+                m: u16,
+                b: bool,
+            }
+            impl Drop for RestoreFmt<'_, '_> {
+                fn drop(&mut self) {
+                    self.f.depth -= 1;
+                    self.f.max_depth = self.m;
+                    self.f.quote_strings = self.q;
+                    self.f.disable_inspect_custom = self.d;
+                    self.f.format_buffer_as_text = self.b;
+                }
+            }
+
             while let Some(field) = iterator.next()? {
                 let value = iterator.value;
                 if field.eql_comptime(b"message")
@@ -5936,11 +5954,12 @@ impl VirtualMachine {
                     continue;
                 }
 
+                if field.eql_comptime(b"cause") {
+                    saw_cause = true;
+                }
+
                 let kind = value.js_type();
                 if kind == JSType::ErrorInstance && !prev_had_errors {
-                    if field.eql_comptime(b"cause") {
-                        saw_cause = true;
-                    }
                     value.protect();
                     errors_to_append.push(value);
                 } else if kind.is_object()
@@ -5957,23 +5976,6 @@ impl VirtualMachine {
                     formatter.max_depth = 1;
                     formatter.quote_strings = true;
                     formatter.disable_inspect_custom = true;
-                    // Hand-rolled drop guard restores the formatter state.
-                    struct RestoreFmt<'a, 'f> {
-                        f: &'a mut crate::console_object::Formatter<'f>,
-                        d: bool,
-                        q: bool,
-                        m: u16,
-                        b: bool,
-                    }
-                    impl Drop for RestoreFmt<'_, '_> {
-                        fn drop(&mut self) {
-                            self.f.depth -= 1;
-                            self.f.max_depth = self.m;
-                            self.f.quote_strings = self.q;
-                            self.f.disable_inspect_custom = self.d;
-                            self.f.format_buffer_as_text = self.b;
-                        }
-                    }
                     let restore = RestoreFmt {
                         f: formatter,
                         d: prev_disable_inspect_custom,
@@ -6026,19 +6028,68 @@ impl VirtualMachine {
                 )?;
             }
 
-            if !is_first_property {
-                writer.write_all(b"\n")?;
-            }
-
-            // "cause" is not enumerable, so the above loop won't see it.
+            // "cause" set via `new Error(msg, { cause })` is non-enumerable, so
+            // the property loop above won't have seen it.
             if !saw_cause {
                 let key = bun_core::String::static_(b"cause");
                 if let Some(cause) = error_instance.get_own(global_ref, &key)? {
                     if cause.is_cell() && cause.js_type() == JSType::ErrorInstance {
                         cause.protect();
                         errors_to_append.push(cause);
+                    } else {
+                        let prev_disable_inspect_custom = formatter.disable_inspect_custom;
+                        let prev_quote_strings = formatter.quote_strings;
+                        let prev_max_depth = formatter.max_depth;
+                        let prev_format_buffer_as_text = formatter.format_buffer_as_text;
+                        formatter.depth += 1;
+                        formatter.format_buffer_as_text = true;
+                        formatter.max_depth = 1;
+                        formatter.quote_strings = true;
+                        formatter.disable_inspect_custom = true;
+                        let restore = RestoreFmt {
+                            f: formatter,
+                            d: prev_disable_inspect_custom,
+                            q: prev_quote_strings,
+                            m: prev_max_depth,
+                            b: prev_format_buffer_as_text,
+                        };
+                        let formatter = &mut *restore.f;
+
+                        let pad_left = longest_name.saturating_sub(b"cause".len());
+                        is_first_property = false;
+                        splat_space(writer, pad_left as u64)?;
+                        pretty_write!(writer, " cause<r><d>:<r> ")?;
+
+                        if allow_side_effects && global_ref.has_exception() {
+                            global_ref.clear_exception();
+                        }
+
+                        let tag = Tag::get_advanced(
+                            cause,
+                            global_ref,
+                            TagOptions::DISABLE_INSPECT_CUSTOM | TagOptions::HIDE_GLOBAL,
+                        )?;
+                        let _ = if allow_ansi_color {
+                            formatter.format::<true>(tag, writer, cause, global_ref)
+                        } else {
+                            formatter.format::<false>(tag, writer, cause, global_ref)
+                        };
+
+                        if allow_side_effects {
+                            if global_ref.has_exception() {
+                                global_ref.clear_exception();
+                            }
+                        } else if global_ref.has_exception() || formatter.failed {
+                            return Ok(());
+                        }
+
+                        pretty_write!(writer, "<r><d>,<r>\n")?;
                     }
                 }
+            }
+
+            if !is_first_property {
+                writer.write_all(b"\n")?;
             }
         } else if error_instance != JSValue::ZERO {
             // If you do `reportError([1,2,3])` we should still show something.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5942,53 +5942,33 @@ impl VirtualMachine {
                 }
             }
 
-            while let Some(field) = iterator.next()? {
-                let value = iterator.value;
-                if field.eql_comptime(b"message")
-                    || field.eql_comptime(b"name")
-                    || field.eql_comptime(b"stack")
-                {
-                    continue;
-                }
-                if field.eql_comptime(b"code") && code.is_some() {
-                    continue;
-                }
-
-                if field.eql_comptime(b"cause") {
-                    saw_cause = true;
-                }
-
-                let kind = value.js_type();
-                if kind == JSType::ErrorInstance && !prev_had_errors {
-                    value.protect();
-                    errors_to_append.push(value);
-                } else if kind.is_object()
-                    || kind.is_array()
-                    || value.is_primitive()
-                    || kind.is_string_like()
-                {
-                    let prev_disable_inspect_custom = formatter.disable_inspect_custom;
-                    let prev_quote_strings = formatter.quote_strings;
-                    let prev_max_depth = formatter.max_depth;
-                    let prev_format_buffer_as_text = formatter.format_buffer_as_text;
-                    formatter.depth += 1;
-                    formatter.format_buffer_as_text = true;
-                    formatter.max_depth = 1;
-                    formatter.quote_strings = true;
-                    formatter.disable_inspect_custom = true;
+            // Renders ` <label>: <value>,\n` for an own property, with the
+            // formatter temporarily forced to max_depth=1/quote_strings/etc.
+            // Expands in place so `?` and the early `return Ok(())` propagate
+            // from the enclosing function.
+            macro_rules! write_error_field {
+                ($label:expr, $label_len:expr, $value:expr) => {{
+                    let value: JSValue = $value;
                     let restore = RestoreFmt {
-                        f: formatter,
-                        d: prev_disable_inspect_custom,
-                        q: prev_quote_strings,
-                        m: prev_max_depth,
-                        b: prev_format_buffer_as_text,
+                        d: formatter.disable_inspect_custom,
+                        q: formatter.quote_strings,
+                        m: formatter.max_depth,
+                        b: formatter.format_buffer_as_text,
+                        f: {
+                            formatter.depth += 1;
+                            formatter.format_buffer_as_text = true;
+                            formatter.max_depth = 1;
+                            formatter.quote_strings = true;
+                            formatter.disable_inspect_custom = true;
+                            formatter
+                        },
                     };
                     let formatter = &mut *restore.f;
 
-                    let pad_left = longest_name.saturating_sub(field.length());
+                    let pad_left = longest_name.saturating_sub($label_len);
                     is_first_property = false;
                     splat_space(writer, pad_left as u64)?;
-                    pretty_write!(writer, " {}<r><d>:<r> ", field)?;
+                    pretty_write!(writer, " {}<r><d>:<r> ", $label)?;
 
                     if allow_side_effects && global_ref.has_exception() {
                         global_ref.clear_exception();
@@ -6014,6 +5994,35 @@ impl VirtualMachine {
                     }
 
                     pretty_write!(writer, "<r><d>,<r>\n")?;
+                }};
+            }
+
+            while let Some(field) = iterator.next()? {
+                let value = iterator.value;
+                if field.eql_comptime(b"message")
+                    || field.eql_comptime(b"name")
+                    || field.eql_comptime(b"stack")
+                {
+                    continue;
+                }
+                if field.eql_comptime(b"code") && code.is_some() {
+                    continue;
+                }
+
+                if field.eql_comptime(b"cause") {
+                    saw_cause = true;
+                }
+
+                let kind = value.js_type();
+                if kind == JSType::ErrorInstance && !prev_had_errors {
+                    value.protect();
+                    errors_to_append.push(value);
+                } else if kind.is_object()
+                    || kind.is_array()
+                    || value.is_primitive()
+                    || kind.is_string_like()
+                {
+                    write_error_field!(field, field.length(), value);
                 }
             }
 
@@ -6037,53 +6046,7 @@ impl VirtualMachine {
                         cause.protect();
                         errors_to_append.push(cause);
                     } else {
-                        let prev_disable_inspect_custom = formatter.disable_inspect_custom;
-                        let prev_quote_strings = formatter.quote_strings;
-                        let prev_max_depth = formatter.max_depth;
-                        let prev_format_buffer_as_text = formatter.format_buffer_as_text;
-                        formatter.depth += 1;
-                        formatter.format_buffer_as_text = true;
-                        formatter.max_depth = 1;
-                        formatter.quote_strings = true;
-                        formatter.disable_inspect_custom = true;
-                        let restore = RestoreFmt {
-                            f: formatter,
-                            d: prev_disable_inspect_custom,
-                            q: prev_quote_strings,
-                            m: prev_max_depth,
-                            b: prev_format_buffer_as_text,
-                        };
-                        let formatter = &mut *restore.f;
-
-                        let pad_left = longest_name.saturating_sub(b"cause".len());
-                        is_first_property = false;
-                        splat_space(writer, pad_left as u64)?;
-                        pretty_write!(writer, " cause<r><d>:<r> ")?;
-
-                        if allow_side_effects && global_ref.has_exception() {
-                            global_ref.clear_exception();
-                        }
-
-                        let tag = Tag::get_advanced(
-                            cause,
-                            global_ref,
-                            TagOptions::DISABLE_INSPECT_CUSTOM | TagOptions::HIDE_GLOBAL,
-                        )?;
-                        let _ = if allow_ansi_color {
-                            formatter.format::<true>(tag, writer, cause, global_ref)
-                        } else {
-                            formatter.format::<false>(tag, writer, cause, global_ref)
-                        };
-
-                        if allow_side_effects {
-                            if global_ref.has_exception() {
-                                global_ref.clear_exception();
-                            }
-                        } else if global_ref.has_exception() || formatter.failed {
-                            return Ok(());
-                        }
-
-                        pretty_write!(writer, "<r><d>,<r>\n")?;
+                        write_error_field!("cause", b"cause".len(), cause);
                     }
                 }
             }

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -72,12 +72,11 @@ note: "duplicateConstDecl" was originally declared here
 });
 
 const normalizeError = str => {
-  // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
+  // remove debug-only stack trace frames like "at require (:1:21)" / "at require (51:24)"
+  if (/ \(:?\d+:\d+\)$/m.test(str)) {
     const splits = str.split("\n");
     for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
+      if (/ \(:?\d+:\d+\)$/.test(splits[i])) {
         splits.splice(i, 1);
         i--;
       }
@@ -87,6 +86,7 @@ const normalizeError = str => {
 
   return str;
 };
+
 
 test("Error inside minified file (no color) ", () => {
   try {
@@ -187,4 +187,70 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
   expect(() => {
     throw err;
   }).toThrow();
+});
+
+describe("non-Error cause", () => {
+  const { bunEnv, bunExe } = require("harness");
+  // Build markers at runtime so they never appear in the source-preview lines
+  // that Bun.inspect prepends to Error output.
+  const objMark = ["OBJ", "CAUSE", "MARK"].join("_");
+  const strMark = ["STR", "CAUSE", "MARK"].join("_");
+
+  test("Bun.inspect prints an object cause", () => {
+    const out = Bun.inspect(new Error("req failed", { cause: { code: objMark, status: 503 } }));
+    expect(out).toContain("cause:");
+    expect(out).toContain(objMark);
+  });
+
+  test("Bun.inspect prints a string cause at depth 2", () => {
+    const out = Bun.inspect(new Error("L1", { cause: new Error("L2", { cause: strMark }) }));
+    expect(out).toContain("error: L1");
+    expect(out).toContain("error: L2");
+    expect(out).toContain(strMark);
+  });
+
+  test.each([
+    ["null", null],
+    ["number", 42],
+    ["undefined", undefined],
+  ])("Bun.inspect prints a %s cause", (_, cause) => {
+    const out = Bun.inspect(new Error("x", { cause }));
+    expect(out).toContain("cause: " + Bun.inspect(cause));
+  });
+
+  test("enumerable non-Error cause is printed once", () => {
+    const err = new Error("x");
+    err.cause = objMark;
+    const out = Bun.inspect(err);
+    expect((out.match(new RegExp(objMark, "g")) || []).length).toBe(1);
+  });
+
+  test.concurrent("console.error and uncaught throw include object cause", async () => {
+    const mark = ["OBJ", "CAUSE", "MARK"].join("");
+    const src = `const e = new Error("req failed", { cause: { code: "ECAUSE", tag: ["OBJ","CAUSE","MARK"].join("") } }); console.error(e); throw e;`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-addons", "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const combined = stdout + stderr;
+    expect(combined).toContain("ECAUSE");
+    expect((combined.match(new RegExp(mark, "g")) || []).length).toBe(2);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("console.error includes string cause at depth 2", async () => {
+    const src = `console.error(new Error("L1", { cause: new Error("L2", { cause: ["STR","CAUSE","MARK"].join("") }) }))`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-addons", "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout + stderr).toContain("STR" + "CAUSE" + "MARK");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -87,7 +87,6 @@ const normalizeError = str => {
   return str;
 };
 
-
 test("Error inside minified file (no color) ", () => {
   try {
     require("./inspect-error-fixture.min.js");

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -9,21 +10,23 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
-5 |   const err2 = new Error("error 2", { cause: err });
+2 | import { bunEnv, bunExe } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
+6 |   const err2 = new Error("error 2", { cause: err });
                        ^
 error: error 2
-      at <anonymous> ([dir]/inspect-error.test.js:5:20)
+      at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
+2 | import { bunEnv, bunExe } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
                       ^
 error: error 1
-      at <anonymous> ([dir]/inspect-error.test.js:4:19)
+      at <anonymous> ([dir]/inspect-error.test.js:5:19)
 "
 `);
 });
@@ -35,15 +38,15 @@ test("Error", () => {
       .replaceAll("\\", "/")
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
-"27 | "
-28 | \`);
-29 | });
-30 | 
-31 | test("Error", () => {
-32 |   const err = new Error("my message");
+"30 | "
+31 | \`);
+32 | });
+33 | 
+34 | test("Error", () => {
+35 |   const err = new Error("my message");
                        ^
 error: my message
-      at <anonymous> ([dir]/inspect-error.test.js:32:19)
+      at <anonymous> ([dir]/inspect-error.test.js:35:19)
 "
 `);
 });
@@ -111,7 +114,7 @@ test("Error inside minified file (no color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:92:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:95:7)"
     `);
   }
 });
@@ -140,7 +143,7 @@ test("Error inside minified file (color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:120:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:123:7)"
     `);
   }
 });
@@ -154,7 +157,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:149:19)"
+    at <anonymous> ([file]:152:19)"
 `);
 });
 
@@ -190,7 +193,6 @@ test("error.stack throwing an error doesn't lead to a crash", () => {
 });
 
 describe("non-Error cause", () => {
-  const { bunEnv, bunExe } = require("harness");
   // Build markers at runtime so they never appear in the source-preview lines
   // that Bun.inspect prepends to Error output.
   const objMark = ["OBJ", "CAUSE", "MARK"].join("_");
@@ -223,6 +225,15 @@ describe("non-Error cause", () => {
     err.cause = objMark;
     const out = Bun.inspect(err);
     expect((out.match(new RegExp(objMark, "g")) || []).length).toBe(1);
+  });
+
+  test("enumerable Error cause at depth 2 gets a full render", () => {
+    const inner = new Error(strMark);
+    const mid = new Error("mid");
+    mid.cause = inner;
+    const out = Bun.inspect(new Error("outer", { cause: mid }));
+    expect((out.match(/error: mid/g) || []).length).toBe(1);
+    expect((out.match(new RegExp("error: " + strMark, "g")) || []).length).toBe(1);
   });
 
   test.concurrent("console.error and uncaught throw include object cause", async () => {

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -72,7 +72,8 @@ note: "duplicateConstDecl" was originally declared here
 });
 
 const normalizeError = str => {
-  // remove debug-only stack trace frames like "at require (:1:21)" / "at require (51:24)"
+  // remove debug-only stack trace frames
+  // like "at require (:1:21)" / "at require (51:24)"
   if (/ \(:?\d+:\d+\)$/m.test(str)) {
     const splits = str.split("\n");
     for (let i = 0; i < splits.length; i++) {


### PR DESCRIPTION
The native error printer silently drops `Error.cause` when it is not itself an `Error` instance. `util.inspect` already shows `[cause]: {...}` for these, so the context is only lost on the code paths that matter most (`console.error` and the uncaught-throw report).

### Repro

```js
console.error(new Error("req failed", { cause: { code: "ECAUSE", status: 503 } }));
// before: prints "error: req failed" with no mention of the cause object
// node:   prints "[cause]: { code: 'ECAUSE', status: 503 }"

console.error(new Error("L1", { cause: new Error("L2", { cause: "deep" }) }));
// before: prints L1 and L2 but drops the string cause at depth 2
```

An assigned enumerable `e.cause = "x"` did print (it flows through the own-property loop), which is why this hid.

### Cause

`VirtualMachine::print_error_instance_body` looks up the non-enumerable `cause` via `get_own` but only recurses when `cause.js_type() == JSType::ErrorInstance`. Every other value (plain object, string, number, `DOMException`, a `Response`, etc.) falls through with no fallback render.

### Fix

`src/jsc/VirtualMachine.rs`:
- When the non-enumerable `cause` is not an `ErrorInstance`, render it inline using the same formatter settings as the enumerable own-property dump, so it appears as `cause: <value>,` in the property block.
- Track `saw_cause` for any enumerable property named `cause` (not just `ErrorInstance`-typed ones) so an assigned non-Error cause is not rendered twice.
- Hoisted the existing `RestoreFmt` drop guard one scope out so both the property loop and the cause fallback can share it.

### Output after

```text
error: req failed
 cause: {
  code: "ECAUSE",
  status: 503,
},

      at ...
```

### Tests

New `non-Error cause` describe block in `test/js/bun/util/inspect-error.test.js` covering object cause, string cause at depth 2, `null`/number/`undefined` cause, no double-print for an enumerable cause, plus spawned-process checks for `console.error` and the uncaught-throw path. All fail on the unfixed build and pass with the fix.

Also widened the existing `normalizeError` helper to strip debug-only `at require (N:N)` frames as well as the older `at require (:N:N)` form so the two pre-existing minified-file snapshot tests stay green under `bun bd`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (8dc69958c)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [6.12ms]
(pass) Error [3.03ms]
(pass) BuildMessage [10.96ms]
(pass) Error inside minified file (no color)  [80.87ms]
(pass) Error inside minified file (color)  [47.03ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [278.98ms]
(pass) observable properties > sourceURL is observable [5.88ms]
(pass) observable properties > line is observable [2.21ms]
(pass) observable properties > column is observable [1.93ms]
(pass) error.stack throwing an error doesn't lead to a crash [4.16ms]
199 |   const strMark = ["STR", "CAUSE", "MARK"].join("_");
200 | 
201 |   test("Bun.inspect prints an object cause", () => {
202 |     const out = Bun.inspect(new Error("req failed", { cause: { code: objMark, status: 503 } }));
203 |     expect(out).toContain("cause:");
204 |     expect(out).toContain(objMark);
                      ^
error: expect(received).toContain(expected)

Expected to contain: "O
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (fc83a0301)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [0.19ms]
(pass) Error [0.08ms]
(pass) BuildMessage [0.28ms]
(pass) Error inside minified file (no color)  [2.36ms]
(pass) Error inside minified file (color)  [0.31ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [4.75ms]
(pass) observable properties > sourceURL is observable [0.13ms]
(pass) observable properties > line is observable [0.05ms]
(pass) observable properties > column is observable [0.03ms]
(pass) error.stack throwing an error doesn't lead to a crash [0.06ms]
(pass) non-Error cause > Bun.inspect prints an object cause [0.10ms]
(pass) non-Error cause > Bun.inspect prints a string cause at depth 2 [0.08ms]
(pass) non-Error cause > Bun.inspect prints a null cause [0.05ms]
(pass) non-Error cause > Bun.inspect prints a number cause [0.03ms]
(pass) non-Error cause > Bun.inspect prints a undefined cause [0.02ms]
(pass) non-Error cause > enumerable non-Error cause is printed once [0.06ms]
(pass) non-Error cause > enumerable Error cause at depth 2 gets a full render [0.12ms]
(pass) non-Error cause > console.error and uncaught throw
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (8dc69958c)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [5.55ms]
(pass) Error [3.16ms]
(pass) BuildMessage [11.06ms]
(pass) Error inside minified file (no color)  [85.91ms]
(pass) Error inside minified file (color)  [64.45ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [309.26ms]
(pass) observable properties > sourceURL is observable [7.83ms]
(pass) observable properties > line is observable [2.23ms]
(pass) observable properties > column is observable [1.83ms]
(pass) error.stack throwing an error doesn't lead to a crash [4.94ms]
(pass) non-Error cause > Bun.inspect prints an object cause [4.85ms]
(pass) non-Error cause > Bun.inspect prints a string cause at depth 2 [7.42ms]
(pass) non-Error cause > Bun.inspect prints a null cause [4.18ms]
(pass) non-Error cause > Bun.inspect prints a number cause [1.97ms]
(pass) non-Error cause > Bun.inspect prints a undefined cause [1.80ms]
(pass) non-Error cause > enumerable non-Error cause i
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 673ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs              | 144 +++++++++++++++++++--------------
 test/js/bun/util/inspect-error.test.js | 121 ++++++++++++++++++++++-----
 2 files changed, 183 insertions(+), 82 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/VirtualMachine.rs                   9      6      0
test/js/bun/util/inspect-error.test.js      7      9      0
```

</details>

**root cause** · written by the author bot

The native error printer only followed an error's `cause` when the value was a JSC `ErrorInstance`, so plain objects, strings, numbers, and other non-Error causes were silently omitted from both `console.error` output and the uncaught error report. The fix removes that type gate and adds a fallback that renders non-Error cause values inline using the inspector, while still recursing into Error-typed causes so chained errors print fully at any depth. This brings the printer's behavior in line with `util.inspect` and Node's `[cause]: ...` output.

<!-- robobun:evidence:end -->