### PR TITLE
error: attribute eval/new Function frames to <anonymous> with an eval origin

### DIFF
--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -58,6 +58,7 @@ void CallSite::finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStac
 
     m_functionName.set(vm, this, stackFrame.functionName());
     m_sourceURL.set(vm, this, stackFrame.sourceURL());
+    m_evalOrigin.set(vm, this, JSC::jsUndefined());
 
     const auto* sourcePositions = stackFrame.getSourcePositions();
     if (sourcePositions) {
@@ -67,6 +68,11 @@ void CallSite::finishCreation(VM& vm, JSC::JSGlobalObject* globalObject, JSCStac
 
     if (stackFrame.isEval()) {
         m_flags |= static_cast<unsigned int>(Flags::IsEval);
+        if (stackFrame.hasEvalSourceURL()) {
+            m_evalOrigin.set(vm, this, stackFrame.sourceURL());
+        } else if (!stackFrame.evalCallerURL().isEmpty()) {
+            m_evalOrigin.set(vm, this, jsString(vm, makeString("eval at <anonymous> ("_s, stackFrame.evalCallerURL(), ')')));
+        }
     } else if (stackFrame.isFunctionOrEval()) {
         m_flags |= static_cast<unsigned int>(Flags::IsFunction);
     }
@@ -90,6 +96,7 @@ void CallSite::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisCallSite->m_function);
     visitor.append(thisCallSite->m_functionName);
     visitor.append(thisCallSite->m_sourceURL);
+    visitor.append(thisCallSite->m_evalOrigin);
 }
 JSC_DEFINE_HOST_FUNCTION(nativeFrameForTesting, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
@@ -158,7 +165,16 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
         if (functionName.length() > 0) {
             sb.append(" ("_s);
         }
-        if (!mySourceURL || mySourceURL->length() == 0) {
+
+        bool isAnonymousEval = isEval() && (!mySourceURL || mySourceURL->length() == 0);
+        if (isAnonymousEval) {
+            JSValue origin = evalOrigin();
+            if (auto* originStr = origin.toStringOrNull(globalObject); originStr && originStr->length() > 0) {
+                sb.append(originStr->getString(globalObject));
+                sb.append(", "_s);
+            }
+            sb.append("<anonymous>"_s);
+        } else if (!mySourceURL || mySourceURL->length() == 0) {
             sb.append("unknown"_s);
         } else {
             sb.append(mySourceURL->getString(globalObject));

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -35,6 +35,7 @@ private:
     JSC::WriteBarrier<JSC::Unknown> m_function;
     JSC::WriteBarrier<JSC::Unknown> m_functionName;
     JSC::WriteBarrier<JSC::Unknown> m_sourceURL;
+    JSC::WriteBarrier<JSC::Unknown> m_evalOrigin;
     OrdinalNumber m_lineNumber;
     OrdinalNumber m_columnNumber;
     unsigned int m_flags;
@@ -74,6 +75,7 @@ public:
     JSC::JSValue function() const { return m_function.get(); }
     JSC::JSValue functionName() const { return m_functionName.get(); }
     JSC::JSValue sourceURL() const { return m_sourceURL.get(); }
+    JSC::JSValue evalOrigin() const { return m_evalOrigin.get(); }
     OrdinalNumber lineNumber() const { return m_lineNumber; }
     OrdinalNumber columnNumber() const { return m_columnNumber; }
     bool isEval() const { return m_flags & static_cast<unsigned int>(Flags::IsEval); }
@@ -85,6 +87,7 @@ public:
     void setLineNumber(OrdinalNumber lineNumber) { m_lineNumber = lineNumber; }
     void setColumnNumber(OrdinalNumber columnNumber) { m_columnNumber = columnNumber; }
     void setSourceURL(JSC::VM& vm, JSC::JSString* sourceURL) { m_sourceURL.set(vm, this, sourceURL); }
+    void setEvalOrigin(JSC::VM& vm, JSC::JSValue evalOrigin) { m_evalOrigin.set(vm, this, evalOrigin); }
 
     void formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::StringBuilder& sb);
 

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -128,7 +128,12 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetMethodName, (JSGlobalObject * globa
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFileName, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-    return JSC::JSValue::encode(callSite->sourceURL());
+    if (callSite->isEval())
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    JSValue url = callSite->sourceURL();
+    if (auto* str = url.toStringOrNull(globalObject); str && str->length() == 0)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    return JSC::JSValue::encode(url);
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetLineNumber, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -145,16 +150,19 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetColumnNumber, (JSGlobalObject * glo
     return JSC::JSValue::encode(jsNumber(std::max(callSite->columnNumber().zeroBasedInt(), 0)));
 }
 
-// TODO:
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetEvalOrigin, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    return JSC::JSValue::encode(JSC::jsUndefined());
+    ENTER_PROTO_FUNC();
+    return JSC::JSValue::encode(callSite->evalOrigin());
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetScriptNameOrSourceURL, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-    return JSC::JSValue::encode(callSite->sourceURL());
+    JSValue url = callSite->sourceURL();
+    if (auto* str = url.toStringOrNull(globalObject); str && str->length() == 0)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    return JSC::JSValue::encode(url);
 }
 
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncIsToplevel, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -23,6 +23,7 @@
 #include <wtf/IterationStatus.h>
 #include <JavaScriptCore/CodeBlock.h>
 #include <JavaScriptCore/FunctionCodeBlock.h>
+#include <JavaScriptCore/FunctionExecutable.h>
 
 #include "ErrorStackFrame.h"
 
@@ -231,6 +232,12 @@ JSCStackFrame::JSCStackFrame(JSC::VM& vm, JSC::StackVisitor& visitor)
         if (codeType == JSC::FunctionCode || codeType == JSC::EvalCode) {
             m_isFunctionOrEval = true;
         }
+        auto evalOrigin = evalOriginForCodeBlock(codeBlock);
+        if (evalOrigin.isEval) {
+            m_isInsideEval = true;
+            m_hasEvalSourceURL = evalOrigin.hasSourceURL;
+            m_evalCallerURL = evalOrigin.callerURL;
+        }
     }
 
     // Based on JSC's GetStackTraceFunctor (Interpreter.cpp)
@@ -288,6 +295,12 @@ JSCStackFrame::JSCStackFrame(JSC::VM& vm, const JSC::StackFrame& frame)
         auto codeType = codeBlock->codeType();
         if (codeType == JSC::FunctionCode || codeType == JSC::EvalCode) {
             m_isFunctionOrEval = true;
+        }
+        auto evalOrigin = evalOriginForCodeBlock(codeBlock);
+        if (evalOrigin.isEval) {
+            m_isInsideEval = true;
+            m_hasEvalSourceURL = evalOrigin.hasSourceURL;
+            m_evalCallerURL = evalOrigin.callerURL;
         }
     }
 
@@ -349,6 +362,12 @@ ALWAYS_INLINE String JSCStackFrame::retrieveSourceURL()
 
     if (m_isWasmFrame) {
         return String(sourceURLWasmString);
+    }
+
+    if (m_isInsideEval && !m_hasEvalSourceURL) {
+        // Line/column refer to the eval string, not any file on disk. Returning
+        // the caller's URL here would blame those positions on the wrong file.
+        return String();
     }
 
     auto url = Zig::sourceURL(m_codeBlock);
@@ -428,6 +447,50 @@ bool JSCStackFrame::calculateSourcePositions()
     m_sourcePositions.column = location.column();
 
     return true;
