### PR TITLE
yaml: replace `TokenScalar.{multiline, is_quoted}` with `ScalarStyle` enum; drop the two `TODO: wrong!` flags

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -1038,8 +1038,7 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
                 if scalar_str.len() == resolved_scalar_len {
                     drop(scalar_str);
                     break 'scalar TokenScalar {
-                        multiline,
-                        is_quoted: false,
+                        style: ScalarStyle::Plain { multiline },
                         data: scalar,
                     };
                 }
@@ -1048,8 +1047,7 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
             }
 
             break 'scalar TokenScalar {
-                multiline,
-                is_quoted: false,
+                style: ScalarStyle::Plain { multiline },
                 data: NodeScalar::String(scalar_str),
             };
         };
@@ -1863,8 +1861,22 @@ pub enum TokenData<Enc: Encoding> {
 #[derive(Clone)]
 pub struct TokenScalar<Enc: Encoding> {
     pub data: NodeScalar<Enc>,
-    pub multiline: bool,
-    pub is_quoted: bool,
+    pub style: ScalarStyle,
+}
+
+/// How a scalar token was written in the source. Only `Plain` carries
+/// `multiline`: the sole reader (`parse_block_indented`'s tag-neutral
+/// rewind) cares exclusively about plain single-line scalars, and the
+/// value has no well-defined meaning for quoted or block styles.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ScalarStyle {
+    /// [131] ns-plain. `multiline` = source text spans more than one line,
+    /// tracked by `ScalarResolverCtx::check_append`.
+    Plain { multiline: bool },
+    /// [170] `|` literal or [174] `>` folded.
+    Block,
+    /// [120] single-quoted or [109] double-quoted.
+    Quoted,
 }
 
 #[derive(Clone, Copy)]
@@ -3545,17 +3557,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     // is now abandoned to the parent, rewind to its start and
                     // re-scan tag-neutral so the sibling key resolves under
                     // the default schema. Only plain single-line scalars are
-                    // tag-resolved at scan time; quoted scalars ignore
+                    // tag-resolved at scan time; quoted/block scalars ignore
                     // ScanOptions.tag (and their token.start is past the
-                    // opening quote, so rewind would be wrong); multiline
+                    // opening indicator, so rewind would be wrong); multiline
                     // plain scalars may have advanced parser state across
                     // lines that a positional rewind cannot fully restore.
                     if value_tag.is_some()
                         && matches!(
                             &self.token.data,
                             TokenData::Scalar(TokenScalar {
-                                is_quoted: false,
-                                multiline: false,
+                                style: ScalarStyle::Plain { multiline: false },
                                 ..
                             })
                         )
@@ -4096,7 +4107,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         _ => unreachable!("token.data was Scalar at match guard"),
                     };
 
-                    let json_key = if scalar.is_quoted {
+                    let json_key = if scalar.style == ScalarStyle::Quoted {
                         self.maybe_set_json_key(opts.flow_pair_allowed)?
                     } else {
                         false
@@ -4810,8 +4821,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     line: self.line,
                     resolved: TokenScalar {
                         data: NodeScalar::String(YamlString::List(self.text)),
-                        multiline: true,
-                        is_quoted: false,
+                        style: ScalarStyle::Block,
                     },
                 }))
             }
@@ -5193,9 +5203,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         indent: scalar_indent,
                         line: scalar_line,
                         resolved: TokenScalar {
-                            // TODO: wrong!
-                            multiline: self.line != scalar_line,
-                            is_quoted: true,
+                            style: ScalarStyle::Quoted,
                             data: NodeScalar::String(YamlString::List(text)),
                         },
                     }));
@@ -5271,9 +5279,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         indent: scalar_indent,
                         line: scalar_line,
                         resolved: TokenScalar {
-                            // TODO: wrong!
-                            multiline: self.line != scalar_line,
-                            is_quoted: true,
+                            style: ScalarStyle::Quoted,
                             data: NodeScalar::String(YamlString::List(text)),
                         },
                     }));

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -1305,6 +1305,36 @@ folded: >
           // ScanOptions.tag doesn't affect their resolution anyway.
           expect(YAML.parse('a: !!str\n"b": c\n')).toEqual({ a: "", b: "c" });
           expect(YAML.parse("a: !!str\n'b': c\n")).toEqual({ a: "", b: "c" });
