### PR TITLE
crash_handler: make setDlOpenAction nesting-safe

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -603,6 +603,11 @@ mod draft {
         /// attach the affected files to crash report. Others, which may have low crash
         /// rate or only crash due to assertion failures, are debug-only. See `Action`.
         pub static CURRENT_ACTION: Cell<Option<Action>> = const { Cell::new(None) };
+
+        /// Snapshot of `CURRENT_ACTION` taken by `CrashHandler__setDlOpenAction` so the
+        /// paired clear can restore it. Actions nest: e.g. auto-install drains microtasks
+        /// inside an `Action::Resolver` frame, and a microtask may call `process.dlopen`.
+        static DLOPEN_PREV_ACTION: Cell<Option<Action>> = const { Cell::new(None) };
     }
 
     // PORTING.md §Concurrency: `bun_threading::Guarded<Vec<..>>` instead of bare Mutex + global Vec.
@@ -3768,18 +3773,18 @@ mod draft {
     #[unsafe(no_mangle)]
     pub(crate) unsafe extern "C" fn CrashHandler__setDlOpenAction(action: *const c_char) {
         if !action.is_null() {
-            debug_assert!(CURRENT_ACTION.with(|c| c.get()).is_none());
+            // Save/restore like `scoped_action`: the caller may already be inside an
+            // enclosing action (e.g. `Action::Resolver` when auto-install ticks the
+            // event loop and a drained microtask calls `process.dlopen`).
+            DLOPEN_PREV_ACTION.with(|c| c.set(current_action()));
             // SAFETY: action is a valid NUL-terminated C string for the duration of the dlopen call
             let s = unsafe { bun_core::ffi::cstr(action) }.to_bytes();
             // SAFETY: noreturn-on-crash usage; the C string outlives the action via caller contract
             let s: &'static [u8] = unsafe { bun_collections::detach_lifetime(s) };
-            CURRENT_ACTION.with(|c| c.set(Some(Action::Dlopen(s))));
+            set_current_action(Some(Action::Dlopen(s)));
         } else {
-            debug_assert!(matches!(
-                CURRENT_ACTION.with(|c| c.get()),
-                Some(Action::Dlopen(_))
-            ));
-            CURRENT_ACTION.with(|c| c.set(None));
+            debug_assert!(matches!(current_action(), Some(Action::Dlopen(_))));
+            set_current_action(DLOPEN_PREV_ACTION.with(|c| c.take()));
         }
     }
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -100,6 +100,7 @@ export const cssInternals = {
 
 export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") as {
   getMachOImageZeroOffset: () => number;
+  getCurrentAction: () => string | undefined;
   segfault: () => void;
   panic: () => void;
   rootError: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -21,6 +21,7 @@ pub mod js_bindings {
             ),
             ("getFeaturesAsVLQ", __jsc_host_js_get_features_as_vlq),
             ("getFeatureData", __jsc_host_js_get_feature_data),
+            ("getCurrentAction", __jsc_host_js_get_current_action),
             ("segfault", __jsc_host_js_segfault),
             ("segfaultInDll", __jsc_host_js_segfault_in_dll),
             ("panic", __jsc_host_js_panic),
@@ -68,6 +69,24 @@ pub mod js_bindings {
 
             Ok(JSValue::js_number((base_address - vmaddr_slide) as f64))
         }
+    }
+
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_get_current_action(
+        global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        use crash_handler::Action;
+        let name: &'static [u8] = match crash_handler::current_action() {
+            None => return Ok(JSValue::UNDEFINED),
+            Some(Action::Parse(_)) => b"parse",
+            Some(Action::Visit(_)) => b"visit",
+            Some(Action::Print(_)) => b"print",
+            Some(Action::BundleGenerateChunk(_)) => b"bundleGenerateChunk",
+            Some(Action::Resolver(_)) => b"resolver",
+            Some(Action::Dlopen(_)) => b"dlopen",
+        };
+        BunString::static_(name).to_js(global)
     }
 
     #[bun_jsc::host_fn]

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -377,8 +377,12 @@ test("process.dlopen inside a resolver auto-install frame does not trip CURRENT_
   using dir = tempDir("crash-handler-dlopen-nested-action", {
     "package.json": JSON.stringify({ name: "box", version: "0.0.0" }),
     "index.ts": `
+      const { crash_handler } = require("bun:internal-for-testing");
       Promise.resolve().then(() => {
+        const before = crash_handler.getCurrentAction();
         try { process.dlopen({ exports: {} }, "/nonexistent-addon.node"); } catch {}
+        const after = crash_handler.getCurrentAction();
+        console.log(JSON.stringify({ before, after }));
       });
       try {
         import.meta.resolve("some-package-that-is-not-installed-xyz", import.meta.url);
@@ -404,6 +408,13 @@ test("process.dlopen inside a resolver auto-install frame does not trip CURRENT_
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("survived");
+  const lines = stdout.trim().split("\n");
+  expect(lines).toHaveLength(2);
+  // The microtask runs inside the resolver's auto-install tick: it must observe
+  // Action::Resolver both before the nested dlopen installs Action::Dlopen and
+  // after the dlopen clear restores it. `after` being undefined would mean the
+  // clear path reverted to `set(None)` and clobbered the enclosing action.
+  expect(JSON.parse(lines[0])).toEqual({ before: "resolver", after: "resolver" });
+  expect(lines[1]).toBe("survived");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -410,11 +410,12 @@ test("process.dlopen inside a resolver auto-install frame does not trip CURRENT_
   expect(stderr).toBe("");
   const lines = stdout.trim().split("\n");
   expect(lines).toHaveLength(2);
-  // The microtask runs inside the resolver's auto-install tick: it must observe
-  // Action::Resolver both before the nested dlopen installs Action::Dlopen and
-  // after the dlopen clear restores it. `after` being undefined would mean the
-  // clear path reverted to `set(None)` and clobbered the enclosing action.
-  expect(JSON.parse(lines[0])).toEqual({ before: "resolver", after: "resolver" });
+  // The microtask runs inside the resolver's auto-install tick: the dlopen
+  // clear must restore whatever action was current before it, not force None.
+  // Action::Resolver is only installed under #[cfg(debug_assertions)] (debug
+  // and ASAN builds); on plain release the enclosing action is None.
+  const enclosing = isDebug || isASAN ? "resolver" : undefined;
+  expect(JSON.parse(lines[0])).toEqual({ before: enclosing, after: enclosing });
   expect(lines[1]).toBe("survived");
   expect(exitCode).toBe(0);
 });

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -365,4 +365,45 @@ describe("automatic crash reporter", () => {
       expect(sent).toBe(true);
     });
   }
+});
+
+// `CrashHandler__setDlOpenAction` used to `debug_assert!(CURRENT_ACTION.is_none())`
+// and force-clear to `None`, but actions legitimately nest: the resolver's
+// auto-install path holds `Action::Resolver` while `PackageManager::sleep_until`
+// ticks the event loop and drains microtasks, and a microtask may call
+// `process.dlopen` (which installs `Action::Dlopen`). On POSIX debug builds the
+// assert panicked; on release the clear silently clobbered the enclosing action.
+test("process.dlopen inside a resolver auto-install frame does not trip CURRENT_ACTION bookkeeping", async () => {
+  using dir = tempDir("crash-handler-dlopen-nested-action", {
+    "package.json": JSON.stringify({ name: "box", version: "0.0.0" }),
+    "index.ts": `
+      Promise.resolve().then(() => {
+        try { process.dlopen({ exports: {} }, "/nonexistent-addon.node"); } catch {}
+      });
+      try {
+        import.meta.resolve("some-package-that-is-not-installed-xyz", import.meta.url);
+      } catch {}
+      console.log("survived");
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--install=fallback", "index.ts"],
+    cwd: String(dir),
+    env: {
+      ...noReportEnv,
+      // Unroutable registry: auto-install enqueues the fetch, ticks the event
+      // loop (draining the dlopen microtask inside the Resolver action), then
+      // fails fast without touching the network.
+      BUN_CONFIG_REGISTRY: "http://127.0.0.1:1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("survived");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What

`CrashHandler__setDlOpenAction` asserted `CURRENT_ACTION.is_none()` before installing `Action::Dlopen` and force-cleared to `None` afterwards. Crash-trace actions legitimately nest, so this is wrong on both ends.

## Repro

```
panic: assertion failed: CURRENT_ACTION.with(|c| c.get()).is_none()
Crashed while 
...
CrashHandler__setDlOpenAction
  src/crash_handler/lib.rs
Bun::Process_functionDlopen(JSC::JSGlobalObject*, JSC::CallFrame*)
  src/jsc/bindings/BunProcess.cpp
...
JSC::runMicrotask(...)
```

Deterministic on a debug/ASAN build (release prints `survived`):

```js
Promise.resolve().then(() => {
  try { process.dlopen({ exports: {} }, "/nonexistent-addon.node"); } catch {}
});
try { import.meta.resolve("some-package-that-is-not-installed-xyz", import.meta.url); } catch {}
console.log("survived");
```

Run with `--install=fallback` from a directory with no `node_modules` ancestor.

## Cause

`import.meta.resolve` → `resolve_and_auto_install` installs `Action::Resolver` (via `set_current_action_resolver`) → `PackageManager::sleep_until` → `AnyEventLoop::tick_raw` drains microtasks inside that frame. A queued microtask calling `process.dlopen` hits `CrashHandler__setDlOpenAction`, which `debug_assert!`s the slot is empty.

Every other action setter (`scoped_action`, `set_current_action_resolver`) snapshots and restores the previous action. Only the Dlopen setter asserted-empty on entry and set `None` on exit, so on release builds the exit also clobbered whatever enclosing `Parse`/`Print`/`Resolver` action was active, losing the "Crashed while …" line for any crash in that frame.

## Fix

Snapshot the previous action into a `DLOPEN_PREV_ACTION` thread-local on set and restore it on clear, matching the `scoped_action`/`ActionGuard` pattern.

## Verification

```
# without fix (src/ stashed)
(fail) process.dlopen inside a resolver auto-install frame does not trip CURRENT_ACTION bookkeeping

# with fix
(pass) process.dlopen inside a resolver auto-install frame does not trip CURRENT_ACTION bookkeeping [511.69ms]
```

Full `run-crash-handler.test.ts`: 15 pass, 4 skip, 0 fail.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->