+}
+
+EvalOrigin evalOriginForCodeBlock(JSC::CodeBlock* codeBlock)
+{
+    EvalOrigin result;
+    if (!codeBlock)
+        return result;
+    auto* executable = codeBlock->ownerExecutable();
+    if (!executable)
+        return result;
+
+    // For eval(), topLevelExecutable() is the EvalExecutable. For new Function(),
+    // FunctionExecutable::fromGlobalCode links with a null parent, so the
+    // top-level is a FunctionExecutable. Ordinary scripts have a Program or
+    // ModuleProgram top-level.
+    auto* topLevel = executable->topLevelExecutable();
+    if (!topLevel)
+        return result;
+    if (!topLevel->isEvalExecutable() && !topLevel->isFunctionExecutable())
+        return result;
+
+    auto* provider = codeBlock->source().provider();
+    if (!provider)
+        return result;
+
+    if (topLevel->isFunctionExecutable() && !provider->sourceURL().isEmpty()) {
+        // A FunctionExecutable top-level with a real sourceURL is a normal
+        // script function (e.g. node:vm compileFunction with a filename), not
+        // a new Function() body.
+        return result;
+    }
+
+    result.isEval = true;
+    result.hasSourceURL = !provider->sourceURLDirective().isEmpty() || !provider->sourceURL().isEmpty();
+
+    const auto& origin = provider->sourceOrigin();
+    if (!origin.isNull()) {
+        const auto& url = origin.url();
+        if (url.protocolIsFile())
+            result.callerURL = url.fileSystemPath();
+        if (result.callerURL.isEmpty())
+            result.callerURL = origin.string();
+    }
+    return result;
 }
 
 String sourceURL(const JSC::SourceOrigin& origin)

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -457,6 +457,8 @@ EvalOrigin evalOriginForCodeBlock(JSC::CodeBlock* codeBlock)
     auto* executable = codeBlock->ownerExecutable();
     if (!executable)
         return result;
+    if (auto* unlinked = codeBlock->unlinkedCodeBlock(); unlinked && unlinked->isBuiltinFunction())
+        return result;
 
     // For eval(), topLevelExecutable() is the EvalExecutable. For new Function(),
     // FunctionExecutable::fromGlobalCode links with a null parent, so the
@@ -472,11 +474,17 @@ EvalOrigin evalOriginForCodeBlock(JSC::CodeBlock* codeBlock)
     if (!provider)
         return result;
 
