### PR TITLE
process.env: drop '='/empty keys, truncate NUL in key/value like Node

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -490,9 +490,18 @@ export function windowsEnv(
       return internalEnv[p];
     },
     set(_, p, value) {
-      const k = String(p).toUpperCase();
+      let k = String(p);
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
       value = String(value); // If toString() throws, we want to avoid it existing in the envMapList
+      // setenv() semantics: NUL truncates key and value; empty or '='-bearing
+      // keys are dropped silently (node ignores the setenv EINVAL).
+      const keyNul = k.indexOf("\0");
+      if (keyNul !== -1) k = k.slice(0, keyNul);
+      if (k.length === 0 || k.indexOf("=") !== -1) return true;
+      const valNul = value.indexOf("\0");
+      if (valNul !== -1) value = value.slice(0, valNul);
+      p = k;
+      k = k.toUpperCase();
       // Track the key for enumeration if it isn't already there. Don't gate on
       // `k in internalEnv`: the proxy-related env-var accessors (HTTP_PROXY,
       // HTTPS_PROXY, NO_PROXY and lowercase variants) always exist on
@@ -528,8 +537,13 @@ export function windowsEnv(
       return typeof p !== "symbol" ? delete internalEnv[k] : false;
     },
     defineProperty(_, p, attributes) {
-      const k = String(p).toUpperCase();
+      let k = String(p);
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
+      const keyNul = k.indexOf("\0");
+      if (keyNul !== -1) k = k.slice(0, keyNul);
+      if (k.length === 0 || k.indexOf("=") !== -1) return true;
+      p = k;
+      k = k.toUpperCase();
       if (!(k in internalEnv) && !envMapList.includes(p)) {
         envMapList.push(p);
       }

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -544,8 +544,9 @@ export function windowsEnv(
       if (k.length === 0 || k.indexOf("=") !== -1) return true;
       p = k;
       k = k.toUpperCase();
+      let v: string | undefined;
       if ("value" in attributes) {
-        let v = String(attributes.value);
+        v = String(attributes.value);
         const valNul = v.indexOf("\0");
         if (valNul !== -1) v = v.slice(0, valNul);
         attributes = { ...attributes, value: v };
@@ -553,7 +554,7 @@ export function windowsEnv(
       if (!(k in internalEnv) && !envMapList.includes(p)) {
         envMapList.push(p);
       }
-      editWindowsEnvVar(k, internalEnv[k]);
+      if (v !== undefined) editWindowsEnvVar(k, v);
       return $Object.$defineProperty(internalEnv, k, attributes);
     },
     getOwnPropertyDescriptor(target, p) {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -544,6 +544,12 @@ export function windowsEnv(
       if (k.length === 0 || k.indexOf("=") !== -1) return true;
       p = k;
       k = k.toUpperCase();
+      if ("value" in attributes) {
+        let v = String(attributes.value);
+        const valNul = v.indexOf("\0");
+        if (valNul !== -1) v = v.slice(0, valNul);
+        attributes = { ...attributes, value: v };
+      }
       if (!(k in internalEnv) && !envMapList.includes(p)) {
         envMapList.push(p);
       }

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -474,7 +474,7 @@ private:
     }
 };
 
-const JSC::ClassInfo JSSharedEnvMap::s_info = { "ProcessEnv"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSharedEnvMap) };
+const JSC::ClassInfo JSSharedEnvMap::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSSharedEnvMap) };
 
 bool JSSharedEnvMap::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
 {
@@ -826,7 +826,9 @@ private:
     }
 };
 
-const JSC::ClassInfo JSProcessEnvMap::s_info = { "ProcessEnv"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSProcessEnvMap) };
+// "Object" so calculatedClassName matches JSFinalObject: toStrictEqual and
+// Bun.inspect treat process.env as a plain object, same as Node.
+const JSC::ClassInfo JSProcessEnvMap::s_info = { "Object"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSProcessEnvMap) };
 
 bool JSProcessEnvMap::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
