### PR TITLE
Bun.serve, FormData: stop content-sniffing typeless Blob bodies into image/* types

### DIFF
--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -1641,4 +1641,3 @@ bun_core::comptime_string_map! {
     b"zmm" => t!("application/vnd.handheld-entertainment+xml"),
     };
 }
-

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -1642,27 +1642,3 @@ bun_core::comptime_string_map! {
     };
 }
 
-const IMAGES_HEADERS: &[(&[u8], Table)] = &[
-    (&[0x42, 0x4d], t!("image/bmp")),
-    (&[0xff, 0xd8, 0xff], t!("image/jpeg")),
-    (&[0x49, 0x49, 0x2a, 0x00], t!("image/tiff")),
-    (&[0x4d, 0x4d, 0x00, 0x2a], t!("image/tiff")),
-    (&[0x47, 0x49, 0x46, 0x38, 0x39, 0x61], t!("image/gif")),
-    (
-        &[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
-        t!("image/png"),
-    ),
-];
-
-pub fn sniff(bytes: &[u8]) -> Option<MimeType> {
-    if bytes.len() < 2 {
-        return None;
-    }
-
-    for (header, table) in IMAGES_HEADERS {
-        if bytes.len() >= header.len() && &bytes[0..header.len()] == *header {
-            return Some(Compact::from(*table).to_mime_type());
-        }
-    }
-    None
-}

--- a/src/http_types/lib.rs
+++ b/src/http_types/lib.rs
@@ -13,7 +13,7 @@ pub use ETag::wtf;
 
 // `mime_type_list_enum::MimeTypeList` is a hand-generated `&'static str`
 // newtype (PERF: stand-in for a packed-u14 table), so
-// `Table`/`Compact`/`EXTENSIONS`/`sniff`/`from_table`/`create_hash_table`/`ALL`
+// `Table`/`Compact`/`EXTENSIONS`/`from_table`/`create_hash_table`/`ALL`
 // all compile.
 pub mod MimeType;
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4705,10 +4705,7 @@ fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (Mime
             }
         }
 
-        // No Content-Type header on the Response. Per Fetch "extract a body",
-        // only a string body and a Blob with a non-empty `type` contribute a
-        // Content-Type; BufferSource and empty-type Blob/File yield none.
-        // Bun.file()/S3 carry their extension-derived mime on the Blob itself.
+        // Fetch "extract a body": BufferSource and empty-type Blob yield no type.
         match blob {
             AnyBlob::WTFStringImpl(_) => bun_http_types::MimeType::TEXT,
             AnyBlob::InternalBlob(ib) if ib.was_string => bun_http_types::MimeType::TEXT,

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3713,10 +3713,6 @@ where
         }
 
         if needs_content_type
-            // do not insert the content type if it is the fallback value
-            // we may not know the content-type when streaming
-            && (!self.blob.is_detached()
-                || content_type.value.as_ptr() != bun_http_types::MimeType::OTHER.value.as_ptr())
             && !content_type
                 .value
                 .iter()
@@ -4709,16 +4705,24 @@ fn get_content_type(headers: Option<&mut FetchHeaders>, blob: &AnyBlob) -> (Mime
             }
         }
 
-        if !blob.content_type().is_empty() {
-            bun_http_types::MimeType::by_name(blob.content_type())
-        } else if let Some(content) = bun_http_types::MimeType::sniff(blob.slice()) {
-            content
-        } else if blob.was_string() {
-            bun_http_types::MimeType::TEXT
-            // TODO: should we get the mime type off of the Blob.Store if it exists?
-            // A little wary of doing this right now due to causing some breaking change
-        } else {
-            bun_http_types::MimeType::OTHER
+        // No Content-Type header on the Response. Per Fetch "extract a body",
+        // only a string body and a Blob with a non-empty `type` contribute a
+        // Content-Type; BufferSource and empty-type Blob/File yield none.
+        // Bun.file()/S3 carry their extension-derived mime on the Blob itself.
+        match blob {
+            AnyBlob::WTFStringImpl(_) => bun_http_types::MimeType::TEXT,
+            AnyBlob::InternalBlob(ib) if ib.was_string => bun_http_types::MimeType::TEXT,
+            AnyBlob::Blob(b) => match b.content_type_or_mime_type() {
+                Some(ct) if !ct.is_empty() => bun_http_types::MimeType::by_name(ct),
+                _ => {
+                    needs_content_type = false;
+                    bun_http_types::MimeType::OTHER
+                }
+            },
+            AnyBlob::InternalBlob(_) => {
+                needs_content_type = false;
+                bun_http_types::MimeType::OTHER
+            }
         }
     };
 

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -300,7 +300,7 @@ pub fn for_each_multipart_entry<C>(
         let mut filename: Option<bun_semver::String> = None;
         let mut header_chunk = header;
         let mut is_file = false;
-        while !header_chunk.is_empty() && (filename.is_none() || name.len() == 0) {
+        while !header_chunk.is_empty() {
             let line_end = strings::index_of(header_chunk, b"\r\n")
                 .ok_or(crate::Error::IsMissingHeaderLineEnd)?;
             let line = &header_chunk[..line_end];

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -200,24 +200,16 @@ pub fn to_js_from_multipart_data(
                     blob.content_type
                         .set(crate::webcore::blob::BlobContentType::Owned(ct.into()));
                     blob.content_type_was_set.set(true);
-                } else {
-                    let mime = 'brk: {
-                        if !filename_str.is_empty() {
-                            let extension = bun_paths::extension(filename_str);
-                            if !extension.is_empty() {
-                                if let Some(m) =
-                                    bun_http::MimeType::by_extension_no_default(&extension[1..])
-                                {
-                                    break 'brk Some(m);
-                                }
-                            }
+                } else if !filename_str.is_empty() {
+                    let extension = bun_paths::extension(filename_str);
+                    if !extension.is_empty() {
+                        if let Some(mime) =
+                            bun_http::MimeType::by_extension_no_default(&extension[1..])
+                        {
+                            blob.content_type
+                                .set(crate::webcore::blob::BlobContentType::from(mime));
+                            blob.content_type_was_set.set(false);
                         }
-                        bun_http::MimeType::sniff(value_str)
-                    };
-                    if let Some(mime) = mime {
-                        blob.content_type
-                            .set(crate::webcore::blob::BlobContentType::from(mime));
-                        blob.content_type_was_set.set(false);
                     }
                 }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2066,6 +2066,48 @@ it("does propagate type for Blob", async () => {
   expect(res.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
 });
 
+describe("response Content-Type is only sent when the body contributes one", () => {
+  // Fetch "extract a body" assigns no type to BufferSource or a Blob whose
+  // own type is empty. Node/undici send no Content-Type for these; Bun.serve
+  // should not fabricate one either so the wire header matches `response.headers`.
+  const bin = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0, 1]);
+  const cases: Record<string, [() => Response, string | null]> = {
+    arraybuffer: [() => new Response(bin.buffer.slice(0)), null],
+    uint8array: [() => new Response(bin.slice()), null],
+    dataview: [() => new Response(new DataView(bin.buffer.slice(0))), null],
+    "typeless-blob-bytes": [() => new Response(new Blob([bin])), null],
+    "typeless-blob-string": [() => new Response(new Blob(["<html><b>x</b></html>"])), null],
+    "typeless-file": [() => new Response(new File([bin], "upload")), null],
+    "typeless-blob-empty": [() => new Response(new Blob([])), null],
+    // body kinds that do carry a type must keep sending it:
+    string: [() => new Response("<html><b>x</b></html>"), "text/plain;charset=utf-8"],
+    "typed-blob": [() => new Response(new Blob([bin], { type: "image/png" })), "image/png"],
+    "typed-blob-empty": [
+      () => new Response(new Blob([], { type: "application/octet-stream" })),
+      "application/octet-stream",
+    ],
+    "explicit-header": [
+      () => new Response(bin.slice(), { headers: { "content-type": "application/custom" } }),
+      "application/custom",
+    ],
+  };
+
+  it.each(Object.keys(cases))("%s", async name => {
+    const [make, expected] = cases[name];
+    using server = Bun.serve({ port: 0, development: false, fetch: () => make() });
+    const res = await fetch(server.url);
+    await res.arrayBuffer();
+    if (expected === null) {
+      expect({
+        object: make().headers.get("Content-Type"),
+        wire: res.headers.get("Content-Type"),
+      }).toEqual({ object: null, wire: null });
+    } else {
+      expect(res.headers.get("Content-Type")).toBe(expected);
+    }
+  });
+});
+
 it("unix socket connection in Bun.serve", async () => {
   const unix = join(tmpdir(), "bun." + Date.now() + ((Math.random() * 32) | 0).toString(16) + ".sock");
   using server = Bun.serve({

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2084,7 +2084,8 @@ describe("response Content-Type is only sent when the body contributes one", () 
     "typeless-blob-bmp-prefix-prose": [() => new Response(new Blob(["BMW rocks, and other prose"])), null],
     "typeless-blob-gif-prefix-prose": [() => new Response(new Blob(["GIF89a; not an image, just text"])), null],
     "typeless-file-png-magic-as-txt": [
-      () => new Response(new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 9, 9])], "readme.txt")),
+      () =>
+        new Response(new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 9, 9])], "readme.txt")),
       null,
     ],
     // body kinds that do carry a type must keep sending it:

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2079,6 +2079,14 @@ describe("response Content-Type is only sent when the body contributes one", () 
     "typeless-blob-string": [() => new Response(new Blob(["<html><b>x</b></html>"])), null],
     "typeless-file": [() => new Response(new File([bin], "upload")), null],
     "typeless-blob-empty": [() => new Response(new Blob([])), null],
+    // Text whose leading bytes collide with an image magic number must not be
+    // content-sniffed into an image/* type (previously: image/bmp, image/gif, image/png).
+    "typeless-blob-bmp-prefix-prose": [() => new Response(new Blob(["BMW rocks, and other prose"])), null],
+    "typeless-blob-gif-prefix-prose": [() => new Response(new Blob(["GIF89a; not an image, just text"])), null],
+    "typeless-file-png-magic-as-txt": [
+      () => new Response(new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 9, 9])], "readme.txt")),
+      null,
+    ],
     // body kinds that do carry a type must keep sending it:
     string: [() => new Response("<html><b>x</b></html>"), "text/plain;charset=utf-8"],
     "typed-blob": [() => new Response(new Blob([bin], { type: "image/png" })), "image/png"],

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -136,7 +136,7 @@ describe("multipart serialization (new Response(formData))", () => {
       ["dup", "first"],
       ["dup", "second"],
       ["unicode name ☺", "ünïcode välue 😊"],
-      ["blob", { file: true, name: undefined, type: "", text: "blob-bytes" }],
+      ["blob", { file: true, name: undefined, type: "application/octet-stream", text: "blob-bytes" }],
       ["file", { file: true, name: "日本語ファイル名.html", type: "text/html;charset=utf-8", text: "<p>hi</p>" }],
     ]);
   });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -895,6 +895,11 @@ it("drops multipart part Content-Type values containing control characters", asy
     'Content-Disposition: form-data; name="tabbed"; filename="tabbed.txt"\r\n' +
     "\r\n" +
     "tabbed\r\n" +
+    "--formboundary\r\n" +
+    'Content-Disposition: form-data; name="stdorder"; filename="stdorder.bin"\r\n' +
+    "Content-Type: application/pdf\r\n" +
+    "\r\n" +
+    "ordered\r\n" +
     "--formboundary--\r\n";
 
   const response = new Response(body, {
@@ -921,6 +926,12 @@ it("drops multipart part Content-Type values containing control characters", asy
   expect(tabbed instanceof Blob).toBe(true);
   expect(await tabbed.text()).toBe("tabbed");
   expect(tabbed.type).toBe("text/plain;\tcharset=utf-8");
+
+  // Content-Type after Content-Disposition (the order browsers/curl/undici emit).
+  const stdorder = formData.get("stdorder") as File;
+  expect(stdorder instanceof Blob).toBe(true);
+  expect(await stdorder.text()).toBe("ordered");
+  expect(stdorder.type).toBe("application/pdf");
 });
 
 it("does not content-sniff multipart file parts that have no Content-Type header", async () => {
@@ -935,8 +946,9 @@ it("does not content-sniff multipart file parts that have no Content-Type header
     part("bmp", "notes", "BM: buy milk") +
     part("gif", "journal", "GIF89a; not an image, just text") +
     part("png", "x.unknownzz", "\x89PNG\r\n\x1a\nzz") +
-    // Control: an explicit part Content-Type is still honored.
-    `--${boundary}\r\nContent-Type: application/pdf\r\nContent-Disposition: form-data; name="typed"; filename="typed.bin"\r\n\r\nBM: typed\r\n` +
+    // Control: an explicit part Content-Type is still honored, in the standard
+    // Content-Disposition-before-Content-Type order real clients emit.
+    `--${boundary}\r\nContent-Disposition: form-data; name="typed"; filename="typed.bin"\r\nContent-Type: application/pdf\r\n\r\nBM: typed\r\n` +
     `--${boundary}--\r\n`;
 
   const formData = await new Response(Buffer.from(body, "latin1"), {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -923,6 +923,40 @@ it("drops multipart part Content-Type values containing control characters", asy
   expect(tabbed.type).toBe("text/plain;\tcharset=utf-8");
 });
 
+it("does not content-sniff multipart file parts that have no Content-Type header", async () => {
+  // A file part with no Content-Type header must not have its `type` derived
+  // from magic bytes in its body. Node/undici leave the type as the sender
+  // declared (here: absent); an "image/*" verdict from a two-byte prefix of
+  // prose is wrong and disagrees with the wire.
+  const boundary = "----formdatanosniff";
+  const part = (name: string, filename: string, body: string) =>
+    `--${boundary}\r\nContent-Disposition: form-data; name="${name}"; filename="${filename}"\r\n\r\n${body}\r\n`;
+  const body =
+    part("bmp", "notes", "BM: buy milk") +
+    part("gif", "journal", "GIF89a; not an image, just text") +
+    part("png", "x.unknownzz", "\x89PNG\r\n\x1a\nzz") +
+    // Control: an explicit part Content-Type is still honored.
+    `--${boundary}\r\nContent-Type: application/pdf\r\nContent-Disposition: form-data; name="typed"; filename="typed.bin"\r\n\r\nBM: typed\r\n` +
+    `--${boundary}--\r\n`;
+
+  const formData = await new Response(Buffer.from(body, "latin1"), {
+    headers: { "Content-Type": `multipart/form-data; boundary=${boundary}` },
+  }).formData();
+
+  expect({
+    bmp: (formData.get("bmp") as File).type,
+    gif: (formData.get("gif") as File).type,
+    png: (formData.get("png") as File).type,
+    typed: (formData.get("typed") as File).type,
+  }).toEqual({
+    bmp: "",
+    gif: "",
+    png: "",
+    typed: "application/pdf",
+  });
+  expect(await (formData.get("bmp") as File).text()).toBe("BM: buy milk");
+});
+
 test("FormData.toJSON merges duplicate numeric field names into an array", async () => {
   // Field names that parse as array indices ("0", "1", ...) are stored as indexed
   // properties on the serialized object; appending the same numeric name more than


### PR DESCRIPTION
## What

Bun content-sniffed typeless `Blob`/`File` bodies against a table of image magic bytes (`BM`, JPEG, TIFF, `GIF89a`, PNG) in two places: the `Bun.serve` response path and the `multipart/form-data` parser. Neither Node/undici nor the Fetch spec sniffs; both leave the type as the caller declared.

**Bun.serve (wire Content-Type).** A typeless Blob whose bytes start with `BM` was served as `image/bmp`:

```js
// new Response(new Blob(["BMW rocks, and other prose"]))
//   -> response.headers.get("content-type") === null   (object)
//   -> wire Content-Type: image/bmp                     (sniffed)
// new Response(new File([pngBytes], "readme.txt"))
//   -> wire Content-Type: image/png
```

More generally, `Bun.serve` wrote a `Content-Type` on the wire for response bodies that per [Fetch "extract a body"](https://fetch.spec.whatwg.org/#concept-bodyinit-extract) carry none (`BufferSource`, typeless `Blob`/`File`), so the `Response` object's headers (`null`) and the wire header disagreed.

**`Response.prototype.formData()` (parsed File type).** A multipart file part with no `Content-Type` header and no recognised filename extension had its `type` derived from its body:

```js
// part: name="notes"; filename="notes"; body "BM: buy milk"
//   -> formData.get("notes").type === "image/bmp"   (was; now "")
```

Node and undici yield `"text/plain"` (the RFC 7578 default) or `""`; they never inspect the bytes.

## Why

`get_content_type` in `RequestContext.rs` fell through `MimeType::sniff(blob.slice())` before the string/fallback branches, so a two-byte prefix of prose (`"BMW..."`) was enough to classify it as `image/bmp`. The multipart parser in `FormData.rs` used the same `MimeType::sniff` as its last-resort fallback. The static-route path (`StaticRoute::init_from_any_blob`) already skipped both by honouring only `has_content_type_from_user()`.

## How

`get_content_type` now matches on the `AnyBlob` variant: string bodies get `TEXT`; a `Blob` uses `content_type_or_mime_type()` so `Bun.file`/S3 keep their extension-derived type; `BufferSource` and typeless `Blob`/`File` set `needs_content_type = false` so no header is written. The detached-fallback guard at the write site is gone because the function itself no longer fabricates. The multipart parser drops the sniff; a part with no `Content-Type` header and no recognised extension yields an empty `type`. `MimeType::sniff` is removed now that both callers are gone.

## Testing

`test/js/bun/http/serve.test.ts` covers all typeless body kinds, the three sniff-triggering prefixes (`BM`, `GIF89a`, PNG magic), and positive controls (string body, typed `Blob`, explicit header). `test/js/web/html/FormData.test.ts` covers multipart parts whose bodies carry each image magic-byte prefix and a control with an explicit part `Content-Type`.

```sh
USE_SYSTEM_BUN=1 bun test test/js/bun/http/serve.test.ts -t "response Content-Type is only sent"      # 10 fail
bun bd test         test/js/bun/http/serve.test.ts -t "response Content-Type is only sent"            # 14 pass
USE_SYSTEM_BUN=1 bun test test/js/web/html/FormData.test.ts -t "does not content-sniff"               # 1 fail (image/bmp, image/gif, image/png)
bun bd test         test/js/web/html/FormData.test.ts -t "does not content-sniff"                     # 1 pass
```

Fixes #21193

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts test/js/web/html/FormData-multipart-serialization.test.ts

<!-- robobun:evidence:end -->
Fixes #33012