### PR TITLE
bundler: make --keep-names preserve .name via __name() runtime calls

### DIFF
--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -314,7 +314,10 @@ $$capture_start$$(${fn.async ? "async " : ""}${
       entrypoints: [tmpFile],
       define,
       target: "bun",
-      minify: { syntax: true, whitespace: false, keepNames: true },
+      // keepNames is intentionally off: it now emits __name() calls whose
+      // runtime helper lives outside the $$capture_start$$/$$capture_end$$
+      // window and so is undefined inside the captured function body.
+      minify: { syntax: true, whitespace: false },
     });
     // TODO: Wait a few versions before removing this
     if (!build.success) {

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -314,10 +314,7 @@ $$capture_start$$(${fn.async ? "async " : ""}${
       entrypoints: [tmpFile],
       define,
       target: "bun",
-      // keepNames is intentionally off: it now emits __name() calls whose
-      // runtime helper lives outside the $$capture_start$$/$$capture_end$$
-      // window and so is undefined inside the captured function body.
-      minify: { syntax: true, whitespace: false },
+      minify: { syntax: true, whitespace: false, keepNames: true },
     });
     // TODO: Wait a few versions before removing this
     if (!build.success) {
@@ -330,12 +327,18 @@ $$capture_start$$(${fn.async ? "async " : ""}${
     let usesDebug = output.includes("$debug_log");
     let usesAssert = output.includes("$assert");
     const captured = output.match(/\$\$capture_start\$\$([\s\S]+)\.\$\$capture_end\$\$/)![1];
+    // keepNames emits its `var __name = ...` helper outside the capture window;
+    // re-inject it inside when the captured body references it.
+    const usesKeepNames = /\b__name\(/.test(captured);
     const finalReplacement =
       (fn.directives.sloppy
         ? captured
         : captured.replace(
             /function\s*\(.*?\)\s*{/,
             '$&"use strict";' +
+              (usesKeepNames
+                ? 'var __name=(t,n)=>(Object.defineProperty(t,"name",{value:n,configurable:!0}),t);'
+                : "") +
               (usesDebug ? createLogClientJS("BUILTINS", fn.name) : "") +
               (usesAssert ? createAssertClientJS(fn.name) : ""),
           )

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -328,7 +328,8 @@ $$capture_start$$(${fn.async ? "async " : ""}${
     let usesAssert = output.includes("$assert");
     const captured = output.match(/\$\$capture_start\$\$([\s\S]+)\.\$\$capture_end\$\$/)![1];
     // keepNames emits its `var __name = ...` helper outside the capture window;
-    // re-inject it inside when the captured body references it.
+    // re-inject a tamper-safe (@Object.@defineProperty) copy inside when the
+    // captured body references it.
     const usesKeepNames = /\b__name\(/.test(captured);
     const finalReplacement =
       (fn.directives.sloppy
@@ -337,7 +338,7 @@ $$capture_start$$(${fn.async ? "async " : ""}${
             /function\s*\(.*?\)\s*{/,
             '$&"use strict";' +
               (usesKeepNames
-                ? 'var __name=(t,n)=>(Object.defineProperty(t,"name",{value:n,configurable:!0}),t);'
+                ? 'var __name=(t,n)=>(__intrinsic__Object.__intrinsic__defineProperty(t,"name",{value:n,configurable:!0}),t);'
                 : "") +
               (usesDebug ? createLogClientJS("BUILTINS", fn.name) : "") +
               (usesAssert ? createAssertClientJS(fn.name) : ""),

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -314,7 +314,11 @@ $$capture_start$$(${fn.async ? "async " : ""}${
       entrypoints: [tmpFile],
       define,
       target: "bun",
-      minify: { syntax: true, whitespace: false, keepNames: true },
+      // keepNames is intentionally off: it emits __name() calls whose runtime
+      // helper lands outside the $$capture_start$$/$$capture_end$$ window, and
+      // identifiers are not minified here so .name inference from bindings
+      // already gives the right value.
+      minify: { syntax: true, whitespace: false },
     });
     // TODO: Wait a few versions before removing this
     if (!build.success) {
@@ -327,19 +331,12 @@ $$capture_start$$(${fn.async ? "async " : ""}${
     let usesDebug = output.includes("$debug_log");
     let usesAssert = output.includes("$assert");
     const captured = output.match(/\$\$capture_start\$\$([\s\S]+)\.\$\$capture_end\$\$/)![1];
-    // keepNames emits its `var __name = ...` helper outside the capture window;
-    // re-inject a tamper-safe (@Object.@defineProperty) copy inside when the
-    // captured body references it.
-    const usesKeepNames = /\b__name\(/.test(captured);
     const finalReplacement =
       (fn.directives.sloppy
         ? captured
         : captured.replace(
             /function\s*\(.*?\)\s*{/,
             '$&"use strict";' +
-              (usesKeepNames
-                ? 'var __name=(t,n)=>(__intrinsic__Object.__intrinsic__defineProperty(t,"name",{value:n,configurable:!0}),t);'
-                : "") +
               (usesDebug ? createLogClientJS("BUILTINS", fn.name) : "") +
               (usesAssert ? createAssertClientJS(fn.name) : ""),
           )

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -213,9 +213,7 @@ const config_cli = [
   process.execPath,
   "build",
   ...bundledEntryPoints,
-  // --keep-names is intentionally off: it now emits __name() calls whose
-  // runtime helper is not available inside the builtin module wrapper.
-  ...(debug ? [] : ["--minify-syntax"]),
+  ...(debug ? [] : ["--minify-syntax", "--keep-names"]),
   "--root",
   TMP_DIR,
   "--target",

--- a/src/codegen/bundle-modules.ts
+++ b/src/codegen/bundle-modules.ts
@@ -213,7 +213,9 @@ const config_cli = [
   process.execPath,
   "build",
   ...bundledEntryPoints,
-  ...(debug ? [] : ["--minify-syntax", "--keep-names"]),
+  // --keep-names is intentionally off: it now emits __name() calls whose
+  // runtime helper is not available inside the builtin module wrapper.
+  ...(debug ? [] : ["--minify-syntax"]),
   "--root",
   TMP_DIR,
   "--target",

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5238,6 +5238,55 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    #[inline]
+    fn should_keep_names(&self) -> bool {
+        self.options.features.minify_keep_names && self.options.features.allow_runtime
+    }
+
+    /// A user-written `static name` member owns `.name`; `__name()` must not clobber it.
+    pub(crate) fn class_has_custom_static_name(class: &G::Class) -> bool {
+        for prop in class.properties.iter() {
+            if !prop.flags.contains(Flags::Property::IsStatic)
+                || prop.flags.contains(Flags::Property::IsComputed)
+            {
+                continue;
+            }
+            if let Some(key) = prop.key {
+                if let js_ast::ExprData::EString(s) = key.data {
+                    if s.eql_comptime(b"name") {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    pub(crate) fn keep_stmt_symbol_name(
+        &mut self,
+        loc: bun_ast::Loc,
+        ref_: Ref,
+        original_name: &[u8],
+    ) -> Option<Stmt> {
+        if !self.should_keep_names() {
+            return None;
+        }
+        self.record_usage(ref_);
+        let name_str = self.new_expr(E::String::init(original_name), loc);
+        let call = self.call_runtime(
+            loc,
+            b"__name",
+            ExprNodeList::from_slice(&[Expr::init_identifier(ref_, loc), name_str]),
+        );
+        Some(self.s(
+            S::SExpr {
+                value: call,
+                ..Default::default()
+            },
+            loc,
+        ))
+    }
+
     pub(crate) fn value_for_this(&mut self, loc: bun_ast::Loc) -> Option<Expr> {
         // Substitute "this" if we're inside a static class property initializer
         if self
@@ -5376,8 +5425,29 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub(crate) fn keep_expr_symbol_name(&mut self, _value: Expr, _name: &[u8]) -> Expr {
-        _value
+    pub(crate) fn keep_expr_symbol_name(&mut self, value: Expr, name: &[u8]) -> Expr {
+        if !self.should_keep_names() {
+            return value;
+        }
+        if let js_ast::ExprData::EClass(cls) = value.data {
+            if Self::class_has_custom_static_name(&cls) {
+                return value;
+            }
+        }
+        let loc = value.loc;
+        let name_str = self.new_expr(E::String::init(name), loc);
+        let target = self.runtime_identifier(loc, b"__name");
+        self.new_expr(
+            E::Call {
+                target,
+                args: ExprNodeList::from_slice(&[value, name_str]),
+                // The only side effect of `__name` is on `value` itself, so if the
+                // whole expression is unused tree-shaking may drop it.
+                can_be_unwrapped_if_unused: js_ast::e::CallUnwrap::IfUnused,
+                ..Default::default()
+            },
+            loc,
+        )
     }
 
     pub(crate) fn is_simple_parameter_list(args: &[G::Arg], has_rest_arg: bool) -> bool {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5279,7 +5279,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Some(self.s(
             S::SExpr {
                 value: call,
-                ..Default::default()
+                // `__name()` only mutates the (otherwise pure) identifier it tags;
+                // it must not pin the containing part.
+                does_not_affect_tree_shaking: true,
             },
             loc,
         ))

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5246,9 +5246,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// A user-written `static name` member owns `.name`; `__name()` must not clobber it.
     pub(crate) fn class_has_custom_static_name(class: &G::Class) -> bool {
         for prop in class.properties.iter() {
-            if !prop.flags.contains(Flags::Property::IsStatic)
-                || prop.flags.contains(Flags::Property::IsComputed)
-            {
+            if !prop.flags.contains(Flags::Property::IsStatic) {
                 continue;
             }
             if let Some(key) = prop.key {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -227,7 +227,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let dup: Option<&mut StringVoidMap> = duplicate_args_check.as_deref_mut();
             self.visit_binding(arg.binding, dup);
             if let Some(default) = arg.default.as_mut() {
+                let was_anonymous_named_expr = default.is_anonymous_named();
                 self.visit_expr(default);
+                if let BData::BIdentifier(bind_) = arg.binding.data {
+                    let bind_ = bind_.get();
+                    let name: &'a [u8] = self.symbols[bind_.r#ref.inner_index() as usize]
+                        .original_name
+                        .slice();
+                    arg.default = Some(self.maybe_keep_expr_symbol_name(
+                        arg.default.expect("unreachable"),
+                        name,
+                        was_anonymous_named_expr,
+                    ));
+                }
             }
         }
     }

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -703,15 +703,30 @@ impl BinaryExpressionVisitor {
                     );
                 }
             }
-            Op::Code::BinNullishCoalescingAssign | Op::Code::BinLogicalOrAssign => {
+            Op::Code::BinNullishCoalescingAssign
+            | Op::Code::BinLogicalOrAssign
+            | Op::Code::BinLogicalAndAssign => {
+                // Optionally preserve the name; `x ??= <anon>` performs
+                // NamedEvaluation with the LHS name, same as plain `=`.
+                if let ExprData::EIdentifier(ident) = e_.left.data {
+                    let name = p.symbols[ident.ref_.inner_index() as usize].original_name;
+                    e_.right = p.maybe_keep_expr_symbol_name(
+                        e_.right,
+                        name.slice(),
+                        was_anonymous_named_expr,
+                    );
+                }
+
                 // Special case `{}.field ??= value` to minify to `value`
                 // This optimization is specifically to target this pattern in HMR:
                 //    `import.meta.hot.data.etc ??= init()`
-                if let Some(dot) = e_.left.data.e_dot() {
-                    if let Some(obj) = dot.target.data.e_object() {
-                        if obj.properties.len_u32() == 0 {
-                            if dot.name != b"__proto__" {
-                                return e_.right;
+                if e_.op != Op::Code::BinLogicalAndAssign {
+                    if let Some(dot) = e_.left.data.e_dot() {
+                        if let Some(obj) = dot.target.data.e_object() {
+                            if obj.properties.len_u32() == 0 {
+                                if dot.name != b"__proto__" {
+                                    return e_.right;
+                                }
                             }
                         }
                     }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2628,6 +2628,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let decorator_name_from_context = p.decorator_class_name;
         p.decorator_class_name = None;
 
+        let original_class_name = e_.class_name;
         let _ = p.visit_class(expr.loc, &mut e_, Ref::NONE);
 
         // Lower standard decorators for class expressions
@@ -2650,6 +2651,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 == 0
         {
             e_.class_name = None;
+        }
+
+        if let Some(name) = original_class_name {
+            if !name.ref_.is_empty() && !Self::class_has_custom_static_name(&e_) {
+                let original_name: &[u8] = p.symbols[name.ref_.inner_index() as usize]
+                    .original_name
+                    .slice();
+                *e = p.keep_expr_symbol_name(expr, original_name);
+            }
         }
     }
 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2631,34 +2631,36 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let original_class_name = e_.class_name;
         let _ = p.visit_class(expr.loc, &mut e_, Ref::NONE);
 
+        // Decorator lowering rewrites `properties`, so decide before lowering.
+        let has_custom_static_name = Self::class_has_custom_static_name(&e_);
+
         // Lower standard decorators for class expressions
         if e_.should_lower_standard_decorators {
             *e = p.lower_standard_decorators_expr(&mut e_, expr.loc, decorator_name_from_context);
-            return;
-        }
-
-        // Remove unused class names when minifying (only when bundling is enabled)
-        // unless --keep-names is specified
-        if p.options.features.minify_syntax
-            && p.options.bundle
-            && !p.options.features.minify_keep_names
-            // SAFETY: current_scope is a live arena ptr while the parser exists.
-            && !p.current_scope().contains_direct_eval
-            && e_.class_name.is_some()
-            && !e_.class_name.unwrap().ref_.is_empty()
-            && p.symbols[e_.class_name.unwrap().ref_.inner_index() as usize]
-                .use_count_estimate
-                == 0
-        {
-            e_.class_name = None;
+        } else {
+            // Remove unused class names when minifying (only when bundling is enabled)
+            // unless --keep-names is specified
+            if p.options.features.minify_syntax
+                && p.options.bundle
+                && !p.options.features.minify_keep_names
+                // SAFETY: current_scope is a live arena ptr while the parser exists.
+                && !p.current_scope().contains_direct_eval
+                && e_.class_name.is_some()
+                && !e_.class_name.unwrap().ref_.is_empty()
+                && p.symbols[e_.class_name.unwrap().ref_.inner_index() as usize]
+                    .use_count_estimate
+                    == 0
+            {
+                e_.class_name = None;
+            }
         }
 
         if let Some(name) = original_class_name {
-            if !name.ref_.is_empty() && !Self::class_has_custom_static_name(&e_) {
+            if !name.ref_.is_empty() && !has_custom_static_name {
                 let original_name: &[u8] = p.symbols[name.ref_.inner_index() as usize]
                     .original_name
                     .slice();
-                *e = p.keep_expr_symbol_name(expr, original_name);
+                *e = p.keep_expr_symbol_name(*e, original_name);
             }
         }
     }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -817,6 +817,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             data.default_name = p.create_default_name(stmt.loc);
                         }
 
+                        // Decorator-name injection, `lower_class`, and the server-components
+                        // wrap all mutate `class.class` in place; capture what keep-names
+                        // needs while it still reflects the user-written shape.
+                        let has_custom_static_name =
+                            Self::class_has_custom_static_name(&class.class);
+                        let keep_name: &[u8] = match class.class.class_name {
+                            Some(n) if !n.ref_.is_empty() => p.load_name_from_ref(n.ref_),
+                            _ => js_ast::ClauseItem::DEFAULT_ALIAS,
+                        };
+
                         // We only inject a name into classes when decorator lowering
                         // needs one: legacy TS decorators (`has_decorators`) or
                         // standard decorator lowering, which also covers classes with
@@ -830,15 +840,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 class.class.class_name = Some(data.default_name);
                             }
                         }
-
-                        // `lower_class` / server-components wrapping mutate `class.class`
-                        // in place; capture what keep-names needs first.
-                        let has_custom_static_name =
-                            Self::class_has_custom_static_name(&class.class);
-                        let keep_name: &[u8] = match class.class.class_name {
-                            Some(n) if !n.ref_.is_empty() => p.load_name_from_ref(n.ref_),
-                            _ => js_ast::ClauseItem::DEFAULT_ALIAS,
-                        };
 
                         // Lower the class (handles both TS legacy and standard decorators).
                         // Standard decorator lowering may produce prefix statements
@@ -860,6 +861,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         data.value = js_ast::StmtOrExpr::Stmt(class_stmts[class_stmt_idx]);
                         stmts.push(*stmt);
 
+                        // `__name()` must land before the decorator suffix so decorator
+                        // callbacks observe the preserved name.
+                        if !has_custom_static_name {
+                            if let Some(keep) =
+                                p.keep_stmt_symbol_name(stmt.loc, data.default_name.ref_, keep_name)
+                            {
+                                stmts.push(keep);
+                            }
+                        }
+
                         // Emit any suffix statements after the export default
                         if class_stmt_idx + 1 < class_stmts.len() {
                             stmts.extend_from_slice(&class_stmts[class_stmt_idx + 1..]);
@@ -874,14 +885,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             data.value = js_ast::StmtOrExpr::Expr(
                                 p.wrap_value_for_server_component_reference(class_expr, b"default"),
                             );
-                        }
-
-                        if !has_custom_static_name {
-                            if let Some(keep) =
-                                p.keep_stmt_symbol_name(stmt.loc, data.default_name.ref_, keep_name)
-                            {
-                                stmts.push(keep);
-                            }
                         }
 
                         restore_dead!();
@@ -1098,18 +1101,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt));
 
         if !mark_as_dead || was_export_inside_namespace {
-            // Lower class field syntax for browsers that don't support it
-            stmts.extend_from_slice(lowered);
-            if let Some(name) = data.class.class_name {
-                if !has_custom_static_name {
+            // `__name()` must land immediately after the class so lowered decorator
+            // callbacks (which run after the class) observe the preserved name.
+            let keep = data
+                .class
+                .class_name
+                .filter(|_| !has_custom_static_name)
+                .and_then(|name| {
                     let original_name = p.symbols[name.ref_.inner_index() as usize]
                         .original_name
                         .slice();
-                    if let Some(keep) = p.keep_stmt_symbol_name(stmt.loc, name.ref_, original_name)
-                    {
-                        stmts.push(keep);
-                    }
-                }
+                    p.keep_stmt_symbol_name(stmt.loc, name.ref_, original_name)
+                });
+            if let Some(keep) = keep {
+                let class_idx = lowered
+                    .iter()
+                    .position(|cs| matches!(cs.data, StmtData::SClass(_)))
+                    .unwrap_or(0);
+                stmts.extend_from_slice(&lowered[..=class_idx]);
+                stmts.push(keep);
+                stmts.extend_from_slice(&lowered[class_idx + 1..]);
+            } else {
+                stmts.extend_from_slice(lowered);
             }
         } else {
             let ref_ = data

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -831,9 +831,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
 
-                        // `lower_class` may rewrite/hoist static members, so decide this first.
+                        // `lower_class` / server-components wrapping mutate `class.class`
+                        // in place; capture what keep-names needs first.
                         let has_custom_static_name =
                             Self::class_has_custom_static_name(&class.class);
+                        let keep_name: &[u8] = match class.class.class_name {
+                            Some(n) if !n.ref_.is_empty() => p.load_name_from_ref(n.ref_),
+                            _ => js_ast::ClauseItem::DEFAULT_ALIAS,
+                        };
 
                         // Lower the class (handles both TS legacy and standard decorators).
                         // Standard decorator lowering may produce prefix statements
@@ -872,10 +877,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         if !has_custom_static_name {
-                            let keep_name: &[u8] = match class.class.class_name {
-                                Some(n) if !n.ref_.is_empty() => p.load_name_from_ref(n.ref_),
-                                _ => js_ast::ClauseItem::DEFAULT_ALIAS,
-                            };
                             if let Some(keep) =
                                 p.keep_stmt_symbol_name(stmt.loc, data.default_name.ref_, keep_name)
                             {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -831,6 +831,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
 
+                        // `lower_class` may rewrite/hoist static members, so decide this first.
+                        let has_custom_static_name =
+                            Self::class_has_custom_static_name(&class.class);
+
                         // Lower the class (handles both TS legacy and standard decorators).
                         // Standard decorator lowering may produce prefix statements
                         // (variable declarations) before the class statement.
@@ -867,7 +871,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             );
                         }
 
-                        if !Self::class_has_custom_static_name(&class.class) {
+                        if !has_custom_static_name {
                             let keep_name: &[u8] = match class.class.class_name {
                                 Some(n) if !n.ref_.is_empty() => p.load_name_from_ref(n.ref_),
                                 _ => js_ast::ClauseItem::DEFAULT_ALIAS,
@@ -943,6 +947,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .expect("infallible: in namespace");
             stmts.reserve(3);
             stmts.push(*stmt);
+            if let Some(keep) = p.keep_stmt_symbol_name(stmt.loc, name_ref, original_name) {
+                stmts.push(keep);
+            }
             let func_name = data.func.name.expect("infallible: name checked");
             stmts.push(Stmt::assign(
                 p.new_expr(
@@ -1083,6 +1090,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             data.is_export = false;
         }
 
+        // `lower_class` may rewrite/hoist static members, so decide this first.
+        let has_custom_static_name = Self::class_has_custom_static_name(&data.class);
+
         // Lower class field syntax for browsers that don't support it
         let lowered = p.lower_class(js_ast::StmtOrExpr::Stmt(*stmt));
 
@@ -1090,7 +1100,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Lower class field syntax for browsers that don't support it
             stmts.extend_from_slice(lowered);
             if let Some(name) = data.class.class_name {
-                if !Self::class_has_custom_static_name(&data.class) {
+                if !has_custom_static_name {
                     let original_name = p.symbols[name.ref_.inner_index() as usize]
                         .original_name
                         .slice();

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -766,6 +766,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             stmts.push(*stmt);
                         }
 
+                        if let Some(keep) =
+                            p.keep_stmt_symbol_name(stmt.loc, data.default_name.ref_, name)
+                        {
+                            stmts.push(keep);
+                        }
+
                         p.react_refresh.hook_ctx_storage = prev;
                         restore_dead!();
                         record_on_exit!();
@@ -859,6 +865,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             data.value = js_ast::StmtOrExpr::Expr(
                                 p.wrap_value_for_server_component_reference(class_expr, b"default"),
                             );
+                        }
+
+                        if !Self::class_has_custom_static_name(&class.class) {
+                            let keep_name: &[u8] = match class.class.class_name {
+                                Some(n) if !n.ref_.is_empty() => p.load_name_from_ref(n.ref_),
+                                _ => js_ast::ClauseItem::DEFAULT_ALIAS,
+                            };
+                            if let Some(keep) =
+                                p.keep_stmt_symbol_name(stmt.loc, data.default_name.ref_, keep_name)
+                            {
+                                stmts.push(keep);
+                            }
                         }
 
                         restore_dead!();
@@ -977,6 +995,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ));
             } else {
                 stmts.push(*stmt);
+                if let Some(keep) = p.keep_stmt_symbol_name(stmt.loc, name_ref, original_name) {
+                    stmts.push(keep);
+                }
             }
         } else if mark_as_dead {
             if let Some(replacement) = p
@@ -1068,6 +1089,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !mark_as_dead || was_export_inside_namespace {
             // Lower class field syntax for browsers that don't support it
             stmts.extend_from_slice(lowered);
+            if let Some(name) = data.class.class_name {
+                if !Self::class_has_custom_static_name(&data.class) {
+                    let original_name = p.symbols[name.ref_.inner_index() as usize]
+                        .original_name
+                        .slice();
+                    if let Some(keep) = p.keep_stmt_symbol_name(stmt.loc, name.ref_, original_name)
+                    {
+                        stmts.push(keep);
+                    }
+                }
+            }
         } else {
             let ref_ = data
                 .class

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -157,6 +157,9 @@ describe("bundler", () => {
         const arrow = () => 1;
         let assigned;
         assigned = function() {};
+        let lazy; lazy ??= () => {};
+        let lazy2; lazy2 ||= () => {};
+        let lazy3 = 1; lazy3 &&= () => {};
         const NamedClassExpr = class Foo {};
         const AnonClassExpr = class {};
         class Base {}
@@ -170,6 +173,9 @@ describe("bundler", () => {
           (function named(){}).name,
           [...registry.keys()].sort().join("|"),
           assigned.name,
+          lazy.name,
+          lazy2.name,
+          lazy3.name,
           NamedClassExpr.name,
           AnonClassExpr.name,
           Base.name,
@@ -187,6 +193,9 @@ describe("bundler", () => {
         "named",
         "UserService|makeThing",
         "assigned",
+        "lazy",
+        "lazy2",
+        "lazy3",
         "Foo",
         "AnonClassExpr",
         "Base",
@@ -217,6 +226,45 @@ describe("bundler", () => {
     },
     run: {
       stdout: JSON.stringify({ a: "myFunc", b: "MyClass", c: "default", d: "default" }),
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    keepNames: true,
+    target: "bun",
+  });
+  itBundled("minify/KeepNamesDecoratorSeesName", {
+    files: {
+      "/tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+      "/entry.ts": /* ts */ `
+        let seen = "";
+        function register(t: any) { seen = t.name; return t; }
+        @register
+        class UserService {}
+        console.log(seen, UserService.name);
+      `,
+    },
+    entryPoints: ["/entry.ts"],
+    run: { stdout: "UserService UserService" },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    keepNames: true,
+    target: "bun",
+  });
+  itBundled("minify/KeepNamesTreeShaking", {
+    files: {
+      "/entry.js": /* js */ `
+        function unusedFn() { return 42; }
+        class UnusedCls {}
+        export function usedFn() { return 1; }
+      `,
+    },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).not.toContain("unusedFn");
+      expect(code).not.toContain("UnusedCls");
+      expect(code).toContain('"usedFn"');
     },
     minifySyntax: true,
     minifyWhitespace: true,

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -107,55 +107,162 @@ describe("bundler", () => {
   itBundled("minify/KeepNamesPreservesNames", {
     files: {
       "/entry.js": /* js */ `
-        export var AB = function A() { };
-        export var CD = function B() { return 1; };
-        export var EF = function C() { C(); };
-        export var GH = function() { };
-        export var IJ = class D { };
-        export var KL = class E { constructor() {} };
-        export var MN = class F { method() { return F; } };
-        export var OP = class { };
+        var AB = function A() { };
+        var CD = function B() { return 1; };
+        var EF = function C() { C(); };
+        var GH = function() { };
+        var IJ = class D { };
+        var KL = class E { constructor() {} };
+        var MN = class F { method() { return F; } };
+        var OP = class { };
+        console.log(JSON.stringify({
+          AB: AB.name, CD: CD.name, EF: EF.name, GH: GH.name,
+          IJ: IJ.name, KL: KL.name, MN: MN.name, OP: OP.name,
+        }));
       `,
+    },
+    run: {
+      stdout: JSON.stringify({
+        AB: "A",
+        CD: "B",
+        EF: "C",
+        GH: "GH",
+        IJ: "D",
+        KL: "E",
+        MN: "F",
+        OP: "OP",
+      }),
     },
     onAfterBundle(api) {
       const code = api.readFile("/out.js");
-      // With keepNames, all names should be preserved even when minifying
-      expect(code).toContain("function A()");
-      expect(code).toContain("function B()");
-      expect(code).toContain("function C()");
-      expect(code).toContain("class D");
-      expect(code).toContain("class E");
-      expect(code).toContain("class F");
-      // Anonymous functions/classes stay anonymous
-      expect(code).toMatch(/\w+ = function\(\) \{\}/); // GH stays anonymous
-      expect(code).toMatch(/\w+ = class \{\s*\}/); // OP stays anonymous
+      // The original names are carried as string arguments to __name().
+      for (const name of ["A", "B", "C", "GH", "D", "E", "F", "OP"]) {
+        expect(code).toContain(`"${name}"`);
+      }
     },
     minifySyntax: true,
-    minifyIdentifiers: false, // Don't minify identifiers to make testing easier
+    minifyIdentifiers: false,
     keepNames: true,
     target: "bun",
   });
   itBundled("minify/KeepNamesWithMinifyIdentifiers", {
     files: {
       "/entry.js": /* js */ `
-        export var AB = function A() { };
-        export var CD = function B() { return 1; };
-        export var EF = class C { };
+        class UserService {}
+        function makeThing() { return 1; }
+        const registry = new Map();
+        function register(k) { registry.set(k.name, k); }
+        register(UserService);
+        register(makeThing);
+        const arrow = () => 1;
+        let assigned;
+        assigned = function() {};
+        const NamedClassExpr = class Foo {};
+        const AnonClassExpr = class {};
+        class Base {}
+        class Derived extends Base {}
+        function* gen() {}
+        async function asyncFn() {}
+        console.log(JSON.stringify([
+          UserService.name,
+          makeThing.name,
+          arrow.name,
+          (function named(){}).name,
+          [...registry.keys()].sort().join("|"),
+          assigned.name,
+          NamedClassExpr.name,
+          AnonClassExpr.name,
+          Base.name,
+          Derived.name,
+          gen.name,
+          asyncFn.name,
+        ]));
+      `,
+    },
+    run: {
+      stdout: JSON.stringify([
+        "UserService",
+        "makeThing",
+        "arrow",
+        "named",
+        "UserService|makeThing",
+        "assigned",
+        "Foo",
+        "AnonClassExpr",
+        "Base",
+        "Derived",
+        "gen",
+        "asyncFn",
+      ]),
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    keepNames: true,
+    target: "bun",
+  });
+  itBundled("minify/KeepNamesExportDefault", {
+    files: {
+      "/entry.js": /* js */ `
+        import a from './a.js';
+        import b from './b.js';
+        import c from './c.js';
+        import d from './d.js';
+        console.log(JSON.stringify({a: a.name, b: b.name, c: c.name, d: d.name}));
+      `,
+      "/a.js": `export default function myFunc() {}`,
+      "/b.js": `export default class MyClass {}`,
+      "/c.js": `export default () => {}`,
+      "/d.js": `export default class {}`,
+    },
+    run: {
+      stdout: JSON.stringify({ a: "myFunc", b: "MyClass", c: "default", d: "default" }),
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    keepNames: true,
+    target: "bun",
+  });
+  itBundled("minify/KeepNamesSkipsStaticNameMember", {
+    files: {
+      "/entry.js": /* js */ `
+        class A { static name = "customA"; }
+        class B { static foo = 1; }
+        const C = class { static name = "customC"; };
+        const D = class Named { static name = "customD"; };
+        const E = class { static get name() { return "getE"; } };
+        console.log(JSON.stringify([A.name, B.name, C.name, D.name, E.name]));
+      `,
+    },
+    run: {
+      stdout: JSON.stringify(["customA", "B", "customC", "customD", "getE"]),
+    },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    keepNames: true,
+    target: "bun",
+  });
+  itBundled("minify/KeepNamesDisabledByDefault", {
+    files: {
+      "/entry.js": /* js */ `
+        class UserService {}
+        function makeThing() {}
+        console.log(UserService.name, makeThing.name);
       `,
     },
     onAfterBundle(api) {
       const code = api.readFile("/out.js");
-      // With keepNames + minifyIdentifiers, names are preserved but minified
-      // The original names A, B, C should still exist (though minified)
-      expect(code).toMatch(/function \w+\(\)/); // Functions should have names
-      expect(code).toMatch(/class \w+/); // Classes should have names
-      // Should not have anonymous functions/classes
-      expect(code).not.toContain("function()");
-      expect(code).not.toContain("class {");
+      // Without --keep-names there must be no __name runtime helper and no
+      // original-name string literals in the output.
+      expect(code).not.toContain('"UserService"');
+      expect(code).not.toContain('"makeThing"');
+      expect(code).not.toContain("defineProperty");
     },
     minifySyntax: true,
+    minifyWhitespace: true,
     minifyIdentifiers: true,
-    keepNames: true,
     target: "bun",
   });
   itBundled("minify/PrivateIdentifiersNameCollision", {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -160,6 +160,7 @@ describe("bundler", () => {
         let lazy; lazy ??= () => {};
         let lazy2; lazy2 ||= () => {};
         let lazy3 = 1; lazy3 &&= () => {};
+        function withDefault(cb = () => {}) { return cb.name; }
         const NamedClassExpr = class Foo {};
         const AnonClassExpr = class {};
         class Base {}
@@ -176,6 +177,7 @@ describe("bundler", () => {
           lazy.name,
           lazy2.name,
           lazy3.name,
+          withDefault(),
           NamedClassExpr.name,
           AnonClassExpr.name,
           Base.name,
@@ -196,6 +198,7 @@ describe("bundler", () => {
         "lazy",
         "lazy2",
         "lazy3",
+        "cb",
         "Foo",
         "AnonClassExpr",
         "Base",

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -224,6 +224,23 @@ describe("bundler", () => {
     keepNames: true,
     target: "bun",
   });
+  itBundled("minify/KeepNamesTSNamespace", {
+    files: {
+      "/entry.ts": /* ts */ `
+        namespace Foo {
+          export function bar() { return 1; }
+          export class Baz {}
+        }
+        console.log(Foo.bar.name, Foo.Baz.name);
+      `,
+    },
+    run: { stdout: "bar Baz" },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    keepNames: true,
+    target: "bun",
+  });
   itBundled("minify/KeepNamesSkipsStaticNameMember", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -249,11 +249,12 @@ describe("bundler", () => {
         const C = class { static name = "customC"; };
         const D = class Named { static name = "customD"; };
         const E = class { static get name() { return "getE"; } };
-        console.log(JSON.stringify([A.name, B.name, C.name, D.name, E.name]));
+        class F { static ["name"] = "computedF"; }
+        console.log(JSON.stringify([A.name, B.name, C.name, D.name, E.name, F.name]));
       `,
     },
     run: {
-      stdout: JSON.stringify(["customA", "B", "customC", "customD", "getE"]),
+      stdout: JSON.stringify(["customA", "B", "customC", "customD", "getE", "computedF"]),
     },
     minifySyntax: true,
     minifyWhitespace: true,

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -313,6 +313,37 @@ describe("bundler", () => {
     keepNames: true,
     target: "bun",
   });
+  // https://github.com/oven-sh/bun/issues/15552
+  // mongoose's debug formatter special-cases `options.session` via
+  // `constructor.name === "ClientSession"`; without --keep-names the minified
+  // bundle falls through and hits ClientSession.toBSON()'s throw.
+  itBundled("minify/KeepNamesCommonJSConstructorName#15552", {
+    files: {
+      "/entry.js": /* js */ `
+        const { ClientSession } = require("./sessions.js");
+        function format(x) {
+          if (x.constructor.name === "ClientSession") return "[ClientSession]";
+          return JSON.stringify(x);
+        }
+        const session = new ClientSession();
+        console.log(format(session));
+      `,
+      "/sessions.js": /* js */ `
+        "use strict";
+        class TypedEventEmitter {}
+        class ClientSession extends TypedEventEmitter {
+          toBSON() { throw new Error("ClientSession cannot be serialized to BSON."); }
+        }
+        exports.ClientSession = ClientSession;
+      `,
+    },
+    run: { stdout: "[ClientSession]" },
+    minifySyntax: true,
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    keepNames: true,
+    target: "bun",
+  });
   itBundled("minify/KeepNamesDisabledByDefault", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -1639,7 +1639,6 @@ describe("bundler", () => {
     run: true,
   });
   itBundled(`extra/FunctionHoistingKeepNames1`, {
-    todo: true, // keepNames requires Object.defineProperty implementation
     files: {
       "in.js": `
       var f
@@ -1651,7 +1650,6 @@ describe("bundler", () => {
     run: true,
   });
   itBundled(`extra/FunctionHoistingKeepNames2`, {
-    todo: true, // keepNames requires Object.defineProperty implementation
     files: {
       "in.js": `
       var f
@@ -1660,6 +1658,7 @@ describe("bundler", () => {
     `,
     },
     keepNames: true,
+    minifyIdentifiers: true,
     run: true,
   });
   itBundled(`extra/FunctionHoistingKeepNames3`, {


### PR DESCRIPTION
## What does this PR do?

`bun build --help` documents `--keep-names` as "Preserve original function and class names when minifying", but the flag's only visible effect was to stop the syntax pass from stripping the inline name off an unused function/class *expression*. Every declared function/class, and every arrow or function expression assigned to a binding, still lost its `.name` to the identifier renamer. Name-keyed DI registries and serializers break in minified bundles.

```js
// e.js
class UserService {}
function makeThing() { return 1; }
const registry = new Map();
function register(k) { registry.set(k.name, k); }
register(UserService); register(makeThing);
const arrow = () => 1;
console.log([UserService.name, makeThing.name, arrow.name, (function named(){}).name, [...registry.keys()].join("|")].join(","));
```

```
bun e.js                                         -> UserService,makeThing,arrow,named,UserService|makeThing
bun build e.js --minify --keep-names | bun -      -> e,o,s,n,e|o   (names NOT kept)
esbuild e.js --bundle --minify --keep-names       -> UserService,makeThing,arrow,named,...
```

### Cause

`keep_expr_symbol_name` in `src/js_parser/p.rs` was a no-op stub that returned its input unchanged. All the visitor call sites that feed it (variable declarators, assignments, class field initializers, default parameter values, `export default`) were already plumbed; the helper just never produced anything. The `__name` runtime helper in `src/runtime.js` and the `__name` entry in `ast/runtime.rs` existed but had no emitter.

### Fix

* Implement `keep_expr_symbol_name` to wrap expressions in `__name(value, "originalName")`, marked `can_be_unwrapped_if_unused: IfUnused` so tree-shaking still removes unused bindings.
* Add `keep_stmt_symbol_name` and emit `__name(ref, "originalName")` after function/class declarations (including `export default function`/`class`).
* Add named-class-expression handling in `e_class` (anonymous class expressions were already covered via `maybe_keep_expr_symbol_name`).
* Skip any class that defines its own `static name` member (field/method/getter/setter) so `__name()` never clobbers a user-supplied value.

All of this is gated on `options.features.minify_keep_names && allow_runtime`, so output without `--keep-names` is byte-identical.

After:
```
bun build e.js --minify --keep-names | bun -  -> UserService,makeThing,arrow,named,UserService|makeThing
```

The JS API path (`Bun.build({ minify: { keepNames: true } })`) already read the option; it now has the same effect as the CLI flag.

### Tests

* `bundler_minify.test.ts`: the two existing keep-names tests are rewritten to **run** the bundle and assert `.name` values with `minifyIdentifiers: true`; added `KeepNamesExportDefault`, `KeepNamesSkipsStaticNameMember`, and a negative `KeepNamesDisabledByDefault` that asserts no `__name`/name strings are emitted without the flag.
* `esbuild/extra.test.ts`: un-todo `FunctionHoistingKeepNames1`/`2` (block-scoped `if (1) function f() {}` hoisting), which now pass.

Fixes #12304
Fixes #25332
Fixes #15552

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts test/bundler/esbuild/extra.test.ts
bun test v1.4.0 (017c8d24f)

test/bundler/bundler_minify.test.ts:

# Unhandled error between tests
-------------------------------
1 | })
2 | (function (process, nextTickQueue, drainMicrotasksFn, reportUncaughtExceptionFn) {"use strict";
3 |   var queue, tickInitHooks, process, nextTickQueue = nextTickQueue, drainMicrotasks = drainMicrotasksFn, reportUncaughtException = reportUncaughtExceptionFn;
4 |   var setup = /* @__PURE__ */ __name(() => {
                                        ^
ReferenceError: __name is not defined
      at internal:streams/destroy (internal:streams/destroy:19:30)
      at internal:streams/pipeline (internal:streams/pipeline:5:94)
      at internal:streams/compose (internal:streams/compose:3:95)
      at internal:stream (internal:stream:7:90)
      at node:stream (node:stream:17:90)
      at internal:fs/streams (internal:fs/streams:21:116)
      at ReadStream (node:fs:897:109)
-------------------------------


# Unhandled error between tests
... (truncated)

release without fix: 10 skipped
bun test v1.4.0-canary.1 (963df7387)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [18.82ms]
(pass) bundler > minify/StringAdditionFolding [4.58ms]
(pass) bundler > minify/FunctionExpressionRemoveName [6.09ms]
(pass) bundler > minify/KeepNamesPreservesNames [17.85ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [17.81ms]
(pass) bundler > minify/KeepNamesExportDefault [16.61ms]
(pass) bundler > minify/KeepNamesDecoratorSeesName [17.50ms]
(pass) bundler > minify/KeepNamesTreeShaking [4.82ms]
(pass) bundler > minify/KeepNamesTSNamespace [16.43ms]
(pass) bundler > minify/KeepNamesSkipsStaticNameMember [16.84ms]
(pass) bundler > minify/KeepNamesDisabledByDefault [4.12ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [21.45ms]
(pass) bundler > minify/MergeAdjacentVars [18.29ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [16.16ms]
(pass) bundler > minify/Infinity [3.40ms]
(pass) bundler > minify+whitespace/Infinity [3.78ms]
(pass) bundler > minify/NumericPropertyKeysPrintedAsComputed [15.61ms]
(pass) bundler > minify/InlineArraySpread [4.01ms]
(pass) bundler > minify/ForAndWhileLoopsWithMissingBlock [16.35
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 10 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_minify.test.ts test/bundler/esbuild/extra.test.ts
bun test v1.4.0 (017c8d24f)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/TemplateStringFolding [724.39ms]
(pass) bundler > minify/StringAdditionFolding [124.33ms]
(pass) bundler > minify/FunctionExpressionRemoveName [134.08ms]
(pass) bundler > minify/KeepNamesPreservesNames [685.33ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [612.04ms]
(pass) bundler > minify/KeepNamesExportDefault [596.32ms]
(pass) bundler > minify/KeepNamesDecoratorSeesName [609.15ms]
(pass) bundler > minify/KeepNamesTreeShaking [112.73ms]
(pass) bundler > minify/KeepNamesTSNamespace [689.58ms]
(pass) bundler > minify/KeepNamesSkipsStaticNameMember [634.72ms]
(pass) bundler > minify/KeepNamesDisabledByDefault [146.64ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1408.88ms]
(pass) bundler > minify/MergeAdjacentVars [907.69ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [603.85ms]
(pass) bundler > minify/Infinity [179.19ms]
(pass) bundler > minif
... (truncated)

release with fix: 10 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 770ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/38] gen cpp.rs (cppbind)
[2/38] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/38] gen JS modules (bundle-modules)
Preprocess modules (7767ms)
Bundle modules (40ms)
Postprocesss modules (205ms)
Bundle Functions (949ms)
Generate Code (27ms)

[9.01s] Bundled "src/js" for production
  2200 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[3/31] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/bundle-functions.ts     |   6 +-
 src/js_parser/p.rs                  |  74 +++++++++++-
 src/js_parser/visit/mod.rs          |  12 ++
 src/js_parser/visit/visit_binary.rs |  27 ++++-
 src/js_parser/visit/visit_expr.rs   |  42 ++++---
 src/js_parser/visit/visit_stmt.rs   |  60 ++++++++-
 test/bundler/bundler_minify.test.ts | 234 +++++++++++++++++++++++++++++++-----
 test/bundler/esbuild/extra.test.ts  |   3 +-
 8 files changed, 401 insertions(+), 57 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/codegen/bundle-functions.ts          4      5      0
src/js_parser/p.rs                       6      7      0
src/js_parser/visit/mod.rs               4      1      0
src/js_parser/visit/visit_binary.rs      1      1      0
src/js_parser/visit/visit_expr.rs        2      4      0
src/js_parser/visit/visit_stmt.rs       13     14      0
test/bundler/bundler_minify.test.ts      1     12      0
test/bundler/esbuild/extra.test.ts       1      1      0
```

</details>

<!-- robobun:evidence:end -->
