### PR TITLE
MimeType: match file extensions case-insensitively

### DIFF
--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -432,7 +432,7 @@ pub fn by_extension(ext_without_leading_dot: &[u8]) -> MimeType {
 }
 
 pub fn by_extension_no_default(ext_without_leading_dot: &[u8]) -> Option<MimeType> {
-    if let Some(entry) = EXTENSIONS.get(ext_without_leading_dot) {
+    if let Some(entry) = EXTENSIONS.get_ascii_case_insensitive(ext_without_leading_dot) {
         return Some(Compact::from(*entry).to_mime_type());
     }
     None

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import fsPromises from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
@@ -154,4 +154,54 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
     emptyErr: "Unexpected end of JSON input",
   });
   expect(exitCode).toBe(0);
+});
+
+test("Bun.file().type maps uppercase and mixed-case extensions to the same MIME type", async () => {
+  using dir = tempDir("bun-file-ext-case", {
+    "a.png": "x",
+    "A.PNG": "x",
+    "a.PnG": "x",
+    "IMG_0001.JPG": "x",
+    "INDEX.HTML": "x",
+    "LOGO.SVG": "x",
+    "S.CSS": "x",
+    "MAIN.JS": "x",
+    "DATA.JSON": "x",
+    "clip.MP4": "x",
+  });
+  const d = String(dir);
+
+  const typeOf = (name: string) => Bun.file(join(d, name)).type.split(";")[0];
+
+  expect({
+    "a.png": typeOf("a.png"),
+    "A.PNG": typeOf("A.PNG"),
+    "a.PnG": typeOf("a.PnG"),
+    "IMG_0001.JPG": typeOf("IMG_0001.JPG"),
+    "INDEX.HTML": typeOf("INDEX.HTML"),
+    "LOGO.SVG": typeOf("LOGO.SVG"),
+    "S.CSS": typeOf("S.CSS"),
+    "MAIN.JS": typeOf("MAIN.JS"),
+    "DATA.JSON": typeOf("DATA.JSON"),
+    "clip.MP4": typeOf("clip.MP4"),
+  }).toEqual({
+    "a.png": "image/png",
+    "A.PNG": "image/png",
+    "a.PnG": "image/png",
+    "IMG_0001.JPG": "image/jpeg",
+    "INDEX.HTML": "text/html",
+    "LOGO.SVG": "image/svg+xml",
+    "S.CSS": "text/css",
+    "MAIN.JS": "text/javascript",
+    "DATA.JSON": "application/json",
+    "clip.MP4": "video/mp4",
+  });
+
+  await using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response(Bun.file(join(d, "IMG_0001.JPG"))),
+  });
+  const res = await fetch(server.url);
+  await res.arrayBuffer();
+  expect(res.headers.get("content-type")).toStartWith("image/jpeg");
 });


### PR DESCRIPTION
## Repro

```js
Bun.file("PHOTO.JPG").type
// before: "application/octet-stream"
// after:  "image/jpeg"
```

Serving the same file via `Bun.serve` sent `Content-Type: application/octet-stream` plus `Content-Disposition: filename="PHOTO.JPG"`, so browsers downloaded the image instead of rendering it. Camera and Windows tooling commonly produce uppercase extensions (`DSC_0001.JPG`, `INDEX.HTML`).

## Cause

`by_extension_no_default` in `src/http_types/MimeType.rs` looked up the extension with `EXTENSIONS.get(...)`, which is a case-sensitive match, and every key in the table is lowercase.

## Fix

Use the map's existing `get_ascii_case_insensitive` lookup (stack-buffer lowercasing, already used for HTTP header names and crypto algorithm names). This matches what `mime-types`, express/send, and nginx do.

## Verification

New test in `test/js/bun/util/bun-file.test.ts` asserts `.PNG`/`.PnG`/`.JPG`/`.HTML`/`.SVG`/`.CSS`/`.JS`/`.JSON`/`.MP4` all resolve to their lowercase MIME types, and that `Bun.serve` sends `Content-Type: image/jpeg` for `IMG_0001.JPG`.

Fails on `main`:
```
-   "A.PNG": "image/png",
+   "A.PNG": "application/octet-stream",
... (9 mismatches)
```
Passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (240ee987d)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [47.77ms]
(pass) writer.end() should not close the fd if it does not own the fd [171.33ms]
(pass) Bun.file() read errors include async stack frames [22.47ms]
(pass) Bun.write() errors include async stack frames [25.78ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [12.39ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [613.49ms]
182 |     "LOGO.SVG": typeOf("LOGO.SVG"),
183 |     "S.CSS": typeOf("S.CSS"),
184 |     "MAIN.JS": typeOf("MAIN.JS"),
185 |     "DATA.JSON": typeOf("DATA.JSON"),
186 |     "clip.MP4": typeOf("clip.MP4"),
187 |   }).toEqual({
           ^
error: expect(received).toEqual(expected)

  {
-   "A.PNG": "image/png",
-   "DATA.JSON": "application/json",
-   "IMG_0001.JPG": "image/jpeg",
-   "INDEX.HTML": "text/html",
-   "LOGO.SVG": "image/svg+xml",
-   "MAIN.JS": "text/javascript",
-   "S.CSS": "text/css",
-   "a.P
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (08fa23e0e)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [2.65ms]
(pass) writer.end() should not close the fd if it does not own the fd [4.65ms]
(pass) Bun.file() read errors include async stack frames [0.27ms]
(pass) Bun.write() errors include async stack frames [0.95ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [0.23ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [39.84ms]
(pass) Bun.file().type maps uppercase and mixed-case extensions to the same MIME type [19.38ms]

 7 pass
 0 fail
 51 expect() calls
Ran 7 tests across 1 file. [244.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (240ee987d)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [43.89ms]
(pass) writer.end() should not close the fd if it does not own the fd [176.94ms]
(pass) Bun.file() read errors include async stack frames [26.79ms]
(pass) Bun.write() errors include async stack frames [26.69ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [20.78ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [602.72ms]
(pass) Bun.file().type maps uppercase and mixed-case extensions to the same MIME type [62.90ms]

 7 pass
 0 fail
 51 expect() calls
Ran 7 tests across 1 file. [3.14s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 752ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/122] gen cpp.rs (cppbind)
[2/122] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/122] gen JS modules (bundle-modules)
Preprocess modules (7455ms)
Bundle modules (52ms)
Postprocesss modules (60ms)
Bundle Functions (793ms)
Generate Code (14ms)

[8.39s] Bundled "src/js" for production
  2067 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[3/121] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_libuv_sys v0.0.0 (/workspace/bun/src/libuv_sys)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_types/MimeType.rs        |  2 +-
 test/js/bun/util/bun-file.test.ts | 52 ++++++++++++++++++++++++++++++++++++++-
 2 files changed, 52 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/http_types/MimeType.rs             1      1      0
test/js/bun/util/bun-file.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->