### PR TITLE
Make dotenv::Loader own its Map; forbid unsafe in bun_ini

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -45,7 +45,7 @@ use crate::{
 /// holds an erased `*mut jsc::EventLoop` driven through a vtable). Stored as
 /// a pointer because the linker borrows the loop owned by the
 /// `BundleThread` / runtime.
-pub type EventLoop = Option<core::ptr::NonNull<bun_event_loop::AnyEventLoop<'static>>>;
+pub type EventLoop = Option<core::ptr::NonNull<bun_event_loop::AnyEventLoop>>;
 
 bun_core::declare_scope!(LinkerCtx, visible);
 bun_core::declare_scope!(TreeShake, hidden);
@@ -313,7 +313,7 @@ impl<'a> LinkerContext<'a> {
     /// `BackRef<BundleV2>` (`&` only).
     #[inline]
     #[allow(clippy::mut_from_ref)]
-    pub fn any_loop_mut(&self) -> Option<&mut bun_event_loop::AnyEventLoop<'static>> {
+    pub fn any_loop_mut(&self) -> Option<&mut bun_event_loop::AnyEventLoop> {
         // SAFETY: BACKREF — set once in `BundleV2::init` from a loop that
         // outlives the bundle pass; the pointee is disjoint from `*self`.
         // Exclusivity: `Js { owner }.enqueue_task_concurrent` is `&self`

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -173,7 +173,7 @@ impl<'a> BundleV2<'a> {
     /// `switch (this.loop().*)` — `linker.loop` is a non-owning backref to the
     /// `AnyEventLoop` that owns this bundle pass and outlives it.
     #[inline]
-    pub fn any_loop_mut(&mut self) -> &mut bun_event_loop::AnyEventLoop<'static> {
+    pub fn any_loop_mut(&mut self) -> &mut bun_event_loop::AnyEventLoop {
         // BACKREF deref centralised in `LinkerContext::any_loop_mut`.
         self.linker
             .any_loop_mut()

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -84,7 +84,7 @@ fn env_string_store_put(
 /// `to_json` is the framework-defaults `RawDefines` map; `to_string` is the
 /// per-env `UserDefinesArray`.
 pub fn copy_env_for_define(
-    env: &bun_dotenv::Loader<'_>,
+    env: &bun_dotenv::Loader,
     to_json: &mut RawDefines,
     to_string: &mut UserDefinesArray,
     framework_defaults_keys: &[&[u8]],

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -140,7 +140,7 @@ pub struct Transpiler<'a> {
     // by `configure_linker` below; `set_log` keeps `linker.log` in sync.
     pub linker: crate::linker::Linker,
     // Raw ptr — the global `DotEnv::Loader` singleton.
-    pub env: *mut dot_env::Loader<'a>,
+    pub env: *mut dot_env::Loader,
 
     pub macro_context: Option<js_ast::Macro::MacroContext>,
 }
@@ -262,7 +262,7 @@ impl<'a> Transpiler<'a> {
     /// [`Self::env_mut`] when only inspecting env vars (e.g. `.get()`), so
     /// call sites can overlap with other `&` borrows of the same loader.
     #[inline]
-    pub fn env(&self) -> &'a dot_env::Loader<'a> {
+    pub fn env(&self) -> &'a dot_env::Loader {
         // SAFETY: `self.env` is non-null after `init` — set to either the
         // caller-provided loader or the `dot_env::INSTANCE` singleton, both of
         // which live for at least `'a`. Shared access cannot conflict with the
@@ -277,7 +277,7 @@ impl<'a> Transpiler<'a> {
     /// borrows.
     #[inline]
     #[allow(clippy::mut_from_ref)]
-    pub fn env_mut(&self) -> &'a mut dot_env::Loader<'a> {
+    pub fn env_mut(&self) -> &'a mut dot_env::Loader {
         // SAFETY: `self.env` is non-null after `init` — set to either the
         // caller-provided loader or the `dot_env::INSTANCE` singleton, both of
         // which live for at least `'a`. No other live `&mut Loader` exists at
@@ -354,9 +354,7 @@ impl<'a> Transpiler<'a> {
                 core::ptr::null_mut(),
                 from.fs,
             ),
-            // SAFETY: lifetime-widen the `Loader<'from>` raw pointer to `'a`
-            // (process-lifetime singleton; see fn doc).
-            env: from.env.cast(),
+            env: from.env,
             // `MacroContext::init(transpiler)` takes the
             // transpiler's *address*; deferred to `wire_after_move`.
             macro_context: None,
@@ -719,7 +717,7 @@ impl<'a> Transpiler<'a> {
         use bun_options_types::schema::api::DotEnvBehavior;
         // Derived once up front; no other live `&mut` to this `Loader` exists
         // for the duration of this call.
-        let env: &mut dot_env::Loader<'_> = self.env_mut();
+        let env: &mut dot_env::Loader = self.env_mut();
 
         match self.options.env.behavior {
             DotEnvBehavior::prefix
@@ -1150,7 +1148,7 @@ impl<'a> Transpiler<'a> {
         arena: &'a Arena,
         log: *mut bun_ast::Log,
         opts: api::TransformOptions,
-        env_loader_: Option<*mut dot_env::Loader<'static>>,
+        env_loader_: Option<*mut dot_env::Loader>,
     ) -> crate::Result<Transpiler<'a>> {
         let mut slot = core::mem::MaybeUninit::<Transpiler<'a>>::uninit();
         Self::init_in_place(&mut slot, arena, log, opts, env_loader_)?;
@@ -1173,7 +1171,7 @@ impl<'a> Transpiler<'a> {
         arena: &'a Arena,
         log: *mut bun_ast::Log,
         opts: api::TransformOptions,
-        env_loader_: Option<*mut dot_env::Loader<'static>>,
+        env_loader_: Option<*mut dot_env::Loader>,
     ) -> crate::Result<()> {
         // Caller contract: `log` is the freshly-boxed per-VM `Log` from
         // `VirtualMachine::init` and is never null. Validate up front so the
@@ -1215,25 +1213,16 @@ impl<'a> Transpiler<'a> {
         };
         let fs: *mut Fs::FileSystem = init_file_system(cwd)?;
 
-        let env_loader: *mut dot_env::Loader<'static> = match env_loader_ {
+        let env_loader: *mut dot_env::Loader = match env_loader_ {
             Some(l) => l,
             None => match dot_env::instance() {
                 Some(l) => l,
                 None => {
                     // PORTING.md §Forbidden bars `Box::leak` even for
-                    // process-lifetime singletons. `bun_dotenv::INSTANCE` is an
-                    // `AtomicPtr<Loader<'static>>` and `Loader` borrows
-                    // an unbounded `&mut Map`, so a `OnceLock<Loader>` here can't
-                    // be expressed without changing `bun_dotenv`'s API.
-                    // Transfer ownership of both allocations into the global
-                    // singleton via `heap::alloc` (the AtomicPtr becomes the
-                    // owner; matches `MiniEventLoop::init_global`).
-                    let map: *mut dot_env::Map =
-                        bun_core::heap::into_raw(Box::new(dot_env::Map::init()));
-                    // SAFETY: `map` is a fresh heap allocation with no other
-                    // alias; `Loader` stores it for process lifetime and is
-                    // itself installed into `dot_env::INSTANCE` below.
-                    bun_core::heap::into_raw(Box::new(dot_env::Loader::init(unsafe { &mut *map })))
+                    // process-lifetime singletons. Transfer ownership into the
+                    // global singleton via `heap::alloc` (the AtomicPtr becomes
+                    // the owner; matches `MiniEventLoop::init_global`).
+                    bun_core::heap::into_raw(Box::new(dot_env::Loader::init()))
                 }
             },
         };
@@ -1286,10 +1275,7 @@ impl<'a> Transpiler<'a> {
         let p = dst.as_mut_ptr();
         // SAFETY: `dst` is an exclusively-borrowed, currently-uninitialised
         // `MaybeUninit<Transpiler>`; each `write` initialises a distinct field
-        // and no field is read before it is written. `env_loader.cast()` matches
-        // the field's `*mut Loader<'a>` (raw-pointer lifetime reinterpretation —
-        // the pointee is the process-lifetime singleton or caller-supplied
-        // loader, as in the original struct literal).
+        // and no field is read before it is written.
         unsafe {
             core::ptr::addr_of_mut!((*p).options).write(bundle_options);
             core::ptr::addr_of_mut!((*p).log).write(log_nn.as_ptr());
@@ -1317,7 +1303,7 @@ impl<'a> Transpiler<'a> {
                 core::ptr::null_mut(),
                 fs,
             ));
-            core::ptr::addr_of_mut!((*p).env).write(env_loader.cast());
+            core::ptr::addr_of_mut!((*p).env).write(env_loader);
             core::ptr::addr_of_mut!((*p).macro_context).write(None);
         }
         Ok(())

--- a/src/dispatch/lib.rs
+++ b/src/dispatch/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! // ── in bun_event_loop (high tier) ──
 //! bun_io::link_impl_EventLoopOps! {
-//!     Mini for MiniEventLoop<'static> => |this| {
+//!     Mini for MiniEventLoop => |this| {
 //!         platform_loop()        => (*this).loop_ptr(),
 //!         set_after_cb(cb, ctx)  => { (*this).cb = cb; (*this).ctx = ctx; },
 //!     }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::ffi::c_char;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
@@ -103,8 +104,8 @@ pub struct S3Credentials {
     pub insecure_http: bool,
 }
 
-pub struct Loader<'a> {
-    pub map: &'a mut Map,
+pub struct Loader {
+    pub map: Map,
     // allocator dropped — global mimalloc (see PORTING.md §Allocators)
     pub env_local: Option<bun_ast::Source>,
     pub env_development: Option<bun_ast::Source>,
@@ -121,7 +122,7 @@ pub struct Loader<'a> {
     pub quiet: bool,
 
     pub did_load_process: bool,
-    pub reject_unauthorized: Option<bool>,
+    pub reject_unauthorized: Cell<Option<bool>>,
 
     // Local POD mirror of `bun_s3_signing::S3Credentials` — see type doc above.
     aws_credentials: Option<S3Credentials>,
@@ -135,7 +136,7 @@ static NODE_PATH_TO_USE_SET_ONCE: bun_core::RwLock<Option<Box<[u8]>>> = bun_core
 // PORTING.md §Concurrency: OnceLock — set once from CLI flag, read many.
 pub static HAS_NO_CLEAR_SCREEN_CLI_FLAG: OnceLock<bool> = OnceLock::new();
 
-impl<'a> Loader<'a> {
+impl Loader {
     /// Shared "empty-ish" predicate for proxy env vars: an unset/empty value,
     /// or a literal empty-quote pair left over from shell `export FOO=""` /
     /// `export FOO=''`.
@@ -287,22 +288,17 @@ impl<'a> Loader<'a> {
     /// Node's `=== '0'` check exactly).
     ///
     /// **Prefer VirtualMachine.getTLSRejectUnauthorized()** for JavaScript, as individual workers could have different settings.
-    pub fn get_tls_reject_unauthorized(&mut self) -> bool {
-        if let Some(reject_unauthorized) = self.reject_unauthorized {
+    pub fn get_tls_reject_unauthorized(&self) -> bool {
+        if let Some(reject_unauthorized) = self.reject_unauthorized.get() {
             return reject_unauthorized;
         }
-        if let Some(reject) = self.get(b"NODE_TLS_REJECT_UNAUTHORIZED") {
-            if reject == b"0" {
-                self.reject_unauthorized = Some(false);
-                return false;
-            }
-        }
         // default: true
-        self.reject_unauthorized = Some(true);
-        true
+        let result = self.get(b"NODE_TLS_REJECT_UNAUTHORIZED") != Some(b"0");
+        self.reject_unauthorized.set(Some(result));
+        result
     }
 
-    pub fn get_http_proxy_for(&mut self, url: &URL<'_>) -> Option<URL<'a>> {
+    pub fn get_http_proxy_for(&self, url: &URL<'_>) -> Option<URL<'_>> {
         self.get_http_proxy(url.is_http(), Some(url.hostname), Some(url.host))
     }
 
@@ -317,28 +313,13 @@ impl<'a> Loader<'a> {
     /// `hostname` is the host without port (e.g., "localhost")
     /// `host` is the host with port if present (e.g., "localhost:3000")
     pub fn get_http_proxy(
-        &mut self,
+        &self,
         is_http: bool,
         hostname: Option<&[u8]>,
         host: Option<&[u8]>,
-    ) -> Option<URL<'a>> {
+    ) -> Option<URL<'_>> {
         // TODO: When Web Worker support is added, make sure to intern these strings
-        //
-        // Lifetime: the returned `URL` borrows env-var values that are
-        // `Box<[u8]>`-owned by `*self.map: Map`, which is borrowed for `'a`
-        // (`map: &'a mut Map`). The boxed allocations are address-stable
-        // across rehashes and Bun never removes/overwrites the proxy env vars
-        // after they are read here, so the slices are valid for `'a`.
-        // Encapsulating the extension here keeps every caller (PackageManager,
-        // fetch, upgrade, create) free of `transmute` (PORTING.md §Forbidden).
-        let extend = |s: &[u8]| -> &'a [u8] {
-            // SAFETY: `s` points into a `Box<[u8]>` owned by `*self.map`, which is
-            // borrowed for `'a`; the boxed allocation is address-stable and never
-            // removed for the proxy env vars (see lifetime note above).
-            unsafe { core::slice::from_raw_parts(s.as_ptr(), s.len()) }
-        };
-
-        let mut http_proxy: Option<URL<'a>> = None;
+        let mut http_proxy: Option<URL<'_>> = None;
 
         let proxy = if is_http {
             self.get_lower_then_upper(b"http_proxy", b"HTTP_PROXY")
@@ -347,7 +328,7 @@ impl<'a> Loader<'a> {
         };
         if let Some(p) = proxy {
             if !Self::is_emptyish(p) {
-                http_proxy = Some(URL::parse(extend(p)));
+                http_proxy = Some(URL::parse(p));
             }
         }
 
@@ -574,7 +555,11 @@ impl<'a> Loader<'a> {
     // — it constructs `E::String` + `DefineData`, both higher-tier types, and
     // only reads `self.map.map.{keys,values}()` from this crate.
 
-    pub fn init(map: &'a mut Map) -> Loader<'a> {
+    pub fn init() -> Loader {
+        Self::init_with_map(Map::init())
+    }
+
+    pub fn init_with_map(map: Map) -> Loader {
         Loader {
             map,
             env_local: None,
@@ -588,7 +573,7 @@ impl<'a> Loader<'a> {
             custom_files_loaded: StringArrayHashMap::default(),
             quiet: false,
             did_load_process: false,
-            reject_unauthorized: None,
+            reject_unauthorized: Cell::new(None),
             aws_credentials: None,
         }
     }
@@ -628,7 +613,7 @@ impl<'a> Loader<'a> {
         // `Source.contents: &'static [u8]` lifetime constraint (callers like
         // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
-        Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, self.map, &mut value_buffer)
+        Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, &mut self.map, &mut value_buffer)
     }
 
     pub fn load<D: DirEntryProbe + ?Sized>(
@@ -887,7 +872,7 @@ impl<'a> Loader<'a> {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut *self.map, value_buffer)?;
+                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
             }
         }
 
@@ -934,7 +919,7 @@ impl<'a> Loader<'a> {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut *self.map, value_buffer)?;
+                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
             }
         }
 
@@ -1546,21 +1531,20 @@ impl StdEnvMapWrapper {
 
 // Drop replaces deinit (only frees hash_map storage; Rust does this automatically)
 
-// Global singleton. Loader is !Sync (holds `&mut Map`); it is only installed
-// and used under a single-thread (CLI-init) invariant.
-// We store a raw `*mut` in an AtomicPtr (overwritable) and hand
-// the raw pointer back to callers so the no-alias `&mut` proof obligation lives at the *call
-// site*, not here — manufacturing `&'static mut` inside an accessor is aliased-&mut UB the
-// moment two callers hold results simultaneously (PORTING.md §Forbidden: lifetime-extension
-// via `unsafe { &*(p as *const _) }`).
-pub static INSTANCE: AtomicPtr<Loader<'static>> = AtomicPtr::new(core::ptr::null_mut());
+// Global singleton. Installed and used under a single-thread (CLI-init)
+// invariant. We store a raw `*mut` in an AtomicPtr (overwritable) and hand the
+// raw pointer back to callers so the no-alias `&mut` proof obligation lives at
+// the *call site*, not here — manufacturing `&'static mut` inside an accessor
+// is aliased-&mut UB the moment two callers hold results simultaneously
+// (PORTING.md §Forbidden: lifetime-extension via `unsafe { &*(p as *const _) }`).
+pub static INSTANCE: AtomicPtr<Loader> = AtomicPtr::new(core::ptr::null_mut());
 
 /// Read the global singleton as a raw pointer — `Some(ptr)` once `set_instance` has been called.
 /// Callers must `unsafe { &mut *ptr }` at point of use under the single-thread
 /// CLI-init invariant: the loader is only installed and dereferenced on the
 /// main thread, so no two `&mut` borrows can be live at once.
 #[inline]
-pub fn instance() -> Option<*mut Loader<'static>> {
+pub fn instance() -> Option<*mut Loader> {
     let ptr = INSTANCE.load(Ordering::Acquire);
     if ptr.is_null() { None } else { Some(ptr) }
 }
@@ -1568,6 +1552,6 @@ pub fn instance() -> Option<*mut Loader<'static>> {
 /// Install the global singleton. Overwrites any previous value (test harnesses
 /// / worker re-init may call this more than once).
 #[inline]
-pub fn set_instance(loader: *mut Loader<'static>) {
+pub fn set_instance(loader: *mut Loader) {
     INSTANCE.store(loader, Ordering::Release);
 }

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -46,17 +46,17 @@ fn jsc_event_loop_handle(js_event_loop: *mut ()) -> JsEventLoop {
 
 /// Useful for code that may need an event loop and could be used from either JavaScript or directly without JavaScript.
 /// Unlike jsc.EventLoopHandle, this owns the event loop when it's not a JavaScript event loop.
-pub enum AnyEventLoop<'a> {
+pub enum AnyEventLoop {
     Js {
         /// Typed handle wrapping the erased `*mut jsc::EventLoop`. The
         /// `link_interface!` invariant ("owner is live for every dispatch") is
         /// established once at construction; dispatch is safe.
         owner: JsEventLoop,
     },
-    Mini(Box<MiniEventLoop<'a>>),
+    Mini(Box<MiniEventLoop>),
 }
 
-impl<'a> Default for AnyEventLoop<'a> {
+impl Default for AnyEventLoop {
     /// Stub default for `#[derive(Default)]` containers (e.g. the
     /// `bun_install::PackageManager` stub). Real consumers always overwrite
     /// this via `init()` / `js_current()` before use.
@@ -65,7 +65,7 @@ impl<'a> Default for AnyEventLoop<'a> {
     }
 }
 
-impl<'a> AnyEventLoop<'a> {
+impl AnyEventLoop {
     pub fn iteration_number(&self) -> u64 {
         match self {
             AnyEventLoop::Js { owner } => owner.iteration_number(),
@@ -77,11 +77,11 @@ impl<'a> AnyEventLoop<'a> {
     /// Convert to an owned [`EventLoopHandle`]. Thin alias for
     /// [`EventLoopHandle::from_any`].
     #[inline]
-    pub fn as_handle(this: &mut AnyEventLoop<'static>) -> EventLoopHandle {
+    pub fn as_handle(this: &mut AnyEventLoop) -> EventLoopHandle {
         EventLoopHandle::from_any(this)
     }
 
-    pub fn init() -> AnyEventLoop<'a> {
+    pub fn init() -> AnyEventLoop {
         AnyEventLoop::Mini(Box::new(MiniEventLoop::init()))
     }
 
@@ -94,7 +94,7 @@ impl<'a> AnyEventLoop<'a> {
     /// `AnyEventLoop`. The pointer is not dereferenced here — it's stored
     /// opaquely in [`JsEventLoop`] and only dereferenced at dispatch sites.
     #[inline]
-    pub fn js(js_event_loop: *mut ()) -> AnyEventLoop<'static> {
+    pub fn js(js_event_loop: *mut ()) -> AnyEventLoop {
         AnyEventLoop::Js {
             owner: jsc_event_loop_handle(js_event_loop),
         }
@@ -103,7 +103,7 @@ impl<'a> AnyEventLoop<'a> {
     /// Construct the `Js` variant for the current thread's JS event loop.
     /// Replaces `jsc::VirtualMachine::get().event_loop()` for tier-≤4 callers
     /// (e.g. `bun_install::PackageManager`).
-    pub fn js_current() -> AnyEventLoop<'static> {
+    pub fn js_current() -> AnyEventLoop {
         AnyEventLoop::Js {
             owner: JsEventLoop::current(),
         }
@@ -167,10 +167,10 @@ impl<'a> AnyEventLoop<'a> {
 // `EventLoopHandle` (below, same file) is the canonical Js/Mini dispatcher for
 // these four methods. `AnyEventLoop` forwards through `from_any` instead of
 // duplicating each `match`. Bound to `'static` because `from_any` stores
-// `BackRef<MiniEventLoop<'static>>`; every concrete `AnyEventLoop`
+// `BackRef<MiniEventLoop>`; every concrete `AnyEventLoop`
 // instantiation in the tree is already `'static` (verified: install, patch,
 // build_command, ChangedFilesFilter, `js()`/`js_current()`).
-impl AnyEventLoop<'static> {
+impl AnyEventLoop {
     #[inline]
     pub fn r#loop(&mut self) -> *mut UwsLoop {
         EventLoopHandle::from_any(self).r#loop()
@@ -218,7 +218,7 @@ pub enum EventLoopHandle {
     // strictly outlive every `EventLoopHandle` derived from them — the
     // [`BackRef`] invariant. Read-only sites use safe `Deref`; the few
     // `&mut`-taking dispatch sites go through [`mini_mut`] (single deref site).
-    Mini(BackRef<MiniEventLoop<'static>>),
+    Mini(BackRef<MiniEventLoop>),
 }
 
 /// Single `unsafe` deref site for the `EventLoopHandle::Mini` arm — collapses
@@ -233,7 +233,7 @@ pub enum EventLoopHandle {
 /// [`BackRef::get_mut`] precondition, discharged once here instead of at each
 /// dispatch site. Private to this module so the invariant is local.
 #[inline]
-fn mini_mut<'a>(mini: &'a mut BackRef<MiniEventLoop<'static>>) -> &'a mut MiniEventLoop<'static> {
+fn mini_mut<'a>(mini: &'a mut BackRef<MiniEventLoop>) -> &'a mut MiniEventLoop {
     // SAFETY: see fn doc — per-thread `!Send` singleton, exclusive for the
     // returned borrow's duration.
     unsafe { mini.get_mut() }
@@ -294,7 +294,7 @@ impl EventLoopHandle {
     }
 
     #[inline]
-    pub fn init_mini(mini: *mut MiniEventLoop<'static>) -> EventLoopHandle {
+    pub fn init_mini(mini: *mut MiniEventLoop) -> EventLoopHandle {
         // `mini` is the live per-thread singleton (or an `AnyEventLoop::Mini`
         // payload) — never null at any call site. `BackRef: From<NonNull<T>>`
         // wraps it without an `unsafe` block; the back-reference invariant
@@ -378,7 +378,7 @@ impl EventLoopHandle {
         uws_loop.internal_loop_data.set_parent_raw(tag, ptr);
     }
 
-    pub fn from_any(any: &mut AnyEventLoop<'static>) -> EventLoopHandle {
+    pub fn from_any(any: &mut AnyEventLoop) -> EventLoopHandle {
         match any {
             AnyEventLoop::Js { owner } => EventLoopHandle::Js { owner: *owner },
             AnyEventLoop::Mini(mini) => EventLoopHandle::Mini(BackRef::new_mut(&mut **mini)),
@@ -477,7 +477,7 @@ impl EventLoopHandle {
         self.native_loop()
     }
 
-    pub fn env(self) -> *mut DotEnvLoader<'static> {
+    pub fn env(self) -> *mut DotEnvLoader {
         match self {
             EventLoopHandle::Js { owner } => owner.env(),
             // `env` must be set — caller invariant. `env_ptr()` takes

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -166,10 +166,7 @@ impl AnyEventLoop {
 // ─── AnyEventLoop → EventLoopHandle forwarders ──────────────────────────────
 // `EventLoopHandle` (below, same file) is the canonical Js/Mini dispatcher for
 // these four methods. `AnyEventLoop` forwards through `from_any` instead of
-// duplicating each `match`. Bound to `'static` because `from_any` stores
-// `BackRef<MiniEventLoop>`; every concrete `AnyEventLoop`
-// instantiation in the tree is already `'static` (verified: install, patch,
-// build_command, ChangedFilesFilter, `js()`/`js_current()`).
+// duplicating each `match`.
 impl AnyEventLoop {
     #[inline]
     pub fn r#loop(&mut self) -> *mut UwsLoop {

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -65,7 +65,7 @@ unsafe impl bun_threading::Linked for AnyTaskWithExtraContext {
 /// FIFO of raw task pointers (tasks are intrusive nodes; the queue does not own them).
 type Queue = LinearFifo<*mut AnyTaskWithExtraContext, DynamicBuffer<*mut AnyTaskWithExtraContext>>;
 
-pub struct MiniEventLoop<'a> {
+pub struct MiniEventLoop {
     pub tasks: Queue,
     pub concurrent_tasks: ConcurrentTaskQueue,
     // Raw pointer because the loop is C-owned
@@ -75,8 +75,7 @@ pub struct MiniEventLoop<'a> {
     /// Mutable; callers (shell spawn,
     /// `createNullDelimitedEnvMap`) write through it. Stored as `NonNull`
     /// (BACKREF) so [`EventLoopHandle::env`] can hand out a `*mut` with
-    /// mutable provenance. `'a` is preserved via PhantomData below.
-    pub env: Option<NonNull<DotEnvLoader<'a>>>,
+    pub env: Option<NonNull<DotEnvLoader>>,
     // Never freed in `deinit`. Use Box<[u8]> and dupe on assign.
     pub top_level_dir: Box<[u8]>,
     // Opaque ctx assigned externally; only read/cleared here.
@@ -89,7 +88,7 @@ thread_local! {
     pub static GLOBAL_INITIALIZED: Cell<bool> = const { Cell::new(false) };
     // Raw pointer because the global is heap-allocated once (heap::alloc) and lives
     // for the thread's lifetime (a true thread-lifetime singleton; never freed).
-    pub static GLOBAL: Cell<*mut MiniEventLoop<'static>> = const { Cell::new(core::ptr::null_mut()) };
+    pub static GLOBAL: Cell<*mut MiniEventLoop> = const { Cell::new(core::ptr::null_mut()) };
 }
 
 /// Returns the thread-local `*mut MiniEventLoop`.
@@ -99,9 +98,9 @@ thread_local! {
 /// overlapping `&mut` to the same allocation — UB. Return the raw pointer;
 /// callers reborrow `&mut` for the scope they need.
 pub fn init_global(
-    env: Option<&'static mut DotEnvLoader<'static>>,
+    env: Option<&'static mut DotEnvLoader>,
     cwd: Option<&[u8]>,
-) -> *mut MiniEventLoop<'static> {
+) -> *mut MiniEventLoop {
     if GLOBAL_INITIALIZED.with(|g| g.get()) {
         // Already initialized: hand back the stored raw pointer. No `&mut` is
         // materialized here (see fn doc — avoids aliased `&'static mut` UB).
@@ -111,7 +110,7 @@ pub fn init_global(
     // §Forbidden bans `Box::leak` for `&'static`; this is a
     // thread-lifetime singleton, so use `heap::alloc` (intrusive ownership)
     // and store the raw pointer in the thread-local.
-    let global_ptr: *mut MiniEventLoop<'static> = bun_core::heap::into_raw(Box::new(loop_));
+    let global_ptr: *mut MiniEventLoop = bun_core::heap::into_raw(Box::new(loop_));
     // SAFETY: `global_ptr` was just allocated via `heap::alloc`; this thread
     // holds the only reference for the duration of first-init. The `GLOBAL`
     // thread-local is NOT yet published (set below, after this `&mut` is dropped),
@@ -133,21 +132,13 @@ pub fn init_global(
         };
     }
 
-    // The process-global loader is stored as `AtomicPtr<Loader<'static>>`.
+    // The process-global loader is stored as `AtomicPtr<Loader>`.
     global.env = env.map(NonNull::from).or_else(|| {
-        NonNull::new(
-            dotenv::INSTANCE
-                .load(core::sync::atomic::Ordering::Acquire)
-                .cast::<DotEnvLoader<'static>>(),
-        )
+        NonNull::new(dotenv::INSTANCE.load(core::sync::atomic::Ordering::Acquire))
     });
     if global.env.is_none() {
-        // Thread-lifetime singletons.
-        let map: *mut dotenv::Map = bun_core::heap::into_raw(Box::new(dotenv::Map::init()));
-        // SAFETY: `map` lives for the thread (singleton); never freed.
-        let loader =
-            bun_core::heap::into_raw_nn(Box::new(DotEnvLoader::init(unsafe { &mut *map })));
-        global.env = Some(loader);
+        // Thread-lifetime singleton.
+        global.env = Some(bun_core::heap::into_raw_nn(Box::new(DotEnvLoader::init())));
     }
 
     // Set top_level_dir from provided cwd or get current working directory
@@ -176,7 +167,7 @@ pub fn init_global(
     global_ptr
 }
 
-impl<'a> MiniEventLoop<'a> {
+impl MiniEventLoop {
     /// Raw `*mut uws::Loop`.
     ///
     /// This is the sole accessor for the `loop_` field. A `&mut UwsLoop`-
@@ -211,7 +202,7 @@ impl<'a> MiniEventLoop<'a> {
     /// SAFETY (invariant): when `Some`, points to a thread-/process-lifetime
     /// loader set in `init_global` that outlives `self` (never freed).
     #[inline]
-    pub fn env_ptr(&self) -> Option<NonNull<DotEnvLoader<'a>>> {
+    pub fn env_ptr(&self) -> Option<NonNull<DotEnvLoader>> {
         self.env
     }
 
@@ -267,7 +258,7 @@ impl<'a> MiniEventLoop<'a> {
         }
     }
 
-    pub fn init() -> MiniEventLoop<'a> {
+    pub fn init() -> MiniEventLoop {
         MiniEventLoop {
             tasks: Queue::init(),
             concurrent_tasks: ConcurrentTaskQueue::default(),
@@ -410,7 +401,7 @@ impl<'a> MiniEventLoop<'a> {
 // in `bun_runtime` (it must name `jsc::VirtualMachine`).
 
 bun_io::link_impl_EventLoopCtx! {
-    Mini for MiniEventLoop<'static> => |this| {
+    Mini for MiniEventLoop => |this| {
         platform_event_loop_ptr() => (*this).loop_ptr(),
         // `file_polls_raw` to avoid aliased `&mut MiniEventLoop` while `tick*`
         // holds `&mut self` across the re-entrant `UwsLoop::tick()` that
@@ -432,18 +423,18 @@ bun_io::link_impl_EventLoopCtx! {
     }
 }
 
-impl<'a> MiniEventLoop<'a> {
+impl MiniEventLoop {
     /// `this` is the per-thread `MiniEventLoop` singleton; the returned ctx
     /// must not outlive it.
     #[inline]
-    pub fn as_event_loop_ctx(this: &mut MiniEventLoop<'a>) -> bun_io::EventLoopCtx {
+    pub fn as_event_loop_ctx(this: &mut MiniEventLoop) -> bun_io::EventLoopCtx {
         // SAFETY: `this` is a live `&mut`, so the pointer handed to `new` is
         // non-null and exclusively borrowed for the call's duration.
         unsafe { bun_io::EventLoopCtx::new(bun_io::EventLoopCtxKind::Mini, this) }
     }
 }
 
-impl<'a> Drop for MiniEventLoop<'a> {
+impl Drop for MiniEventLoop {
     fn drop(&mut self) {
         // `tasks.deinit()` is implicit via Queue's Drop.
         debug_assert!(self.concurrent_tasks.is_empty());

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -133,9 +133,9 @@ pub fn init_global(
     }
 
     // The process-global loader is stored as `AtomicPtr<Loader>`.
-    global.env = env.map(NonNull::from).or_else(|| {
-        NonNull::new(dotenv::INSTANCE.load(core::sync::atomic::Ordering::Acquire))
-    });
+    global.env = env
+        .map(NonNull::from)
+        .or_else(|| NonNull::new(dotenv::INSTANCE.load(core::sync::atomic::Ordering::Acquire)));
     if global.env.is_none() {
         // Thread-lifetime singleton.
         global.env = Some(bun_core::heap::into_raw_nn(Box::new(DotEnvLoader::init())));

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -75,6 +75,7 @@ pub struct MiniEventLoop {
     /// Mutable; callers (shell spawn,
     /// `createNullDelimitedEnvMap`) write through it. Stored as `NonNull`
     /// (BACKREF) so [`EventLoopHandle::env`] can hand out a `*mut` with
+    /// mutable provenance.
     pub env: Option<NonNull<DotEnvLoader>>,
     // Never freed in `deinit`. Use Box<[u8]> and dupe on assign.
     pub top_level_dir: Box<[u8]>,

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -61,7 +61,7 @@ bun_dispatch::link_interface! {
         fn exit();
         fn enqueue_task(task: Task);
         fn enqueue_task_concurrent(task: core::ptr::NonNull<ConcurrentTask::ConcurrentTask>);
-        fn env() -> *mut bun_dotenv::Loader<'static>;
+        fn env() -> *mut bun_dotenv::Loader;
         fn top_level_dir() -> *const [u8];
         fn create_null_delimited_env_map() -> Result<bun_dotenv::NullDelimitedEnvMap, bun_core::AllocError>;
     }

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -86,7 +86,7 @@ use bun_event_loop::MiniEventLoop::MiniEventLoop;
 pub struct HttpThread {
     /// Per-thread `MiniEventLoop` singleton — published by
     /// `MiniEventLoop::init_global()` in [`on_start`]; outlives the thread.
-    pub loop_: *const MiniEventLoop<'static>,
+    pub loop_: *const MiniEventLoop,
     /// The raw uSockets loop inside `loop_.loop` — split out so HTTPContext
     /// can `SocketGroup::init` without naming MiniEventLoop.
     pub uws_loop: *mut uws::Loop,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -618,7 +618,7 @@ impl ProxySettings {
     }
 
     /// Capture `http_proxy` / `https_proxy` / `no_proxy` from the process env.
-    pub fn from_env(env: &bun_dotenv::Loader<'_>) -> Option<Box<Self>> {
+    pub fn from_env(env: &bun_dotenv::Loader) -> Option<Box<Self>> {
         #[inline]
         fn is_emptyish(v: &[u8]) -> bool {
             v.is_empty() || v == b"\"\"" || v == b"''"
@@ -640,7 +640,7 @@ impl ProxySettings {
 
     /// Build from an explicit `fetch(url, { proxy })` option. The same proxy is
     /// used for both schemes; NO_PROXY is still consulted per hop.
-    pub fn from_explicit(proxy_href: &[u8], env: &bun_dotenv::Loader<'_>) -> Option<Box<Self>> {
+    pub fn from_explicit(proxy_href: &[u8], env: &bun_dotenv::Loader) -> Option<Box<Self>> {
         let no_proxy = env
             .get(b"no_proxy")
             .filter(|v| !v.is_empty())

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1,10 +1,5 @@
 #![warn(unused_must_use)]
-// ──────────────────────────────────────────────────────────────────────────
-// The remaining `'static` lifetime erasures and raw-pointer borrow splits in
-// this file are documented at each site; removing them is tracked by the
-// bun_ini Parser lifetime-restructure work item (external arena, split `env`
-// lifetime, `Source` lifetime threading in bun_ast).
-// ──────────────────────────────────────────────────────────────────────────
+#![forbid(unsafe_code)]
 use core::fmt;
 
 use bun_alloc::AllocError;
@@ -217,8 +212,8 @@ mod draft {
     use bun_alloc::{AllocError, Arena, ArenaVec, ArenaVecExt as _};
     use bun_api::{self, BunInstall, NpmRegistry, npm_registry};
     use bun_ast::E::Rope;
-    use bun_ast::{E, Expr, ExprData};
-    use bun_ast::{IntoStr, Loc, Log, Source};
+    use bun_ast::{E, Expr, ExprData, StoreRef};
+    use bun_ast::{Loc, Log, Source};
     use bun_collections::{ArrayHashMap, VecExt};
     use bun_core::ZStr;
     use bun_core::{Global, Output};
@@ -245,12 +240,11 @@ mod draft {
 
     pub struct Parser<'a> {
         pub opts: Options,
-        pub source: Source,
+        pub source: &'a Source,
         pub src: &'a [u8],
         pub out: Expr,
         pub logger: Log,
-        pub arena: Arena,
-        pub env: &'a mut DotEnvLoader<'a>,
+        pub env: &'a DotEnvLoader,
     }
 
     // The result type depends on the usage (`.section -> *Rope`, `.key ->
@@ -281,41 +275,30 @@ mod draft {
     }
 
     impl<'a> Parser<'a> {
-        pub fn init(path: &[u8], src: &'a [u8], env: &'a mut DotEnvLoader<'a>) -> Parser<'a> {
-            // TODO: bun_ast::Source<'bump> — `Source::init_path_string`
-            // currently takes `Str = &'static [u8]`; once the lower tier threads a
-            // lifetime through `Source`, pass `path`/`src` directly. They outlive
-            // the `Parser` and its `Source`/`Expr` tree (arena-freed in lockstep),
-            // so no wrong value is produced today.
-            let path_s: &'static [u8] = path.into_str();
-            let src_s: &'static [u8] = src.into_str();
+        pub fn init(source: &'a Source, env: &'a DotEnvLoader) -> Parser<'a> {
             Parser {
                 opts: Options::default(),
                 logger: Log::init(),
-                src,
+                src: source.contents.as_ref(),
                 out: Expr::init(E::Object::default(), Loc::EMPTY),
-                source: Source::init_path_string(path_s, src_s),
-                arena: Arena::new(),
+                source,
                 env,
             }
         }
 
-        // deinit -> Drop: `logger` and `arena` are owned and drop automatically.
+        // deinit -> Drop: `logger` is owned and drops automatically.
 
         pub fn parse(&mut self, bump: &'a Arena) -> OOM<()> {
-            // borrowck — `arena_allocator` is passed separately (rather than
-            // read off `self.arena`) to avoid overlapping &mut self borrows.
             let src = self.src;
+            let env = self.env;
+            let source_path = self.source.path.text;
             let mut iter = src.split(|&b| b == b'\n');
-            // TODO: borrowck — `head` aliases into `self.out.data.e_object` while
-            // `self` is also borrowed mutably for prepare_str(). Kept as raw `*mut`
-            // (the underlying `E::Object` lives in the Expr Store, not on `self`).
-            let mut head: *mut E::Object = std::ptr::from_mut::<E::Object>(
-                self.out
-                    .data
-                    .e_object_mut()
-                    .expect("Parser.out is E.Object"),
-            );
+            // `StoreRef` is the arena-backed handle `ExprData` already stores;
+            // it is `Copy`, so keeping the root and the current-section head as
+            // separate values is a split borrow, not an alias.
+            let root: StoreRef<E::Object> =
+                self.out.data.e_object().expect("Parser.out is E.Object");
+            let mut head: StoreRef<E::Object> = root;
 
             let ropealloc = bump;
 
@@ -354,22 +337,18 @@ mod draft {
                         let offset = i32::try_from(line.as_ptr() as usize - src.as_ptr() as usize)
                             .unwrap()
                             + 1;
-                        let section: &mut Rope = self
-                            .prepare_str(
-                                Usage::Section,
-                                bump,
-                                ropealloc,
-                                &line[1..close_bracket_idx],
-                                offset,
-                            )?
-                            .into_section();
-                        // SAFETY: `self.out` was constructed as `E.Object` in `init()`.
-                        let root = self
-                            .out
-                            .data
-                            .e_object_mut()
-                            .expect("Parser.out is E.Object");
-                        let mut parent_object = match root.get_or_put_object(section, bump) {
+                        let section: &mut Rope = Self::prepare_str(
+                            env,
+                            source_path,
+                            Usage::Section,
+                            bump,
+                            ropealloc,
+                            &line[1..close_bracket_idx],
+                            offset,
+                        )?
+                        .into_section();
+                        let mut r = root;
+                        let parent_object = match r.get_or_put_object(section, bump) {
                             Ok(v) => v,
                             Err(E::SetError::OutOfMemory) => return Err(AllocError),
                             Err(E::SetError::Clobber) => {
@@ -408,12 +387,10 @@ mod draft {
                                 break 'treat_as_key;
                             }
                         };
-                        head = std::ptr::from_mut::<E::Object>(
-                            parent_object
-                                .data
-                                .e_object_mut()
-                                .expect("get_or_put_object returns E.Object"),
-                        );
+                        head = parent_object
+                            .data
+                            .e_object()
+                            .expect("get_or_put_object returns E.Object");
                         break 'treat_as_key;
                     }
                     if !treat_as_key {
@@ -431,15 +408,16 @@ mod draft {
 
                 let maybe_eq_sign_idx = line.iter().position(|&b| b == b'=');
 
-                let key_raw: &[u8] = self
-                    .prepare_str(
-                        Usage::Key,
-                        bump,
-                        ropealloc,
-                        &line[..maybe_eq_sign_idx.unwrap_or(line.len())],
-                        line_offset,
-                    )?
-                    .into_key();
+                let key_raw: &[u8] = Self::prepare_str(
+                    env,
+                    source_path,
+                    Usage::Key,
+                    bump,
+                    ropealloc,
+                    &line[..maybe_eq_sign_idx.unwrap_or(line.len())],
+                    line_offset,
+                )?
+                .into_key();
                 let is_array: bool = {
                     key_raw.len() > 2 && bun_core::strings::ends_with(key_raw, b"[]")
                     // Commenting out because options are not supported but we might
@@ -469,15 +447,16 @@ mod draft {
                 let value_raw: Expr = 'brk: {
                     if let Some(eq_sign_idx) = maybe_eq_sign_idx {
                         if eq_sign_idx + 1 < line.len() {
-                            break 'brk self
-                                .prepare_str(
-                                    Usage::Value,
-                                    bump,
-                                    ropealloc,
-                                    &line[eq_sign_idx + 1..],
-                                    line_offset + i32::try_from(eq_sign_idx).expect("int cast") + 1,
-                                )?
-                                .into_value();
+                            break 'brk Self::prepare_str(
+                                env,
+                                source_path,
+                                Usage::Value,
+                                bump,
+                                ropealloc,
+                                &line[eq_sign_idx + 1..],
+                                line_offset + i32::try_from(eq_sign_idx).expect("int cast") + 1,
+                            )?
+                            .into_value();
                         }
                         break 'brk Expr::init(E::EString::init(b""), Loc::EMPTY);
                     }
@@ -499,44 +478,41 @@ mod draft {
                     _ => value_raw,
                 };
 
-                // SAFETY: head points into self.out's E::Object tree, valid for the
-                // duration of parse().
-                let head_ref = unsafe { &mut *head };
-
                 if is_array {
-                    if let Some(val) = head_ref.get(key) {
+                    if let Some(val) = E::Object::get(&head, key) {
                         if !matches!(val.data, ExprData::EArray(_)) {
                             let mut arr = E::Array::default();
                             arr.push(bump, val)?;
-                            head_ref.put(bump, key, Expr::init(arr, Loc::EMPTY))?;
+                            head.put(bump, key, Expr::init(arr, Loc::EMPTY))?;
                         }
                     } else {
-                        head_ref.put(bump, key, Expr::init(E::Array::default(), Loc::EMPTY))?;
+                        head.put(bump, key, Expr::init(E::Array::default(), Loc::EMPTY))?;
                     }
                 }
 
                 // safeguard against resetting a previously defined
                 // array by accidentally forgetting the brackets
                 let mut was_already_array = false;
-                if let Some(mut val) = head_ref.get(key) {
+                if let Some(mut val) = E::Object::get(&head, key) {
                     if matches!(val.data, ExprData::EArray(_)) {
                         was_already_array = true;
                         val.data
                             .e_array_mut()
                             .expect("infallible: variant checked")
                             .push(bump, value)?;
-                        head_ref.put(bump, key, val)?;
+                        head.put(bump, key, val)?;
                     }
                 }
                 if !was_already_array {
-                    head_ref.put(bump, key, value)?;
+                    head.put(bump, key, value)?;
                 }
             }
             Ok(())
         }
 
         fn prepare_str(
-            &mut self,
+            env: &DotEnvLoader,
+            source_path: &[u8],
             usage: Usage,
             bump: &'a Arena,
             ropealloc: &'a Arena,
@@ -568,11 +544,7 @@ mod draft {
                     // `bun_ast::Expr` (via the `From` impl in
                     // `bun_ast::expr`) so the rest of this body works
                     // against a single `ExprData`.
-                    // `Str = &'static [u8]` lifetime erasure (see PORTING.md
-                    // §Allocators / `Parser::init` above). `val` is a sub-slice
-                    // of `self.src` and outlives the temporary `Source`.
-                    let val_s: &'static [u8] = val.into_str();
-                    let src = Source::init_path_string(self.source.path.text, val_s);
+                    let src = Source::init_path_string(source_path, val);
                     let mut log = Log::init();
                     // Try to parse it and if it fails will just treat it as a string
                     let json_val: Expr =
@@ -582,7 +554,7 @@ mod draft {
                                 // JSON parse failed (e.g., single-quoted string like '${VAR}')
                                 // Still need to expand env vars in the content
                                 if usage == Usage::Value {
-                                    let expanded = self.expand_env_vars(bump, val)?;
+                                    let expanded = Self::expand_env_vars(env, bump, val)?;
                                     return Ok(PrepareResult::Value(Expr::init(
                                         E::EString::init(expanded),
                                         Loc { start: offset },
@@ -597,7 +569,7 @@ mod draft {
                         let str_ = s.string(bump)?;
                         // Expand env vars in the JSON-parsed string
                         let expanded = if usage == Usage::Value {
-                            self.expand_env_vars(bump, str_)?
+                            Self::expand_env_vars(env, bump, str_)?
                         } else {
                             str_
                         };
@@ -742,7 +714,7 @@ mod draft {
                                     }
 
                                     if let Some(new_i) =
-                                        self.parse_env_substitution(val, i, i, 0, &mut unesc)?
+                                        Self::parse_env_substitution(env, val, i, i, 0, &mut unesc)?
                                     {
                                         // set to true so we heap alloc
                                         did_any_escape = true;
@@ -761,7 +733,7 @@ mod draft {
                             b'.' => {
                                 if usage == Usage::Section && rope_parts < MAX_SECTION_ROPE_SEGMENTS
                                 {
-                                    self.commit_rope_part(bump, ropealloc, &mut unesc, &mut rope)?;
+                                    Self::commit_rope_part(bump, ropealloc, &mut unesc, &mut rope)?;
                                     rope_parts += 1;
                                 } else {
                                     unesc.push(b'.');
@@ -813,7 +785,7 @@ mod draft {
 
                 match usage {
                     Usage::Section => {
-                        self.commit_rope_part(bump, ropealloc, &mut unesc, &mut rope)?;
+                        Self::commit_rope_part(bump, ropealloc, &mut unesc, &mut rope)?;
                         return Ok(PrepareResult::Section(rope.unwrap()));
                     }
                     Usage::Value => {
@@ -870,7 +842,7 @@ mod draft {
         /// - ${VAR} - if VAR is undefined, leave as "${VAR}" (no expansion)
         /// - ${VAR?} - if VAR is undefined, expand to empty string
         /// - Backslash escaping is already handled by JSON parsing
-        fn expand_env_vars(&mut self, bump: &'a Arena, val: &'a [u8]) -> OOM<&'a [u8]> {
+        fn expand_env_vars(env: &DotEnvLoader, bump: &'a Arena, val: &'a [u8]) -> OOM<&'a [u8]> {
             // Quick check if there are any env vars to expand
             if bun_core::index_of(val, b"${").is_none() {
                 // Nothing to expand: return the borrow directly.
@@ -904,7 +876,7 @@ mod draft {
                             env_var_raw
                         };
 
-                        if let Some(expanded) = self.env.get(env_var) {
+                        if let Some(expanded) = env.get(env_var) {
                             result.extend_from_slice(expanded);
                         } else if !optional {
                             // Not found and not optional: leave as-is
@@ -930,7 +902,7 @@ mod draft {
         /// - ${VAR} - if undefined, returns null (leaves as-is)
         /// - ${VAR?} - if undefined, expands to empty string
         fn parse_env_substitution(
-            &mut self,
+            env: &DotEnvLoader,
             val: &[u8],
             start: usize,
             i: usize,
@@ -951,7 +923,8 @@ mod draft {
                         b'\\' => esc = !esc,
                         b'$' => {
                             if !esc {
-                                return self.parse_env_substitution(
+                                return Self::parse_env_substitution(
+                                    env,
                                     val,
                                     start,
                                     j,
@@ -995,7 +968,7 @@ mod draft {
                 };
 
                 // https://github.com/npm/cli/blob/534ad7789e5c61f579f44d782bdd18ea3ff1ee20/workspaces/config/lib/env-replace.js#L6
-                if let Some(expanded) = self.env.get(env_var) {
+                if let Some(expanded) = env.get(env_var) {
                     unesc.extend_from_slice(expanded);
                 } else if !optional {
                     // Not found and not optional: return null to leave as-is
@@ -1017,13 +990,11 @@ mod draft {
         }
 
         fn commit_rope_part(
-            &mut self,
             bump: &'a Arena,
             ropealloc: &'a Arena,
             unesc: &mut ArenaVec<'a, u8>,
             existing_rope: &mut Option<&'a mut Rope>,
         ) -> OOM<()> {
-            let _ = self; // autofix
             let slice = bump.alloc_slice_copy(&unesc[..]);
             let expr = Expr::init(E::EString::init(slice), Loc::EMPTY);
             if let Some(r) = existing_rope.as_deref_mut() {
@@ -1254,7 +1225,7 @@ mod draft {
 
     pub fn load_npmrc_config(
         install: &mut BunInstall,
-        env: &mut DotEnvLoader<'_>,
+        env: &DotEnvLoader,
         auto_loaded: bool,
         npmrc_paths: &[&ZStr],
     ) {
@@ -1285,7 +1256,7 @@ mod draft {
             };
             // `source.contents` is owned; drops at end of loop iteration.
 
-            match load_npmrc(install, env, npmrc_path, &mut log, &source, &mut configs) {
+            match load_npmrc(install, env, &mut log, &source, &mut configs) {
                 Ok(()) => {}
                 Err(AllocError) => bun_core::out_of_memory(),
             }
@@ -1311,30 +1282,14 @@ mod draft {
 
     pub fn load_npmrc(
         install: &mut BunInstall,
-        env: &mut DotEnvLoader<'_>,
-        npmrc_path: &ZStr,
+        env: &DotEnvLoader,
         log: &mut Log,
         source: &Source,
         configs: &mut Vec<ConfigItem>,
     ) -> OOM<()> {
-        // TODO: lifetime — `Parser<'a>` ties `src` and `env: &'a mut DotEnvLoader<'a>`
-        // to a single invariant `'a`; threading that through this fn signature poisons
-        // the `load_npmrc_config` loop (env borrowed-for-'a across iterations). The
-        // local `parser` is dropped before this fn returns, so erase both to a fresh
-        // `'p` (matches `Parser::init`'s own erasures for `path`/`src`).
-        // SAFETY: `parser` does not outlive `env`/`source.contents`.
-        let contents: &'static [u8] = source.contents.as_ref().into_str();
-        // SAFETY: `parser` is dropped before this function returns and so does not
-        // outlive `env` or its borrowed data; this cast only erases lifetimes.
-        let env = unsafe {
-            &mut *std::ptr::from_mut::<DotEnvLoader<'_>>(env).cast::<DotEnvLoader<'static>>()
-        };
-        let mut parser = Parser::init(npmrc_path.as_bytes(), contents, env);
-        // TODO: borrowck — `parser.arena` is borrowed while `parser` is `&mut`.
-        // TODO(refactor): restructure Parser so the bump is passed externally or split borrows.
-        let bump_ptr: *const Arena = &raw const parser.arena;
-        // SAFETY: arena outlives all bump-allocated slices used below.
-        let bump: &Arena = unsafe { &*bump_ptr };
+        let arena = Arena::new();
+        let bump = &arena;
+        let mut parser = Parser::init(source, env);
         parser.parse(bump)?;
         // Need to be very, very careful here with strings.
         // They are allocated in the Parser's arena, which of course gets
@@ -1512,16 +1467,12 @@ mod draft {
 
         let mut registry_map = install.scoped.take().unwrap_or_default();
 
-        // SAFETY: `parser.out` is an `E::Object` produced by `Parser::parse`; the
-        // arena pointee lives until `parser` drops at end of fn.
-        let out_obj: &E::Object = unsafe {
-            &*parser
-                .out
-                .data
-                .e_object()
-                .expect("ini parser always yields object")
-                .as_ptr()
-        };
+        let out_ref = parser
+            .out
+            .data
+            .e_object()
+            .expect("ini parser always yields object");
+        let out_obj: &E::Object = &out_ref;
 
         // Process scopes
         {
@@ -1823,10 +1774,8 @@ mod draft {
 
         match &expr.data {
             ExprData::EString(s) => {
-                // SAFETY: arena-backed `EString::slice` mutates only its own
-                // resolved-data cache; the StoreRef pointee outlives this call.
-                let s_mut: &mut E::EString = unsafe { &mut *s.as_ptr() };
-                let pattern = s_mut.slice(bump);
+                let mut s = *s;
+                let pattern = s.slice(bump);
                 let matcher = match create_matcher(pattern, &mut buf) {
                     Ok(m) => m,
                     Err(CreateMatcherError::OutOfMemory) => return Err(FromExprError::OutOfMemory),

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -318,7 +318,7 @@ pub struct PackageManager {
     // Set once in `init()`/`init_with_runtime()` to the process-singleton
     // `DotEnv.Loader` (leaked allocation; outlives the manager). `BackRef`
     // encapsulates the liveness invariant so `env()` is a safe accessor.
-    pub env: Option<bun_ptr::BackRef<dot_env::Loader<'static>>>,
+    pub env: Option<bun_ptr::BackRef<dot_env::Loader>>,
     pub progress: Progress,
     pub downloads_node: Option<*mut ProgressNode>, // BORROW_FIELD — points into self.progress
     pub scripts_node: Option<NonNull<ProgressNode>>, // points to a caller stack-local Progress node; only valid while that caller frame is live
@@ -398,7 +398,7 @@ pub struct PackageManager {
     // name hash from alias package name -> aliased package dependency version info
     pub known_npm_aliases: NpmAliasMap,
 
-    pub event_loop: AnyEventLoop<'static>,
+    pub event_loop: AnyEventLoop,
 
     // During `installPackages` we learn exactly what dependencies from --trust
     // actually have scripts to run, and we add them to this list
@@ -742,18 +742,11 @@ mod holder {
     pub(super) static INITIALIZED: core::sync::atomic::AtomicBool =
         core::sync::atomic::AtomicBool::new(false);
 
-    // Process-lifetime env storage for `init()`. `dot_env::Loader<'a>` borrows `&'a mut Map`,
-    // so the pair is self-referential and cannot live in `OnceLock<T>` (which only yields `&T`).
-    // Owned by the singleton, never freed. Avoids `Box::leak` per PORTING.md §Forbidden.
-    // (These statics could go away if `dot_env::Loader.map` were retyped to an owned
-    // `Box<Map>`, making this an owned `Box<dot_env::Loader>` field on `PackageManager`.)
-    // Write-once during single-threaded init; never read afterwards (kept only
-    // to anchor the allocation). `AtomicCell<*mut T>` — payload is `Copy` and
-    // pointer-sized, so `.store()` is a safe Release write (no `RacyCell`
-    // raw-ptr deref needed).
-    pub(super) static ENV_MAP: bun_core::AtomicCell<*mut dot_env::Map> =
-        bun_core::AtomicCell::new(core::ptr::null_mut());
-    pub(super) static ENV_LOADER: bun_core::AtomicCell<*mut dot_env::Loader<'static>> =
+    // Process-lifetime env storage for `init()`. Owned by the singleton, never
+    // freed. Avoids `Box::leak` per PORTING.md §Forbidden. Write-once during
+    // single-threaded init. `AtomicCell<*mut T>` — payload is `Copy` and
+    // pointer-sized, so `.store()` is a safe Release write.
+    pub(super) static ENV_LOADER: bun_core::AtomicCell<*mut dot_env::Loader> =
         bun_core::AtomicCell::new(core::ptr::null_mut());
 
     /// Process-lifetime storage for `http::http_thread::InitOpts.abs_ca_file_name`.
@@ -858,18 +851,14 @@ impl PackageManager {
         Ok(unsafe { &mut *ptr })
     }
 
-    pub fn http_proxy(&mut self, url: &URL<'_>) -> Option<URL<'static>> {
-        // `self.env` is `NonNull<dot_env::Loader<'static>>`; `get_http_proxy_for`
-        // returns `Option<URL<'a>>` where `'a` is the loader's map lifetime —
-        // i.e. `'static` here. The lifetime contract (env-map values are
-        // process-lifetime `Box<[u8]>`) is encapsulated in `bun_dotenv`, not at
-        // every call site (PORTING.md §Forbidden: never mint `'static` from
-        // a borrowed reference).
+    pub fn http_proxy(&self, url: &URL<'_>) -> Option<URL<'static>> {
+        // `env_mut()` yields an unbounded `&'a Loader` (process-lifetime
+        // singleton), so the returned `URL<'_>` borrows for `'static`.
         self.env_mut().get_http_proxy_for(url)
     }
 
-    pub fn tls_reject_unauthorized(&mut self) -> bool {
-        self.env_mut().get_tls_reject_unauthorized()
+    pub fn tls_reject_unauthorized(&self) -> bool {
+        self.env().get_tls_reject_unauthorized()
     }
 
     pub fn fail_root_resolution(
@@ -963,7 +952,7 @@ impl PackageManager {
         // and survives the callback's `&mut *this` retag.
         // SAFETY: `this` is valid per fn contract; `&raw mut` does not create a
         // reference, only a place projection.
-        let event_loop: *mut AnyEventLoop<'static> = unsafe { &raw mut (*this).event_loop };
+        let event_loop: *mut AnyEventLoop = unsafe { &raw mut (*this).event_loop };
         // SAFETY: `tick_raw` reborrows `*event_loop` only between `is_done`
         // calls (never across them), so the callback's `&mut PackageManager`
         // never overlaps a live `&mut AnyEventLoop`.
@@ -990,7 +979,7 @@ impl PackageManager {
 
     // Helper: deref env (set-once BackRef to process-singleton loader)
     #[inline]
-    pub fn env(&self) -> &dot_env::Loader<'static> {
+    pub fn env(&self) -> &dot_env::Loader {
         // `env` is set during init() and never None afterward; `BackRef::get`
         // encapsulates the deref under the back-reference invariant.
         self.env.as_ref().expect("env initialised").get()
@@ -1004,7 +993,7 @@ impl PackageManager {
     /// takes `env`, `log`, and reads `lockfile` in the same argument list).
     #[inline]
     #[allow(clippy::mut_from_ref)]
-    pub fn env_mut<'a>(&self) -> &'a mut dot_env::Loader<'static> {
+    pub fn env_mut<'a>(&self) -> &'a mut dot_env::Loader {
         // SAFETY: `env` is set during `init()` and never None afterward; the
         // pointee is a process-lifetime singleton (leaked `DotEnv.Loader`)
         // that lives outside `self`, so the unbounded `'a` is sound under the
@@ -1042,7 +1031,7 @@ fn configure_env_for_scripts_run(
     // `self.env` is `Option<BackRef<Loader>>`; pass the raw pointer so
     // the shim's `Transpiler::init` reuses the manager's loader instead of
     // allocating a fresh singleton.
-    let env_ptr: Option<*mut dot_env::Loader<'static>> = this.env.map(|p| p.as_ptr());
+    let env_ptr: Option<*mut dot_env::Loader> = this.env.map(|p| p.as_ptr());
     let _ = RunCommand::configure_env_for_run(
         ctx,
         &mut this_transpiler_slot,
@@ -1746,15 +1735,11 @@ pub fn init(
         fs::EntriesOption::Err(e) => return Err(e.canonical_error.into()),
     };
 
-    // SAFETY: `init()` runs once on the main thread before any other access to the singleton.
-    // `dot_env::Loader<'a>` borrows `&'a mut Map`, so the pair is self-referential; allocate
-    // both into process-lifetime statics (same allocate-then-fill pattern as `holder::RAW_PTR`)
-    // instead of `Box::leak`.
+    // SAFETY: `init()` runs once on the main thread before any other access to
+    // the singleton. Allocate into a process-lifetime static (same pattern as
+    // `holder::RAW_PTR`) instead of `Box::leak`.
     let env: &mut dot_env::Loader = unsafe {
-        let map_ptr = bun_core::heap::alloc(dot_env::Map::init());
-        holder::ENV_MAP.store(map_ptr);
-
-        let loader_ptr = bun_core::heap::alloc(dot_env::Loader::init(&mut *map_ptr));
+        let loader_ptr = bun_core::heap::alloc(dot_env::Loader::init());
         holder::ENV_LOADER.store(loader_ptr);
         &mut *loader_ptr
     };
@@ -2026,7 +2011,7 @@ pub fn init(
         // SAFETY: singleton fully initialized; main thread, no workers yet.
         let evl = unsafe { &mut (*manager_ptr).event_loop };
         if let AnyEventLoop::Mini(mini) = evl {
-            let mini_ptr: *mut MiniEventLoop<'static> = &raw mut **mini;
+            let mini_ptr: *mut MiniEventLoop = &raw mut **mini;
             // Set ONLY `MiniEventLoop.global`,
             // NOT `globalInitialized`. The distinction is load-bearing: a later
             // `initGlobal(env, top_level_dir)` (e.g. from `bun pm pack` /
@@ -2206,7 +2191,7 @@ pub(crate) fn init_with_runtime(
     // the resolver call site.
     bun_install: Option<&Api::BunInstall>,
     cli: CommandLineArguments,
-    env: &mut dot_env::Loader<'static>,
+    env: &mut dot_env::Loader,
 ) -> crate::Result<*mut PackageManager> {
     // NB: not `bun_core::run_once!` — the body is fallible (reading the root
     // directory hits ENOENT/EACCES at runtime when the cwd was deleted or is
@@ -2230,7 +2215,7 @@ pub(crate) fn init_with_runtime_once(
     log: &mut bun_ast::Log,
     bun_install: Option<&Api::BunInstall>,
     cli: CommandLineArguments,
-    env: &mut dot_env::Loader<'static>,
+    env: &mut dot_env::Loader,
 ) -> crate::Result<()> {
     if env.get(b"BUN_INSTALL_VERBOSE").is_some() {
         PackageManager::set_verbose_install(true);

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -1367,7 +1367,7 @@ impl<'a> SecurityScanSubprocess<'a> {
         self.has_process_exited && self.remaining_fds == 0
     }
 
-    pub fn event_loop(&self) -> &AnyEventLoop<'static> {
+    pub fn event_loop(&self) -> &AnyEventLoop {
         &self.manager.event_loop
     }
 

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -447,13 +447,12 @@ impl hooks::AutoInstaller for PackageManager {
 //   • `install` is `BundleOptions.install` (`?*Api.BunInstall`). The pointee is
 //     the CLI-owned `Box<BunInstall>` (process-lifetime), read-only.
 //   • `env` is the resolver's unwrapped `env_loader` (Transpiler-owned,
-//     process-lifetime). `init_with_runtime` stores it as
-//     `NonNull<Loader<'static>>`.
+//     process-lifetime). `init_with_runtime` stores it as `NonNull<Loader>`.
 #[unsafe(no_mangle)]
 pub(crate) unsafe fn __bun_resolver_init_package_manager(
     mut log: core::ptr::NonNull<bun_ast::Log>,
     install: Option<core::ptr::NonNull<crate::bun_schema::api::BunInstall>>,
-    mut env: core::ptr::NonNull<bun_dotenv::Loader<'static>>,
+    mut env: core::ptr::NonNull<bun_dotenv::Loader>,
 ) -> core::result::Result<core::ptr::NonNull<dyn hooks::AutoInstaller>, bun_errno::SystemErrno> {
     // ABI: the resolver-side `extern "Rust"` declaration names
     // `bun_errno::SystemErrno` (both crates depend on bun_errno; carries the
@@ -469,7 +468,7 @@ pub(crate) unsafe fn __bun_resolver_init_package_manager(
         install.map(|p| unsafe { p.as_ref() });
     // SAFETY: caller guarantees `log` / `env` point at process-lifetime
     // Transpiler-owned storage with no aliasing `&mut` live across this call.
-    let (log_ref, env_ref): (&mut bun_ast::Log, &mut bun_dotenv::Loader<'static>) =
+    let (log_ref, env_ref): (&mut bun_ast::Log, &mut bun_dotenv::Loader) =
         unsafe { (log.as_mut(), env.as_mut()) };
 
     let pm: *mut PackageManager = crate::package_manager::init_with_runtime(

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -802,7 +802,7 @@ impl RunCommand {
     pub fn configure_env_for_run(
         ctx: &mut bun_options_types::context::ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<bun_transpiler::Transpiler<'static>>,
-        env: Option<*mut bun_dotenv::Loader<'static>>,
+        env: Option<*mut bun_dotenv::Loader>,
         _log_errors: bool,
         store_root_fd: bool,
     ) -> Result<*mut (), crate::Error> {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -383,7 +383,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         unsafe { self.manager.get_mut() }
     }
 
-    pub fn event_loop(&self) -> &AnyEventLoop<'static> {
+    pub fn event_loop(&self) -> &AnyEventLoop {
         &self.manager().event_loop
     }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1761,10 +1761,7 @@ impl<'a> Printer<'a> {
             Fs::EntriesOption::Err(e) => return Err(e.canonical_error.into()),
         };
 
-        // PORTING.md §Forbidden patterns: never `Box::leak` — own `map`/`loader` as locals;
-        // they live for the function scope (one-shot CLI path).
-        let mut map = DotEnv::Map::init();
-        let mut env_loader = DotEnv::Loader::init(&mut map);
+        let mut env_loader = DotEnv::Loader::init();
         env_loader.quiet = true;
 
         env_loader.load_process()?;

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -25,7 +25,6 @@ impl IniTestingAPIs {
         use bun_api::BunInstall;
         use bun_ast::{Log, Source};
         use bun_core::String as BunString;
-        use bun_core::ZStr;
         use bun_dotenv as dotenv;
         use bun_ini::{config_iterator, load_npmrc};
         use bun_install::npm::Registry;
@@ -38,16 +37,11 @@ impl IniTestingAPIs {
         let mut log = Log::init();
 
         let envjs = frame.argument(1);
-        // The loader is either VM-owned or built locally. Per PORTING.md §Forbidden
-        // (`Box::leak` is banned), keep both `Map` and `Loader` owned in fn-scope
-        // `Option`s and hand out a raw `*mut Loader` uniformly. Both drop at fn
-        // return.
-        let mut map_storage: Option<Box<dotenv::Map>>;
-        let mut env_storage: Option<dotenv::Loader<'_>>;
-        let env: *mut dotenv::Loader<'static> = if envjs.is_empty_or_undefined_or_null() {
-            // SAFETY: `bun_vm()` is non-null on a constructed `JSGlobalObject`;
-            // `transpiler.env` is set during VM init (transpiler.rs).
-            global.bun_vm().as_mut().transpiler.env
+        // The loader is either VM-owned or built locally; keep local storage in
+        // an `Option` so both arms yield the same `&Loader` type.
+        let mut env_storage: Option<dotenv::Loader> = None;
+        let env: &dotenv::Loader = if envjs.is_empty_or_undefined_or_null() {
+            global.bun_vm().as_mut().transpiler.env()
         } else {
             let mut envmap = dotenv::map::HashTable::new();
             let Some(envobj) = envjs.get_object() else {
@@ -81,32 +75,12 @@ impl IniTestingAPIs {
                 )?;
             }
 
-            map_storage = Some(Box::new(dotenv::Map { map: envmap }));
-            // SAFETY-NOTE: `Loader` borrows from `map_storage`; both live until fn
-            // return.
-            let map_ref: &mut dotenv::Map = map_storage.as_deref_mut().unwrap();
-            env_storage = Some(dotenv::Loader::init(map_ref));
-            // `Loader<'a>` is invariant in `'a` (holds `&'a mut Map`); erase to `'static`
-            // via raw-pointer `.cast()` so both `if` arms unify on a single pointer type.
-            // The borrow does not escape this function — `load_npmrc` only reads through
-            // it and both `env_storage` / `map_storage` drop at fn return.
-            std::ptr::from_mut(env_storage.as_mut().unwrap()).cast::<dotenv::Loader<'static>>()
+            env_storage.insert(dotenv::Loader::init_with_map(dotenv::Map { map: envmap }))
         };
 
         let mut install = Box::new(BunInstall::default());
         let mut configs: Vec<config_iterator::Item> = Vec::new();
-        if load_npmrc(
-            &mut install,
-            // SAFETY: `env` points to either the VM-singleton Loader or `env_storage`;
-            // both outlive this call and are not aliased for its duration.
-            unsafe { &mut *env },
-            ZStr::from_static(b".npmrc\0"),
-            &mut log,
-            &source,
-            &mut configs,
-        )
-        .is_err()
-        {
+        if load_npmrc(&mut install, env, &mut log, &source, &mut configs).is_err() {
             return bun_ast_jsc::log_to_js(&log, global, b"error");
         }
 
@@ -200,21 +174,11 @@ impl IniTestingAPIs {
         let bunstr = bun_core::OwnedString::new(jsstr.to_bun_string(global)?);
         let utf8str = bunstr.to_utf8();
 
-        let env = global.bun_vm().as_mut().transpiler.env_mut();
-        // `Parser::init` ties `src: &'a [u8]` and
-        // `env: &'a mut DotEnvLoader<'a>` to one invariant `'a`; the VM-owned
-        // env is `'static`, so erase `src` to match. SAFETY: `parser` is dropped
-        // before `utf8str` (drop order is reverse of declaration); no borrow
-        // escapes this function. Same pattern as `bun_ini::load_npmrc`.
-        let src: &'static [u8] = bun_ast::IntoStr::into_str(utf8str.slice());
-        let mut parser = Parser::init(b"<src>", src, env);
-
-        // Borrowck — `Parser::parse` takes `&'a Arena`; split the borrow via
-        // raw ptr so the bump outlives the `&mut parser` for the call.
-        let arena_ptr: *const bun_alloc::Arena = &raw const parser.arena;
-        // SAFETY: `parser.arena` is not moved/dropped for the lifetime of `parser`.
-        let bump: &bun_alloc::Arena = unsafe { &*arena_ptr };
-        parser.parse(bump)?;
+        let env = global.bun_vm().as_mut().transpiler.env();
+        let source = bun_ast::Source::init_path_string(b"<src>", utf8str.slice());
+        let arena = bun_alloc::Arena::new();
+        let mut parser = Parser::init(&source, env);
+        parser.parse(&arena)?;
 
         match bun_js_parser_jsc::expr_to_js(&parser.out, global) {
             Ok(v) => Ok(v),

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -50,7 +50,7 @@ pub(crate) fn is_macro_path(str: &[u8]) -> bool {
 // stored in `VirtualMachine` (the only producer of `MacroContext`).
 pub struct MacroContext {
     pub resolver: *mut Resolver<'static>,
-    pub env: *mut DotEnvLoader<'static>,
+    pub env: *mut DotEnvLoader,
     pub macros: MacroMap,
     pub remap: bun_ptr::BackRef<MacroRemap>,
     pub javascript_object: JSValue,
@@ -424,7 +424,7 @@ impl Macro {
         resolver: &mut Resolver<'static>,
         input_specifier: &[u8],
         log: &mut Log,
-        env: *mut DotEnvLoader<'static>,
+        env: *mut DotEnvLoader,
         function_name: &[u8],
         specifier: &[u8],
         hash: i32,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -93,7 +93,7 @@ pub struct InitOptions {
     /// Forwarded to
     /// `RuntimeHooks::init_runtime_state` so the high-tier `Transpiler::init`
     /// reuses the caller's env loader.
-    pub env_loader: Option<NonNull<bun_dotenv::Loader<'static>>>,
+    pub env_loader: Option<NonNull<bun_dotenv::Loader>>,
     pub graph: Option<&'static dyn bun_resolver::StandaloneModuleGraph>,
     /// Must be applied to
     /// `transpiler.resolver.store_fd` BEFORE `configure_linker()` reads
@@ -808,7 +808,7 @@ impl VirtualMachine {
     /// (`vm.transpiler.env`). The loader is allocated once during VM init and
     /// never freed; callers previously open-coded `unsafe { &*vm.transpiler.env }`.
     #[inline]
-    pub fn env_loader(&self) -> &'static bun_dotenv::Loader<'static> {
+    pub fn env_loader(&self) -> &'static bun_dotenv::Loader {
         self.env_loader_opt()
             .expect("transpiler.env set during Transpiler::init")
     }
@@ -817,7 +817,7 @@ impl VirtualMachine {
     /// `Transpiler::init` has not yet run (e.g. `GarbageCollectionController::init`
     /// is reached from `JSGlobalObject::create` before `init_runtime_state`).
     #[inline]
-    pub fn env_loader_opt(&self) -> Option<&'static bun_dotenv::Loader<'static>> {
+    pub fn env_loader_opt(&self) -> Option<&'static bun_dotenv::Loader> {
         // SAFETY: when non-null, `transpiler.env` is set during `Transpiler::init`
         // to a process-lifetime allocation; never freed while a VM is installed.
         unsafe { self.transpiler.env.as_ref() }
@@ -2758,7 +2758,7 @@ pub struct Options {
     pub log: Option<NonNull<bun_ast::Log>>,
     // BORROW_PARAM (`&'a mut bun_dotenv::Loader`) — caller-owned; the loader
     // outlives the VM, so the inner lifetime is erased to `'static`.
-    pub env_loader: Option<NonNull<bun_dotenv::Loader<'static>>>,
+    pub env_loader: Option<NonNull<bun_dotenv::Loader>>,
     pub store_fd: bool,
     pub smol: bool,
     // LAYERING: real type is `bun_runtime::api::dns::Resolver::Order` (forward
@@ -3191,7 +3191,7 @@ impl VirtualMachine {
         // `&'static mut Loader` is independent of `&self`, so `map` may be held
         // across the `&mut self` writes below.
         let env = self.transpiler.env_mut();
-        let map = &mut *env.map;
+        let map = &mut env.map;
 
         ensure_source_code_printer();
         // The runtime VM owns the printer from here on — even if a macro had

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -317,7 +317,7 @@ impl HotReloaderEventLoop for EventLoop {
 /// With `RELOAD_IMMEDIATELY = true`, `Task::enqueue` diverges via
 /// `bun_core::reload_process()` before any concurrent task is enqueued, so
 /// this is never reached.
-impl HotReloaderEventLoop for bun_event_loop::AnyEventLoop<'static> {
+impl HotReloaderEventLoop for bun_event_loop::AnyEventLoop {
     fn enqueue_task_concurrent(_this: &Self, _task: core::ptr::NonNull<ConcurrentTask>) {
         unreachable!()
     }
@@ -1316,7 +1316,7 @@ where
 // in via the `#[no_mangle]` hook below.
 
 impl<'a> HotReloaderCtx for bun_bundler::BundleV2<'a> {
-    type EventLoop = bun_event_loop::AnyEventLoop<'static>;
+    type EventLoop = bun_event_loop::AnyEventLoop;
 
     fn event_loop(&self) -> *mut Self::EventLoop {
         // With RELOAD_IMMEDIATELY=true the only caller
@@ -1391,7 +1391,7 @@ impl<'a> HotReloaderCtx for bun_bundler::BundleV2<'a> {
 /// `'static` because the only caller (`bun build --watch`)
 /// allocates the transpiler from the process-lifetime CLI arena.
 type BundlerWatcher =
-    NewHotReloader<bun_bundler::BundleV2<'static>, bun_event_loop::AnyEventLoop<'static>, true>;
+    NewHotReloader<bun_bundler::BundleV2<'static>, bun_event_loop::AnyEventLoop, true>;
 
 /// CYCLEBREAK extern hook: called from `BundleV2::init` (T5) when
 /// `cli_watch_flag` is set. Defined here (not in

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -167,15 +167,13 @@ pub struct WebWorker {
     // `JsCell` (not `Cell`) because `Arena` is non-`Copy`; worker-thread-only
     // so the single-owner-thread invariant `JsCell` documents is upheld.
     arena: JsCell<Option<bun_alloc::Arena>>,
-    /// Heap-owned cloned env (Map + Loader) for the worker VM. The worker
-    /// `Arena` (`bumpalo::Bump`) does not run `Drop` (so the inner
-    /// `HashTable` would leak), and `clone_with_allocator()` does not route
-    /// through the arena allocator anyway — own them as `Box`es
-    /// here instead. `start_vm()` `heap::alloc`s and stores the pointers;
-    /// `shutdown()` step 5 `heap::take`s after `vm.destroy()` (loader
-    /// first, then map — `Loader<'static>` borrows `*map`).
-    worker_env_map: Cell<*mut bun_dotenv::Map>,
-    worker_env_loader: Cell<*mut bun_dotenv::Loader<'static>>,
+    /// Heap-owned cloned env for the worker VM. The worker `Arena`
+    /// (`bumpalo::Bump`) does not run `Drop` (so the inner `HashTable` would
+    /// leak), and `clone_with_allocator()` does not route through the arena
+    /// allocator anyway — own it as a `Box` here instead. `start_vm()`
+    /// `heap::alloc`s and stores the pointer; `shutdown()` step 5
+    /// `heap::take`s after `vm.destroy()`.
+    worker_env_loader: Cell<*mut bun_dotenv::Loader>,
     /// Set by `exit()` so that `spin()`'s error paths don't clobber an explicit
     /// `process.exit(code)`. Atomic so `exit()` can take `&self` (the struct is
     /// observed concurrently by `terminate_all_and_wait` / parent-thread FFI;
@@ -571,7 +569,6 @@ impl WebWorker {
             parent_poll_ref: JsCell::new(KeepAlive::init()),
             status: Cell::new(Status::Start),
             arena: JsCell::new(None),
-            worker_env_map: Cell::new(core::ptr::null_mut()),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
             exit_called: AtomicBool::new(false),
         }));
@@ -889,29 +886,23 @@ impl WebWorker {
         // state.
         let mut temp_proxy_slots = jsc::rare_data::ProxyEnvSlots::default();
 
-        // Box Map/Loader on the global heap and hand ownership to the VM via
+        // Box the Loader on the global heap and hand ownership to the VM via
         // `transpiler.env`; reclaimed in `vm.destroy()` in `shutdown()`.
-        let mut map = Box::new(bun_dotenv::Map::default());
-        {
+        let mut map = {
             let parent_slots = parent.proxy_env_storage.lock();
             temp_proxy_slots.clone_from(&parent_slots);
             // SAFETY: `parent.transpiler.env` is the parent-owned `DotEnv::Loader`
             // set in `Transpiler::init`; valid while `parent` lives. Read-only.
-            *map = parent.env_loader().map.clone_with_allocator()?;
-        }
+            parent.env_loader().map.clone_with_allocator()?
+        };
         // Ensure map entries point at the exact bytes we hold refs on.
         temp_proxy_slots.sync_into(&mut map);
 
-        // `Loader<'static>` borrows `map` for its lifetime. Both are `heap::alloc`'d
-        // and stashed on `self` so `shutdown()` step 5 reclaims them on every
-        // path — including the early-terminate checkpoint below, which calls
-        // `shutdown()` before the VM exists.
-        let map_ptr: *mut bun_dotenv::Map = bun_core::heap::into_raw(map);
-        // SAFETY: `map_ptr` heap-allocated above; `'static` is the lifetime
-        // erasure for the worker-VM-lifetime borrow.
-        let loader = Box::new(bun_dotenv::Loader::init(unsafe { &mut *map_ptr }));
-        let loader_ptr: *mut bun_dotenv::Loader<'static> = bun_core::heap::into_raw(loader);
-        self.worker_env_map.set(map_ptr);
+        // `heap::alloc`'d and stashed on `self` so `shutdown()` step 5 reclaims
+        // it on every path — including the early-terminate checkpoint below,
+        // which calls `shutdown()` before the VM exists.
+        let loader_ptr: *mut bun_dotenv::Loader =
+            bun_core::heap::into_raw(Box::new(bun_dotenv::Loader::init_with_map(map)));
         self.worker_env_loader.set(loader_ptr);
 
         // Checkpoint before the expensive part: initWorker builds a full JSC
@@ -1233,7 +1224,6 @@ impl WebWorker {
         // worker-thread only field; no other thread reads `arena`.
         let mut arena = self.arena.replace(None);
         let env_loader = self.worker_env_loader.replace(core::ptr::null_mut());
-        let env_map = self.worker_env_map.replace(core::ptr::null_mut());
 
         // ---- 1. Unpublish vm ------------------------------------------------
         self.vm_lock.lock();
@@ -1393,16 +1383,11 @@ impl WebWorker {
                 );
             }
         }
-        // Reclaim the cloned env (loader borrows `*map` — drop loader first).
-        // Both were `heap::alloc`'d in `start_vm()` (see field doc).
+        // Reclaim the cloned env (`heap::alloc`'d in `start_vm()`; see field doc).
         if !env_loader.is_null() {
             // SAFETY: `heap::alloc`'d in `start_vm`; sole owner; the VM is
             // gone so its raw `transpiler.env` borrow is dead.
             drop(unsafe { bun_core::heap::take(env_loader) });
-        }
-        if !env_map.is_null() {
-            // SAFETY: `heap::alloc`'d in `start_vm`; sole owner.
-            drop(unsafe { bun_core::heap::take(env_map) });
         }
         // Same reason as the uWS loop below: this thread's C++ thread_local destructors are not
         // guaranteed to run before the process exits, so free the HPACK scratch buffer that any

--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -185,7 +185,7 @@ impl CompileTarget {
         &self,
         buf: &'a mut PathBuffer,
         version_str: &'a ZStr,
-        _env: &mut bun_dotenv::Loader<'_>,
+        _env: &mut bun_dotenv::Loader,
         needs_download: &mut bool,
     ) -> &'a ZStr {
         if self.is_default() {

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -1627,7 +1627,7 @@ pub fn spawn_opts(
     new_folder: &[u8],
     cwd: &ZStr,
     git: &ZStr,
-    loop_: &mut bun_event_loop::AnyEventLoop<'static>,
+    loop_: &mut bun_event_loop::AnyEventLoop,
 ) -> (bun_spawn::sync::Options, Vec<*const core::ffi::c_char>) {
     let argv: Vec<Box<[u8]>> = {
         const ARGV: &[&[u8]] = &[
@@ -1782,7 +1782,7 @@ pub fn git_diff_preprocess_paths<const SENTINEL: bool>(
 pub fn git_diff_internal(
     old_folder_: &[u8],
     new_folder_: &[u8],
-    loop_: &mut bun_event_loop::AnyEventLoop<'static>,
+    loop_: &mut bun_event_loop::AnyEventLoop,
 ) -> crate::Result<core::result::Result<Vec<u8>, Vec<u8>>> {
     let paths = git_diff_preprocess_paths::<false>(old_folder_, new_folder_);
     let old_folder = &paths[0][..];

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -24,9 +24,7 @@ use ::bun_semver as Semver;
 // `bun_install`, which depends on this crate. The lazy-init body is defined
 // `#[no_mangle]` in `bun_install::auto_installer` and resolved at link time
 // (same pattern as `__bun_regex_*` / `__BUN_RUNTIME_HOOKS`). `install` is the
-// `?*Api.BunInstall` (`self.opts.install`); `env` is the `*DotEnv.Loader`
-// (lifetime-erased to `'static` — the install crate stores it as a raw
-// `NonNull<Loader<'static>>`).
+// `?*Api.BunInstall` (`self.opts.install`); `env` is the `*DotEnv.Loader`.
 unsafe extern "Rust" {
     /// SAFETY (genuine FFI precondition — NOT a `safe fn` candidate): impl
     /// reborrows `&mut *log` / `&mut *env` and reads `*install` if non-null.
@@ -37,7 +35,7 @@ unsafe extern "Rust" {
     fn __bun_resolver_init_package_manager(
         log: NonNull<bun_ast::Log>,
         install: Option<NonNull<bun_options_types::schema::api::BunInstall>>,
-        env: NonNull<bun_dotenv::Loader<'static>>,
+        env: NonNull<bun_dotenv::Loader>,
     ) -> core::result::Result<NonNull<dyn AutoInstaller>, bun_errno::SystemErrno>;
 }
 use crate::cache::Set as CacheSet;
@@ -513,7 +511,7 @@ pub struct Resolver<'a> {
     // → `run_env_loader()` which takes `&mut *self.env`). Holding a live
     // `&Loader` across that `&mut Loader` would be aliased-&mut UB; a raw
     // pointer carries no aliasing guarantee.
-    pub env_loader: Option<NonNull<DotEnv::Loader<'a>>>,
+    pub env_loader: Option<NonNull<DotEnv::Loader>>,
     pub store_fd: bool,
 
     pub standalone_module_graph: Option<&'a dyn StandaloneModuleGraph>,
@@ -635,8 +633,7 @@ impl<'a> Resolver<'a> {
             generation: from.generation,
             package_manager: from.package_manager,
             on_wake_package_manager: from.on_wake_package_manager,
-            // SAFETY: see fn doc — pointee outlives `'a`.
-            env_loader: from.env_loader.map(|p| p.cast::<DotEnv::Loader<'a>>()),
+            env_loader: from.env_loader,
             store_fd: from.store_fd,
             // SAFETY: see fn doc — lifetime-widen the trait-object borrow. The
             // vtable layout is identical (only the borrow-checker tag differs);
@@ -833,13 +830,9 @@ impl<'a> Resolver<'a> {
         if let Some(pm) = self.package_manager {
             return Ok(pm.as_ptr());
         }
-        // SAFETY: `DotEnv::Loader<'a>` is layout-identical across `'a`;
-        // `init_with_runtime` only borrows it for the synchronous init (the
-        // static `PackageManager` retains a raw `NonNull<Loader<'static>>`).
-        let env: NonNull<DotEnv::Loader<'static>> = self
+        let env: NonNull<DotEnv::Loader> = self
             .env_loader
-            .expect("Resolver.env_loader must be set before auto-install")
-            .cast::<DotEnv::Loader<'static>>();
+            .expect("Resolver.env_loader must be set before auto-install");
         // SAFETY: `__bun_resolver_init_package_manager` is defined
         // `#[no_mangle]` in `bun_install::auto_installer` and linked into the
         // final binary; `self.log` / `self.opts.install` / `env` point at
@@ -879,7 +872,7 @@ impl<'a> Resolver<'a> {
     /// live concurrently — see the field comment for why this is *not* stored
     /// as `Option<&'a Loader>`.
     #[inline]
-    pub fn env_loader(&self) -> Option<&'a DotEnv::Loader<'a>> {
+    pub fn env_loader(&self) -> Option<&'a DotEnv::Loader> {
         // SAFETY: BACKREF — `env_loader` names the Transpiler-owned
         // `DotEnv::Loader`, live for the resolver's lifetime `'a`; resolution
         // never mutates the env, so no `&mut Loader` overlaps this shared

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2269,9 +2269,7 @@ pub mod environment_variables {
         // bytes stay alive; if not, they're freed now.
         *slot.ptr = None;
 
-        // NOTE: `Loader.map` is `&'a mut Map` (a mutable reference field);
-        // re-borrow as `&mut *` to avoid moving the reference out of the loader.
-        let env_map = &mut *vm.transpiler.env_mut().map;
+        let env_map = &mut vm.transpiler.env_mut().map;
 
         if value.is_empty() {
             // Store a static empty string rather than removing, so that

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -65,7 +65,7 @@ pub struct JSBundleCompletionTask {
     pub global_this: BackRef<JSGlobalObject>,
     pub promise: jsc::JSPromiseStrong,
     pub poll_ref: KeepAlive,
-    pub env: *mut bun_dotenv::Loader<'static>,
+    pub env: *mut bun_dotenv::Loader,
     pub log: bun_ast::Log,
     pub cancelled: bool,
 
@@ -381,7 +381,7 @@ impl JSBundleCompletionTask {
 
         // SAFETY: `self.env` is the per-VM `DotEnv.Loader` stashed at
         // construction; valid for the lifetime of the VirtualMachine.
-        let env = unsafe { &mut *self.env.cast::<bun_dotenv::Loader>() };
+        let env = unsafe { &mut *self.env };
 
         let result = match to_executable(
             &compile_options.compile_target,
@@ -971,8 +971,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         }
         // `transpiler.env` is the dotenv loader installed by
         // `Transpiler::init`; non-null and valid for `'a`.
-        transpiler.resolver.env_loader =
-            NonNull::new(transpiler.env.cast::<bun_dotenv::Loader<'_>>());
+        transpiler.resolver.env_loader = NonNull::new(transpiler.env);
         // `Resolver.opts` is the resolver-crate subset
         // — re-project from the now-mutated `transpiler.options`.
         transpiler.sync_resolver_opts();
@@ -1050,11 +1049,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         };
 
         let log: *mut bun_ast::Log = &raw mut self.log;
-        // SAFETY: `self.env` is the per-VM dotenv loader stashed at
-        // construction; cast erases `'_` (bun_dotenv::Loader is invariant on
-        // its arena lifetime, but `Transpiler::init` only stores the pointer).
-        let env = self.env.cast::<bun_dotenv::Loader<'static>>();
-        let t = Transpiler::init(bump, log, opts, Some(env))?;
+        let t = Transpiler::init(bump, log, opts, Some(self.env))?;
         let transpiler: &'a mut Transpiler<'a> = bump.alloc(t);
 
         // Post-init field wiring.
@@ -1081,7 +1076,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         // it outlives the BACKREF in `linker.loop`.
         let mut any_loop = bun_event_loop::AnyEventLoop::default();
         let event_loop: bun_bundler::linker_context_mod::EventLoop =
-            Some(NonNull::from(&mut any_loop).cast::<bun_event_loop::AnyEventLoop<'static>>());
+            Some(NonNull::from(&mut any_loop).cast::<bun_event_loop::AnyEventLoop>());
 
         // `thread_pool` is the `WorkPool` singleton (`OnceLock`-backed,
         // process-lifetime, concurrently read by worker threads). Do NOT

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3282,7 +3282,7 @@ impl DevServer {
         let ast_scope = unsafe { &mut *ast_memory_store }.enter();
 
         // The bundler stores
-        // `Option<NonNull<AnyEventLoop<'static>>>`. Park the value in `heap`
+        // `Option<NonNull<AnyEventLoop>>`. Park the value in `heap`
         // — bumpalo chunks are heap-allocated, so the address is stable across
         // the move of `heap` into `bv2.graph.heap` and lives exactly as long
         // as `bv2`.

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -61,10 +61,9 @@ fn side_name(s: bun_bundler::options::Side) -> &'static str {
 }
 
 /// Process-lifetime backing storage for the dotenv singleton; `OnceLock` owns
-/// the allocation. `Loader` self-borrows `Map`, so both live in one cell.
+/// the allocation.
 struct DotenvSingleton {
-    map: UnsafeCell<dotenv::Map>,
-    loader: UnsafeCell<MaybeUninit<dotenv::Loader<'static>>>,
+    loader: UnsafeCell<dotenv::Loader>,
 }
 // SAFETY: `build_command` runs single-threaded during CLI init; the singleton
 // is set exactly once before any reader exists.
@@ -420,22 +419,15 @@ pub(super) fn build_with_vm(
 
     // this is probably wrong
     // Note: process-lifetime dotenv singleton owned via `OnceLock`
-    // (PORTING.md §Forbidden: no leaking). `Loader` self-borrows `Map`,
-    // so both live in `DOTENV_SINGLETON`.
+    // (PORTING.md §Forbidden: no leaking).
     let backing = DOTENV_SINGLETON.get_or_init(|| DotenvSingleton {
-        map: UnsafeCell::new(dotenv::Map::init()),
-        loader: UnsafeCell::new(MaybeUninit::uninit()),
+        loader: UnsafeCell::new(dotenv::Loader::init()),
     });
-    // SAFETY: single-threaded CLI init; `get_or_init` guarantees one-time setup
-    // and `backing` is never moved (static storage), so the exclusive map borrow
-    // self-borrow stored in `Loader` stays valid for process lifetime.
-    let loader = unsafe {
-        let map = &mut *backing.map.get();
-        (*backing.loader.get()).write(dotenv::Loader::init(map));
-        (*backing.loader.get()).assume_init_mut()
-    };
+    // SAFETY: single-threaded CLI init; `get_or_init` guarantees one-time
+    // setup and `backing` is never moved (static storage).
+    let loader = unsafe { &mut *backing.loader.get() };
     loader.map.put(b"NODE_ENV", b"production")?;
-    dotenv::set_instance(std::ptr::from_mut::<dotenv::Loader<'static>>(loader));
+    dotenv::set_instance(std::ptr::from_mut::<dotenv::Loader>(loader));
 
     // In-place init via `MaybeUninit` (`init_transpiler_with_options`
     // keeps the out-param shape shared with the dev-server path).

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -2410,9 +2410,10 @@ impl Example {
             *URL_.get() = Some(api_url.erase_lifetime());
         }
 
-        // SAFETY: `http_proxy` borrows from `env_loader`'s arena-backed map
-        // (see `DotEnv::Loader::init(cli_arena().alloc(...))` in `exec`); erase
-        // to `'static` for `AsyncHTTP::init_sync` — same as `fetch_from_github`.
+        // SAFETY: `http_proxy` borrows from `env_loader`, which outlives this
+        // fn. Erased to `'static` because `async_http` is `cli_arena()`-backed
+        // (so its type parameter is `'static`), but the proxy URL is only read
+        // during the `send_sync()` calls below while `env_loader` is live.
         let mut http_proxy: Option<URL<'static>> = env_loader
             .get_http_proxy_for(unsafe { (*URL_.get()).as_ref().unwrap() })
             .map(|u| unsafe { u.erase_lifetime() });
@@ -2509,7 +2510,7 @@ impl Example {
         // ensure very stable memory address
         let parsed_tarball_url = URL::parse(tarball_url);
 
-        // SAFETY: see note on `http_proxy` above — env-loader-backed `'static`.
+        // SAFETY: see note on `http_proxy` above.
         http_proxy = env_loader
             .get_http_proxy_for(&parsed_tarball_url)
             .map(|u| unsafe { u.erase_lifetime() });

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -280,8 +280,7 @@ impl CreateCommand {
 
         // SAFETY: `fs::FileSystem::init` returns a process-global singleton pointer.
         let filesystem: &mut fs::FileSystem = unsafe { &mut *fs::FileSystem::init(None)? };
-        let mut env_loader: DotEnv::Loader =
-            { DotEnv::Loader::init(crate::cli::cli_arena().alloc(DotEnv::Map::init())) };
+        let mut env_loader = DotEnv::Loader::init();
 
         env_loader.load_process()?;
 
@@ -1664,8 +1663,7 @@ impl CreateCommand {
             Global::crash();
         }
 
-        let mut env_loader: DotEnv::Loader =
-            { DotEnv::Loader::init(crate::cli::cli_arena().alloc(DotEnv::Map::init())) };
+        let mut env_loader = DotEnv::Loader::init();
 
         env_loader.load_process()?;
 
@@ -2699,8 +2697,7 @@ pub(crate) struct CreateListExamplesCommand;
 impl CreateListExamplesCommand {
     pub(crate) fn exec(ctx: &Command::Context) -> crate::Result<()> {
         let filesystem = fs::FileSystem::init(None)?;
-        let mut env_loader: DotEnv::Loader =
-            { DotEnv::Loader::init(crate::cli::cli_arena().alloc(DotEnv::Map::init())) };
+        let mut env_loader = DotEnv::Loader::init();
 
         env_loader.load_process()?;
 

--- a/src/runtime/cli/exec_command.rs
+++ b/src/runtime/cli/exec_command.rs
@@ -66,7 +66,7 @@ impl ExecCommand {
         // process singleton, or freshly `heap::alloc`'d) — never null. The
         // loader is a thread-/process-lifetime singleton, so `&'static mut` is
         // sound for the single CLI dispatch thread.
-        let env = unsafe { &mut *bundle.env.cast::<bun_dotenv::Loader<'static>>() };
+        let env = unsafe { &mut *bundle.env };
         let mini = bun_event_loop::MiniEventLoop::init_global(Some(env), Some(cwd));
         let parts: [&[u8]; 2] = [cwd, b"[eval]"];
         let script_path = bun_paths::resolve_path::join::<bun_paths::platform::Auto>(&parts);

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -260,7 +260,7 @@ struct State<'a> {
     handles: Box<[ProcessHandle<'a>]>,
     // Raw `*mut` — `init_global` returns the
     // thread-local singleton pointer; aliasing &mut would be UB.
-    event_loop: *mut MiniEventLoop<'static>,
+    event_loop: *mut MiniEventLoop,
     /// Typed enum mirror of `event_loop` for the io-layer FilePoll vtable
     /// (`bun_io::EventLoopHandle` wraps `*const EventLoopHandle`).
     event_loop_handle: EventLoopHandle,
@@ -275,7 +275,7 @@ struct State<'a> {
     // by Transpiler; ProcessHandle::start mutates `env.map` (PATH swap) so a
     // shared borrow won't do, and `&'a mut` would conflict with the Transpiler's
     // own raw-ptr field. Reborrow `&mut *env` at use sites.
-    env: *mut bun_dotenv::Loader<'static>,
+    env: *mut bun_dotenv::Loader,
 }
 
 struct ElideResult<'b> {
@@ -866,7 +866,7 @@ pub(crate) fn run_scripts_with_filter(
     }
 
     // SAFETY: Transpiler::init always sets `env` to the process-lifetime singleton.
-    let env_ptr: *mut bun_dotenv::Loader<'static> = this_transpiler.env;
+    let env_ptr: *mut bun_dotenv::Loader = this_transpiler.env;
     let event_loop = MiniEventLoopMod::init_global(
         // SAFETY: see above; `&'static mut` reborrow of the singleton for first-init only.
         Some(unsafe { &mut *env_ptr }),

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -65,7 +65,7 @@ impl<'a> PipeReader<'a> {
         }
     }
 
-    fn event_loop_ptr(&self) -> *mut MiniEventLoop<'static> {
+    fn event_loop_ptr(&self) -> *mut MiniEventLoop {
         // SAFETY: handle is a backref set in ProcessHandle::start() before any read; State
         // outlives all handles (lives on `run`'s stack frame for the whole event loop).
         unsafe { (*(*self.handle).state).event_loop }
@@ -287,7 +287,7 @@ const RESET: &[u8] = ansi::RESET.as_bytes();
 
 struct State<'a> {
     handles: Box<[ProcessHandle<'a>]>,
-    event_loop: *mut MiniEventLoop<'static>,
+    event_loop: *mut MiniEventLoop,
     /// Typed enum mirror of `event_loop` for the io-layer FilePoll vtable
     /// (`bun_io::EventLoopHandle` wraps `*const EventLoopHandle`).
     event_loop_handle: EventLoopHandle,
@@ -297,7 +297,7 @@ struct State<'a> {
     shell_bin: Box<[u8]>,
     aborted: bool,
     no_exit_on_error: bool,
-    env: *mut DotEnvLoader<'static>,
+    env: *mut DotEnvLoader,
     use_colors: bool,
 }
 
@@ -801,7 +801,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     let cwd: &[u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
 
     // SAFETY: transpiler.env is a process-lifetime *mut Loader set in init.
-    let env_ptr: *mut DotEnvLoader<'static> = this_transpiler.env;
+    let env_ptr: *mut DotEnvLoader = this_transpiler.env;
     let event_loop = bun_event_loop::MiniEventLoop::init_global(
         // SAFETY: env_ptr is the process-lifetime DotEnv loader; no other borrow of it is live yet.
         Some(unsafe { &mut *env_ptr }),

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -88,7 +88,7 @@ fn pm_workspace_cache<'a>(
     unsafe { &mut (*m).workspace_package_json_cache }
 }
 #[inline]
-fn pm_env(m: &PackageManager) -> *mut bun_dotenv::Loader<'static> {
+fn pm_env(m: &PackageManager) -> *mut bun_dotenv::Loader {
     // Set during `PackageManager::init`.
     m.env
         .map(|p| p.as_ptr())
@@ -2081,7 +2081,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     // `Transpiler::env` is a process-singleton `*mut` (set by `init`); pass as
     // raw pointer so `run_package_script_foreground` can `&mut` it without
     // conflicting with our `&Transpiler` borrow.
-    let transpiler_env: *mut bun_dotenv::Loader<'static> = this_transpiler.env;
+    let transpiler_env: *mut bun_dotenv::Loader = this_transpiler.env;
     manager.env_mut().map.put(b"npm_command", b"pack")?;
 
     let (postpack_script, publish_script, postpublish_script, ran_scripts): (
@@ -2980,7 +2980,7 @@ fn run_lifecycle_script<const FOR_PUBLISH: bool>(
     script: &[u8],
     name: &[u8],
     abs_workspace_path: &[u8],
-    env: *mut bun_dotenv::Loader<'static>,
+    env: *mut bun_dotenv::Loader,
     silent: bool,
 ) -> Result<(), PackError<FOR_PUBLISH>> {
     // Note: `ctx.command_ctx` and `env` are reborrowed via raw pointer

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -372,8 +372,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             {
                 let mut had_err = false;
 
-                let mut env_map = bun_dotenv::Map::init();
-                let mut process_env = bun_dotenv::Loader::init(&mut env_map);
+                let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
                 let cache_dir = fetch_cache_directory_path(&mut process_env, None);
                 let mut rm_buf = PathBuffer::uninit();

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -109,7 +109,7 @@ pub struct Context<'a, const DIRECTORY_PUBLISH: bool> {
 
     pub publish_script: Option<Box<[u8]>>,
     pub postpublish_script: Option<Box<[u8]>>,
-    pub script_env: Option<&'a mut dotenv::Loader<'a>>,
+    pub script_env: Option<&'a mut dotenv::Loader>,
 }
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -237,7 +237,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         original_script: &[u8],
         name: &[u8],
         cwd: &[u8],
-        env: &mut DotEnv::Loader<'_>,
+        env: &mut DotEnv::Loader,
         passthrough: &[Box<[u8]>],
         silent: bool,
         use_system_shell: bool,
@@ -262,7 +262,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         original_script: &[u8],
         name: &[u8],
         cwd: &[u8],
-        env: &mut DotEnv::Loader<'_>,
+        env: &mut DotEnv::Loader,
         passthrough: &[Box<[u8]>],
         silent: bool,
         use_system_shell: bool,
@@ -308,13 +308,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         if !use_system_shell {
             // SAFETY: `MiniEventLoop` stores `env` as a raw `*mut`; the loader
             // outlives the call (process-lifetime in `configure_env_for_run`).
-            // Erase the loader's borrowed lifetime to `'static` for the
-            // singleton handoff.
             let mini = bun_event_loop::MiniEventLoop::init_global(
-                Some(unsafe {
-                    &mut *std::ptr::from_mut::<DotEnv::Loader<'_>>(env)
-                        .cast::<DotEnv::Loader<'static>>()
-                }),
+                Some(unsafe { &mut *std::ptr::from_mut::<DotEnv::Loader>(env) }),
                 Some(cwd),
             );
             // SAFETY: `init_global` returns the thread-local singleton as a raw
@@ -396,12 +391,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             windows: crate::api::bun_process::WindowsOptions {
                 loop_: bun_jsc::EventLoopHandle::init_mini(
                     bun_event_loop::MiniEventLoop::init_global(
-                        // SAFETY: same lifetime erasure as the `!use_system_shell`
-                        // branch above — `env` outlives the mini event loop.
-                        Some(unsafe {
-                            &mut *::core::ptr::from_mut::<DotEnv::Loader<'_>>(env)
-                                .cast::<DotEnv::Loader<'static>>()
-                        }),
+                        // SAFETY: `env` outlives the mini event loop.
+                        Some(unsafe { &mut *::core::ptr::from_mut::<DotEnv::Loader>(env) }),
                         None,
                     ),
                 ),
@@ -538,7 +529,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     pub fn configure_env_for_run(
         ctx: &mut ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
-        env: Option<*mut DotEnv::Loader<'static>>,
+        env: Option<*mut DotEnv::Loader>,
         log_errors: bool,
         store_root_fd: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
@@ -552,7 +543,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     pub fn configure_env_for_run_without_linker(
         ctx: &mut ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
-        env: Option<*mut DotEnv::Loader<'static>>,
+        env: Option<*mut DotEnv::Loader>,
         log_errors: bool,
         store_root_fd: bool,
     ) -> crate::Result<bun_resolver::DirInfoRef> {
@@ -584,7 +575,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     fn configure_env_for_run_impl(
         ctx: &mut ContextData,
         this_transpiler: &mut ::core::mem::MaybeUninit<Transpiler<'static>>,
-        env: Option<*mut DotEnv::Loader<'static>>,
+        env: Option<*mut DotEnv::Loader>,
         log_errors: bool,
         store_root_fd: bool,
         with_linker: bool,
@@ -899,9 +890,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         let top_level_dir: &[u8] = ctx.args.absolute_working_dir.as_deref().unwrap_or(b"");
         let mini = bun_event_loop::MiniEventLoop::init_global(
             // SAFETY: `bundle.env` points to the process-lifetime DotEnv
-            // singleton (set by `Transpiler::init`); erasing the borrowed
-            // lifetime mirrors the `run_package_script_foreground` handoff.
-            Some(unsafe { &mut *bundle.env.cast::<DotEnv::Loader<'static>>() }),
+            // singleton (set by `Transpiler::init`).
+            Some(unsafe { &mut *bundle.env }),
             None,
         );
         // SAFETY: `init_global` returns the thread-local singleton; single-
@@ -2082,7 +2072,7 @@ impl RunCommand {
         executable: &[u8],
         executable_z: &ZStr,
         cwd: &[u8],
-        env: &mut DotEnv::Loader<'static>,
+        env: &mut DotEnv::Loader,
         passthrough: &[Box<[u8]>],
         original_script_for_bun_run: Option<&[u8]>,
     ) -> crate::Result<::core::convert::Infallible> {
@@ -2137,7 +2127,7 @@ impl RunCommand {
         executable: &[u8],
         executable_z: &ZStr,
         cwd: &[u8],
-        env: &mut DotEnv::Loader<'static>,
+        env: &mut DotEnv::Loader,
         passthrough: &[Box<[u8]>],
         original_script_for_bun_run: Option<&[u8]>,
     ) -> crate::Result<::core::convert::Infallible> {
@@ -2168,12 +2158,8 @@ impl RunCommand {
             windows: crate::api::bun_process::WindowsOptions {
                 loop_: bun_jsc::EventLoopHandle::init_mini(
                     bun_event_loop::MiniEventLoop::init_global(
-                        Some(unsafe {
-                            // SAFETY: env loader is process-lifetime; erase
-                            // borrowed lifetime for the singleton handoff.
-                            &mut *::core::ptr::from_mut::<DotEnv::Loader<'_>>(env)
-                                .cast::<DotEnv::Loader<'static>>()
-                        }),
+                        // SAFETY: env loader is process-lifetime.
+                        Some(unsafe { &mut *::core::ptr::from_mut::<DotEnv::Loader>(env) }),
                         None,
                     ),
                 ),
@@ -2444,7 +2430,7 @@ impl RunCommand {
             root_dir_info.abs_path,
             force_using_bun,
         )?;
-        let env_loader: &mut DotEnv::Loader<'static> = this_transpiler.env_mut();
+        let env_loader: &mut DotEnv::Loader = this_transpiler.env_mut();
         env_loader
             .map
             .put(b"npm_command", b"run-script")
@@ -3993,7 +3979,7 @@ impl BunXFastPath {
     pub fn try_launch(
         ctx: &mut ContextData,
         path_len: usize,
-        env: &mut DotEnv::Loader<'static>,
+        env: &mut DotEnv::Loader,
         passthrough: &[Box<[u8]>],
     ) {
         if !bun_core::FeatureFlags::WINDOWS_BUNX_FAST_PATH {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2120,12 +2120,7 @@ impl TestCommand {
 
         // `exec()` never returns before process exit, so the heap allocation
         // outlives all observers.
-        // `Loader::init` borrows the map; erase to `'static` via raw pointer round-trip
-        // (the map is never freed — process-lifetime singleton).
-        let env_map: *mut DotEnv::Map = bun_core::heap::into_raw(Box::new(DotEnv::Map::init()));
-        // SAFETY: `env_map` is heap-allocated and never freed; valid for process lifetime.
-        let mut env_loader: Box<DotEnv::Loader> =
-            Box::new(DotEnv::Loader::init(unsafe { &mut *env_map }));
+        let mut env_loader: Box<DotEnv::Loader> = Box::new(DotEnv::Loader::init());
         jsc::initialize(false);
         bun_http::http_thread::init(&Default::default());
 
@@ -2292,9 +2287,7 @@ impl TestCommand {
                 transform_options: ctx.args.clone(),
                 debugger: core::mem::take(&mut ctx.runtime_options.debugger),
                 log: core::ptr::NonNull::new(ctx.log),
-                env_loader: core::ptr::NonNull::new(
-                    (&raw mut *env_loader).cast::<DotEnv::Loader<'static>>(),
-                ),
+                env_loader: core::ptr::NonNull::new(&raw mut *env_loader),
                 // we must store file descriptors because we reuse them for
                 // iterating through the directory tree recursively
                 //

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -542,10 +542,7 @@ impl UpgradeCommand {
 
         // SAFETY: FileSystem::init returns the process-global singleton; valid for 'static.
         let filesystem = unsafe { &mut *fs::FileSystem::init(None)? };
-        let mut env_loader: DotEnv::Loader = {
-            // Allocate in the process-lifetime CLI arena.
-            DotEnv::Loader::init(crate::cli::cli_arena().alloc(DotEnv::Map::init()))
-        };
+        let mut env_loader = DotEnv::Loader::init();
         env_loader.load_process()?;
 
         let use_canary: bool = 'brk: {
@@ -694,6 +691,9 @@ impl UpgradeCommand {
                 200 => {}
                 _ => return Err(crate::Error::HTTPError),
             }
+            // Release the immutable borrow of `env_loader` (via `http_proxy`)
+            // before the map mutations below.
+            drop(async_http);
 
             let bytes = zip_file_buffer.slice();
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1600,11 +1600,11 @@ mod _async_tasks {
 
         pub fn create_mini(
             cp_args: args::Cp,
-            // `EventLoopHandle::Mini` stores `*mut MiniEventLoop<'static>` (a
+            // `EventLoopHandle::Mini` stores `*mut MiniEventLoop` (a
             // non-owning erased backref, see `bun_event_loop::AnyEventLoop`). Taking the
             // raw pointer here avoids forcing every caller's `MiniEventLoop` borrow to be
             // `'static`; the task never outlives the loop.
-            mini: *mut MiniEventLoop<'static>,
+            mini: *mut MiniEventLoop,
             shelltask: *mut ShellCpTask,
         ) -> *mut Self {
             let mut task = Box::new(Self {

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -186,13 +186,11 @@ pub fn parse_env(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue
     // before slicing.
     let str = content.to_js_string(global)?.to_slice(global);
 
-    let mut map = envloader::Map::init();
-    let mut p = envloader::Loader::init(&mut map);
+    let mut p = envloader::Loader::init();
     p.load_from_string::<true, false>(str.slice())?;
-    drop(p);
 
-    let obj = JSValue::create_empty_object(global, map.map.count());
-    for (k, v) in map.map.iter() {
+    let obj = JSValue::create_empty_object(global, p.map.map.count());
+    for (k, v) in p.map.map.iter() {
         obj.put(
             global,
             ZigString::init_utf8(k),

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -634,7 +634,7 @@ impl Interpreter {
     /// not bumping `standalone_shell` analytics.
     pub fn init_and_run_from_file(
         ctx: &mut bun_options_types::context::ContextData,
-        mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop<'static>,
+        mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop,
         path: &[u8],
         src: &[u8],
     ) -> crate::Result<ExitCode> {
@@ -651,7 +651,7 @@ impl Interpreter {
     /// without a diagnostic.
     pub fn init_and_run_from_source(
         ctx: &mut bun_options_types::context::ContextData,
-        mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop<'static>,
+        mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop,
         path_for_errors: &[u8],
         src: &[u8],
         cwd: Option<&[u8]>,
@@ -665,7 +665,7 @@ impl Interpreter {
     /// the two entrypoints.
     fn init_and_run_impl(
         ctx: &mut bun_options_types::context::ContextData,
-        mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop<'static>,
+        mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop,
         label: &[u8],
         src: &[u8],
         cwd: Option<&[u8]>,

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1525,7 +1525,7 @@ pub use bun_options_types::compile_target::CompileTarget;
 /// two `download*` fns below in this crate.
 pub(crate) fn download_to_path(
     target: &CompileTarget,
-    env: &mut bun_dotenv::Loader<'_>,
+    env: &mut bun_dotenv::Loader,
     dest_z: &ZStr,
 ) -> crate::Result<()> {
     bun_http::http_thread::init(&Default::default());


### PR DESCRIPTION
## Problem

`Loader<'a> { map: &'a mut Map }` (src/dotenv/env_loader.rs) borrowed its primary state instead of owning it. `&'a mut` makes `'a` invariant, which propagated lifetime plumbing to every consumer. The worst casualty was `src/ini/lib.rs`, which could not satisfy that invariant lifetime and resorted to:

- casting `DotEnvLoader<'_>` to `DotEnvLoader<'static>` via a raw pointer in `load_npmrc`;
- taking a raw `*const Arena` to `parser.arena` while `&mut parser` was live (the arena was a field of the thing borrowing it);
- keeping `head: *mut E::Object` to alias `self.out` across `prepare_str(&mut self, ...)` calls;
- erasing `path`/`src` to `&'static [u8]` via `.into_str()` because `Parser` owned its `Source`.

## Change

**`Loader` owns its map**: `struct Loader { map: Map, ... }`, no lifetime parameter. `Loader::init()` creates a fresh map; `Loader::init_with_map(Map)` wraps an existing one.

**`ini/lib.rs` is now `#![forbid(unsafe_code)]`**:
- `Parser` borrows `&'a Source` and `&'a DotEnvLoader` (read-only; `ini` never mutates the env); the arena is caller-created instead of a self-borrowed field, so `parse(&mut self, bump: &'a Arena)` no longer overlaps `&mut self` with `&self.arena`.
- `prepare_str`, `expand_env_vars`, `parse_env_substitution`, `commit_rope_part` are associated fns taking `env: &DotEnvLoader` rather than `&mut self`, splitting the borrow that forced the raw `head` pointer.
- `head` is a `StoreRef<E::Object>` (the `Copy` arena handle `ExprData` already stores) instead of `*mut E::Object`.
- `load_npmrc` takes `env: &DotEnvLoader` directly; no lifetime cast, no arena raw-pointer split.

**Fallout** (net -209 lines):
- `get_http_proxy` / `get_http_proxy_for` take `&self` and return `URL<'_>`; the `from_raw_parts` lifetime-extension closure is gone.
- `get_tls_reject_unauthorized` takes `&self` (cache moved to `Cell<Option<bool>>`).
- `MiniEventLoop` / `AnyEventLoop` lose their `'a` parameter (it existed only for the loader).
- `WebWorker` drops the separate `worker_env_map` field and its paired free in `shutdown()`.
- `PackageManager` drops the `holder::ENV_MAP` static.
- `bake::DotenvSingleton` drops the self-referential `map` slot.
- Every `Loader::init(&mut heap_leaked_map)` call site simplifies to `Loader::init()`.
- `upgrade_command` explicitly drops `async_http` after the download so the `http_proxy` borrow of `env_loader` ends before the post-download map mutations.

## Verification

```
bun bd test test/js/bun/ini/ini.test.ts        # 62 pass
bun bd test test/cli/run/env.test.ts           # 91 pass
bun bd test test/js/bun/http/proxy.test.ts     # 62 pass
bun run rust:check-all                          # 10/10 targets ok
```