### PR TITLE
fs.copyFile, fs.cp: preserve source file ownership

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4947,7 +4947,6 @@ impl NodeFS {
     /// https://github.com/libuv/libuv/pull/2578
     /// https://github.com/nodejs/node/issues/34624
     fn copy_file_inner(&mut self, args: &args::CopyFile) -> Maybe<ret::CopyFile> {
-        // TODO: do we need to fchown?
         #[cfg(target_os = "macos")]
         {
             let mut src_buf = PathBuffer::uninit();
@@ -4963,74 +4962,75 @@ impl NodeFS {
                     src,
                 )
                 .unwrap_or(Ok(()));
+            }
+
+            let stat_ = match Syscall::stat(src) {
+                Ok(result) => result,
+                Err(err) => return Err(err.with_path(src)),
+            };
+
+            if !sys::S::ISREG(stat_.st_mode as u32) {
+                return Err(sys::Error {
+                    errno: SystemErrno::ENOTSUP as _,
+                    syscall: sys::Tag::copyfile,
+                    ..Default::default()
+                });
+            }
+
+            // 64 KB is about the break-even point for clonefile() to be worth it
+            // at least, on an M1 with an NVME SSD.
+            if stat_.st_size > 128 * 1024 {
+                if !args.mode.shouldnt_overwrite() {
+                    // clonefile() will fail if it already exists
+                    let _ = Syscall::unlink(dest);
+                }
+                if Maybe::<ret::CopyFile>::errno_sys_p(
+                    bun_sys::c::clonefile_rc(src, dest, 0),
+                    sys::Tag::copyfile,
+                    src,
+                )
+                .is_none()
+                {
+                    let _ = Syscall::chmod(dest, stat_.st_mode as u32);
+                    return Ok(());
+                }
             } else {
-                let stat_ = match Syscall::stat(src) {
+                let src_fd = match Syscall::open(src, sys::O::RDONLY, 0o644) {
                     Ok(result) => result,
-                    Err(err) => return Err(err.with_path(src)),
+                    Err(err) => return Err(err.with_path(args.src.slice())),
+                };
+                let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
+
+                let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
+                // VERIFY-FIX(round1): was `usize` then passed as `&mut (wrote as u64)` —
+                // that wrote into a discarded temporary so the deferred ftruncate
+                // always saw 0. The scopeguard variant also double-borrowed `wrote`.
+                // There are no early returns between open(dest) and the
+                // `copy_file_using_read_write_loop` call, so inlining the
+                // cleanup after it is equivalent.
+                let mut wrote: u64 = 0;
+                if args.mode.shouldnt_overwrite() {
+                    flags |= sys::O::EXCL;
+                }
+
+                let dest_fd = match Syscall::open(dest, flags, stat_.st_mode as Mode) {
+                    Ok(result) => result,
+                    Err(err) => return Err(err.with_path(args.dest.slice())),
                 };
 
-                if !sys::S::ISREG(stat_.st_mode as u32) {
-                    return Err(sys::Error {
-                        errno: SystemErrno::ENOTSUP as _,
-                        syscall: sys::Tag::copyfile,
-                        ..Default::default()
-                    });
-                }
-
-                // 64 KB is about the break-even point for clonefile() to be worth it
-                // at least, on an M1 with an NVME SSD.
-                if stat_.st_size > 128 * 1024 {
-                    if !args.mode.shouldnt_overwrite() {
-                        // clonefile() will fail if it already exists
-                        let _ = Syscall::unlink(dest);
-                    }
-                    if Maybe::<ret::CopyFile>::errno_sys_p(
-                        bun_sys::c::clonefile_rc(src, dest, 0),
-                        sys::Tag::copyfile,
-                        src,
-                    )
-                    .is_none()
-                    {
-                        let _ = Syscall::chmod(dest, stat_.st_mode as u32);
-                        return Ok(());
-                    }
-                } else {
-                    let src_fd = match Syscall::open(src, sys::O::RDONLY, 0o644) {
-                        Ok(result) => result,
-                        Err(err) => return Err(err.with_path(args.src.slice())),
-                    };
-                    let _close_src = scopeguard::guard(src_fd, |fd| fd.close());
-
-                    let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
-                    // VERIFY-FIX(round1): was `usize` then passed as `&mut (wrote as u64)` —
-                    // that wrote into a discarded temporary so the deferred ftruncate
-                    // always saw 0. The scopeguard variant also double-borrowed `wrote`.
-                    // There are no early returns between open(dest) and the
-                    // `copy_file_using_read_write_loop` call, so inlining the
-                    // cleanup after it is equivalent.
-                    let mut wrote: u64 = 0;
-                    if args.mode.shouldnt_overwrite() {
-                        flags |= sys::O::EXCL;
-                    }
-
-                    let dest_fd = match Syscall::open(dest, flags, stat_.st_mode as Mode) {
-                        Ok(result) => result,
-                        Err(err) => return Err(err.with_path(args.dest.slice())),
-                    };
-
-                    let result = Self::copy_file_using_read_write_loop(
-                        src,
-                        dest,
-                        src_fd,
-                        dest_fd,
-                        stat_.st_size.max(0) as usize,
-                        &mut wrote,
-                    );
-                    let _ = Syscall::ftruncate(dest_fd, (wrote & ((1u64 << 63) - 1)) as i64);
-                    let _ = Syscall::fchmod(dest_fd, stat_.st_mode as u32);
-                    dest_fd.close();
-                    return result;
-                }
+                let result = Self::copy_file_using_read_write_loop(
+                    src,
+                    dest,
+                    src_fd,
+                    dest_fd,
+                    stat_.st_size.max(0) as usize,
+                    &mut wrote,
+                );
+                let _ = Syscall::ftruncate(dest_fd, (wrote & ((1u64 << 63) - 1)) as i64);
+                let _ = Syscall::fchown(dest_fd, stat_.st_uid as u32, stat_.st_gid as u32);
+                let _ = Syscall::fchmod(dest_fd, stat_.st_mode as u32);
+                dest_fd.close();
+                return result;
             }
 
             // we fallback to copyfile() when the file is > 128 KB and clonefile fails
@@ -5040,12 +5040,16 @@ impl NodeFS {
             if args.mode.shouldnt_overwrite() {
                 mode |= bun_sys::c::COPYFILE_EXCL;
             }
-            return Maybe::<ret::CopyFile>::errno_sys_p(
+            if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
                 bun_sys::c::copyfile_rc(src, dest, mode),
                 sys::Tag::copyfile,
                 src,
-            )
-            .unwrap_or(Ok(()));
+            ) {
+                return err;
+            }
+            let _ = Syscall::chown(dest, stat_.st_uid as u32, stat_.st_gid as u32);
+            let _ = Syscall::chmod(dest, stat_.st_mode as u32);
+            return Ok(());
         }
 
         #[cfg(target_os = "freebsd")]
@@ -5127,6 +5131,8 @@ impl NodeFS {
                 match sys::get_errno(rc) {
                     E::SUCCESS => {
                         if rc == 0 {
+                            let _ =
+                                Syscall::fchown(dest_fd, stat_.st_uid as u32, stat_.st_gid as u32);
                             let _ = Syscall::fchmod(dest_fd, stat_.st_mode as Mode);
                             return Ok(());
                         }
@@ -5156,6 +5162,7 @@ impl NodeFS {
                 let _ = sys::unlink(dest);
                 return Err(err);
             }
+            let _ = Syscall::fchown(dest_fd, stat_.st_uid as u32, stat_.st_gid as u32);
             let _ = Syscall::fchmod(dest_fd, stat_.st_mode as Mode);
             return Ok(());
         }
@@ -5208,6 +5215,7 @@ impl NodeFS {
                     let _ = sys::unlink(dest);
                     return err;
                 }
+                let _ = Syscall::fchown(dest_fd, stat_.st_uid as u32, stat_.st_gid as u32);
                 let _ = Syscall::fchmod(dest_fd, stat_.st_mode as u32);
                 dest_fd.close();
                 return Ok(());
@@ -5217,6 +5225,7 @@ impl NodeFS {
             if sys::S::ISREG(stat_.st_mode as u32) && sys::copy_file::can_use_ioctl_ficlone() {
                 let rc = sys::linux::ioctl_ficlone(dest_fd, src_fd);
                 if rc == 0 {
+                    let _ = Syscall::fchown(dest_fd, stat_.st_uid as u32, stat_.st_gid as u32);
                     let _ = Syscall::fchmod(dest_fd, stat_.st_mode as u32);
                     dest_fd.close();
                     return Ok(());
@@ -5226,14 +5235,17 @@ impl NodeFS {
                 sys::copy_file::disable_ioctl_ficlone();
             }
 
-            let _close_dest =
-                scopeguard::guard((dest_fd, stat_.st_mode, &wrote), |(fd, m, wrote)| {
-                    // ftruncate/fchmod take only ints — no memory-safety preconditions; route
-                    // through the existing `bun_sys` safe wrappers (same as lines above).
+            let _close_dest = scopeguard::guard(
+                (dest_fd, stat_.st_mode, stat_.st_uid, stat_.st_gid, &wrote),
+                |(fd, m, uid, gid, wrote)| {
+                    // ftruncate/fchown/fchmod take only ints — no memory-safety preconditions;
+                    // route through the existing `bun_sys` safe wrappers (same as lines above).
                     let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
+                    let _ = Syscall::fchown(fd, uid as u32, gid as u32);
                     let _ = Syscall::fchmod(fd, m as u32);
                     fd.close();
-                });
+                },
+            );
 
             let mut off_in_copy: i64 = 0;
             let mut off_out_copy: i64 = 0;
@@ -8487,7 +8499,6 @@ impl NodeFS {
     ) -> Maybe<ret::CopyFile> {
         let _ = args; // only the Windows branch consults `args` (shouldIgnoreEbusy)
 
-        // TODO: do we need to fchown?
         #[cfg(target_os = "macos")]
         {
             if mode.is_force_clone() {
@@ -8569,12 +8580,15 @@ impl NodeFS {
 
                 let dest_fd =
                     Self::_cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
-                let _close_dest =
-                    scopeguard::guard((dest_fd, stat_.st_mode, &wrote), |(fd, m, wrote)| {
+                let _close_dest = scopeguard::guard(
+                    (dest_fd, stat_.st_mode, stat_.st_uid, stat_.st_gid, &wrote),
+                    |(fd, m, uid, gid, wrote)| {
                         let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
+                        let _ = Syscall::fchown(fd, uid as u32, gid as u32);
                         let _ = Syscall::fchmod(fd, m as u32);
                         fd.close();
-                    });
+                    },
+                );
 
                 let mut w = wrote.get();
                 let r = Self::copy_file_using_read_write_loop(
@@ -8605,20 +8619,24 @@ impl NodeFS {
                 src.as_bytes(),
             );
             match first_try {
-                None => return Ok(()),
+                None => {}
                 Some(err) if err.get_errno() == E::ENOENT => {
                     let _ = sys::Dir::cwd().make_path(paths::resolve_path::dirname::<
                         paths::platform::Auto,
                     >(dest.as_bytes()));
-                    return Maybe::<ret::CopyFile>::errno_sys_p(
+                    if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
                         bun_sys::c::copyfile_rc(src, dest, mode_),
                         sys::Tag::copyfile,
                         src.as_bytes(),
-                    )
-                    .unwrap_or(Ok(()));
+                    ) {
+                        return err;
+                    }
                 }
                 Some(err) => return err,
             }
+            let _ = Syscall::chown(dest, stat_.st_uid as u32, stat_.st_gid as u32);
+            let _ = Syscall::chmod(dest, stat_.st_mode as u32);
+            return Ok(());
         }
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -8668,6 +8686,7 @@ impl NodeFS {
             if sys::S::ISREG(stat_.st_mode as u32) && sys::copy_file::can_use_ioctl_ficlone() {
                 let rc = sys::linux::ioctl_ficlone(dest_fd, src_fd);
                 if rc == 0 {
+                    let _ = Syscall::fchown(dest_fd, stat_.st_uid as u32, stat_.st_gid as u32);
                     let _ = Syscall::fchmod(dest_fd, stat_.st_mode as u32);
                     dest_fd.close();
                     return Ok(());
@@ -8676,9 +8695,16 @@ impl NodeFS {
             }
 
             let _close_dest = scopeguard::guard(
-                (dest_fd, stat_.st_mode as Mode, &wrote),
-                |(fd, m, wrote)| {
+                (
+                    dest_fd,
+                    stat_.st_mode as Mode,
+                    stat_.st_uid,
+                    stat_.st_gid,
+                    &wrote,
+                ),
+                |(fd, m, uid, gid, wrote)| {
                     let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
+                    let _ = Syscall::fchown(fd, uid as u32, gid as u32);
                     let _ = Syscall::fchmod(fd, m);
                     fd.close();
                 },
@@ -8854,9 +8880,16 @@ impl NodeFS {
             }
 
             let _close_dest = scopeguard::guard(
-                (dest_fd, stat_.st_mode as Mode, &wrote),
-                |(fd, m, wrote)| {
+                (
+                    dest_fd,
+                    stat_.st_mode as Mode,
+                    stat_.st_uid,
+                    stat_.st_gid,
+                    &wrote,
+                ),
+                |(fd, m, uid, gid, wrote)| {
                     let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
+                    let _ = Syscall::fchown(fd, uid as u32, gid as u32);
                     let _ = Syscall::fchmod(fd, m);
                     fd.close();
                 },

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -716,3 +716,52 @@ test.skipIf(!isLinux)("fs.cp and fs.copyFile create the destination with the sou
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
 });
+
+test.skipIf(isWindows || process.getuid?.() !== 0)(
+  "fs.copyFile and fs.cp preserve the source file's ownership",
+  async () => {
+    using dir = tempDir("cp-ownership", {});
+    const script = `
+      const fs = require("node:fs");
+      const own = p => { const s = fs.statSync(p); return s.uid + ":" + s.gid; };
+      fs.writeFileSync("src", "data");
+      fs.chmodSync("src", 0o751);
+      fs.chownSync("src", 7, 8);
+      fs.writeFileSync("existing", "old");
+      fs.chownSync("existing", 9, 9);
+      fs.copyFileSync("src", "d-copyFileSync");
+      await fs.promises.copyFile("src", "d-promisesCopyFile");
+      fs.cpSync("src", "d-cpSync");
+      await fs.promises.cp("src", "d-promisesCp");
+      fs.copyFileSync("src", "existing");
+      console.log(JSON.stringify({
+        src: own("src"),
+        copyFileSync: own("d-copyFileSync"),
+        promisesCopyFile: own("d-promisesCopyFile"),
+        cpSync: own("d-cpSync"),
+        promisesCp: own("d-promisesCp"),
+        ontoExisting: own("existing"),
+        mode: (fs.statSync("d-copyFileSync").mode & 0o777).toString(8),
+      }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      src: "7:8",
+      copyFileSync: "7:8",
+      promisesCopyFile: "7:8",
+      cpSync: "7:8",
+      promisesCp: "7:8",
+      ontoExisting: "7:8",
+      mode: "751",
+    });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
### What does this PR do?

`fs.copyFile*` and `fs.cp*` were leaving the copied file owned by the copying process's euid instead of preserving the source file's owner. Copying onto an existing file kept that file's old owner. Node.js (via libuv's `uv__fs_copyfile`) calls `fchown(dst, src.st_uid, src.st_gid)` on every copy, ignoring errors the same way `cp -p` does; Bun only copied the mode.

#### Repro (run as root)

```js
import fs from 'node:fs';
const dir = fs.mkdtempSync('/tmp/cpown-');
const own = p => { const s = fs.statSync(p); return `${s.uid}:${s.gid}`; };
fs.writeFileSync(`${dir}/src`, 'data'); fs.chmodSync(`${dir}/src`, 0o751); fs.chownSync(`${dir}/src`, 7, 8);
fs.writeFileSync(`${dir}/existing`, 'old'); fs.chownSync(`${dir}/existing`, 9, 9);
fs.copyFileSync(`${dir}/src`, `${dir}/d1`);
await fs.promises.copyFile(`${dir}/src`, `${dir}/d2`);
fs.cpSync(`${dir}/src`, `${dir}/d3`);
await fs.promises.cp(`${dir}/src`, `${dir}/d4`);
fs.copyFileSync(`${dir}/src`, `${dir}/existing`);
console.log(JSON.stringify({ src: own(`${dir}/src`), copyFileSync: own(`${dir}/d1`), promisesCopyFile: own(`${dir}/d2`),
  cpSync: own(`${dir}/d3`), promisesCp: own(`${dir}/d4`), ontoExisting_9_9: own(`${dir}/existing`) }));
```

Before:
```
{"src":"7:8","copyFileSync":"0:0","promisesCopyFile":"0:0","cpSync":"0:0","promisesCp":"0:0","ontoExisting_9_9":"9:9"}
```

After (matches Node.js v26.3.0):
```
{"src":"7:8","copyFileSync":"7:8","promisesCopyFile":"7:8","cpSync":"7:8","promisesCp":"7:8","ontoExisting_9_9":"7:8"}
```

#### Fix

Call `fchown(dest_fd, src.st_uid, src.st_gid)` immediately before the existing `fchmod` on every copy exit path in `copy_file_inner` and `_copy_single_file_sync` (Linux `ioctl_ficlone`/`copy_file_range`/`sendfile` paths, macOS read-write and `copyfile(3)` fallback, FreeBSD `copy_file_range` and read-write fallback). The result is discarded: an unprivileged process gets `EPERM` and the copy proceeds with the caller's ownership, which is the same behaviour libuv and `cp -p` have.

The macOS `clonefile(2)` success path is left alone since `clonefile` already copies ownership when the caller is privileged, and an unprivileged caller would fail the subsequent `chown` anyway.

### How did you verify your code works?

New `test.skipIf(isWindows || process.getuid?.() !== 0)` case in `test/js/node/fs/cp.test.ts` covers `copyFileSync`, `fs.promises.copyFile`, `cpSync`, `fs.promises.cp`, and the overwrite-existing case.

```
bun bd test test/js/node/fs/cp.test.ts       # 48 pass, 5 skip
bun bd test test/js/node/fs/fs.test.ts -t copyFile   # 7 pass
bun run rust:check-all                       # 10/10 targets
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->