### PR TITLE
Bun.serve: validate the WebSocket opening handshake in server.upgrade()

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -415,6 +415,18 @@ pub(super) fn respond_stopped_503<R: RespLike + ?Sized>(resp: &mut R) {
     resp.end_without_body(!R::IS_H3);
 }
 
+/// RFC 6455 §4.1: |Sec-WebSocket-Key| is the base64 encoding of a 16-byte
+/// value, i.e. 22 base64 characters followed by `==`.
+#[inline]
+fn is_valid_sec_websocket_key(key: &[u8]) -> bool {
+    key.len() == 24
+        && key[22] == b'='
+        && key[23] == b'='
+        && key[..22]
+            .iter()
+            .all(|&c| c.is_ascii_alphanumeric() || c == b'+' || c == b'/')
+}
+
 pub(super) type ServerRequestContext<const SSL: bool, const DEBUG: bool> =
     NewRequestContext<NewServer<SSL, DEBUG>, SSL, DEBUG, false>;
 pub(super) type ServerH3RequestContext<const SSL: bool, const DEBUG: bool> =
@@ -1900,12 +1912,16 @@ where
         let mut sec_websocket_key_str = ZigString::EMPTY;
         let mut sec_websocket_protocol = ZigString::EMPTY;
         let mut sec_websocket_extensions = ZigString::EMPTY;
+        let mut sec_websocket_version = ZigString::EMPTY;
+        let mut upgrade_header = ZigString::EMPTY;
 
         // Owned backing storage for sec_websocket_*.
         // `ZigStringSlice` impls `Drop`; reassignment drops the previous value.
         let mut _sec_websocket_key_owned = bun_core::ZigStringSlice::empty();
         let mut _sec_websocket_protocol_owned = bun_core::ZigStringSlice::empty();
         let mut _sec_websocket_extensions_owned = bun_core::ZigStringSlice::empty();
+        let mut _sec_websocket_version_owned = bun_core::ZigStringSlice::empty();
+        let mut _upgrade_header_owned = bun_core::ZigStringSlice::empty();
 
         // NOTE: `FetchHeaders::fast_get` takes `&mut self` (FFI signature
         // is `*mut`), so go through the `BodyMixin` accessor which yields a
@@ -1927,6 +1943,14 @@ where
             if let Some(ext) = head.fast_get(HTTPHeaderName::SecWebSocketExtensions) {
                 _sec_websocket_extensions_owned = ext.to_slice_clone();
                 sec_websocket_extensions = ZigString::init(_sec_websocket_extensions_owned.slice());
+            }
+            if let Some(ver) = head.fast_get(HTTPHeaderName::SecWebSocketVersion) {
+                _sec_websocket_version_owned = ver.to_slice_clone();
+                sec_websocket_version = ZigString::init(_sec_websocket_version_owned.slice());
+            }
+            if let Some(up) = head.fast_get(HTTPHeaderName::Upgrade) {
+                _upgrade_header_owned = up.to_slice_clone();
+                upgrade_header = ZigString::init(_upgrade_header_owned.slice());
             }
         }
 
@@ -1953,9 +1977,35 @@ where
                 sec_websocket_extensions =
                     ZigString::init(r.header(b"sec-websocket-extensions").unwrap_or(b""));
             }
+            if sec_websocket_version.len == 0 {
+                sec_websocket_version =
+                    ZigString::init(r.header(b"sec-websocket-version").unwrap_or(b""));
+            }
+            if upgrade_header.len == 0 {
+                upgrade_header = ZigString::init(r.header(b"upgrade").unwrap_or(b""));
+            }
         }
 
