### PR TITLE
http(h3): defer the request to on_write so the TLS Finished is packetized first

### DIFF
--- a/src/http/h3_client/Stream.rs
+++ b/src/http/h3_client/Stream.rs
@@ -33,6 +33,7 @@ pub struct Stream {
     // BACKREF: borrows the request body owned by `client`; not freed here.
     // `RawSlice` carries the outlives-holder invariant.
     pub pending_body: bun_ptr::RawSlice<u8>,
+    pub headers_sent: bool,
     pub request_body_done: bool,
     pub is_streaming_body: bool,
     pub headers_delivered: bool,
@@ -52,6 +53,7 @@ impl Stream {
             body_buffer: Vec::new(),
             status_code: 0,
             pending_body: bun_ptr::RawSlice::EMPTY,
+            headers_sent: false,
             request_body_done: false,
             is_streaming_body: false,
             headers_delivered: false,

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -196,9 +196,19 @@ extern "C" fn on_stream_open(s: *mut quic::Stream, is_client: c_int) {
     stream_mut(stream).qstream = Some(NonNull::from(&mut *s));
     *s.ext::<Stream>() = NonNull::new(stream);
     bun_core::scoped_log!(h3_client, "stream_open");
-    if let Err(e) = encode::write_request(session, stream_mut(stream), s) {
-        session.fail(stream, e);
-    }
+    // Headers and body go out from `on_stream_writable`, not here.
+    // `on_stream_open` can fire from inside `on_hsk_done`, which lsquic
+    // invokes from `ci_tick`'s crypto-read phase with `SC_BUFFER_STREAM` set
+    // while the client's TLS Finished is still only on the HSK crypto
+    // stream's frab list. Any `lsquic_stream_write` here fills the send
+    // controller so `write_is_possible()` goes false before
+    // `process_streams_write_events` ever dispatches the crypto stream, and
+    // the Finished is never packetized (the server stays a mini-conn and
+    // drops every 1-RTT packet). `on_write` is dispatched via lsquic's
+    // priority iterator, which serves the crypto stream first. This mirrors
+    // lsquic's reference `bin/http_client.c`, whose `on_new_stream` only
+    // calls `lsquic_stream_wantwrite(stream, 1)`.
+    s.want_write(true);
 }
 
 extern "C" fn on_stream_headers(s: *mut quic::Stream) {
@@ -277,7 +287,19 @@ extern "C" fn on_stream_data(s: *mut quic::Stream, data: *const u8, len: c_uint,
 
 extern "C" fn on_stream_writable(s: *mut quic::Stream) {
     let s = qstream_arg(s);
-    let Some(stream) = stream_of(s) else { return };
+    let Some(stream_ptr) = *s.ext::<Stream>() else {
+        return;
+    };
+    let stream_ptr = stream_ptr.as_ptr();
+    let stream = stream_mut(stream_ptr);
+    if !stream.headers_sent {
+        stream.headers_sent = true;
+        let session = stream.session_mut();
+        if let Err(e) = encode::write_request(session, stream_mut(stream_ptr), s) {
+            session.fail(stream_ptr, e);
+        }
+        return;
+    }
     encode::drain_send_body(stream, s);
 }
 

--- a/src/http/h3_client/encode.rs
+++ b/src/http/h3_client/encode.rs
@@ -118,12 +118,22 @@ pub fn write_request(
     drop(lower);
     drop(headers);
 
+    // Defer body bytes to `on_stream_writable`. `on_stream_open` can fire
+    // from inside `on_hsk_done` (which lsquic invokes from `ci_tick`'s
+    // crypto-read phase with `SC_BUFFER_STREAM` set) while the client's TLS
+    // Finished is still only on the HSK crypto stream's frab list. A large
+    // body written here fills the send controller so `write_is_possible()`
+    // goes false before `process_streams_write_events` ever dispatches the
+    // crypto stream, and the Finished is never packetized (the server stays
+    // a mini-conn and drops every 1-RTT packet). `on_write` is dispatched
+    // via lsquic's priority iterator, which serves the crypto stream first.
+    // This matches lsquic's reference `http_client.c:on_new_stream`.
     if has_inline_body {
         stream.pending_body = req_body;
-        drain_send_body(stream, qs);
+        qs.want_write(true);
     } else if is_streaming {
         stream.is_streaming_body = true;
-        drain_send_body(stream, qs);
+        qs.want_write(true);
     } else {
         stream.request_body_done = true;
     }

--- a/src/http/h3_client/encode.rs
+++ b/src/http/h3_client/encode.rs
@@ -14,8 +14,10 @@ use crate::internal_state::HTTPStage;
 use crate::{HTTPClient, HTTPVerboseLevel, Protocol};
 
 /// Build pseudo-headers + user headers and send them on `qs`, then kick off
-/// body transmission. Called from `callbacks.on_stream_open` once lsquic hands
-/// us a stream for a pending request.
+/// body transmission. Called from the first `callbacks.on_stream_writable`
+/// for this stream (not `on_stream_open`; see the comment there for why no
+/// `lsquic_stream_write` may happen before lsquic's priority iterator has
+/// served the HSK crypto stream).
 pub fn write_request(
     session: &ClientSession,
     stream: &mut Stream,
@@ -118,22 +120,12 @@ pub fn write_request(
     drop(lower);
     drop(headers);
 
-    // Defer body bytes to `on_stream_writable`. `on_stream_open` can fire
-    // from inside `on_hsk_done` (which lsquic invokes from `ci_tick`'s
-    // crypto-read phase with `SC_BUFFER_STREAM` set) while the client's TLS
-    // Finished is still only on the HSK crypto stream's frab list. A large
-    // body written here fills the send controller so `write_is_possible()`
-    // goes false before `process_streams_write_events` ever dispatches the
-    // crypto stream, and the Finished is never packetized (the server stays
-    // a mini-conn and drops every 1-RTT packet). `on_write` is dispatched
-    // via lsquic's priority iterator, which serves the crypto stream first.
-    // This matches lsquic's reference `http_client.c:on_new_stream`.
     if has_inline_body {
         stream.pending_body = req_body;
-        qs.want_write(true);
+        drain_send_body(stream, qs);
     } else if is_streaming {
         stream.is_streaming_body = true;
-        qs.want_write(true);
+        drain_send_body(stream, qs);
     } else {
         stream.request_body_done = true;
     }

--- a/test/js/web/fetch/fetch-http3-cold-post-fixture.ts
+++ b/test/js/web/fetch/fetch-http3-cold-post-fixture.ts
@@ -1,12 +1,12 @@
 // A large POST over HTTP/3 as the very first request on the connection, so
 // on_hsk_done and on_new_stream fire in the same lsquic ci_tick. The request
-// body writer must not starve the client's TLS Finished on the HSK crypto
-// stream. Before the fix, writing the body synchronously from on_stream_open
-// filled the send controller from inside the crypto-read phase and (when the
-// pacer throttled) left the 36-byte Finished unpacketized; the server stayed
-// a mini-conn and dropped every 1-RTT packet until the handshake timeout.
-// The fix defers body bytes to on_write, which lsquic's priority iterator
-// serves after the crypto stream.
+// headers and body must not starve the client's TLS Finished on the HSK
+// crypto stream. Before the fix, writing the request synchronously from
+// on_stream_open filled the send controller from inside the crypto-read
+// phase and (when the pacer throttled) left the 36-byte Finished
+// unpacketized; the server stayed a mini-conn and dropped every 1-RTT packet
+// until the handshake timeout. The fix defers the whole request to on_write,
+// which lsquic's priority iterator serves after the crypto stream.
 //
 // This is regression coverage for the fixed code path, not a deterministic
 // reproduction of the race (which needs the handshake RTT to push lsquic's
@@ -26,6 +26,7 @@ const server = Bun.serve({
   hostname: "127.0.0.1",
   tls: ${JSON.stringify(tls)},
   http3: true,
+  http1: false,
   async fetch(req) {
     const buf = await req.arrayBuffer();
     return new Response(String(buf.byteLength));
@@ -33,9 +34,12 @@ const server = Bun.serve({
 });
 console.error("PORT=" + server.port);
 process.stdin.on("data", () => {});
+process.stdin.on("end", () => process.exit(0));
 `;
 
-async function spawnServer() {
+type Server = { port: number; proc: ReturnType<typeof Bun.spawn>; drained: Promise<string> };
+
+function spawnServer(servers: Server[]): Promise<Server> {
   const proc = Bun.spawn({
     cmd: [bunExe(), "-e", serverSrc],
     env: bunEnv,
@@ -43,47 +47,69 @@ async function spawnServer() {
     stderr: "pipe",
     stdin: "pipe",
   });
-  let buf = "";
-  for await (const chunk of proc.stderr) {
-    buf += new TextDecoder().decode(chunk);
-    const m = buf.match(/PORT=(\d+)/);
-    if (m) return { port: Number(m[1]), proc };
-    if (buf.length > 4096) break;
-  }
-  proc.kill();
-  throw new Error("no PORT from server: " + buf);
+  const ready = Promise.withResolvers<Server>();
+  // Keep the whole stderr buffered: readiness resolves at PORT=, and the
+  // remaining output stays drained so a chatty server can't wedge its pipe.
+  const drained = (async () => {
+    let buf = "";
+    for await (const chunk of proc.stderr) {
+      buf += new TextDecoder().decode(chunk);
+      const m = buf.match(/PORT=(\d+)/);
+      if (m) ready.resolve({ port: Number(m[1]), proc, drained });
+    }
+    ready.reject(new Error("no PORT from server: " + buf));
+    return buf;
+  })();
+  // Registered before awaiting readiness so a reject in a sibling spawn (or
+  // this one never emitting PORT=) still reaps this process.
+  servers.push({ port: 0, proc, drained });
+  return ready.promise;
 }
 
 const BODY = 1_000_000;
 const body = Buffer.alloc(BODY, 0x61);
-const PAR = 12;
-const ROUNDS = 4;
+// A multi-packet header block (just under the server's 16 KB
+// es_max_header_list_size) exercises send_headers_ietf going through the
+// same buffered-packet path from on_write.
+const bigHeaders: Record<string, string> = {};
+for (let i = 0; i < 12; i++) bigHeaders["x-pad-" + i] = Buffer.alloc(1000, 0x62).toString();
+
+type Shape = { init: RequestInit; want: string };
+const PAR = 8;
+const shapes: Shape[] = [
+  { init: { method: "POST", body }, want: String(BODY) },
+  { init: { method: "GET", headers: bigHeaders }, want: "0" },
+];
 let fail = 0;
 
-for (let round = 0; round < ROUNDS && fail === 0; round++) {
-  const servers = await Promise.all(Array.from({ length: PAR }, spawnServer));
-  const results = await Promise.allSettled(
-    servers.map(s =>
-      fetch(`https://127.0.0.1:${s.port}/`, {
-        method: "POST",
-        body,
-        // @ts-ignore
-        protocol: "http3",
-        tls: { rejectUnauthorized: false },
-        signal: AbortSignal.timeout(60_000),
-      } as any).then(r => r.text()),
-    ),
-  );
-  for (const r of results) {
-    if (r.status === "rejected" || r.value !== String(BODY)) {
-      fail++;
-      console.error("FAIL", r.status === "rejected" ? String(r.reason) : r.value);
+for (const { init, want } of shapes) {
+  if (fail) break;
+  const servers: Server[] = [];
+  try {
+    const ready = await Promise.all(Array.from({ length: PAR }, () => spawnServer(servers)));
+    const results = await Promise.allSettled(
+      ready.map(s =>
+        fetch(`https://127.0.0.1:${s.port}/`, {
+          ...init,
+          // @ts-ignore
+          protocol: "http3",
+          tls: { rejectUnauthorized: false },
+          signal: AbortSignal.timeout(60_000),
+        } as any).then(r => r.text()),
+      ),
+    );
+    for (const [i, r] of results.entries()) {
+      if (r.status === "rejected" || r.value !== want) {
+        fail++;
+        console.error("FAIL", i, r.status === "rejected" ? String(r.reason) : r.value);
+      }
     }
+  } finally {
+    for (const s of servers) {
+      s.proc.stdin?.end();
+      s.proc.kill();
+    }
+    await Promise.all(servers.map(s => Promise.all([s.proc.exited, s.drained])));
   }
-  for (const s of servers) {
-    s.proc.stdin?.end();
-    s.proc.kill();
-  }
-  await Promise.all(servers.map(s => s.proc.exited));
 }
 process.exit(fail);

--- a/test/js/web/fetch/fetch-http3-cold-post-fixture.ts
+++ b/test/js/web/fetch/fetch-http3-cold-post-fixture.ts
@@ -94,7 +94,9 @@ for (const { init, want } of shapes) {
           // @ts-ignore
           protocol: "http3",
           tls: { rejectUnauthorized: false },
-          signal: AbortSignal.timeout(60_000),
+          // 2 shapes x 10 s keeps the fixture inside the wrapper's 30 s
+          // budget so a wedged handshake self-reports via exit code.
+          signal: AbortSignal.timeout(10_000),
         } as any).then(r => r.text()),
       ),
     );

--- a/test/js/web/fetch/fetch-http3-cold-post-fixture.ts
+++ b/test/js/web/fetch/fetch-http3-cold-post-fixture.ts
@@ -1,0 +1,89 @@
+// A large POST over HTTP/3 as the very first request on the connection, so
+// on_hsk_done and on_new_stream fire in the same lsquic ci_tick. The request
+// body writer must not starve the client's TLS Finished on the HSK crypto
+// stream. Before the fix, writing the body synchronously from on_stream_open
+// filled the send controller from inside the crypto-read phase and (when the
+// pacer throttled) left the 36-byte Finished unpacketized; the server stayed
+// a mini-conn and dropped every 1-RTT packet until the handshake timeout.
+// The fix defers body bytes to on_write, which lsquic's priority iterator
+// serves after the crypto stream.
+//
+// This is regression coverage for the fixed code path, not a deterministic
+// reproduction of the race (which needs the handshake RTT to push lsquic's
+// pacer past its clock-granularity gate, and that depends on scheduler
+// timing that cannot be forced from JS). See the PR for the lsquic trace
+// that proves the deadlock and the fix.
+//
+// Parent spawns this with bunExe() and asserts exit 0.
+import { bunEnv, bunExe, tls } from "harness";
+
+// One subprocess server per cold handshake so the client's h3 engine cannot
+// reuse a connection, and so the handshake RTT is a real process boundary
+// instead of in-process loopback.
+const serverSrc = `
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  tls: ${JSON.stringify(tls)},
+  http3: true,
+  async fetch(req) {
+    const buf = await req.arrayBuffer();
+    return new Response(String(buf.byteLength));
+  },
+});
+console.error("PORT=" + server.port);
+process.stdin.on("data", () => {});
+`;
+
+async function spawnServer() {
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "-e", serverSrc],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+    stdin: "pipe",
+  });
+  let buf = "";
+  for await (const chunk of proc.stderr) {
+    buf += new TextDecoder().decode(chunk);
+    const m = buf.match(/PORT=(\d+)/);
+    if (m) return { port: Number(m[1]), proc };
+    if (buf.length > 4096) break;
+  }
+  proc.kill();
+  throw new Error("no PORT from server: " + buf);
+}
+
+const BODY = 1_000_000;
+const body = Buffer.alloc(BODY, 0x61);
+const PAR = 12;
+const ROUNDS = 4;
+let fail = 0;
+
+for (let round = 0; round < ROUNDS && fail === 0; round++) {
+  const servers = await Promise.all(Array.from({ length: PAR }, spawnServer));
+  const results = await Promise.allSettled(
+    servers.map(s =>
+      fetch(`https://127.0.0.1:${s.port}/`, {
+        method: "POST",
+        body,
+        // @ts-ignore
+        protocol: "http3",
+        tls: { rejectUnauthorized: false },
+        signal: AbortSignal.timeout(60_000),
+      } as any).then(r => r.text()),
+    ),
+  );
+  for (const r of results) {
+    if (r.status === "rejected" || r.value !== String(BODY)) {
+      fail++;
+      console.error("FAIL", r.status === "rejected" ? String(r.reason) : r.value);
+    }
+  }
+  for (const s of servers) {
+    s.proc.stdin?.end();
+    s.proc.kill();
+  }
+  await Promise.all(servers.map(s => s.proc.exited));
+}
+process.exit(fail);

--- a/test/js/web/fetch/fetch-http3-cold-post.test.ts
+++ b/test/js/web/fetch/fetch-http3-cold-post.test.ts
@@ -17,19 +17,15 @@ import { join } from "node:path";
 // rarely does, so this test is regression coverage for the fixed code path
 // rather than a deterministic reproduction. The lsquic debug trace in the PR
 // that introduced this test shows the deadlock directly.
-test(
-  "large POST on a cold connection does not strand the TLS Finished",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "fetch-http3-cold-post-fixture.ts")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("");
-    expect(exitCode).toBe(0);
-  },
-  120_000,
-);
+test("large POST on a cold connection does not strand the TLS Finished", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fetch-http3-cold-post-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+}, 120_000);

