### PR TITLE
node:http: ServerResponse write()/end() observe a handler-destroyed socket

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3062,8 +3062,6 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   }
 
   if (!handle) {
-    // Standalone response: OutgoingMessage.end() owns the finished/outputData
-    // transition, whether or not writeHead() already rendered _header.
     return OutgoingMessagePrototype.end.$call(this, chunk, encoding, callback);
   }
 
@@ -3106,9 +3104,7 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
 
   const flags = handle.flags;
   if (!!(flags & NodeHTTPResponseFlags.closed_or_completed)) {
-    // Socket already gone. Like Node, end() still finishes the response and
-    // emits 'prefinish'; 'finish' (and the end() callback) never fire, and
-    // 'close' comes from the socket close path.
+    // Socket already gone: like Node, 'prefinish' fires but 'finish' never does.
     this._header = " ";
     const req = this.req;
     if (!req._consuming && !req?._readableState?.resumeScheduled) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3062,20 +3062,13 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   }
 
   if (!handle) {
-    // Read the storage directly - the `socket` getter auto-creates a
-    // FakeSocket and would make this condition always true.
-    if (this[fakeSocketSymbol] || this.outputData?.length || !this._header) {
-      // Standalone response writing through an assigned socket (or buffering
-      // until one is assigned): use the OutgoingMessage machinery. The
-      // original chunk passes through (mirroring write()): write_() has its
-      // own !_hasBody handling, including the rejectNonStandardBodyWrites
-      // throw, which the clearing below would bypass.
-      return OutgoingMessagePrototype.end.$call(this, chunk, encoding, callback);
-    }
-    if ($isCallable(callback)) {
-      process.nextTick(callback);
-    }
-    return this;
+    // Standalone response (no native handle): use the OutgoingMessage
+    // machinery unconditionally so `finished` / `writableEnded` transition and
+    // the chunk is buffered into outputData like Node.js, regardless of whether
+    // writeHead() rendered `_header` first. The original chunk passes through
+    // (mirroring write()): write_() has its own !_hasBody handling, including
+    // the rejectNonStandardBodyWrites throw.
+    return OutgoingMessagePrototype.end.$call(this, chunk, encoding, callback);
   }
 
   if (this[headerStateSymbol] === NodeHTTPHeaderState.none) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3062,12 +3062,8 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   }
 
   if (!handle) {
-    // Standalone response (no native handle): use the OutgoingMessage
-    // machinery unconditionally so `finished` / `writableEnded` transition and
-    // the chunk is buffered into outputData like Node.js, regardless of whether
-    // writeHead() rendered `_header` first. The original chunk passes through
-    // (mirroring write()): write_() has its own !_hasBody handling, including
-    // the rejectNonStandardBodyWrites throw.
+    // Standalone response: OutgoingMessage.end() owns the finished/outputData
+    // transition, whether or not writeHead() already rendered _header.
     return OutgoingMessagePrototype.end.$call(this, chunk, encoding, callback);
   }
 
