### PR TITLE
compile_target: make define_values exhaustive over OS/arch/libc

### DIFF
--- a/src/options_types/compile_target.rs
+++ b/src/options_types/compile_target.rs
@@ -402,55 +402,37 @@ impl CompileTarget {
         }
     }
 
-    // Exists for consistentcy with values.
-    pub fn define_keys(&self) -> &'static [&'static [u8]] {
-        &[
+    pub fn define_keys(&self) -> [&'static [u8]; 3] {
+        [
             b"process.platform",
             b"process.arch",
             b"process.versions.bun",
         ]
     }
 
-    pub fn define_values(&self) -> &'static [&'static [u8]] {
-        // Could generate static tables via macro_rules! or
-        // const_format::concatcp! over OperatingSystem::name_string().
-        macro_rules! table {
-            ($platform:literal, $arch:literal) => {{
-                const VALUES: &[&[u8]] = &[
-                    $platform,
-                    $arch,
-                    const_format::concatcp!("\"", bun_core::Global::package_json_version, "\"")
-                        .as_bytes(),
-                ];
-                VALUES
-            }};
-        }
-
-        // Use inline else to avoid extra allocations.
-        match self.arch {
-            Architecture::X64 => match self.libc {
-                // process.platform: Node reports "android" on Android, not "linux".
-                Libc::Android => table!(b"\"android\"", b"\"x64\""),
-                _ => match self.os {
-                    OperatingSystem::Mac => table!(b"\"darwin\"", b"\"x64\""),
-                    OperatingSystem::Linux => table!(b"\"linux\"", b"\"x64\""),
-                    OperatingSystem::Windows => table!(b"\"win32\"", b"\"x64\""),
-                    OperatingSystem::Freebsd => table!(b"\"freebsd\"", b"\"x64\""),
-                    OperatingSystem::Wasm => table!(b"\"wasm\"", b"\"x64\""),
-                },
+    pub fn define_values(&self) -> [&'static [u8]; 3] {
+        // Each axis gets its own exhaustive match so that adding a variant to
+        // `OperatingSystem` / `Architecture` / `Libc` is a compile error here,
+        // not a runtime panic behind a wildcard arm.
+        let platform: &'static [u8] = match self.libc {
+            // process.platform: Node reports "android" on Android, not "linux".
+            Libc::Android => b"\"android\"",
+            Libc::Default | Libc::Musl => match self.os {
+                OperatingSystem::Mac => b"\"darwin\"",
+                OperatingSystem::Linux => b"\"linux\"",
+                OperatingSystem::Windows => b"\"win32\"",
+                OperatingSystem::Freebsd => b"\"freebsd\"",
+                OperatingSystem::Wasm => b"\"wasm\"",
             },
-            Architecture::Arm64 => match self.libc {
-                Libc::Android => table!(b"\"android\"", b"\"arm64\""),
-                _ => match self.os {
-                    OperatingSystem::Mac => table!(b"\"darwin\"", b"\"arm64\""),
-                    OperatingSystem::Linux => table!(b"\"linux\"", b"\"arm64\""),
-                    OperatingSystem::Windows => table!(b"\"win32\"", b"\"arm64\""),
-                    OperatingSystem::Freebsd => table!(b"\"freebsd\"", b"\"arm64\""),
-                    OperatingSystem::Wasm => table!(b"\"wasm\"", b"\"arm64\""),
-                },
-            },
-            _ => panic!("TODO"),
-        }
+        };
+        let arch: &'static [u8] = match self.arch {
+            Architecture::X64 => b"\"x64\"",
+            Architecture::Arm64 => b"\"arm64\"",
+            Architecture::Wasm => b"\"wasm\"",
+        };
+        const VERSION: &[u8] =
+            const_format::concatcp!("\"", bun_core::Global::package_json_version, "\"").as_bytes();
+        [platform, arch, VERSION]
     }
 }
 


### PR DESCRIPTION
## What

`CompileTarget::define_values` in `src/options_types/compile_target.rs` matched over `self.arch` with a trailing `_ => panic!("TODO")` arm. `Architecture` has three variants (`X64`, `Arm64`, `Wasm`); the wildcard swallowed the exhaustiveness check, so adding a new `Architecture` (or `Libc`, via the inner `_`) variant would compile fine and panic at runtime the first time that combination reached this lookup.

## How

Each axis now gets its own exhaustive match:

- `self.libc` (3 arms, `Android` overrides platform to `"android"`)
- `self.os` (5 arms, `name_string()` values)
- `self.arch` (3 arms)

and the three results are composed into a by-value `[&'static [u8]; 3]` instead of selecting from a combinatorial table of `&'static [&'static [u8]]` constants. Both callers (`build_command.rs`, `JSBundler.rs`) only `.iter()`/`.len()`/`zip()` over the result, so the signature change is transparent.

Adding a variant to `OperatingSystem`, `Architecture`, or `Libc` is now a compile error at exactly one match arm instead of a runtime panic. No `panic!("TODO")` or `_ =>` wildcard remains in this file.

Net: 24 insertions, 42 deletions.

## Why no new test

The only input that reached the removed `panic!("TODO")` was `arch == Architecture::Wasm`, and every construction path rejects it before `define_values()` runs:

- CLI: `Arguments.rs` → `CompileTarget::from` → `try_from` returns `ParseError::InvalidTarget` for `arch == Wasm` (compile_target.rs:335), process exits.
- JS API: `compile_target_from_js` → `try_from` (same rejection) → throws `InvalidArguments`.
- `Default::default()` uses `Environment::ARCH`, which is never `Wasm` on a shipping build.

There is no direct struct construction of `CompileTarget` outside `compile_target.rs` itself. So the panic was unreachable from any user-facing surface, and the refactor has no runtime-observable delta: for every reachable `(os, arch, libc)` the function returns byte-identical values to before. The property being added ("new enum variant = compile error") is enforced by `rustc`, not by a runtime test.

Existing coverage of the reachable paths continues to pass:

```
bun bd test test/bundler/bundler_compile.test.ts -t "compile/platform-specific-binary"
  # 2 pass (CLI path via build_command.rs)
bun bd test test/bundler/bundler_compile.test.ts -t "HelloWorldWithProcessVersionsBunAPI"
  # 1 pass (API path via JSBundler.rs)
```
