### PR TITLE
watcher: return Err from start() when thread spawn fails instead of panicking

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -798,8 +798,9 @@ where
         );
 
         // SAFETY: `watcher_ptr` was just installed into `ctx` and is live.
-        if unsafe { (*watcher_ptr).start() }.is_err() {
-            panic!("Failed to start File Watcher");
+        if let Err(err) = unsafe { (*watcher_ptr).start() } {
+            bun_core::handle_error_return_trace(&err);
+            Output::panic(format_args!("Failed to start File Watcher: {}", err.name()));
         }
     }
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -228,7 +228,13 @@ impl Watcher {
                 .spawn(move || unsafe {
                     let _ = Watcher::thread_main(this as *mut Watcher);
                 })
-                .expect("spawn FileWatcher thread"),
+                .map_err(|e| {
+                    crate::Error::Sys(
+                        e.raw_os_error()
+                            .map(bun_errno::from_errno)
+                            .unwrap_or(bun_errno::SystemErrno::EAGAIN),
+                    )
+                })?,
         );
         Ok(())
     }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -229,11 +229,20 @@ impl Watcher {
                     let _ = Watcher::thread_main(this as *mut Watcher);
                 })
                 .map_err(|e| {
-                    crate::Error::Sys(
-                        e.raw_os_error()
-                            .map(bun_errno::from_errno)
-                            .unwrap_or(bun_errno::SystemErrno::EAGAIN),
-                    )
+                    // Windows: raw_os_error() is a Win32 GetLastError() code, so
+                    // route it through the u32 (Win32Error) mapper rather than
+                    // from_errno's i64 discriminant-cast path.
+                    #[cfg(windows)]
+                    let errno = e
+                        .raw_os_error()
+                        .and_then(|c| bun_errno::SystemErrno::init(c as u32))
+                        .unwrap_or(bun_errno::SystemErrno::EAGAIN);
+                    #[cfg(not(windows))]
+                    let errno = e
+                        .raw_os_error()
+                        .map(bun_errno::from_errno)
+                        .unwrap_or(bun_errno::SystemErrno::EAGAIN);
+                    crate::Error::Sys(errno)
                 })?,
         );
         Ok(())

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -58,10 +58,18 @@ it.skipIf(!isLinux || !cc)("propagates FileWatcher thread spawn failure instead 
 #include <dlfcn.h>
 #include <errno.h>
 #include <pthread.h>
+#include <sys/resource.h>
 
 static int (*real_inotify_init1)(int);
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 static volatile int armed = 0;
+
+/* The child is expected to abort; suppress the core file so CI's runner does
+ * not flag it as a crash. RLIMIT_CORE survives execvp. */
+__attribute__((constructor)) static void no_core(void) {
+  struct rlimit rl = {0, 0};
+  setrlimit(RLIMIT_CORE, &rl);
+}
 
 int inotify_init1(int flags) {
   if (!real_inotify_init1) real_inotify_init1 = dlsym(RTLD_NEXT, "inotify_init1");

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,7 +1,7 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBroken, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 
@@ -46,3 +46,66 @@ for (const dir of ["dir", "©️"]) {
 afterEach(() => {
   watchee?.kill();
 });
+
+// Watcher::start() must propagate a failed thread spawn as an Err through its
+// Result return instead of aborting inside start() with `.expect()`. An
+// LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux
+// immediately before start()) and fails the very next pthread_create.
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+it.skipIf(!isLinux || !cc)("propagates FileWatcher thread spawn failure instead of panicking in start()", async () => {
+  const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <pthread.h>
+
+static int (*real_inotify_init1)(int);
+static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
+static volatile int armed = 0;
+
+int inotify_init1(int flags) {
+  if (!real_inotify_init1) real_inotify_init1 = dlsym(RTLD_NEXT, "inotify_init1");
+  armed = 1;
+  return real_inotify_init1(flags);
+}
+
+int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), void *arg) {
+  if (!real_pthread_create) real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+  if (armed) {
+    armed = 0;
+    return EAGAIN;
+  }
+  return real_pthread_create(t, a, f, arg);
+}
+`;
+  using dir = tempDir("watch-spawn-fail", {
+    "shim.c": SHIM_C,
+    "watchee.js": "console.log('unreachable');\n",
+  });
+  const shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--watch", "watchee.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The .expect("spawn FileWatcher thread") panic inside start() must be gone;
+  // the error now reaches the caller, which reports it by name.
+  expect(stderr).not.toContain("spawn FileWatcher thread");
+  expect(stderr).toContain("Failed to start File Watcher");
+  expect(stdout).not.toContain("unreachable");
+  expect(exitCode).not.toBe(0);
+}, 20000);

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -52,10 +52,8 @@ afterEach(() => {
 // LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux
 // immediately before start()) and fails the very next pthread_create.
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
-it.skipIf(!isLinux || !cc)(
-  "propagates FileWatcher thread spawn failure instead of panicking in start()",
-  async () => {
-    const SHIM_C = /* c */ `
+it.skipIf(!isLinux || !cc)("propagates FileWatcher thread spawn failure instead of panicking in start()", async () => {
+  const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
@@ -80,37 +78,36 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
   return real_pthread_create(t, a, f, arg);
 }
 `;
-    using dir = tempDir("watch-spawn-fail", {
-      "shim.c": SHIM_C,
-      "watchee.js": "console.log('unreachable');\n",
-    });
-    const shimPath = join(String(dir), "shim.so");
-    await using ccProc = Bun.spawn({
-      cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
-    if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  using dir = tempDir("watch-spawn-fail", {
+    "shim.c": SHIM_C,
+    "watchee.js": "console.log('unreachable');\n",
+  });
+  const shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
 
-    const existing = bunEnv.LD_PRELOAD;
-    await using proc = Bun.spawn({
-      // --debug-crash-handler-use-trace-string skips the debug build's slow
-      // backtrace symbolication so the child exits promptly.
-      cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "--watch", "watchee.js"],
-      cwd: String(dir),
-      env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    // --debug-crash-handler-use-trace-string skips the debug build's slow
+    // backtrace symbolication so the child exits promptly.
+    cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "--watch", "watchee.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // The .expect("spawn FileWatcher thread") panic inside start() must be gone;
-    // the error now reaches the caller, which reports it by name.
-    expect(stderr).not.toContain("spawn FileWatcher thread");
-    expect(stderr).toContain("Failed to start File Watcher");
-    expect(stdout).not.toContain("unreachable");
-    expect(exitCode).not.toBe(0);
-  },
-);
+  // The .expect("spawn FileWatcher thread") panic inside start() must be gone;
+  // the error now reaches the caller, which reports it by name.
+  expect(stderr).not.toContain("spawn FileWatcher thread");
+  expect(stderr).toContain("Failed to start File Watcher");
+  expect(stdout).not.toContain("unreachable");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -52,8 +52,10 @@ afterEach(() => {
 // LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux
 // immediately before start()) and fails the very next pthread_create.
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
-it.skipIf(!isLinux || !cc)("propagates FileWatcher thread spawn failure instead of panicking in start()", async () => {
-  const SHIM_C = /* c */ `
+it.skipIf(!isLinux || !cc)(
+  "propagates FileWatcher thread spawn failure instead of panicking in start()",
+  async () => {
+    const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
@@ -78,34 +80,36 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
   return real_pthread_create(t, a, f, arg);
 }
 `;
-  using dir = tempDir("watch-spawn-fail", {
-    "shim.c": SHIM_C,
-    "watchee.js": "console.log('unreachable');\n",
-  });
-  const shimPath = join(String(dir), "shim.so");
-  await using ccProc = Bun.spawn({
-    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
-  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+    using dir = tempDir("watch-spawn-fail", {
+      "shim.c": SHIM_C,
+      "watchee.js": "console.log('unreachable');\n",
+    });
+    const shimPath = join(String(dir), "shim.so");
+    await using ccProc = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+    if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
 
-  const existing = bunEnv.LD_PRELOAD;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--watch", "watchee.js"],
-    cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const existing = bunEnv.LD_PRELOAD;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--watch", "watchee.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // The .expect("spawn FileWatcher thread") panic inside start() must be gone;
-  // the error now reaches the caller, which reports it by name.
-  expect(stderr).not.toContain("spawn FileWatcher thread");
-  expect(stderr).toContain("Failed to start File Watcher");
-  expect(stdout).not.toContain("unreachable");
-  expect(exitCode).not.toBe(0);
-}, 20000);
+    // The .expect("spawn FileWatcher thread") panic inside start() must be gone;
+    // the error now reaches the caller, which reports it by name.
+    expect(stderr).not.toContain("spawn FileWatcher thread");
+    expect(stderr).toContain("Failed to start File Watcher");
+    expect(stdout).not.toContain("unreachable");
+    expect(exitCode).not.toBe(0);
+  },
+  20000,
+);

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -113,9 +113,9 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // The .expect("spawn FileWatcher thread") panic inside start() must be gone;
-  // the error now reaches the caller, which reports it by name.
+  // the error now reaches the caller, which reports it by errno name.
   expect(stderr).not.toContain("spawn FileWatcher thread");
-  expect(stderr).toContain("Failed to start File Watcher");
+  expect(stderr).toContain("Failed to start File Watcher: EAGAIN");
   expect(stdout).not.toContain("unreachable");
   expect(exitCode).not.toBe(0);
 });

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -96,7 +96,9 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
 
     const existing = bunEnv.LD_PRELOAD;
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "--watch", "watchee.js"],
+      // --debug-crash-handler-use-trace-string skips the debug build's slow
+      // backtrace symbolication so the child exits promptly.
+      cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "--watch", "watchee.js"],
       cwd: String(dir),
       env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
       stdout: "pipe",
@@ -111,5 +113,4 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
     expect(stdout).not.toContain("unreachable");
     expect(exitCode).not.toBe(0);
   },
-  20000,
 );


### PR DESCRIPTION
## What

`Watcher::start()` is declared as `-> Result<(), crate::Error>`, but the `std::thread::Builder::spawn(...)` call was `.expect()`ed. When thread creation fails (e.g. `EAGAIN` under `RLIMIT_NPROC` / cgroup pids limits, or Windows `ERROR_NO_SYSTEM_RESOURCES` / 1450 under job-object thread caps), the process aborted with a Rust panic inside `start()`:

```
panic: spawn FileWatcher thread: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
```

instead of returning the `Err` that `start()`'s signature already promises.

## Fix

- `Watcher::start()`: map the `std::io::Error` into `crate::Error::Sys` via its raw OS error code and `?`-propagate it. On Windows the code is routed through `SystemErrno::init(u32)` (the Win32Error mapper) so e.g. `ERROR_NOT_ENOUGH_MEMORY` surfaces as `ENOMEM` rather than colliding with an unrelated discriminant; on POSIX it goes through `bun_errno::from_errno`. Falls back to `EAGAIN` if no OS code is present.
- `hot_reloader.rs` (`enable_hot_module_reloading`, the `--watch`/`--hot` caller): bind the error and format `err.name()` instead of discarding it via `.is_err()`, matching the sibling `init()` path. stderr now shows `Failed to start File Watcher: EAGAIN`.
- `DevServer.rs` already threw the `Err` as a catchable JS error; no change needed there.

## Other spawn sites

Audited every `std::thread::Builder::new().spawn(...)` in `src/`: this was the only one using `.expect()` inside a `Result`-returning function. The others already propagate (`?`, `match`, or `.map_err`) or live in functions with no `Result` to return through (e.g. `io/lib.rs` `load()` inside `Once::get_or_init`).

## Test

`test/cli/watch/watch.test.ts` gains a Linux-only fault-injection test: an `LD_PRELOAD` shim hooks `inotify_init1` (which `Watcher::init()` calls on Linux immediately before `start()`) to arm a one-shot `pthread_create` failure, so the spawn failure is deterministic without per-user rlimit races. The shim also sets `RLIMIT_CORE={0,0}` so the child's expected abort leaves no core file for CI to flag. Asserts stderr contains `"Failed to start File Watcher: EAGAIN"` and not the old `"spawn FileWatcher thread"` panic text.

## Verification

- `cargo check -p bun_watcher` passes on `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`
- `bun bd test test/cli/watch/watch.test.ts` passes (all 3 tests)
- Fail-before confirmed: with `src/` reverted to `main`, the new test fails on `expect(stderr).not.toContain("spawn FileWatcher thread")`

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->