### PR TITLE
node:buffer: reject DataView in Buffer.copyBytesFrom

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1010,8 +1010,8 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_copyBytesFromBody(JSC::JS
     auto lengthValue = callFrame->argument(2);
 
     auto view = dynamicDowncast<JSArrayBufferView>(viewValue);
-    if (!view) {
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "view"_s, "TypedArray"_s, viewValue);
+    if (!view || !isTypedArrayType(view->type())) {
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "view"_s, "TypedArray"_s, viewValue);
     }
 
     auto ty = JSC::typedArrayType(view->type());

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4500,6 +4500,57 @@ describe("Buffer.copyBytesFrom", () => {
     const buf = Buffer.copyBytesFrom(view);
     expect([...buf]).toEqual([8, 9, 10, 11, 12, 13, 14, 15]);
   });
+
+  // Node types the parameter as TypedArray only, so a DataView (also a JSArrayBufferView in JSC)
+  // is rejected the same way as any other non-TypedArray argument.
+  const invalidView = received =>
+    expect.objectContaining({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "view" argument must be an instance of TypedArray. Received ${received}`,
+    });
+
+  it.each([
+    ["whole buffer", ab => [new DataView(ab)]],
+    ["with offset and length", ab => [new DataView(ab), 1, 3]],
+    ["sub-range of the buffer", ab => [new DataView(ab, 2, 4)]],
+    ["zero length", () => [new DataView(new ArrayBuffer(0))]],
+  ])("rejects a DataView (%s)", (_, args) => {
+    const ab = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+    expect(() => Buffer.copyBytesFrom(...args(ab))).toThrow(invalidView("an instance of DataView"));
+  });
+
+  it.each([
+    ["an ArrayBuffer", new ArrayBuffer(4), "an instance of ArrayBuffer"],
+    ["a string", "nope", "type string ('nope')"],
+    ["undefined", undefined, "undefined"],
+  ])("rejects %s with Node's wording", (_, view, received) => {
+    expect(() => Buffer.copyBytesFrom(view)).toThrow(invalidView(received));
+  });
+
+  it("still accepts every TypedArray kind", () => {
+    const bytes = Array.from({ length: 16 }, (_, i) => i);
+    const ab = new Uint8Array(bytes).buffer;
+    const kinds = [
+      Int8Array,
+      Uint8Array,
+      Uint8ClampedArray,
+      Int16Array,
+      Uint16Array,
+      Int32Array,
+      Uint32Array,
+      Float16Array,
+      Float32Array,
+      Float64Array,
+      BigInt64Array,
+      BigUint64Array,
+    ];
+    for (const Kind of kinds) {
+      expect([...Buffer.copyBytesFrom(new Kind(ab))]).toEqual(bytes);
+    }
+    expect([...Buffer.copyBytesFrom(Buffer.from(ab), 1, 3)]).toEqual([1, 2, 3]);
+    expect([...Buffer.copyBytesFrom(new Uint32Array(ab), 1, 2)]).toEqual([4, 5, 6, 7, 8, 9, 10, 11]);
+  });
 });
 
 describe("Buffer.prototype.toString binary-to-text encodings", () => {


### PR DESCRIPTION
### Problem
- `Buffer.copyBytesFrom(new DataView(ab))` returns a copy of the bytes. Node throws `TypeError [ERR_INVALID_ARG_TYPE]: The "view" argument must be an instance of TypedArray. Received an instance of DataView`.
- Cause: the argument check in `jsBufferConstructorFunction_copyBytesFromBody` (`src/jsc/bindings/JSBuffer.cpp:1012`) downcasts to `JSArrayBufferView`, and in JSC a `DataView` is a `JSArrayBufferView` too, so it passes the check and the byte copy runs.
- Related: every rejection from this function says `must be of type TypedArray`; Node says `must be an instance of TypedArray`.

```js
const ab = new Uint8Array([1, 2, 3, 4]).buffer;
Buffer.copyBytesFrom(new DataView(ab));
// bun 1.4.0: <Buffer 01 02 03 04>
// node:      TypeError [ERR_INVALID_ARG_TYPE]: The "view" argument must be an instance of TypedArray. Received an instance of DataView
```

### Fix
- Add `isTypedArrayType(view->type())` to the check, so a `DataView` takes the rejection branch.
- Throw through `Bun::ERR::INVALID_ARG_INSTANCE`, which keeps the `ERR_INVALID_ARG_TYPE` code and produces Node's `must be an instance of` wording.
- Why this is right: Node's `copyBytesFrom` is `if (!isTypedArray(view)) throw new ERR_INVALID_ARG_TYPE('view', ['TypedArray'], view)`, and `isTypedArray` is false for `DataView`. `isTypedArrayType` is the same predicate on JSC's side (it is what `BunObject.cpp` and `napi.cpp` already use for "TypedArray but not DataView"). The check now runs before the zero-length early return, so an empty `DataView` is rejected as well, as in Node. `INVALID_ARG_INSTANCE` is the helper the rest of `JSBuffer.cpp` uses for class-instance expectations (`compare`, `concat`, `copy`, ...).
- Scope: this PR changes `copyBytesFrom` only. The other `node:buffer` entry points that take a view through the same `JSArrayBufferView` downcast each need a different rule, so they are separate changes: `Buffer.compare` / `buf.equals` must accept `Uint8Array` only (open #36111); `isUtf8` / `isAscii` accept `ArrayBuffer` or any TypedArray, and the legacy `Buffer(dataView)` constructor must return an empty Buffer like `Buffer.from` (both reported separately, fixes to follow).
- Open #38694 teaches `INVALID_ARG_TYPE` to render a lone class name as `an instance of` on its own. It does not touch this file; with or without it, this line produces the same text, and the wording assertions below hold either way.
- Verified with `test/js/node/buffer.test.js` (`Buffer.copyBytesFrom` block): four `DataView` shapes (whole buffer, offset/length, sub-range, zero length) and the exact message for an `ArrayBuffer`, a string and `undefined` fail on bun 1.4.0 and pass with this build; a control test covers all twelve TypedArray kinds plus `Buffer`.
- `bun bd test test/js/node/buffer.test.js`: 626 pass, 1 skip, 0 fail.
- `bun bd test/js/node/test/parallel/test-buffer-from.js`: exit 0.
- A 15-case probe (every rejected and accepted input shape above, printing hex or name/code/message) produces byte-identical output on this build and node v26.3.0.

### Background
- `JSArrayBufferView` is JSC's common base for everything that views an `ArrayBuffer`: the typed arrays (`Uint8Array`, `Float64Array`, `BigInt64Array`, ...) and `DataView`. `dynamicDowncast<JSArrayBufferView>` therefore succeeds for a `DataView`.
- `JSC::isTypedArrayType(JSType)` is true for the typed array types and false for `DataViewType`; `isTypedArrayTypeIncludingDataView` is the variant that also accepts `DataView`.
- `Bun::ERR::INVALID_ARG_TYPE(name, "X", value)` with a single string renders `must be of type X`; `Bun::ERR::INVALID_ARG_INSTANCE` renders `must be an instance of X`. Both throw with `code: "ERR_INVALID_ARG_TYPE"`. Node picks the wording from the expected name: a capitalized class name like `TypedArray` gets `an instance of`.

<details><summary>Earlier revision of this PR</summary>

The first revision had the same two-line change in `JSBuffer.cpp` (initially with `isTypedView`, swapped to `isTypedArrayType` in review for consistency with the other call sites) and a single test covering three `DataView` shapes. It has since been rebased onto current main, squashed, and the test widened to also cover the zero-length `DataView`, the message wording for non-view arguments, and an accepted-kinds control. #35943 was a second PR for this bug; it was closed in favor of this one since its diff did not contain a buffer change.

A self-review of the current diff asked whether this should instead be folded into #36111 together with the `isUtf8` / `isAscii` and legacy-constructor siblings, and whether the tests should be a Node-vs-Bun differential fixture like the `fill()` one in this file. Kept separate: each site has its own Node rule and message (see Scope above), so a combined PR would be four independent fixes reviewed as one, and the siblings without a PR are now tracked on their own. Kept the hand-written assertions: they pin Node's exact messages without needing a Node binary at test time, which is how the rest of this describe block and of the file is written.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (a51e99cad)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [87.55ms]
(pass) with native Buffer.write > #9120 alloc [64.44ms]
(pass) with native Buffer.write > isAscii [60.82ms]
(pass) with native Buffer.write > isUtf8 [60.21ms]
(pass) with native Buffer.write > Buffer global is settable [56.44ms]
(pass) with native Buffer.write > length overflow [61.17ms]
(pass) with native Buffer.write > truncate input values [185.15ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [56.63ms]
(pass) with native Buffer.write > Buffer.from() [55.73ms]
(pass) with native Buffer.write > offset properties [59.41ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [68.07ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [61.22ms]
(pass) with native Buffer.write > invalid encoding [70.35ms]
(pass) with native Buffer.write > create 0-length buffers [58.32ms]
(pass) with native Buffer.write > write() beyond end of buff
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bbcfc31e1)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [3.89ms]
(pass) with native Buffer.write > #9120 alloc [2.15ms]
(pass) with native Buffer.write > isAscii [1.91ms]
(pass) with native Buffer.write > isUtf8 [1.83ms]
(pass) with native Buffer.write > Buffer global is settable [2.04ms]
(pass) with native Buffer.write > length overflow [2.09ms]
(pass) with native Buffer.write > truncate input values [2.58ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [2.06ms]
(pass) with native Buffer.write > Buffer.from() [2.04ms]
(pass) with native Buffer.write > offset properties [1.81ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [2.78ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [1.78ms]
(pass) with native Buffer.write > invalid encoding [2.39ms]
(pass) with native Buffer.write > create 0-length buffers [3.47ms]
(pass) with native Buffer.write > write() beyond end of buffer [4.27ms]
(pass) with native Buffer.write > write BigInt beyond 64-bit range [4.31ms]
(pass) with native Buffer.write > write BigInt64 with insufficient buffer space
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/buffer.test.js
bun test v1.4.0 (a51e99cad)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [83.50ms]
(pass) with native Buffer.write > #9120 alloc [61.63ms]
(pass) with native Buffer.write > isAscii [65.73ms]
(pass) with native Buffer.write > isUtf8 [61.80ms]
(pass) with native Buffer.write > Buffer global is settable [57.46ms]
(pass) with native Buffer.write > length overflow [60.84ms]
(pass) with native Buffer.write > truncate input values [187.72ms]
(pass) with native Buffer.write > Buffer.allocUnsafe() [57.54ms]
(pass) with native Buffer.write > Buffer.from() [58.58ms]
(pass) with native Buffer.write > offset properties [59.29ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array [67.58ms]
(pass) with native Buffer.write > creating a Buffer from a Uint32Array (old constructor) [63.03ms]
(pass) with native Buffer.write > invalid encoding [67.23ms]
(pass) with native Buffer.write > create 0-length buffers [60.52ms]
(pass) with native Buffer.write > write() beyond end of buff
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/7] cxx obj/src/jsc/bindings/JSBuffer.cpp.o
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m    Blocking^[[0m waiting for file lock on build directory
^[[1m^[[92m    Finished^[[0m `release` profile [optimized + debuginfo] target(s) in 34.02s
[4/7] link bun-profile
[5/7] bun-profile --revision
1.4.0-canary.1+a51e99cad
[7/7] strip bun
[build] done
bun test v1.4.0-canary.1 (a51e99cad)

test/js/node/buffer.test.js:
(pass) with native Buffer.write > #9120 fill [3.02ms]
(pass) with native Buffer.write > #9120 alloc [2.27ms]
(pass) with native Buffer.write > isAscii [2.45ms]
(pass) with native Buffer.write > isUtf8 [1.70ms]
(pass) with native Buffer.write > Buffer global is settable [2.09ms]
(pass) with native Buffer
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSBuffer.cpp |  4 ++--
 test/js/node/buffer.test.js   | 16 ++++++++++++++++
 2 files changed, 18 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/jsc/bindings/JSBuffer.cpp      2      4      0
test/js/node/buffer.test.js        1      1      0
```

</details>

<!-- robobun:evidence:end -->
