### PR TITLE
ci: link PR builds with the base branch symbol order file

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -784,8 +784,9 @@ const traceOrderTargets = [
  * orderfile/generate.ts` (the traced binary doubles as the interpreter), and
  * uploads the result.
  *
- * Non-PR only — `orderFileEligible()` ignores PR builds, so a trace there has
- * no consumer. Soft-fail: the order file is an optimization, and a broken
+ * Main only (plus `[generate symbol order]` opt-in). PR builds inherit the
+ * base branch's file rather than tracing, so a trace step on every PR would
+ * have no consumer. Soft-fail: the order file is an optimization, and a broken
  * tracer must not fail a build.
  * @param {Target} target
  * @param {Platform} tracePlatform

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -179,8 +179,9 @@ async function main(): Promise<void> {
         if (result.output.exe) verifyOrderFileApplied(result.cfg, orderCtx, result.output.exe);
       }
     } else if (orderFileEligible(result.cfg, orderCtx) && result.output.exe) {
-      // Inherited: a stale file is a slower binary, not a broken one.
-      if (!inherited && !canTraceOrderFile(result.cfg)) reportOrderFileCannotTrace(result.cfg);
+      // Inherited: a stale file is a slower binary, not a broken one. PRs have no
+      // trace-order step to point at, so a failed inherit there is just unordered.
+      if (!inherited && !orderCtx.pullRequest && !canTraceOrderFile(result.cfg)) reportOrderFileCannotTrace(result.cfg);
       verifyOrderFileApplied(result.cfg, orderCtx, result.output.exe, { strict: false });
     }
 

--- a/scripts/build/ci.ts
+++ b/scripts/build/ci.ts
@@ -657,7 +657,8 @@ async function waitForStepOutcome(stepKey: string): Promise<void> {
 //
 // A build either generates one (trace its own binary, relink against the result)
 // or inherits an earlier build's and links once. Releases generate, canaries
-// inherit, PRs do neither; one that inherits nothing generates, seeding the chain.
+// inherit, PRs inherit the base branch's; one that inherits nothing generates,
+// seeding the chain (PRs excepted: they ship unordered rather than pay a relink).
 // ═══════════════════════════════════════════════════════════════════════════
 
 /** Cap on builds we ask for an order file before giving up and generating one. */
@@ -677,7 +678,13 @@ export interface OrderFileContext {
   buildkite: boolean;
   /** Buildkite build URL of the running build, for walking the branch. */
   buildUrl: string | undefined;
-  branch: string | undefined;
+  /**
+   * Branch to pull an earlier `.order` artifact from. Own branch on main,
+   * the PR's base branch on a PR: a PR branch has no prior build to inherit
+   * from, and linking with the base's file is what makes a PR artifact
+   * comparable to the base when someone benchmarks startup.
+   */
+  inheritBranch: string | undefined;
   buildNumber: number | undefined;
   commitMessage: string;
   pullRequest: boolean;
@@ -686,19 +693,22 @@ export interface OrderFileContext {
 /** Read the environment once, at the edge. */
 export function orderFileContext(): OrderFileContext {
   const pr = process.env.BUILDKITE_PULL_REQUEST;
+  const pullRequest = pr !== undefined && pr !== "" && pr !== "false";
   return {
     buildkite: isBuildkite,
     buildUrl: process.env.BUILDKITE_BUILD_URL,
-    branch: process.env.BUILDKITE_BRANCH,
+    inheritBranch: pullRequest
+      ? process.env.BUILDKITE_PULL_REQUEST_BASE_BRANCH || "main"
+      : process.env.BUILDKITE_BRANCH,
     buildNumber: Number(process.env.BUILDKITE_BUILD_NUMBER) || undefined,
     commitMessage: process.env.BUILDKITE_MESSAGE ?? "",
-    pullRequest: pr !== undefined && pr !== "" && pr !== "false",
+    pullRequest,
   };
 }
 
-/** Only builds that link, on targets that use an order file, outside PRs. */
+/** Only builds that link, on targets that use an order file. */
 export function orderFileEligible(cfg: Config, ctx: OrderFileContext): boolean {
-  if (!usesOrderFile(cfg) || !ctx.buildkite || ctx.pullRequest) return false;
+  if (!usesOrderFile(cfg) || !ctx.buildkite) return false;
   return cfg.mode === "full" || cfg.mode === "link-only" || cfg.mode === "rust-and-link";
 }
 
@@ -768,10 +778,13 @@ export function shouldGenerateOrderFile(cfg: Config, ctx: OrderFileContext): boo
 
 /**
  * A build that inherited nothing must generate: otherwise it publishes nothing,
- * the next build inherits nothing either, and the chain never recovers.
+ * the next build inherits nothing either, and the chain never recovers. PRs are
+ * not part of the chain (they inherit from the base branch, not each other), so
+ * a PR that inherits nothing ships unordered rather than pay a second link.
  */
 export function mustGenerateOrderFile(cfg: Config, ctx: OrderFileContext, inherited: boolean): boolean {
   if (shouldGenerateOrderFile(cfg, ctx)) return true;
+  if (ctx.pullRequest) return false;
   return orderFileEligible(cfg, ctx) && canTraceOrderFile(cfg) && !inherited;
 }
 
@@ -781,7 +794,7 @@ export function mustGenerateOrderFile(cfg: Config, ctx: OrderFileContext, inheri
  * there, so the happy path is one lookup.
  */
 async function* candidateBuilds(ctx: OrderFileContext): AsyncGenerator<{ id: string; number?: number }> {
-  const { branch, buildUrl } = ctx;
+  const { inheritBranch: branch, buildUrl } = ctx;
   if (!branch || !buildUrl) return;
 
   // https://buildkite.com/<org>/<pipeline>/builds/<n> -> https://buildkite.com/<org>/<pipeline>
@@ -837,7 +850,7 @@ export async function inheritOrderFile(cfg: Config, ctx: OrderFileContext): Prom
   const start = Date.now();
   const artifact = orderFileArtifact(cfg);
 
-  console.log(`Looking for ${artifact} published by an earlier build on ${ctx.branch}...`);
+  console.log(`Looking for ${artifact} published by an earlier build on ${ctx.inheritBranch}...`);
   const downloaded = resolve(cfg.buildDir, artifact);
   let tried = 0;
 

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -49,7 +49,7 @@ const darwinArm64 = { linux: false, darwin: true, abi: undefined, arm64: true } 
 const ctx = (overrides: Partial<OrderFileContext> = {}): OrderFileContext => ({
   buildkite: true,
   buildUrl: "https://buildkite.com/bun/bun/builds/68425",
-  branch: "main",
+  inheritBranch: "main",
   buildNumber: 68425,
   commitMessage: "some ordinary commit",
   pullRequest: false,
@@ -144,10 +144,14 @@ describe("deciding whether a build generates its own order file", () => {
     expect(shouldGenerateOrderFile(cfg(), ctx({ commitMessage: "perf: x [generate symbol order]" }))).toBe(true);
   });
 
-  it("a pull request never does, and never publishes", () => {
-    const pr = ctx({ pullRequest: true });
-    expect(orderFileEligible(cfg(), pr)).toBe(false);
-    expect(shouldGenerateOrderFile(cfg({ canary: false }), pr)).toBe(false);
+  it("a pull request inherits the base branch's, so its artifact is comparable to main", () => {
+    const pr = ctx({ pullRequest: true, inheritBranch: "main" });
+    expect(orderFileEligible(cfg(), pr)).toBe(true);
+    // Never traces: the commit-message tag is the only opt-in, and a PR that
+    // inherits nothing ships unordered rather than pay a second link. PRs are
+    // not part of the inheritance chain, so there is nothing to seed.
+    expect(shouldGenerateOrderFile(cfg(), pr)).toBe(false);
+    expect(mustGenerateOrderFile(cfg(), pr, true)).toBe(false);
     expect(mustGenerateOrderFile(cfg(), pr, false)).toBe(false);
   });
 

--- a/test/js/bun/perf/linker-order.test.ts
+++ b/test/js/bun/perf/linker-order.test.ts
@@ -147,12 +147,20 @@ describe("deciding whether a build generates its own order file", () => {
   it("a pull request inherits the base branch's, so its artifact is comparable to main", () => {
     const pr = ctx({ pullRequest: true, inheritBranch: "main" });
     expect(orderFileEligible(cfg(), pr)).toBe(true);
-    // Never traces: the commit-message tag is the only opt-in, and a PR that
-    // inherits nothing ships unordered rather than pay a second link. PRs are
-    // not part of the inheritance chain, so there is nothing to seed.
+    // A PR that inherits nothing ships unordered rather than pay a second link:
+    // PRs are not part of the inheritance chain, so there is nothing to seed.
     expect(shouldGenerateOrderFile(cfg(), pr)).toBe(false);
     expect(mustGenerateOrderFile(cfg(), pr, true)).toBe(false);
     expect(mustGenerateOrderFile(cfg(), pr, false)).toBe(false);
+  });
+
+  it("a pull request only traces on explicit opt-in", () => {
+    const pr = ctx({ pullRequest: true, inheritBranch: "main" });
+    // `[release]` on a PR dry-runs the release pipeline, and tracing is part of
+    // that pipeline; `[generate symbol order]` is for testing tracer changes.
+    // Both are deliberate, so the second link they cost is asked for.
+    expect(shouldGenerateOrderFile(cfg({ canary: false }), pr)).toBe(true);
+    expect(shouldGenerateOrderFile(cfg(), ctx({ ...pr, commitMessage: "x [generate symbol order]" }))).toBe(true);
   });
 
   it("a target that cannot run on the host never does", () => {


### PR DESCRIPTION
PR release artifacts were linked without a symbol order file, so `bunx bun-pr` binaries read about 0.7ms slower on startup and ~9MB heavier on maxRSS than a main/release build of the same source. That makes PR-vs-main startup comparisons misleading.

## What changed

`orderFileEligible()` no longer excludes pull requests. On a PR build, `inheritOrderFile()` walks the PR's base branch (from `BUILDKITE_PULL_REQUEST_BASE_BRANCH`, defaulting to `main`) instead of the PR branch, downloads the latest `.order` artifact from there, and the single link pass uses it. This is the same inherit path main canary builds already take, redirected to the base branch.

An ordinary PR never traces or relinks: `mustGenerateOrderFile()` returns false for PRs even when inherit fails, so the worst case is an unordered binary (previous behaviour), and the cross-compiled-lane "cannot trace" annotation is suppressed on PRs. Tracing on a PR remains opt-in only, via `[generate symbol order]` in the commit message (for testing tracer changes) or `[release]` (dry-running the release pipeline, which traces by design).

## Cost

One ~1s artifact download per eligible build lane (linux-x64/aarch64-gnu, darwin-aarch64), before the link. No extra link pass.

## Verification

`test/js/bun/perf/linker-order.test.ts` covers the decision functions; the PR case now asserts `orderFileEligible` is true, `mustGenerateOrderFile` stays false with or without an inherited file, and the two opt-in paths (`canary: false`, `[generate symbol order]`) are documented as tracing.

The inherit step itself is visible in this PR's own build: the `Inherit symbol order file` group in the linux/darwin `build-bun` jobs should log `inherited bun-<target>.order, N functions from #<main-build>`.

Local release builds are unchanged (still unordered unless `bun run orderfile` is run manually); that can be a follow-up if wanted.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->