### PR TITLE
Print the AggregateError header before iterating its members

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4761,6 +4761,18 @@ impl VirtualMachine {
         // once the AggregateError branch is taken).
         let global_ref = self.global();
 
+        // Note: reborrow so the add-to-error-list tail can still see it after
+        // `print_error_from_maybe_private_data`.
+        let mut exception_list = exception_list;
+        let was_internal = self.print_error_from_maybe_private_data(
+            value,
+            exception_list.as_deref_mut(),
+            formatter,
+            writer,
+            allow_ansi_color,
+            allow_side_effects,
+        );
+
         if value.is_aggregate_error(global_ref) {
             // Note: `JSValue::for_each` takes a C-ABI fn
             // pointer + erased ctx, so thread the captures through a struct.
@@ -4797,6 +4809,7 @@ impl VirtualMachine {
                 // SAFETY: `ctx.writer` borrows the caller's stack local,
                 // live across the synchronous `for_each` call.
                 let writer = unsafe { &mut *ctx.writer };
+                let _ = writer.write_all(b"\n");
                 vm.print_errorlike_object(
                     next_value,
                     None,
@@ -4811,6 +4824,7 @@ impl VirtualMachine {
                 formatter: std::ptr::from_mut(formatter),
                 writer: std::ptr::from_mut(writer),
                 exception_list: exception_list
+                    .as_deref_mut()
                     .map(std::ptr::from_mut::<ExceptionList>)
                     .unwrap_or(core::ptr::null_mut()),
                 allow_ansi_color,
@@ -4823,18 +4837,6 @@ impl VirtualMachine {
             let _ = errors.for_each(global_ref, (&raw mut ctx).cast(), agg_iter);
             return;
         }
-
-        // Note: reborrow so the add-to-error-list tail can still see it after
-        // `print_error_from_maybe_private_data`.
-        let mut exception_list = exception_list;
-        let was_internal = self.print_error_from_maybe_private_data(
-            value,
-            exception_list.as_deref_mut(),
-            formatter,
-            writer,
-            allow_ansi_color,
-            allow_side_effects,
-        );
 
         if was_internal {
             if let Some(exception_) = exception {

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -178,7 +178,11 @@ describe("AggregateError", () => {
   const header = ["AggregateError", ["TOP", "AGG", "MESSAGE"].join("-")].join(": ");
 
   test.concurrent.each([
-    ["Bun.inspect", `process.stderr.write(Bun.inspect(new AggregateError([new Error("m1"), new RangeError("m2")], ${mk})))`, 0],
+    [
+      "Bun.inspect",
+      `process.stderr.write(Bun.inspect(new AggregateError([new Error("m1"), new RangeError("m2")], ${mk})))`,
+      0,
+    ],
     ["console.error", `console.error(new AggregateError([new Error("m1"), new RangeError("m2")], ${mk}))`, 0],
     ["uncaught throw", `throw new AggregateError([new Error("m1"), new RangeError("m2")], ${mk})`, 1],
     ["unhandled rejection", `Promise.reject(new AggregateError([new Error("m1"), new RangeError("m2")], ${mk}))`, 1],

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 test("error.cause", () => {
   const err = new Error("error 1");
@@ -9,21 +10,23 @@ test("error.cause", () => {
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
 "1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
-5 |   const err2 = new Error("error 2", { cause: err });
+2 | import { bunEnv, bunExe } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
+6 |   const err2 = new Error("error 2", { cause: err });
                        ^
 error: error 2
-      at <anonymous> ([dir]/inspect-error.test.js:5:20)
+      at <anonymous> ([dir]/inspect-error.test.js:6:20)
 
 1 | import { describe, expect, jest, test } from "bun:test";
-2 | 
-3 | test("error.cause", () => {
-4 |   const err = new Error("error 1");
+2 | import { bunEnv, bunExe } from "harness";
+3 | 
+4 | test("error.cause", () => {
+5 |   const err = new Error("error 1");
                       ^
 error: error 1
-      at <anonymous> ([dir]/inspect-error.test.js:4:19)
+      at <anonymous> ([dir]/inspect-error.test.js:5:19)
 "
 `);
 });
@@ -35,15 +38,15 @@ test("Error", () => {
       .replaceAll("\\", "/")
       .replaceAll(import.meta.dir.replaceAll("\\", "/"), "[dir]"),
   ).toMatchInlineSnapshot(`
-"27 | "
-28 | \`);
-29 | });
-30 | 
-31 | test("Error", () => {
-32 |   const err = new Error("my message");
+"30 | "
+31 | \`);
+32 | });
+33 | 
+34 | test("Error", () => {
+35 |   const err = new Error("my message");
                        ^
 error: my message
-      at <anonymous> ([dir]/inspect-error.test.js:32:19)
+      at <anonymous> ([dir]/inspect-error.test.js:35:19)
 "
 `);
 });
@@ -73,19 +76,11 @@ note: "duplicateConstDecl" was originally declared here
 
 const normalizeError = str => {
   // remove debug-only stack trace frames
-  // like "at require (:1:21)"
-  if (str.includes(" (:")) {
-    const splits = str.split("\n");
-    for (let i = 0; i < splits.length; i++) {
-      if (splits[i].includes(" (:")) {
-        splits.splice(i, 1);
-        i--;
-      }
-    }
-    return splits.join("\n");
-  }
-
-  return str;
+  // like "at require (:1:21)" or "at require (51:24)"
+  return str
+    .split("\n")
+    .filter(line => !/^\s+at .+ \(:?\d+:\d+\)$/.test(line))
+    .join("\n");
 };
 
 test("Error inside minified file (no color) ", () => {
@@ -111,7 +106,7 @@ test("Error inside minified file (no color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:92:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:87:7)"
     `);
   }
 });
@@ -140,7 +135,7 @@ test("Error inside minified file (color) ", () => {
       error: error inside long minified file!
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2850)
             at <anonymous> ([dir]/inspect-error-fixture.min.js:26:2890)
-            at <anonymous> ([dir]/inspect-error.test.js:120:7)"
+            at <anonymous> ([dir]/inspect-error.test.js:115:7)"
     `);
   }
 });
@@ -154,7 +149,7 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
       .replaceAll(import.meta.path.replaceAll("\\", "/"), "[file]"),
   ).toMatchInlineSnapshot(`
 "Error: my message
-    at <anonymous> ([file]:149:19)"
+    at <anonymous> ([file]:144:19)"
 `);
 });
 
@@ -173,6 +168,50 @@ describe("observable properties", () => {
       expect(mock).not.toHaveBeenCalled();
     });
   }
+});
+
+describe("AggregateError", () => {
+  // Build the aggregate's message (and the expected header) at runtime so the
+  // source-line preview that the error printer emits cannot contain the
+  // assertion string by accident.
+  const mk = `["TOP","AGG","MESSAGE"].join("-")`;
+  const header = ["AggregateError", ["TOP", "AGG", "MESSAGE"].join("-")].join(": ");
+
+  test.concurrent.each([
+    ["Bun.inspect", `process.stderr.write(Bun.inspect(new AggregateError([new Error("m1"), new RangeError("m2")], ${mk})))`, 0],
+    ["console.error", `console.error(new AggregateError([new Error("m1"), new RangeError("m2")], ${mk}))`, 0],
+    ["uncaught throw", `throw new AggregateError([new Error("m1"), new RangeError("m2")], ${mk})`, 1],
+    ["unhandled rejection", `Promise.reject(new AggregateError([new Error("m1"), new RangeError("m2")], ${mk}))`, 1],
+  ])("%s prints the aggregate header and each member", async (_, code, wantExit) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = stdout + stderr;
+    expect(out).toContain(header);
+    expect(out).toContain("error: m1");
+    expect(out).toContain("RangeError: m2");
+    expect(out.indexOf(header)).toBeLessThan(out.indexOf("error: m1"));
+    expect(exitCode).toBe(wantExit);
+  });
+
+  test.concurrent("unhandled Promise.any rejection prints the aggregate header", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `Promise.any([Promise.reject(new Error("r1")), Promise.reject(new Error("r2"))])`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = stdout + stderr;
+    expect(out).toContain("AggregateError");
+    expect(out).toContain("r1");
+    expect(out).toContain("r2");
+    expect(exitCode).toBe(1);
+  });
 });
 
 test("error.stack throwing an error doesn't lead to a crash", () => {

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -199,6 +199,7 @@ describe("AggregateError", () => {
     expect(out).toContain("error: m1");
     expect(out).toContain("RangeError: m2");
     expect(out.indexOf(header)).toBeLessThan(out.indexOf("error: m1"));
+    expect(out.indexOf("error: m1")).toBeLessThan(out.indexOf("RangeError: m2"));
     expect(exitCode).toBe(wantExit);
   });
 
@@ -212,8 +213,10 @@ describe("AggregateError", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     const out = stdout + stderr;
     expect(out).toContain("AggregateError");
-    expect(out).toContain("r1");
-    expect(out).toContain("r2");
+    expect(out).toContain("error: r1");
+    expect(out).toContain("error: r2");
+    expect(out.indexOf("AggregateError")).toBeLessThan(out.indexOf("error: r1"));
+    expect(out.indexOf("error: r1")).toBeLessThan(out.indexOf("error: r2"));
     expect(exitCode).toBe(1);
   });
 });

--- a/test/regression/issue/jsx-template-string-crash.test.ts
+++ b/test/regression/issue/jsx-template-string-crash.test.ts
@@ -16,10 +16,13 @@ test("JSX lexer should not crash with slice bounds issues", async () => {
 
   expect(exitCode).toBe(1);
   expect(normalizeBunSnapshot(stderr.toString().replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
-    "1 | export function x(){return<div a=\`\`/>}
+    "AggregateError: 2 errors building "<cwd>/[eval]"
+
+    1 | export function x(){return<div a=\`\`/>}
                                          ^
     error: Expected "{" but found "\`"
         at <cwd>/[eval]:1:34
+
 
     1 | export function x(){return<div a=\`\`/>}
                                           ^
@@ -57,10 +60,13 @@ test.concurrent("#30959 JSX attribute with invalid '(' value parses cleanly in d
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(normalizeBunSnapshot(stderr.replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
-    "1 | export function x(){return<r L=((}
+    "AggregateError: 2 errors building "<cwd>/[eval]"
+
+    1 | export function x(){return<r L=((}
                                        ^
     error: Expected "{" but found "("
         at <cwd>/[eval]:1:32
+
 
     1 | export function x(){return<r L=((}
                                          ^


### PR DESCRIPTION
The native error printer (used by `console.log`/`console.error` of an `Error`, an uncaught `throw`, an unhandled rejection, and `Bun.inspect`) handled `AggregateError` by iterating `.errors` and printing each member, then returning. The aggregate's own `AggregateError: <message>` header and stack were never printed, so a `Promise.any()` rejection or any thrown `AggregateError` showed only the member errors with no top-level context. `util.inspect` (the Node-compat path) was already correct.

### Repro

```js
// bun -e 'throw new AggregateError([new Error("m1"), new RangeError("m2")], "TOP-AGG-MESSAGE")'
```

Before:
```
1 | throw new AggregateError([new Error("m1"), new RangeError("m2")], "TOP-AGG-MESSAGE")
                                  ^
error: m1
      at [eval]:1:31
1 | throw new AggregateError([new Error("m1"), new RangeError("m2")], "TOP-AGG-MESSAGE")
                                                   ^
RangeError: m2
      at [eval]:1:48
```

After:
```
1 | throw new AggregateError([new Error("m1"), new RangeError("m2")], "TOP-AGG-MESSAGE")
              ^
AggregateError: TOP-AGG-MESSAGE
      at [eval]:1:11

1 | throw new AggregateError([new Error("m1"), new RangeError("m2")], "TOP-AGG-MESSAGE")
                                  ^
error: m1
      at [eval]:1:31

1 | throw new AggregateError([new Error("m1"), new RangeError("m2")], "TOP-AGG-MESSAGE")
                                                   ^
RangeError: m2
      at [eval]:1:48
```

### Cause

`VirtualMachine::print_errorlike_object` entered the `is_aggregate_error` branch first, iterated `.errors` via `for_each` -> `agg_iter` -> `print_errorlike_object`, and returned. The normal `print_error_from_maybe_private_data` path (which renders name, message, and stack) was never reached for the aggregate itself. The `.errors` property is `DontEnum`, so the own-property dump inside `print_error_instance_body` never sees it either.

### Fix

`src/jsc/VirtualMachine.rs`: move the `.errors` iteration in `print_errorlike_object` to run after `print_error_from_maybe_private_data`, so the aggregate prints its own header and stack first, then each member follows with a blank-line separator (matching the existing `cause` chain layout).

### Tests

New `AggregateError` suite in `test/js/bun/util/inspect-error.test.js` covering `Bun.inspect`, `console.error`, an uncaught `throw`, an unhandled rejection, and `Promise.any`. All five fail on main (no header in the output) and pass with this change. Existing inline snapshots in that file are regenerated for the added import line; `normalizeError` is widened to also strip the newer `at require (N:N)` debug-only frame shape so the minified-file snapshots stay stable across debug/release.

The duplicate render of a primitive `.errors` member (`error: x` followed by `x`) is pre-existing behaviour of `print_error_instance_body` for non-`ErrorInstance` values (also visible via `reportError("x")`) and is left unchanged here.


### Not addressed here

An `AggregateError` reached via `.cause` (e.g. `throw new Error("outer", { cause: new AggregateError([...], "agg") })`) now prints `AggregateError: agg` thanks to this change, but its `.errors` members are still omitted. That path recurses through `print_error_instance_js` (the `errors_to_append` loop in `print_error_instance_body`), which never reaches the `.errors` iteration in `print_errorlike_object`. Pre-existing and left for a follow-up, likely by moving the iteration into `print_error_instance_body` so both entry points share it and reuse the existing circular-reference guard there.

Related: #34892 guards the same branch against deep recursion; the two changes compose (whichever lands second has a trivial rebase).

Fixes #21528

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js test/regression/issue/jsx-template-string-crash.test.ts
bun test v1.4.0 (88317f782)

test/regression/issue/jsx-template-string-crash.test.ts:
13 |     stderr: "pipe",
14 |     stdout: "pipe",
15 |   });
16 | 
17 |   expect(exitCode).toBe(1);
18 |   expect(normalizeBunSnapshot(stderr.toString().replace(/(Bun v.*)$/gm, ""))).toMatchInlineSnapshot(`
                                                                                   ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "AggregateError: 2 errors building "<cwd>/[eval]"
- 
- 1 | export function x(){return<div a=``/>}
+ "1 | export function x(){return<div a=``/>}
                                       ^
  error: Expected "{" but found "`"
      at <cwd>/[eval]:1:34
- 
  
  1 | export function x(){return<div a=``/>}
                                        ^
  error: Unterminated string literal
      at <cwd>/[eval]:1:35"
  

- Expected  - 4
+ Received  + 1

      at <anonymous> (/workspace/bun/test/regression/issue/jsx-template-s
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (573f9462e)

test/regression/issue/jsx-template-string-crash.test.ts:
(pass) JSX lexer should not crash with slice bounds issues [17.91ms]
(pass) #30959 JSX attribute with invalid '(' value parses cleanly in debug builds [11.77ms]

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [0.24ms]
(pass) Error [0.12ms]
(pass) BuildMessage [0.37ms]
(pass) Error inside minified file (no color)  [1.51ms]
(pass) Error inside minified file (color)  [0.53ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [7.77ms]
(pass) observable properties > sourceURL is observable [0.21ms]
(pass) observable properties > line is observable [0.08ms]
(pass) observable properties > column is observable [0.05ms]
(pass) AggregateError > console.error prints the aggregate header and each member [10.84ms]
(pass) AggregateError > uncaught throw prints the aggregate header and each member [17.17ms]
(pass) AggregateError > unhandled rejection prints the aggregate header and each member [20.86ms]
(pass) AggregateError > Bun.inspect prints the aggregate header and each member [25.11ms]
(pass) AggregateError > unhandled Promise.any reject
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js test/regression/issue/jsx-template-string-crash.test.ts
bun test v1.4.0 (88317f782)

test/regression/issue/jsx-template-string-crash.test.ts:
(pass) JSX lexer should not crash with slice bounds issues [480.95ms]
(pass) #30959 JSX attribute with invalid '(' value parses cleanly in debug builds [547.04ms]

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [5.63ms]
(pass) Error [3.46ms]
(pass) BuildMessage [23.04ms]
(pass) Error inside minified file (no color)  [133.77ms]
(pass) Error inside minified file (color)  [73.02ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [440.14ms]
(pass) observable properties > sourceURL is observable [9.17ms]
(pass) observable properties > line is observable [3.26ms]
(pass) observable properties > column is observable [2.85ms]
(pass) AggregateError > unhandled Promise.any rejection prints the aggregate header [449.89ms]
(pass) AggregateError > uncaught throw prints the aggregate header and each member [602.93ms]
(pass) Ag
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 845ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                          |  26 ++---
 test/js/bun/util/inspect-error.test.js             | 110 +++++++++++++++------
 .../issue/jsx-template-string-crash.test.ts        |  10 +-
 3 files changed, 100 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/VirtualMachine.rs                                    8      1      0
test/js/bun/util/inspect-error.test.js                       3      7      0
test/regression/issue/jsx-template-string-crash.test.ts      1      0      0
```

</details>

<!-- robobun:evidence:end -->