### PR TITLE
uws: index HttpRouter children by hash instead of scanning a vector

### DIFF
--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -19,10 +19,12 @@
 #define UWS_HTTPROUTER_HPP
 
 #include <map>
+#include <unordered_map>
 #include <vector>
 #include <cstring>
 #include <string_view>
 #include <string>
+#include <functional>
 #include <algorithm>
 #include <memory>
 #include <utility>
@@ -53,15 +55,49 @@ private:
     std::string_view urlSegmentVector[MAX_URL_SEGMENTS] = {};
     int urlSegmentTop = -1;
 
-    /* The matching tree */
+    /* Transparent hash so find() accepts std::string_view without allocating */
+    struct StringViewHash {
+        using is_transparent = void;
+        size_t operator()(std::string_view s) const noexcept { return std::hash<std::string_view>{}(s); }
+        size_t operator()(const std::string &s) const noexcept { return std::hash<std::string_view>{}(s); }
+    };
+
+    /* The matching tree.
+     *
+     * Children are split by name class so that both registration and routing are
+     * O(1) per segment instead of the previous linear scan over a single vector
+     * (Bun.serve expands an "any" route to ~36 methods, so a flat N-route table
+     * used to cost ~36*N^2 string compares to build):
+     *   - staticChildren: literal segment names, hashed. At most one can match a
+     *     given URL segment so iteration is never needed.
+     *   - specialChildren: ':' param and '*' wildcard segments, kept ordered
+     *     (':' before '*') and tried after the static match at the same priority.
+     * Each is further split by isHighPriority: [1] = HIGH_PRIORITY (upgrade
+     * routes), [0] = everything else. Matching tries [1] before [0].
+     */
     struct Node {
+        using ChildMap = std::unordered_map<std::string, std::unique_ptr<Node>, StringViewHash, std::equal_to<>>;
+
         std::string name = {};
-        std::vector<std::unique_ptr<Node>> children = {};
         std::vector<uint32_t> handlers = {};
         bool isHighPriority = false;
 
-        explicit constexpr Node(std::string name) noexcept : name(std::move(name)) {}
+        ChildMap staticChildren[2] = {};
+        std::vector<std::unique_ptr<Node>> specialChildren[2] = {};
+
+        explicit Node(std::string name) : name(std::move(name)) {}
+
+        bool hasChildren() const {
+            return !staticChildren[0].empty() || !staticChildren[1].empty()
+                || !specialChildren[0].empty() || !specialChildren[1].empty();
+        }
     } root {"rootNode"};
