### PR TITLE
Bun.serve: drop req.cookies mutations when the route handler throws

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3472,6 +3472,11 @@ where
         status: u16,
     ) {
         jsc::mark_binding!();
+        // The route handler failed: any `req.cookies` mutations it queued must
+        // not leak onto the error Response (a session cookie set before a
+        // crash would otherwise be granted on the 500). render_production_error
+        // already bypasses this, so dropping here keeps both paths consistent.
+        drop(self.cookies.take());
         if let Some(server) = self.server {
             // SAFETY: BACKREF
             let server = &*server;

--- a/test/js/bun/http/bun-serve-cookies.test.ts
+++ b/test/js/bun/http/bun-serve-cookies.test.ts
@@ -1,6 +1,76 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
+describe("cookies on error path", () => {
+  type BunRequest = Request & { cookies: Bun.CookieMap };
+
+  async function setCookieHeaders(
+    handler: (req: BunRequest) => Response | Promise<Response>,
+    errorHandler: () => Response | Promise<Response>,
+  ) {
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      routes: { "/login": handler },
+      error: errorHandler,
+    });
+    const res = await fetch(new URL("/login", server.url));
+    await res.arrayBuffer();
+    return { status: res.status, setCookie: res.headers.getSetCookie() };
+  }
+
+  const handlers = [
+    [
+      "sync throw",
+      (req: BunRequest) => {
+        req.cookies.set("session", "TOKEN-abc123", { httpOnly: true, secure: true });
+        throw new Error("db timeout after granting the session");
+      },
+    ],
+    [
+      "async reject",
+      async (req: BunRequest) => {
+        req.cookies.set("session", "TOKEN-abc123", { httpOnly: true, secure: true });
+        await 1;
+        throw new Error("db timeout after granting the session");
+      },
+    ],
+  ] as const;
+
+  const errorHandlers = [
+    ["sync error()", () => new Response("Internal error", { status: 500 })],
+    ["async error()", async () => new Response("Internal error", { status: 500 })],
+  ] as const;
+
+  for (const [handlerLabel, handler] of handlers) {
+    for (const [errorLabel, errorHandler] of errorHandlers) {
+      it(`${handlerLabel} + ${errorLabel}: does not apply req.cookies mutations to the error Response`, async () => {
+        const { status, setCookie } = await setCookieHeaders(handler, errorHandler);
+        expect({ status, setCookie }).toEqual({ status: 500, setCookie: [] });
+      });
+    }
+  }
+
+  it("still applies req.cookies mutations on the success path", async () => {
+    using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/ok": req => {
+          req.cookies.set("session", "TOKEN-abc123", { httpOnly: true, secure: true });
+          return new Response("ok");
+        },
+      },
+      error: () => new Response("Internal error", { status: 500 }),
+    });
+    const res = await fetch(new URL("/ok", server.url));
+    expect(await res.text()).toBe("ok");
+    expect(res.headers.getSetCookie()).toEqual([
+      "session=TOKEN-abc123; Path=/; Secure; HttpOnly; SameSite=Lax",
+    ]);
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("request cookies", () => {
   let server: Server;
 

--- a/test/js/bun/http/bun-serve-cookies.test.ts
+++ b/test/js/bun/http/bun-serve-cookies.test.ts
@@ -64,9 +64,7 @@ describe("cookies on error path", () => {
     });
     const res = await fetch(new URL("/ok", server.url));
     expect(await res.text()).toBe("ok");
-    expect(res.headers.getSetCookie()).toEqual([
-      "session=TOKEN-abc123; Path=/; Secure; HttpOnly; SameSite=Lax",
-    ]);
+    expect(res.headers.getSetCookie()).toEqual(["session=TOKEN-abc123; Path=/; Secure; HttpOnly; SameSite=Lax"]);
     expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## What

A route handler that calls `req.cookies.set(...)` and then throws (or returns a rejected promise) was leaking its queued `Set-Cookie` onto the Response produced by the `error()` handler:

```js
Bun.serve({
  routes: {
    "/login": req => {
      req.cookies.set("session", "TOKEN-abc123", { httpOnly: true, secure: true });
      throw new Error("db timeout after granting the session");
    },
  },
  error() { return new Response("Internal error", { status: 500 }); },
});
// GET /login -> 500 with Set-Cookie: session=TOKEN-abc123; Path=/; Secure; HttpOnly; SameSite=Lax
```

This was internally inconsistent: without an `error()` handler the default 500 goes through `render_production_error` (which never writes cookies), so only an `error()`-returned Response inherited them.

## Why

`RequestContext.cookies` is populated the first time `req.cookies` is accessed (`JSBunRequest::setCookies` -> `Request__setCookiesOnRequestContext`) and is written out in `render_metadata`. When the handler throws, `run_error_handler_with_status_code_dont_check_responded` calls the user's `error()` and passes its Response through `render` -> `render_metadata`, which still had the failed handler's cookie map.

## Fix

Drop the queued cookies at the top of `run_error_handler_with_status_code_dont_check_responded`, before invoking `error()` or rendering any error response. This is the common entry point for both the sync-throw path (`on_response` -> `run_error_handler`) and the async-reject path (`handle_reject` -> `run_error_handler`), and it also keeps the `error()` path consistent with the default-500 path.

## Verification

`test/js/bun/http/bun-serve-cookies.test.ts` (new `cookies on error path` block) covers sync throw and async reject crossed with sync and async `error()` handlers. On main all four leak `Set-Cookie: session=TOKEN-abc123`; with this change the 500 carries no `Set-Cookie`. A success-path test confirms `req.cookies.set` still applies on a normally-returned Response.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-cookies.test.ts
bun test v1.4.0 (f33929d44)

test/js/bun/http/bun-serve-cookies.test.ts:
44 | 
45 |   for (const [handlerLabel, handler] of handlers) {
46 |     for (const [errorLabel, errorHandler] of errorHandlers) {
47 |       it(`${handlerLabel} + ${errorLabel}: does not apply req.cookies mutations to the error Response`, async () => {
48 |         const { status, setCookie } = await setCookieHeaders(handler, errorHandler);
49 |         expect({ status, setCookie }).toEqual({ status: 500, setCookie: [] });
                                           ^
error: expect(received).toEqual(expected)

  {
-   "setCookie": [],
+   "setCookie": [
+     "session=TOKEN-abc123; Path=/; Secure; HttpOnly; SameSite=Lax",
+   ],
    "status": 500,
  }

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-cookies.test.ts:49:39)
(fail) cookies on error path > sync throw + sync error(): does not apply req.cookies mutations to the error Response [193.49ms]
44 | 
45 |   for (const [ha
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/bun-serve-cookies.test.ts:
44 | 
45 |   for (const [handlerLabel, handler] of handlers) {
46 |     for (const [errorLabel, errorHandler] of errorHandlers) {
47 |       it(`${handlerLabel} + ${errorLabel}: does not apply req.cookies mutations to the error Response`, async () => {
48 |         const { status, setCookie } = await setCookieHeaders(handler, errorHandler);
49 |         expect({ status, setCookie }).toEqual({ status: 500, setCookie: [] });
                                           ^
error: expect(received).toEqual(expected)

  {
-   "setCookie": [],
+   "setCookie": [
+     "session=TOKEN-abc123; Path=/; Secure; HttpOnly; SameSite=Lax",
+   ],
    "status": 500,
  }

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-cookies.test.ts:49:39)
(fail) cookies on error path > sync throw + sync error(): does not apply req.cookies mutations to the error Response [37.96ms]
44 | 
45 |   for (const [handlerLabel, handler] of handlers) {
46 |     for (const [errorLabel, errorHandler] of errorHandlers) {
47 |       it(`${handlerLabel} + ${errorLabel}: does not apply re
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-cookies.test.ts
bun test v1.4.0 (f33929d44)

test/js/bun/http/bun-serve-cookies.test.ts:
(pass) cookies on error path > sync throw + sync error(): does not apply req.cookies mutations to the error Response [40.77ms]
(pass) cookies on error path > sync throw + async error(): does not apply req.cookies mutations to the error Response [19.26ms]
(pass) cookies on error path > async reject + sync error(): does not apply req.cookies mutations to the error Response [20.55ms]
(pass) cookies on error path > async reject + async error(): does not apply req.cookies mutations to the error Response [16.33ms]
(pass) cookies on error path > still applies req.cookies mutations on the success path [27.30ms]
(pass) request cookies > parses cookies before headers are accessed [20.83ms]
(pass) request cookies > parses cookies after headers are accessed [15.65ms]
(pass) request cookies > handles requests with no cookies [8.72ms]
(pass) request cookies > has readonly cookies property [13.84ms]
(pass) instanceof and type checks > c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs       |  5 +++
 test/js/bun/http/bun-serve-cookies.test.ts | 68 ++++++++++++++++++++++++++++++
 2 files changed, 73 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/server/RequestContext.rs            5      1      0
test/js/bun/http/bun-serve-cookies.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->