--- a/test/js/web/fetch/fetch-http3-cold-post.test.ts
+++ b/test/js/web/fetch/fetch-http3-cold-post.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// A large POST as the very first request on a cold h3 connection must not
+// starve the client's TLS Finished. lsquic invokes on_hsk_done from inside
+// ci_tick's crypto-read phase while the 36-byte Finished is still only on the
+// HSK crypto stream's frab list; writing the body synchronously from
+// on_new_stream there filled the send controller and (when the pacer
+// throttled) left the Finished unpacketized, so the server stayed a mini-conn
+// and dropped every 1-RTT packet until the handshake timeout. The fix defers
+// body bytes to on_write, which lsquic's priority iterator serves after the
+// crypto stream.
+//
+// The race depends on lsquic's pacer engaging during the initial burst, which
+// in turn needs the handshake RTT to exceed a few ms; on an idle machine it
+// rarely does, so this test is regression coverage for the fixed code path
+// rather than a deterministic reproduction. The lsquic debug trace in the PR
+// that introduced this test shows the deadlock directly.
+test(
+  "large POST on a cold connection does not strand the TLS Finished",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "fetch-http3-cold-post-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  120_000,
+);

--- a/test/js/web/fetch/fetch-http3-cold-post.test.ts
+++ b/test/js/web/fetch/fetch-http3-cold-post.test.ts
@@ -2,22 +2,24 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
-// A large POST as the very first request on a cold h3 connection must not
-// starve the client's TLS Finished. lsquic invokes on_hsk_done from inside
-// ci_tick's crypto-read phase while the 36-byte Finished is still only on the
-// HSK crypto stream's frab list; writing the body synchronously from
-// on_new_stream there filled the send controller and (when the pacer
-// throttled) left the Finished unpacketized, so the server stayed a mini-conn
-// and dropped every 1-RTT packet until the handshake timeout. The fix defers
-// body bytes to on_write, which lsquic's priority iterator serves after the
-// crypto stream.
+// A large first request on a cold h3 connection must not starve the client's
+// TLS Finished. lsquic invokes on_hsk_done from inside ci_tick's crypto-read
+// phase while the 36-byte Finished is still only on the HSK crypto stream's
+// frab list; writing the request synchronously from on_new_stream there
+// filled the send controller and (when the pacer throttled) left the Finished
+// unpacketized, so the server stayed a mini-conn and dropped every 1-RTT
+// packet until the handshake timeout. The fix defers the whole request to
+// on_write, which lsquic's priority iterator serves after the crypto stream.
 //
 // The race depends on lsquic's pacer engaging during the initial burst, which
 // in turn needs the handshake RTT to exceed a few ms; on an idle machine it
 // rarely does, so this test is regression coverage for the fixed code path
 // rather than a deterministic reproduction. The lsquic debug trace in the PR
 // that introduced this test shows the deadlock directly.