@@ -837,6 +839,11 @@ bool JSProcessEnvMap::put(JSCell* cell, JSGlobalObject* globalObject, PropertyNa
     if (propertyName.isSymbol() || !uid)
         RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
 
+    // Base::put would mark the caller's slot cacheable and the put_by_id IC
+    // would then write the raw JSValue directly on subsequent puts, bypassing
+    // this override. Disabling put caching keeps reads on the fast IC path.
+    slot.disableCaching();
+
     String stringValue = value.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
 
@@ -845,11 +852,11 @@ bool JSProcessEnvMap::put(JSCell* cell, JSGlobalObject* globalObject, PropertyNa
         return true;
 
     JSValue jsStringValue = jsString(vm, truncateEnvValueAtNul(stringValue));
+    PutPropertySlot newSlot(asObject(cell), slot.isStrictMode());
     if (key->length() == uid->length())
-        RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, jsStringValue, slot));
+        RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, jsStringValue, newSlot));
 
     Identifier truncated = Identifier::fromString(vm, *key);
-    PutPropertySlot newSlot(asObject(cell), slot.isStrictMode());
     RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, truncated, jsStringValue, newSlot));
 }
 

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -633,25 +633,31 @@ bool JSSharedEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* uid = propertyName.uid();
-    if (!propertyName.isSymbol() && uid && !normalizeEnvKey(String(uid)))
+    if (propertyName.isSymbol() || !uid)
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow));
+
+    auto keyOpt = normalizeEnvKey(String(uid));
+    if (!keyOpt)
         return true;
-    if (propertyName.isSymbol() || !uid || !descriptor.isDataDescriptor() || !descriptor.value()) {
+    String keyStr = *keyOpt;
+    Identifier truncated = keyStr.length() == uid->length() ? Identifier() : Identifier::fromString(vm, keyStr);
+    PropertyName effectiveName = truncated.isNull() ? propertyName : PropertyName(truncated);
+
+    if (!descriptor.isDataDescriptor() || !descriptor.value()) {
         // The descriptor lands on the Base object, but getOwnPropertySlot reads the
         // store first, so a store entry would shadow it. Move the entry onto Base as
         // an enumerable data property first: a partial descriptor then keeps that
         // enumerability, exactly as it does on the regular process.env. (Node rejects
         // accessors on process.env outright — on both maps — so match bun's own map.)
-        if (!propertyName.isSymbol() && uid) {
-            if (auto* store = sharedEnvStoreFor(object)) {
-                String existing = store->get(String(uid));
-                if (!existing.isNull()) {
-                    syncWindowsEnv(store, String(uid), nullptr);
-                    store->remove(String(uid));
-                    object->putDirect(vm, propertyName, jsString(vm, existing), 0);
-                }
+        if (auto* store = sharedEnvStoreFor(object)) {
+            String existing = store->get(keyStr);
+            if (!existing.isNull()) {
+                syncWindowsEnv(store, keyStr, nullptr);
+                store->remove(keyStr);
+                object->putDirect(vm, effectiveName, jsString(vm, existing), 0);
             }
         }
-        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow));
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, effectiveName, descriptor, shouldThrow));
     }
 
     String stringValue = descriptor.value().toWTFString(globalObject);
@@ -660,13 +666,9 @@ bool JSSharedEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* globalO
     auto* store = sharedEnvStoreFor(object);
     if (!store) [[unlikely]] {
         ASSERT_NOT_REACHED();
-        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow));
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, effectiveName, descriptor, shouldThrow));
     }
 
