### PR TITLE
cluster: pass received fd through the (message, handle) slot like Node; bind RoundRobinHandle server callbacks

### DIFF
--- a/src/js/internal/cluster/RoundRobinHandle.ts
+++ b/src/js/internal/cluster/RoundRobinHandle.ts
@@ -30,21 +30,10 @@ export default class RoundRobinHandle {
     this.handle = null;
     this.listening = false;
     this.inFlight = new Map();
-    this.server = net.createServer({ pauseOnConnect: true, allowHalfOpen: true }, socket => {
-      const handle = makeAcceptedHandle(socket);
-      socket.once("close", () => {
-        remove(handle);
-        for (const [id, pending] of this.inFlight) {
-          if (pending === handle) {
-            this.inFlight.delete(id);
-            const worker = this.all.get(id);
-            if (worker !== undefined) this.handoff(worker);
-            break;
-          }
-        }
-      });
-      this.distribute(0, handle);
-    });
+    this.server = net.createServer(
+      { pauseOnConnect: true, allowHalfOpen: true },
+      RoundRobinHandle.prototype.onServerConnection.bind(this),
+    );
 
     if (fd >= 0) this.server.listen({ fd, backlog });
     else if (port >= 0) {
@@ -62,10 +51,31 @@ export default class RoundRobinHandle {
         readableAll,
         writableAll,
       }); // UNIX socket path.
-    this.server.once("listening", () => {
-      this.listening = true;
-      this.handle = this.server._handle;
-    });
+    this.server.once("listening", RoundRobinHandle.prototype.onServerListening.bind(this));
+  }
+
+  onServerConnection(socket) {
+    const handle = makeAcceptedHandle(socket);
+    socket.once("close", RoundRobinHandle.prototype.onAcceptedSocketClose.bind(this, handle));
+    this.distribute(0, handle);
+  }
+
+  onAcceptedSocketClose(handle) {
+    remove(handle);
+    const inFlight = this.inFlight;
+    for (const [id, pending] of inFlight) {
+      if (pending === handle) {
+        inFlight.delete(id);
+        const worker = this.all.get(id);
+        if (worker !== undefined) this.handoff(worker);
+        break;
+      }
+    }
+  }
+
+  onServerListening() {
+    this.listening = true;
+    this.handle = this.server._handle;
   }
 
   add(worker, send) {

--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -78,8 +78,8 @@ cluster._setupWorker = function () {
         return;
       }
     }
