### PR TITLE
net.connect: report resolver failures with a negative errno instead of hanging

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1337,14 +1337,23 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     let { self, req } = socket.data;
     socket[owner_symbol] = self;
     socket.data.req = undefined;
+    // Both paths feed this errno to ExceptionWithHostPort (directly in
+    // afterConnect/internalConnect, or via kConnectDispatch's sync return),
+    // which requires a negative libuv code; anything else throws
+    // ERR_OUT_OF_RANGE inside the constructor. Native can land here with a
+    // resolver failure whose errno is a positive c-ares discriminant (or no
+    // errno), and the throw is swallowed by kConnectDispatch's catch, leaving
+    // the socket with connecting=false and no 'error'/'close'.
+    let errno = error.errno;
+    if (typeof errno !== "number" || errno >= 0) errno = UV_ECANCELED;
     // doConnect dispatches this synchronously when connect()/bind() fails at
     // the syscall; surface it as kConnectTcp/Pipe's return value (callers'
     // Node-derived `if (err)` expects that) instead of re-entering oncomplete.
     if (req!.dispatching) {
-      req.errno = error.errno || UV_ECANCELED;
+      req.errno = errno;
       return;
     }
-    req!.oncomplete(error.errno, self._handle, req, true, true);
+    req!.oncomplete(errno, self._handle, req, true, true);
   },
 };
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1337,15 +1337,12 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     let { self, req } = socket.data;
     socket[owner_symbol] = self;
     socket.data.req = undefined;
-    // Both paths feed this errno to ExceptionWithHostPort (directly in
-    // afterConnect/internalConnect, or via kConnectDispatch's sync return),
-    // which requires a negative libuv code; anything else throws
-    // ERR_OUT_OF_RANGE inside the constructor. Native can land here with a
-    // resolver failure whose errno is a positive c-ares discriminant (or no
-    // errno), and the throw is swallowed by kConnectDispatch's catch, leaving
-    // the socket with connecting=false and no 'error'/'close'.
+    // Both paths rebuild the error via ExceptionWithHostPort from this errno,
+    // and util.getSystemErrorName throws ERR_OUT_OF_RANGE for anything that
+    // isn't a negative safe integer; a throw here is swallowed by
+    // kConnectDispatch's catch and leaves the socket with no 'error'/'close'.
     let errno = error.errno;