+          // Same for a seq entry; the tag resolves e-scalar and the quoted
+          // sibling is not re-scanned.
+          expect(YAML.parse('- !!str\n- "123"\n')).toEqual(["", "123"]);
+          expect(YAML.parse("- !!str\n- '123'\n")).toEqual(["", "123"]);
+          // A quoted scalar that *is* content (indent > n) takes the tag as-is.
+          expect(YAML.parse('a:\n  !!str\n  "0xFF"\n')).toEqual({ a: "0xFF" });
+          expect(YAML.parse("a:\n  !!str\n  '0xFF'\n")).toEqual({ a: "0xFF" });
+          // Block scalar at parent indent after a tag: tag resolves e-scalar
+          // (`|` at indent 0 cannot be [197] flow-in-block content for `a:`).
+          expect(() => YAML.parse("a: !!str\n|\n text\n")).toThrow("Unexpected token");
+        });
+
+        test("multi-line quoted scalars fold line breaks per [120]/[109]", () => {
+          // Line folding: a single break becomes a space, an extra break
+          // becomes a literal newline, and `\\<break>` in double-quoted is a
+          // line continuation (no space). These are the inputs the old
+          // `multiline` computation keyed on; the resolved value is the only
+          // observable.
+          expect(YAML.parse('a: "one\n  two"\n')).toEqual({ a: "one two" });
+          expect(YAML.parse("a: 'one\n  two'\n")).toEqual({ a: "one two" });
+          expect(YAML.parse('a: "one\n\n  two"\n')).toEqual({ a: "one\ntwo" });
+          expect(YAML.parse('a: "one\\\n  two"\n')).toEqual({ a: "onetwo" });
+          expect(YAML.parse('a:\n  "one\n   two"\nb: y\n')).toEqual({ a: "one two", b: "y" });
+          expect(YAML.parse("a:\n  'one\n   two'\nb: y\n")).toEqual({ a: "one two", b: "y" });
+          // Same folding applies in flow context.
+          expect(YAML.parse('["a\n b", c]\n')).toEqual(["a b", "c"]);
+          expect(YAML.parse('{"a\n b": 1}\n')).toEqual({ "a b": 1 });
+          // A multi-line quoted scalar used as an implicit block-map key is
+          // still a [154] violation, regardless of how the value folds.
+          expect(() => YAML.parse('a: !!str\n"b\n c": x\n')).toThrow("Multiline implicit key");
         });
 
         test("tag does not leak to abandoned sibling key", () => {


### PR DESCRIPTION
## What

`scan_single_quoted_scalar` and `scan_double_quoted_scalar` each built a `TokenScalar` with

```rust
// TODO: wrong!
multiline: self.line != scalar_line,
```

The flag is dead for quoted scalars. This PR deletes the dead state from the type by replacing the `(multiline: bool, is_quoted: bool)` pair on `TokenScalar` with

```rust
enum ScalarStyle {
    Plain { multiline: bool },
    Block,
    Quoted,
}
```

so `Quoted` simply has no `multiline` field to get wrong. Both `TODO: wrong!` markers are removed.

## Trace (why it is dead)

`TokenScalar.multiline` is read at exactly one site, the tag-neutral rewind in `parse_block_indented`:

```rust
if value_tag.is_some()
    && matches!(
        &self.token.data,
        TokenData::Scalar(TokenScalar {
            is_quoted: false,
            multiline: false,
            ..
        })
    )
```

That pattern already requires `is_quoted: false`; quoted scalars always set `is_quoted: true`, so whatever they write to `multiline` is unreachable. The only other field consumer is `parse_node`'s `if scalar.is_quoted { maybe_set_json_key(..) }`, which does not look at `multiline` at all.

This matches the original Zig author's own note (commented-out in the first `Bun.YAML` commit) that the sole intended `scalar.multiline` check should be, and was, replaced by `scalar_line != self.token.line`.

## Mutation check

Forcing both quoted-scalar sites to `multiline: true` and then to `multiline: false`, rebuilding, and running `test/js/bun/yaml/{yaml,yaml-test-suite,yaml-block-scalar-matrix}.test.ts` produces identical results in all three cases (2111 pass / 0 fail / 21 todo; yaml-test-suite 402/402). No input changes behavior via `Bun.YAML.parse`.

## Change

| site | before | after |
| --- | --- | --- |
| `ScalarResolverCtx::done` (plain) | `multiline, is_quoted: false` | `Plain { multiline }` |
| `parse_block_indented` rewind | `is_quoted: false, multiline: false` | `Plain { multiline: false }` |
| `parse_node` JSON-key check | `scalar.is_quoted` | `scalar.style == Quoted` |
| block `\|`/`>` done | `multiline: true, is_quoted: false` | `Block` |
| single-quoted done | `// TODO: wrong!` + both bools | `Quoted` |
| double-quoted done | `// TODO: wrong!` + both bools | `Quoted` |

Behavior is unchanged; this is a type-level refactor that makes the unread state unrepresentable.