-    if (message.act === "newconn" && handle == null && typeof message["$fd"] === "number" && message["$fd"] >= 0) {
-      handle = makeConnectionHandle(message["$fd"]);
+    if (message.act === "newconn" && typeof handle === "number" && handle >= 0) {
+      handle = makeConnectionHandle(handle);
     }
     try {
       process.emit("internalMessage", message, handle);
@@ -126,11 +126,12 @@ cluster._getServer = function (obj, options, cb) {
   // Set custom data on handle (i.e. tls tickets key)
   if (obj._getServerData) message.data = obj._getServerData();
 
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/cluster/child.js#L105-L115
   send(message, (reply, handle) => {
     if (typeof obj._setServerData === "function") obj._setServerData(reply.data);
 
-    if (handle == null && typeof reply["$fd"] === "number" && reply["$fd"] >= 0) {
-      handle = makeSharedHandle(reply["$fd"]);
+    if (typeof handle === "number" && handle >= 0) {
+      handle = makeSharedHandle(handle);
     }
 
     if (handle) {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1713,8 +1713,9 @@ pub struct RuntimeHooks {
     /// (forward-dep cycle), so [`uncaught_exception`] reaches it through this
     /// slot instead of the linker.
     pub process_exit: unsafe fn(global: *mut JSGlobalObject, code: u8),
-    /// `node_cluster_binding.handleInternalMessageChild(global, data)`.
-    pub handle_ipc_internal_child: unsafe fn(global: *mut JSGlobalObject, data: JSValue),
+    /// `node_cluster_binding.handleInternalMessageChild(global, data, handle)`.
+    pub handle_ipc_internal_child:
+        unsafe fn(global: *mut JSGlobalObject, data: JSValue, handle: JSValue),
     /// `node_cluster_binding.child_singleton.deinit()`.
     pub ipc_child_singleton_deinit: fn(),
     /// `onBeforePrint()` for the `bun:test` runner, which lives in `bun_runtime`;
@@ -2835,7 +2836,7 @@ impl IPCInstance {
                 if let Some(hooks) = runtime_hooks() {
                     // SAFETY: hook fn is supplied by `bun_runtime` at startup;
                     // `global_this` is the live VM global.
-                    unsafe { (hooks.handle_ipc_internal_child)(global_this, data) };
+                    unsafe { (hooks.handle_ipc_internal_child)(global_this, data, handle) };
                 }
                 event_loop.exit();
             }

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -110,16 +110,7 @@ impl InternalMsgHolder {
 
         let event_loop = global.bun_vm().event_loop_mut();
 
-        let _ = handle;
-        event_loop.run_callback(
-            cb,
-            global,
-            worker,
-            &[
-                message,
-                JSValue::NULL, // handle
-            ],
-        );
+        event_loop.run_callback(cb, global, worker, &[message, handle]);
         Ok(())
     }
 
@@ -2094,6 +2085,13 @@ fn handle_ipc_message(
             }
         }
     } else {
+        // Node's child_process materializes the received handle and passes it
+        // as the second arg to the internalMessage listener; cluster's
+        // onmessage/onInternalMessage then see (message, handle):
+        // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/cluster/utils.js#L33-L49
+        // Pass the raw descriptor through the same slot so cluster/child.ts
+        // can wrap it, instead of writing it onto the message object.
+        let mut handle_js = JSValue::UNDEFINED;
         if let DecodedIPCMessage::Internal(msg_data) = &message {
             let msg_data = *msg_data;
             if msg_data.is_object() {
@@ -2127,7 +2125,7 @@ fn handle_ipc_message(
                         let fd = imported.unwrap();
                         #[cfg(not(windows))]
                         let fd = send_queue.incoming_fd.take().unwrap();
-                        msg_data.put(global_this, b"$fd", received_fd_to_js(fd));
+                        handle_js = received_fd_to_js(fd);
                     }
                     Ok(_) => {}
                     Err(_) => {
@@ -2137,7 +2135,7 @@ fn handle_ipc_message(
             }
         }
         // SAFETY: BACKREF — owner embeds this SendQueue inline and outlives it.
-        unsafe { (*send_queue.owner).handle_ipc_message(message, JSValue::UNDEFINED) };
+        unsafe { (*send_queue.owner).handle_ipc_message(message, handle_js) };
     }
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1352,8 +1352,7 @@ unsafe fn handle_ipc_internal_child(global: *mut JSGlobalObject, data: JSValue, 
     // error.JSError => {} }`); the low tier already wrapped this call in
     // `event_loop.enter()/exit()` which clears any pending exception, so
     // dropping the `Err` is correct.
-    let _ =
-        crate::node::node_cluster_binding::handle_internal_message_child(global, data, handle);
+    let _ = crate::node::node_cluster_binding::handle_internal_message_child(global, data, handle);
 }
 
 /// `node_cluster_binding.child_singleton.deinit()` —

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1345,18 +1345,15 @@ fn load_standalone_sourcemap(
 /// # Safety
 /// `global` is the live VM global; called on the JS thread inside an
 /// `event_loop.enter()` scope.
-unsafe fn handle_ipc_internal_child(global: *mut JSGlobalObject, data: JSValue) {
+unsafe fn handle_ipc_internal_child(global: *mut JSGlobalObject, data: JSValue, handle: JSValue) {
     // SAFETY: per fn contract.
     let global = unsafe { &*global };
     // Spec discards a JS exception here (`catch |err| switch (err) {
     // error.JSError => {} }`); the low tier already wrapped this call in
     // `event_loop.enter()/exit()` which clears any pending exception, so
     // dropping the `Err` is correct.
-    let _ = crate::node::node_cluster_binding::handle_internal_message_child(
-        global,
-        data,
-        JSValue::UNDEFINED,
-    );
+    let _ =
+        crate::node::node_cluster_binding::handle_internal_message_child(global, data, handle);
 }
 
 /// `node_cluster_binding.child_singleton.deinit()` —

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -484,21 +484,20 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
             // SAFETY: sockaddr_storage is plain C data; all-zero is a valid
             unsafe {
                 let mut ss: libc::sockaddr_storage = bun_core::ffi::zeroed_unchecked();
-                let ss_len: libc::socklen_t;
-                if family == libc::AF_INET6 {
+                let ss_len: libc::socklen_t = if family == libc::AF_INET6 {
                     let sin6: &mut libc::sockaddr_in6 =
                         &mut *(&raw mut ss).cast::<libc::sockaddr_in6>();
                     sin6.sin6_family = libc::AF_INET6 as libc::sa_family_t;
                     sin6.sin6_port = (port as u16).to_be();
-                    ss_len = core::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t;
+                    core::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t
                 } else {
                     let sin: &mut libc::sockaddr_in =
                         &mut *(&raw mut ss).cast::<libc::sockaddr_in>();
                     sin.sin_family = libc::AF_INET as libc::sa_family_t;
                     sin.sin_port = (port as u16).to_be();
                     sin.sin_addr.s_addr = libc::INADDR_ANY.to_be();
-                    ss_len = core::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t;
-                }
+                    core::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t
+                };
                 (ss, ss_len)
             }
         }

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -963,6 +963,49 @@ if (cluster.isPrimary) {
   30_000,
 );
 
+test("round-robin newconn reaches the worker's internalMessage listener via the handle slot", async () => {
+  // Node's child_process passes the received handle as the second arg to the
+  // internalMessage listener; the message object itself carries no fd property.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/cluster/utils.js#L33-L49
+  using dir = tempDir("cluster-handle-slot", {
+    "main.ts": `
+const cluster = require("node:cluster");
+const net = require("node:net");
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  worker.on("message", m => { console.log(JSON.stringify(m)); worker.kill(); process.exit(0); });
+  cluster.on("listening", (_w, addr) => {
+    net.connect(addr.port, "127.0.0.1");
+  });
+} else {
+  let reported = false;
+  process.on("internalMessage", (msg, handle) => {
+    if (msg && msg.act === "newconn" && !reported) {
+      reported = true;
+      process.send({
+        hasDollarFd: "$fd" in msg,
+        handleIsObject: typeof handle === "object" && handle !== null,
+        handleHasFd: typeof handle?.fd === "number",
+      });
+    }
+  });
+  net.createServer(() => {}).listen(0, "127.0.0.1");
+}
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), joinP(String(dir), "main.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ hasDollarFd: false, handleIsObject: true, handleHasFd: true });
+  expect(exitCode).toBe(0);
+});
+
 test("cluster child send() clones and stamps cmd:NODE_CLUSTER", async () => {
   using dir = tempDir("cluster-send-shape", {
     "main.ts": `


### PR DESCRIPTION
Follow-up to #31829 (stacked on `ciro/cluster-tests-v26`).

### What does this PR do?

Two follow-ups from review on #31829:

**Drop `reply["$fd"]` and pass the fd through the handle slot like Node.** Node's `child_process` materializes the received handle and passes it as the second arg to the internalMessage listener, so cluster's `onmessage` / the `_getServer` `send` callback see `(message, handle)`: [utils.js L33-L49](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/cluster/utils.js#L33-L49), [child.js L105-L115](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/cluster/child.js#L105-L115). #31829's implementation wrote the raw fd onto the message object as `"$fd"` and read it back in JS. This PR routes it through the same slot Node uses:
- `ipc.rs`: pass the raw fd as the `handle` arg to `handle_ipc_message` instead of `msg_data.put(b"$fd", ...)`.
- `InternalMsgHolder.dispatch_unsafe`: forward `handle` to the JS callback instead of `JSValue::NULL`.
- `VirtualMachine`/`jsc_hooks`: add `handle` to the `handle_ipc_internal_child` hook signature.
- `child.ts`: read `typeof handle === "number"` and wrap via `makeSharedHandle`/`makeConnectionHandle` (same JS-side wrapping as before, just reading the other slot).

**Hoist `RoundRobinHandle` constructor closures to bound prototype methods.** The connection listener, accepted-socket close handler, and server `listening` handler become `onServerConnection`/`onAcceptedSocketClose`/`onServerListening` with `.bind(this)` / `.bind(this, handle)`.

### How did you verify your code works?

`bun bd` clean on linux. All 85 `test/js/node/test/{parallel,sequential}/test-cluster-*.js` pass, `test/js/node/cluster.test.ts` 26/26 pass. The `$fd` dispatch path is exercised by `test-cluster-message`, `test-cluster-send-deadlock`, `test-cluster-net-send`, the SCHED_NONE shared-handle tests, and every round-robin newconn path.

The clippy fix in `node_cluster_binding.rs` is also on the base branch (cb057f546c) so it does not appear in this diff once rebased.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 79 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/cluster.test.ts

<!-- robobun:evidence:end -->