### PR TITLE
test(dlopen): build addon via bun x node-gyp, tighten stdout assertions

### DIFF
--- a/test/js/node/process/dlopen-duplicate-load.test.ts
+++ b/test/js/node/process/dlopen-duplicate-load.test.ts
@@ -11,7 +11,7 @@ import { join } from "path";
 // - non-object exports: null/undefined/primitive exports used to segfault
 
 describe.skipIf(!canBuildNodeAddons())("process.dlopen native addon", () => {
-  let addonPath: string;
+  let addonPathJs: string;
 
   beforeAll(() => {
     const addonSource = `
@@ -58,39 +58,31 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
     const dir = tempDirWithFiles("dlopen-duplicate-test", {
       "addon.cpp": addonSource,
       "binding.gyp": bindingGyp,
-      "package.json": JSON.stringify({
-        name: "test",
-        version: "1.0.0",
-        gypfile: true,
-        scripts: {
-          // Run node-gyp under the bun being tested: the system Node on Windows
-          // is built with clang-cl and its process.config leaks thin-LTO flags
-          // into addon builds (link.exe fails on /opt:lldltojobs), and the
-          // system Node's ABI may not match ours at all (e.g. older macOS CI
-          // machines). gyp -D defines can't override target_defaults, so use
-          // bun's clean process.config instead.
-          install: `${JSON.stringify(bunExe())} --bun node-gyp rebuild`,
-        },
-        devDependencies: {
-          "node-gyp": "^11.2.0",
-        },
-      }),
     });
 
-    // Build the addon
+    // Build the addon. Run node-gyp via `bun x` (global cache, no per-test
+    // node_modules install) under the bun being tested: the system Node on
+    // Windows is built with clang-cl and its process.config leaks thin-LTO
+    // flags into addon builds (link.exe fails on /opt:lldltojobs), and the
+    // system Node's ABI may not match ours at all (e.g. older macOS CI
+    // machines). gyp -D defines can't override target_defaults, so use bun's
+    // clean process.config instead.
     const build = spawnSync({
-      cmd: [bunExe(), "install"],
+      cmd: [bunExe(), "--bun", "x", "node-gyp@11", "configure", "build"],
       cwd: dir,
       env: bunEnv,
-      stdout: "inherit",
-      stderr: "inherit",
+      stdout: "pipe",
+      stderr: "pipe",
     });
 
     if (!build.success) {
-      throw new Error("Failed to build native addon");
+      throw new Error(
+        `Failed to build native addon (exit ${build.exitCode}):\n` +
+          `stdout:\n${build.stdout.toString()}\nstderr:\n${build.stderr.toString()}`,
+      );
     }
 
-    addonPath = join(dir, "build", "Release", "addon.node");
+    addonPathJs = JSON.stringify(join(dir, "build", "Release", "addon.node"));
   }, 180_000);
 
   // Each test spawns an isolated child (dlopen state is process-global), so
@@ -100,12 +92,12 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const testScript = `
       // First load
       const m1 = { exports: {} };
-      process.dlopen(m1, "${addonPath.replace(/\\/g, "\\\\")}");
+      process.dlopen(m1, ${addonPathJs});
       console.log("First load: hello exists?", typeof m1.exports.hello === "function");
 
       // Second load - this should work now
       const m2 = { exports: {} };
-      process.dlopen(m2, "${addonPath.replace(/\\/g, "\\\\")}");
+      process.dlopen(m2, ${addonPathJs});
       console.log("Second load: hello exists?", typeof m2.exports.hello === "function");
 
       // Verify both work
@@ -123,10 +115,12 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
-      expect(stdout).toContain("First load: hello exists? true");
-      expect(stdout).toContain("Second load: hello exists? true");
-      expect(stdout).toContain("First module result: world");
-      expect(stdout).toContain("Second module result: world");
+      expect(stdout.trim().split("\n")).toEqual([
+        "First load: hello exists? true",
+        "Second load: hello exists? true",
+        "First module result: world",
+        "Second module result: world",
+      ]);
       expect(exitCode).toBe(0);
     });
 
@@ -134,12 +128,12 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const testScript = `
       // First load with empty object
       const m1 = { exports: {} };
-      process.dlopen(m1, "${addonPath.replace(/\\/g, "\\\\")}");
+      process.dlopen(m1, ${addonPathJs});
       console.log("m1.exports.hello:", m1.exports.hello());
 
       // Second load with different exports object
       const m2 = { exports: { initial: true } };
-      process.dlopen(m2, "${addonPath.replace(/\\/g, "\\\\")}");
+      process.dlopen(m2, ${addonPathJs});
       console.log("m2.exports.initial:", m2.exports.initial);
       console.log("m2.exports.hello:", m2.exports.hello());
     `;
@@ -154,9 +148,11 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
-      expect(stdout).toContain("m1.exports.hello: world");
-      expect(stdout).toContain("m2.exports.initial: true");
-      expect(stdout).toContain("m2.exports.hello: world");
+      expect(stdout.trim().split("\n")).toEqual([
+        "m1.exports.hello: world",
+        "m2.exports.initial: true",
+        "m2.exports.hello: world",
+      ]);
       expect(exitCode).toBe(0);
     });
   });
