### PR TITLE
jsc: throw RangeError from JSON.parse when a string value cannot be allocated

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -8,7 +8,7 @@
 // importing), every x64 at the nehalem floor (no separate -baseline variant),
 // typed-array constructor ClassInfo kept address-unique under LTO, and the
 // Windows ICU data table filtered + per-item zstd compressed.
-export const WEBKIT_VERSION = "autobuild-preview-pr-317-d9b06a28";
+export const WEBKIT_VERSION = "autobuild-preview-pr-317-23fb575d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -8,7 +8,7 @@
 // importing), every x64 at the nehalem floor (no separate -baseline variant),
 // typed-array constructor ClassInfo kept address-unique under LTO, and the
 // Windows ICU data table filtered + per-item zstd compressed.
-export const WEBKIT_VERSION = "c9296e353e365ecf0de82f273bb0a88a3df465be";
+export const WEBKIT_VERSION = "autobuild-preview-pr-317-d9b06a28";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/util/json-parse-oom-fixture.js
+++ b/test/js/bun/util/json-parse-oom-fixture.js
@@ -1,7 +1,12 @@
 // Force JSON.parse to hit allocator failure for its string-value copy.
-// Prepare a quoted JSON input of N bytes, then fill remaining address
-// space with buffers >= N/4 so an N-byte allocation cannot succeed while
-// smaller allocations (thread stacks, GC bookkeeping) still can.
+// Prepare a JSON input containing an N-byte string, then fill remaining
+// address space with buffers >= N/4 so an N-byte allocation cannot succeed
+// while smaller allocations (thread stacks, GC bookkeeping) still can.
+//
+// argv: <N> <shape>
+//   shape "root"   => "xxxx..."
+//   shape "array"  => ["xxxx..."]
+//   shape "object" => {"k":"xxxx..."}
 //
 // Outcomes, written to stdout:
 //   SETUP-FAIL  the address-space limit was too tight to build the input
@@ -9,15 +14,18 @@
 //   PARSED      JSON.parse succeeded (enough memory for the copy)
 //   CAUGHT:<name>:<message>   JSON.parse threw
 const N = Number(process.argv[2]);
+const shape = process.argv[3] || "root";
+const prefix = shape === "array" ? '["' : shape === "object" ? '{"k":"' : '"';
+const suffix = shape === "array" ? '"]' : shape === "object" ? '"}' : '"';
 let buf;
 try {
-  buf = Buffer.alloc(N + 2, 0x78);
+  buf = Buffer.alloc(prefix.length + N + suffix.length, 0x78);
 } catch {
   process.stdout.write("SETUP-FAIL\n");
   process.exit(2);
 }
