### PR TITLE
fs.Utf8Stream: store first chunk of each buffer group; fix periodicFlush timer

### DIFF
--- a/src/js/internal/streams/fast-utf8-stream.ts
+++ b/src/js/internal/streams/fast-utf8-stream.ts
@@ -179,7 +179,11 @@ class Utf8Stream extends EventEmitter {
     });
 
     if (this.#periodicFlush !== 0) {
-      this.#periodicFlushTimer = setInterval(() => this.flush(), this.#periodicFlush);
+      // Call #flush(undefined) so the periodic tick only drains the in-memory
+      // buffer to the fd (no drain/error listeners registered, no fsync),
+      // matching SonicBoom's periodic timer. The public flush() defaults cb to
+      // a no-op so user calls keep their fsync-on-drain contract.
+      this.#periodicFlushTimer = setInterval(() => this.#flush(undefined), this.#periodicFlush);
       this.#periodicFlushTimer.unref();
     }
   }
@@ -684,7 +688,7 @@ class Utf8Stream extends EventEmitter {
   }
 
   #flushBuffer(cb) {
-    validateFunction(cb, "cb");
+    if (cb !== undefined) validateFunction(cb, "cb");
 
     if (this.#destroyed) {
       const error = $ERR_INVALID_STATE("Utf8Stream is destroyed");
@@ -718,7 +722,7 @@ class Utf8Stream extends EventEmitter {
   }
 
   #flushUtf8(cb) {
-    validateFunction(cb, "cb");
+    if (cb !== undefined) validateFunction(cb, "cb");
 
     if (this.#destroyed) {
       const error = $ERR_INVALID_STATE("Utf8Stream is destroyed");

--- a/src/js/internal/streams/fast-utf8-stream.ts
+++ b/src/js/internal/streams/fast-utf8-stream.ts
@@ -179,7 +179,7 @@ class Utf8Stream extends EventEmitter {
     });
 
     if (this.#periodicFlush !== 0) {
-      this.#periodicFlushTimer = setInterval(() => this.flush(null), this.#periodicFlush);
+      this.#periodicFlushTimer = setInterval(() => this.flush(), this.#periodicFlush);
       this.#periodicFlushTimer.unref();
     }
   }
