### PR TITLE
test(serve-body-leak): warm up with incomplete-streaming and baseline against the median sample

### DIFF
--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -22,8 +22,13 @@ async function warmup(url: URL) {
   while (remaining > 0) {
     const batch = new Array(batchSize);
     for (let j = 0; j < batchSize; j++) {
-      // warmup the server with streaming requests, because is the most memory intensive
-      batch[j] = fetch(`${url.origin}/streaming`, {
+      // Warm up with incomplete-streaming: it is the highest-RSS scenario (the
+      // unread tail of each 512 KB body lingers until the request context is
+      // recycled), so priming the allocator with it leaves every scenario's
+      // start_memory at the shared server's steady-state plateau. Warming with
+      // /streaming instead left incomplete-streaming to grow the heap by ~80 MB
+      // mid-measurement on darwin aarch64 (build 78545), a false positive.
+      batch[j] = fetch(`${url.origin}/incomplete-streaming`, {
         method: "POST",
         body: zeroCopyPayload,
       }).then(res => res.text());
@@ -115,8 +120,14 @@ async function calculateMemoryLeak(fn: (url: URL) => Promise<void>, url: URL) {
   if (end_memory > peak_memory) {
     peak_memory = end_memory;
   }
-  // use first example as a reference if is a memory leak this should keep increasing and not be stable
-  const consumption = end_memory - memory_examples[0];
+  // A per-request leak grows RSS linearly across the samples; a one-time heap
+  // expansion steps up and plateaus. Using the median sample as the baseline
+  // (instead of the first) lets the first half of the run absorb allocator
+  // growth while still flagging linear growth: a leaked 512 KB body produces
+  // ~2.5 GB of growth over the second half, against a 64 MB threshold.
+  const sorted = [...memory_examples].sort((a, b) => a - b);
+  const baseline = sorted[sorted.length >> 1];
+  const consumption = end_memory - baseline;
   // memory leak in MB
   const leak = Math.floor(consumption > 0 ? consumption / 1024 / 1024 : 0);
   return { leak, start_memory, peak_memory, end_memory, memory_examples };


### PR DESCRIPTION
### What does this PR do?

Deflakes `serve-body-leak.test.ts` after #35206. On darwin 26 aarch64 in main build [78545](https://buildkite.com/bun/bun/builds/78545#019f8e0e-5008-44f0-8fda-113747fb9602) the incomplete-streaming scenario failed with:

```
{ leak: 79, start_memory: 102580224, peak_memory: 186155008, end_memory: 186155008,
  memory_examples: [102875136, 109821952, 115507200, 115507200, 136544256,
                    136544256, 136544256, 136544256, 178028544] }
error: expect(received).toBeLessThanOrEqual(expected)
Expected: <= 64
Received: 79
```

The following scenario (streaming-echo) then ran flat at 186 MB, so this was a one-time heap expansion, not a leak. The retry passed with `leak: 21`.

#35206 moved all seven scenarios onto one shared fixture server but left the warmup on `/streaming`, which fully drains the request body. `/incomplete-streaming` reads one chunk and returns, so ~448 KB of each body sits in the server's buffer until the request context is recycled; with 40 concurrent uploads that is the highest-RSS workload. The first time that workload runs is during measurement, and on macOS RSS does not shrink, so the allocator's step-growth shows up as `end_memory - memory_examples[0]`.

Two changes:

- **Warm up with `/incomplete-streaming`** instead of `/streaming`, so the shared server reaches its steady-state plateau before any scenario samples `start_memory`. This also shaves a little off the warmup (one `reader.read()` instead of a drain loop per request).
- **Baseline the leak metric against the median sample** instead of the first. A per-request body leak is linear and still produces ~2.5 GB (release) / ~500 MB (debug/asan) of growth over the second half of the run, against the same 64 MB threshold; step-function allocator growth is absorbed.

Applying the median baseline to the build-78545 sample set above yields 47 MB (was 79 MB); the retry's set yields 12 MB (was 21 MB).

### How did you verify your code works?

Local timing (`bun bd test`, debug+asan): 108 s, 8 pass, `leak` ≤ 1 in every scenario. Release (`USE_SYSTEM_BUN=1`): 26-32 s across three runs, 8 pass, `leak` ≤ 6. No test skipped or threshold widened.

The original slow-test report this was opened for (59 s on darwin 14 x64 in build 78397) predates #35206; that build was branched before the merge. Post-#35206 darwin aarch64 runs in ~15 s, so the speed work is already done; this PR fixes the flake that change introduced.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-body-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/serve-body-leak.test.ts
bun test v1.4.0 (9a6078e24)

test/js/bun/http/serve-body-leak.test.ts:
http://localhost:36871/
{
  leak: 1,
  start_memory: 407564288,
  peak_memory: 407564288,
  end_memory: 385593344,
  memory_examples: [ 384544768, 384544768 ],
}
(pass) request body leak > #10265 should not leak memory when ignoring the body [4358.65ms]
{
  leak: 0,
  start_memory: 385593344,
  peak_memory: 606871552,
  end_memory: 600567808,
  memory_examples: [ 606871552, 591003648 ],
}
(pass) request body leak > should not leak memory when buffering the body [8728.90ms]
{
  leak: 0,
  start_memory: 600567808,
  peak_memory: 642179072,
  end_memory: 627724288,
  memory_examples: [ 642179072, 625737728 ],
}
(pass) request body leak > should not leak memory when buffering a JSON body [30050.66ms]
{
  leak: 0,
  start_memory: 627724288,
  peak_memory: 627724288,
  end_memory: 611905536,
  memory_examples: [ 617009152, 610914304 ],
}
(pass) request body leak > should not leak memory when buffering the body and accessing req.body [11296.40ms]
{
  leak: 0,
  start_memory: 611905536,
  peak_memory: 663769088,
  end_memory: 663769088,
  memory_examples: [ 651976704, 663011328 ],
}
(pass) request body leak > should not leak memory when streaming the body [11865.84ms]
{
  leak: 0,
  start_memory: 663769088,
  peak_memory: 663769088,
  end_memory: 654700544,
  memory_examples: [ 652660736, 660029440 ],
}
(pass) request body leak > should not leak memory when streaming the body incompletely [9456.78ms]
{
  leak: 3,
  start_memory: 655749120,
  peak_memory: 655749120,
  end_memory: 634015744,
  memory_examples: [ 629821440, 630870016 ],
}
(pass) request body leak > should not leak memory when streaming the body and echoing it back [8997.85ms]
(pass) aborting direct-stream responses parked in pull() does not leak the native sink [6058.34ms]

 8 pass
 0 fail
 21031 expect() calls
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/serve-body-leak.test.ts | 19 +++++++++++++++----
 1 file changed, 15 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
test/js/bun/http/serve-body-leak.test.ts      2      2      0
```

</details>

**self-review** · no surviving concerns

24 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->