### PR TITLE
Date.parse: accept Unicode whitespace (NBSP, Zs, BOM) like V8

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -8,7 +8,9 @@
 // importing), every x64 at the nehalem floor (no separate -baseline variant),
 // typed-array constructor ClassInfo kept address-unique under LTO, and the
 // Windows ICU data table filtered + per-item zstd compressed.
-export const WEBKIT_VERSION = "c9296e353e365ecf0de82f273bb0a88a3df465be";
+// Preview build of https://github.com/oven-sh/WebKit/pull/324 (Date.parse
+// Unicode whitespace). Replace with the main-branch sha once that PR lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-324-c0a3ca4d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/date-parse.test.ts
+++ b/test/js/bun/jsc/date-parse.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+
+// V8's date parser treats every ECMAScript WhiteSpace code point as a token
+// separator. Bun's port of that parser scans UTF-8 bytes, so non-ASCII
+// whitespace (NBSP from HTML &nbsp;, the en/em spaces copy-paste carries, BOM,
+// ideographic space) used to fall through as "word" bytes and produce NaN
+// where Node returns the instant.
+
+const hex = (cp: number) => "U+" + cp.toString(16).toUpperCase().padStart(4, "0");
+
+// ECMAScript WhiteSpace (https://tc39.es/ecma262/#sec-white-space): TAB, VT,
+// FF, SP, NBSP, BOM, and every Unicode Zs character. These are exactly the
+// code points V8's IsWhiteSpace() (src/strings/char-predicates.h) recognizes
+// in the date parser's IsWhiteSpaceChar().
+const whiteSpace: ReadonlyArray<[string, number]> = (
+  [
+    [0x0009, "TAB"],
+    [0x000b, "VT"],
+    [0x000c, "FF"],
+    [0x0020, "SPACE"],
+    [0x00a0, "NO-BREAK SPACE"],
+    [0x1680, "OGHAM SPACE MARK"],
+    [0x2000, "EN QUAD"],
+    [0x2001, "EM QUAD"],
+    [0x2002, "EN SPACE"],
+    [0x2003, "EM SPACE"],
+    [0x2004, "THREE-PER-EM SPACE"],
+    [0x2005, "FOUR-PER-EM SPACE"],
+    [0x2006, "SIX-PER-EM SPACE"],
+    [0x2007, "FIGURE SPACE"],
+    [0x2008, "PUNCTUATION SPACE"],
+    [0x2009, "THIN SPACE"],
+    [0x200a, "HAIR SPACE"],
+    [0x202f, "NARROW NO-BREAK SPACE"],
+    [0x205f, "MEDIUM MATHEMATICAL SPACE"],
+    [0x3000, "IDEOGRAPHIC SPACE"],
+    [0xfeff, "BYTE ORDER MARK"],
+  ] as const
+).map(([cp, name]) => [`${hex(cp)} ${name}`, cp]);
+
+// Code points V8's date parser does NOT accept as whitespace. Verified against
+// Node v26.3.0: each of these makes Date.parse return NaN.
+const notWhiteSpace: ReadonlyArray<[string, number]> = (
+  [
+    [0x0085, "NEXT LINE"],
+    [0x00ad, "SOFT HYPHEN"],
+    [0x180e, "MONGOLIAN VOWEL SEPARATOR"],
+    [0x200b, "ZERO WIDTH SPACE"],
+    [0x200c, "ZERO WIDTH NON-JOINER"],
+    [0x200d, "ZERO WIDTH JOINER"],
+    [0x2028, "LINE SEPARATOR"],
+    [0x2029, "PARAGRAPH SEPARATOR"],
+    [0x2060, "WORD JOINER"],
+  ] as const
+).map(([cp, name]) => [`${hex(cp)} ${name}`, cp]);
+
+const base = "Jul 23 2026 10:00:00 GMT+0000";
+const baseTime = Date.UTC(2026, 6, 23, 10, 0, 0);
+
+test("sanity: base string parses", () => {
+  expect(Date.parse(base)).toBe(baseTime);
+});
+
+describe.each(whiteSpace)("Date.parse accepts %s as whitespace", (_label, cp) => {
+  const ch = String.fromCodePoint(cp);
+
+  test("trailing", () => {
+    expect(Date.parse(base + ch)).toBe(baseTime);
+  });
+  test("leading", () => {
+    expect(Date.parse(ch + base)).toBe(baseTime);
+  });
+  test("between date and time", () => {
+    expect(Date.parse("Jul 23 2026" + ch + "10:00:00 GMT+0000")).toBe(baseTime);
+  });
+  test("between GMT and offset", () => {
+    expect(Date.parse("Jul 23 2026 10:00:00 GMT" + ch + "+0000")).toBe(baseTime);
+  });
+  test("new Date(str)", () => {
+    expect(new Date(ch + base + ch).getTime()).toBe(baseTime);
+  });
+});
+
+describe.each(notWhiteSpace)("Date.parse rejects %s", (_label, cp) => {
+  const ch = String.fromCodePoint(cp);
+
+  test("trailing", () => {
+    expect(Date.parse(base + ch)).toBeNaN();
+  });
+  test("leading", () => {
+    expect(Date.parse(ch + base)).toBeNaN();
+  });
+  test("between date and time", () => {
+    expect(Date.parse("Jul 23 2026" + ch + "10:00:00 GMT+0000")).toBeNaN();
+  });
+});
+
+describe("Date.parse with NBSP (real-world shapes)", () => {
+  const NBSP = "\u00a0";
+
+  test("every separator is NBSP", () => {
+    expect(Date.parse(`Jul${NBSP}23${NBSP}2026${NBSP}10:00:00${NBSP}GMT+0000`)).toBe(baseTime);
+  });
+
+  test("toLocaleString-style with NBSP before AM", () => {
+    const s = `7/23/2026, 10:00:00${NBSP}AM`;
+    expect(Date.parse(s)).not.toBeNaN();
+    expect(Date.parse(s)).toBe(Date.parse(`7/23/2026, 10:00:00 AM`));
+  });
+
+  test("ISO date with trailing NBSP", () => {
+    expect(Date.parse(`2026-07-23${NBSP}`)).toBe(Date.parse(`2026-07-23 `));
+  });
+
+  test("ISO date with trailing ideographic space", () => {
+    expect(Date.parse(`2026-07-23\u3000`)).toBe(Date.parse(`2026-07-23 `));
+  });
+
+  test("Latin-1 string (NBSP is the only non-ASCII byte)", () => {
+    expect(Date.parse(`Jul 23 2026${NBSP}10:00:00 GMT+0000`)).toBe(baseTime);
+  });
+});
+
+describe("Date.parse ASCII whitespace and line terminators", () => {
+  // CR and LF are LineTerminator, not WhiteSpace, but V8's legacy parser
+  // accepts them via SkipWhiteSpace().
+  for (const [cp, name] of [
+    [0x000a, "LF"],
+    [0x000d, "CR"],
+  ] as const) {
+    const ch = String.fromCodePoint(cp);
+    test(`accepts ${name} as separator`, () => {
+      expect(Date.parse("Jul 23 2026" + ch + "10:00:00 GMT+0000")).toBe(baseTime);
+      expect(Date.parse(ch + base)).toBe(baseTime);
+      expect(Date.parse(base + ch)).toBe(baseTime);
+    });
+  }
+});
+
+test("Date.parse caching: same string with Unicode whitespace returns same value", () => {
+  const s = `\u2009Jul 23 2026 10:00:00 GMT+0000\u00a0`;
+  const first = Date.parse(s);
+  expect(first).toBe(baseTime);
+  expect(Date.parse(s)).toBe(first);
+});


