### PR TITLE
Bun.serve: throw ERR_HTTP_HEADERS_SENT when req.cookies is mutated after the response head is written

### DIFF
--- a/docs/runtime/http/cookies.mdx
+++ b/docs/runtime/http/cookies.mdx
@@ -55,6 +55,8 @@ Bun.serve({
 });
 ```
 
+Cookies are emitted as `Set-Cookie` response headers, so they must be set before the response head is written. For synchronous and `async` handlers this means before the `Response` is returned (or resolved). Once the head has been written, for example from inside a streaming `ReadableStream` body or from a timer that fires after the handler has returned, calling `set()` or `delete()` on that request's `CookieMap` throws `ERR_HTTP_HEADERS_SENT`. Reading cookies with `get()`/`has()` continues to work.
+
 ## Deleting cookies
 
 To delete a cookie, use the `delete` method on the `request.cookies` (`CookieMap`) object:

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -847,6 +847,16 @@ declare module "bun" {
     readonly params: {
       [Key in keyof Serve.ExtractRouteParams<T>]: Serve.ExtractRouteParams<T>[Key];
     } & {};
+    /**
+     * The cookies sent by the client, parsed from the `Cookie` request header.
+     *
+     * Calling {@link CookieMap.set} or {@link CookieMap.delete} on this map
+     * adds a `Set-Cookie` header to the response. These calls must happen
+     * before the response head is written (for synchronous and `async`
+     * handlers, before the `Response` is returned/resolved). Once the head has
+     * been written, `set()`/`delete()` throw `ERR_HTTP_HEADERS_SENT`. Reading
+     * cookies continues to work.
+     */
     readonly cookies: CookieMap;
     clone(): BunRequest<T>;
   }

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -36,6 +36,12 @@ extern "C" void CookieMap__write(CookieMap* cookie_map, JSC::JSGlobalObject* glo
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http3Response*>(arg2));
         break;
     }
+    cookie_map->setHeadersWritten();
+}
+
+extern "C" void CookieMap__setHeadersWritten(CookieMap* cookie_map)
+{
+    cookie_map->setHeadersWritten();
 }
 
 extern "C" void CookieMap__ref(CookieMap* cookie_map)

--- a/src/jsc/bindings/CookieMap.h
+++ b/src/jsc/bindings/CookieMap.h
@@ -38,6 +38,13 @@ public:
 
     void set(Ref<Cookie>);
 
+    // Set by Bun.serve once the response head has been written (or the
+    // request has finished). Further set()/delete() calls on this map can
+    // never reach the wire, so the JS bindings throw ERR_HTTP_HEADERS_SENT.
+    // Standalone CookieMap instances never have this flag set.
+    bool headersWritten() const { return m_headersWritten; }
+    void setHeadersWritten() { m_headersWritten = true; }
+
     Ref<CookieMap> clone();
 
     ExceptionOr<void> remove(const CookieStoreDeleteOptions& options);
@@ -69,6 +76,7 @@ private:
 
     Vector<KeyValuePair<String, String>> m_originalCookies;
     Vector<Ref<Cookie>> m_modifiedCookies;
+    bool m_headersWritten { false };
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/JSBunRequest.cpp
+++ b/src/jsc/bindings/JSBunRequest.cpp
@@ -135,12 +135,7 @@ JSBunRequest* JSBunRequest::clone(JSC::VM& vm, JSGlobalObject* globalObject)
             auto cookieMap = wrapper->protectedWrapped();
             auto cookieMapClone = cookieMap->clone();
             auto cookies = WebCore::toJSNewlyCreated(globalObject, uncheckedDowncast<JSDOMGlobalObject>(globalObject), WTF::move(cookieMapClone));
-            // The clone's request_context is NULL, so routing through
-            // setCookies() would immediately mark the fresh map as
-            // headers-written. A cloned request's cookies behave like a
-            // standalone CookieMap: detached from any response, freely
-            // mutable, never emitted.
-            clone->m_cookies.set(vm, clone, cookies.getObject());
+            clone->setCookies(cookies.getObject());
         }
     }
 

--- a/src/jsc/bindings/JSBunRequest.cpp
+++ b/src/jsc/bindings/JSBunRequest.cpp
@@ -135,7 +135,12 @@ JSBunRequest* JSBunRequest::clone(JSC::VM& vm, JSGlobalObject* globalObject)
             auto cookieMap = wrapper->protectedWrapped();
             auto cookieMapClone = cookieMap->clone();
             auto cookies = WebCore::toJSNewlyCreated(globalObject, uncheckedDowncast<JSDOMGlobalObject>(globalObject), WTF::move(cookieMapClone));
-            clone->setCookies(cookies.getObject());
+            // The clone's request_context is NULL, so routing through
+            // setCookies() would immediately mark the fresh map as
+            // headers-written. A cloned request's cookies behave like a
+            // standalone CookieMap: detached from any response, freely
+            // mutable, never emitted.
+            clone->m_cookies.set(vm, clone, cookies.getObject());
         }
     }
 

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -31,6 +31,7 @@
 #include <wtf/PointerPreparations.h>
 #include <variant>
 #include "HTTPParsers.h"
+#include "ErrorCode.h"
 namespace WebCore {
 
 using namespace JSC;
@@ -370,6 +371,10 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_setBody(JSC::JSGl
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = castedThis->wrapped();
 
+    if (impl.headersWritten()) [[unlikely]] {
+        return throwVMError(lexicalGlobalObject, throwScope, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_HTTP_HEADERS_SENT, "Cannot set cookie after response headers have been sent to the client"_s));
+    }
+
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(jsUndefined());
 
@@ -434,6 +439,10 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_deleteBody(JSC::J
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto& impl = castedThis->wrapped();
+
+    if (impl.headersWritten()) [[unlikely]] {
+        return throwVMError(lexicalGlobalObject, throwScope, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_HTTP_HEADERS_SENT, "Cannot delete cookie after response headers have been sent to the client"_s));
+    }
 
     if (callFrame->argumentCount() < 1)
         return JSValue::encode(jsUndefined());

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -48,6 +48,11 @@ impl AnyRequestContext {
         tag: CtxTag::None,
         ptr: core::ptr::null_mut(),
     };
+
+    #[inline]
+    pub fn is_null(self) -> bool {
+        self.tag == CtxTag::None
+    }
 }
 
 /// Internal: maps each `RequestContext` monomorphization to its tag so

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -29,6 +29,11 @@ type DebugHttpsH3Ctx = RequestContext<DebugHTTPSServer, true, true, true>;
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum CtxTag {
     None = 0,
+    /// Was attached to a live `RequestContext` that has since been torn down
+    /// (response sent / aborted / upgraded). Distinguished from `None` so
+    /// `req.cookies` can tell a request that never had a response (clones,
+    /// `new Request(...)`) from one whose response head is already committed.
+    Detached,
     Http,
     Https,
     DebugHttp,
@@ -49,9 +54,14 @@ impl AnyRequestContext {
         ptr: core::ptr::null_mut(),
     };
 
+    pub const DETACHED: Self = Self {
+        tag: CtxTag::Detached,
+        ptr: core::ptr::null_mut(),
+    };
+
     #[inline]
-    pub fn is_null(self) -> bool {
-        self.tag == CtxTag::None
+    pub fn is_detached(self) -> bool {
+        self.tag == CtxTag::Detached
     }
 }
 
@@ -117,7 +127,7 @@ macro_rules! dispatch {
             }};
         }
         match this.tag {
-            CtxTag::None => $default,
+            CtxTag::None | CtxTag::Detached => $default,
             CtxTag::Http => arm!(HttpCtx),
             CtxTag::Https => arm!(HttpsCtx),
             CtxTag::DebugHttp => arm!(DebugHttpCtx),

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -617,10 +617,21 @@ where
 
     pub fn set_cookies(&mut self, cookie_map: Option<*mut CookieMap>) {
         // S008: `CookieMap` is an `opaque_ffi!` ZST — safe `*const → &` deref.
+        let map = cookie_map.map(|p| bun_opaque::opaque_deref(p.cast_const()));
+        if self.flags.has_written_status() || self.flags.aborted() || self.resp.is_none() {
+            // Response head already committed (or request is over): this map's
+            // changes can never reach the wire. Mark it so JS-level set()/
+            // delete() throw ERR_HTTP_HEADERS_SENT instead of silently
+            // succeeding. Drop any previously stored ref.
+            if let Some(m) = map {
+                m.set_headers_written();
+            }
+            drop(self.cookies.take());
+            return;
+        }
         // `new_ref` takes a ref for storage. Assigning replaces (and so
         // drops/unrefs) the old one.
-        self.cookies =
-            cookie_map.map(|p| CookieMapRef::new_ref(bun_opaque::opaque_deref(p.cast_const())));
+        self.cookies = map.map(CookieMapRef::new_ref);
     }
 
     pub fn set_timeout_handler(&mut self) {
@@ -1508,8 +1519,12 @@ where
 
         self.request_body_readable_stream_ref.deinit();
 
-        // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
-        drop(self.cookies.take());
+        // Request is over: later set()/delete() on this map can never reach the
+        // wire. Mark it so JS throws ERR_HTTP_HEADERS_SENT, then release the
+        // ref taken in `set_cookies` (via `CookieMapRef::drop`).
+        if let Some(cookies) = self.cookies.take() {
+            cookies.set_headers_written();
+        }
 
         if let Some(request) = self.request_weakref.get() {
             request.request_context = AnyRequestContext::NULL;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1409,6 +1409,12 @@ where
         }
 
         this.detach_response();
+        // Connection is gone: later set()/delete() on this map can never reach
+        // the wire. Mark it so JS throws ERR_HTTP_HEADERS_SENT, then release
+        // the ref taken in `set_cookies`.
+        if let Some(cookies) = this.cookies.take() {
+            cookies.set_headers_written();
+        }
         let any_js_calls = core::cell::Cell::new(false);
         // SAFETY: BACKREF, just asserted Some
         let server = this.server();
@@ -1427,7 +1433,7 @@ where
         }
 
         if let Some(request) = this.request_weakref.get() {
-            request.request_context = AnyRequestContext::NULL;
+            request.request_context = AnyRequestContext::DETACHED;
             if shim::iec_trigger(
                 &request.internal_event_callback,
                 request::EventType::Abort,
@@ -1527,7 +1533,7 @@ where
         }
 
         if let Some(request) = self.request_weakref.get() {
-            request.request_context = AnyRequestContext::NULL;
+            request.request_context = AnyRequestContext::DETACHED;
             // we can already clean this strong refs
             shim::iec_deinit(&request.internal_event_callback);
             self.request_weakref.deref();

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2084,7 +2084,7 @@ where
         upgrader.upgrade_context = Some(usize::MAX as *mut WebSocketUpgradeContext);
         let signal = upgrader.signal.take();
         upgrader.resp = None;
-        request.request_context = AnyRequestContext::NULL;
+        request.request_context = AnyRequestContext::DETACHED;
         upgrader.request_weakref.deref();
 
         data_value.ensure_still_alive();

--- a/src/runtime/webcore/CookieMap.rs
+++ b/src/runtime/webcore/CookieMap.rs
@@ -23,6 +23,8 @@ unsafe extern "C" {
     safe fn CookieMap__deref(cookie_map: &CookieMap);
 
     safe fn CookieMap__ref(cookie_map: &CookieMap);
+
+    safe fn CookieMap__setHeadersWritten(cookie_map: &CookieMap);
 }
 
 impl CookieMap {
@@ -36,6 +38,15 @@ impl CookieMap {
         bun_jsc::from_js_host_call_generic(global_this, || {
             CookieMap__write(self, global_this, kind, uws_http_response)
         })
+    }
+
+    /// Marks this map as having had its Set-Cookie headers committed to the
+    /// wire (or its owning request finished). Further JS-level `set()` /
+    /// `delete()` calls throw `ERR_HTTP_HEADERS_SENT` instead of silently
+    /// mutating a map that can never be sent.
+    #[inline]
+    pub fn set_headers_written(&self) {
+        CookieMap__setHeadersWritten(self)
     }
 
     // NOTE: no inherent `ref`/`deref` on `CookieMap` — `CookieMapRef` is the

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -378,10 +378,12 @@ impl Request {
 
     #[bun_uws::uws_callback(export = "Request__setCookiesOnRequestContext")]
     pub fn ffi_set_cookies_on_request_context(&self, cookie_map: Option<&CookieMap>) {
-        if self.request_context.is_null() {
-            // Request already detached (response finished or aborted). This
-            // map's changes can never be sent; mark it so JS set()/delete()
-            // throw ERR_HTTP_HEADERS_SENT.
+        if self.request_context.is_detached() {
+            // This request was attached to a live Bun.serve response that has
+            // since finished, aborted, or upgraded. The map's changes can never
+            // be sent; mark it so JS set()/delete() throw ERR_HTTP_HEADERS_SENT.
+            // `CtxTag::None` (clones, `new Request(...)`) falls through to the
+            // dispatch no-op below so those maps stay freely mutable.
             if let Some(m) = cookie_map {
                 m.set_headers_written();
             }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -378,6 +378,15 @@ impl Request {
 
     #[bun_uws::uws_callback(export = "Request__setCookiesOnRequestContext")]
     pub fn ffi_set_cookies_on_request_context(&self, cookie_map: Option<&CookieMap>) {
+        if self.request_context.is_null() {
+            // Request already detached (response finished or aborted). This
+            // map's changes can never be sent; mark it so JS set()/delete()
+            // throw ERR_HTTP_HEADERS_SENT.
+            if let Some(m) = cookie_map {
+                m.set_headers_written();
+            }
+            return;
+        }
         self.request_context
             .set_cookies(cookie_map.map(|c| std::ptr::from_ref::<CookieMap>(c).cast_mut()));
     }

--- a/test/js/bun/http/bun-serve-cookies.test.ts
+++ b/test/js/bun/http/bun-serve-cookies.test.ts
@@ -733,18 +733,21 @@ describe("req.cookies after headers sent", () => {
     expect(map.get("a")).toBe("2");
   });
 
-  test("cloned request's cookies are a detached, freely mutable map", async () => {
-    let cloneSetOk = false;
+  test.each([
+    ["after touching req.cookies on the original", true],
+    ["without touching req.cookies on the original", false],
+  ])("cloned request's cookies are a detached, freely mutable map (%s)", async (_, touchFirst) => {
     let cloneValue: string | null = null;
+    let cloneRead: string | null = null;
     await using server = Bun.serve({
       port: 0,
       routes: {
         "/": req => {
-          void req.cookies.get("foo");
+          if (touchFirst) void req.cookies.get("foo");
           const cloned = req.clone();
           cloned.cookies.set("x", "1");
-          cloneSetOk = true;
           cloneValue = cloned.cookies.get("x");
+          cloneRead = cloned.cookies.get("foo");
           return new Response("ok");
         },
       },
@@ -753,7 +756,40 @@ describe("req.cookies after headers sent", () => {
     expect(body).toBe("ok");
     // The clone is detached; its mutations never reach the wire.
     expect(setCookie).toEqual([]);
-    expect(cloneSetOk).toBe(true);
     expect(cloneValue).toBe("1");
+    expect(cloneRead).toBe("bar");
+  });
+
+  test("set() throws after the client aborts mid-handler", async () => {
+    let outcome: { code?: string; value?: unknown } | undefined;
+    const arrived = Promise.withResolvers<void>();
+    const aborted = Promise.withResolvers<void>();
+    const done = Promise.withResolvers<void>();
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/": async req => {
+          const cookies = req.cookies;
+          cookies.set("before", "1");
+          req.signal.addEventListener("abort", () => aborted.resolve());
+          arrived.resolve();
+          await aborted.promise;
+          try {
+            cookies.set("after", "1");
+            outcome = { value: cookies.get("after") };
+          } catch (e) {
+            outcome = { code: (e as any)?.code };
+          }
+          done.resolve();
+          return new Response("ok");
+        },
+      },
+    });
+    const controller = new AbortController();
+    fetch(new URL("/", server.url), { signal: controller.signal }).catch(() => {});
+    await arrived.promise;
+    controller.abort();
+    await done.promise;
+    expect(outcome).toEqual({ code: "ERR_HTTP_HEADERS_SENT" });
   });
 });

--- a/test/js/bun/http/bun-serve-cookies.test.ts
+++ b/test/js/bun/http/bun-serve-cookies.test.ts
@@ -1,5 +1,5 @@
 import type { Server } from "bun";
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 
 describe("request cookies", () => {
   let server: Server;
@@ -590,5 +590,170 @@ describe("Direct usage of Bun.Cookie and Bun.CookieMap", () => {
     const parsed = JSON.parse(jsonString);
     expect(parsed.name).toBe("name");
     expect(parsed.value).toBe("value");
+  });
+});
+
+describe("req.cookies after headers sent", () => {
+  async function collect(server: Server, path: string, init?: RequestInit) {
+    const res = await fetch(new URL(path, server.url), init);
+    const setCookie = res.headers.getSetCookie();
+    const body = await res.text();
+    return { setCookie, body, status: res.status };
+  }
+
+  test("set()/delete() throw ERR_HTTP_HEADERS_SENT once the response head is committed", async () => {
+    type Outcome = { code?: string; value?: unknown };
+    const setTryCatch = (cookies: Bun.CookieMap, name: string): Outcome => {
+      try {
+        cookies.set(name, "1");
+        return { value: cookies.get(name) };
+      } catch (e) {
+        return { code: (e as any)?.code };
+      }
+    };
+    const deleteTryCatch = (cookies: Bun.CookieMap, name: string): Outcome => {
+      try {
+        cookies.delete(name);
+        return { value: cookies.has(name) };
+      } catch (e) {
+        return { code: (e as any)?.code };
+      }
+    };
+
+    let capturedOutcome: { late: Outcome; del: Outcome; read: string | null } | undefined;
+    let lazyOutcome: Outcome | undefined;
+    let streamOutcome: Outcome | undefined;
+    let savedMap: Bun.CookieMap | undefined;
+
+    const capturedDone = Promise.withResolvers<void>();
+    const lazyDone = Promise.withResolvers<void>();
+    const streamHeadWritten = Promise.withResolvers<void>();
+    const streamProceed = Promise.withResolvers<void>();
+
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        // req.cookies captured before returning; mutated after the head is flushed.
+        "/captured": req => {
+          const cookies = req.cookies;
+          cookies.set("before", "1");
+          setImmediate(() => {
+            capturedOutcome = {
+              late: setTryCatch(cookies, "late"),
+              del: deleteTryCatch(cookies, "foo"),
+              // Reads must continue to work.
+              read: cookies.get("foo"),
+            };
+            capturedDone.resolve();
+          });
+          return new Response("ok");
+        },
+        // First access of req.cookies happens after the response is already sent.
+        "/lazy": req => {
+          setImmediate(() => {
+            lazyOutcome = setTryCatch(req.cookies, "late");
+            lazyDone.resolve();
+          });
+          return new Response("ok");
+        },
+        // Mutating from inside the streaming body once the head is out.
+        "/stream": req => {
+          const cookies = req.cookies;
+          cookies.set("before", "1");
+          return new Response(
+            new ReadableStream({
+              async pull(ctrl) {
+                ctrl.enqueue("hello");
+                streamHeadWritten.resolve();
+                await streamProceed.promise;
+                streamOutcome = setTryCatch(cookies, "inside");
+                ctrl.close();
+              },
+            }),
+          );
+        },
+        // Save a stale request's map to mutate after that request has fully finished.
+        "/save": req => {
+          savedMap = req.cookies;
+          return new Response("ok");
+        },
+      },
+    });
+
+    const captured = await collect(server, "/captured", { headers: { Cookie: "foo=bar" } });
+    await capturedDone.promise;
+    expect(captured.body).toBe("ok");
+    expect(captured.setCookie).toEqual(["before=1; Path=/; SameSite=Lax"]);
+    expect(capturedOutcome).toEqual({
+      late: { code: "ERR_HTTP_HEADERS_SENT" },
+      del: { code: "ERR_HTTP_HEADERS_SENT" },
+      read: "bar",
+    });
+
+    const lazy = await collect(server, "/lazy");
+    await lazyDone.promise;
+    expect(lazy.body).toBe("ok");
+    expect(lazy.setCookie).toEqual([]);
+    expect(lazyOutcome).toEqual({ code: "ERR_HTTP_HEADERS_SENT" });
+
+    const streamRes = await fetch(new URL("/stream", server.url));
+    expect(streamRes.headers.getSetCookie()).toEqual(["before=1; Path=/; SameSite=Lax"]);
+    await streamHeadWritten.promise;
+    streamProceed.resolve();
+    expect(await streamRes.text()).toBe("hello");
+    expect(streamOutcome).toEqual({ code: "ERR_HTTP_HEADERS_SENT" });
+
+    const saved = await collect(server, "/save");
+    expect(saved.body).toBe("ok");
+    expect(savedMap).toBeDefined();
+    expect(setTryCatch(savedMap!, "stale")).toEqual({ code: "ERR_HTTP_HEADERS_SENT" });
+  });
+
+  test("set() before the handler returns still emits Set-Cookie", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/": req => {
+          req.cookies.set("a", "1");
+          req.cookies.set("b", "2");
+          return new Response("ok");
+        },
+      },
+    });
+    const { setCookie, body } = await collect(server, "/");
+    expect(body).toBe("ok");
+    expect(setCookie).toEqual(["a=1; Path=/; SameSite=Lax", "b=2; Path=/; SameSite=Lax"]);
+  });
+
+  test("standalone CookieMap is never marked headers-sent", () => {
+    const map = new Bun.CookieMap();
+    map.set("a", "1");
+    map.delete("a");
+    map.set("a", "2");
+    expect(map.get("a")).toBe("2");
+  });
+
+  test("cloned request's cookies are a detached, freely mutable map", async () => {
+    let cloneSetOk = false;
+    let cloneValue: string | null = null;
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/": req => {
+          void req.cookies.get("foo");
+          const cloned = req.clone();
+          cloned.cookies.set("x", "1");
+          cloneSetOk = true;
+          cloneValue = cloned.cookies.get("x");
+          return new Response("ok");
+        },
+      },
+    });
+    const { body, setCookie } = await collect(server, "/", { headers: { Cookie: "foo=bar" } });
+    expect(body).toBe("ok");
+    // The clone is detached; its mutations never reach the wire.
+    expect(setCookie).toEqual([]);
+    expect(cloneSetOk).toBe(true);
+    expect(cloneValue).toBe("1");
   });
 });


### PR DESCRIPTION
### What does this PR do?

`req.cookies.set()` / `req.cookies.delete()` in a `Bun.serve` route handler are supposed to add a `Set-Cookie` header to the response. Today the mutation only reaches the wire if it happens before Bun writes the response head. After that point (from a timer that fires after the handler returns, from inside a streaming `ReadableStream` body, after a client disconnect, or on a `CookieMap` saved from an earlier request) the call returns `undefined`, the map is mutated so `get()`/`has()` see the new value, and nothing is emitted. Whether a `queueMicrotask` scheduled after `return response` still lands depends on microtask drain ordering.

```js
Bun.serve({
  routes: {
    "/": req => {
      setTimeout(() => req.cookies.set("late", "1"), 50); // silently dropped
      return new Response("ok");
    },
  },
});
```

Node's `res.setHeader` (and Express/Fastify on top of it) throw `ERR_HTTP_HEADERS_SENT` in the equivalent situation.

`CookieMap` has no link back to the request's response state. `RequestContext` holds a ref to the map and, while rendering the head, iterates `m_modifiedCookies` to emit `Set-Cookie` and then drops the ref. Later mutations land in the map the `JSBunRequest` still holds, which nothing ever reads again.

This PR adds an `m_headersWritten` flag to `CookieMap`. `CookieMap.prototype.set` / `delete` check it and throw `ERR_HTTP_HEADERS_SENT`; reads (`get`, `has`, iteration, `toJSON`, `toSetCookieHeaders`) keep working.

`AnyRequestContext` gains a `CtxTag::Detached` state alongside the existing `None`, so a request that was attached to a live `Bun.serve` response and has since been torn down is distinguishable from a clone or a user-constructed `Request` that was never attached. The three teardown sites (`on_abort`, `finalize_without_deinit`, and the WebSocket upgrade path) now assign `DETACHED` and mark any stored `CookieMap` on their way out. The flag is set:

* in `CookieMap__write` after the `Set-Cookie` headers are emitted,
* in `RequestContext::set_cookies` when `req.cookies` is first touched after the status has already been written or the connection is gone,
* in `on_abort` and `finalize_without_deinit` when the request ends with a map still attached,
* in `Request::ffi_set_cookies_on_request_context` when the request context is `Detached`.

Standalone `new Bun.CookieMap()` instances are never marked, and `req.clone().cookies` stays a freely mutable detached map regardless of whether the original's `cookies` was touched before cloning.

Docs and the `BunRequest.cookies` JSDoc now spell out the deadline.

### How did you verify your code works?

New cases in `test/js/bun/http/bun-serve-cookies.test.ts` cover: mutating a captured map after the head is out, first access of `req.cookies` after the response finished, mutating from inside a streaming body, mutating a map saved from a finished request, mutating a captured map after a client abort, the happy path (set before return still emits `Set-Cookie`), standalone `CookieMap` staying mutable, and `req.clone().cookies` staying mutable both when the original's cookies were touched first and when they were not. The throw cases fail on current `main` and pass with this change.

```
bun bd test test/js/bun/http/bun-serve-cookies.test.ts
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-cookies.test.ts
bun test v1.4.0 (c5c32f458)

