### PR TITLE
Bun.serve: match percent-encoded route keys against raw or mixed-case request targets

### DIFF
--- a/packages/bun-uws/src/HttpRouter.h
+++ b/packages/bun-uws/src/HttpRouter.h
@@ -50,8 +50,63 @@ private:
 
     /* Current URL cache */
     std::string_view currentUrl = {};
+    std::string normalizedUrlBuffer = {};
     std::string_view urlSegmentVector[MAX_URL_SEGMENTS] = {};
     int urlSegmentTop = -1;
+
+    static constexpr bool isHexDigit(unsigned char c) {
+        return (c >= '0' && c <= '9') || ((c | 32) >= 'a' && (c | 32) <= 'f');
+    }
+
+    static constexpr unsigned char upperHex(unsigned char c) {
+        return c >= 'a' ? (unsigned char) (c - 32) : c;
+    }
+
+    /* RFC 3986 6.2.2.1: percent-encoding hex digits are case-insensitive, and a raw
+     * non-ASCII byte is equivalent to its percent-encoded form. Route keys are required
+     * to be ASCII, so normalize both the registered pattern and the request target to
+     * uppercase-hex percent-encoding before comparing. Returns the input view unchanged
+     * when it is already canonical. */
+    std::string_view normalizePercentEncoding(std::string_view url) {
+        size_t i = 0, length = url.length();
+        const unsigned char *data = (const unsigned char *) url.data();
+        for (; i < length; i++) {
+            unsigned char c = data[i];
+            if (c >= 0x80) {
+                break;
+            }
+            if (c == '%' && i + 2 < length && isHexDigit(data[i + 1]) && isHexDigit(data[i + 2])) {
+                if (data[i + 1] >= 'a' || data[i + 2] >= 'a') {
+                    break;
+                }
+                i += 2;
+            }
+        }
+        if (i == length) {
+            return url;
+        }
+
+        static constexpr char HEX[] = "0123456789ABCDEF";
+        normalizedUrlBuffer.clear();
+        normalizedUrlBuffer.reserve(length + (length >> 1));
+        normalizedUrlBuffer.append(url.data(), i);
+        for (; i < length; i++) {
+            unsigned char c = data[i];
+            if (c >= 0x80) {
+                normalizedUrlBuffer.push_back('%');
+                normalizedUrlBuffer.push_back(HEX[c >> 4]);
+                normalizedUrlBuffer.push_back(HEX[c & 15]);
+            } else if (c == '%' && i + 2 < length && isHexDigit(data[i + 1]) && isHexDigit(data[i + 2])) {
+                normalizedUrlBuffer.push_back('%');
+                normalizedUrlBuffer.push_back((char) upperHex(data[i + 1]));
+                normalizedUrlBuffer.push_back((char) upperHex(data[i + 2]));
+                i += 2;
+            } else {
+                normalizedUrlBuffer.push_back((char) c);
+            }
+        }
+        return normalizedUrlBuffer;
+    }
 
     /* The matching tree */
     struct Node {
@@ -125,7 +180,7 @@ private:
         /* Todo: URL may also start with "http://domain/" or "*", not only "/" */
 
         /* We expect to stand on a slash */
-        currentUrl = url;
+        currentUrl = normalizePercentEncoding(url);
         urlSegmentTop = -1;
     }
 

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -94,6 +94,115 @@ describe("path parameters", () => {
   });
 });
 