-    auto keyOpt = normalizeEnvKey(String(uid));
-    if (!keyOpt)
-        return true;
-    String keyStr = *keyOpt;
     stringValue = truncateEnvValueAtNul(stringValue);
     applySharedEnvSideEffects(globalObject, keyStr, stringValue);
     syncWindowsEnv(store, keyStr, &stringValue);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -37,6 +37,30 @@ namespace Bun {
 
 using namespace WebCore;
 
+// Node's process.env is a proxy over setenv()/getenv(). setenv() fails with
+// EINVAL for an empty name or a name containing '=', and both key and value
+// pass through a NUL-terminated C string, so embedded NULs truncate. Node
+// ignores the setenv failure, so the assignment silently does nothing.
+// normalizeEnvKey encodes that: truncate at NUL, then drop empty / '='.
+static std::optional<String> normalizeEnvKey(const String& rawKey)
+{
+    String key = rawKey;
+    size_t nul = key.find(static_cast<char16_t>(0));
+    if (nul != WTF::notFound)
+        key = key.substring(0, nul);
+    if (key.isEmpty() || key.find('=') != WTF::notFound)
+        return std::nullopt;
+    return key;
+}
+
+static String truncateEnvValueAtNul(const String& value)
+{
+    size_t nul = value.find(static_cast<char16_t>(0));
+    if (nul != WTF::notFound)
+        return value.substring(0, nul);
+    return value;
+}
+
 JSC_DEFINE_CUSTOM_GETTER(jsGetterEnvironmentVariable, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
     VM& vm = globalObject->vm();
@@ -563,7 +587,11 @@ bool JSSharedEnvMap::put(JSCell* cell, JSGlobalObject* globalObject, PropertyNam
     String stringValue = value.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
 
-    String keyStr = String(uid);
+    auto keyOpt = normalizeEnvKey(String(uid));
+    if (!keyOpt)
+        return true;
+    String keyStr = *keyOpt;
+    stringValue = truncateEnvValueAtNul(stringValue);
     applySharedEnvSideEffects(globalObject, keyStr, stringValue);
     syncWindowsEnv(store, keyStr, &stringValue);
     store->set(keyStr, stringValue);
@@ -633,7 +661,11 @@ bool JSSharedEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* globalO
         RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow));
     }
 
-    String keyStr = String(uid);
+    auto keyOpt = normalizeEnvKey(String(uid));
+    if (!keyOpt)
+        return true;
+    String keyStr = *keyOpt;
+    stringValue = truncateEnvValueAtNul(stringValue);
     applySharedEnvSideEffects(globalObject, keyStr, stringValue);
     syncWindowsEnv(store, keyStr, &stringValue);
     store->set(keyStr, stringValue);
@@ -744,6 +776,119 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     return store;
 }
 
