### PR TITLE
FinalizationRegistry: keep the registry alive while it has registrations

### DIFF
--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -2,6 +2,10 @@
 #include <JavaScriptCore/VM.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
+#include <JavaScriptCore/JSFinalizationRegistry.h>
+#include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/WeakMapImplInlines.h>
+#include <JavaScriptCore/JSCInlines.h>
 
 using Ticket = JSC::DeferredWorkTimer::Ticket;
 using Task = JSC::DeferredWorkTimer::Task;
@@ -96,6 +100,26 @@ void JSCTaskScheduler::onCancelPendingWork(WebCore::JSVMClientData* clientData, 
         Bun__eventLoop__incrementRefConcurrently(bunVM, -1);
 }
 
+void JSCTaskScheduler::rootFinalizationRegistry(JSC::VM& vm, JSC::JSFinalizationRegistry* registry)
+{
+    ASSERT(vm.currentThreadIsHoldingAPILock());
+    auto result = m_rootedFinalizationRegistries.add(registry, JSC::Strong<JSC::JSObject>());
+    if (result.isNewEntry)
+        result.iterator->value.set(vm, registry);
+}
+
+void JSCTaskScheduler::unrootFinalizationRegistryIfDrained(JSC::JSFinalizationRegistry* registry)
+{
+    if (!m_rootedFinalizationRegistries.contains(registry))
+        return;
+    {
+        Locker cellLocker { registry->cellLock() };
+        if (registry->liveCount(cellLocker) || registry->deadCount(cellLocker))
+            return;
+    }
+    m_rootedFinalizationRegistries.remove(registry);
+}
+
 static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDeferredWorkTask* job)
 {
     Locker<Lock> holder { scheduler.m_lock };
@@ -109,6 +133,8 @@ static void runPendingWork(void* bunVM, Bun::JSCTaskScheduler& scheduler, JSCDef
 
     if (pendingTicket && !pendingTicket->isCancelled()) {
         job->task(job->ticket.get());
+        if (auto* registry = dynamicDowncast<JSC::JSFinalizationRegistry>(job->ticket->target()))
+            scheduler.unrootFinalizationRegistryIfDrained(registry);
     }
 
     delete job;
@@ -127,8 +153,78 @@ extern "C" void Bun__runDeferredWork(Bun::JSCDeferredWorkTask* job)
 // has its enqueue visible to the drain; any that serializes after drops.
 extern "C" void Bun__JSCTaskScheduler__markShuttingDown(JSC::JSGlobalObject* globalObject)
 {
-    if (auto* clientData = WebCore::clientData(JSC::getVM(globalObject)))
+    if (auto* clientData = WebCore::clientData(JSC::getVM(globalObject))) {
+        clientData->deferredWorkTimer.m_rootedFinalizationRegistries.clear();
         clientData->deferredWorkTimer.markShuttingDown();
+    }
+}
+
+ALWAYS_INLINE static JSFinalizationRegistry* getFinalizationRegistry(VM& vm, JSGlobalObject* globalObject, JSValue value)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (!value.isObject()) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Called FinalizationRegistry function on non-object"_s);
+        return nullptr;
+    }
+    if (auto* registry = dynamicDowncast<JSFinalizationRegistry>(asObject(value))) [[likely]]
+        return registry;
+    throwTypeError(globalObject, scope, "Called FinalizationRegistry function on a non-FinalizationRegistry object"_s);
+    return nullptr;
+}
+
+JSC_DEFINE_HOST_FUNCTION(bunProtoFuncFinalizationRegistryRegister, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* registry = getFinalizationRegistry(vm, globalObject, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue target = callFrame->argument(0);
+    if (!canBeHeldWeakly(target)) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "register requires an object or a non-registered symbol as the target"_s);
+
+    JSValue holdings = callFrame->argument(1);
+    if (target == holdings) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "register expects the target object and the holdings parameter are not the same. Otherwise, the target can never be collected"_s);
+
+    JSValue unregisterToken = callFrame->argument(2);
+    if (!unregisterToken.isUndefined() && !canBeHeldWeakly(unregisterToken)) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "register requires an object or a non-registered symbol as the unregistration token"_s);
+
+    registry->registerTarget(vm, target.asCell(), holdings, unregisterToken);
+
+    if (auto* clientData = WebCore::clientData(vm))
+        clientData->deferredWorkTimer.rootFinalizationRegistry(vm, registry);
+    return encodedJSUndefined();
+}
+
+JSC_DEFINE_HOST_FUNCTION(bunProtoFuncFinalizationRegistryUnregister, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* registry = getFinalizationRegistry(vm, globalObject, callFrame->thisValue());
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue token = callFrame->argument(0);
+    if (!canBeHeldWeakly(token)) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "unregister requires an object or a non-registered symbol as the unregistration token"_s);
+
+    bool result = registry->unregister(vm, token.asCell());
+    if (result) {
+        if (auto* clientData = WebCore::clientData(vm))
+            clientData->deferredWorkTimer.unrootFinalizationRegistryIfDrained(registry);
+    }
+    return JSValue::encode(jsBoolean(result));
+}
+
+void installFinalizationRegistryPrototypeHooks(JSC::JSGlobalObject* globalObject)
+{
+    VM& vm = globalObject->vm();
+    JSObject* prototype = globalObject->finalizationRegistryStructure()->storedPrototypeObject();
+    prototype->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "register"_s), 2, bunProtoFuncFinalizationRegistryRegister, ImplementationVisibility::Public, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    prototype->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "unregister"_s), 1, bunProtoFuncFinalizationRegistryUnregister, ImplementationVisibility::Public, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 // Reclaim a queued-but-never-dispatched job during shutdown. Called while the

