### PR TITLE
bun create: supply a fallback git identity when none is configured

### DIFF
--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -2840,29 +2840,18 @@ impl GitHandler {
         );
         if let Some(git) = which(bun_path_buf, path, destination, b"git") {
             let git: &[u8] = git.as_bytes();
-            let git_commands: [&[&[u8]]; 3] = [
-                &[git, b"init", b"--quiet"],
-                &[git, b"add", destination, b"--ignore-errors"],
-                &[
-                    git,
-                    b"commit",
-                    b"-am",
-                    b"Initial commit (via bun create)",
-                    b"--quiet",
-                ],
-            ];
 
             if VERBOSE {
                 bun_core::pretty_errorln!("git backend: {}", bstr::BStr::new(git));
             }
 
-            for command in git_commands {
-                let _ = spawn_sync::spawn(&spawn_sync::Options {
-                    argv: command.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
+            let spawn_git = |argv: &[&[u8]], stderr: spawn_sync::SyncStdio| -> crate::Result<bool> {
+                let result = spawn_sync::spawn(&spawn_sync::Options {
+                    argv: argv.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
                     cwd: Box::from(destination),
                     stdin: spawn_sync::SyncStdio::Inherit,
-                    stdout: spawn_sync::SyncStdio::Inherit,
-                    stderr: spawn_sync::SyncStdio::Inherit,
+                    stdout: stderr,
+                    stderr,
                     #[cfg(windows)]
                     windows: spawn_sync::WindowsOptions {
                         loop_: win_loop,
@@ -2872,12 +2861,54 @@ impl GitHandler {
                     windows: (),
                     ..Default::default()
                 })?;
+                Ok(matches!(result, Ok(r) if r.is_ok()))
+            };
+
+            // `git commit` refuses to run without a resolvable committer identity
+            // and prints a multi-line "Please tell me who you are" banner to
+            // stderr. Probe for it and supply a placeholder when missing so a
+            // fresh machine without `~/.gitconfig` still gets a clean initial
+            // commit instead of that banner.
+            let has_identity = spawn_git(
+                &[git, b"var", b"GIT_COMMITTER_IDENT"],
+                spawn_sync::SyncStdio::Ignore,
+            )?;
+
+            let mut commit: Vec<&[u8]> = Vec::with_capacity(10);
+            commit.push(git);
+            if !has_identity {
+                commit.extend_from_slice(&[
+                    b"-c",
+                    b"user.name=bun",
+                    b"-c",
+                    b"user.email=bun-create@localhost",
+                ]);
+            }
+            commit.extend_from_slice(&[
+                b"commit",
+                b"-am",
+                b"Initial commit (via bun create)",
+                b"--quiet",
+            ]);
+
+            let git_commands: [&[&[u8]]; 3] = [
+                &[git, b"init", b"--quiet"],
+                &[git, b"add", destination, b"--ignore-errors"],
+                &commit,
+            ];
+
+            let mut ok = true;
+            for command in git_commands {
+                if !spawn_git(command, spawn_sync::SyncStdio::Inherit)? {
+                    ok = false;
+                    break;
+                }
             }
 
             bun_core::pretty_error!("\n");
             Output::print_start_end(git_start, bun_core::time::nano_timestamp());
             bun_core::pretty_error!(" <d>git<r>\n");
-            return Ok(true);
+            return Ok(ok);
         }
 
         Ok(false)

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1449,13 +1449,11 @@ impl CreateCommand {
             if !create_options.skip_install {
                 GitHandler::spawn(destination, path_env, create_options.verbose);
             } else {
-                if create_options.verbose {
-                    create_options.skip_git =
-                        GitHandler::run::<true>(destination, path_env).unwrap_or(false);
+                create_options.skip_git = !if create_options.verbose {
+                    GitHandler::run::<true>(destination, path_env).unwrap_or(false)
                 } else {
-                    create_options.skip_git =
-                        GitHandler::run::<false>(destination, path_env).unwrap_or(false);
-                }
+                    GitHandler::run::<false>(destination, path_env).unwrap_or(false)
+                };
             }
         }
 
@@ -2865,46 +2863,44 @@ impl GitHandler {
                     Ok(matches!(result, Ok(r) if r.is_ok()))
                 };
 
-            // `git commit` refuses to run without a resolvable committer identity
-            // and prints a multi-line "Please tell me who you are" banner to
-            // stderr. Probe for it and supply a placeholder when missing so a
-            // fresh machine without `~/.gitconfig` still gets a clean initial
-            // commit instead of that banner.
-            let has_identity = spawn_git(
-                &[git, b"var", b"GIT_COMMITTER_IDENT"],
-                spawn_sync::SyncStdio::Ignore,
-            )?;
+            let inherit = spawn_sync::SyncStdio::Inherit;
+            let ignore = spawn_sync::SyncStdio::Ignore;
 
-            let mut commit: Vec<&[u8]> = Vec::with_capacity(10);
-            commit.push(git);
-            if !has_identity {
-                commit.extend_from_slice(&[
-                    b"-c",
-                    b"user.name=bun",
-                    b"-c",
-                    b"user.email=bun-create@localhost",
-                ]);
-            }
-            commit.extend_from_slice(&[
-                b"commit",
-                b"-am",
-                b"Initial commit (via bun create)",
-                b"--quiet",
-            ]);
-
-            let git_commands: [&[&[u8]]; 3] = [
-                &[git, b"init", b"--quiet"],
-                &[git, b"add", destination, b"--ignore-errors"],
-                &commit,
-            ];
-
-            let mut ok = true;
-            for command in git_commands {
-                if !spawn_git(command, spawn_sync::SyncStdio::Inherit)? {
-                    ok = false;
-                    break;
+            let ok = 'git: {
+                if !spawn_git(&[git, b"init", b"--quiet"], inherit)? {
+                    break 'git false;
                 }
-            }
+
+                // `git commit` refuses to run without a resolvable author and
+                // committer identity and prints a multi-line "Please tell me who
+                // you are" banner to stderr. Probe after `git init` (so the check
+                // sees the same repo the commit will use, not a parent repo's
+                // local config) and supply a placeholder when either is missing.
+                let has_identity = spawn_git(&[git, b"var", b"GIT_AUTHOR_IDENT"], ignore)?
+                    && spawn_git(&[git, b"var", b"GIT_COMMITTER_IDENT"], ignore)?;
+
+                // `--ignore-errors` keeps staging past per-file index errors but
+                // still exits non-zero, so don't treat its exit code as fatal.
+                let _ = spawn_git(&[git, b"add", destination, b"--ignore-errors"], inherit)?;
+
+                let mut commit: Vec<&[u8]> = Vec::with_capacity(10);
+                commit.push(git);
+                if !has_identity {
+                    commit.extend_from_slice(&[
+                        b"-c",
+                        b"user.name=bun",
+                        b"-c",
+                        b"user.email=bun-create@localhost",
+                    ]);
+                }
+                commit.extend_from_slice(&[
+                    b"commit",
+                    b"-am",
+                    b"Initial commit (via bun create)",
+                    b"--quiet",
+                ]);
+                spawn_git(&commit, inherit)?
+            };
 
             bun_core::pretty_error!("\n");
             Output::print_start_end(git_start, bun_core::time::nano_timestamp());

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -2845,24 +2845,25 @@ impl GitHandler {
                 bun_core::pretty_errorln!("git backend: {}", bstr::BStr::new(git));
             }
 
-            let spawn_git = |argv: &[&[u8]], stderr: spawn_sync::SyncStdio| -> crate::Result<bool> {
-                let result = spawn_sync::spawn(&spawn_sync::Options {
-                    argv: argv.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
-                    cwd: Box::from(destination),
-                    stdin: spawn_sync::SyncStdio::Inherit,
-                    stdout: stderr,
-                    stderr,
-                    #[cfg(windows)]
-                    windows: spawn_sync::WindowsOptions {
-                        loop_: win_loop,
+            let spawn_git =
+                |argv: &[&[u8]], stderr: spawn_sync::SyncStdio| -> crate::Result<bool> {
+                    let result = spawn_sync::spawn(&spawn_sync::Options {
+                        argv: argv.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
+                        cwd: Box::from(destination),
+                        stdin: spawn_sync::SyncStdio::Inherit,
+                        stdout: stderr,
+                        stderr,
+                        #[cfg(windows)]
+                        windows: spawn_sync::WindowsOptions {
+                            loop_: win_loop,
+                            ..Default::default()
+                        },
+                        #[cfg(not(windows))]
+                        windows: (),
                         ..Default::default()
-                    },
-                    #[cfg(not(windows))]
-                    windows: (),
-                    ..Default::default()
-                })?;
-                Ok(matches!(result, Ok(r) if r.is_ok()))
-            };
+                    })?;
+                    Ok(matches!(result, Ok(r) if r.is_ok()))
+                };
 
             // `git commit` refuses to run without a resolvable committer identity
             // and prints a multi-line "Please tell me who you are" banner to

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -209,6 +209,52 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
   expect(proc.resourceUsage!.contextSwitches.voluntary).toBeLessThan(2000);
 });
 
+// On a machine with no ~/.gitconfig (fresh CI agent, new dev box) `git commit`
+// prints the multi-line "Please tell me who you are" banner and exits 128,
+// leaving the new repo with no initial commit. `bun create` now probes
+// `git var GIT_COMMITTER_IDENT` and supplies a placeholder identity when that
+// probe fails.
+it("creates the initial git commit even when git has no user identity configured", async () => {
+  using dir = tempDir("create-no-git-identity", {
+    "home/.keep": "",
+    "bun-create/tmpl/package.json": JSON.stringify({ name: "tmpl", version: "1.0.0" }),
+    "bun-create/tmpl/index.js": "// hi\n",
+  });
+
+  const stripped = Object.fromEntries(
+    Object.entries(env).filter(([k]) => !k.startsWith("GIT_") && k !== "EMAIL" && k !== "XDG_CONFIG_HOME"),
+  );
+
+  await using proc = spawn({
+    cmd: [bunExe(), "create", "tmpl", join(String(dir), "dest"), "--no-install"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...stripped,
+      HOME: join(String(dir), "home"),
+      USERPROFILE: join(String(dir), "home"),
+      GIT_CONFIG_NOSYSTEM: "1",
+      BUN_CREATE_DIR: join(String(dir), "bun-create"),
+    },
+  });
+
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(err).not.toContain("Please tell me who you are");
+  expect(err).not.toContain("unable to auto-detect email address");
+  expect(err).not.toContain("fatal:");
+  expect(out).toContain("Created tmpl project successfully");
+  expect(exitCode).toBe(0);
+
+  const log = spawnSync({
+    cmd: ["git", "-C", join(String(dir), "dest"), "log", "-1", "--format=%an <%ae> %s"],
+    env,
+  });
+  expect(log.stdout.toString().trim()).toBe("bun <bun-create@localhost> Initial commit (via bun create)");
+  expect(log.exitCode).toBe(0);
+});
+
 it("should create template from local folder", async () => {
   const bunCreateDir = join(x_dir, "bun-create");
   const testTemplate = "test-template";

--- a/test/cli/install/bun-create.test.ts
+++ b/test/cli/install/bun-create.test.ts
@@ -212,11 +212,15 @@ it.skipIf(!isPosix)("does not busy-wait on the futex while git runs", async () =
 // On a machine with no ~/.gitconfig (fresh CI agent, new dev box) `git commit`
 // prints the multi-line "Please tell me who you are" banner and exits 128,
 // leaving the new repo with no initial commit. `bun create` now probes
-// `git var GIT_COMMITTER_IDENT` and supplies a placeholder identity when that
-// probe fails.
+// `git var GIT_{AUTHOR,COMMITTER}_IDENT` after `git init` and supplies a
+// placeholder identity when either probe fails.
 it("creates the initial git commit even when git has no user identity configured", async () => {
   using dir = tempDir("create-no-git-identity", {
-    "home/.keep": "",
+    // `useConfigOnly` disables git's auto-detection (GECOS + hostname /
+    // `/etc/mailname`), so the identity probe fails deterministically on every
+    // host: macOS `*.local` hostnames and Debian's mailname would otherwise let
+    // git synthesize an email and skip the fallback path under test.
+    "home/.gitconfig": "[user]\n\tuseConfigOnly = true\n",
     "bun-create/tmpl/package.json": JSON.stringify({ name: "tmpl", version: "1.0.0" }),
     "bun-create/tmpl/index.js": "// hi\n",
   });
@@ -242,9 +246,10 @@ it("creates the initial git commit even when git has no user identity configured
   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(err).not.toContain("Please tell me who you are");
-  expect(err).not.toContain("unable to auto-detect email address");
+  expect(err).not.toContain("auto-detect");
   expect(err).not.toContain("fatal:");
   expect(out).toContain("Created tmpl project successfully");
+  expect(out).toContain("A local git repository was created for you");
   expect(exitCode).toBe(0);
 
   const log = spawnSync({


### PR DESCRIPTION
## What

On a fresh machine with no `~/.gitconfig` (new dev box, CI agent), `bun create` prints git's multi-line "Please tell me who you are" banner mid-run and leaves the new project with staged files but no initial commit:

```
Copying files...
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'buildkite-agent@ip-172-31-33-198.(none)')
```

## Cause

`GitHandler::run` spawns `git init`, `git add`, `git commit` with inherited stderr and discards their exit codes. When no committer identity resolves, the commit step fails loudly but `bun create` carries on as if it worked.

## Fix

Before committing, probe `git var GIT_COMMITTER_IDENT` (silent). When it fails, pass `-c user.name=bun -c user.email=bun-create@localhost` on the commit so the initial commit still lands. When an identity is configured the probe succeeds and the user's own identity is used unchanged. Git exit codes are now propagated so the "A local git repository was created for you" summary reflects reality.

## Verification

```
# before (released bun): prints the banner, no commit
# after (this PR):
$ bun create tmpl dest
Copying files...

[10.00ms] git
...
$ git -C dest log -1 --format='%an <%ae> %s'
bun <bun-create@localhost> Initial commit (via bun create)
```

New test in `test/cli/install/bun-create.test.ts` strips `HOME`/`GIT_*`/`EMAIL` and asserts the banner is gone and the commit exists with the placeholder author.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.0 (ec1690cff)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [151.63ms]
(pass) should not crash > ["create",""] [125.24ms]
(pass) should not crash > ["create","--"] [99.24ms]
(pass) should not crash > ["create","--",""] [164.76ms]
(pass) should not crash > ["create","--help"] [109.92ms]
(pass) should create selected template with @ prefix [511.38ms]
(pass) should create selected template with @ prefix implicit `/create` [585.65ms]
(pass) should create selected template with @ prefix implicit `/create` with version [443.21ms]
(pass) handles a close-delimited GitHub tarball body split across packets [966.14ms]
(pass) does not busy-wait on the futex while git runs [1748.14ms]
243 |     },
244 |   });
245 | 
246 |   const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
247 | 
248 |   expect(err).not.toContain("Please tell me who you are");
                        ^
error: expect(received).not.toContain(expected)

E
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (00e3f91ba)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [4.84ms]
(pass) should not crash > ["create",""] [2.18ms]
(pass) should not crash > ["create","--"] [1.83ms]
(pass) should not crash > ["create","--",""] [1.75ms]
(pass) should not crash > ["create","--help"] [1.72ms]
(pass) should create selected template with @ prefix [298.39ms]
(pass) should create selected template with @ prefix implicit `/create` [213.45ms]
(pass) should create selected template with @ prefix implicit `/create` with version [43.51ms]
(pass) handles a close-delimited GitHub tarball body split across packets [56.24ms]
(pass) does not busy-wait on the futex while git runs [2014.28ms]
247 | 
248 |   expect(err).not.toContain("Please tell me who you are");
249 |   expect(err).not.toContain("auto-detect");
250 |   expect(err).not.toContain("fatal:");
251 |   expect(out).toContain("Created tmpl project successfully");
252 |   expect(out).toContain("A local git repository was created for you");
                    ^
error: expect(received).toContain(expected)

Expected to contain: "A local git repository was created for you"
Received: "\nCome
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-create.test.ts
bun test v1.4.0 (ec1690cff)

test/cli/install/bun-create.test.ts:
(pass) should not crash > ["create"] [119.51ms]
(pass) should not crash > ["create",""] [113.74ms]
(pass) should not crash > ["create","--"] [165.99ms]
(pass) should not crash > ["create","--",""] [106.18ms]
(pass) should not crash > ["create","--help"] [108.15ms]
(pass) should create selected template with @ prefix [482.27ms]
(pass) should create selected template with @ prefix implicit `/create` [491.30ms]
(pass) should create selected template with @ prefix implicit `/create` with version [508.35ms]
(pass) handles a close-delimited GitHub tarball body split across packets [1003.58ms]
(pass) does not busy-wait on the futex while git runs [2672.90ms]
(pass) creates the initial git commit even when git has no user identity configured [199.23ms]
Copying files... 

[20.00ms] git

[118.00ms] bun create /tmp/cr8-11RQOTfH/bun-create/test-template

Come hang out in bun's Discord: https://bun.com/discord

A local git repository was created fo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 697ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/create_command.rs   | 96 ++++++++++++++++++++++++-------------
 test/cli/install/bun-create.test.ts | 51 ++++++++++++++++++++
 2 files changed, 113 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/cli/create_command.rs        4      3      0
test/cli/install/bun-create.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->