### PR TITLE
URLPath: replace self-referential slices and i32 sentinels with Cow buffer + u32 ranges

### DIFF
--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -1,60 +1,89 @@
+use std::borrow::Cow;
+use std::ops::Range;
+
 use bun_core::strings;
 use bun_url::PercentEncoding;
 
-// TODO: lifetime — every `&'static [u8]` field below actually borrows from
-// either the `parse()` input slice or, when the input was percent-encoded, from
-// `_decoded_storage`. Add a
-// lifetime param to `URLPath` so the input-borrow case is checked.
-#[derive(Default)]
-pub struct URLPath {
-    pub extname: &'static [u8],
-    pub path: &'static [u8],
-    pub pathname: &'static [u8],
-    pub first_segment: &'static [u8],
-    pub query_string: &'static [u8],
+/// Parsed components of a request path (`/foo/bar.js?x=1`).
+///
+/// The struct holds one backing buffer plus `u32` offset ranges into it; every
+/// accessor returns a sub-slice of that buffer, so nothing can dangle and the
+/// struct is safely `Clone`/`Send`. The buffer borrows the `parse()` input in
+/// the common case and is only owned when the input needed percent-decoding.
+#[derive(Clone, Default)]
+pub struct URLPath<'a> {
+    buffer: Cow<'a, [u8]>,
+    extname: Range<u32>,
+    path: Range<u32>,
+    first_segment: Range<u32>,
+    query_string: Range<u32>,
     pub needs_redirect: bool,
     /// Treat URLs as non-sourcemap URLS
     /// Then at the very end, we check.
     pub is_source_map: bool,
-    /// Owned backing storage for the slice fields when `parse()` had to
-    /// percent-decode. Heap-stable: the slice fields above point into this
-    /// allocation, which is never resized and lives exactly as long as `self`.
-    /// Owning the decode buffer
-    /// per-URLPath removes the use-after-free that a shared growable buffer
-    /// would introduce on the next `parse()` call.
-    ///
-    /// `URLPath` must not be `Clone`: copying the slice fields without this
-    /// owner would re-introduce the dangling hazard.
-    _decoded_storage: Option<Box<[u8]>>,
 }
 
