### PR TITLE
node:net: adopt connected socket fds in new net.Socket({ fd })

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -345,6 +345,14 @@ const SocketHandlers: SocketHandler = {
     if (!self) return;
 
     self._unrefTimer();
+    // An fd-adopted socket constructed with readable: false has its readable
+    // side already ended; a later resume()/read()/on('data') can restart the
+    // native read. Drop those bytes and re-pause rather than destroy the
+    // write side with ERR_STREAM_PUSH_AFTER_EOF.
+    if (self._readableState?.ended) {
+      socket.pause();
+      return;
+    }
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) {
       socket.pause();
@@ -450,7 +458,9 @@ const SocketHandlers: SocketHandler = {
       self[kBytesWritten] = socket.bytesWritten;
       // Node does not emit 'connect' for a Socket constructed over an
       // already-connected fd (new net.Socket({ fd })): the handle is opened
-      // synchronously in the constructor, before any listener can exist.
+      // synchronously in the constructor, before any listener can exist. A
+      // later connect(port, host) on the same instance goes through
+      // SocketHandlers2, which emits 'connect' without consulting this flag.
       if (!self[kAdoptedFd]) {
         // this is not actually emitted on nodejs when socket used on the connection
         // this is already emmited on non-TLS socket and on TLS socket is emmited secureConnect after handshake
@@ -1626,18 +1636,24 @@ function Socket(options?) {
 
   if (hasFd) {
     const { fd } = options;
-    let stats;
-    try {
-      stats = require("node:fs").fstatSync(fd);
-    } catch {
-      // Node: createHandle -> uv_guess_handle returns UV_UNKNOWN_HANDLE
-      // for an fd it cannot fstat, then throws ERR_INVALID_FD_TYPE.
-      throw $ERR_INVALID_FD_TYPE("UNKNOWN");
-    }
     const optionsReadable = options.readable;
     const optionsWritable = options.writable;
-    if (stats.isSocket()) {
-      if (optionsWritable === true && optionsReadable !== true) {
+    // On Windows us_socket_from_fd is a no-op and fstat on a child_process
+    // extra-stdio fd fails, so the constructor leaves a bare { fd } inert and
+    // Socket.prototype.connect({ fd }) routes it through the named-pipe open
+    // path instead.
+    let stats;
+    if (process.platform !== "win32" || optionsWritable === true) {
+      try {
+        stats = require("node:fs").fstatSync(fd);
+      } catch {
+        // Node: createHandle -> uv_guess_handle returns UV_UNKNOWN_HANDLE
+        // for an fd it cannot fstat, then throws ERR_INVALID_FD_TYPE.
+        throw $ERR_INVALID_FD_TYPE("UNKNOWN");
+      }
+    }
+    if (process.platform !== "win32" && stats.isSocket()) {
+      if (optionsWritable === true && optionsReadable === false) {
         // stdio-style write-only adoption (new Socket({ fd: 2, readable: false,
         // writable: true })): keep synchronous write(2) so data survives an
         // immediate process.exit().
@@ -1668,11 +1684,12 @@ function Socket(options?) {
         // pushes into an already-ended readable (ERR_STREAM_PUSH_AFTER_EOF).
         if (optionsReadable === false) this._handle?.pause?.();
       }
-    } else if (optionsWritable === true) {
+    } else if (stats && optionsWritable === true) {
       // Adopt pipe/character-device/file fds with synchronous writes so data
       // survives an immediate process.exit() (node's effective semantics for
-      // stdio-style sockets).
-      if (stats.isFIFO() || stats.isCharacterDevice() || stats.isFile()) {
+      // stdio-style sockets). On Windows the socketpair form of stdio (which
+      // lands here) is also write-only sync.
+      if (stats.isFIFO() || stats.isCharacterDevice() || stats.isFile() || (isWindows && stats.isSocket())) {
         this[kSyncWriteFd] = fd;
         this._write = fdSyncWrite;
         this._writev = fdSyncWritev;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -137,6 +137,7 @@ const kSetNoDelay = Symbol("kSetNoDelay");
 const kSetTOS = Symbol("kSetTOS");
 const kSetKeepAlive = Symbol("kSetKeepAlive");
 const kSyncWriteFd = Symbol("kSyncWriteFd");
+const kAdoptedFd = Symbol("kAdoptedFd");
 const kSetKeepAliveInitialDelay = Symbol("kSetKeepAliveInitialDelay");
 const kConnectOptions = Symbol("connect-options");
 const kAttach = Symbol("kAttach");
@@ -447,10 +448,15 @@ const SocketHandlers: SocketHandler = {
 
     if (!self[kupgraded]) {
       self[kBytesWritten] = socket.bytesWritten;
-      // this is not actually emitted on nodejs when socket used on the connection
-      // this is already emmited on non-TLS socket and on TLS socket is emmited secureConnect after handshake
-      self.emit("connect", self);
-      self.emit("ready");
+      // Node does not emit 'connect' for a Socket constructed over an
+      // already-connected fd (new net.Socket({ fd })): the handle is opened
+      // synchronously in the constructor, before any listener can exist.
+      if (!self[kAdoptedFd]) {
+        // this is not actually emitted on nodejs when socket used on the connection
+        // this is already emmited on non-TLS socket and on TLS socket is emmited secureConnect after handshake
+        self.emit("connect", self);
+        self.emit("ready");
+      }
     }
 
     SocketHandlers.drain(socket);
@@ -1558,15 +1564,19 @@ function Socket(options?) {
     if (keepAliveInitialDelay < 0) keepAliveInitialDelay = 0;
   }
 
-  if (options?.fd !== undefined) {
+  const hasFd = options?.fd !== undefined;
+  if (hasFd) {
     validateInt32(options.fd, "options.fd", 0);
   }
 
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,
-    readable: true,
-    writable: true,
+    // Node passes options.readable/writable through; for an fd-adopted socket
+    // those flags are authoritative. For the connect() path keep both true so
+    // the stream is usable once the handle attaches.
+    readable: hasFd ? options.readable !== false : true,
+    writable: hasFd ? options.writable !== false : true,
     //For node.js compat do not emit close on destroy.
     emitClose: false,
     autoDestroy: true,
@@ -1614,38 +1624,51 @@ function Socket(options?) {
   // Shut down the socket when we're finished with it.
   this.on("end", onSocketEnd);
 
-  if (options?.fd !== undefined) {
+  if (hasFd) {
     const { fd } = options;
-    validateInt32(fd, "fd", 0);
-    // Adopt pipe/character-device/file fds with synchronous writes. Matches
-    // node's effective semantics for stdio-style sockets: writes to a pipe
-    // complete inline, so data survives an immediate process.exit().
-    // Gated on an explicit `writable: true` (how node's own stdio wraps fds,
-    // e.g. new Socket({ fd: 2, readable: false, writable: true })): a bare
-    // { fd } is the connect({ fd }) path (child_process extra stdio), which
-    // attaches a native duplex handle in Socket.prototype.connect - adopting
-    // here would end its readable side and stomp its write path.
-    // Network-socket fds are not supported (handle adoption needs native
-    // support); those keep the previous validated-but-inert behavior.
-    if (options.writable === true) {
-      let stats;
-      try {
-        stats = require("node:fs").fstatSync(fd);
-      } catch {
-        // Node: createHandle -> uv_guess_handle returns UV_UNKNOWN_HANDLE
-        // for an fd it cannot fstat, then throws ERR_INVALID_FD_TYPE.
-        throw $ERR_INVALID_FD_TYPE("UNKNOWN");
+    let stats;
+    try {
+      stats = require("node:fs").fstatSync(fd);
+    } catch {
+      // Node: createHandle -> uv_guess_handle returns UV_UNKNOWN_HANDLE
+      // for an fd it cannot fstat, then throws ERR_INVALID_FD_TYPE.
+      throw $ERR_INVALID_FD_TYPE("UNKNOWN");
+    }
+    const optionsReadable = options.readable;
+    const optionsWritable = options.writable;
+    if (stats.isSocket()) {
+      if (optionsWritable === true && optionsReadable !== true) {
+        // stdio-style write-only adoption (new Socket({ fd: 2, readable: false,
+        // writable: true })): keep synchronous write(2) so data survives an
+        // immediate process.exit().
+        this[kSyncWriteFd] = fd;
+        this._write = fdSyncWrite;
+        this._writev = fdSyncWritev;
+        this.push(null);
+        this.read(0);
+      } else {
+        // Already-connected socket fd (inherited connection, inetd, a live
+        // connection handed over stdio). Attach the native duplex handle via
+        // the same path net.connect({ fd }) uses; the open handler runs
+        // synchronously for fd adoption so _handle is set on return.
+        this[kAdoptedFd] = true;
+        doConnect(null, {
+          data: this,
+          fd: fd,
+          socket: SocketHandlers,
+          allowHalfOpen: true,
+        }).catch(error => {
+          if (!this.destroyed) {
+            this.emit("error", error);
+            this.emit("close", true);
+          }
+        });
       }
-      // isSocket() covers stdio handed to a child as a socketpair (how spawn
-      // implements pipes on unix); writable-only adoption with sync write(2)
-      // is correct there too.
-      const optionsReadable = options.readable;
-      if (
-        stats.isFIFO() ||
-        stats.isCharacterDevice() ||
-        stats.isFile() ||
-        (stats.isSocket() && optionsReadable !== true)
-      ) {
+    } else if (optionsWritable === true) {
+      // Adopt pipe/character-device/file fds with synchronous writes so data
+      // survives an immediate process.exit() (node's effective semantics for
+      // stdio-style sockets).
+      if (stats.isFIFO() || stats.isCharacterDevice() || stats.isFile()) {
         this[kSyncWriteFd] = fd;
         this._write = fdSyncWrite;
         this._writev = fdSyncWritev;
@@ -1899,6 +1922,12 @@ Socket.prototype.connect = function connect(...args) {
       connection = socket;
     }
     if (fd) {
+      // new Socket({ fd }) already attached the native handle for socket fds;
+      // re-adopting here would close and rewrap the same descriptor.
+      if (this[kAdoptedFd]) {
+        if (pauseOnConnect) this.pause();
+        return this;
+      }
       doConnect(this._handle, {
         data: this,
         fd: fd,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1663,6 +1663,10 @@ function Socket(options?) {
             this.emit("close", true);
           }
         });
+        // Node never starts the handle reading when readable is false, so peer
+        // bytes sit in the kernel buffer. Without this the first data callback
+        // pushes into an already-ended readable (ERR_STREAM_PUSH_AFTER_EOF).
+        if (optionsReadable === false) this._handle?.pause?.();
       }
     } else if (optionsWritable === true) {
       // Adopt pipe/character-device/file fds with synchronous writes so data

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -991,7 +991,11 @@ describe("Socket fd adoption", () => {
   });
 
   it("throws ERR_INVALID_FD_TYPE for an fd that cannot be fstat'ed", () => {
-    for (const opts of [{ fd: 0x7ffff, writable: true }, { fd: 0x7ffff }]) {
+    // On Windows the constructor leaves a bare { fd } inert (no fstat) so
+    // connect({ fd }) can route it through the named-pipe open path; only
+    // { fd, writable: true } is required to fstat.
+    const cases = isWindows ? [{ fd: 0x7ffff, writable: true }] : [{ fd: 0x7ffff, writable: true }, { fd: 0x7ffff }];
+    for (const opts of cases) {
       let error: any;
       try {
         new Socket(opts);

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -990,22 +990,118 @@ describe("Socket fd adoption", () => {
     expect(() => fs.fstatSync(fd)).toThrow();
   });
 
-  it("throws ERR_INVALID_FD_TYPE for a writable fd that cannot be fstat'ed", () => {
-    let error: any;
-    try {
-      new Socket({ fd: 0x7ffff, writable: true });
-    } catch (e) {
-      error = e;
+  it("throws ERR_INVALID_FD_TYPE for an fd that cannot be fstat'ed", () => {
+    for (const opts of [{ fd: 0x7ffff, writable: true }, { fd: 0x7ffff }]) {
+      let error: any;
+      try {
+        new Socket(opts);
+      } catch (e) {
+        error = e;
+      }
+      expect(error?.code).toBe("ERR_INVALID_FD_TYPE");
+      expect(error?.message).toBe("Unsupported fd type: UNKNOWN");
     }
-    expect(error?.code).toBe("ERR_INVALID_FD_TYPE");
-    expect(error?.message).toBe("Unsupported fd type: UNKNOWN");
   });
 
-  it("a bare { fd } does not throw so connect({ fd }) can attach a native handle", () => {
-    // No explicit writable: true -> no adoption, no fstat. child_process
-    // extra stdio relies on this path (connect({ fd }) attaches natively).
-    expect(() => new Socket({ fd: 0x7ffff })).not.toThrow();
+  // Wrapping an already-connected TCP socket fd (inherited connection /
+  // inetd / live connection handed over stdio). POSIX-only: fd inheritance
+  // via stdio is POSIX, and us_socket_from_fd is a no-op on Windows.
+  it.skipIf(isWindows)("new Socket({ fd }) over a connected TCP socket reads and writes", async () => {
+    const child = `
+      const net = require("node:net");
+      const rep = { events: [], read: "" };
+      const s = new net.Socket({ fd: 3 });
+      rep.readable = s.readable;
+      rep.writable = s.writable;
+      rep.pending = s.pending;
+      s.on("connect", () => rep.events.push("connect"));
+      s.on("data", d => { rep.read += d; if (rep.read.includes("\\n")) s.end(); });
+      s.on("error", e => rep.events.push("error:" + e.code));
+      s.on("close", h => {
+        rep.events.push("close:" + h);
+        console.log(JSON.stringify(rep));
+      });
+      s.write("CHILD-HELLO\\n", e => rep.events.push("writecb:" + (e && e.code)));
+    `;
+    const { rep, parentGot } = await runFdChild(child);
+    expect(rep.read).toBe("PARENT-HELLO\n");
+    expect(rep.events).toEqual(["writecb:null", "close:false"]);
+    expect(rep.readable).toBe(true);
+    expect(rep.writable).toBe(true);
+    expect(rep.pending).toBe(false);
+    expect(parentGot).toBe("CHILD-HELLO\n");
   });
+
+  it.skipIf(isWindows)("new Socket({ fd, writable: false }) reads but reports writable=false", async () => {
+    const child = `
+      const net = require("node:net");
+      const rep = { read: "" };
+      const s = new net.Socket({ fd: 3, writable: false });
+      rep.readable = s.readable;
+      rep.writable = s.writable;
+      s.on("data", d => { rep.read += d; if (rep.read.includes("\\n")) s.destroy(); });
+      s.on("close", () => console.log(JSON.stringify(rep)));
+    `;
+    const { rep } = await runFdChild(child);
+    expect(rep.read).toBe("PARENT-HELLO\n");
+    expect(rep.readable).toBe(true);
+    expect(rep.writable).toBe(false);
+  });
+
+  it.skipIf(isWindows)("new Socket({ fd, readable: false }) writes but reports readable=false", async () => {
+    const child = `
+      const net = require("node:net");
+      const rep = {};
+      const s = new net.Socket({ fd: 3, readable: false });
+      rep.readable = s.readable;
+      rep.writable = s.writable;
+      s.write("CHILD-HELLO\\n", e => {
+        rep.writecb = e && e.code;
+        console.log(JSON.stringify(rep));
+        s.destroy();
+      });
+    `;
+    const { rep, parentGot } = await runFdChild(child);
+    expect(rep.writecb).toBe(null);
+    expect(rep.readable).toBe(false);
+    expect(rep.writable).toBe(true);
+    expect(parentGot).toBe("CHILD-HELLO\n");
+  });
+
+  async function runFdChild(childScript: string) {
+    const server = createServer({ pauseOnConnect: true });
+    try {
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const connP = once(server, "connection");
+      const cli = connect((server.address() as any).port, "127.0.0.1");
+      cli.on("error", () => {});
+      let parentGot = "";
+      cli.on("data", d => (parentGot += d));
+      await once(cli, "connect");
+      const [ss] = await connP;
+      ss.on("error", () => {});
+      cli.write("PARENT-HELLO\n");
+      const cliClosed = new Promise<void>(r => cli.on("close", () => r()));
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", childScript],
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "inherit", ss._handle.fd],
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      // The parent's fd and the child's fd are independent references to the
+      // same open file description (stdio inheritance dups). Close the parent
+      // end now the child has exited so `cli` sees the peer close.
+      ss.destroy();
+      await cliClosed;
+      cli.destroy();
+      expect(stdout.trim()).not.toBe("");
+      expect(exitCode).toBe(0);
+      const rep = JSON.parse(stdout.trim());
+      return { rep, parentGot };
+    } finally {
+      server.close();
+    }
+  }
 });
 
 describe("paused socket whose peer sends RST", () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1049,20 +1049,27 @@ describe("Socket fd adoption", () => {
   });
 
   it.skipIf(isWindows)("new Socket({ fd, readable: false }) writes but reports readable=false", async () => {
+    // PARENT-HELLO is already sitting in the kernel receive buffer when the
+    // child adopts the fd. With readable: false the native handle must not
+    // read it: a push into the already-ended readable side would be
+    // ERR_STREAM_PUSH_AFTER_EOF. Let a poll cycle pass before reporting so a
+    // read would have fired if it were going to.
     const child = `
       const net = require("node:net");
       const rep = {};
       const s = new net.Socket({ fd: 3, readable: false });
       rep.readable = s.readable;
       rep.writable = s.writable;
-      s.write("CHILD-HELLO\\n", e => {
-        rep.writecb = e && e.code;
+      s.on("error", e => (rep.error = e.code));
+      s.write("CHILD-HELLO\\n", e => (rep.writecb = e && e.code));
+      setImmediate(() => setImmediate(() => {
         console.log(JSON.stringify(rep));
         s.destroy();
-      });
+      }));
     `;
     const { rep, parentGot } = await runFdChild(child);
     expect(rep.writecb).toBe(null);
+    expect(rep.error).toBeUndefined();
     expect(rep.readable).toBe(false);
     expect(rep.writable).toBe(true);
     expect(parentGot).toBe("CHILD-HELLO\n");


### PR DESCRIPTION
### What

`new net.Socket({ fd })` over an already-connected TCP/Unix socket fd (the documented "wrap an existing socket" form: inherited connection / inetd / a parent handing a live connection to a child over stdio) now attaches a real native handle and reads and writes in both directions.

### Repro

```js
// parent accepts a TCP connection and hands it to the child as fd 3
import net from 'node:net'; import fs from 'node:fs'; import { spawn } from 'node:child_process';
if (process.argv[2] === 'child') {
  const rep = { fd3IsSocket: fs.fstatSync(3).isSocket(), events: [] }; let got = '';
  const s = new net.Socket({ fd: 3 });
  s.on('data', d => (got += d));
  s.on('error', e => rep.events.push('error:' + e.code));
  s.on('close', h => rep.events.push('close:' + h));
  s.write('CHILD-HELLO\n', e => rep.events.push('writecb:' + (e && e.code)));
  setTimeout(() => { rep.read = got; console.log(JSON.stringify(rep)); process.exit(0); }, 500);
} else {
  const server = net.createServer({ pauseOnConnect: true });
  await new Promise(r => server.listen(0, '127.0.0.1', r));
  const conn = new Promise(r => server.once('connection', r));
  const cli = net.connect(server.address().port, '127.0.0.1'); let cg = '';
  cli.on('data', d => (cg += d)); cli.on('error', () => {});
  await new Promise(r => cli.on('connect', r));
  const ss = await conn; ss.on('error', () => {});
  cli.write('PARENT-HELLO\n');
  const ch = spawn(process.execPath, [import.meta.url.replace('file://', ''), 'child'],
    { stdio: ['ignore', 'pipe', 'inherit', ss._handle.fd] });
  let out = ''; ch.stdout.on('data', d => (out += d));
  await new Promise(r => ch.on('exit', r)); await new Promise(r => setTimeout(r, 100));
  console.log('child:', out.trim(), 'parentGotFromChild:', JSON.stringify(cg)); process.exit(0);
}
```

Before:
```
child: {"fd3IsSocket":true,"events":["writecb:ERR_SOCKET_CLOSED","error:ERR_SOCKET_CLOSED","close:true"],"read":""} parentGotFromChild: ""
```

After (matches Node):
```
child: {"fd3IsSocket":true,"events":["writecb:null"],"read":"PARENT-HELLO\n"} parentGotFromChild: "CHILD-HELLO\n"
```

### Cause

The constructor's fd branch only ever wired up a synchronous `write(2)` path for the stdio-style `{ fd, readable: false, writable: true }` pattern. Every other shape (bare `{ fd }`, `{ fd, readable: true }`, `{ fd, writable: false }`) was validated and then left with no handle at all: `readable`/`writable` lied true, `pending` stayed true, no bytes were ever delivered, and the first `write()` failed `ERR_SOCKET_CLOSED`. Raw `fs.readSync`/`writeSync` on the same fd worked, so the inheritance was fine; only the `net.Socket` adoption was dead. The native support already exists (`us_socket_from_fd`, reached today by `net.connect({ fd })` for child_process extra stdio).

### Fix

- Socket constructor: for `stats.isSocket()` fds, attach the native duplex handle via the existing `doConnect` path (`Listener::connect_inner` -> `us_socket_from_fd`). The open handler runs synchronously for fd adoption so `_handle` is set on return and `pending` becomes false. `options.readable`/`options.writable` now pass through to the Duplex constructor for the fd case, so the flags report correctly.
- The stdio-style `{ fd, readable: false, writable: true }` pattern keeps its synchronous `write(2)` path so data survives an immediate `process.exit()`.
- `SocketHandlers.open` skips `'connect'`/`'ready'` for a constructor-adopted fd (Node never emits them for `new Socket({ fd })`; the handle is opened before any listener can exist).
- `Socket.prototype.connect({ fd })` skips re-adoption when the constructor already attached the handle (so `createConnection({ fd })` / child_process extra stdio keep working without double-wrapping the same descriptor).
- Like Node, a bare `{ fd }` now fstats and throws `ERR_INVALID_FD_TYPE("UNKNOWN")` for an unstat-able descriptor.

### Verification

`test/js/node/net/node-net.test.ts -t "Socket fd adoption"`: three new cases spawn a child with a connected TCP fd on stdio slot 3 and assert bidirectional data flow plus correct `readable`/`writable`/`pending`. All fail on main with `ERR_SOCKET_CLOSED` / empty read, all pass with this change.

Sibling of #954 (`server.listen({ fd })`, not addressed here).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->