### PR TITLE
Bun.Cookie.parse: use the RFC 6265 §5.1.1 cookie-date algorithm for Expires

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -16,7 +16,7 @@ namespace WebCore {
 // delimiter set, matches tokens order-independently, uses a 0-69 => 20xx /
 // 70-99 => 19xx two-digit-year rule, and ignores unrecognized tokens (including
 // timezone suffixes). Returns milliseconds since the Unix epoch in UTC.
-static std::optional<int64_t> parseCookieDate(std::span<const Latin1Character> input)
+std::optional<int64_t> parseCookieDate(std::span<const Latin1Character> input)
 {
     auto isDelimiter = [](Latin1Character c) {
         // delimiter = %x09 / %x20-2F / %x3B-40 / %x5B-60 / %x7B-7E
@@ -113,6 +113,11 @@ static std::optional<int64_t> parseCookieDate(std::span<const Latin1Character> i
         year += 2000;
 
     if (day < 1 || day > 31 || year < 1601 || hour > 23 || minute > 59 || second > 59)
+        return std::nullopt;
+
+    // Step 6: "If no such date exists, abort these steps and fail to parse."
+    int daysInMonth = WTF::daysInMonths[month] + (month == 1 && WTF::isLeapYear(year) ? 1 : 0);
+    if (day > daysInMonth)
         return std::nullopt;
 
     double ms = WTF::dateToDaysFrom1970(year, month, day) * WTF::msPerDay

--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -4,11 +4,123 @@
 #include "helpers.h"
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <wtf/WallTime.h>
+#include <wtf/DateMath.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <JavaScriptCore/DateConversion.h>
 #include <JavaScriptCore/DateInstance.h>
 #include "HTTPParsers.h"
 namespace WebCore {
+
+// RFC 6265bis §5.1.1 "Dates". Browsers parse the Expires attribute with this
+// cookie-date algorithm, not a general HTTP-date parser: it tokenizes on a fixed
+// delimiter set, matches tokens order-independently, uses a 0-69 => 20xx /
+// 70-99 => 19xx two-digit-year rule, and ignores unrecognized tokens (including
+// timezone suffixes). Returns milliseconds since the Unix epoch in UTC.
+static std::optional<int64_t> parseCookieDate(std::span<const Latin1Character> input)
+{
+    auto isDelimiter = [](Latin1Character c) {
+        // delimiter = %x09 / %x20-2F / %x3B-40 / %x5B-60 / %x7B-7E
+        return c == 0x09 || (c >= 0x20 && c <= 0x2F) || (c >= 0x3B && c <= 0x40)
+            || (c >= 0x5B && c <= 0x60) || (c >= 0x7B && c <= 0x7E);
+    };
+    auto leadingDigits = [](std::span<const Latin1Character> s, size_t start) -> size_t {
+        size_t i = start;
+        while (i < s.size() && isASCIIDigit(s[i]))
+            i++;
+        return i - start;
+    };
+    auto readInt = [](std::span<const Latin1Character> s, size_t start, size_t len) -> int {
+        int v = 0;
+        for (size_t i = 0; i < len; i++)
+            v = v * 10 + (s[start + i] - '0');
+        return v;
+    };
+
+    static constexpr char monthNames[12][4] = {
+        "jan", "feb", "mar", "apr", "may", "jun",
+        "jul", "aug", "sep", "oct", "nov", "dec"
+    };
+
+    bool foundTime = false, foundDay = false, foundMonth = false, foundYear = false;
+    int hour = 0, minute = 0, second = 0, day = 0, month = 0, year = 0;
+
+    size_t i = 0;
+    while (i < input.size()) {
+        while (i < input.size() && isDelimiter(input[i]))
+            i++;
+        if (i >= input.size())
+            break;
+        size_t tokenStart = i;
+        while (i < input.size() && !isDelimiter(input[i]))
+            i++;
+        auto token = input.subspan(tokenStart, i - tokenStart);
+        size_t digits = leadingDigits(token, 0);
+
+        // 2.1 time = 1*2DIGIT ":" 1*2DIGIT ":" 1*2DIGIT [ non-digit *OCTET ]
+        if (!foundTime && digits >= 1 && digits <= 2 && digits < token.size() && token[digits] == ':') {
+            size_t p = digits + 1;
+            size_t n2 = leadingDigits(token, p);
+            if (n2 >= 1 && n2 <= 2 && p + n2 < token.size() && token[p + n2] == ':') {
+                size_t p2 = p + n2 + 1;
+                size_t n3 = leadingDigits(token, p2);
+                if (n3 >= 1 && n3 <= 2) {
+                    hour = readInt(token, 0, digits);
+                    minute = readInt(token, p, n2);
+                    second = readInt(token, p2, n3);
+                    foundTime = true;
+                    continue;
+                }
+            }
+        }
+
+        // 2.2 day-of-month = 1*2DIGIT [ non-digit *OCTET ]
+        if (!foundDay && digits >= 1 && digits <= 2) {
+            day = readInt(token, 0, digits);
+            foundDay = true;
+            continue;
+        }
+
+        // 2.3 month = ( "jan" / ... / "dec" ) *OCTET
+        if (!foundMonth && token.size() >= 3) {
+            Latin1Character c0 = toASCIILower(token[0]);
+            Latin1Character c1 = toASCIILower(token[1]);
+            Latin1Character c2 = toASCIILower(token[2]);
+            for (int m = 0; m < 12; m++) {
+                if (c0 == monthNames[m][0] && c1 == monthNames[m][1] && c2 == monthNames[m][2]) {
+                    month = m;
+                    foundMonth = true;
+                    break;
+                }
+            }
+            if (foundMonth)
+                continue;
+        }
+
+        // 2.4 year = 2*4DIGIT [ non-digit *OCTET ]
+        if (!foundYear && digits >= 2 && digits <= 4) {
+            year = readInt(token, 0, digits);
+            foundYear = true;
+            continue;
+        }
+    }
+
+    if (!foundTime || !foundDay || !foundMonth || !foundYear)
+        return std::nullopt;
+
+    if (year >= 70 && year <= 99)
+        year += 1900;
+    else if (year >= 0 && year <= 69)
+        year += 2000;
+
+    if (day < 1 || day > 31 || year < 1601 || hour > 23 || minute > 59 || second > 59)
+        return std::nullopt;
+
+    double ms = WTF::dateToDaysFrom1970(year, month, day) * WTF::msPerDay
+        + hour * WTF::msPerHour + minute * WTF::msPerMinute + second * WTF::msPerSecond;
+    if (!std::isfinite(ms))
+        return std::nullopt;
+    return static_cast<int64_t>(ms);
+}
 
 extern "C" WebCore::Cookie* Cookie__fromJS(JSC::EncodedJSValue value)
 {
@@ -133,19 +245,15 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
                 if (!attributeValue.isEmpty() && attributeValue.startsWith('/'))
                     path = attributeValue;
             } else if (attributeName == "expires"_s && !attributeValue.isEmpty()) {
-                if (!attributeValue.is8Bit()) [[unlikely]] {
-                    auto asLatin1 = attributeValue.latin1();
-                    double parsed = WTF::parseDate({ reinterpret_cast<const Latin1Character*>(asLatin1.data()), asLatin1.length() });
-                    if (std::isfinite(parsed)) {
-                        expires = static_cast<int64_t>(parsed);
-                    }
+                std::optional<int64_t> parsed;
+                if (attributeValue.is8Bit()) [[likely]] {
+                    parsed = parseCookieDate(attributeValue.span8());
                 } else {
-                    auto nullTerminated = attributeValue.utf8();
-                    double parsed = WTF::parseDate(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nullTerminated.data()), nullTerminated.length()));
-                    if (std::isfinite(parsed)) {
-                        expires = static_cast<int64_t>(parsed);
-                    }
+                    auto asLatin1 = attributeValue.latin1();
+                    parsed = parseCookieDate({ reinterpret_cast<const Latin1Character*>(asLatin1.data()), asLatin1.length() });
                 }
+                if (parsed)
+                    expires = *parsed;
             } else if (attributeName == "max-age"_s) {
                 if (auto parsed = WTF::parseIntegerAllowingTrailingJunk<int64_t>(attributeValue); parsed.has_value()) {
                     maxAge = static_cast<double>(parsed.value());

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -15,6 +15,8 @@ enum class CookieSameSite : uint8_t {
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, CookieSameSite);
 
+std::optional<int64_t> parseCookieDate(std::span<const Latin1Character>);
+
 struct CookieInit {
     String name = String();
     String value = String();

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -69,17 +69,20 @@ static int64_t getExpiresValue(JSGlobalObject* lexicalGlobalObject, JSC::ThrowSc
     if (expiresValue.isString()) {
         auto expiresStr = convert<IDLUSVString>(*lexicalGlobalObject, expiresValue);
         RETURN_IF_EXCEPTION(throwScope, Cookie::emptyExpiresAtValue);
-        auto nullTerminatedSpan = expiresStr.utf8();
-        if (auto parsed = WTF::parseDate(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nullTerminatedSpan.data()), nullTerminatedSpan.length()))) {
-            if (std::isnan(parsed)) {
-                throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Invalid cookie expiration date"_s));
-                return Cookie::emptyExpiresAtValue;
-            }
-            return static_cast<int64_t>(parsed);
-        } else {
+        auto asLatin1 = expiresStr.latin1();
+        std::span<const Latin1Character> span { reinterpret_cast<const Latin1Character*>(asLatin1.data()), asLatin1.length() };
+        // Match Cookie::parse: apply the RFC 6265 §5.1.1 cookie-date algorithm first so
+        // an Expires string means the same thing here as it does in a Set-Cookie header.
+        // Fall back to the general HTTP-date parser to keep accepting inputs §5.1.1
+        // rejects (e.g. a date with no time component).
+        if (auto parsed = parseCookieDate(span))
+            return *parsed;
+        double parsed = WTF::parseDate(span);
+        if (std::isnan(parsed)) {
             throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Invalid cookie expiration date"_s));
             return Cookie::emptyExpiresAtValue;
         }
+        return static_cast<int64_t>(parsed);
     }
 
     return Bun::ERR::INVALID_ARG_VALUE(throwScope, lexicalGlobalObject, "expires"_s, expiresValue, "Invalid expires value. Must be a Date or a number"_s);

--- a/test/js/bun/cookie/cookie-exotic-inputs.test.ts
+++ b/test/js/bun/cookie/cookie-exotic-inputs.test.ts
@@ -143,41 +143,33 @@ describe("Bun.Cookie.parse with exotic inputs", () => {
   });
 
   describe("handles various Date formats for Expires", () => {
-    const dateFormats = [
-      // Standard format
-      "name=value; Expires=Wed, 21 Oct 2025 07:28:00 GMT",
+    // Expected results follow RFC 6265bis §5.1.1 (the cookie-date algorithm browsers use).
+    const at = "2025-10-21T07:28:00.000Z";
+    const dateFormats: [string, string | undefined][] = [
+      // Standard IMF-fixdate
+      ["Wed, 21 Oct 2025 07:28:00 GMT", at],
       // Without day name
-      "name=value; Expires=21 Oct 2025 07:28:00 GMT",
-      // Different day format
-      "name=value; Expires=Wed, 21-Oct-2025 07:28:00 GMT",
-      // Without seconds
-      "name=value; Expires=Wed, 21 Oct 2025 07:28 GMT",
-      // Without time
-      "name=value; Expires=Wed, 21 Oct 2025",
-      // Without GMT
-      "name=value; Expires=Wed, 21 Oct 2025 07:28:00",
-      // With timezone offset
-      "name=value; Expires=Wed, 21 Oct 2025 07:28:00 +0000",
-      // Non-standard but often accepted
-      "name=value; Expires=2025-10-21T07:28:00Z",
+      ["21 Oct 2025 07:28:00 GMT", at],
+      // Hyphenated rfc850-style date
+      ["Wed, 21-Oct-2025 07:28:00 GMT", at],
+      // Without seconds: time production requires H:M:S, so Expires is dropped
+      ["Wed, 21 Oct 2025 07:28 GMT", undefined],
+      // Without time: dropped
+      ["Wed, 21 Oct 2025", undefined],
+      // Without GMT (cookie-date has no timezone; always UTC)
+      ["Wed, 21 Oct 2025 07:28:00", at],
+      // Numeric timezone offset is tokenized and ignored
+      ["Wed, 21 Oct 2025 07:28:00 +0000", at],
+      // ISO 8601 does not satisfy the cookie-date grammar
+      ["2025-10-21T07:28:00Z", undefined],
     ];
 
-    for (const cookieStr of dateFormats) {
-      test(cookieStr, () => {
-        try {
-          const cookie = Bun.Cookie.parse(cookieStr);
-          expect(cookie).toBeDefined();
-          expect(cookie.name).toBe("name");
-          expect(cookie.value).toBe("value");
-
-          // Expires should be set to some timestamp
-          if ("expires" in cookie) {
-            expect(typeof cookie.expires).toBe("number");
-          }
-        } catch (error) {
-          // Some formats might not be supported
-          expect(error).toBeDefined();
-        }
+    for (const [date, expected] of dateFormats) {
+      test(date, () => {
+        const cookie = Bun.Cookie.parse("name=value; Expires=" + date);
+        expect(cookie.name).toBe("name");
+        expect(cookie.value).toBe("value");
+        expect(cookie.expires?.toISOString()).toBe(expected);
       });
     }
   });

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -160,10 +160,34 @@ describe("Bun.Cookie.parse Expires (RFC 6265bis §5.1.1 cookie-date)", () => {
     expect(parseExpires("0 Oct 2015 07:28:00 GMT")).toBeUndefined();
   });
 
+  test("non-existent calendar dates are rejected (§5.1.1 step 6)", () => {
+    expect(parseExpires("31 Feb 2025 07:28:00 GMT")).toBeUndefined();
+    expect(parseExpires("31 Apr 2025 07:28:00 GMT")).toBeUndefined();
+    expect(parseExpires("29 Feb 2023 07:28:00 GMT")).toBeUndefined();
+    expect(parseExpires("29 Feb 2024 07:28:00 GMT")).toBe("2024-02-29T07:28:00.000Z");
+  });
+
   test("round-trips its own serialized Expires", () => {
     const date = new Date(Date.UTC(2031, 5, 9, 4, 5, 6));
     const header = new Bun.Cookie("a", "b", { expires: date }).toString();
     expect(Bun.Cookie.parse(header).expires?.toISOString()).toBe(date.toISOString());
+  });
+
+  test("constructor / setter string path agrees with parse", () => {
+    // The JS-API string path (new Bun.Cookie({ expires: str }) / cookie.expires = str)
+    // applies the same cookie-date algorithm, then falls back to the general
+    // HTTP-date parser for inputs §5.1.1 rejects.
+    const viaCtor = (d: string) => new Bun.Cookie("a", "v", { expires: d }).expires?.toISOString();
+    expect(viaCtor("21 Oct 65 07:28:00 GMT")).toBe("2065-10-21T07:28:00.000Z");
+    expect(viaCtor("21 Oct 2015 07:28:00 CET")).toBe("2015-10-21T07:28:00.000Z");
+    expect(viaCtor("21 Oct 2015 07:28:00 +0500")).toBe("2015-10-21T07:28:00.000Z");
+    // §5.1.1 rejects a date with no time component; the fallback keeps accepting it.
+    expect(viaCtor("Wed, 21 Oct 2015")).toBe("2015-10-21T00:00:00.000Z");
+    expect(() => new Bun.Cookie("a", "v", { expires: "tomorrow" })).toThrow("Invalid cookie expiration date");
+
+    const cookie = new Bun.Cookie("a", "v");
+    cookie.expires = "21 Oct 65 07:28:00 GMT";
+    expect(cookie.expires?.toISOString()).toBe("2065-10-21T07:28:00.000Z");
   });
 });
 

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -99,6 +99,74 @@ describe("Bun.Cookie validation tests", () => {
   });
 });
 
+describe("Bun.Cookie.parse Expires (RFC 6265bis §5.1.1 cookie-date)", () => {
+  // The cookie-date algorithm diverges from a general HTTP-date parser on four
+  // observable axes: two-digit-year cutoff, timezone handling, range limits, and
+  // token-order independence. Browsers run §5.1.1, so we must too.
+  const parseExpires = (d: string) => Bun.Cookie.parse("a=v; Expires=" + d).expires?.toISOString();
+
+  test("two-digit years use the 0-69 => 20xx, 70-99 => 19xx rule", () => {
+    expect(parseExpires("21 Oct 65 07:28:00 GMT")).toBe("2065-10-21T07:28:00.000Z");
+    expect(parseExpires("21 Oct 69 07:28:00 GMT")).toBe("2069-10-21T07:28:00.000Z");
+    expect(parseExpires("21 Oct 70 07:28:00 GMT")).toBe("1970-10-21T07:28:00.000Z");
+    expect(parseExpires("21 Oct 99 07:28:00 GMT")).toBe("1999-10-21T07:28:00.000Z");
+    // A cookie 39 years in the future must not be reported as already expired.
+    expect(Bun.Cookie.parse("a=v; Expires=21 Oct 65 07:28:00 GMT").isExpired()).toBe(false);
+  });
+
+  test("timezone tokens are ignored, not honored and not fatal", () => {
+    const want = "2015-10-21T07:28:00.000Z";
+    expect(parseExpires("21 Oct 2015 07:28:00 EST")).toBe(want);
+    expect(parseExpires("21 Oct 2015 07:28:00 PST")).toBe(want);
+    expect(parseExpires("21 Oct 2015 07:28:00 CET")).toBe(want);
+    expect(parseExpires("21 Oct 2015 07:28:00 JST")).toBe(want);
+    expect(parseExpires("21 Oct 2015 07:28:00 Z")).toBe(want);
+    expect(parseExpires("21 Oct 2015 07:28:00 +0500")).toBe(want);
+    expect(parseExpires("21 Oct 2015 07:28:00 -0800")).toBe(want);
+  });
+
+  test("years below 1601 are rejected", () => {
+    expect(parseExpires("21 Oct 1600 07:28:00 GMT")).toBeUndefined();
+    expect(parseExpires("21 Oct 1601 07:28:00 GMT")).toBe("1601-10-21T07:28:00.000Z");
+    // 3-digit years stay as-is (no +1900/+2000) and are then rejected by the 1601 floor.
+    expect(parseExpires("21 Oct 100 07:28:00 GMT")).toBeUndefined();
+  });
+
+  test("time must be H:M:S; H:M is not a cookie-date", () => {
+    expect(parseExpires("21 Oct 2015 07:28 GMT")).toBeUndefined();
+    expect(parseExpires("21 Oct 2015 07:28:00 GMT")).toBe("2015-10-21T07:28:00.000Z");
+    expect(parseExpires("21 Oct 2015 7:8:9 GMT")).toBe("2015-10-21T07:08:09.000Z");
+  });
+
+  test("tokens may appear in any order", () => {
+    const want = "2015-10-21T07:28:00.000Z";
+    expect(parseExpires("07:28:00 21 Oct 2015")).toBe(want);
+    expect(parseExpires("2015 Oct 21 07:28:00")).toBe(want);
+    expect(parseExpires("Oct 21 07:28:00 2015")).toBe(want);
+  });
+
+  test("canonical Set-Cookie date formats still parse", () => {
+    const want = "2025-10-21T07:28:00.000Z";
+    expect(parseExpires("Tue, 21 Oct 2025 07:28:00 GMT")).toBe(want);
+    expect(parseExpires("Tue, 21-Oct-2025 07:28:00 GMT")).toBe(want);
+    expect(parseExpires("Tue Oct 21 07:28:00 2025")).toBe(want);
+  });
+
+  test("out-of-range components are rejected", () => {
+    expect(parseExpires("21 Oct 2015 24:00:00 GMT")).toBeUndefined();
+    expect(parseExpires("21 Oct 2015 07:60:00 GMT")).toBeUndefined();
+    expect(parseExpires("21 Oct 2015 07:28:60 GMT")).toBeUndefined();
+    expect(parseExpires("32 Oct 2015 07:28:00 GMT")).toBeUndefined();
+    expect(parseExpires("0 Oct 2015 07:28:00 GMT")).toBeUndefined();
+  });
+
+  test("round-trips its own serialized Expires", () => {
+    const date = new Date(Date.UTC(2031, 5, 9, 4, 5, 6));
+    const header = new Bun.Cookie("a", "b", { expires: date }).toString();
+    expect(Bun.Cookie.parse(header).expires?.toISOString()).toBe(date.toISOString());
+  });
+});
+
 describe("Expires serialization", () => {
   // RFC 6265 expects an IMF-fixdate: "Wdy, DD Mon YYYY HH:MM:SS GMT".
   // Date.prototype.toUTCString() produces exactly that, so the two must agree.

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -181,8 +181,8 @@ describe("Bun.Cookie.parse Expires (RFC 6265bis §5.1.1 cookie-date)", () => {
     expect(viaCtor("21 Oct 65 07:28:00 GMT")).toBe("2065-10-21T07:28:00.000Z");
     expect(viaCtor("21 Oct 2015 07:28:00 CET")).toBe("2015-10-21T07:28:00.000Z");
     expect(viaCtor("21 Oct 2015 07:28:00 +0500")).toBe("2015-10-21T07:28:00.000Z");
-    // §5.1.1 rejects a date with no time component; the fallback keeps accepting it.
-    expect(viaCtor("Wed, 21 Oct 2015")).toBe("2015-10-21T00:00:00.000Z");
+    // §5.1.1 rejects HH:MM without seconds; the fallback keeps accepting it (GMT so TZ-stable).
+    expect(viaCtor("Wed, 21 Oct 2015 07:28 GMT")).toBe("2015-10-21T07:28:00.000Z");
     expect(() => new Bun.Cookie("a", "v", { expires: "tomorrow" })).toThrow("Invalid cookie expiration date");
 
     const cookie = new Bun.Cookie("a", "v");


### PR DESCRIPTION
## What

`Bun.Cookie.parse` was reading the `Expires` attribute with `WTF::parseDate`, the general HTTP-date parser. Every browser cookie jar instead runs the RFC 6265bis §5.1.1 cookie-date algorithm, so Bun's `expires` / `isExpired()` disagreed with clients on several grammar faces.

### Repro

```js
for (const [d, want] of [
  ["21 Oct 65 07:28:00 GMT", "2065 (future, NOT expired)"],
  ["21 Oct 2015 07:28:00 EST", "ignores tz, 07:28Z"],
  ["21 Oct 2015 07:28:00 CET", "ignores tz (bun: session)"],
  ["21 Oct 1600 07:28:00 GMT", "year<1601 invalid"],
]) {
  const c = Bun.Cookie.parse("a=v; Expires=" + d);
  console.log(d, "->", c.expires?.toISOString() ?? "(session)", "isExpired:", c.isExpired(), "| want:", want);
}
```

Before:
```
21 Oct 65 07:28:00 GMT -> 1965-10-21T07:28:00.000Z isExpired: true | want: 2065 (future, NOT expired)
21 Oct 2015 07:28:00 EST -> 2015-10-21T12:28:00.000Z isExpired: true | want: ignores tz, 07:28Z
21 Oct 2015 07:28:00 CET -> (session) isExpired: false | want: ignores tz (bun: session)
21 Oct 1600 07:28:00 GMT -> 1600-10-21T07:28:00.000Z isExpired: true | want: year<1601 invalid
```

## Cause

`WTF::parseDate` is the JavaScript `Date` parser. It diverges from §5.1.1:

* Two-digit years 50-69 map to 19xx (§5.1.1: 0-69 => 20xx). `Expires=21 Oct 65 ...` (year 2065) parsed as 1965, so `isExpired()` flipped to true.
* Timezone tokens are honored (`EST`/`PST`/`+0500` shift the instant), and an unrecognized tz (`CET`, `JST`, `Z`) invalidates the whole date, silently dropping Expires and turning a persistent cookie into a session cookie. §5.1.1 has no timezone grammar; unrecognized tokens are ignored and the time is always UTC.
* Years < 1601 and `HH:MM` without seconds were accepted; §5.1.1 rejects both.
* §5.1.1 matches time/day/month/year tokens order-independently, which `WTF::parseDate` does not.

## Fix

Add a direct §5.1.1 implementation (`parseCookieDate`) in `Cookie.cpp` that tokenizes on the spec's delimiter set, matches time/day/month/year with the spec's productions, applies the 0-69/70-99 year rule, enforces the §5.1.1 range checks, and returns UTC milliseconds via `WTF::dateToDaysFrom1970`. `Cookie::parse` now calls this instead of `WTF::parseDate`.

## Verification

* New `Bun.Cookie.parse Expires (RFC 6265bis §5.1.1 cookie-date)` group in `test/js/bun/cookie/cookie.test.ts` covering each divergence (two-digit years, tz tokens, year<1601, H:M vs H:M:S, token order, canonical formats, range checks, round-trip). 5/8 of those tests fail on current main.
* Replaced the try/catch smoke test in `cookie-exotic-inputs.test.ts` with exact per-format assertions.
* All 169 tests in `test/js/bun/cookie/` and `bun-serve-cookies.test.ts` / `util/cookie.test.js` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-exotic-inputs.test.ts test/js/bun/cookie/cookie.test.ts
bun test v1.4.0 (f09a5b8fc)

test/js/bun/cookie/cookie.test.ts:
describe Bun.serve() cookies
(pass) Bun.Cookie validation tests > expires validation > accepts valid Date for expires [4.87ms]
(pass) Bun.Cookie validation tests > expires validation > accepts valid number for expires [2.33ms]
(pass) Bun.Cookie validation tests > expires validation > throws for NaN Date [4.01ms]
(pass) Bun.Cookie validation tests > expires validation > throws for NaN number [2.85ms]
(pass) Bun.Cookie validation tests > expires validation > throws for non-finite number (Infinity) [2.88ms]
(pass) Bun.Cookie validation tests > expires validation > does not throw for negative number [3.59ms]
(pass) Bun.Cookie validation tests > expires validation > handles undefined expires correctly [1.77ms]
(pass) Bun.Cookie validation tests > expires validation > handles null expires correctly [1.46ms]
(pass) Bun.Cookie validation tests > Cookie.from validation > throws for NaN Date in Cookie.
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (7c280f4d6)

test/js/bun/cookie/cookie.test.ts:
describe Bun.serve() cookies
(pass) Bun.Cookie validation tests > expires validation > accepts valid Date for expires [0.09ms]
(pass) Bun.Cookie validation tests > expires validation > accepts valid number for expires [0.03ms]
(pass) Bun.Cookie validation tests > expires validation > throws for NaN Date [0.07ms]
(pass) Bun.Cookie validation tests > expires validation > throws for NaN number [0.03ms]
(pass) Bun.Cookie validation tests > expires validation > throws for non-finite number (Infinity) [0.02ms]
(pass) Bun.Cookie validation tests > expires validation > does not throw for negative number [0.05ms]
(pass) Bun.Cookie validation tests > expires validation > handles undefined expires correctly [0.02ms]
(pass) Bun.Cookie validation tests > expires validation > handles null expires correctly [0.01ms]
(pass) Bun.Cookie validation tests > Cookie.from validation > throws for NaN Date in Cookie.from [0.03ms]
(pass) Bun.Cookie validation tests > Cookie.from validation > throws for NaN number in Cookie.from [0.04ms]
(pass) Bun.Cookie validation tests > Cookie.from validation > throws for non-finite 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cookie/cookie-exotic-inputs.test.ts test/js/bun/cookie/cookie.test.ts
bun test v1.4.0 (f09a5b8fc)

test/js/bun/cookie/cookie.test.ts:
describe Bun.serve() cookies
(pass) Bun.Cookie validation tests > expires validation > accepts valid Date for expires [7.57ms]
(pass) Bun.Cookie validation tests > expires validation > accepts valid number for expires [3.98ms]
(pass) Bun.Cookie validation tests > expires validation > throws for NaN Date [6.57ms]
(pass) Bun.Cookie validation tests > expires validation > throws for NaN number [4.69ms]
(pass) Bun.Cookie validation tests > expires validation > throws for non-finite number (Infinity) [5.61ms]
(pass) Bun.Cookie validation tests > expires validation > does not throw for negative number [5.96ms]
(pass) Bun.Cookie validation tests > expires validation > handles undefined expires correctly [2.93ms]
(pass) Bun.Cookie validation tests > expires validation > handles null expires correctly [2.65ms]
(pass) Bun.Cookie validation tests > Cookie.from validation > throws for NaN Date in Cookie.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1536ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/28] gen cpp.rs (cppbind)
[2/28] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/28] gen JS modules (bundle-modules)
Preprocess modules (13142ms)
Bundle modules (175ms)
Postprocesss modules (59ms)
Bundle Functions (972ms)
Generate Code (29ms)

[14.44s] Bundled "src/js" for production
  2067 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[3/19] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_hash v0.0.0 (/workspace/bun/src/hash)
[1m[92m   Compiling[0m bun_libuv_sys v0.0.0 (/workspace/bun/src/libuv_sys)
[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/Cookie.cpp                     | 135 ++++++++++++++++++++++--
 src/jsc/bindings/Cookie.h                       |   2 +
 src/jsc/bindings/webcore/JSCookie.cpp           |  19 ++--
 test/js/bun/cookie/cookie-exotic-inputs.test.ts |  56 +++++-----
 test/js/bun/cookie/cookie.test.ts               |  92 ++++++++++++++++
 5 files changed, 253 insertions(+), 51 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/bindings/Cookie.cpp                          2      5      0
src/jsc/bindings/Cookie.h                            1      1      0
src/jsc/bindings/webcore/JSCookie.cpp                2      1      0
test/js/bun/cookie/cookie-exotic-inputs.test.ts      1      1      0
test/js/bun/cookie/cookie.test.ts                    4      3      0
```

</details>

<!-- robobun:evidence:end -->