### PR TITLE
spawn: pipe Response/Request JS-stream body to child stdin instead of hanging

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -326,6 +326,7 @@ impl Stdio {
         global: &JSGlobalObject,
         i: i32,
         body: &mut webcore::body::Value,
+        body_stream: Option<webcore::ReadableStream>,
         is_sync: bool,
     ) -> JsResult<()> {
         body.to_blob_if_possible();
@@ -381,12 +382,30 @@ impl Stdio {
                     }
                 }
 
-                let stream_value = body.to_readable_stream(global)?;
-
-                let Some(stream) = webcore::ReadableStream::from_js(stream_value, global)? else {
-                    return Err(global
-                        .throw_invalid_arguments(format_args!("Failed to create ReadableStream")));
+                // The Request/Response constructor migrates a Locked body's
+                // ReadableStream out of `locked.readable` into the wrapper's
+                // GC-traced stream slot (see `check_body_stream_ref`), so
+                // `body.to_readable_stream()` would find `readable` empty and
+                // synthesize an unconnected native ByteStream. Use the owner's
+                // actual stream (from `get_body_readable_stream`) when present.
+                let mut stream = match body_stream {
+                    Some(s) => s,
+                    None => {
+                        let stream_value = body.to_readable_stream(global)?;
+                        match webcore::ReadableStream::from_js(stream_value, global)? {
+                            Some(s) => s,
+                            None => {
+                                return Err(global.throw_invalid_arguments(format_args!(
+                                    "Failed to create ReadableStream"
+                                )));
+                            }
+                        }
+                    }
                 };
+
+                if let Some(blob) = stream.to_any_blob(global) {
+                    return out_stdio.extract_blob(global, blob, i);
+                }
 
                 if stream.is_disturbed(global) {
                     return Err(global
@@ -507,9 +526,25 @@ impl Stdio {
             // `value` is on the stack. `dupe()` only bumps the store refcount.
             return out_stdio.extract_blob(global, webcore::blob::Any::Blob(blob.dupe()), i);
         } else if let Some(req) = value.as_class_ref::<webcore::Request>() {
-            return Self::extract_body_value(out_stdio, global, i, req.get_body_value(), is_sync);
+            let body_stream = req.get_body_readable_stream(global);
+            return Self::extract_body_value(
+                out_stdio,
+                global,
+                i,
+                req.get_body_value(),
+                body_stream,
+                is_sync,
+            );
         } else if let Some(res) = value.as_class_ref::<webcore::Response>() {
-            return Self::extract_body_value(out_stdio, global, i, res.get_body_value(), is_sync);
+            let body_stream = res.get_body_readable_stream(global);
+            return Self::extract_body_value(
+                out_stdio,
+                global,
+                i,
+                res.get_body_value(),
+                body_stream,
+                is_sync,
+            );
         }
 
         if let Some(stream_) = webcore::ReadableStream::from_js(value, global)? {

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -382,12 +382,8 @@ impl Stdio {
                     }
                 }
 
-                // The Request/Response constructor migrates a Locked body's
-                // ReadableStream out of `locked.readable` into the wrapper's
-                // GC-traced stream slot (see `check_body_stream_ref`), so
-                // `body.to_readable_stream()` would find `readable` empty and
-                // synthesize an unconnected native ByteStream. Use the owner's
-                // actual stream (from `get_body_readable_stream`) when present.
+                // `locked.readable` was moved to the owner's GC `stream` slot by
+                // `check_body_stream_ref`; `body_stream` is that slot's value.
                 let mut stream = match body_stream {
                     Some(s) => s,
                     None => {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -896,3 +896,112 @@ describe("spawn stdin ReadableStream", () => {
     expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
   });
 });
+
+// Response/Request whose body is a JS-authored ReadableStream: the constructor
+// migrates the stream out of `Locked.readable` into the wrapper's GC-traced
+// stream slot, so spawn's stdin extraction must read that slot instead of
+// synthesizing a fresh (unconnected) native ByteStream.
+describe.concurrent("spawn stdin Response/Request with JS-authored ReadableStream body", () => {
+  const childScript = `let n = 0; for await (const c of process.stdin) n += c.length; process.stdout.write("n=" + n);`;
+  const payload = () => new TextEncoder().encode("hello stream");
+
+  const shapes: Record<string, () => Response | Request> = {
+    "Response(start+enqueue+close)": () =>
+      new Response(
+        new ReadableStream({
+          start(c) {
+            c.enqueue(payload());
+            c.close();
+          },
+        }),
+      ),
+    "Response(async pull)": () => {
+      let done = false;
+      return new Response(
+        new ReadableStream({
+          async pull(c) {
+            await Promise.resolve();
+            if (done) return c.close();
+            c.enqueue(payload());
+            done = true;
+          },
+        }),
+      );
+    },
+    "Response(TransformStream.readable)": () => {
+      const { readable, writable } = new TransformStream();
+      const w = writable.getWriter();
+      w.write(payload()).then(() => w.close());
+      return new Response(readable);
+    },
+    "Response(async generator)": () =>
+      new Response(
+        (async function* () {
+          yield payload();
+        })() as any,
+      ),
+    "Request(pull stream)": () => {
+      let done = false;
+      return new Request("http://x/", {
+        method: "POST",
+        body: new ReadableStream({
+          pull(c) {
+            if (done) return c.close();
+            c.enqueue(payload());
+            done = true;
+          },
+        }),
+      });
+    },
+  };
+
+  for (const [name, mk] of Object.entries(shapes)) {
+    test(name, async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", childScript],
+        stdin: mk(),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("n=12");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("Response(Blob) body still works", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", childScript],
+      stdin: new Response(new Blob([payload()])),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("n=12");
+    expect(exitCode).toBe(0);
+  });
+
+  test("Response whose body stream was already consumed throws", async () => {
+    const res = new Response(
+      new ReadableStream({
+        start(c) {
+          c.enqueue(payload());
+          c.close();
+        },
+      }),
+    );
+    await res.arrayBuffer();
+    expect(() =>
+      spawn({
+        cmd: [bunExe(), "-e", childScript],
+        stdin: res,
+        stdout: "pipe",
+        env: bunEnv,
+      }),
+    ).toThrow(/already.*used/i);
+  });
+});

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -971,37 +971,63 @@ describe.concurrent("spawn stdin Response/Request with JS-authored ReadableStrea
     });
   }
 
-  test("Response(Blob) body still works", async () => {
-    await using proc = spawn({
-      cmd: [bunExe(), "-e", childScript],
-      stdin: new Response(new Blob([payload()])),
-      stdout: "pipe",
-      stderr: "pipe",
-      env: bunEnv,
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("n=12");
-    expect(exitCode).toBe(0);
-  });
-
-  test("Response whose body stream was already consumed throws", async () => {
-    const res = new Response(
-      new ReadableStream({
-        start(c) {
-          c.enqueue(payload());
-          c.close();
-        },
-      }),
-    );
-    await res.arrayBuffer();
-    expect(() =>
-      spawn({
+  for (const [label, mk] of [
+    ["Response(Blob)", () => new Response(new Blob([payload()]))],
+    ["Request(Blob)", () => new Request("http://x/", { method: "POST", body: new Blob([payload()]) })],
+  ] as const) {
+    test(`${label} body still works`, async () => {
+      await using proc = spawn({
         cmd: [bunExe(), "-e", childScript],
-        stdin: res,
+        stdin: mk(),
         stdout: "pipe",
+        stderr: "pipe",
         env: bunEnv,
-      }),
-    ).toThrow(/already.*used/i);
-  });
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("n=12");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  for (const [label, mk] of [
+    [
+      "Response",
+      () =>
+        new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(payload());
+              c.close();
+            },
+          }),
+        ),
+    ],
+    [
+      "Request",
+      () =>
+        new Request("http://x/", {
+          method: "POST",
+          body: new ReadableStream({
+            start(c) {
+              c.enqueue(payload());
+              c.close();
+            },
+          }),
+        }),
+    ],
+  ] as const) {
+    test(`${label} whose body stream was already consumed throws`, async () => {
+      const owner = mk();
+      await owner.arrayBuffer();
+      expect(() =>
+        spawn({
+          cmd: [bunExe(), "-e", childScript],
+          stdin: owner,
+          stdout: "pipe",
+          env: bunEnv,
+        }),
+      ).toThrow(/already.*used/i);
+    });
+  }
 });


### PR DESCRIPTION
## What

`Bun.spawn({ stdin: new Response(jsStream) })` (and `Request`) hung forever when the body was a JS-authored `ReadableStream` (start/enqueue/close, async pull, `TransformStream.readable`, async generator). Zero bytes were delivered to the child and stdin was never closed, so the child blocked on read and `await proc.exited` never settled. Passing the same stream directly as `stdin:` worked fine; only the `Response`/`Request` wrapping broke.

## Repro

```js
const child = `let n=0; for await (const c of process.stdin) n+=c.length; console.log("n="+n);`;
const stream = new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("hello stream")); c.close(); } });
const proc = Bun.spawn([process.execPath, "-e", child], { stdin: new Response(stream), stdout: "pipe" });
console.log(await proc.stdout.text()); // never resolves; child blocks on stdin forever
```

## Cause

The `Response`/`Request` constructor moves a `Locked` body's `ReadableStream` out of `PendingValue.readable` into the wrapper's GC-traced `stream` slot (`check_body_stream_ref` in `src/runtime/webcore/Body.rs`), leaving `locked.readable` empty to break a reference cycle.

`Stdio::extract_body_value` later called `body.to_readable_stream()`, which found `locked.readable` empty and fell through to the branch that synthesizes a brand-new native `ByteStream`-backed stream with no producer attached. `assignToStream` then pumped that unconnected stream: `readMany` returned a pending promise that never settled, so no bytes were written and no EOF was sent.

## Fix

Look up the body's stream via `get_body_readable_stream()` (the same accessor `res.body` uses, which checks the JS-side cached slot first and falls back to `locked.readable`) and pass it into `extract_body_value`. When present, use that stream directly for `Stdio::ReadableStream` instead of calling `body.to_readable_stream()`. Also try `stream.to_any_blob()` on it so native-backed bodies (fetch responses, Blob streams) keep taking the blob fast path, matching the direct `ReadableStream` stdin code.

## Verification

New tests in `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts` cover the five failing shapes plus the `Response(Blob)` and already-consumed-body paths.

Before: all five JS-stream shapes time out (child never receives EOF); the already-consumed case spawns instead of throwing.
After: all seven new tests pass; full file (35 tests) passes; the `stdio[3]` throw tests in `spawn.test.ts` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
bun test v1.4.0 (f8ede633f)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [1452.62ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [1468.50ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1478.31ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [1476.64ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1500.03ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1460.91ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1589.29ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1508.66ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [1540.06ms]
(pass) spawn stdin ReadableStream > erroring the stdin Read
... (truncated)

release without fix: 9 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [39.44ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [36.48ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [37.33ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [106.94ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [37.11ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [97.39ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [38.93ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [39.03ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [36.69ms]
(pass) spawn stdin ReadableStream > erroring the stdin ReadableStream does not surface an unhandled rejection [99.34ms]
(pass) spawn stdin ReadableStream > in-flight write when the child dies does not surface an unhandled rejection [38.05ms]
(pass) spawn
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
bun test v1.4.0 (f8ede633f)

test/js/bun/spawn/spawn-stdin-readable-stream.test.ts:
(pass) spawn stdin ReadableStream > basic ReadableStream as stdin [1471.85ms]
(pass) spawn stdin ReadableStream > ReadableStream with multiple chunks [1475.37ms]
(pass) spawn stdin ReadableStream > ReadableStream with Uint8Array chunks [1557.81ms]
(pass) spawn stdin ReadableStream > ReadableStream with delays between chunks [1497.05ms]
(pass) spawn stdin ReadableStream > ReadableStream with pull method [1484.22ms]
(pass) spawn stdin ReadableStream > ReadableStream with async pull and delays [1488.01ms]
(pass) spawn stdin ReadableStream > ReadableStream with large data [1484.35ms]
1048576
(pass) spawn stdin ReadableStream > ReadableStream with very large chunked data [1523.32ms]
(todo) spawn stdin ReadableStream > ReadableStream cancellation when process exits early
(pass) spawn stdin ReadableStream > ReadableStream error handling [1463.68ms]
(pass) spawn stdin ReadableStream > erroring the stdin Read
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f8ede633f7
  features     baseline

22 deps, 108 codegen, 1171 objects in 864ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [7.00ms]
[2/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[4/1234] gen ErrorCode+*.h
[5/1234] gen bindgenv2
[6/1234] fetch zlib
[zlib] up to date
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] gen .bind.ts → GeneratedBindings.cpp
[9/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1234] fetch libjpeg-turbo
[libjpeg-tur
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/spawn/stdio.rs                 |  45 +++++--
 .../bun/spawn/spawn-stdin-readable-stream.test.ts  | 135 +++++++++++++++++++++
 2 files changed, 173 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/api/bun/spawn/stdio.rs                         6      9      0
test/js/bun/spawn/spawn-stdin-readable-stream.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->