### PR TITLE
shell: throw on Response/Request stream body used as redirect instead of delivering zero bytes

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -732,30 +732,8 @@ impl Builtin {
                     // SAFETY: returned a live JSC-owned `*mut Value` borrowed
                     // from a Response/Request wrapper.
                     let body = unsafe { &mut *body };
-                    body.to_blob_if_possible();
-                    match body {
-                        crate::webcore::body::Value::Locked(_) => {
-                            let _ = global.throw_invalid_arguments(format_args!(
-                                "Request/Response body is a ReadableStream, which cannot be \
-                                 redirected in Bun Shell yet. Read it first: \
-                                 $`cmd < ${{await response.bytes()}}`"
-                            ));
-                            return Some(Yield::failed());
-                        }
-                        crate::webcore::body::Value::Used => {
-                            let _ = global
-                                .err(
-                                    crate::jsc::ErrorCode::BODY_ALREADY_USED,
-                                    format_args!("Body already used"),
-                                )
-                                .throw();
-                            return Some(Yield::failed());
-                        }
-                        crate::webcore::body::Value::Error(err) => {
-                            let _ = global.throw_value(err.to_js(global));
-                            return Some(Yield::failed());
-                        }
-                        _ => {}
+                    if crate::shell::util::check_body_for_redirect(body, global).is_err() {
+                        return Some(Yield::failed());
                     }
                     let is_file_blob = matches!(body, crate::webcore::body::Value::Blob(b)
                         if !b.needs_to_read_file());

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -732,6 +732,31 @@ impl Builtin {
                     // SAFETY: returned a live JSC-owned `*mut Value` borrowed
                     // from a Response/Request wrapper.
                     let body = unsafe { &mut *body };
+                    body.to_blob_if_possible();
+                    match body {
+                        crate::webcore::body::Value::Locked(_) => {
+                            let _ = global.throw_invalid_arguments(format_args!(
+                                "Request/Response body is a ReadableStream, which cannot be \
+                                 redirected in Bun Shell yet. Read it first: \
+                                 $`cmd < ${{await response.bytes()}}`"
+                            ));
+                            return Some(Yield::failed());
+                        }
+                        crate::webcore::body::Value::Used => {
+                            let _ = global
+                                .err(
+                                    crate::jsc::ErrorCode::BODY_ALREADY_USED,
+                                    format_args!("Body already used"),
+                                )
+                                .throw();
+                            return Some(Yield::failed());
+                        }
+                        crate::webcore::body::Value::Error(err) => {
+                            let _ = global.throw_value(err.to_js(global));
+                            return Some(Yield::failed());
+                        }
+                        _ => {}
+                    }
                     let is_file_blob = matches!(body, crate::webcore::body::Value::Blob(b)
                         if !b.needs_to_read_file());
                     if (redirect.stdout() || redirect.stderr()) && !is_file_blob {

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -732,7 +732,9 @@ impl Builtin {
                     // SAFETY: returned a live JSC-owned `*mut Value` borrowed
                     // from a Response/Request wrapper.
                     let body = unsafe { &mut *body };
-                    if crate::shell::util::check_body_for_redirect(body, global).is_err() {
+                    if crate::shell::util::check_body_for_redirect(body, global, redirect.stdin())
+                        .is_err()
+                    {
                         return Some(Yield::failed());
                     }
                     let is_file_blob = matches!(body, crate::webcore::body::Value::Blob(b)

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -467,7 +467,7 @@ pub fn handle_template_value(
             return Ok(());
         }
 
-        if let Some(_req) = template_value.as_::<crate::webcore::Response>() {
+        if crate::webcore::body::Value::from_request_or_response(template_value).is_some() {
             let idx = out_jsobjs.len();
             marked_argument_buffer.append(template_value);
             out_jsobjs.push(template_value);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -772,7 +772,7 @@ impl Cmd {
                     // SAFETY: returns a live JSC-owned `*mut Value` borrowed
                     // from the Request/Response wrapper while `jsval` is rooted.
                     let body = unsafe { &mut *body };
-                    crate::shell::util::check_body_for_redirect(body, global)?;
+                    crate::shell::util::check_body_for_redirect(body, global, flags.stdin())?;
                     if flags.stdin() {
                         let b = body.use_as_any_blob();
                         stdio[STDIN_NO].extract_blob(global, b, STDIN_NO as i32)?;

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -766,20 +766,44 @@ impl Cmd {
                     }
                 } else if crate::webcore::ReadableStream::from_js(jsval, global)?.is_some() {
                     panic!("TODO SHELL READABLE STREAM");
-                } else if let Some(req) = jsval.as_::<crate::webcore::Response>() {
-                    // SAFETY: `as_` returns a live JSC-owned `*mut Response`.
-                    let req = unsafe { &mut *req };
-                    req.get_body_value().to_blob_if_possible();
+                } else if let Some(body) =
+                    crate::webcore::body::Value::from_request_or_response(jsval)
+                {
+                    // SAFETY: returns a live JSC-owned `*mut Value` borrowed
+                    // from the Request/Response wrapper while `jsval` is rooted.
+                    let body = unsafe { &mut *body };
+                    body.to_blob_if_possible();
+                    match body {
+                        crate::webcore::body::Value::Locked(_) => {
+                            return Err(global.throw_invalid_arguments(format_args!(
+                                "Request/Response body is a ReadableStream, which cannot be \
+                                 redirected in Bun Shell yet. Read it first: \
+                                 $`cmd < ${{await response.bytes()}}`"
+                            )));
+                        }
+                        crate::webcore::body::Value::Used => {
+                            return Err(global
+                                .err(
+                                    crate::jsc::ErrorCode::BODY_ALREADY_USED,
+                                    format_args!("Body already used"),
+                                )
+                                .throw());
+                        }
+                        crate::webcore::body::Value::Error(err) => {
+                            return Err(global.throw_value(err.to_js(global)));
+                        }
+                        _ => {}
+                    }
                     if flags.stdin() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = body.use_as_any_blob();
                         stdio[STDIN_NO].extract_blob(global, b, STDIN_NO as i32)?;
                     }
                     if flags.stdout() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = body.use_as_any_blob();
                         stdio[STDOUT_NO].extract_blob(global, b, STDOUT_NO as i32)?;
                     }
                     if flags.stderr() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = body.use_as_any_blob();
                         stdio[STDERR_NO].extract_blob(global, b, STDERR_NO as i32)?;
                     }
                 } else {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -772,28 +772,7 @@ impl Cmd {
                     // SAFETY: returns a live JSC-owned `*mut Value` borrowed
                     // from the Request/Response wrapper while `jsval` is rooted.
                     let body = unsafe { &mut *body };
-                    body.to_blob_if_possible();
-                    match body {
-                        crate::webcore::body::Value::Locked(_) => {
-                            return Err(global.throw_invalid_arguments(format_args!(
-                                "Request/Response body is a ReadableStream, which cannot be \
-                                 redirected in Bun Shell yet. Read it first: \
-                                 $`cmd < ${{await response.bytes()}}`"
-                            )));
-                        }
-                        crate::webcore::body::Value::Used => {
-                            return Err(global
-                                .err(
-                                    crate::jsc::ErrorCode::BODY_ALREADY_USED,
-                                    format_args!("Body already used"),
-                                )
-                                .throw());
-                        }
-                        crate::webcore::body::Value::Error(err) => {
-                            return Err(global.throw_value(err.to_js(global)));
-                        }
-                        _ => {}
-                    }
+                    crate::shell::util::check_body_for_redirect(body, global)?;
                     if flags.stdin() {
                         let b = body.use_as_any_blob();
                         stdio[STDIN_NO].extract_blob(global, b, STDIN_NO as i32)?;

--- a/src/runtime/shell/util.rs
+++ b/src/runtime/shell/util.rs
@@ -17,17 +17,25 @@ pub use crate::api::bun_spawn::stdio::Stdio;
 /// that, `Locked` (a JS-driven ReadableStream), `Used` and `Error` all have no
 /// synchronous bytes to hand to the command, and `use_as_any_blob()` / `use_()`
 /// would substitute an empty `Blob` for each of them, so the command would run
-/// on zero bytes and succeed.
+/// on zero bytes and succeed. The stdin hint is only appended for a stdin
+/// redirect; a stream body can never be a write target, so stdout/stderr gets
+/// the bare sentence.
 pub fn check_body_for_redirect(
     body: &mut crate::webcore::body::Value,
     global: &crate::jsc::JSGlobalObject,
+    stdin: bool,
 ) -> crate::jsc::JsResult<()> {
     body.to_blob_if_possible();
     match body {
         crate::webcore::body::Value::Locked(_) => {
             Err(global.throw_invalid_arguments(format_args!(
                 "Request/Response body is a ReadableStream, which cannot be redirected in \
-             Bun Shell yet. Read it first: $`cmd < ${{await response.bytes()}}`"
+                 Bun Shell yet{}",
+                if stdin {
+                    ". Read it first: $`cmd < ${await response.bytes()}`"
+                } else {
+                    ""
+                }
             )))
         }
         crate::webcore::body::Value::Used => Err(global
@@ -36,6 +44,8 @@ pub fn check_body_for_redirect(
                 format_args!("Body already used"),
             )
             .throw()),
+        // Reached via fetch()-driven bodies whose transport failed
+        // (Body::to_error_instance), not via user-constructed `new Response()`.
         crate::webcore::body::Value::Error(err) => Err(global.throw_value(err.to_js(global))),
         _ => Ok(()),
     }

--- a/src/runtime/shell/util.rs
+++ b/src/runtime/shell/util.rs
@@ -9,3 +9,34 @@ pub enum OutKind {
 // low-level `PosixStdio`/`WindowsStdio` spawn-option shape that the
 // `bun_spawn` *crate* re-exports under the same name.
 pub use crate::api::bun_spawn::stdio::Stdio;
+
+/// Reject a Request/Response body that cannot be used as a shell redirect.
+///
+/// Called after `from_request_or_response`; runs `to_blob_if_possible()` so a
+/// native-backed stream (Bun.file, Blob.stream()) is converted first. After
+/// that, `Locked` (a JS-driven ReadableStream), `Used` and `Error` all have no
+/// synchronous bytes to hand to the command, and `use_as_any_blob()` / `use_()`
+/// would substitute an empty `Blob` for each of them, so the command would run
+/// on zero bytes and succeed.
+pub fn check_body_for_redirect(
+    body: &mut crate::webcore::body::Value,
+    global: &crate::jsc::JSGlobalObject,
+) -> crate::jsc::JsResult<()> {
+    body.to_blob_if_possible();
+    match body {
+        crate::webcore::body::Value::Locked(_) => {
+            Err(global.throw_invalid_arguments(format_args!(
+                "Request/Response body is a ReadableStream, which cannot be redirected in \
+             Bun Shell yet. Read it first: $`cmd < ${{await response.bytes()}}`"
+            )))
+        }
+        crate::webcore::body::Value::Used => Err(global
+            .err(
+                crate::jsc::ErrorCode::BODY_ALREADY_USED,
+                format_args!("Body already used"),
+            )
+            .throw()),
+        crate::webcore::body::Value::Error(err) => Err(global.throw_value(err.to_js(global))),
+        _ => Ok(()),
+    }
+}

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1732,6 +1732,22 @@ describe("deno_task", () => {
           expect(stdout.toString()).toBe(P);
         });
       });
+
+      test("stdout redirect to a stream-body Response rejects without the stdin hint", async () => {
+        const body = new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode(P));
+            c.close();
+          },
+        });
+        const err = await $`echo hi > ${new Response(body)}`.text().then(
+          () => null,
+          e => e,
+        );
+        expect(err).not.toBeNull();
+        expect(err.message).toMatch(/body is a ReadableStream/);
+        expect(err.message).not.toContain("Read it first");
+      });
     });
   });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1666,6 +1666,69 @@ describe("deno_task", () => {
     TestBuilder.command`BUN_DEBUG_QUIET_LOGS=1 ${BUN} -e ${code} > /dev/null`
       .quiet()
       .runAsTest("bunception redirect /dev/null");
+
+    describe("stdin from Request/Response", () => {
+      const P = "hello-shell-stdin-0123456789";
+
+      // A Response whose body is a JS-driven ReadableStream cannot be drained
+      // synchronously at redirect setup time. It used to be substituted with an
+      // empty blob, so the command ran on zero bytes and reported success.
+      describe.each([
+        [
+          "ReadableStream start()",
+          () =>
+            new ReadableStream({
+              start(c) {
+                c.enqueue(new TextEncoder().encode(P));
+                c.close();
+              },
+            }),
+        ],
+        [
+          "TransformStream readable",
+          () => {
+            const ts = new TransformStream();
+            const w = ts.writable.getWriter();
+            w.write(new TextEncoder().encode(P));
+            w.close();
+            return ts.readable;
+          },
+        ],
+        [
+          "async generator",
+          () =>
+            (async function* () {
+              yield P;
+            })(),
+        ],
+      ])("Response(%s) as stdin", (_name, body) => {
+        test("rejects instead of delivering zero bytes", async () => {
+          await expect($`cat < ${new Response(body())}`.text()).rejects.toThrow(/body is a ReadableStream/);
+        });
+      });
+
+      test("Response with an already-consumed body rejects", async () => {
+        const res = new Response(P);
+        await res.text();
+        await expect($`cat < ${res}`.text()).rejects.toThrow(/already used/i);
+      });
+
+      test("Response with a string body still works", async () => {
+        const { stdout } = await $`cat < ${new Response(P)}`;
+        expect(stdout.toString()).toBe(P);
+      });
+
+      test("Response with a Blob body still works", async () => {
+        const { stdout } = await $`cat < ${new Response(new Blob([P]))}`;
+        expect(stdout.toString()).toBe(P);
+      });
+
+      test("Request as stdin", async () => {
+        const req = new Request("http://example.com", { method: "POST", body: P });
+        const { stdout } = await $`cat < ${req}`;
+        expect(stdout.toString()).toBe(P);
+      });
+    });
   });
 
   describe("pwd", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1669,64 +1669,68 @@ describe("deno_task", () => {
 
     describe("stdin from Request/Response", () => {
       const P = "hello-shell-stdin-0123456789";
+      const wrap = {
+        Response: (b: BodyInit) => new Response(b),
+        Request: (b: BodyInit) => new Request("http://example.com", { method: "POST", body: b }),
+      } as const;
 
-      // A Response whose body is a JS-driven ReadableStream cannot be drained
-      // synchronously at redirect setup time. It used to be substituted with an
-      // empty blob, so the command ran on zero bytes and reported success.
-      describe.each([
-        [
-          "ReadableStream start()",
-          () =>
-            new ReadableStream({
-              start(c) {
-                c.enqueue(new TextEncoder().encode(P));
-                c.close();
-              },
-            }),
-        ],
-        [
-          "TransformStream readable",
-          () => {
-            const ts = new TransformStream();
-            const w = ts.writable.getWriter();
-            w.write(new TextEncoder().encode(P));
-            w.close();
-            return ts.readable;
-          },
-        ],
-        [
-          "async generator",
-          () =>
-            (async function* () {
-              yield P;
-            })(),
-        ],
-      ])("Response(%s) as stdin", (_name, body) => {
-        test("rejects instead of delivering zero bytes", async () => {
-          await expect($`cat < ${new Response(body())}`.text()).rejects.toThrow(/body is a ReadableStream/);
+      // A Request/Response whose body is a JS-driven ReadableStream cannot be
+      // drained synchronously at redirect setup time. It used to be substituted
+      // with an empty blob, so the command ran on zero bytes and reported
+      // success. On POSIX `cat` resolves to a spawned subprocess
+      // (Cmd::init_subproc_redirections); on Windows it is the shell builtin
+      // (Builtin::init_redirections); both paths route through
+      // check_body_for_redirect.
+      describe.each(["Response", "Request"] as const)("%s", kind => {
+        describe.each([
+          [
+            "ReadableStream start()",
+            () =>
+              new ReadableStream({
+                start(c) {
+                  c.enqueue(new TextEncoder().encode(P));
+                  c.close();
+                },
+              }),
+          ],
+          [
+            "TransformStream readable",
+            () => {
+              const ts = new TransformStream();
+              const w = ts.writable.getWriter();
+              w.write(new TextEncoder().encode(P));
+              w.close();
+              return ts.readable;
+            },
+          ],
+          [
+            "async generator",
+            () =>
+              (async function* () {
+                yield P;
+              })(),
+          ],
+        ])("with a %s body", (_name, body) => {
+          test("rejects instead of delivering zero bytes", async () => {
+            await expect($`cat < ${wrap[kind](body())}`.text()).rejects.toThrow(/body is a ReadableStream/);
+          });
         });
-      });
 
-      test("Response with an already-consumed body rejects", async () => {
-        const res = new Response(P);
-        await res.text();
-        await expect($`cat < ${res}`.text()).rejects.toThrow(/already used/i);
-      });
+        test("with an already-consumed body rejects", async () => {
+          const r = wrap[kind](P);
+          await r.text();
+          await expect($`cat < ${r}`.text()).rejects.toThrow(/already used/i);
+        });
 
-      test("Response with a string body still works", async () => {
-        const { stdout } = await $`cat < ${new Response(P)}`;
-        expect(stdout.toString()).toBe(P);
-      });
+        test("with a string body still works", async () => {
+          const { stdout } = await $`cat < ${wrap[kind](P)}`;
+          expect(stdout.toString()).toBe(P);
+        });
 
-      test("Response with a Blob body still works", async () => {
-        const { stdout } = await $`cat < ${new Response(new Blob([P]))}`;
-        expect(stdout.toString()).toBe(P);
-      });
-
-      test("Request as stdin", async () => {
-        const req = new Request("http://example.com", { method: "POST", body: P });
-        const { stdout } = await $`cat < ${req}`;
-        expect(stdout.toString()).toBe(P);
+        test("with a Blob body still works", async () => {
+          const { stdout } = await $`cat < ${wrap[kind](new Blob([P]))}`;
+          expect(stdout.toString()).toBe(P);
+        });
       });
     });
   });


### PR DESCRIPTION
## What does this PR do?

A `Response` whose body is a JS-driven `ReadableStream` (a `start`/`pull` source, `TransformStream#readable`, an async generator, `pipeThrough(new CompressionStream(...))`) used as a shell stdin redirect runs the command on zero bytes and reports success:

```js
import { $ } from "bun";
const P = "hello-shell-stdin-0123456789";
const body = new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode(P)); c.close(); } });
console.log(await $`cat < ${new Response(body)} | wc -c`.text()); // "0", exit 0
console.log(await $`cat < ${new Response(new Blob([P]))} | wc -c`.text()); // "28"
```

The same `Response`'s `.text()` returns the full payload. "Response as stdin" is the docs' headline shell example; the breakage is only the composed-stream case (string / `Blob` / `blob.stream()` / `Bun.file` / real `fetch()` bodies work).

### Cause

`Cmd::init_subproc_redirections` (src/runtime/shell/states/Cmd.rs) and `Builtin::init_redirections` (src/runtime/shell/Builtin.rs) call `Body::use_as_any_blob()` / `Body::use_()` on the wrapped body. For a `Value::Locked` body whose stream is not backed by a synchronously-readable native source, `to_any_blob_allow_promise()` returns `None` and `use_as_any_blob()` falls back to `.unwrap_or(Blob::default())` (src/runtime/webcore/Body.rs:1249-1251). `Stdio::extract_blob` then maps the empty blob to `Stdio::Ignore`. `Value::Used` and `Value::Error` took the same empty-blob fallback.

### Fix

A new `shell::util::check_body_for_redirect(body, global, stdin)` runs `to_blob_if_possible()` (which converts native-backed streams to a `Blob`) and then throws instead of letting the caller substitute an empty blob:

- `Locked`: `ERR_INVALID_ARG_TYPE` with ``Request/Response body is a ReadableStream, which cannot be redirected in Bun Shell yet``. A stdin redirect appends `` Read it first: $`cmd < ${await response.bytes()}` ``; stdout/stderr get the bare sentence since a stream body can never be a write target.
- `Used`: `ERR_BODY_ALREADY_USED` (`Body already used`), matching `Bun.spawn({ stdin: response })` and the body mixin.
- `Error`: the body's stored error is rethrown.

Both the spawned-subprocess path (used for `cat` on POSIX) and the builtin path (used for `cat` on Windows) call the helper. The branch now uses `Body::from_request_or_response()` so a `Request` is accepted alongside `Response`, matching what `Builtin.rs` and `Bun.spawn` already did (previously `cat < ${request}` threw `Invalid JS object used in shell: [object Request]`).

`Body::use_as_any_blob()` itself is unchanged; its other callers (fetch request bodies, wasm streaming, `Response` init) all sit after an explicit `Locked`/stream check of their own.

Known trade-off: ``$`echo ${request}` `` (a `Request` in *argument* position, not a redirect) now emits the parser's `expected a command or assignment but got: "JSObjRef"` instead of `Invalid JS object used in shell: [object Request]`. `handle_template_value` runs before parsing and cannot see the position, so registering `Request` as a redirect-capable value necessarily routes it there. `Response`, `Blob`, `ReadableStream` and `ArrayBuffer` already produce that parser message on main; a follow-up can improve the parser's `JSObjRef`-in-argument-position error for all of them at once.

### Related

- #30550 implements true `ReadableStream` pumping into shell stdin; once it lands this branch can route the `Locked` case through the same `Stdio::ReadableStream` path instead of throwing.
- #33996 turns the bare `ReadableStream` redirect placeholder `panic!` into a throw and fixes the `Yield::Failed` trampoline so the builtin-path throw does not leave the interpreter keepalive pinned in a standalone script. (The test runner exits cleanly regardless.)
- #18262 tracks the bare `ReadableStream` stdin case.

### How did you verify your code works?

Added to `test/js/bun/shell/bunshell.test.ts` under `deno_task > redirects > stdin from Request/Response`, parameterized over `Response` and `Request`:

- `ReadableStream start()`, `TransformStream#readable`, async-generator bodies as stdin each reject with `/body is a ReadableStream/`
- an already-consumed body rejects with `/already used/`
- string and `Blob` body controls still deliver the full payload
- `echo hi > ${new Response(stream)}` rejects with the stream-body message and without the stdin hint

```
USE_SYSTEM_BUN=1 bun test bunshell.test.ts -t "stdin from Request/Response"   # 11 fail
bun bd test bunshell.test.ts -t "stdin from Request/Response"                 # 13 pass
bun bd test bunshell.test.ts                                                  # 427 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->