--- a/src/jsc/bindings/JSCTaskScheduler.h
+++ b/src/jsc/bindings/JSCTaskScheduler.h
@@ -25,13 +25,23 @@ public:
     static void onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::Task&& task);
     static void onCancelPendingWork(WebCore::JSVMClientData* clientData, JSC::DeferredWorkTimer::Ticket& ticket);
 
-    // JavaScriptCore's async bytecode generator only preserves locals that are
-    // read after an `await`, so a `const fr = new FinalizationRegistry(...)`
+    // JavaScriptCore's generatorification only preserves locals that are read
+    // after an `await`/`yield`, so a `const fr = new FinalizationRegistry(...)`
     // whose last use is `fr.register(...)` is collected at the next suspend
     // point along with its pending registrations. V8 preserves every async
     // local, so Node.js users never observe this. Root a registry on its first
     // successful register() and release it once both its live and dead lists
     // are empty so cleanup callbacks for already-registered targets still run.
+    //
+    // Retention is bound to the shortest-lived target, which over-corrects past
+    // V8 for the case of a registry that is dropped while still holding a
+    // registration for a target that never dies (e.g. globalThis): such a
+    // registry, its callback closure and every held value are kept until VM
+    // shutdown. V8 would collect it. Matching V8 exactly requires walking
+    // unmarked JSFinalizationRegistry cells during marking (private access to
+    // the live list to tell "a target is dying") or changing JSC's
+    // BytecodeGenerator to save every async local; the silent-guard failure
+    // this fixes is judged worse than the retained registry.
     void rootFinalizationRegistry(JSC::VM&, JSC::JSFinalizationRegistry*);
     void unrootFinalizationRegistryIfDrained(JSC::JSFinalizationRegistry*);
 

--- a/src/jsc/bindings/JSCTaskScheduler.h
+++ b/src/jsc/bindings/JSCTaskScheduler.h
@@ -33,7 +33,7 @@ public:
     // successful register() and release it once both its live and dead lists
     // are empty so cleanup callbacks for already-registered targets still run.
     //
-    // Retention is bound to the shortest-lived target, which over-corrects past
+    // Retention is bound to the longest-lived target, which over-corrects past
     // V8 for the case of a registry that is dropped while still holding a
     // registration for a target that never dies (e.g. globalThis): such a
     // registry, its callback closure and every held value are kept until VM

