### PR TITLE
css: propagate custom at-rule block parse errors instead of panicking

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1071,11 +1071,11 @@ pub fn handle_error_return_trace<E>(_err: E) {}
 #[macro_export]
 macro_rules! todo_panic {
     ($($arg:tt)*) => {{
-        // Recorded in the tier-0 `Global::features` counter (same as
-        // css_parser's todo store). `bun_analytics::features::todo_panic` —
-        // the set the crash report serializes via `packed_features()` — is a
-        // re-export of this same static (see `define_features!`'s `core =`
-        // entries in src/analytics/lib.rs), so the bit reaches crash reports.
+        // Recorded in the tier-0 `Global::features` counter.
+        // `bun_analytics::features::todo_panic` — the set the crash report
+        // serializes via `packed_features()` — is a re-export of this same
+        // static (see `define_features!`'s `core =` entries in
+        // src/analytics/lib.rs), so the bit reaches crash reports.
         $crate::Global::features::TODO_PANIC.store(1, ::core::sync::atomic::Ordering::Relaxed);
         $crate::output::panic(::core::format_args!(
             "TODO: {} ({}:{})",

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -207,12 +207,6 @@ pub type CssResult<T> = Maybe<T, ParseError<ParserError>>;
 
 pub type PrintResult<T> = Maybe<T, PrinterError>;
 
-#[cold]
-pub fn todo(msg: &str) -> ! {
-    bun_core::Global::features::TODO_PANIC.store(1, core::sync::atomic::Ordering::Relaxed);
-    panic!("TODO: {msg}");
-}
-
 // ───────────────────────── Derive*-style helpers ─────────────────────────
 //
 // PORTING.md §Comptime reflection: each protocol is a trait
@@ -417,17 +411,18 @@ fn parse_custom_at_rule_body<T: CustomAtRuleParser>(
     at_rule_parser: &mut T,
     is_nested: bool,
 ) -> CssResult<T::AtRule> {
-    let result = match T::parse_block(at_rule_parser, prelude, start, input, options, is_nested) {
-        Ok(vv) => vv,
-        Err(_e) => {
-            // match &err.kind {
-            //   ParseErrorKind::Basic(kind) => ParseError { ... },
-            //   _ => input.new_error(BasicParseErrorKind::at_rule_body_invalid),
-            // }
-            todo("This part here");
-        }
-    };
-    Ok(result)
+    match T::parse_block(at_rule_parser, prelude, start, input, options, is_nested) {
+        Ok(vv) => Ok(vv),
+        Err(e) => Err(match e.kind {
+            errors_::ParserErrorKind::basic(kind) => ParseError {
+                kind: errors_::ParserErrorKind::basic(kind),
+                location: e.location,
+            },
+            errors_::ParserErrorKind::custom(_) => {
+                input.new_error(BasicParseErrorKind::at_rule_body_invalid)
+            }
+        }),
+    }
 }
 
 fn parse_qualified_rule<P: QualifiedRuleParser>(


### PR DESCRIPTION
## What

`parse_custom_at_rule_body` in `src/css/css_parser.rs` called the crate-local `todo()` helper (which does `panic!("TODO: {msg}")`) when `T::parse_block` returned `Err`, instead of returning the error. The intended conversion was sitting commented-out directly above the panic.

This PR routes the error through: a `ParserErrorKind::basic` error is returned as-is with its original location, and a `ParserErrorKind::custom` error is collapsed to `BasicParseErrorKind::at_rule_body_invalid` at the parser's current location. This matches the [lightningcss reference implementation](https://github.com/parcel-bundler/lightningcss/blob/master/src/parser.rs) that the Zig port (and then this Rust port) was derived from.

`todo()` was the only caller of that helper, so the helper itself is removed, along with a stale reference to it in `bun_core::todo_panic!`'s comment.

## Why there is no test

The panic is **not reachable from user CSS input**, so no `.test.ts` can fail-before:

- `AtRulePrelude::Custom` (the only prelude variant that reaches `parse_custom_at_rule_body`) is constructed solely at [`parse_custom_at_rule_prelude`](https://github.com/oven-sh/bun/blob/main/src/css/css_parser.rs#L375), and only when `CustomAtRuleParser::parse_prelude` returns `Ok`.
- Both in-tree implementations, [`DefaultAtRuleParser`](https://github.com/oven-sh/bun/blob/main/src/css/css_parser.rs#L722) and [`BundlerAtRuleParser`](https://github.com/oven-sh/bun/blob/main/src/css/css_parser.rs#L784), unconditionally return `Err(at_rule_invalid)` from `parse_prelude`.
- `StyleSheet::parse_with` is the only generic entry point and is called exclusively with one of those two implementations.
- So every unknown at-rule becomes `AtRulePrelude::Unknown` instead, and `parse_custom_at_rule_body` never runs.

A `#[cfg(test)]` unit test with a stub `CustomAtRuleParser` was also attempted, but `cargo test -p bun_css` cannot link a standalone test binary: constructing a `Parser` requires a `bun_alloc::Arena` (= `MimallocArena`), which references `mi_heap_new` / `mi_heap_destroy` and `__bun_crash_handler_out_of_memory`, none of which are linked outside the full `bun bd` build. There are no existing `#[cfg(test)]` modules in `src/css/` for the same reason.

This was a latent bug that would fire the first time someone adds a `CustomAtRuleParser` whose `parse_prelude` actually returns `Ok`.

## Verification

- `cargo check -p bun_css` and `cargo clippy -p bun_css` pass.
- `bun bd test test/js/bun/css/css.test.ts` passes (1140 tests).
- `bun bd test test/bundler/css/css-modules.test.ts test/js/bun/css/selector-list-error-recovery.test.ts` pass.