### PR TITLE
net/dgram: parse IPv6 zone identifiers in scoped address literals

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1219,8 +1219,9 @@ int bsd_parse_ip_address(const char *host, int port, struct sockaddr_storage *st
 #endif
             if (scope_id == 0) {
                 char *end;
+                errno = 0;
                 unsigned long n = strtoul(zone, &end, 10);
-                if (end != zone && *end == '\0' && n <= 0xffffffffUL) scope_id = (unsigned int)n;
+                if (end != zone && *end == '\0' && errno != ERANGE && n <= 0xffffffffUL) scope_id = (unsigned int)n;
             }
         }
         addr6->sin6_scope_id = scope_id;

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -56,6 +56,8 @@ static void init_debug_logging() {
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <net/if.h>
+#include <arpa/inet.h>
 #else /* _WIN32 */
 #include <mstcpip.h>
 #endif
@@ -1181,6 +1183,65 @@ int bsd_set_defer_accept(LIBUS_SOCKET_DESCRIPTOR listenFd) {
 #endif
 }
 
+/* Parse an IP literal (v4, or v6 with optional %zone) into a sockaddr_storage.
+ * Returns AF_INET / AF_INET6 on success, 0 if host is not an IP literal.
+ * Zone index is resolved via if_nametoindex() with a numeric fallback; an
+ * unknown zone yields scope_id 0 (matches libuv's uv_ip6_addr). */
+int bsd_parse_ip_address(const char *host, int port, struct sockaddr_storage *storage) {
+    memset(storage, 0, sizeof(struct sockaddr_storage));
+
+    struct sockaddr_in *addr4 = (struct sockaddr_in *)storage;
+    if (inet_pton(AF_INET, host, &addr4->sin_addr) == 1) {
+        addr4->sin_port = htons(port);
+        addr4->sin_family = AF_INET;
+#ifdef __APPLE__
+        addr4->sin_len = sizeof(struct sockaddr_in);
+#endif
+        return AF_INET;
+    }
+
+    memset(storage, 0, sizeof(struct sockaddr_storage));
+    struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)storage;
+    const char *ip = host;
+    char address_part[INET6_ADDRSTRLEN];
+    const char *zone = strchr(host, '%');
+    if (zone != NULL) {
+        size_t len = (size_t)(zone - host);
+        if (len >= sizeof(address_part)) len = sizeof(address_part) - 1;
+        memcpy(address_part, host, len);
+        address_part[len] = '\0';
+        ip = address_part;
+        zone++;
+        unsigned int scope_id = 0;
+        if (*zone != '\0') {
+#ifndef _WIN32
+            scope_id = if_nametoindex(zone);
+#endif
+            if (scope_id == 0) {
+                char *end;
+                unsigned long n = strtoul(zone, &end, 10);
+                if (end != zone && *end == '\0' && n <= 0xffffffffUL) scope_id = (unsigned int)n;
+            }
+        }
+        addr6->sin6_scope_id = scope_id;
+    }
+
+    if (inet_pton(AF_INET6, ip, &addr6->sin6_addr) == 1) {
+        addr6->sin6_port = htons(port);
+        addr6->sin6_family = AF_INET6;
+#ifdef __APPLE__
+        addr6->sin6_len = sizeof(struct sockaddr_in6);
+#endif
+        return AF_INET6;
+    }
+
+    return 0;
+}
+
+static socklen_t bsd_sockaddr_len(int family) {
+    return family == AF_INET ? (socklen_t)sizeof(struct sockaddr_in) : (socklen_t)sizeof(struct sockaddr_in6);
+}
+
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options, int* error) {
@@ -1193,6 +1254,32 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
 
     char port_string[16];
     snprintf(port_string, 16, "%d", port);
+
+    /* IP literals are parsed directly so an IPv6 scoped literal (`::1%lo`,
+     * `fe80::1%eth0`) works uniformly: glibc's getaddrinfo rejects a %zone on
+     * a non-link-local address. */
+    struct sockaddr_storage literal;
+    struct addrinfo literal_ai;
+    if (host != NULL) {
+        int family = bsd_parse_ip_address(host, port, &literal);
+        if (family != 0) {
+            memset(&literal_ai, 0, sizeof(literal_ai));
+            literal_ai.ai_family = family;
+            literal_ai.ai_socktype = SOCK_STREAM;
+            literal_ai.ai_addr = (struct sockaddr *)&literal;
+            literal_ai.ai_addrlen = bsd_sockaddr_len(family);
+
+            LIBUS_SOCKET_DESCRIPTOR listenFd = bsd_create_socket(family, SOCK_STREAM, 0, NULL);
+            if (listenFd == LIBUS_SOCKET_ERROR) {
+                return LIBUS_SOCKET_ERROR;
+            }
+            if (bsd_bind_listen_fd(listenFd, &literal_ai, port, options, error) != LIBUS_SOCKET_ERROR) {
+                return listenFd;
+            }
+            bsd_close_socket(listenFd);
+            return LIBUS_SOCKET_ERROR;
+        }
+    }
 
     if (getaddrinfo(host, port_string, &hints, &result)) {
         return LIBUS_SOCKET_ERROR;
@@ -1580,12 +1667,26 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
     char port_string[16];
     snprintf(port_string, 16, "%d", port);
 
-    int gai_result = getaddrinfo(host, port_string, &hints, &result);
-    if (gai_result != 0) {
-        if (err != NULL) {
-            *err = -gai_result;
+    struct sockaddr_storage literal;
+    struct addrinfo literal_ai;
+    struct addrinfo *gai_result_to_free = NULL;
+    int family = host != NULL ? bsd_parse_ip_address(host, port, &literal) : 0;
+    if (family != 0) {
+        memset(&literal_ai, 0, sizeof(literal_ai));
+        literal_ai.ai_family = family;
+        literal_ai.ai_socktype = SOCK_DGRAM;
+        literal_ai.ai_addr = (struct sockaddr *)&literal;
+        literal_ai.ai_addrlen = bsd_sockaddr_len(family);
+        result = &literal_ai;
+    } else {
+        int gai_result = getaddrinfo(host, port_string, &hints, &result);
+        if (gai_result != 0) {
+            if (err != NULL) {
+                *err = -gai_result;
+            }
+            return LIBUS_SOCKET_ERROR;
         }
-        return LIBUS_SOCKET_ERROR;
+        gai_result_to_free = result;
     }
 
     LIBUS_SOCKET_DESCRIPTOR listenFd = LIBUS_SOCKET_ERROR;
@@ -1605,7 +1706,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
     }
 
     if (listenFd == LIBUS_SOCKET_ERROR) {
-        freeaddrinfo(result);
+        if (gai_result_to_free) freeaddrinfo(gai_result_to_free);
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -1618,7 +1719,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 #endif
         }
         bsd_close_socket(listenFd);
-        freeaddrinfo(result);
+        if (gai_result_to_free) freeaddrinfo(gai_result_to_free);
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -1643,11 +1744,11 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 #endif
         }
         bsd_close_socket(listenFd);
-        freeaddrinfo(result);
+        if (gai_result_to_free) freeaddrinfo(gai_result_to_free);
         return LIBUS_SOCKET_ERROR;
     }
 
-    freeaddrinfo(result);
+    if (gai_result_to_free) freeaddrinfo(gai_result_to_free);
     if (err != NULL) {
         *err = 0;
     }
@@ -1655,6 +1756,17 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 }
 
 int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int port) {
+    struct sockaddr_storage literal;
+    if (host != NULL) {
+        int family = bsd_parse_ip_address(host, port, &literal);
+        if (family != 0) {
+            if (connect(fd, (struct sockaddr *)&literal, bsd_sockaddr_len(family)) == 0) {
+                return 0;
+            }
+            return (int)LIBUS_SOCKET_ERROR;
+        }
+    }
+
     struct addrinfo hints, *result;
     memset(&hints, 0, sizeof(struct addrinfo));
 

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -542,28 +542,7 @@ static void init_addr_with_port(struct addrinfo* info, int port, struct sockaddr
 }
 
 static bool try_parse_ip(const char *ip_str, int port, struct sockaddr_storage *storage) {
-    memset(storage, 0, sizeof(struct sockaddr_storage));
-    struct sockaddr_in *addr4 = (struct sockaddr_in *)storage;
-    if (inet_pton(AF_INET, ip_str, &addr4->sin_addr) == 1) {
-        addr4->sin_port = htons(port);
-        addr4->sin_family = AF_INET;
-#ifdef __APPLE__
-        addr4->sin_len = sizeof(struct sockaddr_in);
-#endif
-        return 1;
-    }
-
-    struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)storage;
-    if (inet_pton(AF_INET6, ip_str, &addr6->sin6_addr) == 1) {
-        addr6->sin6_port = htons(port);
-        addr6->sin6_family = AF_INET6;
-#ifdef __APPLE__
-        addr6->sin6_len = sizeof(struct sockaddr_in6);
-#endif
-        return 1;
-    }
-
-    return 0;
+    return bsd_parse_ip_address(ip_str, port, storage) != 0;
 }
 
 void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kind,

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -234,6 +234,8 @@ ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_le
 int bsd_would_block();
 int bsd_send_is_transient_error();
 
