### PR TITLE
glob: collapse MatchResult enum to {matches, negated} struct

### DIFF
--- a/src/glob/matcher.rs
+++ b/src/glob/matcher.rs
@@ -43,19 +43,31 @@ type BraceStack = BoundedArray<Brace, 10>;
 /// alternatives. Patterns that exceed this budget fail to match.
 const BRACE_BRANCH_BUDGET: u32 = 10_000;
 
-// `pub` because it appears in the signature of `pub fn match` (private-in-public is forbidden).
+/// Result of [`match`](r#match). Two independent bits: whether the path matched
+/// (after applying any leading `!` negation), and whether the pattern was negated.
+/// Most callers only want [`matches()`](Self::matches); the negation bit is for
+/// multi-pattern filter loops where a `!pattern` hit is a hard veto.
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub enum MatchResult {
-    NoMatch,
-    Match,
-
-    NegateNoMatch,
-    NegateMatch,
+pub struct MatchResult {
+    matches: bool,
+    negated: bool,
 }
 
 impl MatchResult {
+    /// Overall result: did the path match the pattern? Leading `!`s are already
+    /// applied, so `!foo` against `bar` matches and `!foo` against `foo` does not.
+    #[inline]
     pub fn matches(self) -> bool {
-        self == MatchResult::Match || self == MatchResult::NegateMatch
+        self.matches
+    }
+
+    /// Was the pattern `!`-prefixed (an odd number of times)? Combine with
+    /// `!matches()` to detect an explicit rejection by a negated pattern.
+    /// Callers can't derive this from the pattern string because leading `!`s
+    /// toggle (`!!foo` is un-negated).
+    #[inline]
+    pub fn is_negated(self) -> bool {
+        self.negated
     }
 }
 
@@ -159,21 +171,9 @@ pub fn r#match(glob: &[u8], path: &[u8]) -> MatchResult {
         &mut brace_budget,
     );
 
-    // TODO: consider just returning a bool
-    // return matched != negated;
-    if negated {
-        // FIXME(@DonIsaac): This looks backwards to me
-        if matched {
-            MatchResult::NegateNoMatch
-        } else {
-            MatchResult::NegateMatch
-        }
-    } else {
-        if matched {
-            MatchResult::Match
-        } else {
-            MatchResult::NoMatch
-        }
+    MatchResult {
+        matches: matched != negated,
+        negated,
     }
 }
 

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1301,18 +1301,13 @@ pub(crate) fn get_workspace_filters(
                 }
             };
 
-            match glob::r#match(pattern, path_or_name) {
-                glob::MatchResult::Match | glob::MatchResult::NegateMatch => {
-                    install_root_dependencies = true;
-                }
-
-                glob::MatchResult::NegateNoMatch => {
-                    // always skip if a pattern specifically says "!<name>"
-                    install_root_dependencies = false;
-                    break;
-                }
-
-                glob::MatchResult::NoMatch => {}
+            let result = glob::r#match(pattern, path_or_name);
+            if result.matches() {
+                install_root_dependencies = true;
+            } else if result.is_negated() {
+                // always skip if a pattern specifically says "!<name>"
+                install_root_dependencies = false;
+                break;
             }
         }
     }

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -415,20 +415,16 @@ impl WorkspaceMap {
 
                         // check if it's negated by any remaining patterns
                         for next_pattern in &workspace_globs[i + 1..] {
-                            match glob::r#match(next_pattern, matched_path_without_package_json) {
-                                glob::MatchResult::NoMatch
-                                | glob::MatchResult::Match
-                                | glob::MatchResult::NegateMatch => {}
-
-                                glob::MatchResult::NegateNoMatch => {
-                                    bun_output::scoped_log!(
-                                        Lockfile,
-                                        "skipping negated path: {}, {}\n",
-                                        BStr::new(matched_path_without_package_json),
-                                        BStr::new(next_pattern)
-                                    );
-                                    continue 'next_match;
-                                }
+                            let result =
+                                glob::r#match(next_pattern, matched_path_without_package_json);
+                            if result.is_negated() && !result.matches() {
+                                bun_output::scoped_log!(
+                                    Lockfile,
+                                    "skipping negated path: {}, {}\n",
+                                    BStr::new(matched_path_without_package_json),
+                                    BStr::new(next_pattern)
+                                );
+                                continue 'next_match;
                             }
                         }
                     }

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -654,20 +654,13 @@ pub(crate) fn is_filtered_dependency_or_workspace(
             }
         };
 
