### PR TITLE
CallSite: return 1-based getColumnNumber() to match V8

### DIFF
--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -263,9 +263,11 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncToJSON, (JSGlobalObject * globalObject
 {
     ENTER_PROTO_FUNC();
     JSObject* obj = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
+    auto line = callSite->lineNumber();
+    auto column = callSite->columnNumber();
     obj->putDirect(vm, JSC::Identifier::fromString(vm, "sourceURL"_s), callSite->sourceURL());
-    obj->putDirect(vm, JSC::Identifier::fromString(vm, "lineNumber"_s), jsNumber(callSite->lineNumber().oneBasedInt()));
-    obj->putDirect(vm, JSC::Identifier::fromString(vm, "columnNumber"_s), jsNumber(callSite->columnNumber().oneBasedInt()));
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "lineNumber"_s), line == OrdinalNumber::beforeFirst() ? JSC::jsNull() : jsNumber(line.oneBasedInt()));
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "columnNumber"_s), column == OrdinalNumber::beforeFirst() ? JSC::jsNull() : jsNumber(column.oneBasedInt()));
     obj->putDirect(vm, JSC::Identifier::fromString(vm, "functionName"_s), callSite->functionName());
     return JSC::JSValue::encode(obj);
 }

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -134,15 +134,22 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetFileName, (JSGlobalObject * globalO
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetLineNumber, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-    // https://github.com/mozilla/source-map/blob/60adcb064bf033702d954d6d3f9bc3635dcb744b/lib/source-map-consumer.js#L484-L486
-    return JSC::JSValue::encode(jsNumber(std::max(callSite->lineNumber().oneBasedInt(), 1)));
+    auto line = callSite->lineNumber();
+    if (line == OrdinalNumber::beforeFirst())
+        return JSC::JSValue::encode(JSC::jsNull());
+    return JSC::JSValue::encode(jsNumber(line.oneBasedInt()));
 }
 
+// V8's CallSite#getColumnNumber() is 1-based (https://v8.dev/docs/stack-trace-api). It returns null
+// when no position is available. source-map-support relies on the 1-based value to compute a
+// 0-based offset for originalPositionFor().
 JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncGetColumnNumber, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     ENTER_PROTO_FUNC();
-    // https://github.com/mozilla/source-map/blob/60adcb064bf033702d954d6d3f9bc3635dcb744b/lib/source-map-consumer.js#L488-L489
-    return JSC::JSValue::encode(jsNumber(std::max(callSite->columnNumber().zeroBasedInt(), 0)));
+    auto column = callSite->columnNumber();
+    if (column == OrdinalNumber::beforeFirst())
+        return JSC::JSValue::encode(JSC::jsNull());
+    return JSC::JSValue::encode(jsNumber(column.oneBasedInt()));
 }
 
 // TODO:
@@ -258,7 +265,7 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncToJSON, (JSGlobalObject * globalObject
     JSObject* obj = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 4);
     obj->putDirect(vm, JSC::Identifier::fromString(vm, "sourceURL"_s), callSite->sourceURL());
     obj->putDirect(vm, JSC::Identifier::fromString(vm, "lineNumber"_s), jsNumber(callSite->lineNumber().oneBasedInt()));
-    obj->putDirect(vm, JSC::Identifier::fromString(vm, "columnNumber"_s), jsNumber(callSite->columnNumber().zeroBasedInt()));
+    obj->putDirect(vm, JSC::Identifier::fromString(vm, "columnNumber"_s), jsNumber(callSite->columnNumber().oneBasedInt()));
     obj->putDirect(vm, JSC::Identifier::fromString(vm, "functionName"_s), callSite->functionName());
     return JSC::JSValue::encode(obj);
 }