-        if sec_websocket_key_str.len != 24 {
+        // RFC 6455 §4.2.1: validate the client's opening handshake.
+        // A request whose |Upgrade| token is not "websocket", or whose
+        // |Sec-WebSocket-Key| is not base64 of 16 bytes, is not a WebSocket
+        // handshake; fall through so the caller's fetch() can respond.
+        if !strings::eql_case_insensitive_ascii(upgrade_header.slice(), b"websocket", true) {
+            return Ok(JSValue::FALSE);
+        }
+        if !is_valid_sec_websocket_key(sec_websocket_key_str.slice()) {
+            return Ok(JSValue::FALSE);
+        }
+        // RFC 6455 §4.4: an unsupported |Sec-WebSocket-Version| MUST be
+        // answered with an HTTP error and a |Sec-WebSocket-Version| header
+        // listing the versions the server understands.
+        if sec_websocket_version.slice() != b"13" {
+            resp.write_status(b"426 Upgrade Required");
+            resp.write_header(b"Sec-WebSocket-Version", b"13");
+            // SAFETY: upgrader_ptr is live (ref_() above)
+            let upgrader = unsafe { &mut *upgrader_ptr };
+            upgrader.flags.set_has_written_status(true);
+            upgrader.end_without_body(true);
             return Ok(JSValue::FALSE);
         }
         if sec_websocket_protocol.len > 0 {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1987,10 +1987,12 @@ where
         }
 
         // RFC 6455 §4.2.1: validate the client's opening handshake.
-        // A request whose |Upgrade| token is not "websocket", or whose
-        // |Sec-WebSocket-Key| is not base64 of 16 bytes, is not a WebSocket
-        // handshake; fall through so the caller's fetch() can respond.
-        if !strings::eql_case_insensitive_ascii(upgrade_header.slice(), b"websocket", true) {
+        // A request that does not name "websocket" in its |Upgrade| token list,
+        // or whose |Sec-WebSocket-Key| is not base64 of 16 bytes, is not a
+        // WebSocket handshake; fall through so the caller's fetch() can respond.
+        if !upgrade_header.slice().split(|&c| c == b',').any(|t| {
+            strings::eql_case_insensitive_ascii(t.trim_ascii(), b"websocket", true)
+        }) {
             return Ok(JSValue::FALSE);
         }
         if !is_valid_sec_websocket_key(sec_websocket_key_str.slice()) {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1562,3 +1562,110 @@ it.each(["server", "client"] as const)(
     await server.stop();
   },
 );
+
+// RFC 6455 §4.2.1 / §4.4: server.upgrade() must refuse a client handshake
+// whose Upgrade token, Sec-WebSocket-Key, or Sec-WebSocket-Version is invalid.
+describe("server.upgrade() validates the opening handshake", () => {
+  let opened = 0;
+  let server: Server;
+  afterEach(() => server?.stop(true));
+
+  const rawHandshake = (headers: string[]) =>
+    new Promise<{ status: number | null; headers: string }>(resolve => {
+      let buf = "";
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        sock.destroy();
+        const head = buf.split("\r\n\r\n", 1)[0] ?? "";
+        const m = head.match(/^HTTP\/1\.[01] (\d+)/);
+        resolve({ status: m ? +m[1] : null, headers: head });
+      };
+      const sock = net.connect({ port: server.port, host: "127.0.0.1" }, () => {
+        sock.write("GET /ws HTTP/1.1\r\nHost: x\r\n" + headers.join("\r\n") + "\r\n\r\n");
+      });
+      sock.on("data", d => {
+        buf += d.toString("latin1");
+        if (buf.includes("\r\n\r\n")) done();
+      });
+      sock.on("error", done);
+      sock.on("close", done);
+    });
+
+  const K = "dGhlIHNhbXBsZSBub25jZQ==";
+  const U = "Upgrade: websocket";
+  const C = "Connection: Upgrade";
+  const V = "Sec-WebSocket-Version: 13";
+
+  it("accepts a well-formed request and rejects malformed ones", async () => {
+    opened = 0;
+    server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        open() {
+          opened++;
+        },
+        message() {},
+      },
+    });
+
+    // A valid handshake still upgrades.
+    expect((await rawHandshake([U, C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
+    // Upgrade token is case-insensitive.
+    expect((await rawHandshake(["Upgrade: WebSocket", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
+    expect(opened).toBe(2);
+
+    // Upgrade token other than "websocket": not a WebSocket handshake.
+    expect((await rawHandshake(["Upgrade: h2c", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(400);
+
+    // Sec-WebSocket-Key is not valid base64 of 16 bytes.
+    for (const key of [
+      "!!!!!!!!!!!!!!!!!!!!!!==", // non-alphabet bytes
+      "dGhlIHNhbXBsZSBub25jZQ=A", // wrong padding
+      "dGhlIHNhbXBsZSBub25j", // too short
+    ]) {
+      expect((await rawHandshake([U, C, `Sec-WebSocket-Key: ${key}`, V])).status).toBe(400);
+    }
+
+    // Sec-WebSocket-Version missing or unsupported: RFC 6455 §4.4 requires
+    // a 4xx with a Sec-WebSocket-Version header naming the supported version.
+    for (const hs of [
+      [U, C, `Sec-WebSocket-Key: ${K}`, "Sec-WebSocket-Version: 8"],
+      [U, C, `Sec-WebSocket-Key: ${K}`],
+    ]) {
+      const { status, headers } = await rawHandshake(hs);
+      expect(status).toBe(426);
+      expect(headers.toLowerCase()).toContain("sec-websocket-version: 13");
+    }
+
+    // None of the rejected handshakes reached open().
+    expect(opened).toBe(2);
+  });
+
+  it("returns false for an invalid handshake even when fetch() is async", async () => {
+    let upgradeResult: boolean | undefined;
+    server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req, srv) {
+        // Force the headers to be materialized on the Request before upgrade().
+        void req.headers.get("host");
+        await Promise.resolve();
+        upgradeResult = srv.upgrade(req);
+        if (upgradeResult) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: { message() {} },
+    });
+
+    const { status } = await rawHandshake(["Upgrade: h2c", C, `Sec-WebSocket-Key: ${K}`, V]);
+    expect(status).toBe(400);
+    expect(upgradeResult).toBe(false);
+  });
+});

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1619,7 +1619,9 @@ describe("server.upgrade() validates the opening handshake", () => {
     expect((await rawHandshake([U, C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
     // Upgrade token is case-insensitive.
     expect((await rawHandshake(["Upgrade: WebSocket", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
-    expect(opened).toBe(2);
+    // Upgrade is an RFC 7230 token list; any "websocket" token suffices.
+    expect((await rawHandshake(["Upgrade: keep-alive, websocket", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(101);
+    expect(opened).toBe(3);
 
     // Upgrade token other than "websocket": not a WebSocket handshake.
     expect((await rawHandshake(["Upgrade: h2c", C, `Sec-WebSocket-Key: ${K}`, V])).status).toBe(400);
@@ -1627,8 +1629,8 @@ describe("server.upgrade() validates the opening handshake", () => {
     // Sec-WebSocket-Key is not valid base64 of 16 bytes.
     for (const key of [
       "!!!!!!!!!!!!!!!!!!!!!!==", // non-alphabet bytes
-      "dGhlIHNhbXBsZSBub25jZQ=A", // wrong padding
-      "dGhlIHNhbXBsZSBub25j", // too short
+      "dGhlIHNhbXBsZSBub25jZQ=A", // byte 23 != '='
+      "dGhlIHNhbXBsZSBub25jZQA=", // byte 22 != '='
     ]) {
       expect((await rawHandshake([U, C, `Sec-WebSocket-Key: ${key}`, V])).status).toBe(400);
     }
@@ -1645,7 +1647,7 @@ describe("server.upgrade() validates the opening handshake", () => {
     }
 
     // None of the rejected handshakes reached open().
-    expect(opened).toBe(2);
+    expect(opened).toBe(3);
   });
 
   it("returns false for an invalid handshake even when fetch() is async", async () => {
@@ -1664,8 +1666,15 @@ describe("server.upgrade() validates the opening handshake", () => {
       websocket: { message() {} },
     });
 
-    const { status } = await rawHandshake(["Upgrade: h2c", C, `Sec-WebSocket-Key: ${K}`, V]);
-    expect(status).toBe(400);
+    const h2c = await rawHandshake(["Upgrade: h2c", C, `Sec-WebSocket-Key: ${K}`, V]);
+    expect(h2c.status).toBe(400);
+    expect(upgradeResult).toBe(false);
+
+    // The 426 path writes the response itself and detaches it; the Response
+    // returned from fetch() after the await must not be written a second time.
+    const v8 = await rawHandshake([U, C, `Sec-WebSocket-Key: ${K}`, "Sec-WebSocket-Version: 8"]);
+    expect(v8.status).toBe(426);
+    expect(v8.headers.toLowerCase()).toContain("sec-websocket-version: 13");
     expect(upgradeResult).toBe(false);
   });
 });


### PR DESCRIPTION
### What does this PR do?

`server.upgrade()` accepted any GET request with a 24-byte `Sec-WebSocket-Key` as a WebSocket handshake. A request with `Upgrade: h2c`, a non-base64 key, or `Sec-WebSocket-Version` other than 13 (or absent) was answered with `101 Switching Protocols` and the app's `open()` handler ran.

Repro:

```js
import net from "node:net";
const server = Bun.serve({
  port: 0,
  fetch(req, srv) { if (srv.upgrade(req)) return; return new Response("no", { status: 400 }); },
  websocket: { open(ws) { ws.send("hi"); }, message() {} },
});
const sock = net.connect(server.port, "127.0.0.1", () => {
  sock.write(
    "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: h2c\r\nConnection: Upgrade\r\n" +
    "Sec-WebSocket-Key: !!!!!!!!!!!!!!!!!!!!!!==\r\nSec-WebSocket-Version: 8\r\n\r\n"
  );
});
sock.on("data", d => console.log(d.toString().split("\r\n")[0])); // HTTP/1.1 101 Switching Protocols
```

RFC 6455 requires the server to refuse a handshake whose `Upgrade` token is not `websocket` or whose `Sec-WebSocket-Key` is not the base64 encoding of 16 bytes (section 4.2.1), and to answer an unsupported `Sec-WebSocket-Version` with an HTTP error carrying a `Sec-WebSocket-Version` header naming the supported versions (section 4.4).

`server.upgrade()` now:

- returns `false` if the `Upgrade` header is not `websocket` (case-insensitive), letting the caller's `fetch()` respond;
- returns `false` if `Sec-WebSocket-Key` does not match `^[A-Za-z0-9+/]{22}==$`;
- answers `426 Upgrade Required` with `Sec-WebSocket-Version: 13` and returns `false` if `Sec-WebSocket-Version` is missing or not `13`.

### How did you verify your code works?

New tests in `test/js/bun/websocket/websocket-server.test.ts` drive raw TCP handshakes for each invalid case (bad `Upgrade` token, non-base64 key, wrong padding, short key, version 8, missing version) plus a valid handshake and a mixed-case `Upgrade: WebSocket`, and assert the status and that `open()` is not called for the rejected cases. A second test covers the `req.headers`-materialized async path.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->