### PR TITLE
WebKit: skip eager timezone prewarm in VM::VM (1.3.14 startup regression)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -6,9 +6,10 @@
 // oven-sh/WebKit main: macOS + Windows artifacts cross-compiled on Linux,
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), every x64 at the nehalem floor (no separate -baseline variant),
-// typed-array constructor ClassInfo kept address-unique under LTO, and the
-// Windows ICU data table filtered + per-item zstd compressed.
-export const WEBKIT_VERSION = "c9296e353e365ecf0de82f273bb0a88a3df465be";
+// typed-array constructor ClassInfo kept address-unique under LTO, the
+// Windows ICU data table filtered + per-item zstd compressed, and the eager
+// timezone prewarm in VM::VM skipped under USE(BUN_JSC_ADDITIONS).
+export const WEBKIT_VERSION = "9bded08f48f30b0fe37fdf5424a89b9bcae4349f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -460,7 +460,12 @@ for (let [gcTick, label] of [
           stdout: "ignore",
           stderr: "ignore",
         });
-        proc.stdin!.write(Buffer.alloc(16 * 1024 * 1024, 0x41));
+        // write() may itself reject with EPIPE if the child has already exited by the
+        // time the first pipe-buffer flush runs; keep it unawaited so end() still has
+        // buffered data to drain, but swallow its rejection so it cannot surface as an
+        // unhandled rejection and fail the test.
+        const wrote = proc.stdin!.write(Buffer.alloc(16 * 1024 * 1024, 0x41));
+        if (wrote && typeof (wrote as any).catch === "function") (wrote as Promise<number>).catch(() => {});
         let caught: any;
         try {
           await proc.stdin!.end();

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -334,15 +334,18 @@ test.concurrent("timezone lazy-init is consistent across concurrent Workers", as
       "  postMessage((" + probe.toString() + ")());" +
       "};";
     const url = URL.createObjectURL(new Blob([body]));
-    const threads = [];
-    const results = Array.from({ length: N }, (_, i) => new Promise((resolve, reject) => {
+    const results = Array.from({ length: N }, () => new Promise((resolve, reject) => {
       const w = new Worker(url);
-      threads.push(w);
       w.onmessage = e => { resolve(e.data); w.terminate(); };
       w.onerror = reject;
       w.postMessage(gate);
     }));
-    while (Atomics.load(gate, 0) < N) await Bun.sleep(0);
+    // Race the barrier against the Worker promises so a startup error surfaces
+    // instead of spinning until the outer test times out.
+    await Promise.race([
+      (async () => { while (Atomics.load(gate, 0) < N) await Bun.sleep(0); })(),
+      Promise.all(results),
+    ]);
     Atomics.store(gate, 1, 1);
     Atomics.notify(gate, 1);
     const worker = await Promise.all(results);
@@ -354,7 +357,7 @@ test.concurrent("timezone lazy-init is consistent across concurrent Workers", as
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
-    env: { ...bunEnv, TZ: "America/New_York" },
+    env: { ...bunEnv, TZ: "America/New_York", LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8" },
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -362,6 +365,9 @@ test.concurrent("timezone lazy-init is consistent across concurrent Workers", as
   const result = JSON.parse(stdout.trim());
   expect(result.zone).toBe("America/New_York");
   expect(result.count).toBeGreaterThan(400);
+  expect(result.date).toContain("GMT-0500");
+  // The parenthesized long name exercises the host-zone display-name cache; pinning
+  // LANG above keeps this locale-independent across developer machines.
   expect(result.date).toContain("Eastern Standard Time");
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -10,7 +10,7 @@
 // links the unmodified libicudata.a.
 
 import { describe, expect, test } from "bun:test";
-import { isLinux } from "harness";
+import { bunEnv, bunExe, isLinux } from "harness";
 
 // Snapshots are CLDR-version-specific. Only check them where Bun bundles the
 // ICU they were generated against (Linux); macOS uses Apple's libicucore and
@@ -306,4 +306,44 @@ describe("exhaustive locale sweep (every compressed item)", () => {
       expect(a).toBe(b);
     }
   });
+});
+
+// The IANA timezone table and host-zone display-name cache are filled lazily on
+// first Date / Intl access rather than inside VM::VM, so the first access can
+// race across Workers that each construct their own VM. Exercise that race in a
+// fresh process where nothing has warmed the cache yet: every Worker plus the
+// main thread must observe the same resolved zone, the same supportedValuesOf
+// count, and the same Date.prototype.toString output.
+test.concurrent("timezone lazy-init is consistent across concurrent Workers", async () => {
+  const script = `
+    const probe = () => ({
+      zone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
+      count: Intl.supportedValuesOf("timeZone").length,
+      date: new Date(0).toString(),
+    });
+    const body = "postMessage((" + probe.toString() + ")())";
+    const url = URL.createObjectURL(new Blob([body]));
+    const workers = Array.from({ length: 8 }, () => new Promise((resolve, reject) => {
+      const w = new Worker(url);
+      w.onmessage = e => { resolve(e.data); w.terminate(); };
+      w.onerror = reject;
+    }));
+    const results = [probe(), ...await Promise.all(workers)];
+    for (const r of results)
+      if (r.zone !== results[0].zone || r.count !== results[0].count || r.date !== results[0].date)
+        throw new Error("inconsistent: " + JSON.stringify(r) + " vs " + JSON.stringify(results[0]));
+    console.log(JSON.stringify(results[0]));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, TZ: "America/New_York" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const result = JSON.parse(stdout.trim());
+  expect(result.zone).toBe("America/New_York");
+  expect(result.count).toBeGreaterThan(400);
+  expect(result.date).toContain("Eastern Standard Time");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -311,28 +311,46 @@ describe("exhaustive locale sweep (every compressed item)", () => {
 // The IANA timezone table and host-zone display-name cache are filled lazily on
 // first Date / Intl access rather than inside VM::VM, so the first access can
 // race across Workers that each construct their own VM. Exercise that race in a
-// fresh process where nothing has warmed the cache yet: every Worker plus the
-// main thread must observe the same resolved zone, the same supportedValuesOf
-// count, and the same Date.prototype.toString output.
+// fresh process where nothing has warmed the process-wide table yet: every
+// Worker parks on a shared barrier until all eight are ready, then they probe
+// simultaneously. The main thread touches Date / Intl only after collecting the
+// Worker results, so it cannot warm the cache ahead of them.
 test.concurrent("timezone lazy-init is consistent across concurrent Workers", async () => {
   const script = `
+    const N = 8;
+    // gate[0]: count of workers that have reached the barrier.
+    // gate[1]: release flag; workers Atomics.wait on it until main notifies.
+    const gate = new Int32Array(new SharedArrayBuffer(8));
     const probe = () => ({
       zone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
       count: Intl.supportedValuesOf("timeZone").length,
       date: new Date(0).toString(),
     });
-    const body = "postMessage((" + probe.toString() + ")())";
+    const body =
+      "self.onmessage = e => {" +
+      "  const gate = e.data;" +
+      "  Atomics.add(gate, 0, 1);" +
+      "  Atomics.wait(gate, 1, 0);" +
+      "  postMessage((" + probe.toString() + ")());" +
+      "};";
     const url = URL.createObjectURL(new Blob([body]));
-    const workers = Array.from({ length: 8 }, () => new Promise((resolve, reject) => {
+    const threads = [];
+    const results = Array.from({ length: N }, (_, i) => new Promise((resolve, reject) => {
       const w = new Worker(url);
+      threads.push(w);
       w.onmessage = e => { resolve(e.data); w.terminate(); };
       w.onerror = reject;
+      w.postMessage(gate);
     }));
-    const results = [probe(), ...await Promise.all(workers)];
-    for (const r of results)
-      if (r.zone !== results[0].zone || r.count !== results[0].count || r.date !== results[0].date)
-        throw new Error("inconsistent: " + JSON.stringify(r) + " vs " + JSON.stringify(results[0]));
-    console.log(JSON.stringify(results[0]));
+    while (Atomics.load(gate, 0) < N) await Bun.sleep(0);
+    Atomics.store(gate, 1, 1);
+    Atomics.notify(gate, 1);
+    const worker = await Promise.all(results);
+    const main = probe();
+    for (const r of [main, ...worker])
+      if (r.zone !== worker[0].zone || r.count !== worker[0].count || r.date !== worker[0].date)
+        throw new Error("inconsistent: " + JSON.stringify(r) + " vs " + JSON.stringify(worker[0]));
+    console.log(JSON.stringify(worker[0]));
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],


### PR DESCRIPTION
Picks up [oven-sh/WebKit#322](https://github.com/oven-sh/WebKit/pull/322), which gates the eager IANA-timezone-table and display-name prewarm at the end of `VM::VM` behind `USE(BUN_JSC_ADDITIONS)`.

### Regression

Between 1.3.13 and 1.3.14, upstream WebKit [311982@main](https://commits.webkit.org/311982@main) added this prewarm so the cost lands at process start rather than on a later critical path. That is the right tradeoff for a long-lived browser; for a short-lived CLI process it is backwards, and on Linux the `timeZoneDisplayName` warm pulls in `ucal_getHostTimeZone` → `detectHostTimeZone` → `uprv_tzname`, which walks `/usr/share/zoneinfo/**` byte-comparing every file against `/etc/localtime` when `/etc/localtime` is a regular file rather than a symlink (Amazon Linux, many container base images).

strace on a full-tzdata Linux host with a regular-file `/etc/localtime`:

```
         1.3.13   1.3.14
openat      29     1765   (1726 into /usr/share/zoneinfo)
total      ~1k    ~6.9k
```

hyperfine on the same host, pinned core:

| | 1.3.13 | 1.3.14 |
|---|---|---|
| `TZ` unset | 8.0 ms | 20.1 ms |
| `TZ=UTC` | 8.0 ms | 10.5 ms |

### What the block costs

Direct instrumentation around the block (release build with local WebKit, Linux x64, `/etc/localtime` symlink):

```
initializeAvailableTimeZones = 2.9 ms
timeZoneDisplayName          = 2.8 ms   (adds ~1.7 ms on regular-file localtime, more with full tzdata)
total                        = 5.7 ms
```

hyperfine A/B, 400 runs, pinned core, same binary:

| `/etc/localtime` | workload | before | after | |
|---|---|---|---|---|
| symlink | `bun -e 'console.log(1)'` | 14.6 ms | 8.6 ms | **1.71×** |
| symlink | `bun -e 'new Date().toString()'` | 14.6 ms | 15.3 ms | pays on first use |
| regular file | `bun -e 'console.log(1)'` | 16.3 ms | 8.4 ms | **1.95×** |

`openat` syscalls for `bun -e 'console.log(1)'` on a regular-file host: **447 → 31** (zoneinfo opens **414 → 0**). The block accounts for ~12% of unique function entries in the orderfile trace of `bun -e 'console.log(1)'` (entries 1253–1861 of ~4983).

### Safety

Both caches are `std::call_once` / per-VM-under-JSLock, so first access from `Date` / `Intl` fills them on demand. This is the same path `isInMiniMode()` already takes. Adds a Worker-race test to `intl.test.ts`: in a fresh process, 8 Workers plus the main thread concurrently hit `Date.toString()` / `Intl.supportedValuesOf("timeZone")` / `Intl.DateTimeFormat().resolvedOptions()` and must all agree.

### Verified

`bun bd test` on the new prebuilt: `intl.test.ts` (32/32), `temporal-global.test.ts`, `v8-date-parser.test.js`, `process.env.TZ`, `cron.test.ts` all pass. strace on the debug build confirms zero zoneinfo opens for `bun -e 'console.log(1)'`.

### Note

Conflicts on `WEBKIT_VERSION` with #35193, which bumps to a preview build of oven-sh/WebKit#316 (not yet on main). Whichever merges second can rebase; once oven-sh/WebKit#316 lands the combined bump is one sha.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->