### PR TITLE
child_process: throw ERR_INVALID_ARG_VALUE for invalid stdio values

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1694,7 +1694,7 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
   }
   const result = nodeToBunLookup[item];
   if (result === undefined) {
-    throw new Error(`Invalid stdio option[${index}] "${item}"`);
+    throw $ERR_INVALID_ARG_VALUE("stdio", item);
   }
   return result;
 }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1779,7 +1779,7 @@ function normalizeStdio(stdio): string[] {
       case "inherit":
         return ["inherit", "inherit", "inherit"];
       default:
-        throw ERR_INVALID_OPT_VALUE("stdio", stdio);
+        throw $ERR_INVALID_ARG_VALUE("stdio", stdio);
     }
   } else if ($isJSArray(stdio)) {
     // Validate if each is a valid stdio type
@@ -1793,7 +1793,7 @@ function normalizeStdio(stdio): string[] {
 
     return processedStdio;
   } else {
-    throw ERR_INVALID_OPT_VALUE("stdio", stdio);
+    throw $ERR_INVALID_ARG_VALUE("stdio", stdio);
   }
 }
 
@@ -2048,12 +2048,6 @@ function genericNodeError(message, errorProperties) {
 function ERR_UNKNOWN_SIGNAL(name) {
   const err = new TypeError(`Unknown signal: ${name}`);
   err.code = "ERR_UNKNOWN_SIGNAL";
-  return err;
-}
-
-function ERR_INVALID_OPT_VALUE(name, value) {
-  const err = new TypeError(`The value "${value}" is invalid for option "${name}"`);
-  err.code = "ERR_INVALID_OPT_VALUE";
   return err;
 }
 

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1684,21 +1684,13 @@ function nodeToBun(item: string, index: number): string | number | null | NodeJS
   if (typeof item === "number") {
     return item;
   }
-  if (isNodeStreamReadable(item)) {
+  if (isNodeStreamReadable(item) || isNodeStreamWritable(item)) {
     const itemFd = Object.hasOwn(item, "fd") ? item.fd : undefined;
     if (typeof itemFd === "number") return itemFd;
     const handle = item._handle;
     const handleFd = handle ? handle.fd : undefined;
     if (typeof handleFd === "number") return handleFd;
-    throw new Error(`TODO: stream.Readable stdio @ ${index}`);
-  }
-  if (isNodeStreamWritable(item)) {
-    const itemFd = Object.hasOwn(item, "fd") ? item.fd : undefined;
-    if (typeof itemFd === "number") return itemFd;
-    const handle = item._handle;
-    const handleFd = handle ? handle.fd : undefined;
-    if (typeof handleFd === "number") return handleFd;
-    throw new Error(`TODO: stream.Writable stdio @ ${index}`);
+    throw $ERR_INVALID_ARG_VALUE("stdio", item);
   }
   const result = nodeToBunLookup[item];
   if (result === undefined) {

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -204,6 +204,5 @@ describe("spawn stdio validation", () => {
       message: expect.stringMatching(/^The argument 'stdio' is invalid\. Received /),
     });
     expect(err.message).toContain(name);
-    expect(err.message).not.toContain("TODO");
   });
 });

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { execSync, spawn } from "node:child_process";
 import { once } from "node:events";
+import { Duplex, PassThrough, Readable, Writable } from "node:stream";
 
 const CHILD_PROCESS_FILE = import.meta.dir + "/spawned-child.js";
 const OUT_FILE = import.meta.dir + "/stdio-test-out.txt";
@@ -164,5 +165,45 @@ describe("child.stdin", () => {
       ret: false,
       cbCode: "ERR_STREAM_DESTROYED",
     });
