### PR TITLE
util.inspect: install [nodejs.util.inspect.custom] on web-platform prototypes

### DIFF
--- a/src/codegen/class-definitions.ts
+++ b/src/codegen/class-definitions.ts
@@ -247,7 +247,16 @@ export class ClassDefinition {
   configurable?: boolean;
   enumerable?: boolean;
   structuredClone?: { transferable: boolean; tag: number; storable: boolean };
-  inspectCustom?: boolean;
+  /**
+   * Installs `[Symbol.for("nodejs.util.inspect.custom")]` on the prototype.
+   * - `true`: implementer must provide `inspectCustom(depth, options, inspect)` in Rust.
+   * - `string[]`: generated C++ reads each named getter from `this` and renders
+   *   `ClassName { prop: value, ... }` via `util.inspect`; no Rust required.
+   * - `{ extern }`: install the named `JSC_DEFINE_HOST_FUNCTION` (declared in
+   *   hand-written C++) as the symbol method; codegen emits only the extern
+   *   declaration and the `putDirect` call.
+   */
+  inspectCustom?: boolean | string[] | { extern: string };
 
   callbacks?: Record<string, string>;
 
@@ -295,7 +304,7 @@ export function define(
     ...rest
   } = {} as Partial<ClassDefinition>,
 ): ClassDefinition {
-  if (inspectCustom) {
+  if (inspectCustom === true) {
     proto.inspectCustom = {
       fn: "inspectCustom",
       length: 2,
@@ -304,6 +313,7 @@ export function define(
     };
   }
   return new ClassDefinition({
+    inspectCustom,
     ...rest,
     call,
     overridesToJS,

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -392,6 +392,9 @@ function generatePrototype(typeName, obj) {
   if (Array.isArray(obj.inspectCustom)) {
     const fnName = `${prototypeName(typeName)}__inspectCustom`;
     const props = obj.inspectCustom as string[];
+    if (props.length === 0) {
+      throw new Error(`${typeName}: inspectCustom must name at least one getter`);
+    }
     inspectCustomImpl = `
 JSC_DEFINE_HOST_FUNCTION(${fnName}, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -399,8 +399,10 @@ function generatePrototype(typeName, obj) {
 JSC_DEFINE_HOST_FUNCTION(${fnName}, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     JSC::JSValue thisValue = callFrame->thisValue();
-    if (!thisValue.inherits<${className(typeName)}>()) [[unlikely]]
-        return JSC::JSValue::encode(thisValue);
+    if (!thisValue.inherits<${className(typeName)}>()) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(JSC::getVM(lexicalGlobalObject));
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "${typeName}"_s);
+    }
     static constexpr ASCIILiteral props[] = { ${props.map(p => `${JSON.stringify(p)}_s`).join(", ")} };
     return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "${typeName}"_s, props, ${props.length});
 }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -385,8 +385,33 @@ function generatePrototype(typeName, obj) {
   const proto = prototypeName(typeName);
   const { proto: protoFields } = obj;
   var specialSymbols = "";
+  var inspectCustomImpl = "";
 
   var staticPrototypeValues = "";
+
+  if (Array.isArray(obj.inspectCustom)) {
+    const fnName = `${prototypeName(typeName)}__inspectCustom`;
+    const props = obj.inspectCustom as string[];
+    inspectCustomImpl = `
+JSC_DEFINE_HOST_FUNCTION(${fnName}, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    JSC::JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.inherits<${className(typeName)}>()) [[unlikely]]
+        return JSC::JSValue::encode(thisValue);
+    static constexpr ASCIILiteral props[] = { ${props.map(p => `${JSON.stringify(p)}_s`).join(", ")} };
+    return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "${typeName}"_s, props, ${props.length});
+}
+`;
+    specialSymbols += `
+    this->putDirect(vm, WebCore::clientData(vm)->builtinNames().inspectCustomPublicName(), JSFunction::create(vm, globalObject, 2, String("[nodejs.util.inspect.custom]"_s), ${fnName}, ImplementationVisibility::Public), PropertyAttribute::DontEnum | 0);`;
+  } else if (obj.inspectCustom && typeof obj.inspectCustom === "object" && "extern" in obj.inspectCustom) {
+    const fnName = obj.inspectCustom.extern;
+    externs += `
+JSC_DECLARE_HOST_FUNCTION(${fnName});
+`;
+    specialSymbols += `
+    this->putDirect(vm, WebCore::clientData(vm)->builtinNames().inspectCustomPublicName(), JSFunction::create(vm, globalObject, 2, String("[nodejs.util.inspect.custom]"_s), ${fnName}, ImplementationVisibility::Public), PropertyAttribute::DontEnum | 0);`;
+  }
 
   if (obj.construct) {
     if (obj.constructNeedsThis) {
@@ -497,7 +522,7 @@ ${generateHashTable(
 const ClassInfo ${proto}::s_info = { "${typeName}"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(${proto}) };
 
 ${renderFieldsImpl(protoSymbolName, typeName, obj, protoFields, obj.values || [])}
-
+${inspectCustomImpl}
 void ${proto}::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
@@ -2685,6 +2710,7 @@ const GENERATED_CLASSES_IMPL_HEADER_PRE = `
 #include "WebCoreJSBuiltins.h"
 #include "ErrorCode+List.h"
 #include "ErrorCode.h"
+#include "streams/WebStreamsInspectCustom.h"
 #include <JavaScriptCore/HeapAnalyzer.h>
 
 #if !OS(WINDOWS)

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2232,6 +2232,20 @@ pub mod formatter {
                 });
             }
 
+            // DOMWrapper types (Response, Blob, Headers, ReadableStream, ...)
+            // route to `print_private` first so the native runtime formatter
+            // gets right of first refusal; `print_private` itself consults
+            // `[nodejs.util.inspect.custom]` when the hook declines. Web
+            // platform classes carrying that symbol for `util.inspect` would
+            // otherwise short-circuit here and lose Bun's richer console
+            // rendering (e.g. `Response (N bytes)`).
+            if js_type == jsc::JSType::DOMWrapper {
+                return Ok(TagResult {
+                    tag: TagPayload::Private,
+                    cell: js_type,
+                });
+            }
+
             if js_type.can_get()
                 && js_type != jsc::JSType::ProxyObject
                 && !opts.contains(TagOptions::DISABLE_INSPECT_CUSTOM)
@@ -2255,13 +2269,6 @@ pub mod formatter {
                     }
                     _ => {}
                 }
-            }
-
-            if js_type == jsc::JSType::DOMWrapper {
-                return Ok(TagResult {
-                    tag: TagPayload::Private,
-                    cell: js_type,
-                });
             }
 
             // If we check an Object has a method table and it does not it will crash
@@ -4659,6 +4666,24 @@ pub mod formatter {
                     (hooks.console_print_runtime_object)(self, writer_, value, &NAME_BUF, C)?;
                 if handled {
                     return Ok(());
+                }
+            }
+
+            // The runtime hook declined. `get_tag` sends DOMWrapper values here
+            // unconditionally so the hook above retains priority; any
+            // `[nodejs.util.inspect.custom]` the value carries is consulted now,
+            // covering ReadableStream / AbortSignal / CryptoKey / etc.
+            if !self.disable_inspect_custom {
+                if let Ok(Some(callback)) =
+                    value.fast_get(self.global_this, jsc::BuiltinName::InspectCustom)
+                {
+                    if callback.is_callable() {
+                        self.custom_formatted_object = CustomFormattedObject {
+                            function: callback,
+                            this: value,
+                        };
+                        return self.print_custom_formatted_object::<C>(writer_);
+                    }
                 }
             }
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2174,6 +2174,23 @@ pub mod formatter {
             Self::get_advanced(value, global_this, TagOptions::empty())
         }
 
+        /// `Object.getOwnPropertyDescriptor(value, "constructor")?.value?.prototype === value`,
+        /// the same gate `util.inspect` uses so a class's prototype object is
+        /// rendered as a plain object instead of being fed to its own
+        /// brand-checked `[nodejs.util.inspect.custom]`.
+        fn is_constructor_prototype(value: JSValue, global_this: &JSGlobalObject) -> JsResult<bool> {
+            let Some(constructor) = value.get_own_truthy(global_this, "constructor")? else {
+                return Ok(false);
+            };
+            if !constructor.is_cell() {
+                return Ok(false);
+            }
+            let Some(prototype) = constructor.get(global_this, "prototype")? else {
+                return Ok(false);
+            };
+            Ok(prototype == value)
+        }
+
         pub fn get_advanced(
             value: JSValue,
             global_this: &JSGlobalObject,
@@ -2258,7 +2275,10 @@ pub mod formatter {
                             ..Default::default()
                         });
                     }
