### PR TITLE
Bump WebKit: fix BCRASH being compiled away on Windows clang-cl (BUN-2Z94)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -8,7 +8,9 @@
 // importing), every x64 at the nehalem floor (no separate -baseline variant),
 // typed-array constructor ClassInfo kept address-unique under LTO, and the
 // Windows ICU data table filtered + per-item zstd compressed.
-export const WEBKIT_VERSION = "c9296e353e365ecf0de82f273bb0a88a3df465be";
+// oven-sh/WebKit#316: BCRASH under clang-cl uses __builtin_trap(), so
+// RELEASE_BASSERT in bmalloc is no longer compiled away on Windows (BUN-2Z94).
+export const WEBKIT_VERSION = "autobuild-preview-pr-316-1892d614";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/util/fastmalloc-oom-crash.test.ts
+++ b/test/js/bun/util/fastmalloc-oom-crash.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// BUN-2Z94: on Windows (clang-cl + USE_MIMALLOC), BCRASH() in bmalloc's
+// BAssert.h was gated on defined(__GNUC__), which clang-cl does not define,
+// so it fell back to `((void(*)())0)()`. Clang treats that as unconditional
+// UB and deletes the surrounding branch, so every RELEASE_BASSERT in bmalloc
+// compiled to nothing at -O2 and WTF::fastMalloc/fastCompactMalloc became a
+// bare `jmp mi_malloc`. On OOM mi_malloc returned nullptr and callers
+// placement-newed into 0x0 (std::_Atomic_storage in StringImpl via JSON.parse).
+//
+// With the fix, BCRASH() under clang-cl uses __builtin_trap() preceded by a
+// store to 0xbbadbeef, so an OOM inside fastMalloc is a segfault at
+// 0xBBADBEEF at the allocation site instead of a null deref at some downstream
+// caller.
+//
+// Windows-only: the miscompile is specific to clang-cl's predefined macros,
+// and MIMALLOC_DISALLOW_OS_ALLOC is the only reliable way to force a fast
+// mi_malloc failure (Linux/macOS use overcommit / direct mmap for huge
+// allocations so the same knobs do not produce a prompt failure there).
+test.skipIf(!isWindows)("fastMalloc OOM on Windows crashes at the allocator, not at a downstream null deref", async () => {
+  const script = `
+    const held = [];
+    const bigVal = Buffer.alloc(1024 * 1024, "x").toString();
+    const json = JSON.stringify([bigVal, bigVal, bigVal]);
+    while (true) {
+      held.push(JSON.parse(json));
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: {
+      ...bunEnv,
+      // Constrain mimalloc to a single small reserved arena so the ~1MB
+      // StringImpl allocations inside JSON.parse fail within a few hundred
+      // iterations instead of after exhausting the whole machine.
+      MIMALLOC_RESERVE_OS_MEMORY: "256MiB",
+      MIMALLOC_DISALLOW_OS_ALLOC: "1",
+      MIMALLOC_RETRY_ON_OOM: "0",
+      // Make sure no crash report is posted anywhere.
+      BUN_CRASH_REPORTER_URL: "",
+      BUN_ENABLE_CRASH_REPORTING: "0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The child is expected to crash (there is no catchable OOM error here yet),
+  // but the crash must originate at the RELEASE_BASSERT inside fastMalloc,
+  // which writes to 0xbbadbeef, not at a downstream consumer of a null
+  // StringImpl.
+  expect(stderr).toMatch(/BBADBEEF/i);
+  expect(stderr).not.toMatch(/at address 0x0\b/);
+
+  // And it must actually have crashed (not silently looped or exited 0).
+  expect(exitCode).not.toBe(0);
+
+  void stdout;
+});

--- a/test/js/bun/util/fastmalloc-oom-crash.test.ts
+++ b/test/js/bun/util/fastmalloc-oom-crash.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
 // BUN-2Z94: on Windows (clang-cl + USE_MIMALLOC), BCRASH() in bmalloc's
@@ -18,8 +18,10 @@ import { bunEnv, bunExe, isWindows } from "harness";
 // and MIMALLOC_DISALLOW_OS_ALLOC is the only reliable way to force a fast
 // mi_malloc failure (Linux/macOS use overcommit / direct mmap for huge
 // allocations so the same knobs do not produce a prompt failure there).
-test.skipIf(!isWindows)("fastMalloc OOM on Windows crashes at the allocator, not at a downstream null deref", async () => {
-  const script = `
+test.skipIf(!isWindows)(
+  "fastMalloc OOM on Windows crashes at the allocator, not at a downstream null deref",
+  async () => {
+    const script = `
     const held = [];
     const bigVal = Buffer.alloc(1024 * 1024, "x").toString();
     const json = JSON.stringify([bigVal, bigVal, bigVal]);
@@ -28,35 +30,36 @@ test.skipIf(!isWindows)("fastMalloc OOM on Windows crashes at the allocator, not
     }
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", script],
-    env: {
-      ...bunEnv,
-      // Constrain mimalloc to a single small reserved arena so the ~1MB
-      // StringImpl allocations inside JSON.parse fail within a few hundred
-      // iterations instead of after exhausting the whole machine.
-      MIMALLOC_RESERVE_OS_MEMORY: "256MiB",
-      MIMALLOC_DISALLOW_OS_ALLOC: "1",
-      MIMALLOC_RETRY_ON_OOM: "0",
-      // Make sure no crash report is posted anywhere.
-      BUN_CRASH_REPORTER_URL: "",
-      BUN_ENABLE_CRASH_REPORTING: "0",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: {
+        ...bunEnv,
+        // Constrain mimalloc to a single small reserved arena so the ~1MB
+        // StringImpl allocations inside JSON.parse fail within a few hundred
+        // iterations instead of after exhausting the whole machine.
+        MIMALLOC_RESERVE_OS_MEMORY: "256MiB",
+        MIMALLOC_DISALLOW_OS_ALLOC: "1",
+        MIMALLOC_RETRY_ON_OOM: "0",
+        // Make sure no crash report is posted anywhere.
+        BUN_CRASH_REPORTER_URL: "",
+        BUN_ENABLE_CRASH_REPORTING: "0",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // The child is expected to crash (there is no catchable OOM error here yet),
-  // but the crash must originate at the RELEASE_BASSERT inside fastMalloc,
-  // which writes to 0xbbadbeef, not at a downstream consumer of a null
-  // StringImpl.
-  expect(stderr).toMatch(/BBADBEEF/i);
-  expect(stderr).not.toMatch(/at address 0x0\b/);
+    // The child is expected to crash (there is no catchable OOM error here yet),
+    // but the crash must originate at the RELEASE_BASSERT inside fastMalloc,
+    // which writes to 0xbbadbeef, not at a downstream consumer of a null
+    // StringImpl.
+    expect(stderr).toMatch(/BBADBEEF/i);
+    expect(stderr).not.toMatch(/at address 0x0\b/);
 
-  // And it must actually have crashed (not silently looped or exited 0).
-  expect(exitCode).not.toBe(0);
+    // And it must actually have crashed (not silently looped or exited 0).
+    expect(exitCode).not.toBe(0);
 
-  void stdout;
-});
+    void stdout;
+  },
+);


### PR DESCRIPTION
Fixes [BUN-2Z94](https://bun-p9.sentry.io/issues/7419747874/): `std::_Atomic_storage<unsigned int,4>` segfault at `0x0` on Windows, usually inside `JSON.parse`.

## Repro

```
> MIMALLOC_RESERVE_OS_MEMORY=256MiB MIMALLOC_DISALLOW_OS_ALLOC=1 MIMALLOC_RETRY_ON_OOM=0 bun -e '
  const held = [];
  const json = JSON.stringify(["x".repeat(1<<20), "x".repeat(1<<20), "x".repeat(1<<20)]);
  while (true) held.push(JSON.parse(json));'

panic(main thread): Segmentation fault at address 0x0
```

~100 ms on any Windows machine.

## Cause

Disassembly of `FastMalloc.cpp.obj` from the Windows WebKit prebuilt:

```asm
WTF::fastCompactMalloc(unsigned __int64):
    jmp  mi_malloc
WTF::fastMalloc(unsigned __int64):
    jmp  mi_malloc
```

The `RELEASE_BASSERT(memory)` that should crash on a null `mi_malloc` return is gone.

`BCRASH()` in [`Source/bmalloc/bmalloc/BAssert.h`](https://github.com/oven-sh/WebKit/blob/c9296e353e365ecf0de82f273bb0a88a3df465be/Source/bmalloc/bmalloc/BAssert.h#L63-L73) is gated on `defined(__GNUC__)`. clang-cl defines `__clang__` and `_MSC_VER` but not `__GNUC__`, so it falls into the fallback:

```c
#define BCRASH() do { *(int*)0xbbadbeef = 0; ((void(*)())0)(); } while (0)
```

Calling a null function pointer is UB. clang uses it to prove the containing branch unreachable and deletes the whole `if (!memory)` block, so every `RELEASE_BASSERT` in bmalloc is a no-op on Windows. Minimal reducer:

```c
void* f(size_t n) {
    void* m = mi_malloc(n);
    if (!m) { ((void(*)())0)(); }        // clang-cl /O2 -> jmp mi_malloc (check deleted)
    return m;
}
void* g(size_t n) {
    void* m = mi_malloc(n);
    if (!m) { __builtin_trap(); }        // clang-cl /O2 -> test rax,rax; je; ud2 (check kept)
    return m;
}
```

## Fix

[oven-sh/WebKit#316](https://github.com/oven-sh/WebKit/pull/316) extends the gate to `defined(__GNUC__) || defined(__clang__)` so clang-cl takes the `__builtin_trap()` path.

This PR bumps `WEBKIT_VERSION` to that build and adds a Windows-only regression test that asserts the OOM crash reports `0xBBADBEEF` (the allocator's `RELEASE_BASSERT`) rather than `0x0` (a downstream null deref inside `StringImpl::createUninitializedInternalNonEmpty`).

## Verification

Fail-before with the current canary (`5b98630ac`, Windows x64 baseline):

```
(fail) fastMalloc OOM on Windows crashes at the allocator, not at a downstream null deref
Expected pattern: /BBADBEEF/i
Received: "...panic(main thread): Segmentation fault at address 0x0..."
```

With the patched WebKit, `fastCompactMalloc` compiles to `call mi_malloc; test rax,rax; je .L; ret; .L: mov [0xbbadbeef],0; ud2` and the test passes.

---

**Note:** `WEBKIT_VERSION` currently points at the preview build of oven-sh/WebKit#316. Once that PR is merged to main this will be updated to the resulting `autobuild-<sha>` tag.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->