-test("large POST on a cold connection does not strand the TLS Finished", async () => {
+//
+// The fixture spawns sixteen subprocess debug builds (each a cold QUIC
+// handshake), which cannot fit in the 5 s default.
+test("large first request on a cold connection does not strand the TLS Finished", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "fetch-http3-cold-post-fixture.ts")],
     env: bunEnv,
@@ -28,4 +30,4 @@ test("large POST on a cold connection does not strand the TLS Finished", async (
   expect(stderr).toBe("");
   expect(stdout).toBe("");
   expect(exitCode).toBe(0);
-}, 120_000);
+}, 30_000);

--- a/test/js/web/fetch/fetch-http3-cold-post.test.ts
+++ b/test/js/web/fetch/fetch-http3-cold-post.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug, tls } from "harness";
 import { join } from "node:path";
 
 // A large first request on a cold h3 connection must not starve the client's
@@ -10,13 +10,55 @@ import { join } from "node:path";
 // unpacketized, so the server stayed a mini-conn and dropped every 1-RTT
 // packet until the handshake timeout. The fix defers the whole request to
 // on_write, which lsquic's priority iterator serves after the crypto stream.
-//
-// The race depends on lsquic's pacer engaging during the initial burst, which
-// in turn needs the handshake RTT to exceed a few ms; on an idle machine it
-// rarely does, so this test is regression coverage for the fixed code path
-// rather than a deterministic reproduction. The lsquic debug trace in the PR
-// that introduced this test shows the deadlock directly.
-//
+
+// Deterministic check via the lsquic debug log: on a cold connection the
+// 36-byte CRYPTO frame (client Finished) must be generated before the first
+// app STREAM frame. Before the fix, on_new_stream wrote the request
+// synchronously, so "generated STREAM frame: stream 0" appeared ahead of
+// "generated CRYPTO frame: offset: 0, size: 36". After the fix, lsquic's
+// priority iterator serves the crypto stream first in on_write, so the order
+// flips. This is independent of pacer timing (the STREAM frames go into the
+// buffered queue either way; what changes is whether they are generated from
+// inside on_new_stream or from on_write after the crypto stream).
+// BUN_DEBUG_lsquic is only wired up under BUN_DEBUG.
+test.skipIf(!isDebug)("the TLS Finished is packetized before the first app STREAM frame", async () => {
+  const fixture = `
+    const tls = ${JSON.stringify(tls)};
+    await using server = Bun.serve({
+      port: 0, hostname: "127.0.0.1", tls, http3: true, http1: false,
+      async fetch(req) { return new Response(String((await req.arrayBuffer()).byteLength)); },
+    });
+    const res = await fetch("https://127.0.0.1:" + server.port + "/", {
+      method: "POST",
+      body: Buffer.alloc(1_000_000, 0x61),
+      protocol: "http3",
+      tls: { rejectUnauthorized: false },
+    });
+    console.log("RESULT", await res.text());
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, BUN_DEBUG_lsquic: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Both client and server log to the same process; the client's Finished is
+  // the one whose CRYPTO frame is exactly 36 bytes at HSK offset 0.
+  const finished = stderr.match(/generated CRYPTO frame: offset: 0, size: 36\b/);
+  const firstAppData = stderr.match(/generated STREAM frame: stream 0, offset: 0,/);
+  expect(stdout).toBe("RESULT 1000000\n");
+  expect(finished).not.toBeNull();
+  expect(firstAppData).not.toBeNull();
+  expect(finished!.index).toBeLessThan(firstAppData!.index!);
+  expect(exitCode).toBe(0);
+});
+
+// End-to-end regression coverage: a batch of cold handshakes with a large
+// body and a multi-packet header block each complete. The race itself depends
+// on lsquic's pacer engaging during the initial burst, which needs the
+// handshake RTT to exceed a few ms; on an idle machine it rarely does, so
+// this asserts the fixed code path rather than reproducing the deadlock.
 // The fixture spawns sixteen subprocess debug builds (each a cold QUIC
 // handshake), which cannot fit in the 5 s default.
 test("large first request on a cold connection does not strand the TLS Finished", async () => {


### PR DESCRIPTION
## What

The HTTP/3 fetch client no longer calls `lsquic_stream_send_headers` / `lsquic_stream_write` from inside `on_new_stream`. `on_stream_open` now only binds the request to the lsquic stream and sets `want_write(true)`; headers and body go out from the first `on_stream_writable`.

## Why

Intermittent (~1-2% in CI) hang of an HTTP/3 `fetch()` when the first request on a fresh connection carries a large body (the `POST echo 1000000 bytes` case in `serve-protocols.test.ts`). The fetch fails with `HTTP3HandshakeFailed` or `HTTP3StreamReset` after lsquic's idle/handshake timeout.

### Root cause (in lsquic's `lsquic_full_conn_ietf.c:ci_tick`)

1. `process_crypto_stream_read_events` reads the server's Handshake, BoringSSL produces the client Finished, `cry_sm_write_message` buffers it on the HSK crypto stream's frab list and puts that stream on `write_streams`. Then `ci_hsk_done` runs `handshake_ok()` (sets `LSCONN_HANDSHAKE_DONE`) and fires the user `on_hsk_done`, all still inside the crypto-read phase with `SC_BUFFER_STREAM` set.
2. Our `on_hsk_done` calls `lsquic_conn_make_stream` → `on_new_stream` fires synchronously → `encode::write_request` → `lsquic_stream_write` + `flush` on a 1 MB body (and `lsquic_stream_send_headers`, which packetizes through the same path once the encoded block crosses one packet). With `SC_BUFFER_STREAM` set, this fills the buffered-packet queue to `max_bpq_count ≈ cwnd / packet_size ≈ 38`.
3. Back in `ci_tick`: `LSCONN_HANDSHAKE_DONE` is now set, so `process_crypto_stream_write_events` at :8616 is skipped. `schedule_buffered(BPT_HIGHEST_PRIO)` at :8627 moves those packets to scheduled until `can_send()` goes false. When the pacer has started throttling (handshake RTT of a few ms → `pa_next - pa_now > clock_granularity`), `write_is_possible()` at :8629 is `last_scheduled(PNS_APP).avail > 10 || can_send()` = false, so `goto end_write` and `process_streams_write_events` never runs.
4. The Finished is therefore never packetized. The server stays a mini-conn, can only buffer two undecryptable 1-RTT packets, and drops the rest. None of the client's 1-RTT packets are ever ACKed, so `b_out` never drops below `cwnd` and every subsequent tick hits the same `goto end_write`. Deadlock until lsquic times the connection out.

### Fix

Set `want_write(true)` from `on_stream_open` and write the request in `on_stream_writable`. lsquic dispatches `on_write` via its priority iterator, which serves critical streams (the HSK crypto stream) before app streams, so the Finished is always packetized first. This is how lsquic's own reference `bin/http_client.c` is written:

```c
/* http_client_on_new_stream */
    lsquic_stream_wantwrite(stream, 1);

/* http_client_on_write */
    if (st_h->sh_flags & HEADERS_SENT) {
        /* write body */
    } else {
        st_h->sh_flags |= HEADERS_SENT;
        send_headers(st_h);
    }
```

## Verification

<details>
<summary>lsquic debug trace: before the fix (Finished never packetized)</summary>

```
handshake: wrote 36 bytes to stream at encryption level 2     <- Finished queued to frab list
stream: put on write queue                                    <- HSK crypto stream
stream -0: calling on_new_stream                              <- our app stream
event: generated STREAM frame: stream 0, offset: 0, size: 1199, fin: 0
  ... 37 more STREAM frames ...
sendctl: Remove packet from buffered queue #0; count: 0. It becomes packet #42
sendctl: can_send: b_out: 48322 = (47090 + 1232); cwnd: 47968  <- b_out > cwnd
conn: tickable: stream 18446744073709551613 can be written to  <- crypto stream waiting, every tick
[server] handshake: header protection for level 3 not initialized yet
[server] event: could not decrypt packet (type SHORT)
[server] mini-conn: drop packet, already delayed 2 packets     <- forever
  ... 8 s later ...
TimeoutError: The operation timed out.
```
</details>

<details>
<summary>lsquic debug trace: after the fix (Finished packetized before the request)</summary>

```
handshake: wrote 36 bytes to stream at encryption level 2
stream -0: calling on_new_stream
  ... no STREAM frames here ...
handshake: wrote 36 bytes to stream from frab list
event: generated CRYPTO frame: offset: 0, size: 36            <- Finished packetized
event: generated STREAM frame: stream 0, offset: 0, size: 1154, fin: 0
  ...
RESULT 1000000
```
</details>

`test/js/web/fetch/fetch-http3-client.test.ts` (POST bodies, streaming bodies, bidi, 50-concurrent, 1 MB round-trip), `fetch-http3-adversarial.test.ts`, `serve-http3.test.ts` and `serve-protocols.test.ts` all pass unchanged (148 tests across the h3 suites).

## On the new tests

`the TLS Finished is packetized before the first app STREAM frame` is the deterministic check: it runs a 1 MB cold-connection POST under `BUN_DEBUG_lsquic=1` and asserts that `generated CRYPTO frame: offset: 0, size: 36` appears before the first `generated STREAM frame: stream 0` in the event log. That order is exactly what the fix changes, independent of pacer timing. Debug-only (the log is gated on `BUN_DEBUG`), so release lanes skip it.



`fetch-http3-cold-post.test.ts` runs 16 cold handshakes (8 with a 1 MB POST body, 8 with a multi-packet header block) and asserts none wedge. The race only deadlocks when the handshake RTT is high enough for lsquic's pacer to throttle the initial burst, which is scheduler-timing-dependent and cannot be forced from JS without instrumenting `src/`. On a loaded CI lane the unfixed build hits it at roughly the reported 1-2% rate; on an idle box it may pass both ways. The traces above are the deterministic proof.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/fetch/fetch-http3-cold-post.test.ts"
bun test v1.4.0 (271ca6ff1)

test/js/web/fetch/fetch-http3-cold-post.test.ts:
48 |   const finished = stderr.match(/generated CRYPTO frame: offset: 0, size: 36\b/);
49 |   const firstAppData = stderr.match(/generated STREAM frame: stream 0, offset: 0,/);
50 |   expect(stdout).toBe("RESULT 1000000\n");
51 |   expect(finished).not.toBeNull();
52 |   expect(firstAppData).not.toBeNull();
53 |   expect(finished!.index).toBeLessThan(firstAppData!.index!);
                               ^
error: expect(received).toBeLessThan(expected)

Expected: < 52495
Received: 159030

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-http3-cold-post.test.ts:53:27)
(fail) the TLS Finished is packetized before the first app STREAM frame [824.46ms]
(pass) large first request on a cold connection does not strand the TLS Finished [5494.51ms]

 1 pass
 1 fail
 7 expect() calls
Ran 2 tests across 1 file. [8.40s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 skipped
bun test v1.4.0-canary.1 (21f071141)

test/js/web/fetch/fetch-http3-cold-post.test.ts:
(skip) the TLS Finished is packetized before the first app STREAM frame
(pass) large first request on a cold connection does not strand the TLS Finished [158.75ms]

 1 pass
 1 skip
 0 fail
 3 expect() calls
Ran 2 tests across 1 file. [297.00ms]
__F:0:S:1
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/web/fetch/fetch-http3-cold-post.test.ts"
bun test v1.4.0 (271ca6ff1)

test/js/web/fetch/fetch-http3-cold-post.test.ts:
(pass) the TLS Finished is packetized before the first app STREAM frame [832.53ms]
(pass) large first request on a cold connection does not strand the TLS Finished [5038.19ms]

 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [7.94s]
__F:0:S:0

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 641ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/h3_client/Stream.rs                       |   2 +
 src/http/h3_client/callbacks.rs                    |  30 +++++-
 src/http/h3_client/encode.rs                       |   6 +-
 test/js/web/fetch/fetch-http3-cold-post-fixture.ts | 117 +++++++++++++++++++++
 test/js/web/fetch/fetch-http3-cold-post.test.ts    |  75 +++++++++++++
 5 files changed, 224 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/http/h3_client/Stream.rs                            1      2      0
src/http/h3_client/callbacks.rs                         2      3      0
src/http/h3_client/encode.rs                            4      6      0
test/js/web/fetch/fetch-http3-cold-post-fixture.ts      4     16      0
test/js/web/fetch/fetch-http3-cold-post.test.ts         3      6      0
```

</details>

<!-- robobun:evidence:end -->