### PR TITLE
inspector: bump WebKit so Runtime.evaluate survives validateExceptionChecks

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -10,7 +10,10 @@
 // Windows ICU data table filtered + per-item zstd compressed, and Windows
 // unwind info (RtlAddGrowableFunctionTable) registered for the fixed JIT
 // pool (LLInt pending offlineasm .seh_* emission).
-export const WEBKIT_VERSION = "a40d462206e1caf8388062120acde61e37a4ae7d";
+// Preview of oven-sh/WebKit#328: RELEASE_AND_RETURN on the inspector
+// injected-script prototype host functions so Runtime.evaluate survives
+// validateExceptionChecks=1.
+export const WEBKIT_VERSION = "autobuild-preview-pr-328-31913c3e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isPosix, randomPort, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isDebug, isPosix, randomPort, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -298,6 +298,71 @@ describe("websocket", () => {
   afterEach(() => {
     inspectee?.kill();
   });
+});
+
+// JSInjectedScriptHostPrototype / JSJavaScriptCallFramePrototype host functions declare a
+// ThrowScope and then tail-call into an impl that declares its own; without a
+// RELEASE_AND_RETURN the first Runtime.evaluate aborts under exception-check validation with
+// "Unchecked JS exception ... jsInjectedScriptHostPrototypeFunctionEvaluateWithScopeExtension".
+// validateExceptionChecks is compiled out of release builds, so this is debug-only.
+test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation", async () => {
+  await using child = spawn({
+    cwd: import.meta.dir,
+    cmd: [bunExe(), "--inspect-wait=127.0.0.1:0", "inspectee.js"],
+    env: {
+      ...bunEnv,
+      BUN_JSC_validateExceptionChecks: "1",
+      BUN_JSC_dumpSimulatedThrows: "1",
+    },
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  const decoder = new TextDecoder();
+  const { promise: urlPromise, resolve: resolveUrl } = Promise.withResolvers<URL>();
+  const drained = (async () => {
+    for await (const chunk of child.stderr) {
+      stderr += decoder.decode(chunk);
+      for (const line of stderr.split("\n")) {
+        try {
+          const u = new URL(line.trim());
+          if (u.protocol.includes("ws")) resolveUrl(u);
+        } catch {}
+      }
+    }
+  })();
+
+  const url = await urlPromise;
+  const ws = new WebSocket(url);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
+    });
+
+    ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
+    const reply = await new Promise<unknown>(resolve => {
+      ws.addEventListener("message", ({ data }) => resolve(JSON.parse(String(data))));
+      ws.addEventListener("close", ({ code, reason }) => resolve({ closed: { code, reason } }));
+    });
+
+    // Without the WebKit-side fix, the inspected process aborts with SIGABRT
+    // ("Unchecked JS exception") before replying, so the socket closes 1006
+    // and this assertion sees { closed: { code: 1006, ... } } instead.
+    expect(reply).toMatchObject({
+      id: 1,
+      result: { result: { type: "number", value: 2 } },
+    });
+  } finally {
+    ws.close();
+    child.kill();
+  }
+
+  await Promise.all([child.exited, drained]);
+  if (child.signalCode === "SIGABRT") {
+    throw new Error("inspectee aborted under validateExceptionChecks:\n" + stderr);
+  }
 });
 
 describe("http metadata endpoint", () => {

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -320,7 +320,7 @@ test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation
 
   let stderr = "";
   const decoder = new TextDecoder();
-  const { promise: urlPromise, resolve: resolveUrl } = Promise.withResolvers<URL>();
+  const { promise: urlPromise, resolve: resolveUrl, reject: rejectUrl } = Promise.withResolvers<URL>();
   const drained = (async () => {
     for await (const chunk of child.stderr) {
       stderr += decoder.decode(chunk);
@@ -331,10 +331,12 @@ test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation
         } catch {}
       }
     }
+    rejectUrl(new Error("inspectee exited before printing inspector URL:\n" + stderr));
   })();
 
   const url = await urlPromise;
   const ws = new WebSocket(url);