+// POSIX process.env: a plain property bag, but with a put/defineOwnProperty
+// hook so assignments are filtered like node's setenv-backed store (see
+// normalizeEnvKey). Reads stay on the fast JSObject path; only writes pay.
+class JSProcessEnvMap final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut;
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSProcessEnvMap, Base);
+        return &vm.plainObjectSpace();
+    }
+
+    DECLARE_INFO;
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+    static JSProcessEnvMap* create(JSC::VM& vm, JSC::Structure* structure)
+    {
+        JSProcessEnvMap* ptr = new (NotNull, JSC::allocateCell<JSProcessEnvMap>(vm)) JSProcessEnvMap(vm, structure);
+        ptr->finishCreation(vm);
+        return ptr;
+    }
+
+    static bool put(JSCell*, JSGlobalObject*, JSC::PropertyName, JSC::JSValue, JSC::PutPropertySlot&);
+    static bool putByIndex(JSCell*, JSGlobalObject*, unsigned, JSC::JSValue, bool shouldThrow);
+    static bool defineOwnProperty(JSObject*, JSGlobalObject*, JSC::PropertyName, const JSC::PropertyDescriptor&, bool shouldThrow);
+
+private:
+    JSProcessEnvMap(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm)
+    {
+        Base::finishCreation(vm);
+    }
+};
+
+const JSC::ClassInfo JSProcessEnvMap::s_info = { "ProcessEnv"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSProcessEnvMap) };
+
+bool JSProcessEnvMap::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
+{
+    VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* uid = propertyName.uid();
+    if (propertyName.isSymbol() || !uid)
+        RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, value, slot));
+
+    String stringValue = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    auto key = normalizeEnvKey(String(uid));
+    if (!key)
+        return true;
+
+    JSValue jsStringValue = jsString(vm, truncateEnvValueAtNul(stringValue));
+    if (key->length() == uid->length())
+        RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, jsStringValue, slot));
+
+    Identifier truncated = Identifier::fromString(vm, *key);
+    PutPropertySlot newSlot(asObject(cell), slot.isStrictMode());
+    RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, truncated, jsStringValue, newSlot));
+}
+
+bool JSProcessEnvMap::putByIndex(JSCell* cell, JSGlobalObject* globalObject, unsigned index, JSValue value, bool shouldThrow)
+{
+    VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    String stringValue = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+    RELEASE_AND_RETURN(scope, Base::putByIndex(cell, globalObject, index, jsString(vm, truncateEnvValueAtNul(stringValue)), shouldThrow));
+}
+
+bool JSProcessEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, const PropertyDescriptor& descriptor, bool shouldThrow)
+{
+    VM& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* uid = propertyName.uid();
+    if (propertyName.isSymbol() || !uid || !descriptor.isDataDescriptor() || !descriptor.value())
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow));
+
+    auto key = normalizeEnvKey(String(uid));
+    if (!key)
+        return true;
+
+    String stringValue = descriptor.value().toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    PropertyDescriptor newDescriptor = descriptor;
+    newDescriptor.setValue(jsString(vm, truncateEnvValueAtNul(stringValue)));
+
+    if (key->length() == uid->length())
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, newDescriptor, shouldThrow));
+
+    Identifier truncated = Identifier::fromString(vm, *key);
+    RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, truncated, newDescriptor, shouldThrow));
+}
+
+bool isEnvironmentVariablesMapObject(const JSC::ClassInfo* classInfo)
+{
+    return classInfo == JSProcessEnvMap::info() || classInfo == JSSharedEnvMap::info();
+}
+
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -752,11 +897,18 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     void* list;
     size_t count = Bun__getEnvCount(globalObject, &list);
     JSC::JSObject* object = nullptr;
+#if OS(WINDOWS)
+    // On Windows the object is wrapped in a Proxy (below) whose set trap does the
+    // same filtering, so the backing store stays a plain object.
     if (count < 63) {
         object = constructEmptyObject(globalObject, globalObject->objectPrototype(), count);
     } else {
         object = constructEmptyObject(globalObject, globalObject->objectPrototype());
     }
+#else
+    auto* structure = JSProcessEnvMap::createStructure(vm, globalObject, globalObject->objectPrototype());
+    object = JSProcessEnvMap::create(vm, structure);
+#endif
 
 #if OS(WINDOWS)
     JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -633,6 +633,8 @@ bool JSSharedEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* globalO
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* uid = propertyName.uid();
+    if (!propertyName.isSymbol() && uid && !normalizeEnvKey(String(uid)))
+        return true;
     if (propertyName.isSymbol() || !uid || !descriptor.isDataDescriptor() || !descriptor.value()) {
         // The descriptor lands on the Base object, but getOwnPropertySlot reads the
         // store first, so a store entry would shadow it. Move the entry onto Base as
@@ -864,12 +866,19 @@ bool JSProcessEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* global
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* uid = propertyName.uid();
-    if (propertyName.isSymbol() || !uid || !descriptor.isDataDescriptor() || !descriptor.value())
+    if (propertyName.isSymbol() || !uid)
         RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, shouldThrow));
 
+    // Key filter runs before the descriptor-shape check so an accessor descriptor
+    // at an invalid key is dropped too (matches the Windows defineProperty trap).
     auto key = normalizeEnvKey(String(uid));
     if (!key)
         return true;
+    Identifier truncated = key->length() == uid->length() ? Identifier() : Identifier::fromString(vm, *key);
+    PropertyName effectiveName = truncated.isNull() ? propertyName : PropertyName(truncated);
+
+    if (!descriptor.isDataDescriptor() || !descriptor.value())
+        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, effectiveName, descriptor, shouldThrow));
 
     String stringValue = descriptor.value().toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
