### PR TITLE
feat(pm): add --json flag to `bun pm ls` and `bun list`

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -144,9 +144,10 @@ impl PackageManagerCommand {
   <d>└<r> <cyan>--quiet<r>                   only output the tarball filename
   <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder
   <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder
-  <b><green>bun<r> <blue>list<r>                  list the dependency tree according to the current lockfile
+  <b><green>bun<r> <blue>list<r>                    list the dependency tree according to the current lockfile
   <d>├<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
-  <d>└<r> <cyan>--trusted<r>                 list only trusted dependencies
+  <d>├<r> <cyan>--trusted<r>                 list only trusted dependencies
+  <d>└<r> <cyan>--json<r>                    output in JSON format
   <b><green>bun pm<r> <blue>why<r> <d>\<pkg\><r>            show dependency tree explaining why a package is installed
   <b><green>bun pm<r> <blue>whoami<r>               print the current npm username
   <b><green>bun pm<r> <blue>view<r> <d>name[@version]<r>  view package metadata from the registry <d>(use `bun info` instead)<r>

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -11,10 +11,13 @@ use bun_install::package_manager_real::{
     CommandLineArguments, Subcommand, fetch_cache_directory_path, get_cache_directory,
     package_manager_options::LogLevel, setup_global_dir,
 };
-use bun_install::{DependencyID, PackageID, PackageManager, migration};
+use bun_install::{DependencyID, PackageID, PackageManager, Resolution, migration};
 use bun_paths::{self as Path, PathBuffer};
 use bun_resolver::fs as Fs;
 use bun_sys::{self, Dir, Fd, File};
+
+use bun_ast::{E, Expr, Loc};
+use bun_js_printer as JSPrinter;
 
 use crate::cli::Command;
 use crate::cli::pm_pkg_command::PmPkgCommand;
@@ -155,9 +158,10 @@ impl PackageManagerCommand {
   <d>└<r> <cyan>--quiet<r>                   only output the tarball filename\n\
   <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder\n\
   <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder\n\
-  <b><green>bun<r> <blue>list<r>                  list the dependency tree according to the current lockfile\n\
+  <b><green>bun<r> <blue>list<r>                    list the dependency tree according to the current lockfile\n\
   <d>├<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile\n\
-  <d>└<r> <cyan>--trusted<r>                 list only trusted dependencies\n\
+  <d>├<r> <cyan>--trusted<r>                 list only trusted dependencies\n\
+  <d>└<r> <cyan>--json<r>                    output in JSON format\n\
   <b><green>bun pm<r> <blue>why<r> <d>\\<pkg\\><r>            show dependency tree explaining why a package is installed\n\
   <b><green>bun pm<r> <blue>whoami<r>               print the current npm username\n\
   <b><green>bun pm<r> <blue>view<r> <d>name[@version]<r>  view package metadata from the registry <d>(use `bun info` instead)<r>\n\
@@ -499,6 +503,16 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             Output::flush();
             Output::disable_buffering();
             let lockfile: &Lockfile = &pm.lockfile;
+
+            if pm.options.json_output {
+                let show_all = strings::left_has_any_in_right(args, &[b"-A", b"-a", b"--all"]);
+                if strings::left_has_any_in_right(args, &[b"--trusted"]) {
+                    bun_core::warn!("--trusted is not supported with --json and will be ignored");
+                }
+                print_ls_json(lockfile, pm, show_all)?;
+                Global::exit(0);
+            }
+
             let mut iterator =
                 tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
 
@@ -722,6 +736,250 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             Global::exit(0);
         }
     }
