### PR TITLE
Bun.inspect: treat {depth: null} as unlimited depth

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4217,9 +4217,9 @@ declare module "bun" {
      */
     colors?: boolean;
     /**
-     * The depth of the inspection
+     * The depth of the inspection. Pass `null` or `Infinity` for unlimited depth.
      */
-    depth?: number;
+    depth?: number | null;
     /**
      * Whether to sort the properties of the object
      */

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1350,7 +1350,7 @@ impl FormatOptions {
         let arg1 = arguments[0];
 
         if arg1.is_object() {
-            if let Some(opt) = arg1.get_truthy(global_this, "depth")? {
+            if let Some(opt) = arg1.get(global_this, b"depth")? {
                 if opt.is_int32() {
                     let arg = opt.to_int32();
                     if arg < 0 {
@@ -1368,6 +1368,8 @@ impl FormatOptions {
                             "expected depth to be an integer, got {v}"
                         )));
                     }
+                } else if opt.is_null() {
+                    self.max_depth = u16::MAX;
                 }
             }
             if let Some(opt) = arg1.get_boolean_loose(global_this, "colors")? {
@@ -1400,6 +1402,8 @@ impl FormatOptions {
                             "expected depth to be an integer, got {v}"
                         )));
                     }
+                } else if depth_arg.is_null() {
+                    self.max_depth = u16::MAX;
                 }
                 if arguments.len() > 1 && !arguments[1].is_empty_or_undefined_or_null() {
                     self.enable_colors = arguments[1].to_boolean();

--- a/test/integration/bun-types/fixture/index.ts
+++ b/test/integration/bun-types/fixture/index.ts
@@ -327,6 +327,8 @@ Response.redirect("bun.sh", {
 
 Bun.inspect.custom;
 Bun.inspect;
+Bun.inspect({}, { depth: null });
+Bun.inspect({}, { depth: Infinity });
 
 fetch.preconnect("bun.sh");
 Bun.fetch.preconnect("bun.sh");

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -24,6 +24,34 @@ it("prototype", () => {
   Bun.gc(true);
 });
 
+describe("options.depth", () => {
+  const deep = (() => {
+    let o = { x: 1 };
+    for (let i = 0; i < 15; i++) o = { o };
+    return o;
+  })();
+  const unlimited = Bun.inspect(deep, { depth: Infinity });
+
+  it("null means unlimited", () => {
+    expect(Bun.inspect(deep, { depth: null })).toBe(unlimited);
+    expect(Bun.inspect(deep, { depth: null })).not.toContain("[Object ...]");
+  });
+
+  it("Infinity means unlimited", () => {
+    expect(unlimited).not.toContain("[Object ...]");
+    expect(unlimited).toContain("x: 1");
+  });
+
+  it("undefined keeps the default", () => {
+    expect(Bun.inspect(deep, { depth: undefined })).toBe(Bun.inspect(deep));
+    expect(Bun.inspect(deep, { depth: undefined })).toContain("[Object ...]");
+  });
+
+  it("positional null means unlimited", () => {
+    expect(Bun.inspect(deep, null)).toBe(unlimited);
+  });
+});
+
 it("getters", () => {
   const obj = {
     get foo() {


### PR DESCRIPTION
## What

`Bun.inspect(x, {depth: null})` truncated at the default depth of 8 instead of recursing without limit. Node's `util.inspect` [documents](https://nodejs.org/api/util.html#utilinspectobject-options) `depth: null` as unlimited, and Bun's ported `util.inspect` already honors it, so this only affected the native `Bun.inspect` path.

```js
let o = {x: 1}; for (let i = 0; i < 15; i++) o = {o};
Bun.inspect(o, {depth: null})      // before: truncates at depth 8 -> [Object ...]
Bun.inspect(o, {depth: Infinity})  // prints all 15 levels
util.inspect(o, {depth: null})     // prints all 15 levels
```

## Cause

`FormatOptions::from_js` in `src/jsc/ConsoleObject.rs` read `depth` via `arg1.get_truthy(global_this, "depth")`, which filters out `null`, so the option was silently dropped and `max_depth` stayed at the caller's default. The `console.dir` option parser a few hundred lines up already used `get()` and branched on `is_null()` correctly.

## Fix

Read `depth` with `get()` and add an `is_null()` arm that sets `max_depth = u16::MAX`, matching `Infinity` and the existing `console.dir` handling. The positional `Bun.inspect(x, null)` form gets the same treatment for consistency. `undefined` still means "keep the default". `BunInspectOptions.depth` in the `.d.ts` now accepts `number | null`.

## Verification

New `options.depth` block in `test/js/bun/util/inspect.test.js` covering `null`, `Infinity`, `undefined`, and the positional form. Fails on main (`null` truncates), passes with the fix.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (edd6b5613)

test/js/bun/util/inspect.test.js:
(pass) prototype [317.59ms]
31 |     return o;
32 |   })();
33 |   const unlimited = Bun.inspect(deep, { depth: Infinity });
34 | 
35 |   it("null means unlimited", () => {
36 |     expect(Bun.inspect(deep, { depth: null })).toBe(unlimited);
                                                    ^
error: expect(received).toBe(expected)

  "{
    o: {
      o: {
        o: {
          o: {
            o: {
              o: {
                o: {
                  o: {
-                   o: {
-                     o: {
-                       o: {
-                         o: {
-                           o: {
-                             o: {
-                               o: {
-                                 x: 1,
-                               },
-                             },
-                           },
-                         },
-                       },
-                     },
-                   },
+                   o: [Ob
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/inspect.test.js:
(pass) prototype [4.46ms]
31 |     return o;
32 |   })();
33 |   const unlimited = Bun.inspect(deep, { depth: Infinity });
34 | 
35 |   it("null means unlimited", () => {
36 |     expect(Bun.inspect(deep, { depth: null })).toBe(unlimited);
                                                    ^
error: expect(received).toBe(expected)

  "{
    o: {
      o: {
        o: {
          o: {
            o: {
              o: {
                o: {
                  o: {
-                   o: {
-                     o: {
-                       o: {
-                         o: {
-                           o: {
-                             o: {
-                               o: {
-                                 x: 1,
-                               },
-                             },
-                           },
-                         },
-                       },
-                     },
-                   },
+                   o: [Object ...],
                  },
                },
              },
            },
          },
        },
      },
    },
  }"

- Expected  - 15
+ Received  +
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect.test.js
bun test v1.4.0 (edd6b5613)

test/js/bun/util/inspect.test.js:
(pass) prototype [285.49ms]
(pass) options.depth > null means unlimited [6.47ms]
(pass) options.depth > Infinity means unlimited [1.58ms]
(pass) options.depth > undefined keeps the default [5.38ms]
(pass) options.depth > positional null means unlimited [2.77ms]
(pass) getters [4.18ms]
(pass) setters [3.34ms]
(pass) getter/setters [1.98ms]
(pass) Timeout [4.52ms]
(pass) when prototype defines the same property, don't print the same property twice [2.31ms]
(pass) Blob inspect [8.23ms]
(pass) utf16 property name [58.96ms]
(pass) latin1 [3.74ms]
(pass) Request object [2.41ms]
(pass) MessageEvent [2.00ms]
(pass) MessageEvent with no data set [1.46ms]
(pass) MessageEvent with deleted data [2.56ms]
(pass) TypedArray prints [89.98ms]
(pass) BigIntArray [31.69ms]
(pass) Float32Array 42.68000030517578 [4.07ms]
(pass) Float32Array 42.68 [3.77ms]
(pass) Float64Array 42.68000030517578 [1.34ms]
(pass) Float64Array 42.68 [1.25ms]
(pass) jsx with two elemen
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 698ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts                 |  4 ++--
 src/jsc/ConsoleObject.rs                    |  6 +++++-
 test/integration/bun-types/fixture/index.ts |  2 ++
 test/js/bun/util/inspect.test.js            | 28 ++++++++++++++++++++++++++++
 4 files changed, 37 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
packages/bun-types/bun.d.ts                      1      1      0
src/jsc/ConsoleObject.rs                         1      2      0
test/integration/bun-types/fixture/index.ts      1      1      0
test/js/bun/util/inspect.test.js                 1      2      0
```

</details>

<!-- robobun:evidence:end -->