### PR TITLE
Fix use-after-free in Windows Bun.write file-to-file mkdirp path

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -598,22 +598,21 @@ mod _async_tasks {
             pub task: WorkPoolTask,
         }
 
-        bun_threading::intrusive_work_task!(AsyncMkdirp, task);
+        bun_threading::owned_task!(AsyncMkdirp, task);
 
         impl AsyncMkdirp {
-            pub fn new(init: AsyncMkdirp) -> Box<Self> {
-                Box::new(init)
+            /// Heap-allocate and hand the task to the work pool, which owns the
+            /// allocation and frees it after `run_owned` returns.
+            pub fn schedule(init: AsyncMkdirp) {
+                WorkPool::schedule_new(init);
             }
 
-            /// # Safety
-            /// `task` must point to the `task` field of a live `AsyncMkdirp`.
-            fn work_pool_callback(task: *mut WorkPoolTask) {
-                // SAFETY: task points to AsyncMkdirp.task
-                let this = unsafe { &mut *AsyncMkdirp::from_task_ptr(task) };
-
+            #[allow(clippy::boxed_local)]
+            fn run_owned(self: Box<Self>) {
                 let mut node_fs = NodeFS::default();
-                // SAFETY: caller keeps `path` alive until completion
-                let path = unsafe { &*this.path };
+                // SAFETY: the scheduling caller keeps `path` alive until `completion`
+                // runs (it points into caller-owned state, not this box).
+                let path = unsafe { &*self.path };
                 let result = node_fs.mkdir_recursive(&args::Mkdir {
                     path: PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(
                         path, false,
@@ -623,21 +622,17 @@ mod _async_tasks {
                 });
                 match result {
                     Err(err) => {
-                        (this.completion)(
-                            this.completion_ctx,
+                        (self.completion)(
+                            self.completion_ctx,
                             // `with_path` already clones into a fresh `Box<[u8]>`; pass the
                             // existing path slice.
                             Err(err.with_path(&err.path)),
                         );
                     }
                     Ok(_) => {
-                        (this.completion)(this.completion_ctx, Ok(()));
+                        (self.completion)(self.completion_ctx, Ok(()));
                     }
                 }
-            }
-
-            pub fn schedule(&mut self) {
-                WorkPool::schedule(&raw mut self.task);
             }
         }
 
@@ -647,7 +642,7 @@ mod _async_tasks {
                     completion_ctx: core::ptr::null_mut(),
                     completion: |_, _| {},
                     path: core::ptr::slice_from_raw_parts(core::ptr::null(), 0),
-                    task: work_pool_task(Self::work_pool_callback),
+                    task: WorkPoolTask::default(),
                 }
             }
         }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1713,13 +1713,12 @@ impl<'a> CopyFileWindows<'a> {
         };
 
         self.event_loop.ref_concurrently();
-        node_fs::async_::AsyncMkdirp::new(node_fs::async_::AsyncMkdirp {
+        node_fs::async_::AsyncMkdirp::schedule(node_fs::async_::AsyncMkdirp {
             completion: on_mkdirp_complete_concurrent,
             completion_ctx: core::ptr::from_mut(self).cast::<()>(),
             path,
             ..Default::default()
-        })
-        .schedule();
+        });
     }
 
     fn on_mkdirp_complete(&mut self) {

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -952,27 +952,17 @@ mod windows_impl {
                 .pathlike
                 .path()
                 .slice();
-            // LIFETIME: `AsyncMkdirp::new` returns `Box<Self>`. The allocation
-            // is intentionally leaked here and freed by `work_pool_callback`
-            // after invoking `completion`. A temporary
-            // `Box` would drop at end-of-statement, freeing the allocation immediately
-            // after `schedule()` stashes a raw `*mut WorkPoolTask` into the work pool,
-            // so the worker thread would dereference freed memory. `Box::leak` hands
-            // ownership to the work-pool/completion path.
-            Box::leak(crate::node::fs::async_::AsyncMkdirp::new(
-                crate::node::fs::async_::AsyncMkdirp {
-                    completion: Self::on_mkdirp_complete_concurrent,
-                    completion_ctx: ctx,
-                    // BORROW: AsyncMkdirp.path is `*const [u8]` (not owned); `path`
-                    // points into `self.file_blob.store`, which outlives the mkdirp
-                    // task (it's released only in `deinit()`).
-                    path: bun_core::dirname(path)
-                        // this shouldn't happen
-                        .unwrap_or(path) as *const [u8],
-                    ..Default::default()
-                },
-            ))
-            .schedule();
+            crate::node::fs::async_::AsyncMkdirp::schedule(crate::node::fs::async_::AsyncMkdirp {
+                completion: Self::on_mkdirp_complete_concurrent,
+                completion_ctx: ctx,
+                // BORROW: AsyncMkdirp.path is `*const [u8]` (not owned); `path`
+                // points into `self.file_blob.store`, which outlives the mkdirp
+                // task (it's released only in `deinit()`).
+                path: bun_core::dirname(path)
+                    // this shouldn't happen
+                    .unwrap_or(path) as *const [u8],
+                ..Default::default()
+            });
         }
 
         /// # Safety

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -526,7 +526,7 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     // when uv_fs_copyfile (or opening the destination on the read/write-loop
     // fallback) fails with ENOENT. The task used to be freed before the work
     // pool ran it, crashing the process instead of rejecting.
-    const run = async (dir, body) => {
+    const run = async body => {
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),
@@ -550,7 +550,6 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       using dir = tempDir("bun-write-missing-src", {});
       const p = join(String(dir), "missing");
       const { stdout, stderr, exitCode } = await run(
-        dir,
         `const f = Bun.file(${JSON.stringify(p)}); await Bun.write(f, f);`,
       );
       // The read/write-loop fallback opens the destination with O_CREAT first,
@@ -564,7 +563,6 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     it("rejects with ENOENT for a missing source and a destination whose parent is missing", async () => {
       using dir = tempDir("bun-write-missing-src", {});
       const { stdout, stderr, exitCode } = await run(
-        dir,
         `await Bun.write(
            Bun.file(${JSON.stringify(join(String(dir), "sub", "dst"))}),
            Bun.file(${JSON.stringify(join(String(dir), "src"))}),

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -521,6 +521,60 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     );
   }
 
+  describe("Bun.write(BunFile, BunFile) with a missing source", () => {
+    // On Windows the file-to-file copy path retries via an async mkdirp task
+    // when uv_fs_copyfile (or opening the destination on the read/write-loop
+    // fallback) fails with ENOENT. The task used to be freed before the work
+    // pool ran it, crashing the process instead of rejecting.
+    const run = async (dir, body) => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `try {
+             ${body}
+             console.log("resolved");
+           } catch (e) {
+             console.log("rejected", e.code);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr, exitCode };
+    };
+
+    it("does not crash when the same BunFile is passed as source and destination", async () => {
+      using dir = tempDir("bun-write-missing-src", {});
+      const p = join(String(dir), "missing");
+      const { stdout, stderr, exitCode } = await run(
+        dir,
+        `const f = Bun.file(${JSON.stringify(p)}); await Bun.write(f, f);`,
+      );
+      // The read/write-loop fallback opens the destination with O_CREAT first,
+      // so a self-copy onto a missing path resolves with 0 bytes there instead
+      // of rejecting.
+      const expected = IS_UV_FS_COPYFILE_DISABLED ? "resolved" : "rejected ENOENT";
+      expect({ stdout, stderr }).toEqual({ stdout: expected, stderr: "" });
+      expect(exitCode).toBe(0);
+    });
+
+    it("rejects with ENOENT for a missing source and a destination whose parent is missing", async () => {
+      using dir = tempDir("bun-write-missing-src", {});
+      const { stdout, stderr, exitCode } = await run(
+        dir,
+        `await Bun.write(
+           Bun.file(${JSON.stringify(join(String(dir), "sub", "dst"))}),
+           Bun.file(${JSON.stringify(join(String(dir), "src"))}),
+         );`,
+      );
+      expect({ stdout, stderr }).toEqual({ stdout: "rejected ENOENT", stderr: "" });
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("ENOENT", () => {
     const creates = (...opts) => {
       it("creates the directory", async () => {


### PR DESCRIPTION
`Bun.write(BunFile, BunFile)` crashes the process on Windows whenever the source file is missing, instead of rejecting with `ENOENT`.

### Repro

```js
const f = Bun.file(join(dir, "missing"));
await Bun.write(f, f);
```

```
panic(thread 2020): Segmentation fault at address 0x2231094E8B0
```

The same crash hits any file-to-file `Bun.write` whose source is missing and whose destination triggers the mkdirp retry (also reproduces with the `BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE=1` read/write-loop fallback when the destination parent is missing):

```js
await Bun.write(Bun.file(join(dir, "sub", "dst")), Bun.file(join(dir, "src")));
```

### Cause

`CopyFileWindows::mkdirp()` constructed the `AsyncMkdirp` work-pool task as a temporary `Box` and called `.schedule()` on it. `schedule(&mut self)` only stashes `&raw mut self.task` into the work pool, so the `Box` dropped at end of statement and the worker thread dereferenced freed memory when it ran the callback. On a debug build the freed-memory poison is visible:

```
panic: misaligned pointer dereference: address must be a multiple of 0x8 but is 0xdfdfdfdfdfdfdfdf
```

The two-`StoreRef` aliasing in `copyfile()` turns out to be benign on this path (both views are `&File` behind `Deref`); passing the same `BunFile` twice is just the shortest route to the `ENOENT` → `mkdirp()` retry.

### Fix

Convert `AsyncMkdirp` to the existing `owned_task!` / `WorkPool::schedule_new` pattern so the pool takes ownership of the `Box` and drops it after `run_owned` returns. Both callers are updated:

- `CopyFileWindows::mkdirp` no longer drops the task before the pool runs it.
- `WriteFileWindows::mkdirp` previously worked around the same ownership gap with `Box::leak`, which leaked an `AsyncMkdirp` per write into a missing directory; it now goes through the same owning scheduler.

This is the same `AsyncMkdirp` change carried on #31844 (which is a larger lifetime refactor and has drifted behind `main`), lifted out as a focused fix.

### Verification

Windows x64, `USE_SYSTEM_BUN=1 bun test test/js/bun/io/bun-write.test.js -t "missing source"` on `main`:

```
(fail) Bun.write > Bun.write(BunFile, BunFile) with a missing source > does not crash when the same BunFile is passed as source and destination
(fail) Bun.write > Bun.write(BunFile, BunFile) with a missing source > rejects with ENOENT for a missing source and a destination whose parent is missing
 2 fail
```

(both subprocesses crash with the segfault banner above)

Windows x64, `bun bd test test/js/bun/io/bun-write.test.js` with this change: 36 pass, including the `Bun.write() without uv_fs_copyfile` re-run.

The new tests also pass on POSIX (where the crash never reproduced), so the Linux gate cannot derive a fail-before here; the Windows CI lanes cover it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->