+int bsd_parse_ip_address(const char *host, int port, struct sockaddr_storage *storage);
+
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options, int* error);

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -1177,20 +1177,7 @@ us_quic_socket_context_t *us_create_quic_client_context(
 }
 
 static int us_quic_resolve(const char *host, int port, struct sockaddr_storage *out) {
-    memset(out, 0, sizeof(*out));
-    struct sockaddr_in *v4 = (struct sockaddr_in *) out;
-    struct sockaddr_in6 *v6 = (struct sockaddr_in6 *) out;
-    if (inet_pton(AF_INET, host, &v4->sin_addr) == 1) {
-        v4->sin_family = AF_INET;
-        v4->sin_port = htons((unsigned short) port);
-        return 0;
-    }
-    if (inet_pton(AF_INET6, host, &v6->sin6_addr) == 1) {
-        v6->sin6_family = AF_INET6;
-        v6->sin6_port = htons((unsigned short) port);
-        return 0;
-    }
-    return -1;
+    return bsd_parse_ip_address(host, port, out) != 0 ? 0 : -1;
 }
 
 /* One UDP endpoint for all client connections on this loop. lsquic

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -2285,32 +2285,18 @@ pub fn js_dgram_bind_fd(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
         // Numeric literals only — the JS layer resolves names before calling.
         let mut storage: sockaddr_storage = bun_core::ffi::zeroed();
 
-        // SAFETY: storage is large enough for sockaddr_in; src is NUL-terminated.
-        let addr4 = unsafe { &mut *std::ptr::from_mut(&mut storage).cast::<sockaddr_in>() };
-        // SAFETY: libc addr-format fn; src is NUL-terminated, dst points to in_addr-sized storage.
-        let parsed_v4 = unsafe {
-            inet_pton(
-                inet::AF_INET as c_int,
+        // SAFETY: address_z is NUL-terminated; storage is sockaddr_storage-sized.
+        let family = unsafe {
+            uws::udp::raw::bsd_parse_ip_address(
                 address_z.as_ptr(),
-                (&raw mut addr4.addr).cast::<c_void>(),
+                c_int::from(port),
+                std::ptr::from_mut(&mut storage).cast::<c_void>(),
             )
         };
-        let socklen: libc::socklen_t = if parsed_v4 == 1 {
-            addr4.family = inet::AF_INET as inet::sa_family_t;
-            addr4.port = htons(port);
-            size_of::<sockaddr_in>() as libc::socklen_t
-        } else {
-            // SAFETY: storage is large enough for sockaddr_in6.
-            let addr6 = unsafe { &mut *std::ptr::from_mut(&mut storage).cast::<sockaddr_in6>() };
-            // SAFETY: libc addr-format fn; src is NUL-terminated, dst points to in6_addr-sized storage.
-            let parsed_v6 = unsafe {
-                inet_pton(
-                    inet::AF_INET6 as c_int,
-                    address_z.as_ptr(),
-                    (&raw mut addr6.addr).cast::<c_void>(),
-                )
-            };
-            if parsed_v6 != 1 {
+        let socklen: libc::socklen_t = match family {
+            f if f == inet::AF_INET as c_int => size_of::<sockaddr_in>() as libc::socklen_t,
+            f if f == inet::AF_INET6 as c_int => size_of::<sockaddr_in6>() as libc::socklen_t,
+            _ => {
                 return Err(global.throw_value(
                     bun_sys::Error::from_code_int(
                         SystemErrno::EINVAL as c_int,
@@ -2319,9 +2305,6 @@ pub fn js_dgram_bind_fd(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
                     .to_js(global),
                 ));
             }
-            addr6.family = inet::AF_INET6 as inet::sa_family_t;
-            addr6.port = htons(port);
-            size_of::<sockaddr_in6>() as libc::socklen_t
         };
 
         // IPV6_V6ONLY, SO_REUSEADDR/SO_REUSEPORT and bind(2) go through bsd.c

--- a/src/uws_sys/udp.rs
+++ b/src/uws_sys/udp.rs
@@ -294,6 +294,15 @@ pub mod raw {
             addrlen: c_int,
             flags: c_int,
         ) -> c_int;
+        /// Parse an IPv4/IPv6 literal (with optional `%zone`) into `storage`.
+        /// Returns `AF_INET`/`AF_INET6`, or 0 if `host` is not an IP literal.
+        /// SAFETY: `host` must be NUL-terminated; `storage` must point to a
+        /// `sockaddr_storage`-sized buffer.
+        pub unsafe fn bsd_parse_ip_address(
+            host: *const core::ffi::c_char,
+            port: c_int,
+            storage: *mut c_void,
+        ) -> c_int;
     }
 }
 

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -751,6 +751,13 @@ describe("IPv6 scoped address literals (`%zone`)", () => {
     await using udp = await Bun.udpSocket({ hostname: host!, port: 0, socket: { data() {} } });
     expect(udp.port).toBeGreaterThan(0);
 
+    await using udp2 = await Bun.udpSocket({
+      hostname: "::",
+      connect: { hostname: host!, port: udp.port },
+      socket: { data() {} },
+    });
+    expect((udp2.remoteAddress as any).address).toContain("::1");
+
     await using srv = Bun.listen({
       hostname: "::1",
       port: 0,

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -3,8 +3,10 @@ import { heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
 import { randomUUID } from "node:crypto";
+import dgram from "node:dgram";
 import { once } from "node:events";
 import fs from "node:fs";
+import os from "node:os";
 import {
   BlockList,
   connect,
@@ -689,7 +691,7 @@ describe("IPv6 scoped address literals (`%zone`)", () => {
   // if_nametoindex) and a numeric scope id on Windows; discover the loopback
   // one instead of hardcoding.
   let zone: string | undefined;
-  for (const [name, addrs] of Object.entries(require("node:os").networkInterfaces())) {
+  for (const [name, addrs] of Object.entries(os.networkInterfaces())) {
     for (const a of addrs as any[]) {
       if (a.family === "IPv6" && a.internal) {
         zone = isWindows ? String(a.scopeid) : name;
@@ -724,20 +726,25 @@ describe("IPv6 scoped address literals (`%zone`)", () => {
     const s = createServer();
     s.on("error", reject);
     s.listen(0, host, () => resolve(s.address()));
-    const addr = await promise;
-    expect(addr.family).toBe("IPv6");
-    s.close();
+    try {
+      const addr = await promise;
+      expect(addr.family).toBe("IPv6");
+    } finally {
+      s.close();
+    }
   });
 
   it.skipIf(!host)("dgram bind on `::1%zone`", async () => {
-    const dgram = require("node:dgram");
     const { promise, resolve, reject } = Promise.withResolvers<any>();
     const d = dgram.createSocket("udp6");
     d.on("error", reject);
     d.bind(0, host, () => resolve(d.address()));
-    const addr = await promise;
-    expect(addr.family).toBe("IPv6");
-    d.close();
+    try {
+      const addr = await promise;
+      expect(addr.family).toBe("IPv6");
+    } finally {
+      d.close();
+    }
   });
 
   it.skipIf(!host)("Bun.udpSocket bind and Bun.connect on `::1%zone`", async () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -684,6 +684,90 @@ it("should handle connection error (unix)", done => {
   });
 });
 
+describe("IPv6 scoped address literals (`%zone`)", () => {
+  // The IPv6 loopback interface name differs by platform (lo, lo0, a numeric
+  // index on Windows) so discover it instead of hardcoding.
+  const v6Loopback = Object.entries(require("node:os").networkInterfaces())
+    .filter(([, addrs]) => (addrs as any[]).some(a => a.family === "IPv6" && a.internal))
+    .map(([name]) => name)[0];
+  const zone = isWindows ? "1" : v6Loopback;
+  const host = zone ? `::1%${zone}` : undefined;
+
+  it.skipIf(!host)("net.connect to a `::1%zone` host connects (it used to never settle)", async () => {
+    expect(isIP(host!)).toBe(6);
+
+    const srv = createServer();
+    srv.listen(0, "::1");
+    await once(srv, "listening");
+    const port = (srv.address() as any).port;
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const c = connect({ host, port });
+      c.on("connect", () => {
+        c.destroy();
+        resolve();
+      });
+      c.on("error", reject);
+      await promise;
+    } finally {
+      srv.close();
+    }
+  });
+
+  it.skipIf(!host)("net.Server listen on `::1%zone`", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    const s = createServer();
+    s.on("error", reject);
+    s.listen(0, host, () => resolve(s.address()));
+    const addr = await promise;
+    expect(addr.family).toBe("IPv6");
+    s.close();
+  });
+
+  it.skipIf(!host)("dgram bind on `::1%zone`", async () => {
+    const dgram = require("node:dgram");
+    const { promise, resolve, reject } = Promise.withResolvers<any>();
+    const d = dgram.createSocket("udp6");
+    d.on("error", reject);
+    d.bind(0, host, () => resolve(d.address()));
+    const addr = await promise;
+    expect(addr.family).toBe("IPv6");
+    d.close();
+  });
+
+  it.skipIf(!host)("Bun.udpSocket bind and Bun.connect on `::1%zone`", async () => {
+    await using udp = await Bun.udpSocket({ hostname: host!, port: 0, socket: { data() {} } });
+    expect(udp.port).toBeGreaterThan(0);
+
+    await using srv = Bun.listen({
+      hostname: "::1",
+      port: 0,
+      socket: { data() {}, open() {} },
+    });
+    await using c = await Bun.connect({ hostname: host!, port: srv.port, socket: { data() {} } });
+    expect(c.remoteAddress).toContain("::1");
+  });
+
+  it.skipIf(!v6Loopback)("an unknown zone resolves to scope_id 0 instead of hanging", async () => {
+    const srv = createServer();
+    srv.listen(0, "::1");
+    await once(srv, "listening");
+    const port = (srv.address() as any).port;
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const c = connect({ host: "::1%nosuchif0", port });
+      c.on("connect", () => {
+        c.destroy();
+        resolve();
+      });
+      c.on("error", reject);
+      await promise;
+    } finally {
+      srv.close();
+    }
+  });
+});
+
 it("Socket has a prototype", () => {
   function Connection() {}
   function Connection2() {}

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -685,13 +685,18 @@ it("should handle connection error (unix)", done => {
 });
 
 describe("IPv6 scoped address literals (`%zone`)", () => {
-  // The IPv6 loopback interface name differs by platform (lo, lo0, a numeric
-  // index on Windows) so discover it instead of hardcoding.
-  const v6Loopback = Object.entries(require("node:os").networkInterfaces())
-    .filter(([, addrs]) => (addrs as any[]).some(a => a.family === "IPv6" && a.internal))
-    .map(([name]) => name)[0];
-  const zone = isWindows ? "1" : v6Loopback;
-  const host = zone ? `::1%${zone}` : undefined;
+  // The zone identifier is an interface name on POSIX (resolved via
+  // if_nametoindex) and a numeric scope id on Windows; discover the loopback
+  // one instead of hardcoding.
+  let zone: string | undefined;
+  for (const [name, addrs] of Object.entries(require("node:os").networkInterfaces())) {
+    for (const a of addrs as any[]) {
+      if (a.family === "IPv6" && a.internal) {
+        zone = isWindows ? String(a.scopeid) : name;
+      }
+    }
+  }
+  const host = zone !== undefined ? `::1%${zone}` : undefined;
 
   it.skipIf(!host)("net.connect to a `::1%zone` host connects (it used to never settle)", async () => {
     expect(isIP(host!)).toBe(6);
@@ -748,7 +753,7 @@ describe("IPv6 scoped address literals (`%zone`)", () => {
     expect(c.remoteAddress).toContain("::1");
   });
 
-  it.skipIf(!v6Loopback)("an unknown zone resolves to scope_id 0 instead of hanging", async () => {
+  it.skipIf(!host)("an unknown zone resolves to scope_id 0 instead of hanging", async () => {
     const srv = createServer();
     srv.listen(0, "::1");
     await once(srv, "listening");

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -6,7 +6,6 @@ import { randomUUID } from "node:crypto";
 import dgram from "node:dgram";
 import { once } from "node:events";
 import fs from "node:fs";
-import os from "node:os";
 import {
   BlockList,
   connect,
@@ -19,6 +18,7 @@ import {
   Socket,
   Stream,
 } from "node:net";
+import os from "node:os";
 import { join } from "node:path";
 
 const socket_domain = tmpdirSync();


### PR DESCRIPTION
## Reproduction

```js
import net from 'node:net';
const srv = net.createServer().listen(0, '::1');
await new Promise(r => srv.on('listening', r));
const c = net.connect({ host: '::1%lo', port: srv.address().port });
c.on('connect', () => console.log('connected'));
c.on('error', e => console.log('error', e.code));
```

| API | Node v26.3.0 | Bun before | Bun after |
| --- | --- | --- | --- |
| `net.connect({host:'::1%lo'})` | connected | **never settles** | connected |
| `net.createServer().listen(0,'::1%lo')` | listening | `'error'` with `code === undefined` | listening |
| `dgram.createSocket('udp6').bind(0,'::1%lo')` | bound | `'error'` ENOENT | bound |
| `Bun.udpSocket({hostname:'::1%lo'})` | n/a | throws ENOENT | bound |
| `Bun.connect({hostname:'::1%lo'})` | n/a | throws EBADFAMILY | connected |

`net.isIP('::1%lo')` already returns `6` (the regex accepts a `%zone` suffix), so node:net skips the DNS lookup and hands the literal straight to the native connect/listen path.

## Cause

usockets parsed the literal with a bare `inet_pton`, which does not understand `%zone`, so it fell through to `getaddrinfo`. glibc's `getaddrinfo` rejects a `%zone` on a non-link-local address (`EAI_NONAME`), and:

* TCP connect: the DNS failure reached `handle_connect_error` with a positive c_ares errno. `ExceptionWithHostPort` then threw inside `afterConnect` (after `connecting=false` was already set), the throw was caught natively, the connect promise was rejected, and `kConnectDispatch`'s `.catch(_ => {})` swallowed it. Net effect: no `'connect'`, no `'error'`, forever.
* TCP listen: `bsd_create_listen_socket` returned the getaddrinfo failure without writing `*error`, so the JS side saw `code: undefined`.
* UDP bind: `bsd_create_udp_socket` returned `-gai_result` (`-(-2)` = 2 = `ENOENT`).

## Fix

Add `bsd_parse_ip_address()` in `bsd.c` (same shape as libuv's `uv_ip6_addr`): split on `%`, resolve the zone via `if_nametoindex` on POSIX with a numeric fallback (numeric-only on Windows, matching the existing `UDPSocket::parse_addr`), then `inet_pton` on the stripped address and set `sin6_scope_id`. An unknown zone yields `scope_id 0`, matching Node.

Route these through it before they reach `getaddrinfo`:
* `try_parse_ip` (context.c) for the TCP connect fast path and `localAddress`
* `bsd_create_listen_socket`
* `bsd_create_udp_socket`
* `bsd_connect_udp_socket`

## Verification

```
bun bd test test/js/node/net/node-net.test.ts -t "IPv6 scoped"
  5 pass
```

Gate: all five new tests fail (two by timeout) with the `packages/` change stashed.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->