### PR TITLE
fetch: isomorphic-encode latin-1 request header values on the wire

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1887,30 +1887,31 @@ void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer
         const auto value = pair->value;
 
         ASSERT_WITH_MESSAGE(name.length(), "Header name must not be empty");
+        ASSERT_WITH_MESSAGE(name.containsOnlyASCII(), "Header name must be ASCII. This should already be validated before calling this function.");
 
-        if (name.is8Bit() && name.containsOnlyASCII()) {
+        if (name.is8Bit()) {
             const auto nameSpan = name.span8();
             memcpy(&buf[i], nameSpan.data(), nameSpan.size());
             *names = { i, name.length() };
             i += name.length();
         } else {
-            ASSERT_WITH_MESSAGE(name.containsOnlyASCII(), "Header name must be ASCII. This should already be validated before calling this function.");
-            WTF::CString nameCString = name.utf8();
+            WTF::CString nameCString = name.latin1();
             memcpy(&buf[i], nameCString.data(), nameCString.length());
             *names = { i, static_cast<uint32_t>(nameCString.length()) };
             i += static_cast<uint32_t>(nameCString.length());
         }
 
         if (value.length() > 0) {
-            if (value.is8Bit() && value.containsOnlyASCII()) {
+            // https://fetch.spec.whatwg.org/#concept-header-value
+            // Header values are ByteStrings: isomorphic-encode (1 code unit = 1 byte),
+            // not UTF-8. isValidHTTPHeaderValue already rejects code units > 0xFF.
+            if (value.is8Bit()) {
                 const auto valueSpan = value.span8();
                 memcpy(&buf[i], valueSpan.data(), valueSpan.size());
                 *values = { i, value.length() };
                 i += value.length();
             } else {
-                // HTTP headers can contain non-ASCII characters according to RFC 7230
-                // Non-ASCII content should be properly encoded
-                WTF::CString valueCString = value.utf8();
+                WTF::CString valueCString = value.latin1();
                 memcpy(&buf[i], valueCString.data(), valueCString.length());
                 *values = { i, static_cast<uint32_t>(valueCString.length()) };
                 i += static_cast<uint32_t>(valueCString.length());
@@ -1928,11 +1929,9 @@ void WebCore__FetchHeaders__count(WebCore::FetchHeaders* headers, uint32_t* coun
     auto iter = headers->createIterator();
     size_t i = 0;
     for (auto pair = iter.next(); pair; pair = iter.next()) {
-        // UTF8 byteLength is not strictly necessary here
-        // They should always be ASCII.
-        // However, we can still do this out of an abundance of caution
-        i += BunString::utf8ByteLength(pair->key);
-        i += BunString::utf8ByteLength(pair->value);
+        // copyTo isomorphic-encodes: one byte per code unit.
+        i += pair->key.length();
+        i += pair->value.length();
     }
 
     *count = headers->size();

--- a/test/js/web/fetch/fetch_headers.test.js
+++ b/test/js/web/fetch/fetch_headers.test.js
@@ -37,7 +37,7 @@ describe("Headers", async () => {
   it("isomorphic-encodes latin-1 (obs-text) request header values on the wire", async () => {
     // https://fetch.spec.whatwg.org/#concept-header-value
     // Values are ByteStrings: U+00E9 must go out as the single byte 0xE9, not UTF-8 0xC3 0xA9.
-    const { promise: gotHead, resolve } = Promise.withResolvers();
+    const { promise: gotHead, resolve, reject } = Promise.withResolvers();
     const srv = net.createServer(s => {
       let b = Buffer.alloc(0);
       s.on("data", d => {
@@ -47,16 +47,18 @@ describe("Headers", async () => {
           s.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
         }
       });
-      s.on("error", () => {});
+      s.once("error", reject);
     });
     srv.listen(0, "127.0.0.1");
     await once(srv, "listening");
     try {
       const port = srv.address().port;
-      await fetch(`http://127.0.0.1:${port}/`, {
-        headers: { "x-t": "caf\u00e9", "x-u": "\u0080\u00ff" },
-      });
-      const head = await gotHead;
+      const [, head] = await Promise.all([
+        fetch(`http://127.0.0.1:${port}/`, {
+          headers: { "x-t": "caf\u00e9", "x-u": "\u0080\u00ff" },
+        }),
+        gotHead,
+      ]);
       const lines = head.toString("latin1").split("\r\n");
       const hex = name => {
         const line = lines.find(l => l.toLowerCase().startsWith(name + ":"));

--- a/test/js/web/fetch/fetch_headers.test.js
+++ b/test/js/web/fetch/fetch_headers.test.js
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import net from "node:net";
 import { once } from "node:events";
+import net from "node:net";
 let url = `http://localhost:0`;
 let server;
 

--- a/test/js/web/fetch/fetch_headers.test.js
+++ b/test/js/web/fetch/fetch_headers.test.js
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import net from "node:net";
+import { once } from "node:events";
 let url = `http://localhost:0`;
 let server;
 
@@ -30,6 +32,42 @@ describe("Headers", async () => {
   it("Header values must be valid", async () => {
     expect(() => fetch(url, { headers: { "x-test": "\0" } })).toThrow("Header 'x-test' has invalid value: '\0'");
     expect(() => fetch(url, { headers: { "x-test": "❤️" } })).toThrow("Header 'x-test' has invalid value: '❤️'");
+  });
+
+  it("isomorphic-encodes latin-1 (obs-text) request header values on the wire", async () => {
+    // https://fetch.spec.whatwg.org/#concept-header-value
+    // Values are ByteStrings: U+00E9 must go out as the single byte 0xE9, not UTF-8 0xC3 0xA9.
+    const { promise: gotHead, resolve } = Promise.withResolvers();
+    const srv = net.createServer(s => {
+      let b = Buffer.alloc(0);
+      s.on("data", d => {
+        b = Buffer.concat([b, d]);
+        if (b.indexOf("\r\n\r\n") >= 0) {
+          resolve(b);
+          s.end("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        }
+      });
+      s.on("error", () => {});
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    try {
+      const port = srv.address().port;
+      await fetch(`http://127.0.0.1:${port}/`, {
+        headers: { "x-t": "caf\u00e9", "x-u": "\u0080\u00ff" },
+      });
+      const head = await gotHead;
+      const lines = head.toString("latin1").split("\r\n");
+      const hex = name => {
+        const line = lines.find(l => l.toLowerCase().startsWith(name + ":"));
+        const raw = Buffer.from(line, "latin1").subarray(name.length + 2);
+        return [...raw].map(c => c.toString(16).padStart(2, "0")).join(" ");
+      };
+      expect(hex("x-t")).toBe("63 61 66 e9");
+      expect(hex("x-u")).toBe("80 ff");
+    } finally {
+      await new Promise(r => srv.close(r));
+    }
   });
 
   it("Invalid values for well-known headers name the header, not its index", () => {


### PR DESCRIPTION
## What

`fetch()` was UTF-8 encoding latin-1 (obs-text) request header values instead of writing them byte-for-byte. `café` went out as `63 61 66 c3 a9` where the Fetch spec ([header value](https://fetch.spec.whatwg.org/#concept-header-value) is a ByteString, isomorphic-encoded), Node/undici, Deno, and Bun's own `node:http` client all send `63 61 66 e9`.

## Repro

```js
import net from 'node:net';
let head;
const srv = net.createServer(s => {
  let b = Buffer.alloc(0);
  s.on('data', d => { b = Buffer.concat([b, d]);
    if (b.indexOf('\\r\\n\\r\\n') >= 0) { head = b;
      s.end('HTTP/1.1 200 OK\\r\\nContent-Length: 0\\r\\nConnection: close\\r\\n\\r\\n'); } });
});
await new Promise(r => srv.listen(0, '127.0.0.1', r));
await fetch(`http://127.0.0.1:${srv.address().port}/`, { headers: { 'x-t': 'café' } });
const line = head.toString('latin1').split('\\r\\n').find(l => l.startsWith('x-t:'));
console.log([...Buffer.from(line, 'latin1').subarray(5)].map(c => c.toString(16)).join(' '));
srv.close();
```

Before: `63 61 66 c3 a9`
After / Node: `63 61 66 e9`

## Cause

`WebCore__FetchHeaders__copyTo` in `src/jsc/bindings/bindings.cpp` guarded the 8-bit fast path on `is8Bit() && containsOnlyASCII()`, so a latin-1 `WTF::String` holding `0xE9` failed the ASCII check and fell into the `.utf8()` branch, widening it to `0xC3 0xA9`. The companion `WebCore__FetchHeaders__count` sized the buffer with `utf8ByteLength` to match.

`Bun.serve`'s response header writer (`writeResponseHeader` in `NodeHTTP.cpp`) already does this correctly: it only checks `is8Bit()` and writes `span8()` raw.

## Fix

- `copyTo`: drop the `containsOnlyASCII()` guard so 8-bit values memcpy `span8()` directly; use `.latin1()` (not `.utf8()`) for 16-bit values. `isValidHTTPHeaderValue` already rejects code units > 0x7F in 16-bit strings, so the 16-bit branch only ever holds ASCII, for which `.latin1()` and `.utf8()` are identical, but `.latin1()` is the spec-correct conversion.
- `count`: size by `String::length()` (one byte per code unit) instead of `utf8ByteLength`.

## Verification

New test in `test/js/web/fetch/fetch_headers.test.js` captures raw wire bytes via `net.createServer` and asserts `café` → `63 61 66 e9` and `\\^@\\u00ff` → `80 ff`.

```
bun bd test test/js/web/fetch/fetch_headers.test.js
# without src/ change: 7 pass 1 fail (Received: "63 61 66 c3 a9")
# with src/ change:    8 pass 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch_headers.test.js
bun test v1.4.0 (800a4a4c0)

test/js/web/fetch/fetch_headers.test.js:
(pass) Headers > Headers should work [20.74ms]
(pass) Headers > Header names must be valid [7.74ms]
(pass) Headers > Header values must be valid [7.35ms]
63 |       const hex = name => {
64 |         const line = lines.find(l => l.toLowerCase().startsWith(name + ":"));
65 |         const raw = Buffer.from(line, "latin1").subarray(name.length + 2);
66 |         return [...raw].map(c => c.toString(16).padStart(2, "0")).join(" ");
67 |       };
68 |       expect(hex("x-t")).toBe("63 61 66 e9");
                              ^
error: expect(received).toBe(expected)

Expected: "63 61 66 e9"
Received: "63 61 66 c3 a9"

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch_headers.test.js:68:26)
(fail) Headers > isomorphic-encodes latin-1 (obs-text) request header values on the wire [424.03ms]
(pass) Headers > Invalid values for well-known headers name the header, not its index [14.82ms]
(pass) Headers > repro 1602 [21.43ms]
(p
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (ffbe0c799)

test/js/web/fetch/fetch_headers.test.js:
(pass) Headers > Headers should work [8.58ms]
(pass) Headers > Header names must be valid [0.80ms]
(pass) Headers > Header values must be valid [0.08ms]
(pass) Headers > isomorphic-encodes latin-1 (obs-text) request header values on the wire [12.36ms]
(pass) Headers > Invalid values for well-known headers name the header, not its index [0.09ms]
(pass) Headers > repro 1602 [0.94ms]
(pass) Headers > toJSON() > should provide lowercase header names [0.08ms]
(pass) Headers > toJSON() > should handle numeric string header names [0.14ms]

 8 pass
 0 fail
 16 expect() calls
Ran 8 tests across 1 file. [205.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch_headers.test.js
bun test v1.4.0 (800a4a4c0)

test/js/web/fetch/fetch_headers.test.js:
(pass) Headers > Headers should work [22.87ms]
(pass) Headers > Header names must be valid [7.13ms]
(pass) Headers > Header values must be valid [6.13ms]
(pass) Headers > isomorphic-encodes latin-1 (obs-text) request header values on the wire [423.17ms]
(pass) Headers > Invalid values for well-known headers name the header, not its index [14.13ms]
(pass) Headers > repro 1602 [21.29ms]
(pass) Headers > toJSON() > should provide lowercase header names [4.13ms]
(pass) Headers > toJSON() > should handle numeric string header names [2.58ms]

 8 pass
 0 fail
 16 expect() calls
Ran 8 tests across 1 file. [2.78s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 746ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen cpp.rs (cppbind)
[2/8] cxx obj/src/jsc/bindings/bindings.cpp.o
[3/8] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp           | 23 +++++++++----------
 test/js/web/fetch/fetch_headers.test.js | 40 +++++++++++++++++++++++++++++++++
 2 files changed, 51 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/bindings.cpp                1      2      0
test/js/web/fetch/fetch_headers.test.js      2      3      0
```

</details>

<!-- robobun:evidence:end -->