@@ -877,16 +886,19 @@ bool JSProcessEnvMap::defineOwnProperty(JSObject* object, JSGlobalObject* global
     PropertyDescriptor newDescriptor = descriptor;
     newDescriptor.setValue(jsString(vm, truncateEnvValueAtNul(stringValue)));
 
-    if (key->length() == uid->length())
-        RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, newDescriptor, shouldThrow));
-
-    Identifier truncated = Identifier::fromString(vm, *key);
-    RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, truncated, newDescriptor, shouldThrow));
+    RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, effectiveName, newDescriptor, shouldThrow));
 }
 
 bool isEnvironmentVariablesMapObject(const JSC::ClassInfo* classInfo)
 {
     return classInfo == JSProcessEnvMap::info() || classInfo == JSSharedEnvMap::info();
+}
+
+JSC::JSObject* createProcessEnvMapObject(Zig::GlobalObject* globalObject)
+{
+    VM& vm = globalObject->vm();
+    auto* structure = JSProcessEnvMap::createStructure(vm, globalObject, globalObject->objectPrototype());
+    return JSProcessEnvMap::create(vm, structure);
 }
 
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -13,6 +13,10 @@ namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
+// True for JSProcessEnvMap/JSSharedEnvMap classInfo; both structured-clone like
+// a plain object (Node.js structuredClone(process.env) succeeds).
+bool isEnvironmentVariablesMapObject(const JSC::ClassInfo*);
+
 // worker_threads SHARE_ENV: a `process.env` whose reads/writes/enumeration go
 // through the SharedEnvStore of the tree its global belongs to.
 JSC::JSValue createSharedEnvironmentVariablesMap(Zig::GlobalObject* globalObject);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -13,6 +13,10 @@ namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
+// Bare JSProcessEnvMap (no OS-env getters, no Windows Proxy wrap): filters keys
+// and stringifies values like Node.js. For worker env: {...} snapshots.
+JSC::JSObject* createProcessEnvMapObject(Zig::GlobalObject* globalObject);
+
 // True for JSProcessEnvMap/JSSharedEnvMap classInfo; both structured-clone like
 // a plain object (Node.js structuredClone(process.env) succeeds).
 bool isEnvironmentVariablesMapObject(const JSC::ClassInfo*);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -566,7 +566,11 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                     strings.append(jsString(vm, value));
                 }
 
-                auto env = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), size >= JSFinalObject::maxInlineCapacity ? JSFinalObject::maxInlineCapacity : size);
+                // JSProcessEnvMap is a JSNonFinalObject: putDirectMayBeIndex for an
+                // index-like key routes through method-table defineOwnProperty, which
+                // declares a throw scope; a top scope keeps validation balanced.
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+                auto env = Bun::createProcessEnvMapObject(globalObject);
                 size_t i = 0;
                 for (auto k : map) {
                     // They can have environment variables with numbers as keys.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -566,10 +566,11 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                     strings.append(jsString(vm, value));
                 }
 
-                // JSProcessEnvMap is a JSNonFinalObject: putDirectMayBeIndex for an
+                // JSProcessEnvMap is a JSNonFinalObject, so putDirectMayBeIndex for an
                 // index-like key routes through method-table defineOwnProperty, which
-                // declares a throw scope; check each iteration to keep exception-scope
-                // validation balanced (the only real throw here is OOM).
+                // declares a throw scope. The seed values are non-rope JSStrings built
+                // from HashMap<String,String> above, so defineOwnProperty's toWTFString
+                // is trivial and cannot throw; assert that for scope-validation.
                 auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
                 auto env = Bun::createProcessEnvMapObject(globalObject);
                 size_t i = 0;
@@ -577,10 +578,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                     // They can have environment variables with numbers as keys.
                     // So we must use putDirectMayBeIndex to handle that.
                     env->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, WTF::move(k.key)), strings.at(i++));
-                    if (scope.exception()) [[unlikely]] {
-                        scope.clearException();
-                        break;
-                    }
+                    scope.assertNoExceptionExceptTermination();
                 }
                 globalObject->m_processEnvObject.set(vm, globalObject, env);
             } else if (options.sharedEnvStore) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -568,7 +568,8 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
 
                 // JSProcessEnvMap is a JSNonFinalObject: putDirectMayBeIndex for an
                 // index-like key routes through method-table defineOwnProperty, which
