### PR TITLE
node:http: keep emitting 'connection' after server.reload()

### DIFF
--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -85,10 +85,10 @@ private:
     void clearRoutes() {
         this->router = HttpRouter<RouterData>{};
         this->currentRouter = &router;
-        /* filterHandlers are connection-level (open/close) callbacks, not routes:
-         * Bun registers exactly one (the node:http 'connection' filter) once at
-         * listen time and never re-registers it. They are left in place like
-         * onSocketClosed/onClientError above. */
+        /* filterHandlers are connection-level (open/close) callbacks, not routes;
+         * Bun's only consumer (the node:http 'connection' thunk) is registered
+         * once for the server's lifetime and left in place here like
+         * onSocketClosed / onClientError above. */
     }
 
 public:

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -85,7 +85,10 @@ private:
     void clearRoutes() {
         this->router = HttpRouter<RouterData>{};
         this->currentRouter = &router;
-        filterHandlers.clear();
+        /* filterHandlers are connection-level (open/close) callbacks, not routes:
+         * Bun registers exactly one (the node:http 'connection' filter) once at
+         * listen time and never re-registers it. They are left in place like
+         * onSocketClosed/onClientError above. */
     }
 
 public:

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1187,8 +1187,8 @@ function httpAllowHalfOpenGet(this: Server) {
 
 // Node reads `server.httpAllowHalfOpen` when the peer's FIN arrives (socketOnEnd), so
 // assigning it after listen() has to reach the native listener too. Push the flags
-// alone: setServerCustomOptions() would also re-register the connection filter, which
-// appends rather than replaces and can reallocate the vector uWS is iterating.
+// alone: setServerCustomOptions() would also re-bind the clientError/connection
+// callbacks, which a flag-only update has no reason to touch.
 function httpAllowHalfOpenSet(this: Server, value) {
   const previous = !!this[kHttpAllowHalfOpen];
   this[kHttpAllowHalfOpen] = value;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3710,13 +3710,14 @@ pub(super) fn server_set_on_connection_(
                 // SAFETY: as_ returned a non-null *mut to a live server.
                 let this = unsafe { &mut *this };
                 if let Some(app) = this.app {
-                    // The uWS filter is registered once per native server: under
-                    // `bun --hot` a node:http module re-eval reaches this point
-                    // again on the same server (hot_map returned the existing
-                    // one), and `filter()` appends, so a second registration
-                    // would fire 'connection' N+1 times per socket. The thunk
-                    // reads `self.on_connection` at call time, so updating the
-                    // slot is enough on subsequent calls.
+                    // The uWS filter is registered once per native server.
+                    // Under `bun --hot` a node:http module re-eval reaches
+                    // this point again on the same server (hot_map returned
+                    // the existing one) and `filter()` appends, so without
+                    // this gate `filterHandlers` would grow by one per
+                    // reload. The thunk reads `self.on_connection` at call
+                    // time, so updating the slot is enough on subsequent
+                    // calls.
                     let first = this.on_connection.is_empty();
                     this.on_connection = callback;
                     super::wrap_handler_slot(

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3710,6 +3710,14 @@ pub(super) fn server_set_on_connection_(
                 // SAFETY: as_ returned a non-null *mut to a live server.
                 let this = unsafe { &mut *this };
                 if let Some(app) = this.app {
+                    // The uWS filter is registered once per native server: under
+                    // `bun --hot` a node:http module re-eval reaches this point
+                    // again on the same server (hot_map returned the existing
+                    // one), and `filter()` appends, so a second registration
+                    // would fire 'connection' N+1 times per socket. The thunk
+                    // reads `self.on_connection` at call time, so updating the
+                    // slot is enough on subsequent calls.
+                    let first = this.on_connection.is_empty();
                     this.on_connection = callback;
                     super::wrap_handler_slot(
                         &mut this.on_connection,
@@ -3717,25 +3725,29 @@ pub(super) fn server_set_on_connection_(
                         global,
                         <$T>::js_gc_on_connection_set,
                     );
-                    // uws filters fire with `1` when an HTTP connection is opened
-                    // (for TLS, when its handshake completes) and `-1` on close;
-                    // only the open notification is forwarded to JS.
-                    extern "C" fn thunk(
-                        socket: *mut uws_sys::us_socket_t,
-                        opened: i32,
-                        user_data: *mut c_void,
-                    ) {
-                        if opened != 1 {
-                            return;
+                    if first {
+                        // uws filters fire with `1` when an HTTP connection is
+                        // opened (for TLS, when its handshake completes) and
+                        // `-1` on close; only the open notification is
+                        // forwarded to JS.
+                        extern "C" fn thunk(
+                            socket: *mut uws_sys::us_socket_t,
+                            opened: i32,
+                            user_data: *mut c_void,
+                        ) {
+                            if opened != 1 {
+                                return;
+                            }
+                            // SAFETY: user_data is the `*mut Self` registered
+                            // below; socket is a live uWS socket for this
+                            // server's group.
+                            let this = unsafe { &mut *user_data.cast::<$T>() };
+                            this.on_connection_callback(socket.cast::<c_void>());
                         }
-                        // SAFETY: user_data is the `*mut Self` registered below;
-                        // socket is a live uWS socket for this server's group.
-                        let this = unsafe { &mut *user_data.cast::<$T>() };
-                        this.on_connection_callback(socket.cast::<c_void>());
+                        // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
+                        bun_opaque::opaque_deref_mut(app)
+                            .filter(thunk, core::ptr::from_mut::<$T>(this).cast::<c_void>());
                     }
-                    // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
-                    bun_opaque::opaque_deref_mut(app)
-                        .filter(thunk, core::ptr::from_mut::<$T>(this).cast::<c_void>());
                 }
                 return Ok(JSValue::UNDEFINED);
             }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1305,6 +1305,54 @@ it("reload() of a node:http-backed server keeps the 'connection' event firing", 
   }
 });
 
+// Under --hot the module re-evaluates and listen() runs again against the same
+// native server from the hot map; the 'connection' filter must be registered
+// once for the server's lifetime, not re-appended per reload.
+it("--hot reload of a node:http server fires 'connection' once per socket", async () => {
+  using dir = tempDir("hot-node-http-connection", {
+    "server.mjs": `
+      import { createServer } from "node:http";
+      import { once } from "node:events";
+      import { connect } from "node:net";
+      import { writeFileSync, readFileSync } from "node:fs";
+
+      globalThis.__reloads ??= 0;
+      const n = globalThis.__reloads++;
+
+      let fired = 0;
+      const server = createServer((req, res) => res.end("ok"));
+      server.on("connection", () => fired++);
+      await once(server.listen(0, "127.0.0.1"), "listening");
+
+      const s = connect(server.address().port, "127.0.0.1");
+      s.on("error", () => {});
+      await once(s, "connect");
+      s.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+      s.resume();
+      await once(s, "close");
+
+      console.log("[reload " + n + "] " + fired);
+      if (n < 3) {
+        const self = new URL(import.meta.url);
+        writeFileSync(self, readFileSync(self, "utf8"));
+      } else {
+        process.exit(fired === 1 ? 0 : 1);
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--hot", "server.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.replaceAll(/^DEBUG:.*\n/gm, "")).toBe("");
+  expect(stdout).toBe("[reload 0] 1\n[reload 1] 1\n[reload 2] 1\n[reload 3] 1\n");
+  expect(exitCode).toBe(0);
+}, 30_000);
+
 it("reload() cannot turn a Bun.serve server into a node:http server", async () => {
   // The server's kind is fixed when listen() sizes its connections' native
   // per-socket block; a reload that smuggles in the node:http handler used by

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -20,7 +20,9 @@ import { join, resolve } from "path";
 // import app_jsx from "./app.jsx";
 import { heapStats } from "bun:jsc";
 import { spawn } from "child_process";
-import net from "node:net";
+import { once } from "node:events";
+import { createServer as createHttpServer } from "node:http";
+import net, { type AddressInfo } from "node:net";
 import { networkInterfaces } from "node:os";
 import nodeTls from "node:tls";
 import { tmpdir } from "os";
@@ -1266,6 +1268,41 @@ it("reload() of a node:http-backed server is not treated as a mode switch", asyn
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("OK\n");
   expect(exitCode).toBe(0);
+});
+
+// reload() clears the uWS route table; the connection-open filter that backs
+// node:http's 'connection' event is not a route and must survive that. `bun --hot`
+// on a node:http app takes this reload path on every file change.
+it("reload() of a node:http-backed server keeps the 'connection' event firing", async () => {
+  let connections = 0;
+  const httpServer = createHttpServer((req, res) => res.end("ok"));
+  httpServer.on("connection", () => connections++);
+  httpServer.listen(0, "127.0.0.1");
+  await once(httpServer, "listening");
+  try {
+    const { port } = httpServer.address() as AddressInfo;
+    const hit = async () => {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+      // Drain the response so 'end' (and then 'close') is delivered.
+      socket.resume();
+      await once(socket, "close");
+    };
+
+    await hit();
+    expect(connections).toBe(1);
+
+    const native = (httpServer as any)[Symbol.for("::bunternal::")] as Server;
+    native.reload({ fetch: () => new Response("x") });
+
+    await hit();
+    expect(connections).toBe(2);
+  } finally {
+    httpServer.closeAllConnections();
+    httpServer.close();
+  }
 });
 
 it("reload() cannot turn a Bun.serve server into a node:http server", async () => {

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1306,8 +1306,10 @@ it("reload() of a node:http-backed server keeps the 'connection' event firing", 
 });
 
 // Under --hot the module re-evaluates and listen() runs again against the same
-// native server from the hot map; the 'connection' filter must be registered
-// once for the server's lifetime, not re-appended per reload.
+// native server from the hot map, re-invoking Server__setOnConnection. The JS
+// onServerConnection callback dedupes on socketHandle.duplex, so this asserts
+// the user-visible contract (exactly one 'connection' per accept) holds across
+// hot reloads, not the native filter-vector size.
 it("--hot reload of a node:http server fires 'connection' once per socket", async () => {
   using dir = tempDir("hot-node-http-connection", {
     "server.mjs": `


### PR DESCRIPTION
## What does this PR do?

`HttpContextData<SSL>::clearRoutes()` cleared `filterHandlers` along with the router. Bun's only filter handler is the thunk that `Server__setOnConnection` registers to drive node:http's `'connection'` event, so after a direct `server.reload()` new TCP connections stopped emitting `'connection'`.

Before:
```
after first hit: 1
after reload + second hit: 1   # should be 2
```

### Fix

`filterHandlers` are connection-level open/close callbacks, not routes, so `clearRoutes()` now leaves them in place the same way it already leaves `onSocketClosed` / `onClientError`.

Under `bun --hot` on a node:http app the module re-evaluates, `listen()` runs again, and `Bun.serve` returns the *same* native server from the hot map, after which `applyServerCustomOptions` reaches `Server__setOnConnection` again. `filter()` appends, and previously `clearRoutes()` clearing the vector between those two steps is what kept it at one entry. `server_set_on_connection_` now registers the thunk only on the first call and just updates the callback slot thereafter (the thunk reads `self.on_connection` at call time). Without that gate the `.duplex` early-return in `onServerConnection` would still keep the emit count at one, but `filterHandlers` would grow by one entry per reload.

## How did you verify your code works?

Two new tests in `test/js/bun/http/serve.test.ts`:

- `reload() of a node:http-backed server keeps the 'connection' event firing`: opens two raw TCP connections around a direct `native.reload()` and asserts `'connection'` fires for both. Fails on main (`Expected 2, Received 1`), passes with the fix.
- `--hot reload of a node:http server fires 'connection' once per socket`: runs `bun --hot` on a node:http server through four reloads and asserts each fresh socket emits `'connection'` exactly once. This pins the user-visible contract under `--hot`; it does not observe the native filter-vector size, which the JS `.duplex` dedup would mask.

All other `reload` tests and the node-http `'connection'` tests still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->