-    if (typeof errno !== "number" || errno >= 0) errno = UV_ECANCELED;
+    if (!Number.isSafeInteger(errno) || errno >= 0) errno = UV_ECANCELED;
     // doConnect dispatches this synchronously when connect()/bind() fails at
     // the syscall; surface it as kConnectTcp/Pipe's return value (callers'
     // Node-derived `if (err)` expects that) instead of re-entering oncomplete.

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -799,7 +799,6 @@ pub(crate) fn uv_eai_errno(e: c_ares::Error) -> i32 {
     const UV_EAI_NODATA: i32 = -3007;
     const UV_EAI_NONAME: i32 = -3008;
     const UV_EAI_SERVICE: i32 = -3010;
-    const UV_EAI_SOCKTYPE: i32 = -3011;
     const UV_EAI_BADHINTS: i32 = -3013;
     match e {
         c_ares::Error::ENODATA => UV_EAI_NODATA,
@@ -813,10 +812,12 @@ pub(crate) fn uv_eai_errno(e: c_ares::Error) -> i32 {
         c_ares::Error::EBADHINTS => UV_EAI_BADHINTS,
         c_ares::Error::ENOMEM => UV_EAI_MEMORY,
         c_ares::Error::ESERVICE => UV_EAI_SERVICE,
-        c_ares::Error::ECONNREFUSED => UV_EAI_SOCKTYPE,
         c_ares::Error::ETIMEOUT => UV_EAI_AGAIN,
         c_ares::Error::ECANCELLED => UV_EAI_CANCELED,
         c_ares::Error::EBADSTR => UV_EAI_BADHINTS,
+        // ARES_ECONNREFUSED ("could not contact DNS servers") and the
+        // remaining c-ares-specific codes have no getaddrinfo(3) equivalent;
+        // Node's dns.lookup can only surface them as EAI_FAIL.
         _ => UV_EAI_FAIL,
     }
 }

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -783,6 +783,44 @@ pub(crate) fn error_to_js_with_syscall(
     Ok(instance)
 }
 
+/// libuv's platform-invariant `EAI_*` errno for a c-ares resolver failure.
+/// Node's getaddrinfo errors carry this negative value in `err.errno`, and
+/// `util.getSystemErrorName()` / `ExceptionWithHostPort` reject a non-negative
+/// number with `ERR_OUT_OF_RANGE`, so the raw positive c-ares discriminant is
+/// never a valid errno on a getaddrinfo-shaped error.
+pub(crate) fn uv_eai_errno(e: c_ares::Error) -> i32 {
+    // uv/errno.h EAI_* — platform-invariant ABI constants.
+    const UV_EAI_AGAIN: i32 = -3001;
+    const UV_EAI_BADFLAGS: i32 = -3002;
+    const UV_EAI_CANCELED: i32 = -3003;
+    const UV_EAI_FAIL: i32 = -3004;
+    const UV_EAI_FAMILY: i32 = -3005;
+    const UV_EAI_MEMORY: i32 = -3006;
+    const UV_EAI_NODATA: i32 = -3007;
+    const UV_EAI_NONAME: i32 = -3008;
+    const UV_EAI_SERVICE: i32 = -3010;
+    const UV_EAI_SOCKTYPE: i32 = -3011;
+    const UV_EAI_BADHINTS: i32 = -3013;
+    match e {
+        c_ares::Error::ENODATA => UV_EAI_NODATA,
+        // `c_ares::Error::code()` aliases ENOTFOUND/ENONAME/EBADNAME to
+        // "DNS_ENOTFOUND"; keep errno in lockstep with code.
+        c_ares::Error::ENOTFOUND | c_ares::Error::ENONAME | c_ares::Error::EBADNAME => {
+            UV_EAI_NONAME
+        }
+        c_ares::Error::EBADFAMILY => UV_EAI_FAMILY,
+        c_ares::Error::EBADFLAGS => UV_EAI_BADFLAGS,
+        c_ares::Error::EBADHINTS => UV_EAI_BADHINTS,
+        c_ares::Error::ENOMEM => UV_EAI_MEMORY,
+        c_ares::Error::ESERVICE => UV_EAI_SERVICE,
+        c_ares::Error::ECONNREFUSED => UV_EAI_SOCKTYPE,
+        c_ares::Error::ETIMEOUT => UV_EAI_AGAIN,
+        c_ares::Error::ECANCELLED => UV_EAI_CANCELED,
+        c_ares::Error::EBADSTR => UV_EAI_BADHINTS,
+        _ => UV_EAI_FAIL,
+    }
+}
+
 /// `SystemError` fields for a resolver failure, in the shape `node:dns`
 /// reports them: `code`/`errno` derived from the DNS error, message
 /// `"<syscall> <CODE> <hostname>"`, plus `syscall` and `hostname`.
@@ -795,7 +833,7 @@ pub(crate) fn system_error_with_syscall_and_hostname(
 ) -> SystemError {
     let code = this.code();
     SystemError {
-        errno: this as i32,
+        errno: uv_eai_errno(this),
         code: bstr::String::static_(&code[4..]),
         message: bstr::String::create_format(format_args!(
             "{} {} {}",

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -684,6 +684,36 @@ it("should handle connection error (unix)", done => {
   });
 });
 
+// isIP() accepts an IPv6 scoped literal that the native IP parser may not;
+// the getaddrinfo fallback then reports a c-ares error whose errno is the
+// positive enum discriminant. ExceptionWithHostPort threw ERR_OUT_OF_RANGE on
+// that, kConnectDispatch's promise.catch swallowed the throw, and the socket
+// was left with connecting=false and no 'error'/'close' ever emitted.
+it("emits 'error' when the native connect error carries a non-libuv errno", async () => {
+  const fixture = `
+    const net = require("node:net");
+    const s = net.connect({ host: "fe80::1%bun-no-such-iface", port: 1 });
+    s.on("error", e => console.log("error", e.code, e.errno < 0 ? "neg" : e.errno));
+    s.on("close", () => console.log("close"));
+    s.on("connect", () => { console.log("connect"); s.destroy(); });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const lines = stdout.trim().split("\n");
+  // The exact code is platform/resolver dependent (EAI_FAMILY, EINVAL, ...);
+  // the invariant is that an error surfaced with a negative errno and the
+  // socket closed instead of silently draining the event loop.
+  expect(lines[0]).toMatch(/^error \S+ neg$/);
+  expect(lines[1]).toBe("close");
+  expect(exitCode).toBe(0);
+});
+
 it("Socket has a prototype", () => {
   function Connection() {}
   function Connection2() {}


### PR DESCRIPTION
## Repro

```sh
bun -e 'require("net").connect({ host: "fe80::1%bun-no-such-iface", port: 1 }).on("error", e => console.log(e.code, e.errno))'
```

Node prints `EINVAL -22`. Bun prints nothing and exits: the socket is left with `connecting=false`, `destroyed=false`, and neither `error` nor `close` ever fires.

## Cause

`isIP()` accepts an IPv6 scoped literal that `bsd_parse_ip_address()` rejects, so `us_socket_group_connect` falls through to Bun's async resolver. When that fails, `handle_connect_error` builds the error via `system_error_with_syscall_and_hostname`, which set `errno` to the positive c-ares enum discriminant (e.g. `9` for `EBADFAMILY`).

`net.ts`'s `connectError` handler passed `error.errno` straight to `afterConnect`, which hands it to `new ExceptionWithHostPort(status, ...)`. That constructor calls `util.getSystemErrorName(err)`, which throws `ERR_OUT_OF_RANGE` for any non-negative value. The throw propagated back into native, rejecting the connect promise, and `kConnectDispatch`'s `promise.catch(_ => {})` swallowed it. `afterConnect` had already cleared `connecting`, so the socket hung with no error or close event.

## Fix

- `system_error_with_syscall_and_hostname` now maps the c-ares error to libuv's negative `UV_EAI_*` code via a new `uv_eai_errno` helper. Node's getaddrinfo errors carry this negative value, and it is what `util.getSystemErrorName()` / `ExceptionWithHostPort` accept. With this, a resolver failure on the `Bun.connect`/`fetch()` path now reports e.g. `errno: -3005` instead of `errno: 9`.
- `net.ts` `connectError` now normalises `error.errno` to `UV_ECANCELED` when it isn't a negative number before handing it to `afterConnect` / the sync-return path. The sync branch already had `|| UV_ECANCELED` for falsy values; this extends the same guard to the async branch and to non-negative numbers so the error path can't throw into the swallowed rejection again.

## Verification

New test in `test/js/node/net/node-net.test.ts` spawns a subprocess that connects to `fe80::1%bun-no-such-iface:1`. Without the fix the subprocess exits with empty stdout (no `error`/`close`); with the fix it prints `error <CODE> neg` followed by `close`. The test asserts the error has a negative errno and does not assert a specific code since the exact code varies by platform/resolver.

Related: #30987 addresses the same errno-shape issue on the `dns.lookup()` path, and #35220 teaches the native IP parser about IPv6 zone identifiers (after which this specific literal no longer reaches the resolver fallback, but any literal `isIP()` accepts and `bsd_parse_ip_address()` rejects still would).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->