### PR TITLE
shell: helpful error when Response/Blob/ArrayBuffer is interpolated outside a redirect

### DIFF
--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1339,6 +1339,12 @@ impl<'bump> Parser<'bump> {
         let name = match self.parse_atom()? {
             Some(n) => n,
             None => {
+                if self.peek().tag() == TokenTag::JSObjRef {
+                    self.add_error(format_args!(
+                        "Response, Blob, ReadableStream, ArrayBuffer, and TypedArray values can only be used as a redirect in a shell command (e.g. `< ${{value}}` or `> ${{value}}`), not as a command or argument"
+                    ))?;
+                    return Err(ParseError::Expected.into());
+                }
                 if assigns.is_empty() {
                     self.add_error(format_args!(
                         "expected a command or assignment but got: \"{}\"",
@@ -2114,7 +2120,9 @@ impl Token {
             Token::Text(r) => &strpool[r.start as usize..r.end as usize],
             Token::SingleQuotedText(r) => &strpool[r.start as usize..r.end as usize],
             Token::DoubleQuotedText(r) => &strpool[r.start as usize..r.end as usize],
-            Token::JSObjRef(_) => b"JSObjRef",
+            Token::JSObjRef(_) => {
+                b"an interpolated Response, Blob, ReadableStream, ArrayBuffer, or TypedArray"
+            }
             Token::DoubleBracketOpen => b"[[",
             Token::DoubleBracketClose => b"]]",
             Token::Delimit => b"Delimit",

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -1339,12 +1339,6 @@ impl<'bump> Parser<'bump> {
         let name = match self.parse_atom()? {
             Some(n) => n,
             None => {
-                if self.peek().tag() == TokenTag::JSObjRef {
-                    self.add_error(format_args!(
-                        "Response, Blob, ReadableStream, ArrayBuffer, and TypedArray values can only be used as a redirect in a shell command (e.g. `< ${{value}}` or `> ${{value}}`), not as a command or argument"
-                    ))?;
-                    return Err(ParseError::Expected.into());
-                }
                 if assigns.is_empty() {
                     self.add_error(format_args!(
                         "expected a command or assignment but got: \"{}\"",
@@ -1650,6 +1644,12 @@ impl<'bump> Parser<'bump> {
                         ))?;
                         return Err(ParseError::Unexpected.into());
                     }
+                    Token::JSObjRef(_) => {
+                        self.add_error(format_args!(
+                            "Response, Blob, ReadableStream, ArrayBuffer, and TypedArray values can only be used with a redirect operator (`<`, `>`), not as a command name, argument, or assignment value"
+                        ))?;
+                        return Err(ParseError::Expected.into());
+                    }
                     Token::Pipe
                     | Token::DoublePipe
                     | Token::Ampersand
@@ -1661,7 +1661,6 @@ impl<'bump> Parser<'bump> {
                     | Token::Newline
                     | Token::CmdSubstQuoted
                     | Token::CmdSubstEnd
-                    | Token::JSObjRef(_)
                     | Token::Delimit
                     | Token::Eof
                     | Token::DoubleBracketOpen

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -1,3 +1,4 @@
+import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
 import { createTestBuilder, redirect } from "./util";
 const { parse } = shellInternals;
@@ -1057,9 +1058,41 @@ describe("parse shell", () => {
 });
 
 describe("parse shell invalid input", () => {
+  const jsObjRefErr =
+    "Response, Blob, ReadableStream, ArrayBuffer, and TypedArray values can only be used as a redirect in a shell command (e.g. `< ${value}` or `> ${value}`), not as a command or argument";
+
   test("invalid js obj", async () => {
     const file = new Uint8Array(420);
-    await TestBuilder.command`${file} | cat`.error(`expected a command or assignment but got: "JSObjRef"`).run();
+    await TestBuilder.command`${file} | cat`.error(jsObjRefErr).run();
+  });
+
+  describe.each([
+    ["Response", () => new Response("x")],
+    ["Blob", () => new Blob(["x"])],
+    ["ReadableStream", () => new ReadableStream()],
+    ["ArrayBuffer", () => new ArrayBuffer(4)],
+    ["Uint8Array", () => new Uint8Array(4)],
+  ])("%s in non-redirect position", (_, make) => {
+    test("as command", async () => {
+      await TestBuilder.command`${make()}`.error(jsObjRefErr).run();
+    });
+    test("as argument", async () => {
+      await TestBuilder.command`echo ${make()}`.error(jsObjRefErr).run();
+    });
+    test("after assignment", async () => {
+      await TestBuilder.command`FOO=bar ${make()}`.error(jsObjRefErr).run();
+    });
+    test("after pipe", async () => {
+      await TestBuilder.command`echo hi | ${make()}`.error(jsObjRefErr).run();
+    });
+  });
+
+  test("error for interpolated Response/Blob/etc does not leak internal token name", () => {
+    for (const value of [new Response("x"), new Blob(["x"]), new ArrayBuffer(4)]) {
+      expect(() => $`echo ${value}`).toThrow(/can only be used as a redirect/);
+      expect(() => $`echo ${value}`).not.toThrow(/JSObjRef/);
+      expect(() => $`if [[ ${value} == foo ]]; then echo hi; fi`).not.toThrow(/JSObjRef/);
+    }
   });
 
   test("subshell", async () => {

--- a/test/js/bun/shell/parse.test.ts
+++ b/test/js/bun/shell/parse.test.ts
@@ -1059,7 +1059,7 @@ describe("parse shell", () => {
 
 describe("parse shell invalid input", () => {
   const jsObjRefErr =
-    "Response, Blob, ReadableStream, ArrayBuffer, and TypedArray values can only be used as a redirect in a shell command (e.g. `< ${value}` or `> ${value}`), not as a command or argument";
+    "Response, Blob, ReadableStream, ArrayBuffer, and TypedArray values can only be used with a redirect operator (`<`, `>`), not as a command name, argument, or assignment value";
 
   test("invalid js obj", async () => {
     const file = new Uint8Array(420);
@@ -1079,20 +1079,34 @@ describe("parse shell invalid input", () => {
     test("as argument", async () => {
       await TestBuilder.command`echo ${make()}`.error(jsObjRefErr).run();
     });
-    test("after assignment", async () => {
+    test("as assignment value", async () => {
+      await TestBuilder.command`FOO=${make()}`.error(jsObjRefErr).run();
+    });
+    test("glued to assignment value", async () => {
+      await TestBuilder.command`FOO=bar${make()}`.error(jsObjRefErr).run();
+    });
+    test("as command after assignment", async () => {
       await TestBuilder.command`FOO=bar ${make()}`.error(jsObjRefErr).run();
     });
     test("after pipe", async () => {
       await TestBuilder.command`echo hi | ${make()}`.error(jsObjRefErr).run();
     });
-  });
-
-  test("error for interpolated Response/Blob/etc does not leak internal token name", () => {
-    for (const value of [new Response("x"), new Blob(["x"]), new ArrayBuffer(4)]) {
-      expect(() => $`echo ${value}`).toThrow(/can only be used as a redirect/);
-      expect(() => $`echo ${value}`).not.toThrow(/JSObjRef/);
-      expect(() => $`if [[ ${value} == foo ]]; then echo hi; fi`).not.toThrow(/JSObjRef/);
-    }
+    test("as [[ ]] operand", async () => {
+      await TestBuilder.command`if [[ ${make()} == foo ]]; then echo hi; fi`.error(jsObjRefErr).run();
+    });
+    test("as [[ ]] operator", async () => {
+      await TestBuilder.command`if [[ foo ${make()} bar ]]; then echo hi; fi`
+        .error(
+          "Expected a conditional expression operator, but got: an interpolated Response, Blob, ReadableStream, ArrayBuffer, or TypedArray",
+        )
+        .run();
+    });
+    test("does not leak internal token name", () => {
+      expect(() => $`echo ${make()}`).not.toThrow(/JSObjRef/);
+      expect(() => $`FOO=${make()}`).not.toThrow(/JSObjRef/);
+      expect(() => $`if [[ ${make()} == foo ]]; then echo hi; fi`).not.toThrow(/JSObjRef/);
+      expect(() => $`if [[ foo ${make()} bar ]]; then echo hi; fi`).not.toThrow(/JSObjRef/);
+    });
   });
 
   test("subshell", async () => {


### PR DESCRIPTION
## Repro

```js
import { $ } from "bun";
await $`echo ${new Response("x")}`;
// ShellError: expected a command or assignment but got: "JSObjRef"

await $`FOO=${new Blob(["x"])}`;
// ShellError: Expected an atom

await $`if [[ ${new ArrayBuffer(4)} == foo ]]; then echo hi; fi`;
// ShellError: Expected a conditional expression operand, but got: JSObjRef
```

Same for `Blob`, `ReadableStream`, `ArrayBuffer`, and typed arrays. Three different unhelpful messages for what is a single misuse: interpolating a stream/buffer object anywhere that is not the operand of a redirect operator.

## Cause

`handle_template_value` registers these values as a `JSObjRef` token without knowing whether they sit in a redirect or an argument/assignment position; that's decided later by the parser. `parse_atom()` grouped `Token::JSObjRef` in with `Pipe`/`Eof`/etc. and returned `Ok(None)`, so each caller produced its own generic fallthrough:

- `parse_simple_cmd`: printed the raw `TokenTag` variant name (`"JSObjRef"`)
- `parse_assign`: `"Expected an atom"`
- the `[[ ]]` operand path: printed `Token::as_human_readable`, which was also `"JSObjRef"`

## Fix

`parse_atom()` now handles `Token::JSObjRef` in its own match arm and emits a single actionable error listing the accepted types and the valid position. `parse_redirect` consumes a `JSObjRef` via `r#match` before it ever calls `parse_atom`, so valid `< ${value}` / `> ${buffer}` redirects are unaffected.

`Token::as_human_readable` is also updated so the one path that peeks without going through `parse_atom` (the `[[ ]]` operator position, `if self.peek().tag() != Text`) cannot surface the internal name either.

After:

```
Response, Blob, ReadableStream, ArrayBuffer, and TypedArray values can only be
used with a redirect operator (`<`, `>`), not as a command name, argument, or
assignment value
```

The message names the operators rather than giving a full example because `> ${value}` is rejected for `Blob`/`Response` (immutable) and `< ${ReadableStream}` currently panics (pre-existing, see #33996 / #30550). Whether a particular type is valid for a particular direction is validated by the interpreter with its own message; this error is only about grammar position.

## Verification

New cases in `test/js/bun/shell/parse.test.ts` cover Response/Blob/ReadableStream/ArrayBuffer/Uint8Array in eight positions each: command, argument, assignment value (`FOO=${v}`), glued assignment value (`FOO=bar${v}`), command-after-assignment, after-pipe, `[[ ]]` operand, and `[[ ]]` operator, plus a per-type guard that `JSObjRef` never appears in the thrown message. The pre-existing "invalid js obj" test is updated.

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/shell/parse.test.ts -t "parse shell invalid input"
46 fail

$ bun bd test test/js/bun/shell/parse.test.ts
63 pass, 0 fail

$ bun bd test test/js/bun/shell/bunshell.test.ts
414 pass, 0 fail

$ bun bd test test/js/bun/shell/lex.test.ts test/js/bun/shell/bunshell-instance.test.ts test/js/bun/shell/shell-sentinel-hardening.test.ts test/js/bun/shell/shell-seq-condexpr.test.ts
54 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 46 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/parse.test.ts
bun test v1.4.0 (80c639750)

test/js/bun/shell/parse.test.ts:
(pass) parse shell > basic [8.04ms]
(pass) parse shell > basic redirect [5.26ms]
(pass) parse shell > single atom [6.56ms]
Result {"stmts":[{"exprs":[{"cmd":{"assigns":[],"name_and_args":[{"compound":{"atoms":[{"Text":"FOO "},{"Var":"NICE"},{"Text":"!"}],"brace_expansion_hint":false,"glob_hint":false}}],"redirect":{"stdin":false,"stdout":false,"stderr":false,"append":false,"duplicate_out":false,"__unused":0},"redirect_file":null}}]}]}
(pass) parse shell > compound atom [5.63ms]
(pass) parse shell > pipelines [6.02ms]
(pass) parse shell > binary expressions [7.15ms]
(pass) parse shell > precedence [8.93ms]
Result {"stmts":[{"exprs":[{"cmd":{"assigns":[{"label":"FOO","value":{"simple":{"Text":"bar"}}},{"label":"BAR","value":{"simple":{"Text":"baz"}}}],"name_and_args":[{"simple":{"Text":"export"}},{"simple":{"Text":"LMAO=nice"}}],"redirect":{"stdin":false,"stdout":false,"stderr":false,"append":false,"duplicate_out":false,"__unused":0},"redirect_f
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (80c639750)

test/js/bun/shell/parse.test.ts:
(pass) parse shell > basic [0.16ms]
(pass) parse shell > basic redirect [0.09ms]
(pass) parse shell > single atom [0.09ms]
Result {"stmts":[{"exprs":[{"cmd":{"assigns":[],"name_and_args":[{"compound":{"atoms":[{"Text":"FOO "},{"Var":"NICE"},{"Text":"!"}],"brace_expansion_hint":false,"glob_hint":false}}],"redirect":{"stdin":false,"stdout":false,"stderr":false,"append":false,"duplicate_out":false,"__unused":0},"redirect_file":null}}]}]}
(pass) parse shell > compound atom [0.12ms]
(pass) parse shell > pipelines [0.13ms]
(pass) parse shell > binary expressions [0.13ms]
(pass) parse shell > precedence [0.20ms]
Result {"stmts":[{"exprs":[{"cmd":{"assigns":[{"label":"FOO","value":{"simple":{"Text":"bar"}}},{"label":"BAR","value":{"simple":{"Text":"baz"}}}],"name_and_args":[{"simple":{"Text":"export"}},{"simple":{"Text":"LMAO=nice"}}],"redirect":{"stdin":false,"stdout":false,"stderr":false,"append":false,"duplicate_out":false,"__unused":0},"redirect_file":null}}]}]}
(pass) parse shell > assigns [0.11ms]
(pass) parse shell > redirect js obj [0.98ms]
(pass) parse shell > cmd subst [0.12ms]
(pass) parse she
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/parse.test.ts
bun test v1.4.0 (80c639750)

test/js/bun/shell/parse.test.ts:
(pass) parse shell > basic [8.67ms]
(pass) parse shell > basic redirect [5.38ms]
(pass) parse shell > single atom [6.72ms]
Result {"stmts":[{"exprs":[{"cmd":{"assigns":[],"name_and_args":[{"compound":{"atoms":[{"Text":"FOO "},{"Var":"NICE"},{"Text":"!"}],"brace_expansion_hint":false,"glob_hint":false}}],"redirect":{"stdin":false,"stdout":false,"stderr":false,"append":false,"duplicate_out":false,"__unused":0},"redirect_file":null}}]}]}
(pass) parse shell > compound atom [6.16ms]
(pass) parse shell > pipelines [6.44ms]
(pass) parse shell > binary expressions [7.98ms]
(pass) parse shell > precedence [9.69ms]
Result {"stmts":[{"exprs":[{"cmd":{"assigns":[{"label":"FOO","value":{"simple":{"Text":"bar"}}},{"label":"BAR","value":{"simple":{"Text":"baz"}}}],"name_and_args":[{"simple":{"Text":"export"}},{"simple":{"Text":"LMAO=nice"}}],"redirect":{"stdin":false,"stdout":false,"stderr":false,"append":false,"duplicate_out":false,"__unused":0},"redirect_f
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 744ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_shell_parser v0.0.0 (/workspace/bun/src/shell_parser)
[1m[92m   Compiling[0m bun_glob v0.0.0 (/workspace/bun/src/glob)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Compiling[0m bun_api v0.0.0 (/workspace/bun/src/api)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/shell_parser/parse.rs       | 11 +++++++--
 test/js/bun/shell/parse.test.ts | 49 ++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 57 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/shell_parser/parse.rs            7      4      0
test/js/bun/shell/parse.test.ts      4      6      0
```

</details>

<!-- robobun:evidence:end -->