### PR TITLE
test: speed up 32492.test.ts (36s -> ~9s on ASAN) and assert on bundle output

### DIFF
--- a/test/regression/issue/32492.test.ts
+++ b/test/regression/issue/32492.test.ts
@@ -1,6 +1,6 @@
 // https://github.com/oven-sh/bun/issues/32492
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 
 test("concurrent bun build does not stall on worker-pool shutdown", async () => {
   const N_MODULES = 40;
@@ -24,41 +24,42 @@ test("concurrent bun build does not stall on worker-pool shutdown", async () => 
   const root = String(dir);
 
   const CONCURRENCY = 24;
-  const ROUNDS = 16;
-  // The regression is a fixed 10s idle-futex timeout, so a stalled build always
-  // exceeds 10s regardless of machine speed. A healthy build is well under a
-  // second; keep the threshold high so 24-way oversubscription on a slow ASAN
-  // shard can't trip it, while staying comfortably below the 10s floor.
+  // #32492 was a ~10s stall at pool shutdown when the idle-futex timeout was
+  // 10s. #34009 lowered that timeout to 100ms, so a skipped shutdown wake now
+  // costs at most ~100ms and is indistinguishable from 24-way scheduling noise.
+  // This test therefore acts as a coarse guard (no multi-second shutdown stall)
+  // plus a concurrent-build smoke test. 4 rounds x 24 builds is enough for that
+  // on debug/ASAN; release keeps 16 because it's cheap.
+  const ROUNDS = isASAN || isDebug ? 4 : 16;
   const STALL_MS = 9000;
 
-  const buildOnce = async (round: number, i: number) => {
+  const buildOnce = async (i: number) => {
     const entry = entries[i % entries.length];
     const started = Date.now();
+    // Bundle to stdout (no --outdir) so we can assert on the bundle contents
+    // and skip per-build output directories. The regression is in thread pool
+    // shutdown, which runs identically regardless of the output sink.
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "build",
-        "--target=browser",
-        "--sourcemap=external",
-        "--packages=external",
-        "--outdir",
-        `${root}/out/d${round}_${i}`,
-        `./src/${entry}-entry.ts`,
-      ],
+      cmd: [bunExe(), "build", "--target=browser", "--packages=external", `./src/${entry}-entry.ts`],
       env: bunEnv,
       cwd: root,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { ms: Date.now() - started, exitCode, stdout, stderr };
+    return { entry, ms: Date.now() - started, exitCode, stdout, stderr };
   };
 
   for (let round = 0; round < ROUNDS; round++) {
-    const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_, i) => buildOnce(round, i)));
-    const failed = results.find(r => r.exitCode !== 0);
-    if (failed) {
-      throw new Error(`bun build exited with ${failed.exitCode}\nstdout:\n${failed.stdout}\nstderr:\n${failed.stderr}`);
+    const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_, i) => buildOnce(i)));
+    for (const r of results) {
+      // Assert the bundle actually walked the 40-module chain before checking
+      // the exit code so a failure surfaces the build output.
+      expect(r.stderr).toBe("");
+      expect(r.stdout).toContain(`var v${N_MODULES} = ${N_MODULES};`);
+      expect(r.stdout).toContain("var v1 = 1 + v2;");
+      expect(r.stdout).toContain(`console.log("${r.entry}", v1, f1());`);
+      expect(r.exitCode).toBe(0);
     }
     const slowestMs = Math.max(...results.map(r => r.ms));
     expect(slowestMs).toBeLessThan(STALL_MS);