+}
+
+fn print_ls_json(
+    lockfile: &Lockfile,
+    pm: &PackageManager,
+    show_all: bool,
+) -> Result<(), crate::Error> {
+    let dependencies = lockfile.buffers.dependencies.as_slice();
+    let slice = lockfile.packages.slice();
+    let resolutions = slice.items_resolution();
+    let pkg_dependencies = slice.items_dependencies();
+    let string_bytes = lockfile.buffers.string_bytes.as_slice();
+    let resolutions_buf = lockfile.buffers.resolutions.as_slice();
+
+    let mut cwd_buf = PathBuffer::uninit();
+    let cwd: &[u8] = match bun_sys::getcwd(&mut cwd_buf[..]) {
+        Ok(len) => &cwd_buf[..len],
+        Err(_) => {
+            bun_core::pretty_errorln!("<r><red>error<r>: Could not get current working directory",);
+            Global::exit(1);
+        }
+    };
+
+    // `E::String` stores its bytes by reference, so keys and values must
+    // outlive the AST through printing — dupe into the process-lifetime arena.
+    let bump = crate::cli::cli_arena();
+
+    let mut root_name: &[u8] = &pm.root_package_json_name_at_time_of_init;
+    let mut root_version: &[u8] = b"";
+    'from_package_json: {
+        if !pm.root_dir.has_comptime_query(b"package.json") {
+            break 'from_package_json;
+        }
+        let fd = pm.root_dir.fd;
+        if !fd.is_valid() {
+            break 'from_package_json;
+        }
+        let contents = match bun_sys::File::read_from(fd, b"package.json") {
+            Ok(s) => s,
+            Err(_) => break 'from_package_json,
+        };
+        let parse_bump = bun_alloc::Arena::new();
+        let contents: &[u8] = parse_bump.alloc_slice_copy(&contents);
+        let source = &bun_ast::Source::init_path_string(b"package.json", contents);
+        let mut parse_log = bun_ast::Log::init();
+        let Ok(json) = bun_parsers::json::parse_utf8(source, &mut parse_log, &parse_bump) else {
+            break 'from_package_json;
+        };
+        if let Some(name) = json.get_string_cloned(&parse_bump, b"name").ok().flatten() {
+            if !name.is_empty() {
+                root_name = crate::cli::cli_dupe(name);
+            }
+        }
+        if let Some(version) = json.get_string_cloned(&parse_bump, b"version").ok().flatten() {
+            root_version = crate::cli::cli_dupe(version);
+        }
+    }
+
+    let mut root_obj = E::Object::default();
+    if !root_name.is_empty() {
+        root_obj.put(
+            bump,
+            b"name",
+            Expr::init(E::String::init(crate::cli::cli_dupe(root_name)), Loc::EMPTY),
+        )?;
+    }
+    if !root_version.is_empty() {
+        root_obj.put(
+            bump,
+            b"version",
+            Expr::init(E::String::init(root_version), Loc::EMPTY),
+        )?;
+    }
+    root_obj.put(
+        bump,
+        b"path",
+        Expr::init(E::String::init(crate::cli::cli_dupe(cwd)), Loc::EMPTY),
+    )?;
+
+    let mut prod_deps = E::Object::default();
+    let mut dev_deps = E::Object::default();
+    let mut optional_deps = E::Object::default();
+    let mut peer_deps = E::Object::default();
+    let mut transitive_deps = E::Object::default();
+
+    // Track direct dependency IDs so transitive deps can skip them below.
+    let mut direct_dep_ids: std::collections::HashSet<DependencyID> = std::collections::HashSet::new();
+
+    let by_name = ByName {
+        dependencies,
+        buf: string_bytes,
+    };
+
+    // Map each installed dependency edge to the node_modules folder it actually
+    // lives in, so `path` reflects the real (possibly nested) install location
+    // rather than assuming everything is hoisted to `<cwd>/node_modules`.
+    let mut dep_folders: std::collections::HashMap<DependencyID, &[u8]> = std::collections::HashMap::new();
+    {
+        let mut iterator = tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
+        while let Some(node_modules) = iterator.next(None) {
+            // `relative_path` is only valid until the next `next()`, so dupe it
+            // into the process-lifetime arena before storing.
+            let folder_rel = crate::cli::cli_dupe(node_modules.relative_path.as_bytes());
+            for &dep_id in node_modules.dependencies {
+                dep_folders.insert(dep_id, folder_rel);
+            }
+        }
+    }
+
+    // Direct deps first.
+    let root_deps = pkg_dependencies[0];
+    let mut sorted_direct: Vec<DependencyID> = Vec::with_capacity(root_deps.len as usize);
+    for i in 0..root_deps.len {
+        sorted_direct.push((root_deps.off + i) as DependencyID);
+    }
+    sorted_direct.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
+
+    for &dependency_id in &sorted_direct {
+        let package_id = resolutions_buf[dependency_id as usize];
+        if package_id as usize >= lockfile.packages.len() {
+            continue;
+        }
+        direct_dep_ids.insert(dependency_id);
+
+        let dep = &dependencies[dependency_id as usize];
+        let folder_rel = dep_folders.get(&dependency_id).copied().unwrap_or(b"node_modules");
+        let dep_expr =
+            build_dep_info(dep, &resolutions[package_id as usize], string_bytes, cwd, folder_rel)?;
+        let name = crate::cli::cli_dupe(dep.name.slice(string_bytes));
+
+        if dep.behavior.is_dev() {
+            dev_deps.put(bump, name, dep_expr)?;
+        } else if dep.behavior.is_peer() {
+            peer_deps.put(bump, name, dep_expr)?;
+        } else if dep.behavior.is_optional() {
+            optional_deps.put(bump, name, dep_expr)?;
+        } else {
+            prod_deps.put(bump, name, dep_expr)?;
+        }
+    }
+
+    // Transitive deps (only with --all). Sourced from the same tree walk that
+    // produced `dep_folders`, so every edge carries its real install path.
+    if show_all {
+        let mut sorted_transitive: Vec<DependencyID> = dep_folders
+            .keys()
+            .copied()
+            .filter(|id| !direct_dep_ids.contains(id))
+            .collect();
+        sorted_transitive.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
+
+        for &dependency_id in &sorted_transitive {
+            let package_id = resolutions_buf[dependency_id as usize];
+            if package_id as usize >= lockfile.packages.len() {
+                continue;
+            }
+            let dep = &dependencies[dependency_id as usize];
+            let folder_rel = dep_folders.get(&dependency_id).copied().unwrap_or(b"node_modules");
+            let dep_expr =
+                build_dep_info(dep, &resolutions[package_id as usize], string_bytes, cwd, folder_rel)?;
+            let name = crate::cli::cli_dupe(dep.name.slice(string_bytes));
+            transitive_deps.put(bump, name, dep_expr)?;
+        }
+    }
+
+    // Always emit the four direct-dependency buckets so the JSON schema is
+    // stable for consumers, even when a bucket is empty.
+    root_obj.put(bump, b"dependencies", Expr::init(prod_deps, Loc::EMPTY))?;
+    root_obj.put(bump, b"devDependencies", Expr::init(dev_deps, Loc::EMPTY))?;
+    root_obj.put(bump, b"optionalDependencies", Expr::init(optional_deps, Loc::EMPTY))?;
+    root_obj.put(bump, b"peerDependencies", Expr::init(peer_deps, Loc::EMPTY))?;
+    // transitiveDependencies is only meaningful with --all; omit it otherwise
+    // rather than emit an empty object that implies there are none.
+    if show_all {
+        root_obj.put(bump, b"transitiveDependencies", Expr::init(transitive_deps, Loc::EMPTY))?;
+    }
+
+    let root_expr = Expr::init(root_obj, Loc::EMPTY);
+    let source = &bun_ast::Source::init_empty_file(b"ls.json");
+
+    let mut buffer_writer = JSPrinter::BufferWriter::init();
+    buffer_writer.append_newline = true;
+    let mut printer = JSPrinter::BufferPrinter::init(buffer_writer);
+    JSPrinter::print_json(
+        &mut printer,
+        root_expr,
+        source,
+        JSPrinter::PrintJsonOptions {
+            mangled_props: None,
+            ..Default::default()
+        },
+    )?;
+
+    Output::print(format_args!(
+        "{}",
+        bstr::BStr::new(printer.ctx.get_written())
+    ));
+    Output::flush();
+    Ok(())
+}
+
+// ==== Format ====
+// {
+//   from: "package-name",
+//   version: "1.2.3",
+//   path: "path/to/the/package/in/node_modules"
+// }
+fn build_dep_info(
+    dep: &Dependency,
+    resolution: &Resolution,
+    string_bytes: &[u8],
+    cwd: &[u8],
+    folder_rel: &[u8],
+) -> Result<Expr, crate::Error> {
+    let bump = crate::cli::cli_arena();
+    let mut dep_info = E::Object::default();
+
+    let name = dep.name.slice(string_bytes);
+
+    dep_info.put(
+        bump,
+        b"from",
+        Expr::init(E::String::init(crate::cli::cli_dupe(name)), Loc::EMPTY),
+    )?;
+
+    let version = {
+        let mut v = Vec::new();
+        let _ = write!(&mut v, "{}", resolution.fmt(string_bytes, PathSep::Auto));
+        crate::cli::cli_dupe(&v)
+    };
+    dep_info.put(
+        bump,
+        b"version",
+        Expr::init(E::String::init(version), Loc::EMPTY),
+    )?;
+
+    let path = Path::resolve_path::join::<Path::platform::Auto>(&[cwd, folder_rel, name]);
+    dep_info.put(
+        bump,
+        b"path",
+        Expr::init(E::String::init(crate::cli::cli_dupe(path)), Loc::EMPTY),
+    )?;
+
+    Ok(Expr::init(dep_info, Loc::EMPTY))
 }
 
 fn print_node_modules_folder_structure(

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -906,3 +906,441 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+test("bun pm ls --json outputs JSON format", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-ls-json",
+      version: "1.2.3",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--json"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  const parsed = JSON.parse(stdoutText);
+  expect(parsed.name).toBe("test-ls-json");
+  expect(parsed.version).toBe("1.2.3");
+  expect(parsed.path).toBe(package_dir);
+  expect(parsed.dependencies.bar).toEqual({
+    from: "bar",
+    version: "0.0.2",
+    path: join(package_dir, "node_modules", "bar"),
+  });
+  // Direct-dependency buckets are always present for a stable schema, even when empty.
+  expect(parsed.devDependencies).toEqual({});
+  expect(parsed.optionalDependencies).toEqual({});
+  expect(parsed.peerDependencies).toEqual({});
+  // transitiveDependencies is only emitted with --all.
+  expect(parsed.transitiveDependencies).toBeUndefined();
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm ls --all --json shows transitive dependencies", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-ls-json-all",
+      version: "1.0.0",
+      dependencies: {
+        moo: "./moo",
+      },
+    }),
+  );
+  await mkdir(join(package_dir, "moo"));
+  await writeFile(
+    join(package_dir, "moo", "package.json"),
+    JSON.stringify({
+      name: "moo",
+      version: "0.1.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--all", "--json"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  const parsed = JSON.parse(stdoutText);
+  expect(parsed.name).toBe("test-ls-json-all");
+  expect(parsed.dependencies.moo).toBeDefined();
+  expect(parsed.transitiveDependencies).toBeDefined();
+  expect(parsed.transitiveDependencies.bar).toEqual({
+    from: "bar",
+    version: "0.0.2",
+    path: join(package_dir, "node_modules", "bar"),
+  });
+  expect(exitCode).toBe(0);
+});
+
+test("bun list --json works as alias", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-list-json-alias",
+      version: "1.0.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "list", "--json"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  const parsed = JSON.parse(stdoutText);
+  expect(parsed.name).toBe("test-list-json-alias");
+  expect(parsed.dependencies.bar.version).toBe("0.0.2");
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm ls --json separates dependencies and devDependencies", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-ls-json-dev",
+      version: "1.0.0",
+      dependencies: {
+        bar: "latest",
+      },
+      devDependencies: {
+        boba: "latest",
+      },
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--json"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  const parsed = JSON.parse(stdoutText);
+  expect(parsed.dependencies.bar).toBeDefined();
+  expect(parsed.dependencies.boba).toBeUndefined();
+  expect(parsed.devDependencies.boba).toBeDefined();
+  expect(parsed.devDependencies.bar).toBeUndefined();
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm ls --json classifies optionalDependencies and peerDependencies", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-ls-json-optional-peer",
+      version: "1.0.0",
+      dependencies: {
+        bar: "latest",
+      },
+      optionalDependencies: {
+        qux: "latest",
+      },
+      peerDependencies: {
+        peer: "latest",
+      },
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--json"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  const parsed = JSON.parse(stdoutText);
+  expect(parsed.dependencies.bar).toBeDefined();
+  // Each declared dependency lands in exactly its own bucket.
+  expect(parsed.dependencies.qux).toBeUndefined();
+  expect(parsed.dependencies.peer).toBeUndefined();
+  expect(parsed.optionalDependencies.qux).toEqual({
+    from: "qux",
+    version: "0.0.2",
+    path: join(package_dir, "node_modules", "qux"),
+  });
+  expect(parsed.peerDependencies.peer).toEqual({
+    from: "peer",
+    version: "0.0.2",
+    path: join(package_dir, "node_modules", "peer"),
+  });
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm ls --trusted --json warns that --trusted is ignored", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-ls-json-trusted-warn",
+      version: "1.0.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--trusted", "--json"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  // The warning goes to stderr; stdout stays valid JSON (the full tree).
+  expect(stderrText).toContain("--trusted is not supported with --json");
+  const parsed = JSON.parse(stdoutText);
+  expect(parsed.dependencies.bar).toBeDefined();
+  expect(exitCode).toBe(0);
+});
+
+test("bun pm ls --json --all reports the real nested install path", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls, { "0.0.3": {}, "0.0.5": {}, latest: "0.0.5" }));
+  // Root pins baz@0.0.3 at the top level; nested-parent pulls in a conflicting
+  // baz@0.0.5, which must be installed nested under nested-parent/node_modules.
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "test-ls-json-nested",
+      version: "1.0.0",
+      dependencies: {
+        baz: "0.0.3",
+        "nested-parent": "./nested-parent",
+      },
+    }),
+  );
+  await mkdir(join(package_dir, "nested-parent"));
+  await writeFile(
+    join(package_dir, "nested-parent", "package.json"),
+    JSON.stringify({
+      name: "nested-parent",
+      version: "1.0.0",
+      dependencies: {
+        baz: "0.0.5",
+      },
+    }),
+  );
+
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--json", "--all"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrText, stdoutText, exitCode] = await Promise.all([
+    new Response(stderr).text(),
+    new Response(stdout).text(),
+    exited,
+  ]);
+
+  expect(stderrText).toBe("");
+  const parsed = JSON.parse(stdoutText);
+
+  // The root-hoisted copy (a direct dep) sits at the top-level node_modules.
+  expect(parsed.dependencies.baz).toEqual({
+    from: "baz",
+    version: "0.0.3",
+    path: join(package_dir, "node_modules", "baz"),
+  });
+
+  // The conflicting copy is installed nested, and its reported path must
+  // reflect that real location (the tree-walk fix) rather than a flat
+  // `<cwd>/node_modules/baz`.
+  expect(parsed.transitiveDependencies.baz).toEqual({
+    from: "baz",
+    version: "0.0.5",
+    path: join(package_dir, "node_modules", "nested-parent", "node_modules", "baz"),
+  });
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

  Add a `--json` flag to `bun pm ls` (and its `bun list` alias) that emits
  the dependency tree as JSON instead of the human-readable tree, in a
  pnpm-compatible shape for easy scripting.

  The output is a single root object with:
  - `name`, `version`, `path` for the current project
  - `dependencies`, `devDependencies`, `optionalDependencies`,
    `peerDependencies` buckets, each keyed by package name with
    `{ from, version, path }` entries
  - `transitiveDependencies` (only with `--all`)

  The four direct-dependency buckets are always emitted (empty object when a
  bucket has no members) so consumers get a stable schema.
  `transitiveDependencies` is omitted unless `--all` is passed.

  Also documents `--json` in the `bun pm`/`bun list` help output and fixes
  the alignment of the `bun list` header line, which was two columns short
  of its siblings.

  This is a port of the original Zig implementation (#26223), which was
  closed after Bun's package manager was rewritten to Rust. Filtering
  support is intentionally deferred to a follow-up.

  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

  Closes #26222

### How did you verify your code works?

- Added unit tests
- Testing the debug build in my local gives the below output (heroku cli):

  ```bash
  $ BUN_DEBUG_QUIET_LOGS=1 ../bun/build/debug/bun-debug list --json
  {
    "path": "/my/personal/workspace/cli",
    "dependencies": {
      "heroku": {
        "from": "heroku",
        "version": "workspace:packages/cli",
        "path": "/my/personal/workspace/cli/node_modules/heroku"
      }
    },
    "devDependencies": {
      "@actions/core": {
        "from": "@actions/core",
        "version": "1.11.1",
        "path": "/my/personal/workspace/cli/node_modules/@actions/core"
      },
      ...
      "tmp": {
        "from": "tmp",
        "version": "0.2.5",
        "path": "/my/personal/workspace/cli/node_modules/tmp"
      }
    }
  }
  ```
  and with `--all` flag the output is:

  ```bash
  $ BUN_DEBUG_QUIET_LOGS=1 ../bun/build/debug/bun-debug list --json --all
  {
    "path": "/my/personal/workspace/cli",
    "dependencies": {
      "heroku": {
        "from": "heroku",
        "version": "workspace:packages/cli",
        "path": "/my/personal/workspace/cli/node_modules/heroku"
      }
    },
    "devDependencies": {
      "@actions/core": {
        "from": "@actions/core",
        "version": "1.11.1",
        "path": "/my/personal/workspace/cli/node_modules/@actions/core"
      },
      ...
      "tmp": {
        "from": "tmp",
        "version": "0.2.5",
        "path": "/my/personal/workspace/cli/node_modules/tmp"
      }
    },
    "transitiveDependencies": {
      "@actions/exec": {
        "from": "@actions/exec",
        "version": "1.1.1",
        "path": "/my/personal/workspace/cli/node_modules/@actions/exec"
      },
      ...
      "@aws-sdk/region-config-resolver": {
        "from": "@aws-sdk/region-config-resolver",
        "version": "3.969.0",
        "path": "/my/personal/workspace/cli/node_modules/@aws-sdk/region-config-resolver"
      },
      ...
      "acorn": {
        "from": "acorn",
        "version": "8.15.0",
        "path": "/my/personal/workspace/cli/node_modules/acorn"
      },
      ...
      "zod-to-json-schema": {
        "from": "zod-to-json-schema",
        "version": "3.25.1",
        "path": "/my/personal/workspace/cli/node_modules/zod-to-json-schema"
      }
    }
  }
  ```
