### PR TITLE
jsc: reject callables in validate_object to match Node's validateObject

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1204,9 +1204,12 @@ impl JSGlobalObject {
         value: JSValue,
         opts: ValidateObjectOpts,
     ) -> JsResult<()> {
+        // In JSC a function cell satisfies `is_object()` (JSType >= Object), so callables must be
+        // checked separately to match Node's `typeof value !== 'object'` semantics.
         if (!opts.nullable && value.is_null())
             || (!opts.allow_array && value.is_array())
-            || (!value.is_object() && (!opts.allow_function || !value.is_function()))
+            || (!opts.allow_function && value.is_callable())
+            || !value.is_object()
         {
             return Err(self.throw_invalid_argument_type_value(
                 arg_name.as_bytes(),

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1204,10 +1204,17 @@ impl JSGlobalObject {
         value: JSValue,
         opts: ValidateObjectOpts,
     ) -> JsResult<()> {
-        // In JSC a function cell satisfies `is_object()` (JSType >= Object), so callables must be
-        // checked separately to match Node's `typeof value !== 'object'` semantics.
-        if (!opts.nullable && value.is_null())
-            || (!opts.allow_array && value.is_array())
+        // `is_object()` is JSC's `isObjectType` (cell with JSType >= Object), not JS `typeof`: it is
+        // true for functions and false for null, so the allow_function/nullable opt-ins are handled
+        // explicitly rather than folded into the final `!is_object()` term.
+        if value.is_null() {
+            return if opts.nullable {
+                Ok(())
+            } else {
+                Err(self.throw_invalid_argument_type_value(arg_name.as_bytes(), b"object", value))
+            };
+        }
+        if (!opts.allow_array && value.is_array())
             || (!opts.allow_function && value.is_callable())
             || !value.is_object()
         {

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -339,51 +339,19 @@ pub(crate) fn validate_object(
     name: impl fmt::Display + Copy,
     options: ValidateObjectOptions,
 ) -> JsResult<()> {
-    if !options.allow_nullable() && !options.allow_array() && !options.allow_function() {
-        if value.is_null() || value.js_type().is_array() {
-            return Err(throw_err_invalid_arg_type(
-                global_this,
-                name,
-                "object",
-                value,
-            ));
-        }
-
-        if !value.is_object() {
-            return Err(throw_err_invalid_arg_type(
-                global_this,
-                name,
-                "object",
-                value,
-            ));
-        }
-    } else {
-        if !options.allow_nullable() && value.is_null() {
-            return Err(throw_err_invalid_arg_type(
-                global_this,
-                name,
-                "object",
-                value,
-            ));
-        }
-
-        if !options.allow_array() && value.js_type().is_array() {
-            return Err(throw_err_invalid_arg_type(
-                global_this,
-                name,
-                "object",
-                value,
-            ));
-        }
-
-        if !value.is_object() && (!options.allow_function() || !value.js_type().is_function()) {
-            return Err(throw_err_invalid_arg_type(
-                global_this,
-                name,
-                "object",
-                value,
-            ));
-        }
+    // In JSC a function cell satisfies `is_object()` (JSType >= Object), so the callable check
+    // cannot be folded into `!is_object()` the way Node's `typeof !== 'object'` does.
+    if (!options.allow_nullable() && value.is_null())
+        || (!options.allow_array() && value.js_type().is_array())
+        || (!options.allow_function() && value.is_callable())
+        || !value.is_object()
+    {
+        return Err(throw_err_invalid_arg_type(
+            global_this,
+            name,
+            "object",
+            value,
+        ));
     }
     Ok(())
 }

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -346,7 +346,12 @@ pub(crate) fn validate_object(
         return if options.allow_nullable() {
             Ok(())
         } else {
-            Err(throw_err_invalid_arg_type(global_this, name, "object", value))
+            Err(throw_err_invalid_arg_type(
+                global_this,
+                name,
+                "object",
+                value,
+            ))
         };
     }
     if (!options.allow_array() && value.js_type().is_array())

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -339,10 +339,17 @@ pub(crate) fn validate_object(
     name: impl fmt::Display + Copy,
     options: ValidateObjectOptions,
 ) -> JsResult<()> {
-    // In JSC a function cell satisfies `is_object()` (JSType >= Object), so the callable check
-    // cannot be folded into `!is_object()` the way Node's `typeof !== 'object'` does.
-    if (!options.allow_nullable() && value.is_null())
-        || (!options.allow_array() && value.js_type().is_array())
+    // `is_object()` is JSC's `isObjectType` (cell with JSType >= Object), not JS `typeof`: it is
+    // true for functions and false for null, so the allow_function/nullable opt-ins are handled
+    // explicitly rather than folded into the final `!is_object()` term.
+    if value.is_null() {
+        return if options.allow_nullable() {
+            Ok(())
+        } else {
+            Err(throw_err_invalid_arg_type(global_this, name, "object", value))
+        };
+    }
+    if (!options.allow_array() && value.js_type().is_array())
         || (!options.allow_function() && value.is_callable())
         || !value.is_object()
     {

--- a/test/js/node/module/sourcemap.test.js
+++ b/test/js/node/module/sourcemap.test.js
@@ -22,6 +22,17 @@ test("SourceMap payload must be an object", () => {
   );
 });
 
+test.each([[() => {}], [class {}], [[]], [null]])("SourceMap payload rejects %p", payload => {
+  let err;
+  try {
+    new SourceMap(payload);
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+  expect(err.message).toMatch(/"payload" argument must be of type object/);
+});
+
 test("SourceMap instance has expected methods", () => {
   const sourceMap = new SourceMap({
     version: 3,

--- a/test/js/node/path/parse-format.test.js
+++ b/test/js/node/path/parse-format.test.js
@@ -191,7 +191,7 @@ describe("path.parse", () => {
         assert.strictEqual(path.format(element), expect);
       });
 
-      [null, undefined, 1, true, false, "string"].forEach(pathObject => {
+      [null, undefined, 1, true, false, "string", () => {}, class {}].forEach(pathObject => {
         assert.throws(
           () => {
             path.format(pathObject);


### PR DESCRIPTION
## Problem

Both Rust `validate_object` helpers (in `src/jsc/JSGlobalObject.rs` and `src/runtime/node/util/validators.rs`) were intended to mirror Node's `validateObject`, which rejects functions unless `kValidateObjectAllowFunction` is passed. The previous clause was:

```rust
(!value.is_object() && (!opts.allow_function || !value.is_function()))
```

In JSC a `JSFunction` cell has `JSType` 36 and `ObjectType` is 33, so `is_object()` is `true` for every function. The clause short-circuited to `false` for any callable, and `allow_function` was dead code. The sibling `nullable` option was dead for the mirror reason: `null` is not a cell, so `!is_object()` rejected it regardless of the flag. Both diverged from Node's `typeof`-based check (where `typeof function` is `'function'` and `typeof null` is `'object'`) and from Bun's own C++ `V::validateObject` in `NodeValidator.cpp`, which checks `value.isCallable()` separately.

## Repro

```js
require('node:path').format(() => {});           // Node: ERR_INVALID_ARG_TYPE, Bun: returns ""
require('node:crypto').randomUUID(() => {});     // Node: ERR_INVALID_ARG_TYPE, Bun: returns a uuid
require('node:util').parseArgs({ options: () => {} });  // Node: ERR_INVALID_ARG_TYPE, Bun: accepts
new (require('node:module').SourceMap)(() => {}); // Node: "payload must be of type object", Bun: "mappings must be a string"
```

## Fix

Handle `null` up front (so `opts.nullable` can short-circuit to `Ok`), add an explicit `!opts.allow_function && value.is_callable()` clause, and keep `!is_object()` as the final catch-all for primitives. This also collapses the two-path version in `validators.rs` into a single condition, matching `NodeValidator.cpp`.

Callers audited: `SourceMap` payload, `path.format`, `crypto.randomUUID`/`randomUUIDv7`, `util.parseArgs` options, `process.send` options (unreachable: a callable third arg is already diverted to `callback` before the check). No caller passes `nullable` or `allow_function` today, so every observable change is the function-rejection tightening.

## Why this is correct

Node's `validateObject` rejects via `typeof value !== 'object' && (throwOnFunction || typeof value !== 'function')`. Because every callable in JSC is an object cell, `!is_object()` alone can never reject a function; the separate `is_callable()` term restores the `typeof` semantics exactly. When `allow_function` is set, callables fall through and `!is_object()` is `false` for them, so they pass. When `nullable` is set, `null` returns `Ok` before the `!is_object()` catch-all. Both now match Node.

## Verification

- `bun bd test test/js/node/path/parse-format.test.js test/js/node/module/sourcemap.test.js` passes
- Both test files fail under a build without the `src/` change
- Upstream `test/js/node/test/parallel/test-crypto-randomuuid.js` and `test-path-parse-format.js` still pass
- Full `test/js/node/path/` and `test/js/node/module/` suites pass

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/sourcemap.test.js test/js/node/path/parse-format.test.js
bun test v1.4.0 (d75292c49)

test/js/node/path/parse-format.test.js:
190 |       testCases.forEach(([element, expect]) => {
191 |         assert.strictEqual(path.format(element), expect);
192 |       });
193 | 
194 |       [null, undefined, 1, true, false, "string", () => {}, class {}].forEach(pathObject => {
195 |         assert.throws(
                     ^
AssertionError: Missing expected exception (TypeError).
      at innerFail (node:assert:62:32)
      at expectsError (node:assert:553:14)
      at throws (node:assert:603:15)
      at <anonymous> (/workspace/bun/test/js/node/path/parse-format.test.js:195:16)
      at forEach (15:27)
      at checkFormat (/workspace/bun/test/js/node/path/parse-format.test.js:194:71)
      at <anonymous> (/workspace/bun/test/js/node/path/parse-format.test.js:99:5)
(fail) path.parse > general [124.35ms]
(pass) path.format > formats { dir, name, ext } with a dot-less ext when the result exceeds the platform path limit [540.8
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/path/parse-format.test.js:
190 |       testCases.forEach(([element, expect]) => {
191 |         assert.strictEqual(path.format(element), expect);
192 |       });
193 | 
194 |       [null, undefined, 1, true, false, "string", () => {}, class {}].forEach(pathObject => {
195 |         assert.throws(
                     ^
AssertionError: Missing expected exception (TypeError).
      at innerFail (node:assert:37:32)
      at expectsError (node:assert:441:14)
      at throws (node:assert:486:15)
      at <anonymous> (/workspace/bun/test/js/node/path/parse-format.test.js:195:16)
      at forEach (1:11)
      at checkFormat (/workspace/bun/test/js/node/path/parse-format.test.js:194:71)
      at <anonymous> (/workspace/bun/test/js/node/path/parse-format.test.js:99:5)
(fail) path.parse > general [3.03ms]
(pass) path.format > formats { dir, name, ext } with a dot-less ext when the result exceeds the platform path limit [16.79ms]

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [0.03ms]
(pass) SourceMap constructor requires payload [0.05ms]
(pass) SourceMap payload must be an object [0.03ms]
28 |     new S
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/sourcemap.test.js test/js/node/path/parse-format.test.js
bun test v1.4.0 (d75292c49)

test/js/node/path/parse-format.test.js:
(pass) path.parse > general [116.41ms]
(pass) path.format > formats { dir, name, ext } with a dot-less ext when the result exceeds the platform path limit [548.69ms]

test/js/node/module/sourcemap.test.js:
(pass) SourceMap class exists [7.54ms]
(pass) SourceMap constructor requires payload [3.45ms]
(pass) SourceMap payload must be an object [2.57ms]
(pass) SourceMap payload rejects [Function] [4.13ms]
(pass) SourceMap payload rejects [class (anonymous)] [1.51ms]
(pass) SourceMap payload rejects [] [0.71ms]
(pass) SourceMap payload rejects null [0.67ms]
(pass) SourceMap instance has expected methods [2.82ms]
(pass) SourceMap payload getter [1.78ms]
(pass) SourceMap lineLengths getter [2.15ms]
(pass) SourceMap lineLengths undefined when not provided [1.73ms]
(pass) SourceMap findEntry returns mapping data [2.87ms]
(pass) SourceMap findOrigin returns origin data [2.20ms]
(pass) SourceMap with na
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d75292c491
  features     baseline

22 deps, 108 codegen, 1170 objects in 1012ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [8.00ms]
[2/1233] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1233] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [3.00ms]
[4/1233] gen ErrorCode+*.h
[5/1233] gen bindgenv2
[6/1233] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1233] gen .bind.ts → GeneratedBindings.cpp
[8/1233] fetch picohttpparser
[picohttpparser] up to date
[9/1233] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1233] gen ProcessBindingConstants.lut.h
Generating /workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs              | 16 +++++++--
 src/runtime/node/util/validators.rs    | 62 ++++++++++++----------------------
 test/js/node/module/sourcemap.test.js  | 11 ++++++
 test/js/node/path/parse-format.test.js |  2 +-
 4 files changed, 46 insertions(+), 45 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/JSGlobalObject.rs                   2      2      0
src/runtime/node/util/validators.rs         2      2      0
test/js/node/module/sourcemap.test.js       1      2      0
test/js/node/path/parse-format.test.js      2      1      0
```

</details>

<!-- robobun:evidence:end -->