### PR TITLE
Accept any iterable of pairs in new Bun.CookieMap()

### DIFF
--- a/docs/runtime/cookies.mdx
+++ b/docs/runtime/cookies.mdx
@@ -22,11 +22,18 @@ const cookies2 = new Bun.CookieMap({
   theme: "dark",
 });
 
-// From an array of name/value pairs
+// From any iterable of name/value pairs (Map, Headers, URLSearchParams,
+// another CookieMap, an array of pairs, a generator, ...)
 const cookies3 = new Bun.CookieMap([
   ["session", "abc123"],
   ["theme", "dark"],
 ]);
+const cookies4 = new Bun.CookieMap(
+  new Map([
+    ["session", "abc123"],
+    ["theme", "dark"],
+  ]),
+);
 ```
 
 ### In HTTP servers
@@ -433,7 +440,7 @@ class Cookie {
 }
 
 class CookieMap implements Iterable<[string, string]> {
-  constructor(init?: string[][] | Record<string, string> | string);
+  constructor(init?: Iterable<readonly [string, string]> | Record<string, string> | string);
 
   get(name: string): string | null;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9748,10 +9748,11 @@ declare module "bun" {
      *
      * @param init - Optional initial data for the cookie map:
      *   - string: A cookie header string (e.g., "name=value; foo=bar")
-     *   - string[][]: An array of name/value pairs (e.g., [["name", "value"], ["foo", "bar"]])
+     *   - Iterable<[string, string]>: Any iterable of name/value pairs, including `Map`, `Headers`,
+     *     `URLSearchParams`, another `CookieMap`, an array of pairs, or a generator
      *   - Record<string, string>: An object with cookie names as keys (e.g., { name: "value", foo: "bar" })
      */
-    constructor(init?: string[][] | Record<string, string> | string);
+    constructor(init?: Iterable<readonly [string, string]> | Record<string, string> | string);
 
     /**
      * Gets the value of a cookie with the specified name.

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -64,7 +64,7 @@ CookieMap::CookieMap(Vector<KeyValuePair<String, String>>&& cookies)
 {
 }
 
-ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& variant, bool throwOnInvalidCookieString)
+ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String>&& variant, bool throwOnInvalidCookieString)
 {
     auto visitor = WTF::makeVisitor(
         [&](const Vector<Vector<String>>& pairs) -> ExceptionOr<Ref<CookieMap>> {
@@ -73,18 +73,13 @@ ExceptionOr<Ref<CookieMap>> CookieMap::create(std::variant<Vector<Vector<String>
                 if (pair.size() == 2) {
                     cookies.append(KeyValuePair<String, String>(pair[0], pair[1]));
                 } else if (throwOnInvalidCookieString) {
-                    return Exception { TypeError, "Invalid cookie string: expected name=value pair"_s };
+                    return Exception { TypeError, "Expected name/value pair to have exactly two items"_s };
                 }
             }
             return adoptRef(*new CookieMap(WTF::move(cookies)));
         },
-        [&](const HashMap<String, String>& pairs) -> ExceptionOr<Ref<CookieMap>> {
-            Vector<KeyValuePair<String, String>> cookies;
-            for (const auto& entry : pairs) {
-                cookies.append(KeyValuePair<String, String>(entry.key, entry.value));
-            }
-
-            return adoptRef(*new CookieMap(WTF::move(cookies)));
+        [&](Vector<KeyValuePair<String, String>>& pairs) -> ExceptionOr<Ref<CookieMap>> {
+            return adoptRef(*new CookieMap(WTF::move(pairs)));
         },
         [&](const String& cookieString) -> ExceptionOr<Ref<CookieMap>> {
             StringView forCookieHeader = cookieString;

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -28,7 +28,7 @@ public:
 
     // Define a simple struct to hold the key-value pair
 
-    static ExceptionOr<Ref<CookieMap>> create(std::variant<Vector<Vector<String>>, HashMap<String, String>, String>&& init, bool throwOnInvalidCookieString = true);
+    static ExceptionOr<Ref<CookieMap>> create(std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String>&& init, bool throwOnInvalidCookieString = true);
 
     std::optional<String> get(const String& name) const;
     Vector<KeyValuePair<String, String>> getAll() const;

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -3,7 +3,7 @@
 
 #include "Cookie.h"
 #include "ExceptionOr.h"
-#include <wtf/HashMap.h>
+#include <wtf/KeyValuePair.h>
 #include <wtf/Vector.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -16,6 +16,7 @@
 #include "JSDOMConvertRecord.h"
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
+#include "JSDOMConvertUnion.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMGlobalObjectInlines.h"
@@ -102,79 +103,22 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieMapDOMConstructo
     auto* castedThis = uncheckedDowncast<JSCookieMapDOMConstructor>(callFrame->jsCallee());
 
     // Check arguments
-    JSValue initValue = callFrame->argument(0);
+    EnsureStillAliveScope argument0 = callFrame->argument(0);
+    JSValue initValue = argument0.value();
 
-    std::variant<Vector<Vector<String>>, HashMap<String, String>, String> init;
+    std::variant<Vector<Vector<String>>, Vector<KeyValuePair<String, String>>, String> init;
 
-    if (initValue.isUndefinedOrNull() || (initValue.isString() && initValue.getString(lexicalGlobalObject).isEmpty())) {
+    if (initValue.isUndefinedOrNull()) {
         init = String();
     } else if (initValue.isString()) {
         init = initValue.getString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
     } else if (initValue.isObject()) {
-        auto* object = initValue.getObject();
-
-        // Note: isArray() accepts Proxy->Array, but jsDynamicCast returns null for Proxy.
-        auto* array = dynamicDowncast<JSArray>(object);
-        if (array) {
-            Vector<Vector<String>> seqSeq;
-
-            uint32_t length = array->length();
-            for (uint32_t i = 0; i < length; ++i) {
-                auto element = array->getIndex(lexicalGlobalObject, i);
-                RETURN_IF_EXCEPTION(throwScope, {});
-
-                if (!element.isObject() || !dynamicDowncast<JSArray>(element)) {
-                    throwTypeError(lexicalGlobalObject, throwScope, "Expected each element to be an array of two strings"_s);
-                    return {};
-                }
-
-                auto* subArray = uncheckedDowncast<JSArray>(element);
-                if (subArray->length() != 2) {
-                    throwTypeError(lexicalGlobalObject, throwScope, "Expected arrays of exactly two strings"_s);
-                    return {};
-                }
-
-                auto first = subArray->getIndex(lexicalGlobalObject, 0);
-                RETURN_IF_EXCEPTION(throwScope, {});
-                auto second = subArray->getIndex(lexicalGlobalObject, 1);
-                RETURN_IF_EXCEPTION(throwScope, {});
-
-                auto firstStr = first.toString(lexicalGlobalObject)->value(lexicalGlobalObject);
-                RETURN_IF_EXCEPTION(throwScope, {});
-                auto secondStr = second.toString(lexicalGlobalObject)->value(lexicalGlobalObject);
-                RETURN_IF_EXCEPTION(throwScope, {});
-
-                Vector<String> pair;
-                pair.append(firstStr);
-                pair.append(secondStr);
-                seqSeq.append(WTF::move(pair));
-            }
-            init = WTF::move(seqSeq);
-        } else {
-            // Handle as record<USVString, USVString>. Build a sequence so the
-            // CookieMap preserves insertion order — going through HashMap would
-            // scramble it (and the hash order itself shifted when WTF moved
-            // its string hash to RapidHash).
-            Vector<Vector<String>> seqSeq;
-
-            PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-            JSObject::getOwnPropertyNames(object, lexicalGlobalObject, propertyNames, DontEnumPropertiesMode::Include);
-            RETURN_IF_EXCEPTION(throwScope, {});
-
-            for (const auto& propertyName : propertyNames) {
-                JSValue value = object->get(lexicalGlobalObject, propertyName);
-                RETURN_IF_EXCEPTION(throwScope, {});
-
-                auto valueStr = value.toString(lexicalGlobalObject)->value(lexicalGlobalObject);
-                RETURN_IF_EXCEPTION(throwScope, {});
-
-                Vector<String> pair;
-                pair.append(propertyName.string());
-                pair.append(WTF::move(valueStr));
-                seqSeq.append(WTF::move(pair));
-            }
-            init = WTF::move(seqSeq);
-        }
+        // WebIDL union: any object with @@iterator is treated as
+        // sequence<sequence<USVString>>; otherwise record<USVString, USVString>.
+        auto converted = convert<IDLUnion<IDLSequence<IDLSequence<IDLUSVString>>, IDLRecord<IDLUSVString, IDLUSVString>>>(*lexicalGlobalObject, initValue);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        std::visit([&](auto&& arg) { init = WTF::move(arg); }, converted);
     } else {
         throwTypeError(lexicalGlobalObject, throwScope, "Invalid initializer type"_s);
         return {};

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -267,6 +267,16 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
       expect(map.toSetCookieHeaders()).toEqual([]);
     });
 
+    test("empty iterable produces an empty CookieMap", () => {
+      for (const init of [new Map(), (function* () {})(), new Bun.CookieMap()]) {
+        const map = new Bun.CookieMap(init);
+        expect(map.size).toBe(0);
+        expect(map.get("name")).toBe(null);
+        expect([...map]).toEqual([]);
+        expect(map.toSetCookieHeaders()).toEqual([]);
+      }
+    });
+
     test("iterable yielding wrong-length pair throws", () => {
       expect(() => new Bun.CookieMap(new Set([["only-one"]]) as any)).toThrow(TypeError);
       expect(() => new Bun.CookieMap([["a", "b", "c"]] as any)).toThrow(TypeError);

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -227,6 +227,59 @@ describe("Bun.Cookie and Bun.CookieMap", () => {
     expect(map.toSetCookieHeaders()).toMatchInlineSnapshot(`[]`);
   });
 
+  describe("can create CookieMap from any iterable of pairs", () => {
+    const pairs: [string, string][] = [
+      ["name", "value"],
+      ["foo", "bar"],
+    ];
+    const cases: readonly [string, () => Iterable<[string, string]>][] = [
+      ["Map", () => new Map(pairs)],
+      ["Headers", () => new Headers({ name: "value", foo: "bar" })],
+      ["URLSearchParams", () => new URLSearchParams({ name: "value", foo: "bar" })],
+      ["Set", () => new Set(pairs)],
+      [
+        "generator",
+        () =>
+          (function* () {
+            yield ["name", "value"] as [string, string];
+            yield ["foo", "bar"] as [string, string];
+          })(),
+      ],
+      ["CookieMap", () => new Bun.CookieMap("name=value; foo=bar")],
+      [
+        "custom @@iterator",
+        () => ({
+          *[Symbol.iterator]() {
+            yield ["name", "value"];
+            yield ["foo", "bar"];
+          },
+        }),
+      ],
+    ];
+    test.each(cases)("%s", (_, makeInit) => {
+      const map = new Bun.CookieMap(makeInit());
+      expect(map.size).toBe(2);
+      expect(map.get("name")).toBe("value");
+      expect(map.get("foo")).toBe("bar");
+      // Entries must match the source iterable's output (Headers sorts its
+      // entries, so compare without asserting a fixed order here).
+      expect([...map]).toEqual([...makeInit()]);
+      expect(map.toSetCookieHeaders()).toEqual([]);
+    });
+
+    test("iterable yielding wrong-length pair throws", () => {
+      expect(() => new Bun.CookieMap(new Set([["only-one"]]) as any)).toThrow(TypeError);
+      expect(() => new Bun.CookieMap([["a", "b", "c"]] as any)).toThrow(TypeError);
+    });
+
+    test("iterable yielding non-iterable pair throws", () => {
+      function* gen() {
+        yield 42 as any;
+      }
+      expect(() => new Bun.CookieMap(gen())).toThrow(TypeError);
+    });
+  });
+
   test("CookieMap methods work", () => {
     const map = new Bun.CookieMap();
 

--- a/test/js/bun/cookie/cookie.test.ts
+++ b/test/js/bun/cookie/cookie.test.ts
@@ -399,7 +399,7 @@ test("delete cookie invalid path option", () => {
 describe("Bun.CookieMap constructor", () => {
   test("throws for invalid array", () => {
     expect(() => new Bun.CookieMap([["abc defg =fhaingj809读写汉字学中文"]])).toThrowErrorMatchingInlineSnapshot(
-      `"Expected arrays of exactly two strings"`,
+      `"Expected name/value pair to have exactly two items"`,
     );
   });
   test("accepts unicode cookie value in object", () => {

--- a/test/regression/issue/isArray-proxy-crash.test.ts
+++ b/test/regression/issue/isArray-proxy-crash.test.ts
@@ -66,8 +66,9 @@ describe("isArray + Proxy crash fixes", () => {
   });
 
   test("new Bun.CookieMap does not crash with Proxy-wrapped array", () => {
-    // Before: debug assertion in jsCast<JSArray*>. Now: falls through to record path.
-    // A Proxy wrapping [] has no own enumerable string keys, so this yields an empty map.
+    // Before: debug assertion in jsCast<JSArray*>. Now: the WebIDL union
+    // converter sees @@iterator (forwarded from Array.prototype via the
+    // default get trap) and iterates the empty array as a sequence.
     const map = new Bun.CookieMap(new Proxy([], {}));
     expect(map.size).toBe(0);
   });


### PR DESCRIPTION
## What

`new Bun.CookieMap(init)` now accepts any iterable of `[name, value]` pairs as `init` (Map, Headers, URLSearchParams, Set, generators, another CookieMap, anything with `@@iterator`), matching `Headers` and `URLSearchParams`.

## Why

The constructor only took the sequence branch for a literal `JSArray`. Any other iterable (the natural pair container `Map` included) silently fell into the record branch, which enumerates own string keys; for a `Map`/`Headers`/generator there are none, so the result was an empty `CookieMap` with no error:

```js
new Bun.CookieMap([["a", "1"]]).size            // 1
new Bun.CookieMap(new Map([["a", "1"]])).size   // 0 (silently empty)
new Bun.CookieMap(new Headers({ a: "1" })).size // 0 (silently empty)
new Bun.CookieMap((function*(){ yield ["a","1"]; })()).size // 0

