### PR TITLE
sys: add #[track_caller] + fd/err to Fd::close() UAF assert

### DIFF
--- a/src/sys/fd.rs
+++ b/src/sys/fd.rs
@@ -68,11 +68,19 @@ pub trait FdExt: Copy + Sized {
 }
 
 impl FdExt for Fd {
+    #[track_caller]
     fn close(self) {
         let err = self.close_allowing_bad_file_descriptor(None);
-        debug_assert!(err.is_none()); // use after close!
+        // use after close!
+        debug_assert!(
+            err.is_none(),
+            "close({self}) = {} at {}",
+            err.as_ref().unwrap(),
+            core::panic::Location::caller(),
+        );
     }
 
+    #[track_caller]
     fn close_allowing_bad_file_descriptor(
         self,
         return_address: Option<usize>,
@@ -84,6 +92,7 @@ impl FdExt for Fd {
         self.close_allowing_standard_io(return_address)
     }
 
+    #[track_caller]
     fn close_allowing_standard_io(self, return_address: Option<usize>) -> Option<sys::Error> {
         debug_assert!(self.is_valid()); // probably a UAF
 


### PR DESCRIPTION
## What

`Fd::close()` has a `debug_assert!(err.is_none())` tripwire that fires when a close returns an error (double-close / use-after-close). The panic text was the bare `assertion failed: err.is_none()` with the reported location being `src/sys/fd.rs:72` itself, so an occurrence gave no hint which caller was at fault.

This adds `#[track_caller]` to `close()` / `close_allowing_bad_file_descriptor()` / `close_allowing_standard_io()` and includes the fd value, the close error, and `Location::caller()` in the assert message.

Before:
```
assertion failed: err.is_none()
```

After (example):
```
close(7[libuv]) = EBADF: bad file descriptor at src/install/PackageManager/security_scanner.rs:1214:9
```

## Why

This was seen twice during `bun install` on Windows (while running `test/cli/install/bun-security-scanner-workspaces.test.ts`) under I/O error load, with no usable backtrace. The invariant break is unambiguous from the assert site, but the offending caller is not; with this change the next occurrence names it directly.

## Audit notes

I audited every asserting `Fd::close()` call reachable from `src/install/`:

- `security_scanner.rs:1143-1216` (`spawn_windows`): scopeguard + post-spawn closes of `ipc_output_fds[1]` and `fds.0`. Traced `spawn_process_windows`: `Stdio::Pipe(fd)` maps to `UV_INHERIT_FD`, libuv duplicates into the child and does not close the parent's copy, so the post-spawn closes are single-owner. The `fds` scopeguard is disarmed via `= None` on each transfer. No double-close found, but this is the only Windows-only site on the security-scanner path, so it remains the prime suspect if spawn has a partial-ownership-transfer error path I missed.
- `TarballStream.rs` `out_fd`/`dest`: all closes go through `.take()` or are followed by `= None`; `Drop` checks `Option`.
- `Installer.rs:1217`, `patch_install.rs:555`, `isolated_install.rs:1723`, `bin.rs:641`, `PackageInstall.rs:790,2061,2071,2081,2142`: all single-owner.

No confirmed double-close site; instrumentation is the pragmatic next step.

## Verification

`cargo check -p bun_sys` and `cargo check -p bun_install` clean on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`, debug and release.