### PR TITLE
http(h3): pass &mut HTTPClient into drain_send_body instead of re-deriving (Stacked Borrows)

### DIFF
--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -132,7 +132,7 @@ impl ClientSession {
             if let crate::HTTPRequestBody::Stream(s) = &mut client.state.original_request_body {
                 s.ended = ended;
                 if let Some(qs) = stream.qstream_mut() {
-                    encode::drain_send_body(stream, qs);
+                    encode::drain_send_body(client, stream, qs);
                 }
             }
             return true;

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -278,7 +278,9 @@ extern "C" fn on_stream_data(s: *mut quic::Stream, data: *const u8, len: c_uint,
 extern "C" fn on_stream_writable(s: *mut quic::Stream) {
     let s = qstream_arg(s);
     let Some(stream) = stream_of(s) else { return };
-    encode::drain_send_body(stream, s);
+    let Some(client_ptr) = stream.client else { return };
+    let client = super::client_session::client_mut(client_ptr);
+    encode::drain_send_body(client, stream, s);
 }
 
 extern "C" fn on_stream_close(s: *mut quic::Stream) {

--- a/src/http/h3_client/callbacks.rs
+++ b/src/http/h3_client/callbacks.rs
@@ -278,7 +278,9 @@ extern "C" fn on_stream_data(s: *mut quic::Stream, data: *const u8, len: c_uint,
 extern "C" fn on_stream_writable(s: *mut quic::Stream) {
     let s = qstream_arg(s);
     let Some(stream) = stream_of(s) else { return };
-    let Some(client_ptr) = stream.client else { return };
+    let Some(client_ptr) = stream.client else {
+        return;
+    };
     let client = super::client_session::client_mut(client_ptr);
     encode::drain_send_body(client, stream, s);
 }

--- a/src/http/h3_client/encode.rs
+++ b/src/http/h3_client/encode.rs
@@ -120,19 +120,14 @@ pub fn write_request(
 
     if has_inline_body {
         stream.pending_body = req_body;
-        drain_send_body(stream, qs);
+        drain_send_body(client, stream, qs);
     } else if is_streaming {
         stream.is_streaming_body = true;
-        drain_send_body(stream, qs);
+        drain_send_body(client, stream, qs);
     } else {
         stream.request_body_done = true;
     }
 
-    // SAFETY: re-derive — `drain_send_body` forms its own `&mut HTTPClient`
-    // from this same backref, which invalidates the prior Unique tag under
-    // Stacked Borrows (same shape as the `detach()` notes in
-    // `ClientSession::deliver`).
-    let client = super::client_session::client_mut(client_ptr);
     client.state.request_stage = if stream.request_body_done {
         HTTPStage::Done
     } else {
@@ -151,15 +146,14 @@ pub fn write_request(
 /// Push as much of the request body onto `qs` as flow control allows. Called
 /// from `write_request`, `callbacks.on_stream_writable`, and
 /// `ClientSession.stream_body_by_http_id` (when the JS sink delivers more bytes).
-pub(crate) fn drain_send_body(stream: &mut Stream, qs: &mut quic::Stream) {
+///
+/// `client` is passed in (like `apply_headers`) rather than re-derived from
+/// `stream.client` so callers may keep using their `&mut HTTPClient` after the
+/// call without a Stacked-Borrows re-derive.
+pub(crate) fn drain_send_body(client: &mut HTTPClient, stream: &mut Stream, qs: &mut quic::Stream) {
     if stream.request_body_done {
         return;
     }
-    let Some(client_ptr) = stream.client else {
-        return;
-    };
-    // `stream.client` is a live backref while attached — see `client_mut` doc.
-    let client: &mut HTTPClient = super::client_session::client_mut(client_ptr);
 
     if stream.is_streaming_body {
         let HTTPRequestBody::Stream(body) = &mut client.state.original_request_body else {

--- a/src/http/h3_client/encode.rs
+++ b/src/http/h3_client/encode.rs
@@ -128,6 +128,11 @@ pub fn write_request(
         stream.request_body_done = true;
     }
 
+    // SAFETY: re-derive — `drain_send_body` forms its own `&mut HTTPClient`
+    // from this same backref, which invalidates the prior Unique tag under
+    // Stacked Borrows (same shape as the `detach()` notes in
+    // `ClientSession::deliver`).
+    let client = super::client_session::client_mut(client_ptr);
     client.state.request_stage = if stream.request_body_done {
         HTTPStage::Done
     } else {


### PR DESCRIPTION
## What

`write_request` in `src/http/h3_client/encode.rs` forms `let client = client_mut(client_ptr)` near the top, then calls `drain_send_body(stream, qs)`, which internally does `client_mut(stream.client)` on the same raw backref. Under Stacked Borrows the second `&mut HTTPClient` pops the first one's Unique tag, so the trailing uses after `drain_send_body` returns are UB:

```rust
let client = super::client_session::client_mut(client_ptr);   // tag T1
// ...
drain_send_body(stream, qs);                                  // forms tag T2 from the same raw ptr, pops T1
// ...
client.state.request_stage = ...;                             // uses T1 (popped)
client.progress_update_h3();                                  // uses T1 (popped)
```

Flagged by review on #35274; the issue is pre-existing on `main` (that PR's `encode.rs` diff is a doc-comment change only).

## Fix

Lift `client: &mut HTTPClient` into `drain_send_body`'s signature so the callee reborrows the caller's reference instead of deriving a sibling from the raw backref. This matches `apply_headers(stream: &mut Stream, client: &mut HTTPClient)` in the same module, which `deliver` uses the same way (calls it, then keeps using `client` afterward with no re-derive):

https://github.com/oven-sh/bun/blob/892b1dabc6/src/http/h3_client/ClientSession.rs#L468

Callers:

- `write_request` (encode.rs): passes the `client` it already holds; the `&mut` stays valid across the call, so the trailing `client.state.request_stage` / `progress_update_h3()` writes need no re-derive.
- `stream_body_by_http_id` (ClientSession.rs): passes the `client` it already holds; NLL ends the `s` borrow at `s.ended = ended` so `client` is free for the call.
- `on_stream_writable` (callbacks.rs): hoists the two-line `stream.client` Some-check + `client_mut` that `drain_send_body` used to do internally.

`Stream.client` is `Option<NonNull<HttpClient<'static>>>` (a raw pointer), so `&mut Stream` and `&mut HTTPClient` coexist under the borrow checker.

Net: +8 / -12 against `main`. No runtime behaviour change; `client_mut` is a thin `NonNull::as_mut` wrapper.

## Why pass the reference rather than re-derive at the call site

A re-derive after the call fixes `write_request` today but leaves the hazard in `drain_send_body` itself: any future caller (or edit to the two existing ones) that touches `client` after the call re-introduces the same UB with no compiler help. Taking `client` as a parameter removes the footgun and matches the in-module precedent.

## Tests

No new test: this is a pointer-provenance fix with no runtime-observable symptom. `bun_http` links lsquic via FFI so `cargo miri test` cannot execute this path (the approach used for #34536's `bun_collections` fix does not apply here), and `bun run rust:miri` runs under Tree Borrows which accepts the old shape anyway. rustc does not currently exploit this aliasing.

The existing h3 suites cover all three callers (`has_inline_body` via `Uint8Array`/string bodies, `is_streaming` via `ReadableStream` request bodies, `on_stream_writable` via flow-control backpressure on large uploads) and remain green:

```
$ bun bd test test/js/web/fetch/fetch-http3-client.test.ts
52 pass, 0 fail

$ bun bd test test/js/web/fetch/fetch-http3-adversarial.test.ts
27 pass, 0 fail
```

#35274 also touches `on_stream_writable`; whichever lands second picks up a trivial 2-line conflict there (add the `client` derive before the `drain_send_body` call).