-        match bun_glob::r#match(pattern, name_or_path) {
-            bun_glob::MatchResult::Match | bun_glob::MatchResult::NegateMatch => {
-                workspace_matched = true;
-            }
-
-            bun_glob::MatchResult::NegateNoMatch => {
-                // always skip if a pattern specifically says "!<name|path>"
-                workspace_matched = false;
-                break;
-            }
-
-            bun_glob::MatchResult::NoMatch => {
-                // keep looking
-            }
+        let result = bun_glob::r#match(pattern, name_or_path);
+        if result.matches() {
+            workspace_matched = true;
+        } else if result.is_negated() {
+            // always skip if a pattern specifically says "!<name|path>"
+            workspace_matched = false;
+            break;
         }
     }
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -28,7 +28,6 @@ type CowString = CowSlice<u8>;
 use crate::cli::run_command::RunCommand;
 use bun_core::ZBox;
 use bun_core::{ZStr, strings};
-use bun_glob::matcher::MatchResult as GlobMatchResult;
 use bun_paths::resolve_path;
 use bun_semver as Semver;
 use bun_sha_hmac::sha;
@@ -554,12 +553,8 @@ fn iterate_included_project_tree(
                     } else {
                         entry_subpath.as_bytes()
                     };
-                    match glob::r#match(include.glob.slice(), match_path) {
-                        GlobMatchResult::Match => included = true,
-                        GlobMatchResult::NegateNoMatch | GlobMatchResult::NegateMatch => {
-                            unreachable!()
-                        }
-                        _ => {}
+                    if glob::r#match(include.glob.slice(), match_path).matches() {
+                        included = true;
                     }
                 }
             }
@@ -582,11 +577,9 @@ fn iterate_included_project_tree(
                     } else {
                         entry_subpath.as_bytes()
                     };
-                    // NOTE: These patterns have `!` so `.match` logic is
-                    // inverted here
-                    match glob::r#match(exclude.glob.slice(), match_path) {
-                        GlobMatchResult::NegateNoMatch => included = false,
-                        _ => {}
+                    let result = glob::r#match(exclude.glob.slice(), match_path);
+                    if result.is_negated() && !result.matches() {
+                        included = false;
                     }
                 }
             }
@@ -1581,14 +1574,9 @@ fn is_unconditionally_excluded(
     if dir_depth == 1 {
         // check default ignores that only apply to the root project directory
         for &pattern in ROOT_DEFAULT_IGNORE_PATTERNS {
-            match glob::r#match(pattern, entry_name) {
-                GlobMatchResult::Match => {
-                    // cannot be reversed
-                    return Some((pattern, IgnorePatternsKind::Default));
-                }
-                GlobMatchResult::NoMatch => {}
-                // default patterns don't use `!`
-                GlobMatchResult::NegateNoMatch | GlobMatchResult::NegateMatch => unreachable!(),
+            if glob::r#match(pattern, entry_name).matches() {
+                // cannot be reversed
+                return Some((pattern, IgnorePatternsKind::Default));
             }
         }
     }
@@ -1597,11 +1585,8 @@ fn is_unconditionally_excluded(
         if can_override {
             continue;
         }
-        match glob::r#match(pattern, entry_name) {
-            GlobMatchResult::Match => return Some((pattern, IgnorePatternsKind::Default)),
-            GlobMatchResult::NoMatch => {}
-            // default patterns don't use `!`
-            GlobMatchResult::NegateNoMatch | GlobMatchResult::NegateMatch => unreachable!(),
+        if glob::r#match(pattern, entry_name).matches() {
+            return Some((pattern, IgnorePatternsKind::Default));
         }
     }
 
@@ -1641,19 +1626,14 @@ fn is_excluded<'a>(
         if !can_override {
             continue;
         }
-        match glob::r#match(pattern, entry_name) {
-            GlobMatchResult::Match => {
-                ignored = true;
-                ignore_pattern = pattern;
-                ignore_kind = IgnorePatternsKind::Default;
+        if glob::r#match(pattern, entry_name).matches() {
+            ignored = true;
+            ignore_pattern = pattern;
+            ignore_kind = IgnorePatternsKind::Default;
 
-                // break. doesn't matter if more default patterns
-                // match this path
-                break;
-            }
-            GlobMatchResult::NoMatch => {}
-            // default patterns don't use `!`
-            GlobMatchResult::NegateNoMatch | GlobMatchResult::NegateMatch => unreachable!(),
+            // break. doesn't matter if more default patterns
+            // match this path
+            break;
         }
     }
 
@@ -1682,14 +1662,15 @@ fn is_excluded<'a>(
             } else {
                 entry_name
             };
