### PR TITLE
DOMJIT wrappers: route returns through OPERATION_RETURN

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -125,6 +125,7 @@ JSC_DEFINE_JIT_OPERATION(${DOMJITName(
   )}Wrapper, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue${formattedArgs}))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     IGNORE_WARNINGS_BEGIN("frame-address")
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     IGNORE_WARNINGS_END
@@ -145,9 +146,9 @@ JSC_DEFINE_JIT_OPERATION(${DOMJITName(
           ? std::optional<JSC::JSType>(decoded.asCell()->type())
           : std::optional<JSC::JSType>(std::nullopt);
     }
-    return { result };
+    OPERATION_RETURN(throwScope, result);
 #endif
-    return {${DOMJITName(symName)}(reinterpret_cast<${jsClassName}*>(thisValue)->wrapped(), lexicalGlobalObject${retArgs})};
+    OPERATION_RETURN(throwScope, ${DOMJITName(symName)}(reinterpret_cast<${jsClassName}*>(thisValue)->wrapped(), lexicalGlobalObject${retArgs}));
 }
 `.trim();
 }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1249,6 +1249,7 @@ JSC_DEFINE_HOST_FUNCTION(${symbolName(typeName, name)}Callback, (JSGlobalObject 
       !proto[name].DOMJIT
         ? ""
         : `
+    RETURN_IF_EXCEPTION(scope, result);
     JSValue decoded = JSValue::decode(result);
     if (thisObject->m_${fn}_expectedResultType) {
       if (decoded.isCell() && !decoded.isEmpty()) {

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -133,6 +133,7 @@ JSC_DEFINE_JIT_OPERATION(${DOMJITName(
 #if BUN_DEBUG
     ${jsClassName}* wrapper = reinterpret_cast<${jsClassName}*>(thisValue);
     JSC::EncodedJSValue result = ${DOMJITName(symName)}(wrapper->wrapped(), lexicalGlobalObject${retArgs});
+    OPERATION_RETURN_IF_EXCEPTION(throwScope, result);
     JSValue decoded = JSValue::decode(result);
     if (wrapper->m_${fn}_expectedResultType) {
         if (decoded.isCell() && !decoded.isEmpty()) {

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -2802,31 +2802,34 @@ static size_t validateOffsetBigInt64(JSC::JSGlobalObject* lexicalGlobalObject, J
 JSC_DEFINE_JIT_OPERATION(jsBufferConstructorAllocWithoutTypeChecks, JSUint8Array*, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int byteLength))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     IGNORE_WARNINGS_BEGIN("frame-address")
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     IGNORE_WARNINGS_END
     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { allocBuffer(lexicalGlobalObject, byteLength) };
+    OPERATION_RETURN(throwScope, allocBuffer(lexicalGlobalObject, byteLength));
 }
 
 JSC_DEFINE_JIT_OPERATION(jsBufferConstructorAllocUnsafeWithoutTypeChecks, JSUint8Array*, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int byteLength))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     IGNORE_WARNINGS_BEGIN("frame-address")
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     IGNORE_WARNINGS_END
     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { allocBufferUnsafe(lexicalGlobalObject, byteLength) };
+    OPERATION_RETURN(throwScope, allocBufferUnsafe(lexicalGlobalObject, byteLength));
 }
 
 JSC_DEFINE_JIT_OPERATION(jsBufferConstructorAllocUnsafeSlowWithoutTypeChecks, JSUint8Array*, (JSC::JSGlobalObject * lexicalGlobalObject, void* thisValue, int byteLength))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     IGNORE_WARNINGS_BEGIN("frame-address")
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     IGNORE_WARNINGS_END
     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { allocBufferUnsafe(lexicalGlobalObject, byteLength) };
+    OPERATION_RETURN(throwScope, allocBufferUnsafe(lexicalGlobalObject, byteLength));
 }
 
 JSC_ANNOTATE_HOST_FUNCTION(JSBufferConstructorConstruct, JSBufferConstructor::construct);

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -133,11 +133,12 @@ JSC_DEFINE_HOST_FUNCTION(functionPerformanceNow, (JSGlobalObject * globalObject,
 JSC_DEFINE_JIT_OPERATION(functionPerformanceNowWithoutTypeCheck, JSC::EncodedJSValue, (JSC::JSGlobalObject * lexicalGlobalObject, JSPerformance* castedThis))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     IGNORE_WARNINGS_BEGIN("frame-address")
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     IGNORE_WARNINGS_END
     JSC::JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
-    return { functionPerformanceNowBody(vm) };
+    OPERATION_RETURN(throwScope, functionPerformanceNowBody(vm));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsPerformancePrototypeFunction_markResourceTiming, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/test/regression/issue/14001.test.ts
+++ b/test/regression/issue/14001.test.ts
@@ -1,0 +1,46 @@
+// DOMJIT exception return protocol: an exception thrown from a DOMJIT fast-path
+// wrapper must be visible in the operation's return value so the DFG/FTL
+// post-CallDOM exception check branches correctly and the surrounding try/catch
+// catches it. https://github.com/oven-sh/bun/issues/14001
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("TextDecoder.decode exception is caught under DFG/FTL tier-up (#14001)", async () => {
+  const src = `
+    const decoder = new TextDecoder("utf-8", { fatal: true });
+    const invalid = new Uint8Array([0xff]);
+    const N = 20000;
+    let caught = 0;
+    for (let i = 0; i < N; i++) {
+      try {
+        decoder.decode(invalid);
+      } catch {
+        caught++;
+      }
+    }
+    if (caught !== N) {
+      console.log("ESCAPED: " + (N - caught) + " exceptions were not caught");
+      process.exit(1);
+    }
+    console.log("OK");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: {
+      ...bunEnv,
+      BUN_JSC_useConcurrentJIT: "0",
+      BUN_JSC_thresholdForJITSoon: "10",
+      BUN_JSC_thresholdForJITAfterWarmUp: "10",
+      BUN_JSC_thresholdForOptimizeSoon: "10",
+      BUN_JSC_thresholdForOptimizeAfterWarmUp: "10",
+      BUN_JSC_thresholdForFTLOptimizeSoon: "100",
+      BUN_JSC_thresholdForFTLOptimizeAfterWarmUp: "100",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/regression/issue/14001.test.ts
+++ b/test/regression/issue/14001.test.ts
@@ -1,7 +1,4 @@
-// DOMJIT exception return protocol: an exception thrown from a DOMJIT fast-path
-// wrapper must be visible in the operation's return value so the DFG/FTL
-// post-CallDOM exception check branches correctly and the surrounding try/catch
-// catches it. https://github.com/oven-sh/bun/issues/14001
+// https://github.com/oven-sh/bun/issues/14001
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 

--- a/test/regression/issue/14001.test.ts
+++ b/test/regression/issue/14001.test.ts
@@ -1,4 +1,7 @@
 // https://github.com/oven-sh/bun/issues/14001
+// TextDecoder.decode DOMJIT is currently disabled (class-definitions.ts nulls DOMJIT on
+// every generated signature), so this passes on released bun too. It exists to guard the
+// exception-return protocol once that signature is re-enabled.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 


### PR DESCRIPTION
## Problem

Since JSC's exception-in-return-register change (in our WebKit since the 2024-07-01 pin bump), `JSC_DEFINE_JIT_OPERATION(..., EncodedJSValue, ...)` expands to a function returning `ExceptionOperationResult<EncodedJSValue> { value, exception }`. Bun's DOMJIT wrappers return with `return { result };`, which aggregate-initializes `exception = nullptr` even when the body just threw. The DFG's post-`CallDOM` exception check branches on that returned register, sees null, and continues as if nothing threw: it consumes the empty return value (`Segmentation fault at address 0x5` in #14001) while the real exception stays pending on the VM and surfaces later at an unrelated check, escaping the local `try/catch`. Root cause of #14001, #12335, #13470.

## Fix

Declare a `ThrowScope` and route every return through `OPERATION_RETURN(throwScope, result)` (= `return { result, scope.exception() }`):

- `src/codegen/generate-classes.ts` `DOMJITFunctionDefinition`: both the `BUN_DEBUG` and release returns, plus an `OPERATION_RETURN_IF_EXCEPTION` before the debug-path result-type assertions so a throwing call never reaches them
- `src/jsc/bindings/webcore/JSPerformance.cpp` `functionPerformanceNowWithoutTypeCheck` (the only DOMJIT signature currently live)
- `src/jsc/bindings/JSBuffer.cpp` `jsBufferConstructorAlloc{,Unsafe,UnsafeSlow}WithoutTypeChecks` (defined but not currently registered)

`class-definitions.ts` still nulls `DOMJIT` on every generated signature; this PR does not re-enable any. Re-enabling is a separate decision per signature once the WebKit-side items below are resolved.

## Verification

No automated test covers the `OPERATION_RETURN` change on today's build: `performance.now()` is the only live DOMJIT path and cannot throw, and the `Buffer.alloc*` operations are not registered. `domjit.test.ts -t "Performance.now"` passes (including under `BUN_JSC_validateExceptionChecks=1`), which confirms the non-throwing path is unchanged.

Generated C++ was checked by temporarily removing the `class-definitions.ts` nulling and rebuilding: 7 `JSC_DEFINE_JIT_OPERATION` wrappers are emitted with `DECLARE_THROW_SCOPE` + `OPERATION_RETURN`, and the C++ compiles (the Rust side no longer has the `*_without_type_checks` implementations, so a full build with DOMJIT enabled also needs those restored; out of scope here).

`test/regression/issue/14001.test.ts` runs the #14001 repro (`TextDecoder("utf-8",{fatal:true}).decode(0xFF)` inside `try/catch`, 20k iterations with forced early DFG/FTL tier-up) as a guard for when that signature is re-enabled. It passes on released bun because `TextDecoder.decode` DOMJIT is currently disabled.

## WebKit fork fixes

The two fork-specific DFG DOMJIT bugs investigated below are fixed in oven-sh/WebKit#318 (companion PR).

### 1. `DFGFixupPhase.cpp` `attemptToMakeCallDOM` argument predicates are inverted

Upstream (lines 5357-5368):
```cpp
case SpecString:
    if (edge->shouldSpeculateNotString())
        shouldConvertToCallDOM = false;
```
Fork (`vendor/WebKit/.../DFGFixupPhase.cpp:5316`):
```cpp
case SpecString:
    if (!edge->shouldSpeculateNotString())
        shouldConvertToCallDOM = false;
```
All three upstream cases (`SpecString`/`SpecInt32Only`/`SpecBoolean`) carry the extra `!`, and the fork-added typed-array / Int52 cases bail when the arg *is* the expected type (`if (edge->shouldSpeculateUint8Array()) bail`). Net effect: argument-bearing DOMJIT signatures never convert when the argument profiles as the expected type. The inversion was introduced in oven-sh/WebKit@80063b38aadb (committed 2023-01-29). oven-sh/WebKit@bcfcd061ec47 (2024-11-25) had the correct fix (drop the `!`, add `shouldSpeculateNot*Array()` predicates) but was reverted by oven-sh/WebKit@e17d16e0060b (2024-12-05) without a recorded reason; the revert landed inside bun #15328's WebKit bump and nothing in either repo's history, PR comments, or issues explains it. Bun's generated DOMJIT was already disabled (#14005, 2024-09-17) when the fix was tried. The unrelated hunks in bcfcd061 (`InternalFieldTuple.h`, `JSDateMath-v8.cpp`) are `WTF_ALLOW_UNSAFE_BUFFER_USAGE` wrappers only.

### 2. DFG backend / Fixup / FTL type-support skew

| | `SpecString/Int32/Boolean` | typed-array `Spec*Array` | `SpecInt52Any`/`SpecAnyIntAsDouble` |
| --- | --- | --- | --- |
| `DFGFixupPhase.cpp` `fixupCallDOM` (5445) | yes | yes (`CellUse`) | yes (`Int52RepUse`) |
| `FTLLowerDFGToB3.cpp` `compileCallDOM` (21117) | yes | yes (per-type `FTL_TYPE_CHECK`) | yes (`lowStrictInt52`) |
| `DFGSpeculativeJIT.cpp` `compileCallDOM` (11338) | yes | **`RELEASE_ASSERT_NOT_REACHED`** | **`RELEASE_ASSERT_NOT_REACHED`** |

At bcfcd061ec47 the DFG backend still had the `appendInt8Array` .. `appendFloat64Array` / `appendAnyIntAsDouble` lambdas (checked against that revision). oven-sh/WebKit@fc230df99f4e (2025-09-20, "Merge upstream") dropped them from the DFG backend while leaving Fixup and FTL in place, so today a well-typed typed-array or Int52 signature that reaches the DFG backend would `RELEASE_ASSERT`. The inverted predicates in item 1 currently keep that unreachable.