-                // declares a throw scope; a top scope keeps validation balanced.
+                // declares a throw scope; check each iteration to keep exception-scope
+                // validation balanced (the only real throw here is OOM).
                 auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
                 auto env = Bun::createProcessEnvMapObject(globalObject);
                 size_t i = 0;
@@ -576,6 +577,10 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
                     // They can have environment variables with numbers as keys.
                     // So we must use putDirectMayBeIndex to handle that.
                     env->putDirectMayBeIndex(globalObject, JSC::Identifier::fromString(vm, WTF::move(k.key)), strings.at(i++));
+                    if (scope.exception()) [[unlikely]] {
+                        scope.clearException();
+                        break;
+                    }
                 }
                 globalObject->m_processEnvObject.set(vm, globalObject, env);
             } else if (options.sharedEnvStore) {

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -120,6 +120,7 @@
 #include "CryptoKeyType.h"
 #include "JSNodePerformanceHooksHistogram.h"
 #include "../napi.h"
+#include "../JSEnvironmentVariableMap.h"
 #include <limits>
 #include <algorithm>
 
@@ -2812,7 +2813,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             // like a plain object from JS's perspective (matches Node.js).
             // ObjectPrototype is allowed because %Object.prototype% is an immutable
             // prototype exotic object that the spec carves out of this rejection.
-            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info())
+            // process.env (JSProcessEnvMap / JSSharedEnvMap) is allowed because
+            // Node.js structured-clones it as a plain object of its string entries.
+            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info() && !Bun::isEnvironmentVariablesMapObject(inObject->classInfo()))
                 return SerializationReturnCode::DataCloneError;
             inputObjectStack.append(inObject);
             indexStack.append(0);

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -901,8 +901,7 @@ for (const shell of ["system", "bun"]) {
   });
 }
 
