### PR TITLE
test(bun-serve-static-stress): reduce iteration count under ASAN/debug

### DIFF
--- a/test/expected-durations.json
+++ b/test/expected-durations.json
@@ -2283,13 +2283,13 @@
   },
   "js/bun/http/bun-serve-static-stress-access-body.test.ts": {
     "default": 32903,
-    "asan": 65153,
+    "asan": 30000,
     "musl": 29873,
     "windows": 1057
   },
   "js/bun/http/bun-serve-static-stress-no-body.test.ts": {
     "default": 34371,
-    "asan": 62151,
+    "asan": 30000,
     "musl": 30951,
     "windows": 955
   },

--- a/test/js/bun/http/bun-serve-static-helpers.ts
+++ b/test/js/bun/http/bun-serve-static-helpers.ts
@@ -1,6 +1,6 @@
 import { expect } from "bun:test";
 import type { Server } from "bun";
-import { fillRepeating, isASAN, isWindows } from "harness";
+import { fillRepeating, isASAN, isDebug, isWindows } from "harness";
 
 // /big is 4MB so that the first send() cannot drain the body in one write: the
 // static-route sender has to take the to_async + on_writable backpressure loop
@@ -54,10 +54,13 @@ export async function runStress(
   method: (typeof stressMethods)[number],
 ) {
   const bytes = method === "blob" ? static_responses[path] : await static_responses[path][method]();
+  const contentLength = String(static_responses[path].size);
 
   // macOS limits backlog to 128.
   const batchSize = Math.ceil(64 / (isWindows ? 8 : 1));
-  const iterations = Math.ceil(12 / (isWindows ? 8 : 1));
+  // ASAN/debug: memory-safety faults are caught on the first offending access, so extra
+  // passes only add wall time. Release builds keep the full 12 for leak visibility.
+  const iterations = isWindows ? 2 : isASAN || isDebug ? 3 : 12;
 
   async function iterate() {
     let array = new Array(batchSize);
@@ -67,6 +70,7 @@ export async function runStress(
         .then(res => {
           expect(res.status).toBe(200);
           expect(res.url).toBe(route);
+          expect(res.headers.get("content-length")).toBe(contentLength);
           if (accessBody) {
             res.body;
           }
@@ -101,9 +105,17 @@ export async function runStress(
   Bun.gc(true);
 
   const rss = (process.memoryUsage.rss() / 1024 / 1024) | 0;
-  // ASAN's shadow memory + quarantine raise the absolute RSS floor.
-  expect(rss).toBeLessThan(isASAN ? 6144 : 4092);
   const delta = rss - baseline;
   console.log("Final RSS", rss);
   console.log("Delta RSS", delta);
+  // ASAN's shadow memory + quarantine raise the absolute RSS floor.
+  expect(rss).toBeLessThan(isASAN ? 6144 : 4092);
+  if (isASAN || isDebug) {
+    // The measurement half repeats the warmup half's work, so growth between the two
+    // Bun.gc(true) bookends is the leak signal. A single leaked 4MB body per batch is
+    // batchSize * 4MB = 256MB; 200 is under that and above observed jitter (±40MB).
+    // Release builds are not asserted: mimalloc page retention makes the delta swing
+    // by hundreds of MB between the two gc() calls (observed -644..+223).
+    expect(delta).toBeLessThan(200);
+  }
 }

--- a/test/js/bun/http/bun-serve-static-stress-access-body.test.ts
+++ b/test/js/bun/http/bun-serve-static-stress-access-body.test.ts
@@ -1,7 +1,7 @@
 // Stress half of bun-serve-static: body read via res[method]() *after* touching
 // res.body (materialises a ReadableStream before the buffered-read fast path).
 // Split from the sibling "-no-body" file so each half stays well inside the
-// per-file wall clock on a slow runner while doing the full 4MB × 64 × 24 loop.
+// per-file wall clock on a slow runner. Loop shape lives in runStress.
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, test } from "bun:test";
 import { isBroken, isMacOS } from "harness";

--- a/test/js/bun/http/bun-serve-static-stress-no-body.test.ts
+++ b/test/js/bun/http/bun-serve-static-stress-no-body.test.ts
@@ -1,7 +1,7 @@
 // Stress half of bun-serve-static: body read via res[method]() *without* first
 // touching res.body (exercises the buffered-stream fast path added in #13704).
 // Split from the sibling "-access-body" file so each half stays well inside the
-// per-file wall clock on a slow runner while doing the full 4MB × 64 × 24 loop.
+// per-file wall clock on a slow runner. Loop shape lives in runStress.
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, test } from "bun:test";
 import { isBroken, isMacOS } from "harness";


### PR DESCRIPTION
The two `bun-serve-static-stress-*` files run 64 concurrent fetches × (12 warmup + 12 measurement) iterations per test case on every lane except Windows. Under debug+ASAN that is ~96s per file; the CI `asan` lane records ~63-65s (build #78055, `test/expected-durations.json`).

### Change

In `runStress` (shared by both stress files):

- Drop `iterations` to 3 when `isASAN || isDebug`. ASAN catches memory-safety faults on the first offending access, so extra passes only add wall time; `batchSize` stays at 64 so the concurrent-write path in `StaticRoute::do_render_blob` is still hit with the same fan-out, and `/big` stays 4MB so the `to_async` + `on_writable` backpressure loop is still exercised (the constraint #34081 documented). Release/musl/Windows counts are unchanged.
- Add a `Content-Length` header assertion on every response.
- Add an RSS-delta bound under ASAN/debug: growth between the two `Bun.gc(true)` bookends must be < 200 MB. A single leaked 4MB body per 64-wide batch would be 256 MB, so this catches a per-batch leak that the existing absolute ceiling (6144 MB under ASAN, observed peak ~730 MB) would not. The delta bound is not asserted on release builds; mimalloc page retention makes it swing by hundreds of MB between the two `gc()` calls (observed -644..+223 over 7 runs locally) and would flake. The absolute ceiling stays for release.

### Timing (local, debug+ASAN, `bun bd test`)

| file | before | after |
|---|---|---|
| `bun-serve-static-stress-access-body.test.ts` | 95.9s | 28.2s |
| `bun-serve-static-stress-no-body.test.ts` | 97.2s | 29.9s |

Release (`USE_SYSTEM_BUN=1`) is unchanged at 12+12 iterations; both files pass in ~24s with no new failures over 4 runs.

`test/expected-durations.json` reseeded for the `asan` lane.