-                    Ok(Some(callback_value)) if callback_value.is_callable() => {
+                    Ok(Some(callback_value))
+                        if callback_value.is_callable()
+                            && !Tag::is_constructor_prototype(value, global_this)? =>
+                    {
                         return Ok(TagResult {
                             tag: TagPayload::CustomFormattedObject(CustomFormattedObject {
                                 function: callback_value,
@@ -3928,12 +3948,23 @@ pub mod formatter {
                 // A custom inspector that returns its own `this` would recurse
                 // forever; re-tag without the custom hook so it falls through to
                 // default formatting (mirrors util.inspect's `ret !== context`).
-                let tag = if result == self.custom_formatted_object.this {
-                    Tag::get_advanced(result, self.global_this, TagOptions::DISABLE_INSPECT_CUSTOM)?
+                // `print_private` consults `self.disable_inspect_custom` rather
+                // than the tag option, so the suppression has to flow through
+                // the formatter field as well.
+                if result == self.custom_formatted_object.this {
+                    let prev = self.disable_inspect_custom;
+                    self.disable_inspect_custom = true;
+                    let _restore = defer_restore!(self.disable_inspect_custom, prev);
+                    let tag = Tag::get_advanced(
+                        result,
+                        self.global_this,
+                        TagOptions::DISABLE_INSPECT_CUSTOM,
+                    )?;
+                    self.format::<C>(tag, writer_, result, self.global_this)?;
                 } else {
-                    Tag::get(result, self.global_this)?
-                };
-                self.format::<C>(tag, writer_, result, self.global_this)?;
+                    let tag = Tag::get(result, self.global_this)?;
+                    self.format::<C>(tag, writer_, result, self.global_this)?;
+                }
             }
             Ok(())
         }
@@ -4677,7 +4708,9 @@ pub mod formatter {
                 if let Some(callback) =
                     value.fast_get(self.global_this, jsc::BuiltinName::InspectCustom)?
                 {
-                    if callback.is_callable() {
+                    if callback.is_callable()
+                        && !Tag::is_constructor_prototype(value, self.global_this)?
+                    {
                         self.custom_formatted_object = CustomFormattedObject {
                             function: callback,
                             this: value,

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4703,6 +4703,24 @@ pub mod formatter {
                 }
             }
 
+            // `DOMFormData` is a C++-backed WebCore type — no `JsClass` derive,
+            // so use its dedicated `from_js` FFI downcast instead of `value.as_`.
+            // Ordered before the generic custom-inspect probe so Bun's native
+            // `toJSON`-driven rendering keeps priority (same as the runtime hook
+            // does for Response/Headers above).
+            if crate::DOMFormData::from_js(value).is_some() {
+                if let Some(to_json_function) = value.get(self.global_this, "toJSON")? {
+                    let prev_quote_keys = self.quote_keys;
+                    self.quote_keys = true;
+                    let _r = defer_restore!(self.quote_keys, prev_quote_keys);
+
+                    let result = to_json_function
+                        .call(self.global_this, value, &[])
+                        .unwrap_or_else(|err| self.global_this.take_exception(err));
+                    return self.print_as::<C>(Tag::Object, writer_, result, jsc::JSType::Object);
+                }
+            }
+
             // The runtime hook declined. `get_tag` sends DOMWrapper values here
             // unconditionally so the hook above retains priority; any
             // `[nodejs.util.inspect.custom]` the value carries is consulted now,
@@ -4723,28 +4741,7 @@ pub mod formatter {
                 }
             }
 
-            // `DOMFormData` is a C++-backed WebCore type — no `JsClass` derive,
-            // so use its dedicated `from_js` FFI downcast instead of `value.as_`.
-            if crate::DOMFormData::from_js(value).is_some() {
-                if let Some(to_json_function) = value.get(self.global_this, "toJSON")? {
-                    let prev_quote_keys = self.quote_keys;
-                    self.quote_keys = true;
-                    let _r = defer_restore!(self.quote_keys, prev_quote_keys);
-
-                    let result = to_json_function
-                        .call(self.global_this, value, &[])
-                        .unwrap_or_else(|err| self.global_this.take_exception(err));
-                    return self.print_as::<C>(Tag::Object, writer_, result, jsc::JSType::Object);
-                }
-
-                // this case should never happen
-                return self.print_as::<C>(
-                    Tag::Undefined,
-                    writer_,
-                    JSValue::UNDEFINED,
-                    jsc::JSType::Cell,
-                );
-            } else if js_type != jsc::JSType::DOMWrapper {
+            if js_type != jsc::JSType::DOMWrapper {
                 if *remove_before_recurse {
                     *remove_before_recurse = false;
                     let _ = self.map.remove(&value);

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3951,23 +3951,16 @@ pub mod formatter {
                 // A custom inspector that returns its own `this` would recurse
                 // forever; re-tag without the custom hook so it falls through to
                 // default formatting (mirrors util.inspect's `ret !== context`).
-                // `print_private` consults `self.disable_inspect_custom` rather
-                // than the tag option, so the suppression has to flow through
-                // the formatter field as well.
-                if result == self.custom_formatted_object.this {
-                    let prev = self.disable_inspect_custom;
-                    self.disable_inspect_custom = true;
-                    let _restore = defer_restore!(self.disable_inspect_custom, prev);
-                    let tag = Tag::get_advanced(
-                        result,
-                        self.global_this,
-                        TagOptions::DISABLE_INSPECT_CUSTOM,
-                    )?;
-                    self.format::<C>(tag, writer_, result, self.global_this)?;
+                // `print_private`'s own probe compares against
+                // `custom_formatted_object.this` for the same reason; leaving
+                // it set to `result` here is what suppresses re-entry there
+                // without blanket-disabling custom inspect for nested values.
+                let tag = if result == self.custom_formatted_object.this {
+                    Tag::get_advanced(result, self.global_this, TagOptions::DISABLE_INSPECT_CUSTOM)?
                 } else {
-                    let tag = Tag::get(result, self.global_this)?;
-                    self.format::<C>(tag, writer_, result, self.global_this)?;
-                }
+                    Tag::get(result, self.global_this)?
+                };
+                self.format::<C>(tag, writer_, result, self.global_this)?;
             }
             Ok(())
         }
@@ -4725,7 +4718,12 @@ pub mod formatter {
             // unconditionally so the hook above retains priority; any
             // `[nodejs.util.inspect.custom]` the value carries is consulted now,
             // covering ReadableStream / AbortSignal / CryptoKey / etc.
-            if !self.disable_inspect_custom {
+            // Re-entry on the exact value a custom inspector just returned (the
+            // `ret === this` opt-out) is suppressed by comparing against
+            // `custom_formatted_object.this`, which `print_custom_formatted_object`
+            // leaves pointing at that value; this keeps custom inspect active
+            // for *nested* values of the same format pass.
+            if !self.disable_inspect_custom && value != self.custom_formatted_object.this {
                 if let Some(callback) =
                     value.fast_get(self.global_this, jsc::BuiltinName::InspectCustom)?
                 {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2178,7 +2178,10 @@ pub mod formatter {
         /// the same gate `util.inspect` uses so a class's prototype object is
         /// rendered as a plain object instead of being fed to its own
         /// brand-checked `[nodejs.util.inspect.custom]`.
-        fn is_constructor_prototype(value: JSValue, global_this: &JSGlobalObject) -> JsResult<bool> {
+        fn is_constructor_prototype(
+            value: JSValue,
+            global_this: &JSGlobalObject,
+        ) -> JsResult<bool> {
             let Some(constructor) = value.get_own_truthy(global_this, "constructor")? else {
                 return Ok(false);
             };

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4674,8 +4674,8 @@ pub mod formatter {
             // `[nodejs.util.inspect.custom]` the value carries is consulted now,
             // covering ReadableStream / AbortSignal / CryptoKey / etc.
             if !self.disable_inspect_custom {
-                if let Ok(Some(callback)) =
-                    value.fast_get(self.global_this, jsc::BuiltinName::InspectCustom)
+                if let Some(callback) =
+                    value.fast_get(self.global_this, jsc::BuiltinName::InspectCustom)?
                 {
                     if callback.is_callable() {
                         self.custom_formatted_object = CustomFormattedObject {

--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -5,6 +5,7 @@
 #include <JavaScriptCore/FunctionPrototype.h>
 #include "JSDOMFile.h"
 #include "streams/WebStreamsInspectCustom.h"
+#include "ErrorCode.h"
 
 using namespace JSC;
 
@@ -17,8 +18,10 @@ extern "C" SYSV_ABI bool JSDOMFile__hasInstance(EncodedJSValue, JSC::JSGlobalObj
 JSC_DEFINE_HOST_FUNCTION(JSBlob__inspectCustom, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     JSC::JSValue thisValue = callFrame->thisValue();
-    if (!thisValue.inherits<WebCore::JSBlob>()) [[unlikely]]
-        return JSC::JSValue::encode(thisValue);
+    if (!thisValue.inherits<WebCore::JSBlob>()) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(JSC::getVM(lexicalGlobalObject));
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "Blob"_s);
+    }
 
     if (JSDOMFile__hasInstance(JSValue::encode(jsUndefined()), lexicalGlobalObject, JSValue::encode(thisValue))) {
         static constexpr ASCIILiteral props[] = { "size"_s, "type"_s, "name"_s, "lastModified"_s };

--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -4,11 +4,29 @@
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include "JSDOMFile.h"
+#include "streams/WebStreamsInspectCustom.h"
 
 using namespace JSC;
 
 extern "C" SYSV_ABI void* JSDOMFile__construct(JSC::JSGlobalObject*, JSC::CallFrame* callframe);
 extern "C" SYSV_ABI bool JSDOMFile__hasInstance(EncodedJSValue, JSC::JSGlobalObject*, EncodedJSValue);
+
+// File and Blob share Blob's prototype, so this lives here rather than in
+// generated code. Branches on the Rust-side `is_file` flag (via the same
+// host hook `File[Symbol.hasInstance]` uses) to decide which shape to print.
+JSC_DEFINE_HOST_FUNCTION(JSBlob__inspectCustom, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    JSC::JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.inherits<WebCore::JSBlob>()) [[unlikely]]
+        return JSC::JSValue::encode(thisValue);
+
+    if (JSDOMFile__hasInstance(JSValue::encode(jsUndefined()), lexicalGlobalObject, JSValue::encode(thisValue))) {
+        static constexpr ASCIILiteral props[] = { "size"_s, "type"_s, "name"_s, "lastModified"_s };
+        return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "File"_s, props, std::size(props));
+    }
+    static constexpr ASCIILiteral props[] = { "size"_s, "type"_s };
+    return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "Blob"_s, props, std::size(props));
+}
 
 // TODO: make this inehrit from JSBlob instead of InternalFunction
 // That will let us remove this hack for [Symbol.hasInstance] and fix the prototype chain.

--- a/src/jsc/bindings/webcore/JSAbortController.cpp
+++ b/src/jsc/bindings/webcore/JSAbortController.cpp
@@ -49,6 +49,7 @@
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include "streams/WebStreamsInspectCustom.h"
+#include "ErrorCode.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -149,8 +150,10 @@ const ClassInfo JSAbortControllerPrototype::s_info = { "AbortController"_s, &Bas
 JSC_DEFINE_HOST_FUNCTION(jsAbortControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     JSValue thisValue = callFrame->thisValue();
-    if (!thisValue.inherits<JSAbortController>()) [[unlikely]]
-        return JSValue::encode(thisValue);
+    if (!thisValue.inherits<JSAbortController>()) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(JSC::getVM(lexicalGlobalObject));
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "AbortController"_s);
+    }
     static constexpr ASCIILiteral props[] = { "signal"_s };
     return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "AbortController"_s, props, std::size(props));
 }

--- a/src/jsc/bindings/webcore/JSAbortController.cpp
+++ b/src/jsc/bindings/webcore/JSAbortController.cpp
@@ -48,6 +48,7 @@
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
+#include "streams/WebStreamsInspectCustom.h"
 #include <wtf/URL.h>
 
 namespace WebCore {
@@ -145,10 +146,20 @@ static const HashTableValue JSAbortControllerPrototypeTableValues[] = {
 
 const ClassInfo JSAbortControllerPrototype::s_info = { "AbortController"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSAbortControllerPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsAbortControllerPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.inherits<JSAbortController>()) [[unlikely]]
+        return JSValue::encode(thisValue);
+    static constexpr ASCIILiteral props[] = { "signal"_s };
+    return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "AbortController"_s, props, std::size(props));
+}
+
 void JSAbortControllerPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSAbortController::info(), JSAbortControllerPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsAbortControllerPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/JSAbortSignal.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignal.cpp
@@ -160,8 +160,10 @@ const ClassInfo JSAbortSignalPrototype::s_info = { "AbortSignal"_s, &Base::s_inf
 JSC_DEFINE_HOST_FUNCTION(jsAbortSignalPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
     JSValue thisValue = callFrame->thisValue();
-    if (!thisValue.inherits<JSAbortSignal>()) [[unlikely]]
-        return JSValue::encode(thisValue);
+    if (!thisValue.inherits<JSAbortSignal>()) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(JSC::getVM(lexicalGlobalObject));
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "AbortSignal"_s);
+    }
     static constexpr ASCIILiteral props[] = { "aborted"_s };
     return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "AbortSignal"_s, props, std::size(props));
 }

--- a/src/jsc/bindings/webcore/JSAbortSignal.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignal.cpp
@@ -54,6 +54,7 @@
 #include <wtf/PointerPreparations.h>
 #include <wtf/URL.h>
 #include "ErrorCode.h"
+#include "streams/WebStreamsInspectCustom.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -156,10 +157,20 @@ static const HashTableValue JSAbortSignalPrototypeTableValues[] = {
 
 const ClassInfo JSAbortSignalPrototype::s_info = { "AbortSignal"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSAbortSignalPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsAbortSignalPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.inherits<JSAbortSignal>()) [[unlikely]]
+        return JSValue::encode(thisValue);
+    static constexpr ASCIILiteral props[] = { "aborted"_s };
+    return Bun::WebStreams::customInspectGetters(lexicalGlobalObject, callFrame, thisValue, "AbortSignal"_s, props, std::size(props));
+}
+
 void JSAbortSignalPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSAbortSignal::info(), JSAbortSignalPrototypeTableValues, *this);
+    Bun::WebStreams::installInspectCustom(vm, this, jsAbortSignalPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -57,6 +57,7 @@
 #include "ZigGeneratedClasses.h"
 #include "GCDefferalContext.h"
 #include "streams/WebStreamsInspectCustom.h"
+#include "ErrorCode.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -224,7 +225,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDOMFormDataPrototype_inspectCustom, (JSGlobalObject *
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSDOMFormData>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "FormData"_s);
     JSValue data = WebCore::getInternalProperties(vm, lexicalGlobalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, {});
     // getInternalProperties stamps @@toStringTag for toJSON; strip it so the

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -56,6 +56,7 @@
 #include <wtf/URL.h>
 #include "ZigGeneratedClasses.h"
 #include "GCDefferalContext.h"
+#include "streams/WebStreamsInspectCustom.h"
 
 namespace WebCore {
 using namespace JSC;
@@ -216,11 +217,31 @@ static const HashTableValue JSDOMFormDataPrototypeTableValues[] = {
 
 const ClassInfo JSDOMFormDataPrototype::s_info = { "FormData"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFormDataPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsDOMFormDataPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSDOMFormData>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSValue data = WebCore::getInternalProperties(vm, lexicalGlobalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    // getInternalProperties stamps @@toStringTag for toJSON; strip it so the
+    // formatter does not render "FormData FormData { ... }".
+    JSObject* dataObject = asObject(data);
+    DeletePropertySlot slot;
+    dataObject->methodTable()->deleteProperty(dataObject, lexicalGlobalObject, vm.propertyNames->toStringTagSymbol, slot);
+    scope.assertNoException();
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "FormData"_s, dataObject));
+}
+
 void JSDOMFormDataPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSDOMFormData::info(), JSDOMFormDataPrototypeTableValues, *this);
     putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    Bun::WebStreams::installInspectCustom(vm, this, jsDOMFormDataPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -43,6 +43,7 @@
 #include "JavaScriptCore/JSCJSValue.h"
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
+#include "streams/WebStreamsInspectCustom.h"
 #include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
@@ -320,11 +321,25 @@ static const HashTableValue JSFetchHeadersPrototypeTableValues[] = {
 
 const ClassInfo JSFetchHeadersPrototype::s_info = { "Headers"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSFetchHeadersPrototype) };
 
+JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSFetchHeaders>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSValue data = WebCore::getInternalProperties(vm, lexicalGlobalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "Headers"_s, asObject(data)));
+}
+
 void JSFetchHeadersPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSFetchHeaders::info(), JSFetchHeadersPrototypeTableValues, *this);
     putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    Bun::WebStreams::installInspectCustom(vm, this, jsFetchHeadersPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -44,6 +44,7 @@
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
 #include "streams/WebStreamsInspectCustom.h"
+#include "ErrorCode.h"
 #include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
@@ -328,7 +329,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototype_inspectCustom, (JSGlobalObject 
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSFetchHeaders>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "Headers"_s);
     JSValue data = WebCore::getInternalProperties(vm, lexicalGlobalObject, thisObject);
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, Bun::WebStreams::customInspect(lexicalGlobalObject, callFrame, thisValue, "Headers"_s, asObject(data)));

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -58,6 +58,9 @@
 #include <variant>
 #include "GCDefferalContext.h"
 #include "wtf/StdLibExtras.h"
+#include "streams/WebStreamsInspectCustom.h"
+#include "ZigGlobalObject.h"
+#include <wtf/text/MakeString.h>
 
 namespace WebCore {
 using namespace JSC;
@@ -188,11 +191,68 @@ static const HashTableValue JSURLSearchParamsPrototypeTableValues[] = {
 
 const ClassInfo JSURLSearchParamsPrototype::s_info = { "URLSearchParams"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSURLSearchParamsPrototype) };
 
+// Node renders URLSearchParams like a Map: `URLSearchParams { 'a' => '1', 'b' => '2' }`.
+// This preserves duplicate keys and ordering, which the toJSON-shaped object cannot.
+JSC_DEFINE_HOST_FUNCTION(jsURLSearchParamsPrototype_inspectCustom, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    auto* thisObject = dynamicDowncast<JSURLSearchParams>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(thisValue);
+
+    JSValue depthValue = callFrame->argument(0);
+    JSValue optionsValue = callFrame->argument(1);
+    double depth = depthValue.toNumber(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (depth < 0)
+        return JSValue::encode(thisValue);
+
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    JSFunction* utilInspect = globalObject->utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, {});
+    auto callData = JSC::getCallData(utilInspect);
+    auto inspect = [&](JSValue v) -> String {
+        MarkedArgumentBuffer args;
+        args.append(v);
+        args.append(optionsValue);
+        ASSERT(!args.hasOverflowed());
+        JSValue result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, utilInspect, callData, jsUndefined(), args);
+        RETURN_IF_EXCEPTION(scope, String());
+        auto* str = result.toString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, String());
+        return str->value(lexicalGlobalObject);
+    };
+
+    auto& impl = thisObject->wrapped();
+    if (impl.size() == 0)
+        return JSValue::encode(jsNontrivialString(vm, "URLSearchParams {}"_s));
+
+    StringBuilder builder;
+    builder.append("URLSearchParams { "_s);
+    auto iter = impl.createIterator();
+    bool first = true;
+    for (auto entry = iter.next(); entry.has_value(); entry = iter.next()) {
+        if (!first)
+            builder.append(", "_s);
+        first = false;
+        String key = inspect(jsString(vm, entry.value().key));
+        RETURN_IF_EXCEPTION(scope, {});
+        String value = inspect(jsString(vm, entry.value().value));
+        RETURN_IF_EXCEPTION(scope, {});
+        builder.append(key, " => "_s, value);
+    }
+    builder.append(" }"_s);
+    return JSValue::encode(jsString(vm, builder.toString()));
+}
+
 void JSURLSearchParamsPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     reifyStaticProperties(vm, JSURLSearchParams::info(), JSURLSearchParamsPrototypeTableValues, *this);
     putDirect(vm, vm.propertyNames->iteratorSymbol, getDirect(vm, vm.propertyNames->builtinNames().entriesPublicName()), static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
+    Bun::WebStreams::installInspectCustom(vm, this, jsURLSearchParamsPrototype_inspectCustom);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
 }
 

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -60,6 +60,7 @@
 #include "wtf/StdLibExtras.h"
 #include "streams/WebStreamsInspectCustom.h"
 #include "ZigGlobalObject.h"
+#include "ErrorCode.h"
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -200,7 +201,7 @@ JSC_DEFINE_HOST_FUNCTION(jsURLSearchParamsPrototype_inspectCustom, (JSGlobalObje
     JSValue thisValue = callFrame->thisValue();
     auto* thisObject = dynamicDowncast<JSURLSearchParams>(thisValue);
     if (!thisObject) [[unlikely]]
-        return JSValue::encode(thisValue);
+        return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "URLSearchParams"_s);
 
     JSValue depthValue = callFrame->argument(0);
     JSValue optionsValue = callFrame->argument(1);

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -76,6 +76,15 @@ EncodedJSValue customInspectGetters(JSGlobalObject* lexicalGlobalObject, CallFra
 
     if (!thisValue.isObject()) [[unlikely]]
         return JSValue::encode(thisValue);
+
+    // customInspect() checks this too, but hoisting it avoids running the
+    // getters (and caching body/headers/signal wrappers on Response/Request)
+    // when the value is nested beyond options.depth.
+    double depth = callFrame->argument(0).toNumber(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (depth < 0)
+        return JSValue::encode(thisValue);
+
     JSObject* thisObject = asObject(thisValue);
 
     JSObject* data = constructEmptyObject(lexicalGlobalObject);

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -69,12 +69,32 @@ EncodedJSValue customInspect(JSGlobalObject* lexicalGlobalObject, CallFrame* cal
     return JSValue::encode(jsString(vm, makeString(name, " "_s, view.data)));
 }
 
+EncodedJSValue customInspectGetters(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSValue thisValue, ASCIILiteral name, const ASCIILiteral* propNames, unsigned propCount)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!thisValue.isObject()) [[unlikely]]
+        return JSValue::encode(thisValue);
+    JSObject* thisObject = asObject(thisValue);
+
+    JSObject* data = constructEmptyObject(lexicalGlobalObject);
+    for (unsigned i = 0; i < propCount; ++i) {
+        auto ident = Identifier::fromString(vm, propNames[i]);
+        JSValue v = thisObject->get(lexicalGlobalObject, ident);
+        RETURN_IF_EXCEPTION(scope, {});
+        data->putDirect(vm, ident, v, 0);
+    }
+
+    RELEASE_AND_RETURN(scope, customInspect(lexicalGlobalObject, callFrame, thisValue, name, data));
+}
+
 void installInspectCustom(VM& vm, JSObject* prototype, NativeFunction nativeFunction)
 {
     auto* globalObject = prototype->globalObject();
     prototype->putDirectNativeFunction(vm, globalObject, WebCore::builtinNames(vm).inspectCustomPublicName(), 2,
         nativeFunction, ImplementationVisibility::Public, NoIntrinsic,
-        static_cast<unsigned>(JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontEnum));
+        static_cast<unsigned>(JSC::PropertyAttribute::DontEnum));
 }
 
 } // namespace WebStreams

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h
@@ -14,6 +14,12 @@ namespace WebStreams {
 // depth < 0 returns `thisValue`; otherwise `${name} ${inspect(data, {...options, depth-1})}`.
 JSC::EncodedJSValue customInspect(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, ASCIILiteral name, JSC::JSObject* data);
 
+// Reads each `propNames[i]` off `thisValue` via [[Get]] into a plain object,
+// then defers to `customInspect`. Used by the `inspectCustom: string[]`
+// codegen path and hand-written DOM classes whose state lives behind
+// prototype accessors.
+JSC::EncodedJSValue customInspectGetters(JSC::JSGlobalObject*, JSC::CallFrame*, JSC::JSValue thisValue, ASCIILiteral name, const ASCIILiteral* propNames, unsigned propCount);
+
 // Installs the host function on a prototype under Symbol.for("nodejs.util.inspect.custom").
 void installInspectCustom(JSC::VM&, JSC::JSObject* prototype, JSC::NativeFunction);
 

--- a/src/runtime/node/node.classes.ts
+++ b/src/runtime/node/node.classes.ts
@@ -138,6 +138,7 @@ export default [
     configurable: false,
     klass: {},
     JSType: "0b11101110",
+    inspectCustom: ["_idleTimeout", "_idleStart", "_onTimeout", "_repeat", "_destroyed"],
     proto: {
       ref: {
         fn: "doRef",

--- a/src/runtime/webcore/encoding.classes.ts
+++ b/src/runtime/webcore/encoding.classes.ts
@@ -8,6 +8,7 @@ export default [
     JSType: "0b11101110",
     configurable: false,
     klass: {},
+    inspectCustom: ["encoding", "fatal", "ignoreBOM"],
     proto: {
       encoding: {
         getter: "getEncoding",

--- a/src/runtime/webcore/response.classes.ts
+++ b/src/runtime/webcore/response.classes.ts
@@ -16,6 +16,21 @@ export default [
     overridesToJS: true,
     memoryCost: true,
     values: ["stream"],
+    inspectCustom: [
+      "method",
+      "url",
+      "headers",
+      "destination",
+      "referrer",
+      "referrerPolicy",
+      "mode",
+      "credentials",
+      "cache",
+      "redirect",
+      "integrity",
+      "bodyUsed",
+      "signal",
+    ],
     proto: {
       text: { fn: "getText", async: true },
       json: { fn: "getJSON", async: true },
@@ -93,6 +108,7 @@ export default [
       },
     },
     values: ["stream"],
+    inspectCustom: ["status", "statusText", "headers", "body", "bodyUsed", "ok", "redirected", "type", "url"],
     proto: {
       url: {
         getter: "getURL",
@@ -155,6 +171,7 @@ export default [
     estimatedSize: true,
     values: ["stream"],
     overridesToJS: true,
+    inspectCustom: { extern: "JSBlob__inspectCustom" },
     proto: {
       text: { fn: "getText", async: true },
       json: { fn: "getJSON", async: true },

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -459,10 +459,16 @@ describe("util.inspect web-platform classes", () => {
     expect(util.format("%o", AbortSignal.abort())).toBe("AbortSignal { aborted: true }");
   });
 
-  test("calling with a foreign receiver falls through without throwing", () => {
-    const fn = Response.prototype[customSymbol];
-    expect(fn.call({}, 2, {})).toEqual({});
-    expect(fn.call(null, 2, {})).toBeNull();
-    expect(() => inspect(Object.create(Response.prototype))).not.toThrow();
+  test("calling with a foreign receiver throws ERR_INVALID_THIS", () => {
+    for (const C of [Response, Request, Headers, Blob, URLSearchParams, FormData, AbortSignal, AbortController]) {
+      const fn = C.prototype[customSymbol];
+      expect(() => fn.call(null)).toThrow(expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_THIS" }));
+      expect(() => fn.call({}, 2, {})).toThrow(
+        expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_THIS" }),
+      );
+    }
+    // inspect.js filters the prototype object itself out of the customInspect
+    // dispatch, so inspecting it still formats as a plain object.
+    expect(() => inspect(Headers.prototype)).not.toThrow();
   });
 });

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -368,11 +368,13 @@ describe("util.inspect web-platform classes", () => {
     expect(out).toContain("status: 404");
     expect(out).toContain("statusText: 'Not Found'");
     expect(out).toContain("headers: Headers { 'x-a': '1'");
+    expect(out).toContain("body: ReadableStream {");
     expect(out).toContain("bodyUsed: false");
     expect(out).toContain("ok: false");
     expect(out).toContain("redirected: false");
     expect(out).toContain("type: 'default'");
     expect(out).toContain("url: ''");
+    expect(inspect(new Response())).toContain("body: null");
   });
 
   test("Request", () => {
@@ -382,7 +384,15 @@ describe("util.inspect web-platform classes", () => {
     expect(out).toContain("method: 'POST'");
     expect(out).toContain("url: 'https://example.com/path'");
     expect(out).toContain("headers: Headers { 'x-a': '1'");
+    expect(out).toContain("destination: ''");
+    expect(out).toContain("referrer: ''");
+    expect(out).toContain("referrerPolicy: ''");
+    expect(out).toContain("mode: 'cors'");
+    expect(out).toContain("credentials: ");
+    expect(out).toContain("cache: 'default'");
     expect(out).toContain("redirect: 'follow'");
+    expect(out).toContain("integrity: ''");
+    expect(out).toContain("bodyUsed: false");
     expect(out).toContain("signal: AbortSignal { aborted: false }");
   });
 
@@ -393,9 +403,11 @@ describe("util.inspect web-platform classes", () => {
 
   test("Blob and File", () => {
     expect(inspect(new Blob(["abc"], { type: "text/plain" }))).toMatch(/^Blob { size: 3, type: 'text\/plain.*' }$/);
+    expect(inspect(new Blob())).toBe("Blob { size: 0, type: '' }");
     const file = inspect(new File(["abc"], "name.txt", { type: "text/plain", lastModified: 123 }));
     expect(file).toStartWith("File {");
     expect(file).toContain("size: 3");
+    expect(file).toMatch(/type: 'text\/plain[^']*'/);
     expect(file).toContain("name: 'name.txt'");
     expect(file).toContain("lastModified: 123");
   });
@@ -433,7 +445,9 @@ describe("util.inspect web-platform classes", () => {
       const out = inspect(t);
       expect(out).toStartWith("Timeout {");
       expect(out).toContain("_idleTimeout: 50");
+      expect(out).toMatch(/_idleStart: \d+/);
       expect(out).toContain("_onTimeout: [Function: callback]");
+      expect(out).toContain("_repeat: null");
       expect(out).toContain("_destroyed: false");
     } finally {
       clearTimeout(t);

--- a/test/js/node/util/custom-inspect.test.js
+++ b/test/js/node/util/custom-inspect.test.js
@@ -331,3 +331,124 @@ describe("Web Streams [nodejs.util.inspect.custom]", () => {
     expect(inspect(globalThis[className].prototype)).toContain("encoding: [Getter]");
   });
 });
+
+// These classes keep all state in native slots and expose it via prototype
+// accessors, so without [nodejs.util.inspect.custom] util.inspect would render
+// each of them as `ClassName {}`. Bun's own console.log had a native formatter
+// for them already; this covers the util.inspect / util.format('%o') / Console
+// path that pino, winston, and debug use.
+describe("util.inspect web-platform classes", () => {
+  const inspect = util.inspect;
+
+  test("Symbol.for(nodejs.util.inspect.custom) is installed and non-enumerable", () => {
+    for (const C of [
+      Response,
+      Request,
+      Headers,
+      Blob,
+      URLSearchParams,
+      FormData,
+      AbortSignal,
+      AbortController,
+      TextDecoder,
+    ]) {
+      const desc = Object.getOwnPropertyDescriptor(C.prototype, customSymbol);
+      expect({
+        class: C.name,
+        type: typeof desc?.value,
+        enumerable: desc?.enumerable,
+      }).toEqual({ class: C.name, type: "function", enumerable: false });
+    }
+  });
+
+  test("Response", () => {
+    const res = new Response("hello", { status: 404, statusText: "Not Found", headers: { "x-a": "1" } });
+    const out = inspect(res);
+    expect(out).toStartWith("Response {");
+    expect(out).toContain("status: 404");
+    expect(out).toContain("statusText: 'Not Found'");
+    expect(out).toContain("headers: Headers { 'x-a': '1'");
+    expect(out).toContain("bodyUsed: false");
+    expect(out).toContain("ok: false");
+    expect(out).toContain("redirected: false");
+    expect(out).toContain("type: 'default'");
+    expect(out).toContain("url: ''");
+  });
+
+  test("Request", () => {
+    const req = new Request("https://example.com/path", { method: "POST", headers: { "x-a": "1" } });
+    const out = inspect(req);
+    expect(out).toStartWith("Request {");
+    expect(out).toContain("method: 'POST'");
+    expect(out).toContain("url: 'https://example.com/path'");
+    expect(out).toContain("headers: Headers { 'x-a': '1'");
+    expect(out).toContain("redirect: 'follow'");
+    expect(out).toContain("signal: AbortSignal { aborted: false }");
+  });
+
+  test("Headers", () => {
+    expect(inspect(new Headers({ a: "1", b: "2" }))).toBe("Headers { a: '1', b: '2' }");
+    expect(inspect(new Headers())).toBe("Headers {}");
+  });
+
+  test("Blob and File", () => {
+    expect(inspect(new Blob(["abc"], { type: "text/plain" }))).toMatch(/^Blob { size: 3, type: 'text\/plain.*' }$/);
+    const file = inspect(new File(["abc"], "name.txt", { type: "text/plain", lastModified: 123 }));
+    expect(file).toStartWith("File {");
+    expect(file).toContain("size: 3");
+    expect(file).toContain("name: 'name.txt'");
+    expect(file).toContain("lastModified: 123");
+  });
+
+  test("URLSearchParams", () => {
+    expect(inspect(new URLSearchParams("a=1&b=2"))).toBe("URLSearchParams { 'a' => '1', 'b' => '2' }");
+    expect(inspect(new URLSearchParams("a=1&b=2&a=3"))).toBe("URLSearchParams { 'a' => '1', 'b' => '2', 'a' => '3' }");
+    expect(inspect(new URLSearchParams())).toBe("URLSearchParams {}");
+  });
+
+  test("FormData", () => {
+    const f = new FormData();
+    f.append("a", "1");
+    f.append("b", "2");
+    f.append("a", "3");
+    expect(inspect(f)).toBe("FormData { a: [ '1', '3' ], b: '2' }");
+    expect(inspect(new FormData())).toBe("FormData {}");
+  });
+
+  test("AbortSignal and AbortController", () => {
+    expect(inspect(AbortSignal.abort())).toBe("AbortSignal { aborted: true }");
+    expect(inspect(new AbortController())).toBe("AbortController { signal: AbortSignal { aborted: false } }");
+  });
+
+  test("TextDecoder", () => {
+    expect(inspect(new TextDecoder("utf-8"))).toBe("TextDecoder { encoding: 'utf-8', fatal: false, ignoreBOM: false }");
+    expect(inspect(new TextDecoder("utf-16le", { fatal: true }))).toBe(
+      "TextDecoder { encoding: 'utf-16le', fatal: true, ignoreBOM: false }",
+    );
+  });
+
+  test("Timeout", () => {
+    const t = setTimeout(function callback() {}, 50);
+    try {
+      const out = inspect(t);
+      expect(out).toStartWith("Timeout {");
+      expect(out).toContain("_idleTimeout: 50");
+      expect(out).toContain("_onTimeout: [Function: callback]");
+      expect(out).toContain("_destroyed: false");
+    } finally {
+      clearTimeout(t);
+    }
+  });
+
+  test("util.format('%o', ...) uses the custom inspect", () => {
+    expect(util.format("%o", new Headers({ a: "1" }))).toBe("Headers { a: '1' }");
+    expect(util.format("%o", AbortSignal.abort())).toBe("AbortSignal { aborted: true }");
+  });
+
+  test("calling with a foreign receiver falls through without throwing", () => {
+    const fn = Response.prototype[customSymbol];
+    expect(fn.call({}, 2, {})).toEqual({});
+    expect(fn.call(null, 2, {})).toBeNull();
+    expect(() => inspect(Object.create(Response.prototype))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What

`util.inspect` (and therefore `util.format('%o')`, the ported `Console` class, and every logger built on them: pino, winston, debug) rendered web-platform objects as empty shells:

```js
import util from "node:util";
util.inspect(new Response("hello", { status: 404, headers: { "x-a": "1" } }));
// before: Response {}
// after : Response { status: 404, statusText: '', headers: Headers { 'x-a': '1' }, body: ReadableStream {...}, bodyUsed: false, ok: false, redirected: false, type: 'default', url: '' }

util.inspect(new Headers({ a: "1" }));          // before: Headers {}           after: Headers { a: '1' }
util.inspect(new File(["abc"], "n.txt"));       // before: Blob {}              after: File { size: 3, type: '', name: 'n.txt', lastModified: ... }
util.inspect(new URLSearchParams("a=1&b=2"));   // before: URLSearchParams {}   after: URLSearchParams { 'a' => '1', 'b' => '2' }
util.inspect(AbortSignal.abort());              // before: AbortSignal {}       after: AbortSignal { aborted: true }
```

Bun's native `console.log` already formatted these richly, so the gap only surfaced on the `util.inspect` path loggers use, where status codes, URLs, and header sets silently disappeared from application logs.

## Why

These classes keep all state in native slots exposed through prototype accessors; there are no own enumerable properties for `util.inspect` to walk. Node solves this by defining `[Symbol.for("nodejs.util.inspect.custom")]` on each prototype. Bun already had the same mechanism wired for Web Streams and `CryptoKey` via `Bun::WebStreams::customInspect`; it just had not been applied to these classes.

## How

* **codegen**: `inspectCustom` in `*.classes.ts` may now be a `string[]` of getter names. `generate-classes.ts` emits a C++ host function that reads each getter into a plain object and routes through the existing `Bun::WebStreams::customInspect` helper, then installs it on the prototype under the well-known symbol. `Response`, `Request`, `TextDecoder`, and `Timeout` use this path. `Blob` uses an `{ extern }` variant pointing at a hand-written function in `JSDOMFile.cpp` so it can branch on the Rust-side `is_file` flag and print `File { size, type, name, lastModified }` vs `Blob { size, type }` (they still share a prototype).
* **hand-written C++ prototypes** (`Headers`, `FormData`, `AbortSignal`, `AbortController`, `URLSearchParams`) install a host function in `finishCreation` via `installInspectCustom`. Headers and FormData reuse their existing `getInternalProperties` (the `toJSON` body); URLSearchParams renders Node's Map-like `'a' => '1'` shape so duplicate keys survive.
* **`WebStreamsInspectCustom`**: gains `customInspectGetters(name, propNames[])` which builds the data object from `this`; `installInspectCustom` drops `ReadOnly` so the installed property matches Node's `{writable:true, enumerable:false, configurable:true}`.
* **`ConsoleObject.rs`**: DOMWrapper values now reach `print_private` before the generic custom-inspect probe so Bun's native `console.log` keeps its richer `Response (N bytes)` / `Blob (N bytes)` / `Headers { "k": "v" }` / `Timeout (#n)` output unchanged. `print_private` then consults the symbol itself when the runtime hook declines, which also cleans up native `console.log(AbortSignal.abort())` (previously a 30-line dump of `DOMException` fields and prototype methods, now `AbortSignal { aborted: true }`).

## Verified

```sh
bun bd test test/js/node/util/custom-inspect.test.js
```

12 new tests cover symbol presence/attributes, output for each class, `util.format('%o')`, and foreign-receiver safety. `test/js/bun/util/inspect.test.js`, `test/js/web/fetch/headers.test.ts`, `test/js/web/fetch/response.test.ts`, `test/js/web/url/url.test.ts`, `test/js/web/html/FormData.test.ts`, `test/js/web/abort/`, `test/js/web/encoding/`, and the vendored Node `test-webstream-encoding-inspect.js` / `test-broadcastchannel-custom-inspect.js` pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/custom-inspect.test.js
bun test v1.4.0 (47fc789c8)

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [1.76ms]
(pass) util.inspect calls inspect.custom [18.28ms]
(pass) util.inspect calls inspect.custom recursivly [3.85ms]
(pass) util.inspect calls inspect.custom recursivly nested [53.19ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [5.40ms]
(pass) util.inspect calls inspect.custom with valid options [4.73ms]
(pass) util.inspect stylize function works without color [3.88ms]
(pass) util.inspect stylize function works with color [6.82ms]
(pass) util.inspect stylize function gives correct depth [18.22ms]
(pass) util.inspect stylize function gives correct depth [5.63ms]
(pass) util.inspect non-callable does not get called [4.68ms]
(pass) util.inspect handles exceptions %s [4.21ms]
(pass) util.inspect handles exceptions %s [1.08ms]
(pass) Bun.inspect calls inspect.custom [1.03ms]
(pass) Bun.inspect calls inspect.custom recursivly [0.59ms]
(pass) Bun.inspect calls inspect.custom r
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (892bb1705)

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [0.02ms]
(pass) util.inspect calls inspect.custom [0.34ms]
(pass) util.inspect calls inspect.custom recursivly [0.04ms]
(pass) util.inspect calls inspect.custom recursivly nested [1.05ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [0.08ms]
(pass) util.inspect calls inspect.custom with valid options [0.06ms]
(pass) util.inspect stylize function works without color [0.04ms]
(pass) util.inspect stylize function works with color [0.11ms]
(pass) util.inspect stylize function gives correct depth [0.30ms]
(pass) util.inspect stylize function gives correct depth [0.08ms]
(pass) util.inspect non-callable does not get called [0.10ms]
(pass) util.inspect handles exceptions %s [0.06ms]
(pass) util.inspect handles exceptions %s
(pass) Bun.inspect calls inspect.custom [0.02ms]
(pass) Bun.inspect calls inspect.custom recursivly
(pass) Bun.inspect calls inspect.custom recursivly nested [0.03ms]
(pass) Bun.inspect calls inspect.custom recursivly nested 2
(pass) Bun.inspect calls inspect.custom with valid options
(pass) Bun.inspect stylize function works
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/custom-inspect.test.js
bun test v1.4.0 (47fc789c8)

test/js/node/util/custom-inspect.test.js:
(pass) util.inspect.custom exists [2.49ms]
(pass) util.inspect calls inspect.custom [18.14ms]
(pass) util.inspect calls inspect.custom recursivly [3.82ms]
(pass) util.inspect calls inspect.custom recursivly nested [53.38ms]
(pass) util.inspect calls inspect.custom recursivly nested 2 [5.57ms]
(pass) util.inspect calls inspect.custom with valid options [4.83ms]
(pass) util.inspect stylize function works without color [3.86ms]
(pass) util.inspect stylize function works with color [7.05ms]
(pass) util.inspect stylize function gives correct depth [18.13ms]
(pass) util.inspect stylize function gives correct depth [5.66ms]
(pass) util.inspect non-callable does not get called [4.77ms]
(pass) util.inspect handles exceptions %s [4.19ms]
(pass) util.inspect handles exceptions %s [1.09ms]
(pass) Bun.inspect calls inspect.custom [1.04ms]
(pass) Bun.inspect calls inspect.custom recursivly [0.62ms]
(pass) Bun.inspect calls inspect.custom r
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 638ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/50] gen cpp.rs (cppbind)
[2/50] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (31 fields)
Found 8 classes from /workspace/bun/src/runtime/api/html_rewriter.classes.ts
  - HTMLRewriter (3 fields)
  - TextChunk (7 fi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/class-definitions.ts                   |  14 +-
 src/codegen/generate-classes.ts                    |  33 ++++-
 src/jsc/ConsoleObject.rs                           |  88 ++++++++++---
 src/jsc/bindings/JSDOMFile.cpp                     |  21 +++
 src/jsc/bindings/webcore/JSAbortController.cpp     |  14 ++
 src/jsc/bindings/webcore/JSAbortSignal.cpp         |  13 ++
 src/jsc/bindings/webcore/JSDOMFormData.cpp         |  22 ++++
 src/jsc/bindings/webcore/JSFetchHeaders.cpp        |  16 +++
 src/jsc/bindings/webcore/JSURLSearchParams.cpp     |  61 +++++++++
 .../webcore/streams/WebStreamsInspectCustom.cpp    |  31 ++++-
 .../webcore/streams/WebStreamsInspectCustom.h      |   6 +
 src/runtime/node/node.classes.ts                   |   1 +
 src/runtime/webcore/encoding.classes.ts            |   1 +
 src/runtime/webcore/response.classes.ts            |  17 +++
 test/js/node/util/custom-inspect.test.js           | 141 +++++++++++++++++++++
 15 files changed, 459 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/codegen/class-definitions.ts                              2      3      0
src/codegen/generate-classes.ts                               8      9      0
src/jsc/ConsoleObject.rs                                     16     11      0
src/jsc/bindings/JSDOMFile.cpp                                2      3      0
src/jsc/bindings/webcore/JSAbortController.cpp                4      4      0
src/jsc/bindings/webcore/JSAbortSignal.cpp                    2      3      0
src/jsc/bindings/webcore/JSDOMFormData.cpp                    2      5      0
src/jsc/bindings/webcore/JSFetchHeaders.cpp                   2      4      0
src/jsc/bindings/webcore/JSURLSearchParams.cpp                2      4      0
…sc/bindings/webcore/streams/WebStreamsInspectCustom.cpp      3      5      0
…/jsc/bindings/webcore/streams/WebStreamsInspectCustom.h      1      1      0
src/runtime/node/node.classes.ts                              1      1      0
src/runtime/webcore/encoding.classes.ts                       1      1      0
src/runtime/webcore/response.classes.ts                       1      3      0
test/js/node/util/custom-inspect.test.js                      3      6      0
```

</details>

<!-- robobun:evidence:end -->