### PR TITLE
test(watch): suppress crash report upload from deliberate EAGAIN panic

### DIFF
--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -106,7 +106,15 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
     // backtrace symbolication so the child exits promptly.
     cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "--watch", "watchee.js"],
     cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+      // This panic is deliberate; uploading it to CI's BUN_CRASH_REPORT_URL
+      // would pin a spurious "crash reported" on the next test to exit
+      // non-zero (see scripts/runner.node.mjs).
+      BUN_CRASH_REPORT_URL: "",
+      BUN_ENABLE_CRASH_REPORTING: "0",
+    },
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
## What does this PR do?

The `propagates FileWatcher thread spawn failure` test in `test/cli/watch/watch.test.ts` (added in #35185) deliberately panics a `bun --watch` subprocess via an LD_PRELOAD shim that fails `pthread_create` with `EAGAIN` right after `inotify_init1`. The test asserts on the expected `Failed to start File Watcher: EAGAIN` message and passes.

However, `Output::panic()` also routes through the crash handler, which uploads a report to `BUN_CRASH_REPORT_URL` (set by the CI runner, inherited through `bunEnv` via `...process.env`). The test already sets `RLIMIT_CORE=0` to suppress the core file, but not the report upload.

Because this test exits 0, `scripts/runner.node.mjs` does not drain the local crash-report queue (it only does so when `exitCode !== 0`, per the documented quirk at line 1467). The stale report then gets attributed to whichever later test on the shard exits non-zero, e.g. the native trace below pinned on `test-fs-promises-file-handle-readFile.js` in [build 78980](https://buildkite.com/bun/bun/builds/78980) (also seen on main builds 78969 and 79091):

```
"message": "panic: Failed to start File Watcher: EAGAIN",
"command": "a"
```

## Fix

Clear `BUN_CRASH_REPORT_URL` and `BUN_ENABLE_CRASH_REPORTING` in the child env, matching the established pattern in `run-crash-handler.test.ts`, `tls-syscall-fault.test.ts`, `native-plugin.test.ts`, and `30205.test.ts`.

## How did you verify your code works?

Ran the subprocess against a local crash-report sink:

| | crash-report hits | stderr has expected msg | exit |
|---|---|---|---|
| without suppression | 1 | yes | 134 |
| with suppression | 0 | yes | 134 |

`bun bd test test/cli/watch/watch.test.ts` passes (3/3).

Note: #35218 reworks this test but keeps a deliberate-panic case without suppression; whichever lands second will want the same env vars.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->