### PR TITLE
TextDecoder: reject primitive options per WebIDL dictionary conversion

### DIFF
--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -220,7 +220,15 @@ impl TextDecoder {
         // `decodeSlice` reading through a stale pointer into memory that may have
         // been freed or reused. Node.js reads options first as well.
         let stream = 'stream: {
-            if arguments.len() > 1 && arguments[1].is_object() {
+            if arguments.len() > 1 && !arguments[1].is_undefined_or_null() {
+                // https://webidl.spec.whatwg.org/#es-dictionary step 1
+                if !arguments[1].is_object() {
+                    return Err(global_this.throw_invalid_argument_type_value(
+                        b"options",
+                        b"object",
+                        arguments[1],
+                    ));
+                }
                 if let Some(stream_value) =
                     arguments[1].fast_get(global_this, jsc::BuiltinName::stream)?
                 {
@@ -607,10 +615,14 @@ impl TextDecoder {
             }
         }
 
-        if !options_value.is_undefined() {
+        if !options_value.is_undefined_or_null() {
+            // https://webidl.spec.whatwg.org/#es-dictionary step 1
             if !options_value.is_object() {
-                return Err(global_this
-                    .throw_invalid_arguments(format_args!("TextDecoder(options) is invalid",)));
+                return Err(global_this.throw_invalid_argument_type_value(
+                    b"options",
+                    b"object",
+                    options_value,
+                ));
             }
 
             if let Some(fatal) = options_value.get(global_this, b"fatal")? {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -304,6 +304,52 @@ describe("TextDecoder", () => {
       const decoder = new TextDecoder("utf-8", undefined);
     }).not.toThrow();
   });
+
+  // https://webidl.spec.whatwg.org/#es-dictionary step 1:
+  // "If Type(V) is not Undefined, Null or Object, then throw a TypeError."
+  describe("options WebIDL dictionary conversion", () => {
+    const bytes = new Uint8Array([0x41, 0x42, 0x43]);
+
+    it.each([5, "x", true, 0n])("decode() rejects primitive options: %p", opt => {
+      const decoder = new TextDecoder();
+      expect(() => decoder.decode(bytes, opt)).toThrow(
+        expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    });
+
+    it("decode() rejects symbol options", () => {
+      const decoder = new TextDecoder();
+      expect(() => decoder.decode(bytes, Symbol())).toThrow(
+        expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    });
+
+    it.each([[null], [undefined], [{}], [() => {}], [[]]])("decode() accepts %p options", opt => {
+      expect(new TextDecoder().decode(bytes, opt)).toBe("ABC");
+    });
+
+    it("decode() with bad options throws before touching stream state", () => {
+      const decoder = new TextDecoder();
+      decoder.decode(new Uint8Array([0xf0, 0x9f]), { stream: true });
+      expect(() => decoder.decode(new Uint8Array(), 5)).toThrow(TypeError);
+      // The streamed partial sequence is still buffered: the throw above did
+      // not flush it.
+      expect(decoder.decode(new Uint8Array([0x92, 0xa9]))).toBe("\u{1F4A9}");
+    });
+
+    it("constructor accepts null options", () => {
+      const decoder = new TextDecoder("utf-8", null);
+      expect(decoder.encoding).toBe("utf-8");
+      expect(decoder.fatal).toBe(false);
+      expect(decoder.ignoreBOM).toBe(false);
+    });
+
+    it("constructor rejects primitive options with ERR_INVALID_ARG_TYPE", () => {
+      expect(() => new TextDecoder("utf-8", 5)).toThrow(
+        expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    });
+  });
 });
 
 describe("TextDecoder ignoreBOM", () => {

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -337,17 +337,25 @@ describe("TextDecoder", () => {
       expect(decoder.decode(new Uint8Array([0x92, 0xa9]))).toBe("\u{1F4A9}");
     });
 
-    it("constructor accepts null options", () => {
-      const decoder = new TextDecoder("utf-8", null);
-      expect(decoder.encoding).toBe("utf-8");
-      expect(decoder.fatal).toBe(false);
-      expect(decoder.ignoreBOM).toBe(false);
-    });
-
-    it("constructor rejects primitive options with ERR_INVALID_ARG_TYPE", () => {
-      expect(() => new TextDecoder("utf-8", 5)).toThrow(
+    it.each([5, "x", true, 0n])("constructor rejects primitive options: %p", opt => {
+      expect(() => new TextDecoder("utf-8", opt)).toThrow(
         expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
       );
+    });
+
+    it("constructor rejects symbol options", () => {
+      expect(() => new TextDecoder("utf-8", Symbol())).toThrow(
+        expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    });
+
+    it.each([[null], [undefined], [{}], [() => {}], [[]]])("constructor accepts %p options", opt => {
+      const decoder = new TextDecoder("utf-8", opt);
+      expect({ encoding: decoder.encoding, fatal: decoder.fatal, ignoreBOM: decoder.ignoreBOM }).toEqual({
+        encoding: "utf-8",
+        fatal: false,
+        ignoreBOM: false,
+      });
     });
   });
 });


### PR DESCRIPTION
## Repro

```js
new TextDecoder().decode(new Uint8Array([65, 66, 67]), 5);
// Bun:  "ABC"
// Node: TypeError [ERR_INVALID_ARG_TYPE]: The "options" argument must be of type object. Received type number (5)

new TextDecoder("utf-8", null);
// Bun:  TypeError: TextDecoder(options) is invalid
// Node: ok (null is a valid default dictionary)
```

## Cause

[WebIDL dictionary conversion](https://webidl.spec.whatwg.org/#es-dictionary) step 1: *If Type(esDict) is not Undefined, Null or Object, then throw a TypeError.*

`decode()` only read `options.stream` when `options.is_object()` was true and otherwise fell through to `stream = false`, so primitives were accepted silently. The constructor gated on `!is_undefined()` rather than `!is_undefined_or_null()`, so `null` was rejected.

## Fix

In both `decode()` and the constructor: when the options argument is present and not undefined/null, require it to be an object and throw `ERR_INVALID_ARG_TYPE` (matching Node) if it is not. `null` is now accepted as the default dictionary in both places. The `decode()` check runs before input validation and before the stream state is touched, so a rejected options argument leaves the decoder unchanged.

## Verification

```
USE_SYSTEM_BUN=1 bun test text-decoder.test.js -t "options WebIDL"   # 7 fail
bun bd test text-decoder.test.js -t "options WebIDL"                 # 13 pass
bun bd test text-decoder.test.js                                     # 117 pass
```

Node WPT encoding tests in `test/js/node/test/parallel/test-whatwg-encoding-*.js` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-decoder.test.js
bun test v1.4.0 (88244f808)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [2477.77ms]
(pass) TextDecoder > should decode ascii text [133.44ms]
(pass) TextDecoder > should decode unicode text [2901.99ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [2.83ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array [0.49ms]
(pass) TextDecoder > typedArrays > should decode Uint32Array [0.40ms]
(pass) TextDecoder > typedArrays > should decode Int8Array [0.33ms]
(pass) TextDecoder > typedArrays > should decode Int16Array [0.36ms]
(pass) TextDecoder > typedArrays > should decode Int32Array [0.33ms]
(pass) TextDecoder > typedArrays > should decode Float16Array [0.35ms]
(pass) TextDecoder > typedArrays > should decode Float32Array [0.43ms]
(pass) TextDecoder > typedArrays > should decode Float64Array [0.45ms]
(pass) TextDecoder > typedArrays > should decode DataView [0.35ms]
(pass) TextDecoder > typedArrays > should decode BigInt64Arra
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (88244f808)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [10.46ms]
(pass) TextDecoder > should decode ascii text [5.83ms]
(pass) TextDecoder > should decode unicode text [96.20ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [0.12ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array [0.01ms]
(pass) TextDecoder > typedArrays > should decode Uint32Array
(pass) TextDecoder > typedArrays > should decode Int8Array
(pass) TextDecoder > typedArrays > should decode Int16Array
(pass) TextDecoder > typedArrays > should decode Int32Array
(pass) TextDecoder > typedArrays > should decode Float16Array
(pass) TextDecoder > typedArrays > should decode Float32Array
(pass) TextDecoder > typedArrays > should decode Float64Array
(pass) TextDecoder > typedArrays > should decode DataView
(pass) TextDecoder > typedArrays > should decode BigInt64Array
(pass) TextDecoder > typedArrays > should decode BigUint64Array
(pass) TextDecoder > typedArrays > DOMJIT call [35.30ms]
(pass) TextDecoder > should decode unicode text with multiple consecutive emoji [8.92ms]
(pass) TextDecoder > coerces the
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/encoding/text-decoder.test.js
bun test v1.4.0 (88244f808)

test/js/web/encoding/text-decoder.test.js:
(pass) TextDecoder > should not crash on empty text [2462.81ms]
(pass) TextDecoder > should decode ascii text [141.91ms]
(pass) TextDecoder > should decode unicode text [2913.99ms]
(pass) TextDecoder > typedArrays > should decode Uint8Array [3.14ms]
(pass) TextDecoder > typedArrays > should decode Uint16Array [0.52ms]
(pass) TextDecoder > typedArrays > should decode Uint32Array [0.37ms]
(pass) TextDecoder > typedArrays > should decode Int8Array [0.38ms]
(pass) TextDecoder > typedArrays > should decode Int16Array [0.35ms]
(pass) TextDecoder > typedArrays > should decode Int32Array [0.38ms]
(pass) TextDecoder > typedArrays > should decode Float16Array [0.35ms]
(pass) TextDecoder > typedArrays > should decode Float32Array [0.47ms]
(pass) TextDecoder > typedArrays > should decode Float64Array [0.33ms]
(pass) TextDecoder > typedArrays > should decode DataView [0.38ms]
(pass) TextDecoder > typedArrays > should decode BigInt64Arra
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 723ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/27] cc obj/packages/bun-usockets/src/context.c.o
[2/27] cc obj/packages/bun-usockets/src/bsd.c.o
[3/27] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[4/27] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[5/27] cc obj/packages/bun-usockets/src/loop.c.o
[6/27] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[7/27] cc obj/packages/bun-usockets/src/socket.c.o
[8/27] cc obj/packages/bun-usockets/src/quic.c.o
[9/27] cc obj/packages/bun-usockets/src/udp.c.o
[10/27] cc obj/packages/bun-usockets/src/fault_inject.c.o
[11/27] cxx obj/src/jsc/bindings/bindings.cpp.o
[12/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[13/27] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[14/27] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[15/27] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[16/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[17/27] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[18/27] cxx obj/unified/UnifiedSource
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/TextDecoder.rs        | 20 +++++++++---
 test/js/web/encoding/text-decoder.test.js | 54 +++++++++++++++++++++++++++++++
 2 files changed, 70 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/webcore/TextDecoder.rs             2      2      0
test/js/web/encoding/text-decoder.test.js      4      3      0
```

</details>

<!-- robobun:evidence:end -->