### PR TITLE
Bun.spawn: reject timeout: NaN and killSignal: 0

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -747,11 +747,23 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
             if let Some(timeout_value) = args.get(global_this, "timeout")? {
                 'brk: {
                     if timeout_value != JSValue::NULL {
-                        if timeout_value.is_number()
-                            && timeout_value.as_number().is_infinite()
-                            && timeout_value.as_number() > 0.0
-                        {
-                            break 'brk;
+                        if timeout_value.is_number() {
+                            let n = timeout_value.as_number();
+                            // +Infinity is accepted as "no timeout"; NaN is always a
+                            // caller-side bug (validate_integer_range would map it to 0).
+                            if n.is_nan() {
+                                return Err(global_this.throw_range_error(
+                                    n,
+                                    bun_fmt::OutOfRangeOptions {
+                                        field_name: b"timeout",
+                                        msg: b"a non-negative integer",
+                                        ..Default::default()
+                                    },
+                                ));
+                            }
+                            if n.is_infinite() && n > 0.0 {
+                                break 'brk;
+                            }
                         }
 
                         let timeout_int = global_this.validate_integer_range::<u64>(
@@ -775,6 +787,14 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
 
             if let Some(val) = args.get(global_this, "killSignal")? {
                 kill_signal = signal_code_from_js(val, global_this)?;
+                if kill_signal.0 == 0 {
+                    return Err(global_this
+                        .err(
+                            jsc::ErrorCode::ERR_UNKNOWN_SIGNAL,
+                            format_args!("Unknown signal: 0"),
+                        )
+                        .throw());
+                }
             }
 
             if let Some(val) = args.get(global_this, "maxBuffer")? {

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -58,10 +58,12 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
   // is the same bound Node gives spawnSync.
   const bound = maxBuffer + 64 * 1024;
 
-  // `killSignal: 0` sends no signal at all, so the child outlives the kill and
-  // keeps writing for as long as Bun keeps reading. A child that merely
-  // installs a SIGTERM handler, or is slow to die, behaves the same way.
+  // The child traps SIGTERM so it outlives the maxBuffer kill and keeps
+  // writing for as long as Bun keeps reading. On Windows SIGTERM maps to
+  // TerminateProcess (untrappable), so the child dies; the cap assertion still
+  // holds, it just doesn't exercise the "writer survives" path there.
   const firehose = `
+    process.on("SIGTERM", () => {});
     const { writeSync } = require("fs");
     const chunk = Buffer.alloc(1024 * 1024, 97);
     for (let i = 0; i < 8; i++) {
@@ -73,7 +75,6 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
   test.concurrent("Bun.spawnSync", () => {
     const proc = Bun.spawnSync([bunExe(), "-e", firehose], {
       maxBuffer,
-      killSignal: 0,
       stdio: ["ignore", "pipe", "pipe"],
     });
     expect(proc.exitedDueToMaxBuffer).toBe(true);
@@ -86,7 +87,6 @@ describe("maxBuffer caps the buffer while the child is still writing", () => {
   test.concurrent("Bun.spawn", async () => {
     await using proc = Bun.spawn([bunExe(), "-e", firehose], {
       maxBuffer,
-      killSignal: 0,
       stdio: ["ignore", "pipe", "pipe"],
     });
     await proc.exited;

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("spawn AbortSignal works after spawning", async () => {
@@ -66,4 +66,51 @@ test("spawnSync AbortSignal works as timeout", async () => {
   expect(subprocess.success).toBeFalse();
   const end = performance.now();
   expect(end - start).toBeLessThan(100);
+});
+
+describe("Bun.spawn option validation", () => {
+  const spawners = [
+    ["Bun.spawn", (opts: any) => Bun.spawn(opts)],
+    ["Bun.spawnSync", (opts: any) => Bun.spawnSync(opts)],
+  ] as const;
+
+  describe.each(spawners)("%s", (_, spawn) => {
+    test("timeout: NaN throws ERR_OUT_OF_RANGE", () => {
+      expect(() =>
+        spawn({
+          cmd: [bunExe(), "-e", ""],
+          env: bunEnv,
+          timeout: NaN,
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          code: "ERR_OUT_OF_RANGE",
+          message: expect.stringContaining('"timeout"'),
+        }),
+      );
+    });
+
+    test("killSignal: 0 throws ERR_UNKNOWN_SIGNAL", () => {
+      expect(() =>
+        spawn({
+          cmd: [bunExe(), "-e", ""],
+          env: bunEnv,
+          timeout: 100,
+          killSignal: 0,
+        }),
+      ).toThrow(expect.objectContaining({ code: "ERR_UNKNOWN_SIGNAL" }));
+    });
+  });
+
+  test("proc.kill(0) is still accepted", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "setTimeout(() => {}, 100000)"],
+      env: bunEnv,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    expect(() => proc.kill(0)).not.toThrow();
+    expect(proc.killed).toBe(false);
+    proc.kill(9);
+    await proc.exited;
+  });
 });


### PR DESCRIPTION
## What

`Bun.spawn` / `Bun.spawnSync` now throw synchronously for two option values that previously disabled the timeout without any indication:

| option | before | after |
|---|---|---|
| `timeout: NaN` | silently treated as no timeout | `RangeError [ERR_OUT_OF_RANGE]` |
| `killSignal: 0` | signal 0 sent on timeout/maxBuffer (no-op) | `TypeError [ERR_UNKNOWN_SIGNAL]` |

Unchanged:
- `timeout: Infinity` still means "no timeout" (existing tested behavior in `spawn-maxbuf.test.ts`).
- `timeout: undefined` / `null` still mean "no timeout".
- `proc.kill(0)` still works as an existence probe.

## Repro

```js
// before: child runs forever, no error
const p = Bun.spawn({ cmd: ["sleep", "1000"], timeout: NaN });
// before: timeout fires but sends signal 0, child keeps running
const q = Bun.spawn({ cmd: ["sleep", "1000"], timeout: 100, killSignal: 0 });
```

Node's `child_process.spawn` throws `ERR_OUT_OF_RANGE` / `ERR_UNKNOWN_SIGNAL` for the same inputs, and Bun's `node:child_process` wrapper already validated them via `validateTimeout` / `sanitizeKillSignal`. Only the native `Bun.spawn` path was loose.

## Cause

- `validate_integer_range` maps `NaN` to the default value (`0`), so `timeout: NaN` fell through to "no timeout set".
- `signal_code_jsc::from_js` accepts `0` (needed for `proc.kill(0)`), so `killSignal: 0` produced `SignalCode(0)` which `kill(2)` treats as a liveness check only.

## Fix

Explicit checks at the two `Bun.spawn` option-parse sites in `js_bun_spawn_bindings.rs`. The shared `signal_code_jsc::from_js` is left untouched so `proc.kill(0)` keeps working.

`spawn-maxbuf.test.ts` previously passed `killSignal: 0` to keep the child writing past the maxBuffer kill; switched that fixture to trap `SIGTERM` instead (the existing comment already called out that equivalence).

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/spawn/spawn-signal.test.ts -t "option validation"
  4 fail  (NaN + killSignal:0, for spawn and spawnSync)
$ bun bd test test/js/bun/spawn/spawn-signal.test.ts
  9 pass, 0 fail
$ bun bd test test/js/bun/spawn/spawn-kill-signal.test.ts test/js/bun/spawn/spawn-maxbuf.test.ts -t "maxBuffer caps"
  all pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-maxbuf.test.ts

<!-- robobun:evidence:end -->