### PR TITLE
test(worker_threads): speed up worker_heap_snapshot_gc via getHeapStatistics for the race loop

### DIFF
--- a/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
+++ b/test/js/node/worker_threads/heap-snapshot-gc-race-fixture.js
@@ -26,11 +26,27 @@ async function makeWorker() {
 
 let worker = await makeWorker();
 
+// getHeapSnapshot() and getHeapStatistics() share the same cross-VM round-trip
+// (Worker::registerCrossVMRequest + postTaskToWorkerGlobalScope + postTaskTo),
+// so their lambda capture/destruction against the parent VM's HandleSet is
+// identical. The first SNAPSHOT_ITERS iterations use getHeapSnapshot() to
+// guard its specific capture list and the snapshot output; the remainder use
+// getHeapStatistics(), which round-trips ~400x faster, so the total round-trip
+// count (and thus race windows) is preserved without paying a full worker GC
+// and V8-JSON serialization per iteration.
 const iters = Number(process.env.ITERS);
+const snapshotIters = Math.min(iters, Number(process.env.SNAPSHOT_ITERS ?? iters));
+let firstSnapshotKeys;
+let heapStatsKeys;
 for (let i = 0; i < iters; i++) {
   let stream;
   try {
-    stream = await worker.getHeapSnapshot();
+    if (i < snapshotIters) {
+      stream = await worker.getHeapSnapshot();
+    } else {
+      const stats = await worker.getHeapStatistics();
+      heapStatsKeys ??= Object.keys(stats).sort().join(",");
+    }
   } catch (e) {
     // On some CI platforms the worker has been observed to exit on its own
     // after a few hundred heap snapshots — that surfaces here as a clean
@@ -51,9 +67,19 @@ for (let i = 0; i < iters; i++) {
   // synchronous full GC so the "Sh" constraint walks m_strongList while
   // the worker would have been removing a node from it.
   Bun.gc(true);
-  stream.on("data", () => {});
-  await new Promise(resolve => stream.once("end", resolve));
+  if (stream) {
+    if (firstSnapshotKeys === undefined) {
+      // Once per process: read the stream and verify it is a structurally
+      // valid V8 heap snapshot, so this fixture also guards
+      // getHeapSnapshot()'s output rather than only its crash-freedom.
+      let json = "";
+      for await (const chunk of stream) json += chunk;
+      firstSnapshotKeys = Object.keys(JSON.parse(json)).sort().join(",");
+    } else {
+      stream.destroy();
+    }
+  }
 }
 
 await worker.terminate();
-console.log("ok");
+console.log(JSON.stringify({ iters, snapshotIters, snapshotKeys: firstSnapshotKeys, heapStatsKeys }));

--- a/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
+++ b/test/js/node/worker_threads/worker_heap_snapshot_gc.test.ts
@@ -24,8 +24,29 @@ test.skipIf(isWindows || isIntelMacOS)(
   async () => {
     const slow = isDebug || isASAN;
     const attempts = slow ? 1 : 15;
-    const iters = isDebug ? "5" : slow ? "100" : "300";
+    const iters = isDebug ? 5 : slow ? 100 : 300;
+    // The first SNAPSHOT_ITERS round-trips use getHeapSnapshot(); the rest use
+    // getHeapStatistics(), which shares the same registerCrossVMRequest path
+    // and lambda structure but is ~400x cheaper per call, so the 15x300
+    // race-window count is unchanged without 4500 full worker-heap GCs.
+    const snapshotIters = slow ? iters : 20;
     const fixture = join(import.meta.dir, "heap-snapshot-gc-race-fixture.js");
+    // The fixture additionally parses its first snapshot/stats and reports the
+    // top-level keys, so this also guards the V8 heap-snapshot and
+    // getHeapStatistics() shapes.
+    const expected: Record<string, unknown> = {
+      iters,
+      snapshotIters,
+      snapshotKeys: "edges,locations,nodes,samples,snapshot,strings,trace_function_infos,trace_tree",
+    };
+    if (snapshotIters < iters) {
+      expected.heapStatsKeys =
+        "does_zap_garbage,external_memory,heap_size_limit,malloced_memory,number_of_detached_contexts," +
+        "number_of_native_contexts,peak_malloced_memory,total_allocated_bytes,total_available_size," +
+        "total_global_handles_size,total_heap_size,total_heap_size_executable,total_physical_size," +
+        "used_global_handles_size,used_heap_size";
+    }
+    const expectedStdout = JSON.stringify(expected) + "\n";
 
     // The attempts are independent processes with no shared state, so run them
     // all concurrently; the race being guarded is intra-process.
@@ -33,7 +54,7 @@ test.skipIf(isWindows || isIntelMacOS)(
       Array.from({ length: attempts }, async (_, i) => {
         await using proc = Bun.spawn({
           cmd: [bunExe(), fixture],
-          env: { ...bunEnv, ITERS: iters },
+          env: { ...bunEnv, ITERS: String(iters), SNAPSHOT_ITERS: String(snapshotIters) },
           stdout: "pipe",
           stderr: "pipe",
         });
@@ -45,7 +66,7 @@ test.skipIf(isWindows || isIntelMacOS)(
       // One assertion per attempt so a crash shows stdout/stderr/signal together.
       expect(result).toEqual({
         attempt: result.attempt,
-        stdout: "ok\n",
+        stdout: expectedStdout,
         stderr: "",
         exitCode: 0,
         signalCode: null,


### PR DESCRIPTION
## What does this PR do?

`worker_heap_snapshot_gc.test.ts` takes ~52s on alpine 3.23 x64 (build #78055). The fixture loops `await worker.getHeapSnapshot(); Bun.gc(true)` 300 times across 15 concurrent processes on release, and since #31216 every worker carries the full stdio + control-port infrastructure, so each `getHeapSnapshot()` now walks and serializes ~630KB of JSON and the per-iteration cost is ~40ms.

The race this test guards (#30185) lives in the cross-VM promise round-trip: `Worker::registerCrossVMRequest` + `postTaskToWorkerGlobalScope` + `postTaskTo(parentId)` + `resolveCrossVMRequest`. Since #31216 that path is shared verbatim by `getHeapSnapshot()`, `getHeapStatistics()`, `cpuUsage()` and the CPU/heap-profile APIs; their outer lambda captures (`[reqId, parentId, protectedWorker = Ref { worker }]`) are byte-identical. `getHeapSnapshot()` additionally runs a full worker-side GC + V8 JSON build before posting back, but that work sits **outside** the race window (the window is the handful of instructions where the worker thread destroys its outer `EventLoopTask` after posting, while the parent GC iterates `HandleSet::m_strongList`).

So on release the fixture now does:
- **20 `getHeapSnapshot()` round-trips** per process, guarding `getHeapSnapshot()`'s specific lambda and asserting the V8 snapshot top-level key set;
- **280 `getHeapStatistics()` round-trips** per process, exercising the same `registerCrossVMRequest` hop at ~0.1ms each instead of ~40ms, and asserting the Node-matching `getHeapStatistics()` key set.

The 15×300 cross-VM round-trip count (and therefore the number of race windows against the parent VM's `HandleSet`) is unchanged. Debug and ASAN paths keep `getHeapSnapshot()` for every iteration, so their behaviour is unchanged.

## Why is this correct?

A regression of #30185 would mean a parent-VM `Strong<>` ends up captured by value in one of the cross-thread lambdas. That capture list is now defined once by the `registerCrossVMRequest` pattern and copy-pasted across all five introspection methods in `JSWorker.cpp`; any change to the shared pattern affects `getHeapStatistics()` and `getHeapSnapshot()` identically. The fixture still calls `getHeapSnapshot()` 15×20 = 300 times per build on release (and unchanged on debug/ASAN) for its own capture list, and adds shape assertions that the original `"ok\n"` never had.

## Verification

**CI** (build #78055 vs this PR's #78287, both run the test at the front of its shard):

| lane | before (#78055) | this PR (#78287) |
|---|---|---|
| alpine 3.23 x64 | 51.97s | **5.88s** |
| alpine 3.23 aarch64 | 47.21s | *(see build)* |
| debian 13 x64 | 47.97s | **6.83s** |
| ubuntu 25.04 x64 | 48.48s | **6.88s** |
| debian 13 x64-asan | 5.98s | 6.54s (ASAN path unchanged) |

**Local** (release binary built from this branch, linux-x64 glibc, 12 effective cores, median of 2):

| | wall | user | sys |
|---|---|---|---|
| before | 13.8s | 113s | 50s |
| after | 1.9s | 14s | 6s |

`bun bd test` (debug, 1 proc × 5 iters, all `getHeapSnapshot()`): 21.9s → 19.0s.

A previous revision of this PR tried shrinking the worker heap by dropping the `node:worker_threads` import, but that is a no-op on current `main` because #31216 loads the module in every worker for the control port; the local numbers in that revision were accidentally measured against a pre-#31216 release build. This revision is measured against a release binary built from this branch.
