### PR TITLE
test(http): share one fixture server across serve-body-leak scenarios

### DIFF
--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -1,44 +1,16 @@
-import { expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isCI, isDebug, isFlaky, isLinux, isWindows } from "harness";
+import type { Subprocess } from "bun";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug, isFlaky, isLinux, isWindows } from "harness";
 import { join } from "path";
 
 const payload = Buffer.alloc(512 * 1024, "1").toString("utf-8"); // decent size payload to test memory leak
 const batchSize = 40;
-const totalCount = 10_000;
+// A leaked 512 KB body × totalCount would grow RSS by gigabytes; the assertions
+// below compare against O(100 MB), so the slower ASAN/debug lanes keep the same
+// margin with fewer iterations (each request is ~2-10× slower there).
+const totalCount = isASAN || isDebug ? 4_000 : 10_000;
 const zeroCopyPayload = new Blob([payload]);
 const zeroCopyJSONPayload = new Blob([JSON.stringify({ bun: payload })]);
-
-// let HARDCODED_URL = "http://localhost:52666/";
-let HARDCODED_URL = null;
-
-async function getURL() {
-  if (HARDCODED_URL) {
-    const url = new URL(HARDCODED_URL);
-    await warmup(url);
-    return {
-      url,
-      process: {
-        [Symbol.asyncDispose]() {
-          return Promise.resolve();
-        },
-      },
-    };
-  }
-  let defer = Promise.withResolvers<string>();
-  const process = Bun.spawn([bunExe(), "--smol", join(import.meta.dirname, "body-leak-test-fixture.ts")], {
-    env: bunEnv,
-    stdout: "inherit",
-    stderr: "inherit",
-    stdin: "ignore",
-    ipc(message) {
-      defer.resolve(message);
-    },
-  });
-  const url: URL = new URL(await defer.promise);
-  process.unref();
-  await warmup(url);
-  return { url, process };
-}
 
 async function getMemoryUsage(url: URL): Promise<number> {
   return (await fetch(`${url.origin}/report`).then(res => res.json())) as number;
@@ -151,54 +123,67 @@ async function calculateMemoryLeak(fn: (url: URL) => Promise<void>, url: URL) {
 }
 
 // Since the payload size is 512 KB
-// If it was leaking the body, the memory usage would be at least 512 KB * 10_000 = 5 GB
+// If it was leaking the body, the memory usage would be at least 512 KB * totalCount = multiple GB
 // If it ends up around 280 MB, it's probably not leaking the body.
-for (const test_info of [
-  ["#10265 should not leak memory when ignoring the body", callIgnore, false, 64],
-  ["should not leak memory when buffering the body", callBuffering, false, 64],
-  ["should not leak memory when buffering a JSON body", callJSONBuffering, false, 64],
-  ["should not leak memory when buffering the body and accessing req.body", callBufferingBodyGetter, false, 64],
-  ["should not leak memory when streaming the body", callStreaming, isFlaky && isLinux, 64],
-  ["should not leak memory when streaming the body incompletely", callIncompleteStreaming, false, 64],
-  ["should not leak memory when streaming the body and echoing it back", callStreamingEcho, false, 64],
-] as const) {
-  const [testName, fn, skip, maxMemoryGrowth] = test_info;
-  it.todoIf(skip || (isFlaky && isWindows))(
-    testName,
-    async () => {
-      const { url, process } = await getURL();
-      try {
+//
+// One fixture subprocess serves every scenario below: spawning a fresh one per
+// test (and re-running the 10k-request warmup each time) was the dominant cost
+// on ASAN. Sequential reuse keeps the RSS assertions meaningful because a real
+// body leak compounds across scenarios instead of being hidden by a restart.
+describe.todoIf(isFlaky && isWindows)("request body leak", () => {
+  let fixture: Subprocess;
+  let url: URL;
+
+  beforeAll(async () => {
+    const defer = Promise.withResolvers<string>();
+    fixture = Bun.spawn([bunExe(), "--smol", join(import.meta.dirname, "body-leak-test-fixture.ts")], {
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "ignore",
+      ipc(message) {
+        defer.resolve(message);
+      },
+    });
+    fixture.unref();
+    url = new URL(await defer.promise);
+    await warmup(url);
+  }, 60_000);
+
+  afterAll(async () => {
+    fixture?.kill();
+    await fixture?.exited;
+  });
+
+  for (const test_info of [
+    ["#10265 should not leak memory when ignoring the body", callIgnore, false, 64],
+    ["should not leak memory when buffering the body", callBuffering, false, 64],
+    ["should not leak memory when buffering a JSON body", callJSONBuffering, false, 64],
+    ["should not leak memory when buffering the body and accessing req.body", callBufferingBodyGetter, false, 64],
+    ["should not leak memory when streaming the body", callStreaming, isFlaky && isLinux, 64],
+    ["should not leak memory when streaming the body incompletely", callIncompleteStreaming, false, 64],
+    ["should not leak memory when streaming the body and echoing it back", callStreamingEcho, false, 64],
+  ] as const) {
+    const [testName, fn, skip, maxMemoryGrowth] = test_info;
+    it.todoIf(skip)(
+      testName,
+      async () => {
         const report = await calculateMemoryLeak(fn, url);
         console.log(report);
         // peak memory is too high
         expect(report.peak_memory).not.toBeGreaterThan(report.start_memory * 2.5);
-
         // acceptable memory leak
         expect(report.leak).toBeLessThanOrEqual(maxMemoryGrowth);
-
         // ASAN quarantine + debug-assertions instrumentation inflate RSS;
         // give the asan lane more headroom than a plain release build.
         expect(report.end_memory).toBeLessThanOrEqual((isASAN ? 768 : 512) * 1024 * 1024);
-      } catch (e) {
-        if (!isCI && process.platform !== "win32") {
-          try {
-            await fetch(`${url.origin}/heap-snapshot`);
-            await Bun.sleep(10);
-          } catch (e) {
-            console.error(e);
-          }
-        }
-
-        throw e;
-      } finally {
-        process.kill?.();
-      }
-    },
-    // release-asan runs streaming-echo at ~31s median (27-39s over 35 CI runs),
-    // so 40s leaves no margin on a slow runner; give ASAN the same 60s as debug.
-    isDebug || isASAN ? 60_000 : 40_000,
-  );
-}
+        // the fixture must still be serving (no crash / OOM-kill mid-run)
+        expect(fixture.exitCode).toBeNull();
+      },
+      isDebug || isASAN ? 60_000 : 40_000,
+    );
+  }
+});
 
 // A client disconnecting while a direct response stream is suspended inside pull() must not
 // leak the native response sink (nothing else can ever free it once the request context is
@@ -257,7 +242,7 @@ it("aborting direct-stream responses parked in pull() does not leak the native s
     const leaked = /SUMMARY: AddressSanitizer: (\d+) byte\(s\) leaked/.exec(stderr);
     return leaked ? Number(leaked[1]) : 0;
   };
-  const [small, large] = [await runAborts(2), await runAborts(22)];
+  const [small, large] = await Promise.all([runAborts(2), runAborts(22)]);
   // 20 extra aborted requests leaked ~176 bytes each before the fix.
   expect(large - small).toBeLessThan(1000);
-});
+}, 30_000);

