### PR TITLE
Validate require.resolve options.paths entries and handle relative paths

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -372,6 +372,12 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                 WTF::Vector<BunString> paths;
                 for (size_t i = 0; i < userPathListArray->length(); ++i) {
                     JSValue path = userPathListArray->getIndex(globalObject, i);
+                    if (scope.exception()) [[unlikely]]
+                        goto cleanup;
+                    if (!path.isString()) {
+                        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, makeString("paths["_s, i, "]"_s), "string"_s, path);
+                        goto cleanup;
+                    }
                     WTF::String pathStr = path.toWTFString(globalObject);
                     if (scope.exception()) [[unlikely]]
                         goto cleanup;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -374,11 +374,18 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
             }
 
             WTF::Vector<BunString> paths;
+            size_t pathIndex = 0;
 
             // Iterate through the array using forEachInIterable
             forEachInIterable(globalObject, pathsValue, [&](JSC::VM&, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue item) {
                 if (scope.exception())
                     return;
+
+                if (!item.isString()) {
+                    Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, makeString("paths["_s, pathIndex, "]"_s), "string"_s, item);
+                    return;
+                }
+                pathIndex++;
 
                 WTF::String pathStr = item.toWTFString(lexicalGlobalObject);
                 if (scope.exception())

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2052,12 +2052,7 @@ impl<'a> Resolver<'a> {
                             None => continue,
                         }
                     };
-                    match self.check_package_path(
-                        abs_custom,
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    match self.check_package_path(abs_custom, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2040,10 +2040,20 @@ impl<'a> Resolver<'a> {
 
             if let Some(custom_paths) = self.custom_dir_paths {
                 bun_core::hint::cold();
+                let mut abs_buf = bun_paths::path_buffer_pool::get();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
+                    let custom_slice = custom_utf8.slice();
+                    let abs_custom = if bun_paths::is_absolute(custom_slice) {
+                        custom_slice
+                    } else {
+                        match self.fs_ref().abs_buf_checked(&[custom_slice], &mut abs_buf) {
+                            Some(p) => p,
+                            None => continue,
+                        }
+                    };
                     match self.check_package_path(
-                        custom_utf8.slice(),
+                        abs_custom,
                         import_path,
                         kind,
                         global_cache,

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -199,3 +199,41 @@ test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is no
     Module._resolveFilename("path", __filename, false, { paths: { 0: "/some/path" } });
   }).toThrow();
 });
+
+test("require.resolve throws ERR_INVALID_ARG_TYPE if options.paths contains a non-string", () => {
+  let err;
+  try {
+    require.resolve("nonexistent", { paths: [new DataView(new ArrayBuffer(8))] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+
+  err = undefined;
+  try {
+    require.resolve("nonexistent", { paths: ["/tmp", {}] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+});
+
+test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths contains a non-string", () => {
+  let err;
+  try {
+    Module._resolveFilename("nonexistent", null, false, { paths: [{}] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+});
+
+test("require.resolve with a relative directory in options.paths does not crash", () => {
+  let err;
+  try {
+    require.resolve("nonexistent", { paths: ["not/an/absolute/path"] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("MODULE_NOT_FOUND");
+});


### PR DESCRIPTION
Fuzzer found a panic: `cannot resolve DirInfo for non-absolute path: [object DataView]`.

## What
`require.resolve('x', { paths: [...] })` and `Module._resolveFilename(..., { paths: [...] })` were coercing every `paths` entry to a string via `toWTFString`, so an object became `"[object Foo]"`. That string then flowed into the resolver's `check_package_path` as a search directory and hit the `dir_info_cached` assertion that the input is absolute. A plain relative string like `"rel/dir"` hit the same assertion.

## Fix
- `ImportMetaObject.cpp` / `NodeModuleModule.cpp`: throw `ERR_INVALID_ARG_TYPE` with `paths[i]` when an entry is not a string, matching Node.js.
- `resolver.rs`: when iterating `custom_dir_paths` for package resolution, absolutize non-absolute entries against `top_level_dir` before calling `check_package_path`. This matches Node, which resolves relative `paths` entries against cwd.

## Repro
```js
require.resolve('x', { paths: [new DataView(new ArrayBuffer(8))] }); // panicked, now ERR_INVALID_ARG_TYPE
require.resolve('x', { paths: ['rel/dir'] });                        // panicked, now MODULE_NOT_FOUND
```