### PR TITLE
console: format Date from internal [[DateValue]], not JSON.stringify

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4314,29 +4314,18 @@ pub mod formatter {
                 failed: false,
                 estimated_line_length: &mut self.estimated_line_length,
             };
-            let mut str = OwnedString::new(BunString::empty());
 
-            value.json_stringify(self.global_this, self.indent, &mut str)?;
-            writer.add_for_new_line(str.length());
             if js_type == jsc::JSType::JSDate {
-                // in the code for printing dates, it never exceeds this amount
-                let mut iso_string_buf = [0u8; 36];
-                let mut out_buf: &[u8] = {
-                    use std::io::Write as _;
-                    let mut cursor = &mut iso_string_buf[..];
-                    let start_len = cursor.len();
-                    let _ = write!(cursor, "{str}");
-                    let written = start_len - cursor.len();
-                    &iso_string_buf[..written]
-                };
+                // Format from the Date's internal [[DateValue]] so that own/overridden
+                // `toJSON`/`toISOString` properties are never invoked (they could throw
+                // out of console.log or spoof the output). `to_iso_string` reads
+                // `DateInstance::internalNumber()` directly; `None` means NaN.
+                let mut iso_string_buf = [0u8; 64];
+                let out_buf: &[u8] = value
+                    .to_iso_string(self.global_this, &mut iso_string_buf)
+                    .unwrap_or(b"Invalid Date");
 
-                if out_buf == b"null" {
-                    out_buf = b"Invalid Date";
-                } else if out_buf.len() > 2 {
-                    // trim the quotes
-                    out_buf = &out_buf[1..out_buf.len() - 1];
-                }
-
+                writer.add_for_new_line(out_buf.len());
                 writer.print(format_args!(
                     "{}{}{}",
                     pfmt!("<r><magenta>", C),
@@ -4348,6 +4337,11 @@ pub mod formatter {
                 }
                 return Ok(());
             }
+
+            let mut str = OwnedString::new(BunString::empty());
+
+            value.json_stringify(self.global_this, self.indent, &mut str)?;
+            writer.add_for_new_line(str.length());
 
             writer.print(format_args!("{str}"));
             if writer.failed {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1862,29 +1862,16 @@ impl<'a> Formatter<'a> {
                     writer.write_all(b"\n");
                 }
                 Tag::JSON => {
-                    let mut str = bun_core::String::empty();
-
-                    value.json_stringify(self.global_this, self.indent, &mut str)?;
-                    self.add_for_new_line(str.length());
                     if js_type == JSType::JSDate {
-                        // in the code for printing dates, it never exceeds this amount
-                        let mut iso_string_buf = [0u8; 36];
-                        let mut out_buf: &[u8] = {
-                            use std::io::Write;
-                            let mut cursor = &mut iso_string_buf[..];
-                            match write!(cursor, "{}", str) {
-                                Ok(()) => {
-                                    let written = 36 - cursor.len();
-                                    &iso_string_buf[..written]
-                                }
-                                Err(_) => b"",
-                            }
-                        };
-                        if out_buf.len() > 2 {
-                            // trim the quotes
-                            out_buf = &out_buf[1..out_buf.len() - 1];
-                        }
+                        // Format from the Date's internal [[DateValue]] so that own/overridden
+                        // `toJSON`/`toISOString` properties are never invoked. `to_iso_string`
+                        // reads `DateInstance::internalNumber()` directly; `None` means NaN.
+                        let mut iso_string_buf = [0u8; 64];
+                        let out_buf: &[u8] = value
+                            .to_iso_string(self.global_this, &mut iso_string_buf)
+                            .unwrap_or(b"Invalid Date");
 
+                        self.add_for_new_line(out_buf.len());
                         writer.print(format_args!(
                             "{}{}{}",
                             pretty_fmt_const::<ENABLE_ANSI_COLORS>("<r><magenta>"),
@@ -1893,6 +1880,11 @@ impl<'a> Formatter<'a> {
                         ));
                         return Ok(());
                     }
+
+                    let mut str = bun_core::String::empty();
+
+                    value.json_stringify(self.global_this, self.indent, &mut str)?;
+                    self.add_for_new_line(str.length());
 
                     writer.print(format_args!("{}", str));
                 }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -490,6 +490,77 @@ it("new Date(..)", () => {
   expect(Bun.inspect(new Date("Invalid Date"))).toBe("Invalid Date");
 });
 
+it("Date ignores own toJSON/toISOString when formatting", () => {
+  // The formatter must read the Date's internal [[DateValue]] and never call
+  // user-provided toJSON/toISOString (which could throw or spoof the output).
+  const iso = "1970-01-01T00:00:00.000Z";
+
+  const a = new Date(0);
+  a.toISOString = () => {
+    throw new Error("iso-boom");
+  };
+  expect(() => Bun.inspect(a)).not.toThrow();
+  expect(Bun.inspect(a)).toBe(iso);
+
+  const b = new Date(0);
+  b.toISOString = 5;
+  expect(() => Bun.inspect(b)).not.toThrow();
+  expect(Bun.inspect(b)).toBe(iso);
+
+  const c = new Date(0);
+  c.toJSON = () => "SPOOFED";
+  expect(Bun.inspect(c)).toBe(iso);
+
+  const d = new Date(0);
+  d.toJSON = () => ({ nested: { fake: 1 } });
+  expect(Bun.inspect(d)).toBe(iso);
+
+  const e = new Date(0);
+  e.toJSON = () => {
+    throw new Error("mid");
+  };
+  expect(() => Bun.inspect(["before", e, "after"])).not.toThrow();
+  expect(Bun.inspect(["before", e, "after"])).toBe(`[ "before", ${iso}, "after" ]`);
+
+  const f = new Date(NaN);
+  f.toJSON = () => "SPOOFED-INVALID";
+  expect(Bun.inspect(f)).toBe("Invalid Date");
+
+  class SubDate extends Date {
+    toJSON() {
+      throw new Error("sub-boom");
+    }
+  }
+  expect(Bun.inspect(new SubDate(0))).toBe(iso);
+});
+
+it("console.log of Date with throwing toJSON does not throw", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const a = new Date(0);
+        a.toISOString = () => { throw new Error("iso-boom"); };
+        console.log(a);
+        const e = new Date(0);
+        e.toJSON = () => { throw new Error("mid"); };
+        console.log(["before", e, "after"]);
+        console.log("DONE");
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.replaceAll("\r\n", "\n")).toBe(
+    `1970-01-01T00:00:00.000Z\n[ "before", 1970-01-01T00:00:00.000Z, "after" ]\nDONE\n`,
+  );
+  expect(exitCode).toBe(0);
+});
+
 it("Bun.inspect.custom exists", () => {
   expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -554,11 +554,11 @@ it("console.log of Date with throwing toJSON does not throw", async () => {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout.replaceAll("\r\n", "\n")).toBe(
-    `1970-01-01T00:00:00.000Z\n[ "before", 1970-01-01T00:00:00.000Z, "after" ]\nDONE\n`,
-  );
-  expect(exitCode).toBe(0);
+  expect({ stdout: stdout.replaceAll("\r\n", "\n"), stderr, exitCode }).toEqual({
+    stdout: `1970-01-01T00:00:00.000Z\n[ "before", 1970-01-01T00:00:00.000Z, "after" ]\nDONE\n`,
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 it("Bun.inspect.custom exists", () => {


### PR DESCRIPTION
## What

`console.log` / `Bun.inspect` formatted `Date` values by calling `JSON.stringify(value)` and trimming the surrounding quotes. `JSON.stringify` dispatches through the value's own `toJSON` → `toISOString`, so any `Date` carrying an own/subclass hook ran user code inside the formatter.

## Repro

```js
const a = new Date(0);
a.toISOString = () => { throw new Error("iso-boom") };
console.log(a);            // bun: throws iso-boom OUT of console.log; node: 1970-01-01T00:00:00.000Z

const c = new Date(0);
c.toJSON = () => "SPOOFED";
console.log(c);            // bun prints: SPOOFED

const d = new Date(0);
d.toJSON = () => ({ nested: { fake: 1 } });
console.log(d);            // bun prints corrupted: "nested":{"fake":1}  (quote-trim slices a non-string)

const e = new Date(0);
e.toJSON = () => { throw new Error("mid") };
console.log(["before", e, "after"]);   // bun: prints `[ "before",` then throws mid-print
```

Node reads the internal date value and never calls user `toJSON`/`toISOString`. Bun's own ported `util.inspect(date)` is also correct; only the native console arm dispatches.

Realistic trigger: any Date carrying an own/subclass `toJSON`/`toISOString` (ORM wrappers, moment-style subclasses, `Object.assign(new Date(), {toJSON})`). Logging it kills the logging call.

## Fix

Switch both formatters (`ConsoleObject.rs` and the test runner's `pretty_format.rs`) to `value.to_iso_string()`, which reads `DateInstance::internalNumber()` via `Bun::toISOString` and never executes JS. `None` (NaN time value) yields `Invalid Date` as before. This also drops the `json_stringify` → fixed-buffer render → quote-trim dance.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t "Date ignores own toJSON"
(fail) Date ignores own toJSON/toISOString when formatting
  error: expect(received).not.toThrow()
  Error message: "iso-boom"

$ bun bd test test/js/bun/util/inspect.test.js -t "Date ignores own toJSON"
(pass) Date ignores own toJSON/toISOString when formatting
(pass) console.log of Date with throwing toJSON does not throw
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (1b04c4f4c)

test/js/bun/util/inspect.test.js:
(pass) prototype [306.22ms]
(pass) getters [5.28ms]
(pass) setters [3.49ms]
(pass) getter/setters [2.12ms]
(pass) Timeout [4.76ms]
(pass) when prototype defines the same property, don't print the same property twice [2.15ms]
(pass) Blob inspect [8.55ms]
(pass) utf16 property name [64.75ms]
(pass) latin1 [4.08ms]
(pass) Request object [2.60ms]
(pass) MessageEvent [1.86ms]
(pass) MessageEvent with no data set [1.79ms]
(pass) MessageEvent with deleted data [2.46ms]
(pass) TypedArray prints [96.64ms]
(pass) BigIntArray [31.49ms]
(pass) Float32Array 42.68000030517578 [4.12ms]
(pass) Float32Array 42.68 [3.93ms]
(pass) Float64Array 42.68000030517578 [1.34ms]
(pass) Float64Array 42.68 [1.53ms]
(pass) jsx with two elements [26.83ms]
(pass) jsx with anon component [2.43ms]
(pass) jsx with fragment [4.39ms]
(pass) inspect [75.03ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [1.79ms]
(pass) latin1 supplemental > latin1 (input) "cbä" 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1b04c4f4c)

test/js/bun/util/inspect.test.js:
(pass) prototype [3.94ms]
(pass) getters [0.10ms]
(pass) setters [0.04ms]
(pass) getter/setters [0.02ms]
(pass) Timeout [0.10ms]
(pass) when prototype defines the same property, don't print the same property twice [0.04ms]
(pass) Blob inspect [0.31ms]
(pass) utf16 property name [1.15ms]
(pass) latin1 [0.05ms]
(pass) Request object [0.05ms]
(pass) MessageEvent [0.03ms]
(pass) MessageEvent with no data set [0.02ms]
(pass) MessageEvent with deleted data [0.03ms]
(pass) TypedArray prints [0.96ms]
(pass) BigIntArray [0.31ms]
(pass) Float32Array 42.68000030517578 [0.07ms]
(pass) Float32Array 42.68 [0.05ms]
(pass) Float64Array 42.68000030517578 [0.03ms]
(pass) Float64Array 42.68
(pass) jsx with two elements [0.57ms]
(pass) jsx with anon component [0.03ms]
(pass) jsx with fragment [0.07ms]
(pass) inspect [0.72ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [0.03ms]
(pass) latin1 supplemental > latin1 (input) "cbä" [ "cbä" ]
(pass) latin1 supplemental > latin1 (input) "cäb" [ "cäb" ]
(pass) latin1 supplemental > latin1 (input) "äbc äbc" [ "äbc äbc" ]
(pass) latin1 supplemental >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (1b04c4f4c)

test/js/bun/util/inspect.test.js:
(pass) prototype [292.28ms]
(pass) getters [5.04ms]
(pass) setters [3.41ms]
(pass) getter/setters [2.06ms]
(pass) Timeout [5.20ms]
(pass) when prototype defines the same property, don't print the same property twice [2.18ms]
(pass) Blob inspect [8.45ms]
(pass) utf16 property name [59.86ms]
(pass) latin1 [3.89ms]
(pass) Request object [2.37ms]
(pass) MessageEvent [1.79ms]
(pass) MessageEvent with no data set [1.95ms]
(pass) MessageEvent with deleted data [2.43ms]
(pass) TypedArray prints [90.46ms]
(pass) BigIntArray [31.82ms]
(pass) Float32Array 42.68000030517578 [4.08ms]
(pass) Float32Array 42.68 [4.07ms]
(pass) Float64Array 42.68000030517578 [1.32ms]
(pass) Float64Array 42.68 [1.49ms]
(pass) jsx with two elements [26.58ms]
(pass) jsx with anon component [2.49ms]
(pass) jsx with fragment [4.37ms]
(pass) inspect [65.36ms]
(pass) latin1 supplemental > latin1 (input) "äbc" [ "äbc" ] [1.59ms]
(pass) latin1 supplemental > latin1 (input) "cbä" 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs                 | 36 +++++++---------
 src/runtime/test_runner/pretty_format.rs | 36 +++++++---------
 test/js/bun/util/inspect.test.js         | 71 ++++++++++++++++++++++++++++++++
 3 files changed, 100 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/jsc/ConsoleObject.rs                      2      2      0
src/runtime/test_runner/pretty_format.rs      1      2      0
test/js/bun/util/inspect.test.js              3      3      0
```

</details>

<!-- robobun:evidence:end -->