### PR TITLE
Bun.serve: reject Transfer-Encoding lists that name a coding other than a single final chunked

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -283,6 +283,13 @@ struct HttpResponseData;
             bool has: 1 = false;
             bool chunked: 1 = false;
             bool invalid: 1 = false;
+            /* More than one coding token was named across all Transfer-Encoding
+             * fields (e.g. "gzip, chunked" or a "gzip" field plus a "chunked"
+             * field). Bun.serve implements no transfer coding other than chunked,
+             * so when this is set the extra coding would be silently dropped and
+             * the still-encoded body handed to the app; Bun.serve rejects it
+             * (RFC 9112 6.1). node:http accepts it to match llhttp. */
+            bool multipleCodings: 1 = false;
         };
 
         TransferEncoding getTransferEncoding()
@@ -293,13 +300,12 @@ struct HttpResponseData;
                 return te;
             }
 
+            bool seenAnyCoding = false;
             for (Header *h = headers; (++h)->key.length();) {
                 if (h->key.length() == 17 && !strncasecmp(h->key.data(), "transfer-encoding", 17)) {
                     // Parse comma-separated values, ensuring "chunked" is last if present
                     const auto value = h->value;
                     size_t pos = 0;
-                    size_t lastTokenStart = 0;
-                    size_t lastTokenLen = 0;
 
                     while (pos < value.length()) {
                         // Skip leading whitespace
@@ -323,8 +329,20 @@ struct HttpResponseData;
 
                         size_t tokenLen = tokenEnd - tokenStart;
                         if (tokenLen > 0) {
-                            lastTokenStart = tokenStart;
-                            lastTokenLen = tokenLen;
+                            /* A prior coding (from this or an earlier TE field) was
+                             * "chunked": chunked MUST be the final coding (RFC 9112
+                             * 6.1), so any token after it is invalid. llhttp
+                             * (s_n_llhttp__internal__n_header_value_te_chunked_last)
+                             * rejects here too, for "chunked, chunked" as well. */
+                            if (te.chunked) [[unlikely]] {
+                                te.invalid = true;
+                                return te;
+                            }
+                            if (seenAnyCoding) {
+                                te.multipleCodings = true;
+                            }
+                            seenAnyCoding = true;
+                            te.chunked = tokenLen == 7 && strncasecmp(value.data() + tokenStart, "chunked", 7) == 0;
                         }
 
                         // Move past comma if present
@@ -333,20 +351,10 @@ struct HttpResponseData;
                         }
                     }
 
-                    if (te.chunked) [[unlikely]] {
-                        te.invalid = true;
-                        return te;
-                    }
-
                     /* Present even when the value names no transfer coding: treating
                      * an empty/whitespace-only field as absent would fall back to
                      * Content-Length framing (request smuggling; RFC 9112 6.3). */
                     te.has = true;
-
-                    // Check if the last token is "chunked"
-                    if (lastTokenLen == 7 && strncasecmp(value.data() + lastTokenStart, "chunked", 7) == 0) [[likely]] {
-                        te.chunked = true;
-                    }
                 }
             }
 
@@ -1209,7 +1217,14 @@ struct HttpResponseData;
             bool deferredTransferEncodingError = IsNodeHttp && transferEncoding.has
                 && !transferEncoding.invalid && !transferEncoding.chunked && !contentLengthStringLen;
 
