### PR TITLE
node:url: validate argument to urlToHttpOptions()

### DIFF
--- a/src/js/internal/url.ts
+++ b/src/js/internal/url.ts
@@ -1,23 +1,24 @@
 function urlToHttpOptions(url) {
+  if (url === null || (typeof url !== "object" && typeof url !== "function")) {
+    throw $ERR_INVALID_ARG_TYPE("url", "object", url);
+  }
+  const { hostname, pathname, port, username, password, search } = url;
   const options = {
+    __proto__: null,
     ...url,
     protocol: url.protocol,
-    hostname:
-      typeof url.hostname === "string" && url.hostname.startsWith("[") ? url.hostname.slice(1, -1) : url.hostname,
+    hostname: typeof hostname === "string" && hostname.startsWith("[") ? hostname.slice(1, -1) : hostname,
     hash: url.hash,
-    search: url.search,
-    pathname: url.pathname,
-    path: `${url.pathname || ""}${url.search || ""}`,
+    search: search,
+    pathname: pathname,
+    path: `${pathname || ""}${search || ""}`,
     href: url.href,
   };
-  const port = url.port;
   if (port !== "") {
     options.port = Number(port);
   }
-  const username = url.username;
-  let password;
-  if (username || (password = url.password)) {
-    options.auth = `${decodeURIComponent(username)}:${decodeURIComponent(password ?? url.password)}`;
+  if (username || password) {
+    options.auth = `${decodeURIComponent(username)}:${decodeURIComponent(password)}`;
   }
   return options;
 }

--- a/test/js/node/url/url.test.ts
+++ b/test/js/node/url/url.test.ts
@@ -1,4 +1,4 @@
-import { parse } from "url";
+import { parse, urlToHttpOptions } from "url";
 
 describe("Url.prototype.parse", () => {
   it("parses URL correctly", () => {
@@ -78,6 +78,42 @@ it("URL constructor throws ERR_MISSING_ARGS", () => {
 
   // @ts-expect-error
   expect(err?.code).toEqual("ERR_MISSING_ARGS");
+});
+
+describe("urlToHttpOptions", () => {
+  it("throws ERR_INVALID_ARG_TYPE for non-object arguments", () => {
+    // Node.js: validateObject(url, "url", kValidateObjectAllowObjects)
+    for (const value of ["http://h/", 42, true, null, undefined, Symbol("s"), 1n]) {
+      expect(() => urlToHttpOptions(value as any)).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+          message: expect.stringContaining('"url" argument must be of type object'),
+        }),
+      );
+    }
+    expect(() => (urlToHttpOptions as any)()).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+  });
+
+  it("accepts arrays and functions (kValidateObjectAllowObjects)", () => {
+    expect(() => urlToHttpOptions([] as any)).not.toThrow();
+    expect(() => urlToHttpOptions(function () {} as any)).not.toThrow();
+  });
+
+  it("returns a null-prototype object", () => {
+    const opts = urlToHttpOptions(new URL("http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test"));
+    expect(Object.getPrototypeOf(opts)).toBe(null);
+    expect(opts).toEqual({
+      protocol: "http:",
+      hostname: "foo.bar.com",
+      hash: "#test",
+      search: "?l=24",
+      pathname: "/aaa/zzz",
+      path: "/aaa/zzz?l=24",
+      href: "http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test",
+      port: 21,
+      auth: "user:pass",
+    });
+  });
 });
 
 // https://github.com/oven-sh/bun/issues/16705


### PR DESCRIPTION
## Repro

```js
import * as url from "node:url";
console.log(url.urlToHttpOptions("http://h/"));
```

Node v26 throws `TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type object`. Bun returned a garbage object: the string's characters spread as own keys `{"0":"h","1":"t",...}`, and `path` was set to `"function search() {\n    [native code]\n}"` because `String.prototype.search` is a method and the template literal stringified it.

## Cause

`src/js/internal/url.ts` spread `{...url}` and read `url.search` / `url.pathname` without any type guard. Node calls `validateObject(url, 'url', kValidateObjectAllowObjects)` first, which rejects primitives and nullish but permits arrays and functions.

## Fix

Add the equivalent guard inline (Bun's C++ `validateObject` does not support the `kValidateObjectAllowObjects` flag, so the check is written directly). While here, match Node's implementation exactly: destructure the properties once and return a null-prototype object.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/url/url.test.ts
  (fail) urlToHttpOptions > throws ERR_INVALID_ARG_TYPE for non-object arguments
  (fail) urlToHttpOptions > returns a null-prototype object

$ bun bd test test/js/node/url/url.test.ts
  9 pass, 0 fail

$ bun bd test/js/node/test/parallel/test-url-urltooptions.js
  (exit 0)
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/url/url.test.ts

<!-- robobun:evidence:end -->