+
+    /* ':' and '*' segments live in specialChildren; everything else (including
+     * the empty segment from "//") is a static name. */
+    static bool isSpecialName(std::string_view name) {
+        return !name.empty() && (name[0] == ':' || name[0] == '*');
+    }
 
     /* Sort wildcards after alphanum */
     int lexicalOrder(std::string_view name) {
@@ -79,22 +115,32 @@ private:
 
     /* Advance from parent to child, adding child if necessary */
     Node *getNode(Node *parent, std::string_view child, bool isHighPriority) {
-        for (const std::unique_ptr<Node> &node : parent->children) {
-            if (node->name == child && node->isHighPriority == isHighPriority) {
+        unsigned int prio = isHighPriority ? 1 : 0;
+        if (!isSpecialName(child)) {
+            auto &map = parent->staticChildren[prio];
+            if (auto it = map.find(child); it != map.end()) {
+                return it->second.get();
+            }
+            auto newNode = std::make_unique<Node>(std::string(child));
+            newNode->isHighPriority = isHighPriority;
+            Node *ptr = newNode.get();
+            map.emplace(ptr->name, std::move(newNode));
+            return ptr;
+        }
+
+        auto &vec = parent->specialChildren[prio];
+        for (const std::unique_ptr<Node> &node : vec) {
+            if (node->name == child) {
                 return node.get();
             }
         }
-
-        /* Insert sorted, but keep order if parent is root (we sort methods by priority elsewhere) */
         auto newNode = std::make_unique<Node>(std::string(child));
         newNode->isHighPriority = isHighPriority;
-        auto iter = std::upper_bound(parent->children.begin(), parent->children.end(), newNode, [parent, this](auto &a, auto &b) {
-            if (a->isHighPriority != b->isHighPriority) {
-                return a->isHighPriority;
-            }
-            return !b->name.empty() && (parent != &root) && (lexicalOrder(b->name) < lexicalOrder(a->name));
+        /* Keep ':' before '*' so executeHandlers tries param before wildcard. */
+        auto iter = std::upper_bound(vec.begin(), vec.end(), newNode, [this](auto &a, auto &b) {
+            return lexicalOrder(b->name) < lexicalOrder(a->name);
         });
-        return parent->children.emplace(iter, std::move(newNode))->get();
+        return vec.emplace(iter, std::move(newNode))->get();
     }
 
     /* Basically a pre-allocated stack */
@@ -180,25 +226,33 @@ private:
             return false;
         }
 
-        for (auto &p : parent->children) {
-            if (p->name.starts_with('*')) {
-                /* Wildcard match (can be seen as a shortcut) */
-                for (uint32_t handler : p->handlers) {
-                    if (handlers[handler & HANDLER_MASK](this)) {
+        /* High-priority tier first, then normal. Within a tier: the (at most one)
+         * static match, then ':' param, then '*' wildcard. This is the same order
+         * the old sorted children vector produced. */
+        for (int prio = 1; prio >= 0; prio--) {
+            auto &staticMap = parent->staticChildren[prio];
+            if (!staticMap.empty()) {
+                if (auto it = staticMap.find(segment); it != staticMap.end()) {
+                    if (executeHandlers(it->second.get(), urlSegment + 1, userData)) {
                         return true;
                     }
                 }
-            } else if (p->name.starts_with(':') && !segment.empty()) {
-                /* Parameter match */
-                routeParameters.push(segment);
-                if (executeHandlers(p.get(), urlSegment + 1, userData)) {
-                    return true;
-                }
-                routeParameters.pop();
-            } else if (p->name == segment) {
-                /* Static match */
-                if (executeHandlers(p.get(), urlSegment + 1, userData)) {
-                    return true;
+            }
+            for (auto &p : parent->specialChildren[prio]) {
+                if (p->name.starts_with('*')) {
+                    /* Wildcard match (can be seen as a shortcut) */
+                    for (uint32_t handler : p->handlers) {
+                        if (handlers[handler & HANDLER_MASK](this)) {
+                            return true;
+                        }
+                    }
+                } else if (p->name.starts_with(':') && !segment.empty()) {
+                    /* Parameter match */
+                    routeParameters.push(segment);
+                    if (executeHandlers(p.get(), urlSegment + 1, userData)) {
+                        return true;
+                    }
+                    routeParameters.pop();
                 }
             }
         }
@@ -207,41 +261,64 @@ private:
 
     /* Scans for one matching handler, returning the handler and its priority or UINT32_MAX for not found */
     uint32_t findHandler(std::string_view method, std::string_view pattern, uint32_t priority) {
-        for (const std::unique_ptr<Node> &node : root.children) {
-            if (method == node->name) {
-                setUrl(pattern);
-                Node *n = node.get();
-                for (int i = 0; !getUrlSegment(i).second; i++) {
-                    /* Go to next segment or quit */
-                    std::string segment(getUrlSegment(i).first);
-                    Node *next = nullptr;
-                    for (const std::unique_ptr<Node> &child : n->children) {
-                        if (((segment.starts_with(':') && child->name.starts_with(':')) || child->name == segment) && child->isHighPriority == (priority == HIGH_PRIORITY)) {
-                            next = child.get();
-                            break;
-                        }
-                    }
-                    if (!next) {
-                        return UINT32_MAX;
-                    }
-                    n = next;
-                }
-                /* Seek for a priority match in the found node */
-                for (unsigned int i = 0; i < n->handlers.size(); i++) {
-                    if ((n->handlers[i] & ~HANDLER_MASK) == priority) {
-                        return n->handlers[i];
+        bool isHighPrio = (priority == HIGH_PRIORITY);
+        Node *n = findMethodNode(method);
+        if (!n) {
+            return UINT32_MAX;
+        }
+        setUrl(pattern);
+        for (int i = 0; !getUrlSegment(i).second; i++) {
+            std::string_view segment = getUrlSegment(i).first;
+            Node *next = nullptr;
+            if (isSpecialName(segment)) {
+                /* ':' pattern segments match the single ':' child (names were
+                 * stripped on insert); '*' matches by exact name. */
+                bool segIsParam = segment[0] == ':';
+                for (auto &c : n->specialChildren[isHighPrio ? 1 : 0]) {
+                    if (segIsParam ? c->name.starts_with(':') : c->name == segment) {
+                        next = c.get();
+                        break;
                     }
                 }
+            } else {
+                auto &map = n->staticChildren[isHighPrio ? 1 : 0];
+                if (auto it = map.find(segment); it != map.end()) {
+                    next = it->second.get();
+                }
+            }
+            if (!next) {
                 return UINT32_MAX;
+            }
+            n = next;
+        }
+        /* Seek for a priority match in the found node */
+        for (unsigned int i = 0; i < n->handlers.size(); i++) {
+            if ((n->handlers[i] & ~HANDLER_MASK) == priority) {
+                return n->handlers[i];
             }
         }
         return UINT32_MAX;
     }
 
+    /* Root's children are method names; all are isHighPriority=false. */
+    Node *findMethodNode(std::string_view method) {
+        if (isSpecialName(method)) {
+            for (auto &c : root.specialChildren[0]) {
+                if (c->name == method) {
+                    return c.get();
+                }
+            }
+            return nullptr;
+        }
+        auto &map = root.staticChildren[0];
+        auto it = map.find(method);
+        return it != map.end() ? it->second.get() : nullptr;
+    }
+
 public:
     HttpRouter() {
         /* Always have ANY route */
-        getNode(&root, std::string(ANY_METHOD_TOKEN), false);
+        getNode(&root, ANY_METHOD_TOKEN, false);
     }
 
     std::pair<int, std::string_view *> getParameters() {
@@ -259,22 +336,22 @@ public:
         routeParameters.reset();
 
         /* Begin by finding the method node */
-        for (auto &p : root.children) {
-            if (p->name == method) {
-                /* Then route the url */
-                if (executeHandlers(p.get(), 0, userData)) {
-                    return true;
-                } else {
-                    break;
-                }
+        auto it = root.staticChildren[0].find(method);
+        if (it != root.staticChildren[0].end()) {
+            if (executeHandlers(it->second.get(), 0, userData)) {
+                return true;
             }
         }
 
-        /* Always test any route last (this check should not be necessary if we always have at least one handler) */
-        if (root.children.empty()) [[unlikely]] {
-            return false;
+        /* Always test any route last. ANY_METHOD_TOKEN is root's only
+         * specialChildren[0] entry in practice, but look it up by name so a
+         * cullNode() that removed it cannot leave a stale pointer behind. */
+        for (auto &p : root.specialChildren[0]) {
+            if (p->name == ANY_METHOD_TOKEN) {
+                return executeHandlers(p.get(), 0, userData);
+            }
         }
-        return executeHandlers(root.children.back().get(), 0, userData);
+        return false;
     }
 
     /* Adds the corresponding entires in matching tree and handler list */
@@ -302,31 +379,24 @@ public:
 
         /* Alloate this handler */
         handlers.emplace_back(std::move(handler));
-
-        /* ANY method must be last, GET must be first */
-        std::sort(root.children.begin(), root.children.end(), [](const auto &a, const auto &b) {
-            if (a->name == "GET" && b->name != "GET") {
-                return true;
-            } else if (b->name == "GET" && a->name != "GET") {
-                return false;
-            } else if (a->name == ANY_METHOD_TOKEN && b->name != ANY_METHOD_TOKEN) {
-                return false;
-            } else if (b->name == ANY_METHOD_TOKEN && a->name != ANY_METHOD_TOKEN) {
-                return true;
-            } else {
-                return a->name < b->name;
-            }
-        });
     }
 
     bool cullNode(Node *parent, Node *node, uint32_t handler) {
-        /* For all children */
-        for (unsigned int i = 0; i < node->children.size(); ) {
-            /* Optimization todo: only enter those with same isHighPrioirty */
-            /* Enter child so we get depth first */
-            if (!cullNode(node, node->children[i].get(), handler)) {
-                /* Only increase if this node was not removed */
-                i++;
+        /* For all children of either kind */
+        for (int prio = 0; prio < 2; prio++) {
+            for (auto it = node->staticChildren[prio].begin(); it != node->staticChildren[prio].end(); ) {
+                if (cullNode(node, it->second.get(), handler)) {
+                    it = node->staticChildren[prio].erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            for (unsigned int i = 0; i < node->specialChildren[prio].size(); ) {
+                if (cullNode(node, node->specialChildren[prio][i].get(), handler)) {
+                    node->specialChildren[prio].erase(node->specialChildren[prio].begin() + i);
+                } else {
+                    i++;
+                }
             }
         }
 
@@ -343,14 +413,8 @@ public:
                 it++;
             }
 
-            /* If we have no children and no handlers, remove us from the parent->children list */
-            if (!node->handlers.size() && !node->children.size()) {
-                parent->children.erase(std::find_if(parent->children.begin(), parent->children.end(), [node](const std::unique_ptr<Node> &a) {
-                    return a.get() == node;
-                }));
-                /* Returning true means we removed node from parent */
-                return true;
-            }
+            /* Returning true signals the caller to erase us from its container */
+            return node->handlers.empty() && !node->hasChildren();
         }
 
         return false;

--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -74,22 +74,31 @@ private:
      *     (':' before '*') and tried after the static match at the same priority.
      * Each is further split by isHighPriority: [1] = HIGH_PRIORITY (upgrade
      * routes), [0] = everything else. Matching tries [1] before [0].
+     *
+     * The child containers live behind a lazily-allocated Children block so a
+     * leaf Node (the vast majority: one per route per method) carries only a
+     * null pointer instead of two empty hash maps and two empty vectors.
      */
     struct Node {
         using ChildMap = std::unordered_map<std::string, std::unique_ptr<Node>, StringViewHash, std::equal_to<>>;
 
+        struct Children {
+            ChildMap staticChildren[2] = {};
+            std::vector<std::unique_ptr<Node>> specialChildren[2] = {};
+        };
+
         std::string name = {};
         std::vector<uint32_t> handlers = {};
+        std::unique_ptr<Children> children = {};
         bool isHighPriority = false;
-
-        ChildMap staticChildren[2] = {};
-        std::vector<std::unique_ptr<Node>> specialChildren[2] = {};
 
         explicit Node(std::string name) : name(std::move(name)) {}
 
-        bool hasChildren() const {
-            return !staticChildren[0].empty() || !staticChildren[1].empty()
-                || !specialChildren[0].empty() || !specialChildren[1].empty();
+        Children &ensureChildren() {
+            if (!children) {
+                children = std::make_unique<Children>();
+            }
+            return *children;
         }
     } root {"rootNode"};
 
@@ -115,9 +124,10 @@ private:
 
     /* Advance from parent to child, adding child if necessary */
     Node *getNode(Node *parent, std::string_view child, bool isHighPriority) {
+        auto &children = parent->ensureChildren();
         unsigned int prio = isHighPriority ? 1 : 0;
         if (!isSpecialName(child)) {
-            auto &map = parent->staticChildren[prio];
+            auto &map = children.staticChildren[prio];
             if (auto it = map.find(child); it != map.end()) {
                 return it->second.get();
             }
@@ -128,7 +138,7 @@ private:
             return ptr;
         }
 
-        auto &vec = parent->specialChildren[prio];
+        auto &vec = children.specialChildren[prio];
         for (const std::unique_ptr<Node> &node : vec) {
             if (node->name == child) {
                 return node.get();
@@ -226,11 +236,16 @@ private:
             return false;
         }
 
+        if (!parent->children) {
+            return false;
+        }
+        auto &children = *parent->children;
+
         /* High-priority tier first, then normal. Within a tier: the (at most one)
          * static match, then ':' param, then '*' wildcard. This is the same order
          * the old sorted children vector produced. */
         for (int prio = 1; prio >= 0; prio--) {
-            auto &staticMap = parent->staticChildren[prio];
+            auto &staticMap = children.staticChildren[prio];
             if (!staticMap.empty()) {
                 if (auto it = staticMap.find(segment); it != staticMap.end()) {
                     if (executeHandlers(it->second.get(), urlSegment + 1, userData)) {
@@ -238,7 +253,7 @@ private:
                     }
                 }
             }
-            for (auto &p : parent->specialChildren[prio]) {
+            for (auto &p : children.specialChildren[prio]) {
                 if (p->name.starts_with('*')) {
                     /* Wildcard match (can be seen as a shortcut) */
                     for (uint32_t handler : p->handlers) {
@@ -268,20 +283,24 @@ private:
         }
         setUrl(pattern);
         for (int i = 0; !getUrlSegment(i).second; i++) {
+            if (!n->children) {
+                return UINT32_MAX;
+            }
+            auto &children = *n->children;
             std::string_view segment = getUrlSegment(i).first;
             Node *next = nullptr;
             if (isSpecialName(segment)) {
                 /* ':' pattern segments match the single ':' child (names were
                  * stripped on insert); '*' matches by exact name. */
                 bool segIsParam = segment[0] == ':';
-                for (auto &c : n->specialChildren[isHighPrio ? 1 : 0]) {
+                for (auto &c : children.specialChildren[isHighPrio ? 1 : 0]) {
                     if (segIsParam ? c->name.starts_with(':') : c->name == segment) {
                         next = c.get();
                         break;
                     }
                 }
             } else {
-                auto &map = n->staticChildren[isHighPrio ? 1 : 0];
+                auto &map = children.staticChildren[isHighPrio ? 1 : 0];
                 if (auto it = map.find(segment); it != map.end()) {
                     next = it->second.get();
                 }
@@ -302,15 +321,19 @@ private:
 
     /* Root's children are method names; all are isHighPriority=false. */
     Node *findMethodNode(std::string_view method) {
+        if (!root.children) {
+            return nullptr;
+        }
+        auto &children = *root.children;
         if (isSpecialName(method)) {
-            for (auto &c : root.specialChildren[0]) {
+            for (auto &c : children.specialChildren[0]) {
                 if (c->name == method) {
                     return c.get();
                 }
             }
             return nullptr;
         }
-        auto &map = root.staticChildren[0];
+        auto &map = children.staticChildren[0];
         auto it = map.find(method);
         return it != map.end() ? it->second.get() : nullptr;
     }
@@ -335,9 +358,14 @@ public:
         setUrl(url);
         routeParameters.reset();
 
+        if (!root.children) [[unlikely]] {
+            return false;
+        }
+        auto &children = *root.children;
+
         /* Begin by finding the method node */
-        auto it = root.staticChildren[0].find(method);
-        if (it != root.staticChildren[0].end()) {
+        auto it = children.staticChildren[0].find(method);
+        if (it != children.staticChildren[0].end()) {
             if (executeHandlers(it->second.get(), 0, userData)) {
                 return true;
             }
@@ -346,7 +374,7 @@ public:
         /* Always test any route last. ANY_METHOD_TOKEN is root's only
          * specialChildren[0] entry in practice, but look it up by name so a
          * cullNode() that removed it cannot leave a stale pointer behind. */
-        for (auto &p : root.specialChildren[0]) {
+        for (auto &p : children.specialChildren[0]) {
             if (p->name == ANY_METHOD_TOKEN) {
                 return executeHandlers(p.get(), 0, userData);
             }
@@ -383,20 +411,27 @@ public:
 
     bool cullNode(Node *parent, Node *node, uint32_t handler) {
         /* For all children of either kind */
-        for (int prio = 0; prio < 2; prio++) {
-            for (auto it = node->staticChildren[prio].begin(); it != node->staticChildren[prio].end(); ) {
-                if (cullNode(node, it->second.get(), handler)) {
-                    it = node->staticChildren[prio].erase(it);
-                } else {
-                    ++it;
+        if (node->children) {
+            auto &children = *node->children;
+            for (int prio = 0; prio < 2; prio++) {
+                for (auto it = children.staticChildren[prio].begin(); it != children.staticChildren[prio].end(); ) {
+                    if (cullNode(node, it->second.get(), handler)) {
+                        it = children.staticChildren[prio].erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+                for (unsigned int i = 0; i < children.specialChildren[prio].size(); ) {
+                    if (cullNode(node, children.specialChildren[prio][i].get(), handler)) {
+                        children.specialChildren[prio].erase(children.specialChildren[prio].begin() + i);
+                    } else {
+                        i++;
+                    }
                 }
             }
-            for (unsigned int i = 0; i < node->specialChildren[prio].size(); ) {
-                if (cullNode(node, node->specialChildren[prio][i].get(), handler)) {
-                    node->specialChildren[prio].erase(node->specialChildren[prio].begin() + i);
-                } else {
-                    i++;
-                }
+            if (children.staticChildren[0].empty() && children.staticChildren[1].empty()
+                && children.specialChildren[0].empty() && children.specialChildren[1].empty()) {
+                node->children.reset();
             }
         }
 
@@ -414,7 +449,7 @@ public:
             }
 
             /* Returning true signals the caller to erase us from its container */
-            return node->handlers.empty() && !node->hasChildren();
+            return node->handlers.empty() && !node->children;
         }
 
         return false;

--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -72,7 +72,7 @@ private:
      *     given URL segment so iteration is never needed.
      *   - specialChildren: ':' param and '*' wildcard segments, kept ordered
      *     (':' before '*') and tried after the static match at the same priority.
-     * Each is further split by isHighPriority: [1] = HIGH_PRIORITY (upgrade
+     * Each is further split by priority tier: [1] = HIGH_PRIORITY (upgrade
      * routes), [0] = everything else. Matching tries [1] before [0].
      *
      * The child containers live behind a lazily-allocated Children block so a
@@ -90,7 +90,6 @@ private:
         std::string name = {};
         std::vector<uint32_t> handlers = {};
         std::unique_ptr<Children> children = {};
-        bool isHighPriority = false;
 
         explicit Node(std::string name) : name(std::move(name)) {}
 
@@ -132,7 +131,6 @@ private:
                 return it->second.get();
             }
             auto newNode = std::make_unique<Node>(std::string(child));
-            newNode->isHighPriority = isHighPriority;
             Node *ptr = newNode.get();
             map.emplace(ptr->name, std::move(newNode));
             return ptr;
@@ -145,7 +143,6 @@ private:
             }
         }
         auto newNode = std::make_unique<Node>(std::string(child));
-        newNode->isHighPriority = isHighPriority;
         /* Keep ':' before '*' so executeHandlers tries param before wildcard. */
         auto iter = std::upper_bound(vec.begin(), vec.end(), newNode, [this](auto &a, auto &b) {
             return lexicalOrder(b->name) < lexicalOrder(a->name);
@@ -319,7 +316,7 @@ private:
         return UINT32_MAX;
     }
 
-    /* Root's children are method names; all are isHighPriority=false. */
+    /* Root's children are method names; all live in the normal-priority tier. */
     Node *findMethodNode(std::string_view method) {
         if (!root.children) {
             return nullptr;

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1114,4 +1114,28 @@ describe("many routes", () => {
     expect(await fetch(`${base}/api/other`).then(r => r.text())).toBe("param:other");
     expect(await fetch(`${base}/api/a/b`).then(r => r.text())).toBe("wild");
   });
+
+  test("reload() replaces a large route table and routes correctly afterwards", async () => {
+    const n = 1000;
+    using server = Bun.serve({ port: 0, routes: buildFlatTable(n) });
+    const base = `http://127.0.0.1:${server.port}`;
+
+    expect(await fetch(`${base}/leaf0`).then(r => r.text())).toBe("0");
+    expect(await fetch(`${base}/leaf${n - 1}`).then(r => r.text())).toBe(String(n - 1));
+
+    const replacement: Record<string, () => Response> = {};
+    for (let i = 0; i < n; i++) {
+      replacement[`/other${i}`] = () => new Response(`other${i}`);
+    }
+    server.reload({ routes: replacement });
+
+    expect((await fetch(`${base}/leaf0`)).status).toBe(404);
+    expect(await fetch(`${base}/other0`).then(r => r.text())).toBe("other0");
+    expect(await fetch(`${base}/other${n - 1}`).then(r => r.text())).toBe(`other${n - 1}`);
+
+    server.reload({ routes: buildFlatTable(n) });
+
+    expect((await fetch(`${base}/other0`)).status).toBe(404);
+    expect(await fetch(`${base}/leaf500`).then(r => r.text())).toBe("500");
+  });
 });

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1060,35 +1060,31 @@ describe("many routes", () => {
   // This asserts registration scales linearly in N. A perf outlier, hence the
   // explicit per-test timeout: before the fix the 2400-route build alone took
   // several seconds under ASAN.
-  test(
-    "route registration time scales linearly with route count",
-    async () => {
-      function timeBuild(n: number) {
-        const routes = buildFlatTable(n);
-        const t0 = performance.now();
-        const srv = Bun.serve({ port: 0, routes });
-        const dt = performance.now() - t0;
-        srv.stop(true);
-        return dt;
-      }
+  test("route registration time scales linearly with route count", async () => {
+    function timeBuild(n: number) {
+      const routes = buildFlatTable(n);
+      const t0 = performance.now();
+      const srv = Bun.serve({ port: 0, routes });
+      const dt = performance.now() - t0;
+      srv.stop(true);
+      return dt;
+    }
 
-      // Warm up JIT + allocator so the small sample is not dominated by
-      // first-call overhead.
-      timeBuild(300);
-      timeBuild(300);
+    // Warm up JIT + allocator so the small sample is not dominated by
+    // first-call overhead.
+    timeBuild(300);
+    timeBuild(300);
 
-      // Best of three for the small sample to cut scheduling jitter; the ratio
-      // is what matters, not the absolute times.
-      const small = Math.min(timeBuild(300), timeBuild(300), timeBuild(300));
-      const large = timeBuild(2400);
-      const ratio = large / small;
+    // Best of three for the small sample to cut scheduling jitter; the ratio
+    // is what matters, not the absolute times.
+    const small = Math.min(timeBuild(300), timeBuild(300), timeBuild(300));
+    const large = timeBuild(2400);
+    const ratio = large / small;
 
-      // 8x the routes. Linear ~= 8x; the old O(N^2) path measured 50-80x here.
-      // Printed alongside the assertion so a failure shows the raw timings.
-      expect({ small, large, ratio, linear: ratio < 24 }).toMatchObject({ linear: true });
-    },
-    30_000,
-  );
+    // 8x the routes. Linear ~= 8x; the old O(N^2) path measured 50-80x here.
+    // Printed alongside the assertion so a failure shows the raw timings.
+    expect({ small, large, ratio, linear: ratio < 24 }).toMatchObject({ linear: true });
+  }, 30_000);
 
   test("routes to the right handler in a large flat table", async () => {
     const n = 1200;

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1044,3 +1044,80 @@ describe.concurrent("false route with no fetch handler", () => {
     await proc.exited;
   });
 });
+
+describe("many routes", () => {
+  function buildFlatTable(n: number) {
+    const routes: Record<string, () => Response> = {};
+    for (let i = 0; i < n; i++) {
+      routes[`/leaf${i}`] = () => new Response(String(i));
+    }
+    return routes;
+  }
+
+  // Route registration used to linear-scan sibling nodes in the uWS router and
+  // an `any` route fans out to every supported HTTP method, so an N-entry flat
+  // table cost ~36*N^2 string compares to build (and again on every reload()).
+  // This asserts registration scales linearly in N. A perf outlier, hence the
+  // explicit per-test timeout: before the fix the 2400-route build alone took
+  // several seconds under ASAN.
+  test(
+    "route registration time scales linearly with route count",
+    async () => {
+      function timeBuild(n: number) {
+        const routes = buildFlatTable(n);
+        const t0 = performance.now();
+        const srv = Bun.serve({ port: 0, routes });
+        const dt = performance.now() - t0;
+        srv.stop(true);
+        return dt;
+      }
+
+      // Warm up JIT + allocator so the small sample is not dominated by
+      // first-call overhead.
+      timeBuild(300);
+      timeBuild(300);
+
+      // Best of three for the small sample to cut scheduling jitter; the ratio
+      // is what matters, not the absolute times.
+      const small = Math.min(timeBuild(300), timeBuild(300), timeBuild(300));
+      const large = timeBuild(2400);
+      const ratio = large / small;
+
+      // 8x the routes. Linear ~= 8x; the old O(N^2) path measured 50-80x here.
+      // Printed alongside the assertion so a failure shows the raw timings.
+      expect({ small, large, ratio, linear: ratio < 24 }).toMatchObject({ linear: true });
+    },
+    30_000,
+  );
+
+  test("routes to the right handler in a large flat table", async () => {
+    const n = 1200;
+    using server = Bun.serve({ port: 0, routes: buildFlatTable(n) });
+    const base = `http://127.0.0.1:${server.port}`;
+
+    const results = await Promise.all(
+      [0, 1, 123, n - 2, n - 1].map(i => fetch(`${base}/leaf${i}`).then(r => r.text())),
+    );
+    expect(results).toEqual(["0", "1", "123", String(n - 2), String(n - 1)]);
+
+    const miss = await fetch(`${base}/leaf${n}`);
+    expect(miss.status).toBe(404);
+  });
+
+  test("param and wildcard precedence is preserved in a large table", async () => {
+    const routes: Record<string, (req: BunRequest) => Response> = {};
+    for (let i = 0; i < 1000; i++) {
+      routes[`/api/static${i}`] = () => new Response(`static${i}`);
+    }
+    routes["/api/:id"] = req => new Response(`param:${req.params.id}`);
+    routes["/api/*"] = () => new Response("wild");
+
+    using server = Bun.serve({ port: 0, routes });
+    const base = `http://127.0.0.1:${server.port}`;
+
+    expect(await fetch(`${base}/api/static0`).then(r => r.text())).toBe("static0");
+    expect(await fetch(`${base}/api/static999`).then(r => r.text())).toBe("static999");
+    expect(await fetch(`${base}/api/other`).then(r => r.text())).toBe("param:other");
+    expect(await fetch(`${base}/api/a/b`).then(r => r.text())).toBe("wild");
+  });
+});

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -1057,10 +1057,8 @@ describe("many routes", () => {
   // Route registration used to linear-scan sibling nodes in the uWS router and
   // an `any` route fans out to every supported HTTP method, so an N-entry flat
   // table cost ~36*N^2 string compares to build (and again on every reload()).
-  // This asserts registration scales linearly in N. A perf outlier, hence the
-  // explicit per-test timeout: before the fix the 2400-route build alone took
-  // several seconds under ASAN.
-  test("route registration time scales linearly with route count", async () => {
+  // This asserts registration scales linearly in N.
+  test("route registration time scales linearly with route count", () => {
     function timeBuild(n: number) {
       const routes = buildFlatTable(n);
       const t0 = performance.now();
@@ -1084,7 +1082,7 @@ describe("many routes", () => {
     // 8x the routes. Linear ~= 8x; the old O(N^2) path measured 50-80x here.
     // Printed alongside the assertion so a failure shows the raw timings.
     expect({ small, large, ratio, linear: ratio < 24 }).toMatchObject({ linear: true });
-  }, 30_000);
+  });
 
   test("routes to the right handler in a large flat table", async () => {
     const n = 1200;


### PR DESCRIPTION
## Problem

`Bun.serve({routes})` route registration time is superlinear in the route count, and `server.reload()` pays the same cost synchronously on the event loop every call. 8000 flat routes take ~43s to register; a 100k-route table is unusable.

Profile: ~60% `memcmp` + ~38% `uWS::HttpRouter::getNode`.

```js
const sizes = [500, 1000, 2000, 4000];
const build = {};
for (const n of sizes) {
  const routes = {};
  for (let i = 0; i < n; i++) routes[`/leaf${i}`] = () => new Response("x");
  const t0 = performance.now();
  const srv = Bun.serve({ port: 0, routes });
  build[n] = Math.round(performance.now() - t0);
  srv.stop(true);
}
// observed: 4000 routes takes 78-241x the time of 500 routes (linear would be 8x)
```

Per-request lookup on the last-registered route also grows linearly with sibling count (0.02ms@1k vs 0.075ms@8k).

## Cause

`uWS::HttpRouter::Node` stored every child in a single sorted `std::vector<std::unique_ptr<Node>>`. `getNode()` (registration) and `executeHandlers()` (routing) both linear-scanned it. `Bun.serve` expands an `any` route to all ~36 supported HTTP methods, so an N-route flat table cost ~36*N^2 string compares to build, and every request linear-scanned siblings.

## Fix

Split each node's children into:
- `staticChildren[2]`: `unordered_map<string, unique_ptr<Node>>` keyed by literal segment name, one map per priority tier. O(1) lookup/insert.
- `specialChildren[2]`: tiny ordered vector for `:` param and `*` wildcard segments, one per priority tier.

Matching preserves the existing precedence (high-priority before normal; static before `:` before `*`): `executeHandlers()` tries a single hash lookup for the URL segment, then the handful of special children, per priority tier. The per-`add()` `std::sort` of root children is no longer needed since method lookup is hashed.

## Verification

| build (debug+ASAN) | 500 | 1000 | 2000 | 4000 | 8000 | 16000 | ratio vs smallest |
|---|---|---|---|---|---|---|---|
| before | ~370ms | | | ~27s | ~43s (release) | | ~70x for 8x N |
| after | 82ms | 160ms | 321ms | 645ms | 1321ms | 2656ms | 8.0x for 8x N |

New tests in `bun-serve-routes.test.ts`:
- `route registration time scales linearly with route count`: 300 vs 2400 routes, asserts ratio < 24 (before: ~62x, after: ~8x)
- `routes to the right handler in a large flat table`: 1200 routes, spot-checks first/middle/last + 404
- `param and wildcard precedence is preserved in a large table`: 1000 static siblings + `:id` + `*`, verifies precedence is unchanged

All 58 `bun-serve-routes.test.ts`, 261 `serve.test.ts` (minus 4 env-only), 107 `websocket-server.test.ts`, and 142 `node-http.test.ts` (minus 1 env-only) pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (0f38761ea)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [22.03ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [10.08ms]
(pass) path parameters > handles encoded parameters [12.13ms]
(pass) path parameters > handles unicode parameters [6.64ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [354.03ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [47.38ms]
(pass) HTTP methods > GET request [22.77ms]
(pass) HTTP methods > POST request [4.58ms]
(pass) HTTP methods > PUT request [3.63ms]
(pass) HTTP methods > DELETE request [12.16ms]
(pass) HTTP methods > PATCH request [4.19ms]
(pass) HTTP methods > OPTIONS request [8.56ms]
(pass) HTTP methods > HEAD request [4.31ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [47.96ms]
(pass) impli
... (truncated)

release without fix: 13 FAILED
bun test v1.3.14 (0d9b296a)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [1.15ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.26ms]
(pass) path parameters > handles encoded parameters [0.15ms]
(pass) path parameters > handles unicode parameters [0.14ms]
88 |     socket.on("data", chunk => chunks.push(chunk));
89 |     socket.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
90 |     socket.on("connect", () => socket.write(request));
91 |     const response = await promise;
92 |     expect(response).toContain("HTTP/1.1 200");
93 |     expect(JSON.parse(response.slice(response.indexOf("\r\n\r\n") + 4))).toEqual({ id: expected, method: "GET" });
                                                                              ^
error: expect(received).toEqual(expected)

  {
-   "id": "é",
+   "id": "Ã©",
    "method": "GET",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-routes.test.ts:93:74)
(fail) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [5.24ms]
88 |    
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (0f38761ea)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [23.30ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [9.96ms]
(pass) path parameters > handles encoded parameters [16.91ms]
(pass) path parameters > handles unicode parameters [13.61ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [343.02ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [48.30ms]
(pass) HTTP methods > GET request [21.25ms]
(pass) HTTP methods > POST request [4.65ms]
(pass) HTTP methods > PUT request [3.79ms]
(pass) HTTP methods > DELETE request [12.08ms]
(pass) HTTP methods > PATCH request [4.02ms]
(pass) HTTP methods > OPTIONS request [9.35ms]
(pass) HTTP methods > HEAD request [4.23ms]
(pass) implicit HEAD for per-method route objects > HEAD is served by the GET handler when no HEAD handler is declared [47.92ms]
(pass) impli
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0f38761ea0
  features     baseline

22 deps, 108 codegen, 1170 objects in 827ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1237] mkdir codegen
[2/1237] mkdir stamps
[3/1237] mkdir pch
[4/1237] mkdir obj
[5/1237] install /workspace/bun
bun install v1.3.14 (0d9b296a)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[6/1237] install /workspace/bun/packages/bun-error
bun install v1.3.14 (0d9b296a)

Checked 1 install across 2 packages (no changes) [2.00ms]
[7/1237] gen ErrorCode+*.h
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.3.14 (0d9b296a)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[9/1237] gen bindgenv2
[10/1237] fetch zlib
[zlib] up to date
[11/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[12/1237] fetch tinycc
[tinycc] up to date
[13/1237] gen .bind.ts → GeneratedBindings.cpp
[14/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpRouter.h         | 288 ++++++++++++++++++++----------
 test/js/bun/http/bun-serve-routes.test.ts |  95 ++++++++++
 2 files changed, 287 insertions(+), 96 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
packages/bun-uws/src/HttpRouter.h              6     24      0
test/js/bun/http/bun-serve-routes.test.ts      3      6      0
```

</details>

<!-- robobun:evidence:end -->