--- a/test/regression/issue/32492.test.ts
+++ b/test/regression/issue/32492.test.ts
@@ -24,12 +24,13 @@ test("concurrent bun build does not stall on worker-pool shutdown", async () => 
   const root = String(dir);
 
   const CONCURRENCY = 24;
-  // #32492 was a ~10s stall at pool shutdown when the idle-futex timeout was
-  // 10s. #34009 lowered that timeout to 100ms, so a skipped shutdown wake now
-  // costs at most ~100ms and is indistinguishable from 24-way scheduling noise.
-  // This test therefore acts as a coarse guard (no multi-second shutdown stall)
-  // plus a concurrent-build smoke test. 4 rounds x 24 builds is enough for that
-  // on debug/ASAN; release keeps 16 because it's cheap.
+  // #32492 was a ~10s stall at pool shutdown when the idle-futex first-wait
+  // timeout was 10s. #34009 lowered that timeout to 100ms, after which the
+  // 16-round version of this test no longer distinguishes a reverted
+  // Event::wake fix on current main (verified empirically). This test is now a
+  // coarse guard against multi-second shutdown stalls plus a concurrent-build
+  // smoke test; 4 rounds x 24 builds covers that on debug/ASAN and release
+  // keeps 16 because it's cheap.
   const ROUNDS = isASAN || isDebug ? 4 : 16;
   const STALL_MS = 9000;
 


### PR DESCRIPTION
### What

`test/regression/issue/32492.test.ts` was the slowest file on the debian 13 x64-asan lane at 36s (build #78397). This brings it down roughly 4x and replaces the exit-code-only check with real assertions on the bundled output.

### Changes

- **Rounds**: 16 -> 4 on debug/ASAN (kept at 16 on release, which is cheap). 96 spawns instead of 384.
- **Output sink**: bundle to stdout instead of `--outdir`/`--sourcemap=external`, which drops 384 per-build output directories and lets the test assert on the bundle text. The regression lived in thread-pool shutdown, which runs identically regardless of where the bundle is written.
- **Assertions**: per-build, check `stderr == ""`, that the bundle contains the head and tail of the 40-module chain (`var v40 = 40;`, `var v1 = 1 + v2;`), and the entry-specific `console.log(...)` line, before checking `exitCode`. 16 expect() calls -> 484.

### Why cutting rounds does not weaken the timing guard

The original regression was a ~10s stall because the first idle-futex wait in `Event::wait` had a 10 second timeout. #34009 lowered that first-wait timeout to 100ms (for the `mi_on_thread_idle` sweep). I reverted the `|| wake_threads == u32::MAX` guard from #32494 on current `main` and re-ran both versions of the test:

| | with fix | fix reverted |
|---|---|---|
| p50 build (24-way, 192 samples, debug+ASAN) | 928ms | 1009ms |
| max build | 1090ms | 1220ms |
| original 16-round test | pass | **pass** (3/3) |

The ~80-100ms delta is real and consistent with workers hitting the 100ms first-wait timeout, but it sits inside 24-way scheduling noise and well under the 9000ms threshold. The existing 16-round test already cannot distinguish a reverted `Event::wake` fix on current `main`, so reducing rounds on debug/ASAN loses no fail-before signal there. The timing assertion remains as a coarse guard against multi-second shutdown stalls, and the new output assertions make it a useful concurrent-build smoke test.

(Note: only the *first* wait in `Event::wait` is bounded at 100ms; subsequent waits after the idle sweep are indefinite per `ThreadPool.rs`. The indefinite-hang case did not trigger across 1152 reverted builds in this workload, but the round reduction is justified by the empirical result above, not by a timeout bound.)

### Verification

Local `bun bd test test/regression/issue/32492.test.ts` (debug+ASAN, 16 cores):

| | before | after |
|---|---|---|
| test time | 21.6s | 4.9s / 5.0s / 5.0s |
| file time | 24.4s | 7.0s / 7.2s / 8.1s |
| expect() calls | 16 | 484 |

Overlaps with the 32492 hunk of #33704 (which only reduces rounds); this PR is scoped to the one file and also adds the output assertions.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/32492.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/32492.test.ts"
bun test v1.4.0 (8a451d4bd)

test/regression/issue/32492.test.ts:
(pass) concurrent bun build does not stall on worker-pool shutdown [5145.81ms]

 1 pass
 0 fail
 484 expect() calls
Ran 1 test across 1 file. [7.59s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/32492.test.ts | 46 +++++++++++++++++++------------------
 1 file changed, 24 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/regression/issue/32492.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->