@@ -3110,13 +3106,9 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
 
   const flags = handle.flags;
   if (!!(flags & NodeHTTPResponseFlags.closed_or_completed)) {
-    // The underlying socket is already closed (or the response completed
-    // natively). Node.js's OutgoingMessage.end() still transitions to
-    // `finished` and emits 'prefinish' in this state; the `finish` callback
-    // that would emit 'finish' is dropped by _writeRaw()'s conn.destroyed
-    // early-return, so 'finish' never fires and the end() callback (registered
-    // on 'finish') is never called. 'close' is emitted by the socket close
-    // path.
+    // Socket already gone. Like Node, end() still finishes the response and
+    // emits 'prefinish'; 'finish' (and the end() callback) never fire, and
+    // 'close' comes from the socket close path.
     this._header = " ";
     const req = this.req;
     if (!req._consuming && !req?._readableState?.resumeScheduled) {
@@ -3292,8 +3284,7 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
 
   const flags = handle.flags;
   if (!!(flags & NodeHTTPResponseFlags.closed_or_completed)) {
-    // Node.js's OutgoingMessage._writeRaw() returns false when the assigned
-    // socket is destroyed; the write callback is dropped (never invoked).
+    // Socket already gone: like Node's _writeRaw(), report false and drop the callback.
     return false;
   }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3036,9 +3036,6 @@ ServerResponse.prototype.writeContinue = function (cb) {
 // But we don't want it for the fetch() response version.
 ServerResponse.prototype.end = function (chunk, encoding, callback) {
   const handle = this[kHandle];
-  if (handle?.aborted) {
-    return this;
-  }
 
   if ($isCallable(chunk)) {
     callback = chunk;
@@ -3120,9 +3117,22 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
 
   const flags = handle.flags;
   if (!!(flags & NodeHTTPResponseFlags.closed_or_completed)) {
-    // node.js will return true if the handle is closed but the internal state is not
-    // and will not throw or emit an error
-    return true;
+    // The underlying socket is already closed (or the response completed
+    // natively). Node.js's OutgoingMessage.end() still transitions to
+    // `finished` and emits 'prefinish' in this state; the `finish` callback
+    // that would emit 'finish' is dropped by _writeRaw()'s conn.destroyed
+    // early-return, so 'finish' never fires and the end() callback (registered
+    // on 'finish') is never called. 'close' is emitted by the socket close
+    // path.
+    this._header = " ";
+    const req = this.req;
+    if (!req._consuming && !req?._readableState?.resumeScheduled) {
+      req._dump();
+    }
+    this.finished = true;
+    process.nextTick(markResponseEndedNT, this);
+    this.emit("prefinish");
+    return this;
   }
   const sentState = NodeHTTPHeaderState.sent;
   if (headerState !== sentState) {
@@ -3289,9 +3299,9 @@ ServerResponse.prototype.write = function (chunk, encoding, callback) {
 
   const flags = handle.flags;
   if (!!(flags & NodeHTTPResponseFlags.closed_or_completed)) {
-    // node.js will return true if the handle is closed but the internal state is not
-    // and will not throw or emit an error
-    return true;
+    // Node.js's OutgoingMessage._writeRaw() returns false when the assigned
+    // socket is destroyed; the write callback is dropped (never invoked).
+    return false;
   }
 
   if (this[headerStateSymbol] !== NodeHTTPHeaderState.sent) {

--- a/test/js/node/http/node-http-server-abort-events.test.ts
+++ b/test/js/node/http/node-http-server-abort-events.test.ts
@@ -308,9 +308,11 @@ test("res.write()/end() after req.socket.destroy() inside the handler", async ()
   const events: string[] = [];
   const { promise: resClosed, resolve: resolveResClosed } = Promise.withResolvers<void>();
   let writeResult: boolean | undefined;
-  let endResult: unknown;
+  let endReturnedSelf: boolean | undefined;
   let finishedAfterEnd: boolean | undefined;
   let writableEndedAfterEnd: boolean | undefined;
+  let writeCbCalled = false;
+  let endCbCalled = false;
 
   const server = createServer((req, res) => {
     res.on("prefinish", () => events.push("res.prefinish"));
@@ -321,8 +323,8 @@ test("res.write()/end() after req.socket.destroy() inside the handler", async ()
     });
 
     req.socket.destroy();
-    writeResult = res.write("body");
-    endResult = res.end("done");
+    writeResult = res.write("body", () => (writeCbCalled = true));
+    endReturnedSelf = res.end("done", () => (endCbCalled = true)) === res;
     finishedAfterEnd = res.finished;
     writableEndedAfterEnd = res.writableEnded;
   });
@@ -337,13 +339,23 @@ test("res.write()/end() after req.socket.destroy() inside the handler", async ()
     client.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
     await resClosed;
 
-    expect({ writeResult, finishedAfterEnd, writableEndedAfterEnd, events }).toEqual({
+    expect({
+      writeResult,
+      endReturnedSelf,
+      finishedAfterEnd,
+      writableEndedAfterEnd,
+      writeCbCalled,
+      endCbCalled,
+      events,
+    }).toEqual({
       writeResult: false,
+      endReturnedSelf: true,
       finishedAfterEnd: true,
       writableEndedAfterEnd: true,
+      writeCbCalled: false,
+      endCbCalled: false,
       events: ["res.prefinish", "res.close"],
     });
-    expect(endResult).toBeInstanceOf(Object);
   } finally {
     server.close();
   }

--- a/test/js/node/http/node-http-server-abort-events.test.ts
+++ b/test/js/node/http/node-http-server-abort-events.test.ts
@@ -299,3 +299,52 @@ describe("res.destroy() defers 'close'", () => {
     expect(events).toEqual(["destroy()", "destroy() returned (closed: false)", "res.close (closed: true)"]);
   });
 });
+
+test("res.write()/end() after req.socket.destroy() inside the handler", async () => {
+  // The request handler destroys its own socket before writing: write() must
+  // report false (Node.js's OutgoingMessage._writeRaw returns false for a
+  // destroyed socket) and end() must still transition to `finished` /
+  // `writableEnded` and emit 'prefinish', without emitting 'finish'.
+  const events: string[] = [];
+  const { promise: resClosed, resolve: resolveResClosed } = Promise.withResolvers<void>();
+  let writeResult: boolean | undefined;
+  let endResult: unknown;
+  let finishedAfterEnd: boolean | undefined;
+  let writableEndedAfterEnd: boolean | undefined;
+
+  const server = createServer((req, res) => {
+    res.on("prefinish", () => events.push("res.prefinish"));
+    res.on("finish", () => events.push("res.finish"));
+    res.on("close", () => {
+      events.push("res.close");
+      resolveResClosed();
+    });
+
+    req.socket.destroy();
+    writeResult = res.write("body");
+    endResult = res.end("done");
+    finishedAfterEnd = res.finished;
+    writableEndedAfterEnd = res.writableEnded;
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const client = connect(port, "127.0.0.1");
+    client.on("error", () => {});
+    await once(client, "connect");
+    client.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    await resClosed;
+
+    expect({ writeResult, finishedAfterEnd, writableEndedAfterEnd, events }).toEqual({
+      writeResult: false,
+      finishedAfterEnd: true,
+      writableEndedAfterEnd: true,
+      events: ["res.prefinish", "res.close"],
+    });
+    expect(endResult).toBeInstanceOf(Object);
+  } finally {
+    server.close();
+  }
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2982,22 +2982,20 @@ it("standalone ServerResponse discards body writes to a no-body response without
   expect(out).not.toContain("body");
 });
 
-it("standalone ServerResponse end() after writeHead() sets writableEnded (#25632)", () => {
+it("standalone ServerResponse end() after writeHead() sets writableEnded (#25632)", async () => {
   // With no native handle and no socket assigned, end() after writeHead() must
   // still transition to `finished` / `writableEnded` and buffer the rendered
   // header block into outputData, like Node.js's OutgoingMessage.end().
   const res = new ServerResponse(new IncomingMessage(null as any));
   res.writeHead(403);
   res.end("forbidden");
-  expect({
-    finished: res.finished,
-    writableEnded: res.writableEnded,
-    outputDataLength: (res as any).outputData.length > 0,
-  }).toEqual({
+  expect({ finished: res.finished, writableEnded: res.writableEnded }).toEqual({
     finished: true,
     writableEnded: true,
-    outputDataLength: true,
   });
+  const buffered = (res as any).outputData.map((x: any) => String(x.data)).join("");
+  expect(buffered).toStartWith("HTTP/1.1 403 Forbidden\r\n");
+  expect(buffered).toEndWith("\r\n\r\nforbidden");
 
   // And with end() alone (no chunk), the end() callback is registered on
   // 'finish' (which never fires without a socket), not invoked via nextTick.
@@ -3009,7 +3007,8 @@ it("standalone ServerResponse end() after writeHead() sets writableEnded (#25632
     finished: true,
     writableEnded: true,
   });
-  process.nextTick(() => expect(cbCalled).toBe(false));
+  await new Promise<void>(r => process.nextTick(r));
+  expect(cbCalled).toBe(false);
 });
 
 it("flushHeaders on a 204 response carries no chunked framing", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2982,6 +2982,36 @@ it("standalone ServerResponse discards body writes to a no-body response without
   expect(out).not.toContain("body");
 });
 
+it("standalone ServerResponse end() after writeHead() sets writableEnded (#25632)", () => {
+  // With no native handle and no socket assigned, end() after writeHead() must
+  // still transition to `finished` / `writableEnded` and buffer the rendered
+  // header block into outputData, like Node.js's OutgoingMessage.end().
+  const res = new ServerResponse(new IncomingMessage(null as any));
+  res.writeHead(403);
+  res.end("forbidden");
+  expect({
+    finished: res.finished,
+    writableEnded: res.writableEnded,
+    outputDataLength: (res as any).outputData.length > 0,
+  }).toEqual({
+    finished: true,
+    writableEnded: true,
+    outputDataLength: true,
+  });
+
+  // And with end() alone (no chunk), the end() callback is registered on
+  // 'finish' (which never fires without a socket), not invoked via nextTick.
+  const res2 = new ServerResponse(new IncomingMessage(null as any));
+  let cbCalled = false;
+  res2.writeHead(200);
+  res2.end(() => (cbCalled = true));
+  expect({ finished: res2.finished, writableEnded: res2.writableEnded }).toEqual({
+    finished: true,
+    writableEnded: true,
+  });
+  process.nextTick(() => expect(cbCalled).toBe(false));
+});
+
 it("flushHeaders on a 204 response carries no chunked framing", async () => {
   // noBodyStatus must suppress the Transfer-Encoding header in flushHeaders()
   // and the terminating chunk in internalEnd(), like the one-shot end() path.


### PR DESCRIPTION
## What

Three `ServerResponse.prototype.end()` paths returned without ever setting `finished` / `writableEnded`, and `write()` on a dead socket reported `true`:

1. A request handler calls `req.socket.destroy()` and then writes to the response: `res.write()` returns `true` (reporting the bytes as buffered) and `res.end()` is a silent no-op that leaves `finished` / `writableEnded` at `false`.
2. A standalone `new ServerResponse(req)` (no native handle; light-my-request / fastify inject) that calls `writeHead()` before `end()`: the `!handle` fallback returned `this` without setting `finished` once `_header` was rendered.

## Repro

```js
import http from 'node:http';
const log = [];
const srv = http.createServer((rq, rs) => {
  srv.close(); rq.socket.destroy();
  const w = rs.write('body'); rs.end('done');
  log.push('write=' + w + ' finished=' + rs.finished + ' writableEnded=' + rs.writableEnded);
});
await new Promise(r => srv.listen(0, '127.0.0.1', r));
try { await fetch(`http://127.0.0.1:${srv.address().port}/`); } catch {}
await new Promise(r => setTimeout(r, 150));
console.log(JSON.stringify(log));
```

```
node v26.3.0 : ["write=false finished=true writableEnded=true", ...]
bun (before) : ["write=true finished=false writableEnded=false", ...]
bun (after)  : ["write=false finished=true writableEnded=true", ...]
```

```js
import { ServerResponse, IncomingMessage } from 'node:http';
const res = new ServerResponse(new IncomingMessage(null));
res.writeHead(403);
res.end('forbidden');
console.log(res.writableEnded);  // node: true, bun (before): false, bun (after): true
```

## Cause

`ServerResponse.prototype.end` had an `if (handle?.aborted) return this` early return, and both `write()` and `end()` had a `flags & closed_or_completed` check that returned `true` without updating any writable-side state. Separately, the `!handle` branch skipped the `OutgoingMessage.end()` delegation when `_header` was already set (writeHead already called) and returned without setting `finished`.

Node.js's `OutgoingMessage._writeRaw()` returns `false` once the assigned socket is destroyed, and `OutgoingMessage.end()` sets `finished = true` unconditionally; on a destroyed socket the `finish` callback handed to `_send` is dropped by the `conn.destroyed` branch, so `'prefinish'` fires but `'finish'` never does.

## Fix

In `src/js/node/_http_server.ts`:

- `write()`: return `false` on a closed/completed native handle instead of `true`; the write callback is dropped (never invoked), matching Node.js.
- `end()` with a closed/completed native handle: drop the redundant `handle?.aborted` early return. Set `_header`, dump the request, set `finished = true`, emit `'prefinish'`, and return `this` without calling into the native handle or scheduling `'finish'` / the end callback. `'close'` is emitted by the existing socket-close path.
- `end()` with no native handle: always delegate to `OutgoingMessage.prototype.end`, so `finished` is set and the header/body are buffered into `outputData` regardless of whether `writeHead()` was called first. The previous fallback also invoked the end callback via `nextTick`, which Node.js does not do (it registers it on `'finish'`).

## Verification

New test in `test/js/node/http/node-http-server-abort-events.test.ts` destroys `req.socket` from inside the handler, then asserts `write() === false`, `finished === true`, `writableEnded === true`, and the event sequence `['res.prefinish', 'res.close']` (no `'finish'`).

New test in `test/js/node/http/node-http.test.ts` covers the standalone `writeHead()` + `end()` path: `finished` / `writableEnded` are `true`, `outputData` is populated, and the end callback is not invoked via nextTick.

Both fail on main; both pass with this change and match Node v26.3.0. `node-http.test.ts`, `node-http-backpressure.test.ts`, `node-http-transfer-encoding.test.ts`, `node-http-server-socket-end-drain.test.ts`, and the `test-http-outgoing-*` / `test-http-pipeline-*` / `test-http-server-response-standalone` / `test-http-writable-true-after-close` parallel scripts all pass unchanged.

Fixes #25632

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-abort-events.test.ts test/js/node/http/node-http.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/164] gen cpp.rs (cppbind)
[2/164] gen JS modules (bundle-modules)
Preprocess modules (12850ms)
Bundle modules (49ms)
Postprocesss modules (36ms)
Bundle Functions (627ms)
Generate Code (44ms)

[13.61s] Bundled "src/js" for development
  2787 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/164] cargo bun_runtime → libbun_runtime.a
[3/164] cc obj/codegen/InternalModuleRegistryConstants.S.o
[5/164] pch pch/root-pch.h.hxx.pch
[6/164] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[7/164] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[8/164] cxx obj/unified/UnifiedSource-src_jsc_bindings-10.cpp.o
[9/164] cxx obj/unified/UnifiedSource-src_jsc_bindings-9.cpp.o
[10/164] cxx obj/unified/UnifiedSource-src_jsc_bindings-6.cpp.o
[11/164] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[12/164] cxx obj/unified/UnifiedSour
... (truncated)

release without fix: 6 failed, 1 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [10.54ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [2.10ms]
(pass) node:http > createServer > request & response body streaming (large) [3.32ms]
(pass) node:http > createServer > request & response body streaming (small) [1.91ms]
(pass) node:http > createServer > listen should return server [0.96ms]
(pass) node:http > createServer > listen callback should be bound to server [0.85ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [1.09ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [1.37ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [1.98ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [30.06ms]
(pass) node:http > createServer > https: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [35.32ms]
(pass) node:http > createServer > should use the provided port [1.43ms]
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-abort-events.test.ts test/js/node/http/node-http.test.ts
bun test v1.4.1 (65362b53b)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [424.86ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [61.12ms]
(pass) node:http > createServer > request & response body streaming (large) [107.71ms]
(pass) node:http > createServer > request & response body streaming (small) [65.24ms]
(pass) node:http > createServer > listen should return server [29.59ms]
(pass) node:http > createServer > listen callback should be bound to server [30.53ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [36.76ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [44.27ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [49.60ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > 
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4eaf10511e
  features     baseline

23 deps, 131 codegen, 1172 objects in 590ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [12.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [4.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] gen .bind.ts → GeneratedBindings.cpp
[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[11/1243] fetch libjpeg-turbo
[libjp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        | 36 +++++--------
 .../http/node-http-server-abort-events.test.ts     | 61 ++++++++++++++++++++++
 test/js/node/http/node-http.test.ts                | 29 ++++++++++
 3 files changed, 103 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 5 passed · 2 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js/node/_http_server.ts                                 12      7      0
test/js/node/http/node-http-server-abort-events.test.ts      3      2      0
test/js/node/http/node-http.test.ts                          3      3      0
```

</details>

<!-- robobun:evidence:end -->