+  });
+});
+
+describe("spawn stdio validation", () => {
+  it.each([
+    [
+      "Writable",
+      () =>
+        new Writable({
+          write(c, e, cb) {
+            cb();
+          },
+        }),
+    ],
+    ["Readable", () => new Readable({ read() {} })],
+    [
+      "Duplex",
+      () =>
+        new Duplex({
+          read() {},
+          write(c, e, cb) {
+            cb();
+          },
+        }),
+    ],
+    ["PassThrough", () => new PassThrough()],
+  ])("stream without an fd (%s) throws ERR_INVALID_ARG_VALUE", (name, make) => {
+    let err;
+    try {
+      spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: ["pipe", make(), "pipe"] });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(TypeError);
+    expect({ code: err.code, message: err.message }).toEqual({
+      code: "ERR_INVALID_ARG_VALUE",
+      message: expect.stringMatching(/^The argument 'stdio' is invalid\. Received /),
+    });
+    expect(err.message).toContain(name);
+    expect(err.message).not.toContain("TODO");
   });
 });

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -205,4 +205,18 @@ describe("spawn stdio validation", () => {
     });
     expect(err.message).toContain(name);
   });
+
+  it("unrecognized stdio value throws ERR_INVALID_ARG_VALUE", () => {
+    let err;
+    try {
+      spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: ["pipe", { foo: 1 }, "pipe"] });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(TypeError);
+    expect({ code: err.code, message: err.message }).toEqual({
+      code: "ERR_INVALID_ARG_VALUE",
+      message: expect.stringMatching(/^The argument 'stdio' is invalid\. Received \{/),
+    });
+  });
 });

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -206,17 +206,21 @@ describe("spawn stdio validation", () => {
     expect(err.message).toContain(name);
   });
 