--- a/src/jsc/bindings/JSCTaskScheduler.h
+++ b/src/jsc/bindings/JSCTaskScheduler.h
@@ -5,6 +5,11 @@ class JSVMClientData;
 }
 
 #include <JavaScriptCore/DeferredWorkTimer.h>
+#include <JavaScriptCore/Strong.h>
+
+namespace JSC {
+class JSFinalizationRegistry;
+}
 
 namespace Bun {
 
@@ -19,6 +24,16 @@ public:
     static void onAddPendingWork(WebCore::JSVMClientData* clientData, Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::WorkType kind);
     static void onScheduleWorkSoon(WebCore::JSVMClientData* clientData, Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::Task&& task);
     static void onCancelPendingWork(WebCore::JSVMClientData* clientData, JSC::DeferredWorkTimer::Ticket& ticket);
+
+    // JavaScriptCore's async bytecode generator only preserves locals that are
+    // read after an `await`, so a `const fr = new FinalizationRegistry(...)`
+    // whose last use is `fr.register(...)` is collected at the next suspend
+    // point along with its pending registrations. V8 preserves every async
+    // local, so Node.js users never observe this. Root a registry on its first
+    // successful register() and release it once both its live and dead lists
+    // are empty so cleanup callbacks for already-registered targets still run.
+    void rootFinalizationRegistry(JSC::VM&, JSC::JSFinalizationRegistry*);
+    void unrootFinalizationRegistryIfDrained(JSC::JSFinalizationRegistry*);
 
     // Set once the owning VM's event loop has taken its last tick. After this,
     // onScheduleWorkSoon drops the task instead of enqueueing a ConcurrentTask
@@ -37,6 +52,11 @@ public:
     bool m_isShuttingDown WTF_GUARDED_BY_LOCK(m_lock) { false };
     UncheckedKeyHashSet<Ref<JSC::DeferredWorkTimer::Ticket>> m_pendingTicketsKeepingEventLoopAlive;
     UncheckedKeyHashSet<Ref<JSC::DeferredWorkTimer::Ticket>> m_pendingTicketsOther;
+
+    // JS-thread only; see rootFinalizationRegistry above.
+    UncheckedKeyHashMap<JSC::JSCell*, JSC::Strong<JSC::JSObject>> m_rootedFinalizationRegistries;
 };
+
+void installFinalizationRegistryPrototypeHooks(JSC::JSGlobalObject*);
 
 }

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -939,6 +939,8 @@ void NodeVMGlobalObject::finishCreation(JSC::VM& vm)
 {
     Base::finishCreation(vm);
 
+    Bun::installFinalizationRegistryPrototypeHooks(this);
+
     // microtaskMode: "afterEvaluate" — give this context its own microtask
     // queue, like Node's contextify own_microtask_queue. Microtasks enqueued
     // for this global no longer land on the VM's default queue (which the

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3152,6 +3152,8 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     // ----- Extensions to Built-in objects -----
 
+    Bun::installFinalizationRegistryPrototypeHooks(this);
+
     JSC::JSObject* errorConstructor = this->errorConstructor();
     errorConstructor->putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "captureStackTrace"_s), 2, errorConstructorFuncCaptureStackTrace, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
     errorConstructor->putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "appendStackTrace"_s), 2, errorConstructorFuncAppendStackTrace, ImplementationVisibility::Private, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);