-            transferEncoding.invalid = transferEncoding.invalid || (transferEncoding.has && (contentLengthStringLen || !transferEncoding.chunked));
+            /* Bun.serve: no transfer coding other than chunked is implemented, so a
+             * list that ends in chunked but also names another coding ("gzip, chunked",
+             * "x, chunked", two TE fields) would hand the still-encoded body to the
+             * app. Reject it. node:http keeps llhttp's behaviour (accepts the list,
+             * body remains un-decoded for the other coding). */
+            transferEncoding.invalid = transferEncoding.invalid
+                || (transferEncoding.has && (contentLengthStringLen || !transferEncoding.chunked))
+                || (!IsNodeHttp && transferEncoding.multipleCodings);
 
             if (transferEncoding.invalid && !deferredTransferEncodingError) [[unlikely]] {
                 /* Invalid Transfer-Encoding (multiple headers or chunked not last - request smuggling attempt) */

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -303,6 +303,15 @@ struct HttpResponseData;
             bool seenAnyCoding = false;
             for (Header *h = headers; (++h)->key.length();) {
                 if (h->key.length() == 17 && !strncasecmp(h->key.data(), "transfer-encoding", 17)) {
+                    /* An earlier Transfer-Encoding field already named "chunked": any
+                     * later TE field (even one with an empty value) is invalid. The
+                     * per-token guard below handles the non-empty case too; this catches
+                     * the empty one so the change is strictly tightening. */
+                    if (te.chunked) [[unlikely]] {
+                        te.invalid = true;
+                        return te;
+                    }
+
                     // Parse comma-separated values, ensuring "chunked" is last if present
                     const auto value = h->value;
                     size_t pos = 0;

--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -288,18 +288,23 @@ test("accepts valid Transfer-Encoding: chunked", async () => {
   });
 });
 
-test("accepts valid Transfer-Encoding: gzip, chunked", async () => {
-  // Valid: chunked is last
+test("rejects Transfer-Encoding: gzip, chunked", async () => {
+  // chunked is last, but gzip isn't implemented: the body would reach the app
+  // still gzip-encoded with no signal. RFC 9112 6.1 says a server SHOULD 501
+  // an unimplemented transfer coding; Bun.serve rejects the request instead of
+  // silently dropping the coding.
+  let handlerReached = false;
   await using server = Bun.serve({
     port: 0,
     fetch(req) {
+      handlerReached = true;
       return new Response("Success");
     },
   });
 
   const client = net.connect(server.port, "127.0.0.1");
 
-  const validRequest = ["POST / HTTP/1.1", "Host: localhost", "Transfer-Encoding: gzip, chunked", "", "0", "", ""].join(
+  const request = ["POST / HTTP/1.1", "Host: localhost", "Transfer-Encoding: gzip, chunked", "", "0", "", ""].join(
     "\r\n",
   );
 
@@ -307,21 +312,22 @@ test("accepts valid Transfer-Encoding: gzip, chunked", async () => {
     client.on("error", reject);
     client.on("data", data => {
       const response = data.toString();
-      expect(response).toContain("HTTP/1.1 200");
+      expect(response).toContain("HTTP/1.1 400");
       client.end();
       resolve();
     });
-    client.write(validRequest);
+    client.write(request);
   });
+  expect(handlerReached).toBe(false);
 });
 
-test("accepts Transfer-Encoding with whitespace variations", async () => {
-  let didSucceed = false;
-  // Should handle tabs and spaces properly
+test("accepts Transfer-Encoding with whitespace around chunked", async () => {
+  let receivedBody = "";
+  // OWS around the single "chunked" token must be tolerated
   await using server = Bun.serve({
     port: 0,
-    fetch(req) {
-      didSucceed = true;
+    async fetch(req) {
+      receivedBody = await req.text();
       return new Response("Success");
     },
   });
@@ -331,8 +337,10 @@ test("accepts Transfer-Encoding with whitespace variations", async () => {
   const validRequest = [
     "POST / HTTP/1.1",
     "Host: localhost",
-    "Transfer-Encoding: gzip,\tchunked", // tab after comma
+    "Transfer-Encoding: \tchunked ", // tab before, space after
     "",
+    "5",
+    "Hello",
     "0",
     "",
     "",
@@ -349,7 +357,7 @@ test("accepts Transfer-Encoding with whitespace variations", async () => {
     client.write(validRequest);
   });
 
-  expect(didSucceed).toBe(true);
+  expect(receivedBody).toBe("Hello");
 });
 
 test("rejects malformed Transfer-Encoding with chunked-false", async () => {
@@ -454,18 +462,21 @@ test("prevents request smuggling attack", async () => {
   expect(smuggled).toBe(false);
 });
 
-test("handles multiple valid Transfer-Encoding headers", async () => {
-  // Multiple headers with non-chunked values should work
+test("rejects split Transfer-Encoding headers gzip + chunked", async () => {
+  // Two TE fields are the comma-separated list "gzip, chunked": gzip is not
+  // implemented, so Bun.serve rejects rather than silently dropping it.
+  let handlerReached = false;
   await using server = Bun.serve({
     port: 0,
     fetch(req) {
+      handlerReached = true;
       return new Response("Success");
     },
   });
 
   const client = net.connect(server.port, "127.0.0.1");
 
-  const validRequest = [
+  const request = [
     "POST / HTTP/1.1",
     "Host: localhost",
     "Transfer-Encoding: gzip",
@@ -480,11 +491,131 @@ test("handles multiple valid Transfer-Encoding headers", async () => {
     client.on("error", reject);
     client.on("data", data => {
       const response = data.toString();
-      expect(response).toContain("HTTP/1.1 200");
+      expect(response).toContain("HTTP/1.1 400");
       client.end();
       resolve();
     });
-    client.write(validRequest);
+    client.write(request);
+  });
+  expect(handlerReached).toBe(false);
+});
+
+describe("Transfer-Encoding lists with codings other than a single chunked", () => {
+  // RFC 9112 6.1: a server that receives a transfer coding it does not
+  // understand SHOULD respond 501; Bun.serve implements only "chunked", so any
+  // extra coding in the list is rejected rather than silently dropped (the body
+  // would otherwise reach the app still encoded with no signal).
+  async function rawPost(port: number, headerLines: string[], body: string) {
+    const { promise, resolve } = Promise.withResolvers<{ status: string; raw: string }>();
+    const client = net.connect(port, "127.0.0.1");
+    let raw = "";
+    const done = () => {
+      client.destroy();
+      resolve({ status: raw.match(/HTTP\/1\.[01] (\d{3})/)?.[1] ?? "none", raw });
+    };
+    client.on("connect", () =>
+      client.write(
+        Buffer.from(
+          `POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n${headerLines.join("\r\n")}\r\n\r\n${body}`,
+          "latin1",
+        ),
+      ),
+    );
+    client.on("data", d => (raw += d.toString("latin1")));
+    client.on("close", done);
+    client.on("error", done);
+    return promise;
+  }
+
+  const plainChunked = "5\r\nhello\r\n0\r\n\r\n";
+
+  test.each([
+    ["x, chunked", ["Transfer-Encoding: x, chunked"]],
+    ["chunked, chunked", ["Transfer-Encoding: chunked, chunked"]],
+    ["gzip,\\tchunked", ["Transfer-Encoding: gzip,\tchunked"]],
+    ["identity, chunked", ["Transfer-Encoding: identity, chunked"]],
+  ])("Bun.serve rejects Transfer-Encoding: %s", async (_name, headerLines) => {
+    let handlerReached = false;
+    await using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch() {
+        handlerReached = true;
+        return new Response("OK");
+      },
+    });
+    const { status } = await rawPost(server.port, headerLines, plainChunked);
+    expect(status).toBe("400");
+    expect(handlerReached).toBe(false);
+  });
+
+  test("Bun.serve rejects a real gzip,chunked body instead of delivering it raw", async () => {
+    // Previously the gzip coding was silently dropped and the still-compressed
+    // bytes reached the handler (first byte 0x1f).
+    let seen: { length: number; first: number } | undefined;
+    await using server = Bun.serve({
+      port: 0,
+      development: false,
+      async fetch(req) {
+        const b = new Uint8Array(await req.arrayBuffer());
+        seen = { length: b.length, first: b[0] ?? -1 };
+        return new Response("OK");
+      },
+    });
+    const gz = Buffer.from(Bun.gzipSync("hello"));
+    const body = gz.length.toString(16) + "\r\n" + gz.toString("latin1") + "\r\n0\r\n\r\n";
+    const { status } = await rawPost(server.port, ["Transfer-Encoding: gzip, chunked"], body);
+    expect(status).toBe("400");
+    expect(seen).toBeUndefined();
+  });
+
+  test("node:http accepts Transfer-Encoding: gzip, chunked (llhttp compat)", async () => {
+    // llhttp tokenises the list and only requires chunked to be final; it does
+    // not reject the unimplemented coding. node:http keeps that behaviour.
+    let bodyFirstByte = -1;
+    const server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", c => chunks.push(c));
+      req.on("end", () => {
+        const b = Buffer.concat(chunks);
+        bodyFirstByte = b[0] ?? -1;
+        res.end("OK");
+      });
+    });
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+    try {
+      const port = (server.address() as net.AddressInfo).port;
+      const gz = Buffer.from(Bun.gzipSync("hello"));
+      const body = gz.length.toString(16) + "\r\n" + gz.toString("latin1") + "\r\n0\r\n\r\n";
+      const { status } = await rawPost(port, ["Transfer-Encoding: gzip, chunked"], body);
+      expect(status).toBe("200");
+      expect(bodyFirstByte).toBe(0x1f);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  test.each([
+    ["chunked, chunked", ["Transfer-Encoding: chunked, chunked"]],
+    ["chunked,chunked (no space)", ["Transfer-Encoding: chunked,chunked"]],
+  ])("node:http rejects Transfer-Encoding: %s (llhttp compat)", async (_name, headerLines) => {
+    // llhttp's te_chunked_last state rejects any token after "chunked" in a
+    // single field value with HPE_INVALID_TRANSFER_ENCODING, before the
+    // headers-complete callback fires.
+    let handlerReached = false;
+    const server = createServer((req, res) => {
+      handlerReached = true;
+      res.end("OK");
+    });
+    await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+    try {
+      const port = (server.address() as net.AddressInfo).port;
+      const { status } = await rawPost(port, headerLines, plainChunked);
+      expect(status).toBe("400");
+      expect(handlerReached).toBe(false);
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
   });
 });
 


### PR DESCRIPTION
## What

`Bun.serve` now responds `400 Bad Request` to any request whose `Transfer-Encoding` field list names a coding other than a single final `chunked`:

| Request header(s) | Before | After |
|---|---|---|
| `Transfer-Encoding: gzip, chunked` | 200 (body still gzipped) | **400** |
| `Transfer-Encoding: x, chunked` | 200 | **400** |
| `Transfer-Encoding: chunked, chunked` | 200 | **400** |
| `Transfer-Encoding: gzip` + `Transfer-Encoding: chunked` | 200 (body still gzipped) | **400** |
| `Transfer-Encoding: chunked` | 200 | 200 |
| `Transfer-Encoding: gzip` alone | 400 | 400 |

`node:http` keeps llhttp's behaviour: `gzip, chunked` is still accepted (the body is delivered un-decoded for `gzip`, same as Node), but single-field `chunked, chunked` is now rejected to match llhttp's `te_chunked_last` state.

## Why

`getTransferEncoding()` in `packages/bun-uws/src/HttpParser.h` only inspected the *last* token of each `Transfer-Encoding` field value. A `gzip, chunked` request was chunked-decoded and the still-gzipped bytes handed to the app with no signal:

```
WRONG status=200 handler-saw=len=25 first=31  gzip, chunked        <- 0x1f = gzip magic
WRONG status=200 handler-saw=len=5  first=104 x, chunked
WRONG status=200 handler-saw=len=5  first=104 chunked, chunked
WRONG status=200 handler-saw=len=25 first=31  two TE fields gzip / chunked
```

RFC 9112 6.1: a server that receives a transfer coding it does not understand SHOULD respond 501, and a sender MUST NOT apply `chunked` more than once. Bun.serve implements no transfer coding other than `chunked`, so accepting the list silently drops the extra coding.

This is **not** a CL/TE request-smuggling primitive: every `Transfer-Encoding` variant combined with a `Content-Length` was already rejected `400`+close in both orders, so framing agreement with an upstream proxy holds. This is the ignored-coding / data-integrity face only.

## How

The tokenizer now classifies every token as it walks the comma list: a token appearing after a `chunked` token sets `invalid` (so `chunked, chunked` and `chunked, gzip` both fail, matching llhttp); a second token of any kind sets `multipleCodings`. Bun.serve folds `multipleCodings` into `invalid`; `node:http` does not.

## Tests

`test/js/bun/http/request-smuggling.test.ts`:
- flipped the three existing `gzip, chunked` / split-field acceptance tests to expect 400
- added a `describe.each` covering `x, chunked` / `chunked, chunked` / `gzip,\tchunked` / `identity, chunked`
- added a real gzip body case proving the handler is never reached
- added `node:http` compat cases: `gzip, chunked` still accepted, `chunked, chunked` rejected

All 83 tests in the file pass; the Node parallel `test-http-transfer-encoding-*` tests and `hspec.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/request-smuggling.test.ts
bun test v1.4.0 (3695d6812)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [337.20ms]
(pass) rejects Transfer-Encoding with chunked not last [103.07ms]
(pass) rejects duplicate chunked in Transfer-Encoding [60.14ms]
(pass) rejects Transfer-Encoding + Content-Length [55.56ms]
(pass) rejects conflicting duplicate Content-Length headers [61.83ms]
(pass) accepts duplicate Content-Length headers with identical values [60.84ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [63.18ms]
(pass) accepts valid Transfer-Encoding: chunked [56.35ms]
310 | 
311 |   await new Promise<void>((resolve, reject) => {
312 |     client.on("error", reject);
313 |     client.on("data", data => {
314 |       const response = data.toString();
315 |       expect(response).toContain("HTTP/1.1 400");
      ^
error: expect(received).toContain(expected)

Expected to contain: "HTTP/1.1 400"
Received: "HTTP/1.1 200 OK\r\ncontent-type: t
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3695d6812)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [5.41ms]
(pass) rejects Transfer-Encoding with chunked not last [2.22ms]
(pass) rejects duplicate chunked in Transfer-Encoding [1.24ms]
(pass) rejects Transfer-Encoding + Content-Length [1.05ms]
(pass) rejects conflicting duplicate Content-Length headers [1.21ms]
(pass) accepts duplicate Content-Length headers with identical values [1.23ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [1.25ms]
(pass) accepts valid Transfer-Encoding: chunked [1.17ms]
(pass) rejects Transfer-Encoding: gzip, chunked [1.54ms]
(pass) accepts Transfer-Encoding with whitespace around chunked [1.14ms]
(pass) rejects malformed Transfer-Encoding with chunked-false [1.01ms]
(pass) prevents request smuggling attack [1.19ms]
(pass) rejects split Transfer-Encoding headers gzip + chunked [1.10ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > Bun.serve rejects Transfer-Encoding: x, chunked [1.44ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > Bun.serve rejects Transf
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/request-smuggling.test.ts
bun test v1.4.0 (3695d6812)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [333.18ms]
(pass) rejects Transfer-Encoding with chunked not last [106.33ms]
(pass) rejects duplicate chunked in Transfer-Encoding [60.56ms]
(pass) rejects Transfer-Encoding + Content-Length [55.06ms]
(pass) rejects conflicting duplicate Content-Length headers [61.81ms]
(pass) accepts duplicate Content-Length headers with identical values [65.77ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [62.65ms]
(pass) accepts valid Transfer-Encoding: chunked [65.14ms]
(pass) rejects Transfer-Encoding: gzip, chunked [57.12ms]
(pass) accepts Transfer-Encoding with whitespace around chunked [61.62ms]
(pass) rejects malformed Transfer-Encoding with chunked-false [57.53ms]
(pass) prevents request smuggling attack [54.62ms]
(pass) rejects split Transfer-Encoding headers gzip + chunked [62.88ms]
(pass) Transfer-Encoding lists with codings oth
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 646ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/10] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[2/10] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[3/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[4/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/10] cxx obj/src/jsc/bindings/bindings.cpp.o
[6/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[7/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[7/10] link bun-profile
[8/10] bun-profile --revision
1.4.0-canary.1+3695d6812
[10/10] strip bun
[build] done
bun test v1.4.0-canary.1 (3695d6812)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [5.52ms]
(pass) rejects Transfer-Encoding with chunked not last [1.96ms]
(pass) rejects duplicate chunked in Transfer-Encoding [1.23ms]
(pass) rejects Transfer-Encoding + Content-Length [1.13ms]
(pass) rejects conflicting duplicate Content-Length headers [2.68ms]
(pass) accepts duplicate Content-Length headers with identical values [2.08ms]
(pas
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpParser.h          |  54 +++++++---
 test/js/bun/http/request-smuggling.test.ts | 165 ++++++++++++++++++++++++++---
 2 files changed, 187 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-uws/src/HttpParser.h               4      3      0
test/js/bun/http/request-smuggling.test.ts      3      5      0
```

</details>

<!-- robobun:evidence:end -->