### PR TITLE
shell(cat): read regular files synchronously in the builtin on POSIX

### DIFF
--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -104,6 +104,36 @@ impl Cat {
         Builtin::done(interp, cmd, exit_code)
     }
 
+    /// `Some(yield)` if a chunk was enqueued on fd-backed stdout, `None` if written synchronously.
+    fn write_buf_to_stdout(interp: &Interpreter, cmd: NodeId, buf: &[u8]) -> Option<Yield> {
+        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+            match &mut Self::state_mut(interp, cmd).state {
+                CatState::ExecStdin {
+                    in_done,
+                    chunks_queued,
+                    ..
+                }
+                | CatState::ExecFilepathArgs {
+                    in_done,
+                    chunks_queued,
+                    ..
+                } => {
+                    *in_done = true;
+                    *chunks_queued += 1;
+                }
+                _ => panic!("Invalid state"),
+            }
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Some(
+                Builtin::of_mut(interp, cmd)
+                    .stdout
+                    .enqueue(child, buf, safeguard),
+            );
+        }
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, buf);
+        None
+    }
+
     pub(crate) fn next(interp: &Interpreter, cmd: NodeId) -> Yield {
         // Read scalars, drop the borrow, then act.
         enum Branch {
@@ -111,118 +141,136 @@ impl Cat {
             FileArg { args_start: usize, idx: usize },
             WaitingErr,
         }
-        let branch = match &Self::state_mut(interp, cmd).state {
-            CatState::Idle => panic!("Invalid state"),
-            CatState::ExecStdin { .. } => Branch::Stdin,
-            CatState::ExecFilepathArgs {
-                args_start, idx, ..
-            } => Branch::FileArg {
-                args_start: *args_start,
-                idx: *idx,
-            },
-            CatState::WaitingWriteErr => Branch::WaitingErr,
-        };
-        match branch {
-            Branch::Stdin => {
-                // Stdin doesn't need IO (captured/ignored): read it all
-                // synchronously and write straight to stdout.
-                let stdin_needs_io = Builtin::of(interp, cmd).stdin.needs_io();
-                if !stdin_needs_io {
-                    if let CatState::ExecStdin { in_done, .. } =
-                        &mut Self::state_mut(interp, cmd).state
-                    {
-                        *in_done = true;
+        loop {
+            let branch = match &Self::state_mut(interp, cmd).state {
+                CatState::Idle => panic!("Invalid state"),
+                CatState::ExecStdin { .. } => Branch::Stdin,
+                CatState::ExecFilepathArgs {
+                    args_start, idx, ..
+                } => Branch::FileArg {
+                    args_start: *args_start,
+                    idx: *idx,
+                },
+                CatState::WaitingWriteErr => Branch::WaitingErr,
+            };
+            return match branch {
+                Branch::Stdin => {
+                    // Stdin doesn't need IO (captured/ignored): read it all
+                    // synchronously and write straight to stdout.
+                    let stdin_needs_io = Builtin::of(interp, cmd).stdin.needs_io();
+                    if !stdin_needs_io {
+                        // Copy stdin bytes so the &mut on `stdout`/`write_no_io`
+                        // doesn't overlap a borrow of `stdin`.
+                        let buf = Builtin::read_stdin_no_io(interp, cmd).to_vec();
+                        return Self::write_buf_to_stdout(interp, cmd, &buf)
+                            .unwrap_or_else(|| Builtin::done(interp, cmd, 0));
                     }
-                    // Copy stdin bytes so the &mut on `stdout`/`write_no_io`
-                    // doesn't overlap a borrow of `stdin`.
-                    let buf = Builtin::read_stdin_no_io(interp, cmd).to_vec();
-                    if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-                        let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                        return Builtin::of_mut(interp, cmd)
-                            .stdout
-                            .enqueue(child, &buf, safeguard);
+                    // Clone the `Arc<IOReader>`
+                    // out of `stdin` so we hold no borrow of `interp` across
+                    // `start()` (which may re-enter via the raw interp backref).
+                    let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                    let reader = match &Builtin::of(interp, cmd).stdin {
+                        BuiltinInput::Fd(r) => Arc::clone(r),
+                        _ => unreachable!("needs_io() returned true"),
+                    };
+                    // The fd stays owned by `Builtin::stdin`.
+                    if let Some(result) = slurp_regular_file(reader.fd()) {
+                        return match result {
+                            Ok(buf) => Self::write_buf_to_stdout(interp, cmd, &buf)
+                                .unwrap_or_else(|| Builtin::done(interp, cmd, 0)),
+                            Err(e) => {
+                                let buf = Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e)
+                                    .to_vec();
+                                Self::write_failing_error(interp, cmd, &buf, 1)
+                            }
+                        };
                     }
-                    let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-                    return Builtin::done(interp, cmd, 0);
+                    reader.set_interp(interp_ptr);
+                    reader.add_reader(ReaderChildPtr {
+                        node: cmd,
+                        tag: ReaderTag::Cat,
+                    });
+                    reader.start()
                 }
-                // Clone the `Arc<IOReader>`
-                // out of `stdin` so we hold no borrow of `interp` across
-                // `start()` (which may re-enter via the raw interp backref).
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
-                let reader = match &Builtin::of(interp, cmd).stdin {
-                    BuiltinInput::Fd(r) => Arc::clone(r),
-                    _ => unreachable!("needs_io() returned true"),
-                };
-                reader.set_interp(interp_ptr);
-                reader.add_reader(ReaderChildPtr {
-                    node: cmd,
-                    tag: ReaderTag::Cat,
-                });
-                reader.start()
-            }
-            Branch::FileArg { args_start, idx } => {
-                let argc = Builtin::of(interp, cmd).args_slice().len();
-                let n_files = argc - args_start;
-                if idx >= n_files {
-                    // Drop the reader if any.
-                    if let CatState::ExecFilepathArgs { reader, .. } =
-                        &mut Self::state_mut(interp, cmd).state
+                Branch::FileArg { args_start, idx } => {
+                    let argc = Builtin::of(interp, cmd).args_slice().len();
+                    let n_files = argc - args_start;
+                    if idx >= n_files {
+                        // Drop the reader if any.
+                        if let CatState::ExecFilepathArgs { reader, .. } =
+                            &mut Self::state_mut(interp, cmd).state
+                        {
+                            *reader = None;
+                        }
+                        return Builtin::done(interp, cmd, 0);
+                    }
+                    if let CatState::ExecFilepathArgs {
+                        reader,
+                        chunks_done,
+                        chunks_queued,
+                        in_done,
+                        out_done,
+                        ..
+                    } = &mut Self::state_mut(interp, cmd).state
                     {
                         *reader = None;
+                        *chunks_done = 0;
+                        *chunks_queued = 0;
+                        *in_done = false;
+                        *out_done = false;
                     }
-                    return Builtin::done(interp, cmd, 0);
-                }
-                if let CatState::ExecFilepathArgs { reader, .. } =
-                    &mut Self::state_mut(interp, cmd).state
-                {
-                    *reader = None;
-                }
 
-                let path = Builtin::of(interp, cmd).arg_zstr(args_start + idx);
+                    let path = Builtin::of(interp, cmd).arg_zstr(args_start + idx);
 
-                if let CatState::ExecFilepathArgs { idx: i, .. } =
-                    &mut Self::state_mut(interp, cmd).state
-                {
-                    *i += 1;
-                }
-
-                let dir = Builtin::cwd(interp, cmd);
-                let fd = match shell_openat(dir, path, bun_sys::O::RDONLY, 0) {
-                    Ok(fd) => fd,
-                    Err(e) => {
-                        let buf =
-                            Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e).to_vec();
-                        // The reader was already taken to `None` above.
-                        return Self::write_failing_error(interp, cmd, &buf, 1);
+                    if let CatState::ExecFilepathArgs { idx: i, .. } =
+                        &mut Self::state_mut(interp, cmd).state
+                    {
+                        *i += 1;
                     }
-                };
 
-                let evtloop = Builtin::event_loop(interp, cmd);
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
-                let reader = IOReader::init(fd, evtloop);
-                reader.set_interp(interp_ptr);
-                if let CatState::ExecFilepathArgs {
-                    reader: slot,
-                    chunks_done,
-                    chunks_queued,
-                    in_done,
-                    out_done,
-                    ..
-                } = &mut Self::state_mut(interp, cmd).state
-                {
-                    *chunks_done = 0;
-                    *chunks_queued = 0;
-                    *in_done = false;
-                    *out_done = false;
-                    *slot = Some(Arc::clone(&reader));
+                    let dir = Builtin::cwd(interp, cmd);
+                    let fd = match shell_openat(dir, path, bun_sys::O::RDONLY, 0) {
+                        Ok(fd) => fd,
+                        Err(e) => {
+                            let buf =
+                                Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e).to_vec();
+                            // The reader was already taken to `None` above.
+                            return Self::write_failing_error(interp, cmd, &buf, 1);
+                        }
+                    };
+
+                    if let Some(result) = slurp_regular_file(fd) {
+                        let _ = bun_sys::close(fd);
+                        match result {
+                            Ok(buf) => match Self::write_buf_to_stdout(interp, cmd, &buf) {
+                                Some(y) => return y,
+                                None => continue,
+                            },
+                            Err(e) => {
+                                let buf = Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e)
+                                    .to_vec();
+                                return Self::write_failing_error(interp, cmd, &buf, 1);
+                            }
+                        }
+                    }
+
+                    let evtloop = Builtin::event_loop(interp, cmd);
+                    let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                    let reader = IOReader::init(fd, evtloop);
+                    reader.set_interp(interp_ptr);
+                    if let CatState::ExecFilepathArgs { reader: slot, .. } =
+                        &mut Self::state_mut(interp, cmd).state
+                    {
+                        *slot = Some(Arc::clone(&reader));
+                    }
+                    reader.add_reader(ReaderChildPtr {
+                        node: cmd,
+                        tag: ReaderTag::Cat,
+                    });
+                    reader.start()
                 }
-                reader.add_reader(ReaderChildPtr {
-                    node: cmd,
-                    tag: ReaderTag::Cat,
-                });
-                reader.start()
-            }
-            Branch::WaitingErr => Yield::failed(),
+                Branch::WaitingErr => Yield::failed(),
+            };
         }
     }
 
@@ -372,7 +420,7 @@ impl Cat {
             } => {
                 *in_done = true;
                 if errno != 0 {
-                    if *out_done || !stdout_needs_io {
+                    if *out_done || *chunks_done >= *chunks_queued || !stdout_needs_io {
                         // Drop the reader ref.
                         *reader = None;
                         Step::Done(errno)
@@ -399,6 +447,51 @@ impl Cat {
             Step::Done(code) => Builtin::done(interp, cmd, code),
             Step::Next => Self::next(interp, cmd),
         }
+    }
+}
+
+/// Reads an `S_IFREG` fd to EOF; `None` for other fd types (Linux epoll rejects regular files).
+#[allow(unused_variables)]
+fn slurp_regular_file(fd: bun_sys::Fd) -> Option<bun_sys::Result<Vec<u8>>> {
+    #[cfg(unix)]
+    {
+        let st = match bun_sys::fstat(fd) {
+            Ok(st) => st,
+            Err(e) => return Some(Err(e)),
+        };
+        if !bun_sys::S::ISREG(st.st_mode as _) {
+            return None;
+        }
+        let size_hint = usize::try_from(st.st_size).unwrap_or(0);
+        let mut buf: Vec<u8> = Vec::new();
+        if buf.try_reserve(size_hint.saturating_add(1)).is_err() {
+            return Some(Err(bun_sys::Error::from_code(
+                bun_sys::E::ENOMEM,
+                bun_sys::Tag::read,
+            )));
+        }
+        loop {
+            if buf.len() == buf.capacity() && buf.try_reserve(64 * 1024).is_err() {
+                return Some(Err(bun_sys::Error::from_code(
+                    bun_sys::E::ENOMEM,
+                    bun_sys::Tag::read,
+                )));
+            }
+            // SAFETY: `bun_sys::read` only writes initialised bytes into the
+            // prefix it reports; `commit_spare` exposes exactly that prefix.
+            let spare = unsafe { bun_core::vec::spare_bytes_mut(&mut buf) };
+            match bun_sys::read(fd, spare) {
+                Ok(0) => return Some(Ok(buf)),
+                // SAFETY: `n` bytes were just initialised by the syscall.
+                Ok(n) => unsafe { bun_core::vec::commit_spare(&mut buf, n) },
+                Err(e) if e.is_retry() => continue,
+                Err(e) => return Some(Err(e)),
+            }
+        }
+    }
+    #[cfg(windows)]
+    {
+        None
     }
 }
 

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import path from "node:path";
+
+// On POSIX, `cat` falls through to the subprocess path unless
+// BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS is set (see `Kind::DISABLED_ON_POSIX`).
+// These spawn a child with the flag so the builtin path is taken on every
+// platform.
+const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+async function runShell(dir: string, script: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import {$} from "bun"; const r = await $\`${script}\`.cwd(${JSON.stringify(
+        dir,
+      )}).quiet().nothrow(); process.stdout.write(r.stdout); process.stderr.write(r.stderr); process.exitCode = r.exitCode;`,
+    ],
+    env: builtinEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("cat (builtin)", () => {
+  test("reads a regular file given as an argument", async () => {
+    using dir = tempDir("shell-cat-arg", { "a.txt": "hello from a\n" });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("hello from a\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("reads a regular file via stdin redirect", async () => {
+    using dir = tempDir("shell-cat-stdin", { "a.txt": "hello from stdin\n" });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat < a.txt");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("hello from stdin\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("empty regular file", async () => {
+    using dir = tempDir("shell-cat-empty", { "empty.txt": "" });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat empty.txt > out.txt");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(await Bun.file(path.join(String(dir), "out.txt")).text()).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("concatenates multiple file arguments", async () => {
+    using dir = tempDir("shell-cat-multi", {
+      "a.txt": "first\n",
+      "b.txt": "second\n",
+    });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt b.txt");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("first\nsecond\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("reads a multi-chunk regular file", async () => {
+    const big = Buffer.alloc(300_000, "abcdefghij").toString();
+    using dir = tempDir("shell-cat-big", { "big.txt": big });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat big.txt");
+    expect(stderr).toBe("");
+    expect(stdout.length).toBe(big.length);
+    expect(stdout).toBe(big);
+    expect(exitCode).toBe(0);
+  });
+
+  test("still works through a pipe (pollable stdin)", async () => {
+    using dir = tempDir("shell-cat-pipe", {});
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "echo piped | cat");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("piped\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("file redirect out still works", async () => {
+    using dir = tempDir("shell-cat-out", { "a.txt": "payload\n" });
+    const { stderr, exitCode } = await runShell(String(dir), "cat a.txt > out.txt");
+    expect(stderr).toBe("");
+    expect(await Bun.file(path.join(String(dir), "out.txt")).text()).toBe("payload\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("sequential cat commands", async () => {
+    using dir = tempDir("shell-cat-seq", {
+      "a.txt": "A\n",
+      "b.txt": "B\n",
+      "c.txt": "C\n",
+      "d.txt": "D\n",
+    });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt; cat b.txt; cat c.txt; cat d.txt");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("A\nB\nC\nD\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("sequential cat redirected to files", async () => {
+    using dir = tempDir("shell-cat-seq-out", {
+      "a.txt": "A\n",
+      "b.txt": "B\n",
+      "c.txt": "C\n",
+    });
+    const { stderr, exitCode } = await runShell(
+      String(dir),
+      "cat a.txt > o1.txt; cat b.txt > o2.txt; cat c.txt > o3.txt",
+    );
+    expect(stderr).toBe("");
+    expect(await Bun.file(path.join(String(dir), "o1.txt")).text()).toBe("A\n");
+    expect(await Bun.file(path.join(String(dir), "o2.txt")).text()).toBe("B\n");
+    expect(await Bun.file(path.join(String(dir), "o3.txt")).text()).toBe("C\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Opening a directory succeeds on Linux but the first read fails (and the
+  // epoll registration returns EPERM), landing in `Cat::on_io_reader_done`
+  // with no chunk queued. With fd-backed stdout that previously suspended
+  // forever instead of finishing.
+  test.if(isPosix)("directory as file argument with fd stdout does not hang", async () => {
+    using dir = tempDir("shell-cat-isdir", { "sub/keep": "" });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat sub > out.txt");
+    // The reader error is surfaced only through the exit code (errno differs
+    // per platform), so a clean failure leaves both streams empty; a panic or
+    // a broken -e script would not.
+    expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    // The redirect target was opened before the read failed.
+    expect(await Bun.file(path.join(String(dir), "out.txt")).text()).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("many file arguments", async () => {
+    const files: Record<string, string> = {};
+    let expected = "";
+    for (let i = 0; i < 100; i++) {
+      files[`f${i}.txt`] = `line${i}\n`;
+      expected += `line${i}\n`;
+    }
+    using dir = tempDir("shell-cat-many", files);
+    const args = Object.keys(files).join(" ");
+    const { stdout, stderr, exitCode } = await runShell(String(dir), `cat ${args}`);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

On POSIX, `IOReader::start()` always registers the fd with epoll. Linux returns `EPERM` for regular files, which `register_poll()` surfaces through `on_reader_error` as a spurious read failure.

With `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` (so `cat` runs as a builtin rather than a subprocess on POSIX):

```sh
$ echo SRC > /tmp/s.txt
$ BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e \
    'import {$} from "bun"; const r = await $`cat < /tmp/s.txt`.nothrow(); console.log(r.exitCode, r.stdout.toString())'
1 ""
# and `cat /tmp/s.txt` hangs forever
```

Two things were going on:

- `cat < file` exited 1 with no output: the `EPERM` from `epoll_ctl` reached `Cat::on_io_reader_done` (`ExecStdin` arm) and became the exit code.
- `cat file` hung: the `ExecFilepathArgs` error arm of `Cat::on_io_reader_done` gated completion on `out_done` rather than `chunks_done >= chunks_queued`, so an error that arrives before any chunk is queued suspends waiting on writer callbacks that will never fire (and the failed `FilePoll`'s keep-alive pin kept the process up).

Builtin `cat` is in `Kind::DISABLED_ON_POSIX`, so the broken path was only reachable via the env flag (or on Windows, where reads go through libuv and this branch isn't taken). The same hardcoded `is_pollable = true` is in the pre-Rust `IOReader.zig`, so this has never worked.

### Fix

`Cat::next` now `fstat`s the fd before handing it to `IOReader::start`. For `S_IFREG` only, it reads the file to EOF with `bun_sys::read` and reuses the existing in-memory-stdin shape (`write_buf_to_stdout`: one chunk enqueued on fd-backed stdout, `write_no_io` otherwise), so completion is returned to the enclosing `Yield::run` trampoline instead of being driven inline. This is the read-side analogue of `IOWriter::do_file_write`.

Pipes, sockets, TTYs, and character devices keep the unchanged `IOReader::start()` path, so `echo x | cat` and `cat < /dev/zero` behave exactly as before. `Cat::next`'s `Branch::FileArg` is wrapped in a loop so many file arguments with captured stdout iterate rather than recurse. The `ExecFilepathArgs` error arm is aligned with the `ExecStdin` arm so a read error before any chunk is queued finishes rather than suspending.

### Why is this fix correct?

`read(2)` on a regular file is finite and never returns `EAGAIN`, so the synchronous slurp is bounded. It hands one buffer to the same `enqueue`/`write_no_io` path the existing `!stdin_needs_io` branch already uses, so the downstream state machine is unchanged; each file becomes either one `Yield::OnIoWriterChunk` trampoline iteration (fd-backed stdout) or one `loop` iteration inside `Cat::next` (captured stdout), and sequential commands stay at `DbgDepthGuard` depth 1. Windows returns `None` from `slurp_regular_file` and is untouched.

### Related

- #37743 reworks the same `on_io_reader_done` / `on_io_writer_chunk` completion logic in `cat.rs` (covering read errors that arrive after chunks are already queued, which this PR does not touch). The one-line `ExecFilepathArgs` error-arm change here is a subset of it; whichever of the two lands second needs a small rebase in `cat.rs` and `cat.test.ts`.
- #37752 fixes restarting the shared stdin `IOReader` for a second `cat`. Independent of this PR: regular-file stdin never reaches `IOReader` here, and non-regular stdin is unchanged.

## How did you verify your code works?

Added `test/js/bun/shell/commands/cat.test.ts`, which spawns a child with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` so the builtin path is taken on every platform. It covers `cat file`, `cat < file`, multi-file args, a multi-chunk 300 KB file, `echo | cat` (pollable control), `cat file > out`, four sequential `cat` commands (captured and redirected), an empty file, a directory argument with fd-backed stdout (pins the error-arm change), and a 100-file-argument case.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/cat.test.ts   # 1 pass, 10 fail (arg cases time out)
bun bd test test/js/bun/shell/commands/cat.test.ts                 # 11 pass
bun bd test test/js/bun/shell/bunshell.test.ts                     # 418 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/cat.test.ts
bun test v1.4.0 (fa328bcc1)

test/js/bun/shell/commands/cat.test.ts:
35 | 
36 |   test("reads a regular file via stdin redirect", async () => {
37 |     using dir = tempDir("shell-cat-stdin", { "a.txt": "hello from stdin\n" });
38 |     const { stdout, stderr, exitCode } = await runShell(String(dir), "cat < a.txt");
39 |     expect(stderr).toBe("");
40 |     expect(stdout).toBe("hello from stdin\n");
                        ^
error: expect(received).toBe(expected)

- "hello from stdin
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/shell/commands/cat.test.ts:40:20)
(fail) cat (builtin) > reads a regular file via stdin redirect [1274.29ms]
55 |       "a.txt": "first\n",
56 |       "b.txt": "second\n",
57 |     });
58 |     const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt b.txt");
59 |     expect(stderr).toBe("");
60 |     expect(stdout).toBe("first\nsecond\n");
                        ^
error: expect(received).toBe(expected)

- 
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/shell/commands/cat.test.ts:
27 | describe.concurrent("cat (builtin)", () => {
28 |   test("reads a regular file given as an argument", async () => {
29 |     using dir = tempDir("shell-cat-arg", { "a.txt": "hello from a\n" });
30 |     const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt");
31 |     expect(stderr).toBe("");
32 |     expect(stdout).toBe("hello from a\n");
                        ^
error: expect(received).toBe(expected)

- "hello from a
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/shell/commands/cat.test.ts:32:20)
(fail) cat (builtin) > reads a regular file given as an argument [24.34ms]
55 |       "a.txt": "first\n",
56 |       "b.txt": "second\n",
57 |     });
58 |     const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt b.txt");
59 |     expect(stderr).toBe("");
60 |     expect(stdout).toBe("first\nsecond\n");
                        ^
error: expect(received).toBe(expected)

- "first
- second
- "
+ ""

- Expected  - 3
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/shell/commands/cat.test.t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/cat.test.ts
bun test v1.4.0 (fa328bcc1)

test/js/bun/shell/commands/cat.test.ts:
(pass) cat (builtin) > reads a regular file given as an argument [1253.56ms]
(pass) cat (builtin) > reads a regular file via stdin redirect [1221.44ms]
(pass) cat (builtin) > concatenates multiple file arguments [1219.92ms]
(pass) cat (builtin) > empty regular file [1256.61ms]
(pass) cat (builtin) > reads a multi-chunk regular file [1254.61ms]
(pass) cat (builtin) > still works through a pipe (pollable stdin) [1227.23ms]
(pass) cat (builtin) > sequential cat commands [1266.05ms]
(pass) cat (builtin) > file redirect out still works [1296.06ms]
(pass) cat (builtin) > directory as file argument with fd stdout does not hang [1221.06ms]
(pass) cat (builtin) > sequential cat redirected to files [1249.79ms]
(pass) cat (builtin) > many file arguments [1299.89ms]

 11 pass
 0 fail
 38 expect() calls
Ran 11 tests across 1 file. [6.18s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 994ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/46] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/46] gen cpp.rs (cppbind)
[3/46] gen JS modules (bundle-modules)
Preprocess modules (9306ms)
Bundle modules (46ms)
Postprocesss modules (240ms)
Bundle Functions (803ms)
Generate Code (43ms)

[10.46s] Bundled "src/js" for production
  2625 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/37] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_simdutf_sys v0.0.0 (/workspace/bun/src/simdutf_sys)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sy
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/builtin/cat.rs       | 295 ++++++++++++++++++++++-----------
 test/js/bun/shell/commands/cat.test.ts | 151 +++++++++++++++++
 2 files changed, 345 insertions(+), 101 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/shell/builtin/cat.rs            7     15      0
test/js/bun/shell/commands/cat.test.ts      3     10      0
```

</details>

<!-- robobun:evidence:end -->