// Meanwhile, next door:
new Headers(new Map([["a", "1"]])).get("a")    // "1"
```

The WebIDL union rule for `(sequence<sequence<USVString>> or record<USVString, USVString>)` picks the sequence branch whenever the input has `@@iterator`.

## How

Replace the hand-rolled `dynamicDowncast<JSArray>` / `getOwnPropertyNames` dispatch in `JSCookieMapDOMConstructor::construct` with the same `convert<IDLUnion<IDLSequence<IDLSequence<IDLUSVString>>, IDLRecord<IDLUSVString, IDLUSVString>>>` path that `Headers` and `URLSearchParams` already use. `CookieMap::create`'s record variant becomes `Vector<KeyValuePair<String, String>>` (matches `IDLRecord`'s implementation type; the old `HashMap` variant was already unused by the JS constructor).

Also updates the `Bun.CookieMap` constructor type to `Iterable<readonly [string, string]>`.

## Verification

Added parameterized tests in `test/js/bun/cookie/cookie-map.test.ts` covering Map, Headers, URLSearchParams, Set, generator, CookieMap, and a custom `@@iterator` object, plus wrong-length/non-iterable pair error cases. All fail on main (size 0), pass with this change.

Related: #34724 fixes the Proxy-wrapped record branch; this PR replaces the record branch with the shared `IDLRecord` converter, which already routes through `methodTable()->getOwnPropertyNames` and filters non-enumerable keys, so the two changes are consistent (merge conflict is mechanical).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/regression/issue/isArray-proxy-crash.test.ts

<!-- robobun:evidence:end -->