@@ -770,7 +770,7 @@ class Utf8Stream extends EventEmitter {
     }
 
     if (bufs.length === 0 || lens[lens.length - 1] + dataLength > this.#maxWrite) {
-      bufs.push([]);
+      bufs.push([data]);
       lens.push(dataLength);
     } else {
       bufs[bufs.length - 1].push(data);

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -47,10 +47,20 @@ describe("fs.Utf8Stream contentMode: buffer", () => {
 });
 
 describe("fs.Utf8Stream periodicFlush", () => {
+  // Utf8Stream's periodicFlush interval is unref()'d. On Windows, bun:test's
+  // event loop doesn't drive unref'd timers while a test awaits a promise
+  // with no ref'd handles outstanding; keep one ref'd interval alive so the
+  // periodic tick actually fires.
+  function keepAlive() {
+    const t = setInterval(() => {}, 50);
+    return { [Symbol.dispose]: () => clearInterval(t) };
+  }
+
   // The periodicFlush timer used to call this.flush(null), which bypasses the
   // default cb argument and then fails validateFunction(cb). Every timer tick
   // would throw an uncaught ERR_INVALID_ARG_TYPE instead of flushing.
   test.each([true, false])("timer tick flushes buffered data (sync=%p)", async sync => {
+    using _ = keepAlive();
     using dir = tempDir("utf8stream-periodic", {});
     const dest = join(String(dir), "out.log");
     const fd = openSync(dest, "w");
@@ -72,6 +82,7 @@ describe("fs.Utf8Stream periodicFlush", () => {
   });
 
   test("timer tick flushes buffered data (contentMode: buffer)", async () => {
+    using _ = keepAlive();
     using dir = tempDir("utf8stream-periodic-buffer", {});
     const dest = join(String(dir), "out.log");
     const fd = openSync(dest, "w");
@@ -94,6 +105,7 @@ describe("fs.Utf8Stream periodicFlush", () => {
   // fix that routed the timer through flush()'s default no-op cb would call
   // fs.fsync on every tick and accumulate listeners under sustained writes.
   test("timer tick does not fsync or accumulate drain listeners", async () => {
+    using _ = keepAlive();
     using dir = tempDir("utf8stream-periodic-nolisten", {});
     const dest = join(String(dir), "out.log");
     const fd = openSync(dest, "w");

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import { openSync, readFileSync, Utf8Stream } from "node:fs";
+import { join } from "node:path";
+import { tempDir } from "harness";
+
+describe("fs.Utf8Stream contentMode: buffer", () => {
+  // https://github.com/nodejs/node/pull/63833: when starting a new buffer
+  // group, the chunk itself must be stored (bufs.push([data])), not an empty
+  // array. Previously the first chunk of every group was silently dropped and
+  // #len drifted past the real buffered bytes, crashing in mergeBuf.
+  test.each([true, false])("write() stores the first chunk of each group (sync=%p)", async sync => {
+    using dir = tempDir("utf8stream-buffer", {});
+    const dest = join(String(dir), "out.log");
+    const fd = openSync(dest, "w");
+    const stream = new Utf8Stream({ fd, sync, contentMode: "buffer" });
+    try {
+      await once(stream, "ready");
+      expect(stream.write(Buffer.from("hello world\n"))).toBe(true);
+      expect(stream.write(Buffer.from("something else\n"))).toBe(true);
+      stream.end();
+      await once(stream, "finish");
+      expect(readFileSync(dest, "utf8")).toBe("hello world\nsomething else\n");
+    } finally {
+      stream.destroy();
+    }
+  });
+
+  test("write() stores the first chunk when a new group is forced by maxWrite", async () => {
+    using dir = tempDir("utf8stream-buffer-maxwrite", {});
+    const dest = join(String(dir), "out.log");
+    const fd = openSync(dest, "w");
+    // maxWrite: 8 forces each 6-byte write into its own buffer group.
+    const stream = new Utf8Stream({ fd, sync: true, contentMode: "buffer", maxWrite: 8, minLength: 1 });
+    try {
+      await once(stream, "ready");
+      stream.write(Buffer.from("aaaaaa"));
+      stream.write(Buffer.from("bbbbbb"));
+      stream.write(Buffer.from("cccccc"));
+      stream.flushSync();
+      expect(readFileSync(dest, "utf8")).toBe("aaaaaabbbbbbcccccc");
+    } finally {
+      stream.destroy();
+    }
+  });
+});
+
+describe("fs.Utf8Stream periodicFlush", () => {
+  // The periodicFlush timer used to call this.flush(null), which bypasses the
+  // default cb argument and then fails validateFunction(cb). Every timer tick
+  // would throw an uncaught ERR_INVALID_ARG_TYPE instead of flushing.
+  test.each([true, false])("timer tick flushes buffered data (sync=%p)", async sync => {
+    using dir = tempDir("utf8stream-periodic", {});
+    const dest = join(String(dir), "out.log");
+    const fd = openSync(dest, "w");
+    // minLength keeps the write buffered until the periodic flush fires.
+    const stream = new Utf8Stream({ fd, sync, minLength: 4096, periodicFlush: 5 });
+    let errored: unknown;
+    stream.on("error", err => (errored = err));
+    try {
+      await once(stream, "ready");
+      stream.write("hello world\n");
+      // Data is buffered (below minLength) until periodicFlush fires.
+      expect(readFileSync(dest, "utf8")).toBe("");
+      await once(stream, "drain");
+      expect(errored).toBeUndefined();
+      expect(readFileSync(dest, "utf8")).toBe("hello world\n");
+    } finally {
+      stream.destroy();
+    }
+  });
+
+  test("timer tick flushes buffered data (contentMode: buffer)", async () => {
+    using dir = tempDir("utf8stream-periodic-buffer", {});
+    const dest = join(String(dir), "out.log");
+    const fd = openSync(dest, "w");
+    const stream = new Utf8Stream({ fd, contentMode: "buffer", minLength: 4096, periodicFlush: 5 });
+    let errored: unknown;
+    stream.on("error", err => (errored = err));
+    try {
+      await once(stream, "ready");
+      stream.write(Buffer.from("hello world\n"));
+      await once(stream, "drain");
+      expect(errored).toBeUndefined();
+      expect(readFileSync(dest, "utf8")).toBe("hello world\n");
+    } finally {
+      stream.destroy();
+    }
+  });
+});

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 import { once } from "node:events";
 import { fsync, openSync, readFileSync, Utf8Stream } from "node:fs";
 import { join } from "node:path";
-import { tempDir } from "harness";
 
 describe("fs.Utf8Stream contentMode: buffer", () => {
   // https://github.com/nodejs/node/pull/63833: when starting a new buffer
@@ -131,9 +131,7 @@ describe("fs.Utf8Stream periodicFlush", () => {
     const stream = new Utf8Stream({ fd, minLength: 4096 });
     try {
       await once(stream, "ready");
-      expect(() => stream.flush(null)).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-      );
+      expect(() => stream.flush(null)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
     } finally {
       stream.destroy();
     }

--- a/test/js/node/fs/fast-utf8-stream.test.ts
+++ b/test/js/node/fs/fast-utf8-stream.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
-import { openSync, readFileSync, Utf8Stream } from "node:fs";
+import { fsync, openSync, readFileSync, Utf8Stream } from "node:fs";
 import { join } from "node:path";
 import { tempDir } from "harness";
 
@@ -30,8 +30,9 @@ describe("fs.Utf8Stream contentMode: buffer", () => {
     using dir = tempDir("utf8stream-buffer-maxwrite", {});
     const dest = join(String(dir), "out.log");
     const fd = openSync(dest, "w");
-    // maxWrite: 8 forces each 6-byte write into its own buffer group.
-    const stream = new Utf8Stream({ fd, sync: true, contentMode: "buffer", maxWrite: 8, minLength: 1 });
+    // minLength: 7 keeps the first 6-byte write buffered so the second write
+    // evaluates lens[last] + 6 > maxWrite (8) and starts a fresh group.
+    const stream = new Utf8Stream({ fd, sync: true, contentMode: "buffer", maxWrite: 8, minLength: 7 });
     try {
       await once(stream, "ready");
       stream.write(Buffer.from("aaaaaa"));
@@ -83,6 +84,56 @@ describe("fs.Utf8Stream periodicFlush", () => {
       await once(stream, "drain");
       expect(errored).toBeUndefined();
       expect(readFileSync(dest, "utf8")).toBe("hello world\n");
+    } finally {
+      stream.destroy();
+    }
+  });
+
+  // The periodic tick should only drain the in-memory buffer to the fd, like
+  // SonicBoom: no fsync, and no once('drain')/once('error') listeners. A naive
+  // fix that routed the timer through flush()'s default no-op cb would call
+  // fs.fsync on every tick and accumulate listeners under sustained writes.
+  test("timer tick does not fsync or accumulate drain listeners", async () => {
+    using dir = tempDir("utf8stream-periodic-nolisten", {});
+    const dest = join(String(dir), "out.log");
+    const fd = openSync(dest, "w");
+    let fsyncCalls = 0;
+    const stream = new Utf8Stream({
+      fd,
+      minLength: 4096,
+      periodicFlush: 2,
+      fs: {
+        fsync: (fd, cb) => {
+          fsyncCalls++;
+          fsync(fd, cb);
+        },
+      },
+    });
+    try {
+      await once(stream, "ready");
+      stream.write("hello world\n");
+      await once(stream, "drain");
+      // Let a few more ticks fire with nothing buffered.
+      for (let i = 0; i < 3; i++) await once(stream, "drain");
+      expect(fsyncCalls).toBe(0);
+      expect(stream.listenerCount("drain")).toBe(0);
+      expect(stream.listenerCount("error")).toBe(0);
+      expect(readFileSync(dest, "utf8")).toBe("hello world\n");
+    } finally {
+      stream.destroy();
+    }
+  });
+
+  test("flush(null) from user code still rejects", async () => {
+    using dir = tempDir("utf8stream-flush-null", {});
+    const dest = join(String(dir), "out.log");
+    const fd = openSync(dest, "w");
+    const stream = new Utf8Stream({ fd, minLength: 4096 });
+    try {
+      await once(stream, "ready");
+      expect(() => stream.flush(null)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
     } finally {
       stream.destroy();
     }


### PR DESCRIPTION
Two transcription bugs from the SonicBoom → Node `Utf8Stream` port (#34505).

## 1. `#writeBuffer` drops the first chunk of every buffer group

```js
// before
bufs.push([]);
lens.push(dataLength);
```

The chunk itself is never stored, only its length. `#len` advances past bytes that are not in `#bufs`, so once `#actualWriteBuffer` drains the real bytes and re-enters with `len > 0` but `bufs` empty, `mergeBuf(undefined, undefined)` crashes:

```
TypeError: undefined is not an object (evaluating 'bufs')
    at mergeBuf (internal:streams/fast-utf8-stream:687:11)
    at #actualWriteBuffer (internal:streams/fast-utf8-stream:441:77)
    at #release (internal:streams/fast-utf8-stream:318:24)
```

SonicBoom pushes `[data]`. Node v26.3.0 shipped the same typo and fixed it in nodejs/node#63833.

## 2. `periodicFlush` timer throws on every tick

```js
setInterval(() => this.flush(null), this.#periodicFlush);
```

`flush(cb = function(_err) {})` only defaults for `undefined`; an explicit `null` reaches `#flushUtf8` / `#flushBuffer`, whose first line is `validateFunction(cb, "cb")`, so every interval tick throws an uncaught `ERR_INVALID_ARG_TYPE` instead of flushing. Node's own `test-fastutf8stream-periodicflush.js` never lets the timer fire (it checks the option value and destroys immediately), so the bug is uncovered there too.

SonicBoom's periodic timer passes a falsy `cb` so the tick only drains the in-memory buffer to the fd: no `fsync`, no `once('drain')`/`once('error')` registration. This PR preserves that by having the timer call the private `#flush(undefined)` directly and guarding `validateFunction` on `cb !== undefined`. The public `flush(cb = function(){})` still defaults for user calls, so `stream.flush()` keeps its fsync-on-drain contract and `stream.flush(null)` keeps throwing `ERR_INVALID_ARG_TYPE` like Node.

## Verification

```
bun bd test test/js/node/fs/fast-utf8-stream.test.ts
```

8 tests covering both content modes and sync/async, including that the periodic tick does not fsync or accumulate listeners, and that user `flush(null)` still rejects. All fail on main (TypeError / ERR_INVALID_ARG_TYPE) except the `flush(null)` rejection, which is existing behavior. All 14 `test/js/node/test/parallel/test-fastutf8stream-*.js` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/fs/fast-utf8-stream.test.ts"
bun test v1.4.0 (8d26498c2)

test/js/node/fs/fast-utf8-stream.test.ts:
682 |   }
683 |   len = Math.max(len - n, 0);
684 |   writingBuf = writingBuf.slice(n);
685 |   return { writingBuf, len };
686 | }
687 |   if (bufs.length === 0) {
                ^
TypeError: undefined is not an object (evaluating 'bufs')
      at mergeBuf (internal:streams/fast-utf8-stream:687:11)
      at #actualWriteBuffer (internal:streams/fast-utf8-stream:441:77)
      at #release (internal:streams/fast-utf8-stream:318:24)
      at #actualWriteBuffer (internal:streams/fast-utf8-stream:445:22)
      at #writeBuffer (internal:streams/fast-utf8-stream:643:24)
      at <anonymous> (/workspace/bun/test/js/node/fs/fast-utf8-stream.test.ts:19:21)
(fail) fs.Utf8Stream contentMode: buffer > write() stores the first chunk of each group (sync=true) [376.54ms]
682 |   }
683 |   len = Math.max(len - n, 0);
684 |   writingBuf = writingBuf.slice(n);
685 |   return { writingBuf, len };
686 | }
687 |   if (bufs.length === 0) {
      
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/fs/fast-utf8-stream.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'Utf8Stream' not found in module 'node:fs'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [317.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/fs/fast-utf8-stream.test.ts"
bun test v1.4.0 (8d26498c2)

test/js/node/fs/fast-utf8-stream.test.ts:
(pass) fs.Utf8Stream contentMode: buffer > write() stores the first chunk of each group (sync=true) [548.30ms]
(pass) fs.Utf8Stream contentMode: buffer > write() stores the first chunk of each group (sync=false) [37.38ms]
(pass) fs.Utf8Stream contentMode: buffer > write() stores the first chunk when a new group is forced by maxWrite [25.58ms]
(pass) fs.Utf8Stream periodicFlush > timer tick flushes buffered data (sync=true) [39.66ms]
(pass) fs.Utf8Stream periodicFlush > timer tick flushes buffered data (sync=false) [41.54ms]
(pass) fs.Utf8Stream periodicFlush > timer tick flushes buffered data (contentMode: buffer) [369.56ms]
(pass) fs.Utf8Stream periodicFlush > timer tick does not fsync or accumulate drain listeners [252.40ms]
(pass) fs.Utf8Stream periodicFlush > flush(null) from user code still rejects [55.91ms]

 8 pass
 0 fail
 20 expect() calls
Ran 8 tests across 1 file. [7.34s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1812ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/105] gen JS modules (bundle-modules)
Preprocess modules (17710ms)
Bundle modules (144ms)
Postprocesss modules (366ms)
Bundle Functions (2027ms)
Generate Code (42ms)

[20.34s] Bundled "src/js" for production
  2076 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/101] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 49s
[97/101] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[98/101] link bun-profile
[99/101] bun-profile --revision
1.4.0-canary.1+8d26498c2
[101/101] strip bun
[build] done
bun test v1.4.0-canary.1 (8d26498c2)

test/js/node/fs/fast-utf8-stream.test.ts:
(pass) fs.Utf8Stream contentMode: buffer > write() stores the first chunk of each group (sync=true) [15.84ms]
(pass) fs.Utf8Stream cont
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/streams/fast-utf8-stream.ts |  12 ++-
 test/js/node/fs/fast-utf8-stream.test.ts    | 151 ++++++++++++++++++++++++++++
 2 files changed, 159 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/internal/streams/fast-utf8-stream.ts      3      4      0
test/js/node/fs/fast-utf8-stream.test.ts         3      4      0
```

</details>

<!-- robobun:evidence:end -->