### PR TITLE
Blob/Response .text(): stop sniffing UTF-16LE BOM on in-memory bytes

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -296,6 +296,7 @@ pub trait BlobExt {
         &self,
         global: &JSGlobalObject,
         raw_bytes: *mut [u8],
+        sniff_utf16: bool,
     ) -> JsResult<JSValue>;
     fn to_string_transfer(&self, global: &JSGlobalObject) -> JsResult<JSValue>;
     fn to_string(&self, global: &JSGlobalObject, lifetime: Lifetime) -> JsResult<JSValue>;
@@ -307,6 +308,7 @@ pub trait BlobExt {
         &self,
         global: &JSGlobalObject,
         raw_bytes: *mut [u8],
+        sniff_utf16: bool,
     ) -> JsResult<JSValue>;
     /// # Safety
     /// `buf` must be valid for reads for the duration of the call.
@@ -2608,14 +2610,17 @@ impl BlobExt for Blob {
         &self,
         global: &JSGlobalObject,
         raw_bytes: *mut [u8],
+        sniff_utf16: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: `raw_bytes` is valid for reads for the duration of this call
         // (either a leaked Box for `Temporary` or a store-backed view otherwise).
         let raw_slice: &[u8] = unsafe { &*raw_bytes };
         // File API `text()` is "UTF-8 decode" (strip only EF BB BF). The UTF-16LE
         // BOM sniff is a Bun.file/S3 convenience (documented in docs/runtime/s3.mdx)
-        // and must not leak into standard Blob/Response(blob).text().
-        let (bom, buf) = if self.is_bun_file() || self.is_s3() {
+        // and must not leak into standard Blob/Response(blob).text(). `sniff_utf16`
+        // is decided at dispatch time because the S3 download callback swaps the
+        // store to `Data::Bytes` before this runs.
+        let (bom, buf) = if sniff_utf16 {
             strings::BOM::detect_and_split(raw_slice)
         } else {
             (None, strings::without_utf8_bom(raw_slice))
@@ -2787,15 +2792,15 @@ impl BlobExt for Blob {
             // SAFETY: `view_ptr` is the store-backed view from `shared_view_raw`;
             // valid for reads while the store ref is held.
             Lifetime::Clone => unsafe {
-                self.to_string_with_bytes::<{ Lifetime::Clone }>(global, view_ptr)
+                self.to_string_with_bytes::<{ Lifetime::Clone }>(global, view_ptr, false)
             },
             // SAFETY: same as `Clone` above.
             Lifetime::Transfer => unsafe {
-                self.to_string_with_bytes::<{ Lifetime::Transfer }>(global, view_ptr)
+                self.to_string_with_bytes::<{ Lifetime::Transfer }>(global, view_ptr, false)
             },
             // SAFETY: same as `Clone` above.
             Lifetime::Share => unsafe {
-                self.to_string_with_bytes::<{ Lifetime::Share }>(global, view_ptr)
+                self.to_string_with_bytes::<{ Lifetime::Share }>(global, view_ptr, false)
             },
             // UB guard: `Temporary` would `heap::take(view_ptr)`, but
             // `view_ptr` points at a store-owned interior slice (not a leaked
@@ -2825,15 +2830,15 @@ impl BlobExt for Blob {
             // SAFETY: `view_ptr` is the store-backed view from `shared_view_raw`;
             // valid for reads while the store ref is held.
             Lifetime::Clone => unsafe {
-                self.to_json_with_bytes::<{ Lifetime::Clone }>(global, view_ptr)
+                self.to_json_with_bytes::<{ Lifetime::Clone }>(global, view_ptr, false)
             },
             // SAFETY: same as `Clone` above.
             Lifetime::Transfer => unsafe {
-                self.to_json_with_bytes::<{ Lifetime::Transfer }>(global, view_ptr)
+                self.to_json_with_bytes::<{ Lifetime::Transfer }>(global, view_ptr, false)
             },
             // SAFETY: same as `Clone` above.
             Lifetime::Share => unsafe {
-                self.to_json_with_bytes::<{ Lifetime::Share }>(global, view_ptr)
+                self.to_json_with_bytes::<{ Lifetime::Share }>(global, view_ptr, false)
             },
             // UB guard: `Temporary` would `heap::take(view_ptr)`, but
             // `view_ptr` points at a store-owned interior slice (not a leaked
@@ -2854,12 +2859,13 @@ impl BlobExt for Blob {
         &self,
         global: &JSGlobalObject,
         raw_bytes: *mut [u8],
+        sniff_utf16: bool,
     ) -> JsResult<JSValue> {
         // SAFETY: `raw_bytes` is valid for reads for the duration of this call
         // (either a leaked Box for `Temporary` or a store-backed view otherwise).
         let raw_slice: &[u8] = unsafe { &*raw_bytes };
         // Same gate as `to_string_with_bytes`: only Bun.file/S3 sniff a UTF-16LE BOM.
-        let (bom, buf) = if self.is_bun_file() || self.is_s3() {
+        let (bom, buf) = if sniff_utf16 {
             strings::BOM::detect_and_split(raw_slice)
         } else {
             (None, strings::without_utf8_bom(raw_slice))
@@ -6292,14 +6298,19 @@ pub struct ToFormDataWithBytesFn;
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl read_file::ReadFileToJs for ToStringWithBytesFn {
     fn call(b: &Blob, g: &JSGlobalObject, by: *mut [u8], l: Lifetime) -> JsResult<JSValue> {
+        // `ReadFileToJs` is only reached via `do_read_file` / `do_read_from_s3`,
+        // i.e. the bytes originate from Bun.file()/S3, so the UTF-16LE BOM sniff
+        // is enabled here (and nowhere else).
         // SAFETY: `by` upholds the `ReadFileToJs::call` contract — a leaked
         // `Box<[u8]>` for `Temporary`, store-backed otherwise.
         unsafe {
             match l {
-                Lifetime::Clone => b.to_string_with_bytes::<{ Lifetime::Clone }>(g, by),
-                Lifetime::Temporary => b.to_string_with_bytes::<{ Lifetime::Temporary }>(g, by),
-                Lifetime::Share => b.to_string_with_bytes::<{ Lifetime::Share }>(g, by),
-                Lifetime::Transfer => b.to_string_with_bytes::<{ Lifetime::Transfer }>(g, by),
+                Lifetime::Clone => b.to_string_with_bytes::<{ Lifetime::Clone }>(g, by, true),
+                Lifetime::Temporary => {
+                    b.to_string_with_bytes::<{ Lifetime::Temporary }>(g, by, true)
+                }
+                Lifetime::Share => b.to_string_with_bytes::<{ Lifetime::Share }>(g, by, true),
+                Lifetime::Transfer => b.to_string_with_bytes::<{ Lifetime::Transfer }>(g, by, true),
             }
         }
     }
@@ -6310,10 +6321,10 @@ impl read_file::ReadFileToJs for ToJsonWithBytesFn {
         // SAFETY: see `ToStringWithBytesFn::call`.
         unsafe {
             match l {
-                Lifetime::Clone => b.to_json_with_bytes::<{ Lifetime::Clone }>(g, by),
-                Lifetime::Temporary => b.to_json_with_bytes::<{ Lifetime::Temporary }>(g, by),
-                Lifetime::Share => b.to_json_with_bytes::<{ Lifetime::Share }>(g, by),
-                Lifetime::Transfer => b.to_json_with_bytes::<{ Lifetime::Transfer }>(g, by),
+                Lifetime::Clone => b.to_json_with_bytes::<{ Lifetime::Clone }>(g, by, true),
+                Lifetime::Temporary => b.to_json_with_bytes::<{ Lifetime::Temporary }>(g, by, true),
+                Lifetime::Share => b.to_json_with_bytes::<{ Lifetime::Share }>(g, by, true),
+                Lifetime::Transfer => b.to_json_with_bytes::<{ Lifetime::Transfer }>(g, by, true),
             }
         }
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2612,7 +2612,14 @@ impl BlobExt for Blob {
         // SAFETY: `raw_bytes` is valid for reads for the duration of this call
         // (either a leaked Box for `Temporary` or a store-backed view otherwise).
         let raw_slice: &[u8] = unsafe { &*raw_bytes };
-        let (bom, buf) = strings::BOM::detect_and_split(raw_slice);
+        // File API `text()` is "UTF-8 decode" (strip only EF BB BF). The UTF-16LE
+        // BOM sniff is a Bun.file/S3 convenience (documented in docs/runtime/s3.mdx)
+        // and must not leak into standard Blob/Response(blob).text().
+        let (bom, buf) = if self.is_bun_file() || self.is_s3() {
+            strings::BOM::detect_and_split(raw_slice)
+        } else {
+            (None, strings::without_utf8_bom(raw_slice))
+        };
 
         if buf.is_empty() {
             // If all it contained was the bom, we need to free the bytes
@@ -2850,7 +2857,13 @@ impl BlobExt for Blob {
     ) -> JsResult<JSValue> {
         // SAFETY: `raw_bytes` is valid for reads for the duration of this call
         // (either a leaked Box for `Temporary` or a store-backed view otherwise).
-        let (bom, buf) = strings::BOM::detect_and_split(unsafe { &*raw_bytes });
+        let raw_slice: &[u8] = unsafe { &*raw_bytes };
+        // Same gate as `to_string_with_bytes`: only Bun.file/S3 sniff a UTF-16LE BOM.
+        let (bom, buf) = if self.is_bun_file() || self.is_s3() {
+            strings::BOM::detect_and_split(raw_slice)
+        } else {
+            (None, strings::without_utf8_bom(raw_slice))
+        };
         if buf.is_empty() {
             if LIFETIME == Lifetime::Temporary {
                 // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -348,6 +348,17 @@ for (let credentials of allCredentials) {
               expect(text).toBe("Hello Bun!");
             });
 
+            it("text()/json() should honour a UTF-16LE BOM", async () => {
+              // docs/runtime/s3.mdx: S3File.text()/json() decode as UTF-16 when
+              // the payload begins with a UTF-16LE BOM (FF FE).
+              await using tmpfile = await tmp();
+              const file = bucket.file(tmpfile.name, options!);
+              await file.write(Buffer.of(0xff, 0xfe, 0x68, 0x00, 0x69, 0x00));
+              expect(await file.text()).toBe("hi");
+              await file.write(Buffer.of(0xff, 0xfe, 0x34, 0x00, 0x32, 0x00));
+              expect(await file.json()).toBe(42);
+            });
+
             it("should download range", async () => {
               await using tmpfile = await tmp();
               const file = bucket.file(tmpfile.name, options!);

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -348,17 +348,6 @@ for (let credentials of allCredentials) {
               expect(text).toBe("Hello Bun!");
             });
 
-            it("text()/json() should honour a UTF-16LE BOM", async () => {
-              // docs/runtime/s3.mdx: S3File.text()/json() decode as UTF-16 when
-              // the payload begins with a UTF-16LE BOM (FF FE).
-              await using tmpfile = await tmp();
-              const file = bucket.file(tmpfile.name, options!);
-              await file.write(Buffer.of(0xff, 0xfe, 0x68, 0x00, 0x69, 0x00));
-              expect(await file.text()).toBe("hi");
-              await file.write(Buffer.of(0xff, 0xfe, 0x34, 0x00, 0x32, 0x00));
-              expect(await file.json()).toBe(42);
-            });
-
             it("should download range", async () => {
               await using tmpfile = await tmp();
               const file = bucket.file(tmpfile.name, options!);

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -523,13 +523,11 @@ test("Blob constructor copies typed array parts before later parts run user code
   expect(exitCode).toBe(0);
 });
 
-test("Bun.file().slice at an odd byte offset decodes UTF-16LE (BOM) content with text() and json()", async () => {
+test("Bun.file() with a leading UTF-16LE BOM decodes via text() and json(), including after slice()", async () => {
   // Bun.file().text()/.json() sniff a leading UTF-16LE BOM (FF FE) as a
-  // convenience (standard Blob does not). A file sliced at an odd start keeps a
-  // view into the store at an odd byte offset; the UTF-16 decode of those
-  // odd-aligned bytes must not abort on alignment. Run in a subprocess so a
-  // process abort surfaces as a nonzero exit code.
-  using dir = tempDir("bunfile-utf16le-odd-slice", {});
+  // convenience; standard Blob does not. Run in a subprocess so a process abort
+  // surfaces as a nonzero exit code rather than killing the test runner.
+  using dir = tempDir("bunfile-utf16le-bom", {});
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -537,17 +535,17 @@ test("Bun.file().slice at an odd byte offset decodes UTF-16LE (BOM) content with
       `
         import { writeFileSync } from "node:fs";
         // 0x41 prefix byte, then UTF-16LE BOM (FF FE) followed by "hi" / "42".
-        // slice(1) makes the decoded view start at an odd offset into the file.
+        // slice(1) makes the read window start one byte into the file.
         writeFileSync("t.bin", new Uint8Array([0x41, 0xff, 0xfe, 0x68, 0x00, 0x69, 0x00]));
-        const oddText = await Bun.file("t.bin").slice(1).text();
+        const slicedText = await Bun.file("t.bin").slice(1).text();
 
         writeFileSync("j.bin", new Uint8Array([0x41, 0xff, 0xfe, 0x34, 0x00, 0x32, 0x00]));
-        const oddJson = await Bun.file("j.bin").slice(1).json();
+        const slicedJson = await Bun.file("j.bin").slice(1).json();
 
         writeFileSync("a.bin", new Uint8Array([0xff, 0xfe, 0x68, 0x00, 0x69, 0x00]));
-        const alignedText = await Bun.file("a.bin").text();
+        const wholeText = await Bun.file("a.bin").text();
 
-        console.log(JSON.stringify({ oddText, oddJson, alignedText }));
+        console.log(JSON.stringify({ slicedText, slicedJson, wholeText }));
       `,
     ],
     env: bunEnv,
@@ -558,7 +556,7 @@ test("Bun.file().slice at an odd byte offset decodes UTF-16LE (BOM) content with
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim()).toBe(JSON.stringify({ oddText: "hi", oddJson: 42, alignedText: "hi" }));
+  expect(stdout.trim()).toBe(JSON.stringify({ slicedText: "hi", slicedJson: 42, wholeText: "hi" }));
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -523,32 +523,35 @@ test("Blob constructor copies typed array parts before later parts run user code
   expect(exitCode).toBe(0);
 });
 
-test("Blob.slice at an odd byte offset decodes UTF-16LE (BOM) content with text() and json()", async () => {
-  // A blob sliced at an odd start keeps a view into the original store at an odd
-  // byte offset. When the bytes at that offset begin with a UTF-16LE BOM (FF FE),
-  // text()/json() must decode the remaining (odd-aligned) bytes as UTF-16 instead
-  // of aborting. Run in a subprocess so a process abort surfaces as a nonzero exit
-  // code rather than killing the test runner.
+test("Bun.file().slice at an odd byte offset decodes UTF-16LE (BOM) content with text() and json()", async () => {
+  // Bun.file().text()/.json() sniff a leading UTF-16LE BOM (FF FE) as a
+  // convenience (standard Blob does not). A file sliced at an odd start keeps a
+  // view into the store at an odd byte offset; the UTF-16 decode of those
+  // odd-aligned bytes must not abort on alignment. Run in a subprocess so a
+  // process abort surfaces as a nonzero exit code.
+  using dir = tempDir("bunfile-utf16le-odd-slice", {});
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
+        import { writeFileSync } from "node:fs";
         // 0x41 prefix byte, then UTF-16LE BOM (FF FE) followed by "hi" / "42".
-        // slice(1) makes the decoded view start at an odd offset into the backing store.
-        const textBytes = new Uint8Array([0x41, 0xff, 0xfe, 0x68, 0x00, 0x69, 0x00]);
-        const oddText = await new Blob([textBytes]).slice(1).text();
+        // slice(1) makes the decoded view start at an odd offset into the file.
+        writeFileSync("t.bin", new Uint8Array([0x41, 0xff, 0xfe, 0x68, 0x00, 0x69, 0x00]));
+        const oddText = await Bun.file("t.bin").slice(1).text();
 
-        const jsonBytes = new Uint8Array([0x41, 0xff, 0xfe, 0x34, 0x00, 0x32, 0x00]);
-        const oddJson = await new Blob([jsonBytes]).slice(1).json();
+        writeFileSync("j.bin", new Uint8Array([0x41, 0xff, 0xfe, 0x34, 0x00, 0x32, 0x00]));
+        const oddJson = await Bun.file("j.bin").slice(1).json();
 
-        // The aligned (offset 0) UTF-16LE BOM case keeps working too.
-        const alignedText = await new Blob([new Uint8Array([0xff, 0xfe, 0x68, 0x00, 0x69, 0x00])]).text();
+        writeFileSync("a.bin", new Uint8Array([0xff, 0xfe, 0x68, 0x00, 0x69, 0x00]));
+        const alignedText = await Bun.file("a.bin").text();
 
         console.log(JSON.stringify({ oddText, oddJson, alignedText }));
       `,
     ],
     env: bunEnv,
+    cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/web/fetch/utf8-bom.test.ts
+++ b/test/js/web/fetch/utf8-bom.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { join } from "node:path";
 import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 // File API spec: Blob.text() is "UTF-8 decode" — it strips only the UTF-8 BOM
 // (EF BB BF). A leading FF FE is two invalid UTF-8 bytes, not a signal to switch
@@ -78,11 +78,7 @@ describe("UTF-16LE BOM is not sniffed by Blob/Response .text()", () => {
       console.log(JSON.stringify([a, b, c]));
     `;
     await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual([utf8, utf8, utf8]);
     expect(exitCode).toBe(0);

--- a/test/js/web/fetch/utf8-bom.test.ts
+++ b/test/js/web/fetch/utf8-bom.test.ts
@@ -1,4 +1,93 @@
 import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+import { writeFileSync } from "node:fs";
+
+// File API spec: Blob.text() is "UTF-8 decode" — it strips only the UTF-8 BOM
+// (EF BB BF). A leading FF FE is two invalid UTF-8 bytes, not a signal to switch
+// encodings. Bun.file()/S3 keep a documented UTF-16LE convenience; standard
+// Blob/Response must not.
+describe("UTF-16LE BOM is not sniffed by Blob/Response .text()", () => {
+  // FF FE 68 69: as UTF-16LE this is U+6968 "楨"; as UTF-8 it is two invalid
+  // bytes then "hi".
+  const FF_FE_hi = Uint8Array.of(0xff, 0xfe, 0x68, 0x69);
+  const utf8 = "\uFFFD\uFFFDhi";
+
+  test("Blob.text()", async () => {
+    expect(await new Blob([FF_FE_hi]).text()).toBe(utf8);
+  });
+
+  test("File.text()", async () => {
+    expect(await new File([FF_FE_hi], "f").text()).toBe(utf8);
+  });
+
+  test("Response(blob).text() matches Response(bytes).text()", async () => {
+    expect(await new Response(new Blob([FF_FE_hi])).text()).toBe(utf8);
+    expect(await new Response(FF_FE_hi).text()).toBe(utf8);
+  });
+
+  test("Request(blob).text()", async () => {
+    const req = new Request("http://x", { method: "POST", body: new Blob([FF_FE_hi]) });
+    expect(await req.text()).toBe(utf8);
+  });
+
+  test("fetch().text() and fetch().blob().text() agree", async () => {
+    await using server = Bun.serve({ port: 0, fetch: () => new Response(FF_FE_hi) });
+    const url = `http://127.0.0.1:${server.port}/`;
+    const [direct, viaBlob] = await Promise.all([
+      fetch(url).then(r => r.text()),
+      fetch(url)
+        .then(r => r.blob())
+        .then(b => b.text()),
+    ]);
+    expect({ direct, viaBlob }).toEqual({ direct: utf8, viaBlob: utf8 });
+  });
+
+  test("Blob.json() does not sniff FF FE either", async () => {
+    // FF FE then `1` `\0` — would parse as JSON `1` under UTF-16LE, must throw
+    // as invalid UTF-8 JSON.
+    const blob = new Blob([Uint8Array.of(0xff, 0xfe, 0x31, 0x00)]);
+    expect(async () => await blob.json()).toThrow();
+  });
+
+  test("UTF-32LE-looking prefix is not misread as UTF-16LE", async () => {
+    const u32 = Uint8Array.of(0xff, 0xfe, 0x00, 0x00, 0x41, 0x00, 0x00, 0x00);
+    expect(await new Blob([u32]).text()).toBe("\uFFFD\uFFFD\0\0A\0\0\0");
+  });
+
+  test("UTF-16BE BOM is not sniffed either (control)", async () => {
+    const be = Uint8Array.of(0xfe, 0xff, 0x00, 0x41);
+    expect(await new Blob([be]).text()).toBe("\uFFFD\uFFFD\0A");
+  });
+
+  // Bun.file() intentionally keeps the UTF-16LE sniff (#8219, docs/runtime/s3.mdx).
+  test("Bun.file().text() still honours a UTF-16LE BOM", async () => {
+    using dir = tempDir("blob-utf16le-bom", {});
+    const p = join(String(dir), "f.txt");
+    writeFileSync(p, Buffer.of(0xff, 0xfe, 0x68, 0x00, 0x69, 0x00));
+    expect(await Bun.file(p).text()).toBe("hi");
+  });
+
+  // Node.js parity in a fresh process: every reader agrees.
+  test("subprocess: Blob/Response readers all UTF-8-decode FF FE", async () => {
+    const src = `
+      const u = Uint8Array.of(0xff, 0xfe, 0x68, 0x69);
+      const a = await new Blob([u]).text();
+      const b = await new Response(u).text();
+      const c = await new Response(new Blob([u])).text();
+      console.log(JSON.stringify([a, b, c]));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([utf8, utf8, utf8]);
+    expect(exitCode).toBe(0);
+  });
+});
 
 describe("UTF-8 BOM should be ignored", () => {
   test("handles empty strings", async () => {


### PR DESCRIPTION
## Problem

`Blob.text()` / `File.text()` / `new Response(blob).text()` detect a leading `FF FE` (UTF-16LE BOM) and decode the whole payload as UTF-16LE, while the byte-backed readers of the **same** bytes (`new Response(uint8array).text()`, `fetch(url).text()`, `TextDecoder`) do the specified UTF-8 decode. The [File API spec](https://w3c.github.io/FileAPI/#dom-blob-text) defines `Blob.text()` as "UTF-8 decode", which strips only the UTF-8 BOM (`EF BB BF`).

```js
const u = Uint8Array.of(0xff, 0xfe, 0x68, 0x69);
await new Response(u).text();              // "\uFFFD\uFFFDhi"  (spec)
await new Response(new Blob([u])).text();  // "\u6968"          (sniffed as UTF-16LE)
await fetch(url).then(r => r.text());      // "\uFFFD\uFFFDhi"
await fetch(url).then(r => r.blob()).then(b => b.text()); // "\u6968"
```

Node.js and browsers produce `"\uFFFD\uFFFDhi"` for all four. The sniff is also LE-only (`FE FF` is not sniffed) and mis-reads a UTF-32LE BOM (`FF FE 00 00 ...`) as UTF-16LE.

## Cause

`to_string_with_bytes` / `to_json_with_bytes` in `src/runtime/webcore/Blob.rs` call `strings::BOM::detect_and_split` unconditionally, which returns `Utf16Le` for any payload starting with `FF FE`. That branch was added in #8219 as a convenience for `Bun.file()` on Windows (where text files are sometimes saved as UTF-16LE with BOM) but applies to every byte-backed Blob.

## Fix

Gate the UTF-16LE sniff on `self.is_bun_file() || self.is_s3()`. In-memory `Blob` / `File` / `Response(blob)` / `Request(blob)` now do the spec UTF-8 decode (strip only `EF BB BF`), matching Node and browsers. `Bun.file().text()` and S3 `.text()` keep the documented UTF-16LE convenience (see `docs/runtime/s3.mdx`).

The existing odd-offset UTF-16LE alignment regression test in `blob.test.ts` is retargeted at `Bun.file()`, the only path that still reaches the UTF-16LE branch.

## Verification

```
$ bun bd test test/js/web/fetch/utf8-bom.test.ts test/js/web/fetch/blob.test.ts test/js/web/fetch/body.test.ts
 425 pass
 4 skip
 0 fail
```

Before the fix, 8 of the new `utf8-bom.test.ts` cases fail with `Received: "楨"` where `"\uFFFD\uFFFDhi"` is expected.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts "test/js/web/fetch/utf8-bom.test.ts"
bun test v1.4.0 (86c989a56)

test/js/web/fetch/utf8-bom.test.ts:
12 |   // bytes then "hi".
13 |   const FF_FE_hi = Uint8Array.of(0xff, 0xfe, 0x68, 0x69);
14 |   const utf8 = "\uFFFD\uFFFDhi";
15 | 
16 |   test("Blob.text()", async () => {
17 |     expect(await new Blob([FF_FE_hi]).text()).toBe(utf8);
                                                   ^
error: expect(received).toBe(expected)

Expected: "��hi"
Received: "楨"

      at <anonymous> (/workspace/bun/test/js/web/fetch/utf8-bom.test.ts:17:47)
(fail) UTF-16LE BOM is not sniffed by Blob/Response .text() > Blob.text() [8.04ms]
16 |   test("Blob.text()", async () => {
17 |     expect(await new Blob([FF_FE_hi]).text()).toBe(utf8);
18 |   });
19 | 
20 |   test("File.text()", async () => {
21 |     expect(await new File([FF_FE_hi], "f").text()).toBe(utf8);
                                                        ^
error: expect(received).toBe(expected)

Expected: "��hi"
Received: "楨"

      at <anonymous> 
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (5fdc7e8dc)

test/js/web/fetch/utf8-bom.test.ts:
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Blob.text() [0.13ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > File.text() [0.05ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Response(blob).text() matches Response(bytes).text() [0.11ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Request(blob).text() [0.09ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > fetch().text() and fetch().blob().text() agree [1.90ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Blob.json() does not sniff FF FE either [0.13ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > UTF-32LE-looking prefix is not misread as UTF-16LE [0.06ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > UTF-16BE BOM is not sniffed either (control) [0.04ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Bun.file().text() still honours a UTF-16LE BOM [1.05ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > subprocess: Blob/Response readers all UTF-8-decode FF FE [11.78ms]
(pass) UTF-8 B
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts "test/js/web/fetch/utf8-bom.test.ts"
bun test v1.4.0 (86c989a56)

test/js/web/fetch/utf8-bom.test.ts:
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Blob.text() [5.75ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > File.text() [4.40ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Response(blob).text() matches Response(bytes).text() [6.52ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Request(blob).text() [8.36ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > fetch().text() and fetch().blob().text() agree [42.16ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Blob.json() does not sniff FF FE either [7.28ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > UTF-32LE-looking prefix is not misread as UTF-16LE [4.58ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > UTF-16BE BOM is not sniffed either (control) [4.53ms]
(pass) UTF-16LE BOM is not sniffed by Blob/Response .text() > Bun.fi
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 827ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[2/28] cc obj/packages/bun-usockets/src/bsd.c.o
[3/28] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[4/28] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[5/28] cc obj/packages/bun-usockets/src/fault_inject.c.o
[6/28] cc obj/packages/bun-usockets/src/context.c.o
[7/28] cc obj/packages/bun-usockets/src/loop.c.o
[8/28] cc obj/packages/bun-usockets/src/quic.c.o
[9/28] cc obj/packages/bun-usockets/src/socket.c.o
[10/28] cc obj/packages/bun-usockets/src/udp.c.o
[11/28] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[12/28] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[13/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[14/28] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[15/28] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[16/28] cxx obj/src/jsc/bindings/bindings.cpp.o
[17/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[18/28] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs        | 56 ++++++++++++++++++-------
 test/js/web/fetch/blob.test.ts     | 31 +++++++-------
 test/js/web/fetch/utf8-bom.test.ts | 85 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 141 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/runtime/webcore/Blob.rs             9      7      0
test/js/web/fetch/blob.test.ts          1      2      0
test/js/web/fetch/utf8-bom.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->