### PR TITLE
spawn: give child a pipe for empty-buffer stdin, not the null device

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -554,10 +554,12 @@ impl Stdio {
         if let Some(array_buffer) = value.as_array_buffer(global) {
             // Change in Bun v1.0.34: don't throw for empty ArrayBuffer.
             // At stdin let it fall through to `Stdio::ArrayBuffer` so the child
-            // gets a pipe (matching the non-empty case and Node's spawnSync
-            // `{input: Buffer.alloc(0)}`); `StaticPipeWriter::start` closes the
-            // write end immediately for the zero-byte source. Other slots have
-            // no reader wired for `Stdio::ArrayBuffer`, so keep them as Ignore.
+            // sees the same fd type as for a non-empty buffer (pipe on
+            // macOS/Windows via `StaticPipeWriter::start` which closes the
+            // zero-byte write end immediately; memfd on Linux via
+            // `use_memfd`), matching Node's spawnSync `{input: Buffer.alloc(0)}`.
+            // Other slots have no reader wired for `Stdio::ArrayBuffer`, so keep
+            // them as Ignore.
             if i != 0 && array_buffer.byte_slice().is_empty() {
                 *out_stdio = Stdio::Ignore;
                 return Ok(());

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -552,8 +552,13 @@ impl Stdio {
         }
 
         if let Some(array_buffer) = value.as_array_buffer(global) {
-            // Change in Bun v1.0.34: don't throw for empty ArrayBuffer
-            if array_buffer.byte_slice().is_empty() {
+            // Change in Bun v1.0.34: don't throw for empty ArrayBuffer.
+            // At stdin let it fall through to `Stdio::ArrayBuffer` so the child
+            // gets a pipe (matching the non-empty case and Node's spawnSync
+            // `{input: Buffer.alloc(0)}`); `StaticPipeWriter::start` closes the
+            // write end immediately for the zero-byte source. Other slots have
+            // no reader wired for `Stdio::ArrayBuffer`, so keep them as Ignore.
+            if i != 0 && array_buffer.byte_slice().is_empty() {
                 *out_stdio = Stdio::Ignore;
                 return Ok(());
             }

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -641,7 +641,11 @@ impl Stdio {
         }
 
         // Nothing to write: treat an empty blob the same as "ignore"
-        // (/dev/null at fds 0-2, left closed at extra slots).
+        // (/dev/null at fds 0-2, left closed at extra slots). This diverges
+        // from the empty-ArrayBuffer stdin case above, which now keeps the
+        // pipe; `extract_blob` is also called from the shell's redirect path
+        // (`Cmd.rs`) where a synchronous `on_close_io` inside `start()` would
+        // alias the `&mut subproc.stdin` held at the call site.
         if blob.fast_size() == 0 {
             *self = Stdio::Ignore;
             return Ok(());

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -725,7 +725,9 @@ impl Cmd {
                     if flags.stdin() {
                         let bytes = buf.byte_slice();
                         // An empty buffer delivers EOF immediately; `Stdio::Ignore`
-                        // matches what `Stdio::extract`/`extract_blob` already do.
+                        // matches `extract_blob` (`Stdio::extract` now keeps an
+                        // empty ArrayBuffer at stdin as a real pipe, but the shell
+                        // reaches this arm before `extract` would run).
                         stdio[STDIN_NO] = if bytes.is_empty() {
                             Stdio::Ignore
                         } else {

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -180,14 +180,21 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                 // `started` is false so no other site re-derefs.
                 unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
             } else if empty {
-                // Nothing to write: WindowsBufferedWriter::write() returns
-                // without issuing a uv_write for a zero-length buffer, so the
+                // Nothing to write: WindowsBufferedWriter::write() returned
+                // without issuing a uv_write for the zero-length buffer, so the
                 // pipe would stay open and the child would block on stdin.
-                // Drive the drained path now so the write end closes and the
-                // child reads EOF. `on_write(.., Drained)` may free `self`
-                // via on_close -> on_close_io -> finalize; this is the last
-                // access (same contract as PipeWriter.rs's on_poll tail call).
-                self.on_write(0, WriteStatus::Drained);
+                // Close the write end now so the child reads EOF. Mirror
+                // `on_write`'s POSIX `release_start_ref` path (clear `started`,
+                // close, deref) so start()'s `+1` is balanced; `on_close_io`
+                // replaces stdin with `Ignore`, so `take_pending_start_writer`
+                // can never re-release it. The trailing deref may free `self`;
+                // this is the last access (same contract as PipeWriter.rs's
+                // on_poll tail call).
+                self.started = false;
+                self.writer.close();
+                // SAFETY: start()'s +1 was live; `started` cleared so no other
+                // site re-derefs.
+                unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
             }
             return r;
         }

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -167,6 +167,7 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         unsafe { RefCount::<Self>::ref_(std::ptr::from_mut::<Self>(self)) };
         // Self-borrow into `self.source` — see `buffer` field invariant.
         self.buffer = RawSlice::new(self.source.slice());
+        let empty = self.buffer.is_empty();
         #[cfg(windows)]
         {
             let r = self.writer.start_with_current_pipe();
@@ -178,6 +179,15 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                 // `start()`; the caller's `IntrusiveRc` keeps it alive and
                 // `started` is false so no other site re-derefs.
                 unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+            } else if empty {
+                // Nothing to write: WindowsBufferedWriter::write() returns
+                // without issuing a uv_write for a zero-length buffer, so the
+                // pipe would stay open and the child would block on stdin.
+                // Drive the drained path now so the write end closes and the
+                // child reads EOF. `on_write(.., Drained)` may free `self`
+                // via on_close -> on_close_io -> finalize; this is the last
+                // access (same contract as PipeWriter.rs's on_poll tail call).
+                self.on_write(0, WriteStatus::Drained);
             }
             return r;
         }
@@ -203,6 +213,17 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                         if let Some(poll) = self.writer.handle.get_poll() {
                             poll.set_flag(bun_io::FilePollFlag::Socket);
                         }
+                    }
+                    if empty {
+                        // Nothing to write: PosixBufferedWriter's on_poll
+                        // returns without closing for a zero-length buffer, so
+                        // the pipe would stay open and the child would block on
+                        // stdin. Drive the drained path now so the write end
+                        // closes and the child reads EOF. `on_write(.., Drained)`
+                        // may free `self` via on_close -> on_close_io ->
+                        // finalize; this is the last access (same contract as
+                        // PipeWriter.rs's on_poll tail call).
+                        self.on_write(0, WriteStatus::Drained);
                     }
                     bun_sys::Result::Ok(())
                 }

--- a/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
+++ b/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
@@ -28,7 +28,8 @@ describe("spawn with empty", () => {
 // An empty stdin buffer should hand the child the same fd type as a non-empty
 // one (a pipe/socket on macOS+Windows, a memfd on Linux), not /dev/null or NUL.
 // Node's spawnSync({input: Buffer.alloc(0)}) never gives the child a character
-// device on any platform.
+// device on any platform. Blob/Response are not covered here: `extract_blob`
+// still maps an empty body to Ignore (see the comment at that site).
 describe("empty buffer stdin is not the null device", () => {
   const probe =
     `const fs = require("fs"); let n = 0;` +

--- a/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
+++ b/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
@@ -1,6 +1,6 @@
-import { spawnSync as cpSpawnSync } from "node:child_process";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { spawnSync as cpSpawnSync } from "node:child_process";
 
 describe("spawn with empty", () => {
   for (const [stdin, label] of [

--- a/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
+++ b/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
@@ -37,7 +37,7 @@ describe("empty buffer stdin is not the null device", () => {
     `  console.log(JSON.stringify({ chr: fs.fstatSync(0).isCharacterDevice(), n })));`;
 
   for (const mk of [() => new ArrayBuffer(0), () => new Uint8Array(0), () => Buffer.alloc(0)]) {
-    test.concurrent(`Bun.spawnSync stdin: ${mk().constructor.name}`, () => {
+    test(`Bun.spawnSync stdin: ${mk().constructor.name}`, () => {
       const r = Bun.spawnSync({
         cmd: [bunExe(), "-e", probe],
         stdin: mk(),
@@ -66,7 +66,7 @@ describe("empty buffer stdin is not the null device", () => {
     });
   }
 
-  test.concurrent("child_process.spawnSync input: Buffer.alloc(0)", () => {
+  test("child_process.spawnSync input: Buffer.alloc(0)", () => {
     const r = cpSpawnSync(bunExe(), ["-e", probe], { input: Buffer.alloc(0), env: bunEnv });
     expect(r.stderr.toString()).toBe("");
     expect(JSON.parse(r.stdout.toString())).toEqual({ chr: false, n: 0 });

--- a/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
+++ b/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync as cpSpawnSync } from "node:child_process";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
@@ -22,4 +23,53 @@ describe("spawn with empty", () => {
       expect(stderr).toBeEmpty();
     });
   }
+});
+
+// An empty stdin buffer should hand the child the same fd type as a non-empty
+// one (a pipe/socket on macOS+Windows, a memfd on Linux), not /dev/null or NUL.
+// Node's spawnSync({input: Buffer.alloc(0)}) never gives the child a character
+// device on any platform.
+describe("empty buffer stdin is not the null device", () => {
+  const probe =
+    `const fs = require("fs"); let n = 0;` +
+    `process.stdin.on("data", d => (n += d.length));` +
+    `process.stdin.on("end", () =>` +
+    `  console.log(JSON.stringify({ chr: fs.fstatSync(0).isCharacterDevice(), n })));`;
+
+  for (const mk of [() => new ArrayBuffer(0), () => new Uint8Array(0), () => Buffer.alloc(0)]) {
+    test.concurrent(`Bun.spawnSync stdin: ${mk().constructor.name}`, () => {
+      const r = Bun.spawnSync({
+        cmd: [bunExe(), "-e", probe],
+        stdin: mk(),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+      expect(r.stderr.toString()).toBe("");
+      expect(JSON.parse(r.stdout.toString())).toEqual({ chr: false, n: 0 });
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent(`Bun.spawn stdin: ${mk().constructor.name}`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", probe],
+        stdin: mk(),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ chr: false, n: 0 });
+      expect(exitCode).toBe(0);
+      expect(proc.stdin).toBeUndefined();
+    });
+  }
+
+  test.concurrent("child_process.spawnSync input: Buffer.alloc(0)", () => {
+    const r = cpSpawnSync(bunExe(), ["-e", probe], { input: Buffer.alloc(0), env: bunEnv });
+    expect(r.stderr.toString()).toBe("");
+    expect(JSON.parse(r.stdout.toString())).toEqual({ chr: false, n: 0 });
+    expect(r.status).toBe(0);
+  });
 });


### PR DESCRIPTION
`Bun.spawn` / `Bun.spawnSync` with an empty `stdin` buffer (and `child_process.spawnSync` with `input: Buffer.alloc(0)`) hand the child the null device (`/dev/null` on POSIX, `NUL` on Windows) instead of a pipe. A non-empty buffer uses a pipe; Node uses a pipe for both.

## Repro

```c
// probe.c
HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
printf("GetFileType(stdin) = %lu\n", GetFileType(h));
```

```
$ bun -e 'Bun.spawnSync({cmd:["./probe.exe"], stdin: Buffer.alloc(0), stdout:"pipe"}).stdout.toString()'
GetFileType(stdin) = 2   // FILE_TYPE_CHAR (NUL)

$ bun -e 'Bun.spawnSync({cmd:["./probe.exe"], stdin: Buffer.from("x"), stdout:"pipe"}).stdout.toString()'
GetFileType(stdin) = 3   // FILE_TYPE_PIPE

$ node -e 'require("child_process").spawnSync("./probe.exe",[],{input:Buffer.alloc(0)}).stdout.toString()'
GetFileType(stdin) = 3   // FILE_TYPE_PIPE
```

Same on POSIX via `fstat(0).isCharacterDevice()`. The child's stdin fd type flips on whether the buffer happened to be empty, which trips tools that branch on `S_ISFIFO`/`S_ISSOCK`, and in a Windows AppContainer opening `NUL` fails with `EPERM`.

## Cause

`Stdio::extract` short-circuits an empty `ArrayBuffer` at any slot to `Stdio::Ignore`:

```rust
if array_buffer.byte_slice().is_empty() {
    *out_stdio = Stdio::Ignore;   // /dev/null or NUL
    return Ok(());
}
```

This was #9557's "don't throw for empty ArrayBuffer", but Ignore gives a character device; the non-empty path gives a pipe.

Letting the empty buffer fall through to `Stdio::ArrayBuffer` alone would deadlock on macOS/Windows: `StaticPipeWriter` with a zero-byte source registers for write readiness (POSIX) or returns from `write()` (Windows) and never closes the pipe, so the child's `read(0)` blocks forever.

## Fix

- `Stdio::extract`: only downgrade an empty `ArrayBuffer` to `Ignore` at `i != 0`; at stdin let it become `Stdio::ArrayBuffer` like a non-empty one. stdout/stderr/extras are unchanged (no reader is wired for `Stdio::ArrayBuffer` at those slots).
- `StaticPipeWriter::start`: after a successful start, if the source is empty, drive the `on_write(0, Drained)` path immediately so the write end closes and the child reads EOF. This is the same tail-call contract `PosixPipeWriter::on_poll` already documents ("don't touch `self` after the callback").

What the child sees on fd 0 for `stdin: Buffer.alloc(0)` after this change matches the non-empty case on each platform: a pipe on macOS/Windows, a memfd on Linux (`can_use_memfd` still converts the `ArrayBuffer` slot). `subprocess.stdin` stays `undefined` for buffer stdin (it is `Writable::Buffer` regardless of size).

Blob stdin (`stdin: new Blob([])`) still becomes `Ignore`; changing `extract_blob` would pull in the shell's `Cmd::extract_blob` callers. Only the ArrayBuffer path changes, which is what `child_process.spawnSync` `input:` uses.

## Relation to #34477

\#34477 removes the `Stdio::Pipe` -> `Ignore` remap for a bare `stdin: "pipe"` under `spawnSync`. That is the other half of the same symptom (the handoff that prompted this PR reported both); this PR addresses the empty-buffer path, which #34477 does not touch. The two changes are independent and compose.

## Verification

New tests in `test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts` cover `Bun.spawnSync`, `Bun.spawn`, and `child_process.spawnSync` with `ArrayBuffer(0)` / `Uint8Array(0)` / `Buffer.alloc(0)`, asserting `!isCharacterDevice()` and 0 bytes to EOF.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts   # 7 fail
bun bd          test test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts        # 10 pass
```

Same result on Windows x64. `spawnSync.test.ts`, the stdin subset of `spawn.test.ts`, and the `child_process.spawnSync*` node parallel tests pass on both platforms; `rust:check-all` is green across the target matrix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
bun test v1.4.0 (97ee042cf)

test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts:
(pass) spawn with empty > ArrayBuffer for stdin [1436.51ms]
(pass) spawn with empty > Uint8Array for stdin [1420.17ms]
(pass) spawn with empty > Blob for stdin [1427.18ms]
45 |         stdout: "pipe",
46 |         stderr: "pipe",
47 |         env: bunEnv,
48 |       });
49 |       expect(r.stderr.toString()).toBe("");
50 |       expect(JSON.parse(r.stdout.toString())).toEqual({ chr: false, n: 0 });
                                                   ^
error: expect(received).toEqual(expected)

  {
-   "chr": false,
+   "chr": true,
    "n": 0,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts:50:47)
(fail) empty buffer stdin is not the null device > Bun.spawnSync stdin: ArrayBuffer [1385.44ms]
59 |         stderr: "pipe",
60 |         env: bunEnv,
61 |       });
62 |       const [stdout, stderr, exitCode] = await Prom
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6d334110a)

test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts:
(pass) spawn with empty > ArrayBuffer for stdin [26.67ms]
(pass) spawn with empty > Uint8Array for stdin [25.82ms]
(pass) spawn with empty > Blob for stdin [26.05ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: ArrayBuffer [24.79ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: ArrayBuffer [25.19ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: Uint8Array [24.93ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: Uint8Array [24.73ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: Buffer [24.53ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: Buffer [24.37ms]
(pass) empty buffer stdin is not the null device > child_process.spawnSync input: Buffer.alloc(0) [25.39ms]

 10 pass
 0 fail
 33 expect() calls
Ran 10 tests across 1 file. [399.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts
bun test v1.4.0 (97ee042cf)

test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts:
(pass) spawn with empty > ArrayBuffer for stdin [1424.05ms]
(pass) spawn with empty > Uint8Array for stdin [1420.76ms]
(pass) spawn with empty > Blob for stdin [1397.43ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: ArrayBuffer [1367.34ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: ArrayBuffer [1369.77ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: Uint8Array [1355.79ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: Uint8Array [1361.83ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: Buffer [1369.23ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: Buffer [1382.23ms]
(pass) empty buffer stdin is not the null device > child_process.spawnSync input: Buffer.alloc(0) [1424.45ms]

 10 pass
 0 fail
 33 expect() calls
Ran 10 tests across 1 file. [16.01s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 644ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[build] done
bun test v1.4.0-canary.1 (97ee042cf)

test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts:
(pass) spawn with empty > ArrayBuffer for stdin [27.13ms]
(pass) spawn with empty > Uint8Array for stdin [25.66ms]
(pass) spawn with empty > Blob for stdin [25.87ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: ArrayBuffer [25.56ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: ArrayBuffer [25.51ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: Uint8Array [25.23ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: Uint8Array [24.65ms]
(pass) empty buffer stdin is not the null device > Bun.spawnSync stdin: Buffer [25.00ms]
(pass) empty buffer stdin is not the null device > Bun.spawn stdin: Buffer [25.10ms]
(pass) empty buffer stdin is not the null device > child_process.s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/spawn/stdio.rs                 | 17 ++++++--
 src/runtime/shell/states/Cmd.rs                    |  4 +-
 src/spawn/static_pipe_writer.rs                    | 28 ++++++++++++
 .../spawn/spawn-empty-arrayBufferOrBlob.test.ts    | 51 ++++++++++++++++++++++
 4 files changed, 96 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/runtime/api/bun/spawn/stdio.rs                           2      3      0
src/runtime/shell/states/Cmd.rs                              1      1      0
src/spawn/static_pipe_writer.rs                              2      2      0
test/js/bun/spawn/spawn-empty-arrayBufferOrBlob.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->