### PR TITLE
test(proxy-stress): hold deadPort() bound so concurrent listen(0) can't steal it

### DIFF
--- a/test/js/bun/http/proxy-stress-errors.test.ts
+++ b/test/js/bun/http/proxy-stress-errors.test.ts
@@ -120,11 +120,11 @@ describe("proxy unreachable", () => {
   for (const originTls of [false, true] as const) {
     test.concurrent(`proxy port refused, ${originTls ? "https" : "http"} origin`, async () => {
       await using origin = await createAdversarialOrigin({ tls: originTls, body: "unreachable" });
-      const port = await deadPort();
+      using dead = await deadPort();
       let code: string;
       try {
         const res = await fetch(origin.url, {
-          proxy: `http://127.0.0.1:${port}`,
+          proxy: `http://127.0.0.1:${dead.port}`,
           keepalive: false,
           tls: laxTls,
           signal: AbortSignal.timeout(15_000),
@@ -148,12 +148,12 @@ describe("proxy unreachable", () => {
 describe("upstream unreachable via proxy", () => {
   for (const proxyTls of [false, true] as const) {
     test.concurrent(`${proxyTls ? "https" : "http"}-proxy, CONNECT upstream refused → 502`, async () => {
-      const port = await deadPort();
+      using dead = await deadPort();
       await using proxy = await createAdversarialProxy({ tls: proxyTls });
 
       // Point at a refused port directly — the client will CONNECT to it,
       // the proxy will fail to dial, and return 502.
-      const res = await fetch(`https://127.0.0.1:${port}/`, {
+      const res = await fetch(`https://127.0.0.1:${dead.port}/`, {
         proxy: proxy.url,
         keepalive: false,
         tls: laxTls,
@@ -163,9 +163,9 @@ describe("upstream unreachable via proxy", () => {
     });
 
     test.concurrent(`${proxyTls ? "https" : "http"}-proxy, absolute-form upstream refused → 502`, async () => {
-      const port = await deadPort();
+      using dead = await deadPort();
       await using proxy = await createAdversarialProxy({ tls: proxyTls });
-      const res = await fetch(`http://127.0.0.1:${port}/`, {
+      const res = await fetch(`http://127.0.0.1:${dead.port}/`, {
         proxy: proxy.url,
         keepalive: false,
         tls: laxTls,

--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -703,20 +703,48 @@ export function errcode(e: unknown): string {
   return typeof any?.code === "string" ? any.code : typeof any?.name === "string" ? any.name : String(e);
 }
 
+export interface DeadPort {
+  port: number;
+  [Symbol.dispose](): void;
+}
+
 /**
- * A port that's definitely closed. We bind and immediately release a port,
- * then return it; nothing reuses it in the microseconds before the caller
- * dials. Good enough for "connect refused" assertions without racing other
- * tests on a fixed well-known-closed port.
+ * A port on 127.0.0.1 that refuses connections for as long as the returned
+ * handle is alive.
+ *
+ * The port is held as the *local* side of a live TCP connection: bound, so
+ * the kernel's ephemeral allocator will not hand it to a concurrent
+ * `listen(0)`, and not listening, so `connect()` to it is refused. The
+ * previous bind-close-return implementation raced with the file's other
+ * `test.concurrent` `listen(0)` calls, which the kernel happily satisfied
+ * with the just-freed port before the caller got to dial it (build 77839:
+ * a live origin answered 200, build 78501: an auth-requiring proxy answered
+ * 407).
  */
-export async function deadPort(): Promise<number> {
-  const s = net.createServer();
-  s.listen(0, "127.0.0.1");
-  await once(s, "listening");
-  const port = (s.address() as net.AddressInfo).port;
-  s.close();
-  await once(s, "close");
-  return port;
+export async function deadPort(): Promise<DeadPort> {
+  let accepted: net.Socket | undefined;
+  const sink = net.createServer(s => {
+    accepted = s;
+    s.on("error", () => {});
+  });
+  sink.listen(0, "127.0.0.1");
+  await once(sink, "listening");
+  const holder = net.connect({ host: "127.0.0.1", port: (sink.address() as net.AddressInfo).port });
+  holder.on("error", () => {});
+  await once(holder, "connect");
+  const port = (holder.address() as net.AddressInfo).port;
+  // `sink` has served its purpose (giving `holder` something to connect to);
+  // stop accepting so its listening port can be recycled. The established
+  // connection — and with it `holder`'s local-port binding — survives
+  // server.close().
+  sink.close();
+  return {
+    port,
+    [Symbol.dispose]() {
+      holder.destroy();
+      accepted?.destroy();
+    },
+  };
 }
 
 /**

--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -714,12 +714,9 @@ export interface DeadPort {
  *
  * The port is held as the *local* side of a live TCP connection: bound, so
  * the kernel's ephemeral allocator will not hand it to a concurrent
- * `listen(0)`, and not listening, so `connect()` to it is refused. The
- * previous bind-close-return implementation raced with the file's other
- * `test.concurrent` `listen(0)` calls, which the kernel happily satisfied
- * with the just-freed port before the caller got to dial it (build 77839:
- * a live origin answered 200, build 78501: an auth-requiring proxy answered
- * 407).
+ * `listen(0)`, and not listening, so `connect()` to it is refused. Do not
+ * simplify to bind-then-close: that frees the port into exactly the pool
+ * `listen(0)` draws from, and a sibling `test.concurrent` will take it.
  */
 export async function deadPort(): Promise<DeadPort> {
   let accepted: net.Socket | undefined;


### PR DESCRIPTION
## Problem

`test/js/bun/http/proxy-stress-errors.test.ts` went red in [build 78599](https://buildkite.com/bun/bun/builds/78599) (debian 13 x64), [build 78501](https://buildkite.com/bun/bun/builds/78501) (debian 13 aarch64), and [build 77839](https://buildkite.com/bun/bun/builds/77839) (alpine 3.23 x64). Each sighting is a different "upstream unreachable via proxy" or "proxy authentication" subtest getting the wrong result:

| build | test | expected | got |
|---|---|---|---|
| 77839 | `http-proxy, absolute-form upstream refused → 502` | 502 | 200 |
| 77839 | `https-proxy → http-origin: wrong auth → 403` | origin not reached | `origin.requests.length == 1` |
| 78501 | `https-proxy, CONNECT upstream refused → 502` | 502 | 407 |
| 78599 | `http-proxy, absolute-form upstream refused → 502` | 502 | ECONNRESET |

Each build's annotation also carries `1 crashes reported during this test`; those traces are `panic: Failed to start File Watcher: EAGAIN` from `src/jsc/hot_reloader.rs`, which this test cannot reach (it spawns no subprocess, uses no watcher). They are the shard-level crash-attribution issue already diagnosed in #33984/#34049 and only serve to suppress the automatic retry, promoting the flake to a hard fail.

## Cause

`deadPort()` binds `127.0.0.1:0`, closes the server, and returns the port for the caller to dial expecting `ECONNREFUSED`. The doc comment says "nothing reuses it in the microseconds before the caller dials", which is false under `test.concurrent`: the file's 53 concurrent tests each issue one to three `listen(0, "127.0.0.1")` calls of their own, and the kernel's ephemeral allocator happily satisfies one of them with the port `deadPort()` just released. Mechanically:

```
$ bun -e '... oldDeadPort() then 20× listen(0), 500 trials ...'
old deadPort: port grabbed by subsequent listen(0) in 3 / 500 trials
```

That explains every observed value: 200 is a concurrent `createAdversarialOrigin` answering; 407 is a concurrent `createAdversarialProxy({ tls: true, auth })` answering (the test proxy's upstream TCP connect succeeds, it replies 200 Connection Established, the client's inner TLS handshake completes against the auth proxy, which then 407s the GET); ECONNRESET is a concurrent TLS server receiving plaintext absolute-form bytes; and `origin.requests.length == 1` is this test's origin being another test's "dead" port.

Introduced by #32635 (the file has always paired `deadPort()` with `test.concurrent`); same family as the ephemeral-port races #33975/#33984/#34049 fixed in the sibling files.

## Fix

Hold the port as the local side of a live TCP connection for the lifetime of the test: bound, so `listen(0)` will not be handed it, and not listening, so `connect()` to it still gets `ECONNREFUSED`. `deadPort()` now returns a disposable and the three call sites become `using dead = await deadPort()`.

```
$ bun -e '... newDeadPort() held, 2000× listen(0) ...'
listen(0) collisions with held port out of 2000: 0
connect to held port: error:ECONNREFUSED
```

## Verification

```
# before (release bun, flake-prone subset -t "unreachable|authentication|unsupported proxy scheme")
6 / 200 runs had a failure

# after (same command)
0 / 200 runs had a failure

# full file, 100 release runs: stable
# bun bd (debug+ASAN), 10 runs: 53 pass / 0 fail / 132 expect() each
```

All six sibling `proxy-stress-*.test.ts` files (788 tests) pass unchanged.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/proxy-stress-errors.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/proxy-stress-errors.test.ts
bun test v1.4.0 (1e135bfec)

test/js/bun/http/proxy-stress-errors.test.ts:
(pass) CONNECT failure status > http-proxy CONNECT → 400 is surfaced as-is [608.07ms]
(pass) CONNECT failure status > http-proxy CONNECT → 403 is surfaced as-is [357.19ms]
(pass) CONNECT failure status > http-proxy CONNECT → 407 is surfaced as-is [353.15ms]
(pass) CONNECT failure status > http-proxy CONNECT → 500 is surfaced as-is [443.44ms]
(pass) CONNECT failure status > http-proxy CONNECT → 502 is surfaced as-is [445.88ms]
(pass) CONNECT failure status > http-proxy CONNECT → 503 is surfaced as-is [281.49ms]
(pass) CONNECT failure status > http-proxy CONNECT → 504 is surfaced as-is [279.92ms]
(pass) CONNECT failure status > https-proxy CONNECT → 400 is surfaced as-is [341.27ms]
(pass) CONNECT failure status > https-proxy CONNECT → 403 is surfaced as-is [316.94ms]
(pass) CONNECT failure status > https-proxy CONNECT → 407 is surfaced as-is [316.58ms]
(pass) CONNECT failure status > https-proxy CONNECT → 500 is surfaced as-is [347.12ms]
(pass) CONNECT failure status > https-proxy CONNECT → 502 is surfaced as-is [351.66ms]
(pass) CONNECT failure status > https-proxy CONNECT → 503 is surfaced as-is [386.69ms]
(pass) CONNECT failure status > https-proxy CONNECT → 504 is surfaced as-is [369.56ms]
(pass) CONNECT failure status > CONNECT → 301 with Location is not followed [386.12ms]
(pass) CONNECT failure status > CONNECT → 302 with Location is not followed [575.16ms]
(pass) proxy unreachable > proxy port refused, http origin [449.75ms]
(pass) proxy unreachable > proxy port refused, https origin [437.50ms]
(pass) CONNECT failure status > https-proxy CONNECT → 101 fails even when the request asked to upgrade [614.67ms]
(pass) CONNECT failure status > http-proxy CONNECT → 101 fails even when the request asked to upgrade [718.76ms]

... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/proxy-stress-errors.test.ts | 12 +++----
 test/js/bun/http/proxy-stress-helpers.ts     | 49 +++++++++++++++++++++-------
 2 files changed, 43 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
test/js/bun/http/proxy-stress-errors.test.ts      1      3      0
test/js/bun/http/proxy-stress-helpers.ts          2      4      0
```

</details>

<!-- robobun:evidence:end -->