### PR TITLE
node:stream: make Readable.resume() a no-op on destroyed errored streams

### DIFF
--- a/src/js/internal/streams/readable.ts
+++ b/src/js/internal/streams/readable.ts
@@ -1136,12 +1136,14 @@ function nReadingNextTick(self) {
 Readable.prototype.resume = function () {
   const state = this._readableState;
   // Node 26 (nodejs/node#62557) early-returns on kDestroyed. We narrow it to
-  // kDestroyed && kEndEmitted: fd-slicer-style readables set `destroyed` right
-  // before push(null), and the full guard strands their buffered tail when a
-  // piped dest drains (yauzl/extract-zip). Once 'end' has fired there is
-  // nothing left to flush, so becoming a no-op restores readableFlowing /
-  // isPaused() parity for consumers that resume() past EOF (Readable.toWeb).
-  if ((state[kState] & (kDestroyed | kEndEmitted)) === (kDestroyed | kEndEmitted)) {
+  // kDestroyed && (kEndEmitted || kErrored): fd-slicer-style readables set
+  // `destroyed` right before push(null), and the full guard strands their
+  // buffered tail when a piped dest drains (yauzl/extract-zip). Once 'end' has
+  // fired there is nothing left to flush, and once the stream is errored there
+  // is no tail-flush rationale either (flowing an errored stream would deliver
+  // 'data' ahead of the scheduled 'error'), so in both cases we match Node's
+  // no-op and preserve readableFlowing / isPaused() / readableLength.
+  if ((state[kState] & kDestroyed) !== 0 && (state[kState] & (kEndEmitted | kErrored)) !== 0) {
     return this;
   }
   if ((state[kState] & kFlowing) === 0) {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1461,6 +1461,56 @@ describe("node v26 stream semantics", () => {
     expect(received).toBe(65536 * 2 + 40000);
   });
 
+  // The fd-slicer narrowing above has no rationale once the stream is errored:
+  // delivering buffered 'data' ahead of a scheduled 'error' is an ordering
+  // contract break Node never exhibits. resume() on a destroyed+errored stream
+  // must match Node's no-op, leaving the buffer and readableFlowing untouched.
+  it("resume() / on('data') on a destroyed errored stream is a no-op", async () => {
+    const settle = () => new Promise(resolve => setImmediate(resolve));
+    const boom = () => Object.assign(new Error("boom"), { code: "EBOOM" });
+    const snapshot = s => ({ len: s.readableLength, flowing: s.readableFlowing, paused: s.isPaused() });
+
+    const resumed = new Readable({ read() {} });
+    resumed.push("buffered-payload");
+    resumed.on("error", () => {});
+    resumed.destroy(boom());
+    await settle();
+    expect(resumed.resume()).toBe(resumed);
+    await settle();
+    expect(snapshot(resumed)).toEqual({ len: 16, flowing: null, paused: false });
+
+    const listened = new Readable({ read() {} });
+    const delivered = [];
+    listened.push("buffered-payload");
+    listened.on("error", () => {});
+    listened.destroy(boom());
+    await settle();
+    listened.on("data", c => delivered.push(String(c)));
+    await settle();
+    expect({ ...snapshot(listened), delivered }).toEqual({ len: 16, flowing: null, paused: false, delivered: [] });
+  });
+
+  it("a resume scheduled by removeListener('readable') after destroy(err) does not flow the buffered tail", async () => {
+    const r = new Readable({ read() {}, highWaterMark: 4 });
+    const ev = [];
+    const onReadable = () => {};
+    r.on("readable", onReadable);
+    r.on("data", c => ev.push("data:" + c));
+    r.on("error", e => ev.push("error:" + e.code));
+    r.on("close", () => ev.push("close"));
+    // Schedules updateReadableListening on nextTick, which calls resume() now
+    // that only a 'data' listener remains.
+    r.removeListener("readable", onReadable);
+    r.push("0123456789");
+    r.read(3);
+    r.destroy(Object.assign(new Error("boom"), { code: "EBOOM" }));
+    await new Promise(resolve => r.on("close", resolve));
+    // Node: the scheduled resume() sees kDestroyed and no-ops, so the 7-byte
+    // buffered tail is never flowed and 'error' follows the one read() emit.
+    expect(ev).toEqual(["data:012", "error:EBOOM", "close"]);
+    expect(r.readableLength).toBe(7);
+  });
+
   // Upstream: nodejs/node#60907 (test-stream-compose-operator.js).
   it("compose returns the composed Duplex directly", () => {
     expect(Object.hasOwn(Readable.prototype, "compose")).toBe(true);


### PR DESCRIPTION
## What

`Readable.prototype.resume()` now no-ops when the stream is both destroyed **and** errored, matching Node. The existing narrowing for the fd-slicer/yauzl tail-flush case (destroyed without an error) is unchanged.

## Repro

```js
import { Readable } from "node:stream";
const r = new Readable({ read() {}, highWaterMark: 4 });
const ev = [];
const onR = () => {};
r.on("readable", onR);
r.on("data", c => ev.push("data:" + c));
r.on("error", e => ev.push("error:" + e.code));
r.on("close", () => ev.push("close"));
r.removeListener("readable", onR);      // schedules an internal resume()
r.push("0123456789");
r.read(3);
r.destroy(Object.assign(new Error("boom"), { code: "EBOOM" }));
await new Promise(r => setTimeout(r, 25));
console.log(ev);
// node  : [ 'data:012', 'error:EBOOM', 'close' ]
// before: [ 'data:012', 'data:3456789', 'error:EBOOM', 'close' ]
```

## Cause

Node 26 (nodejs/node#62557) made `resume()` a no-op on destroyed streams. Bun narrows that guard to `destroyed && endEmitted` so fd-slicer-style readables (which set `this.destroyed = true` before `push(null)`) can still flush their buffered tail to a piped destination on drain. That narrowing only considered `endEmitted`, so a stream destroyed with an error would still start flowing when `resume()` was called on it. `removeListener('readable')` schedules `updateReadableListening` on nextTick, which calls `self.resume()` when only a `'data'` listener remains, and `destroy(err)` sets `kErrored | kDestroyed` synchronously before that tick runs. The late `resume()` set `kFlowing`, and the already-scheduled `emitReadable_` then drained the buffered tail via `flow()`, emitting `'data'` ahead of `'error'`.

There is no tail-flush rationale for an errored stream: the fd-slicer pattern never sets `errored`, and delivering `'data'` after `destroy(err)` was called is an ordering Node does not have.

## Fix

Extend the guard in `Readable.prototype.resume()` to `destroyed && (endEmitted || errored)`. The yauzl/fd-slicer case (error-free destroy) keeps the Node-24 behavior; errored streams match Node's no-op and preserve `readableLength` / `readableFlowing` / `isPaused()`. A flow that was already scheduled before `destroy(err)` still delivers, which is also what Node does.

## Verification

```
$ bun bd test test/js/node/stream/node-stream.test.js
 100 pass, 1 skip, 5 todo, 0 fail
```

The two new tests fail on `main` with `+"data:3456789"` in the event sequence and `{len: 0, flowing: true}` instead of `{len: 16, flowing: null}`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->