### PR TITLE
test: speed up bun-install-security-provider large-payload IPC test

### DIFF
--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -108,6 +108,10 @@ test("basic", {
       url: "https://example.com/advisory-1",
     },
   ],
+  expect: ({ out }) => {
+    expect(out).toContain("Advisory 1 description");
+    expect(out).toContain("https://example.com/advisory-1");
+  },
 });
 
 test("shows progress message when scanner takes more than 1 second", {
@@ -600,6 +604,10 @@ describe("Edge Cases", () => {
   test("empty advisories array", {
     scanner: async () => [],
     expectedExitCode: 0,
+    expect: ({ out }) => {
+      expect(out).toContain("installed bar@");
+      expect(out).not.toContain("advisory");
+    },
   });
 
   test("special characters in advisory", {
@@ -699,17 +707,18 @@ describe("Package Resolution", () => {
 });
 
 describe("Large payload via ipc pipe", () => {
-  // Pad package names so the JSON exceeds 1MB with fewer packages. Each
-  // package resolution triggers an HTTP round-trip to the dummy registry,
-  // which is the slow part on Windows aarch64. The name appears twice in
-  // each JSON entry (name field + tarball URL), so 170-char padding gives
-  // ~470 bytes/entry; 2500 entries = ~1.2MB. Filenames stay under 200 chars.
-  const PKG_COUNT = 2500;
-  const NAME_PAD = Buffer.alloc(170, "x").toString();
-  const pkgName = (i: number) => `test-pkg-${NAME_PAD}-${i}`;
+  // The >1MB payload threshold is reached via long tarball URLs (query-string
+  // padding) rather than many packages. Each package still costs a manifest
+  // fetch + tarball fetch + extract, so fewer packages keeps this test fast on
+  // Windows aarch64 while the IPC pipe still round-trips >1MB of JSON.
+  //
+  // 400 packages x ~3KB tarball URL = ~1.25MB; the scanner returns a fatal
+  // advisory after validating the payload so the subsequent node_modules link
+  // step (which is not under test here) is skipped.
+  const PKG_COUNT = 400;
+  const URL_PAD = Buffer.alloc(3000, "p").toString();
+  const pkgName = (i: number) => `test-pkg-${i}`;
 
-  // Every package resolves to the same tarball bytes, served from memory so
-  // the registry never touches the filesystem.
   let barTarballBytes: Uint8Array;
 
   beforeAll(async () => {
@@ -717,7 +726,7 @@ describe("Large payload via ipc pipe", () => {
   });
 
   test("handles packages JSON larger than max arg length (>1MB)", {
-    testTimeout: 120_000,
+    testTimeout: 60_000,
     scanner: async ({ packages }) => {
       const jsonSize = JSON.stringify(packages).length;
       console.log(`Received JSON payload of ${jsonSize} bytes from ${packages.length} packages`);
@@ -730,7 +739,9 @@ describe("Large payload via ipc pipe", () => {
         throw new Error("Expected to receive packages");
       }
 
-      return [];
+      // Abort the install after the IPC payload has been validated; linking
+      // hundreds of packages into node_modules is not what is under test here.
+      return [{ package: packages[0].name, description: "abort after IPC payload check", level: "fatal", url: null }];
     },
 
     packageJson: (() => {
@@ -746,13 +757,12 @@ describe("Large payload via ipc pipe", () => {
       };
     })(),
     packages: [],
-    concurrent: false,
-    customRegistry: (urls, ctx) => {
+    fails: true,
+    customRegistry: (_urls, ctx) => {
       return async (request: Request) => {
-        urls.push(request.url);
         const url = request.url.replaceAll("%2f", "/");
         expect(request.method).toBe("GET");
-        if (url.endsWith(".tgz")) {
+        if (new URL(url).pathname.endsWith(".tgz")) {
           return new Response(barTarballBytes);
         }
         expect(request.headers.get("accept")).toBe(
@@ -765,21 +775,25 @@ describe("Large payload via ipc pipe", () => {
           JSON.stringify({
             name,
             versions: {
-              "0.0.2": { name, version: "0.0.2", dist: { tarball: `${ctx.registry_url}${name}-0.0.2.tgz` } },
+              "0.0.2": {
+                name,
+                version: "0.0.2",
+                dist: { tarball: `${ctx.registry_url}${name}-0.0.2.tgz?pad=${URL_PAD}` },
+              },
             },
             "dist-tags": { latest: "0.0.2" },
           }),
         );
       };
     },
-    expectedExitCode: 0,
     expect: ({ out }) => {
-      expect(out).toContain("Received JSON payload");
-
-      const match = out.match(/Received JSON payload of (\d+) bytes/);
+      const match = out.match(/Received JSON payload of (\d+) bytes from (\d+) packages/);
       expect(match).not.toBeNull();
       const bytes = parseInt(match![1], 10);
+      const count = parseInt(match![2], 10);
       expect(bytes).toBeGreaterThan(1024 * 1024);
+      expect(count).toBe(PKG_COUNT);
+      expect(out).toContain("abort after IPC payload check");
     },
   });
 });


### PR DESCRIPTION
## What does this PR do?

`test/cli/install/bun-install-security-provider.test.ts` spends essentially all of its wall time in the single "Large payload via ipc pipe" test. On Windows 11 aarch64 that test resolves, downloads, extracts, and then links 2500 packages into node_modules purely to produce a >1MB JSON payload for the IPC pipe; the link step alone pushes it past its 120s timeout on that lane.

Reach the same >1MB payload with far fewer packages, without weakening the IPC assertion:

- **Pad tarball URLs instead of package names.** A ~3KB query string on each `dist.tarball` URL is passed through to the scanner JSON's `tarball` field verbatim, so 400 packages x ~3KB = ~1.25MB of IPC JSON (still asserted with `expect(bytes).toBeGreaterThan(1024 * 1024)`). That is 6x fewer manifest fetches, tarball fetches, and extractions.
- **Abort after the payload is validated.** The scanner now returns a fatal advisory once it has verified the >1MB payload, so the subsequent node_modules link step (hundreds of packages on Windows) is skipped. The link step is not what this test covers; the IPC round-trip is.
- **Run concurrently.** With the test now light, drop `concurrent: false` so it overlaps with the other 42 tests instead of running after them.
- **Tighten a couple of assertions** that previously only checked exit code: `basic` now asserts the advisory description and URL appear in output; `empty advisories array` now asserts the package was actually installed. The IPC test additionally asserts the exact package count reached the scanner and the advisory description round-tripped.

No tests removed or skipped; same 43 tests, same IPC >1MB assertion.

## How did you verify your code works?

`bun bd test test/cli/install/bun-install-security-provider.test.ts`, 43/43 pass on all CI lanes.

### CI timings

| Lane | Build [#78055](https://buildkite.com/bun/bun/builds/78055) (before) | Build [#78259](https://buildkite.com/bun/bun/builds/78259) (this PR) | Delta |
| --- | --- | --- | --- |
| Windows 11 aarch64 | 109.51s | **2.40s** | -97.8% |
| Windows 2019 x64 | 8.07s | 2.11s | -73.9% |
| Linux x64 debian-13 | 3.03s | 1.72s | -43.2% |

### Local debug+ASAN

| | Before | After |
| --- | --- | --- |
| File total | 43.0s | 20.6s |
| IPC test alone | 21.9s | 4.0s |

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-install-security-provider.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-install-security-provider.test.ts
bun test v1.4.0 (a577976ce)

test/cli/install/bun-install-security-provider.test.ts:
(pass) basic [1470.59ms]
(pass) expect output to contain the advisory [1452.39ms]
(pass) Security Scanner Edge Cases > scanner module not found [1464.33ms]
(pass) stdout contains all input package metadata [1534.33ms]
(pass) shows progress message when scanner takes more than 1 second [2817.23ms]
(pass) Security Scanner Edge Cases > scanner missing version field [1393.71ms]
(pass) Security Scanner Edge Cases > scanner module throws during import [1422.85ms]
(pass) Security Scanner Edge Cases > scanner missing scan [1379.19ms]
(pass) Security Scanner Edge Cases > scanner wrong version [1498.30ms]
(pass) Invalid Return Values > scanner returns null [1372.78ms]
(pass) Invalid Return Values > scanner returns non-array [1388.67ms]
(pass) Invalid Return Values > scanner throws exception [1383.48ms]
(pass) Security Scanner Edge Cases > scanner scan not a function [1548.78ms]
(pass) Invalid Return Values > scanner returns undefined [1568.13ms]
(pass) Invalid Advisory Formats > advisory missing package field [1365.61ms]
(pass) Invalid Return Values > scanner returns non-object in array [1463.13ms]
(pass) Invalid Advisory Formats > advisory package field empty string [1370.88ms]
(pass) Invalid Advisory Formats > advisory package field not string [1469.59ms]
(pass) Invalid Advisory Formats > advisory missing description field [1379.91ms]
(pass) Invalid Advisory Formats > advisory with null description field [1356.43ms]
(pass) Invalid Advisory Formats > advisory description field not string or null [1357.01ms]
(pass) Invalid Advisory Formats > advisory with empty string description [1481.85ms]
(pass) Invalid Advisory Formats > advisory missing url field [1372.56ms]
(pass) Invalid Advisory Formats > advisory with null url field [1430.66ms]
(pass) Inval
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../install/bun-install-security-provider.test.ts  | 58 ++++++++++++++--------
 1 file changed, 36 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
test/cli/install/bun-install-security-provider.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->