### PR TITLE
tls: treat ca: [] as an empty trust store instead of falling through to defaults

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -997,12 +997,14 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
                                     : SSL_VERIFY_PEER,
         us_verify_callback);
 
-  } else if (options.ca && options.ca_count > 0) {
+  } else if (options.ca) {
     us_ex_idx_ensure();
     SSL_CTX_set_ex_data(ssl_context, us_ctx_user_ca_ex_idx, (void *)1);
     /* As above: user CAs only, into the SSL_CTX's own initially-empty store —
      * otherwise a server doing mTLS with `ca: [internalCA]` would also accept
-     * any client certificate that chains to a public root. */
+     * any client certificate that chains to a public root. ca_count may be 0
+     * (`ca: []`): that leaves the empty store in place so every peer fails
+     * chain verification, matching Node. */
     X509_STORE *cert_store = SSL_CTX_get_cert_store(ssl_context);
     for (unsigned int i = 0; i < options.ca_count; i++) {
       if (!add_ca_cert_to_ctx_store(ssl_context, options.ca[i], cert_store)) {
@@ -1011,11 +1013,11 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
         return NULL;
       }
       ERR_clear_error();
-      SSL_CTX_set_verify(ssl_context,
-          options.reject_unauthorized ? (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
-                                      : SSL_VERIFY_PEER,
-          us_verify_callback);
     }
+    SSL_CTX_set_verify(ssl_context,
+        options.reject_unauthorized ? (SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
+                                    : SSL_VERIFY_PEER,
+        us_verify_callback);
   } else if (options.request_cert) {
     /* No per-config CAs are added to this store, so the process-wide shared
      * copy (built once) can be used instead of re-parsing the ~150 bundled
@@ -1107,10 +1109,16 @@ int us_ssl_ctx_add_ca_cert(SSL_CTX *ctx, const char *content) {
    * way Node does, so when the store is the shared one - or still empty -
    * replace it with a fresh full default store (bundled roots, NODE_EXTRA_CA
    * certificates, system CAs when enabled) before appending the user's CA. */
+  us_ex_idx_ensure();
   int store_is_empty = 0;
   if (store && !store_is_shared) {
     const STACK_OF(X509_OBJECT) *objs = X509_STORE_get0_objects(store);
     store_is_empty = objs == NULL || sk_X509_OBJECT_num(objs) == 0;
+  }
+  /* An empty store that the user asked for (`ca: []`) is not the "never
+   * configured" default: it replaces the trust set, so extend it alone. */
+  if (store_is_empty && SSL_CTX_get_ex_data(ctx, us_ctx_user_ca_ex_idx)) {
+    store_is_empty = 0;
   }
   if (store_is_shared || store_is_empty) {
     X509_STORE *own = us_get_default_ca_store();
@@ -1123,7 +1131,6 @@ int us_ssl_ctx_add_ca_cert(SSL_CTX *ctx, const char *content) {
   if (!store) {
     return 0;
   }
-  us_ex_idx_ensure();
   SSL_CTX_set_ex_data(ctx, us_ctx_user_ca_ex_idx, (void *)1);
   return add_ca_cert_to_ctx_store(ctx, content, store);
 }

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -337,9 +337,9 @@ fn handle_file_array(
     global: &JSGlobalObject,
     elements: &[jsc::generated::SSLConfigSingleFile],
 ) -> Result<CStrSlice, ReadFromBlobError> {
-    if elements.is_empty() {
-        return Ok(None);
-    }
+    // An explicit empty array must stay `Some([])` (not `None`): `ca: []`
+    // means "replace the trust store with nothing" in Node, so `as_usockets`
+    // must see a non-null `ca` pointer with `ca_count == 0`.
     let mut result: Vec<*const c_char> = Vec::with_capacity(elements.len());
     // Error path: free_sensitive each, then drop result — need zeroing on error:
     let mut guard = scopeguard::guard(&mut result, |r| {

--- a/test/js/node/tls/node-tls-cert.test.ts
+++ b/test/js/node/tls/node-tls-cert.test.ts
@@ -620,6 +620,62 @@ it("tls.connect should use NODE_EXTRA_CA_CERTS even if the used CA is not first 
   expect(await proc.exited).toBe(0);
 });
 
+it("tls.connect with ca: [] replaces the default trust store (rejects NODE_EXTRA_CA_CERTS-signed peers)", async () => {
+  // In Node, passing `ca` replaces the trusted CA set. `ca: []` therefore
+  // means zero trust anchors: every peer fails chain verification, including
+  // one whose root is in NODE_EXTRA_CA_CERTS.
+  const caPath = join(tmpdirSync(), "ca.pem");
+  await Bun.write(caPath, serverTls.ca);
+
+  await using server = await createTLSServer({
+    key: serverTls.key,
+    cert: serverTls.cert,
+    passphrase: "123123123",
+  });
+
+  const fixture = `
+    const tls = require("node:tls");
+    const port = Number(process.env.SERVER_PORT);
+    const connect = extra => new Promise(resolve => {
+      const s = tls.connect({
+        host: "127.0.0.1",
+        port,
+        checkServerIdentity: () => undefined,
+        ...extra,
+      }, () => { resolve({ ok: true, authorized: s.authorized }); s.end(); });
+      s.on("error", e => resolve({ ok: false, code: e.code }));
+    });
+    (async () => {
+      const control = await connect({});
+      const caEmpty = await connect({ ca: [] });
+      const ctxEmpty = await connect({ secureContext: tls.createSecureContext({ ca: [] }) });
+      console.log(JSON.stringify({ control, caEmpty, ctxEmpty }));
+    })();
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: {
+      ...bunEnv,
+      SERVER_PORT: server.address.port.toString(),
+      NODE_EXTRA_CA_CERTS: caPath,
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout);
+  // Control: no `ca` given -> NODE_EXTRA_CA_CERTS applies, connection authorized.
+  expect(result.control).toEqual({ ok: true, authorized: true });
+  // `ca: []` -> empty trust store, chain verification fails closed.
+  expect(result.caEmpty.ok).toBe(false);
+  expect(result.caEmpty.code).toMatch(/SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_VERIFY_LEAF_SIGNATURE|UNABLE_TO_GET_ISSUER_CERT/);
+  // Same via createSecureContext({ ca: [] }).
+  expect(result.ctxEmpty.ok).toBe(false);
+  expect(result.ctxEmpty.code).toMatch(/SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_VERIFY_LEAF_SIGNATURE|UNABLE_TO_GET_ISSUER_CERT/);
+  expect(exitCode).toBe(0);
+});
+
 it("tls.connect should ignore invalid NODE_EXTRA_CA_CERTS", async () => {
   await using server = await createTLSServer({
     key: serverTls.key,

--- a/test/js/node/tls/node-tls-cert.test.ts
+++ b/test/js/node/tls/node-tls-cert.test.ts
@@ -669,10 +669,14 @@ it("tls.connect with ca: [] replaces the default trust store (rejects NODE_EXTRA
   expect(result.control).toEqual({ ok: true, authorized: true });
   // `ca: []` -> empty trust store, chain verification fails closed.
   expect(result.caEmpty.ok).toBe(false);
-  expect(result.caEmpty.code).toMatch(/SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_VERIFY_LEAF_SIGNATURE|UNABLE_TO_GET_ISSUER_CERT/);
+  expect(result.caEmpty.code).toMatch(
+    /SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_VERIFY_LEAF_SIGNATURE|UNABLE_TO_GET_ISSUER_CERT/,
+  );
   // Same via createSecureContext({ ca: [] }).
   expect(result.ctxEmpty.ok).toBe(false);
-  expect(result.ctxEmpty.code).toMatch(/SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_VERIFY_LEAF_SIGNATURE|UNABLE_TO_GET_ISSUER_CERT/);
+  expect(result.ctxEmpty.code).toMatch(
+    /SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_VERIFY_LEAF_SIGNATURE|UNABLE_TO_GET_ISSUER_CERT/,
+  );
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
## What

In Node.js, passing the `ca` option replaces the trusted CA set, so `ca: []` means zero trust anchors and every peer fails chain verification (`SELF_SIGNED_CERT_IN_CHAIN` / `UNABLE_TO_VERIFY_LEAF_SIGNATURE`). Bun was collapsing an empty `ca` array into "no `ca` provided", so a client connecting with `ca: []` verified against the default bundled roots plus `NODE_EXTRA_CA_CERTS` and succeeded where Node rejects.

This matters for dynamically computed trust lists (`ca: allowedRoots` where `allowedRoots` can legitimately be empty) and "trust nothing until configured" bootstraps: those fail closed under Node and were failing open under Bun.

Affects `tls.connect({ca:[]})`, `https.request({ca:[]})`, `tls.createSecureContext({ca:[]})`, `fetch(url,{tls:{ca:[]}})`, and `Bun.connect({tls:{ca:[]}})`.

## Repro

```js
import tls from "node:tls";
// server uses a cert signed by a root listed in NODE_EXTRA_CA_CERTS
tls.connect({ host, port, ca: [] }, () => {
  // node: never reaches here, emits 'error' with UNABLE_TO_VERIFY_LEAF_SIGNATURE
  // bun (before): reaches here with authorized=true
});
```

## Cause

Two layers collapsed the empty array:

1. `handle_file_array` in `src/runtime/socket/SSLConfig.rs` early-returned `None` for an empty input, making `ca: []` indistinguishable from an omitted `ca`.
2. `us_ssl_ctx_build_raw` in `packages/bun-usockets/src/crypto/openssl.c` gated the user-CA branch on `options.ca && options.ca_count > 0`, falling through to the default-roots branch when the count was zero.

## Fix

- Preserve an explicit empty array as `Some([])` so `as_usockets()` emits a non-null `ca` pointer with `ca_count == 0`.
- Enter the user-CA branch on `options.ca` alone: the `SSL_CTX` keeps its initially-empty `X509_STORE`, the user-CA ex_data marker is set (so the per-socket client attach does not override with the shared default roots), and `SSL_CTX_set_verify` is called once outside the per-cert loop.
- `us_ssl_ctx_add_ca_cert` now checks the user-CA marker before treating an empty store as the "never configured" default, so `addCACert` on a `ca: []` context extends the explicitly-empty store rather than backfilling the bundled roots into it.

`cert: []` and `key: []` are unchanged in behaviour (the C side still gates those on `*_count > 0`).

## Verification

New test in `test/js/node/tls/node-tls-cert.test.ts` spawns a child with `NODE_EXTRA_CA_CERTS` pointing at the server's signing CA, then asserts that `ca: []` (both inline and via `createSecureContext`) rejects while the no-`ca` control succeeds. Fails on canary, passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-cert.test.ts
bun test v1.4.0 (ad7628722)

test/js/node/tls/node-tls-cert.test.ts:
(pass) complete cert chains sent to peer. [602.09ms]
(pass) complete cert chains sent to peer, but without requesting client's cert. [175.56ms]
(pass) Request cert from TLS1.2 client that doesn't have one. [87.48ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. [119.72ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. But using multi-PEM [96.98ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. But using multi-PEM in an array [79.96ms]
(pass) Fail to complete server's chain [70.84ms]
(pass) Fail to complete client's chain. [98.52ms]
(pass) rejects an unverifiable client certificate by default when requestCert is true [265.99ms]
(pass) explicit rejectUnauthorized: f
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/tls/node-tls-cert.test.ts:
(pass) complete cert chains sent to peer. [13.94ms]
(pass) complete cert chains sent to peer, but without requesting client's cert. [3.58ms]
(pass) Request cert from TLS1.2 client that doesn't have one. [4.90ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. [3.84ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. But using multi-PEM [3.60ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. But using multi-PEM in an array [3.34ms]
(pass) Fail to complete server's chain [3.71ms]
(pass) Fail to complete client's chain. [3.36ms]
(pass) rejects an unverifiable client certificate by default when requestCert is true [6.78ms]
(pass) explicit rejectUnauthorized: false still admits an unverified client certificate [3.33ms]
(pass) Fail to find CA for server. [13.02ms]
(pass) Server sent their CA, but CA cannot be trusted if it is not loc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-cert.test.ts
bun test v1.4.0 (ad7628722)

test/js/node/tls/node-tls-cert.test.ts:
(pass) complete cert chains sent to peer. [606.46ms]
(pass) complete cert chains sent to peer, but without requesting client's cert. [168.07ms]
(pass) Request cert from TLS1.2 client that doesn't have one. [80.79ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. [122.10ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. But using multi-PEM [96.54ms]
(pass) Typical configuration error, incomplete cert chains sent, we have to know the peer's subordinate CAs in order to verify the peer. But using multi-PEM in an array [89.46ms]
(pass) Fail to complete server's chain [72.13ms]
(pass) Fail to complete client's chain. [89.43ms]
(pass) rejects an unverifiable client certificate by default when requestCert is true [281.93ms]
(pass) explicit rejectUnauthorized: f
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ad76287223
  features     baseline

22 deps, 108 codegen, 1170 objects in 815ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1233] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1233] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[4/1233] gen bindgenv2
[5/1233] gen ErrorCode+*.h
[6/1233] fetch picohttpparser
[picohttpparser] up to date
[7/1233] fetch tinycc
[tinycc] up to date
[8/1233] fetch zlib
[zlib] up to date
[9/1233] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1233] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingCon
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c | 21 +++++++----
 src/runtime/socket/SSLConfig.rs            |  6 +--
 test/js/node/tls/node-tls-cert.test.ts     | 60 ++++++++++++++++++++++++++++++
 3 files changed, 77 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c      1      2      0
src/runtime/socket/SSLConfig.rs                 1      1      0
test/js/node/tls/node-tls-cert.test.ts          2      1      0
```

</details>

<!-- robobun:evidence:end -->