### PR TITLE
tls: don't let NODE_TLS_REJECT_UNAUTHORIZED=0 weaken a server's rejectUnauthorized default

### DIFF
--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -73,7 +73,8 @@ impl SecureContext {
 
         // SAFETY: `bun_vm()` returns the live per-global VM pointer; valid for the call.
         let vm = global.bun_vm().as_mut();
-        let config = SSLConfig::from_js(vm, global, opts)?.unwrap_or_else(SSLConfig::zero);
+        // A SecureContext carries no client/server role; keep the client default.
+        let config = SSLConfig::from_js(vm, global, opts, false)?.unwrap_or_else(SSLConfig::zero);
         // `defer config.deinit()` — handled by Drop.
 
         SecureContext::create(global, &config)
@@ -231,7 +232,8 @@ impl SecureContext {
 
         // SAFETY: `bun_vm()` returns the live per-global VM pointer; valid for the call.
         let vm = global.bun_vm().as_mut();
-        let config = SSLConfig::from_js(vm, global, opts)?.unwrap_or_else(SSLConfig::zero);
+        // A SecureContext carries no client/server role; keep the client default.
+        let config = SSLConfig::from_js(vm, global, opts, false)?.unwrap_or_else(SSLConfig::zero);
         // `defer config.deinit()` — handled by Drop.
 
         let ctx_opts = config.as_usockets();
@@ -271,7 +273,8 @@ impl SecureContext {
 
         // SAFETY: `bun_vm()` returns the live per-global VM pointer; valid for the call.
         let vm = global.bun_vm().as_mut();
-        let config = SSLConfig::from_js(vm, global, opts)?.unwrap_or_else(SSLConfig::zero);
+        // A SecureContext carries no client/server role; keep the client default.
+        let config = SSLConfig::from_js(vm, global, opts, false)?.unwrap_or_else(SSLConfig::zero);
         // `defer config.deinit()` — handled by Drop.
 
         let ctx_opts = config.as_usockets();

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -234,7 +234,7 @@ mod sql_hooks {
     }
     unsafe fn ssl_config_from_js(global: &JSGlobalObject, value: JSValue) -> *mut c_void {
         use crate::socket::SSLConfigFromJs;
-        match crate::socket::SSLConfig::from_js(global.bun_vm_ref(), global, value) {
+        match crate::socket::SSLConfig::from_js(global.bun_vm_ref(), global, value, false) {
             Ok(Some(cfg)) => bun_core::heap::into_raw(Box::new(cfg)).cast::<c_void>(),
             Ok(None) => core::ptr::null_mut(),
             Err(bun_jsc::JsError::OutOfMemory) => {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1249,7 +1249,7 @@ impl ServerConfig {
                     // Empty TLS array means no TLS - this is valid
                 } else {
                     while let Some(item) = value_iter.next()? {
-                        let Some(ssl_config) = SSLConfig::from_js(vm, global, item)? else {
+                        let Some(ssl_config) = SSLConfig::from_js(vm, global, item, true)? else {
                             // Backwards-compatibility; we ignored empty tls objects.
                             continue;
                         };
@@ -1272,7 +1272,7 @@ impl ServerConfig {
                     }
                 }
             } else {
-                if let Some(ssl_config) = SSLConfig::from_js(vm, global, tls)? {
+                if let Some(ssl_config) = SSLConfig::from_js(vm, global, tls, true)? {
                     args.ssl_config = Some(ssl_config);
                 }
             }
@@ -1281,7 +1281,7 @@ impl ServerConfig {
         // @compatibility Bun v0.x - v0.2.1
         // this used to be top-level, now it's "tls" object
         if args.ssl_config.is_none() {
-            if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg)? {
+            if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg, true)? {
                 args.ssl_config = Some(ssl_config);
             }
         }

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -492,12 +492,14 @@ impl SocketConfig {
                 GeneratedTls::None => None,
                 GeneratedTls::Boolean(b) => {
                     if *b {
-                        Some(super::tls_true_defaults(vm))
+                        Some(super::tls_true_defaults(vm, mode.is_server()))
                     } else {
                         None
                     }
                 }
-                GeneratedTls::Object(ssl) => SSLConfig::from_generated(vm, global, ssl)?,
+                GeneratedTls::Object(ssl) => {
+                    SSLConfig::from_generated(vm, global, ssl, mode.is_server())?
+                }
             };
             break 'blk SocketConfig {
                 hostname_or_unix: Utf8Bytes::EMPTY,

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -760,7 +760,7 @@ impl Listener {
         } else if let Some(ssl_config) = {
             // SAFETY: per-thread VM; valid for program lifetime.
             let vm = VirtualMachine::get().as_mut();
-            SSLConfig::from_js(vm, global, tls)?
+            SSLConfig::from_js(vm, global, tls, true)?
         } {
             // Note: `cfg` cleanup handled by Drop on SSLConfig
             let mut create_err = uws::create_bun_socket_error_t::none;

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -121,10 +121,8 @@ fn read_from_blob(
 /// JSC-dependent constructors for the canonical `bun_http::SSLConfig`.
 /// Import this trait to call `SSLConfig::from_js(..)` / `::from_generated(..)`.
 ///
-/// `is_server` selects the default for an unset `rejectUnauthorized`:
-/// servers always default to enforcing, while clients consult
-/// `NODE_TLS_REJECT_UNAUTHORIZED` — the env var never weakens a server,
-/// matching Node.
+/// `is_server` picks the default for an unset `rejectUnauthorized`: `true`
+/// for servers, `NODE_TLS_REJECT_UNAUTHORIZED` for clients (Node semantics).
 pub trait SSLConfigFromJs: Sized {
     fn from_js(
         vm: &VirtualMachine,

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -120,17 +120,24 @@ fn read_from_blob(
 
 /// JSC-dependent constructors for the canonical `bun_http::SSLConfig`.
 /// Import this trait to call `SSLConfig::from_js(..)` / `::from_generated(..)`.
+///
+/// `is_server` selects the default for an unset `rejectUnauthorized`:
+/// servers always default to enforcing, while clients consult
+/// `NODE_TLS_REJECT_UNAUTHORIZED` — the env var never weakens a server,
+/// matching Node.
 pub trait SSLConfigFromJs: Sized {
     fn from_js(
         vm: &VirtualMachine,
         global: &JSGlobalObject,
         value: JSValue,
+        is_server: bool,
     ) -> JsResult<Option<Self>>;
 
     fn from_generated(
         vm: &VirtualMachine,
         global: &JSGlobalObject,
         generated: &jsc::generated::SSLConfig,
+        is_server: bool,
     ) -> JsResult<Option<Self>>;
 }
 
@@ -139,16 +146,18 @@ impl SSLConfigFromJs for SSLConfig {
         vm: &VirtualMachine,
         global: &JSGlobalObject,
         value: JSValue,
+        is_server: bool,
     ) -> JsResult<Option<SSLConfig>> {
         let generated = jsc::generated::SSLConfig::from_js(global, value)?;
         // `generated` dropped at scope exit
-        Self::from_generated(vm, global, &generated)
+        Self::from_generated(vm, global, &generated, is_server)
     }
 
     fn from_generated(
         vm: &VirtualMachine,
         global: &JSGlobalObject,
         generated: &jsc::generated::SSLConfig,
+        is_server: bool,
     ) -> JsResult<Option<SSLConfig>> {
         let mut result = SSLConfig::zero();
         // `result` cleanup handled by Drop on error-path `?`
@@ -170,7 +179,7 @@ impl SSLConfigFromJs for SSLConfig {
         result.low_memory_mode = generated.low_memory_mode;
         result.reject_unauthorized = generated
             .reject_unauthorized
-            .unwrap_or_else(|| vm.get_tls_reject_unauthorized())
+            .unwrap_or_else(|| is_server || vm.get_tls_reject_unauthorized())
             as i32;
         result.request_cert = generated.request_cert as i32;
         result.secure_options = generated.secure_options;
@@ -268,9 +277,9 @@ impl SSLConfigFromJs for SSLConfig {
 
 /// The `SSLConfig` for the `tls: true` shorthand: every option at its
 /// documented default, unlike `SSLConfig::zero()`.
-pub fn tls_true_defaults(vm: &VirtualMachine) -> SSLConfig {
+pub fn tls_true_defaults(vm: &VirtualMachine, is_server: bool) -> SSLConfig {
     let mut cfg = SSLConfig::zero();
-    cfg.reject_unauthorized = vm.get_tls_reject_unauthorized() as i32;
+    cfg.reject_unauthorized = (is_server || vm.get_tls_reject_unauthorized()) as i32;
     cfg
 }
 
@@ -445,7 +454,7 @@ extern "C" fn Bun__WebSocket__parseSSLConfig(
     // constructor only runs on the JS thread with an initialized VM.
     let vm = global_this.bun_vm();
     // Use SSLConfig::from_js for clean and safe parsing
-    let config_opt = match SSLConfig::from_js(vm, global_this, tls_value) {
+    let config_opt = match SSLConfig::from_js(vm, global_this, tls_value, false) {
         Ok(c) => c,
         // Exception is already set on globalThis
         Err(_) => return None,

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3465,6 +3465,7 @@ impl<const SSL: bool> NewSocket<SSL> {
                         VirtualMachine::get().as_mut(),
                         global,
                         t,
+                        is_server,
                     )?;
                 }
             }
@@ -3475,9 +3476,10 @@ impl<const SSL: bool> NewSocket<SSL> {
                     VirtualMachine::get().as_mut(),
                     global,
                     tls_js,
+                    is_server,
                 )?;
             } else if tls_js.to_boolean() {
-                ssl_opts = Some(crate::socket::tls_true_defaults(handlers.vm));
+                ssl_opts = Some(crate::socket::tls_true_defaults(handlers.vm, is_server));
             }
             let cfg = ssl_opts
                 .as_mut()
@@ -4629,9 +4631,9 @@ pub fn js_upgrade_duplex_to_tls(
     // Drop frees ssl_opts on error.
     if let Some(tls) = opts.get_truthy(global, "tls")? {
         if !tls.is_boolean() {
-            ssl_opts = SSLConfig::from_js(handlers.vm, global, tls)?;
+            ssl_opts = SSLConfig::from_js(handlers.vm, global, tls, is_server)?;
         } else if tls.to_boolean() {
-            ssl_opts = Some(crate::socket::tls_true_defaults(handlers.vm));
+            ssl_opts = Some(crate::socket::tls_true_defaults(handlers.vm, is_server));
         }
     }
     if owned_ctx.is_none() && ssl_opts.is_none() {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1932,7 +1932,7 @@ impl Options {
             } else if tls.is_object() {
                 // SAFETY: `bun_vm()` returns the live per-global VM pointer.
                 if let Some(ssl_config) =
-                    SSLConfig::from_js(global_object.bun_vm(), global_object, tls)?
+                    SSLConfig::from_js(global_object.bun_vm(), global_object, tls, false)?
                 {
                     this.tls = valkey::TLS::Custom(Box::new(ssl_config));
                 } else {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -665,7 +665,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             }
                         }
 
-                        if let Some(config) = SSLConfig::from_js(vm, global_this, tls)? {
+                        if let Some(config) = SSLConfig::from_js(vm, global_this, tls, false)? {
                             // Intern via `ssl_config::global_registry` for dedup and pointer equality
                             break 'extract_ssl_config Some(ssl_config_intern_for_http(config));
                         }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -3748,6 +3748,94 @@ Reo=
       expect(t.serverReceived.join("")).toBe("client-app-data\n");
     });
   });
+
+  // https://github.com/oven-sh/bun/issues/35240
+  // NODE_TLS_REJECT_UNAUTHORIZED only changes the client-side default; a
+  // server with requestCert: true must keep enforcing its rejectUnauthorized
+  // default of true. The env var is read at startup, so run in a subprocess.
+  describe.concurrent("NODE_TLS_REJECT_UNAUTHORIZED=0", () => {
+    async function verdictFor(fixture: string) {
+      using dir = tempDir("tls-reject-env", { "fixture.ts": fixture });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.ts"],
+        env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout.trim();
+    }
+
+    it("does not disable the server's default requestCert enforcement", async () => {
+      const verdict = await verdictFor(`
+        const server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          // rejectUnauthorized deliberately unset: the server default is true
+          // regardless of NODE_TLS_REJECT_UNAUTHORIZED.
+          tls: { key: ${JSON.stringify(SERVER_KEY)}, cert: ${JSON.stringify(SERVER_CRT)}, ca: ${JSON.stringify(CA_CRT)}, requestCert: true },
+          socket: {
+            open() {},
+            handshake() {},
+            data(socket, chunk) { socket.write(chunk); },
+            close() {},
+            error() {},
+          },
+        });
+        await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          // rejectUnauthorized: false so the client can never close on its
+          // own; a "closed" verdict can only come from the server.
+          tls: { ca: ${JSON.stringify(CA_CRT)}, serverName: "localhost", key: ${JSON.stringify(ROGUE_KEY)}, cert: ${JSON.stringify(ROGUE_CRT)}, rejectUnauthorized: false },
+          socket: {
+            open() {},
+            handshake(socket) { socket.write("ping"); },
+            data() { console.log("stayed-open"); server.stop(true); process.exit(0); },
+            close() { console.log("closed"); server.stop(true); process.exit(0); },
+            error() {},
+            connectError(_socket, err) { console.error("connectError:", err.message); process.exit(1); },
+          },
+        });
+      `);
+      expect(verdict).toBe("closed");
+    });
+
+    it("still disables the client's default verification", async () => {
+      const verdict = await verdictFor(`
+        const server = Bun.listen({
+          hostname: "127.0.0.1",
+          port: 0,
+          tls: { key: ${JSON.stringify(ROGUE_KEY)}, cert: ${JSON.stringify(ROGUE_CRT)} },
+          socket: {
+            open() {},
+            handshake() {},
+            data(socket, chunk) { socket.write(chunk); },
+            close() {},
+            error() {},
+          },
+        });
+        await Bun.connect({
+          hostname: "127.0.0.1",
+          port: server.port,
+          // The client can't verify the server's certificate, but its unset
+          // rejectUnauthorized defaults to false via the env var.
+          tls: { ca: ${JSON.stringify(CA_CRT)}, serverName: "localhost" },
+          socket: {
+            open() {},
+            handshake(socket) { socket.write("ping"); },
+            data() { console.log("stayed-open"); server.stop(true); process.exit(0); },
+            close() { console.log("closed"); server.stop(true); process.exit(0); },
+            error() {},
+            connectError(_socket, err) { console.error("connectError:", err.message); process.exit(1); },
+          },
+        });
+      `);
+      expect(verdict).toBe("stayed-open");
+    });
+  });
 });
 
 // Linux-only: uses /proc/self/fd to find and close the connected socket's fd

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2708,8 +2708,9 @@ it("tls.createServer keeps enforcing its rejectUnauthorized default under NODE_T
     env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // stderr carries Node's one-time NODE_TLS_REJECT_UNAUTHORIZED warning.
+  expect(stderr).toContain("NODE_TLS_REJECT_UNAUTHORIZED");
   expect(JSON.parse(stdout)).toEqual({ sawSecureConnection: false });
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2671,3 +2671,45 @@ describe("pauseOnConnect", () => {
     }
   });
 });
+
+// https://github.com/oven-sh/bun/issues/35240
+it("tls.createServer keeps enforcing its rejectUnauthorized default under NODE_TLS_REJECT_UNAUTHORIZED=0", async () => {
+  // Node's Server default for an unset rejectUnauthorized is a hardcoded
+  // true; the env var only changes the tls.connect() (client) default. The
+  // env var is read when the server is built, so run in a subprocess.
+  const fixtures = join(import.meta.dir, "fixtures");
+  const script = `
+    const tls = require("node:tls");
+    const { readFileSync } = require("node:fs");
+    const key = readFileSync(${JSON.stringify(join(fixtures, "agent6-key.pem"))}, "utf8");
+    const certChain = readFileSync(${JSON.stringify(join(fixtures, "agent6-cert.pem"))}, "utf8");
+    // The server trusts no CA, so the client's certificate is unverifiable
+    // and must be rejected before 'secureConnection'.
+    let sawSecureConnection = false;
+    const server = tls.createServer({ key, cert: certChain, requestCert: true }, s => s.end());
+    server.on("secureConnection", () => { sawSecureConnection = true; });
+    server.listen(0, "127.0.0.1", () => {
+      const client = tls.connect({
+        port: server.address().port,
+        host: "127.0.0.1",
+        rejectUnauthorized: false,
+        key,
+        cert: certChain,
+      });
+      client.on("error", () => {}); // the server resets the connection
+      client.on("close", () => {
+        console.log(JSON.stringify({ sawSecureConnection }));
+        server.close();
+      });
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  // stderr carries Node's one-time NODE_TLS_REJECT_UNAUTHORIZED warning.
+  expect(JSON.parse(stdout)).toEqual({ sawSecureConnection: false });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2686,8 +2686,10 @@ it("tls.createServer keeps enforcing its rejectUnauthorized default under NODE_T
     // The server trusts no CA, so the client's certificate is unverifiable
     // and must be rejected before 'secureConnection'.
     let sawSecureConnection = false;
+    let tlsClientError = null;
     const server = tls.createServer({ key, cert: certChain, requestCert: true }, s => s.end());
     server.on("secureConnection", () => { sawSecureConnection = true; });
+    server.on("tlsClientError", err => { tlsClientError = err.code; });
     server.listen(0, "127.0.0.1", () => {
       const client = tls.connect({
         port: server.address().port,
@@ -2698,7 +2700,7 @@ it("tls.createServer keeps enforcing its rejectUnauthorized default under NODE_T
       });
       client.on("error", () => {}); // the server resets the connection
       client.on("close", () => {
-        console.log(JSON.stringify({ sawSecureConnection }));
+        console.log(JSON.stringify({ sawSecureConnection, tlsClientError }));
         server.close();
       });
     });
@@ -2711,6 +2713,11 @@ it("tls.createServer keeps enforcing its rejectUnauthorized default under NODE_T
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // stderr carries Node's one-time NODE_TLS_REJECT_UNAUTHORIZED warning.
   expect(stderr).toContain("NODE_TLS_REJECT_UNAUTHORIZED");
-  expect(JSON.parse(stdout)).toEqual({ sawSecureConnection: false });
+  // The teardown must be the certificate-verification rejection, not some
+  // unrelated handshake failure.
+  expect(JSON.parse(stdout)).toEqual({
+    sawSecureConnection: false,
+    tlsClientError: "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #35240. Fixes #35092.

`Bun.listen({ tls: { requestCert: true } })` with `rejectUnauthorized` left unset is documented to default to `true`. But the default was computed from `vm.get_tls_reject_unauthorized()`, which reads `NODE_TLS_REJECT_UNAUTHORIZED`, with no awareness of whether the config was being built for a server or a client. So setting `NODE_TLS_REJECT_UNAUTHORIZED=0` anywhere in the process (a common workaround for a self-signed cert on some unrelated outbound request) silently disabled the server's client-certificate enforcement added in #33755:

```
$ bun repro.js
handshake callback saw: {"success":true,"authorizationError":"self signed certificate","authorized":false}
RESULT: connection was REJECTED (correct)

$ NODE_TLS_REJECT_UNAUTHORIZED=0 bun repro.js
handshake callback saw: {"success":true,"authorizationError":"self signed certificate","authorized":false}
RESULT: connection stayed open (bug) - not torn down within 1500ms
```

In Node the env var only changes the client-side default; it never weakens a server.

### How does it work?

Threads the server/client role into `SSLConfig::from_js` / `from_generated` and `tls_true_defaults` (`src/runtime/socket/SSLConfig.rs`), so an unset `rejectUnauthorized` defaults to `true` for servers and to the env-var value for clients, matching how `resolve_reject_unauthorized`'s no-config branch already scopes it. This also flows into the native context options (`FAIL_IF_NO_PEER_CERT`), so the no-client-cert case is enforced too. Call sites pass their role:

- server: `Bun.listen` / `Bun.connect` via `SocketMode`, `Bun.serve` (`ServerConfig`), `upgradeTLS` / duplex upgrades via their `is_server`, `addServerName` SNI contexts
- client: `fetch`, WebSocket, SQL, valkey
- `SecureContext` (role-agnostic, `tls.createSecureContext`) keeps the client default, preserving its current behavior

An explicit `rejectUnauthorized` from the user still wins in both roles, and client defaults are unchanged.

The `node:tls` Server had the same bug one layer up (#35092): its JS-side `_rejectUnauthorized` default read the env var. The rebase onto current main dropped that part of this PR: main now hardcodes the server default to `true` (the `tls.Server` constructor rework from the #35006 follow-ups). This PR keeps the regression test for it.

### Tests

Subprocess tests with `NODE_TLS_REJECT_UNAUTHORIZED=0` (the env var is read at startup):

- `test/js/bun/net/socket.test.ts` ("TLS rejectUnauthorized" suite): a `Bun.listen` server with `requestCert: true` and `rejectUnauthorized` unset still tears down a connection with an unverifiable client cert; a `Bun.connect` client with `rejectUnauthorized` unset still skips verification (env var keeps its client-side meaning)
- `test/js/node/tls/node-tls-server.test.ts`: `tls.createServer({ requestCert: true })` with `rejectUnauthorized` unset rejects an unverifiable client cert before `secureConnection`, with `tlsClientError` carrying `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`

The `Bun.listen` enforcement test fails without the fix ("stayed-open" instead of "closed") and passes with it. After the rebase, also re-ran the TLS suites (`socket.test.ts` "TLS rejectUnauthorized", `bun-serve-ssl`, `node-tls-server`, `fetch.tls`): green.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-server.test.ts, test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->