test/js/bun/http/bun-serve-cookies.test.ts:
(pass) request cookies > parses cookies before headers are accessed [27.33ms]
(pass) request cookies > parses cookies after headers are accessed [16.65ms]
(pass) request cookies > handles requests with no cookies [12.35ms]
(pass) request cookies > has readonly cookies property [9.70ms]
(pass) instanceof and type checks > cookies is instance of Bun.CookieMap and has right prototype [21.03ms]
(pass) instanceof and type checks > constructors match expected types [14.44ms]
(pass) complex cookie parsing > handles cookie values with spaces [18.56ms]
(pass) complex cookie parsing > handles cookie values with equals signs [8.43ms]
(pass) complex cookie parsing > handles duplicate cookie names [14.52ms]
(pass) complex cookie parsing > CookieMap methods work correctly [9.62ms]
(pass) CookieMap iterator > implements entries() iterator [35.47ms]
(pass) CookieMap iterator > implements for...of iteration [24.73ms]
(pass) CookieMap iter
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e42076067)

test/js/bun/http/bun-serve-cookies.test.ts:
(pass) request cookies > parses cookies before headers are accessed [1.81ms]
(pass) request cookies > parses cookies after headers are accessed [0.50ms]
(pass) request cookies > handles requests with no cookies [0.16ms]
(pass) request cookies > has readonly cookies property [0.17ms]
(pass) instanceof and type checks > cookies is instance of Bun.CookieMap and has right prototype [0.75ms]
(pass) instanceof and type checks > constructors match expected types [0.20ms]
(pass) complex cookie parsing > handles cookie values with spaces [0.61ms]
(pass) complex cookie parsing > handles cookie values with equals signs [0.18ms]
(pass) complex cookie parsing > handles duplicate cookie names [0.16ms]
(pass) complex cookie parsing > CookieMap methods work correctly [0.15ms]
(pass) CookieMap iterator > implements entries() iterator [0.91ms]
(pass) CookieMap iterator > implements for...of iteration [0.29ms]
(pass) CookieMap iterator > implements keys() and values() iterators [0.23ms]
(pass) CookieMap iterator > implements forEach method [0.24ms]
(pass) Direct usage of Bun.Cookie and Bun.CookieMap > ca
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-cookies.test.ts
bun test v1.4.0 (c5c32f458)

