### PR TITLE
process.env: make runtime-set TZ / NODE_TLS_REJECT_UNAUTHORIZED / BUN_CONFIG_VERBOSE_FETCH enumerable

### DIFF
--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -87,7 +87,9 @@ static void makeEnvAccessorEnumerable(VM& vm, JSGlobalObject* globalObject, JSOb
     auto scope = DECLARE_THROW_SCOPE(vm);
     unsigned attributes = 0;
     JSValue existing = object->getDirect(vm, propertyName, attributes);
-    if (!existing || !(attributes & JSC::PropertyAttribute::DontEnum))
+    // `object` is the [[Set]] receiver, which under Reflect.set(process.env, k, v, r)
+    // is `r`, not process.env: only re-put when the slot is actually our accessor.
+    if (!existing || !(attributes & JSC::PropertyAttribute::DontEnum) || !existing.isCustomGetterSetter())
         return;
     object->deleteProperty(globalObject, propertyName);
     RETURN_IF_EXCEPTION(scope, void());

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -76,6 +76,25 @@ JSC_DEFINE_CUSTOM_SETTER(jsSetterEnvironmentVariable, (JSGlobalObject * globalOb
     return true;
 }
 
+// The HTTP_PROXY / TZ / NODE_TLS_REJECT_UNAUTHORIZED / BUN_CONFIG_VERBOSE_FETCH
+// accessors are installed with DontEnum when the var was absent from the launch
+// env. After the first write the property must become enumerable so
+// {...process.env} / Object.keys / JSON.stringify (and therefore child_process /
+// Worker env inheritance) see it. putDirectCustomAccessor asserts NewProperty,
+// so delete first and re-add without DontEnum.
+static void makeEnvAccessorEnumerable(VM& vm, JSGlobalObject* globalObject, JSObject* object, PropertyName propertyName)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    unsigned attributes = 0;
+    JSValue existing = object->getDirect(vm, propertyName, attributes);
+    if (!existing || !(attributes & JSC::PropertyAttribute::DontEnum))
+        return;
+    object->deleteProperty(globalObject, propertyName);
+    RETURN_IF_EXCEPTION(scope, void());
+    object->putDirectCustomAccessor(vm, propertyName, existing,
+        attributes & ~JSC::PropertyAttribute::DontEnum);
+}
+
 // Proxy-related env vars (HTTP_PROXY, HTTPS_PROXY, NO_PROXY and lowercase
 // variants) are read by fetch()'s native proxy resolution via
 // env_loader.getHttpProxyFor(). Writes from JS must sync back to the native env
@@ -118,23 +137,8 @@ JSC_DEFINE_CUSTOM_SETTER(jsSetterProxyEnvironmentVariable, (JSGlobalObject * glo
     BunString val = Bun::toStringView(view);
     Bun__setEnvValue(globalObject, &name, &val);
 
-    // The proxy-var accessors are added with `DontEnum` when the var was not
-    // present in the OS env at startup. The regular env-var setter
-    // (`jsSetterEnvironmentVariable`) makes a written var enumerable by
-    // replacing the accessor with a data property; this setter keeps the
-    // accessor (so the native env map stays the source of truth) but must
-    // still clear `DontEnum` — otherwise `process.env.HTTP_PROXY = "..."`
-    // followed by `Bun.spawn({env: {...process.env}})` silently drops the var
-    // (the spread skips non-enumerable properties).
-    unsigned attributes;
-    JSValue existing = object->getDirect(vm, propertyName, attributes);
-    if (existing && (attributes & JSC::PropertyAttribute::DontEnum)) {
-        // putDirectCustomAccessor asserts NewProperty, so delete first.
-        object->deleteProperty(globalObject, propertyName);
-        RETURN_IF_EXCEPTION(scope, false);
-        object->putDirectCustomAccessor(vm, propertyName, existing,
-            attributes & ~JSC::PropertyAttribute::DontEnum);
-    }
+    makeEnvAccessorEnumerable(vm, globalObject, object, propertyName);
+    RETURN_IF_EXCEPTION(scope, false);
     return true;
 }
 
@@ -173,25 +177,6 @@ JSC_DEFINE_CUSTOM_GETTER(jsTimeZoneEnvironmentVariableGetter, (JSGlobalObject * 
 static void applyTZFromString(JSGlobalObject*, const String&);
 static void applyTLSRejectFromString(JSGlobalObject*, const String&);
 static void applyVerboseFetchFromString(JSGlobalObject*, const String&);
-
-// The side-effecting accessors above are installed with DontEnum when the var
-// was absent from the launch env. After the first write the property must become
-// enumerable so {...process.env} / Object.keys / JSON.stringify (and therefore
-// child_process / Worker env inheritance) see it. putDirectCustomAccessor asserts
-// NewProperty, so delete first and re-add without DontEnum, same as
-// jsSetterProxyEnvironmentVariable does inline.
-static void makeEnvAccessorEnumerable(VM& vm, JSGlobalObject* globalObject, JSObject* object, PropertyName propertyName)
-{
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    unsigned attributes = 0;
-    JSValue existing = object->getDirect(vm, propertyName, attributes);
-    if (!existing || !(attributes & JSC::PropertyAttribute::DontEnum))
-        return;
-    object->deleteProperty(globalObject, propertyName);
-    RETURN_IF_EXCEPTION(scope, void());
-    object->putDirectCustomAccessor(vm, propertyName, existing,
-        attributes & ~JSC::PropertyAttribute::DontEnum);
-}
 
 // In Node.js, the "TZ" environment variable is special.
 // Setting it automatically updates the timezone.

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -174,12 +174,32 @@ static void applyTZFromString(JSGlobalObject*, const String&);
 static void applyTLSRejectFromString(JSGlobalObject*, const String&);
 static void applyVerboseFetchFromString(JSGlobalObject*, const String&);
 
+// The side-effecting accessors above are installed with DontEnum when the var
+// was absent from the launch env. After the first write the property must become
+// enumerable so {...process.env} / Object.keys / JSON.stringify (and therefore
+// child_process / Worker env inheritance) see it. putDirectCustomAccessor asserts
+// NewProperty, so delete first and re-add without DontEnum, same as
+// jsSetterProxyEnvironmentVariable does inline.
+static void makeEnvAccessorEnumerable(VM& vm, JSGlobalObject* globalObject, JSObject* object, PropertyName propertyName)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    unsigned attributes = 0;
+    JSValue existing = object->getDirect(vm, propertyName, attributes);
+    if (!existing || !(attributes & JSC::PropertyAttribute::DontEnum))
+        return;
+    object->deleteProperty(globalObject, propertyName);
+    RETURN_IF_EXCEPTION(scope, void());
+    object->putDirectCustomAccessor(vm, propertyName, existing,
+        attributes & ~JSC::PropertyAttribute::DontEnum);
+}
+
 // In Node.js, the "TZ" environment variable is special.
 // Setting it automatically updates the timezone.
 // We also expose an explicit setTimeZone function in bun:jsc
 JSC_DEFINE_CUSTOM_SETTER(jsTimeZoneEnvironmentVariableSetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, PropertyName propertyName))
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSObject* object = JSValue::decode(thisValue).getObject();
     if (!object)
         return false;
@@ -187,6 +207,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsTimeZoneEnvironmentVariableSetter, (JSGlobalObject * 
     JSValue decodedValue = JSValue::decode(value);
     if (decodedValue.isString()) {
         auto timeZoneName = decodedValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, false);
         applyTZFromString(globalObject, timeZoneName);
     }
 
@@ -195,9 +216,8 @@ JSC_DEFINE_CUSTOM_SETTER(jsTimeZoneEnvironmentVariableSetter, (JSGlobalObject * 
     auto privateName = builtinNames->dataPrivateName();
     object->putDirect(vm, privateName, JSValue::decode(value), 0);
 
-    // TODO: this is an assertion failure
-    // Recreate this because the property visibility needs to be set correctly
-    // object->putDirectWithoutTransition(vm, propertyName, JSC::CustomGetterSetter::create(vm, jsTimeZoneEnvironmentVariableGetter, jsTimeZoneEnvironmentVariableSetter), JSC::PropertyAttribute::CustomAccessor | 0);
+    makeEnvAccessorEnumerable(vm, globalObject, object, propertyName);
+    RETURN_IF_EXCEPTION(scope, false);
     return true;
 }
 
@@ -266,9 +286,8 @@ JSC_DEFINE_CUSTOM_SETTER(jsNodeTLSRejectUnauthorizedSetter, (JSGlobalObject * gl
     const auto& privateName = NODE_TLS_REJECT_UNAUTHORIZED_PRIVATE_PROPERTY(vm);
     object->putDirect(vm, privateName, JSValue::decode(value), 0);
 
-    // TODO: this is an assertion failure
-    // Recreate this because the property visibility needs to be set correctly
-    // object->putDirectWithoutTransition(vm, propertyName, JSC::CustomGetterSetter::create(vm, jsTimeZoneEnvironmentVariableGetter, jsTimeZoneEnvironmentVariableSetter), JSC::PropertyAttribute::CustomAccessor | 0);
+    makeEnvAccessorEnumerable(vm, globalObject, object, propertyName);
+    RETURN_IF_EXCEPTION(scope, false);
     return true;
 }
 
@@ -314,9 +333,8 @@ JSC_DEFINE_CUSTOM_SETTER(jsBunConfigVerboseFetchSetter, (JSGlobalObject * global
     const auto& privateName = BUN_CONFIG_VERBOSE_FETCH_PRIVATE_PROPERTY(vm);
     object->putDirect(vm, privateName, JSValue::decode(value), 0);
 
-    // TODO: this is an assertion failure
-    // Recreate this because the property visibility needs to be set correctly
-    // object->putDirectWithoutTransition(vm, propertyName, JSC::CustomGetterSetter::create(vm, jsTimeZoneEnvironmentVariableGetter, jsTimeZoneEnvironmentVariableSetter), JSC::PropertyAttribute::CustomAccessor | 0);
+    makeEnvAccessorEnumerable(vm, globalObject, object, propertyName);
+    RETURN_IF_EXCEPTION(scope, false);
     return true;
 }
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -285,6 +285,35 @@ it("process.env: runtime-set TZ / NODE_TLS_REJECT_UNAUTHORIZED / BUN_CONFIG_VERB
   expect(exitCode).toBe(0);
 });
 
+it("process.env: Reflect.set with a foreign receiver does not crash the TZ / TLS / verbose-fetch / proxy setters", async () => {
+  const vars = ["TZ", "NODE_TLS_REJECT_UNAUTHORIZED", "BUN_CONFIG_VERBOSE_FETCH", "HTTP_PROXY"];
+  const childEnv = { ...bunEnv };
+  for (const k of vars) delete childEnv[k];
+
+  // The CustomAccessor setters receive the [[Set]] receiver as thisValue; a
+  // receiver with an own DontEnum data property at the same name used to hit
+  // ASSERT(value.isCustomGetterSetter()) in putDirectCustomAccessor.
+  const script = `
+    const vars = ${JSON.stringify(vars)};
+    for (const k of vars) {
+      const r = {};
+      Object.defineProperty(r, k, { value: "x", enumerable: false, configurable: true });
+      Reflect.set(process.env, k, "v", r);
+    }
+    process.stdout.write("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: childEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
 const MIN_ICU_VERSIONS_BY_PLATFORM_ARCH = {
   "darwin-x64": "70.1",
   "darwin-arm64": "72.1",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -231,6 +231,60 @@ it("process.env is spreadable and editable", () => {
   expect(eval(`globalThis.process.env.USER = "${orig}"`)).toBe(String(orig));
 });
 
+// TZ / NODE_TLS_REJECT_UNAUTHORIZED / BUN_CONFIG_VERBOSE_FETCH are backed by
+// CustomAccessors that are installed DontEnum when the var was absent at launch.
+// Writing one must make it enumerable so {...process.env}, Object.keys,
+// JSON.stringify, and child_process/Worker env inheritance see it (node does).
+it("process.env: runtime-set TZ / NODE_TLS_REJECT_UNAUTHORIZED / BUN_CONFIG_VERBOSE_FETCH become enumerable", async () => {
+  const vars = ["TZ", "NODE_TLS_REJECT_UNAUTHORIZED", "BUN_CONFIG_VERBOSE_FETCH"];
+  const childEnv = { ...bunEnv };
+  for (const k of vars) delete childEnv[k];
+
+  const script = `
+    const { spawnSync } = require("node:child_process");
+    const vars = ${JSON.stringify(vars)};
+    for (const k of vars) {
+      if (process.env[k] !== undefined) throw new Error(k + " was set at launch; test invalid");
+    }
+    process.env.TZ = "Asia/Tokyo";
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    process.env.BUN_CONFIG_VERBOSE_FETCH = "curl";
+    const spread = { ...process.env };
+    const json = JSON.parse(JSON.stringify(process.env));
+    const grand = spawnSync(process.execPath, ["-e",
+      'process.stdout.write(JSON.stringify([process.env.TZ, process.env.NODE_TLS_REJECT_UNAUTHORIZED, process.env.BUN_CONFIG_VERBOSE_FETCH]))',
+    ], { encoding: "utf8" });
+    process.stdout.write(JSON.stringify({
+      readback: vars.map(k => process.env[k]),
+      enumerable: vars.map(k => Object.prototype.propertyIsEnumerable.call(process.env, k)),
+      inKeys: vars.map(k => Object.keys(process.env).includes(k)),
+      spread: vars.map(k => spread[k] ?? null),
+      json: vars.map(k => json[k] ?? null),
+      grand: JSON.parse(grand.stdout),
+      tzStillApplies: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: childEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    readback: ["Asia/Tokyo", "0", "curl"],
+    enumerable: [true, true, true],
+    inKeys: [true, true, true],
+    spread: ["Asia/Tokyo", "0", "curl"],
+    json: ["Asia/Tokyo", "0", "curl"],
+    grand: ["Asia/Tokyo", "0", "curl"],
+    tzStillApplies: "Asia/Tokyo",
+  });
+  expect(exitCode).toBe(0);
+});
+
 const MIN_ICU_VERSIONS_BY_PLATFORM_ARCH = {
   "darwin-x64": "70.1",
   "darwin-arm64": "72.1",


### PR DESCRIPTION
When `TZ`, `NODE_TLS_REJECT_UNAUTHORIZED`, or `BUN_CONFIG_VERBOSE_FETCH` are absent from the launch environment and then assigned at runtime, the value applies in-process (TZ retargets Date/Intl, the TLS flag takes effect) but the `process.env` property keeps `DontEnum`. It is invisible to `Object.keys(process.env)` / `{...process.env}` / `JSON.stringify(process.env)`, so every `child_process` child, every `Worker` env copy, and `Bun.spawn({env:{...process.env}})` never receive it. Node makes the property enumerable on write.

### Repro

```js
// env -u TZ -u NODE_TLS_REJECT_UNAUTHORIZED bun x.mjs   (node: exit 0)
import { spawnSync } from "node:child_process";
process.env.TZ = "Asia/Tokyo";
process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
const K = ["TZ", "NODE_TLS_REJECT_UNAUTHORIZED"];
console.log("keys():", K.map(k => `${k}:${Object.keys(process.env).includes(k)}`));
const child = spawnSync(process.execPath, ["-e",
  "console.log(process.argv.slice(1).map(k=>k+'='+(process.env[k]??'(unset)')).join(' '))", "--", ...K],
  { encoding: "utf8" }).stdout.trim();
console.log("child:", child);   // TZ=(unset) NODE_TLS_REJECT_UNAUTHORIZED=(unset)
if (child.includes("TZ=(unset)")) process.exit(1);
```

### Cause

`createEnvironmentVariablesMap` installs these three as `CustomAccessor` with `DontEnum` when the var was not in the OS env block. The setter stores the value in a private property but leaves the accessor's attributes alone. An earlier attempt at re-adding the accessor via `putDirectWithoutTransition` was commented out (`// TODO: this is an assertion failure`) in all three setters.

`jsSetterProxyEnvironmentVariable` already handles the same situation for the `HTTP_PROXY` family: `getDirect` the existing accessor, `deleteProperty`, then `putDirectCustomAccessor` without `DontEnum`.

### Fix

Factor that pattern into `makeEnvAccessorEnumerable` and call it from the TZ / TLS-reject / verbose-fetch setters. The TZ setter also gains a throw scope so it handles exceptions from `toWTFString` / `deleteProperty`.

### Verification

New test in `test/js/node/process/process.test.js` spawns a child with the three vars unset, has it set them at runtime, and checks `propertyIsEnumerable`, `Object.keys`, `{...process.env}`, `JSON.stringify`, a `spawnSync` grandchild, and that the TZ side effect still applies. Fails before, passes after, passes under `BUN_JSC_validateExceptionChecks=1`.

Note: #35003 includes an equivalent helper as part of a larger `delete process.env.TZ` rework; this PR is the minimal enumeration fix on its own.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->