### PR TITLE
Bun.serve: send a Blob body's declared Content-Type verbatim

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4540,7 +4540,17 @@ fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (Mime
         }
 
         if !blob.content_type().is_empty() {
-            bun_http_types::MimeType::by_name(blob.content_type())
+            // Emit the blob's declared type verbatim. `by_name` classifies the
+            // essence for `.category` but may return a canonical table const
+            // whose `.value` rewrites the parameters (e.g. forcing
+            // `;charset=utf-8`); keep the declared string so the wire matches
+            // `response.headers.get("content-type")`.
+            let ct = blob.content_type();
+            let mut mt = bun_http_types::MimeType::by_name(ct);
+            if mt.value.as_ref() != ct {
+                mt.value = ct.to_vec().into();
+            }
+            mt
         } else if let Some(content) = bun_http_types::MimeType::sniff(blob.slice()) {
             content
         } else if blob.was_string() {

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -160,3 +160,49 @@ describe("response Connection: close closes the socket", () => {
     }
   });
 });
+
+// The Content-Type on the wire must be the body's declared type string, not a
+// re-canonicalized entry from Bun's MIME table. Previously a Blob typed
+// "text/html; charset=utf-16" was sent as "text/html;charset=utf-8", silently
+// replacing the declared charset.
+test("Blob body Content-Type is sent verbatim", async () => {
+  const cases: Record<string, () => Response> = {
+    "blob-utf16": () => new Response(new Blob(["<b>x</b>"], { type: "text/html; charset=utf-16" })),
+    "blob-latin1": () => new Response(new Blob(["\xe9"], { type: "text/plain; charset=iso-8859-1" })),
+    "blob-param": () => new Response(new Blob(["b"], { type: "application/octet-stream; foo=bar" })),
+    "blob-json": () => new Response(new Blob(["{}"], { type: "application/json; charset=utf-16" })),
+    "file-utf16": () => new Response(new File(["<b>x</b>"], "x.bin", { type: "text/html; charset=utf-16" })),
+    // non-table essence already passed through untouched; keep as a control
+    "control-nontable": () =>
+      new Response(new Blob(["b"], { type: "application/vnd.api+json; charset=utf-16" })),
+  };
+
+  using server = Bun.serve({
+    port: 0,
+    development: false,
+    fetch(req) {
+      return cases[new URL(req.url).pathname.slice(1)]();
+    },
+  });
+
+  const norm = (s: string | null) => (s ?? "").toLowerCase().replace(/\s+/g, "");
+  const results: Record<string, { declared: string; wire: string }> = {};
+  for (const k of Object.keys(cases)) {
+    const declared = norm(cases[k]().headers.get("content-type"));
+    const r = await fetch(new URL("/" + k, server.url));
+    await r.arrayBuffer();
+    results[k] = { declared, wire: norm(r.headers.get("content-type")) };
+  }
+
+  expect(results).toEqual({
+    "blob-utf16": { declared: "text/html;charset=utf-16", wire: "text/html;charset=utf-16" },
+    "blob-latin1": { declared: "text/plain;charset=iso-8859-1", wire: "text/plain;charset=iso-8859-1" },
+    "blob-param": { declared: "application/octet-stream;foo=bar", wire: "application/octet-stream;foo=bar" },
+    "blob-json": { declared: "application/json;charset=utf-16", wire: "application/json;charset=utf-16" },
+    "file-utf16": { declared: "text/html;charset=utf-16", wire: "text/html;charset=utf-16" },
+    "control-nontable": {
+      declared: "application/vnd.api+json;charset=utf-16",
+      wire: "application/vnd.api+json;charset=utf-16",
+    },
+  });
+});

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -173,8 +173,7 @@ test("Blob body Content-Type is sent verbatim", async () => {
     "blob-json": () => new Response(new Blob(["{}"], { type: "application/json; charset=utf-16" })),
     "file-utf16": () => new Response(new File(["<b>x</b>"], "x.bin", { type: "text/html; charset=utf-16" })),
     // non-table essence already passed through untouched; keep as a control
-    "control-nontable": () =>
-      new Response(new Blob(["b"], { type: "application/vnd.api+json; charset=utf-16" })),
+    "control-nontable": () => new Response(new Blob(["b"], { type: "application/vnd.api+json; charset=utf-16" })),
   };
 
   using server = Bun.serve({


### PR DESCRIPTION
## What

When a `Response` body is a `Blob`/`File` whose declared `type` has an essence in Bun's MIME table (`text/html`, `text/plain`, `application/json`, `application/octet-stream`, ...), `Bun.serve` rewrote the wire `Content-Type` to the canonical table string: declared parameters were dropped and text types were forced to `charset=utf-8`. The `Response` object's own `headers.get("content-type")` still reported the declared value, so the object and the wire disagreed.

```js
const s = Bun.serve({
  port: 0,
  fetch: () => new Response(new Blob(["<b>x</b>"], { type: "text/html; charset=utf-16" })),
});
const r = await fetch(s.url);
console.log(r.headers.get("content-type"));
// before: "text/html;charset=utf-8"   (charset silently replaced)
// after:  "text/html; charset=utf-16"
```

Node/undici and the Fetch spec send the declared type verbatim. Non-table essences (`application/vnd.api+json; ...`, `multipart/mixed; boundary=...`) were already passed through unchanged, and an explicit `Content-Type` in the `headers` init always won; both of those remain the same.

## Cause

`get_content_type` in `src/runtime/server/RequestContext.rs` handed `blob.content_type()` to `MimeType::by_name`, which classifies the essence but returns one of the canonical `pub const` entries (`HTML` = `"text/html;charset=utf-8"` etc.) for recognised types. `render_metadata` then wrote that constant's `.value` to the wire instead of the blob's declared string.

## Fix

Keep the `by_name` lookup for `.category` (still used by `autoset_filename`) but override `.value` with the blob's declared string whenever the table lookup returned something different, so the wire header matches `response.headers.get("content-type")`.

## Verification

New test in `test/js/bun/http/bun-serve-headers.test.ts` covers `text/html; charset=utf-16`, `text/plain; charset=iso-8859-1`, `application/octet-stream; foo=bar`, `application/json; charset=utf-16`, a `File` body, and a non-table control. Fails on main (`wire` shows the rewritten table string for 5/6 cases), passes with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.0 (e844173ce)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [609.77ms]
(pass) response Connection: close closes the socket > string body [427.76ms]
(pass) response Connection: close closes the socket > case-insensitive value [70.63ms]
(pass) response Connection: close closes the socket > token list [65.82ms]
(pass) response Connection: close closes the socket > streaming body [77.24ms]
(pass) response Connection: close closes the socket > keep-alive still the default [74.12ms]
191 |     const r = await fetch(new URL("/" + k, server.url));
192 |     await r.arrayBuffer();
193 |     results[k] = { declared, wire: norm(r.headers.get("content-type")) };
194 |   }
195 | 
196 |   expect(results).toEqual({
                        ^
error: expect(received).toEqual(expected)

  {
    "blob-json": {
      "declared": "application/json;charset=utf-16",
-     "wire": "application/json;charset=utf-16",
+     "wire": "application/json;charset=utf-8",
    },
    "blob-latin1
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ee7153c54)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [10.21ms]
(pass) response Connection: close closes the socket > string body [7.62ms]
(pass) response Connection: close closes the socket > case-insensitive value [1.73ms]
(pass) response Connection: close closes the socket > token list [1.21ms]
(pass) response Connection: close closes the socket > streaming body [1.61ms]
(pass) response Connection: close closes the socket > keep-alive still the default [1.43ms]
(pass) Blob body Content-Type is sent verbatim [2.03ms]

 7 pass
 0 fail
 88 expect() calls
Ran 7 tests across 1 file. [179.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.0 (e844173ce)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [685.68ms]
(pass) response Connection: close closes the socket > string body [452.01ms]
(pass) response Connection: close closes the socket > case-insensitive value [76.35ms]
(pass) response Connection: close closes the socket > token list [72.93ms]
(pass) response Connection: close closes the socket > streaming body [82.72ms]
(pass) response Connection: close closes the socket > keep-alive still the default [77.97ms]
(pass) Blob body Content-Type is sent verbatim [118.48ms]

 7 pass
 0 fail
 88 expect() calls
Ran 7 tests across 1 file. [3.94s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1002ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/122] gen cpp.rs (cppbind)
[2/122] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/122] gen JS modules (bundle-modules)
Preprocess modules (7290ms)
Bundle modules (49ms)
Postprocesss modules (24ms)
Bundle Functions (769ms)
Generate Code (13ms)

[8.16s] Bundled "src/js" for production
  2067 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[3/121] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_libuv_sys v0.0.0 (/workspace/bun/src/libuv_sys)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs       | 12 +++++++-
 test/js/bun/http/bun-serve-headers.test.ts | 45 ++++++++++++++++++++++++++++++
 2 files changed, 56 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/server/RequestContext.rs            1      1      0
test/js/bun/http/bun-serve-headers.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->