### PR TITLE
test(node:http): cut node-http-uaf.test.ts ASAN workload, assert subprocess output

### DIFF
--- a/test/js/node/http/node-http-uaf-fixture-2.ts
+++ b/test/js/node/http/node-http-uaf-fixture-2.ts
@@ -11,8 +11,9 @@ const url = `http://localhost:${server.address().port}`;
 console.log(`Server running at ${url}`);
 
 const body = new Blob([Buffer.allocUnsafe(1024 * 1024 * 10)]);
+const ROUNDS = Number(process.env.ROUNDS ?? 100);
 
-for (let i = 0; i < 100; i++) {
+for (let i = 0; i < ROUNDS; i++) {
   await Promise.all(
     [...Array(10)].map(() =>
       fetch(url, {
@@ -26,3 +27,4 @@ for (let i = 0; i < 100; i++) {
 }
 
 server.close();
+console.log("Done");

--- a/test/js/node/http/node-http-uaf-fixture.ts
+++ b/test/js/node/http/node-http-uaf-fixture.ts
@@ -4,6 +4,7 @@ import bodyParser from "body-parser";
 import { setTimeout as sleep } from "node:timers/promises";
 
 const CONCURRENCY = 100;
+const REQUESTS = Number(process.env.REQUESTS ?? 10000);
 
 const app = express();
 app.use(bodyParser.json());
@@ -45,8 +46,8 @@ var server = app.listen(0, async () => {
     active.delete(id);
   }
 
-  console.log(`Starting concurrent requests...`);
-  for (let i = 0; i < 10000; i++) {
+  console.log(`Starting ${REQUESTS} concurrent requests...`);
+  for (let i = 0; i < REQUESTS; i++) {
     while (active.size >= CONCURRENCY) {
       await sleep(1);
     }
@@ -58,6 +59,7 @@ var server = app.listen(0, async () => {
     }
   }
 
-  console.log("Done");
   server.close();
+  while (active.size > 0) await sleep(1);
+  console.log("Done");
 });

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -5,17 +5,20 @@ import http from "node:http";
 import net, { type AddressInfo } from "node:net";
 import { join } from "path";
 
-// Each fixture internally loops thousands of requests to hit the abort/destroy
-// race; running the whole subprocess a second time adds no new coverage. On
-// ASAN/debug builds the access-after-free is caught on the first bad touch, so
-// the request count only needs to be large enough to land the timing window a
-// few times. Release builds keep the original counts.
+// Each fixture internally loops hundreds/thousands of requests to hit the
+// abort/destroy race. The counts below were validated by running the fixtures
+// against the pre-fix release build (bun 1.2.6, commit 8ebd5d53d, before both
+// #18485 and #18564) and counting crashes out of 10 runs:
+//
+//   fixture 1 (#18485): REQUESTS=500 5/5, 1000 5/5, 2000 10/10, 10000 10/10
+//   fixture 2 (#18564): ROUNDS=20 1/5, 40-100 8/10, 200 10/10
+//
+// so a single spawn at 2000 / 200 catches the original bugs 10/10 on a release
+// build without ASAN. ASAN/debug only reduces fixture 1 (the 80 s one); fixture
+// 2 stays at 200 everywhere, equal to the previous 2x100 total.
 const slow = isASAN || isDebug;
-// #18485: reporter "spammed in a bash while loop" to crash a release build; 2000
-// aborted requests at CONCURRENCY=100 is still 20 full windows under ASAN.
 uafTest("node-http-uaf-fixture.ts", { REQUESTS: slow ? "2000" : "10000" });
-// #18564: the repro in the PR body was a single request; 200 is 200x that.
-uafTest("node-http-uaf-fixture-2.ts", { ROUNDS: slow ? "20" : "100" });
+uafTest("node-http-uaf-fixture-2.ts", { ROUNDS: "200" });
 
 function uafTest(fixture: string, extraEnv: Record<string, string>) {
   test.concurrent(
@@ -33,10 +36,10 @@ function uafTest(fixture: string, extraEnv: Record<string, string>) {
       expect(stdout.trimEnd().split("\n").at(-1)).toBe("Done");
       expect(exitCode).toBe(0);
     },
-    // One reduced-count pass measured ~22 s (fixture 1) / ~3.5 s (fixture 2) on
-    // a 16-core debug+ASAN box with the other concurrent tests contending;
-    // release runs the full 10k in ~1 s. Keep the 20 s release ceiling for the
-    // windows-aarch64 lane that previously ran one fixture to 5006 ms.
+    // Measured ~21 s (fixture 1) / ~10 s (fixture 2) on a 16-core debug+ASAN
+    // box with the other concurrent tests contending; release runs the full
+    // 10k in ~1 s. Keep the 20 s release ceiling for the windows-aarch64 lane
+    // that previously ran one fixture to 5006 ms.
     slow ? 60_000 : 20_000,
   );
 }

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -1,37 +1,43 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { once } from "node:events";
 import http from "node:http";
 import net, { type AddressInfo } from "node:net";
 import { join } from "path";
 
-uafTest("node-http-uaf-fixture.ts");
-uafTest("node-http-uaf-fixture-2.ts");
+// Each fixture internally loops thousands of requests to hit the abort/destroy
+// race; running the whole subprocess a second time adds no new coverage. On
+// ASAN/debug builds the access-after-free is caught on the first bad touch, so
+// the request count only needs to be large enough to land the timing window a
+// few times. Release builds keep the original counts.
+const slow = isASAN || isDebug;
+// #18485: reporter "spammed in a bash while loop" to crash a release build; 2000
+// aborted requests at CONCURRENCY=100 is still 20 full windows under ASAN.
+uafTest("node-http-uaf-fixture.ts", { REQUESTS: slow ? "2000" : "10000" });
+// #18564: the repro in the PR body was a single request; 200 is 200x that.
+uafTest("node-http-uaf-fixture-2.ts", { ROUNDS: slow ? "20" : "100" });
 
-function uafTest(fixture, iterations = 2) {
-  test(
+function uafTest(fixture: string, extraEnv: Record<string, string>) {
+  test.concurrent(
     `should not crash on abort (${fixture})`,
     async () => {
-      for (let i = 0; i < iterations; i++) {
-        const { exited } = Bun.spawn({
-          cmd: [bunExe(), join(import.meta.dir, fixture)],
-          env: bunEnv,
-          stdout: "inherit",
-          stderr: "inherit",
-          stdin: "ignore",
-        });
-        const exitCode = await exited;
-        expect(exitCode).not.toBeNull();
-        expect(exitCode).toBe(0);
-      }
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, fixture)],
+        env: { ...bunEnv, ...extraEnv },
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trimEnd().split("\n").at(-1)).toBe("Done");
+      expect(exitCode).toBe(0);
     },
-    // The express fixture pushes 10k aborted requests; one iteration runs
-    // ~10 s under ASAN instrumentation (~1 s on release), so two iterations
-    // can never fit the 5 s default there. The full file measures ~2.1 s on a
-    // release x64 box, and the windows-11-aarch64 agent ran a single fixture
-    // to 5006 ms - just over the default - so give release the same measured
-    // headroom instead of sitting on the line.
-    isASAN ? 90_000 : 20_000,
+    // One reduced-count pass measured ~22 s (fixture 1) / ~3.5 s (fixture 2) on
+    // a 16-core debug+ASAN box with the other concurrent tests contending;
+    // release runs the full 10k in ~1 s. Keep the 20 s release ceiling for the
+    // windows-aarch64 lane that previously ran one fixture to 5006 ms.
+    slow ? 60_000 : 20_000,
   );
 }
 


### PR DESCRIPTION
### What does this PR do?

`test/js/node/http/node-http-uaf.test.ts` is one of the slower files on the ASAN lane. Locally on a 16-core debug+ASAN build the file actually times out: one iteration of the express fixture's 10,000 aborted requests takes ~83 s by itself and the test spawns it twice under a 90 s cap.

**CI timing, `debian 13 x64-asan`:**

| | build | file time |
|---|---|---|
| before | [#78055](https://buildkite.com/bun/bun/builds/78055) (`main`) | 35.93 s |
| after (first push) | [#78252](https://buildkite.com/bun/bun/builds/78252) | 13.96 s |

Changes:

- **Drop the outer 2x spawn loop** in favour of a single spawn with an equal-or-validated request count (see table below).
- **Make the fixture request counts env-configurable** and reduce fixture 1 on ASAN/debug only:
  - `node-http-uaf-fixture.ts` (#18485): 10,000 → 2,000 on ASAN/debug; release keeps 10,000.
  - `node-http-uaf-fixture-2.ts` (#18564): 200 rounds everywhere (= the previous 2×100 total, no reduction).
- **Run the two fixture tests with `test.concurrent`** so they overlap with each other and the four existing `test.concurrent.each` drain tests.
- **Pipe and assert stdout/stderr** instead of inheriting: `stderr` must be empty and `stdout` must end in `Done`, checked before the exit-code assertion so a failure prints the actual subprocess output. Both fixtures now print `Done` as their last line; fixture 1 waits for the in-flight set to drain after `server.close()` so the marker is deterministic (server still closes with requests in flight, same path as before).

Fixture defaults (no env set) are the original 10k / 100, so running them standalone is unchanged.

### How did you verify your code works?

Ran each fixture at the chosen counts against **release bun 1.2.6** (`8ebd5d53d`, the last tag before #18485 and #18564 landed) and counted crashes across repeated runs:

| fixture | count | crashes on 1.2.6 |
|---|---|---|
| fixture 1 (#18485) | REQUESTS=100 | 0/5 |
| | REQUESTS=500 | 5/5 |
| | **REQUESTS=2000** (ASAN/debug) | **10/10** |
| | **REQUESTS=10000** (release) | **10/10** |
| fixture 2 (#18564) | ROUNDS=20 | 1/5 |
| | ROUNDS=40–100 | 8/10 |
| | **ROUNDS=200** (all lanes) | **10/10** |

So every count this PR uses crashes the pre-fix release build 10/10 without ASAN's help; the ASAN lane is at least as sensitive. Fixture 2's initial 20-round guess was dropped after the 1/5 result.

Local `bun bd test test/js/node/http/node-http-uaf.test.ts` on a 16-core debug+ASAN box:

| | before | after |
|---|---|---|
| debug+ASAN, 16-core local | times out (>90 s on fixture 1 alone; one 10k iteration ran 83 s) | **~25 s** (3 runs: 24.5, 24.8, 24.9 s) |
| release (`USE_SYSTEM_BUN=1`) | ~2.1 s per the old comment | **1.1 s** |

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http/node-http-uaf.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/http/node-http-uaf.test.ts
bun test v1.4.0 (0152dc68c)

test/js/node/http/node-http-uaf.test.ts:
(pass) should not crash when drain fires after onWritable slot is set to 0 [2645.63ms]
(pass) should not crash when drain fires after onWritable slot is set to undefined [2674.10ms]
(pass) should not crash when drain fires after onWritable slot is set to null [2676.84ms]
(pass) should not crash when drain fires after onWritable slot is set to false [2674.00ms]
(pass) should not crash on abort (node-http-uaf-fixture-2.ts) [9622.85ms]
(pass) should not crash on abort (node-http-uaf-fixture.ts) [21051.27ms]
(pass) 'connection' and 'clientError' callbacks survive GC [553.71ms]

 7 pass
 0 fail
 15 expect() calls
Ran 7 tests across 1 file. [24.48s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/http/node-http-uaf-fixture-2.ts |  4 +-
 test/js/node/http/node-http-uaf-fixture.ts   |  8 ++--
 test/js/node/http/node-http-uaf.test.ts      | 57 ++++++++++++++++------------
 3 files changed, 41 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
test/js/node/http/node-http-uaf-fixture-2.ts      1      1      0
test/js/node/http/node-http-uaf-fixture.ts        1      3      0
test/js/node/http/node-http-uaf.test.ts           2      4      0
```

</details>

<!-- robobun:evidence:end -->