+  let reply: unknown;
   try {
     await new Promise<void>((resolve, reject) => {
       ws.addEventListener("open", () => resolve());
@@ -342,17 +344,9 @@ test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation
     });
 
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
-    const reply = await new Promise<unknown>(resolve => {
+    reply = await new Promise<unknown>(resolve => {
       ws.addEventListener("message", ({ data }) => resolve(JSON.parse(String(data))));
       ws.addEventListener("close", ({ code, reason }) => resolve({ closed: { code, reason } }));
-    });
-
-    // Without the WebKit-side fix, the inspected process aborts with SIGABRT
-    // ("Unchecked JS exception") before replying, so the socket closes 1006
-    // and this assertion sees { closed: { code: 1006, ... } } instead.
-    expect(reply).toMatchObject({
-      id: 1,
-      result: { result: { type: "number", value: 2 } },
     });
   } finally {
     ws.close();
@@ -360,9 +354,17 @@ test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation
   }
 
   await Promise.all([child.exited, drained]);
+  // Without the WebKit-side fix the inspectee SIGABRTs ("Unchecked JS exception")
+  // before replying, so the socket closes 1006 and reply is { closed: { code: 1006, ... } }.
   if (child.signalCode === "SIGABRT") {
-    throw new Error("inspectee aborted under validateExceptionChecks:\n" + stderr);
+    throw new Error(
+      `inspectee aborted under validateExceptionChecks (reply=${JSON.stringify(reply)}):\n${stderr}`,
+    );
   }
+  expect(reply).toMatchObject({
+    id: 1,
+    result: { result: { type: "number", value: 2 } },
+  });
 });
 
 describe("http metadata endpoint", () => {

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -1,7 +1,7 @@
 import { Subprocess, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isDebug, isPosix, randomPort, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isPosix, randomPort, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 import stripAnsi from "strip-ansi";
 import { WebSocket } from "ws";
@@ -304,8 +304,9 @@ describe("websocket", () => {
 // ThrowScope and then tail-call into an impl that declares its own; without a
 // RELEASE_AND_RETURN the first Runtime.evaluate aborts under exception-check validation with
 // "Unchecked JS exception ... jsInjectedScriptHostPrototypeFunctionEvaluateWithScopeExtension".
-// validateExceptionChecks is compiled out of release builds, so this is debug-only.
-test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation", async () => {
+// ENABLE_EXCEPTION_SCOPE_VERIFICATION is (ASSERT_ENABLED || ASAN_ENABLED), so this runs on
+// debug and asan builds; plain release compiles it out.
+test.skipIf(!isDebug && !isASAN)("Runtime.evaluate does not trip exception-check validation", async () => {
   await using child = spawn({
     cwd: import.meta.dir,
     cmd: [bunExe(), "--inspect-wait=127.0.0.1:0", "inspectee.js"],
@@ -344,9 +345,10 @@ test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation
     });
 
     ws.send(JSON.stringify({ id: 1, method: "Runtime.evaluate", params: { expression: "1 + 1" } }));
-    reply = await new Promise<unknown>(resolve => {
+    reply = await new Promise<unknown>((resolve, reject) => {
       ws.addEventListener("message", ({ data }) => resolve(JSON.parse(String(data))));
       ws.addEventListener("close", ({ code, reason }) => resolve({ closed: { code, reason } }));
+      ws.addEventListener("error", cause => reject(new Error("WebSocket error", { cause })));
     });
   } finally {
     ws.close();

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -357,9 +357,7 @@ test.skipIf(!isDebug)("Runtime.evaluate does not trip exception-check validation
   // Without the WebKit-side fix the inspectee SIGABRTs ("Unchecked JS exception")
   // before replying, so the socket closes 1006 and reply is { closed: { code: 1006, ... } }.
   if (child.signalCode === "SIGABRT") {
-    throw new Error(
-      `inspectee aborted under validateExceptionChecks (reply=${JSON.stringify(reply)}):\n${stderr}`,
-    );
+    throw new Error(`inspectee aborted under validateExceptionChecks (reply=${JSON.stringify(reply)}):\n${stderr}`);
   }
   expect(reply).toMatchObject({
     id: 1,

--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -81,7 +81,6 @@ test/js/bun/spawn/spawn-maxbuf.test.ts [ FLAKY ]
 
 # Tests timed out due to ASAN
 [ ASAN ] test/js/bun/spawn/spawn.test.ts [ TIMEOUT ]
-[ ASAN ] test/cli/inspect/inspect.test.ts [ TIMEOUT ]
 
 # Tests failed due to memory leaks
 [ ASAN ] test/js/node/url/pathToFileURL.test.ts [ LEAK ] # pathToFileURL doesn't leak memory

--- a/test/internal/source-lints/webkit-prebuilt-url.test.ts
+++ b/test/internal/source-lints/webkit-prebuilt-url.test.ts
@@ -123,4 +123,11 @@ describe("WebKit prebuilt URL", () => {
   test("WEBKIT_VERSION is either a 40-hex sha or an autobuild-* tag", () => {
     expect(/^[0-9a-f]{40}$/.test(WEBKIT_VERSION) || WEBKIT_VERSION.startsWith("autobuild-")).toBe(true);
   });
+
+  // autobuild-preview-pr-* releases are deleted when the oven-sh/WebKit PR
+  // merges or closes, which would 404 every fresh build of main. Preview pins
+  // are fine on a branch while iterating; this test is the merge gate.
+  test("WEBKIT_VERSION is not an autobuild-preview-* tag (preview releases are deleted on upstream merge)", () => {
+    expect(WEBKIT_VERSION.startsWith("autobuild-preview-")).toBe(false);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Any `Runtime.evaluate` (or `Debugger.evaluateOnCallFrame`) over an inspector connection aborts the inspected process under `BUN_JSC_validateExceptionChecks=1`:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: evaluateWithScopeExtension @ JSInjectedScriptHost.cpp:120
        (ExceptionScope::m_recursionDepth was 6)
    But the exception was unchecked as of this scope: jsInjectedScriptHostPrototypeFunctionEvaluateWithScopeExtension @ JSInjectedScriptHostPrototype.cpp:275
        (ExceptionScope::m_recursionDepth was 5)
```

This was surfaced by #31823, which currently exempts its `inspector.open()` fixture from exception-check validation on ASAN to work around it. It is also why `test/cli/inspect/inspect.test.ts` has been quarantined on ASAN since ASAN CI was enabled: its `describe("websocket")` tests spawn inspectees with `bunEnv` (which inherits the runner's `BUN_JSC_validateExceptionChecks=1`) and send `Runtime.evaluate`, the inspectee SIGABRTs before replying, and the file times out.

### Cause

Every host function in `JSInjectedScriptHostPrototype.cpp` and `JSJavaScriptCallFramePrototype.cpp` declares a `ThrowScope` for the `dynamicDowncast` type error and then tail-calls into a `JSInjectedScriptHost` / `JSJavaScriptCallFrame` member. Thirteen of those members declare their own `ThrowScope` (`evaluateWithScopeExtension`, `getInternalProperties`, `iteratorEntries`, `queryInstances`, `queryHolders`, `weakMapEntries`, `weakSetEntries`, `getOwnPrivatePropertySymbols`, `getOwnPrivatePropertyMethods`, `isPromiseRejectedWithNativeGetterTypeError`, and `JSJavaScriptCallFrame`'s `evaluateWithScopeExtension` / `scopeDescriptions` / `scopeChain`). The outer scope is never released before the inner one is created, so exception-scope validation trips on the first call. The same code is present in upstream WebKit.

### Fix

[oven-sh/WebKit#328](https://github.com/oven-sh/WebKit/pull/328) wraps all 31 `return JSValue::encode(castedThis->...)` sites in both files in `RELEASE_AND_RETURN(scope, ...)`. This PR:

- bumps `WEBKIT_VERSION` to that change's preview build;
- removes `[ ASAN ] test/cli/inspect/inspect.test.ts [ TIMEOUT ]` from `test/expectations.txt`, so the existing websocket tests exercise `Runtime.evaluate` under the ambient `validateExceptionChecks` flag on the ASAN lane again;
- adds an explicit regression test to `test/cli/inspect/inspect.test.ts` that spawns an inspectee with `BUN_JSC_validateExceptionChecks=1`, sends `Runtime.evaluate`, and asserts the reply arrives (gated on `isDebug || isASAN`, since `ENABLE_EXCEPTION_SCOPE_VERIFICATION` is `ASSERT_ENABLED || ASAN_ENABLED`);
- adds a source-lint test in `test/internal/source-lints/webkit-prebuilt-url.test.ts` that fails when `WEBKIT_VERSION` is an `autobuild-preview-*` tag, so a preview pin cannot be merged to `main` by accident.

### Verification

With the current `WEBKIT_VERSION` (`a40d462206…`, debug build) the new test fails because the inspectee SIGABRTs before replying and the WebSocket closes 1006:

<details><summary>fail-before (debug build, current WebKit)</summary>

```console
$ ./build/debug/bun-debug test test/cli/inspect/inspect.test.ts -t "does not trip exception-check validation"
bun test v1.4.0 (1498d7b77)

test/cli/inspect/inspect.test.ts:
error: inspectee aborted under validateExceptionChecks (reply={"closed":{"code":1006,"reason":"Connection ended"}}):
--------------------- Bun Inspector ---------------------
Listening:
  ws://127.0.0.1:40947/86d01a62-a396-4012-9272-836477a8e715
--------------------- Bun Inspector ---------------------
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: evaluateWithScopeExtension @ vendor/WebKit/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:120
        (ExceptionScope::m_recursionDepth was 6)
    But the exception was unchecked as of this scope: jsInjectedScriptHostPrototypeFunctionEvaluateWithScopeExtension @ vendor/WebKit/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp:275
        (ExceptionScope::m_recursionDepth was 5)
ASSERTION FAILED: exception check validation failed
(fail) Runtime.evaluate does not trip exception-check validation [1437.59ms]
```

</details>

### Merge gate

`WEBKIT_VERSION` is currently pinned to `autobuild-preview-pr-328-31913c3e` so CI can exercise the fix before oven-sh/WebKit#328 merges. Preview releases are deleted when the upstream PR closes, so **before merging this PR**, oven-sh/WebKit#328 must be merged first and `WEBKIT_VERSION` here swapped to the resulting 40-hex `main` sha. The new `webkit-prebuilt-url.test.ts` lint test fails until that swap is made, so CI enforces this.

The preview build also includes `81ea8578e5` (oven-sh/WebKit#324, the `Date.parse` Unicode-whitespace fold), which sits between the current pin and oven-sh/WebKit `main`.

The fix lives in `scripts/build/deps/webkit.ts` (not `src/`), so a `src/`-stashing fail-before check sees the new WebKit in both arms; the fail-before evidence above is against a build with the current pin.
