### PR TITLE
node:http: adopt external sockets fed in via server.emit('connection')

### DIFF
--- a/src/js/node/_http_outgoing.ts
+++ b/src/js/node/_http_outgoing.ts
@@ -1296,6 +1296,7 @@ export default {
   kOutHeaders,
   kErrored,
   kSocket,
+  kChunkedLength,
   kRejectNonStandardBodyWrites,
   parseUniqueHeadersOption,
   validateHeaderName,

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1587,8 +1587,12 @@ function socketOnDrain(socket, state) {
     socket.resume();
   }
 
+  // Like Node v26: only emit 'drain' once the message has no data pending
+  // anywhere. socketOnDrain runs synchronously from updateOutgoingData during
+  // _flushOutput, when the bytes just handed to the socket mean the message
+  // is not actually drained yet; wait for the socket's own 'drain' instead.
   const msg = socket._httpMessage;
-  if (msg && !msg.finished && msg[kNeedDrain]) {
+  if (msg && !msg.finished && msg[kNeedDrain] && msg.writableLength === 0) {
     msg[kNeedDrain] = false;
     msg.emit("drain");
   }
@@ -1654,8 +1658,14 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   if (ret instanceof Error) {
     prepareError(ret, parser, d);
     socketOnError.$call(socket, ret);
-  } else if (incoming?.upgrade) {
-    // Upgrade or CONNECT
+  } else if (incoming?.upgrade && incoming.complete) {
+    // Upgrade or CONNECT. The upgrade verdict sticks at headers-complete, but
+    // the handoff must wait for llhttp to finish the request body (it pauses
+    // with the upgrade flag at message end): freeing the parser mid-body
+    // would leave req without its body and spill the remaining body bytes
+    // into the tunnel stream. Node v26 emits early through an UpgradeStream
+    // wrapper instead; without it, the first tunnel bytes arrive in bodyHead
+    // rather than as the socket's first 'data' event.
     const req = incoming;
     const bytesParsed = ret;
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1519,7 +1519,8 @@ function connectionListenerInternal(server, socket) {
 
   // If the user has added a listener to the server, request, or response,
   // then it's their responsibility. Otherwise, destroy on timeout by default.
-  if (server.timeout && typeof socket.setTimeout === "function") socket.setTimeout(server.timeout);
+  const serverTimeout = server.timeout;
+  if (serverTimeout && typeof socket.setTimeout === "function") socket.setTimeout(serverTimeout);
   socket.on("timeout", socketOnTimeout);
 
   const parser = parsers.alloc();
@@ -1529,8 +1530,9 @@ function connectionListenerInternal(server, socket) {
   socket.parser = parser;
 
   // Propagate headers limit from server instance to parser
-  if (typeof server.maxHeadersCount === "number") {
-    parser.maxHeaderPairs = server.maxHeadersCount << 1;
+  const { maxHeadersCount } = server;
+  if (typeof maxHeadersCount === "number") {
+    parser.maxHeaderPairs = maxHeadersCount << 1;
   }
 
   const state = {
@@ -1580,7 +1582,8 @@ function socketOnDrain(socket, state) {
   // If we previously paused, then start reading again.
   if (socket._paused && !needPause) {
     socket._paused = false;
-    if (socket.parser) socket.parser.resume();
+    const { parser } = socket;
+    if (parser) parser.resume();
     socket.resume();
   }
 
@@ -1624,15 +1627,18 @@ function abortOutgoing(outgoing) {
 function socketOnEnd(server, socket, parser, state) {
   const ret = parser.finish();
 
+  const { outgoing } = state;
+  const outgoingLength = outgoing.length;
+  const message = socket._httpMessage;
   if (ret instanceof Error) {
     // socketOnError has additional logic and will call socket.destroy(err).
     socketOnError.$call(socket, ret);
   } else if (!server.httpAllowHalfOpen) {
     socket.end();
-  } else if (state.outgoing.length) {
-    state.outgoing[state.outgoing.length - 1]._last = true;
-  } else if (socket._httpMessage) {
-    socket._httpMessage._last = true;
+  } else if (outgoingLength) {
+    outgoing[outgoingLength - 1]._last = true;
+  } else if (message) {
+    message._last = true;
   } else {
     socket.end();
   }
@@ -1644,12 +1650,13 @@ function socketOnData(server, socket, parser, state, d) {
 }
 
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {
+  const { incoming } = parser;
   if (ret instanceof Error) {
     prepareError(ret, parser, d);
     socketOnError.$call(socket, ret);
-  } else if (parser.incoming?.upgrade) {
+  } else if (incoming?.upgrade) {
     // Upgrade or CONNECT
-    const req = parser.incoming;
+    const req = incoming;
     const bytesParsed = ret;
 
     if (!d) d = parser.getCurrentBuffer();
@@ -1672,14 +1679,16 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
       // Got upgrade or CONNECT method, but have no handler.
       socket.destroy();
     }
-  } else if (parser.incoming && parser.incoming.method === "PRI") {
+  } else if (incoming && incoming.method === "PRI") {
     // An HTTP/2 connection preface on an HTTP/1 connection.
     socket.destroy();
   }
 
-  if (socket._paused && socket.parser) {
+  // Re-read socket.parser: the upgrade branch freed it (freeParser nulls it).
+  const socketParser = socket.parser;
+  if (socket._paused && socketParser) {
     // onIncoming paused the socket, we should pause the parser as well
-    socket.parser.pause();
+    socketParser.pause();
   }
 }
 
@@ -1820,15 +1829,16 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
       res.maxRequestsOnConnectionReached = server.maxRequestsPerSocket <= state.requestsCount;
     }
 
+    const { expect } = req.headers;
     if (isRequestsLimitSet && server.maxRequestsPerSocket < state.requestsCount) {
       handled = true;
       server.emit("dropRequest", req, socket);
       res.writeHead(503);
       res.end();
-    } else if (req.headers.expect !== undefined) {
+    } else if (expect !== undefined) {
       handled = true;
 
-      if (continueExpression.test(req.headers.expect)) {
+      if (continueExpression.test(expect)) {
         res._expect_continue = true;
         if (server.listenerCount("checkContinue") > 0) {
           server.emit("checkContinue", req, res);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -85,6 +85,7 @@ const {
   kErrored,
   kHighWaterMark,
   kSocket,
+  kChunkedLength,
   kRejectNonStandardBodyWrites,
   kUniqueHeaders,
   parseUniqueHeadersOption,
@@ -3885,6 +3886,15 @@ Object.defineProperty(ServerResponse.prototype, "writableFinished", {
 Object.defineProperty(ServerResponse.prototype, "writableLength", {
   get() {
     if (this.writableFinished) return 0;
+    // Standalone path (no native handle, e.g. a socket adopted via
+    // server.emit('connection', duplex)): the OutgoingMessage accounting.
+    // OutgoingMessage.end() branches on this to decide whether 'finish' must
+    // be queued behind buffered output; the native shape below reports 0 for
+    // a queued standalone response and made 'finish' fire before the response
+    // was assigned its socket.
+    if (!this[kHandle]) {
+      return this.outputSize + this[kChunkedLength] + (this[kSocket]?.writableLength ?? 0);
+    }
     // Bytes handed off this event-loop turn (including chunked framing, like
     // Node.js's outputData accounting) plus whatever the native handle still
     // has buffered, plus anything buffered while queued behind a pipelined

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3864,6 +3864,11 @@ ServerResponse.prototype._implicitHeader = function () {
 
 Object.defineProperty(ServerResponse.prototype, "writableNeedDrain", {
   get() {
+    // Standalone path (no native handle): OutgoingMessage semantics, where
+    // write() sets kNeedDrain when the buffered write returned false.
+    if (!this[kHandle]) {
+      return !this.destroyed && !this.finished && !!this[kNeedDrain];
+    }
     // True between a write() that returned false and the next 'drain': either
     // the native handle still has buffered bytes, or this turn's accounting
     // (kBytesBuffered) crossed the high-water mark and a 'drain' is pending.
@@ -3879,7 +3884,13 @@ Object.defineProperty(ServerResponse.prototype, "writableNeedDrain", {
 
 Object.defineProperty(ServerResponse.prototype, "writableFinished", {
   get() {
-    return !!(this.finished && (!this[kHandle] || this[kHandle].finished));
+    // Standalone path (no native handle): OutgoingMessage semantics; a queued
+    // pipelined response that end()ed with bytes still in outputData has not
+    // finished writing yet.
+    if (!this[kHandle]) {
+      return this.finished && this.outputSize === 0 && (!this[kSocket] || this[kSocket].writableLength === 0);
+    }
+    return !!(this.finished && this[kHandle].finished);
   },
 });
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1559,11 +1559,22 @@ function connectionListenerInternal(server, socket) {
   socket.on("end", state.onEnd);
   socket.on("close", state.onClose);
   socket.on("drain", state.onDrain);
+  socket.on("resume", onSocketResume);
   parser.onIncoming = parserOnIncoming.bind(undefined, server, socket, state);
 
   socket.setEncoding = socketSetEncoding;
 
   socket._paused = false;
+}
+
+// Node's onSocketResume also drives the consumed StreamBase handle
+// (readStart); parsing here is always fed by 'data' events, so only the
+// re-pause guard is load-bearing: a user resume() on the adopted duplex must
+// not feed data to a parser paused by the pipelining backpressure gate
+// (execute() on a paused llhttp returns HPE_PAUSED, which would surface as a
+// spurious clientError).
+function onSocketResume() {
+  if (this._paused) this.pause();
 }
 
 function socketSetEncoding() {
@@ -1660,13 +1671,13 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     prepareError(ret, parser, d);
     socketOnError.$call(socket, ret);
   } else if (incoming?.upgrade && incoming.complete) {
-    // Upgrade or CONNECT. The upgrade verdict sticks at headers-complete, but
-    // the handoff must wait for llhttp to finish the request body (it pauses
-    // with the upgrade flag at message end): freeing the parser mid-body
-    // would leave req without its body and spill the remaining body bytes
-    // into the tunnel stream. Node v26 emits early through an UpgradeStream
-    // wrapper instead; without it, the first tunnel bytes arrive in bodyHead
-    // rather than as the socket's first 'data' event.
+    // Upgrade or CONNECT. parserOnIncoming returned 2 (skip body), so llhttp
+    // fires message-complete at the end of the headers and pauses with the
+    // upgrade flag: any request-body bytes arrive through bodyHead and the
+    // socket's own 'data' events, like Node before its UpgradeStream (which
+    // instead streams the body into req). The complete gate is belt and
+    // suspenders: handing off with the message still open would free the
+    // parser mid-message.
     const req = incoming;
     const bytesParsed = ret;
 
@@ -1678,6 +1689,7 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     socket.removeListener("drain", state.onDrain);
     socket.removeListener("error", socketOnError);
     socket.removeListener("timeout", socketOnTimeout);
+    socket.removeListener("resume", onSocketResume);
     parser.finish();
     freeParser(parser, req, socket);
 
@@ -1774,7 +1786,13 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   if (req.upgrade) {
     req.upgrade = req.method === "CONNECT" || !!server.shouldUpgradeCallback(req);
     if (req.upgrade) {
-      return 0;
+      // 2 = skip body + upgrade: llhttp pauses at the end of the headers and
+      // any request-body bytes reach the 'upgrade'/'connect' listener as raw
+      // tunnel data (bodyHead + 'data' events), like Node before its
+      // UpgradeStream. Returning 0 (v26) would parse the body into req, but
+      // without the UpgradeStream early emit nothing drains req, so a body
+      // larger than the readable high-water mark pauses the socket forever.
+      return 2;
     }
   }
 
@@ -3258,6 +3276,12 @@ Object.defineProperty(ServerResponse.prototype, "socket", {
       // Queued pipelined response: like Node.js, res.socket is null until the
       // response is assigned the socket.
       return null;
+    }
+    if (!this[kHandle] && !this[kDeprecatedReplySymbol]) {
+      // Standalone response (adopted socket or user-constructed): like Node,
+      // res.socket is null until assignSocket() and after detachSocket().
+      // Only the deprecated fetch()-style response keeps the FakeSocket.
+      return this[fakeSocketSymbol] ?? null;
     }
     return (this[fakeSocketSymbol] ??= new FakeSocket(this));
   },

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -4005,6 +4005,12 @@ ServerResponse.prototype.writeHead = function (statusCode, statusMessage, header
   // assignSocket(writable)) write through the OutgoingMessage machinery, so
   // render the header block immediately like Node.js does.
   if (!this[kHandle] && !this._header) {
+    // Like Node: don't keep alive connections where the client expects
+    // 100 Continue but we sent a final status; they may put extra bytes on
+    // the wire (the unsent request body would desync the parser).
+    if (this._expect_continue && !this._sent100) {
+      this.shouldKeepAlive = false;
+    }
     const statusLine = `HTTP/1.1 ${this.statusCode} ${this.statusMessage}\r\n`;
     this._storeHeader(statusLine, this[kOutHeaders]);
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -5,9 +5,14 @@ const { Socket: NetSocket } = require("node:net");
 const {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   chunkExpression,
+  continueExpression,
   validateHeaderName,
   validateHeaderValue,
   HTTPParser,
+  parsers,
+  freeParser,
+  prepareError,
+  calculateLenientFlags,
 } = require("node:_http_common");
 const {
   validateObject,
@@ -64,11 +69,13 @@ const {
   fakeSocketSymbol,
   noBodySymbol,
   kOutHeaders,
+  kNeedDrain,
   onDataIncomingMessage,
   validateMsecs,
 } = require("internal/http");
 const { FakeSocket } = require("internal/http/FakeSocket");
 const NumberIsNaN = Number.isNaN;
+const NumberIsFinite = Number.isFinite;
 
 const { format } = require("internal/util/inspect");
 
@@ -300,6 +307,11 @@ function Server(options, callback): void {
   if (!(this instanceof Server)) return new Server(options, callback);
   EventEmitter.$call(this);
   this.on("listening", setupConnectionsTracking);
+  // Like Node.js: the server itself listens for 'connection' so that sockets
+  // user code feeds in via server.emit('connection', duplex) get an HTTP
+  // parser attached (natively accepted connections skip this, see
+  // connectionListener).
+  this.on("connection", connectionListener);
 
   this.listening = false;
   this._unref = false;
@@ -1453,7 +1465,13 @@ function socketOnError(this: any, err) {
     // Node checks _headerSent (bytes reached the socket), not headersSent
     // (writeHead called): after res.writeHead() but before write/end/flush,
     // no bytes are on the wire yet so the raw error response is still safe.
-    if (this.writable && (!message || message[headerStateSymbol] !== NodeHTTPHeaderState.sent)) {
+    // Native responses track this via headerStateSymbol; standalone responses
+    // (sockets adopted via server.emit('connection', duplex)) go through the
+    // OutgoingMessage machinery, which maintains _headerSent.
+    if (
+      this.writable &&
+      (!message || (message[headerStateSymbol] !== NodeHTTPHeaderState.sent && !message._headerSent))
+    ) {
       let response;
       switch (err?.code) {
         case "HPE_HEADER_OVERFLOW":
@@ -1482,6 +1500,364 @@ function socketOnError(this: any, err) {
   }
 }
 function noopOnError() {}
+
+// Node.js's connectionListener, for sockets that user code feeds into the
+// server via `server.emit('connection', duplex)` (e.g. a TLS-terminated
+// stream from a proxy tunnel): attach an llhttp parser to the duplex and
+// dispatch 'request' events over it. Connections accepted by the server
+// itself arrive as NodeHTTPServerSocket wrappers and are parsed natively by
+// uWS, so they skip this path.
+// Port of https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js
+function connectionListener(this: Server, socket) {
+  if (socket instanceof NodeHTTPServerSocket) return;
+  connectionListenerInternal(this, socket);
+}
+
+function connectionListenerInternal(server, socket) {
+  // Ensure that the server property of the socket is correctly set.
+  socket.server = server;
+
+  // If the user has added a listener to the server, request, or response,
+  // then it's their responsibility. Otherwise, destroy on timeout by default.
+  if (server.timeout && typeof socket.setTimeout === "function") socket.setTimeout(server.timeout);
+  socket.on("timeout", socketOnTimeout);
+
+  const parser = parsers.alloc();
+  const lenientFlags = calculateLenientFlags(server.httpValidation, server.insecureHTTPParser);
+  parser.initialize(HTTPParser.REQUEST, {}, server.maxHeaderSize || 0, lenientFlags);
+  parser.socket = socket;
+  socket.parser = parser;
+
+  // Propagate headers limit from server instance to parser
+  if (typeof server.maxHeadersCount === "number") {
+    parser.maxHeaderPairs = server.maxHeadersCount << 1;
+  }
+
+  const state = {
+    onData: null,
+    onEnd: null,
+    onClose: null,
+    onDrain: null,
+    outgoing: [],
+    incoming: [],
+    // `outgoingData` is an approximate amount of bytes queued through all
+    // inactive responses. If more data than the high watermark is queued -
+    // the socket and the parser are paused until the data is written out.
+    outgoingData: 0,
+    requestsCount: 0,
+    keepAliveTimeoutSet: false,
+  };
+  state.onData = socketOnData.bind(undefined, server, socket, parser, state);
+  state.onEnd = socketOnEnd.bind(undefined, server, socket, parser, state);
+  state.onClose = socketOnClose.bind(undefined, socket, state);
+  state.onDrain = socketOnDrain.bind(undefined, socket, state);
+  socket.on("data", state.onData);
+  socket.on("error", socketOnError);
+  socket.on("end", state.onEnd);
+  socket.on("close", state.onClose);
+  socket.on("drain", state.onDrain);
+  parser.onIncoming = parserOnIncoming.bind(undefined, server, socket, state);
+
+  socket.setEncoding = socketSetEncoding;
+
+  socket._paused = false;
+}
+
+function socketSetEncoding() {
+  const err = new Error("Changing the socket encoding is not allowed per RFC7230 Section 3.");
+  err.code = "ERR_HTTP_SOCKET_ENCODING";
+  throw err;
+}
+
+function updateOutgoingData(socket, state, delta) {
+  state.outgoingData += delta;
+  socketOnDrain(socket, state);
+}
+
+function socketOnDrain(socket, state) {
+  const needPause = state.outgoingData > socket.writableHighWaterMark;
+
+  // If we previously paused, then start reading again.
+  if (socket._paused && !needPause) {
+    socket._paused = false;
+    if (socket.parser) socket.parser.resume();
+    socket.resume();
+  }
+
+  const msg = socket._httpMessage;
+  if (msg && !msg.finished && msg[kNeedDrain]) {
+    msg[kNeedDrain] = false;
+    msg.emit("drain");
+  }
+}
+
+function socketOnTimeout() {
+  const req = this.parser?.incoming;
+  const reqTimeout = req && !req.complete && req.emit("timeout", this);
+  const res = this._httpMessage;
+  const resTimeout = res && res.emit("timeout", this);
+  const serverTimeout = this.server.emit("timeout", this);
+
+  if (!reqTimeout && !resTimeout && !serverTimeout) this.destroy();
+}
+
+function socketOnClose(socket, state) {
+  freeParser(socket.parser, null, socket);
+  abortIncoming(state.incoming);
+  abortOutgoing(state.outgoing);
+}
+
+function abortIncoming(incoming) {
+  while (incoming.length) {
+    const req = incoming.shift();
+    req.destroy(new ConnResetException("aborted"));
+  }
+}
+
+function abortOutgoing(outgoing) {
+  while (outgoing.length) {
+    const res = outgoing.shift();
+    res.destroy(new ConnResetException("aborted"));
+  }
+}
+
+function socketOnEnd(server, socket, parser, state) {
+  const ret = parser.finish();
+
+  if (ret instanceof Error) {
+    // socketOnError has additional logic and will call socket.destroy(err).
+    socketOnError.$call(socket, ret);
+  } else if (!server.httpAllowHalfOpen) {
+    socket.end();
+  } else if (state.outgoing.length) {
+    state.outgoing[state.outgoing.length - 1]._last = true;
+  } else if (socket._httpMessage) {
+    socket._httpMessage._last = true;
+  } else {
+    socket.end();
+  }
+}
+
+function socketOnData(server, socket, parser, state, d) {
+  const ret = parser.execute(d);
+  onParserExecuteCommon(server, socket, parser, state, ret, d);
+}
+
+function onParserExecuteCommon(server, socket, parser, state, ret, d) {
+  if (ret instanceof Error) {
+    prepareError(ret, parser, d);
+    socketOnError.$call(socket, ret);
+  } else if (parser.incoming?.upgrade) {
+    // Upgrade or CONNECT
+    const req = parser.incoming;
+    const bytesParsed = ret;
+
+    if (!d) d = parser.getCurrentBuffer();
+
+    socket.removeListener("data", state.onData);
+    socket.removeListener("end", state.onEnd);
+    socket.removeListener("close", state.onClose);
+    socket.removeListener("drain", state.onDrain);
+    socket.removeListener("error", socketOnError);
+    socket.removeListener("timeout", socketOnTimeout);
+    parser.finish();
+    freeParser(parser, req, socket);
+
+    const eventName = req.method === "CONNECT" ? "connect" : "upgrade";
+    if (server.listenerCount(eventName) > 0) {
+      const bodyHead = d.slice(bytesParsed, d.length);
+      socket.readableFlowing = null;
+      server.emit(eventName, req, socket, bodyHead);
+    } else {
+      // Got upgrade or CONNECT method, but have no handler.
+      socket.destroy();
+    }
+  } else if (parser.incoming && parser.incoming.method === "PRI") {
+    // An HTTP/2 connection preface on an HTTP/1 connection.
+    socket.destroy();
+  }
+
+  if (socket._paused && socket.parser) {
+    // onIncoming paused the socket, we should pause the parser as well
+    socket.parser.pause();
+  }
+}
+
+function clearIncoming(req) {
+  req = req || this;
+  const parser = req.socket?.parser;
+  // Reset the .incoming property so that the request object can be gc'ed.
+  if (parser && parser.incoming === req) {
+    if (req.readableEnded) {
+      parser.incoming = null;
+    } else {
+      req.on("end", clearIncoming);
+    }
+  }
+}
+
+function resOnFinish(req, res, socket, state, server) {
+  // Usually the first incoming element should be our request. It may be that
+  // in the case abortIncoming() was called the incoming array is empty.
+  $assert(state.incoming.length === 0 || state.incoming[0] === req);
+
+  state.incoming.shift();
+
+  // If the user never called req.read(), and didn't pipe() or .resume() or
+  // .on('data'), then we call req._dump() so that the bytes will be pulled
+  // off the wire.
+  if (!req._consuming && !req._readableState.resumeScheduled) req._dump();
+
+  res.detachSocket(socket);
+  clearIncoming(req);
+  process.nextTick(emitCloseNT, res);
+
+  if (res._last) {
+    if (typeof socket.destroySoon === "function") {
+      socket.destroySoon();
+    } else {
+      socket.end();
+    }
+  } else if (state.outgoing.length === 0) {
+    const keepAliveTimeout =
+      NumberIsFinite(server.keepAliveTimeout) && server.keepAliveTimeout >= 0 ? server.keepAliveTimeout : 0;
+    const keepAliveTimeoutBuffer =
+      NumberIsFinite(server.keepAliveTimeoutBuffer) && server.keepAliveTimeoutBuffer >= 0
+        ? server.keepAliveTimeoutBuffer
+        : 1e3;
+
+    if (keepAliveTimeout && typeof socket.setTimeout === "function") {
+      // Extend the internal timeout by the configured buffer to reduce the
+      // likelihood of ECONNRESET errors.
+      socket.setTimeout(keepAliveTimeout + keepAliveTimeoutBuffer);
+      state.keepAliveTimeoutSet = true;
+    }
+  } else {
+    // Start sending the next message
+    const m = state.outgoing.shift();
+    if (m) {
+      m.assignSocket(socket);
+    }
+  }
+}
+
+function hasBodyHeaders(headers) {
+  return "content-length" in headers || "transfer-encoding" in headers;
+}
+
+// The following callback is issued after the headers have been read on a new
+// message. In this callback we setup the response object and pass it to the
+// user.
+function parserOnIncoming(server, socket, state, req, keepAlive) {
+  resetSocketTimeout(server, socket, state);
+
+  if (req.upgrade) {
+    req.upgrade = req.method === "CONNECT" || !!server.shouldUpgradeCallback(req);
+    if (req.upgrade) {
+      return 0;
+    }
+  }
+
+  state.incoming.push(req);
+
+  // If the writable end isn't consuming, then stop reading so that we don't
+  // become overwhelmed by a flood of pipelined requests that may never be
+  // resolved.
+  if (!socket._paused) {
+    const ws = socket._writableState;
+    if (ws.needDrain || state.outgoingData >= socket.writableHighWaterMark) {
+      socket._paused = true;
+      // We also need to pause the parser, but don't do that until after the
+      // call to execute, because we may still be processing the last chunk.
+      socket.pause();
+    }
+  }
+
+  const res = new server[kServerResponse](req, {
+    highWaterMark: socket.writableHighWaterMark,
+    rejectNonStandardBodyWrites: server.rejectNonStandardBodyWrites,
+  });
+  res._keepAliveTimeout = server.keepAliveTimeout;
+  res._maxRequestsPerSocket = server.maxRequestsPerSocket;
+  res._onPendingData = updateOutgoingData.bind(undefined, socket, state);
+
+  res.shouldKeepAlive = keepAlive;
+  res[kUniqueHeaders] = server[kUniqueHeaders];
+
+  // Fast processing for requests without body headers: 'data'/'end'/'close'
+  // events are skipped and the (empty) body is dumped.
+  if (server[kOptimizeEmptyRequests] === true && !hasBodyHeaders(req.headers)) {
+    req._dumpAndCloseReadable();
+    req._read();
+  }
+
+  if (socket._httpMessage) {
+    // There are already pending outgoing res, append.
+    state.outgoing.push(res);
+  } else {
+    res.assignSocket(socket);
+  }
+
+  // When we're finished writing the response, check if this is the last
+  // response, if so destroy the socket.
+  res.on("finish", resOnFinish.bind(undefined, req, res, socket, state, server));
+
+  let handled = false;
+
+  if (req.httpVersionMajor === 1 && req.httpVersionMinor === 1) {
+    // From RFC 7230 5.4: a server MUST respond with a 400 (Bad Request)
+    // status code to any HTTP/1.1 request message that lacks a Host header.
+    if (server.requireHostHeader && req.headers.host === undefined) {
+      res.writeHead(400, ["Connection", "close"]);
+      res.end();
+      return 0;
+    }
+
+    const isRequestsLimitSet = typeof server.maxRequestsPerSocket === "number" && server.maxRequestsPerSocket > 0;
+
+    if (isRequestsLimitSet) {
+      state.requestsCount++;
+      res.maxRequestsOnConnectionReached = server.maxRequestsPerSocket <= state.requestsCount;
+    }
+
+    if (isRequestsLimitSet && server.maxRequestsPerSocket < state.requestsCount) {
+      handled = true;
+      server.emit("dropRequest", req, socket);
+      res.writeHead(503);
+      res.end();
+    } else if (req.headers.expect !== undefined) {
+      handled = true;
+
+      if (continueExpression.test(req.headers.expect)) {
+        res._expect_continue = true;
+        if (server.listenerCount("checkContinue") > 0) {
+          server.emit("checkContinue", req, res);
+        } else {
+          res.writeContinue();
+          server.emit("request", req, res);
+        }
+      } else if (server.listenerCount("checkExpectation") > 0) {
+        server.emit("checkExpectation", req, res);
+      } else {
+        res.writeHead(417);
+        res.end();
+      }
+    }
+  }
+
+  if (!handled) {
+    server.emit("request", req, res);
+  }
+
+  return 0; // No special treatment.
+}
+
+function resetSocketTimeout(server, socket, state) {
+  if (!state.keepAliveTimeoutSet) return;
+
+  socket.setTimeout(server.timeout || 0);
+  state.keepAliveTimeoutSet = false;
+}
 
 function onSocketTimeoutTimerExpired(socket) {
   // The keep-alive idle timer is left armed across the request to avoid a
@@ -3972,5 +4348,6 @@ function ensureReadableStreamController(run) {
 export default {
   Server,
   ServerResponse,
+  connectionListener,
   kConnectionsCheckingInterval,
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1822,15 +1822,16 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
       return 0;
     }
 
-    const isRequestsLimitSet = typeof server.maxRequestsPerSocket === "number" && server.maxRequestsPerSocket > 0;
+    const { maxRequestsPerSocket } = server;
+    const isRequestsLimitSet = typeof maxRequestsPerSocket === "number" && maxRequestsPerSocket > 0;
 
     if (isRequestsLimitSet) {
       state.requestsCount++;
-      res.maxRequestsOnConnectionReached = server.maxRequestsPerSocket <= state.requestsCount;
+      res.maxRequestsOnConnectionReached = maxRequestsPerSocket <= state.requestsCount;
     }
 
     const { expect } = req.headers;
-    if (isRequestsLimitSet && server.maxRequestsPerSocket < state.requestsCount) {
+    if (isRequestsLimitSet && maxRequestsPerSocket < state.requestsCount) {
       handled = true;
       server.emit("dropRequest", req, socket);
       res.writeHead(503);
@@ -2380,9 +2381,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
   }
 
   setEncoding(_encoding) {
-    const err = new Error("Changing the socket encoding is not allowed per RFC7230 Section 3.");
-    err.code = "ERR_HTTP_SOCKET_ENCODING";
-    throw err;
+    socketSetEncoding();
   }
 
   unref() {
@@ -3497,20 +3496,17 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   }
 
   if (!handle) {
-    // Read the storage directly - the `socket` getter auto-creates a
-    // FakeSocket and would make this condition always true.
-    if (this[fakeSocketSymbol] || this.outputData?.length || !this._header) {
-      // Standalone response writing through an assigned socket (or buffering
-      // until one is assigned): use the OutgoingMessage machinery. The
-      // original chunk passes through (mirroring write()): write_() has its
-      // own !_hasBody handling, including the rejectNonStandardBodyWrites
-      // throw, which the clearing below would bypass.
-      return OutgoingMessagePrototype.end.$call(this, chunk, encoding, callback);
-    }
-    if ($isCallable(callback)) {
-      process.nextTick(callback);
-    }
-    return this;
+    // Standalone response (no native handle): always use the OutgoingMessage
+    // machinery, like Node. The original chunk passes through (mirroring
+    // write()): write_() has its own !_hasBody handling, including the
+    // rejectNonStandardBodyWrites throw. This must also run when the header
+    // was rendered by writeHead() but no socket is assigned yet (a response
+    // queued behind an in-flight pipelined response on an adopted socket):
+    // end() buffers the header block into outputData so a later
+    // assignSocket() -> _flush() writes it and 'finish' fires. An early
+    // return here dropped the 400/503/417 auto-responses and hung the
+    // connection.
+    return OutgoingMessagePrototype.end.$call(this, chunk, encoding, callback);
   }
 
   if (this[headerStateSymbol] === NodeHTTPHeaderState.none) {

--- a/src/js/node/http.ts
+++ b/src/js/node/http.ts
@@ -5,7 +5,7 @@ const { ClientRequest } = require("node:_http_client");
 const { validateHeaderName, validateHeaderValue, parsers } = require("node:_http_common");
 const { IncomingMessage } = require("node:_http_incoming");
 const { OutgoingMessage } = require("node:_http_outgoing");
-const { Server, ServerResponse } = require("node:_http_server");
+const { Server, ServerResponse, connectionListener } = require("node:_http_server");
 
 const { METHODS, STATUS_CODES, setMaxHTTPHeaderSize, getMaxHTTPHeaderSize } = require("internal/http");
 
@@ -44,6 +44,7 @@ function get(url, options, cb) {
 }
 
 const http_exports = {
+  _connectionListener: connectionListener,
   Agent,
   Server,
   METHODS,

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -45,7 +45,10 @@ function collect(client: net.Socket) {
 async function setup(handler?: http.RequestListener) {
   const httpServer = http.createServer(handler);
   const raw = net.createServer(sock => httpServer.emit("connection", sock));
-  await new Promise<void>(resolve => raw.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve, reject) => {
+    raw.once("error", reject);
+    raw.listen(0, "127.0.0.1", resolve);
+  });
   const port = (raw.address() as net.AddressInfo).port;
   const client = net.connect(port, "127.0.0.1");
   await new Promise<void>((resolve, reject) => {
@@ -219,7 +222,10 @@ test.concurrent("http._connectionListener serves a socket when invoked directly"
   // as `this` instead of emitting 'connection'.
   const httpServer = http.createServer((req, res) => res.end("direct:" + req.url));
   const raw = net.createServer(sock => (http as any)._connectionListener.call(httpServer, sock));
-  await new Promise<void>(resolve => raw.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve, reject) => {
+    raw.once("error", reject);
+    raw.listen(0, "127.0.0.1", resolve);
+  });
   const port = (raw.address() as net.AddressInfo).port;
   const client = net.connect(port, "127.0.0.1");
   try {

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -8,9 +8,12 @@ import http from "node:http";
 import net from "node:net";
 
 // Accumulates client data and lets tests await the arrival of a substring.
+// Terminal socket events reject pending waiters so a regression fails with
+// the bytes received so far instead of an opaque test timeout.
 function collect(client: net.Socket) {
   let buf = "";
-  const waiters: { needle: string; resolve: (buf: string) => void }[] = [];
+  let failure: Error | undefined;
+  const waiters: { needle: string; resolve: (buf: string) => void; reject: (err: Error) => void }[] = [];
   client.on("data", d => {
     buf += d.toString("latin1");
     for (let i = waiters.length - 1; i >= 0; i--) {
@@ -19,13 +22,20 @@ function collect(client: net.Socket) {
       }
     }
   });
+  const fail = (why: string) => {
+    failure ??= new Error(`${why} before needle arrived; received so far: ${JSON.stringify(buf)}`);
+    while (waiters.length) waiters.shift()!.reject(failure);
+  };
+  client.on("error", err => fail(`socket error (${err.message})`));
+  client.on("close", () => fail("socket closed"));
   return {
     get buf() {
       return buf;
     },
     until(needle: string): Promise<string> {
       if (buf.includes(needle)) return Promise.resolve(buf);
-      return new Promise(resolve => waiters.push({ needle, resolve }));
+      if (failure) return Promise.reject(failure);
+      return new Promise((resolve, reject) => waiters.push({ needle, resolve, reject }));
     },
   };
 }
@@ -38,7 +48,10 @@ async function setup(handler?: http.RequestListener) {
   await new Promise<void>(resolve => raw.listen(0, "127.0.0.1", resolve));
   const port = (raw.address() as net.AddressInfo).port;
   const client = net.connect(port, "127.0.0.1");
-  await new Promise<void>(resolve => client.on("connect", resolve));
+  await new Promise<void>((resolve, reject) => {
+    client.once("connect", resolve);
+    client.once("error", reject);
+  });
   return {
     httpServer,
     raw,
@@ -89,6 +102,19 @@ test.concurrent("chunked response when no content-length is known", async () => 
   const buf = await ctx.reader.until("part2");
   expect(buf).toContain("Transfer-Encoding: chunked");
   expect(buf).toContain("X-Test: 1");
+});
+
+test.concurrent("auto 400 on a pipelined request queued behind an in-flight response", async () => {
+  // The second request arrives while the first response is still in flight,
+  // so its response is queued without a socket; the requireHostHeader 400
+  // must still reach the wire once the socket is assigned.
+  using ctx = await setup(async (req, res) => {
+    await new Promise(r => setImmediate(r));
+    res.end("ok:" + req.url);
+  });
+  ctx.client.write("GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + "GET /b HTTP/1.1\r\n\r\n");
+  const buf = await ctx.reader.until("400 Bad Request");
+  expect(buf).toContain("ok:/a");
 });
 
 test.concurrent("malformed request emits 'clientError'", async () => {

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -150,6 +150,27 @@ test.concurrent("'upgrade' hands the adopted socket to the listener", async () =
   await ctx.reader.until("echo:ping");
 });
 
+test.concurrent("upgrade request with a body spanning packets hands off after the body completes", async () => {
+  using ctx = await setup();
+  ctx.httpServer.on("upgrade", async (req, socket, head) => {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    socket.write("HTTP/1.1 101 Switching Protocols\r\n\r\n");
+    // Like Node, the request body is parsed into req and stays out of the
+    // tunnel byte stream. (Node v26 delivers the first tunnel bytes as the
+    // socket's first 'data' event via its UpgradeStream; here they arrive in
+    // `head` instead. Either way, tunnel bytes = head + data events.)
+    socket.write("B:" + body + "|H:" + head.toString());
+    socket.on("data", d => socket.write("D:" + d));
+  });
+  ctx.client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: upgrade\r\nUpgrade: tcp\r\nContent-Length: 5\r\n\r\nhel");
+  // Rest of the request body plus the first tunnel bytes in a second packet.
+  ctx.client.write("loWORLD");
+  await ctx.reader.until("B:hello|H:WORLD");
+  ctx.client.write("ping");
+  await ctx.reader.until("D:ping");
+});
+
 test.concurrent("CONNECT hands the adopted socket to the 'connect' listener with bodyHead", async () => {
   using ctx = await setup();
   const connectEvent = new Promise<{ method: string | undefined; head: string }>(resolve => {

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -122,11 +122,12 @@ test.concurrent("auto 400 on a pipelined request queued behind an in-flight resp
 
 test.concurrent("malformed request emits 'clientError'", async () => {
   using ctx = await setup();
-  const clientError = new Promise<Error>(resolve => {
+  const clientError = new Promise<Error>((resolve, reject) => {
     ctx.httpServer.on("clientError", (err, socket) => {
       socket.destroy();
       resolve(err as Error);
     });
+    ctx.client.once("close", () => reject(new Error("client closed before 'clientError' fired")));
   });
   ctx.client.write("NOT A VALID REQUEST\r\n\r\n");
   const err = (await clientError) as Error & { code?: string };
@@ -176,12 +177,13 @@ test.concurrent("upgrade request with a body spanning packets hands off after th
 
 test.concurrent("CONNECT hands the adopted socket to the 'connect' listener with bodyHead", async () => {
   using ctx = await setup();
-  const connectEvent = new Promise<{ method: string | undefined; head: string }>(resolve => {
+  const connectEvent = new Promise<{ method: string | undefined; head: string }>((resolve, reject) => {
     ctx.httpServer.on("connect", (req, socket, head) => {
       socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
       socket.on("data", d => socket.write("tun:" + d));
       resolve({ method: req.method, head: head.toString() });
     });
+    ctx.client.once("close", () => reject(new Error("client closed before 'connect' fired")));
   });
   // Tunnel bytes in the same packet as the request head must surface as bodyHead.
   ctx.client.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\nearly");

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -125,8 +125,11 @@ test.concurrent("queued pipelined response with Content-Length and write() befor
   // an explicit Content-Length and the body written before end(), 'finish'
   // must wait until the response is assigned the socket and flushed.
   let queuedWritableFinished: boolean | undefined;
+  let queuedSocket: unknown = "unset";
   using ctx = await setup(async (req, res) => {
     if (req.url === "/a") await new Promise(r => setImmediate(r));
+    // A queued response has no socket until assignSocket(), like Node.
+    if (req.url === "/b") queuedSocket = res.socket;
     res.writeHead(200, { "Content-Length": "5" });
     res.write("ok:" + req.url);
     res.end();
@@ -138,6 +141,7 @@ test.concurrent("queued pipelined response with Content-Length and write() befor
   const buf = await ctx.reader.until("ok:/b");
   expect(buf.indexOf("ok:/a")).toBeLessThan(buf.indexOf("ok:/b"));
   expect(queuedWritableFinished).toBe(false);
+  expect(queuedSocket).toBe(null);
 });
 
 test.concurrent("writableNeedDrain and 'drain' track buffered writes on an adopted socket", async () => {
@@ -193,29 +197,53 @@ test.concurrent("'upgrade' hands the adopted socket to the listener", async () =
   await ctx.reader.until("echo:ping");
 });
 
-test.concurrent("upgrade request with a body spanning packets hands off after the body completes", async () => {
+test.concurrent("upgrade request with a body spanning packets hands off at end of headers", async () => {
   using ctx = await setup();
   ctx.httpServer.on("upgrade", async (req, socket, head) => {
     let body = "";
     for await (const chunk of req) body += chunk;
     socket.write("HTTP/1.1 101 Switching Protocols\r\n\r\n");
-    // Like Node, the request body is parsed into req and stays out of the
-    // tunnel byte stream. (Node v26 delivers the first tunnel bytes as the
-    // socket's first 'data' event via its UpgradeStream; here they arrive in
-    // `head` instead. Either way, tunnel bytes = head + data events.)
+    // The body is skipped by the parser (like Node before its UpgradeStream):
+    // req carries no body and every byte after the headers reaches the
+    // listener raw, as bodyHead + 'data' events.
     socket.write("B:" + body + "|H:" + head.toString());
     socket.on("data", d => socket.write("D:" + d));
   });
   ctx.client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: upgrade\r\nUpgrade: tcp\r\nContent-Length: 5\r\n\r\nhel");
-  // Yield so the server reads the partial body before the rest arrives;
-  // back-to-back writes would coalesce into one 'data' event and skip the
-  // multi-chunk path this test exists for.
-  await new Promise(r => setImmediate(r));
-  // Rest of the request body plus the first tunnel bytes in a second packet.
+  await ctx.reader.until("B:|H:hel");
+  // Rest of the request body plus tunnel bytes flow as raw socket data.
   ctx.client.write("loWORLD");
-  await ctx.reader.until("B:hello|H:WORLD");
+  await ctx.reader.until("D:loWORLD");
   ctx.client.write("ping");
   await ctx.reader.until("D:ping");
+});
+
+test.concurrent("upgrade request with a body larger than the high-water mark does not stall", async () => {
+  const bodySize = 256 * 1024;
+  using ctx = await setup();
+  ctx.httpServer.on("upgrade", (req, socket, head) => {
+    socket.write("HTTP/1.1 101 Switching Protocols\r\n\r\n");
+    let received = head.length;
+    let replied = false;
+    const check = () => {
+      if (!replied && received >= bodySize + 4) {
+        replied = true;
+        socket.write("GOT:" + received);
+      }
+    };
+    socket.on("data", d => {
+      received += d.length;
+      check();
+    });
+    check();
+  });
+  ctx.client.write(
+    `GET / HTTP/1.1\r\nHost: x\r\nConnection: upgrade\r\nUpgrade: tcp\r\nContent-Length: ${bodySize}\r\n\r\n`,
+  );
+  await new Promise(r => setImmediate(r));
+  ctx.client.write(Buffer.alloc(bodySize, "b").toString());
+  ctx.client.write("ping");
+  await ctx.reader.until("GOT:" + (bodySize + 4));
 });
 
 test.concurrent("CONNECT hands the adopted socket to the 'connect' listener with bodyHead", async () => {

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -150,6 +150,23 @@ test.concurrent("'upgrade' hands the adopted socket to the listener", async () =
   await ctx.reader.until("echo:ping");
 });
 
+test.concurrent("CONNECT hands the adopted socket to the 'connect' listener with bodyHead", async () => {
+  using ctx = await setup();
+  const connectEvent = new Promise<{ method: string | undefined; head: string }>(resolve => {
+    ctx.httpServer.on("connect", (req, socket, head) => {
+      socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      socket.on("data", d => socket.write("tun:" + d));
+      resolve({ method: req.method, head: head.toString() });
+    });
+  });
+  // Tunnel bytes in the same packet as the request head must surface as bodyHead.
+  ctx.client.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\nearly");
+  expect(await connectEvent).toEqual({ method: "CONNECT", head: "early" });
+  await ctx.reader.until("200 Connection Established");
+  ctx.client.write("ping");
+  await ctx.reader.until("tun:ping");
+});
+
 test.concurrent("Expect: 100-continue is answered before the body", async () => {
   using ctx = await setup(async (req, res) => {
     let body = "";
@@ -176,6 +193,25 @@ test.concurrent("server sockets accepted natively are unaffected", async () => {
   }
 });
 
-test.concurrent("http._connectionListener is exported", () => {
-  expect(typeof (http as any)._connectionListener).toBe("function");
+test.concurrent("http._connectionListener serves a socket when invoked directly", async () => {
+  // The httpolyglot/spdy pattern: call the exported listener with the server
+  // as `this` instead of emitting 'connection'.
+  const httpServer = http.createServer((req, res) => res.end("direct:" + req.url));
+  const raw = net.createServer(sock => (http as any)._connectionListener.call(httpServer, sock));
+  await new Promise<void>(resolve => raw.listen(0, "127.0.0.1", resolve));
+  const port = (raw.address() as net.AddressInfo).port;
+  const client = net.connect(port, "127.0.0.1");
+  try {
+    const reader = collect(client);
+    await new Promise<void>((resolve, reject) => {
+      client.once("connect", resolve);
+      client.once("error", reject);
+    });
+    client.write("GET /x HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    const buf = await reader.until("direct:/x");
+    expect(buf).toContain("HTTP/1.1 200 OK");
+  } finally {
+    client.destroy();
+    raw.close();
+  }
 });

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -124,15 +124,39 @@ test.concurrent("queued pipelined response with Content-Length and write() befor
   // The /b handler runs while its response is still queued behind /a's: with
   // an explicit Content-Length and the body written before end(), 'finish'
   // must wait until the response is assigned the socket and flushed.
+  let queuedWritableFinished: boolean | undefined;
   using ctx = await setup(async (req, res) => {
     if (req.url === "/a") await new Promise(r => setImmediate(r));
     res.writeHead(200, { "Content-Length": "5" });
     res.write("ok:" + req.url);
     res.end();
+    // The queued response still has its bytes in outputData, so it has not
+    // finished writing (like Node's OutgoingMessage accounting).
+    if (req.url === "/b") queuedWritableFinished = res.writableFinished;
   });
   ctx.client.write("GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + "GET /b HTTP/1.1\r\nHost: x\r\n\r\n");
   const buf = await ctx.reader.until("ok:/b");
   expect(buf.indexOf("ok:/a")).toBeLessThan(buf.indexOf("ok:/b"));
+  expect(queuedWritableFinished).toBe(false);
+});
+
+test.concurrent("writableNeedDrain and 'drain' track buffered writes on an adopted socket", async () => {
+  const big = Buffer.alloc(1 << 20, "x").toString();
+  const states: unknown[] = [];
+  using ctx = await setup((req, res) => {
+    res.writeHead(200, { "Content-Length": String(big.length) });
+    const accepted = res.write(big);
+    states.push(accepted, res.writableNeedDrain);
+    res.on("drain", () => {
+      states.push("drain", res.writableNeedDrain);
+      res.end();
+    });
+  });
+  ctx.client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  // Connection: close ends the socket once the response has fully flushed.
+  await new Promise<void>(resolve => ctx.client.on("close", () => resolve()));
+  expect(states).toEqual([false, true, "drain", false]);
+  expect(ctx.reader.buf.length).toBeGreaterThanOrEqual(big.length);
 });
 
 test.concurrent("malformed request emits 'clientError'", async () => {

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -120,6 +120,21 @@ test.concurrent("auto 400 on a pipelined request queued behind an in-flight resp
   expect(buf).toContain("ok:/a");
 });
 
+test.concurrent("queued pipelined response with Content-Length and write() before end()", async () => {
+  // The /b handler runs while its response is still queued behind /a's: with
+  // an explicit Content-Length and the body written before end(), 'finish'
+  // must wait until the response is assigned the socket and flushed.
+  using ctx = await setup(async (req, res) => {
+    if (req.url === "/a") await new Promise(r => setImmediate(r));
+    res.writeHead(200, { "Content-Length": "5" });
+    res.write("ok:" + req.url);
+    res.end();
+  });
+  ctx.client.write("GET /a HTTP/1.1\r\nHost: x\r\n\r\n" + "GET /b HTTP/1.1\r\nHost: x\r\n\r\n");
+  const buf = await ctx.reader.until("ok:/b");
+  expect(buf.indexOf("ok:/a")).toBeLessThan(buf.indexOf("ok:/b"));
+});
+
 test.concurrent("malformed request emits 'clientError'", async () => {
   using ctx = await setup();
   const clientError = new Promise<Error>((resolve, reject) => {
@@ -168,6 +183,10 @@ test.concurrent("upgrade request with a body spanning packets hands off after th
     socket.on("data", d => socket.write("D:" + d));
   });
   ctx.client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: upgrade\r\nUpgrade: tcp\r\nContent-Length: 5\r\n\r\nhel");
+  // Yield so the server reads the partial body before the rest arrives;
+  // back-to-back writes would coalesce into one 'data' event and skip the
+  // multi-chunk path this test exists for.
+  await new Promise(r => setImmediate(r));
   // Rest of the request body plus the first tunnel bytes in a second packet.
   ctx.client.write("loWORLD");
   await ctx.reader.until("B:hello|H:WORLD");
@@ -209,7 +228,10 @@ test.concurrent("Expect: 100-continue is answered before the body", async () => 
 
 test.concurrent("server sockets accepted natively are unaffected", async () => {
   const httpServer = http.createServer((req, res) => res.end("native:" + req.url));
-  await new Promise<void>(resolve => httpServer.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
+    httpServer.listen(0, "127.0.0.1", resolve);
+  });
   try {
     const port = (httpServer.address() as net.AddressInfo).port;
     const res = await fetch(`http://127.0.0.1:${port}/n`);

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -1,0 +1,155 @@
+// https://github.com/oven-sh/bun/issues/35281
+// http.Server must adopt external sockets fed in via server.emit('connection',
+// socket): Node attaches an HTTPParser to any duplex passed through the
+// 'connection' event, so user code can terminate TLS elsewhere (or bridge any
+// stream) and still get 'request' events.
+import { expect, test } from "bun:test";
+import http from "node:http";
+import net from "node:net";
+
+// Accumulates client data and lets tests await the arrival of a substring.
+function collect(client: net.Socket) {
+  let buf = "";
+  const waiters: { needle: string; resolve: (buf: string) => void }[] = [];
+  client.on("data", d => {
+    buf += d.toString("latin1");
+    for (let i = waiters.length - 1; i >= 0; i--) {
+      if (buf.includes(waiters[i].needle)) {
+        waiters.splice(i, 1)[0].resolve(buf);
+      }
+    }
+  });
+  return {
+    get buf() {
+      return buf;
+    },
+    until(needle: string): Promise<string> {
+      if (buf.includes(needle)) return Promise.resolve(buf);
+      return new Promise(resolve => waiters.push({ needle, resolve }));
+    },
+  };
+}
+
+// Raw TCP server that forwards every accepted socket into the http.Server via
+// emit('connection'), plus a connected client.
+async function setup(handler?: http.RequestListener) {
+  const httpServer = http.createServer(handler);
+  const raw = net.createServer(sock => httpServer.emit("connection", sock));
+  await new Promise<void>(resolve => raw.listen(0, "127.0.0.1", resolve));
+  const port = (raw.address() as net.AddressInfo).port;
+  const client = net.connect(port, "127.0.0.1");
+  await new Promise<void>(resolve => client.on("connect", resolve));
+  return {
+    httpServer,
+    raw,
+    client,
+    reader: collect(client),
+    [Symbol.dispose]() {
+      client.destroy();
+      raw.close();
+      httpServer.closeAllConnections?.();
+    },
+  };
+}
+
+test.concurrent("dispatches 'request' for sockets emitted via emit('connection')", async () => {
+  using ctx = await setup((req, res) => res.end("hello " + req.url));
+  ctx.client.write("GET /emit-test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+  const buf = await ctx.reader.until("hello /emit-test");
+  expect(buf).toContain("HTTP/1.1 200 OK");
+});
+
+test.concurrent("keep-alive serves sequential requests on one adopted socket", async () => {
+  using ctx = await setup((req, res) => res.end("r:" + req.url));
+  ctx.client.write("GET /a HTTP/1.1\r\nHost: x\r\n\r\n");
+  const first = await ctx.reader.until("r:/a");
+  expect(first).toContain("Connection: keep-alive");
+  ctx.client.write("GET /b HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  const second = await ctx.reader.until("r:/b");
+  expect(second).toContain("Connection: close");
+});
+
+test.concurrent("request body flows through the adopted socket", async () => {
+  using ctx = await setup(async (req, res) => {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    res.end("body=" + body);
+  });
+  ctx.client.write("POST /p HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello");
+  await ctx.reader.until("body=hello");
+});
+
+test.concurrent("chunked response when no content-length is known", async () => {
+  using ctx = await setup((req, res) => {
+    res.writeHead(200, { "X-Test": "1" });
+    res.write("part1");
+    res.end("part2");
+  });
+  ctx.client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  const buf = await ctx.reader.until("part2");
+  expect(buf).toContain("Transfer-Encoding: chunked");
+  expect(buf).toContain("X-Test: 1");
+});
+
+test.concurrent("malformed request emits 'clientError'", async () => {
+  using ctx = await setup();
+  const clientError = new Promise<Error>(resolve => {
+    ctx.httpServer.on("clientError", (err, socket) => {
+      socket.destroy();
+      resolve(err as Error);
+    });
+  });
+  ctx.client.write("NOT A VALID REQUEST\r\n\r\n");
+  const err = (await clientError) as Error & { code?: string };
+  expect(err.code).toStartWith("HPE_");
+});
+
+test.concurrent("malformed request gets the default 400 response", async () => {
+  using ctx = await setup();
+  ctx.client.write("garbage\r\n\r\n");
+  const closed = new Promise<void>(resolve => ctx.client.on("close", () => resolve()));
+  await ctx.reader.until("400 Bad Request");
+  await closed;
+});
+
+test.concurrent("'upgrade' hands the adopted socket to the listener", async () => {
+  using ctx = await setup();
+  ctx.httpServer.on("upgrade", (req, socket) => {
+    socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n");
+    socket.on("data", d => socket.write("echo:" + d));
+  });
+  ctx.client.write("GET / HTTP/1.1\r\nHost: x\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n");
+  await ctx.reader.until("101 Switching Protocols");
+  ctx.client.write("ping");
+  await ctx.reader.until("echo:ping");
+});
+
+test.concurrent("Expect: 100-continue is answered before the body", async () => {
+  using ctx = await setup(async (req, res) => {
+    let body = "";
+    for await (const chunk of req) body += chunk;
+    res.end("got=" + body);
+  });
+  ctx.client.write(
+    "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 2\r\nExpect: 100-continue\r\nConnection: close\r\n\r\n",
+  );
+  await ctx.reader.until("100 Continue");
+  ctx.client.write("hi");
+  await ctx.reader.until("got=hi");
+});
+
+test.concurrent("server sockets accepted natively are unaffected", async () => {
+  const httpServer = http.createServer((req, res) => res.end("native:" + req.url));
+  await new Promise<void>(resolve => httpServer.listen(0, "127.0.0.1", resolve));
+  try {
+    const port = (httpServer.address() as net.AddressInfo).port;
+    const res = await fetch(`http://127.0.0.1:${port}/n`);
+    expect(await res.text()).toBe("native:/n");
+  } finally {
+    httpServer.close();
+  }
+});
+
+test.concurrent("http._connectionListener is exported", () => {
+  expect(typeof (http as any)._connectionListener).toBe("function");
+});

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -149,12 +149,17 @@ test.concurrent("writableNeedDrain and 'drain' track buffered writes on an adopt
   const states: unknown[] = [];
   using ctx = await setup((req, res) => {
     res.writeHead(200, { "Content-Length": String(big.length) });
-    const accepted = res.write(big);
-    states.push(accepted, res.writableNeedDrain);
     res.on("drain", () => {
       states.push("drain", res.writableNeedDrain);
       res.end();
     });
+    const accepted = res.write(big);
+    states.push(accepted, res.writableNeedDrain);
+    // No backpressure means no 'drain' is coming: end now so the connection
+    // closes and the states assertion reports the regression instead of the
+    // test hanging. (Ending eagerly on the expected path would set `finished`
+    // and suppress the 'drain' emit this test exists to observe.)
+    if (accepted) res.end();
   });
   ctx.client.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
   // Connection: close ends the socket once the response has fully flushed.

--- a/test/js/node/http/node-http-emit-connection.test.ts
+++ b/test/js/node/http/node-http-emit-connection.test.ts
@@ -283,6 +283,22 @@ test.concurrent("Expect: 100-continue is answered before the body", async () => 
   await ctx.reader.until("got=hi");
 });
 
+test.concurrent("rejected Expect: 100-continue closes the connection", async () => {
+  // A final status without writeContinue() must advertise Connection: close
+  // and end the socket, like Node: the client may still send the request
+  // body, which would desync the parser on a kept-alive connection.
+  using ctx = await setup();
+  ctx.httpServer.on("checkContinue", (req, res) => {
+    res.writeHead(401);
+    res.end();
+  });
+  ctx.client.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\nExpect: 100-continue\r\n\r\n");
+  const closed = new Promise<void>(resolve => ctx.client.on("close", () => resolve()));
+  const buf = await ctx.reader.until("401 Unauthorized");
+  expect(buf).toContain("Connection: close");
+  await closed;
+});
+
 test.concurrent("server sockets accepted natively are unaffected", async () => {
   const httpServer = http.createServer((req, res) => res.end("native:" + req.url));
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Fixes #35281

### Problem

Node's `http.Server` registers an internal `connection` listener that attaches an `HTTPParser` to every socket passed through the event, so user code can feed arbitrary Duplex streams (e.g. a TLS-terminated socket from a proxy tunnel) into `http.createServer()` via `server.emit('connection', socket)`. In Bun, HTTP parsing happens natively in uWS and only for sockets the server itself accepted, so emitting a foreign socket attached no parser and `request` never fired.

```js
const httpServer = http.createServer((req, res) => res.end('hello ' + req.url));
const raw = net.createServer(sock => httpServer.emit('connection', sock));
// Node: 'request' fires; Bun: timeout, request event never fired
```

### Fix

Port Node v26.3.0's `connectionListener` / `connectionListenerInternal` (lib/_http_server.js) and its socket/parser plumbing for sockets that are not native `NodeHTTPServerSocket` wrappers:

- attaches a REQUEST-mode llhttp parser (the existing `process.binding('http_parser')` binding, driven through `node:_http_common`'s parser freelist) to the adopted duplex
- builds `IncomingMessage`/`ServerResponse` over the duplex using the existing standalone response path (`assignSocket` + OutgoingMessage header rendering/chunked framing)
- includes keep-alive + pipelining queue, `resOnFinish` socket lifecycle, upgrade/CONNECT handoff, `clientError` (raw 400/431 replies), `Expect: 100-continue` / `checkContinue` / `checkExpectation`, `maxRequestsPerSocket` 503 + `dropRequest`, `requireHostHeader`, server/keep-alive timeouts
- natively accepted connections skip the listener (instanceof check), so the uWS fast path is unchanged
- exports `http._connectionListener` like Node

Also extends the shared `socketOnError` raw-reply guard to honor `_headerSent`, which only standalone (adopted-socket) responses maintain; native responses keep using `headerStateSymbol` and are unaffected.

Review follow-ups hardened the handle-less `ServerResponse` surfaces the new path exercises: `end()` always routes through `OutgoingMessage.end`, and `socket`/`writableLength`/`writableNeedDrain`/`writableFinished` fall through to the OutgoingMessage accounting when there is no native handle (`kChunkedLength` is exported from `node:_http_outgoing` for exactly that getter). Upgrade requests skip their body at the parser (headers-complete returns 2, like Node before its UpgradeStream), so bodied upgrades cannot stall on readable backpressure; body and tunnel bytes reach the `'upgrade'`/`'connect'` listener as `bodyHead` + raw `'data'` events.

### Verification

- the issue's repro passes (`PASS — got request`), identical behavior on Node v26
- new tests in `test/js/node/http/node-http-emit-connection.test.ts` cover request dispatch, keep-alive, request bodies, chunked responses, `clientError`, default 400, upgrade, 100-continue, the native path, and the `_connectionListener` export; all 10 fail on bun 1.4.0 and pass with this change (verified against Node for parity)
- no regressions in the http/http2-fallback suites (`node-http.test.ts`, CONNECT, server timeouts, backpressure, `test-http2-https-fallback*`, `test-http-server-unconsume-consume`, clientError node tests)

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-emit-connection.test.ts
bun test v1.4.0 (42afacffa)

test/js/node/http/node-http-emit-connection.test.ts:
(fail) dispatches 'request' for sockets emitted via emit('connection') [5000.80ms]
  ^ this test timed out after 5000ms.
(fail) keep-alive serves sequential requests on one adopted socket [5003.75ms]
  ^ this test timed out after 5000ms.
(fail) request body flows through the adopted socket [5007.17ms]
  ^ this test timed out after 5000ms.
(fail) chunked response when no content-length is known [5015.54ms]
  ^ this test timed out after 5000ms.
(fail) auto 400 on a pipelined request queued behind an in-flight response [5005.92ms]
  ^ this test timed out after 5000ms.
(fail) queued pipelined response with Content-Length and write() before end() [5000.40ms]
  ^ this test timed out after 5000ms.
(fail) writableNeedDrain and 'drain' track buffered writes on an adopted socket [5004.38ms]
  ^ this test timed out after 5000ms.
(fail) malformed request emits 'clientError' [5004.13ms]
  ^ this test timed out after 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (607236689)

test/js/node/http/node-http-emit-connection.test.ts:
(pass) malformed request emits 'clientError' [26.41ms]
(pass) server sockets accepted natively are unaffected [25.50ms]
293 |     res.end();
294 |   });
295 |   ctx.client.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\nExpect: 100-continue\r\n\r\n");
296 |   const closed = new Promise<void>(resolve => ctx.client.on("close", () => resolve()));
297 |   const buf = await ctx.reader.until("401 Unauthorized");
298 |   expect(buf).toContain("Connection: close");
                    ^
error: expect(received).toContain(expected)

Expected to contain: "Connection: close"
Received: "HTTP/1.1 401 Unauthorized\r\nDate: Thu, 23 Jul 2026 19:18:01 GMT\r\nConnection: keep-alive\r\nKeep-Alive: timeout=5\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n"

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-emit-connection.test.ts:298:15)
(pass) dispatches 'request' for sockets emitted via emit('connection') [33.94ms]
(pass) request body flows through the adopted socket [30.79ms]
(pass) chunked response when no content-length is known [30.61ms]
(pass) upgrade request with a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-emit-connection.test.ts
bun test v1.4.0 (42afacffa)

test/js/node/http/node-http-emit-connection.test.ts:
(pass) dispatches 'request' for sockets emitted via emit('connection') [1144.28ms]
(pass) request body flows through the adopted socket [1021.13ms]
(pass) chunked response when no content-length is known [1024.87ms]
(pass) auto 400 on a pipelined request queued behind an in-flight response [1025.37ms]
(pass) keep-alive serves sequential requests on one adopted socket [1179.35ms]
(pass) malformed request emits 'clientError' [242.02ms]
(pass) queued pipelined response with Content-Length and write() before end() [355.35ms]
(pass) malformed request gets the default 400 response [442.42ms]
(pass) 'upgrade' hands the adopted socket to the listener [407.53ms]
(pass) upgrade request with a body larger than the high-water mark does not stall [245.73ms]
(pass) writableNeedDrain and 'drain' track buffered writes on an adopted socket [712.35ms]
(pass) upgrade request with a body spanning packets hands off at end of
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 869ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7292ms)
Bundle modules (30ms)
Postprocesss modules (199ms)
Bundle Functions (666ms)
Generate Code (27ms)

[8.23s] Bundled "src/js" for production
  2085 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_outgoing.ts                      |   1 +
 src/js/node/_http_server.ts                        | 482 ++++++++++++++++++++-
 src/js/node/http.ts                                |   3 +-
 .../js/node/http/node-http-emit-connection.test.ts | 341 +++++++++++++++
 4 files changed, 807 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 9 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/js/node/_http_outgoing.ts                            1      1      0
src/js/node/_http_server.ts                             26     22      0
src/js/node/http.ts                                      1      1      0
test/js/node/http/node-http-emit-connection.test.ts      2     15      0
```

</details>

**root cause** · written by the author bot

When a request arrived with Expect: 100-continue on an adopted socket, the `_expect_continue` flag was set but never read, so a handler that rejected the request without sending 100 Continue still produced a keep-alive response and left the socket open. Since the client is allowed to send the request body anyway, those body bytes were then parsed as a fresh request, producing spurious parse errors where Node cleanly closes the connection. The fix ports Node's check into the standalone writeHead path, clearing shouldKeepAlive when a final status is written before any 100 Continue, so the res…

<!-- robobun:evidence:end -->