-            match glob::r#match(pattern.glob.slice(), match_path) {
-                GlobMatchResult::Match => {
-                    ignored = true;
-                    ignore_pattern = pattern.glob.slice();
-                    ignore_kind = ignore.kind;
+            let result = glob::r#match(pattern.glob.slice(), match_path);
+            if result.is_negated() {
+                if !result.matches() {
+                    ignored = false;
                 }
-                GlobMatchResult::NegateNoMatch => ignored = false,
-                _ => {}
+            } else if result.matches() {
+                ignored = true;
+                ignore_pattern = pattern.glob.slice();
+                ignore_kind = ignore.kind;
             }
         }
     }

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -227,8 +227,7 @@ impl<'a> TestRunner<'a> {
 
         // Check if the file path matches any of the glob patterns
         for pattern in glob_patterns {
-            let result = bun_glob::matcher::r#match(pattern, file_path);
-            if result == bun_glob::matcher::MatchResult::Match {
+            if bun_glob::matcher::r#match(pattern, file_path).matches() {
                 return true;
             }
         }

--- a/test/cli/test/concurrent-test-glob.test.ts
+++ b/test/cli/test/concurrent-test-glob.test.ts
@@ -145,6 +145,59 @@ test("sequential test 2", async () => {
     expect(lines).toEqual(["seq1-start", "seq1-end", "seq2-start", "seq2-end"]);
   });
 
+  test("negated glob pattern selects non-matching files", async () => {
+    const testFile = `
+import { test, expect } from "bun:test";
+import { appendFileSync } from "fs";
+import { join } from "path";
+
+const logFile = join(import.meta.dir, "execution.log");
+
+test("test 1", async () => {
+  appendFileSync(logFile, "test1-start\\n");
+  await Bun.sleep(50);
+  appendFileSync(logFile, "test1-end\\n");
+  expect(1).toBe(1);
+});
+
+test("test 2", async () => {
+  appendFileSync(logFile, "test2-start\\n");
+  await Bun.sleep(50);
+  appendFileSync(logFile, "test2-end\\n");
+  expect(2).toBe(2);
+});
+`;
+
+    using dir = tempDir("negated-glob", {
+      "bunfig.toml": `[test]\nconcurrentTestGlob = "!**/sequential-*.test.ts"`,
+      "fast.test.ts": testFile,
+      "execution.log": "",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout + stderr).toContain("2 pass");
+
+    const logPath = join(String(dir), "execution.log");
+    const log = await Bun.file(logPath).text();
+    const lines = log.trim().split("\n").filter(Boolean);
+
+    // fast.test.ts does not match sequential-*.test.ts, so the negated
+    // pattern selects it and its tests should interleave.
+    const firstEndIndex = lines.findIndex(line => line.includes("-end"));
+    const startsBeforeFirstEnd = lines.slice(0, firstEndIndex).filter(line => line.includes("-start")).length;
+
+    expect(startsBeforeFirstEnd).toBeGreaterThan(1);
+  });
+
   test("multiple glob patterns work correctly", async () => {
     const testFile1 = `
 import { test, expect } from "bun:test";


### PR DESCRIPTION
The 4-variant `MatchResult` enum (`NoMatch`/`Match`/`NegateNoMatch`/`NegateMatch`) encoded two independent bits with names that were hard to keep straight: the `FIXME(@DonIsaac)` in `matcher.rs` thought the negate arms were backwards (they are not; the suffix names the overall result, consistent with the non-negated arms).

## What changed

`MatchResult` is now a struct with two accessors:

```rust
pub struct MatchResult { matches: bool, negated: bool }

impl MatchResult {
    pub fn matches(self) -> bool;      // overall result, `!` already applied
    pub fn is_negated(self) -> bool;   // pattern had odd leading `!`s
}
```

`r#match()` now returns `MatchResult { matches: matched != negated, negated }` in place of the four-arm `if`.

## Callers

- **~20 `.matches()` call sites**: unchanged.
- **`Tree.rs` / `install_with_manager.rs`** (workspace `--filter` loops): `Match | NegateMatch` → `result.matches()`; `NegateNoMatch` veto → `else if result.is_negated()`.
- **`WorkspaceMap.rs`** (workspace glob negation): `NegateNoMatch` → `is_negated() && !matches()`.
- **`pack_command.rs`**: the three `unreachable!()` negate arms on default-pattern loops become plain `.matches()` calls; the `files` exclude loop and the `.npmignore` loop spell the veto as `is_negated() && !matches()`. The `.npmignore` loop is the one place that needs both bits independently (a positive hit ignores, a negated hit un-ignores, everything else is a no-op).
- **`jest.rs`** (`concurrentTestGlob`): `== MatchResult::Match` → `.matches()`. This is the same one-line fix as #35315 (which has the regression test for it); required here regardless since the variant no longer exists.

Dropped along the way: the `FIXME(@DonIsaac)` comment, the `TODO: consider just returning a bool`, the `GlobMatchResult` import alias, and the three `unreachable!()` arms in `pack_command.rs`.

Net: +74/-110.

## Verification

```
bun bd test test/js/bun/glob/match.test.ts       # 27 pass (1514 expect)
bun bd test test/js/bun/glob/scan.test.ts        # 194 pass
bun bd test test/cli/install/bun-pack.test.ts    # 76 pass (incl. ".gitignore/.npmignore > can ignore and un-ignore")
```

`Bun.Glob#match` output is byte-identical to main for all `!`/`!!` combinations.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/concurrent-test-glob.test.ts
bun test v1.4.0 (d514e135b)

test/cli/test/concurrent-test-glob.test.ts:
(pass) concurrent-test-glob > tests matching glob pattern run concurrently [1358.09ms]
(pass) concurrent-test-glob > tests not matching glob pattern run sequentially [1301.07ms]
(pass) concurrent-test-glob > negated glob pattern selects non-matching files [1240.02ms]
(pass) concurrent-test-glob > multiple glob patterns work correctly [1323.35ms]
(pass) concurrent-test-glob > concurrent flag overrides concurrent-test-glob [312.98ms]

 5 pass
 0 fail
 14 expect() calls
Ran 5 tests across 1 file. [7.59s]
__F:0:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/test/concurrent-test-glob.test.ts:
(pass) concurrent-test-glob > tests matching glob pattern run concurrently [133.56ms]
(pass) concurrent-test-glob > tests not matching glob pattern run sequentially [131.19ms]
193 |     // fast.test.ts does not match sequential-*.test.ts, so the negated
194 |     // pattern selects it and its tests should interleave.
195 |     const firstEndIndex = lines.findIndex(line => line.includes("-end"));
196 |     const startsBeforeFirstEnd = lines.slice(0, firstEndIndex).filter(line => line.includes("-start")).length;
197 | 
198 |     expect(startsBeforeFirstEnd).toBeGreaterThan(1);
                                       ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 1
Received: 1

      at <anonymous> (/workspace/bun/test/cli/test/concurrent-test-glob.test.ts:198:34)
(fail) concurrent-test-glob > negated glob pattern selects non-matching files [131.70ms]
(pass) concurrent-test-glob > multiple glob patterns work correctly [131.63ms]
(pass) concurrent-test-glob > concurrent flag overrides concurrent-test-glob [14.42ms]

 4 pass
 1 fail
 14 expect() calls
Ran 5 tests across 1 f
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/concurrent-test-glob.test.ts
bun test v1.4.0 (d514e135b)

test/cli/test/concurrent-test-glob.test.ts:
(pass) concurrent-test-glob > tests matching glob pattern run concurrently [1354.25ms]
(pass) concurrent-test-glob > tests not matching glob pattern run sequentially [1304.56ms]
(pass) concurrent-test-glob > negated glob pattern selects non-matching files [1245.62ms]
(pass) concurrent-test-glob > multiple glob patterns work correctly [1345.02ms]
(pass) concurrent-test-glob > concurrent flag overrides concurrent-test-glob [302.29ms]

 5 pass
 0 fail
 14 expect() calls
Ran 5 tests across 1 file. [7.67s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 986ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/1195] esbuild runtime.out.js

  build/release/codegen/runtime.out.js  5.3kb

⚡ Done in 10ms
[2/1195] esbuild fallback-decoder.js

  build/release/codegen/fallback-decoder.js  8.8kb

⚡ Done in 17ms
[3/1195] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       42.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 48ms
[4/1195] fetch mimalloc
[mimalloc] up to date
[5/1195] fetch lsquic
[lsquic] up to date
[6/1195] fetch boringssl
[boringssl] up to date
[7/1195] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1195] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[9/1195] fetch lolhtml
[lolhtml] up to date
[10/1195] cc obj/vendor/zlib/compress.c.o
[11/1195] cc obj/vendor/zlib/crc32.c.o
[12/1195] cc obj/vendor/zlib/adler32.c.o
[13/1195] cc obj/vendor/zlib/deflate_fast.c.o
[14/1195] cc obj/vendor/zlib/crc32_braid_co
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/glob/matcher.rs                                | 46 +++++++-------
 src/install/PackageManager/install_with_manager.rs | 19 +++---
 src/install/lockfile/Package/WorkspaceMap.rs       | 24 +++-----
 src/install/lockfile/Tree.rs                       | 21 +++----
 src/runtime/cli/pack_command.rs                    | 71 ++++++++--------------
 src/runtime/test_runner/jest.rs                    |  3 +-
 test/cli/test/concurrent-test-glob.test.ts         | 53 ++++++++++++++++
 7 files changed, 127 insertions(+), 110 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/glob/matcher.rs                                     1      2      0
src/install/PackageManager/install_with_manager.rs      1      1      0
src/install/lockfile/Package/WorkspaceMap.rs            1      1      0
src/install/lockfile/Tree.rs                            1      1      0
src/runtime/cli/pack_command.rs                         4      7      0
src/runtime/test_runner/jest.rs                         1      1      0
test/cli/test/concurrent-test-glob.test.ts              1      1      0
```

</details>

<!-- robobun:evidence:end -->