-const todoOnPosix = process.platform !== "win32" ? test.todo : test;
-todoOnPosix("setting process.env coerces the value to a string", () => {
+test("setting process.env coerces the value to a string", () => {
   // @ts-expect-error
   process.env.SET_TO_TRUE = true;
   let did_call = 0;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -902,19 +902,24 @@ for (const shell of ["system", "bun"]) {
 }
 
 test("setting process.env coerces the value to a string", () => {
-  // @ts-expect-error
-  process.env.SET_TO_TRUE = true;
-  let did_call = 0;
-  // @ts-expect-error
-  process.env.SET_TO_BUN = {
-    toString() {
-      did_call++;
-      return "bun!";
-    },
-  };
-  expect(process.env.SET_TO_TRUE).toBe("true");
-  expect(process.env.SET_TO_BUN).toBe("bun!");
-  expect(did_call).toBe(1);
+  try {
+    // @ts-expect-error
+    process.env.SET_TO_TRUE = true;
+    let did_call = 0;
+    // @ts-expect-error
+    process.env.SET_TO_BUN = {
+      toString() {
+        did_call++;
+        return "bun!";
+      },
+    };
+    expect(process.env.SET_TO_TRUE).toBe("true");
+    expect(process.env.SET_TO_BUN).toBe("bun!");
+    expect(did_call).toBe(1);
+  } finally {
+    delete process.env.SET_TO_TRUE;
+    delete process.env.SET_TO_BUN;
+  }
 });
 
 test("NODE_ENV=test loads .env.test even when .env.production exists", () => {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -253,6 +253,11 @@ it("process.env rejects invalid keys and NUL like node", async () => {
     try { Object.defineProperty(process.env, "E=F", { get: () => "v", enumerable: true, configurable: true }); } catch {}
     out.dpAccEqStored = "E=F" in process.env;
 
+    // process.env is no longer a JSFinalObject on POSIX; structuredClone must
+    // still treat it as a plain object. (Windows wraps it in a Proxy, which
+    // structured clone rejects there regardless of this change.)
+    try { out.clone = structuredClone(process.env).NULVAL; } catch (e) { out.clone = e.name; }
+
     const r = spawnSync(process.execPath, ["-e",
       "process.stdout.write(JSON.stringify({A: process.env.A ?? null, NULKEY: process.env.NULKEY ?? null}))"
     ], { encoding: "utf8" });
@@ -280,12 +285,13 @@ it("process.env rejects invalid keys and NUL like node", async () => {
     dpEqStored: false,
     dpNulVal: "a",
     dpAccEqStored: false,
+    clone: isWindows ? "DataCloneError" : "a",
     child: { A: null, NULKEY: "x" },
     childStatus: 0,
     childErr: null,
   });
   expect(exitCode).toBe(0);
-}, 20000);
+});
 
 it("process.env is spreadable and editable", () => {
   process.env["LOL SMILE UTF16 😂"] = "😂";

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -243,6 +243,16 @@ it("process.env rejects invalid keys and NUL like node", async () => {
     process.env.NULVAL = "a\\0b";
     out.nulVal = process.env.NULVAL;
 
+    const d = { writable: true, enumerable: true, configurable: true };
+    Object.defineProperty(process.env, "C=D", { value: "v", ...d });
+    out.dpEqStored = "C=D" in process.env;
+    Object.defineProperty(process.env, "DPNULVAL", { value: "a\\0b", ...d });
+    out.dpNulVal = process.env.DPNULVAL;
+    // node throws ERR_INVALID_OBJECT_DEFINE_PROPERTY for accessor descriptors on
+    // process.env; either way an '='-bearing key must never land on the object.
+    try { Object.defineProperty(process.env, "E=F", { get: () => "v", enumerable: true, configurable: true }); } catch {}
+    out.dpAccEqStored = "E=F" in process.env;
+
     const r = spawnSync(process.execPath, ["-e",
       "process.stdout.write(JSON.stringify({A: process.env.A ?? null, NULKEY: process.env.NULKEY ?? null}))"
     ], { encoding: "utf8" });
@@ -267,6 +277,9 @@ it("process.env rejects invalid keys and NUL like node", async () => {
     nulKeyValue: "x",
     leadNulStored: false,
     nulVal: "a",
+    dpEqStored: false,
+    dpNulVal: "a",
+    dpAccEqStored: false,
     child: { A: null, NULKEY: "x" },
     childStatus: 0,
     childErr: null,

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -218,6 +218,62 @@ it("process.env", () => {
   expect(process.env["LOL SMILE latin1 <abc>"]).toBe(undefined);
 });
 
+it("process.env rejects invalid keys and NUL like node", async () => {
+  // node's process.env is a setenv()/getenv() proxy: setenv() fails EINVAL for
+  // an empty name or a name containing '=', and both key and value pass through
+  // a NUL-terminated C string. node ignores the failure, so the write is silent.
+  const script = `
+    const { spawnSync } = require("node:child_process");
+    const out = {};
+
+    process.env["A=B"] = "v";
+    out.eqStored = "A=B" in process.env;
+    out.eqParentA = process.env.A ?? null;
+
+    process.env[""] = "e";
+    out.emptyStored = "" in process.env;
+
+    process.env["NULKEY\\0TAIL"] = "x";
+    out.nulKeyStored = Object.keys(process.env).filter(k => k.startsWith("NULKEY"));
+    out.nulKeyValue = process.env.NULKEY ?? null;
+
+    process.env["\\0LEADNUL"] = "y";
+    out.leadNulStored = "" in process.env;
+
+    process.env.NULVAL = "a\\0b";
+    out.nulVal = process.env.NULVAL;
+
+    const r = spawnSync(process.execPath, ["-e",
+      "process.stdout.write(JSON.stringify({A: process.env.A ?? null, NULKEY: process.env.NULKEY ?? null}))"
+    ], { encoding: "utf8" });
+    out.child = r.stdout ? JSON.parse(r.stdout) : null;
+    out.childStatus = r.status;
+    out.childErr = r.error ? r.error.code : null;
+
+    process.stdout.write(JSON.stringify(out));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    eqStored: false,
+    eqParentA: null,
+    emptyStored: false,
+    nulKeyStored: ["NULKEY"],
+    nulKeyValue: "x",
+    leadNulStored: false,
+    nulVal: "a",
+    child: { A: null, NULKEY: "x" },
+    childStatus: 0,
+    childErr: null,
+  });
+  expect(exitCode).toBe(0);
+}, 20000);
+
 it("process.env is spreadable and editable", () => {
   process.env["LOL SMILE UTF16 😂"] = "😂";
   const { "LOL SMILE UTF16 😂": lol, ...rest } = process.env;


### PR DESCRIPTION
## What

`process.env` now filters assignments the way Node's does: keys containing `=` or empty keys are silently dropped, and an embedded NUL in a key or value truncates at the NUL. Previously all three were stored verbatim.

## Repro

```js
import { spawnSync } from "node:child_process";
process.env["A=B"] = "v";
process.env["N\0K"] = "x";
console.log(spawnSync(process.execPath, ["-e",
  "console.log(process.env.A ?? '(unset)')"], { encoding: "utf8" }).stdout.trim());
// bun (before): B=v       node: (unset)
try { spawnSync(process.execPath, ["-e", "1"]); console.log("spawn ok"); }
catch (e) { console.log("every later spawn:", e.code); }
// bun (before): ERR_INVALID_ARG_VALUE   node: spawn ok
```

Storing `A=B` ships the entry `A=B=v` to every child, which parses it as the different variable `A = "B=v"`: any code that maps an externally-supplied name into `process.env[name]` sets an arbitrary variable in its children. A NUL key is stored intact and then makes every later default-env `child_process` spawn throw `ERR_INVALID_ARG_VALUE` until the key is deleted (while `Bun.spawn` silently drops it, so the two APIs disagree).

## Cause

Node's `process.env` is a proxy over `setenv()`/`getenv()`. `setenv()` returns `EINVAL` for an empty name or a name containing `=`, and both key and value pass through a NUL-terminated C string, so embedded NULs truncate. Node ignores the `setenv` failure, so a bad-key write is a silent no-op and the C-string round trip does the truncation.

Bun's POSIX `process.env` was a plain `JSObject` seeded with `CustomValue` getters for the OS env keys; writes to new keys went straight to `JSObject::put` with no interception.

## Fix

- `JSEnvironmentVariableMap.cpp`: add `normalizeEnvKey` / `truncateEnvValueAtNul` and a `JSProcessEnvMap` (`JSNonFinalObject` with `OverridesPut`) whose `put` / `putByIndex` / `defineOwnProperty` normalize the key, stringify + truncate the value, then delegate to `Base::put` so the existing TZ / proxy-var CustomAccessor setters still fire. `createEnvironmentVariablesMap` uses it on POSIX.
- `JSSharedEnvMap::put` / `defineOwnProperty` (worker_threads `SHARE_ENV`): same normalization before writing to the store.
- `ProcessObjectInternals.ts` (`windowsEnv` Proxy `set` / `defineProperty` traps): same normalization in JS.
- `SerializedScriptValue.cpp`: whitelist the new class so `structuredClone(process.env)` keeps working.

## Verification

- `test/js/node/process/process.test.js`: new "process.env rejects invalid keys and NUL like node" case covering `=`-in-key, empty key, NUL-in-key (stored under the truncated key), leading-NUL key (dropped), NUL-in-value, and a `child_process.spawnSync` after all of them that would previously throw. Fails on main with `ERR_INVALID_ARG_VALUE`, passes with the fix; verified byte-identical to Node v26.3.0 output.
- `test/cli/run/env.test.ts`: un-todos the existing "setting process.env coerces the value to a string" case (the `put` hook stringifies as a side effect).

Overlaps with #34728 (value string-coercion) and #34727 (descriptor validation): all three introduce a `JSProcessEnvMap` write hook; whichever lands first, the others rebase over it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts test/js/node/process/process.test.js

<!-- robobun:evidence:end -->