### PR TITLE
bundler: warn when a bare import is dropped by sideEffects

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2915,6 +2915,14 @@ impl<'a> LinkerContext<'a> {
         if source.path.is_node_module() {
             return;
         }
+        // A "file" / "napi" / "wasm" loader copies the asset into the output
+        // even though its JS wrapper has no side effects, so the import is not
+        // actually ignored. esbuild drops the asset and warns; we keep it.
+        let other_loader =
+            self.parse_graph().input_files.items_loader()[other_source_index as usize];
+        if other_loader.should_copy_for_bundling() {
+            return;
+        }
         let other_source = self.get_source(other_source_index);
 
         let note_text: std::borrow::Cow<'static, [u8]> = match se {
@@ -2924,9 +2932,9 @@ impl<'a> LinkerContext<'a> {
             SideEffects::NoSideEffectsPureData => std::borrow::Cow::Borrowed(
                 b"This file is considered to have no side effects because of the loader used",
             ),
-            SideEffects::NoSideEffectsEmptyAst => std::borrow::Cow::Borrowed(
-                b"This file is considered to have no side effects because it was empty after parsing",
-            ),
+            // Don't warn for type-only / .d.ts files; the import is a no-op by
+            // design and there's nothing actionable.
+            SideEffects::NoSideEffectsEmptyAst => return,
             SideEffects::HasSideEffects => return,
         };
         let notes: Box<[Data]> = Box::new([Data {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2854,6 +2854,17 @@ impl<'a> LinkerContext<'a> {
                     let se = ctx.side_effects[other_source_index as usize];
 
                     if se != SideEffects::HasSideEffects && !self.options.ignore_dce_annotations {
+                        if record
+                            .flags
+                            .contains(bun_ast::ImportRecordFlags::WAS_ORIGINALLY_BARE_IMPORT)
+                        {
+                            self.warn_ignored_bare_import(
+                                source_index,
+                                other_source_index,
+                                record.range,
+                                se,
+                            );
+                        }
                         continue;
                     }
 
@@ -2888,6 +2899,50 @@ impl<'a> LinkerContext<'a> {
                 }
             }
         }
+    }
+
+    #[cold]
+    fn warn_ignored_bare_import(
+        &self,
+        source_index: crate::IndexInt,
+        other_source_index: crate::IndexInt,
+        range: Range,
+        se: SideEffects,
+    ) {
+        let source = self.get_source(source_index);
+        // Don't warn about bare imports inside "node_modules"; the package
+        // author presumably knows what they're doing (esbuild issue 999).
+        if source.path.is_node_module() {
+            return;
+        }
+        let other_source = self.get_source(other_source_index);
+
+        let note_text: std::borrow::Cow<'static, [u8]> = match se {
+            SideEffects::NoSideEffectsPackageJson => std::borrow::Cow::Borrowed(
+                b"\"sideEffects\" is false in the enclosing \"package.json\" file",
+            ),
+            SideEffects::NoSideEffectsPureData => std::borrow::Cow::Borrowed(
+                b"This file is considered to have no side effects because of the loader used",
+            ),
+            SideEffects::NoSideEffectsEmptyAst => std::borrow::Cow::Borrowed(
+                b"This file is considered to have no side effects because it was empty after parsing",
+            ),
+            SideEffects::HasSideEffects => return,
+        };
+        let notes: Box<[Data]> = Box::new([Data {
+            text: note_text,
+            location: None,
+        }]);
+
+        self.log_disjoint().add_range_warning_fmt_with_notes(
+            Some(source),
+            range,
+            notes,
+            format_args!(
+                "Ignoring this import because \"{}\" was marked as having no side effects",
+                bstr::BStr::new(&other_source.path.pretty),
+            ),
+        );
     }
 
     fn mark_part_live_step(

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2919,7 +2919,7 @@ impl<'a> LinkerContext<'a> {
 
         let note_text: std::borrow::Cow<'static, [u8]> = match se {
             SideEffects::NoSideEffectsPackageJson => std::borrow::Cow::Borrowed(
-                b"\"sideEffects\" is false in the enclosing \"package.json\" file",
+                b"This is because of \"sideEffects\" in the enclosing \"package.json\" file",
             ),
             SideEffects::NoSideEffectsPureData => std::borrow::Cow::Borrowed(
                 b"This file is considered to have no side effects because of the loader used",

--- a/test/bundler/esbuild/dce.test.ts
+++ b/test/bundler/esbuild/dce.test.ts
@@ -210,6 +210,11 @@ describe("bundler", () => {
       `,
     },
     dce: true,
+    bundleWarnings: {
+      "/Users/user/project/src/entry.js": [
+        `Ignoring this import because "Users/user/project/node_modules/demo-pkg/index.js" was marked as having no side effects`,
+      ],
+    },
     run: {
       stdout: "unused import",
     },
@@ -231,6 +236,11 @@ describe("bundler", () => {
       `,
     },
     dce: true,
+    bundleWarnings: {
+      "/Users/user/project/src/entry.js": [
+        `Ignoring this import because "Users/user/project/node_modules/demo-pkg/index.js" was marked as having no side effects`,
+      ],
+    },
     run: {
       stdout: "unused import",
     },
@@ -613,6 +623,11 @@ describe("bundler", () => {
       `,
     },
     dce: true,
+    bundleWarnings: {
+      "/Users/user/project/src/entry.js": [
+        `Ignoring this import because "Users/user/project/node_modules/demo-pkg/remove/this/file.js" was marked as having no side effects`,
+      ],
+    },
     run: {
       stdout: "this should be kept",
     },
@@ -923,6 +938,7 @@ describe("bundler", () => {
       `,
     },
     dce: true,
+    bundleWarnings: {},
     run: {
       stdout: "unused import\nused import",
     },


### PR DESCRIPTION
Closes the diagnostic gap where `import "pkg"` resolving to a module marked side-effect-free is silently dropped from the bundle.

## Repro

```sh
mkdir -p node_modules/poly
printf '{"name":"poly","main":"index.js","sideEffects":false}\n' > node_modules/poly/package.json
printf 'globalThis.__poly = "installed";\n' > node_modules/poly/index.js
printf 'import "poly";\nconsole.log("poly=" + (globalThis.__poly ?? "MISSING"));\n' > e.js
bun build e.js --outdir=out && bun out/e.js   # poly=MISSING, no warning
```

The drop itself is correct (matches esbuild/webpack), but bun emitted nothing: `Bun.build().logs` was `[]` and the CLI printed only the summary. esbuild emits `[ignored-bare-import]` here, so a polyfill that vanished because of a wrong `sideEffects` flag is diagnosable there and was silent in bun.

## Cause

`mark_file_live_step` in `LinkerContext.rs` skips the side-effect-free target with a bare `continue`, discarding the fact that `WAS_ORIGINALLY_BARE_IMPORT` is set on the record. The flag has always been set by the parser but was never read on this path.

## Fix

Before the `continue`, if the record was originally a bare `import "x"` statement, emit a warning at the import site naming the dropped file, with a note explaining why it was considered side-effect-free (`"sideEffects"` in package.json / data loader / empty AST). The warning is suppressed when the importing file is itself inside `node_modules`, matching esbuild issue 999.

After:

```
1 | import "poly";
           ^
warn: Ignoring this import because "node_modules/poly/index.js" was marked as having no side effects
   at e.js:1:8

note: "sideEffects" is false in the enclosing "package.json" file
```

`Bun.build().logs` now contains the corresponding `BuildMessage`.

## Verification

- `dce/PackageJsonSideEffectsFalseRemoveBareImportES6`, `...CommonJS`, `...ArrayGlob` now assert the warning via `bundleWarnings` (fail on released bun, pass with this change)
- `dce/PackageJsonSideEffectsFalseNoWarningInNodeModulesESBuildIssue999` now asserts no warning is emitted
- Named imports (`import {foo} from "pkg"`) and `--ignore-dce-annotations` produce no warning
- Full `dce.test.ts` plus edgecase/barrel/importstar/ts/extra/jsx/default bundler suites: 771 pass, 0 fail

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/esbuild/dce.test.ts

<!-- robobun:evidence:end -->