### PR TITLE
http: append ;charset=utf-8 to every text/* extension-derived MIME type

### DIFF
--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -87,9 +87,28 @@ impl Compact {
         }
 
         let slice = self.value.slice();
+        let category = Category::from_table(self.value);
+
+        // Every `text/*` subtype is UTF-8 by default (mime-types/express/send
+        // behaviour). Without the charset parameter, browsers fall back to
+        // their default (often windows-1252) and render mojibake for served
+        // `.md`/`.csv`/`.ics`/`.yaml`/etc. The five text subtypes that already
+        // carry `;charset=utf-8` were handled above; promote the rest here.
+        if strings::has_prefix_comptime(slice, b"text/")
+            && strings::index_of_char(slice, b';').is_none()
+        {
+            let mut value = Vec::with_capacity(slice.len() + b";charset=utf-8".len());
+            value.extend_from_slice(slice);
+            value.extend_from_slice(b";charset=utf-8");
+            return MimeType {
+                value: Cow::Owned(value),
+                category,
+            };
+        }
+
         MimeType {
             value: Cow::Borrowed(slice),
-            category: Category::from_table(self.value),
+            category,
         }
     }
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1977,10 +1977,11 @@ impl BlobExt for Blob {
         blob.size.set(len);
 
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
-        // infer the content type if it was not specified
-        if content_type.is_empty()
-            && matches!(self.content_type.get(), BlobContentType::Static(s) if !s.is_empty())
-        {
+        // Inherit the parent's type when the caller did not pass one. The
+        // parent's `content_type` may be `Owned` (e.g. the `text/*` charset
+        // promotion in `Compact::to_mime_type`), so match on emptiness rather
+        // than on the `Static` variant.
+        if content_type.is_empty() && !self.content_type.get().is_empty() {
             blob.content_type.set(self.content_type.get().clone());
         } else {
             blob.content_type.set(content_type);

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -4,7 +4,9 @@ describe("util file tests", () => {
     const file = Bun.file("test", {
       type: "text/markdown",
     });
-    expect(file.type).toBe("text/markdown");
+    // Known `text/*` values are normalized to carry the UTF-8 charset,
+    // matching how `text/plain` and `text/css` already behave.
+    expect(file.type).toBe("text/markdown;charset=utf-8");
 
     const custom_type = Bun.file("test", {
       type: "custom/mimetype",
@@ -15,5 +17,37 @@ describe("util file tests", () => {
   test("mime-type is text/css;charset=utf-8", () => {
     const file = Bun.file("test.css");
     expect(file.type).toBe("text/css;charset=utf-8");
+  });
+
+  test("every text/* extension-derived type carries ;charset=utf-8", () => {
+    const cases: Record<string, string> = {
+      // the five that already carried a charset:
+      "a.txt": "text/plain;charset=utf-8",
+      "a.html": "text/html;charset=utf-8",
+      "a.css": "text/css;charset=utf-8",
+      "a.js": "text/javascript;charset=utf-8",
+      "a.json": "application/json;charset=utf-8",
+      // text/* subtypes that previously lacked a charset:
+      "a.md": "text/markdown;charset=utf-8",
+      "a.markdown": "text/markdown;charset=utf-8",
+      "a.csv": "text/csv;charset=utf-8",
+      "a.tsv": "text/tab-separated-values;charset=utf-8",
+      "a.ics": "text/calendar;charset=utf-8",
+      "a.yaml": "text/yaml;charset=utf-8",
+      "a.yml": "text/yaml;charset=utf-8",
+      "a.vcf": "text/x-vcard;charset=utf-8",
+      "a.vtt": "text/vtt;charset=utf-8",
+      "a.c": "text/x-c;charset=utf-8",
+      "a.java": "text/x-java-source;charset=utf-8",
+      "a.appcache": "text/cache-manifest;charset=utf-8",
+      "a.rtx": "text/richtext;charset=utf-8",
+      // non-text/* types stay as-is:
+      "a.wasm": "application/wasm",
+      "a.svg": "image/svg+xml",
+      "a.png": "image/png",
+      "a.pdf": "application/pdf",
+    };
+    const actual = Object.fromEntries(Object.keys(cases).map(name => [name, Bun.file(name).type]));
+    expect(actual).toEqual(cases);
   });
 });

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "path";
+
 describe("util file tests", () => {
   test("custom set mime-type respected (#6507)", () => {
     const file = Bun.file("test", {
@@ -49,5 +52,18 @@ describe("util file tests", () => {
     };
     const actual = Object.fromEntries(Object.keys(cases).map(name => [name, Bun.file(name).type]));
     expect(actual).toEqual(cases);
+  });
+
+  test("Bun.file().slice() inherits a text/* charset-promoted type", () => {
+    using dir = tempDir("slice-type", { "a.md": "hello", "a.txt": "hello", "a.png": "x" });
+    expect({
+      md: Bun.file(join(String(dir), "a.md")).slice(0, 3).type,
+      txt: Bun.file(join(String(dir), "a.txt")).slice(0, 3).type,
+      png: Bun.file(join(String(dir), "a.png")).slice(0, 3).type,
+    }).toEqual({
+      md: "text/markdown;charset=utf-8",
+      txt: "text/plain;charset=utf-8",
+      png: "image/png",
+    });
   });
 });

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -54,16 +54,26 @@ describe("util file tests", () => {
     expect(actual).toEqual(cases);
   });
 
-  test("Bun.file().slice() inherits a text/* charset-promoted type", () => {
+  test("slice() inherits the parent's non-empty type", () => {
     using dir = tempDir("slice-type", { "a.md": "hello", "a.txt": "hello", "a.png": "x" });
     expect({
+      // extension-derived, charset-promoted (Owned):
       md: Bun.file(join(String(dir), "a.md")).slice(0, 3).type,
+      // extension-derived, static constant:
       txt: Bun.file(join(String(dir), "a.txt")).slice(0, 3).type,
       png: Bun.file(join(String(dir), "a.png")).slice(0, 3).type,
+      // user-set type not in the MIME table (Owned):
+      custom: new Blob(["hello"], { type: "custom/mimetype" }).slice(0, 3).type,
+      customFile: Bun.file("x", { type: "application/x-foo" }).slice(0, 3).type,
+      // explicit override still wins:
+      override: Bun.file(join(String(dir), "a.md")).slice(0, 3, "text/plain").type,
     }).toEqual({
       md: "text/markdown;charset=utf-8",
       txt: "text/plain;charset=utf-8",
       png: "image/png",
+      custom: "custom/mimetype",
+      customFile: "application/x-foo",
+      override: "text/plain;charset=utf-8",
     });
   });
 });


### PR DESCRIPTION
## What

`Compact::to_mime_type` only promoted five hardcoded types (`text/plain`, `text/html`, `text/css`, `text/javascript`, `application/json`) to carry `;charset=utf-8`. Every other `text/*` subtype fell through as-is, so the extension-derived `Bun.file().type` (and therefore the `Content-Type` header `Bun.serve` emits for a `Bun.file()` response) was charset-less for `.md`, `.csv`, `.ics`, `.yaml`, `.vcf`, `.tsv`, `.c`, `.java`, `.vtt`, etc.

Browsers opened directly against such a response decode with their default charset (often windows-1252) and render UTF-8 content as mojibake.

## Repro

```js
Bun.file("x.txt").type  // "text/plain;charset=utf-8"
Bun.file("x.md").type   // "text/markdown"            (no charset)
Bun.file("x.csv").type  // "text/csv"                 (no charset)
Bun.file("x.ics").type  // "text/calendar"            (no charset)
```

## Fix

In the `Compact::to_mime_type` fallthrough, prefix-match `text/` on the table value and append `;charset=utf-8` when no parameter is already present. This matches `mime-types` / express / `send`, which default every `text/*` subtype to UTF-8.

Non-`text/*` types (`application/wasm`, `image/svg+xml`, `application/pdf`, ...) are unchanged. `application/xml` and `application/manifest+json` are left alone for now; those need a per-type table (mime-db carries explicit `charset` entries for them) rather than a prefix rule.

### `slice()` inheritance

The promoted `text/*` values are `Cow::Owned`, which `BlobContentType::from_mime` maps to the `Owned` variant. `get_slice_from` previously only inherited a parent's `content_type` when it was `Static`, so `Bun.file("a.md").slice(0, 5).type` would have regressed to `""`. The guard now checks for a non-empty parent type regardless of variant. As a side effect `new Blob(["x"], {type: "custom/mimetype"}).slice(0, 3).type` now returns `"custom/mimetype"` instead of `""`; previously a `{type: "text/plain"}` blob inherited (table hit, `Static`) while a `{type: "custom/x"}` blob did not (table miss, `Owned`), so this makes the two consistent.

The existing `#6507` assertion for `Bun.file("test", {type: "text/markdown"}).type` is updated to `"text/markdown;charset=utf-8"`; that path was already returning `"text/plain;charset=utf-8"` for `{type: "text/plain"}`, so this makes the known-`text/*` behaviour consistent rather than dependent on which five subtypes happened to be special-cased.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/util/file-type.test.ts
 1 pass  3 fail
$ bun bd test test/js/bun/util/file-type.test.ts
 4 pass  0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/file-type.test.ts
bun test v1.4.0 (0a327adf6)

test/js/bun/util/file-type.test.ts:
 7 |     const file = Bun.file("test", {
 8 |       type: "text/markdown",
 9 |     });
10 |     // Known `text/*` values are normalized to carry the UTF-8 charset,
11 |     // matching how `text/plain` and `text/css` already behave.
12 |     expect(file.type).toBe("text/markdown;charset=utf-8");
                           ^
error: expect(received).toBe(expected)

Expected: "text/markdown;charset=utf-8"
Received: "text/markdown"

      at <anonymous> (/workspace/bun/test/js/bun/util/file-type.test.ts:12:23)
(fail) util file tests > custom set mime-type respected (#6507) [25.69ms]
(pass) util file tests > mime-type is text/css;charset=utf-8 [2.99ms]
49 |       "a.svg": "image/svg+xml",
50 |       "a.png": "image/png",
51 |       "a.pdf": "application/pdf",
52 |     };
53 |     const actual = Object.fromEntries(Object.keys(cases).map(name => [name, Bun.file(name).type]));
54 |     expect(actual).toEqual(cases);
                        ^
er
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e3cfb9ebc)

test/js/bun/util/file-type.test.ts:
(pass) util file tests > custom set mime-type respected (#6507) [3.73ms]
(pass) util file tests > mime-type is text/css;charset=utf-8 [0.05ms]
(pass) util file tests > every text/* extension-derived type carries ;charset=utf-8 [0.17ms]
(pass) util file tests > slice() inherits the parent's non-empty type [1.69ms]

 4 pass
 0 fail
 5 expect() calls
Ran 4 tests across 1 file. [187.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/file-type.test.ts
bun test v1.4.0 (0a327adf6)

test/js/bun/util/file-type.test.ts:
(pass) util file tests > custom set mime-type respected (#6507) [24.11ms]
(pass) util file tests > mime-type is text/css;charset=utf-8 [3.63ms]
(pass) util file tests > every text/* extension-derived type carries ;charset=utf-8 [14.83ms]
(pass) util file tests > slice() inherits the parent's non-empty type [28.68ms]

 4 pass
 0 fail
 5 expect() calls
Ran 4 tests across 1 file. [2.15s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 656ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_types/MimeType.rs         | 21 ++++++++++++-
 src/runtime/webcore/Blob.rs        |  9 +++---
 test/js/bun/util/file-type.test.ts | 62 +++++++++++++++++++++++++++++++++++++-
 3 files changed, 86 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/http_types/MimeType.rs              1      1      0
src/runtime/webcore/Blob.rs             5      1      0
test/js/bun/util/file-type.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->