-buf[0] = 0x22;
-buf[N + 1] = 0x22;
+buf.write(prefix, 0, "latin1");
+buf.write(suffix, prefix.length + N, "latin1");
 let input;
 try {
   input = buf.toString("latin1");

--- a/test/js/bun/util/json-parse-oom-fixture.js
+++ b/test/js/bun/util/json-parse-oom-fixture.js
@@ -4,9 +4,10 @@
 // while smaller allocations (thread stacks, GC bookkeeping) still can.
 //
 // argv: <N> <shape>
-//   shape "root"   => "xxxx..."
-//   shape "array"  => ["xxxx..."]
-//   shape "object" => {"k":"xxxx..."}
+//   shape "root"    => "xxxx..."
+//   shape "array"   => ["xxxx..."]
+//   shape "object"  => {"k":"xxxx..."}
+//   shape "reviver" => "xxxx..." parsed with JSON.parse(input, (k, v) => v)
 //
 // Outcomes, written to stdout:
 //   SETUP-FAIL  the address-space limit was too tight to build the input
@@ -35,12 +36,14 @@ try {
 }
 buf = null;
 
+// allocUnsafe reserves address space (which is what RLIMIT_AS bounds) without
+// committing pages, so this loop is fast and its RSS cost is negligible.
 const filler = [];
 let chunk = N;
 const floor = N >> 2;
 while (chunk >= floor) {
   try {
-    filler.push(Buffer.alloc(chunk));
+    filler.push(Buffer.allocUnsafe(chunk));
   } catch {
     chunk = chunk >> 1;
   }
@@ -48,7 +51,8 @@ while (chunk >= floor) {
 process.stdout.write("INPUT-OK\n");
 
 try {
-  JSON.parse(input);
+  if (shape === "reviver") JSON.parse(input, (k, v) => v);
+  else JSON.parse(input);
   process.stdout.write("PARSED\n");
   process.exit(1);
 } catch (e) {

--- a/test/js/bun/util/json-parse-oom-fixture.js
+++ b/test/js/bun/util/json-parse-oom-fixture.js
@@ -1,0 +1,49 @@
+// Force JSON.parse to hit allocator failure for its string-value copy.
+// Prepare a quoted JSON input of N bytes, then fill remaining address
+// space with buffers >= N/4 so an N-byte allocation cannot succeed while
+// smaller allocations (thread stacks, GC bookkeeping) still can.
+//
+// Outcomes, written to stdout:
+//   SETUP-FAIL  the address-space limit was too tight to build the input
+//   INPUT-OK    input built; JSON.parse is about to run
+//   PARSED      JSON.parse succeeded (enough memory for the copy)
+//   CAUGHT:<name>:<message>   JSON.parse threw
+const N = Number(process.argv[2]);
+let buf;
+try {
+  buf = Buffer.alloc(N + 2, 0x78);
+} catch {
+  process.stdout.write("SETUP-FAIL\n");
+  process.exit(2);
+}
+buf[0] = 0x22;
+buf[N + 1] = 0x22;
+let input;
+try {
+  input = buf.toString("latin1");
+} catch {
+  process.stdout.write("SETUP-FAIL\n");
+  process.exit(2);
+}
+buf = null;
+
+const filler = [];
+let chunk = N;
+const floor = N >> 2;
+while (chunk >= floor) {
+  try {
+    filler.push(Buffer.alloc(chunk));
+  } catch {
+    chunk = chunk >> 1;
+  }
+}
+process.stdout.write("INPUT-OK\n");
+
+try {
+  JSON.parse(input);
+  process.stdout.write("PARSED\n");
+  process.exit(1);
+} catch (e) {
+  process.stdout.write("CAUGHT:" + e.name + ":" + e.message + "\n");
+  process.exit(0);
+}

--- a/test/js/bun/util/json-parse-oom.test.ts
+++ b/test/js/bun/util/json-parse-oom.test.ts
@@ -16,22 +16,31 @@ test.skipIf(!isLinux || isASAN)(
   async () => {
     const fixture = join(import.meta.dir, "json-parse-oom-fixture.js");
     const limitKiB = 5 * 1024 * 1024;
-    // A single size/limit can miss the window on a given machine's address-space
-    // layout. Sweep a few sizes; every run that reaches INPUT-OK must either
-    // succeed or throw RangeError, never crash.
-    const sizes = [200, 300, 400, 500].map(mb => mb * 1024 * 1024);
+    // The filler loop in the fixture exhausts address space down to N/4, so any
+    // size should hit the OOM path, but mimalloc's arena layout varies. Sweep a
+    // couple of sizes and every parsePrimitiveValue caller (top-level literal,
+    // array element, object property value); every run that reaches INPUT-OK
+    // must either succeed or throw RangeError, never crash.
+    const cases: Array<[shape: string, mb: number]> = [
+      ["root", 200],
+      ["root", 400],
+      ["array", 300],
+      ["object", 300],
+    ];
     let sawCaught = false;
     let sawInputOK = false;
 
-    for (const size of sizes) {
+    for (const [shape, mb] of cases) {
+      const size = mb * 1024 * 1024;
       await using proc = Bun.spawn({
         cmd: [
           "/bin/sh",
           "-c",
-          `ulimit -v ${limitKiB} && ulimit -c 0 && exec "$0" "$1" "$2"`,
+          `ulimit -v ${limitKiB} && ulimit -c 0 && exec "$0" "$1" "$2" "$3"`,
           bunExe(),
           fixture,
           String(size),
+          shape,
         ],
         env: bunEnv,
         stdout: "pipe",
@@ -44,17 +53,19 @@ test.skipIf(!isLinux || isASAN)(
       sawInputOK = true;
 
       // Once the input is built, JSON.parse must not kill the process.
-      expect({ size, stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signal: proc.signalCode }).toMatchObject({
+      expect({ shape, size, stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signal: proc.signalCode }).toMatchObject({
+        shape,
         size,
         signal: null,
       });
-      expect([0, 1]).toContain(exitCode);
 
       if (stdout.includes("CAUGHT:")) {
         expect(stdout).toContain("CAUGHT:RangeError:Out of memory");
+        expect(exitCode).toBe(0);
         sawCaught = true;
       } else {
         expect(stdout).toContain("PARSED");
+        expect(exitCode).toBe(1);
       }
     }
 

--- a/test/js/bun/util/json-parse-oom.test.ts
+++ b/test/js/bun/util/json-parse-oom.test.ts
@@ -56,10 +56,10 @@ test.skipIf(!isLinux || isASAN || isDebug)(
     );
 
     let sawCaught = false;
-    let sawInputOK = false;
+    const reachedShapes = new Set<string>();
     for (const { shape, size, stdout, stderr, exitCode, signal } of results) {
       if (!stdout.includes("INPUT-OK")) continue;
-      sawInputOK = true;
+      reachedShapes.add(shape);
 
       // Once the input is built, JSON.parse must not kill the process.
       expect({ shape, size, stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signal }).toMatchObject({
@@ -78,9 +78,9 @@ test.skipIf(!isLinux || isASAN || isDebug)(
       }
     }
 
-    // The sweep has to actually reach JSON.parse at least once; otherwise the
-    // address-space cap was too tight and nothing was exercised.
-    expect(sawInputOK).toBe(true);
+    // Every shape must reach JSON.parse; a SETUP-FAIL means the address-space
+    // cap was too tight for that case and nothing was exercised there.
+    expect([...reachedShapes].sort()).toEqual([...new Set(cases.map(([s]) => s))].sort());
     // And at least one of those runs must have taken the out-of-memory branch,
     // otherwise the sweep never exercised the path this test is for.
     expect(sawCaught).toBe(true);

--- a/test/js/bun/util/json-parse-oom.test.ts
+++ b/test/js/bun/util/json-parse-oom.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isLinux } from "harness";
+import { join } from "node:path";
+
+// JSON.parse copies every string value longer than 16 chars into a fresh
+// StringImpl. That copy used the crash-or-succeed StringImplMalloc::malloc
+// path, so a near-OOM process died with SIGILL inside fastCompactMalloc
+// instead of throwing. The fix routes through StringImpl::tryCreateUninitialized
+// and surfaces a RangeError, same as "x".repeat(tooLarge).
+//
+// RLIMIT_AS is the only portable way to make tryMalloc actually fail, and it
+// cannot be combined with AddressSanitizer's 16 TB shadow reservation, so this
+// test runs on non-ASAN Linux only.
+test.skipIf(!isLinux || isASAN)(
+  "JSON.parse throws RangeError instead of crashing when a string value cannot be allocated",
+  async () => {
+    const fixture = join(import.meta.dir, "json-parse-oom-fixture.js");
+    const limitKiB = 5 * 1024 * 1024;
+    // A single size/limit can miss the window on a given machine's address-space
+    // layout. Sweep a few sizes; every run that reaches INPUT-OK must either
+    // succeed or throw RangeError, never crash.
+    const sizes = [200, 300, 400, 500].map(mb => mb * 1024 * 1024);
+    let sawCaught = false;
+    let sawInputOK = false;
+
+    for (const size of sizes) {
+      await using proc = Bun.spawn({
+        cmd: [
+          "/bin/sh",
+          "-c",
+          `ulimit -v ${limitKiB} && ulimit -c 0 && exec "$0" "$1" "$2"`,
+          bunExe(),
+          fixture,
+          String(size),
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const reachedParse = stdout.includes("INPUT-OK");
+      if (!reachedParse) continue;
+      sawInputOK = true;
+
+      // Once the input is built, JSON.parse must not kill the process.
+      expect({ size, stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signal: proc.signalCode }).toMatchObject({
+        size,
+        signal: null,
+      });
+      expect([0, 1]).toContain(exitCode);
+
+      if (stdout.includes("CAUGHT:")) {
+        expect(stdout).toContain("CAUGHT:RangeError:Out of memory");
+        sawCaught = true;
+      } else {
+        expect(stdout).toContain("PARSED");
+      }
+    }
+
+    // The sweep has to actually reach JSON.parse at least once; otherwise the
+    // address-space cap was too tight and nothing was exercised.
+    expect(sawInputOK).toBe(true);
+    // And at least one of those runs must have taken the out-of-memory branch,
+    // otherwise the sweep never exercised the path this test is for.
+    expect(sawCaught).toBe(true);
+  },
+  30_000,
+);

--- a/test/js/bun/util/json-parse-oom.test.ts
+++ b/test/js/bun/util/json-parse-oom.test.ts
@@ -53,7 +53,14 @@ test.skipIf(!isLinux || isASAN)(
       sawInputOK = true;
 
       // Once the input is built, JSON.parse must not kill the process.
-      expect({ shape, size, stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signal: proc.signalCode }).toMatchObject({
+      expect({
+        shape,
+        size,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode,
+        signal: proc.signalCode,
+      }).toMatchObject({
         shape,
         size,
         signal: null,

--- a/test/js/bun/util/json-parse-oom.test.ts
+++ b/test/js/bun/util/json-parse-oom.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isLinux } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux } from "harness";
 import { join } from "node:path";
 
 // JSON.parse copies every string value longer than 16 chars into a fresh
@@ -9,9 +9,10 @@ import { join } from "node:path";
 // and surfaces a RangeError, same as "x".repeat(tooLarge).
 //
 // RLIMIT_AS is the only portable way to make tryMalloc actually fail, and it
-// cannot be combined with AddressSanitizer's 16 TB shadow reservation, so this
-// test runs on non-ASAN Linux only.
-test.skipIf(!isLinux || isASAN)(
+// cannot be combined with AddressSanitizer's 16 TB shadow reservation. Debug
+// builds take several seconds per fixture just to zero-fill and toString() the
+// ~200 MB inputs, so this runs only on release Linux lanes.
+test.skipIf(!isLinux || isASAN || isDebug)(
   "JSON.parse throws RangeError instead of crashing when a string value cannot be allocated",
   async () => {
     const fixture = join(import.meta.dir, "json-parse-oom-fixture.js");
@@ -19,48 +20,49 @@ test.skipIf(!isLinux || isASAN)(
     // The filler loop in the fixture exhausts address space down to N/4, so any
     // size should hit the OOM path, but mimalloc's arena layout varies. Sweep a
     // couple of sizes and every parsePrimitiveValue caller (top-level literal,
-    // array element, object property value); every run that reaches INPUT-OK
-    // must either succeed or throw RangeError, never crash.
+    // reviver-mode literal, array element, object property value); every run
+    // that reaches INPUT-OK must either succeed or throw RangeError, never
+    // crash. The fixture's filler uses allocUnsafe, which reserves address
+    // space without committing pages, so the children's combined RSS stays
+    // well under the host's memory and they can run concurrently.
     const cases: Array<[shape: string, mb: number]> = [
       ["root", 200],
       ["root", 400],
       ["array", 300],
       ["object", 300],
+      ["reviver", 300],
     ];
+
+    const results = await Promise.all(
+      cases.map(async ([shape, mb]) => {
+        const size = mb * 1024 * 1024;
+        await using proc = Bun.spawn({
+          cmd: [
+            "/bin/sh",
+            "-c",
+            `ulimit -v ${limitKiB} && ulimit -c 0 && exec "$0" "$1" "$2" "$3"`,
+            bunExe(),
+            fixture,
+            String(size),
+            shape,
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { shape, size, stdout, stderr, exitCode, signal: proc.signalCode };
+      }),
+    );
+
     let sawCaught = false;
     let sawInputOK = false;
-
-    for (const [shape, mb] of cases) {
-      const size = mb * 1024 * 1024;
-      await using proc = Bun.spawn({
-        cmd: [
-          "/bin/sh",
-          "-c",
-          `ulimit -v ${limitKiB} && ulimit -c 0 && exec "$0" "$1" "$2" "$3"`,
-          bunExe(),
-          fixture,
-          String(size),
-          shape,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      const reachedParse = stdout.includes("INPUT-OK");
-      if (!reachedParse) continue;
+    for (const { shape, size, stdout, stderr, exitCode, signal } of results) {
+      if (!stdout.includes("INPUT-OK")) continue;
       sawInputOK = true;
 
       // Once the input is built, JSON.parse must not kill the process.
-      expect({
-        shape,
-        size,
-        stdout: stdout.trim(),
-        stderr: stderr.trim(),
-        exitCode,
-        signal: proc.signalCode,
-      }).toMatchObject({
+      expect({ shape, size, stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signal }).toMatchObject({
         shape,
         size,
         signal: null,
@@ -83,5 +85,4 @@ test.skipIf(!isLinux || isASAN)(
     // otherwise the sweep never exercised the path this test is for.
     expect(sawCaught).toBe(true);
   },
-  30_000,
 );


### PR DESCRIPTION
## What does this PR do?

`JSON.parse` copies every string value longer than 16 chars into a fresh `WTF::StringImpl` via `JSONAtomStringCache::makeJSString`. That copy used `String(characters)`, which lands in `StringImplMalloc::malloc`, the crash-or-succeed allocator. When the process cannot satisfy that allocation, `JSON.parse` dies inside `fastCompactMalloc` instead of throwing. Seen in Sentry as BUN-2Z94 (Windows null deref in `fastCompactMalloc`).

The fix itself is in oven-sh/WebKit#317: the >16 char branch now goes through `StringImpl::tryCreateUninitialized` and a null result surfaces as `throwOutOfMemoryError(m_globalObject, scope)` in `LiteralParser::parsePrimitiveValue`. All of `parsePrimitiveValue`'s callers already treat an empty return with a pending exception correctly (they assert `(!!scope.exception() || !m_parseErrorMessage.isNull()) == !value` and the top-level `JSON.parse` callers check `RETURN_IF_EXCEPTION` before throwing `SyntaxError`).

This PR bumps `WEBKIT_VERSION` to that change and adds a test.

## Why

Crashing on catchable OOM is worse than throwing. `String.prototype.repeat`, `Buffer#toString`, and every other WTF-string-backed allocation already throw `RangeError: Out of memory`; `JSON.parse` string values were the odd one out because the copy happened inside JSC's literal parser on the non-try path.

## How did you verify your code works?

Reproduced on Linux by parsing a ~200 MB quoted string under `ulimit -v` with the rest of the address space filled so the value copy cannot fit:

```
before:  INPUT-OK → panic(main thread): Illegal instruction at address 0x177B834  (SIGILL, exit 132)
after:   INPUT-OK → CAUGHT:RangeError:Out of memory                               (exit 0)
```

Stable across 5 runs each. Also verified the fix covers string values as top-level literals, array elements, object property values, and under a reviver (all go through `parsePrimitiveValue`).

The test spawns the fixture under `ulimit -v` and sweeps four string sizes; for every run that reaches `INPUT-OK` it asserts the child either parsed or threw `RangeError` and was never signal-killed. `RLIMIT_AS` cannot coexist with AddressSanitizer's ~16 TB shadow reservation, so the test is gated `skipIf(!isLinux || isASAN)`.

### Fail-before proof

The fix is a WebKit change pulled in via `WEBKIT_VERSION`; with the fix reverted to `c9296e35` the test fails on the first 200 MB run (`signalCode: "SIGILL"`). The harness fail-before step stashes `src/` only, so it cannot mechanically revert the prebuilt-WebKit pin; the before/after evidence above stands in for that check.

---

Depends on oven-sh/WebKit#317. `WEBKIT_VERSION` points at its preview tag; once that PR is merged the pin should move to the merged main sha.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->