-    if (topLevel->isFunctionExecutable() && !provider->sourceURL().isEmpty()) {
+    if (topLevel->isFunctionExecutable()) {
         // A FunctionExecutable top-level with a real sourceURL is a normal
         // script function (e.g. node:vm compileFunction with a filename), not
-        // a new Function() body.
-        return result;
+        // a new Function() body. Bun's bundled builtins also link with a null
+        // parent but have a null source origin (new Function always has one
+        // from callerSourceOrigin), so use that to tell them apart when the
+        // sourceURL is empty.
+        if (!provider->sourceURL().isEmpty())
+            return result;
+        if (provider->sourceOrigin().isNull())
+            return result;
     }
 
     result.isEval = true;

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -66,6 +66,9 @@ private:
 
     bool m_isFunctionOrEval = false;
     bool m_isAsync = false;
+    bool m_isInsideEval = false;
+    bool m_hasEvalSourceURL = false;
+    WTF::String m_evalCallerURL;
 
     enum class SourcePositionsState {
         NotCalculated,
@@ -91,6 +94,9 @@ public:
 
     bool isFunctionOrEval() const { return m_isFunctionOrEval; }
     bool isAsync() const { return m_isAsync; }
+    bool isInsideEval() const { return m_isInsideEval; }
+    bool hasEvalSourceURL() const { return m_hasEvalSourceURL; }
+    const WTF::String& evalCallerURL() const { return m_evalCallerURL; }
 
     bool hasBytecodeIndex() const { return (m_bytecodeIndex.offset() != UINT_MAX) && !m_isWasmFrame; }
     JSC::BytecodeIndex bytecodeIndex() const
@@ -102,34 +108,14 @@ public:
     SourcePositions* getSourcePositions();
 
     bool isWasmFrame() const { return m_isWasmFrame; }
-    bool isEval()
+    bool isEval() const
     {
-        if (m_codeBlock) {
-            if (m_codeBlock->codeType() == JSC::EvalCode) {
-                return true;
-            }
-            auto* executable = m_codeBlock->ownerExecutable();
-            if (!executable) {
-                return false;
-            }
-
-            switch (executable->evalContextType()) {
-            case JSC::EvalContextType::None: {
-                return false;
-            }
-            case JSC::EvalContextType::FunctionEvalContext:
-            case JSC::EvalContextType::InstanceFieldEvalContext:
-                return true;
-            }
+        if (m_isInsideEval) {
+            return true;
         }
-
-        if (m_callee && m_callee->inherits<JSC::JSFunction>()) {
-            auto* function = uncheckedDowncast<JSC::JSFunction>(m_callee);
-            if (function->isHostFunction()) {
-                return false;
-            }
+        if (m_codeBlock && m_codeBlock->codeType() == JSC::EvalCode) {
+            return true;
         }
-
         return false;
     }
     bool isConstructor() const
@@ -219,6 +205,22 @@ String sourceURL(JSC::CodeBlock& codeBlock);
 String sourceURL(JSC::VM& vm, const JSC::StackFrame& frame);
 String sourceURL(JSC::StackVisitor& visitor);
 String sourceURL(JSC::VM& vm, JSC::JSFunction* function);
+
+// A frame is "eval-originated" when its code block's top-level executable is an
+// EvalExecutable (code inside eval("...")) or a FunctionExecutable with no
+// sourceURL (code inside new Function("...")). JSC records the CALLER's URL as
+// the source origin for such providers, but not the caller's line/column.
+struct EvalOrigin {
+    // The frame's own source came from eval / new Function.
+    bool isEval { false };
+    // The provider has a //# sourceURL= directive (or a real sourceURL), so the
+    // location should be displayed as that name rather than "eval at ...".
+    bool hasSourceURL { false };
+    // sourceOrigin() of the eval's provider, i.e. the calling script's URL.
+    String callerURL;
+};
+
+EvalOrigin evalOriginForCodeBlock(JSC::CodeBlock* codeBlock);
 
 enum class FinalizerSafety {
     NotInFinalizer,

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -32,6 +32,59 @@ using namespace WebCore;
 
 namespace Bun {
 
+// Build the V8-style "eval at <name> (<location>)" origin string for a frame
+// whose code came from eval / new Function. JSC stores only the calling
+// script's URL on the eval's SourceProvider (sourceOrigin()); the caller's
+// line/column are recovered by walking outward past consecutive frames that
+// share the eval's SourceProvider until we reach the eval-code frame, then
+// taking the next outer frame's location. If the eval-created function was
+// called after the eval returned (no EvalCode frame on the stack), only the
+// URL is available.
+static WTF::String computeEvalOriginString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const Vector<StackFrame>& stackTrace, size_t frameIndex, const Zig::EvalOrigin& evalOrigin, const WTF::Vector<WTF::String, 8>& locationStrings)
+{
+    auto* codeBlock = stackTrace.at(frameIndex).codeBlock();
+    if (!codeBlock)
+        return String();
+    auto* provider = codeBlock->source().provider();
+
+    size_t callerIndex = stackTrace.size();
+    bool sawEvalCodeFrame = codeBlock->codeType() == JSC::EvalCode;
+    for (size_t j = frameIndex + 1; j < stackTrace.size(); j++) {
+        auto* outerBlock = stackTrace.at(j).codeBlock();
+        if (!outerBlock)
+            continue;
+        if (outerBlock->source().provider() == provider) {
+            if (outerBlock->codeType() == JSC::EvalCode)
+                sawEvalCodeFrame = true;
+            continue;
+        }
+        if (sawEvalCodeFrame)
+            callerIndex = j;
+        break;
+    }
+
+    WTF::StringBuilder origin;
+    origin.append("eval at "_s);
+    if (callerIndex < stackTrace.size()) {
+        auto callerName = Zig::functionName(vm, globalObject, stackTrace.at(callerIndex), Zig::FinalizerSafety::NotInFinalizer, nullptr);
+        origin.append(callerName.isEmpty() ? "<anonymous>"_s : callerName);
+        origin.append(" ("_s);
+        if (!locationStrings[callerIndex].isEmpty())
+            origin.append(locationStrings[callerIndex]);
+        else if (!evalOrigin.callerURL.isEmpty())
+            origin.append(evalOrigin.callerURL);
+        origin.append(')');
+    } else {
+        origin.append("<anonymous>"_s);
+        if (!evalOrigin.callerURL.isEmpty()) {
+            origin.append(" ("_s);
+            origin.append(evalOrigin.callerURL);
+            origin.append(')');
+        }
+    }
+    return origin.toString();
+}
+
 static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -244,10 +297,12 @@ WTF::String formatStackTrace(
     WTF::Vector<ZigStackFrame, 8> remappedFrames;
     WTF::Vector<WTF::String, 8> sourceURLs;
     WTF::Vector<LineColumn, 8> originalLineColumns;
+    WTF::Vector<Zig::EvalOrigin, 8> evalOrigins;
     remappedFrames.grow(framesCount);
     memset(remappedFrames.begin(), 0, sizeof(ZigStackFrame) * framesCount);
     sourceURLs.grow(framesCount);
     originalLineColumns.grow(framesCount);
+    evalOrigins.grow(framesCount);
     bool anyRemap = false;
 
     for (size_t i = 0; i < framesCount; i++) {
@@ -273,6 +328,13 @@ WTF::String formatStackTrace(
             }
         }
 
+        evalOrigins[i] = Zig::evalOriginForCodeBlock(frame.codeBlock());
+        if (evalOrigins[i].isEval && !evalOrigins[i].hasSourceURL) {
+            // Positions for this frame refer to the eval string, not any file
+            // the source-map cache knows about.
+            continue;
+        }
+
         sourceURLs[i] = Zig::sourceURL(vm, frame);
 
         bool isDefinitelyNotRunninginNodeVMGlobalObject = globalObject == globalObjectForFrame;
@@ -292,8 +354,67 @@ WTF::String formatStackTrace(
         Bun__remapStackFramePositions(getBunVM(), remappedFrames.begin(), framesCount);
     }
 
-    // Pass 2: format. Everything except (display line/col, source_url) is
-    // re-derived from `frame`; only the remap output is read from pass 1.
+    // Pass 2: compute the location text for every frame, outer → inner, so an
+    // eval frame can embed its caller's already-computed location in the
+    // "eval at <name> (<location>)" origin.
+    WTF::Vector<WTF::String, 8> locationStrings;
+    locationStrings.grow(framesCount);
+    for (size_t idx = framesCount; idx-- > 0;) {
+        StackFrame& frame = stackTrace.at(idx);
+        ZigStackFrame& remappedFrame = remappedFrames[idx];
+
+        OrdinalNumber displayLine = {};
+        OrdinalNumber displayColumn = {};
+        WTF::String sourceURLForFrame = sourceURLs[idx];
+
+        if (frame.hasLineAndColumnInfo()) {
+            displayLine = OrdinalNumber::fromOneBasedInt(originalLineColumns[idx].line);
+            displayColumn = OrdinalNumber::fromOneBasedInt(originalLineColumns[idx].column);
+            if (remappedFrame.remapped) {
+                displayLine = remappedFrame.position.line();
+                displayColumn = remappedFrame.position.column();
+                sourceURLForFrame = remappedFrame.source_url.toWTFString();
+            }
+        }
+
+        WTF::StringBuilder loc;
+        if (evalOrigins[idx].isEval && !evalOrigins[idx].hasSourceURL) {
+            if (errorInstance) {
+                auto origin = computeEvalOriginString(vm, lexicalGlobalObject, stackTrace, idx, evalOrigins[idx], locationStrings);
+                if (!origin.isEmpty()) {
+                    loc.append(origin);
+                    loc.append(", "_s);
+                }
+            } else if (!evalOrigins[idx].callerURL.isEmpty()) {
+                loc.append("eval at <anonymous> ("_s);
+                loc.append(evalOrigins[idx].callerURL);
+                loc.append("), "_s);
+            }
+            loc.append("<anonymous>"_s);
+            if (displayLine.zeroBasedInt() > 0 || displayColumn.zeroBasedInt() > 0) {
+                loc.append(':');
+                loc.append(displayLine.oneBasedInt());
+                if (displayColumn.zeroBasedInt() > 0) {
+                    loc.append(':');
+                    loc.append(displayColumn.oneBasedInt());
+                }
+            }
+        } else if (!sourceURLForFrame.isEmpty()) {
+            loc.append(sourceURLForFrame);
+            if (displayLine.zeroBasedInt() > 0 || displayColumn.zeroBasedInt() > 0) {
+                loc.append(':');
+                loc.append(displayLine.oneBasedInt());
+                if (displayColumn.zeroBasedInt() > 0) {
+                    loc.append(':');
+                    loc.append(displayColumn.oneBasedInt());
+                }
+            }
+        }
+        locationStrings[idx] = loc.toString();
+    }
+
+    // Pass 3: format. Everything except the location string is re-derived from
+    // `frame`; only the remap output is read from pass 1.
     for (size_t i = 0; i < framesCount; i++) {
         StackFrame& frame = stackTrace.at(i);
         ZigStackFrame& remappedFrame = remappedFrames[i];
@@ -309,36 +430,21 @@ WTF::String formatStackTrace(
         }
 
         WTF::String functionName = Zig::functionName(vm, globalObjectForFrame, frame, errorInstance ? Zig::FinalizerSafety::NotInFinalizer : Zig::FinalizerSafety::MustNotTriggerGC, &flags);
-        OrdinalNumber originalLine = {};
-        OrdinalNumber originalColumn = {};
-        OrdinalNumber displayLine = {};
-        OrdinalNumber displayColumn = {};
-        WTF::String sourceURLForFrame = sourceURLs[i];
 
-        if (frame.hasLineAndColumnInfo()) {
-            originalLine = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line);
-            originalColumn = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column);
-            displayLine = originalLine;
-            displayColumn = originalColumn;
-
+        if (frame.hasLineAndColumnInfo() && !hasSet) {
+            OrdinalNumber displayLine = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line);
+            OrdinalNumber displayColumn = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column);
             if (remappedFrame.remapped) {
                 displayLine = remappedFrame.position.line();
                 displayColumn = remappedFrame.position.column();
-                sourceURLForFrame = remappedFrame.source_url.toWTFString();
             }
-
-            if (!hasSet) {
-                hasSet = true;
-                line = displayLine;
-                column = displayColumn;
-                sourceURL = sourceURLForFrame;
-
-                if (remappedFrame.remapped) {
-                    if (errorInstance) {
-                        errorInstance->putDirect(vm, builtinNames(vm).originalLinePublicName(), jsNumber(originalLine.oneBasedInt()), PropertyAttribute::DontEnum | 0);
-                        errorInstance->putDirect(vm, builtinNames(vm).originalColumnPublicName(), jsNumber(originalColumn.oneBasedInt()), PropertyAttribute::DontEnum | 0);
-                    }
-                }
+            hasSet = true;
+            line = displayLine;
+            column = displayColumn;
+            sourceURL = remappedFrame.remapped ? remappedFrame.source_url.toWTFString() : sourceURLs[i];
+            if (remappedFrame.remapped && errorInstance) {
+                errorInstance->putDirect(vm, builtinNames(vm).originalLinePublicName(), jsNumber(OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line).oneBasedInt()), PropertyAttribute::DontEnum | 0);
+                errorInstance->putDirect(vm, builtinNames(vm).originalColumnPublicName(), jsNumber(OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column).oneBasedInt()), PropertyAttribute::DontEnum | 0);
             }
         }
 
@@ -348,15 +454,14 @@ WTF::String formatStackTrace(
             }
         }
 
-        if (sourceURLForFrame.isEmpty()) {
+        WTF::String locationString = locationStrings[i];
+        if (locationString.isEmpty()) {
             if (flags & static_cast<unsigned int>(FunctionNameFlags::Builtin)) {
-                sourceURLForFrame = "native"_s;
+                locationString = "native"_s;
             } else {
-                sourceURLForFrame = "unknown"_s;
+                locationString = "unknown"_s;
             }
         }
-
-        // --- actually render the text ---
 
         sb.append("    at "_s);
 
@@ -368,18 +473,7 @@ WTF::String formatStackTrace(
             sb.append(" ("_s);
         }
 
-        if (!sourceURLForFrame.isEmpty()) {
-            sb.append(sourceURLForFrame);
-            if (displayLine.zeroBasedInt() > 0 || displayColumn.zeroBasedInt() > 0) {
-                sb.append(':');
-                sb.append(displayLine.oneBasedInt());
-
-                if (displayColumn.zeroBasedInt() > 0) {
-                    sb.append(':');
-                    sb.append(displayColumn.oneBasedInt());
-                }
-            }
-        }
+        sb.append(locationString);
 
         if (!functionName.isEmpty()) {
             sb.append(')');
@@ -455,11 +549,16 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
     for (int i = 0; i < n; i++) {
         ZigStackFrame& frame = remappedFrames[i];
         auto& stackFrame = stackFrames.at(i);
-        sourceURLs[i] = Zig::sourceURL(vm, stackFrame);
         didRemap[i] = false;
         frame.position.line_zero_based = -1;
         frame.position.column_zero_based = -1;
         frame.position.byte_position = -1;
+
+        auto& jscFrame = stackTrace.at(i);
+        if (jscFrame.isInsideEval() && !jscFrame.hasEvalSourceURL())
+            continue;
+
+        sourceURLs[i] = Zig::sourceURL(vm, stackFrame);
 
         // When you use node:vm, the global object can be different on a
         // per-frame basis. We should sourcemap the frames which are in Bun's
@@ -507,6 +606,75 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
         if (frame.remapped) {
             callsite->setLineNumber(frame.position.line());
             callsite->setColumnNumber(frame.position.column());
+        }
+    }
+
+    // Compute eval origins outer → inner so an eval frame can reference its
+    // caller's (possibly also eval) location string. formatAsString reads the
+    // same evalOrigin, so the default-format path and a user prepareStackTrace
+    // see identical text.
+    {
+        WTF::Vector<WTF::String, 8> locationStrings;
+        locationStrings.grow(n);
+        for (int idx = n - 1; idx >= 0; idx--) {
+            auto* callsite = uncheckedDowncast<CallSite>(callSites.at(idx));
+            auto& jscFrame = stackTrace.at(idx);
+            WTF::StringBuilder loc;
+            JSValue urlValue = callsite->sourceURL();
+            auto* urlStr = urlValue.toStringOrNull(lexicalGlobalObject);
+            bool isAnonymousEval = callsite->isEval() && (!urlStr || urlStr->length() == 0);
+            if (isAnonymousEval) {
+                auto* provider = jscFrame.codeBlock() ? jscFrame.codeBlock()->source().provider() : nullptr;
+                int callerIdx = n;
+                bool sawEvalCodeFrame = jscFrame.codeBlock() && jscFrame.codeBlock()->codeType() == JSC::EvalCode;
+                for (int j = idx + 1; j < n && provider; j++) {
+                    auto* outerBlock = stackTrace.at(j).codeBlock();
+                    if (!outerBlock) continue;
+                    if (outerBlock->source().provider() == provider) {
+                        if (outerBlock->codeType() == JSC::EvalCode) sawEvalCodeFrame = true;
+                        continue;
+                    }
+                    if (sawEvalCodeFrame) callerIdx = j;
+                    break;
+                }
+
+                WTF::StringBuilder origin;
+                origin.append("eval at "_s);
+                if (callerIdx < n) {
+                    auto* callerSite = uncheckedDowncast<CallSite>(callSites.at(callerIdx));
+                    auto* callerName = callerSite->functionName().toStringOrNull(lexicalGlobalObject);
+                    if (callerName && callerName->length() > 0)
+                        origin.append(callerName->getString(lexicalGlobalObject));
+                    else
+                        origin.append("<anonymous>"_s);
+                    origin.append(" ("_s);
+                    if (!locationStrings[callerIdx].isEmpty())
+                        origin.append(locationStrings[callerIdx]);
+                    else if (!jscFrame.evalCallerURL().isEmpty())
+                        origin.append(jscFrame.evalCallerURL());
+                    origin.append(')');
+                } else {
+                    origin.append("<anonymous>"_s);
+                    if (!jscFrame.evalCallerURL().isEmpty()) {
+                        origin.append(" ("_s);
+                        origin.append(jscFrame.evalCallerURL());
+                        origin.append(')');
+                    }
+                }
+                auto originStr = origin.toString();
+                callsite->setEvalOrigin(vm, jsString(vm, originStr));
+                loc.append(originStr);
+                loc.append(", <anonymous>"_s);
+            } else if (urlStr && urlStr->length() > 0) {
+                loc.append(urlStr->getString(lexicalGlobalObject));
+            }
+            if (!loc.isEmpty() && callsite->lineNumber().zeroBasedInt() >= 0) {
+                loc.append(':');
+                loc.append(callsite->lineNumber().oneBasedInt());
+                loc.append(':');
+                loc.append(callsite->columnNumber().oneBasedInt());
+            }
+            locationStrings[idx] = loc.toString();
         }
     }
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -32,25 +32,22 @@ using namespace WebCore;
 
 namespace Bun {
 
-// Build the V8-style "eval at <name> (<location>)" origin string for a frame
-// whose code came from eval / new Function. JSC stores only the calling
-// script's URL on the eval's SourceProvider (sourceOrigin()); the caller's
-// line/column are recovered by walking outward past consecutive frames that
-// share the eval's SourceProvider until we reach the eval-code frame, then
-// taking the next outer frame's location. If the eval-created function was
-// called after the eval returned (no EvalCode frame on the stack), only the
-// URL is available.
-static WTF::String computeEvalOriginString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, const Vector<StackFrame>& stackTrace, size_t frameIndex, const Zig::EvalOrigin& evalOrigin, const WTF::Vector<WTF::String, 8>& locationStrings)
+// JSC stores only the calling script's URL on an eval / new Function source
+// (sourceOrigin()); the caller's line/column are recovered by walking outward
+// past consecutive frames that share the eval's SourceProvider until we pass
+// the EvalCode frame, then taking the next outer frame. If the eval-created
+// function is called after the eval returned (no EvalCode frame on the stack),
+// frames.size() is returned and the origin falls back to the URL alone.
+template<typename Frames>
+static size_t findEvalCallerIndex(Frames& frames, size_t frameIndex, JSC::CodeBlock* codeBlock)
 {
-    auto* codeBlock = stackTrace.at(frameIndex).codeBlock();
+    size_t n = frames.size();
     if (!codeBlock)
-        return String();
+        return n;
     auto* provider = codeBlock->source().provider();
-
-    size_t callerIndex = stackTrace.size();
     bool sawEvalCodeFrame = codeBlock->codeType() == JSC::EvalCode;
-    for (size_t j = frameIndex + 1; j < stackTrace.size(); j++) {
-        auto* outerBlock = stackTrace.at(j).codeBlock();
+    for (size_t j = frameIndex + 1; j < n; j++) {
+        auto* outerBlock = frames.at(j).codeBlock();
         if (!outerBlock)
             continue;
         if (outerBlock->source().provider() == provider) {
@@ -58,27 +55,25 @@ static WTF::String computeEvalOriginString(JSC::VM& vm, JSC::JSGlobalObject* glo
                 sawEvalCodeFrame = true;
             continue;
         }
-        if (sawEvalCodeFrame)
-            callerIndex = j;
-        break;
+        return sawEvalCodeFrame ? j : n;
     }
+    return n;
+}
 
+static WTF::String buildEvalOriginText(bool foundCaller, const WTF::String& callerName, const WTF::String& callerLocation, const WTF::String& fallbackURL)
+{
     WTF::StringBuilder origin;
     origin.append("eval at "_s);
-    if (callerIndex < stackTrace.size()) {
-        auto callerName = Zig::functionName(vm, globalObject, stackTrace.at(callerIndex), Zig::FinalizerSafety::NotInFinalizer, nullptr);
+    if (foundCaller) {
         origin.append(callerName.isEmpty() ? "<anonymous>"_s : callerName);
         origin.append(" ("_s);
-        if (!locationStrings[callerIndex].isEmpty())
-            origin.append(locationStrings[callerIndex]);
-        else if (!evalOrigin.callerURL.isEmpty())
-            origin.append(evalOrigin.callerURL);
+        origin.append(callerLocation.isEmpty() ? fallbackURL : callerLocation);
         origin.append(')');
     } else {
         origin.append("<anonymous>"_s);
-        if (!evalOrigin.callerURL.isEmpty()) {
+        if (!fallbackURL.isEmpty()) {
             origin.append(" ("_s);
-            origin.append(evalOrigin.callerURL);
+            origin.append(fallbackURL);
             origin.append(')');
         }
     }
@@ -379,18 +374,14 @@ WTF::String formatStackTrace(
 
         WTF::StringBuilder loc;
         if (evalOrigins[idx].isEval && !evalOrigins[idx].hasSourceURL) {
-            if (errorInstance) {
-                auto origin = computeEvalOriginString(vm, lexicalGlobalObject, stackTrace, idx, evalOrigins[idx], locationStrings);
-                if (!origin.isEmpty()) {
-                    loc.append(origin);
-                    loc.append(", "_s);
-                }
-            } else if (!evalOrigins[idx].callerURL.isEmpty()) {
-                loc.append("eval at <anonymous> ("_s);
-                loc.append(evalOrigins[idx].callerURL);
-                loc.append("), "_s);
-            }
-            loc.append("<anonymous>"_s);
+            size_t callerIdx = findEvalCallerIndex(stackTrace, idx, frame.codeBlock());
+            bool foundCaller = callerIdx < framesCount;
+            WTF::String callerName;
+            if (foundCaller)
+                callerName = Zig::functionName(vm, lexicalGlobalObject, stackTrace.at(callerIdx), errorInstance ? Zig::FinalizerSafety::NotInFinalizer : Zig::FinalizerSafety::MustNotTriggerGC, nullptr);
+            auto origin = buildEvalOriginText(foundCaller, callerName, foundCaller ? locationStrings[callerIdx] : String(), evalOrigins[idx].callerURL);
+            loc.append(origin);
+            loc.append(", <anonymous>"_s);
             if (frame.hasLineAndColumnInfo()) {
                 loc.append(':');
                 loc.append(displayLine.oneBasedInt());
@@ -622,46 +613,17 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
             auto* urlStr = urlValue.toStringOrNull(lexicalGlobalObject);
             bool isAnonymousEval = callsite->isEval() && (!urlStr || urlStr->length() == 0);
             if (isAnonymousEval) {
-                auto* provider = jscFrame.codeBlock() ? jscFrame.codeBlock()->source().provider() : nullptr;
-                int callerIdx = n;
-                bool sawEvalCodeFrame = jscFrame.codeBlock() && jscFrame.codeBlock()->codeType() == JSC::EvalCode;
-                for (int j = idx + 1; j < n && provider; j++) {
-                    auto* outerBlock = stackTrace.at(j).codeBlock();
-                    if (!outerBlock) continue;
-                    if (outerBlock->source().provider() == provider) {
-                        if (outerBlock->codeType() == JSC::EvalCode) sawEvalCodeFrame = true;
-                        continue;
-                    }
-                    if (sawEvalCodeFrame) callerIdx = j;
-                    break;
-                }
-
-                WTF::StringBuilder origin;
-                origin.append("eval at "_s);
-                if (callerIdx < n) {
+                size_t callerIdx = findEvalCallerIndex(stackTrace, static_cast<size_t>(idx), jscFrame.codeBlock());
+                bool foundCaller = callerIdx < static_cast<size_t>(n);
+                WTF::String callerName;
+                if (foundCaller) {
                     auto* callerSite = uncheckedDowncast<CallSite>(callSites.at(callerIdx));
-                    auto* callerName = callerSite->functionName().toStringOrNull(lexicalGlobalObject);
-                    if (callerName && callerName->length() > 0)
-                        origin.append(callerName->getString(lexicalGlobalObject));
-                    else
-                        origin.append("<anonymous>"_s);
-                    origin.append(" ("_s);
-                    if (!locationStrings[callerIdx].isEmpty())
-                        origin.append(locationStrings[callerIdx]);
-                    else if (!jscFrame.evalCallerURL().isEmpty())
-                        origin.append(jscFrame.evalCallerURL());
-                    origin.append(')');
-                } else {
-                    origin.append("<anonymous>"_s);
-                    if (!jscFrame.evalCallerURL().isEmpty()) {
-                        origin.append(" ("_s);
-                        origin.append(jscFrame.evalCallerURL());
-                        origin.append(')');
-                    }
+                    if (auto* name = callerSite->functionName().toStringOrNull(lexicalGlobalObject))
+                        callerName = name->getString(lexicalGlobalObject);
                 }
-                auto originStr = origin.toString();
-                callsite->setEvalOrigin(vm, jsString(vm, originStr));
-                loc.append(originStr);
+                auto origin = buildEvalOriginText(foundCaller, callerName, foundCaller ? locationStrings[callerIdx] : String(), jscFrame.evalCallerURL());
+                callsite->setEvalOrigin(vm, jsString(vm, origin));
+                loc.append(origin);
                 loc.append(", <anonymous>"_s);
             } else if (urlStr && urlStr->length() > 0) {
                 loc.append(urlStr->getString(lexicalGlobalObject));

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -391,13 +391,11 @@ WTF::String formatStackTrace(
                 loc.append("), "_s);
             }
             loc.append("<anonymous>"_s);
-            if (displayLine.zeroBasedInt() > 0 || displayColumn.zeroBasedInt() > 0) {
+            if (frame.hasLineAndColumnInfo()) {
                 loc.append(':');
                 loc.append(displayLine.oneBasedInt());
-                if (displayColumn.zeroBasedInt() > 0) {
-                    loc.append(':');
-                    loc.append(displayColumn.oneBasedInt());
-                }
+                loc.append(':');
+                loc.append(displayColumn.oneBasedInt());
             }
         } else if (!sourceURLForFrame.isEmpty()) {
             loc.append(sourceURLForFrame);

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -55,7 +55,10 @@ static size_t findEvalCallerIndex(Frames& frames, size_t frameIndex, JSC::CodeBl
                 sawEvalCodeFrame = true;
             continue;
         }
-        return sawEvalCodeFrame ? j : n;
+        if (sawEvalCodeFrame)
+            return j;
+        // Foreign-provider frame before the EvalCode frame: the eval-defined
+        // function called out through script-defined code. Keep looking.
     }
     return n;
 }

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -455,11 +455,25 @@ WTF::String formatStackTrace(
 
         WTF::String locationString = locationStrings[i];
         if (locationString.isEmpty()) {
-            if (flags & static_cast<unsigned int>(FunctionNameFlags::Builtin)) {
-                locationString = "native"_s;
-            } else {
-                locationString = "unknown"_s;
+            WTF::StringBuilder fallback;
+            fallback.append(flags & static_cast<unsigned int>(FunctionNameFlags::Builtin) ? "native"_s : "unknown"_s);
+            if (frame.hasLineAndColumnInfo()) {
+                OrdinalNumber displayLine = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].line);
+                OrdinalNumber displayColumn = OrdinalNumber::fromOneBasedInt(originalLineColumns[i].column);
+                if (remappedFrame.remapped) {
+                    displayLine = remappedFrame.position.line();
+                    displayColumn = remappedFrame.position.column();
+                }
+                if (displayLine.zeroBasedInt() > 0 || displayColumn.zeroBasedInt() > 0) {
+                    fallback.append(':');
+                    fallback.append(displayLine.oneBasedInt());
+                    if (displayColumn.zeroBasedInt() > 0) {
+                        fallback.append(':');
+                        fallback.append(displayColumn.oneBasedInt());
+                    }
+                }
             }
+            locationString = fallback.toString();
         }
 
         sb.append("    at "_s);

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -377,8 +377,15 @@ WTF::String formatStackTrace(
             size_t callerIdx = findEvalCallerIndex(stackTrace, idx, frame.codeBlock());
             bool foundCaller = callerIdx < framesCount;
             WTF::String callerName;
-            if (foundCaller)
-                callerName = Zig::functionName(vm, lexicalGlobalObject, stackTrace.at(callerIdx), errorInstance ? Zig::FinalizerSafety::NotInFinalizer : Zig::FinalizerSafety::MustNotTriggerGC, nullptr);
+            if (foundCaller) {
+                auto& callerFrame = stackTrace.at(callerIdx);
+                JSC::JSGlobalObject* callerGlobalObject = lexicalGlobalObject;
+                if (auto* callee = callerFrame.callee()) {
+                    if (auto* object = callee->getObject())
+                        callerGlobalObject = object->globalObject();
+                }
+                callerName = Zig::functionName(vm, callerGlobalObject, callerFrame, errorInstance ? Zig::FinalizerSafety::NotInFinalizer : Zig::FinalizerSafety::MustNotTriggerGC, nullptr);
+            }
             auto origin = buildEvalOriginText(foundCaller, callerName, foundCaller ? locationStrings[callerIdx] : String(), evalOrigins[idx].callerURL);
             loc.append(origin);
             loc.append(", <anonymous>"_s);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -313,6 +313,11 @@ public:
                     break;
                 }
             }
+            // A path with an unmatched ')' (e.g. "/tmp/a)b/file.js") leaves
+            // depth > 0; fall back to the first '(' rather than dropping the
+            // whole remaining trace.
+            if (openingParentheses == WTF::notFound)
+                openingParentheses = line.find('(');
         }
 
         if (openingParentheses == WTF::notFound || closingParentheses == WTF::notFound || openingParentheses > closingParentheses) {

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -84,9 +84,18 @@ static void populateStackFrameMetadata(JSC::VM& vm, JSC::JSGlobalObject* globalO
         return;
     }
 
-    auto sourceURL = Zig::sourceURL(vm, stackFrame);
-    frame.source_url = Bun::toStringRef(sourceURL);
     auto m_codeBlock = stackFrame.codeBlock();
+    auto evalOrigin = Zig::evalOriginForCodeBlock(m_codeBlock);
+    if (evalOrigin.isEval && !evalOrigin.hasSourceURL) {
+        // Positions refer to the eval string; the Rust remapper must not look
+        // them up against the caller file's source map. "<anonymous>" is not a
+        // real path, so resolve_source_mapping returns None and the source
+        // preview falls back to collect_source_lines (the eval provider).
+        frame.source_url = Bun::toStringRef("<anonymous>"_s);
+    } else {
+        auto sourceURL = Zig::sourceURL(vm, stackFrame);
+        frame.source_url = Bun::toStringRef(sourceURL);
+    }
     if (m_codeBlock) {
         switch (m_codeBlock->codeType()) {
         case JSC::EvalCode: {
@@ -290,13 +299,10 @@ public:
         offset = end;
 
         // the proper singular spelling is parenthesis
-        auto openingParentheses = line.reverseFind('(');
+        auto openingParentheses = line.find('(');
         auto closingParentheses = line.reverseFind(')');
 
-        if (openingParentheses > closingParentheses)
-            openingParentheses = WTF::notFound;
-
-        if (openingParentheses == WTF::notFound || closingParentheses == WTF::notFound) {
+        if (openingParentheses == WTF::notFound || closingParentheses == WTF::notFound || openingParentheses > closingParentheses) {
             // Special case: "unknown" frames don't have parentheses but are valid
             // These appear in stack traces from certain error paths
             if (line == "unknown"_s) {
@@ -311,6 +317,12 @@ public:
         }
 
         auto lineInner = StringView_slice(line, openingParentheses + 1, closingParentheses);
+
+        if (lineInner.startsWith("eval at "_s)) {
+            auto comma = lineInner.reverseFind(", "_s);
+            if (comma != WTF::notFound)
+                lineInner = lineInner.substring(comma + 2);
+        }
 
         {
             auto marker1 = 0;

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -299,8 +299,21 @@ public:
         offset = end;
 
         // the proper singular spelling is parenthesis
-        auto openingParentheses = line.find('(');
         auto closingParentheses = line.reverseFind(')');
+        size_t openingParentheses = WTF::notFound;
+        if (closingParentheses != WTF::notFound) {
+            // Balance parentheses from the end so nested "eval at <name> (<loc>)"
+            // origins and function names that themselves contain '(' both work.
+            size_t depth = 0;
+            for (size_t i = closingParentheses + 1; i-- > 0;) {
+                if (line[i] == ')') {
+                    depth++;
+                } else if (line[i] == '(' && --depth == 0) {
+                    openingParentheses = i;
+                    break;
+                }
+            }
+        }
 
         if (openingParentheses == WTF::notFound || closingParentheses == WTF::notFound || openingParentheses > closingParentheses) {
             // Special case: "unknown" frames don't have parentheses but are valid

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -461,7 +461,7 @@ test("CallFrame isEval works as expected", () => {
   })()`);
 
   Error.prepareStackTrace = prevPrepareStackTrace;
-  // TODO: 0 and 1 should both return true here.
+  expect(stack[0].isEval()).toBe(true);
   expect(stack[1].isEval()).toBe(true);
   expect(stack[0].getFunctionName()).toBe(name);
 });
@@ -478,7 +478,7 @@ test("CallFrame isTopLevel returns false for Function constructor", () => {
     expect(s[0].getFunction()).toBe(sloppyFn);
 
     expect(s[0].isToplevel()).toBe(false);
-    expect(s[0].isEval()).toBe(false);
+    expect(s[0].isEval()).toBe(true);
 
     // Strict-mode functions shouldn't have getThis or getFunction
     // available.
@@ -1119,5 +1119,78 @@ test("lazy error-info materialization does not store an empty stack value when t
     stdout: JSON.stringify({ first: "msg-boom", secondType: "undefined" }),
     signalCode: null,
   });
+  expect(exitCode).toBe(0);
+});
+
+// Errors thrown from inside eval() / new Function() bodies used to be attributed
+// to the CALLING file at the eval body's own line/column (with a file:// scheme)
+// because Zig::sourceURL fell back to the provider's sourceOrigin() for eval
+// sources. These frames now use <anonymous> for the source name and carry a
+// V8-style "eval at <name> (<caller location>)" origin.
+test("eval frames are labelled <anonymous> with an eval origin, not the caller file", async () => {
+  const src =
+    "const DECOY_LINE_1 = 'a line the eval body positions would otherwise blame';\n" +
+    "const body = ['','','','function work(){ throw new Error(\"boom\") }','work()'].join('\\n');\n" +
+    "function outer() { eval(body); }\n" +
+    "try { outer(); } catch (e) {\n" +
+    "  const lines = e.stack.split('\\n').filter(l => l.trim().startsWith('at '));\n" +
+    "  console.log(JSON.stringify({\n" +
+    "    work: lines[0].split(__filename).join('F').trim(),\n" +
+    "    hasFileScheme: e.stack.includes('file://'),\n" +
+    "  }));\n" +
+    "}\n" +
+    "try { new Function('x', '\\n\\n\\nthrow new Error(\"fn\")')(1); } catch (e) {\n" +
+    "  const first = e.stack.split('\\n').find(l => l.trim().startsWith('at '));\n" +
+    "  console.log(JSON.stringify({ fn: first.split(__filename).join('F').trim() }));\n" +
+    "}\n";
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const out = stdout
+    .trim()
+    .split("\n")
+    .map(l => JSON.parse(l));
+
+  // The eval body's positions must be on <anonymous>, not on the calling file,
+  // and the origin must name the caller at the line where eval() was invoked.
+  expect(out[0].work).toMatch(/^at work \(eval at outer \(F:3:\d+\), <anonymous>:4:\d+\)$/);
+  expect(out[0].hasFileScheme).toBe(false);
+  // new Function(): no EvalCode frame on the stack, so the origin is URL-only.
+  expect(out[1].fn).toMatch(/^at anonymous \(eval at <anonymous> \(F\), <anonymous>:6:\d+\)$/);
+  expect(exitCode).toBe(0);
+});
+
+test("CallSite eval metadata for eval / new Function frames matches Node.js", async () => {
+  const src =
+    "const old = Error.prepareStackTrace;\n" +
+    "Error.prepareStackTrace = (_, s) => s;\n" +
+    "function caller() { return eval('(function inner(){ return new Error().stack })()'); }\n" +
+    "const evalStack = caller();\n" +
+    "const named = eval('new Error().stack\\n//# sourceURL=named.js');\n" +
+    "const fn = new Function('return new Error().stack')();\n" +
+    "Error.prepareStackTrace = old;\n" +
+    "const pick = f => ({ file: f.getFileName(), script: f.getScriptNameOrSourceURL(), isEval: f.isEval(), origin: typeof f.getEvalOrigin() === 'string' ? f.getEvalOrigin().split(__filename).join('F') : f.getEvalOrigin() });\n" +
+    "console.log(JSON.stringify({ inner: pick(evalStack[0]), body: pick(evalStack[1]), named: pick(named[0]), fn: pick(fn[0]) }));\n";
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const out = JSON.parse(stdout.trim());
+
+  expect({
+    inner: { file: out.inner.file, script: out.inner.script, isEval: out.inner.isEval },
+    body: { file: out.body.file, script: out.body.script, isEval: out.body.isEval },
+    named: out.named,
+    fn: { file: out.fn.file, isEval: out.fn.isEval },
+  }).toEqual({
+    inner: { file: undefined, script: undefined, isEval: true },
+    body: { file: undefined, script: undefined, isEval: true },
+    named: { file: undefined, script: "named.js", isEval: true, origin: "named.js" },
+    fn: { file: undefined, isEval: true },
+  });
+  expect(out.inner.origin).toMatch(/^eval at caller \(F:3:\d+\)$/);
+  expect(out.body.origin).toMatch(/^eval at caller \(F:3:\d+\)$/);
+  expect(out.fn.origin).toMatch(/^eval at <anonymous> \(F\)$/);
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1194,3 +1194,41 @@ test("CallSite eval metadata for eval / new Function frames matches Node.js", as
   expect(out.fn.origin).toMatch(/^eval at <anonymous> \(F\)$/);
   expect(exitCode).toBe(0);
 });
+
+test("Bun.inspect/native printer shows <anonymous> for eval frames, not the caller file", async () => {
+  // populateStackFrameMetadata (ZigException.cpp) is a sibling consumer of
+  // Zig::sourceURL that was still stamping eval-body positions on the caller's
+  // file:// URL, so the Rust-side source-map remapper would look up nonsense
+  // coordinates. With a .cjs file (no transpile remap), the top frame's
+  // attribution is directly observable in Bun.inspect(err).
+  const src =
+    "const body = ['','','','function work(){ throw new Error(\"boom\") }','work()'].join('\\n');\n" +
+    "try { eval(body); } catch(e) { process.stdout.write(Bun.inspect(e)); }\n";
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const workLine = stdout.split("\n").find(l => l.includes("at work "));
+  expect(workLine).toBeDefined();
+  expect(workLine).not.toContain("file://");
+  expect(workLine).toMatch(/at work \(<anonymous>:4:\d+\)/);
+  expect(exitCode).toBe(0);
+});
+
+test("eval origin caller line/col is recovered when an eval-defined function calls through script code", async () => {
+  const src =
+    "function helper(cb) { cb(); }\n" +
+    "function outer() {\n" +
+    "  eval('helper(function inner(){ throw new Error(\"x\") })');\n" +
+    "}\n" +
+    "try { outer(); } catch (e) {\n" +
+    "  const first = e.stack.split('\\n').find(l => l.includes('inner'));\n" +
+    "  console.log(first.split(__filename).join('F').trim());\n" +
+    "}\n";
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toMatch(/^at inner \(eval at outer \(F:3:\d+\), <anonymous>:1:\d+\)$/);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

Stack frames from code created by `eval()` or `new Function()` are attributed to the *calling* file at the eval body's own line/column, with a `file://` scheme no other frame uses:

```js
// repro.cjs
const body = ["", "", "", "function work(){ throw new Error('boom') }", "work()"].join("\n");
try { eval(body); } catch (e) { console.log(e.stack); }
```

Before:
```
at work (file:///path/repro.cjs:4:33)     <-- line 4 is inside the eval STRING, blamed on repro.cjs
```

Node.js:
```
at work (eval at <anonymous> (repro.cjs:2:7), <anonymous>:4:24)
```

`CallSite.isEval()` returned `false` for functions defined inside eval, and `getEvalOrigin()` was a stub returning `undefined`. Every template engine / `new Function` compiler / eval-based devtool loader reports a plausible-but-wrong location that stack parsers relay verbatim.

## Cause

`Zig::sourceURL(SourceProvider*)` falls back to `sourceOrigin()` when the provider has no `sourceURL`. For eval and `new Function` sources, JSC sets `sourceURL()` to empty and `sourceOrigin()` to the *caller's* URL, so the eval body's positions get stamped onto the caller's file. `JSCStackFrame::isEval()` only checked `codeType() == EvalCode`, missing functions *defined inside* eval code.

## Fix

Detect eval-originated frames via `codeBlock->ownerExecutable()->topLevelExecutable()`: an `EvalExecutable` for `eval()` bodies (and nested functions), or a `FunctionExecutable` with an empty `sourceURL` for `new Function()` bodies.

For such frames:

- `error.stack` prints `eval at <caller> (<url>:<line>:<col>), <anonymous>:<line>:<col>`. The caller line/column are recovered by walking outward past frames that share the eval's `SourceProvider` until the `EvalCode` frame, then taking the next outer frame's location. If the eval-created function is called *after* the eval returned (so no `EvalCode` frame is on the stack), the origin uses the caller URL alone: JSC records only the URL on the provider, not the call-site position.
- `CallSite.isEval()` is `true` for functions defined inside eval as well as the eval body itself.
- `CallSite.getFileName()` returns `undefined`; `getScriptNameOrSourceURL()` still returns a `//# sourceURL=` directive when present.
- `CallSite.getEvalOrigin()` returns the `eval at ...` origin string, or the `sourceURL` directive when one is set.
- Eval frames are skipped when batching source-map remaps, since their positions refer to the eval string rather than the caller file.

After:
```
at work (eval at <anonymous> (repro.cjs:2:7), <anonymous>:4:33)
```

## Verification

```sh
bun bd test test/js/node/v8/capture-stack-trace.test.js
```

Four tests fail without the `src/` change and pass with it. Two of the updated assertions were previously encoding the incorrect behaviour (`isEval()` on `new Function()` frames and on functions defined inside eval); both now match Node.js.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (e77482c99)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [14.69ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.10ms]
(pass) capture stack trace [6.84ms]
(pass) capture stack trace with message [7.04ms]
(pass) capture stack trace with constructor [5.30ms]
(pass) capture stack trace limit [21.81ms]
(pass) prepare stack trace [10.93ms]
(pass) capture stack trace second argument [17.01ms]
(pass) capture stack trace edge cases [10.71ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [20.03ms]
(pass) prepare stack trace call sites [11.82ms]
(pass) sanity check [12.08ms]
459 |   const stack = eval(`(function ${name}() {
460 |     return new Error().stack;
461 |   })()`);
462 | 
463 |   Error.prepareStackTrace = prevPrepareStackTrace;
464 |   expect(stack[0].isEval()).toBe(true);
                                  ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (540c57ba5)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.69ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.10ms]
(pass) capture stack trace [0.06ms]
(pass) capture stack trace with message [0.06ms]
(pass) capture stack trace with constructor [0.07ms]
(pass) capture stack trace limit [0.21ms]
(pass) prepare stack trace [0.10ms]
(pass) capture stack trace second argument [0.17ms]
(pass) capture stack trace edge cases [0.12ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [0.24ms]
(pass) prepare stack trace call sites [0.12ms]
(pass) sanity check [0.12ms]
(pass) CallFrame isEval works as expected [0.10ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.10ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.09ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.04ms]
(pass) err.stack should invoke prepareStackTrace [0.22ms]
(pass) Error.prepareStackTrace inside a node:vm works [5.40ms]
(pass) Error.captureStackTrace i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (e77482c99)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [12.40ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.09ms]
(pass) capture stack trace [6.11ms]
(pass) capture stack trace with message [6.88ms]
(pass) capture stack trace with constructor [4.99ms]
(pass) capture stack trace limit [21.61ms]
(pass) prepare stack trace [10.69ms]
(pass) capture stack trace second argument [16.94ms]
(pass) capture stack trace edge cases [10.39ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [18.69ms]
(pass) prepare stack trace call sites [11.13ms]
(pass) sanity check [11.65ms]
(pass) CallFrame isEval works as expected [6.99ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.46ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.72ms]
(pass) CallFrame.p.isConstructor [3.21ms]
(pass) CallFrame.p.isNative [2.72ms]
(pass) return non-strings from Error.prepareStackTrace [3.22ms]
(pass) CallF
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 619ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/29] cc obj/packages/bun-usockets/src/context.c.o
[2/29] cc obj/packages/bun-usockets/src/bsd.c.o
[3/29] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[4/29] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[5/29] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[6/29] cc obj/packages/bun-usockets/src/fault_inject.c.o
[7/29] cc obj/packages/bun-usockets/src/loop.c.o
[8/29] cc obj/packages/bun-usockets/src/quic.c.o
[9/29] cc obj/packages/bun-usockets/src/socket.c.o
[10/29] cc obj/packages/bun-usockets/src/udp.c.o
[11/29] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[12/29] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[13/29] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[14/29] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[15/29] cxx obj/src/jsc/bindings/bindings.cpp.o
[16/29] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[17/29] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[18/29] cxx obj/unified/UnifiedSource
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/CallSite.cpp               |  18 +-
 src/jsc/bindings/CallSite.h                 |   3 +
 src/jsc/bindings/CallSitePrototype.cpp      |  16 +-
 src/jsc/bindings/ErrorStackTrace.cpp        |  71 ++++++++
 src/jsc/bindings/ErrorStackTrace.h          |  52 +++---
 src/jsc/bindings/FormatStackTraceForJS.cpp  | 246 ++++++++++++++++++++++------
 src/jsc/bindings/ZigException.cpp           |  44 ++++-
 test/js/node/v8/capture-stack-trace.test.js | 115 ++++++++++++-
 8 files changed, 479 insertions(+), 86 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/CallSite.cpp                    1      4      0
src/jsc/bindings/CallSite.h                      1      3      0
src/jsc/bindings/CallSitePrototype.cpp           1      3      0
src/jsc/bindings/ErrorStackTrace.cpp             2      6      0
src/jsc/bindings/ErrorStackTrace.h               1      4      0
src/jsc/bindings/FormatStackTraceForJS.cpp       9     19      0
src/jsc/bindings/ZigException.cpp                7      6      0
test/js/node/v8/capture-stack-trace.test.js      2      4      0
```

</details>

<!-- robobun:evidence:end -->

## Intentionally excluded sibling callers

Three more `Zig::sourceURL(visitor)` → `Bun__remapStackFramePositions` consumers share the same shape but are left for a follow-up because they are pre-existing and require calling the relevant API from inside `eval()`:

- `Bun__CallFrame__getCallerSrcLoc` (bindings.cpp) — `toMatchInlineSnapshot()` / `Bun.cron` caller-location lookup
- `Bun__CallFrame__getLineNumber` (bindings.cpp) — `test()`/`describe()` source-line reporting
- `InspectorTestReporterAgent.cpp` — inspector-reported test locations

Behaviour at these sites is byte-identical to `main`; the clean fix is to move the eval gate into `Zig::sourceURL(CodeBlock&)` so every consumer inherits it, which is a wider audit than this PR should carry.
