### PR TITLE
Bun.serve: treat empty header values as absent so auto Content-Type/Date are not duplicated

### DIFF
--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -143,11 +143,7 @@ impl FetchHeaders {
         value: &BunString,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
-        // `fast_get` returns None for a zero-length value, so an empty entry is
-        // treated as absent and overwritten with the default (`Response.json`'s
-        // `application/json`, StaticRoute's was-string `text/plain`). `fast_has`
-        // would leave the empty value in place.
-        if self.fast_get(name_).is_some() {
+        if self.fast_has(name_) {
             return Ok(());
         }
 

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -143,7 +143,11 @@ impl FetchHeaders {
         value: &BunString,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
-        if self.fast_has(name_) {
+        // `fast_get` returns None for a zero-length value, so an empty entry is
+        // treated as absent and overwritten with the default (`Response.json`'s
+        // `application/json`, StaticRoute's was-string `text/plain`). `fast_has`
+        // would leave the empty value in place.
+        if self.fast_get(name_).is_some() {
             return Ok(());
         }
 

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -778,7 +778,9 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     auto& internalHeaders = headers.internalHeaders();
 
     for (auto& value : internalHeaders.getSetCookieHeaders()) {
-
+        if (value.isEmpty()) {
+            continue;
+        }
         if (value.is8Bit()) {
             const auto valueSpan = value.span8();
             res->writeHeader(std::string_view("set-cookie", 10), std::string_view(reinterpret_cast<const char*>(valueSpan.data()), valueSpan.size()));
@@ -1534,6 +1536,9 @@ static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::H
     };
 
     for (auto& value : internalHeaders.getSetCookieHeaders()) {
+        if (value.isEmpty()) {
+            continue;
+        }
         if (value.is8Bit()) {
             const auto s = value.span8();
             res->writeHeader(std::string_view("set-cookie", 10), std::string_view(reinterpret_cast<const char*>(s.data()), s.size()));

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -852,7 +852,9 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     for (auto& header : internalHeaders.uncommonHeaders()) {
         const auto& name = header.key;
         const auto& value = header.value;
-
+        if (value.isEmpty()) {
+            continue;
+        }
         writeResponseHeader<isSSL>(res, name, value);
     }
 }
@@ -1560,6 +1562,9 @@ static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::H
     }
 
     for (auto& header : internalHeaders.uncommonHeaders()) {
+        if (header.value.isEmpty()) {
+            continue;
+        }
         writeOne(header.key, header.value);
     }
 }

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -795,6 +795,15 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
         const auto& name = WebCore::httpHeaderNameString(header.key);
         const auto& value = header.value;
 
+        // FetchHeaders strips leading/trailing HTTP whitespace, so an empty value here
+        // covers `""` and whitespace-only. Treat it as absent: don't write the line and
+        // don't set the wrote-this-header state bits, so the matching auto-header (Date,
+        // Content-Type from render_metadata) is emitted exactly once instead of alongside
+        // an empty duplicate.
+        if (value.isEmpty()) {
+            continue;
+        }
+
         // We have to tell uWS not to automatically insert a TransferEncoding or Date header.
         // Otherwise, you get this when using Fastify;
         //
@@ -1533,6 +1542,9 @@ static void writeFetchHeadersToH3Response(WebCore::FetchHeaders& headers, uWS::H
     }
 
     for (const auto& header : internalHeaders.commonHeaders()) {
+        if (header.value.isEmpty()) {
+            continue;
+        }
         if (header.key == WebCore::HTTPHeaderName::ContentLength) {
             if (!(data->state & uWS::Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER)) {
                 data->state |= uWS::Http3ResponseData::HTTP_WROTE_CONTENT_LENGTH_HEADER;

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -120,10 +120,10 @@ impl FileRoute {
         bun_core::heap::into_raw(Box::new(FileRoute {
             ref_count: Cell::new(1),
             server: Cell::new(opts.server),
-            has_last_modified_header: headers.get(b"last-modified").is_some(),
-            has_content_length_header: headers.get(b"content-length").is_some(),
-            has_content_range_header: headers.get(b"content-range").is_some(),
-            has_date_header: headers.get(b"date").is_some(),
+            has_last_modified_header: headers.get(b"last-modified").is_some_and(|v| !v.is_empty()),
+            has_content_length_header: headers.get(b"content-length").is_some_and(|v| !v.is_empty()),
+            has_content_range_header: headers.get(b"content-range").is_some_and(|v| !v.is_empty()),
+            has_date_header: headers.get(b"date").is_some_and(|v| !v.is_empty()),
             blob,
             headers,
             status_code: opts.status_code,
@@ -180,10 +180,10 @@ impl FileRoute {
                 return Ok(Some(bun_core::heap::into_raw(Box::new(FileRoute {
                     ref_count: Cell::new(1),
                     server: Cell::new(None),
-                    has_last_modified_header: headers.get(b"last-modified").is_some(),
-                    has_content_length_header: headers.get(b"content-length").is_some(),
-                    has_content_range_header: headers.get(b"content-range").is_some(),
-                    has_date_header: headers.get(b"date").is_some(),
+                    has_last_modified_header: headers.get(b"last-modified").is_some_and(|v| !v.is_empty()),
+                    has_content_length_header: headers.get(b"content-length").is_some_and(|v| !v.is_empty()),
+                    has_content_range_header: headers.get(b"content-range").is_some_and(|v| !v.is_empty()),
+                    has_date_header: headers.get(b"date").is_some_and(|v| !v.is_empty()),
                     blob,
                     headers,
                     status_code,
@@ -230,6 +230,9 @@ impl FileRoute {
             AnyResponse::SSL(s) => {
                 let s = bun_opaque::opaque_deref_mut(s);
                 for (name, value) in names.iter().zip(values) {
+                    if value.length == 0 {
+                        continue;
+                    }
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
                 }
                 if let Some(srv) = self.server.get() {
@@ -241,6 +244,9 @@ impl FileRoute {
             AnyResponse::TCP(s) => {
                 let s = bun_opaque::opaque_deref_mut(s);
                 for (name, value) in names.iter().zip(values) {
+                    if value.length == 0 {
+                        continue;
+                    }
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
                 }
                 if let Some(srv) = self.server.get() {
@@ -252,6 +258,9 @@ impl FileRoute {
             AnyResponse::H3(s) => {
                 let s = bun_opaque::opaque_deref_mut(s);
                 for (name, value) in names.iter().zip(values) {
+                    if value.length == 0 {
+                        continue;
+                    }
                     s.write_header(sp_slice(*name, buf), sp_slice(*value, buf));
                 }
                 // tag == .H3 → no alt-svc header

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -121,7 +121,9 @@ impl FileRoute {
             ref_count: Cell::new(1),
             server: Cell::new(opts.server),
             has_last_modified_header: headers.get(b"last-modified").is_some_and(|v| !v.is_empty()),
-            has_content_length_header: headers.get(b"content-length").is_some_and(|v| !v.is_empty()),
+            has_content_length_header: headers
+                .get(b"content-length")
+                .is_some_and(|v| !v.is_empty()),
             has_content_range_header: headers.get(b"content-range").is_some_and(|v| !v.is_empty()),
             has_date_header: headers.get(b"date").is_some_and(|v| !v.is_empty()),
             blob,
@@ -180,9 +182,15 @@ impl FileRoute {
                 return Ok(Some(bun_core::heap::into_raw(Box::new(FileRoute {
                     ref_count: Cell::new(1),
                     server: Cell::new(None),
-                    has_last_modified_header: headers.get(b"last-modified").is_some_and(|v| !v.is_empty()),
-                    has_content_length_header: headers.get(b"content-length").is_some_and(|v| !v.is_empty()),
-                    has_content_range_header: headers.get(b"content-range").is_some_and(|v| !v.is_empty()),
+                    has_last_modified_header: headers
+                        .get(b"last-modified")
+                        .is_some_and(|v| !v.is_empty()),
+                    has_content_length_header: headers
+                        .get(b"content-length")
+                        .is_some_and(|v| !v.is_empty()),
+                    has_content_range_header: headers
+                        .get(b"content-range")
+                        .is_some_and(|v| !v.is_empty()),
                     has_date_header: headers.get(b"date").is_some_and(|v| !v.is_empty()),
                     blob,
                     headers,

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1831,7 +1831,7 @@ where
         let user_handles_range = if let Some(r) = self.response_weakref.get() {
             r.status_code() != 200
                 || r.get_init_headers_mut()
-                    .map(|h| h.fast_has(jsc::HTTPHeaderName::ContentRange))
+                    .map(|h| h.fast_get(jsc::HTTPHeaderName::ContentRange).is_some())
                     .unwrap_or(false)
         } else {
             false
@@ -3630,8 +3630,12 @@ where
         let mut has_content_disposition = false;
         let mut has_content_range = false;
         if let Some(mut headers_) = response.swap_init_headers() {
-            has_content_disposition = headers_.fast_has(jsc::HTTPHeaderName::ContentDisposition);
-            has_content_range = headers_.fast_has(jsc::HTTPHeaderName::ContentRange);
+            has_content_disposition = headers_
+                .fast_get(jsc::HTTPHeaderName::ContentDisposition)
+                .is_some();
+            has_content_range = headers_
+                .fast_get(jsc::HTTPHeaderName::ContentRange)
+                .is_some();
             // For .slice()-driven ranges, only promote to 206 if the user
             // also set Content-Range (preserves the old contract). For an
             // incoming Range: header (sendfile.total > 0) we always 206.

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -102,7 +102,7 @@ impl StaticRoute {
         }
 
         let cached_blob_size = blob.size();
-        let has_date = headers.get(b"date").is_some();
+        let has_date = headers.get(b"date").is_some_and(|v| !v.is_empty());
         bun_core::heap::into_raw(Box::new(StaticRoute {
             ref_count: Cell::new(1),
             blob,
@@ -244,7 +244,7 @@ impl StaticRoute {
             }
 
             let cached_blob_size = blob.size();
-            let has_date = headers.get(b"date").is_some();
+            let has_date = headers.get(b"date").is_some_and(|v| !v.is_empty());
             return Ok(Some(bun_core::heap::into_raw(Box::new(StaticRoute {
                 ref_count: Cell::new(1),
                 blob,
@@ -494,6 +494,9 @@ impl StaticRoute {
 
         debug_assert_eq!(names.len(), values.len());
         for (name, value) in names.iter().zip(values) {
+            if value.length == 0 {
+                continue;
+            }
             resp.write_header(
                 &buf[name.offset as usize..][..name.length as usize],
                 &buf[value.offset as usize..][..value.length as usize],

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -95,7 +95,7 @@ impl StaticRoute {
         }
 
         // Generate ETag if not already present
-        if headers.get(b"etag").is_none_or(|v| v.is_empty()) {
+        if headers.get(b"etag").is_none() {
             if !blob.slice().is_empty() {
                 append_etag(blob.slice(), &mut headers);
             }
@@ -244,7 +244,7 @@ impl StaticRoute {
             );
 
             // Generate ETag if not already present
-            if headers.get(b"etag").is_none_or(|v| v.is_empty()) {
+            if headers.get(b"etag").is_none() {
                 if !blob.slice().is_empty() {
                     append_etag(blob.slice(), &mut headers);
                 }

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -95,7 +95,7 @@ impl StaticRoute {
         }
 
         // Generate ETag if not already present
-        if headers.get(b"etag").is_none() {
+        if headers.get(b"etag").is_none_or(|v| v.is_empty()) {
             if !blob.slice().is_empty() {
                 append_etag(blob.slice(), &mut headers);
             }
@@ -222,13 +222,20 @@ impl StaticRoute {
             // Consuming the body left a plain `Blob` behind, which no longer implies
             // the `text/plain` a string body carried. Record it on the response's own
             // headers so re-registering the same `Response` serves the same type.
+            // `fast_get` (unlike `put_default`'s `fast_has`) treats an empty value as
+            // absent, so an explicit `content-type: ""` is overwritten here — a
+            // Bun-specific choice for the `static:` route API, not at Fetch-spec
+            // construction time.
             if was_string {
-                let text_mime = bun_http_types::MimeType::TEXT;
-                response.get_or_create_headers(global_this)?.put_default(
-                    HTTPHeaderName::ContentType,
-                    &bun_core::String::ascii(text_mime.value.as_ref()),
-                    global_this,
-                )?;
+                let h = response.get_or_create_headers(global_this)?;
+                if h.fast_get(HTTPHeaderName::ContentType).is_none() {
+                    let text_mime = bun_http_types::MimeType::TEXT;
+                    h.put(
+                        HTTPHeaderName::ContentType,
+                        &bun_core::String::ascii(text_mime.value.as_ref()),
+                        global_this,
+                    )?;
+                }
             }
 
             let mut headers: Headers = bun_http_jsc::headers_jsc::from_fetch_headers(
@@ -237,7 +244,7 @@ impl StaticRoute {
             );
 
             // Generate ETag if not already present
-            if headers.get(b"etag").is_none() {
+            if headers.get(b"etag").is_none_or(|v| v.is_empty()) {
                 if !blob.slice().is_empty() {
                     append_etag(blob.slice(), &mut headers);
                 }

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -146,10 +146,14 @@ describe("empty header value does not duplicate auto-headers", () => {
     expect(lines(head, "date")).toEqual(["Date: Sun, 06 Oct 2024 13:37:01 GMT"]);
   });
 
-  test("uncommon header with empty value is unaffected", async () => {
-    const head = await rawHead(() => new Response("x", { headers: { "x-custom": "", "content-type": "text/html" } }));
-    expect(lines(head, "x-custom")).toEqual(["x-custom: "]);
-    expect(lines(head, "content-type")).toEqual(["Content-Type: text/html"]);
+  test("empty custom header is dropped on both paths", async () => {
+    for (const head of [
+      await rawHead(() => new Response("x", { headers: { "x-custom": "", "content-type": "text/html" } })),
+      await rawHeadStatic(new Response("x", { headers: { "x-custom": "", "content-type": "text/html" } })),
+    ]) {
+      expect(lines(head, "x-custom")).toEqual([]);
+      expect(lines(head, "content-type")).toEqual(["Content-Type: text/html"]);
+    }
   });
 });
 

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -2,6 +2,94 @@ import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import * as net from "node:net";
 
+// An empty (or whitespace-only) header value must be treated as absent for the
+// well-known headers Bun fills in automatically, so the response head carries
+// exactly one Content-Type and exactly one Date (RFC 9110 forbids duplicate
+// Content-Type; an origin server MUST send a valid Date).
+describe("empty header value does not duplicate auto-headers", () => {
+  async function rawHead(makeResponse: () => Response): Promise<string> {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      development: false,
+      fetch: makeResponse,
+    });
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+      let raw = "";
+      await new Promise<void>(resolve => {
+        socket.on("data", c => (raw += c.toString("latin1")));
+        socket.on("close", resolve);
+      });
+      return raw.split("\r\n\r\n")[0];
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  const lines = (head: string, name: string) => head.split("\r\n").filter(l => l.toLowerCase().startsWith(name + ":"));
+
+  for (const [label, value] of [
+    ["empty", ""],
+    ["whitespace", "  \t "],
+  ] as const) {
+    test(`content-type: ${label}`, async () => {
+      const head = await rawHead(() => new Response("x", { headers: { "content-type": value } }));
+      const ct = lines(head, "content-type");
+      expect(ct).toHaveLength(1);
+      expect(ct[0].toLowerCase()).toBe("content-type: text/plain;charset=utf-8");
+    });
+
+    test(`date: ${label}`, async () => {
+      const head = await rawHead(() => new Response("x", { headers: { date: value } }));
+      const date = lines(head, "date");
+      expect(date).toHaveLength(1);
+      // auto Date is a valid IMF-fixdate, never an empty value
+      expect(date[0]).toMatch(/^Date: \S/);
+      expect(Number.isFinite(new Date(date[0].slice(6)).getTime())).toBe(true);
+    });
+  }
+
+  test("headers.set('content-type', '')", async () => {
+    const head = await rawHead(() => {
+      const r = new Response("x");
+      r.headers.set("content-type", "");
+      return r;
+    });
+    const ct = lines(head, "content-type");
+    expect(ct).toHaveLength(1);
+    expect(ct[0].toLowerCase()).toBe("content-type: text/plain;charset=utf-8");
+  });
+
+  test("Response.json with empty content-type", async () => {
+    const head = await rawHead(() => Response.json({ a: 1 }, { headers: { "content-type": "" } }));
+    expect(lines(head, "content-type")).toHaveLength(1);
+  });
+
+  test("both empty at once: one of each", async () => {
+    const head = await rawHead(() => new Response("x", { headers: { "content-type": "", "date": "" } }));
+    expect(lines(head, "content-type")).toHaveLength(1);
+    expect(lines(head, "date")).toHaveLength(1);
+  });
+
+  test("non-empty user values are still preserved", async () => {
+    const head = await rawHead(
+      () => new Response("x", { headers: { "content-type": "text/html", "date": "Sun, 06 Oct 2024 13:37:01 GMT" } }),
+    );
+    expect(lines(head, "content-type")).toEqual(["Content-Type: text/html"]);
+    expect(lines(head, "date")).toEqual(["Date: Sun, 06 Oct 2024 13:37:01 GMT"]);
+  });
+
+  test("uncommon header with empty value is unaffected", async () => {
+    const head = await rawHead(() => new Response("x", { headers: { "x-custom": "", "content-type": "text/html" } }));
+    expect(lines(head, "x-custom")).toEqual(["x-custom: "]);
+    expect(lines(head, "content-type")).toEqual(["Content-Type: text/html"]);
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {
   using server = Bun.serve({

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -71,10 +71,15 @@ describe("empty header value does not duplicate auto-headers", () => {
   });
 
   test("Response.json with empty content-type", async () => {
+    // The Fetch spec's "initialize a response" gates the default Content-Type on
+    // "header list contains" (key presence), so the Response object keeps the
+    // empty value; the wire serializer drops it and backfills from the body.
+    const r = Response.json({ a: 1 }, { headers: { "content-type": "" } });
+    expect(r.headers.get("content-type")).toBe("");
     const head = await rawHead(() => Response.json({ a: 1 }, { headers: { "content-type": "" } }));
     const ct = lines(head, "content-type");
     expect(ct).toHaveLength(1);
-    expect(ct[0].toLowerCase()).toBe("content-type: application/json;charset=utf-8");
+    expect(ct[0]).toMatch(/^content-type: \S/i);
   });
 
   test("both empty at once: one of each", async () => {
@@ -154,6 +159,22 @@ describe("empty header value does not duplicate auto-headers", () => {
       expect(lines(head, "x-custom")).toEqual([]);
       expect(lines(head, "content-type")).toEqual(["Content-Type: text/html"]);
     }
+  });
+
+  test("empty set-cookie is dropped on both paths", async () => {
+    for (const head of [
+      await rawHead(() => new Response("x", { headers: { "set-cookie": "" } })),
+      await rawHeadStatic(new Response("x", { headers: { "set-cookie": "" } })),
+    ]) {
+      expect(lines(head, "set-cookie")).toEqual([]);
+    }
+  });
+
+  test("static route: empty etag gets the auto content-hash", async () => {
+    const head = await rawHeadStatic(new Response("x", { headers: { etag: "" } }));
+    const etag = lines(head, "etag");
+    expect(etag).toHaveLength(1);
+    expect(etag[0]).toMatch(/^etag: "\S/);
   });
 });
 

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -170,11 +170,12 @@ describe("empty header value does not duplicate auto-headers", () => {
     }
   });
 
-  test("static route: empty etag gets the auto content-hash", async () => {
+  test("static route: empty etag is dropped", async () => {
+    // An empty user etag is not overwritten with the auto content-hash (that
+    // would leave two snapshot entries and render_precondition reads the first),
+    // so the write-loop skip drops it and the route simply has no ETag.
     const head = await rawHeadStatic(new Response("x", { headers: { etag: "" } }));
-    const etag = lines(head, "etag");
-    expect(etag).toHaveLength(1);
-    expect(etag[0]).toMatch(/^etag: "\S/);
+    expect(lines(head, "etag")).toEqual([]);
   });
 });
 

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -139,7 +139,9 @@ describe("empty header value does not duplicate auto-headers", () => {
 
   test("file route: date empty", async () => {
     using dir = tempDir("serve-file-empty-date", { "a.txt": "x" });
-    const head = await rawHeadStatic(new Response(Bun.file(path.join(String(dir), "a.txt")), { headers: { date: "" } }));
+    const head = await rawHeadStatic(
+      new Response(Bun.file(path.join(String(dir), "a.txt")), { headers: { date: "" } }),
+    );
     const date = lines(head, "date");
     expect(date).toHaveLength(1);
     expect(date[0]).toMatch(/^Date: \S/);

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -9,6 +9,23 @@ import * as path from "node:path";
 // exactly one Content-Type and exactly one Date (RFC 9110 forbids duplicate
 // Content-Type; an origin server MUST send a valid Date).
 describe("empty header value does not duplicate auto-headers", () => {
+  async function readHead(port: number): Promise<string> {
+    const socket = net.connect(port, "127.0.0.1");
+    try {
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+      let raw = "";
+      await new Promise<void>((resolve, reject) => {
+        socket.on("data", c => (raw += c.toString("latin1")));
+        socket.on("error", reject);
+        socket.on("close", resolve);
+      });
+      return raw.split("\r\n\r\n")[0];
+    } finally {
+      socket.destroy();
+    }
+  }
+
   async function rawHead(makeResponse: () => Response): Promise<string> {
     using server = Bun.serve({
       port: 0,
@@ -16,20 +33,7 @@ describe("empty header value does not duplicate auto-headers", () => {
       development: false,
       fetch: makeResponse,
     });
-    const socket = net.connect(server.port, "127.0.0.1");
-    try {
-      socket.on("error", () => {});
-      await once(socket, "connect");
-      socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
-      let raw = "";
-      await new Promise<void>(resolve => {
-        socket.on("data", c => (raw += c.toString("latin1")));
-        socket.on("close", resolve);
-      });
-      return raw.split("\r\n\r\n")[0];
-    } finally {
-      socket.destroy();
-    }
+    return await readHead(server.port);
   }
 
   const lines = (head: string, name: string) => head.split("\r\n").filter(l => l.toLowerCase().startsWith(name + ":"));
@@ -89,20 +93,7 @@ describe("empty header value does not duplicate auto-headers", () => {
         return new Response("unreachable");
       },
     });
-    const socket = net.connect(server.port, "127.0.0.1");
-    try {
-      socket.on("error", () => {});
-      await once(socket, "connect");
-      socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
-      let raw = "";
-      await new Promise<void>(resolve => {
-        socket.on("data", c => (raw += c.toString("latin1")));
-        socket.on("close", resolve);
-      });
-      return raw.split("\r\n\r\n")[0];
-    } finally {
-      socket.destroy();
-    }
+    return await readHead(server.port);
   }
 
   test("static route: content-type empty", async () => {

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
 import { once } from "node:events";
 import * as net from "node:net";
+import * as path from "node:path";
 
 // An empty (or whitespace-only) header value must be treated as absent for the
 // well-known headers Bun fills in automatically, so the response head carries
@@ -66,13 +68,81 @@ describe("empty header value does not duplicate auto-headers", () => {
 
   test("Response.json with empty content-type", async () => {
     const head = await rawHead(() => Response.json({ a: 1 }, { headers: { "content-type": "" } }));
-    expect(lines(head, "content-type")).toHaveLength(1);
+    const ct = lines(head, "content-type");
+    expect(ct).toHaveLength(1);
+    expect(ct[0].toLowerCase()).toBe("content-type: application/json;charset=utf-8");
   });
 
   test("both empty at once: one of each", async () => {
     const head = await rawHead(() => new Response("x", { headers: { "content-type": "", "date": "" } }));
     expect(lines(head, "content-type")).toHaveLength(1);
     expect(lines(head, "date")).toHaveLength(1);
+  });
+
+  async function rawHeadStatic(response: Response): Promise<string> {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      development: false,
+      static: { "/": response },
+      fetch() {
+        return new Response("unreachable");
+      },
+    });
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+      let raw = "";
+      await new Promise<void>(resolve => {
+        socket.on("data", c => (raw += c.toString("latin1")));
+        socket.on("close", resolve);
+      });
+      return raw.split("\r\n\r\n")[0];
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  test("static route: content-type empty", async () => {
+    const head = await rawHeadStatic(new Response("x", { headers: { "content-type": "" } }));
+    const ct = lines(head, "content-type");
+    expect(ct).toHaveLength(1);
+    expect(ct[0].toLowerCase()).toBe("content-type: text/plain;charset=utf-8");
+  });
+
+  test("static route: date empty", async () => {
+    const head = await rawHeadStatic(new Response("x", { headers: { date: "" } }));
+    const date = lines(head, "date");
+    expect(date).toHaveLength(1);
+    expect(date[0]).toMatch(/^Date: \S/);
+    expect(Number.isFinite(new Date(date[0].slice(6)).getTime())).toBe(true);
+  });
+
+  test("static route: both empty", async () => {
+    const head = await rawHeadStatic(new Response("x", { headers: { "content-type": "", "date": "" } }));
+    const ct = lines(head, "content-type");
+    const date = lines(head, "date");
+    expect({ ct: ct.length, date: date.length }).toEqual({ ct: 1, date: 1 });
+    expect(ct[0].toLowerCase()).toBe("content-type: text/plain;charset=utf-8");
+    expect(date[0]).toMatch(/^Date: \S/);
+  });
+
+  test("static route: non-empty user values preserved", async () => {
+    const head = await rawHeadStatic(
+      new Response("x", { headers: { "content-type": "text/html", "date": "Sun, 06 Oct 2024 13:37:01 GMT" } }),
+    );
+    expect(lines(head, "content-type")).toEqual(["Content-Type: text/html"]);
+    expect(lines(head, "date")).toEqual(["Date: Sun, 06 Oct 2024 13:37:01 GMT"]);
+  });
+
+  test("file route: date empty", async () => {
+    using dir = tempDir("serve-file-empty-date", { "a.txt": "x" });
+    const head = await rawHeadStatic(new Response(Bun.file(path.join(String(dir), "a.txt")), { headers: { date: "" } }));
+    const date = lines(head, "date");
+    expect(date).toHaveLength(1);
+    expect(date[0]).toMatch(/^Date: \S/);
   });
 
   test("non-empty user values are still preserved", async () => {


### PR DESCRIPTION
## Repro

```ts
import net from "node:net";
const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
  fetch() { return new Response("x", { headers: { "content-type": "" } }); } });
const head = await new Promise<string>(res => { const c = net.connect(s.port, "127.0.0.1"); let b = "";
  c.on("connect", () => c.write("GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n"));
  c.on("data", d => b += d.toString("latin1")); c.on("close", () => res(b.split("\r\n\r\n")[0])); });
console.log(head.split("\r\n").filter(l => /^content-type:/i.test(l)));
// [ "Content-Type: ", "content-type: text/plain;charset=utf-8" ]
s.stop(true);
```

RFC 9110 forbids duplicate `Content-Type`. The `Date` case inverts: `{ date: "" }` emits a lone empty `Date: ` and suppresses the auto Date, so the origin sends no valid Date at all. Same for `"  "` / `"\t"`, `headers.set("content-type", "")`, `Response.json(v, { headers: { "content-type": "" } })`, and the static/file-route siblings (`static: { "/": new Response("x", { headers: { date: "" } }) }`).

## Cause

Two serializers write a `FetchHeaders` to the wire, and both let an empty value through while the presence check that gates the matching auto-header disagrees about whether empty means present:

- **Dynamic handler** (`writeFetchHeadersToUWSResponse`, `src/jsc/bindings/NodeHTTP.cpp`): writes every header unconditionally and sets wrote-this-header state as it goes. `render_metadata` decides whether to append the auto `content-type:` via `FetchHeaders::fast_get`, which returns `None` for a zero-length value, so for `content-type: ""` the serializer writes the empty line and the auto value is appended as a second line. The Date check is key-presence, so the empty entry sets `HTTP_WROTE_DATE_HEADER` and only the empty line remains.
- **Static / file routes** (`StaticRoute::do_write_headers`, `FileRoute::write_headers`): snapshot the `FetchHeaders` via `from_fetch_headers`/`copyTo` at registration time and replay the snapshot per request. The snapshot preserves empty entries, `has_date` is `headers.get(b"date").is_some()` (true for `b""`), and the replay loop writes every entry, so an empty `Date: ` is written with the auto-Date suppressed.

## Fix

Treat an empty value as absent at each serializer-layer site. `FetchHeaders` already strips leading/trailing HTTP whitespace, so `isEmpty()` / `len == 0` covers whitespace-only too.

- `writeFetchHeadersToUWSResponse` and its HTTP/3 sibling: `continue` past empty values in all three loops (Set-Cookie, common, uncommon) before any state bit is touched.
- `StaticRoute::do_write_headers`, `FileRoute::write_headers`: skip zero-length values in the replay loop.
- `StaticRoute`/`FileRoute` `has_date*` and the other header-presence bits: `.is_some_and(|v| !v.is_empty())`.
- `render_metadata`'s `has_content_disposition` / `has_content_range` and the `user_handles_range` check: gate on `fast_get(...).is_some()` so an empty user value does not both suppress the auto-header and be dropped by the serializer (a 206 must carry `Content-Range`).
- The StaticRoute was-string path overwrites an empty Content-Type with `text/plain` at the Bun-specific `static:` registration call site rather than inside `put_default`, so `Response.json(v, { headers: { "content-type": "" } }).headers.get("content-type")` stays `""` per the Fetch spec.

`node:http`'s `setHeader("content-type", "")` still writes the single empty line it does today; that path serializes through the flat name/value array rather than `FetchHeaders` and is unchanged.

After:

```
HTTP/1.1 200 OK
content-type: text/plain;charset=utf-8
Date: Thu, 23 Jul 2026 23:55:41 GMT
Content-Length: 1
```

## Verification

`test/js/bun/http/bun-serve-headers.test.ts` gains a describe block that reads the raw response head over a plain socket and asserts exactly one non-empty `content-type` / `date` line for `""` and whitespace-only values, via the init dict, `headers.set`, `Response.json`, a static route, and a `Bun.file()` route; that an empty custom header and an empty `set-cookie` are dropped on both the dynamic and static paths; that an empty `etag` on a static route is dropped rather than written as an empty line; and that non-empty user values are unchanged. The `Response.json` case also asserts the Headers object itself keeps the empty value. 22 cases total; the behaviour-asserting ones fail on main and all pass with the fix. `serve.test.ts`, `bun-serve-date.test.ts`, `bun-serve-routes.test.ts`, `bun-serve-file.test.ts`, `bun-serve-cookies.test.ts`, and `response.test.ts` are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.0 (9976fc858)

test/js/bun/http/bun-serve-headers.test.ts:
43 |     ["whitespace", "  \t "],
44 |   ] as const) {
45 |     test(`content-type: ${label}`, async () => {
46 |       const head = await rawHead(() => new Response("x", { headers: { "content-type": value } }));
47 |       const ct = lines(head, "content-type");
48 |       expect(ct).toHaveLength(1);
                      ^
error: expect(received).toHaveLength(expected)

Expected length: 1
Received length: 2

      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-headers.test.ts:48:18)
(fail) empty header value does not duplicate auto-headers > content-type: empty [417.87ms]
52 |     test(`date: ${label}`, async () => {
53 |       const head = await rawHead(() => new Response("x", { headers: { date: value } }));
54 |       const date = lines(head, "date");
55 |       expect(date).toHaveLength(1);
56 |       // auto Date is a valid IMF-fixdate, never an empty value
57 |       expect(date[0]).toMatch(/^Date: \S/);
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (a0fef71f9)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) empty header value does not duplicate auto-headers > content-type: empty [9.96ms]
(pass) empty header value does not duplicate auto-headers > date: empty [2.53ms]
(pass) empty header value does not duplicate auto-headers > content-type: whitespace [1.38ms]
(pass) empty header value does not duplicate auto-headers > date: whitespace [2.18ms]
(pass) empty header value does not duplicate auto-headers > headers.set('content-type', '') [1.60ms]
(pass) empty header value does not duplicate auto-headers > Response.json with empty content-type [1.61ms]
(pass) empty header value does not duplicate auto-headers > both empty at once: one of each [1.74ms]
(pass) empty header value does not duplicate auto-headers > static route: content-type empty [1.55ms]
(pass) empty header value does not duplicate auto-headers > static route: date empty [1.38ms]
(pass) empty header value does not duplicate auto-headers > static route: both empty [1.31ms]
(pass) empty header value does not duplicate auto-headers > static route: non-empty user values preserved [1.65ms]
(pass) empty header value does not dup
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.0 (9976fc858)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) empty header value does not duplicate auto-headers > content-type: empty [425.30ms]
(pass) empty header value does not duplicate auto-headers > date: empty [69.87ms]
(pass) empty header value does not duplicate auto-headers > content-type: whitespace [48.33ms]
(pass) empty header value does not duplicate auto-headers > date: whitespace [45.70ms]
(pass) empty header value does not duplicate auto-headers > headers.set('content-type', '') [61.95ms]
(pass) empty header value does not duplicate auto-headers > Response.json with empty content-type [60.24ms]
(pass) empty header value does not duplicate auto-headers > both empty at once: one of each [55.64ms]
(pass) empty header value does not duplicate auto-headers > static route: content-type empty [62.60ms]
(pass) empty header value does not duplicate auto-headers > static route: date empty [45.33ms]
(pass) empty header value does not duplicate auto-headers > static rou
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 659ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/8] gen cpp.rs (cppbind)
[3/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeHTTP.cpp              |  26 ++++-
 src/runtime/server/FileRoute.rs            |  33 ++++--
 src/runtime/server/RequestContext.rs       |  10 +-
 src/runtime/server/StaticRoute.rs          |  26 +++--
 test/js/bun/http/bun-serve-headers.test.ts | 177 +++++++++++++++++++++++++++++
 5 files changed, 251 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/NodeHTTP.cpp                   6      5      0
src/runtime/server/FileRoute.rs                 2      1      0
src/runtime/server/RequestContext.rs            3      1      0
src/runtime/server/StaticRoute.rs               8      5      0
test/js/bun/http/bun-serve-headers.test.ts      7     11      0
```

</details>

<!-- robobun:evidence:end -->