### PR TITLE
Worker: flush the worker→parent inbox before 'close' on natural exit

### DIFF
--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -602,7 +602,20 @@ bool Worker::dispatchExit(int32_t exitCode)
     return ScriptExecutionContext::postTaskTo(
         m_parentContextId,
         [this] { this->deref(); },
-        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext&) {
+        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
+            // Flush the worker→parent inbox before 'close'. Node delivers every
+            // parentPort.postMessage() that ran before the worker exited, then
+            // fires 'exit'; without this, a drainToParent that hit its yield
+            // budget while the worker was still posting has re-posted itself
+            // BEHIND this close task, and once m_state == Closed dispatchEvent()
+            // drops the rest on the floor. The worker thread has already torn
+            // down its VM (this task is posted from shutdown() step 4), so
+            // m_toParent cannot grow and one drainToParent pass empties it
+            // (limit = max(queue.size(), 1000) ≥ queue.size()). terminate()
+            // still drops pending messages: dispatchEvent() is gated on
+            // m_terminateRequested, so the dispatches below are no-ops.
+            protectedThis->drainToParent(context);
+
             // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'
             // handlers observe threadId == -1 and isOnline() == false while
             // postMessage() (gated only on Closed) still accepts and drops the

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -603,17 +603,11 @@ bool Worker::dispatchExit(int32_t exitCode)
         m_parentContextId,
         [this] { this->deref(); },
         [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
-            // Flush the worker→parent inbox before 'close'. Node delivers every
-            // parentPort.postMessage() that ran before the worker exited, then
-            // fires 'exit'; without this, a drainToParent that hit its yield
-            // budget while the worker was still posting has re-posted itself
-            // BEHIND this close task, and once m_state == Closed dispatchEvent()
-            // drops the rest on the floor. The worker thread has already torn
-            // down its VM (this task is posted from shutdown() step 4), so
-            // m_toParent cannot grow and one drainToParent pass empties it
-            // (limit = max(queue.size(), 1000) ≥ queue.size()). terminate()
-            // still drops pending messages: dispatchEvent() is gated on
-            // m_terminateRequested, so the dispatches below are no-ops.
+            // Node delivers every parentPort message before 'exit'. The worker VM
+            // is already torn down (this task is shutdown() step 4), so m_toParent
+            // can't grow and one drain pass empties it; a drain that rescheduled
+            // behind this task would otherwise dispatch into Closed and drop.
+            // terminate() still discards: dispatchEvent gates on m_terminateRequested.
             protectedThis->drainToParent(context);
 
             // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -602,46 +602,70 @@ bool Worker::dispatchExit(int32_t exitCode)
     return ScriptExecutionContext::postTaskTo(
         m_parentContextId,
         [this] { this->deref(); },
-        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext& context) {
-            // Node delivers every parentPort message before 'exit'. The worker VM
-            // is already torn down (this task is shutdown() step 4), so m_toParent
-            // can't grow and one drain pass empties it; a drain that rescheduled
-            // behind this task would otherwise dispatch into Closed and drop.
-            // terminate() still discards: dispatchEvent gates on m_terminateRequested.
-            protectedThis->drainToParent(context);
-
-            // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'
-            // handlers observe threadId == -1 and isOnline() == false while
-            // postMessage() (gated only on Closed) still accepts and drops the
-            // message, matching browser/Node and pre-refactor behaviour.
-            //
-            // Drop any tasks queued while the worker was Pending and never
-            // reached Running (m_pendingCrossVMRequests / rejectAllCrossVMRequests
-            // settles the callers' promises + frees the parent-VM Strong<>).
-            // Take the queue under the same lock that flips m_state so a racing
-            // postTaskToWorkerGlobalScope either lands in the cleared queue or
-            // sees Closing and returns false.
-            {
-                Locker lock(protectedThis->m_pendingTasksMutex);
-                protectedThis->m_state.store(State::Closing);
-                protectedThis->m_pendingTasks.clear();
-            }
-            // Reject any introspection promises whose round-trip never completed.
-            if (auto* ctx = protectedThis->scriptExecutionContext())
-                protectedThis->rejectAllCrossVMRequests(ctx->globalObject());
-
-            if (protectedThis->hasEventListeners(eventNames().closeEvent)) {
-                auto event = CloseEvent::create(exitCode == 0, static_cast<unsigned short>(exitCode), exitCode == 0 ? "Worker terminated normally"_s : "Worker exited abnormally"_s);
-                protectedThis->EventTargetWithInlineData::dispatchEvent(event);
-            }
-
-            protectedThis->m_state.store(State::Closed);
-            WebWorker__releaseParentPollRef(protectedThis->impl_);
+        [exitCode, protectedThis = Ref { *this }](ScriptExecutionContext&) {
+            protectedThis->closeTask(exitCode);
             // protectedThis (and the JSWorker GC cell, if still rooted) keep us
             // alive across the close-event dispatch; both deref on the parent
             // thread (lambda destruction here / GC sweep), so ~Worker never runs
             // on the worker thread.
         });
+}
+
+void Worker::closeTask(int32_t exitCode)
+{
+    // The worker VM is already torn down (this task is shutdown() step 4), so
+    // m_toParent cannot grow. If messages remain (a drainToParent hit its yield
+    // budget and re-posted itself behind us), re-post this task on the SAME
+    // lane the drain reschedule uses and return. In FIFO order each re-post
+    // lands behind one drain turn, so close re-checks once per turn and only
+    // proceeds once the inbox is empty and no drain is scheduled: every posted
+    // message is delivered before 'close', and the drain's per-turn budget
+    // still paces delivery instead of one unbounded synchronous flush.
+    //
+    // terminate() skips the chase: dispatchEvent() is already a no-op under
+    // m_terminateRequested, so any undrained tail is discarded and close fires
+    // on the next turn.
+    if (!m_terminateRequested.load()) {
+        bool pending;
+        {
+            Locker locker { m_toParent.lock };
+            pending = !m_toParent.queue.isEmpty() || m_toParent.drainScheduled.load(std::memory_order_relaxed);
+        }
+        if (pending) {
+            postTaskToParent([exitCode, protectedThis = Ref { *this }](ScriptExecutionContext&) {
+                protectedThis->closeTask(exitCode);
+            });
+            return;
+        }
+    }
+
+    // Closing → dispatch 'close' → Closed. The split lets 'close'/'exit'
+    // handlers observe threadId == -1 and isOnline() == false while
+    // postMessage() (gated only on Closed) still accepts and drops the
+    // message, matching browser/Node and pre-refactor behaviour.
+    //
+    // Drop any tasks queued while the worker was Pending and never
+    // reached Running (m_pendingCrossVMRequests / rejectAllCrossVMRequests
+    // settles the callers' promises + frees the parent-VM Strong<>).
+    // Take the queue under the same lock that flips m_state so a racing
+    // postTaskToWorkerGlobalScope either lands in the cleared queue or
+    // sees Closing and returns false.
+    {
+        Locker lock(m_pendingTasksMutex);
+        m_state.store(State::Closing);
+        m_pendingTasks.clear();
+    }
+    // Reject any introspection promises whose round-trip never completed.
+    if (auto* ctx = scriptExecutionContext())
+        rejectAllCrossVMRequests(ctx->globalObject());
+
+    if (hasEventListeners(eventNames().closeEvent)) {
+        auto event = CloseEvent::create(exitCode == 0, static_cast<unsigned short>(exitCode), exitCode == 0 ? "Worker terminated normally"_s : "Worker exited abnormally"_s);
+        EventTargetWithInlineData::dispatchEvent(event);
+    }
+
+    m_state.store(State::Closed);
+    WebWorker__releaseParentPollRef(impl_);
 }
 
 // ---- extern "C" shims (called from native code) ------------------------------

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -173,6 +173,7 @@ private:
 
     void enqueueToWorker(MessageWithMessagePorts&&);
     void drainToParent(ScriptExecutionContext&);
+    void closeTask(int32_t exitCode);
 
     WorkerOptions m_options;
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1684,12 +1684,19 @@ test("parentPort.postMessage queue is flushed to the parent before 'exit' fires"
          if (first) {
            first = false;
            // Hold this handler (and so the current drain pass) open until the
-           // worker has enqueued the whole burst AND entered shutdown, so the
-           // worker's close task is posted before this drain pass reschedules.
+           // worker has enqueued the whole burst AND posted its close task, so
+           // this drain pass's reschedule lands behind it. flag[1] flips in
+           // process.on('exit'), which is shutdown() step 2; the close task is
+           // posted in step 4 after step 3's full sync GC (teardownJSCVM). No
+           // worker-side JS runs after step 2, so nothing observable marks the
+           // actual post: the busy-wait below covers steps 3+4. Wider on
+           // debug/ASAN where collectNow is slower; in practice the 999
+           // remaining dispatches after this handler returns buy additional
+           // margin on the same slow builds.
            Atomics.store(flag, 0, 1);
            Atomics.notify(flag, 0);
            while (Atomics.load(flag, 1) === 0);
-           const t = Date.now(); while (Date.now() - t < 500);
+           const t = Date.now(); while (Date.now() - t < ${isDebug ? 3000 : 500});
            return;
          }
          if (m === "END") gotEnd = true; else got++;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1652,6 +1652,66 @@ test("MessagePort: transferring a port from inside its own close()'s flush windo
   B2.close();
 });
 
+test("parentPort.postMessage queue is flushed to the parent before 'exit' fires", async () => {
+  // A worker that posts a burst and then falls off the end of its script must
+  // deliver every message (node: the worker's parentPort queue drains before
+  // teardown). The parent's drain loop yields after ~1000 messages and
+  // re-posts itself; without the pre-'close' flush that re-post lands behind
+  // the close task, which flips the Worker to Closed and makes the re-posted
+  // drain's dispatches silent no-ops.
+  //
+  // Subprocess because the handler busy-spins (would stall the test runner).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+       const { Worker } = require("node:worker_threads");
+       const N = 5000;
+       const flag = new Int32Array(new SharedArrayBuffer(8));
+       const w = new Worker(
+         \`const { parentPort, workerData } = require("node:worker_threads");
+          const flag = new Int32Array(workerData);
+          parentPort.postMessage(-1);
+          Atomics.wait(flag, 0, 0);
+          for (let i = 0; i < \${N}; i++) parentPort.postMessage(i);
+          parentPort.postMessage("END");
+          process.on("exit", () => Atomics.store(flag, 1, 1));\`,
+         { eval: true, workerData: flag.buffer },
+       );
+       let got = 0, gotEnd = false, first = true;
+       w.on("message", m => {
+         if (first) {
+           first = false;
+           // Hold this handler (and so the current drain pass) open until the
+           // worker has enqueued the whole burst AND entered shutdown, so the
+           // worker's close task is posted before this drain pass reschedules.
+           Atomics.store(flag, 0, 1);
+           Atomics.notify(flag, 0);
+           while (Atomics.load(flag, 1) === 0);
+           const t = Date.now(); while (Date.now() - t < 500);
+           return;
+         }
+         if (m === "END") gotEnd = true; else got++;
+       });
+       w.on("error", e => { console.error(e); process.exit(1); });
+       w.on("exit", code => {
+         console.log(JSON.stringify({ got, gotEnd, code }));
+         process.exit(gotEnd && got === N && code === 0 ? 0 : 1);
+       });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ out: stdout.trim(), stderr, exitCode }).toEqual({
+    out: '{"got":5000,"gotEnd":true,"code":0}',
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 test("MessagePort: peer closing while a port is in transit still delivers 'close' and doesn't hang", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -309,6 +309,69 @@ describe("web worker", () => {
       done();
     });
   });
+
+  test("messages posted before natural exit are all delivered before 'close'", async () => {
+    // A worker that posts a burst and then falls off the end of its script
+    // must deliver every message before 'close'. The parent's drain loop
+    // yields after ~1000 messages and re-posts itself; without the pre-close
+    // flush in dispatchExit that re-post lands behind the close task, which
+    // flips the Worker to Closed and makes the re-posted drain's dispatches
+    // silent no-ops.
+    //
+    // Subprocess because the handler busy-spins to pin the interleaving.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+         const N = 5000;
+         const flag = new Int32Array(new SharedArrayBuffer(8));
+         const src = \`self.onmessage = e => {
+           const flag = new Int32Array(e.data);
+           self.onmessage = null;
+           postMessage(-1);
+           Atomics.wait(flag, 0, 0);
+           for (let i = 0; i < \${N}; i++) postMessage(i);
+           postMessage({ done: true });
+           process.on("exit", () => Atomics.store(flag, 1, 1));
+         };\`;
+         const w = new Worker(URL.createObjectURL(new Blob([src], { type: "text/javascript" })));
+         w.postMessage(flag.buffer);
+         let got = 0, sawDone = false, first = true;
+         w.onmessage = e => {
+           if (first) {
+             first = false;
+             // Hold this handler (and so the current drain pass) open until the
+             // worker has enqueued the whole burst AND posted its close task, so
+             // this drain pass's reschedule lands behind it. flag[1] flips in
+             // process.on('exit') (shutdown step 2); the close task is posted
+             // in step 4 after step 3's full sync GC. No worker-side JS runs
+             // after step 2, so the busy-wait below covers steps 3+4.
+             Atomics.store(flag, 0, 1);
+             Atomics.notify(flag, 0);
+             while (Atomics.load(flag, 1) === 0);
+             const t = Date.now(); while (Date.now() - t < ${isDebug ? 3000 : 500});
+             return;
+           }
+           if (e.data && e.data.done) sawDone = true; else got++;
+         };
+         w.onerror = e => { console.error(e.message); process.exit(1); };
+         w.addEventListener("close", () => {
+           console.log(JSON.stringify({ got, sawDone }));
+           process.exit(sawDone && got === N ? 0 : 1);
+         });
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: stdout.trim(), stderr, exitCode }).toEqual({
+      out: '{"got":5000,"sawDone":true}',
+      stderr: "",
+      exitCode: 0,
+    });
+  }, 30_000);
 
   describe("worker event", () => {
     test("is fired with the right object", () => {


### PR DESCRIPTION
### What

A worker that posts a burst via `postMessage()` (web Worker global or node `parentPort`) and then exits naturally silently drops the tail of that burst. The parent gets a prefix, never sees the final messages, and `'close'`/`'exit'` fires anyway. Node and browsers deliver every message then fire the exit event.

```js
const N = 300_000;
const src = `for (let i=0;i<${N};i++) postMessage(i); postMessage({done:true});`;
const w = new Worker(URL.createObjectURL(new Blob([src], {type:"text/javascript"})));
let got = 0, done = false;
w.onmessage = e => { if (e.data?.done) done = true; else got++; };
w.addEventListener("close", () => setTimeout(() => {
  console.log({ got, lost: N - got, done });
  // node/browser:  { got: 300000, lost: 0, done: true }
  // bun:           { got: ~150k-290k, lost: ~10k-150k, done: false }
}, 500));
```

### Why

`Worker::enqueueToParent()` coalesces: N posts schedule one `drainToParent` task on the parent, which dispatches up to its budget and then re-posts itself to yield to the event loop. The close task that `dispatchExit()` queues from `shutdown()` lands in the same FIFO task queue, so a drain reschedule can sit *behind* the close task. The close task flips `m_state` to `Closed`, after which `Worker::dispatchEvent()` is a no-op, so the re-posted drain walks the remaining inbox dispatching into a void.

A transferred `MessagePort` is unaffected (its inbox lives in a `MessagePortPipe::Side` that nothing gates on worker state); a worker kept alive (`setInterval`) is unaffected (no close task posted). Only the built-in `m_toParent` inbox is lost.

### Fix

The close task body is pulled out into `Worker::closeTask()`. At the top, if `terminate()` has not been requested and the inbox is still pending (`!queue.isEmpty() || drainScheduled`, checked under the inbox lock), it re-posts itself via `postTaskToParent` (the same lane the drain reschedule uses) and returns without touching `m_state`. Each re-post lands behind one drain turn in FIFO order, so close re-checks once per turn and only proceeds to `Closing → 'close' → Closed` once the inbox is empty and no drain is scheduled.

`terminate()` is unchanged: the chase is skipped when `m_terminateRequested` is set, and `dispatchEvent()`'s existing gate on that flag makes any remaining dispatches no-ops, so terminate still discards the undrained tail and close fires on the next turn.

A synchronous `drainToParent()` call in the close task was considered and rejected: it dispatches the whole backlog in one unbroken run on the parent, defeating the drain's yield budget. Chasing keeps the drain as the pacing mechanism and composes with any change to its reschedule lane or per-turn cap.

### Verification

Two SAB-pinned tests (web Worker in `test/js/web/workers/worker.test.ts`, node `worker_threads` in `test/js/node/worker_threads/worker_threads.test.ts`) hold the parent's first drain handler open until the worker has enqueued its whole burst and posted its close task, so the drain's reschedule lands behind close deterministically. Without the fix both receive exactly 999 of 5000 and never see the sentinel; with the fix both receive all 5000 plus the sentinel before `'close'`/`'exit'`. The 300k repro above now delivers all 300k + sentinel.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (461c7c406)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [11.52ms]
(pass) web worker > preload > string [144.16ms]
(pass) web worker > preload > array of 2 strings [148.47ms]
(pass) web worker > preload > array of string [132.26ms]
(pass) web worker > preload > error in preload doesn't crash parent [125.95ms]
(pass) web worker > worker [126.27ms]
(pass) web worker > worker-env [141.22ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [922.94ms]
(pass) web worker > worker-env with a lot of properties [338.35ms]
(pass) web worker > argv / execArgv defaults [142.69ms]
(pass) web worker > argv / execArgv options [137.12ms]
(pass) web worker > sending 50 messages should just work [177.41ms]
(pass) web worker > worker with event listeners doesn't close event loop [509.32ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [500.68ms]
(pass) web worke
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.22ms]
(pass) web worker > preload > string [8.14ms]
(pass) web worker > preload > array of 2 strings [4.83ms]
(pass) web worker > preload > array of string [5.08ms]
(pass) web worker > preload > error in preload doesn't crash parent [3.49ms]
(pass) web worker > worker [4.38ms]
(pass) web worker > worker-env [5.01ms]
162 |       ],
163 |       env: bunEnv,
164 |       stderr: "pipe",
165 |     });
166 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
167 |     expect(JSON.parse(stdout)).toEqual({ seen: "from-parent", parentSees: "from-worker" });
                      ^
SyntaxError: JSON Parse error: Unexpected EOF
      at <anonymous> (/workspace/bun/test/js/web/workers/worker.test.ts:167:17)
(fail) web worker > worker-env: SHARE_ENV via the global Worker constructor [24.20ms]
(pass) web worker > worker-env with a lot of properties [15.70ms]
(pass) web worker > argv / execArgv defaults [6.38ms]
(pass) web worker > argv / execArgv options [5.69ms]
(pass) web worker > sending 50 mes
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (461c7c406)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [11.95ms]
(pass) web worker > preload > string [214.04ms]
(pass) web worker > preload > array of 2 strings [186.25ms]
(pass) web worker > preload > array of string [147.49ms]
(pass) web worker > preload > error in preload doesn't crash parent [149.24ms]
(pass) web worker > worker [148.04ms]
(pass) web worker > worker-env [139.45ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [982.43ms]
(pass) web worker > worker-env with a lot of properties [339.86ms]
(pass) web worker > argv / execArgv defaults [142.46ms]
(pass) web worker > argv / execArgv options [142.57ms]
(pass) web worker > sending 50 messages should just work [171.47ms]
(pass) web worker > worker with event listeners doesn't close event loop [555.36ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [536.48ms]
(pass) web worke
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     461c7c406b
  features     baseline

22 deps, 108 codegen, 1171 objects in 1146ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [21.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [6.00ms]
[3/1234] gen bindgenv2
[4/1234] gen ErrorCode+*.h
[5/1234] fetch picohttpparser
[picohttpparser] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] fetch zlib
[zlib] up to date
[11/1234] subst deps/libjpeg-turbo/jconfig.h
[12/1234] subst deps/zlib/zlib.h
[13/1234] fetch zstd
[zstd] up to date
[14/1234] 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/Worker.cpp                | 85 +++++++++++++++-------
 src/jsc/bindings/webcore/Worker.h                  |  1 +
 test/js/node/worker_threads/worker_threads.test.ts | 67 +++++++++++++++++
 test/js/web/workers/worker.test.ts                 | 65 ++++++++++++++++-
 4 files changed, 190 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/Worker.cpp                     2      2      0
src/jsc/bindings/webcore/Worker.h                       1      0      0
test/js/node/worker_threads/worker_threads.test.ts      4      2      0
test/js/web/workers/worker.test.ts                      1      0      0
```

</details>

<!-- robobun:evidence:end -->