### PR TITLE
watcher(kqueue): drop per-cycle Vec, two-phase init, and raw libc::kevent

### DIFF
--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -181,17 +181,8 @@ impl INotifyWatcher {
         result
     }
 
-    // kept as in-place &mut self init (not `-> Result<Self, _>`) because
-    // INotifyWatcher is embedded as `Watcher.platform` with field defaults already set.
-    pub(crate) fn init(&mut self, _root: &[u8]) -> Result<(), crate::Error> {
+    pub(crate) fn new(_root: &[u8]) -> crate::Result<Self> {
         use bun_sys::linux::IN;
-        debug_assert!(!self.loaded);
-        self.loaded = true;
-
-        self.coalesce_interval = env_var::BUN_INOTIFY_COALESCE_INTERVAL
-            .get()
-            .and_then(|v| isize::try_from(v).ok())
-            .unwrap_or(100_000);
 
         let raw = bun_sys::linux::inotify_init1(IN::CLOEXEC);
         let errno = bun_sys::get_errno(raw);
@@ -200,9 +191,17 @@ impl INotifyWatcher {
             // init-failed tag.
             return Err(crate::Error::Sys(errno));
         }
-        self.fd = Fd::from_native(raw);
-        bun_core::scoped_log!(watcher, "{} init", self.fd);
-        Ok(())
+        let fd = Fd::from_native(raw);
+        bun_core::scoped_log!(watcher, "{} init", fd);
+        Ok(Self {
+            fd,
+            loaded: true,
+            coalesce_interval: env_var::BUN_INOTIFY_COALESCE_INTERVAL
+                .get()
+                .and_then(|v| isize::try_from(v).ok())
+                .unwrap_or(100_000),
+            ..Self::default()
+        })
     }
 
     pub(crate) fn read(&mut self) -> bun_sys::Result<&[*const Event]> {
@@ -519,22 +518,9 @@ fn process_inotify_event_batch(
     if watch_events.is_empty() {
         return Ok(());
     }
-    // End the &mut borrow of `this` via `watch_events` before re-borrowing other
-    // fields below; we re-slice `this.watch_events` directly after the lock.
-    let _ = watch_events;
 
-    let _guard = this.mutex.lock_guard();
-    if this.running.load() {
-        // watch_events.len == 0 is checked above, so last_event_index + 1 is safe.
-        // reshaped for borrowck — split disjoint field borrows so we can
-        // pass `&mut watch_events[..]` in place
-        // without a gratuitous `.to_vec()`/`.clone()`.
-        let deduped = &mut this.watch_events[..last_event_index + 1];
-        let changed = &this.changed_filepaths[..name_off as usize];
-        crate::watcher_trace::write_events(&this.watchlist, deduped, changed);
-        (this.on_file_update)(this.ctx, deduped, changed, &this.watchlist);
-    }
-
+    // watch_events.len == 0 is checked above, so last_event_index + 1 is safe.
+    this.dispatch_file_updates(last_event_index + 1, name_off as usize);
     Ok(())
 }
 

--- a/src/watcher/KEventWatcher.rs
+++ b/src/watcher/KEventWatcher.rs
@@ -1,5 +1,3 @@
-use core::ffi::c_int;
-
 use bun_core::output as Output;
 use bun_sys::Fd;
 
@@ -7,26 +5,25 @@ use crate::watcher_impl::{Op, WatchEvent, Watcher};
 
 pub(crate) type Platform = KEventWatcher;
 
-#[derive(Default)]
 pub struct KEventWatcher {
-    pub fd: Option<Fd>,
+    pub fd: Fd,
 }
 
 const CHANGELIST_COUNT: usize = 128;
 
 impl KEventWatcher {
-    pub fn init(&mut self, _: &[u8]) -> crate::Result<()> {
+    pub fn new(_root: &[u8]) -> crate::Result<Self> {
         let fd = bun_sys::kqueue()?;
         if fd.native() == 0 {
             return Err(crate::Error::KQueueError);
         }
-        self.fd = Some(fd);
-        Ok(())
+        Ok(Self { fd })
     }
 
     pub fn stop(&mut self) {
-        if let Some(fd) = self.fd.take() {
-            let _ = bun_sys::close(fd);
+        if self.fd.is_valid() {
+            let _ = bun_sys::close(self.fd);
+            self.fd = Fd::INVALID;
         }
     }
 }
@@ -54,63 +51,30 @@ pub(crate) fn watch_event_from_kevent(kevent: &libc::kevent) -> WatchEvent {
 }
 
 pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
-    use bun_sys::c;
-    let fd: Fd = this
-        .platform
-        .fd
-        .expect("KEventWatcher has an invalid file descriptor");
+    let _flush = Output::flush_guard();
+    let fd = this.platform.fd;
 
-    // not initialized each time
-    // SAFETY: all-zero is a valid Kevent (#[repr(C)] POD)
-    let mut changelist_array: [libc::kevent; CHANGELIST_COUNT] = bun_core::ffi::zeroed();
-    let changelist = &mut changelist_array;
+    let mut changelist: [libc::kevent; CHANGELIST_COUNT] = bun_core::ffi::zeroed();
 
-    // SAFETY: fd is a valid kqueue fd; changelist points to CHANGELIST_COUNT zeroed entries
-    let mut count: c_int = unsafe {
-        c::kevent(
-            fd.native(),
-            changelist.as_ptr(),
-            0,
-            changelist.as_mut_ptr(),
-            CHANGELIST_COUNT as c_int,
-            core::ptr::null(), // timeout
-        )
-    };
+    let mut count = bun_sys::kevent(fd, &[], &mut changelist, None)?;
 
     // Give the events more time to coalesce
-    if count < 128 / 2 {
-        let remain: c_int = 128 - count;
-        let off = usize::try_from(count).expect("int cast");
+    if count < CHANGELIST_COUNT / 2 {
         let ts = libc::timespec {
             tv_sec: 0,
             tv_nsec: 100_000,
         }; // 0.0001 seconds
-        // SAFETY: off < CHANGELIST_COUNT (count < 64), remain entries fit in the buffer
-        let extra: c_int = unsafe {
-            c::kevent(
-                fd.native(),
-                changelist.as_ptr().add(off),
-                0,
-                changelist.as_mut_ptr().add(off),
-                remain,
-                &raw const ts,
-            )
-        };
-
-        count += extra;
+        count += bun_sys::kevent(fd, &[], &mut changelist[count..], Some(&ts))?;
     }
 
-    let changes_len = usize::try_from(count.max(0)).expect("int cast");
-    let changes = &changelist[0..changes_len];
-    // Track out_len and slice once at the end to avoid overlapping &mut
-    // borrows of `this`.
-    let watchevents = &mut this.watch_events[0..changes_len];
+    let changes = &changelist[..count];
+    let watchevents = &mut this.watch_events[..count];
     let mut out_len: usize = 0;
-    if changes_len > 0 {
-        watchevents[0] = watch_event_from_kevent(&changes[0]);
+    if let [first, rest @ ..] = changes {
+        watchevents[0] = watch_event_from_kevent(first);
         out_len = 1;
-        let mut prev_event = changes[0];
-        for event in &changes[1..] {
+        let mut prev_event = first;
+        for event in rest {
             if prev_event.udata == event.udata {
                 let new = watch_event_from_kevent(event);
                 watchevents[out_len - 1].merge(new);
@@ -118,26 +82,11 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
             }
 
             watchevents[out_len] = watch_event_from_kevent(event);
-            prev_event = *event;
+            prev_event = event;
             out_len += 1;
         }
     }
 
-    // RAII: `MutexGuard` holds the mutex by raw pointer (no borrow of `this`)
-    // and unlocks on Drop.
-    let _guard = this.mutex.lock_guard();
-    if this.running.load() {
-        // reshaped for borrowck — copy the (small, ≤128) deduped slice
-        // into a local so `this` is no longer mutably borrowed via `watch_events`
-        // when calling `write_trace_events(&self, …)`.
-        let mut deduped: Vec<WatchEvent> = this.watch_events[0..out_len].to_vec();
-        let changed = &this.changed_filepaths[0..out_len];
-        this.write_trace_events(&deduped, changed);
-        (this.on_file_update)(this.ctx, &mut deduped, changed, &this.watchlist);
-    }
-
-    // No early returns above, so flush once at the single exit point instead
-    // of via scopeguard.
-    Output::flush();
+    this.dispatch_file_updates(out_len, out_len);
     Ok(())
 }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -182,14 +182,14 @@ impl Watcher {
             ctx.on_watch_error(err);
         }
 
-        let mut this = Box::new(Watcher {
+        let this = Box::new(Watcher {
             watchlist: WatchList::default(),
             mutex: Mutex::default(),
             cwd: top_level_dir,
             ctx: ctx.cast::<()>(),
             on_file_update: on_file_update_wrapped::<T>,
             on_error: on_error_wrapped::<T>,
-            platform: Platform::default(),
+            platform: Platform::new(top_level_dir)?,
             watch_events: vec![WatchEvent::default(); MAX_COUNT].into_boxed_slice(),
             changed_filepaths: [const { None }; MAX_COUNT],
             watchloop_handle: bun_core::AtomicCell::new(false),
@@ -201,18 +201,27 @@ impl Watcher {
             thread_lock: ThreadLock::init_unlocked(),
         });
 
-        this.platform.init(top_level_dir)?;
-
         // Initialize trace file if BUN_WATCHER_TRACE env var is set
         WatcherTrace::init();
 
         Ok(this)
     }
 
-    /// Write trace events to the trace file if enabled.
-    /// This runs on the watcher thread, so no locking is needed.
-    pub fn write_trace_events(&self, events: &[WatchEvent], changed_files: &[ChangedFilePath]) {
-        WatcherTrace::write_events(&self.watchlist, events, changed_files);
+    /// Lock, check `running`, then dispatch a batch of `watch_events` /
+    /// `changed_filepaths` through the trace writer and `on_file_update`.
+    ///
+    /// The platform `watch_loop_cycle` fills `self.watch_events[..event_count]`
+    /// and `self.changed_filepaths[..changed_count]` and calls this instead of
+    /// open-coding the lock/trace/callback sequence.
+    pub(crate) fn dispatch_file_updates(&mut self, event_count: usize, changed_count: usize) {
+        let _guard = self.mutex.lock_guard();
+        if !self.running.load() {
+            return;
+        }
+        let events = &mut self.watch_events[..event_count];
+        let changed = &self.changed_filepaths[..changed_count];
+        WatcherTrace::write_events(&self.watchlist, events, changed);
+        (self.on_file_update)(self.ctx, events, changed, &self.watchlist);
     }
 
     pub fn start(&mut self) -> Result<(), crate::Error> {
@@ -351,11 +360,10 @@ impl Watcher {
         // the still-present entry's now-closed fd → `EBADF reading "<path>"`.
         //
         // We do NOT lock here: the only callers are deferred from
-        // `WatcherContext::on_file_update`, which is itself invoked while the
-        // platform watcher already holds `self.mutex` (KEventWatcher.rs:138,
-        // INotifyWatcher.rs:555, WindowsWatcher.rs). `bun_threading::Mutex` is
-        // non-recursive — re-locking here is `os_unfair_lock` SIGILL on darwin
-        // and self-deadlock on Linux/Windows.
+        // `WatcherContext::on_file_update`, which is itself invoked from
+        // `dispatch_file_updates` while `self.mutex` is already held.
+        // `bun_threading::Mutex` is non-recursive — re-locking here is
+        // `os_unfair_lock` SIGILL on darwin and self-deadlock on Linux/Windows.
         debug_assert!(
             self.mutex.is_held_by_current_thread(),
             "flush_evictions: caller must hold self.mutex (platform watcher holds it around on_file_update)",
@@ -446,14 +454,10 @@ impl Watcher {
     /// Does not propagate kevent registration errors.
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub fn add_file_descriptor_to_kqueue_without_checks(&mut self, fd: Fd, watchlist_id: usize) {
-        // Raw libc::kevent on purpose:
-        // this is a registration-only call (nevents = 0) whose return value
-        // is intentionally ignored.
         use libc::{EV_ADD, EV_CLEAR, EV_ENABLE, EVFILT_VNODE, kevent as KEvent};
         use libc::{NOTE_DELETE, NOTE_RENAME, NOTE_WRITE};
 
         // https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html
-        // SAFETY: all-zero is a valid KEvent
         let mut event: KEvent = bun_core::ffi::zeroed();
 
         event.flags = (EV_ADD | EV_CLEAR | EV_ENABLE) as _;
@@ -467,23 +471,12 @@ impl Watcher {
 
         // Store the index for fast filtering later
         event.udata = watchlist_id as _;
-        let mut events: [KEvent; 1] = [event];
 
         // This took a lot of work to figure out the right permutation
         // Basically:
         // - We register the event here.
         // our while(true) loop above receives notification of changes to any of the events created here.
-        // SAFETY: events ptr/len valid; kqueue fd unwrapped from Some
-        let _ = unsafe {
-            libc::kevent(
-                self.platform.fd.unwrap().native(),
-                events.as_ptr(),
-                1,
-                events.as_mut_ptr(),
-                0,
-                core::ptr::null(),
-            )
-        };
+        let _ = bun_sys::kevent(self.platform.fd, &[event], &mut [], None);
     }
 
     fn append_file_assume_capacity<const CLONE_FILE_PATH: bool>(

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -211,9 +211,16 @@ impl EventIterator {
 }
 
 impl WindowsWatcher {
-    // `self` is the pre-allocated `platform` slot inside crate::Watcher
-    // (64KB+ buffers; avoid moving).
-    pub(crate) fn init(&mut self, root: &[u8]) -> Result<(), crate::Error> {
+    // `Self` carries the 64 KiB `DirWatcher` buffer inline; it is moved once
+    // into `Box::new(Watcher { .. })` in `Watcher::init`.
+    #[allow(clippy::large_stack_frames)]
+    pub(crate) fn new(root: &[u8]) -> crate::Result<Self> {
+        let mut this = Self::default();
+        this.init(root)?;
+        Ok(this)
+    }
+
+    fn init(&mut self, root: &[u8]) -> Result<(), crate::Error> {
         use bun_paths::string_paths as paths;
         let mut pathbuf = WPathBuffer::uninit();
         let wpath = paths::to_nt_path(&mut pathbuf, root);
@@ -522,30 +529,14 @@ fn process_watch_event_batch(this: &mut Watcher, event_count: usize) -> bun_sys:
     if all_events.is_empty() {
         return Ok(());
     }
-    // reshaped for borrowck — copy the (small) deduped slice into a
-    // local so `this` is no longer mutably borrowed via `watch_events` when we
-    // call `write_trace_events` / `on_file_update`. Mirrors INotifyWatcher.
-    let mut deduped: Vec<WatchEvent> = all_events[..last_event_index + 1].to_vec();
 
     bun_core::scoped_log!(
         watcher,
         "calling onFileUpdate (all_events.len = {})",
-        deduped.len()
+        last_event_index + 1
     );
 
-    // Hold `this.mutex` for the on_file_update dispatch — mirrors
-    // KEventWatcher.rs:138 / INotifyWatcher.rs:555. `on_file_update` impls
-    // defer `flush_evictions()`, which assumes the lock is held to serialize
-    // its close+swap_remove against the JS thread's
-    // `snapshot_fd_and_package_json` / `append_file_maybe_lock<true>`.
-    let _guard = this.mutex.lock_guard();
-    if !this.running.load() {
-        return Ok(());
-    }
-    let changed = &this.changed_filepaths[0..last_event_index + 1];
-    this.write_trace_events(&deduped, changed);
-    (this.on_file_update)(this.ctx, &mut deduped, changed, &this.watchlist);
-
+    this.dispatch_file_updates(last_event_index + 1, last_event_index + 1);
     Ok(())
 }
 


### PR DESCRIPTION
Cleans up `src/watcher/KEventWatcher.rs` per the Rust-cleanup pass: move guarantees into the type system, no perf regression, no behavior change.

### What changed

**`KEventWatcher.rs` (143 -> 92 lines)**
- `fd: Option<Fd>` + `init(&mut self)` -> `fd: Fd` + `fn new() -> Result<Self>`. The `.expect("KEventWatcher has an invalid file descriptor")` is gone.
- Two `unsafe { c::kevent(...) }` blocks -> the existing safe `bun_sys::kevent` slice wrapper. The file is now `unsafe`-free. As a side effect, a `kevent()` error now propagates to `on_error` via `?` instead of panicking in `usize::try_from(count)`.
- The `.to_vec()` that copied the deduped event slice every cycle (added only to end a borrow before calling `write_trace_events(&self, ...)`) is removed.
- No direct references to `mutex`, `ctx`, `on_file_update`, or `changed_filepaths` remain; those are accessed via the new `dispatch_file_updates` below.

**`Watcher.rs`**
- `Watcher::init` constructs `Platform::new(top_level_dir)?` directly instead of `Platform::default()` + in-place `init()`.
- New `dispatch_file_updates(&mut self, event_count, changed_count)`: lock -> `running.load()` -> trace -> `on_file_update`, using disjoint field borrows so the event slice is passed in place. Every platform backend now calls this instead of open-coding the sequence.
- `add_file_descriptor_to_kqueue_without_checks` uses the safe `bun_sys::kevent` wrapper and `self.platform.fd` (no `.unwrap()`).
- Removed the one-line `write_trace_events` wrapper (only caller was the duplicated dispatch block).

**`INotifyWatcher.rs` / `WindowsWatcher.rs`**
- Both now expose `new()` (Windows keeps its in-place `init` as a private helper since the struct carries a 64 KiB buffer inline).
- Both call `dispatch_file_updates`; the Windows backend's per-cycle `.to_vec()` is gone too.

### Preserved semantics

Event coalescing (the 100 us re-poll when `count < 64`), the dedup/merge pass, and the lock held around `on_file_update` (which `flush_evictions` relies on) are unchanged.

### Not in this PR

The detached-mutex / fn-pointer-ctx shape now lives in exactly one place (`dispatch_file_updates`) rather than three, but `Watcher.mutex` is still a peer field rather than `watchlist: Guarded<WatchList>`. Wrapping it requires restructuring `flush_evictions`, which is reached mid-callback via a raw-pointer detour from `HotReloader::on_file_update` / `DevServer::on_file_update` while the lock is already held; a `Guarded` there would deadlock on the non-recursive mutex. That restructure touches the scopeguard drop ordering that keeps the JS-thread EBADF window closed, so it belongs in its own change.

### Verification

- `cargo check -p bun_watcher` on `aarch64-apple-darwin`, `x86_64-unknown-freebsd`, `x86_64-unknown-linux-gnu`, `aarch64-linux-android`, `x86_64-pc-windows-msvc`
- `cargo clippy -p bun_watcher --no-deps` clean on darwin/freebsd/linux (windows has pre-existing unrelated lints)
- `bun bd test test/cli/hot/hot.test.ts test/cli/watch/watcher-trace.test.ts test/cli/hot/watch.test.ts test/cli/hot/watch-many-dirs.test.ts` all pass on linux (exercises the shared `dispatch_file_updates` path via inotify)