-  it("unrecognized stdio value throws ERR_INVALID_ARG_VALUE", () => {
+  it.each([
+    ["unrecognized array entry", ["pipe", { foo: 1 }, "pipe"], /^The argument 'stdio' is invalid\. Received \{/],
+    ["unknown top-level string", "bogus", /^The argument 'stdio' is invalid\. Received 'bogus'$/],
+    ["non-array non-string", 42, /^The argument 'stdio' is invalid\. Received 42$/],
+  ])("%s throws ERR_INVALID_ARG_VALUE", (_label, stdio, messagePattern) => {
     let err;
     try {
-      spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: ["pipe", { foo: 1 }, "pipe"] });
+      spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio });
     } catch (e) {
       err = e;
     }
     expect(err).toBeInstanceOf(TypeError);
     expect({ code: err.code, message: err.message }).toEqual({
       code: "ERR_INVALID_ARG_VALUE",
-      message: expect.stringMatching(/^The argument 'stdio' is invalid\. Received \{/),
+      message: expect.stringMatching(messagePattern),
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

`src/js/node/child_process.ts` had four stdio-validation throws that didn't match Node's `getValidStdio()`:

| input | before | Node |
|---|---|---|
| `stdio: ['pipe', new Writable(), 'pipe']` (stream, no fd) | `Error: TODO: stream.Readable stdio @ 1` (no `.code`) | `TypeError [ERR_INVALID_ARG_VALUE]` |
| `stdio: ['pipe', {foo:1}, 'pipe']` (unrecognized entry) | `Error: Invalid stdio option[1] "[object Object]"` (no `.code`) | `TypeError [ERR_INVALID_ARG_VALUE]` |
| `stdio: 'bogus'` (unknown top-level string) | `TypeError [ERR_INVALID_OPT_VALUE]` (code removed from Node in v15) | `TypeError [ERR_INVALID_ARG_VALUE]` |
| `stdio: 42` (non-string, non-array) | `TypeError [ERR_INVALID_OPT_VALUE]` | `TypeError [ERR_INVALID_ARG_VALUE]` |

User code that branches on `err.code === 'ERR_INVALID_ARG_VALUE'` or `err instanceof TypeError` was taking the wrong path, and the first message leaked an internal TODO rather than describing the caller's mistake.

## Repro

```js
import cp from 'node:child_process';
import { Writable } from 'node:stream';
try {
  cp.spawn('true', [], { stdio: ['pipe', new Writable({ write(c, e, cb) { cb(); } }), 'pipe'] });
} catch (e) {
  console.log(e.name, e.code, JSON.stringify(e.message.split('\n')[0]));
}
// node : TypeError ERR_INVALID_ARG_VALUE "The argument 'stdio' is invalid. Received Writable {"
// bun  : Error undefined "TODO: stream.Readable stdio @ 1"
```

## Fix

All four sites now go through `$ERR_INVALID_ARG_VALUE("stdio", ...)`. The duplicated readable/writable branches in `nodeToBun()` are merged since they did identical work, and the `ERR_INVALID_OPT_VALUE` helper is deleted as dead code. Streams that do carry an fd (an `fs.WriteStream` after `'open'`, `process.stdout`, a numeric fd) are unaffected.

## How did you verify your code works?

Tests in `test/js/node/child_process/child-process-stdio.test.js`: four stream kinds (Writable / Readable / Duplex / PassThrough), a non-stream array entry, an unknown top-level string, and a non-string/non-array top-level value. Each asserts `instanceof TypeError`, `code === 'ERR_INVALID_ARG_VALUE'`, and the Node-shaped message prefix.

```
bun bd test child-process-stdio.test.js -t ERR_INVALID_ARG_VALUE   # 7 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/child_process/child-process-stdio.test.js
bun test v1.4.0 (d76446076)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [1297.84ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [1565.68ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [1670.45ms]
(pass) process.stdin > should allow us to read > 65kb from stdin [1598.65ms]
(pass) process.stdin > should allow us to read from a file [1708.80ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [200.57ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [1663.31ms]
196 |     try {
197 |       spawn(bunExe(), ["-e", "0"], { env: bunEnv, stdio: ["pipe", make(), "pipe"] });
198 |     } catch (e) {
199 |       err = e;
200 |     }
201 |     expect(err).toBeInstanceOf(TypeError);
                      ^
error: expect(received).toBeInstanceO
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (d76446076)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [31.93ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [30.01ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [29.31ms]
(pass) process.stdin > should allow us to read > 65kb from stdin [35.46ms]
(pass) process.stdin > should allow us to read from a file [28.59ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [2.21ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [27.02ms]
(pass) spawn stdio validation > stream without an fd (Writable) throws ERR_INVALID_ARG_VALUE [0.52ms]
(pass) spawn stdio validation > stream without an fd (Readable) throws ERR_INVALID_ARG_VALUE [0.17ms]
(pass) spawn stdio validation > stream without an fd (Duplex) throws ERR_INVALID_ARG_VALUE [0.27ms]
(pass) spawn stdio validation > stream without an fd (PassThrough) throws ERR_INVALID_ARG_VALUE [0.30ms]
(pass) spawn stdio validation > unrecognized array entry th
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/child_process/child-process-stdio.test.js
bun test v1.4.0 (d76446076)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [1263.33ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [1491.27ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [1504.49ms]
(pass) process.stdin > should allow us to read > 65kb from stdin [1728.28ms]
(pass) process.stdin > should allow us to read from a file [1473.47ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [143.43ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [1504.07ms]
(pass) spawn stdio validation > stream without an fd (Writable) throws ERR_INVALID_ARG_VALUE [26.89ms]
(pass) spawn stdio validation > stream without an fd (Readable) throws ERR_INVALID_ARG_VALUE [16.05ms]
(pass) spawn stdio validation > stream without an fd (Duplex) throws 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 957ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[2/25] gen JS modules (bundle-modules)
Preprocess modules (7039ms)
Bundle modules (30ms)
Postprocesss modules (22ms)
Bundle Functions (726ms)
Generate Code (13ms)

[7.84s] Bundled "src/js" for production
  2049 kb
  166 internal modules
  13 native modules
  90 internal functions across 19 files
[2/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_hash v0.0.0 (/workspace/bun/src/hash)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/child_process.ts                       | 24 ++-------
 .../node/child_process/child-process-stdio.test.js | 58 ++++++++++++++++++++++
 2 files changed, 63 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 3 passed · 2 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/node/child_process.ts                                5      6      0
test/js/node/child_process/child-process-stdio.test.js      4      7      0
```

</details>

<!-- robobun:evidence:end -->