test/js/bun/http/bun-serve-cookies.test.ts:
(pass) request cookies > parses cookies before headers are accessed [27.63ms]
(pass) request cookies > parses cookies after headers are accessed [20.98ms]
(pass) request cookies > handles requests with no cookies [13.76ms]
(pass) request cookies > has readonly cookies property [10.53ms]
(pass) instanceof and type checks > cookies is instance of Bun.CookieMap and has right prototype [21.75ms]
(pass) instanceof and type checks > constructors match expected types [14.45ms]
(pass) complex cookie parsing > handles cookie values with spaces [19.65ms]
(pass) complex cookie parsing > handles cookie values with equals signs [13.37ms]
(pass) complex cookie parsing > handles duplicate cookie names [9.79ms]
(pass) complex cookie parsing > CookieMap methods work correctly [16.18ms]
(pass) CookieMap iterator > implements entries() iterator [38.94ms]
(pass) CookieMap iterator > implements for...of iteration [24.52ms]
(pass) CookieMap it
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 645ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/17] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[2/17] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[3/17] cxx obj/src/jsc/bindings/BunObject.cpp.o
[4/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[5/17] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[6/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[7/17] cxx obj/src/jsc/bindings/bindings.cpp.o
[8/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[9/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[10/17] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[11/17] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[12/17] gen cpp.rs (cppbind)
[13/17] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[13/17] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    B
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/http/cookies.mdx              |   2 +
 packages/bun-types/serve.d.ts              |  10 ++
 src/jsc/bindings/CookieMap.cpp             |   6 +
 src/jsc/bindings/CookieMap.h               |   8 ++
 src/jsc/bindings/webcore/JSCookieMap.cpp   |   9 ++
 src/runtime/server/AnyRequestContext.rs    |  17 ++-
 src/runtime/server/RequestContext.rs       |  33 ++++-
 src/runtime/server/server_body.rs          |   2 +-
 src/runtime/webcore/CookieMap.rs           |  11 ++
 src/runtime/webcore/Request.rs             |  11 ++
 test/js/bun/http/bun-serve-cookies.test.ts | 203 ++++++++++++++++++++++++++++-
 11 files changed, 303 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
docs/runtime/http/cookies.mdx                   1      1      0
packages/bun-types/serve.d.ts                   1      1      0
src/jsc/bindings/CookieMap.cpp                  1      1      0
src/jsc/bindings/CookieMap.h                    1      2      0
src/jsc/bindings/webcore/JSCookieMap.cpp        1      3      0
src/runtime/server/AnyRequestContext.rs         3      4      0
src/runtime/server/RequestContext.rs            6      5      0
src/runtime/server/server_body.rs               2      1      0
src/runtime/webcore/CookieMap.rs                1      2      0
src/runtime/webcore/Request.rs                  3      3      0
test/js/bun/http/bun-serve-cookies.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->