+// RFC 3986 6.2.2.1: percent-encoding hex digits are case-insensitive, and a raw
+// non-ASCII byte on the wire is equivalent to its percent-encoded form. Route keys
+// must be ASCII, so the only way to register a non-ASCII path is percent-encoded;
+// that key must still match clients that send raw UTF-8 or lowercase hex.
+describe("percent-encoded route keys", () => {
+  let server: Server;
+
+  async function rawGet(pathBytes: Buffer | number[]): Promise<string> {
+    const request = Buffer.concat([
+      Buffer.from("GET "),
+      Buffer.from(pathBytes),
+      Buffer.from(" HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+    ]);
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const socket = net.connect(server.port, "127.0.0.1");
+    const chunks: Buffer[] = [];
+    socket.on("error", reject);
+    socket.on("data", chunk => chunks.push(chunk));
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    socket.on("connect", () => socket.write(request));
+    const httpResponse = await promise;
+    return httpResponse.slice(httpResponse.indexOf("\r\n\r\n") + 4);
+  }
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      routes: {
+        "/caf%C3%A9": req => new Response("cafe-upper:" + new URL(req.url).pathname),
+        "/t%c3%a9a": () => new Response("tea-lower"),
+        "/%F0%9F%A6%8A": () => new Response("fox"),
+        "/m%C3%aFx": () => new Response("mix"),
+        "/caf%C3%A9/:id": req => new Response("cafe-id:" + req.params.id),
+        "/%c3%a9tat": new Response("static"),
+        "/plain": () => new Response("plain"),
+      },
+      fetch: req => new Response("fallback:" + new URL(req.url).pathname),
+    });
+    server.unref();
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it("matches an uppercase-hex route key via fetch()", async () => {
+    const res = await fetch(new URL("/caf%C3%A9", server.url));
+    expect(await res.text()).toBe("cafe-upper:/caf%C3%A9");
+  });
+
+  it("matches the encoded route key when fetch() is given a literal non-ASCII path", async () => {
+    const res = await fetch(new URL("/café", server.url));
+    expect(await res.text()).toBe("cafe-upper:/caf%C3%A9");
+  });
+
+  it.each([
+    // /café as raw UTF-8 bytes, the way curl and node:http send it
+    ["raw UTF-8 bytes", [0x2f, 0x63, 0x61, 0x66, 0xc3, 0xa9]],
+    ["lowercase-hex percent-encoding", Buffer.from("/caf%c3%a9")],
+    ["mixed-case percent-encoding", Buffer.from("/caf%c3%A9")],
+  ])("matches an uppercase-hex route key from %s on the wire", async (_label, pathBytes) => {
+    expect(await rawGet(pathBytes)).toStartWith("cafe-upper:");
+  });
+
+  it("req.url reports the encoded form for raw UTF-8 bytes even though routing matched", async () => {
+    expect(await rawGet([0x2f, 0x63, 0x61, 0x66, 0xc3, 0xa9])).toBe("cafe-upper:/caf%C3%A9");
+  });
+
+  it.each([
+    ["uppercase-hex on the wire", Buffer.from("/t%C3%A9a")],
+    ["raw UTF-8 bytes", [0x2f, 0x74, 0xc3, 0xa9, 0x61]],
+  ])("matches a lowercase-hex route key from %s", async (_label, pathBytes) => {
+    expect(await rawGet(pathBytes)).toBe("tea-lower");
+  });
+
+  it("reaches a lowercase-hex route key via fetch()", async () => {
+    // fetch() emits uppercase hex, so without normalization this key is unreachable.
+    const res = await fetch(new URL("/téa", server.url));
+    expect(await res.text()).toBe("tea-lower");
+  });
+
+  it("matches an encoded emoji route key from raw UTF-8 bytes", async () => {
+    expect(await rawGet([0x2f, 0xf0, 0x9f, 0xa6, 0x8a])).toBe("fox");
+  });
+
+  it("matches a mixed-hex-case route key", async () => {
+    const res = await fetch(new URL("/mïx", server.url));
+    expect(await res.text()).toBe("mix");
+  });
+
+  it("matches the encoded segment before a path parameter and decodes the parameter", async () => {
+    expect(await rawGet([0x2f, 0x63, 0x61, 0x66, 0xc3, 0xa9, 0x2f, 0xc3, 0xa9])).toBe("cafe-id:é");
+  });
+
+  it("matches a lowercase-hex static Response route", async () => {
+    const res = await fetch(new URL("/état", server.url));
+    expect(await res.text()).toBe("static");
+  });
+
+  it("leaves plain-ASCII routes unaffected", async () => {
+    const res = await fetch(new URL("/plain", server.url));
+    expect(await res.text()).toBe("plain");
+  });
+
+  it("does not treat a percent-encoded slash as a path separator", async () => {
+    expect(await rawGet(Buffer.from("/caf%C3%A9%2Fextra"))).toStartWith("fallback:");
+  });
+});
+
 describe("HTTP methods", () => {
   let server: Server;
 

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -129,6 +129,10 @@ describe("percent-encoded route keys", () => {
         "/caf%C3%A9/:id": req => new Response("cafe-id:" + req.params.id),
         "/%c3%a9tat": new Response("static"),
         "/plain": () => new Response("plain"),
+        "/bad%": () => new Response("bad-trailing"),
+        "/bad%A": () => new Response("bad-short"),
+        "/bad%G0": () => new Response("bad-nonhex"),
+        "/bad%G0%c3%a9": () => new Response("bad-nonhex-then-valid"),
       },
       fetch: req => new Response("fallback:" + new URL(req.url).pathname),
     });
@@ -150,16 +154,13 @@ describe("percent-encoded route keys", () => {
   });
 
   it.each([
-    // /café as raw UTF-8 bytes, the way curl and node:http send it
-    ["raw UTF-8 bytes", [0x2f, 0x63, 0x61, 0x66, 0xc3, 0xa9]],
-    ["lowercase-hex percent-encoding", Buffer.from("/caf%c3%a9")],
-    ["mixed-case percent-encoding", Buffer.from("/caf%c3%A9")],
-  ])("matches an uppercase-hex route key from %s on the wire", async (_label, pathBytes) => {
-    expect(await rawGet(pathBytes)).toStartWith("cafe-upper:");
-  });
-
-  it("req.url reports the encoded form for raw UTF-8 bytes even though routing matched", async () => {
-    expect(await rawGet([0x2f, 0x63, 0x61, 0x66, 0xc3, 0xa9])).toBe("cafe-upper:/caf%C3%A9");
+    // /café as raw UTF-8 bytes, the way curl and node:http send it. req.url percent-encodes
+    // raw bytes via WTF::URL but preserves the hex case of an existing %-encoding.
+    ["raw UTF-8 bytes", [0x2f, 0x63, 0x61, 0x66, 0xc3, 0xa9], "cafe-upper:/caf%C3%A9"],
+    ["lowercase-hex percent-encoding", Buffer.from("/caf%c3%a9"), "cafe-upper:/caf%c3%a9"],
+    ["mixed-case percent-encoding", Buffer.from("/caf%c3%A9"), "cafe-upper:/caf%c3%A9"],
+  ])("matches an uppercase-hex route key from %s on the wire", async (_label, pathBytes, expected) => {
+    expect(await rawGet(pathBytes)).toBe(expected);
   });
 
   it.each([
@@ -199,7 +200,19 @@ describe("percent-encoded route keys", () => {
   });
 
   it("does not treat a percent-encoded slash as a path separator", async () => {
-    expect(await rawGet(Buffer.from("/caf%C3%A9%2Fextra"))).toStartWith("fallback:");
+    expect(await rawGet(Buffer.from("/caf%C3%A9%2Fextra"))).toBe("fallback:/caf%C3%A9%2Fextra");
+  });
+
+  it.each([
+    ["a trailing %", "/bad%", "bad-trailing"],
+    ["a single hex digit", "/bad%A", "bad-short"],
+    ["a non-hex pair", "/bad%G0", "bad-nonhex"],
+  ])("matches a malformed %%-escape literally (%s)", async (_label, path, expected) => {
+    expect(await rawGet(Buffer.from(path))).toBe(expected);
+  });
+
+  it("still normalizes valid %-escapes that follow a malformed one", async () => {
+    expect(await rawGet(Buffer.from("/bad%G0%C3%A9"))).toBe("bad-nonhex-then-valid");
   });
 });
 


### PR DESCRIPTION
### What

`Bun.serve` route keys must be ASCII: a literal non-ASCII key throws \"Please encode all non-ASCII characters in the path\", so the only way to register a `/café` or `/🦊` route is percent-encoded. The uWS router then compared that key byte-for-byte against the raw request-target, with two consequences:

- A client that sends raw UTF-8 in the path (`curl`, `node:http`, or any raw socket) never reaches the route even though `new URL(req.url).pathname` on that same request already shows the percent-encoded form.
- A route key registered with lowercase hex (`/caf%c3%a9`) is silently accepted but unreachable from any browser or `fetch()` client, which emit uppercase hex. RFC 3986 6.2.2.1 says hex case in a percent-encoding is equivalent.

```js
Bun.serve({
  port: 3000,
  routes: {
    "/caf%C3%A9": () => new Response("hit"),
  },
  fetch: req => new Response("miss: " + new URL(req.url).pathname),
});
```
```
$ printf 'GET /caf\xc3\xa9 HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n' | nc localhost 3000
...
miss: /caf%C3%A9
```

### Fix

Normalize in `HttpRouter::setUrl` (`packages/bun-uws/src/HttpRouter.h`), which every route registration, removal, and match already goes through: percent-encode bytes `>= 0x80` as uppercase `%XX` and uppercase the hex digits of existing `%xx` sequences. A path that is already canonical (no high bytes, no lowercase `%`-hex, which is every ordinary ASCII route) returns the input view unchanged with no copy. Malformed `%` sequences (fewer than two hex digits) are left untouched so both sides see the same bytes.

No percent-decoding is performed, so `%2F` is still not a path separator and `/p/%73ecret` still matches `/p/:v` rather than a literal `/p/secret` route, the same semantics as before.

Route parameters are unaffected: a raw-UTF-8 segment captured by `:id` is now stored as `%XX` rather than raw bytes, but `req.params` already passes through `decodeURIComponentSIMD`, so the JS-visible value is identical (covered by the existing `decodes raw … in a parameter segment` tests).

#33096 handles the path-structure half of this disagreement (dot-segments, `\\`, `#`) and explicitly defers percent-encoding equivalence; this PR is that follow-up. Both touch `HttpRouter.h` and add a `normalizedUrlBuffer` member, so whichever lands second will need a small rebase.

### Verification

New `percent-encoded route keys` block in `test/js/bun/http/bun-serve-routes.test.ts`: 15 cases covering raw UTF-8 bytes on the wire, lowercase/uppercase/mixed-case hex in both key and request, an encoded emoji key, a static `Response` route with a lowercase-hex key, an encoded segment followed by a `:param`, and a `%2F` non-separator check. 11 of the 15 fail on `main` and all pass with this change; the existing 55 tests in the file are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (ba1fa5057)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [42.43ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [26.64ms]
(pass) path parameters > handles encoded parameters [23.31ms]
(pass) path parameters > handles unicode parameters [22.18ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [569.98ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [55.98ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key via fetch() [26.52ms]
(pass) percent-encoded route keys > matches the encoded route key when fetch() is given a literal non-ASCII path [17.86ms]
158 |     // raw bytes via WTF::URL but preserves the hex case of an existing %-encoding.
159 |     ["raw UTF-8 bytes", [0x2f, 0x63, 0x61, 0x66, 0xc3, 0xa9], "cafe-upper:/caf%C3%A9"],
160 |     ["lowercase-hex percent-encoding", Buffer.fr
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (00b4e33dd)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [1.90ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.32ms]
(pass) path parameters > handles encoded parameters [0.17ms]
(pass) path parameters > handles unicode parameters [0.15ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [5.98ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [1.07ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key via fetch() [1.21ms]
(pass) percent-encoded route keys > matches the encoded route key when fetch() is given a literal non-ASCII path [0.19ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key from raw UTF-8 bytes on the wire [0.79ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key from lowercase-hex percent-encoding on the wire [0.57ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key from mixed-case percent-encoding on the wire [0.45ms]
(pass) percent-encoded route keys > matches a l
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-routes.test.ts
bun test v1.4.0 (ba1fa5057)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [34.63ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [26.23ms]
(pass) path parameters > handles encoded parameters [21.90ms]
(pass) path parameters > handles unicode parameters [21.58ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [546.84ms]
(pass) path parameters > decodes raw an invalid UTF-8 byte in a parameter segment [90.55ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key via fetch() [19.60ms]
(pass) percent-encoded route keys > matches the encoded route key when fetch() is given a literal non-ASCII path [9.00ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key from raw UTF-8 bytes on the wire [86.00ms]
(pass) percent-encoded route keys > matches an uppercase-hex route key from lowercase-hex percent-encoding on the wire [62.36
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 875ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/11] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 2m 59s
[7/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[8/11] link bun-profile
[9/11] bun-profile --revision
1.4.0-canary.1+ba1fa5057
[11/11] strip bun
[build] done
bun test v1.4.0-canary.1 (ba1fa5057)

test/js/bun/http/bun-serve-routes.test.ts:
(pass) path parameters > handles single parameter [2.03ms]
RequestParams {
  postId: "456",
  commentId: "789",
}
(pass) path parameters > handles multiple parameters [0.32ms]
(pass) path parameters > handles encoded parameters [0.15ms]
(pass) path parameters > handles unicode parameters [0.14ms]
(pass) path parameters > decodes raw valid UTF-8 bytes in a parameter segment [6.61ms]
(pass) path parameters > decodes raw an invalid U
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpRouter.h         |  57 +++++++++++++-
 test/js/bun/http/bun-serve-routes.test.ts | 122 ++++++++++++++++++++++++++++++
 2 files changed, 178 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
packages/bun-uws/src/HttpRouter.h              2      3      0
test/js/bun/http/bun-serve-routes.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->