### PR TITLE
test: fail the cron --hot test at once when the child dies from a signal

### DIFF
--- a/test/js/bun/cron/in-process-cron.test.ts
+++ b/test/js/bun/cron/in-process-cron.test.ts
@@ -451,8 +451,10 @@ describe.concurrent("Bun.cron (in-process) — firing", () => {
     const stderrP = proc.stderr.text();
     const waitFor = async (file: string) => {
       while (!(await Bun.file(m(file)).exists())) {
-        if (proc.exitCode !== null)
-          throw new Error(`subprocess exited ${proc.exitCode} before ${file}: ${await stderrP}`);
+        // A crashed child (SIGABRT from a panic) has exitCode null and only
+        // signalCode set; without this check the loop spins to the test timeout.
+        if (proc.exitCode !== null || proc.signalCode !== null)
+          throw new Error(`subprocess exited ${proc.exitCode ?? proc.signalCode} before ${file}: ${await stderrP}`);
         await Bun.sleep(10);
       }
     };


### PR DESCRIPTION
### Problem
- `test/js/bun/cron/in-process-cron.test.ts` ("--hot reload clears jobs deleted from source") ran for the full 130 s timeout on Ubuntu 25.04 aarch64 after the `bun --hot` child died with `panic: Failed to start File Watcher: EAGAIN`.
- The `waitFor` poll at `in-process-cron.test.ts:452` only checks `proc.exitCode`. A child that dies from a signal (SIGABRT from the panic) has `exitCode === null`, so the poll never notices and the child's stderr is never shown.

### Fix
- `waitFor` also checks `proc.signalCode`, and the error message carries whichever one is set. A crashed child now fails the test at once with its stderr attached.
- Verified: `bun bd test test/js/bun/cron/in-process-cron.test.ts` (27 pass). Test-only change.

### Background
- The crash itself (`pthread_create` returns `EAGAIN` on a loaded host while the watcher thread starts) is handled separately. Main already retries once (#34660) and reports a persistent failure as an error instead of a panic. #39864 replaces that with a shared `spawn_with_retry` helper for every thread bun starts. This PR originally carried its own watcher retry; that part is dropped in favor of #39864 (see Notes).
- `Bun.spawn` reports a signal death through `signalCode` and leaves `exitCode` null, so a poll loop that wants to notice any child death has to check both.

<details><summary>Notes</summary>

Earlier revisions of this PR changed `Watcher::start()` to retry the thread spawn with bounded exponential backoff (1..128 ms) and extended the `LD_PRELOAD` shim in `test/cli/watch/watch.test.ts` to inject N failures. Since then main gained a single retry in #34660, and #39864 generalizes it into `bun_threading::spawn_with_retry` (20 attempts) across the HTTP, bundle, IO, process waiter and watcher threads. That supersedes the watcher part of this PR, so it now contains only the test diagnostic fix, which #39864 does not include.

Root cause of the original CI report: the `describe.concurrent` block in this file starts about ten bun subprocesses at once (one of them with 20 workers), so the `--hot` child's `pthread_create` for the watcher thread hit the box's thread limit.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/cron/in-process-cron.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/cron/in-process-cron.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/cron/in-process-cron.test.ts:
(pass) Bun.cron (in-process) > validates cron expression [25.17ms]
(pass) Bun.cron (in-process) > validates schedule is a string [3.66ms]
(pass) Bun.cron (in-process) > rejects expressions with no future occurrences [159.89ms]
(pass) Bun.cron (in-process) > returns CronJob with cron getter [5.06ms]
(pass) Bun.cron (in-process) > is Disposable [4.33ms]
(pass) Bun.cron (in-process) > stop() cancels before first fire [2.20ms]
(pass) Bun.cron (in-process) > stop() is idempotent [3.06ms]
(pass) Bun.cron (in-process) > ref()/unref() are chainable [2.79ms]
(pass) Bun.cron (in-process) > multiple jobs coexist independently [2.93ms]
(pass) Bun.cron (in-process) > accepts @nicknames [2.21ms]
(pass) Bun.cron (in-process) > supports named weekdays and months [2.19ms]
(pass) Bun.cron (in-process) > keeps process alive by default; unref() allows exit [454.17ms]
(pass) Bun.cron (in-process) > ref'd job prevents process exit [491.38ms]
(pass) Bun.cron (in-process) > honors jest fake timers [8.26ms]
(pass) Bun.cron (in-process) > stop() under fake timers prevents further fires [4.50ms]
(pass) Bun.cron (in-process) > distinguishes callback overload from OS-level overload [3.06ms]
(pass) Bun.cron (in-process) — firing > ref() after stop() does not keep process alive [435.97ms]
(pass) Bun.cron (in-process) — firing > async callback: stop() during await prevents reschedule [25852.39ms]
(pass) Bun.cron (in-process) — firing > callback fires at minute boundary, this === job [25877.01ms]
(pass) Bun.cron (in-process) — firing > unreferenced running job survives GC [26028.70ms]
(pass) Bun.cron (in-process) — firing > worker terminate while async callback pending releases cleanly [26091.85ms]
(pass) Bun.cron (in-process) — firing > worker terminate mid-callback does not report Term
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/cron/in-process-cron.test.ts | 6 ++++--
 1 file changed, 4 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/bun/cron/in-process-cron.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->