--- a/test/js/web/finalization-registry.test.ts
+++ b/test/js/web/finalization-registry.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // JavaScriptCore's async bytecode generator only preserves locals that are read
@@ -19,11 +19,7 @@ async function run(source: string) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   let json: unknown;
   try {
     json = JSON.parse(stdout.trim());
@@ -34,10 +30,8 @@ async function run(source: string) {
 }
 
 describe("FinalizationRegistry keeps itself alive while it has registrations", () => {
-  test.concurrent(
-    "cleanup callbacks fire when the registry local dies before its targets",
-    async () => {
-      const { stdout, stderr, exitCode, json } = await run(/* js */ `
+  test.concurrent("cleanup callbacks fire when the registry local dies before its targets", async () => {
+    const { stdout, stderr, exitCode, json } = await run(/* js */ `
         const sleep = ms => new Promise(r => setTimeout(r, ms));
         const K = 500;
         let cleaned = 0;
@@ -57,17 +51,16 @@ describe("FinalizationRegistry keeps itself alive while it has registrations", (
         const collected = wrs.filter(w => w.deref() === undefined).length;
         console.log(JSON.stringify({ K, collected, cleaned }));
       `);
-      expect(stderr).toBe("");
-      expect(stdout.trim()).not.toBe("");
-      const { K, collected, cleaned } = json as { K: number; collected: number; cleaned: number };
-      expect(collected).toBeGreaterThanOrEqual(K - 1);
-      // Without the rooting fix `cleaned` is 0 here; with it every collected
-      // target's callback runs.
-      expect(cleaned).toBe(collected);
-      expect(cleaned).toBeGreaterThanOrEqual(K - 1);
-      expect(exitCode).toBe(0);
-    },
-  );
+    expect(stderr).toBe("");
+    expect(stdout.trim()).not.toBe("");
+    const { K, collected, cleaned } = json as { K: number; collected: number; cleaned: number };
+    expect(collected).toBeGreaterThanOrEqual(K - 1);
+    // Without the rooting fix `cleaned` is 0 here; with it every collected
+    // target's callback runs.
+    expect(cleaned).toBe(collected);
+    expect(cleaned).toBeGreaterThanOrEqual(K - 1);
+    expect(exitCode).toBe(0);
+  });
 
   test.concurrent("same inside an async function (not just module top level)", async () => {
     const { stderr, exitCode, json } = await run(/* js */ `

--- a/test/js/web/finalization-registry.test.ts
+++ b/test/js/web/finalization-registry.test.ts
@@ -1,0 +1,207 @@
+import { test, expect, describe } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// JavaScriptCore's async bytecode generator only preserves locals that are read
+// after an `await`, so a FinalizationRegistry held only by a module-level or
+// async-function `const` whose last use is `register()` becomes unreachable at
+// the next suspend point. Without an extra root the registry is swept before
+// its targets are observed as dead, and no cleanup callback ever fires (node
+// delivers them because V8 preserves every async-function local across await).
+
+async function run(source: string) {
+  // Module files, not `-e`: the eval wrapper's extra frames leave conservative
+  // stack roots that keep otherwise-dead cells alive for a few extra cycles.
+  using dir = tempDir("finalization-registry", { "entry.mjs": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  let json: unknown;
+  try {
+    json = JSON.parse(stdout.trim());
+  } catch {
+    json = undefined;
+  }
+  return { stdout, stderr, exitCode, json };
+}
+
+describe("FinalizationRegistry keeps itself alive while it has registrations", () => {
+  test.concurrent(
+    "cleanup callbacks fire when the registry local dies before its targets",
+    async () => {
+      const { stdout, stderr, exitCode, json } = await run(/* js */ `
+        const sleep = ms => new Promise(r => setTimeout(r, ms));
+        const K = 500;
+        let cleaned = 0;
+        const fr = new FinalizationRegistry(() => { cleaned++; });
+        const wrs = [];
+        for (let i = 0; i < K; i++) {
+          const o = { i, pad: Buffer.alloc(30, "p").toString() };
+          wrs.push(new WeakRef(o));
+          fr.register(o, i);
+        }
+        await sleep(300);
+        for (let r = 0; r < 30; r++) {
+          Bun.gc(true);
+          await sleep(10);
+          if (cleaned >= K) break;
+        }
+        const collected = wrs.filter(w => w.deref() === undefined).length;
+        console.log(JSON.stringify({ K, collected, cleaned }));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).not.toBe("");
+      const { K, collected, cleaned } = json as { K: number; collected: number; cleaned: number };
+      expect(collected).toBeGreaterThanOrEqual(K - 1);
+      // Without the rooting fix `cleaned` is 0 here; with it every collected
+      // target's callback runs.
+      expect(cleaned).toBe(collected);
+      expect(cleaned).toBeGreaterThanOrEqual(K - 1);
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test.concurrent("same inside an async function (not just module top level)", async () => {
+    const { stderr, exitCode, json } = await run(/* js */ `
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      async function main() {
+        let cleaned = 0;
+        const fr = new FinalizationRegistry(() => { cleaned++; });
+        for (let i = 0; i < 200; i++) fr.register({ i }, i);
+        await 0;
+        for (let r = 0; r < 30; r++) {
+          Bun.gc(true);
+          await sleep(10);
+          if (cleaned >= 200) break;
+        }
+        console.log(JSON.stringify({ cleaned }));
+      }
+      await main();
+    `);
+    expect(stderr).toBe("");
+    expect((json as { cleaned: number }).cleaned).toBeGreaterThanOrEqual(199);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("the registry is released once every registration is drained", async () => {
+    const { stderr, exitCode, json } = await run(/* js */ `
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      let cleaned = 0;
+      globalThis.frw = undefined;
+      (function () {
+        const fr = new FinalizationRegistry(() => { cleaned++; });
+        globalThis.frw = new WeakRef(fr);
+        for (let i = 0; i < 100; i++) fr.register({ i }, i);
+      })();
+      for (let r = 0; r < 30; r++) {
+        Bun.gc(true);
+        await sleep(10);
+        if (cleaned >= 100) break;
+      }
+      for (let r = 0; r < 30; r++) {
+        Bun.gc(true);
+        await sleep(10);
+        if (globalThis.frw.deref() === undefined) break;
+      }
+      console.log(JSON.stringify({ cleaned, drained: globalThis.frw.deref() === undefined }));
+    `);
+    expect(stderr).toBe("");
+    const { cleaned, drained } = json as { cleaned: number; drained: boolean };
+    expect(cleaned).toBe(100);
+    // Released once drained; otherwise the Strong root would leak it forever.
+    expect(drained).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  // Conservative stack scanning can pin any one cell for a few cycles; use a
+  // batch of registries so a stray stack word can only shadow the count, never
+  // the invariant that the Strong root is released.
+  test.concurrent("unregister() that drains every entry releases the root", async () => {
+    const { stderr, exitCode, json } = await run(/* js */ `
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      const wrs = [];
+      (function () {
+        const tok = {};
+        for (let n = 0; n < 200; n++) {
+          const fr = new FinalizationRegistry(() => {});
+          wrs.push(new WeakRef(fr));
+          for (let i = 0; i < 4; i++) fr.register(globalThis, i, tok);
+          fr.unregister(tok);
+        }
+      })();
+      for (let r = 0; r < 30; r++) {
+        Bun.gc(true);
+        await sleep(5);
+        if (wrs.every(w => w.deref() === undefined)) break;
+      }
+      const alive = wrs.filter(w => w.deref() !== undefined).length;
+      console.log(JSON.stringify({ alive, total: wrs.length }));
+    `);
+    expect(stderr).toBe("");
+    const { alive, total } = json as { alive: number; total: number };
+    expect(total).toBe(200);
+    expect(alive).toBeLessThanOrEqual(2);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a registry that never registers stays collectable", async () => {
+    const { stderr, exitCode, json } = await run(/* js */ `
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      const wrs = [];
+      (function () {
+        for (let n = 0; n < 200; n++) {
+          const fr = new FinalizationRegistry(() => {});
+          wrs.push(new WeakRef(fr));
+        }
+      })();
+      for (let r = 0; r < 30; r++) {
+        Bun.gc(true);
+        await sleep(5);
+        if (wrs.every(w => w.deref() === undefined)) break;
+      }
+      const alive = wrs.filter(w => w.deref() !== undefined).length;
+      console.log(JSON.stringify({ alive, total: wrs.length }));
+    `);
+    expect(stderr).toBe("");
+    const { alive, total } = json as { alive: number; total: number };
+    expect(total).toBe(200);
+    expect(alive).toBeLessThanOrEqual(2);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("register/unregister argument validation is unchanged", async () => {
+    const { stderr, exitCode, json } = await run(/* js */ `
+      const fr = new FinalizationRegistry(() => {});
+      const errors = [];
+      const catchType = fn => { try { fn(); errors.push(null); } catch (e) { errors.push(e?.constructor?.name); } };
+      catchType(() => fr.register(42, "x"));
+      catchType(() => fr.register({}, "x", 42));
+      const obj = {};
+      catchType(() => fr.register(obj, obj));
+      catchType(() => fr.unregister(42));
+      catchType(() => FinalizationRegistry.prototype.register.call({}, {}, "x"));
+      const tok = {};
+      fr.register({}, "x", tok);
+      const ok = fr.unregister(tok);
+      const okTwice = fr.unregister(tok);
+      console.log(JSON.stringify({ errors, ok, okTwice, len: fr.register.length, ulen: fr.unregister.length }));
+    `);
+    expect(stderr).toBe("");
+    expect(json).toEqual({
+      errors: ["TypeError", "TypeError", "TypeError", "TypeError", "TypeError"],
+      ok: true,
+      okTwice: false,
+      len: 2,
+      ulen: 1,
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/finalization-registry.test.ts
+++ b/test/js/web/finalization-registry.test.ts
@@ -42,6 +42,10 @@ describe("FinalizationRegistry keeps itself alive while it has registrations", (
           wrs.push(new WeakRef(o));
           fr.register(o, i);
         }
+        // Exact repro shape from the report: the unpatched build's opportunistic
+        // GC fires during this idle window and sweeps fr. The suspend point is
+        // what matters (test 2 shows await 0 is enough); keep the shape so this
+        // remains the fail-before case for the originally-reported sequence.
         await sleep(300);
         for (let r = 0; r < 30; r++) {
           Bun.gc(true);
@@ -167,6 +171,65 @@ describe("FinalizationRegistry keeps itself alive while it has registrations", (
     const { alive, total } = json as { alive: number; total: number };
     expect(total).toBe(200);
     expect(alive).toBeLessThanOrEqual(2);
+    expect(exitCode).toBe(0);
+  });
+
+  // Documents the over-correction relative to V8: a registry whose only
+  // remaining registration watches a target that never dies (here globalThis)
+  // is retained until that target does. V8 collects such a registry. The
+  // precise fix would require either walking unmarked JSFinalizationRegistry
+  // cells during marking or saving every async local at generatorification;
+  // see the comment on rootFinalizationRegistry in JSCTaskScheduler.h.
+  test.concurrent("a registry with an immortal target is retained (documented over-correction)", async () => {
+    const { stderr, exitCode, json } = await run(/* js */ `
+      const sleep = ms => new Promise(r => setTimeout(r, ms));
+      const wrs = [];
+      (function () {
+        for (let n = 0; n < 50; n++) {
+          const fr = new FinalizationRegistry(() => {});
+          wrs.push(new WeakRef(fr));
+          fr.register(globalThis, n);
+        }
+      })();
+      for (let r = 0; r < 10; r++) {
+        Bun.gc(true);
+        await sleep(5);
+      }
+      const alive = wrs.filter(w => w.deref() !== undefined).length;
+      console.log(JSON.stringify({ alive, total: wrs.length }));
+    `);
+    expect(stderr).toBe("");
+    const { alive, total } = json as { alive: number; total: number };
+    expect(total).toBe(50);
+    // With the Strong root, every registry is retained. If this ever drops to
+    // ~0 a future change has narrowed the retention and this test should be
+    // updated to assert that instead.
+    expect(alive).toBe(50);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("node:vm contexts get the rooting hooks", async () => {
+    const { stderr, exitCode, json } = await run(/* js */ `
+      const vm = require("node:vm");
+      const ctx = vm.createContext({ Bun, setTimeout, console });
+      vm.runInContext(\`
+        (async () => {
+          const sleep = ms => new Promise(r => setTimeout(r, ms));
+          let cleaned = 0;
+          const fr = new FinalizationRegistry(() => { cleaned++; });
+          for (let i = 0; i < 200; i++) fr.register({ i }, i);
+          await 0;
+          for (let r = 0; r < 30; r++) {
+            Bun.gc(true);
+            await sleep(10);
+            if (cleaned >= 200) break;
+          }
+          console.log(JSON.stringify({ cleaned }));
+        })();
+      \`, ctx);
+    `);
+    expect(stderr).toBe("");
+    expect((json as { cleaned: number }).cleaned).toBeGreaterThanOrEqual(199);
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### What does this PR do?

A `FinalizationRegistry` whose only reference is a module-level or async-function `const` can be collected, with all its pending registrations, before a single cleanup callback fires.

```js
// bun repro.mjs  -> {collected:500, cleaned:0}
// node --expose-gc repro.mjs -> {collected:499, cleaned:499}
const sleep = ms => new Promise(r => setTimeout(r, ms));
const K = 500; let cleaned = 0;
const fr = new FinalizationRegistry(() => { cleaned++; });
const wrs = [];
for (let i = 0; i < K; i++) { const o = { i, pad: "p".repeat(30) }; wrs.push(new WeakRef(o)); fr.register(o, i); }
await sleep(300);
for (let r = 0; r < 20; r++) { Bun.gc(true); await sleep(20); if (cleaned >= K) break; }
console.log(JSON.stringify({ collected: wrs.filter(w => w.deref() === undefined).length, cleaned }));
```

### Cause

JavaScriptCore's generatorification only saves locals that are read after an `await`/`yield` into the suspended generator state. `fr` is last read at `fr.register(o, i)`, so after `await sleep(300)` nothing roots it. The GC that fires during the sleep marks neither `fr` nor its targets; `finalizeMarkedUnconditionalFinalizers` only walks marked cells, so `JSFinalizationRegistry::finalizeUnconditionally` never runs for `fr` and no cleanup task is ever scheduled. The registry is swept along with its registrations. The same applies to plain `function*` and async generators.

V8 preserves every async-function local across `await`, so the same program keeps `fr` reachable in Node.js (verified: a `WeakRef` to `fr` derefs non-undefined there, undefined in Bun). When the registry is truly unreachable in both engines (e.g. created inside an IIFE that returns), both deliver zero callbacks, so this is purely the generatorified-local-lifetime difference being exposed. Standalone jsc-shell repro and analysis for an upstream report are in the linked thread.

The spec permits collecting an unreferenced registry without running its callbacks, but the Node.js behaviour is what every `FinalizationRegistry`-based resource guard assumes.

### Fix

Override `FinalizationRegistry.prototype.{register,unregister}` with Bun host functions that call JSC's `registerTarget` / `unregister` and additionally maintain a per-VM `JSC::Strong<>` root set on `JSCTaskScheduler`:

- `register()` adds the receiver on the first successful registration.
- `unregister()` drops it when `liveCount + deadCount` reaches zero.
- After each `runFinalizationCleanup` deferred-work task runs, the same zero check drops the root.

A registry with no registrations is never rooted; a drained one becomes collectable on the next GC. The map is cleared in `Bun__JSCTaskScheduler__markShuttingDown` so no `Strong` outlives the event loop's final tick. The hooks are installed for both the main global and `node:vm` globals.

**Retention trade-off:** a registry whose only remaining registration watches a target that never dies (e.g. `globalThis`) is retained until VM shutdown. V8 would collect it. Matching V8 exactly requires either walking unmarked `JSFinalizationRegistry` cells during marking (private access to the target list to tell "a target is dying this cycle") or changing JSC's `BytecodeGenerator` to save every generatorified local; the silent-guard failure this fixes is judged worse than the retained registry. The comment on `rootFinalizationRegistry` and a dedicated test document this.

### How did you verify your code works?

New `test/js/web/finalization-registry.test.ts` (eight concurrent subprocess tests):

- the repro shape above and an async-function variant deliver every callback (both hit `cleaned == 0` on the unpatched build)
- a registry created in an IIFE delivers all callbacks and is then collectable
- a batch of 200 registries that `unregister()` their entries / never register at all are all collected (not leaked by the new root)
- a `node:vm` context delivers every callback
- the immortal-target retention is asserted so a future narrowing is visible
- `register` / `unregister` argument validation and `.length` are unchanged

`USE_SYSTEM_BUN=1 bun test ...`: 5 fail with `cleaned == 0` / `alive == 0`.
`bun bd test ...`: 8 pass.

Adjacent PRs #30857 and #34270 touch the same `runPendingWork` block for different reasons (exception reporting / worker termination); this change is additive to both.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/finalization-registry.test.ts
bun test v1.4.0 (8e3d7306d)

test/js/web/finalization-registry.test.ts:
(pass) FinalizationRegistry keeps itself alive while it has registrations > a registry that never registers stays collectable [480.66ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > unregister() that drains every entry releases the root [586.23ms]
82 |         console.log(JSON.stringify({ cleaned }));
83 |       }
84 |       await main();
85 |     `);
86 |     expect(stderr).toBe("");
87 |     expect((json as { cleaned: number }).cleaned).toBeGreaterThanOrEqual(199);
                                                       ^
error: expect(received).toBeGreaterThanOrEqual(expected)

Expected: >= 199
Received: 0

      at <anonymous> (/workspace/bun/test/js/web/finalization-registry.test.ts:87:51)
(fail) FinalizationRegistry keeps itself alive while it has registrations > same inside an async function (not just module top level) [1128.92ms]
202 |     const { alive, total } = json as { alive: numbe
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (438efb9f4)

test/js/web/finalization-registry.test.ts:
(pass) FinalizationRegistry keeps itself alive while it has registrations > register/unregister argument validation is unchanged [14.20ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > unregister() that drains every entry releases the root [18.78ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > a registry that never registers stays collectable [18.33ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > same inside an async function (not just module top level) [24.20ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > node:vm contexts get the rooting hooks [30.01ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > the registry is released once every registration is drained [34.33ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > a registry with an immortal target is retained (documented over-correction) [67.96ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > cleanup callbacks fire when the re
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/finalization-registry.test.ts
bun test v1.4.0 (8e3d7306d)

test/js/web/finalization-registry.test.ts:
(pass) FinalizationRegistry keeps itself alive while it has registrations > same inside an async function (not just module top level) [489.76ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > the registry is released once every registration is drained [517.03ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > unregister() that drains every entry releases the root [520.40ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > a registry that never registers stays collectable [552.87ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > cleanup callbacks fire when the registry local dies before its targets [895.20ms]
(pass) FinalizationRegistry keeps itself alive while it has registrations > register/unregister argument validation is unchanged [496.19ms]
(pass) FinalizationRegistry keeps itself alive while it has registra
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 780ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] gen bindgenv2
[2/136] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/136] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[4/136] gen cpp.rs (cppbind)
[5/136] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fie
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCTaskScheduler.cpp     |  98 ++++++++++-
 src/jsc/bindings/JSCTaskScheduler.h       |  30 ++++
 src/jsc/bindings/NodeVM.cpp               |   2 +
 src/jsc/bindings/ZigGlobalObject.cpp      |   2 +
 test/js/web/finalization-registry.test.ts | 263 ++++++++++++++++++++++++++++++
 5 files changed, 394 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/JSCTaskScheduler.cpp          2     11      0
src/jsc/bindings/JSCTaskScheduler.h            3      5      0
src/jsc/bindings/NodeVM.cpp                    1      1      0
src/jsc/bindings/ZigGlobalObject.cpp           1      1      0
test/js/web/finalization-registry.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->