### PR TITLE
spawn(windows): release StaticPipeWriter start() ref when buffer-stdin write completes

### DIFF
--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1510,7 +1510,10 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
             return;
         }
         let pending = Self::r(this).get_buffer_internal();
-        let has_pending_data = (pending.len() - written) != 0;
+        // `close()` may have run before this callback (exit-first ordering) and
+        // cleared the parent's buffer to 0 while `written` still carries the
+        // submitted size; treat that as no pending data rather than underflowing.
+        let has_pending_data = pending.len().saturating_sub(written) != 0;
         let is_done_before = Self::r(this).is_done;
         // SAFETY: parent BACKREF valid.
         unsafe {

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -211,10 +211,22 @@ const _: () = {
 };
 
 impl<'a> Subprocess<'a> {
+    /// Claim `start()`'s outstanding +1 on the buffer-stdin writer (if any)
+    /// for the caller to `deref()`. Clears `started` so `StaticPipeWriter::
+    /// on_write`'s own release site becomes a no-op if a queued write-complete
+    /// callback still fires after the caller closes the pipe (Windows: a
+    /// `uv_write` whose I/O already completed is delivered with its real
+    /// status after `uv_close`, not `ECANCELED`).
     fn take_pending_start_writer(&self) -> Option<*mut StaticPipeWriter<'a>> {
         match self.stdin.get() {
-            Writable::Buffer(buffer) if Writable::buffer_writer_mut(buffer).started => {
-                Some(buffer.as_ptr())
+            Writable::Buffer(buffer) => {
+                let writer = Writable::buffer_writer_mut(buffer);
+                if writer.started {
+                    writer.started = false;
+                    Some(buffer.as_ptr())
+                } else {
+                    None
+                }
             }
             _ => None,
         }

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -226,14 +226,18 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         let len = self.buffer.len();
         self.buffer = RawSlice::new(&self.buffer.slice()[amount.min(len)..]);
         if status == WriteStatus::EndOfFile || self.buffer.is_empty() {
-            #[cfg(not(windows))]
+            // `started` is the token for start()'s outstanding +1. Clearing it
+            // before the deref makes this release mutually exclusive with the
+            // owner's close-time release (`Subprocess::take_pending_start_writer`,
+            // which also clears `started`). On POSIX, `writer.close()` →
+            // `Parent::on_close` may drop `create()`'s +1, so keep start()'s +1
+            // across it. `EndOfFile` is skipped because `PosixBufferedWriter::
+            // _on_write` still touches `self` after this returns on that status.
             let release_start_ref = self.started && status != WriteStatus::EndOfFile;
-            #[cfg(not(windows))]
             if release_start_ref {
                 self.started = false;
             }
             self.writer.close();
-            #[cfg(not(windows))]
             if release_start_ref {
                 // SAFETY: start()'s +1 was still outstanding; `started` cleared above so no other site re-derefs.
                 unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
@@ -264,6 +268,15 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             "StaticPipeWriter(0x{:x}) onClose()",
             std::ptr::from_ref(self) as usize
         );
+        // On Windows the error arm of `WindowsBufferedWriter::on_write_complete`
+        // reaches here via `close()` without ever calling `Parent::on_write`, so
+        // this is the last point `started` can be claimed for that path.
+        // `write()`'s +1 (held by that callback's scopeguard) keeps `self` live
+        // past the deref. POSIX must not release here: `drain_buffered_data`
+        // may call `on_error()` -> `close()` -> here and then `on_write()` on
+        // the same object, with no extra ref held.
+        #[cfg(windows)]
+        let release_start_ref = core::mem::replace(&mut self.started, false);
         // `buffer` aliases `self.source`'s storage; clear it before detach()
         // frees that storage so no dangling slice survives the close.
         self.buffer = RawSlice::EMPTY;
@@ -271,6 +284,12 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         // SAFETY: `process` is a backref to the owning process, guaranteed alive
         // for the lifetime of this writer (the process owns/outlives its stdio writers).
         unsafe { P::on_close_io(self.process, StdioKind::Stdin) };
+        #[cfg(windows)]
+        if release_start_ref {
+            // SAFETY: `started` was the token for start()'s outstanding +1;
+            // cleared above so no other site re-derefs. Last use of `self`.
+            unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+        }
     }
 
     pub fn memory_cost(&self) -> usize {


### PR DESCRIPTION
On Windows, `Bun.spawn`/`Bun.spawnSync` with a non-empty `ArrayBuffer`/`Blob` `stdin` leaked one `StaticPipeWriter` allocation per spawn.

## Cause

`StaticPipeWriter::start()` takes a `+1` and sets `started = true`. #30875 added a `release_start_ref` block to `on_write()` that clears `started` and derefs once the buffer drains, but gated it behind `#[cfg(not(windows))]`:

https://github.com/oven-sh/bun/blob/892b1dabc6/src/spawn/static_pipe_writer.rs#L228-L241

On Windows, when the `uv_write` completes before the child exits (the common ordering for a small buffer):

```
on_write_complete(status=0)
  -> Parent::on_write(Pending)             (release_start_ref gated out)
     -> writer.close()
        -> BaseWindowsPipeWriter::close -> on_close_source
           -> StaticPipeWriter::on_close -> Subprocess::on_close_io(Stdin)
              stdin <- Writable::Ignore; buffer.deref()   (create()'s +1)
  scopeguard deref                                         (write()'s +1)
```

Net: `started` is still `true` but `stdin` is `Writable::Ignore`, so the other release site, `take_pending_start_writer` (called from `on_process_exit` / `close_io`), matches nothing and start()'s `+1` is stranded. The error arm of `on_write_complete` (e.g. `ERROR_BROKEN_PIPE` when the child closes stdin without reading) reaches `on_close` via `close()` without ever calling `Parent::on_write`, so start()'s `+1` is stranded there the same way.

`ShellSubprocess` has the same leak for `cmd < ${buf}` stdin since its `on_process_exit`/`close_io` never look at `started` at all and depend entirely on `on_write`'s release.

## Fix

- `StaticPipeWriter::on_write`: drop the `cfg(not(windows))` gates so `release_start_ref` runs on every platform. `WindowsBufferedWriter` never passes `EndOfFile`, so the existing `status != EndOfFile` guard is a no-op there and is left for the POSIX path (`PosixBufferedWriter::_on_write` still touches `self` after the callback on `EndOfFile`).
- `StaticPipeWriter::on_close` (Windows only): claim `started` and deref after `on_close_io` for paths that reach `close()` without going through `on_write` (the `on_write_complete` error arm). `write()`'s +1, held by that callback's scopeguard, keeps `self` live past the release. This is gated to Windows because on POSIX `drain_buffered_data` may call `on_error()` -> `close()` -> `on_close` and then `on_write()` on the same object with no extra ref held; #34697 changes that ordering and the gate can go once it lands.
- `Subprocess::take_pending_start_writer`: clear `started` when it claims the pointer. The three release sites are then mutually exclusive via `started`, covering the ordering where `on_process_exit` closes the pipe while a `uv_write` whose I/O already completed is still queued (libuv delivers that callback with its real status after `uv_close`, not `ECANCELED`).
- `WindowsBufferedWriter::on_write_complete`: `saturating_sub` for `has_pending_data` so the late-success-after-close ordering does not underflow in debug builds.

`SecurityScanSubprocess` already derefs and writes `started = false` immediately after `start()`, so both new release sites see `started = false`; no change in its refcount balance.

## Verification

Verified on Windows x64 by instrumenting `Drop` with a live counter and spawning 400 children per mode: unfixed leaves 400 live writers after each of the drain (64 B into `sort`) and reject (256 KB into `cmd /c exit`) workloads; fixed returns to 0 on both, in release and debug builds.

Also verified on Windows x64: `spawn.test.ts -t 'stdin|Uint8Array|Blob'` (45/45), `spawnSync.test.ts` (6/6), `file-io.test.ts` (26/26), `child_process.test.ts` (41/41), and on Linux: `bunshell.test.ts` (414/414), `bun-security-scanner-workspaces.test.ts` (3/3). `rust:check-all` is green across all 10 targets.

Found while working on #35286, which scopes its change to the empty-buffer path and does not overlap.