--- a/test/js/node/test/common/index.js
+++ b/test/js/node/test/common/index.js
@@ -641,7 +641,8 @@ function canCreateSymLink() {
 
 function getCallSite(top) {
   const originalStackFormatter = Error.prepareStackTrace;
-  Error.prepareStackTrace = (err, stack) => `${stack[0].getFileName()}:${stack[0].getLineNumber()}:${stack[0].getColumnNumber()}`;
+  Error.prepareStackTrace = (err, stack) =>
+    `${stack[0].getFileName()}:${stack[0].getLineNumber()}`;
   const err = new Error();
   Error.captureStackTrace(err, top);
   // With the V8 Error API, the stack is not formatted until it is accessed

--- a/test/js/node/test/parallel/test-common-must-not-call.js
+++ b/test/js/node/test/parallel/test-common-must-not-call.js
@@ -26,14 +26,14 @@ const createValidate = (line, args = []) => common.mustCall((e) => {
   assert.strictEqual(rest, line + argsInfo);
 });
 
-const validate1 = createValidate('9:29');
+const validate1 = createValidate('9:30');
 try {
   testFunction1();
 } catch (e) {
   validate1(e);
 }
 
-const validate2 = createValidate('11:29', ['hello', 42]);
+const validate2 = createValidate('11:30', ['hello', 42]);
 try {
   testFunction2('hello', 42);
 } catch (e) {

--- a/test/js/node/test/parallel/test-common-must-not-call.js
+++ b/test/js/node/test/parallel/test-common-must-not-call.js
@@ -26,14 +26,14 @@ const createValidate = (line, args = []) => common.mustCall((e) => {
   assert.strictEqual(rest, line + argsInfo);
 });
 
-const validate1 = createValidate('9:30');
+const validate1 = createValidate('9');
 try {
   testFunction1();
 } catch (e) {
   validate1(e);
 }
 
-const validate2 = createValidate('11:30', ['hello', 42]);
+const validate2 = createValidate('11', ['hello', 42]);
 try {
   testFunction2('hello', 42);
 } catch (e) {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -551,6 +551,52 @@ test("CallFrame.p.isNative", () => {
   Error.prepareStackTrace = prevPrepareStackTrace;
 });
 
+// https://github.com/oven-sh/bun/issues/17303
+// https://github.com/oven-sh/bun/issues/18250
+test("CallFrame.p.getColumnNumber is 1-based and matches toString()", async () => {
+  // Run in a subprocess so the column isn't shifted by the CJS-wrapper transform applied
+  // to .js test files: the function-call column must be observable at exactly 1.
+  const src = [
+    `let frames;`,
+    `Error.prepareStackTrace = (_, s) => s;`,
+    `function callee() { frames = new Error().stack; }`,
+    `callee();`,
+    `Error.prepareStackTrace = undefined;`,
+    `const callee0 = frames[0];`,
+    `const caller = frames[1];`,
+    `const colOf = f => Number(/:(\\d+):(\\d+)\\)?$/.exec(f.toString())[2]);`,
+    `console.log(JSON.stringify({`,
+    `  calleeMatch: callee0.getColumnNumber() === colOf(callee0),`,
+    `  callerCol: caller.getColumnNumber(),`,
+    `  callerStrCol: colOf(caller),`,
+    `  json: callee0.toJSON().columnNumber === callee0.getColumnNumber(),`,
+    `}));`,
+  ].join("\n");
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // `callee()` starts at column 1; V8 reports 1, source-map-support subtracts 1 to get 0.
+  expect(JSON.parse(stdout)).toEqual({ calleeMatch: true, callerCol: 1, callerStrCol: 1, json: true });
+  expect(exitCode).toBe(0);
+});
+
+test("CallFrame.p.getLineNumber/getColumnNumber return null for native frames", () => {
+  let prevPrepareStackTrace = Error.prepareStackTrace;
+  Error.prepareStackTrace = (e, s) => s;
+  let frames;
+  nativeFrameForTesting(() => {
+    const err = new Error("");
+    Error.captureStackTrace(err);
+    frames = err.stack;
+    return 0;
+  });
+  Error.prepareStackTrace = prevPrepareStackTrace;
+  const nativeFrame = frames[1];
+  expect(nativeFrame.isNative()).toBe(true);
+  expect(nativeFrame.getLineNumber()).toBeNull();
+  expect(nativeFrame.getColumnNumber()).toBeNull();
+});
+
 test("return non-strings from Error.prepareStackTrace", () => {
   // This behavior is allowed by V8 and used by the node-depd npm package.
   let prevPrepareStackTrace = Error.prepareStackTrace;

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -595,6 +595,8 @@ test("CallFrame.p.getLineNumber/getColumnNumber return null for native frames", 
   expect(nativeFrame.isNative()).toBe(true);
   expect(nativeFrame.getLineNumber()).toBeNull();
   expect(nativeFrame.getColumnNumber()).toBeNull();
+  const json = nativeFrame.toJSON();
+  expect({ lineNumber: json.lineNumber, columnNumber: json.columnNumber }).toEqual({ lineNumber: null, columnNumber: null });
 });
 
 test("return non-strings from Error.prepareStackTrace", () => {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -596,7 +596,10 @@ test("CallFrame.p.getLineNumber/getColumnNumber return null for native frames", 
   expect(nativeFrame.getLineNumber()).toBeNull();
   expect(nativeFrame.getColumnNumber()).toBeNull();
   const json = nativeFrame.toJSON();
-  expect({ lineNumber: json.lineNumber, columnNumber: json.columnNumber }).toEqual({ lineNumber: null, columnNumber: null });
+  expect({ lineNumber: json.lineNumber, columnNumber: json.columnNumber }).toEqual({
+    lineNumber: null,
+    columnNumber: null,
+  });
 });
 
 test("return non-strings from Error.prepareStackTrace", () => {


### PR DESCRIPTION
## Problem

`CallSite#getColumnNumber()` returned a 0-based column. V8 (and Node.js) return 1-based. `CallSite#toString()` already prints the 1-based column, so Bun was inconsistent with itself.

This bit `source-map-support`: `wrapCallSite` does `frame.getColumnNumber() - 1` to obtain a 0-based index for `originalPositionFor()`. On a Bun frame whose (1-based) column is 1, that yields `-1` and the consumer throws:

```
TypeError: Column must be greater than or equal to 0, got -1
```

Reported as #17303 (`medusa build`) and #18250 (`nestjs` / `swc`).

## Repro

```js
let frames;
Error.prepareStackTrace = (_, s) => s;
function callee() { frames = new Error().stack; }
callee();
Error.prepareStackTrace = undefined;
frames[1].getColumnNumber();        // node: 1   bun: 0
/:(\d+)\)?$/.exec(frames[1] + "");  // node: 1   bun: 1  (toString was already 1-based)
```

## Cause

`callSiteProtoFuncGetColumnNumber` in `src/jsc/bindings/CallSitePrototype.cpp` returned `std::max(columnNumber().zeroBasedInt(), 0)`. The comment next to it links to `mozilla/source-map`'s 0-based consumer API, but the V8 Stack Trace API contract for `CallSite` is 1-based, and ecosystem code subtracts 1 to reach the 0-based consumer.

## Fix

- `getColumnNumber()` now returns `oneBasedInt()`, matching V8 and making it consistent with `toString()`.
- `getLineNumber()` / `getColumnNumber()` now return `null` when the frame has no source position (native frames), matching V8 and `@types/node`'s `number | null`. Previously they were clamped to `1` / `0`.
- `toJSON().lineNumber` / `columnNumber` follow the same rules (Bun-specific method; no external consumers).

Nothing in `src/` reads the JS-level `getColumnNumber()` return value. One test fixture did: `test/js/node/test/common/index.js`'s `getCallSite()` carried a Bun-local `:${getColumnNumber()}` suffix whose pinned value in `test-common-must-not-call.js` encoded the old 0-based column. Both are restored to the upstream Node line-only form, decoupling the vendored test from CallSite column semantics; column coverage now lives in `capture-stack-trace.test.js`.

## Verification

```
bun bd test test/js/node/v8/capture-stack-trace.test.js
 45 pass
 0 fail

bun bd test/js/node/test/parallel/test-common-must-not-call.js
 (exit 0, matches node)
```

Fail-before (`USE_SYSTEM_BUN=1`):

```
CallFrame.p.getColumnNumber is 1-based and matches toString()
  - "calleeMatch": true,   + "calleeMatch": false,
  - "callerCol": 1,        + "callerCol": 0,
CallFrame.p.getLineNumber/getColumnNumber return null for native frames
  Received: 1
```

Fixes #17303
Fixes #18250

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (3aaf2bf24)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.23ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [8.11ms]
(pass) capture stack trace [6.20ms]
(pass) capture stack trace with message [7.69ms]
(pass) capture stack trace with constructor [7.52ms]
(pass) capture stack trace limit [23.45ms]
(pass) prepare stack trace [12.95ms]
(pass) capture stack trace second argument [19.22ms]
(pass) capture stack trace edge cases [10.97ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [21.06ms]
(pass) prepare stack trace call sites [12.63ms]
(pass) sanity check [14.98ms]
(pass) CallFrame isEval works as expected [8.05ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.65ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.46ms]
(pass) CallFrame.p.isConstructor [3.43ms]
(pass) CallFrame.p.isNative [2.84ms]
574 |   ].join("\n");
575 |   await using proc = Bun.spawn({ cmd: [bunExe(),
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.16ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.10ms]
(pass) capture stack trace [0.08ms]
(pass) capture stack trace with message [0.07ms]
(pass) capture stack trace with constructor [0.07ms]
(pass) capture stack trace limit [0.25ms]
(pass) prepare stack trace [0.13ms]
(pass) capture stack trace second argument [3.27ms]
(pass) capture stack trace edge cases [0.12ms]
312 |   };
313 | 
314 |   // plain object target
315 |   const o = { a: 1 };
316 |   Error.captureStackTrace(o);
317 |   expect(Object.keys(o)).toEqual(["a"]);
                               ^
error: expect(received).toEqual(expected)

  [
    "a",
+   "stack",
  ]

- Expected  - 0
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/v8/capture-stack-trace.test.js:317:26)
(fail) Error.captureStackTrace installs .stack as non-enumerable [2.07ms]
(pass) prepare stack trace call sites [0.22ms]
(pass) sanity check [0.13ms]
(pass) CallFrame isEval works as expected [0.84ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.98ms]
(pass) CallFrame.p.getT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.0 (3aaf2bf24)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [15.29ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.42ms]
(pass) capture stack trace [6.20ms]
(pass) capture stack trace with message [9.44ms]
(pass) capture stack trace with constructor [5.45ms]
(pass) capture stack trace limit [21.74ms]
(pass) prepare stack trace [12.04ms]
(pass) capture stack trace second argument [19.48ms]
(pass) capture stack trace edge cases [11.11ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [19.26ms]
(pass) prepare stack trace call sites [11.33ms]
(pass) sanity check [12.01ms]
(pass) CallFrame isEval works as expected [7.47ms]
(pass) CallFrame isTopLevel returns false for Function constructor [8.49ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.32ms]
(pass) CallFrame.p.isConstructor [3.36ms]
(pass) CallFrame.p.isNative [2.81ms]
(pass) CallFrame.p.getColumnNumber is 1-based and matches toString() [469.26
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3aaf2bf248
  features     baseline

22 deps, 108 codegen, 1170 objects in 1348ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [8.00ms]
[2/1233] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1233] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [5.00ms]
[4/1233] gen .bind.ts → GeneratedBindings.cpp
[5/1233] gen bindgenv2
[6/1233] gen ErrorCode+*.h
[7/1233] fetch zlib
[zlib] up to date
[8/1233] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1233] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/CallSitePrototype.cpp             | 21 ++++++---
 test/js/node/test/common/index.js                  |  3 +-
 .../test/parallel/test-common-must-not-call.js     |  4 +-
 test/js/node/v8/capture-stack-trace.test.js        | 51 ++++++++++++++++++++++
 4 files changed, 70 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/CallSitePrototype.cpp                       2      4      0
test/js/node/test/common/index.js                            1      1      0
test/js/node/test/parallel/test-common-must-not-call.js      1      2      0
test/js/node/v8/capture-stack-trace.test.js                  4      2      0
```

</details>

<!-- robobun:evidence:end -->