@@ -166,7 +162,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const testScript = `
       const m = { exports: null };
       try {
-        process.dlopen(m, "${addonPath.replace(/\\/g, "\\\\")}");
+        process.dlopen(m, ${addonPathJs});
         console.log("FAIL: Should have thrown");
       } catch (e) {
         console.log("SUCCESS:", e.message);
@@ -183,7 +179,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
-      expect(stdout).toContain("SUCCESS:");
+      expect(stdout).toStartWith("SUCCESS:");
       expect(stdout).toContain("null is not an object");
       expect(exitCode).toBe(0);
     });
@@ -192,7 +188,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const testScript = `
       const m = { exports: undefined };
       try {
-        process.dlopen(m, "${addonPath.replace(/\\/g, "\\\\")}");
+        process.dlopen(m, ${addonPathJs});
         console.log("FAIL: Should have thrown");
       } catch (e) {
         console.log("SUCCESS:", e.message);
@@ -209,7 +205,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
-      expect(stdout).toContain("SUCCESS:");
+      expect(stdout).toStartWith("SUCCESS:");
       expect(stdout).toContain("undefined is not an object");
       expect(exitCode).toBe(0);
     });
@@ -218,7 +214,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
       // Primitives get converted to wrapper objects
       const testScript = `
       const m = { exports: "primitive" };
-      process.dlopen(m, "${addonPath.replace(/\\/g, "\\\\")}");
+      process.dlopen(m, ${addonPathJs});
       console.log("Type:", typeof m.exports);
       console.log("Value:", m.exports);
     `;
@@ -234,8 +230,7 @@ NODE_MODULE_CONTEXT_AWARE(addon, demo::Initialize)
 
       // Should not crash - primitives get converted to wrapper objects
       expect(stderr).toBe("");
-      expect(stdout).toContain("Type: string");
-      expect(stdout).toContain("Value: primitive");
+      expect(stdout.trim().split("\n")).toEqual(["Type: string", "Value: primitive"]);
       expect(exitCode).toBe(0);
     });
   });


### PR DESCRIPTION
### What does this PR do?

Follow-up to #35198 for `test/js/node/process/dlopen-duplicate-load.test.ts`:

- Build the addon with `bun --bun x node-gyp@11 configure build` instead of `bun install` + a `devDependencies` entry + an install script. This skips creating an 87-package `node_modules` tree in the temp dir and skips node-gyp's `clean` step. The bunx invocation matches the pattern already used in `test/napi/node-napi-tests/harness.ts`.
- Pipe build stdout/stderr instead of inheriting; on failure the captured output is included in the thrown error. Previously every CI run printed ~60 lines of node-gyp/MSBuild noise for this file.
- Serialize the addon path once with `JSON.stringify` instead of escaping backslashes inline at seven interpolation sites.
- Tighten stdout assertions from `toContain` chains to exact-line `toEqual` / `toStartWith`.

### Why not faster?

On Windows CI the wall time is dominated by MSBuild: in build 78055 the MSBuild step alone was ~36s for one source file. Bypassing MSBuild would need a direct `cl.exe` fast path, which is outside the scope of a single-file test change. On the Linux debug lane the remaining cost is node-gyp's own JS running under the ASAN binary.

### How did you verify your code works?

`bun bd test test/js/node/process/dlopen-duplicate-load.test.ts`, three runs each, warm caches:

| platform | before (main) | after |
| --- | --- | --- |
| linux x64 debug+ASAN | 14.2 / 15.1 / 15.8 s | 13.0 / 13.3 / 13.4 s |
| windows x64 release (`USE_SYSTEM_BUN=1`), cold caches | 18.6 / 18.8 / 19.2 s | 18.5 / 18.6 / 18.6 s |

Windows first run on a fresh machine: 47.0s before vs 12.1s after, because the old `bun install` path paid the full 87-package download; `bun x` reuses its global cache.

All five tests pass on linux x64 debug and windows x64.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/process/dlopen-duplicate-load.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/process/dlopen-duplicate-load.test.ts
bun test v1.4.0 (f946b880d)

test/js/node/process/dlopen-duplicate-load.test.ts:
(pass) process.dlopen native addon > process.dlopen duplicate loads > should load the same module twice successfully [441.24ms]
(pass) process.dlopen native addon > process.dlopen with non-object exports > should throw error when exports is null [425.27ms]
(pass) process.dlopen native addon > process.dlopen duplicate loads > should load module with different exports objects [442.63ms]
(pass) process.dlopen native addon > process.dlopen with non-object exports > should throw error when exports is undefined [430.21ms]
(pass) process.dlopen native addon > process.dlopen with non-object exports > should handle primitive exports gracefully [420.97ms]

 5 pass
 0 fail
 17 expect() calls
Ran 5 tests across 1 file. [12.62s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/process/dlopen-duplicate-load.test.ts | 79 ++++++++++------------
 1 file changed, 37 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
test/js/node/process/dlopen-duplicate-load.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->