### PR TITLE
bun:test: defer the AsyncContextFrame wrap past .length/.bind() for tests and hooks

### DIFF
--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -188,11 +188,7 @@ pub(crate) fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> Js
         ParseArgumentsCfg { callback: callback_mode, kind: FunctionKind::TestOrDescribe },
     )?;
 
-    let callback_length: usize = if let Some(callback) = args.callback {
-        callback.get_length(global)? as usize
-    } else {
-        0
-    };
+    let callback_length: usize = args.callback_length as usize;
 
     if !this.each.is_empty() {
         if this.each.is_undefined_or_null() || !this.each.is_array() {
@@ -521,6 +517,10 @@ fn error_in_ci(global: &JSGlobalObject, signature: &[u8]) -> JsResult<()> {
 pub struct ParseArgumentsResult {
     pub description: Option<Vec<u8>>,
     pub callback: Option<JSValue>,
+    /// `.length` of the original callback, read before any `AsyncContextFrame`
+    /// wrapping. `callback` may be the wrapper (which has no `.length`), so
+    /// callers must read arity from here, not from `callback.get_length()`.
+    pub callback_length: u64,
     pub options: ParseArgumentsOptions,
 }
 
@@ -665,18 +665,24 @@ pub fn parse_arguments(
     };
     let (description, callback, options) = (items.description, items.callback, items.options);
 
-    let result_callback: Option<JSValue> = if cfg.callback != CallbackMode::Require && callback.is_undefined_or_null() {
-        None
-    } else if callback.is_function() {
-        Some(callback.with_async_context_if_needed(global))
-    } else {
-        let ordinal = if cfg.kind == FunctionKind::Hook { "first" } else { "second" };
-        return Err(global.throw(format_args!("{} expects a function as the {} argument", signature, ordinal)));
-    };
+    let (result_callback, callback_length): (Option<JSValue>, u64) =
+        if cfg.callback != CallbackMode::Require && callback.is_undefined_or_null() {
+            (None, 0)
+        } else if callback.is_function() {
+            // Read `.length` from the user's function before wrapping it in an
+            // `AsyncContextFrame`: the wrapper has no `.length` and callers
+            // would otherwise misread the arity (done-callback detection).
+            let length = callback.get_length(global)?;
+            (Some(callback.with_async_context_if_needed(global)), length)
+        } else {
+            let ordinal = if cfg.kind == FunctionKind::Hook { "first" } else { "second" };
+            return Err(global.throw(format_args!("{} expects a function as the {} argument", signature, ordinal)));
+        };
 
     let mut result = ParseArgumentsResult {
         description: None,
         callback: result_callback,
+        callback_length,
         options: ParseArgumentsOptions::default(),
     };
     // `result` cleanup handled by Drop on early return.

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -188,7 +188,11 @@ pub(crate) fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> Js
         ParseArgumentsCfg { callback: callback_mode, kind: FunctionKind::TestOrDescribe },
     )?;
 
-    let callback_length: usize = args.callback_length as usize;
+    let callback_length: usize = if let Some(callback) = args.callback {
+        callback.get_length(global)? as usize
+    } else {
+        0
+    };
 
     if !this.each.is_empty() {
         if this.each.is_undefined_or_null() || !this.each.is_array() {
@@ -325,6 +329,12 @@ impl ScopeFunctions {
         line_no: u32,
     ) -> JsResult<()> {
         let _g = group_log::begin();
+
+        // Snapshot any active AsyncLocalStorage context now that the caller has
+        // finished reading `.length` / `.bind()` from the bare function. This
+        // runs synchronously inside the user's `als.run(...)` body, so the
+        // captured frame is the same one `parse_arguments` would have seen.
+        let callback = callback.map(|cb| cb.with_async_context_if_needed(global));
 
         // only allow in collection phase
         match bun_test.phase {
@@ -516,11 +526,10 @@ fn error_in_ci(global: &JSGlobalObject, signature: &[u8]) -> JsResult<()> {
 
 pub struct ParseArgumentsResult {
     pub description: Option<Vec<u8>>,
+    /// The user's callback as passed. Callers read `.length` (done-callback
+    /// detection) and `.bind()` (test.each) from it, then wrap via
+    /// `with_async_context_if_needed` at the storage point.
     pub callback: Option<JSValue>,
-    /// `.length` of the original callback, read before any `AsyncContextFrame`
-    /// wrapping. `callback` may be the wrapper (which has no `.length`), so
-    /// callers must read arity from here, not from `callback.get_length()`.
-    pub callback_length: u64,
     pub options: ParseArgumentsOptions,
 }
 
@@ -665,24 +674,18 @@ pub fn parse_arguments(
     };
     let (description, callback, options) = (items.description, items.callback, items.options);
 
-    let (result_callback, callback_length): (Option<JSValue>, u64) =
-        if cfg.callback != CallbackMode::Require && callback.is_undefined_or_null() {
-            (None, 0)
-        } else if callback.is_function() {
-            // Read `.length` from the user's function before wrapping it in an
-            // `AsyncContextFrame`: the wrapper has no `.length` and callers
-            // would otherwise misread the arity (done-callback detection).
-            let length = callback.get_length(global)?;
-            (Some(callback.with_async_context_if_needed(global)), length)
-        } else {
-            let ordinal = if cfg.kind == FunctionKind::Hook { "first" } else { "second" };
-            return Err(global.throw(format_args!("{} expects a function as the {} argument", signature, ordinal)));
-        };
+    let result_callback: Option<JSValue> = if cfg.callback != CallbackMode::Require && callback.is_undefined_or_null() {
+        None
+    } else if callback.is_function() {
+        Some(callback)
+    } else {
+        let ordinal = if cfg.kind == FunctionKind::Hook { "first" } else { "second" };
+        return Err(global.throw(format_args!("{} expects a function as the {} argument", signature, ordinal)));
+    };
 
     let mut result = ParseArgumentsResult {
         description: None,
         callback: result_callback,
-        callback_length,
         options: ParseArgumentsOptions::default(),
     };
     // `result` cleanup handled by Drop on early return.

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -180,11 +180,7 @@ pub mod js_fns {
                 ScopeFunctions::ParseArgumentsCfg { callback: ScopeFunctions::CallbackMode::Require, kind: ScopeFunctions::FunctionKind::Hook },
             )?;
 
-            let has_done_parameter = if let Some(callback) = args.callback {
-                callback.get_length(global_this)? > 0
-            } else {
-                false
-            };
+            let has_done_parameter = args.callback.is_some() && args.callback_length > 0;
 
             let bun_test_root = get_active_test_root(
                 global_this,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -180,7 +180,19 @@ pub mod js_fns {
                 ScopeFunctions::ParseArgumentsCfg { callback: ScopeFunctions::CallbackMode::Require, kind: ScopeFunctions::FunctionKind::Hook },
             )?;
 
-            let has_done_parameter = args.callback.is_some() && args.callback_length > 0;
+            let has_done_parameter = if let Some(callback) = args.callback {
+                callback.get_length(global_this)? > 0
+            } else {
+                false
+            };
+
+            // Snapshot any active AsyncLocalStorage context now that `.length`
+            // has been read from the bare function (an AsyncContextFrame has no
+            // `.length`). Still synchronous inside the user's `als.run(...)`
+            // body, so the captured frame is the one the caller expects.
+            let callback = args
+                .callback
+                .map(|cb| cb.with_async_context_if_needed(global_this));
 
             let bun_test_root = get_active_test_root(
                 global_this,
@@ -204,7 +216,7 @@ pub mod js_fns {
 
                 let _ = bun_test_root.hook_scope.append_hook(
                     tag.as_hook_tag().unwrap(),
-                    args.callback,
+                    callback,
                     cfg,
                     BaseScopeCfg::default(),
                     AddedInPhase::Preload,
@@ -222,7 +234,7 @@ pub mod js_fns {
                     }
                     let _ = bun_test.collection.active_scope_mut().append_hook(
                         tag.as_hook_tag().unwrap(),
-                        args.callback,
+                        callback,
                         cfg,
                         BaseScopeCfg::default(),
                         AddedInPhase::Collection,
@@ -295,7 +307,7 @@ pub mod js_fns {
 
                     let new_item = ExecutionEntry::create(
                         None,
-                        args.callback,
+                        callback,
                         cfg,
                         None,
                         BaseScopeCfg::default(),

--- a/test/js/bun/test/als-hook-arity.fixture.ts
+++ b/test/js/bun/test/als-hook-arity.fixture.ts
@@ -1,0 +1,71 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+// When a test or hook is registered while an AsyncLocalStorage context is
+// active, bun:test wraps the callback in an AsyncContextFrame so the context
+// is restored at call time. Done-param detection must read the arity of the
+// *user* function, not the wrapper (which has no `.length`), otherwise every
+// zero-arg callback waits for a done() that never comes and times out.
+
+const als = new AsyncLocalStorage<{ tag: string }>();
+const order: string[] = [];
+
+describe("registered inside an active ALS context", () => {
+  als.run({ tag: "collection" }, () => {
+    beforeAll(function zeroArg() {
+      order.push("beforeAll");
+    });
+    beforeEach(function zeroArg() {
+      order.push("beforeEach");
+    });
+    afterEach(function zeroArg() {
+      order.push("afterEach");
+    });
+    afterAll(function zeroArg() {
+      order.push("afterAll");
+    });
+    afterAll(function withDone(done) {
+      order.push("afterAll-done");
+      setImmediate(done);
+    });
+
+    test("zero-arg test", function zeroArg() {
+      order.push("zero-arg test");
+      expect(als.getStore()?.tag).toBe("collection");
+    });
+
+    test("one-arg test still receives done", function withDone(done) {
+      order.push("done test");
+      expect(typeof done).toBe("function");
+      expect(als.getStore()?.tag).toBe("collection");
+      setImmediate(done);
+    });
+
+    describe("nested describe", function zeroArg() {
+      afterAll(function zeroArg() {
+        order.push("nested.afterAll");
+      });
+      test("passes", function zeroArg() {
+        order.push("nested.test");
+      });
+    });
+  });
+});
+
+test("hooks and tests registered inside an ALS context use the callback's real arity", () => {
+  expect(order).toEqual([
+    "beforeAll",
+    "beforeEach",
+    "zero-arg test",
+    "afterEach",
+    "beforeEach",
+    "done test",
+    "afterEach",
+    "beforeEach",
+    "nested.test",
+    "afterEach",
+    "nested.afterAll",
+    "afterAll",
+    "afterAll-done",
+  ]);
+});

--- a/test/js/bun/test/als-hook-arity.fixture.ts
+++ b/test/js/bun/test/als-hook-arity.fixture.ts
@@ -3,9 +3,9 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 // When a test or hook is registered while an AsyncLocalStorage context is
 // active, bun:test wraps the callback in an AsyncContextFrame so the context
-// is restored at call time. Done-param detection must read the arity of the
-// *user* function, not the wrapper (which has no `.length`), otherwise every
-// zero-arg callback waits for a done() that never comes and times out.
+// is restored at call time. The wrapper has no `.length` and is not itself
+// callable via JSC::getCallData, so `.length` (done-param detection) and
+// `.bind()` (test.each) must be read from the user's function before wrapping.
 
 const als = new AsyncLocalStorage<{ tag: string }>();
 const order: string[] = [];
@@ -41,6 +41,11 @@ describe("registered inside an active ALS context", () => {
       setImmediate(done);
     });
 
+    test.each([[1], [2]])("each %p", function withArg(n) {
+      order.push(`each ${n}`);
+      expect(als.getStore()?.tag).toBe("collection");
+    });
+
     describe("nested describe", function zeroArg() {
       afterAll(function zeroArg() {
         order.push("nested.afterAll");
@@ -60,6 +65,12 @@ test("hooks and tests registered inside an ALS context use the callback's real a
     "afterEach",
     "beforeEach",
     "done test",
+    "afterEach",
+    "beforeEach",
+    "each 1",
+    "afterEach",
+    "beforeEach",
+    "each 2",
     "afterEach",
     "beforeEach",
     "nested.test",

--- a/test/js/bun/test/als-hook-arity.fixture.ts
+++ b/test/js/bun/test/als-hook-arity.fixture.ts
@@ -9,74 +9,75 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 const als = new AsyncLocalStorage<{ tag: string }>();
 const order: string[] = [];
+const mark = (label: string) => order.push(`${label}:${als.getStore()?.tag ?? "none"}`);
 
 describe("registered inside an active ALS context", () => {
-  als.run({ tag: "collection" }, () => {
+  als.run({ tag: "ctx" }, () => {
     beforeAll(function zeroArg() {
-      order.push("beforeAll");
+      mark("beforeAll");
     });
     beforeEach(function zeroArg() {
-      order.push("beforeEach");
+      mark("beforeEach");
     });
     afterEach(function zeroArg() {
-      order.push("afterEach");
+      mark("afterEach");
     });
     afterAll(function zeroArg() {
-      order.push("afterAll");
+      mark("afterAll");
     });
     afterAll(function withDone(done) {
-      order.push("afterAll-done");
+      mark("afterAll-done");
       setImmediate(done);
     });
 
     test("zero-arg test", function zeroArg() {
-      order.push("zero-arg test");
-      expect(als.getStore()?.tag).toBe("collection");
+      mark("zero-arg test");
     });
 
     test("one-arg test still receives done", function withDone(done) {
-      order.push("done test");
+      mark("done test");
       expect(typeof done).toBe("function");
-      expect(als.getStore()?.tag).toBe("collection");
       setImmediate(done);
     });
 
     test.each([[1], [2]])("each %p", function withArg(n) {
-      order.push(`each ${n}`);
-      expect(als.getStore()?.tag).toBe("collection");
+      mark(`each ${n}`);
     });
 
     describe("nested describe", function zeroArg() {
+      mark("nested.body");
       afterAll(function zeroArg() {
-        order.push("nested.afterAll");
+        mark("nested.afterAll");
       });
       test("passes", function zeroArg() {
-        order.push("nested.test");
+        mark("nested.test");
       });
     });
   });
 });
 
-test("hooks and tests registered inside an ALS context use the callback's real arity", () => {
+test("hooks and tests registered inside an ALS context use the callback's real arity and restore the context", () => {
+  // Every entry ran inside the restored `{ tag: "ctx" }` store, in order.
   expect(order).toEqual([
-    "beforeAll",
-    "beforeEach",
-    "zero-arg test",
-    "afterEach",
-    "beforeEach",
-    "done test",
-    "afterEach",
-    "beforeEach",
-    "each 1",
-    "afterEach",
-    "beforeEach",
-    "each 2",
-    "afterEach",
-    "beforeEach",
-    "nested.test",
-    "afterEach",
-    "nested.afterAll",
-    "afterAll",
-    "afterAll-done",
+    "nested.body:ctx",
+    "beforeAll:ctx",
+    "beforeEach:ctx",
+    "zero-arg test:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "done test:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "each 1:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "each 2:ctx",
+    "afterEach:ctx",
+    "beforeEach:ctx",
+    "nested.test:ctx",
+    "afterEach:ctx",
+    "nested.afterAll:ctx",
+    "afterAll:ctx",
+    "afterAll-done:ctx",
   ]);
 });

--- a/test/js/bun/test/als-hook-arity.test.ts
+++ b/test/js/bun/test/als-hook-arity.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import path from "node:path";
+
+// Registering a zero-arg test() or hook inside an active AsyncLocalStorage
+// context used to be treated as taking a done callback (the AsyncContextFrame
+// wrapper has no `.length`), so the callback would wait for done() and time
+// out. Run the fixture with a short per-test timeout so the unfixed build
+// fails fast rather than sitting on the 5s default for each entry.
+test("tests and hooks registered inside an AsyncLocalStorage context detect done-callback arity correctly", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--timeout=500", path.join(import.meta.dir, "als-hook-arity.fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+    "test/js/bun/test/als-hook-arity.fixture.ts:
+    (pass) registered inside an active ALS context > zero-arg test
+    (pass) registered inside an active ALS context > one-arg test still receives done
+    (pass) registered inside an active ALS context > nested describe > passes
+    (pass) hooks and tests registered inside an ALS context use the callback's real arity
+
+     4 pass
+     0 fail
+     4 expect() calls
+    Ran 4 tests across 1 file."
+  `);
+  expect(stdout).not.toContain("timed out");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/als-hook-arity.test.ts
+++ b/test/js/bun/test/als-hook-arity.test.ts
@@ -5,8 +5,9 @@ import path from "node:path";
 // Registering a zero-arg test() or hook inside an active AsyncLocalStorage
 // context used to be treated as taking a done callback (the AsyncContextFrame
 // wrapper has no `.length`), so the callback would wait for done() and time
-// out. Run the fixture with a short per-test timeout so the unfixed build
-// fails fast rather than sitting on the 5s default for each entry.
+// out; test.each() threw "bind() called on non-callable" on the same wrapper.
+// Run the fixture with a short per-test timeout so the unfixed build fails
+// fast rather than sitting on the 5s default for each entry.
 test("tests and hooks registered inside an AsyncLocalStorage context detect done-callback arity correctly", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--timeout=500", path.join(import.meta.dir, "als-hook-arity.fixture.ts")],
@@ -21,14 +22,16 @@ test("tests and hooks registered inside an AsyncLocalStorage context detect done
     "test/js/bun/test/als-hook-arity.fixture.ts:
     (pass) registered inside an active ALS context > zero-arg test
     (pass) registered inside an active ALS context > one-arg test still receives done
+    (pass) registered inside an active ALS context > each 1
+    (pass) registered inside an active ALS context > each 2
     (pass) registered inside an active ALS context > nested describe > passes
     (pass) hooks and tests registered inside an ALS context use the callback's real arity
 
-     4 pass
+     6 pass
      0 fail
-     4 expect() calls
-    Ran 4 tests across 1 file."
+     6 expect() calls
+    Ran 6 tests across 1 file."
   `);
-  expect(stdout).not.toContain("timed out");
+  expect(stdout).toStartWith("bun test ");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/als-hook-arity.test.ts
+++ b/test/js/bun/test/als-hook-arity.test.ts
@@ -25,11 +25,11 @@ test("tests and hooks registered inside an AsyncLocalStorage context detect done
     (pass) registered inside an active ALS context > each 1
     (pass) registered inside an active ALS context > each 2
     (pass) registered inside an active ALS context > nested describe > passes
-    (pass) hooks and tests registered inside an ALS context use the callback's real arity
+    (pass) hooks and tests registered inside an ALS context use the callback's real arity and restore the context
 
      6 pass
      0 fail
-     6 expect() calls
+     2 expect() calls
     Ran 6 tests across 1 file."
   `);
   expect(stdout).toStartWith("bun test ");


### PR DESCRIPTION
## What

Registering a zero-arg `test()` or hook (`beforeAll`/`afterAll`/`beforeEach`/`afterEach`) while an `AsyncLocalStorage` context is active makes bun:test wait for a `done()` callback that was never declared, so the entry times out (or, on Windows before #34478, hangs the file). `test.each()` in the same context throws `TypeError: bind() called on non-callable`:

```js
const { test } = require("bun:test");
const { AsyncLocalStorage } = require("node:async_hooks");
const als = new AsyncLocalStorage();

als.run({}, () => {
  test("passes instantly", () => {});
  test.each([[1], [2]])("n=%p", n => {});
});
```

```
(fail) passes instantly [5000.01ms]
  ^ this test timed out after 5000ms, before its done callback was called. If a done callback was not intended, remove the last parameter from the test callback function
TypeError: bind() called on non-callable
```

## Why

`parse_arguments()` wrapped the callback with `with_async_context_if_needed()` so the captured ALS context is restored when the callback runs. An `AsyncContextFrame` has no `.length` (so `JSC__JSValue__getLengthIfPropertyExistsInternal` falls through to `infinity`, which `get_length()` clamps to `(1<<51)-1`, and `has_done_parameter` is always true) and is not itself callable via `JSC::getCallData` (so `Bun__JSValue__bind` rejects it).

## Fix

Move the `with_async_context_if_needed()` call out of `parse_arguments()` and into the two storage points: `enqueue_describe_or_test_callback()` (after `.length` is read and, for `test.each`, after `.bind()`) and `generic_hook_impl()` (after `.length` is read). Both run synchronously inside the user's `als.run(...)` body, so the captured context frame is the same one `parse_arguments()` would have seen.

Found while investigating a Windows-only hang in #34515's `node:test` run-child mode, where `describe()` wrappers register the suite-completion `afterAll` from inside `AsyncLocalStorage.run()`; that PR's workaround of making the hook take an explicit `done` parameter is no longer needed with this fix.

## Verification

```
bun bd test test/js/bun/test/als-hook-arity.test.ts
```

Passes on linux-x64 and windows-x64. Fails on the released bun with `hook timed out before its done callback was called` (hooks/test) and `bind() called on non-callable` (test.each).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/als-hook-arity.test.ts
bun test v1.4.0 (ea0889bd9)

test/js/bun/test/als-hook-arity.test.ts:
16 |     stderr: "pipe",
17 |   });
18 | 
19 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
20 | 
21 |   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "test/js/bun/test/als-hook-arity.fixture.ts:
- (pass) registered inside an active ALS context > zero-arg test
- (pass) registered inside an active ALS context > one-arg test still receives done
- (pass) registered inside an active ALS context > each 1
- (pass) registered inside an active ALS context > each 2
- (pass) registered inside an active ALS context > nested describe > passes
- (pass) hooks and tests registered inside an ALS context use the callback's real arity and restore the context
  
-  6 pass
-  0 fail
-  2 expect() calls
- Ran 6 tests across 1 file."
- 
+ # Unhandled error between
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/als-hook-arity.test.ts:
16 |     stderr: "pipe",
17 |   });
18 | 
19 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
20 | 
21 |   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "test/js/bun/test/als-hook-arity.fixture.ts:
- (pass) registered inside an active ALS context  zero-arg test
- (pass) registered inside an active ALS context  one-arg test still receives done
- (pass) registered inside an active ALS context  each 1
- (pass) registered inside an active ALS context  each 2
- (pass) registered inside an active ALS context  nested describe  passes
- (pass) hooks and tests registered inside an ALS context use the callback's real arity and restore the context
  
-  6 pass
-  0 fail
-  2 expect() calls
- Ran 6 tests across 1 file."
- 
+ # Unhandled error between tests
+ -------------------------------
+ 38 |       mark("done test");
+ 39 |       expect(typeof done).toBe("function");
+ 40 |       setImmediate(done);
+ 41 |     })
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/als-hook-arity.test.ts
bun test v1.4.0 (ea0889bd9)

test/js/bun/test/als-hook-arity.test.ts:
(pass) tests and hooks registered inside an AsyncLocalStorage context detect done-callback arity correctly [2101.24ms]

 1 pass
 0 fail
 1 snapshots, 3 expect() calls
Ran 1 test across 1 file. [4.12s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ea0889bd94
  features     baseline

22 deps, 108 codegen, 1170 objects in 1168ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [17.00ms]
[2/1233] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [6.00ms]
[3/1233] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1233] gen bindgenv2
[5/1233] gen ErrorCode+*.h
[6/1233] fetch zlib
[zlib] up to date
[7/1233] fetch tinycc
[tinycc] up to date
[8/1233] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[9/1233] fetch picohttpparser
[picohttpparser] up to date
[10/1233] gen .bind.ts → GeneratedBindings.cpp
[11/1233] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/ScopeFunctions.rs  | 11 +++-
 src/runtime/test_runner/bun_test.rs        | 14 +++--
 test/js/bun/test/als-hook-arity.fixture.ts | 83 ++++++++++++++++++++++++++++++
 test/js/bun/test/als-hook-arity.test.ts    | 37 +++++++++++++
 4 files changed, 141 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/test_runner/ScopeFunctions.rs       7      8      0
src/runtime/test_runner/bun_test.rs            12      8      0
test/js/bun/test/als-hook-arity.fixture.ts      1      4      0
test/js/bun/test/als-hook-arity.test.ts         4      4      0
```

</details>

<!-- robobun:evidence:end -->