### PR TITLE
node:fs: accept AbortSignal-shaped objects in readFile/writeFile/watch

### DIFF
--- a/src/js/internal/fs/watch.ts
+++ b/src/js/internal/fs/watch.ts
@@ -173,6 +173,16 @@ class FSWatcher extends EventEmitter {
       throw e;
     }
     this._handle = new FSEvent(this);
+
+    // Native AbortSignals are wired up by the native watch() call above. An
+    // AbortSignal-shaped object (polyfill, cross-realm) passes the shape check
+    // there but has no native hook, so honour its pre-aborted state here the
+    // way Node's lib/internal/fs/watchers.js does. Real AbortSignals are
+    // handled by the native layer and skipped here.
+    const signal = options?.signal;
+    if (signal?.aborted && !$isAbortSignal(signal)) {
+      process.nextTick(() => this.close());
+    }
   }
 
   #onEvent(eventType, filenameOrError) {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -240,6 +240,12 @@ const _readFile = fs.readFile.bind(fs);
 const _writeFile = fs.writeFile.bind(fs);
 const _appendFile = fs.appendFile.bind(fs);
 
+// Node's checkAborted: reads `.aborted` off the signal object itself (so
+// AbortSignal-shaped polyfills work) and throws before any I/O is started.
+function checkAborted(signal) {
+  if (signal?.aborted) throw $makeAbortError(undefined, { cause: signal.reason });
+}
+
 // Argument validation must run at the first .next(), not at call time: Node's
 // fs/promises glob is an async generator whose body constructs Glob lazily.
 async function* glob(pattern, options) {
@@ -250,6 +256,7 @@ const exports = {
   access: asyncWrap(fs.access, "access"),
   appendFile: async function (fileHandleOrFdOrPath, ...args) {
     fileHandleOrFdOrPath = fileHandleOrFdOrPath?.[kFd] ?? fileHandleOrFdOrPath;
+    checkAborted(args[1]?.signal);
     return _appendFile(fileHandleOrFdOrPath, ...args);
   },
   close: asyncWrap(fs.close, "close"),
@@ -306,10 +313,12 @@ const exports = {
   readdir: asyncWrap(fs.readdir, "readdir"),
   readFile: async function (fileHandleOrFdOrPath, ...args) {
     fileHandleOrFdOrPath = fileHandleOrFdOrPath?.[kFd] ?? fileHandleOrFdOrPath;
+    checkAborted(args[0]?.signal);
     return _readFile(fileHandleOrFdOrPath, ...args);
   },
   writeFile: async function (fileHandleOrFdOrPath, ...args: any[]) {
     fileHandleOrFdOrPath = fileHandleOrFdOrPath?.[kFd] ?? fileHandleOrFdOrPath;
+    checkAborted(args[1]?.signal);
     if (
       !$isTypedArrayView(args[0]) &&
       typeof args[0] !== "string" &&

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -31,6 +31,18 @@ function ensureCallback(callback) {
   return callback;
 }
 
+// Node's checkAborted for the callback API: if the signal is already aborted,
+// deliver AbortError via the callback on the next tick and return true so the
+// caller can skip the native call.
+function callbackAborted(options, callback) {
+  const signal = options?.signal;
+  if (signal?.aborted) {
+    process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
+    return true;
+  }
+  return false;
+}
+
 // Micro-optimization: avoid creating a new function for every call
 // bind() is slightly more optimized in JSC
 // This code is equivalent to:
@@ -63,11 +75,7 @@ var access = function access(path, mode, callback) {
 
     ensureCallback(callback);
 
-    const signal = options?.signal;
-    if (signal?.aborted) {
-      process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
-      return;
-    }
+    if (callbackAborted(options, callback)) return;
 
     fs.appendFile(path, data, options).then(nullcallback(callback), callback);
   },
@@ -340,11 +348,7 @@ var access = function access(path, mode, callback) {
     callback ||= options;
     ensureCallback(callback);
 
-    const signal = options?.signal;
-    if (signal?.aborted) {
-      process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
-      return;
-    }
+    if (callbackAborted(options, callback)) return;
 
     fs.readFile(path, options).then(function (data) {
       callback(null, data);
@@ -354,11 +358,7 @@ var access = function access(path, mode, callback) {
     callback ||= options;
     ensureCallback(callback);
 
-    const signal = options?.signal;
-    if (signal?.aborted) {
-      process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
-      return;
-    }
+    if (callbackAborted(options, callback)) return;
 
     fs.writeFile(path, data, options).then(nullcallback(callback), callback);
   },
@@ -399,11 +399,7 @@ var access = function access(path, mode, callback) {
 
     ensureCallback(callback);
 
-    const signal = options?.signal;
-    if (signal?.aborted) {
-      process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
-      return;
-    }
+    if (callbackAborted(options, callback)) return;
 
     fs.stat(path, options).then(function (stats) {
       callback(null, stats);

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -63,6 +63,12 @@ var access = function access(path, mode, callback) {
 
     ensureCallback(callback);
 
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
+      return;
+    }
+
     fs.appendFile(path, data, options).then(nullcallback(callback), callback);
   },
   close = function close(fd, callback) {
@@ -334,6 +340,12 @@ var access = function access(path, mode, callback) {
     callback ||= options;
     ensureCallback(callback);
 
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
+      return;
+    }
+
     fs.readFile(path, options).then(function (data) {
       callback(null, data);
     }, callback);
@@ -341,6 +353,12 @@ var access = function access(path, mode, callback) {
   writeFile = function writeFile(path, data, options, callback) {
     callback ||= options;
     ensureCallback(callback);
+
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      process.nextTick(callback, $makeAbortError(undefined, { cause: signal.reason }));
+      return;
+    }
 
     fs.writeFile(path, data, options).then(nullcallback(callback), callback);
   },

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4200,7 +4200,10 @@ pub mod args {
                         if let Some(signal) = AbortSignal::ref_from_js(value) {
                             signal.pending_activity_ref();
                             *abort_signal = Some(signal);
-                        } else {
+                        } else if !value.is_object() || value.get(ctx, "aborted")?.is_none() {
+                            // node's validateAbortSignal accepts any object with an
+                            // `aborted` property (abort-controller polyfills, cross-realm
+                            // signals). Only reject values that fail that shape check.
                             return Err(ctx.throw_invalid_argument_type_value(
                                 b"signal",
                                 b"AbortSignal",
@@ -4303,7 +4306,10 @@ pub mod args {
                         if let Some(signal) = AbortSignal::ref_from_js(value) {
                             signal.pending_activity_ref();
                             *abort_signal = Some(signal);
-                        } else {
+                        } else if !value.is_object() || value.get(ctx, "aborted")?.is_none() {
+                            // node's validateAbortSignal accepts any object with an
+                            // `aborted` property (abort-controller polyfills, cross-realm
+                            // signals). Only reject values that fail that shape check.
                             return Err(ctx.throw_invalid_argument_type_value(
                                 b"signal",
                                 b"AbortSignal",

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -667,10 +667,14 @@ impl<'a> Arguments<'a> {
                         // `opaque_ffi!` ZST handle; `opaque_ref` is the
                         // centralised deref proof.
                         signal = Some(AbortSignal::opaque_ref(signal_obj));
-                    } else {
-                        return Err(ctx.throw_invalid_arguments(format_args!(
-                            "signal is not of type AbortSignal"
-                        )));
+                    } else if !signal_.is_object() || signal_.get(ctx, "aborted")?.is_none() {
+                        // node's validateAbortSignal accepts any object with an
+                        // `aborted` property (polyfills, cross-realm signals).
+                        return Err(ctx.throw_invalid_argument_type_value(
+                            b"options.signal",
+                            b"AbortSignal",
+                            signal_,
+                        ));
                     }
                 }
 

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -570,6 +570,55 @@ describe("readFile/writeFile accept AbortSignal-shaped objects", () => {
     expect(writeErr).toBeNull();
   });
 
+  test("fs.watch", () => {
+    const dir = tempDirWithFiles("fs-duck-signal-watch", { "f.txt": "hello" });
+    const w = fs.watch(dir, { signal: duck });
+    w.close();
+  });
+
+  // node's fs.readFile checks `signal.aborted` on the object itself (not via a
+  // brand check), so a pre-aborted polyfill signal rejects with AbortError.
+  test("a pre-aborted signal-shaped object rejects with AbortError", async () => {
+    const dir = tempDirWithFiles("fs-duck-signal-preaborted", { "f.txt": "hello" });
+    const reason = new Error("stop");
+    const aborted = { aborted: true, reason, addEventListener() {}, removeEventListener() {} };
+    for (const op of [
+      () => fsPromises.readFile(join(dir, "f.txt"), { signal: aborted }),
+      () => fsPromises.writeFile(join(dir, "o.txt"), "x", { signal: aborted }),
+      () => fsPromises.appendFile(join(dir, "o.txt"), "x", { signal: aborted }),
+    ]) {
+      let err;
+      try {
+        await op();
+      } catch (e) {
+        err = e;
+      }
+      expect({ name: err?.name, code: err?.code, cause: err?.cause }).toEqual({
+        name: "AbortError",
+        code: "ABORT_ERR",
+        cause: reason,
+      });
+    }
+  });
+
+  test("callback readFile/writeFile with a pre-aborted signal-shaped object", async () => {
+    const dir = tempDirWithFiles("fs-duck-signal-preaborted-cb", { "f.txt": "hello" });
+    const reason = new Error("stop");
+    const aborted = { aborted: true, reason, addEventListener() {}, removeEventListener() {} };
+    const readErr = await new Promise(resolve => fs.readFile(join(dir, "f.txt"), { signal: aborted }, resolve));
+    expect({ name: readErr?.name, code: readErr?.code, cause: readErr?.cause }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      cause: reason,
+    });
+    const writeErr = await new Promise(resolve => fs.writeFile(join(dir, "o.txt"), "x", { signal: aborted }, resolve));
+    expect({ name: writeErr?.name, code: writeErr?.code, cause: writeErr?.cause }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      cause: reason,
+    });
+  });
+
   test("values that fail node's shape check still throw ERR_INVALID_ARG_TYPE", async () => {
     const dir = tempDirWithFiles("fs-duck-signal-reject", { "f.txt": "hello" });
     for (const signal of [{}, 42, "x"]) {

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -536,3 +536,47 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     expectNodeAbortError(writeErr, signal.reason);
   });
 });
+
+// node's validateAbortSignal accepts any object with an `aborted` property, so
+// abort-controller polyfills and cross-realm signals work. Bun's timers.promises,
+// child_process and events already accept these; fs.readFile/writeFile must too.
+describe("readFile/writeFile accept AbortSignal-shaped objects", () => {
+  const duck = {
+    aborted: false,
+    reason: undefined,
+    addEventListener() {},
+    removeEventListener() {},
+    onabort: null,
+  };
+
+  test("fsPromises.readFile", async () => {
+    const dir = tempDirWithFiles("fs-duck-signal-read", { "f.txt": "hello" });
+    expect(await fsPromises.readFile(join(dir, "f.txt"), { signal: duck, encoding: "utf8" })).toBe("hello");
+  });
+
+  test("fsPromises.writeFile and appendFile", async () => {
+    const dir = tempDirWithFiles("fs-duck-signal-write", {});
+    const p = join(dir, "f.txt");
+    await fsPromises.writeFile(p, "a", { signal: duck });
+    await fsPromises.appendFile(p, "b", { signal: duck });
+    expect(await fsPromises.readFile(p, "utf8")).toBe("ab");
+  });
+
+  test("callback fs.readFile and fs.writeFile", async () => {
+    const dir = tempDirWithFiles("fs-duck-signal-cb", { "f.txt": "hello" });
+    const readErr = await new Promise(resolve => fs.readFile(join(dir, "f.txt"), { signal: duck }, resolve));
+    expect(readErr).toBeNull();
+    const writeErr = await new Promise(resolve => fs.writeFile(join(dir, "o.txt"), "x", { signal: duck }, resolve));
+    expect(writeErr).toBeNull();
+  });
+
+  test("values that fail node's shape check still throw ERR_INVALID_ARG_TYPE", async () => {
+    const dir = tempDirWithFiles("fs-duck-signal-reject", { "f.txt": "hello" });
+    for (const signal of [{}, 42, "x"]) {
+      await expectReject(() => fsPromises.readFile(join(dir, "f.txt"), { signal }), { code: "ERR_INVALID_ARG_TYPE" });
+      await expectReject(() => fsPromises.writeFile(join(dir, "o.txt"), "x", { signal }), {
+        code: "ERR_INVALID_ARG_TYPE",
+      });
+    }
+  });
+});

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -580,8 +580,9 @@ describe("readFile/writeFile accept AbortSignal-shaped objects", () => {
     const dir = tempDirWithFiles("fs-duck-signal-watch-aborted", { "f.txt": "hello" });
     const aborted = { aborted: true, reason: new Error("stop"), addEventListener() {}, removeEventListener() {} };
     const w = fs.watch(dir, { signal: aborted });
-    const { promise, resolve } = Promise.withResolvers();
+    const { promise, resolve, reject } = Promise.withResolvers();
     w.on("close", resolve);
+    w.on("error", reject);
     await promise;
   });
 
@@ -608,24 +609,21 @@ describe("readFile/writeFile accept AbortSignal-shaped objects", () => {
         cause: reason,
       });
     }
+    expect(fs.existsSync(join(dir, "o.txt"))).toBe(false);
   });
 
-  test("callback readFile/writeFile with a pre-aborted signal-shaped object", async () => {
+  test("callback readFile/writeFile/appendFile with a pre-aborted signal-shaped object", async () => {
     const dir = tempDirWithFiles("fs-duck-signal-preaborted-cb", { "f.txt": "hello" });
     const reason = new Error("stop");
     const aborted = { aborted: true, reason, addEventListener() {}, removeEventListener() {} };
+    const expected = { name: "AbortError", code: "ABORT_ERR", cause: reason };
     const readErr = await new Promise(resolve => fs.readFile(join(dir, "f.txt"), { signal: aborted }, resolve));
-    expect({ name: readErr?.name, code: readErr?.code, cause: readErr?.cause }).toEqual({
-      name: "AbortError",
-      code: "ABORT_ERR",
-      cause: reason,
-    });
+    expect({ name: readErr?.name, code: readErr?.code, cause: readErr?.cause }).toEqual(expected);
     const writeErr = await new Promise(resolve => fs.writeFile(join(dir, "o.txt"), "x", { signal: aborted }, resolve));
-    expect({ name: writeErr?.name, code: writeErr?.code, cause: writeErr?.cause }).toEqual({
-      name: "AbortError",
-      code: "ABORT_ERR",
-      cause: reason,
-    });
+    expect({ name: writeErr?.name, code: writeErr?.code, cause: writeErr?.cause }).toEqual(expected);
+    const appendErr = await new Promise(resolve => fs.appendFile(join(dir, "o.txt"), "x", { signal: aborted }, resolve));
+    expect({ name: appendErr?.name, code: appendErr?.code, cause: appendErr?.cause }).toEqual(expected);
+    expect(fs.existsSync(join(dir, "o.txt"))).toBe(false);
   });
 
   test("values that fail node's shape check still throw ERR_INVALID_ARG_TYPE", async () => {

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -576,6 +576,15 @@ describe("readFile/writeFile accept AbortSignal-shaped objects", () => {
     w.close();
   });
 
+  test("fs.watch with a pre-aborted signal-shaped object closes on nextTick", async () => {
+    const dir = tempDirWithFiles("fs-duck-signal-watch-aborted", { "f.txt": "hello" });
+    const aborted = { aborted: true, reason: new Error("stop"), addEventListener() {}, removeEventListener() {} };
+    const w = fs.watch(dir, { signal: aborted });
+    const { promise, resolve } = Promise.withResolvers();
+    w.on("close", resolve);
+    await promise;
+  });
+
   // node's fs.readFile checks `signal.aborted` on the object itself (not via a
   // brand check), so a pre-aborted polyfill signal rejects with AbortError.
   test("a pre-aborted signal-shaped object rejects with AbortError", async () => {

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -621,7 +621,9 @@ describe("readFile/writeFile accept AbortSignal-shaped objects", () => {
     expect({ name: readErr?.name, code: readErr?.code, cause: readErr?.cause }).toEqual(expected);
     const writeErr = await new Promise(resolve => fs.writeFile(join(dir, "o.txt"), "x", { signal: aborted }, resolve));
     expect({ name: writeErr?.name, code: writeErr?.code, cause: writeErr?.cause }).toEqual(expected);
-    const appendErr = await new Promise(resolve => fs.appendFile(join(dir, "o.txt"), "x", { signal: aborted }, resolve));
+    const appendErr = await new Promise(resolve =>
+      fs.appendFile(join(dir, "o.txt"), "x", { signal: aborted }, resolve),
+    );
     expect({ name: appendErr?.name, code: appendErr?.code, cause: appendErr?.cause }).toEqual(expected);
     expect(fs.existsSync(join(dir, "o.txt"))).toBe(false);
   });


### PR DESCRIPTION
## Repro

```js
import fsp from "node:fs/promises";
const duck = { aborted: false, reason: undefined, addEventListener() {}, removeEventListener() {}, onabort: null };
await fsp.readFile("/etc/hostname", { signal: duck });
// node:   resolves
// bun:    TypeError: The "signal" argument must be of type AbortSignal. Received an instance of Object [ERR_INVALID_ARG_TYPE]
```

The same object is already accepted by Bun's `timers/promises.setTimeout`, `child_process.spawn`, and `events.once`/`on`, so a polyfill or cross-realm signal threaded through those works until it reaches an `fs` call and hard-throws.

## Cause

Node's `validateAbortSignal` accepts any object with an `aborted` property:

```js
if (signal !== undefined &&
    (signal === null || typeof signal !== 'object' || !('aborted' in signal))) {
  throw new ERR_INVALID_ARG_TYPE(name, 'AbortSignal', signal);
}
```

Bun's `jsFunction_validateAbortSignal` (`src/jsc/bindings/NodeValidator.cpp`) already matches this, which is why the other modules accept the duck. `fs.readFile`/`writeFile` however parse the `signal` option in Rust (`src/runtime/node/node_fs.rs`) with a `jsDynamicCast<WebCore::JSAbortSignal>` brand check and throw `ERR_INVALID_ARG_TYPE` when it fails; `fs.watch` does the same in `src/runtime/node/node_fs_watcher.rs`.

## Fix

- `node_fs.rs` / `node_fs_watcher.rs`: when the native cast fails, apply the same shape check as `validateAbortSignal`: accept an object that has an `aborted` property, otherwise keep throwing. A signal that is not a native `AbortSignal` cannot be wired into the native abort path, so it does not abort mid-read.
- `fs.promises.ts` / `fs.ts`: read `signal.aborted` before the native call (mirroring Node's `checkAborted`), so a pre-aborted AbortSignal-shaped object rejects with `AbortError` (`code === "ABORT_ERR"`, `cause === signal.reason`) instead of silently running the I/O.

Values that fail the shape check (`42`, `"x"`, `{}`) continue to throw `ERR_INVALID_ARG_TYPE`.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/node/fs/promises.test.js -t "AbortSignal-shaped"
# fails: duck rejected / pre-aborted duck silently succeeds
bun bd test test/js/node/fs/promises.test.js -t "AbortSignal-shaped"
# 7 pass
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/promises.test.js
bun test v1.4.0 (ef37e4824)

test/js/node/fs/promises.test.js:
(pass) should exist [3.77ms]
(pass) should be enumerable [1.39ms]
(pass) access > should work [5.08ms]
(pass) access > should fail on non-existant files [15.16ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [37.73ms]
(pass) open > should return an object [9.89ms]
(pass) open > should be closable [4.16ms]
(pass) more > is an object [38.14ms]
(pass) more > stat [54.28ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [57.08ms]
(pass) errors from fs.promises include async stack frames [17.37ms]
(pass) fs.promises async stack through Promise subclass [18.29ms]
(pass) fs.promises async stack through custom thenable [11.38ms]
(pass) fs.promises async stack with Promise.all [10.64ms]
(pass) an unused FileHandle.writer() does not prevent close() [36.46ms]
(pass) sources created before close() refuse t
... (truncated)

release without fix: 5 skipped
bun test v1.4.0-canary.1 (8f2a1b765)

test/js/node/fs/promises.test.js:
(pass) should exist [0.05ms]
(pass) should be enumerable [0.02ms]
(pass) access > should work [0.11ms]
(pass) access > should fail on non-existant files [0.25ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [0.59ms]
(pass) open > should return an object [0.24ms]
(pass) open > should be closable [0.34ms]
(pass) more > is an object [1.02ms]
(pass) more > stat [6.40ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [6.31ms]
(pass) errors from fs.promises include async stack frames [0.25ms]
(pass) fs.promises async stack through Promise subclass [0.26ms]
(pass) fs.promises async stack through custom thenable [0.14ms]
(pass) fs.promises async stack with Promise.all [0.13ms]
(pass) an unused FileHandle.writer() does not prevent close() [0.62ms]
(pass) sources created before close() refuse to use the stale fd [1.32ms]
(pass) rm and promises.rm report ERR_FS_EISDIR for directories like rmSync [1.77ms]
(pass) close() while an operation is in flight actually
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/promises.test.js
bun test v1.4.0 (ef37e4824)

test/js/node/fs/promises.test.js:
(pass) should exist [3.03ms]
(pass) should be enumerable [1.38ms]
(pass) access > should work [4.96ms]
(pass) access > should fail on non-existant files [14.09ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [30.52ms]
(pass) open > should return an object [9.66ms]
(pass) open > should be closable [4.19ms]
(pass) more > is an object [46.39ms]
(pass) more > stat [71.96ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [68.29ms]
(pass) errors from fs.promises include async stack frames [17.14ms]
(pass) fs.promises async stack through Promise subclass [18.59ms]
(pass) fs.promises async stack through custom thenable [11.86ms]
(pass) fs.promises async stack with Promise.all [11.15ms]
(pass) an unused FileHandle.writer() does not prevent close() [26.58ms]
(pass) sources created before close() refuse t
... (truncated)

release with fix: 5 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 626ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (7099ms)
Bundle modules (77ms)
Postprocesss modules (21ms)
Bundle Functions (644ms)
Generate Code (12ms)

[7.86s] Bundled "src/js" for production
  2076 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/fs/watch.ts         |  10 ++++
 src/js/node/fs.promises.ts          |   9 ++++
 src/js/node/fs.ts                   |  24 +++++++--
 src/runtime/node/node_fs.rs         |  10 +++-
 src/runtime/node/node_fs_watcher.rs |  12 +++--
 test/js/node/fs/promises.test.js    | 102 ++++++++++++++++++++++++++++++++++++
 6 files changed, 156 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js/internal/fs/watch.ts              2      2      0
src/js/node/fs.promises.ts               3      3      0
src/js/node/fs.ts                        5      6      0
src/runtime/node/node_fs.rs              4      2      0
src/runtime/node/node_fs_watcher.rs      3      1      0
test/js/node/fs/promises.test.js         3      5      0
```

</details>

<!-- robobun:evidence:end -->