### PR TITLE
shell: fix inverted file-blob check for builtin `> ${Response(...)}` redirect

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -251,7 +251,6 @@ pub enum BuiltinIO {
         buf: PinnedArrayBuf,
         i: u32,
     },
-    Blob(Arc<BuiltinBlob>),
     Ignore,
 }
 
@@ -316,15 +315,14 @@ impl BuiltinIO {
 
     /// Bump refcounts and return a shallow copy. Only reachable from the
     /// `duplicate_out` path, which fires before any `.jsbuf` redirect, so
-    /// `ArrayBuf`/`Blob` are unreachable here. The `Buf` target is copied
-    /// verbatim so stderr writes accumulate in (and flush from) stdout's
-    /// buffer; that aliasing is the carried `IoKind`.
+    /// `ArrayBuf` is unreachable here. The `Buf` target is copied verbatim so
+    /// stderr writes accumulate in (and flush from) stdout's buffer; that
+    /// aliasing is the carried `IoKind`.
     fn dup_ref(&self) -> BuiltinIO {
         match self {
             BuiltinIO::Fd(fd) => BuiltinIO::Fd(fd.clone()),
             BuiltinIO::Buf(target) => BuiltinIO::Buf(*target),
             BuiltinIO::Ignore => BuiltinIO::Ignore,
-            BuiltinIO::Blob(b) => BuiltinIO::Blob(Arc::clone(b)),
             BuiltinIO::ArrayBuf { .. } => {
                 unreachable!("duplicate_out precedes jsbuf redirects")
             }
@@ -395,7 +393,7 @@ impl BuiltinIO {
                 *i = i.saturating_add(write_len as u32);
                 Ok(write_len)
             }
-            BuiltinIO::Blob(_) | BuiltinIO::Ignore => Ok(buf.len()),
+            BuiltinIO::Ignore => Ok(buf.len()),
         }
     }
 
@@ -788,8 +786,7 @@ impl Builtin {
     /// A file-backed blob (`Bun.file(path)` / `Bun.file(fd)`) is opened via
     /// `open_file_redirect` / wrapped in an `IOWriter`/`IOReader` so reads and
     /// writes go to disk. An in-memory blob is only valid for stdin; as a
-    /// stdout/stderr target it would silently discard output (`write_no_io_to`
-    /// treats `BuiltinIO::Blob` as a no-op), so we reject it up front.
+    /// stdout/stderr target it is rejected (there is no writable sink).
     fn setup_blob_redirect(
         interp: &Interpreter,
         cmd: NodeId,

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::interpreter::{
-    Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable_from_mode, shell_openat,
+    Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable_from_mode, shell_dup,
+    shell_openat,
 };
 use crate::shell::io::{InKind, OutFd, OutKind};
 use crate::shell::io_reader::IOReader;
@@ -561,129 +562,7 @@ impl Builtin {
                 };
                 // SAFETY: `path_buf` ends in NUL by construction.
                 let path = bun_core::ZStr::from_slice_with_nul(&path_buf[..]);
-                let perm: bun_sys::Mode = 0o666;
-                let cwd_fd = Self::cwd(interp, cmd);
-                let evtloop = interp.event_loop;
-
-                let mut pollable = false;
-                let mut is_socket = false;
-                let mut is_nonblocking = false;
-
-                let redirfd: bun_sys::Fd = if redirect.stdin() {
-                    match shell_openat(cwd_fd, path, redirect.to_flags(), perm) {
-                        Err(e) => {
-                            let sys = e.to_shell_system_error();
-                            return Some(Self::cmd_write_failing_error(
-                                interp,
-                                cmd,
-                                format_args!(
-                                    "bun: {}: {}",
-                                    bstr::BStr::new(sys.message.byte_slice()),
-                                    bstr::BStr::new(path.as_bytes()),
-                                ),
-                            ));
-                        }
-                        Ok(f) => f,
-                    }
-                } else {
-                    let result = bun_io::open_for_writing_impl(
-                        cwd_fd,
-                        &path,
-                        redirect.to_flags(),
-                        perm,
-                        &mut pollable,
-                        &mut is_socket,
-                        false,
-                        &mut is_nonblocking,
-                        (),
-                        |_| {},
-                        is_pollable_from_mode,
-                        shell_openat,
-                    );
-                    match result {
-                        Err(e) => {
-                            let sys = e.to_shell_system_error();
-                            return Some(Self::cmd_write_failing_error(
-                                interp,
-                                cmd,
-                                format_args!(
-                                    "bun: {}: {}",
-                                    bstr::BStr::new(sys.message.byte_slice()),
-                                    bstr::BStr::new(path.as_bytes()),
-                                ),
-                            ));
-                        }
-                        Ok(f) => {
-                            #[cfg(windows)]
-                            {
-                                use bun_sys::FdExt as _;
-                                match f.make_lib_uv_owned_for_syscall(
-                                    bun_sys::Tag::open,
-                                    bun_sys::ErrorCase::CloseOnFail,
-                                ) {
-                                    Err(e) => {
-                                        let sys = e.to_shell_system_error();
-                                        return Some(Self::cmd_write_failing_error(
-                                            interp,
-                                            cmd,
-                                            format_args!(
-                                                "bun: {}: {}",
-                                                bstr::BStr::new(sys.message.byte_slice()),
-                                                bstr::BStr::new(path.as_bytes()),
-                                            ),
-                                        ));
-                                    }
-                                    Ok(f2) => f2,
-                                }
-                            }
-                            #[cfg(not(windows))]
-                            {
-                                f
-                            }
-                        }
-                    }
-                };
-
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
-                if redirect.stdin() {
-                    let r = IOReader::init(redirfd, evtloop);
-                    r.set_interp(interp_ptr);
-                    Self::of_mut(interp, cmd).stdin = BuiltinInput::Fd(r);
-                }
-
-                if !redirect.stdout() && !redirect.stderr() {
-                    return None;
-                }
-
-                // Honor the `pollable` computed by `open_for_writing_impl` on
-                // POSIX so a FIFO/socket target (whose fd is now O_NONBLOCK)
-                // takes the pollable path; Windows keeps the async writer.
-                let redirect_writer = IOWriter::init(
-                    redirfd,
-                    io_writer::Flags {
-                        pollable: if cfg!(windows) { true } else { pollable },
-                        nonblock: is_nonblocking,
-                        is_socket,
-                        ..Default::default()
-                    },
-                    evtloop,
-                );
-                redirect_writer.set_interp(interp_ptr);
-
-                if redirect.stdout() {
-                    let me = Self::of_mut(interp, cmd);
-                    me.stdout = BuiltinIO::Fd(OutFd {
-                        writer: Arc::clone(&redirect_writer),
-                        captured: None,
-                    });
-                }
-                if redirect.stderr() {
-                    let me = Self::of_mut(interp, cmd);
-                    me.stderr = BuiltinIO::Fd(OutFd {
-                        writer: redirect_writer,
-                        captured: None,
-                    });
-                }
+                return Self::open_file_redirect(interp, cmd, path, redirect);
             }
             Some(ast::Redirect::JsBuf(jsbuf)) => {
                 // ── JS object redirect (`> ${arraybuf}` / `> ${blob}`).
@@ -732,51 +611,16 @@ impl Builtin {
                     // SAFETY: returned a live JSC-owned `*mut Value` borrowed
                     // from a Response/Request wrapper.
                     let body = unsafe { &mut *body };
-                    let is_file_blob = matches!(body, crate::webcore::body::Value::Blob(b)
-                        if !b.needs_to_read_file());
-                    if (redirect.stdout() || redirect.stderr()) && !is_file_blob {
-                        let _ = global.throw(format_args!(
-                            "Cannot redirect stdout/stderr to an immutable blob. Expected a file"
-                        ));
-                        return Some(Yield::failed());
-                    }
-                    let original_blob = body.use_();
-                    if !redirect.stdin() && !redirect.stdout() && !redirect.stderr() {
-                        drop(original_blob);
-                        return None;
-                    }
-                    let blob = Arc::new(BuiltinBlob {
-                        blob: original_blob.dupe(),
-                    });
-                    drop(original_blob);
-                    let me = Self::of_mut(interp, cmd);
-                    if redirect.stdin() {
-                        me.stdin = BuiltinInput::Blob(Arc::clone(&blob));
-                    }
-                    if redirect.stdout() {
-                        me.stdout = BuiltinIO::Blob(Arc::clone(&blob));
-                    }
-                    if redirect.stderr() {
-                        me.stderr = BuiltinIO::Blob(blob);
-                    }
+                    let blob = body.use_();
+                    return Self::setup_blob_redirect(interp, cmd, global, redirect, blob);
                 } else if let Some(blob_ref) = jsval.as_class_ref::<crate::webcore::Blob>() {
-                    if (redirect.stdout() || redirect.stderr()) && !blob_ref.needs_to_read_file() {
-                        let _ = global.throw(format_args!(
-                            "Cannot redirect stdout/stderr to an immutable blob. Expected a file"
-                        ));
-                        return Some(Yield::failed());
-                    }
-                    let theblob = Arc::new(BuiltinBlob {
-                        blob: blob_ref.dupe(),
-                    });
-                    let me = Self::of_mut(interp, cmd);
-                    if redirect.stdin() {
-                        me.stdin = BuiltinInput::Blob(theblob);
-                    } else if redirect.stdout() {
-                        me.stdout = BuiltinIO::Blob(theblob);
-                    } else if redirect.stderr() {
-                        me.stderr = BuiltinIO::Blob(theblob);
-                    }
+                    return Self::setup_blob_redirect(
+                        interp,
+                        cmd,
+                        global,
+                        redirect,
+                        blob_ref.dupe(),
+                    );
                 } else {
                     let _ = global.throw(format_args!(
                         "Unknown JS value used in shell: {}",
@@ -799,6 +643,243 @@ impl Builtin {
             None => {}
         }
 
+        None
+    }
+
+    /// Open `path` for the direction indicated by `redirect` and attach an
+    /// `IOReader`/`IOWriter` to stdin/stdout/stderr. Shared by the `Atom`
+    /// redirect arm (`> file`) and the `JsBuf` arm when the target is a
+    /// file-backed Blob (`> ${Bun.file(path)}` / `> ${new Response(Bun.file(path))}`).
+    fn open_file_redirect(
+        interp: &Interpreter,
+        cmd: NodeId,
+        path: &bun_core::ZStr,
+        redirect: ast::RedirectFlags,
+    ) -> Option<Yield> {
+        let perm: bun_sys::Mode = 0o666;
+        let cwd_fd = Self::cwd(interp, cmd);
+        let evtloop = interp.event_loop;
+
+        let mut pollable = false;
+        let mut is_socket = false;
+        let mut is_nonblocking = false;
+
+        let redirfd: bun_sys::Fd = if redirect.stdin() {
+            match shell_openat(cwd_fd, path, redirect.to_flags(), perm) {
+                Err(e) => {
+                    let sys = e.to_shell_system_error();
+                    return Some(Self::cmd_write_failing_error(
+                        interp,
+                        cmd,
+                        format_args!(
+                            "bun: {}: {}",
+                            bstr::BStr::new(sys.message.byte_slice()),
+                            bstr::BStr::new(path.as_bytes()),
+                        ),
+                    ));
+                }
+                Ok(f) => f,
+            }
+        } else {
+            let result = bun_io::open_for_writing_impl(
+                cwd_fd,
+                &path,
+                redirect.to_flags(),
+                perm,
+                &mut pollable,
+                &mut is_socket,
+                false,
+                &mut is_nonblocking,
+                (),
+                |_| {},
+                is_pollable_from_mode,
+                shell_openat,
+            );
+            match result {
+                Err(e) => {
+                    let sys = e.to_shell_system_error();
+                    return Some(Self::cmd_write_failing_error(
+                        interp,
+                        cmd,
+                        format_args!(
+                            "bun: {}: {}",
+                            bstr::BStr::new(sys.message.byte_slice()),
+                            bstr::BStr::new(path.as_bytes()),
+                        ),
+                    ));
+                }
+                Ok(f) => {
+                    #[cfg(windows)]
+                    {
+                        use bun_sys::FdExt as _;
+                        match f.make_lib_uv_owned_for_syscall(
+                            bun_sys::Tag::open,
+                            bun_sys::ErrorCase::CloseOnFail,
+                        ) {
+                            Err(e) => {
+                                let sys = e.to_shell_system_error();
+                                return Some(Self::cmd_write_failing_error(
+                                    interp,
+                                    cmd,
+                                    format_args!(
+                                        "bun: {}: {}",
+                                        bstr::BStr::new(sys.message.byte_slice()),
+                                        bstr::BStr::new(path.as_bytes()),
+                                    ),
+                                ));
+                            }
+                            Ok(f2) => f2,
+                        }
+                    }
+                    #[cfg(not(windows))]
+                    {
+                        f
+                    }
+                }
+            }
+        };
+
+        let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+        if redirect.stdin() {
+            let r = IOReader::init(redirfd, evtloop);
+            r.set_interp(interp_ptr);
+            Self::of_mut(interp, cmd).stdin = BuiltinInput::Fd(r);
+        }
+
+        if !redirect.stdout() && !redirect.stderr() {
+            return None;
+        }
+
+        // Honor the `pollable` computed by `open_for_writing_impl` on
+        // POSIX so a FIFO/socket target (whose fd is now O_NONBLOCK)
+        // takes the pollable path; Windows keeps the async writer.
+        let redirect_writer = IOWriter::init(
+            redirfd,
+            io_writer::Flags {
+                pollable: if cfg!(windows) { true } else { pollable },
+                nonblock: is_nonblocking,
+                is_socket,
+                ..Default::default()
+            },
+            evtloop,
+        );
+        redirect_writer.set_interp(interp_ptr);
+
+        if redirect.stdout() {
+            let me = Self::of_mut(interp, cmd);
+            me.stdout = BuiltinIO::Fd(OutFd {
+                writer: Arc::clone(&redirect_writer),
+                captured: None,
+            });
+        }
+        if redirect.stderr() {
+            let me = Self::of_mut(interp, cmd);
+            me.stderr = BuiltinIO::Fd(OutFd {
+                writer: redirect_writer,
+                captured: None,
+            });
+        }
+        None
+    }
+
+    /// Attach a `Blob` redirect target (bare Blob or a Request/Response body)
+    /// to stdin/stdout/stderr.
+    ///
+    /// A file-backed blob (`Bun.file(path)` / `Bun.file(fd)`) is opened via
+    /// `open_file_redirect` / wrapped in an `IOWriter`/`IOReader` so reads and
+    /// writes go to disk. An in-memory blob is only valid for stdin; as a
+    /// stdout/stderr target it would silently discard output (`write_no_io_to`
+    /// treats `BuiltinIO::Blob` as a no-op), so we reject it up front.
+    fn setup_blob_redirect(
+        interp: &Interpreter,
+        cmd: NodeId,
+        global: &crate::jsc::JSGlobalObject,
+        redirect: ast::RedirectFlags,
+        blob: crate::webcore::Blob,
+    ) -> Option<Yield> {
+        if !redirect.stdin() && !redirect.stdout() && !redirect.stderr() {
+            drop(blob);
+            return None;
+        }
+
+        if blob.needs_to_read_file() {
+            if let Some(store) = blob.store.get().as_deref() {
+                if let crate::webcore::blob::store::Data::File(file) = &store.data {
+                    match &file.pathlike {
+                        crate::node::PathOrFileDescriptor::Path(p) => {
+                            let mut path_buf = p.slice().to_vec();
+                            path_buf.push(0);
+                            drop(blob);
+                            let path = bun_core::ZStr::from_slice_with_nul(&path_buf[..]);
+                            return Self::open_file_redirect(interp, cmd, path, redirect);
+                        }
+                        crate::node::PathOrFileDescriptor::Fd(fd) => {
+                            // The store's fd is borrowed from user code; dup
+                            // it so `IOWriter`/`IOReader` own a private fd
+                            // they can close on Drop.
+                            let duped = match shell_dup(*fd) {
+                                Ok(d) => d,
+                                Err(e) => {
+                                    drop(blob);
+                                    let sys = e.to_shell_system_error();
+                                    return Some(Self::cmd_write_failing_error(
+                                        interp,
+                                        cmd,
+                                        format_args!(
+                                            "bun: {}\n",
+                                            bstr::BStr::new(sys.message.byte_slice()),
+                                        ),
+                                    ));
+                                }
+                            };
+                            drop(blob);
+                            let evtloop = interp.event_loop;
+                            let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                            if redirect.stdin() {
+                                let r = IOReader::init(duped, evtloop);
+                                r.set_interp(interp_ptr);
+                                Self::of_mut(interp, cmd).stdin = BuiltinInput::Fd(r);
+                                return None;
+                            }
+                            let w = IOWriter::init(
+                                duped,
+                                io_writer::Flags {
+                                    pollable: cfg!(windows),
+                                    ..Default::default()
+                                },
+                                evtloop,
+                            );
+                            w.set_interp(interp_ptr);
+                            if redirect.stdout() {
+                                Self::of_mut(interp, cmd).stdout = BuiltinIO::Fd(OutFd {
+                                    writer: Arc::clone(&w),
+                                    captured: None,
+                                });
+                            }
+                            if redirect.stderr() {
+                                Self::of_mut(interp, cmd).stderr = BuiltinIO::Fd(OutFd {
+                                    writer: w,
+                                    captured: None,
+                                });
+                            }
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+
+        if redirect.stdout() || redirect.stderr() {
+            drop(blob);
+            let _ = global.throw(format_args!(
+                "Cannot redirect stdout/stderr to an immutable blob. Expected a file"
+            ));
+            return Some(Yield::failed());
+        }
+
+        let theblob = Arc::new(BuiltinBlob { blob: blob.dupe() });
+        drop(blob);
+        Self::of_mut(interp, cmd).stdin = BuiltinInput::Blob(theblob);
         None
     }
 

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::interpreter::{
-    Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable_from_mode, shell_dup,
-    shell_openat,
+    Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable, is_pollable_from_mode,
+    shell_dup, shell_openat,
 };
 use crate::shell::io::{InKind, OutFd, OutKind};
 use crate::shell::io_reader::IOReader;
@@ -844,7 +844,11 @@ impl Builtin {
                             let w = IOWriter::init(
                                 duped,
                                 io_writer::Flags {
-                                    pollable: cfg!(windows),
+                                    pollable: if cfg!(windows) {
+                                        true
+                                    } else {
+                                        is_pollable(duped)
+                                    },
                                     ..Default::default()
                                 },
                                 evtloop,

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2066,7 +2066,7 @@ fn open_null_device() -> bun_sys::Result<Fd> {
 /// .file.mode`; `EventLoopHandle` is still a shim, so we `fstat` the (already
 /// dup'd) fd here instead. On `fstat` failure we conservatively return `false`
 /// (non-pollable → synchronous write path), matching Windows behavior.
-fn is_pollable(fd: Fd) -> bool {
+pub fn is_pollable(fd: Fd) -> bool {
     #[cfg(windows)]
     {
         let _ = fd;

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -506,11 +506,7 @@ describe("bunshell", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
       return stdout.trim();
@@ -551,11 +547,7 @@ describe("bunshell", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
       expect(await Bun.file(out).text()).toBe("via-fd\n");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -527,7 +527,7 @@ describe("bunshell", () => {
     ])("%s rejects (immutable)", async (_label, expr) => {
       using dir = tempDir("shell-immutable-blob", {});
       const result = await run(expr, String(dir));
-      expect(result).toContain("throw: Cannot redirect stdout/stderr to an immutable blob");
+      expect(result).toBe("throw: Cannot redirect stdout/stderr to an immutable blob. Expected a file");
     });
 
     test.concurrent("Bun.file(fd) writes to the fd", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -481,6 +481,87 @@ describe("bunshell", () => {
     expect(await file.text()).toEqual(thisFileText);
   });
 
+  // `echo` is always a shell builtin, so these exercise `Builtin::init_redirections`
+  // (the JsBuf arm) directly. The guard on Response/Request bodies had its polarity
+  // inverted: `new Response(new Blob([..]))` was accepted and the output silently
+  // dropped, while `new Response(Bun.file(..))` threw "immutable blob". Each case
+  // runs in a spawned process because a throw from the builtin redirect setup
+  // currently leaves the interpreter keepalive pinned in-process.
+  describe("redirect builtin stdout to Blob / Response body", () => {
+    const run = async (expr: string, dir: string) => {
+      const code = /* ts */ `
+        import { $ } from "bun";
+        try {
+          await $\`echo hello > \${${expr}}\`;
+          console.log("ok");
+        } catch (e) {
+          console.log("throw: " + e.message);
+        }
+        process.exit(0);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout.trim();
+    };
+
+    test.concurrent("Response(Bun.file) writes to the file", async () => {
+      using dir = tempDir("shell-resp-bunfile", {});
+      const out = join(String(dir), "out.txt");
+      const result = await run(`new Response(Bun.file(${JSON.stringify(out)}))`, String(dir));
+      expect(result).toBe("ok");
+      expect(await Bun.file(out).text()).toBe("hello\n");
+    });
+
+    test.concurrent.each([
+      ["Response(Blob)", `new Response(new Blob(["x"]))`],
+      ["Response(string)", `new Response("x")`],
+      ["bare Blob", `new Blob(["x"])`],
+    ])("%s rejects (immutable)", async (_label, expr) => {
+      using dir = tempDir("shell-immutable-blob", {});
+      const result = await run(expr, String(dir));
+      expect(result).toContain("throw: Cannot redirect stdout/stderr to an immutable blob");
+    });
+
+    test.concurrent("Bun.file(fd) writes to the fd", async () => {
+      using dir = tempDir("shell-bunfile-fd", {});
+      const out = join(String(dir), "out.txt");
+      const code = /* ts */ `
+        import { $ } from "bun";
+        import { openSync, closeSync } from "node:fs";
+        const fd = openSync(${JSON.stringify(out)}, "w");
+        await $\`echo via-fd > \${Bun.file(fd)}\`;
+        closeSync(fd);
+        process.exit(0);
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", code],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      expect(await Bun.file(out).text()).toBe("via-fd\n");
+    });
+  });
+
   // TODO This sometimes fails
   test("redirect stderr", async () => {
     const buffer = Buffer.alloc(128, 0);


### PR DESCRIPTION
## What does this PR do?

`Builtin::init_redirections` guards a `> ${jsvalue}` stdout/stderr redirect against in-memory Blob bodies with:

```rust
let is_file_blob = matches!(body, Value::Blob(b) if !b.needs_to_read_file());
if (redirect.stdout() || redirect.stderr()) && !is_file_blob { /* throw */ }
```

`needs_to_read_file()` is *true* for file-backed blobs, so `is_file_blob` was true for in-memory bodies and false for file-backed ones, the opposite of the sibling direct-Blob branch. Since `echo` always runs as a builtin:

```js
import { $ } from "bun";
// throws "Cannot redirect stdout/stderr to an immutable blob", should write
await $`echo hi > ${new Response(Bun.file("/tmp/out"))}`;
// succeeds with exit 0 and output discarded, should throw
await $`echo hi > ${new Response(new Blob(["x"]))}`;
```

Fixing the predicate alone isn't sufficient: a file-backed body that passes the guard was stored as `BuiltinIO::Blob(..)`, and `write_no_io_to` treated that variant as `Ok(buf.len())` (a no-op), so output would still be silently dropped. The same silent drop also affected `echo hi > ${Bun.file(fd)}` (fd-backed blobs reach the JsBuf arm because only path-backed `Bun.file` is inlined as a path string by `handle_template_value`).

### Fix

The Request/Response and bare-Blob JsBuf branches now share one `setup_blob_redirect` helper:

- a file-backed blob has its `store.data.File.pathlike` extracted and is opened through the same `IOReader`/`IOWriter` path that an `Atom` (`> filename`) redirect already uses (hoisted into `open_file_redirect`); an fd-backed blob is `shell_dup`'d so the writer owns a private fd, and the dup'd fd is probed with `is_pollable()` so a pipe/socket/tty takes the async writer path
- an in-memory blob as stdout/stderr throws "Cannot redirect stdout/stderr to an immutable blob"; as stdin it stays `BuiltinInput::Blob`

This mirrors what `Stdio::extract_blob` already does for the spawned-subprocess path in `Cmd::init_subproc_redirections`.

The `BuiltinIO::Blob` output variant is no longer constructed anywhere and has been removed so the silent-drop arm cannot reappear; `BuiltinInput::Blob` stays for in-memory stdin.

### Related

- #35314 adds a `Locked`/`Used`/`Error` body check just before this branch; that PR does not touch the polarity and its added `check_body_for_redirect` call sits cleanly above the new `body.use_()` line.
- #33996 fixes the interpreter keepalive left pinned after a `Yield::failed()` throw; the new tests spawn a subprocess per case so they do not depend on that fix.
- `setup_blob_redirect` also routes `< ${Response(Bun.file(p))}` stdin through `IOReader` (previously it delivered empty bytes via `shared_view()` on a file store). This is only observable via builtin `cat` (Windows, or POSIX with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`), where builtin `cat < file` has a separate pre-existing issue on POSIX; left out of this PR's test coverage.

### How did you verify your code works?

Added to `test/js/bun/shell/bunshell.test.ts` under `redirect builtin stdout to Blob / Response body`:

- `echo > ${new Response(Bun.file(path))}` writes `hello\n` to the file
- `echo > ${new Response(new Blob([..]))}`, `${new Response("..")}`, `${new Blob([..])}` each reject with the exact "immutable blob" message
- `echo > ${Bun.file(fd)}` writes to the fd (and the user's fd stays open)

```
USE_SYSTEM_BUN=1 bun test bunshell.test.ts -t "redirect builtin stdout"   # 3 fail, 2 pass
bun bd test bunshell.test.ts -t "redirect builtin stdout"                 # 5 pass
bun bd test bunshell.test.ts                                              # 419 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->