### PR TITLE
resolver: stop honoring removed trailing-slash exports subpath folder mappings

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1138,8 +1138,7 @@ impl<'a> Visitor<'a> {
                 json_parser::ValueLocation::Property(prop.key_loc),
             );
 
-            // safe to use "/" on windows. exports in package.json does not use "\\"
-            if strings::ends_with(&key, b"/") || strings::contains_char(&key, b'*') {
+            if strings::contains_char(&key, b'*') {
                 expansion_keys.push(MapEntry {
                     value: value.clone(),
                     key: key.clone(),
@@ -1156,9 +1155,9 @@ impl<'a> Visitor<'a> {
 
         // this leaks a lil, but it's fine.
 
-        // Let expansionKeys be the list of keys of matchObj either ending in "/"
-        // or containing only a single "*", sorted by the sorting function
-        // PATTERN_KEY_COMPARE which orders in descending order of specificity.
+        // Let expansionKeys be the list of keys of matchObj containing only a
+        // single "*", sorted by the sorting function PATTERN_KEY_COMPARE which
+        // orders in descending order of specificity.
         expansion_keys.sort_by(|a, b| strings::glob_length_compare(&a.key, &b.key));
 
         Entry {
@@ -1304,7 +1303,6 @@ pub enum Status {
     Null,
     Exact,
     ExactEndsWithStar,
-    Inexact, // This means we may need to try CommonJS-style extension suffixes
 
     /// Module specifier is an invalid URL, package name or package subpath specifier.
     InvalidModuleSpecifier,
@@ -1587,10 +1585,7 @@ impl<'a> ESModule<'a> {
 
     pub fn finalize(result_: Resolution) -> Resolution {
         let mut result = result_;
-        if result.status != Status::Exact
-            && result.status != Status::ExactEndsWithStar
-            && result.status != Status::Inexact
-        {
+        if result.status != Status::Exact && result.status != Status::ExactEndsWithStar {
             return result;
         }
 
@@ -1737,49 +1732,31 @@ impl<'a> ESModule<'a> {
         if let EntryData::Map(map) = &match_obj.data {
             let expansion_keys = &map.expansion_keys;
             for expansion in expansion_keys.iter() {
-                // If expansionKey contains "*", set patternBase to the substring of
-                // expansionKey up to but excluding the first "*" character
-                if let Some(star) = strings::index_of_char(&expansion.key, b'*') {
-                    let star = star as usize;
-                    let pattern_base = &expansion.key[0..star];
-                    // If patternBase is not null and matchKey starts with but is not equal
-                    // to patternBase, then
-                    if strings::starts_with(match_key, pattern_base) {
-                        // Let patternTrailer be the substring of expansionKey from the index
-                        // after the first "*" character.
-                        let pattern_trailer = &expansion.key[star + 1..];
+                // expansion_keys only contains keys with a "*" (trailing-slash
+                // "./dir/" subpath folder mappings were removed from Node.js in
+                // v17 / DEP0148 and are no longer treated as patterns).
+                let Some(star) = strings::index_of_char(&expansion.key, b'*') else {
+                    debug_assert!(false, "expansion_keys must contain '*'");
+                    continue;
+                };
+                let star = star as usize;
+                let pattern_base = &expansion.key[0..star];
+                // If matchKey starts with but is not equal to patternBase, then
+                if strings::starts_with(match_key, pattern_base) {
+                    // Let patternTrailer be the substring of expansionKey from the index
+                    // after the first "*" character.
+                    let pattern_trailer = &expansion.key[star + 1..];
 
-                        // If patternTrailer has zero length, or if matchKey ends with
-                        // patternTrailer and the length of matchKey is greater than or
-                        // equal to the length of expansionKey, then
-                        if pattern_trailer.is_empty()
-                            || (strings::ends_with(match_key, pattern_trailer)
-                                && match_key.len() >= expansion.key.len())
-                        {
-                            let target = &expansion.value;
-                            let subpath = &match_key
-                                [pattern_base.len()..match_key.len() - pattern_trailer.len()];
-                            if let Some(log) = self.debug_logs.as_deref_mut() {
-                                log.add_note_fmt(format_args!(
-                                    "The key \"{}\" matched with \"{}\" left over",
-                                    bstr::BStr::new(&expansion.key),
-                                    bstr::BStr::new(subpath)
-                                ));
-                            }
-                            return self.resolve_target::<true>(
-                                package_url,
-                                target,
-                                subpath,
-                                is_imports,
-                            );
-                        }
-                    }
-                } else {
-                    // Otherwise if patternBase is null and matchKey starts with
-                    // expansionKey, then
-                    if strings::starts_with(match_key, &expansion.key) {
+                    // If patternTrailer has zero length, or if matchKey ends with
+                    // patternTrailer and the length of matchKey is greater than or
+                    // equal to the length of expansionKey, then
+                    if pattern_trailer.is_empty()
+                        || (strings::ends_with(match_key, pattern_trailer)
+                            && match_key.len() >= expansion.key.len())
+                    {
                         let target = &expansion.value;
-                        let subpath = &match_key[expansion.key.len()..];
+                        let subpath =
+                            &match_key[pattern_base.len()..match_key.len() - pattern_trailer.len()];
                         if let Some(log) = self.debug_logs.as_deref_mut() {
                             log.add_note_fmt(format_args!(
                                 "The key \"{}\" matched with \"{}\" left over",
@@ -1787,15 +1764,12 @@ impl<'a> ESModule<'a> {
                                 bstr::BStr::new(subpath)
                             ));
                         }
-                        let mut result =
-                            self.resolve_target::<false>(package_url, target, subpath, is_imports);
-                        if result.status == Status::Exact
-                            || result.status == Status::ExactEndsWithStar
-                        {
-                            // Return the object { resolved, exact: false }.
-                            result.status = Status::Inexact;
-                        }
-                        return result;
+                        return self.resolve_target::<true>(
+                            package_url,
+                            target,
+                            subpath,
+                            is_imports,
+                        );
                     }
                 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1864,31 +1864,18 @@ impl<'a> ESModule<'a> {
                     };
                 }
 
-                // If pattern is false, subpath has non-zero length and target
-                // does not end with "/", throw an Invalid Module Specifier error.
                 if !PATTERN {
-                    if !subpath.is_empty() && !strings::ends_with_char(str, b'/') {
-                        if let Some(log) = self.debug_logs.as_deref_mut() {
-                            log.add_note_fmt(format_args!(
-                                "The target \"{}\" is invalid because it doesn't end with a \"/\"",
-                                bstr::BStr::new(str)
-                            ));
-                        }
-                        dedent!();
-
-                        return Resolution {
-                            path: Box::<[u8]>::from(str),
-                            status: Status::InvalidModuleSpecifier,
-                        };
-                    }
+                    // The only `<false>` callers pass `b""` (exact-key / "." main export);
+                    // the removed DEP0148 folder-mapping branch was the sole source of a
+                    // non-empty subpath without PATTERN.
+                    debug_assert!(subpath.is_empty());
                 }
 
-                // If the wildcard match (or trailing-slash remainder) taken from
-                // the import specifier contains any ".", ".." or "node_modules"
-                // segments, throw an Invalid Module Specifier error. Node's
-                // PACKAGE_TARGET_RESOLVE applies the same validation to
-                // patternMatch; without it the specifier can substitute "../"
-                // segments into the target and escape the package directory.
+                // If the wildcard match taken from the import specifier contains any
+                // ".", ".." or "node_modules" segments, throw an Invalid Module
+                // Specifier error. Node's PACKAGE_TARGET_RESOLVE applies the same
+                // validation to patternMatch; without it the specifier can substitute
+                // "../" segments into the target and escape the package directory.
                 if !subpath.is_empty() {
                     if let Some(invalid) = find_invalid_subpath_segment(subpath) {
                         if let Some(log) = self.debug_logs.as_deref_mut() {
@@ -1939,30 +1926,9 @@ impl<'a> ESModule<'a> {
                                 status: Status::PackageResolve,
                             };
                         } else {
-                            // Latent Windows bug (#30839): this branch runs when an
-                            // `imports` target is itself a package specifier
-                            // (e.g. `@myproject/resolver`) that we hand back to
-                            // package-resolve. Per the Node.js packages spec these
-                            // are URL-like specifiers and must keep forward slashes;
-                            // `Auto` normalizes them to `\` on Windows and the
-                            // scoped-name match fails, falling through to `main`.
-                            let parts2 = [str, subpath];
-                            let result = resolve_path::resolve_path::join_string_buf::<
-                                resolve_path::platform::Posix,
-                            >(
-                                &mut resolve_target_buf2.0, &parts2
-                            );
-                            if let Some(log) = self.debug_logs.as_deref_mut() {
-                                log.add_note_fmt(format_args!(
-                                    "Resolved \".{}\" to \".{}\"",
-                                    bstr::BStr::new(str),
-                                    bstr::BStr::new(result)
-                                ));
-                            }
-                            let path = Box::<[u8]>::from(result);
                             dedent!();
                             return Resolution {
-                                path,
+                                path: Box::<[u8]>::from(str),
                                 status: Status::PackageResolve,
                             };
                         }
@@ -2058,22 +2024,15 @@ impl<'a> ESModule<'a> {
                         status,
                     };
                 } else {
-                    let parts2 = [package_url, str, subpath];
-                    let result = resolve_path::resolve_path::join_string_buf::<
-                        resolve_path::platform::Auto,
-                    >(&mut resolve_target_buf2.0, &parts2);
                     if let Some(log) = self.debug_logs.as_deref_mut() {
                         log.add_note_fmt(format_args!(
-                            "Substituted \"{}\" for \"*\" in \".{}\" to get \".{}\" ",
-                            bstr::BStr::new(subpath),
-                            bstr::BStr::new(resolved_target),
-                            bstr::BStr::new(result)
+                            "Resolved to \".{}\"",
+                            bstr::BStr::new(resolved_target)
                         ));
                     }
-                    let path = Box::<[u8]>::from(result);
                     dedent!();
                     return Resolution {
-                        path,
+                        path: Box::<[u8]>::from(resolved_target),
                         status: Status::Exact,
                     };
                 }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3639,7 +3639,7 @@ impl<'a> Resolver<'a> {
         use crate::package_json::Status;
         if !((matches!(
             esm_resolution.status,
-            Status::Inexact | Status::Exact | Status::ExactEndsWithStar
+            Status::Exact | Status::ExactEndsWithStar
         )) && !esm_resolution.path.is_empty()
             && esm_resolution.path[0] == SEP)
         {
@@ -3817,23 +3817,6 @@ impl<'a> Resolver<'a> {
                     ..Default::default()
                 };
                 MatchStatus::Success
-            }
-            Status::Inexact => {
-                // If this was resolved against an expansion key ending in a "/"
-                // instead of a "*", we need to try CommonJS-style implicit
-                // extension and/or directory detection.
-                if self
-                    .load_as_file_or_directory(abs_esm_path, kind, out)
-                    .is_success()
-                {
-                    out.is_node_module = true;
-                    out.package_json = out
-                        .package_json
-                        .or_else(|| Some(std::ptr::from_ref(package_json)));
-                    return MatchStatus::Success;
-                }
-                esm_resolution.status = Status::ModuleNotFound;
-                MatchStatus::NotFound
             }
             _ => unreachable!(),
         }

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1449,22 +1449,6 @@ describe("bundler", () => {
       stdout: "SUCCESS",
     },
   });
-  itBundled("packagejson/ExportsNotExactMissingExtension", {
-    files: {
-      "/Users/user/project/src/entry.js": `import 'pkg1/foo/bar'`,
-      "/Users/user/project/node_modules/pkg1/package.json": /* json */ `
-        {
-          "exports": {
-            "./foo/": "./dir/"
-          }
-        }
-      `,
-      "/Users/user/project/node_modules/pkg1/dir/bar.js": `console.log('SUCCESS')`,
-    },
-    bundleErrors: {
-      "/Users/user/project/src/entry.js": [`Could not resolve: "pkg1/foo/bar". Maybe you need to "bun install"?`],
-    },
-  });
   itBundled("packagejson/ExportsNotExactMissingExtensionPattern", {
     files: {
       "/Users/user/project/src/entry.js": `import 'pkg1/foo/bar'`,

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -1339,8 +1339,8 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/pkg1/package.json": /* json */ `
         {
           "exports": {
-            "./": "./1/",
-            "./foo/": "./2/"
+            "./*": "./1/*",
+            "./foo/*": "./2/*"
           }
         }
       `,
@@ -1349,8 +1349,8 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/pkg2/package.json": /* json */ `
         {
           "exports": {
-            "./foo/": "./1/",
-            "./": "./2/"
+            "./foo/*": "./1/*",
+            "./*": "./2/*"
           }
         }
       `,
@@ -1359,6 +1359,24 @@ describe("bundler", () => {
     },
     run: {
       stdout: "SUCCESS\nSUCCESS",
+    },
+  });
+  // Node.js removed trailing-slash subpath folder mappings (DEP0148) in v17.
+  // A "./dir/" key must not act as a prefix pattern anymore.
+  itBundled("packagejson/ExportsTrailingSlashNotSupported", {
+    files: {
+      "/Users/user/project/src/entry.js": `import 'pkg1/foo/bar.js'`,
+      "/Users/user/project/node_modules/pkg1/package.json": /* json */ `
+        {
+          "exports": {
+            "./foo/": "./dir/"
+          }
+        }
+      `,
+      "/Users/user/project/node_modules/pkg1/dir/bar.js": `console.log('FAILURE')`,
+    },
+    bundleErrors: {
+      "/Users/user/project/src/entry.js": [`Could not resolve: "pkg1/foo/bar.js". Maybe you need to "bun install"?`],
     },
   });
   itBundled("packagejson/ExportsWildcard", {
@@ -1443,8 +1461,8 @@ describe("bundler", () => {
       `,
       "/Users/user/project/node_modules/pkg1/dir/bar.js": `console.log('SUCCESS')`,
     },
-    run: {
-      stdout: "SUCCESS",
+    bundleErrors: {
+      "/Users/user/project/src/entry.js": [`Could not resolve: "pkg1/foo/bar". Maybe you need to "bun install"?`],
     },
   });
   itBundled("packagejson/ExportsNotExactMissingExtensionPattern", {
@@ -1626,7 +1644,7 @@ describe("bundler", () => {
       "/Users/user/project/node_modules/pkg/package.json": /* json */ `
         {
           "exports": {
-            "./apples/": ["./good-apples/", "./bad-apples/"],
+            "./apples/*": ["./good-apples/*", "./bad-apples/*"],
             "./books/*": ["./good-books/*-book.js", "./bad-books/*-book.js"]
           }
         }
@@ -1649,25 +1667,22 @@ describe("bundler", () => {
         import '#top-level'
         import '#nested/path.js'
         import '#star/c.js'
-        import '#slash/d.js'
       `,
       "/Users/user/project/src/package.json": /* json */ `
         {
           "imports": {
             "#top-level": "./a.js",
             "#nested/path.js": "./b.js",
-            "#star/*": "./some-star/*",
-            "#slash/": "./some-slash/"
+            "#star/*": "./some-star/*"
           }
         }
       `,
       "/Users/user/project/src/a.js": `console.log('a.js')`,
       "/Users/user/project/src/b.js": `console.log('b.js')`,
       "/Users/user/project/src/some-star/c.js": `console.log('c.js')`,
-      "/Users/user/project/src/some-slash/d.js": `console.log('d.js')`,
     },
     run: {
-      stdout: `a.js\nb.js\nc.js\nd.js`,
+      stdout: `a.js\nb.js\nc.js`,
     },
   });
   itBundled("packagejson/ImportsRemapToOtherPackage", {
@@ -1676,25 +1691,22 @@ describe("bundler", () => {
         import '#top-level'
         import '#nested/path.js'
         import '#star/c.js'
-        import '#slash/d.js'
       `,
       "/Users/user/project/src/package.json": /* json */ `
         {
           "imports": {
             "#top-level": "pkg/a.js",
             "#nested/path.js": "pkg/b.js",
-            "#star/*": "pkg/some-star/*",
-            "#slash/": "pkg/some-slash/"
+            "#star/*": "pkg/some-star/*"
           }
         }
       `,
       "/Users/user/project/src/node_modules/pkg/a.js": `console.log('a.js')`,
       "/Users/user/project/src/node_modules/pkg/b.js": `console.log('b.js')`,
       "/Users/user/project/src/node_modules/pkg/some-star/c.js": `console.log('c.js')`,
-      "/Users/user/project/src/node_modules/pkg/some-slash/d.js": `console.log('d.js')`,
     },
     run: {
-      stdout: `a.js\nb.js\nc.js\nd.js`,
+      stdout: `a.js\nb.js\nc.js`,
     },
   });
   itBundled("packagejson/ImportsErrorMissingRemappedPackage", {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -975,6 +975,69 @@ describe.if(isWindows)("#30839 - imports entry pointing at a scoped package", ()
   });
 }
 
+// Node.js removed "subpath folder mappings" (exports/imports keys ending in
+// "/", DEP0148) in v17. A key like "./legacy/": "./real/" must no longer act
+// as a prefix pattern; only "./legacy/*": "./real/*" does.
+it("rejects removed trailing-slash exports subpath folder mappings", async () => {
+  using dir = tempDir("exports-trailing-slash", {
+    "package.json": JSON.stringify({ name: "app", type: "module" }),
+    "node_modules/tp/package.json": JSON.stringify({
+      name: "tp",
+      exports: { "./legacy/": "./real/", "./modern/*": "./real/*" },
+      imports: { "#legacy/": "./real/", "#modern/*": "./real/*" },
+    }),
+    "node_modules/tp/real/f.js": `module.exports = "tp/real/f.js";\n`,
+    "node_modules/tp/probe-imports.cjs": `
+      const out = {};
+      for (const s of ["#legacy/f.js", "#modern/f.js"]) {
+        try { out[s] = require(s); } catch (e) { out[s] = "THREW " + (e.code || e.name); }
+      }
+      console.log(JSON.stringify(out));
+    `,
+    "probe.mjs": `
+      const out = {};
+      for (const s of ["tp/legacy/f.js", "tp/modern/f.js"]) {
+        try { out[s] = (await import(s)).default; } catch (e) { out[s] = "THREW " + (e.code || e.name); }
+      }
+      console.log(JSON.stringify(out));
+    `,
+  });
+
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "probe.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "tp/legacy/f.js": expect.stringMatching(/^THREW /),
+      "tp/modern/f.js": "tp/real/f.js",
+    });
+    expect(exitCode).toBe(0);
+  }
+
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "node_modules/tp/probe-imports.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "#legacy/f.js": expect.stringMatching(/^THREW /),
+      "#modern/f.js": "tp/real/f.js",
+    });
+    expect(exitCode).toBe(0);
+  }
+});
+
 describe("resolving external URL specifiers with non-ASCII characters", () => {
   // The resolver returns http://, https://, and // specifiers as-is (marked external).
   // When the specifier contains non-ASCII characters, the intermediate UTF-8 buffer

--- a/test/snippets/package-json-exports/_node_modules_copy/inexact/package.json
+++ b/test/snippets/package-json-exports/_node_modules_copy/inexact/package.json
@@ -11,10 +11,10 @@
       "browser": "./browser/foo.js",
       "default": "./default/foo.js"
     },
-    "./": {
-      "node": "./node/dir/",
-      "browser": "./browser/dir/",
-      "default": "./default/dir/"
+    "./*": {
+      "node": "./node/dir/*.js",
+      "browser": "./browser/dir/*.js",
+      "default": "./default/dir/*.js"
     }
   }
 }


### PR DESCRIPTION
## Problem

The `"./dir/": "./target/"` subpath folder mapping in `package.json` `exports`/`imports` was deprecated under [DEP0148](https://nodejs.org/api/deprecations.html#DEP0148) and removed in Node.js 17. Every supported Node release rejects it with `ERR_PACKAGE_PATH_NOT_EXPORTED`, but Bun still prefix-matched it, so code that resolves under Bun hard-fails under Node.

```js
// node_modules/tp/package.json
{ "exports": { "./legacy/": "./real/", "./modern/*": "./real/*" } }
```

| import | node v26.3.0 | bun (before) |
| --- | --- | --- |
| `tp/legacy/f.js` | `ERR_PACKAGE_PATH_NOT_EXPORTED` | resolves to `./real/f.js` |
| `tp/modern/f.js` | resolves to `./real/f.js` | resolves to `./real/f.js` |

## Cause

`ESModule::resolve_imports_exports` still implemented the pre-v17 algorithm: keys ending in `/` were added to `expansion_keys` at parse time, and the expansion loop had a non-`*` branch that did `starts_with` prefix matching and appended the remainder to the target, producing `Status::Inexact`.

## Fix

Keys ending in `/` are no longer treated as expansion keys; only keys containing `*` are, matching the current [`PACKAGE_IMPORTS_EXPORTS_RESOLVE`](https://nodejs.org/api/esm.html#resolution-algorithm-specification) spec. The non-`*` expansion branch and the now-unreachable `Status::Inexact` path (which existed solely to trigger CommonJS extension/directory fallback on folder mappings) are removed.

The esbuild-parity bundler tests that exercised the removed syntax are updated to use the `"./dir/*"` replacement (preserving their intent: `PATTERN_KEY_COMPARE` ordering and array-alternative semantics), plus a new negative `packagejson/ExportsTrailingSlashNotSupported` case. esbuild itself still accepts the removed form, but Bun follows Node here.

## Verification

New `test/js/bun/resolve/resolve.test.ts` case covers both `exports` and `imports` trailing-slash keys with a `./modern/*` control; fails on `main` (`tp/legacy/f.js` resolves) and passes with this change.

```
bun bd test test/js/bun/resolve/resolve.test.ts
bun bd test test/bundler/esbuild/packagejson.test.ts
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->