--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isFlaky, isLinux, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { join } from "path";
 
 const payload = Buffer.alloc(512 * 1024, "1").toString("utf-8"); // decent size payload to test memory leak
@@ -8,7 +8,7 @@ const batchSize = 40;
 // A leaked 512 KB body × totalCount would grow RSS by gigabytes; the assertions
 // below compare against O(100 MB), so the slower ASAN/debug lanes keep the same
 // margin with fewer iterations (each request is ~2-10× slower there).
-const totalCount = isASAN || isDebug ? 4_000 : 10_000;
+const totalCount = isASAN || isDebug ? 3_000 : 10_000;
 const zeroCopyPayload = new Blob([payload]);
 const zeroCopyJSONPayload = new Blob([JSON.stringify({ bun: payload })]);
 
@@ -26,7 +26,7 @@ async function warmup(url: URL) {
       batch[j] = fetch(`${url.origin}/streaming`, {
         method: "POST",
         body: zeroCopyPayload,
-      });
+      }).then(res => res.text());
     }
     await Promise.all(batch);
     remaining -= batchSize;
@@ -130,7 +130,7 @@ async function calculateMemoryLeak(fn: (url: URL) => Promise<void>, url: URL) {
 // test (and re-running the 10k-request warmup each time) was the dominant cost
 // on ASAN. Sequential reuse keeps the RSS assertions meaningful because a real
 // body leak compounds across scenarios instead of being hidden by a restart.
-describe.todoIf(isFlaky && isWindows)("request body leak", () => {
+describe("request body leak", () => {
   let fixture: Subprocess;
   let url: URL;
 
@@ -145,7 +145,6 @@ describe.todoIf(isFlaky && isWindows)("request body leak", () => {
         defer.resolve(message);
       },
     });
-    fixture.unref();
     fixture.exited.then(code => defer.reject(new Error(`body-leak fixture exited (${code}) before sending its URL`)));
     url = new URL(await defer.promise);
     await warmup(url);
@@ -157,24 +156,28 @@ describe.todoIf(isFlaky && isWindows)("request body leak", () => {
   });
 
   for (const test_info of [
-    ["#10265 should not leak memory when ignoring the body", callIgnore, false, 64],
-    ["should not leak memory when buffering the body", callBuffering, false, 64],
-    ["should not leak memory when buffering a JSON body", callJSONBuffering, false, 64],
-    ["should not leak memory when buffering the body and accessing req.body", callBufferingBodyGetter, false, 64],
-    ["should not leak memory when streaming the body", callStreaming, isFlaky && isLinux, 64],
-    ["should not leak memory when streaming the body incompletely", callIncompleteStreaming, false, 64],
-    ["should not leak memory when streaming the body and echoing it back", callStreamingEcho, false, 64],
+    ["#10265 should not leak memory when ignoring the body", callIgnore, 64],
+    ["should not leak memory when buffering the body", callBuffering, 64],
+    ["should not leak memory when buffering a JSON body", callJSONBuffering, 64],
+    ["should not leak memory when buffering the body and accessing req.body", callBufferingBodyGetter, 64],
+    ["should not leak memory when streaming the body", callStreaming, 64],
+    ["should not leak memory when streaming the body incompletely", callIncompleteStreaming, 64],
+    ["should not leak memory when streaming the body and echoing it back", callStreamingEcho, 64],
   ] as const) {
-    const [testName, fn, skip, maxMemoryGrowth] = test_info;
-    it.todoIf(skip)(
+    const [testName, fn, maxMemoryGrowth] = test_info;
+    it(
       testName,
       async () => {
         // fail fast with the exit code instead of a ConnectionRefused cascade if a prior scenario crashed the fixture
         expect(fixture.exitCode ?? fixture.signalCode).toBeNull();
         const report = await calculateMemoryLeak(fn, url);
         console.log(report);
-        // peak memory is too high
-        expect(report.peak_memory).not.toBeGreaterThan(report.start_memory * 2.5);
+        // Peak should stay within a small multiple of the post-GC baseline; a
+        // leaked 512 KB body per request would blow past this by an order of
+        // magnitude. 3x (was 2.5x) gives headroom for the incomplete-streaming
+        // scenario on Windows, where 40 concurrent half-read uploads briefly
+        // hold ~2.6x of a low shared-server baseline before dropping back.
+        expect(report.peak_memory).not.toBeGreaterThan(report.start_memory * 3);
         // acceptable memory leak
         expect(report.leak).toBeLessThanOrEqual(maxMemoryGrowth);
         // ASAN quarantine + debug-assertions instrumentation inflate RSS;

--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -146,6 +146,7 @@ describe.todoIf(isFlaky && isWindows)("request body leak", () => {
       },
     });
     fixture.unref();
+    fixture.exited.then(code => defer.reject(new Error(`body-leak fixture exited (${code}) before sending its URL`)));
     url = new URL(await defer.promise);
     await warmup(url);
   }, 60_000);
@@ -168,6 +169,8 @@ describe.todoIf(isFlaky && isWindows)("request body leak", () => {
     it.todoIf(skip)(
       testName,
       async () => {
+        // fail fast with the exit code instead of a ConnectionRefused cascade if a prior scenario crashed the fixture
+        expect(fixture.exitCode ?? fixture.signalCode).toBeNull();
         const report = await calculateMemoryLeak(fn, url);
         console.log(report);
         // peak memory is too high
@@ -177,8 +180,6 @@ describe.todoIf(isFlaky && isWindows)("request body leak", () => {
         // ASAN quarantine + debug-assertions instrumentation inflate RSS;
         // give the asan lane more headroom than a plain release build.
         expect(report.end_memory).toBeLessThanOrEqual((isASAN ? 768 : 512) * 1024 * 1024);
-        // the fixture must still be serving (no crash / OOM-kill mid-run)
-        expect(fixture.exitCode).toBeNull();
       },
       isDebug || isASAN ? 60_000 : 40_000,
     );


### PR DESCRIPTION
### What does this PR do?

`serve-body-leak.test.ts` was one of the slowest files in the suite (131s on debian 13 x64-asan, build #78055). Each of the seven body-leak scenarios spawned its own fixture subprocess and re-ran the full 10,000-request warmup before measuring, so roughly half of the file's wall time was redundant warmup against a server that would be killed a few seconds later.

Changes:

- **Hoist the fixture spawn + warmup into `beforeAll`** and reuse one server across all seven scenarios. The RSS assertions stay meaningful because they measure delta from each scenario's own `start_memory`; a real body leak would compound across scenarios on a shared server instead of being hidden by a restart, so if anything this is a stricter check.
- **Branch `totalCount` on `isASAN || isDebug`** (10,000 → 3,000). A leaked 512 KB body over the 2,000 requests between the first sample and the end is still ~1 GB of growth against a 64 MB threshold; the signal is unchanged, the iteration cost on the slowest lanes is not.
- **Run on Windows and drop the Linux-streaming todo.** Two fixes made Windows viable: drain the tiny `"Ok"` responses in warmup (ten thousand undrained `Response` objects were keeping the process from exiting on Windows), and drop the `unref()` on the IPC child (under `bun test` on Windows it was dropping IPC messages and wedging exit; `afterAll` explicitly kills the fixture so it was dead weight). The peak-ratio check is widened from 2.5× to 3× because a shared server's post-GC baseline can be ~40 MB instead of ~85 MB, which the Windows incomplete-streaming working set briefly brushes against; a real body leak is an order of magnitude past 3×.
- **Run the two LSAN abort-leak subprocesses concurrently** (they share no state) and give that test a 30s timeout. Debug-asan subprocess startup + LSAN exit scan is ~6s each, which overran the default 5s.
- Fail fast with the fixture's exit code/signal if it dies: `fixture.exited` rejects the `beforeAll` ready promise, and each scenario checks liveness before fetching so a crash in scenario N shows as "exited (code=...)" in scenarios N+1..7 instead of a cascade of `ConnectionRefused`.
- Drop the unused `HARDCODED_URL` dev hook and the `!isCI` heap-snapshot-on-failure block (which referenced `.platform` on a `Subprocess`, so the platform guard never did anything).

No tests are skipped or deleted; the per-request `expect(result).toBe("Ok")` / payload-echo checks and the three RSS assertions are preserved. The file now runs all eight tests on every lane.

### How did you verify your code works?

CI wall-clock for this file, `expected-durations.json` on main vs build [#78330](https://buildkite.com/bun/bun/builds/78330) on this branch:

| lane | before | after |
| :-- | --: | --: |
| debian 13 x64-asan | 145.1s (7 pass + 1 todo) | **40.8s** (8 pass) |
| debian 13 x64 | 46.0s | **25.4s** |
| windows 2019 x64 | todo'd | **52.5s** (8 pass) |
| windows 11 aarch64 | todo'd | **55.1s** (8 pass) |

On the asan lane: peak RSS 537 MB against the 768 MB cap, `leak` metric ≤ 15 MB in every scenario.

Local `bun bd test` (debug+asan) went from every test timing out (>420s) to 8 pass.