### PR DESCRIPTION
### What does this PR do?

`Date.parse` / `new Date(str)` return `NaN` for date strings that carry a non-ASCII Unicode space, where Node/V8 return the instant. The common real-world shape is U+00A0 NO-BREAK SPACE (HTML `&nbsp;`, fr/ru locale CSV exports, text copy-pasted from a browser), but every ECMAScript `WhiteSpace` code point except the ASCII ones and U+202F is affected:

```js
Date.parse("Jul\u00a023\u00a02026\u00a010:00:00\u00a0GMT+0000");
Date.parse("7/23/2026, 10:00:00\u00a0AM");
Date.parse("2026-07-23\u3000");
// Node v26.3.0: 1784800800000 / <local 10:00> / 1784764800000
// Bun 1.4.0:    NaN / NaN / NaN
```

#### Cause

V8's date parser reads UTF-16 code units and its `IsWhiteSpaceChar()` recognises the full ECMAScript `WhiteSpace` production (all Unicode Zs plus TAB/VT/FF/SP/NBSP/BOM). Bun's port of that parser in `JSDateMath-v8.cpp` is fed the UTF-8 encoding one byte at a time and only tests `isASCIIWhitespace`, so U+00A0 arrives as `0xC2 0xA0`, the `IsAsciiAlphaOrAbove()` check matches, and `ReadWord` swallows it as a keyword byte. `DateCache::parseDate` already special-cased U+202F NARROW NO-BREAK SPACE (for ICU 72 `toLocaleString` output) but nothing else.

#### Fix

The parser lives in JavaScriptCore, so the code change is in [oven-sh/WebKit#324](https://github.com/oven-sh/WebKit/pull/324): `DateCache::parseDate` now folds every ECMAScript `WhiteSpace` code point into an ASCII space before encoding to UTF-8, generalising the existing `narrowNoBreakSpace` replacement. `Lexer<char16_t>::isWhiteSpace` covers exactly the same set V8's `IsWhiteSpace` does. `LineTerminator` code points (U+2028/U+2029) are left alone so they keep rejecting, matching V8. All-ASCII input (the common case) takes the fast path and keeps the string as-is.

This PR bumps `WEBKIT_VERSION` to the preview build of that change and adds `test/js/bun/jsc/date-parse.test.ts`.

#### Verification

- Compiled `JSDateMath.cpp.o` against the current prebuilt's headers and swapped it into `libJavaScriptCore.a`: `test/js/bun/jsc/date-parse.test.ts` goes from 55/141 pass → 141/141 pass.
- Every assertion in the test (21 `WhiteSpace` code points × 5 positions, 9 look-alike code points × 3 positions, the NBSP real-world shapes, LF/CR) was checked against Node v26.3.0 and matches exactly.
- Fail-before: `USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/date-parse.test.ts` → 86 fail.

#### Notes for the reviewer

- `WEBKIT_VERSION` is currently set to the preview tag `autobuild-preview-pr-324-c0a3ca4d`. Once [oven-sh/WebKit#324](https://github.com/oven-sh/WebKit/pull/324) is merged I will replace it with the main-branch sha.
- The preview build is branched from WebKit `main` (af2e8dc639), so it also pulls in [#320](https://github.com/oven-sh/WebKit/pull/320), [#321](https://github.com/oven-sh/WebKit/pull/321) and [#322](https://github.com/oven-sh/WebKit/pull/322) relative to the currently pinned `c9296e353e`.