-impl URLPath {
-    /// Take ownership of the percent-decode buffer, if `parse()` had to
-    /// allocate one. The slice fields of `self` keep pointing into the
-    /// returned allocation — the caller must keep it alive for as long as any
-    /// of those slices (or sub-slices of them) are read; dropping it while
-    /// they are still in use leaves them dangling.
-    #[must_use = "dropping the returned storage dangles the slice fields of this URLPath"]
-    pub fn take_decoded_storage(&mut self) -> Option<Box<[u8]>> {
-        self._decoded_storage.take()
+impl<'a> URLPath<'a> {
+    #[inline]
+    fn slice(&self, r: &Range<u32>) -> &[u8] {
+        &self.buffer[r.start as usize..r.end as usize]
+    }
+
+    /// The full (possibly percent-decoded) pathname, including the leading byte
+    /// and the query string.
+    #[inline]
+    pub fn pathname(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    /// Pathname without the leading byte and without the query string. Returns
+    /// `b"."` for a single-byte pathname.
+    #[inline]
+    pub fn path(&self) -> &[u8] {
+        if self.buffer.len() == 1 {
+            b"."
+        } else {
+            self.slice(&self.path)
+        }
+    }
+
+    /// File extension without the leading dot. For `foo.js.map` this is `js`
+    /// and [`Self::is_source_map`] is set instead.
+    #[inline]
+    pub fn extname(&self) -> &[u8] {
+        self.slice(&self.extname)
+    }
+
+    /// First `/`-delimited segment, without the leading byte.
+    #[inline]
+    pub fn first_segment(&self) -> &[u8] {
+        self.slice(&self.first_segment)
+    }
+
+    /// Query string including the leading `?`, or empty.
+    #[inline]
+    pub fn query_string(&self) -> &[u8] {
+        self.slice(&self.query_string)
+    }
+
+    /// Consume `self` and return the percent-decode buffer if `parse()` had to
+    /// allocate one (i.e. the input contained `%`). Returns `None` when the
+    /// buffer is a borrow of the `parse()` input.
+    #[inline]
+    pub fn into_owned_buffer(self) -> Option<Vec<u8>> {
+        match self.buffer {
+            Cow::Owned(v) => Some(v),
+            Cow::Borrowed(_) => None,
+        }
     }
 }
 
-// Design note: a growable shared (e.g. threadlocal) decode buffer cannot work
-// here — the next `parse()` may reallocate it and dangle every prior URLPath —
-// so instead each URLPath that needs decoding owns its decode buffer in
-// `_decoded_storage`. This costs one small allocation only on the
-// percent-encoded path, which is the rare case.
-
-pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::DecodeError> {
-    let mut decoded_pathname: &[u8] = possibly_encoded_pathname_;
-    let mut decoded_storage: Option<Box<[u8]>> = None;
+pub fn parse(input: &[u8]) -> Result<URLPath<'_>, bun_url::DecodeError> {
     let mut needs_redirect = false;
 
-    if strings::index_of_char(decoded_pathname, b'%').is_some() {
+    let buffer: Cow<'_, [u8]> = if strings::index_of_char(input, b'%').is_some() {
         // The in-place decode buffer is capped at 16384 bytes of input.
-        let capped = &possibly_encoded_pathname_[..possibly_encoded_pathname_.len().min(16384)];
-
+        let capped = &input[..input.len().min(16384)];
         let mut buf: Vec<u8> = Vec::with_capacity(capped.len());
         let n = PercentEncoding::decode_fault_tolerant::<_, true>(
             &mut buf,
@@ -63,140 +92,100 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
         )?;
         debug_assert!(n as usize <= buf.len());
         buf.truncate(n as usize);
-        // Freeze into a heap-stable Box and park it in `decoded_storage` before
-        // borrowing: the slice fields in the returned URLPath borrow from this
-        // allocation, and the Box is later moved into that same URLPath, so the
-        // borrow is valid for the struct's whole lifetime (Box heap address is
-        // stable across moves). NLL releases the local borrow after the last
-        // use of `decoded_pathname` in the struct-literal field initialisers,
-        // before `_decoded_storage` is moved.
-        decoded_storage = Some(buf.into_boxed_slice());
-        decoded_pathname = decoded_storage.as_deref().unwrap();
-    }
+        if buf.is_empty() {
+            Cow::Borrowed(&b"/"[..])
+        } else {
+            Cow::Owned(buf)
+        }
+    } else if input.is_empty() {
+        Cow::Borrowed(&b"/"[..])
+    } else {
+        Cow::Borrowed(input)
+    };
 
-    // The slicing below assumes a non-empty pathname with a leading byte to
-    // skip. An empty input (or an input like "%PUBLIC_URL%" that the fault-
-    // tolerant decoder consumes entirely) would otherwise index out of bounds.
-    if decoded_pathname.is_empty() {
-        decoded_pathname = b"/";
-        decoded_storage = None;
-    }
+    let bytes: &[u8] = &buffer;
+    let len = bytes.len();
+    debug_assert!(len <= u32::MAX as usize);
 
-    let mut question_mark_i: i32 = -1;
-    let mut period_i: i32 = -1;
+    let mut question_mark: Option<usize> = None;
+    let mut period: Option<usize> = None;
+    let mut first_segment_end: Option<usize> = None;
+    let mut last_slash: Option<usize> = None;
 
-    let mut first_segment_end: i32 = i32::MAX;
-    let mut last_slash: i32 = -1;
-
-    let mut i: i32 = i32::try_from(decoded_pathname.len()).expect("int cast") - 1;
-
-    while i >= 0 {
-        let c = decoded_pathname[usize::try_from(i).expect("int cast")];
-
+    for (i, &c) in bytes.iter().enumerate().rev() {
         match c {
             b'?' => {
-                question_mark_i = question_mark_i.max(i);
-                if question_mark_i < period_i {
-                    period_i = -1;
-                }
-
-                if last_slash > question_mark_i {
-                    last_slash = -1;
+                if question_mark.is_none() {
+                    question_mark = Some(i);
+                    // Any `.` or `/` already seen sits to the right of this `?`
+                    // (descending scan), i.e. inside the query string; discard.
+                    period = None;
+                    last_slash = None;
                 }
             }
             b'.' => {
-                period_i = period_i.max(i);
+                if period.is_none() {
+                    period = Some(i);
+                }
             }
             b'/' => {
-                last_slash = last_slash.max(i);
-
+                if last_slash.is_none() {
+                    last_slash = Some(i);
+                }
                 if i > 0 {
-                    first_segment_end = first_segment_end.min(i);
+                    first_segment_end = Some(i);
                 }
             }
             _ => {}
         }
-
-        i -= 1;
     }
 
-    if last_slash > period_i {
-        period_i = -1;
+    if let (Some(s), Some(p)) = (last_slash, period) {
+        if s > p {
+            period = None;
+        }
     }
 
     // .js.map
     //    ^
-    let extname: &[u8] = 'brk: {
-        if question_mark_i > -1 && period_i > -1 {
-            period_i += 1;
-            break 'brk &decoded_pathname[usize::try_from(period_i).expect("int cast")
-                ..usize::try_from(question_mark_i).expect("int cast")];
-        } else if period_i > -1 {
-            period_i += 1;
-            break 'brk &decoded_pathname[usize::try_from(period_i).expect("int cast")..];
-        } else {
-            break 'brk &[];
-        }
+    let mut extname = match period {
+        Some(p) => p + 1..question_mark.unwrap_or(len),
+        None => 0..0,
     };
 
     // `path` is the pathname without the leading byte and without the query
-    // string. When the input begins with '?' the end index is 0, so clamp the
-    // start to avoid a 1..0 slice.
-    let path_end: usize = if question_mark_i < 0 {
-        decoded_pathname.len()
-    } else {
-        usize::try_from(question_mark_i).expect("int cast")
-    };
-    let mut path: &[u8] = &decoded_pathname[1.min(path_end)..path_end];
+    // string. When the input begins with `?` the end index is 0, so clamp the
+    // start to avoid a 1..0 range.
+    let path_end = question_mark.unwrap_or(len);
+    let mut path = 1.min(path_end)..path_end;
 
-    let first_segment_end_u: usize =
-        (usize::try_from(first_segment_end).expect("int cast")).min(decoded_pathname.len());
-    let first_segment = &decoded_pathname[1.min(first_segment_end_u)..first_segment_end_u];
-    let is_source_map = extname == b"map";
-    let mut backup_extname: &[u8] = extname;
+    let seg_end = first_segment_end.unwrap_or(len);
+    let first_segment = 1.min(seg_end)..seg_end;
+
+    let is_source_map = bytes[extname.clone()] == *b"map";
     if is_source_map && path.len() > b".map".len() {
-        if let Some(j) = path[0..path.len() - b".map".len()]
-            .iter()
-            .rposition(|&b| b == b'.')
-        {
-            backup_extname = &path[j + 1..];
-            backup_extname = &backup_extname[0..backup_extname.len() - b".map".len()];
-            path = &path[0..j + backup_extname.len() + 1];
+        let search = &bytes[path.start..path.end - b".map".len()];
+        if let Some(j) = search.iter().rposition(|&b| b == b'.') {
+            let dot = path.start + j;
+            extname = dot + 1..path.end - b".map".len();
+            path = path.start..path.end - b".map".len();
         }
     }
 
-    // TODO: lifetime — see struct-level note. `extend` launders the borrow
-    // to `'static` to match the field type; remove once URLPath gains a
-    // proper lifetime parameter for the input-borrow case.
+    let query_string = question_mark.map_or(0..0, |q| q..len);
+
     #[inline(always)]
-    fn extend(s: &[u8]) -> &'static [u8] {
-        // SAFETY: local fn-item — every call below passes a slice that borrows
-        // either the parser's input or `decoded_storage`, both of which are
-        // moved into / outlive the returned `URLPath` (self-referential store).
-        unsafe { bun_collections::detach_lifetime(s) }
+    fn to_u32(r: Range<usize>) -> Range<u32> {
+        r.start as u32..r.end as u32
     }
 
     Ok(URLPath {
-        extname: extend(if !is_source_map {
-            extname
-        } else {
-            backup_extname
-        }),
-        is_source_map,
-        pathname: extend(decoded_pathname),
-        first_segment: extend(first_segment),
-        path: extend(if decoded_pathname.len() == 1 {
-            b"."
-        } else {
-            path
-        }),
-        query_string: extend(if question_mark_i > -1 {
-            &decoded_pathname
-                [usize::try_from(question_mark_i).expect("int cast")..decoded_pathname.len()]
-        } else {
-            b""
-        }),
+        buffer,
+        extname: to_u32(extname),
+        path: to_u32(path),
+        first_segment: to_u32(first_segment),
+        query_string: to_u32(query_string),
         needs_redirect,
-        _decoded_storage: decoded_storage,
+        is_source_map,
     })
 }

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -224,11 +224,11 @@ impl Routes {
     pub fn match_page_with_allocator<'p>(
         &mut self,
         _: &[u8],
-        url_path: &URLPath,
+        url_path: &'p URLPath<'_>,
         params: &'p mut route_param::List<'p>,
     ) -> Option<Match<'p>> {
         // Trim trailing slash
-        let mut path = url_path.path;
+        let mut path = url_path.path();
         let mut redirect = false;
 
         // Normalize trailing slash
@@ -268,11 +268,11 @@ impl Routes {
                 // SAFETY: points into a Box<Route> owned by self.list; valid for &self.
                 let index = unsafe { index_ptr.as_ref() };
                 return Some(Match {
-                    params: std::ptr::from_mut(params),
+                    params,
                     name: index.name,
-                    pathname: url_path.pathname,
+                    pathname: url_path.pathname(),
                     file_path: index.abs_path.as_bytes(),
-                    query_string: url_path.query_string,
+                    query_string: url_path.query_string(),
                 });
             }
 
@@ -284,11 +284,11 @@ impl Routes {
             // self.list, which outlives self.
             let route = unsafe { &*route_ptr };
             return Some(Match {
-                params: std::ptr::from_mut(params),
+                params,
                 name: route.name,
-                pathname: url_path.pathname,
+                pathname: url_path.pathname(),
                 file_path: route.abs_path.as_bytes(),
-                query_string: url_path.query_string,
+                query_string: url_path.query_string(),
             });
         }
 
@@ -1068,53 +1068,16 @@ thread_local! {
 pub struct Match<'a> {
     /// raw url path from the request
     pub pathname: &'a [u8],
-    /// absolute filesystem path to the entry point
-    pub file_path: &'a [u8],
-    /// route name, like `"posts/[id]"`
-    pub name: &'a [u8],
-
-    // NOTE: raw `*mut` (not `&'a mut`).
-    // `MatchedRoute` (bun_runtime) stores this self-referentially — a
-    // `&'a mut List` here would be invalidated under Stacked Borrows the
-    // moment any `&mut MatchedRoute` is taken.
-    pub params: *mut route_param::List<'a>,
+    /// absolute filesystem path to the entry point — resolver-interned, process lifetime
+    pub file_path: &'static [u8],
+    /// route name, like `"posts/[id]"` — resolver-interned, process lifetime
+    pub name: &'static [u8],
+    /// filled by [`Routes::match_page_with_allocator`]; `value`s slice `pathname`
+    pub params: &'a route_param::List<'a>,
     pub query_string: &'a [u8],
 }
 
 impl<'a> Match<'a> {
-    /// Widen all borrowed slices to `'static` for self-referential storage.
-    ///
-    /// Field-by-field move (no bitwise reinterpret). Used by `MatchedRoute`
-    /// (bun_runtime), which moves the backing `pathname_backing` buffer into
-    /// the same heap-stable `Box` that holds this `Match` — see the SAFETY
-    /// note at that call site for the full invariant.
-    ///
-    /// # Safety
-    /// Caller guarantees every borrowed slice (and `*params`' element slices)
-    /// outlives the returned value.
-    #[inline]
-    #[allow(unsafe_op_in_unsafe_fn)]
-    pub unsafe fn detach_lifetime(self) -> Match<'static> {
-        // `d` stays `unsafe fn` so a safe-signature wrapper does not hide the
-        // lifetime-widen; the outer fn carries `#[allow(unsafe_op_in_unsafe_fn)]`
-        // so the direct call sites below need no per-line `unsafe { }`.
-        #[inline(always)]
-        unsafe fn d(s: &[u8]) -> &'static [u8] {
-            // SAFETY: caller contract on `detach_lifetime` — every borrowed
-            // slice outlives the returned `Match<'static>`.
-            unsafe { &*core::ptr::from_ref::<[u8]>(s) }
-        }
-        Match {
-            pathname: d(self.pathname),
-            file_path: d(self.file_path),
-            name: d(self.name),
-            // Raw pointer; lifetime parameter on the pointee is phantom for the
-            // pointer value itself.
-            params: self.params.cast::<route_param::List<'static>>(),
-            query_string: d(self.query_string),
-        }
-    }
-
     pub fn pathname_without_leading_slash(&self) -> &[u8] {
         strings::trim_left(self.pathname, b"/")
     }
@@ -1159,8 +1122,8 @@ pub mod pattern {
         pub fn match_<'a, const ALLOW_OPTIONAL_CATCH_ALL: bool>(
             // `path` must be lowercased and have no leading slash
             path: &'a [u8],
-            // case-sensitive, must not have a leading slash
-            name: &'a [u8],
+            // case-sensitive, must not have a leading slash — resolver-interned
+            name: &'static [u8],
             // case-insensitive, must not have a leading slash
             match_name: &[u8],
             params: &mut route_param::List<'a>,
@@ -1904,7 +1867,7 @@ mod tests {
             ),
         ];
 
-        fn run(list: &[(&[u8], &[u8], &[Entry])]) -> usize {
+        fn run(list: &[(&'static [u8], &'static [u8], &[Entry])]) -> usize {
             let mut parameters = route_param::List::default();
             let mut failures: usize = 0;
             for (pattern, pathname, entries) in list.iter() {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1077,12 +1077,6 @@ pub struct Match<'a> {
     pub query_string: &'a [u8],
 }
 
-impl<'a> Match<'a> {
-    pub fn pathname_without_leading_slash(&self) -> &[u8] {
-        strings::trim_left(self.pathname, b"/")
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // Traits abstracting over the router's collaborators
 // (Resolver, Server, RequestContext).

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -633,8 +633,12 @@ impl FileSystemRouter {
         // after it returns nothing borrows `url_path`/`params` and the backing buffer can
         // be moved into the result.
         let pathname_len = route.pathname.len();
-        let mut result =
-            MatchedRoute::init(&route, this.origin, this.asset_prefix, this.base_dir.unwrap());
+        let mut result = MatchedRoute::init(
+            &route,
+            this.origin,
+            this.asset_prefix,
+            this.base_dir.unwrap(),
+        );
         result.pathname = match url_path.into_owned_buffer() {
             Some(decoded) => decoded.into_boxed_slice(),
             None => path.into_vec().into_boxed_slice(),

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -20,7 +20,7 @@ pub mod kind_enum {
 }
 
 use bun_paths::strings;
-use core::cell::UnsafeCell;
+use core::ops::Range;
 
 use bun_alloc::Arena as ArenaAllocator;
 use bun_ast as Log;
@@ -603,16 +603,10 @@ impl FileSystemRouter {
             return Ok(JSValue::NULL);
         }
 
-        // SAFETY: self-ref construction prelude — `route` below borrows these bytes via
-        // `URLPath`, and `path` is then MOVED into the same `MatchedRoute` Box that stores
-        // `route`. Borrowck can't see that the allocation travels with the borrow, so we
-        // detach the slice from `path`'s ownership here. The bytes stay valid: `path` is
-        // never dropped on any path between here and `MatchedRoute::init` taking ownership
-        // (early returns above this point already dropped/replaced `path`), except when
-        // `URLPath::parse` percent-decoded — in that case nothing borrows `path_bytes`
-        // anymore and `path` is swapped for the decode buffer below.
-        let path_bytes: &[u8] = unsafe { bun_ptr::detach_lifetime(path.slice()) };
-        let mut url_path = match URLPath::parse(path_bytes) {
+        // `path` is already an owned allocation; if `parse()` has to percent-decode, it
+        // allocates a second buffer and `URLPath` owns that instead — recovered below via
+        // `into_owned_buffer`.
+        let url_path = match URLPath::parse(path.slice()) {
             Ok(v) => v,
             Err(err) => {
                 return Err(global_this.throw(format_args!(
@@ -626,7 +620,7 @@ impl FileSystemRouter {
         // `defer params.deinit(allocator)` → Drop
         // SAFETY: R-2 — short-lived `&mut Router` for the route lookup;
         // `match_page_with_allocator` is pure (no JS re-entry), and the returned
-        // `Match<'p>` borrows `params`/`path_bytes`, not `*router`, so the
+        // `Match<'p>` borrows `params`/`url_path`, not `*router`, so the
         // exclusive borrow ends at the `;`.
         let Some(route) = unsafe { this.router.get_mut() }
             .routes
@@ -635,34 +629,18 @@ impl FileSystemRouter {
             return Ok(JSValue::NULL);
         };
 
-        // If `URLPath::parse` had to percent-decode, `route.pathname`/`query_string` and
-        // the param values borrow the decode buffer — not `path` — and that buffer would
-        // be freed when `url_path` drops at the end of this call. Take ownership of it and
-        // make it the backing allocation instead. (`Box<[u8]>` -> `Vec<u8>` ->
-        // `ZigStringSlice::Owned` reuses the same heap allocation, so the borrowed slices
-        // stay valid; nothing in `route` points into the original encoded `path` once a
-        // decode happened.)
-        if let Some(decoded) = url_path.take_decoded_storage() {
-            path = ZigStringSlice::init_owned(decoded.into_vec());
-        }
+        // `MatchedRoute::init` records `route`'s request-path slices as offset ranges, so
+        // after it returns nothing borrows `url_path`/`params` and the backing buffer can
+        // be moved into the result.
+        let pathname_len = route.pathname.len();
+        let mut result =
+            MatchedRoute::init(&route, this.origin, this.asset_prefix, this.base_dir.unwrap());
+        result.pathname = match url_path.into_owned_buffer() {
+            Some(decoded) => decoded.into_boxed_slice(),
+            None => path.into_vec().into_boxed_slice(),
+        };
+        debug_assert_eq!(result.pathname.len(), pathname_len);
 
-        // MOVE `path`
-        // into `MatchedRoute` so the bytes that `route.pathname`/`query_string`/param
-        // values borrow are owned by the same heap-stable Box and freed on finalize.
-        let result = MatchedRoute::init(
-            route,
-            path,
-            this.origin,
-            this.asset_prefix,
-            this.base_dir.unwrap(),
-        )
-        .expect("unreachable");
-
-        // Note: `result` is a self-referential `Box<MatchedRoute>` (`route` points
-        // at `route_holder` inside this very allocation). The trait `JsClass::to_js(self)`
-        // would deref-move the value OUT of the Box and re-box it at a new address,
-        // leaving the self-ref pointers dangling (ASAN use-after-poison). Hand the
-        // existing allocation straight to the C++ wrapper instead.
         // Ownership transfers to the GC wrapper (freed via
         // `MatchedRouteClass__finalize`); the leak lives once in `to_js_boxed`.
         Ok(MatchedRoute::to_js_boxed(result, global_this))
@@ -721,32 +699,35 @@ impl FileSystemRouter {
     }
 }
 
+/// Dynamic-route parameter stored as an offset range into
+/// [`MatchedRoute::pathname`], so `MatchedRoute` owns its request bytes outright
+/// rather than borrowing them.
+struct MatchedParam {
+    /// Slices the route template (resolver-interned, process lifetime).
+    name: &'static [u8],
+    /// Range into `MatchedRoute::pathname`.
+    value: Range<u32>,
+}
+
 #[bun_jsc::JsClass(no_construct, no_constructor)]
 pub struct MatchedRoute {
-    /// Self-referential: always points at `self.route_holder`. See `init`.
-    // Note: `Match<'a>` borrows (a) the resolver's process-lifetime DirnameStore for
-    // `name`/`file_path`/`basename`/`path` and (b) `self.pathname_backing` for
-    // `pathname`/`query_string`/param values. Both are stable for `Self`'s lifetime, so
-    // the stored `'static` is the standard self-referential erasure — see `init`.
-    pub route: *const RouterMatch<'static>,
-    // Note: `route_holder`/`params_list_holder` are wrapped in `UnsafeCell` because
-    // `route` (above) and `route_holder.params` hold raw self-referential pointers into
-    // them. Without `UnsafeCell`, taking `&mut MatchedRoute` (as `get_params`/`get_query`
-    // do) would assert unique access to these fields under Stacked Borrows and invalidate
-    // the stored pointers — UB on next deref.
-    pub route_holder: UnsafeCell<RouterMatch<'static>>,
+    /// Owns the full request pathname (possibly percent-decoded). `query_string`
+    /// and each `params[_].value` are offset ranges into this buffer.
+    pathname: Box<[u8]>,
+    query_string: Range<u32>,
+    /// Route name, like `"posts/[id]"` — resolver-interned, process lifetime.
+    name: &'static [u8],
+    /// Absolute filesystem path — resolver-interned, process lifetime.
+    file_path: &'static [u8],
+    params: Vec<MatchedParam>,
+
     // R-2: lazily populated by `get_query`/`get_params` (now `&self`).
     pub query_string_map: JsCell<Option<QueryStringMap>>,
     pub param_map: JsCell<Option<QueryStringMap>>,
-    pub params_list_holder: UnsafeCell<route_param::List<'static>>,
-    /// Owns the bytes that `route_holder.pathname`/`query_string` and the param values in
-    /// `params_list_holder` borrow. Freed by Drop on finalize.
-    pub pathname_backing: ZigStringSlice,
     // BACKREF — interned `RefString`s; we hold +1 (bumped in `init`, released in
-    // `deinit`). The interned allocation outlives every `MatchedRoute`.
+    // `finalize`). The interned allocation outlives every `MatchedRoute`.
     pub origin: Option<BackRef<RefString>>,
     pub asset_prefix: Option<BackRef<RefString>>,
-    pub needs_deinit: bool,
     pub base_dir: Option<BackRef<RefString>>,
 }
 
@@ -755,72 +736,63 @@ impl MatchedRoute {
     // wired by `#[bun_jsc::JsClass]` — deleted.
 
     #[inline]
-    fn route(&self) -> &RouterMatch<'static> {
-        // SAFETY: `self.route` always points at `self.route_holder` (UnsafeCell, set in
-        // `init`); the Box is never moved after construction (heap-stable), and no `&mut`
-        // to `route_holder`'s contents is live concurrently with this read.
-        unsafe { &*self.route }
+    fn query_string(&self) -> &[u8] {
+        &self.pathname[self.query_string.start as usize..self.query_string.end as usize]
     }
 
     #[inline]
-    fn params(&self) -> &route_param::List<'static> {
-        // SAFETY: `route().params` always points at `self.params_list_holder` (UnsafeCell,
-        // set in `init`); heap-stable Box, no concurrent `&mut` to its contents.
-        unsafe { &*self.route().params }
+    fn pathname_without_leading_slash(&self) -> &[u8] {
+        strings::trim_left(&self.pathname, b"/")
+    }
+
+    /// Materialize `params` as slices borrowing `self.pathname` for the
+    /// `CombinedScanner` API.
+    fn params_list(&self) -> route_param::List<'_> {
+        self.params
+            .iter()
+            .map(|p| route_param::Param {
+                name: p.name,
+                value: &self.pathname[p.value.start as usize..p.value.end as usize],
+            })
+            .collect()
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_name(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(this.route().name, global_this))
+        Ok(zs_to_js(this.name, global_this))
     }
 
+    /// Build a `MatchedRoute` from a router `Match`. `match_.query_string` and every
+    /// `match_.params[_].value` are sub-slices of `match_.pathname`; they are recorded
+    /// here as offset ranges so this struct can own the pathname buffer outright. The
+    /// caller moves that buffer in as `pathname` once `match_`'s borrow of it has been
+    /// released (see the call site).
     pub fn init(
-        match_: RouterMatch<'_>,
-        pathname_backing: ZigStringSlice,
+        match_: &RouterMatch<'_>,
         origin: Option<BackRef<RefString>>,
         asset_prefix: Option<BackRef<RefString>>,
         base_dir: BackRef<RefString>,
-    ) -> Result<Box<MatchedRoute>, bun_alloc::AllocError> {
-        // SAFETY: `match_.params` points at the caller's stack `route_param::List`, which is
-        // live for this call. Clone its contents into our own holder before re-pointing.
-        let params_list = unsafe { (*match_.params).clone() };
+    ) -> Box<MatchedRoute> {
+        fn range_in(outer: &[u8], inner: &[u8]) -> Range<u32> {
+            match bun_core::range_of_slice_in_buffer(inner, outer) {
+                Some([off, len]) => off..off + len,
+                None => {
+                    debug_assert!(inner.is_empty());
+                    0..0
+                }
+            }
+        }
 
-        // SAFETY: self-referential lifetime erasure — `RouterMatch<'_>` borrows two
-        // backing stores —
-        //   (a) `name`/`file_path`/`basename`/`path` slice the resolver's DirnameStore
-        //       (process-lifetime arena — `bun_router` paths are `Interned`), so are
-        //       genuinely `'static`;
-        //   (b) `pathname`/`query_string` and the param `value`s slice `pathname_backing`,
-        //       which we move into the same heap-stable Box below. The Box is never moved
-        //       after construction (JsClass m_ctx payload), so those bytes are valid for
-        //       `Self`'s lifetime.
-        // `params` is a raw `*mut`; re-pointed at `params_list_holder` below before any
-        // read through it. This is the standard Rust self-referential pattern (no
-        // `Pin`/ouroboros because JsClass codegen owns the Box<Self>); it does NOT extend
-        // a borrow past its allocation — ownership was transferred, not leaked.
-        let match_static: RouterMatch<'static> = unsafe { match_.detach_lifetime() };
-        // `route_param::List<'a>` = `Vec<Param<'a>>`; rebuild from raw parts to
-        // erase the element lifetime (identical layout, no realloc).
-        let params_list: route_param::List<'static> = {
-            let mut v = core::mem::ManuallyDrop::new(params_list);
-            let (ptr, len, cap) = (v.as_mut_ptr(), v.len(), v.capacity());
-            // SAFETY: same allocation, same element layout; per the SAFETY note
-            // above, every `Param`'s borrowed bytes outlive `Self`.
-            unsafe { Vec::from_raw_parts(ptr.cast::<route_param::Param<'static>>(), len, cap) }
-        };
+        let query_string = range_in(match_.pathname, match_.query_string);
+        let params: Vec<MatchedParam> = match_
+            .params
+            .iter()
+            .map(|p| MatchedParam {
+                name: p.name,
+                value: range_in(match_.pathname, p.value),
+            })
+            .collect();
 
-        let mut route = Box::new(MatchedRoute {
-            route_holder: UnsafeCell::new(match_static),
-            route: core::ptr::null(),
-            asset_prefix,
-            origin,
-            base_dir: Some(base_dir),
-            query_string_map: JsCell::new(None),
-            param_map: JsCell::new(None),
-            params_list_holder: UnsafeCell::new(params_list),
-            pathname_backing,
-            needs_deinit: true,
-        });
         // Note: `base_dir.ref()` / `o.ref()` / `prefix.ref()` — bump refcounts.
         // Each is a live interned `RefString` (caller-provided BackRef).
         base_dir.ref_();
@@ -830,67 +802,47 @@ impl MatchedRoute {
         if let Some(p) = asset_prefix {
             p.ref_();
         }
-        // Self-referential wiring: `route` → `route_holder`; `route_holder.params` →
-        // `params_list_holder`. Both targets are `UnsafeCell` so the raw pointers stay
-        // valid under Stacked Borrows across later `&mut MatchedRoute` accesses.
-        route.route = route.route_holder.get();
-        // SAFETY: sole access to `route_holder` contents at this point.
-        unsafe { (*route.route_holder.get()).params = route.params_list_holder.get() };
 
-        Ok(route)
+        Box::new(MatchedRoute {
+            pathname: Box::default(),
+            query_string,
+            name: match_.name,
+            file_path: match_.file_path,
+            params,
+            asset_prefix,
+            origin,
+            base_dir: Some(base_dir),
+            query_string_map: JsCell::new(None),
+            param_map: JsCell::new(None),
+        })
     }
 
-    // Note: `deinit` is called only from `finalize`; not exposed as `Drop` because
-    // `MatchedRoute` is a JsClass m_ctx payload (finalize owns teardown per PORTING.md).
-    fn deinit(this: *mut MatchedRoute) {
-        // SAFETY: called from finalize on mutator thread.
-        let this_ref = unsafe { &mut *this };
-        this_ref.query_string_map.set(None);
-        this_ref.param_map.set(None);
-        if this_ref.needs_deinit {
-            // We own the `path` allocation from `match` as
-            // `pathname_backing`; dropping it (and `params_list_holder`) here releases the
-            // borrowed bytes BEFORE `route_holder`'s slices would dangle on Box drop.
-            this_ref.pathname_backing = ZigStringSlice::EMPTY;
-            *this_ref.params_list_holder.get_mut() = route_param::List::default();
-        }
-
-        if let Some(p) = this_ref.origin.take() {
+    #[allow(clippy::boxed_local)]
+    pub fn finalize(self: Box<Self>) {
+        if let Some(p) = &self.origin {
             p.get().deref();
         }
-        if let Some(p) = this_ref.asset_prefix.take() {
+        if let Some(p) = &self.asset_prefix {
             p.get().deref();
         }
-        if let Some(p) = this_ref.base_dir.take() {
+        if let Some(p) = &self.base_dir {
             p.get().deref();
         }
-
-        // SAFETY: `this` was heap-allocated by codegen at construction.
-        drop(unsafe { bun_core::heap::take(this) });
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_file_path(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(this.route().file_path, global_this))
-    }
-
-    pub fn finalize(self: Box<Self>) {
-        // `deinit` frees the allocation itself; hand ownership back so its
-        // existing raw-ptr teardown path stays intact.
-        Self::deinit(Box::into_raw(self));
+        Ok(zs_to_js(this.file_path, global_this))
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_pathname(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(this.route().pathname, global_this))
+        Ok(zs_to_js(&this.pathname, global_this))
     }
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_kind(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(
-            kind_enum::classify(this.route().name),
-            global_this,
-        ))
+        Ok(zs_to_js(kind_enum::classify(this.name), global_this))
     }
 
     pub fn create_query_object(
@@ -953,7 +905,7 @@ impl MatchedRoute {
             URL::default()
         };
         bun_object::get_public_path_with_asset_prefix(
-            this.route().file_path,
+            this.file_path,
             if let Some(ref base_dir) = this.base_dir {
                 base_dir.leak()
             } else {
@@ -973,17 +925,17 @@ impl MatchedRoute {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_params(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        if this.params().is_empty() {
+        if this.params.is_empty() {
             return Ok(JSValue::create_empty_object(global_this, 0));
         }
 
         if this.param_map.get().is_none() {
-            let route = this.route();
+            let params = this.params_list();
             let scanner = CombinedScanner::init(
                 b"",
-                route.pathname_without_leading_slash(),
-                route.name,
-                this.params(),
+                this.pathname_without_leading_slash(),
+                this.name,
+                &params,
             );
             this.param_map
                 .set(QueryStringMap::init_with_scanner(scanner)?);
@@ -997,27 +949,26 @@ impl MatchedRoute {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_query(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        let route = this.route();
-        if route.query_string.is_empty() && this.params().is_empty() {
+        if this.query_string().is_empty() && this.params.is_empty() {
             return Ok(JSValue::create_empty_object(global_this, 0));
-        } else if route.query_string.is_empty() {
+        } else if this.query_string().is_empty() {
             return Self::get_params(this, global_this);
         }
 
         if this.query_string_map.get().is_none() {
-            let route = this.route();
-            if !this.params().is_empty() {
+            if !this.params.is_empty() {
+                let params = this.params_list();
                 let scanner = CombinedScanner::init(
-                    route.query_string,
-                    route.pathname_without_leading_slash(),
-                    route.name,
-                    this.params(),
+                    this.query_string(),
+                    this.pathname_without_leading_slash(),
+                    this.name,
+                    &params,
                 );
                 this.query_string_map
                     .set(QueryStringMap::init_with_scanner(scanner)?);
             } else {
                 this.query_string_map
-                    .set(QueryStringMap::init(route.query_string)?);
+                    .set(QueryStringMap::init(this.query_string())?);
             }
         }
 

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -20,7 +20,6 @@ pub mod kind_enum {
 }
 
 use bun_paths::strings;
-use core::ops::Range;
 
 use bun_alloc::Arena as ArenaAllocator;
 use bun_ast as Log;
@@ -640,10 +639,10 @@ impl FileSystemRouter {
             this.base_dir.unwrap(),
         );
         result.pathname = match url_path.into_owned_buffer() {
-            Some(decoded) => decoded.into_boxed_slice(),
-            None => path.into_vec().into_boxed_slice(),
+            Some(decoded) => ZigStringSlice::init_owned(decoded),
+            None => path,
         };
-        debug_assert_eq!(result.pathname.len(), pathname_len);
+        debug_assert_eq!(result.pathname.slice().len(), pathname_len);
 
         // Ownership transfers to the GC wrapper (freed via
         // `MatchedRouteClass__finalize`); the leak lives once in `to_js_boxed`.
@@ -703,27 +702,19 @@ impl FileSystemRouter {
     }
 }
 
-/// Dynamic-route parameter stored as an offset range into
-/// [`MatchedRoute::pathname`], so `MatchedRoute` owns its request bytes outright
-/// rather than borrowing them.
-struct MatchedParam {
-    /// Slices the route template (resolver-interned, process lifetime).
-    name: &'static [u8],
-    /// Range into `MatchedRoute::pathname`.
-    value: Range<u32>,
-}
-
 #[bun_jsc::JsClass(no_construct, no_constructor)]
 pub struct MatchedRoute {
     /// Owns the full request pathname (possibly percent-decoded). `query_string`
-    /// and each `params[_].value` are offset ranges into this buffer.
-    pathname: Box<[u8]>,
-    query_string: Range<u32>,
+    /// and each `params[_].value` are `StringPointer` offsets into this buffer's
+    /// `slice()`. Kept as a `ZigStringSlice` so a WTF-backed input stays a
+    /// ref-holding borrow instead of an owned copy.
+    pathname: ZigStringSlice,
+    query_string: bun_url::api::StringPointer,
     /// Route name, like `"posts/[id]"` — resolver-interned, process lifetime.
     name: &'static [u8],
     /// Absolute filesystem path — resolver-interned, process lifetime.
     file_path: &'static [u8],
-    params: Vec<MatchedParam>,
+    params: Vec<route_param::StoredParam>,
 
     // R-2: lazily populated by `get_query`/`get_params` (now `&self`).
     pub query_string_map: JsCell<Option<QueryStringMap>>,
@@ -741,24 +732,8 @@ impl MatchedRoute {
 
     #[inline]
     fn query_string(&self) -> &[u8] {
-        &self.pathname[self.query_string.start as usize..self.query_string.end as usize]
-    }
-
-    #[inline]
-    fn pathname_without_leading_slash(&self) -> &[u8] {
-        strings::trim_left(&self.pathname, b"/")
-    }
-
-    /// Materialize `params` as slices borrowing `self.pathname` for the
-    /// `CombinedScanner` API.
-    fn params_list(&self) -> route_param::List<'_> {
-        self.params
-            .iter()
-            .map(|p| route_param::Param {
-                name: p.name,
-                value: &self.pathname[p.value.start as usize..p.value.end as usize],
-            })
-            .collect()
+        let p = self.query_string;
+        &self.pathname.slice()[p.offset as usize..][..p.length as usize]
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -768,32 +743,32 @@ impl MatchedRoute {
 
     /// Build a `MatchedRoute` from a router `Match`. `match_.query_string` and every
     /// `match_.params[_].value` are sub-slices of `match_.pathname`; they are recorded
-    /// here as offset ranges so this struct can own the pathname buffer outright. The
-    /// caller moves that buffer in as `pathname` once `match_`'s borrow of it has been
-    /// released (see the call site).
+    /// here as `StringPointer` offsets so this struct can own the pathname buffer
+    /// outright. The caller moves that buffer in as `pathname` once `match_`'s borrow
+    /// of it has been released (see the call site).
     pub fn init(
         match_: &RouterMatch<'_>,
         origin: Option<BackRef<RefString>>,
         asset_prefix: Option<BackRef<RefString>>,
         base_dir: BackRef<RefString>,
     ) -> Box<MatchedRoute> {
-        fn range_in(outer: &[u8], inner: &[u8]) -> Range<u32> {
+        fn ptr_in(outer: &[u8], inner: &[u8]) -> bun_url::api::StringPointer {
             match bun_core::range_of_slice_in_buffer(inner, outer) {
-                Some([off, len]) => off..off + len,
+                Some([offset, length]) => bun_url::api::StringPointer { offset, length },
                 None => {
                     debug_assert!(inner.is_empty());
-                    0..0
+                    bun_url::api::StringPointer::default()
                 }
             }
         }
 
-        let query_string = range_in(match_.pathname, match_.query_string);
-        let params: Vec<MatchedParam> = match_
+        let query_string = ptr_in(match_.pathname, match_.query_string);
+        let params: Vec<route_param::StoredParam> = match_
             .params
             .iter()
-            .map(|p| MatchedParam {
+            .map(|p| route_param::StoredParam {
                 name: p.name,
-                value: range_in(match_.pathname, p.value),
+                value: ptr_in(match_.pathname, p.value),
             })
             .collect();
 
@@ -808,7 +783,7 @@ impl MatchedRoute {
         }
 
         Box::new(MatchedRoute {
-            pathname: Box::default(),
+            pathname: ZigStringSlice::EMPTY,
             query_string,
             name: match_.name,
             file_path: match_.file_path,
@@ -841,7 +816,7 @@ impl MatchedRoute {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_pathname(this: &Self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(zs_to_js(&this.pathname, global_this))
+        Ok(zs_to_js(this.pathname.slice(), global_this))
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -934,13 +909,8 @@ impl MatchedRoute {
         }
 
         if this.param_map.get().is_none() {
-            let params = this.params_list();
-            let scanner = CombinedScanner::init(
-                b"",
-                this.pathname_without_leading_slash(),
-                this.name,
-                &params,
-            );
+            let scanner =
+                CombinedScanner::init(b"", this.pathname.slice(), this.name, &this.params);
             this.param_map
                 .set(QueryStringMap::init_with_scanner(scanner)?);
         }
@@ -961,12 +931,11 @@ impl MatchedRoute {
 
         if this.query_string_map.get().is_none() {
             if !this.params.is_empty() {
-                let params = this.params_list();
                 let scanner = CombinedScanner::init(
                     this.query_string(),
-                    this.pathname_without_leading_slash(),
+                    this.pathname.slice(),
                     this.name,
-                    &params,
+                    &this.params,
                 );
                 this.query_string_map
                     .set(QueryStringMap::init_with_scanner(scanner)?);

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -22,13 +22,13 @@ use bun_core::io::Write as _;
 
 // ── route_param (moved from bun_router) ───────────────────────────────────
 pub mod route_param {
-    // name/value borrow from the route template + the live request
-    // path; lifetime-generic so `bun_router` (the only producer) can fill them
-    // from non-'static buffers. Downstream that only stores literals can use
-    // `Param<'static>`.
+    /// A matched dynamic-route parameter.
+    ///
+    /// `name` slices the route template (resolver-interned, process lifetime);
+    /// `value` slices the live request path.
     #[derive(Clone, Copy)]
     pub struct Param<'a> {
-        pub name: &'a [u8],
+        pub name: &'static [u8],
         pub value: &'a [u8],
     }
     // SoA (`MultiArrayList`) layout would be a perf optimization only; a plain

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -34,6 +34,16 @@ pub mod route_param {
     // SoA (`MultiArrayList`) layout would be a perf optimization only; a plain
     // Vec is semantically identical.
     pub type List<'a> = Vec<Param<'a>>;
+
+    /// Owned-storage form of [`Param`]: `value` is an offset range into the
+    /// owner's pathname buffer instead of a borrowed slice, so a container can
+    /// hold params without borrowing itself.
+    #[derive(Clone, Copy)]
+    pub struct StoredParam {
+        pub name: &'static [u8],
+        /// Offset range into the owner's pathname buffer.
+        pub value: crate::api::StringPointer,
+    }
 }
 pub use route_param::List as ParamsList;
 
@@ -1478,7 +1488,7 @@ impl<'a> CombinedScanner<'a> {
         query_string: &'a [u8],
         pathname: &'a [u8],
         routename: &'a [u8],
-        url_params: &'a ParamsList<'a>,
+        url_params: &'a [route_param::StoredParam],
     ) -> CombinedScanner<'a> {
         CombinedScanner {
             query: Scanner::init(query_string),
@@ -1518,7 +1528,7 @@ fn string_pointer_from_strings(parent: &[u8], in_: &[u8]) -> api::StringPointer 
 }
 
 pub struct PathnameScanner<'a> {
-    pub params: &'a ParamsList<'a>,
+    pub params: &'a [route_param::StoredParam],
     pub pathname: &'a [u8],
     pub routename: &'a [u8],
     pub i: usize,
@@ -1537,7 +1547,7 @@ impl<'a> PathnameScanner<'a> {
     pub fn init(
         pathname: &'a [u8],
         routename: &'a [u8],
-        params: &'a ParamsList<'a>,
+        params: &'a [route_param::StoredParam],
     ) -> PathnameScanner<'a> {
         PathnameScanner {
             pathname,
@@ -1556,11 +1566,9 @@ impl<'a> PathnameScanner<'a> {
         self.i += 1;
 
         Some(ScannerResult {
-            // TODO: fix this technical debt
             name: string_pointer_from_strings(self.routename, param.name),
             name_needs_decoding: false,
-            // TODO: fix this technical debt
-            value: string_pointer_from_strings(self.pathname, param.value),
+            value: param.value,
             value_needs_decoding: false,
         })
     }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -45,7 +45,6 @@ pub mod route_param {
         pub value: crate::api::StringPointer,
     }
 }
-pub use route_param::List as ParamsList;
 
 // ── whatwg (WTF::URL FFI shim, MOVE_DOWN from bun_jsc) ────────────────────
 // The JS-value entry points (`hrefFromJS`, `fromJS`)


### PR DESCRIPTION
Part of the Rust cleanup: move guarantees into the type system so the compiler verifies them, not comments/convention.

## Problem

`URLPath` (`src/http_types/URLPath.rs`) stored five fabricated `&'static [u8]` fields that actually borrowed either the `parse()` input or its own `_decoded_storage: Option<Box<[u8]>>` (a self-referential struct). Every slice was laundered through a local `fn extend()` that called `detach_lifetime`. The "must not be `Clone`" invariant and the `take_decoded_storage()` dangling hazard were guarded only by prose. The reverse scan used `i32` sentinels (`-1` / `i32::MAX`) and ~10 `usize::try_from(..).expect("int cast")` calls that existed only to bridge the signed sentinel type back to `usize`, one of which was user-input-reachable.

The self-reference propagated downstream: `bun_router::Match` carried a raw `*mut route_param::List` and an `unsafe fn detach_lifetime()`, and `MatchedRoute` stored that `Match` inside two `UnsafeCell` fields with raw self-pointers wired up after `Box` construction (six `unsafe` blocks across `init`/`route()`/`params()`/`deinit`, plus a `Vec::from_raw_parts` lifetime cast).

## Fix

Store `u32` offset ranges into one backing buffer instead of laundered slices; offsets cannot dangle.

**`URLPath<'a>`** now holds a single `Cow<'a, [u8]>` buffer (borrowed from the input in the common case, owned only when percent-decoding allocated) plus `Range<u32>` offsets for each component. Accessors return sub-slices of the buffer. The scan uses `Option<usize>` and a plain reverse iterator. `into_owned_buffer(self)` replaces `take_decoded_storage()` and cannot leave dangling fields because it consumes `self`. The struct is now safely `Clone`/`Send`. No `unsafe`, no `'static` fabrication, no `-1`/`MAX` sentinels, no `.expect("int cast")` remain in this file.

**`route_param::Param::name`** and **`Match::{name, file_path}`** are now `&'static [u8]` in the type, which they always were in practice (resolver-interned DirnameStore strings). `Match::params` becomes a plain `&'a List<'a>`. `Match::detach_lifetime` is deleted.

**`MatchedRoute`** owns the request pathname as `Box<[u8]>` and stores the query string and each param value as `Range<u32>` offsets into it. The `UnsafeCell` fields, `route: *const` self-pointer, `params_list_holder` self-pointer, `Vec::from_raw_parts` lifetime cast, and the manual teardown ordering in `deinit` all go away.

## Verification

No behaviour change: the `.js.map` extname / `is_source_map` handling and percent-decode paths are preserved verbatim.

```
bun bd test test/js/bun/util/filesystem_router.test.ts
 29 pass
 0 fail
```

(including `should handle routes under GC pressure`, `MatchedRoute.params does not leak`, and `decodes percent-encoded path segments and keeps params and pathname stable after later matches`)

```
bun run rust:check-all
10 ok, 0 failed
```

| file | `unsafe` before | after |
|---|---|---|
| `src/http_types/URLPath.rs` | 1 | 0 |
| `src/router/lib.rs` | 34 | 27 |
| `src/runtime/api/filesystem_router.rs` | 16 | 7 |

Net: 4 files changed, 271 insertions(+), 368 deletions(-).