### PR TITLE
Bun.CryptoHasher: reject odd-length hex in update()

### DIFF
--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -579,6 +579,23 @@ impl CryptoHasher {
             );
         }
         let encoding = arguments.ptr[1];
+        if input.is_string()
+            && encoding.is_cell()
+            && Encoding::from_js(encoding, global)? == Some(Encoding::Hex)
+        {
+            let length = input.to_js_string(global)?.length();
+            if length % 2 != 0 {
+                return Err(global
+                    .err(
+                        ErrorCode::INVALID_ARG_VALUE,
+                        format_args!(
+                            "The argument 'encoding' is invalid for data of length {}. Received 'hex'",
+                            length
+                        ),
+                    )
+                    .throw());
+            }
+        }
         let buffer =
             match BlobOrStringOrBuffer::from_js_with_encoding_value(global, input, encoding)? {
                 Some(b) => b,

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -599,18 +599,16 @@ impl CryptoHasher {
                     .throw());
             }
         }
-        let buffer =
-            match BlobOrStringOrBuffer::from_js_with_encoding(global, input, encoding)? {
-                Some(b) => b,
-                None => {
-                    if !global.has_exception() {
-                        return Err(global.throw_invalid_arguments(format_args!(
-                            "expected blob, string or buffer"
-                        )));
-                    }
-                    return Err(JsError::Thrown);
+        let buffer = match BlobOrStringOrBuffer::from_js_with_encoding(global, input, encoding)? {
+            Some(b) => b,
+            None => {
+                if !global.has_exception() {
+                    return Err(global
+                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
                 }
-            };
+                return Err(JsError::Thrown);
+            }
+        };
         // `defer buffer.deinit()` — handled by Drop.
         if is_bun_file_blob(&buffer) {
             return Err(global.throw(format_args!(

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -579,7 +579,9 @@ impl CryptoHasher {
             );
         }
         let encoding_value = arguments.ptr[1];
-        let encoding = if encoding_value.is_cell() {
+        // Encoding only affects string inputs (same gate as JSHash.cpp); don't
+        // coerce it for Blob/Buffer inputs where it is ignored.
+        let encoding = if input.is_string() && encoding_value.is_cell() {
             Encoding::from_js(encoding_value, global)?.unwrap_or(Encoding::Utf8)
         } else {
             Encoding::Utf8

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -578,26 +578,29 @@ impl CryptoHasher {
                 global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
             );
         }
-        let encoding = arguments.ptr[1];
-        if input.is_string()
-            && encoding.is_cell()
-            && Encoding::from_js(encoding, global)? == Some(Encoding::Hex)
-        {
+        let encoding_value = arguments.ptr[1];
+        let encoding = if encoding_value.is_cell() {
+            Encoding::from_js(encoding_value, global)?.unwrap_or(Encoding::Utf8)
+        } else {
+            Encoding::Utf8
+        };
+        if input.is_string() && encoding == Encoding::Hex {
             let length = input.to_js_string(global)?.length();
             if length % 2 != 0 {
+                let actual = JSGlobalObject::inspect_for_error_message(global, encoding_value)?;
                 return Err(global
                     .err(
                         ErrorCode::INVALID_ARG_VALUE,
                         format_args!(
-                            "The argument 'encoding' is invalid for data of length {}. Received 'hex'",
-                            length
+                            "The argument 'encoding' is invalid for data of length {}. Received {}",
+                            length, actual
                         ),
                     )
                     .throw());
             }
         }
         let buffer =
-            match BlobOrStringOrBuffer::from_js_with_encoding_value(global, input, encoding)? {
+            match BlobOrStringOrBuffer::from_js_with_encoding(global, input, encoding)? {
                 Some(b) => b,
                 None => {
                     if !global.has_exception() {

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -584,7 +584,7 @@ impl CryptoHasher {
         } else {
             Encoding::Utf8
         };
-        if input.is_string() && encoding == Encoding::Hex {
+        if input.is_string_literal() && encoding == Encoding::Hex {
             let length = input.to_js_string(global)?.length();
             if length % 2 != 0 {
                 let actual = JSGlobalObject::inspect_for_error_message(global, encoding_value)?;

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -164,6 +164,25 @@ impl BlobOrStringOrBuffer {
         )
     }
 
+    /// Like [`from_js_with_encoding_value`] but takes an already-parsed
+    /// [`Encoding`], so callers that must inspect the encoding first (e.g. to
+    /// validate odd-length hex) don't coerce `encoding_value` twice.
+    pub fn from_js_with_encoding(
+        global: &JSGlobalObject,
+        value: JSValue,
+        encoding: Encoding,
+    ) -> JsResult<Option<BlobOrStringOrBuffer>> {
+        if value.js_type() == jsc::JSType::DOMWrapper {
+            if let Some(blob) = value.as_class_ref::<Blob>() {
+                return Ok(Some(Self::Blob(Box::new(blob.dupe()))));
+            }
+        }
+        match StringOrBuffer::from_js_with_encoding(global, value, encoding)? {
+            Some(s) => Ok(Some(Self::StringOrBuffer(s))),
+            None => Ok(None),
+        }
+    }
+
     pub fn from_js_with_encoding_value_allow_request_response(
         global: &JSGlobalObject,
         value: JSValue,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -151,22 +151,10 @@ impl BlobOrStringOrBuffer {
         Self::from_js_maybe_file_maybe_async(global, value, true, true)
     }
 
-    pub fn from_js_with_encoding_value(
-        global: &JSGlobalObject,
-        value: JSValue,
-        encoding_value: JSValue,
-    ) -> JsResult<Option<BlobOrStringOrBuffer>> {
-        Self::from_js_with_encoding_value_allow_request_response(
-            global,
-            value,
-            encoding_value,
-            false,
-        )
-    }
-
-    /// Like [`from_js_with_encoding_value`] but takes an already-parsed
-    /// [`Encoding`], so callers that must inspect the encoding first (e.g. to
-    /// validate odd-length hex) don't coerce `encoding_value` twice.
+    /// Like [`from_js_with_encoding_value_allow_request_response`] but takes an
+    /// already-parsed [`Encoding`], so callers that must inspect the encoding
+    /// first (e.g. to validate odd-length hex) don't coerce `encoding_value`
+    /// twice.
     pub fn from_js_with_encoding(
         global: &JSGlobalObject,
         value: JSValue,

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -48,7 +48,9 @@ test("CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto", 
   }
 
   // Buffers are unaffected by the input encoding parameter.
-  expect(() => new Bun.CryptoHasher("sha1").update(Buffer.from("abc"), "hex")).not.toThrow();
+  expect(new Bun.CryptoHasher("sha1").update(Buffer.from("abc"), "hex").digest("hex")).toBe(
+    createHash("sha1").update(Buffer.from("abc")).digest("hex"),
+  );
 });
 test("CryptoHasher throws on non-latin1 algorithm names instead of crashing", () => {
   // @ts-expect-error

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -32,6 +32,14 @@ test("CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto", 
     }
   }
 
+  // Error message echoes the encoding argument as passed.
+  expect(() => new Bun.CryptoHasher("sha1").update("abc", "HEX")).toThrow(
+    expect.objectContaining({
+      code: "ERR_INVALID_ARG_VALUE",
+      message: "The argument 'encoding' is invalid for data of length 3. Received 'HEX'",
+    }),
+  );
+
   // Even-length hex decodes and matches node:crypto (including truncation at the first invalid char).
   for (const s of ["ab", "deadbeef", "ffzz"]) {
     expect(new Bun.CryptoHasher("sha1").update(s, "hex").digest("hex")).toBe(

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { withoutAggressiveGC } from "harness";
+import { createHash } from "node:crypto";
 
 test("Bun.file in CryptoHasher is not supported yet", () => {
   expect(() => Bun.SHA1.hash(Bun.file(import.meta.path))).toThrow();
@@ -14,6 +15,32 @@ test("CryptoHasher update should throw when no parameter/null/undefined is passe
   expect(() => new Bun.CryptoHasher("sha1").update(undefined)).toThrow();
   // @ts-expect-error
   expect(() => new Bun.CryptoHasher("sha1").update(null)).toThrow();
+});
+test("CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto", () => {
+  // Odd-length hex strings must throw instead of silently hashing the longest valid even prefix.
+  for (const s of ["abc", "SGVsbG8", "deadbee", "ff\nff", "a"]) {
+    for (const alg of ["sha1", "sha3-256"] as const) {
+      expect(() => new Bun.CryptoHasher(alg).update(s, "hex"), `input ${JSON.stringify(s)} alg ${alg}`).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_VALUE",
+          message: `The argument 'encoding' is invalid for data of length ${s.length}. Received 'hex'`,
+        }),
+      );
+      expect(() => new Bun.CryptoHasher(alg, "key").update(s, "hex")).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+      );
+    }
+  }
+
+  // Even-length hex decodes and matches node:crypto (including truncation at the first invalid char).
+  for (const s of ["ab", "deadbeef", "ffzz"]) {
+    expect(new Bun.CryptoHasher("sha1").update(s, "hex").digest("hex")).toBe(
+      createHash("sha1").update(s, "hex").digest("hex"),
+    );
+  }
+
+  // Buffers are unaffected by the input encoding parameter.
+  expect(() => new Bun.CryptoHasher("sha1").update(Buffer.from("abc"), "hex")).not.toThrow();
 });
 test("CryptoHasher throws on non-latin1 algorithm names instead of crashing", () => {
   // @ts-expect-error


### PR DESCRIPTION
## What

`new Bun.CryptoHasher(alg).update(str, "hex")` now throws `ERR_INVALID_ARG_VALUE` when `str` has odd length, matching `crypto.createHash(alg).update(str, "hex")` in both Node.js and Bun's own `node:crypto`.

## Why

Previously the hex decoder used `Buffer.from` semantics (silently truncate to the longest valid even prefix), so odd-length or trailing-garbage hex produced a digest of the *prefix* bytes with no error. Two hashing surfaces inside Bun disagreed and the native one handed back a silently wrong digest.

```js
// before
new Bun.CryptoHasher("sha1").update("deadbee", "hex").digest("hex")
// => "0edfa62f..." (sha1 of 0xde 0xad 0xbe, no error)

require("crypto").createHash("sha1").update("deadbee", "hex")
// => TypeError [ERR_INVALID_ARG_VALUE]: The argument 'encoding' is invalid for data of length 7. Received 'hex'
```

## How

`CryptoHasher::update` now parses the encoding once up front, rejects odd-length primitive-string input when the encoding is hex (same check `jsHashProtoFuncUpdate` performs in `src/jsc/bindings/node/crypto/JSHash.cpp`), and passes the already-parsed encoding through a new `BlobOrStringOrBuffer::from_js_with_encoding` helper so the encoding argument is coerced exactly once. The error message echoes the caller's encoding argument via `inspect_for_error_message`. Even-length strings with invalid hex characters continue to truncate at the first invalid char (matches Node).

Deleted `BlobOrStringOrBuffer::from_js_with_encoding_value`; this was its only caller.

## Verified

```
$ bun bd test test/js/bun/util/bun-cryptohasher.test.ts
 398 pass
 0 fail
```

Fails on main with `Received function did not throw`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts
bun test v1.4.0 (32d52256d)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [11.83ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [6.37ms]
18 | });
19 | test("CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto", () => {
20 |   // Odd-length hex strings must throw instead of silently hashing the longest valid even prefix.
21 |   for (const s of ["abc", "SGVsbG8", "deadbee", "ff\nff", "a"]) {
22 |     for (const alg of ["sha1", "sha3-256"] as const) {
23 |       expect(() => new Bun.CryptoHasher(alg).update(s, "hex"), `input ${JSON.stringify(s)} alg ${alg}`).toThrow(
                                                                                                             ^
error: input "abc" alg sha1

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: CryptoHasher {
  algorithm: "sha1",
  byteLength: 20,
  copy: [Function: copy],
  digest: [Fun
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (f2ad1db72)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [0.22ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [0.06ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [0.66ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [0.20ms]
(pass) HMAC > sha1 (key: String) [0.13ms]
(pass) HMAC > sha256 (key: String) [0.04ms]
(pass) HMAC > sha384 (key: String) [0.03ms]
(pass) HMAC > sha512 (key: String) [0.03ms]
(pass) HMAC > blake2b512 (key: String) [0.02ms]
(pass) HMAC > md5 (key: String) [0.02ms]
(pass) HMAC > sha224 (key: String) [0.02ms]
(pass) HMAC > sha512-224 (key: String) [0.02ms]
(pass) HMAC > sha512-256 (key: String) [0.03ms]
(pass) HMAC > sha3-224 (key: String) [0.02ms]
(pass) HMAC > sha3-256 (key: String) [0.03ms]
(pass) HMAC > sha3-384 (key: String) [0.02ms]
(pass) HMAC > sha3-512 (key: String) [0.02ms]
(pass) HMAC > ripemd160 (key: String) [0.02ms]
(pass) HMAC > sha1 (key: Buffer) [0.01ms]
(pass) HMAC > sha256 (key: Buffer) [0.02ms]
(pass) HMAC > sha384 (key: Buffer) [0.02ms]
(pass) HMAC
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-cryptohasher.test.ts
bun test v1.4.0 (32d52256d)

test/js/bun/util/bun-cryptohasher.test.ts:
(pass) Bun.file in CryptoHasher is not supported yet [11.36ms]
(pass) CryptoHasher update should throw when no parameter/null/undefined is passed [5.88ms]
(pass) CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto [34.80ms]
(pass) CryptoHasher throws on non-latin1 algorithm names instead of crashing [8.93ms]
(pass) HMAC > sha1 (key: String) [13.71ms]
(pass) HMAC > sha256 (key: String) [5.38ms]
(pass) HMAC > sha384 (key: String) [3.46ms]
(pass) HMAC > sha512 (key: String) [3.37ms]
(pass) HMAC > blake2b512 (key: String) [3.40ms]
(pass) HMAC > md5 (key: String) [3.61ms]
(pass) HMAC > sha224 (key: String) [3.38ms]
(pass) HMAC > sha512-224 (key: String) [3.34ms]
(pass) HMAC > sha512-256 (key: String) [3.61ms]
(pass) HMAC > sha3-224 (key: String) [3.34ms]
(pass) HMAC > sha3-256 (key: String) [3.40ms]
(pass) HMAC > sha3-384 (key: String) [3.35ms]
(pass) HMAC > sha3-512 (key: String) [3.56ms]
(pass) HMAC > ripem
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 649ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] cc obj/packages/bun-usockets/src/bsd.c.o
[2/28] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[3/28] cc obj/packages/bun-usockets/src/context.c.o
[4/28] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[5/28] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[6/28] cc obj/packages/bun-usockets/src/fault_inject.c.o
[7/28] cc obj/packages/bun-usockets/src/loop.c.o
[8/28] cc obj/packages/bun-usockets/src/quic.c.o
[9/28] cc obj/packages/bun-usockets/src/socket.c.o
[10/28] cc obj/packages/bun-usockets/src/udp.c.o
[11/28] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[12/28] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[13/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[14/28] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[15/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[16/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[17/28] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[18/28] cxx obj/unified/UnifiedSo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/crypto/CryptoHasher.rs        | 44 ++++++++++++++++++++++---------
 src/runtime/node/types.rs                 | 23 ++++++++++------
 test/js/bun/util/bun-cryptohasher.test.ts | 37 ++++++++++++++++++++++++++
 3 files changed, 84 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/crypto/CryptoHasher.rs             4      6      0
src/runtime/node/types.rs                      5      2      0
test/js/bun/util/bun-cryptohasher.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->