### PR TITLE
refactor(rust): remove resolved borrowck-reshape comments (bucket A, 256 sites)

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -303,8 +303,6 @@ impl Chunk {
         // Look up the CSS chunk via the JS chunk's css_chunks indices.
         // This correctly handles deduplicated CSS chunks that are shared
         // across multiple HTML entry points (see issue #23668).
-        // Note: reshaped for borrowck — we scan immutably for the JS chunk, copy the
-        // css-chunk index into a local, drop the borrow, then re-borrow mutably.
         let entry_point_id = self.entry_point.entry_point_id();
         let css_idx: Option<usize> = 'find: {
             for other in chunks.iter() {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -557,6 +557,8 @@ impl<'a> LinkerContext<'a> {
         }
 
         if self.options.output_format == Format::Cjs || self.options.output_format == Format::Iife {
+            // INVARIANT: self.graph.ast is not resized while ast_slice is live
+            // (Slice<T> holds raw column pointers).
             let mut ast_slice = self.graph.ast.slice();
             let ast_cols = ast_slice.split_mut();
             let exports_kind: &mut [ExportsKind] = ast_cols.exports_kind;

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -557,11 +557,6 @@ impl<'a> LinkerContext<'a> {
         }
 
         if self.options.output_format == Format::Cjs || self.options.output_format == Format::Iife {
-            // Note: reshaped for borrowck — `Slice<T>` is a value-type
-            // snapshot of column pointers (does not borrow `self.graph.ast`),
-            // so `split_mut()` on the local can coexist with the
-            // `self.graph.meta` borrow below. The slab does not reallocate for
-            // the duration of this loop.
             let mut ast_slice = self.graph.ast.slice();
             let ast_cols = ast_slice.split_mut();
             let exports_kind: &mut [ExportsKind] = ast_cols.exports_kind;

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2728,6 +2728,10 @@ pub mod parse_worker {
                 }
             }
 
+            // `entry` must be written back into `this.stage` on every path before `break 'value`:
+            // `Success.source.contents` borrows its `Contents::Owned` buffer via the
+            // arena-erased `StoreStr` path (see `run_with_source_code`), so dropping the local
+            // would free the buffer underneath the borrowed source.
             let mut entry =
                 match core::mem::replace(&mut this.stage, ParseTaskStage::NeedsSourceCode) {
                     ParseTaskStage::NeedsParse(e) => e,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2728,13 +2728,6 @@ pub mod parse_worker {
                 }
             }
 
-            // reshaped for borrowck — `this` and `this.stage.needs_parse`
-            // both borrowed mutably. The entry must live
-            // in-place so its `Contents::Owned` buffer survives in
-            // `task.stage` for the bundle's lifetime (Success.source.contents
-            // borrows it via the arena-erased `StoreStr` path). Take it out, parse, then *write it
-            // back* on every path before `break 'value` so dropping the local
-            // can't free the buffer underneath the borrowed source.
             let mut entry =
                 match core::mem::replace(&mut this.stage, ParseTaskStage::NeedsSourceCode) {
                     ParseTaskStage::NeedsParse(e) => e,

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -691,10 +691,8 @@ impl Worker {
 
     /// Build a per-worker `Transpiler` from `from`.
     ///
-    /// reshaped for borrowck — associated fn (no `&mut self`) so
-    /// callers can borrow `self.data.log` disjointly. The returned value is a
-    /// fully-owned `Transpiler` whose `Drop` is sound; `wire_after_move` must
-    /// be called once it is at its final address.
+    /// The returned value is a fully-owned `Transpiler` whose `Drop` is sound;
+    /// `wire_after_move` must be called once it is at its final address.
     fn initialize_transpiler(
         log: *mut bun_ast::Log,
         from: &Transpiler<'_>,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1129,8 +1129,9 @@ pub mod bv2_impl {
                 }
                 pub fn run_on_js_thread(&mut self) {
                     let kind = self.import_record.kind;
-                    // reshaped for borrowck — capture the erased self
-                    // pointer before borrowing fields immutably for the FFI call.
+                    // SAFETY: self_ptr is the *mut c_void context handed to
+                    // JSBundlerPlugin__matchOnResolve; the JS completion callback
+                    // mutates/consumes self, so *mut Self provenance is required.
                     let self_ptr = std::ptr::from_mut::<Self>(self).cast::<core::ffi::c_void>();
                     // SAFETY: `bv2` is a valid backref set by `init`; the plugin
                     // storage is disjoint from `self`, so the `&mut JSBundlerPlugin`
@@ -1262,8 +1263,9 @@ pub mod bv2_impl {
                 pub fn run_on_js_thread(&mut self) {
                     let is_server_side = self.bake_graph() != crate::bake_types::Graph::Client;
                     let default_loader = self.default_loader;
-                    // reshaped for borrowck — capture the erased self
-                    // pointer before borrowing fields immutably for the FFI call.
+                    // SAFETY: self_ptr is the *mut c_void context handed to
+                    // JSBundlerPlugin__matchOnLoad; the JS completion callback
+                    // mutates/consumes self, so *mut Self provenance is required.
                     let self_ptr = std::ptr::from_mut::<Self>(self).cast::<core::ffi::c_void>();
                     // SAFETY: `bv2` is a valid backref set by `init`; the plugin
                     // storage is disjoint from `self`, so the `&mut JSBundlerPlugin`
@@ -1889,19 +1891,12 @@ pub mod bv2_impl {
 
             self.dynamic_import_entry_points = ArrayHashMap::new();
 
-            // reshaped for borrowck — hoist the values that would
-            // otherwise re-borrow `self`/`self.graph` while the visitor holds
-            // disjoint column refs.
             // Always materialize a valid slice; when the boundary list is empty
             // this is a cheap `{ list: empty, map: &map }`. Avoids constructing a
             // null `&Map` via `mem::zeroed()` (UB even though it was never read
             // when `scb_bitset` is `None`).
             let scb_list = self.graph.server_component_boundaries.slice();
 
-            // reshaped for borrowck — `Slice<T>` is a value-type
-            // snapshot of column pointers (does not borrow `self.graph.ast`), so
-            // `split_mut()` on the local can coexist with the shared borrows
-            // below. The slab does not resize for the duration of this function.
             let mut ast_slice = self.graph.ast.slice();
             let all_import_records: &mut [import_record::List<'_>] =
                 ast_slice.split_mut().import_records;
@@ -1960,13 +1955,8 @@ pub mod bv2_impl {
                 }
             }
 
-            // reshaped for borrowck — release the visitor's `&mut`
-            // borrows on the two bitsets and `input_files` columns before the
-            // cleanup loop reads them.
             let ReachableFileVisitor { reachable, .. } = visitor;
 
-            // reshaped for borrowck — three disjoint mutable SoA
-            // columns via `split_mut()` on a value-type `Slice` snapshot.
             let mut input_files_slice = self.graph.input_files.slice();
             let input_files_cols = input_files_slice.split_mut();
             let additional_files: &mut [bun_alloc::AstVec<crate::AdditionalFile>] =
@@ -2066,12 +2056,6 @@ pub mod bv2_impl {
             // version and exports a non-object in CommonJS (often a function). If we
             // pick the "module" field and the package is imported with "require" then
             // code expecting a function will crash.
-            //
-            // reshaped for borrowck — the mutable `import_records` column is
-            // needed alongside shared columns. `split_mut()` on a
-            // value-type `Slice` snapshot yields the one mutable column without
-            // borrowing `self.graph.ast`; read the per-target map through the
-            // disjoint `build_graphs` field instead of the `&mut self` accessor.
             let mut ast_slice = self.graph.ast.slice();
             let ast_import_records: &mut [import_record::List<'_>] =
                 ast_slice.split_mut().import_records;
@@ -6454,10 +6438,9 @@ pub mod bv2_impl {
             importer_source_index: IndexInt,
         ) -> i32 {
             let mut diff: i32 = 0;
-            // reshaped for borrowck — `graph` and the
-            // path map are both needed across the loop body. We (a) capture a raw self ptr for
-            // ParseTask.ctx, (b) hoist dev_server check, and (c) scope the map
-            // borrow to the get_or_put so later `self.graph.*` writes don't overlap.
+            // SAFETY: self_ptr is a ParentRef<BundleV2> stored into ParseTask.ctx and scheduled
+            // on the thread pool; the task calls back into BundleV2, so *mut Self write
+            // provenance is required.
             // SAFETY: write provenance from `ptr::from_mut`; outlives every ParseTask.
             let self_ptr: Option<bun_ptr::ParentRef<BundleV2<'static>>> = Some(unsafe {
                 bun_ptr::ParentRef::from_raw_mut(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1897,6 +1897,8 @@ pub mod bv2_impl {
             // when `scb_bitset` is `None`).
             let scb_list = self.graph.server_component_boundaries.slice();
 
+            // INVARIANT: self.graph.ast is not resized while ast_slice is live
+            // (Slice<T> holds raw column pointers).
             let mut ast_slice = self.graph.ast.slice();
             let all_import_records: &mut [import_record::List<'_>] =
                 ast_slice.split_mut().import_records;
@@ -2056,6 +2058,8 @@ pub mod bv2_impl {
             // version and exports a non-object in CommonJS (often a function). If we
             // pick the "module" field and the package is imported with "require" then
             // code expecting a function will crash.
+            // INVARIANT: self.graph.ast is not resized while ast_slice is live
+            // (Slice<T> holds raw column pointers).
             let mut ast_slice = self.graph.ast.slice();
             let ast_import_records: &mut [import_record::List<'_>] =
                 ast_slice.split_mut().import_records;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6438,10 +6438,9 @@ pub mod bv2_impl {
             importer_source_index: IndexInt,
         ) -> i32 {
             let mut diff: i32 = 0;
-            // SAFETY: self_ptr is a ParentRef<BundleV2> stored into ParseTask.ctx and scheduled
-            // on the thread pool; the task calls back into BundleV2, so *mut Self write
-            // provenance is required.
-            // SAFETY: write provenance from `ptr::from_mut`; outlives every ParseTask.
+            // SAFETY: stored into ParseTask.ctx and scheduled on the thread pool; the task
+            // calls back into BundleV2, so `ptr::from_mut` write provenance is required.
+            // Outlives every ParseTask.
             let self_ptr: Option<bun_ptr::ParentRef<BundleV2<'static>>> = Some(unsafe {
                 bun_ptr::ParentRef::from_raw_mut(
                     std::ptr::from_mut::<Self>(self).cast::<BundleV2<'static>>(),

--- a/src/bundler/entry_points.rs
+++ b/src/bundler/entry_points.rs
@@ -155,8 +155,6 @@ impl MacroEntryPoint {
         let hash = hasher.final_();
         let fmt = bun_fmt::hex_int_lower::<16>(hash);
 
-        // reshaped for borrowck — capture cursor position, drop &mut
-        // borrow, then re-borrow `buf` immutably.
         let n = {
             let mut cursor = std::io::Cursor::new(&mut buf[..]);
             write!(
@@ -192,9 +190,6 @@ impl MacroEntryPoint {
         } else {
             import_path.dir_with_trailing_slash()
         };
-        // reshaped for borrowck — capture the label length, write the
-        // body via a scoped &mut borrow, then re-borrow `code_buffer` immutably
-        // for the (label, code) slices passed to `init_path_string`.
         let label_len = macro_label_.len();
         entry.code_buffer[..label_len].copy_from_slice(macro_label_);
 

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -278,7 +278,6 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
             }
         }
     }
-    // reshaped for borrowck — re-borrow file_entry_bits after the loop above mutated it
     let file_entry_bits: &mut [AutoBitSet] = this.graph.files.items_entry_bits_mut();
 
     let css_reprs = this.graph.ast.items_css();

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -291,8 +291,6 @@ pub fn generate_code_for_lazy_export(
                 }
             }
 
-            // The Visitor is constructed inside the loop with a fresh `parts`
-            // borrow each time (reshaped for borrowck).
             let all_symbols = this.graph.ast.items_symbols();
             // SAFETY: `LinkerContext::arena()` returns a stable `&Arena` valid for the
             // link pass; detach via raw-pointer round-trip so it doesn't hold a `&self`

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1577,7 +1577,6 @@ impl<'a> BundleOptions<'a> {
 
             Some(Cow::Borrowed(b"\"development\"".as_slice()))
         };
-        // reshaped for borrowck — node_env computed before passing self.log
         self.define = defines_from_transform_options(
             // No other `&mut Log` is live across this call (see `log_mut`
             // caller contract).

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -463,11 +463,6 @@ impl<'a> Transpiler<'a> {
                 let mut cache_bust_buf = bun_paths::PathBuffer::uninit();
 
                 // Bust directory cache and try again
-                // reshaped for borrowck — a single labelled block would
-                // return a slice that aliases either `entry_point` (via
-                // `dirname`) or `cache_bust_buf`. Rust can't unify the two
-                // disjoint mutable borrows of `cache_bust_buf` across `break`,
-                // so compute `busted` directly instead.
                 let busted: bool = 'name: {
                     if bun_paths::is_absolute(entry_point) {
                         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
@@ -1928,9 +1923,6 @@ fn parse_data_loader<'a>(
                     bun_collections::StringHashMap::default();
                 // duplicate_key_checker drops at end of scope (defer .deinit())
                 let mut count: usize = 0;
-                // reshaped for borrowck — cannot zip 4
-                // slices with one mutable borrow into `decls` and
-                // also random-access `decls[prev]`.
                 for i in 0..n {
                     let prop = &mut properties[i];
                     // SAFETY: data-format parsers always emit

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -358,7 +358,6 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         #[cfg(debug_assertions)]
         {
             // set old range to undefined. Note: may be wrapped around
-            // reshaped for borrowck — capture len, then re-borrow.
             let slice_len = self.readable_slice_mut(0).len();
             if slice_len >= count {
                 poison(self.readable_slice_mut(0), count);
@@ -448,8 +447,6 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         self.ensure_unused_capacity(size)?;
 
         // try to avoid realigning buffer
-        // reshaped for borrowck — check len, drop borrow, maybe
-        // realign, then take the final borrow.
         if self.writable_slice(0).len() < size {
             self.realign();
         }
@@ -474,8 +471,6 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 
         let mut src_left = src;
         while !src_left.is_empty() {
-            // reshaped for borrowck — scoped block drops the
-            // `writable` borrow before `self.update`.
             let n = {
                 let writable = self.writable_slice(0);
                 debug_assert!(!writable.is_empty());
@@ -544,8 +539,6 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 
         self.rewind(src.len());
 
-        // reshaped for borrowck — copy into first chunk in a scoped
-        // block, drop borrow, then re-borrow for the wrapped chunk.
         let slice_len = {
             let s = self.readable_slice_mut(0);
             let n = s.len().min(src.len());

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -581,7 +581,6 @@ fn parse_nested_block<T>(
         BlockType::SquareBracket => Delimiters::CLOSE_SQUARE_BRACKET,
         BlockType::Parenthesis => Delimiters::CLOSE_PARENTHESIS,
     };
-    // Note: reshaped for borrowck — same aliasing as parse_until_before.
     // Swap stop_before/at_start_of in place rather than constructing a second
     // Parser over the invariant `&'a mut ParserInput<'a>`.
     let saved_stop_before = parser.stop_before;

--- a/src/css/properties/animation.rs
+++ b/src/css/properties/animation.rs
@@ -339,8 +339,6 @@ impl AnimationName {
                 // SAFETY: arena-owned slice valid for 'bump.
                 let name: &[u8] = unsafe { crate::arena_str(s.v) };
                 if css_module_animation_enabled {
-                    // reshaped for borrowck — capture arena/source_index
-                    // before borrowing dest.css_module mutably.
                     let arena = dest.arena;
                     let source_index = dest.loc.source_index;
                     if let Some(css_module) = &mut dest.css_module {
@@ -353,7 +351,6 @@ impl AnimationName {
                 // SAFETY: arena-owned slice valid for 'bump.
                 let name: &[u8] = unsafe { crate::arena_str(*s) };
                 if css_module_animation_enabled {
-                    // reshaped for borrowck
                     let arena = dest.arena;
                     let source_index = dest.loc.source_index;
                     if let Some(css_module) = &mut dest.css_module {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1106,9 +1106,6 @@ impl<'a> Parser<'a> {
         if end >= self.src.len() {
             return Ok(&self.src[self.src.len()..]);
         }
-        // reshaped for borrowck — `parse_quoted` returns a borrow of
-        // `self.value_buffer`; capture only its length, then re-borrow the buffer
-        // after the match so the unquoted fallthrough can re-borrow `self`.
         let quoted_len: Option<usize> = match self.src[end] {
             b'`' => self.parse_quoted::<b'`'>()?.map(|v| v.len()),
             b'"' => self.parse_quoted::<b'"'>()?.map(|v| v.len()),

--- a/src/exe_format/elf.rs
+++ b/src/exe_format/elf.rs
@@ -88,8 +88,6 @@ impl ElfFile {
                 return;
             }
 
-            // reshaped for borrowck — compute replacement under an
-            // immutable borrow, then take a mutable borrow for the writes.
             let replacement: &'static [u8] = {
                 let interp_region = &self.data[interp_offset..][..interp_filesz];
                 let current = slice_to_nul(interp_region);
@@ -167,8 +165,6 @@ impl ElfFile {
         if strtab_end > self.data.len() as u64 {
             return;
         }
-        // reshaped for borrowck — copy strtab bounds out so we can
-        // re-borrow self.data mutably below.
         let strtab_off = usize::try_from(strtab_shdr.sh_offset).expect("int cast");
         let strtab_len = usize::try_from(strtab_shdr.sh_size).expect("int cast");
 

--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -745,7 +745,6 @@ impl MachoSigner {
         self.data.extend_from_slice(id);
 
         // Hash and write pages
-        // reshaped for borrowck — index instead of slicing self.data while pushing.
         let mut off: usize = 0;
         let end = self.sig_off;
         while end - off >= PAGE_SIZE {

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -793,7 +793,6 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
 
     pub fn next(&mut self) -> Result<Maybe<Option<MatchedPath>>, Error> {
         'outer: loop {
-            // Note: reshaped for borrowck — take/replace iter_state where needed.
             match &mut self.iter_state {
                 IterState::Matched(_) => {
                     let IterState::Matched(path) =
@@ -842,8 +841,6 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             // `path_buf` and `pattern_components` (disjoint fields) for the
                             // write+normalize, then drop the &mut and read via `self.walker`.
                             let mut symlink_full_path_len = work_item_path.len();
-                            // Note: reshaped for borrowck — entry_name is a sub-slice
-                            // of symlink_full_path; capture range and re-slice later.
                             let entry_start = work_item.entry_start as usize;
 
                             let mut has_dot_dot = false;
@@ -1004,7 +1001,6 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
                             let dir_fd = dir.fd;
                             let at_cwd = dir.at_cwd;
                             let dir_path = dir.dir_path();
-                            // Note: reshaped for borrowck
                             let err = self.walker.handle_sys_err_with_path(&err, dir_path);
                             if !at_cwd {
                                 self.close_disallowing_cwd(dir_fd);

--- a/src/http/HeaderBuilder.rs
+++ b/src/http/HeaderBuilder.rs
@@ -79,8 +79,6 @@ impl HeaderBuilder {
 
         let _ = self.content.append(name);
 
-        // Note: reshaped for borrowck — `fmt` returns a borrow into the
-        // builder buffer; capture its length, then re-read `content.len`.
         let value_len = self.content.fmt(args).len();
 
         let value_ptr = api::StringPointer {

--- a/src/http/h2_client/PendingConnect.rs
+++ b/src/http/h2_client/PendingConnect.rs
@@ -65,7 +65,6 @@ impl PendingConnect {
     /// Box until scope exit.
     pub fn unregister_from(this: *const Self, ctx: &mut NewHTTPContext<true>) -> Option<Box<Self>> {
         let list = &mut ctx.pending_h2_connects;
-        // reshaped for borrowck (was `for + swapRemove + return`)
         list.iter()
             .position(|p| core::ptr::eq(&raw const **p, this))
             .map(|i| list.swap_remove(i))

--- a/src/http/h3_client/AltSvc.rs
+++ b/src/http/h3_client/AltSvc.rs
@@ -158,7 +158,6 @@ fn key<'a>(buf: &'a mut [u8], hostname: &[u8], port: u16) -> &'a [u8] {
     // hostname verbatim, then format only the port.
     cursor.write_all(hostname).expect("unreachable");
     write!(cursor, ":{}", port).expect("unreachable");
-    // reshaped for borrowck — capture remaining len before reborrowing buf.
     let remaining = cursor.len();
     let written = buf.len() - remaining;
     &buf[..written]

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4368,7 +4368,6 @@ impl<'a> HTTPClient<'a> {
     /// transport, so there is no `ctx`/`socket` to hand back to the pool here.
     fn send_progress_update_multiplexed(&mut self) {
         debug_assert!(self.flags.protocol != Protocol::Http1_1);
-        // See send_progress_update_without_stage_check for the same pattern.
         let body = self.state.body_out_str;
         // Snapshot the body buffer's CONTENTS by value; restored below.
         let body_snapshot = body_out::take_list(body);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3164,11 +3164,6 @@ impl<'a> HTTPClient<'a> {
         ) {
             return;
         }
-        // reshaped for borrowck — copy out the Copy bits we need
-        // (`upgrade_state`, the stream-buffer NonNull, `ended`) so the
-        // `&mut self.state.original_request_body` borrow is dropped before any
-        // call that takes `&mut self`. The stream is re-borrowed only at the
-        // `detach()` sites via `request_stream_detach`.
         let upgrade_state = self.flags.upgrade_state;
         let (stream_buffer_ptr, ended) = {
             let HTTPRequestBody::Stream(stream) = &mut self.state.original_request_body else {
@@ -4176,14 +4171,6 @@ impl<'a> HTTPClient<'a> {
         if self.flags.protocol != Protocol::Http1_1 {
             return self.send_progress_update_multiplexed();
         }
-        // reshaped for borrowck — `to_result()` returns an
-        // `HTTPClientResult<'_>` whose lifetime is tied to `&mut self` (via the
-        // `body: &mut MutableString` borrow). Holding that result across the
-        // `is_done` mutations below would require a second live `&mut Self`,
-        // which PORTING.md §Forbidden flags as aliased `&mut`. Instead:
-        // snapshot every owned/Copy field out of the result, drop it, mutate
-        // `self` directly, then rebuild a fresh `HTTPClientResult` for the
-        // callback from the snapshotted fields + the restored body.
         let body = self.state.body_out_str;
         // Snapshot the body buffer's CONTENTS by value so that `state.reset()`
         // — which calls `body.reset()` and clears the list — doesn't deliver
@@ -4381,11 +4368,6 @@ impl<'a> HTTPClient<'a> {
     /// transport, so there is no `ctx`/`socket` to hand back to the pool here.
     fn send_progress_update_multiplexed(&mut self) {
         debug_assert!(self.flags.protocol != Protocol::Http1_1);
-        // reshaped for borrowck — `to_result()` ties `result`'s
-        // lifetime to `&mut self`, so holding it across the `is_done` mutations
-        // would require a second live `&mut Self` (aliased UB). Instead snapshot
-        // every owned/Copy field out of the result, drop it, mutate `self`
-        // directly, then rebuild a fresh `HTTPClientResult` for the callback.
         // See send_progress_update_without_stage_check for the same pattern.
         let body = self.state.body_out_str;
         // Snapshot the body buffer's CONTENTS by value; restored below.
@@ -4715,11 +4697,6 @@ impl<'a> HTTPClient<'a> {
         &mut self,
         incoming_data: &[u8],
     ) -> crate::Result<bool> {
-        // reshaped for borrowck — get_body_buffer() may return
-        // `&mut self.state.compressed_body`, so its borrow must be scoped
-        // tightly and not held across other `self.state.*` accesses (would be
-        // aliased `&mut`). Read the Copy fields first, then borrow the buffer
-        // only for the write block.
         let content_length = self.state.content_length;
 
         let remainder: &[u8] = if let Some(cl) = content_length {
@@ -4793,11 +4770,6 @@ impl<'a> HTTPClient<'a> {
         &mut self,
         incoming_data: &[u8],
     ) -> crate::Result<bool> {
-        // reshaped for borrowck — `chunked_decoder` and the body
-        // buffer (`compressed_body` / `body_out_str`) are disjoint fields of
-        // `self.state`, so borrow them once together via the split accessor and
-        // operate on safe references. Deep-cloning the buffer here would
-        // diverge (mutations from process_body_buffer would be lost).
         let (decoder, body_buf) = self.state.chunked_decoder_and_body_buffer();
         body_buf.append_slice(incoming_data)?;
 

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -515,7 +515,6 @@ impl WebSocketProxyTunnel {
         unsafe {
             let to_send = (*this).write_buffer.slice();
             if !to_send.is_empty() {
-                // reshaped for borrowck — capture len before re-borrowing write_buffer
                 let to_send_len = to_send.len();
                 let written = (*this).socket.write(to_send);
                 if written < 0 {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -470,7 +470,6 @@ impl<'a> PackageInstaller<'a> {
             let mut link_target_buf = PathBuffer::uninit();
             let mut link_dest_buf = PathBuffer::uninit();
             let mut link_rel_buf = PathBuffer::uninit();
-            // reshaped for borrowck — pass tree_id, re-borrow tree inside.
             self.link_tree_bins(
                 tree_id,
                 link_target_buf.as_mut_slice(),
@@ -672,7 +671,6 @@ impl<'a> PackageInstaller<'a> {
 
         let trees_len = self.trees.len();
         for tree_id in 0..trees_len {
-            // reshaped for borrowck — index instead of `for (self.trees, 0..) |*tree, tree_id|`.
             if self.trees[tree_id].binaries.count() > 0 {
                 self.seen_bin_links.clear();
                 self.node_modules.path.truncate(
@@ -781,7 +779,6 @@ impl<'a> PackageInstaller<'a> {
 
         let trees_len = self.trees.len();
         for i in 0..trees_len {
-            // reshaped for borrowck — index instead of iter_mut.
             if FORCE
                 || Self::can_install_package_for_tree(
                     &self.completed_trees,
@@ -835,8 +832,6 @@ impl<'a> PackageInstaller<'a> {
     }
 
     pub(crate) fn complete_remaining_scripts(&mut self, log_level: Options::LogLevel) {
-        // reshaped for borrowck — drain by move since loop body needs `&mut
-        // self.manager` and `spawn_package_lifecycle_scripts` consumes the list.
         for entry in core::mem::take(&mut self.pending_lifecycle_scripts) {
             let package_name: Box<[u8]> = entry.list.package_name.clone();
             // .monotonic is okay because this value isn't modified from any other thread.

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -632,8 +632,6 @@ pub fn cached_npm_package_folder_name_print<'a>(
         cached_npm_package_folder_print_basename(buf, name, version, None, include_version_number)
             .as_bytes()
             .len();
-    // reshaped for borrowck — resume the cursor at the basename's
-    // tail instead of holding the returned `&ZStr` across the re-borrow.
     let scope_url = scope.url.url();
     let mut w = ByteCursor {
         buf,
@@ -844,7 +842,6 @@ pub fn path_for_cached_npm_path<'a>(
         None,
     );
     let cache_path_len = cache_path.as_bytes().len();
-    // reshaped for borrowck — drop borrow before mutating buffer
 
     debug_assert!(cache_path_buf[package_name.len()] == b'@');
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1339,9 +1339,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else {
                 TaskCallbackContext::Dependency(id)
             };
-            // reshaped for borrowck — `entry` mutably borrows
-            // `this.task_queue`; scope it tightly so the calls below can
-            // reborrow `*this`.
             {
                 let entry = this
                     .task_queue
@@ -1537,7 +1534,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else {
                 TaskCallbackContext::Dependency(id)
             };
-            // reshaped for borrowck — scope `entry` tightly.
             {
                 let entry = this
                     .task_queue

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -231,9 +231,9 @@ impl PackageManager {
     }
 
     pub fn tick_lifecycle_scripts(&mut self) {
-        // SAFETY: event_loop.tick_once holds &mut self.event_loop while task.run(ctx) reborrows
-        // the enclosing PackageManager; raw *mut c_void ctx is the correct provenance
-        // carrier.
+        // `tick_once` forwards `ctx` opaquely; no reachable task callback dereferences it
+        // (the Js arm discards it, every Mini-arm callback takes `_: *mut ()`), so this does
+        // not alias the `&mut self.event_loop` receiver.
         let ctx = std::ptr::from_mut::<PackageManager>(self).cast::<core::ffi::c_void>();
         self.event_loop.tick_once(ctx);
     }

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -231,9 +231,9 @@ impl PackageManager {
     }
 
     pub fn tick_lifecycle_scripts(&mut self) {
-        // reshaped for borrowck — `self.event_loop.tick_once(self)`
-        // would borrow `self` twice. Erase `self` to a raw context pointer
-        // first; `tick_once` only forwards it opaquely to task callbacks.
+        // SAFETY: event_loop.tick_once holds &mut self.event_loop while task.run(ctx) reborrows
+        // the enclosing PackageManager; raw *mut c_void ctx is the correct provenance
+        // carrier.
         let ctx = std::ptr::from_mut::<PackageManager>(self).cast::<core::ffi::c_void>();
         self.event_loop.tick_once(ctx);
     }

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -241,7 +241,7 @@ impl PackageManager {
     pub fn sleep(&mut self) {
         self.report_slow_lifecycle_scripts();
         Output::flush();
-        // see `tick_lifecycle_scripts` — `is_done` callback reborrows
+        // `is_done` callback reborrows
         // `self` (the struct that owns `event_loop`), so use the raw-pointer
         // `tick_raw` variant which only holds `&mut event_loop` between
         // `is_done` calls.

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -59,13 +59,6 @@ impl PackageManager {
                     return None;
                 }
 
-                // reshaped for borrowck —
-                // `this.manifests.byNameHash(this, …, .load_from_memory, …)`
-                // would require simultaneous `&mut self.manifests`
-                // (receiver) and `&mut self` (arg). The memory-only path touches
-                // nothing on `PackageManager` besides the map, so use the
-                // disjoint-borrow helper and read `self.options` / `self.lockfile`
-                // alongside the held `&mut self.manifests` field borrow.
                 let manifest = self.manifests.by_name_hash_in_memory(name_hash)?;
 
                 if let Some(latest_version) = manifest
@@ -256,7 +249,6 @@ impl PackageManager {
     }
 
     pub fn assign_resolution(&mut self, dependency_id: DependencyID, package_id: PackageID) {
-        // reshaped for borrowck — capture lengths before mutable borrows.
         debug_assert!(
             (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
         );
@@ -275,7 +267,6 @@ impl PackageManager {
     }
 
     pub fn assign_root_resolution(&mut self, dependency_id: DependencyID, package_id: PackageID) {
-        // reshaped for borrowck — capture lengths before mutable borrows.
         debug_assert!(
             (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
         );

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -660,10 +660,6 @@ pub fn install_with_manager(
         root_scripts.append_to_lockfile(&mut manager.lockfile);
     }
     {
-        // reshaped for borrowck — shared slices into the
-        // resolution/meta/scripts columns are held while pushing into
-        // `manager.lockfile.scripts`. Field-level split borrow keeps the two
-        // disjoint columns alive simultaneously without raw-pointer routing.
         let lockfile = &mut *manager.lockfile;
         let packages = &lockfile.packages;
         let string_bytes = lockfile.buffers.string_bytes.as_slice();
@@ -1418,9 +1414,6 @@ fn report_lockfile_load_error(
 #[inline(never)]
 fn record_updating_package_versions(manager: &mut PackageManager) {
     // existing lockfile, get the original version is updating
-    // reshaped for borrowck — the lockfile is read while
-    // also mutating `manager.updating_packages`. Field-level split
-    // borrow keeps the disjoint columns alive without raw pointers.
     let lockfile: &Lockfile = &manager.lockfile;
     let updating_packages = &mut manager.updating_packages;
     let packages = lockfile.packages.slice();
@@ -1779,9 +1772,6 @@ fn write_yarn_lock_with_progress(
     manager: &mut PackageManager,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
-    // reshaped for borrowck — `Progress::start` returns
-    // `&mut self.root`, so re-access it via `manager.progress.root` after the
-    // `&mut manager` borrow ends instead of keeping a live `&mut Node`.
     let mut node_started = false;
     if log_level.show_progress() {
         manager.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -100,7 +100,6 @@ pub fn do_patch_commit(
         .root_package_id
         .get(&lockfile, manager.workspace_name_hash);
     let not_in_workspace_root = workspace_package_id != 0;
-    // reshaped for borrowck — owned buffer kept separately so `argument` can borrow it
     let argument_owned: Option<Box<[u8]>>;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root
@@ -734,7 +733,6 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
         .root_package_id
         .get(&manager.lockfile, workspace_name_hash);
     let not_in_workspace_root = workspace_package_id != 0;
-    // reshaped for borrowck — owned buffer kept so `argument` can borrow it.
     let argument_owned: Option<Box<[u8]>>;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -282,9 +282,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     // `store.entries.items_scripts()[entry_id]`; this Task is
                     // its sole consumer (see Installer.rs Yield::RunScripts).
                     let list_val = unsafe { (*list).clone() };
-                    // reshaped for borrowck — `Command::Context<'a>`
-                    // is `&'a mut ContextData`; reborrow instead of moving the
-                    // field out of `*installer`.
                     let command_ctx: Command::Context<'_> = &mut *installer.command_ctx;
                     // `installer.manager == manager` (same allocation,
                     // see fn-signature note); call via the body shadow which is a
@@ -552,13 +549,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             .insert(name_hash, ManifestEntry::Manifest(manifest));
 
                         if manager.options.enable.contains(Enable::MANIFEST_CACHE) {
-                            // reshaped for borrowck — compute the
-                            // `&mut`-taking directory accessors first so the
-                            // shared `scope_for_package_name` / `manifests`
-                            // borrows below do not overlap them. `save_async`
-                            // only needs `&PackageManifest`, so reborrow the
-                            // freshly-inserted entry immutably alongside the
-                            // scope (both `&manager`, no conflict).
                             let tmp_fd = directories::get_temporary_directory(manager).handle.fd;
                             let cache_fd = directories::get_cache_directory(manager);
                             npm::package_manifest::Serializer::save_async(
@@ -605,8 +595,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     &mut crate::network_task::filename_store_appender(),
                 )
                 .expect("unreachable");
-                // reshaped for borrowck — split the nested `&mut
-                // manager` borrows (`task_batch.push` vs. `enqueue_*`).
                 // SAFETY: `task_ptr` is non-null (checked by the iterator loop guard)
                 // and exclusively owned by this batch; `manager` is the live PackageManager.
                 let queued = unsafe {
@@ -892,7 +880,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     }
                 }
 
-                // reshaped for borrowck — split nested `&mut manager`.
                 let queued = enqueue::enqueue_extract_npm_package(manager, &*extract, task_ptr);
                 manager.task_batch.push(ThreadPoolBatch::from(queued));
             }
@@ -1336,13 +1323,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     // this dependency might be something other than a git dependency! only need the name and
                     // behavior, use the resolution from the task.
                     let dep_id = clone.dep_id;
-                    // reshaped for borrowck — copy the small `String` handles
-                    // + behavior bit so
-                    // the `&manager.lockfile` borrow doesn't extend across the
-                    // `&mut manager` calls (`has_created_network_task`,
-                    // `enqueue_git_checkout`) below; detach the slice backing
-                    // through `string_buf_ptr` (matching the
-                    // `PackageManifest`-arm `name` detach pattern above).
                     let (dep_name_handle, is_required) = {
                         let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
                         (dep.name, dep.behavior.is_required())
@@ -1375,7 +1355,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         continue;
                     }
 
-                    // reshaped for borrowck — split nested `&mut manager`.
                     let queued = enqueue::enqueue_git_checkout(
                         manager,
                         checkout_id,
@@ -1768,11 +1747,6 @@ pub fn generate_network_task_for_tarball<'a>(
         return Ok(None);
     }
 
-    // reshaped for borrowck —
-    // all `&mut this` uses (patch-task alloc, cache/temp dir, pool slot) happen
-    // first; the immutable `pkg_name`/`scope` borrows are taken afterwards and
-    // live only through `for_tarball`, leaving `this` free for the streaming
-    // tail.
     // The patched-dependency entry can be missing (or its hash not yet
     // computed) when install state went stale — e.g. the patch was removed
     // from package.json, leaving the hash only in

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -868,7 +868,6 @@ fn attempt_security_scan_with_retry(
             b"false"
         });
         new_code.extend_from_slice(&temp_source[index + suppress_placeholder.len()..]);
-        // reshaped for borrowck — drop borrow of `code` (via `temp_source`) before reassigning.
         code = new_code;
     }
 

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -73,9 +73,6 @@ fn update_package_json_and_install_with_manager_with_updates_and_update_requests
 ) -> Result<(), Error> {
     let subcommand = manager.subcommand;
     if subcommand != Subcommand::PatchCommit && subcommand != Subcommand::Patch {
-        // reshaped for borrowck — `parse` returns a `&mut [UpdateRequest]`
-        // sub-slice of `update_requests`; we take its length and truncate the Vec so
-        // the next call can take the Vec by value.
         let len = UpdateRequest::parse(
             // `dependency::parse_with_tag` is the only consumer of `pm`; it inserts
             // into `pm.known_npm_aliases` for `npm:`-aliased positionals.
@@ -104,10 +101,6 @@ fn update_package_json_and_install_with_manager_with_updates_and_update_requests
 fn update_package_json_and_install_with_manager_with_updates(
     manager: &mut PackageManager,
     ctx: Command::Context,
-    // reshaped for borrowck — taking by
-    // value lets us hand ownership to `manager.update_requests` (typed
-    // `Box<[UpdateRequest]>`) and re-borrow afterwards without
-    // aliasing `&mut manager`.
     mut updates: Vec<UpdateRequest>,
     subcommand: Subcommand,
     original_cwd: &[u8],
@@ -242,10 +235,6 @@ fn update_package_json_and_install_with_manager_with_updates(
                 for list in LISTS {
                     if let Some(query) = current_package_json_root.as_property(list) {
                         if query.expr.data.is_e_object() {
-                            // reshaped for borrowck —
-                            // `StoreRef<E::Object>` is `Copy` and derefs to a raw arena
-                            // pointer, so taking it once works across writes to both the
-                            // inner list and the parent object.
                             let mut e_object = query.expr.data.as_e_object();
                             let dependencies = e_object.properties.slice_mut();
                             let mut i: usize = 0;
@@ -359,9 +348,6 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     manager.to_update = subcommand == Subcommand::Update;
 
-    // reshaped for borrowck — the field is owning
-    // (`Box<[UpdateRequest]>`), so we transfer ownership here and re-borrow from
-    // `manager.update_requests` after `install_with_manager` (which is the only writer).
     manager.update_requests = updates.into_boxed_slice();
 
     let mut buffer_writer = js_printer::BufferWriter::init();
@@ -523,9 +509,6 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     install_with_manager::install_with_manager(manager, ctx, root_package_json_path, original_cwd)?;
 
-    // reshaped for borrowck — see assignment above. `install_with_manager`
-    // is the only writer to `manager.update_requests` between the assignment and
-    // here, so taking it back yields exactly the slice assigned above.
     let mut updates: Box<[UpdateRequest]> = core::mem::take(&mut manager.update_requests);
 
     if subcommand == Subcommand::Update

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1024,8 +1024,6 @@ impl<'a> Linker<'a> {
             return;
         }
 
-        // reshaped for borrowck — bind the owned buffer first, then
-        // borrow `content` from it (or fall back to the stack `chunk`).
         let content_to_free: Box<[u8]>;
         let content: &[u8] = if chunk.len() >= shebang_buf.len() {
             // Partial read. Need to read the rest of the file.
@@ -1504,7 +1502,6 @@ impl<'a> Linker<'a> {
         let dest_dir_without_trailing_slash =
             strings::without_trailing_slash(unsafe { (*self.target_node_modules_path).slice() });
 
-        // reshaped for borrowck — track offset instead of remain.ptr arithmetic
         let mut off: usize = 0;
         let buf = &mut *self.abs_target_buf;
 

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1211,9 +1211,6 @@ impl Task {
                         let _ = Fd::cwd().delete_tree(staging.slice());
                     }
 
-                    // reshaped for borrowck — `defer if (cached_package_dir) |d| d.close()`
-                    // becomes a guard that *owns* the `Option<Fd>` so the loop body can reassign
-                    // through `*cached_package_dir` without an outstanding closure borrow.
                     let mut cached_package_dir = scopeguard::guard(None::<Fd>, |dir| {
                         if let Some(d) = dir {
                             d.close();

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -254,7 +254,6 @@ impl<'a, const PATH_STYLE: IteratorPathStyle> Iterator<'a, PATH_STYLE> {
             return None;
         }
 
-        // reshaped for borrowck — cannot mutably borrow completed_trees in loop while moved.
         let mut completed_trees = completed_trees;
 
         while trees[self.tree_id as usize].dependencies.len == 0 {
@@ -698,7 +697,6 @@ impl Tree {
             dependencies: DependencyIDList::default(),
         })?;
 
-        // reshaped for borrowck.
         let next_id = (builder.list.len() - 1) as Id;
 
         // Copy the `ParentRef` out (it's `Copy`) so the resulting `&Lockfile`
@@ -708,8 +706,6 @@ impl Tree {
         let lockfile: &Lockfile = lockfile_ref.get();
         let pkgs = lockfile.packages.slice();
         let pkg_resolutions = pkgs.items_resolution();
-        // reshaped for borrowck — copy the `&'a [Dependency]` out of
-        // `builder` so `&dependencies[i]` does not keep `builder` borrowed.
         let dependencies: &[Dependency] = builder.dependencies;
 
         builder.sort_buf.clear();
@@ -734,8 +730,6 @@ impl Tree {
             });
         }
 
-        // reshaped for borrowck — iterate over a snapshot of sort_buf indices since
-        // builder is mutably borrowed inside the loop.
         let sort_buf_len = builder.sort_buf.len();
         'dep: for sort_idx in 0..sort_buf_len {
             let dep_id = builder.sort_buf[sort_idx];
@@ -944,7 +938,6 @@ impl Tree {
             }
         }
 
-        // reshaped for borrowck — re-read `next` via index.
         let next: Tree = builder.list.items_tree()[next_id as usize];
         if next.dependencies.len == 0 {
             debug_assert!(builder.list.len() == (next.id as usize) + 1);
@@ -1063,11 +1056,6 @@ impl Tree {
             }
 
             if AS_DEFINED && !dep.behavior.is_peer() {
-                // reshaped for borrowck — `maybe_report_error` takes
-                // `&mut self` but the format args borrow `&self` (via
-                // `package_name`/`package_version`/`buf`). Inline against split
-                // field borrows: copy the `ParentRef` out so the `&Lockfile` is
-                // not tied to `&builder`, then write to `builder.log`.
                 let lockfile_ref = builder.lockfile;
                 let lockfile: &Lockfile = lockfile_ref.get();
                 let buf = lockfile.buffers.string_bytes.as_slice();

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -561,10 +561,6 @@ pub(crate) fn load(
                     .ensure_total_capacity(overrides_name_hashes.len())?;
                 let override_versions_external: Vec<dependency::External> =
                     buffers::read_array(stream)?;
-                // reshaped for borrowck — `Context.buffer` borrows
-                // `lockfile.buffers.string_bytes` while we also need
-                // `&mut lockfile.overrides`. Split the disjoint fields up front so
-                // borrowck sees sibling borrows (no raw-ptr provenance laundering).
                 let Lockfile {
                     buffers, overrides, ..
                 } = &mut *lockfile;
@@ -636,12 +632,6 @@ pub(crate) fn load(
 
                 let default_deps: Vec<dependency::External> = buffers::read_array(stream)?;
 
-                // reshaped for borrowck — `dependency::Context` /
-                // `ArrayHashContext` borrow `lockfile.buffers.string_bytes` while
-                // we also need `&mut lockfile.catalogs`. Split the disjoint
-                // fields up front so borrowck sees sibling borrows (no raw-ptr
-                // provenance laundering). `string_bytes` is not reallocated for
-                // the remainder of this block.
                 let Lockfile {
                     buffers, catalogs, ..
                 } = &mut *lockfile;

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -502,9 +502,6 @@ pub mod registry {
             let final_href: Box<[u8]> = if needs_normalize {
                 url.href_without_auth()
             } else {
-                // reshaped for borrowck — `url` (borrowing
-                // `registry_url`) is dead on this branch (every path that
-                // mutated `url.pathname` also set `needs_normalize = true`).
                 registry_url
             };
 
@@ -2611,7 +2608,6 @@ impl PackageManifest {
                     let has_meta_only_peers =
                         peer_deps_meta.is_some_and(|meta| !meta.properties().is_empty());
                     if items.len() > 0 || has_meta_only_peers {
-                        // reshaped for borrowck — index into all_extern_strings / version_extern_strings
                         let names_base = dependency_names_cursor;
                         let values_base = dependency_values_cursor;
 

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1022,10 +1022,6 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
 
         let name_hash = string_hash(name_to_use);
 
-        // reshaped for borrowck — compute the resolution before the
-        // `this.packages.append(...)` call so the per-field `sbuf!()` borrows of
-        // `this.buffers.string_bytes` don't overlap the two-phase reservation
-        // on `this.packages`.
         let pkg_name = sbuf!().append_with_hash(name_to_use, name_hash)?;
         let resolution = 'blk: {
             if entry.workspace {
@@ -1247,9 +1243,6 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         let dependencies_start = dependencies_buf.as_mut_ptr();
         let resolutions_start = resolutions_buf.as_mut_ptr();
 
-        // reshaped for borrowck — iterate by index and re-borrow
-        // `yarn_lock.entries[yarn_idx]` for each map so the shared borrow of
-        // `yarn_lock` passed into `process_deps` doesn't overlap an iterator.
         if let Some(deps) = yarn_lock.entries[yarn_idx].dependencies.as_ref() {
             let processed = process_deps(
                 deps,

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -120,7 +120,6 @@ pub trait PosixPipeWriter {
     }
 
     fn on_poll(&mut self, size_hint: isize, received_hup: bool) {
-        // reshaped for borrowck — capture buffer.len() before further &mut self calls.
         let buffer_len = self.get_buffer().len();
         log!("onPoll({})", buffer_len);
         if buffer_len == 0 && !received_hup {
@@ -506,7 +505,8 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         self.parent = Some(bun_ptr::ParentRef::from(
             core::ptr::NonNull::new(parent).expect("set_parent: parent must not be null"),
         ));
-        // reshaped for borrowck — capture *mut Self before borrowing field.
+        // SAFETY: *mut Self is stored as the poll Owner backref for later on_poll/on_close
+        // dispatch (may free self); required provenance.
         let owner = std::ptr::from_mut(self).cast::<c_void>();
         self.handle
             .set_owner(Owner::new(Parent::POLL_OWNER_TAG, owner.cast()));
@@ -756,7 +756,8 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
 
     pub fn set_parent(&mut self, parent: *mut Parent) {
         self.parent = parent;
-        // reshaped for borrowck — capture *mut Self before borrowing field.
+        // SAFETY: *mut Self is stored as the poll Owner backref for later on_poll/on_close
+        // dispatch (may free self); required provenance.
         let owner = std::ptr::from_mut(self).cast::<c_void>();
         self.handle
             .set_owner(Owner::new(Parent::POLL_OWNER_TAG, owner.cast()));

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -1233,8 +1233,6 @@ lexer_impl_header! {
         let original_text = self.raw();
 
         debug_assert!(self.temp_buffer_u16.is_empty());
-        // Note: reshaped for borrowck — we move temp_buffer_u16 out, use it, then
-        // clear and put it back (mirrors `defer clearRetainingCapacity()`).
         let mut tmp = core::mem::take(&mut self.temp_buffer_u16);
         tmp.reserve(original_text.len());
         let decode_res =

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -51,7 +51,6 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 st.is_export = false;
 
                 let mut new_len: usize = 0;
-                // Note: reshaped for borrowck — index loop instead of `|*decl_ptr|`.
                 let decls_len = st.decls.len_u32() as usize;
                 for i in 0..decls_len {
                     // explicit field copies (G::Decl is not `Copy`) to avoid aliasing
@@ -730,8 +729,6 @@ impl<'a> ConvertESMExportsForHmr<'a> {
             self.last_part
                 .import_record_indices
                 .append_slice(part.import_record_indices.slice());
-            // Note: reshaped for borrowck — index loop avoids
-            // holding two shared borrows of `part.symbol_uses` while &mut-borrowing `last_part`.
             for i in 0..part.symbol_uses.count() {
                 let k = part.symbol_uses.keys()[i];
                 let v = part.symbol_uses.values()[i];

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3270,7 +3270,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     last_i -= 1;
                 }
 
-                // reshaped for borrowck — copy out loc before borrowing self mutably.
                 if let Some(prev_loc) = self.scopes_in_order[last_i].as_ref().map(|s| s.loc) {
                     if prev_loc.start >= loc.start {
                         self.log().level = bun_ast::Level::Verbose;

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -252,8 +252,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Handle the start of an arrow expression
         if p.lexer.token == T::TEqualsGreaterThan && level.lte(Level::Assign) {
             let ref_ = p.store_name_in_ref(name);
-            // reshaped for borrowck — build binding before borrowing arena.
-            // `Arg` is non-Copy (owns Vec) → use fill_iter instead of alloc_slice_copy.
             let binding = p.b(B::Identifier { r#ref: ref_ }, loc);
             let args = p.arena.alloc_slice_fill_iter([Arg {
                 binding,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1078,9 +1078,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                         let args_len = func_args.len();
                         for arg_idx in 0..args_len {
-                            // reshaped for borrowck — copy the scalars we need
-                            // (id_ref, bind_loc) out of the arg before calling `&mut self`
-                            // helpers, so no live `&Arg` overlaps `self.new_expr`/`declare_symbol`.
                             let (id_ref, bind_loc) = {
                                 let arg = &func_args[arg_idx];
                                 if !arg.is_typescript_ctor_field {

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -695,8 +695,6 @@ impl BinaryExpressionVisitor {
             Op::Code::BinAssign => {
                 // Optionally preserve the name
                 if let ExprData::EIdentifier(ident) = e_.left.data {
-                    // reshaped for borrowck — copy the `StoreStr` out of
-                    // `p.symbols` before taking `&mut self` for `maybe_keep_expr_symbol_name`.
                     let name = p.symbols[ident.ref_.inner_index() as usize].original_name;
                     e_.right = p.maybe_keep_expr_symbol_name(
                         e_.right,

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -573,8 +573,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             js_ast::StmtOrExpr::Stmt(s2) => {
-                // reshaped for borrowck — `s2` borrows from `data.value`; copy
-                // `s2.loc`/`s2.data` (both Copy) so we can mutate `data.value` below.
                 let s2_loc = s2.loc;
                 let s2_data = s2.data;
                 let s2_copy = *s2;
@@ -1408,8 +1406,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if to_convert != u32::MAX {
                         p.commonjs_named_exports_needs_conversion = u32::MAX;
                         'convert: {
-                            // reshaped for borrowck — copy StoreRef so DerefMut
-                            // points into the arena, freeing `&mut data.value`.
                             let js_ast::ExprData::EBinary(mut bin_ref) = data.value.data else {
                                 break 'convert;
                             };

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -219,9 +219,9 @@ impl MacroContext {
         unsafe { (*(*vm).event_loop()).ensure_waker() };
 
         let javascript_object = self.javascript_object;
-        // reshaped for borrowck — `self.bump` is shared-borrowed for
-        // the closure while `self.macros` was already released above; capture
-        // as a raw pointer so the closure does not extend `&mut self`.
+        // SAFETY: closure is run through JSC__VM__holdAPILock and executes the JS macro, which
+        // may re-enter MacroContext::call and mutate self.macros/self.bump; holding
+        // &-refs across that would alias.
         // Lazy-init the backing arena now that a macro is actually being
         // invoked (see field doc — avoids per-`import()` `mi_heap_new`).
         let bump: *const bun_alloc::Arena =
@@ -744,9 +744,6 @@ impl<'a> Run<'a> {
                     i += 1;
                 }
 
-                // reshaped for borrowck — `Expr.data.e_array` is a
-                // `StoreRef` (raw arena ptr) so re-borrow it after the `run`
-                // recursion releases `self`.
                 if let ExprData::EArray(mut e_array) = expr.data {
                     e_array.items = array;
                     e_array.items.truncate(i);

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -219,9 +219,10 @@ impl MacroContext {
         unsafe { (*(*vm).event_loop()).ensure_waker() };
 
         let javascript_object = self.javascript_object;
-        // SAFETY: closure is run through JSC__VM__holdAPILock and executes the JS macro, which
-        // may re-enter MacroContext::call and mutate self.macros/self.bump; holding
-        // &-refs across that would alias.
+        // SAFETY: `self.bump` is `Option<Arena>` stored inline in this heap-boxed `MacroContext`,
+        // so its address is stable for the box's lifetime. The closure may re-enter
+        // `MacroContext::call` via JS, but re-entry sees `bump` already `Some` and does not move
+        // it. Captured raw so the closure does not extend a `&self` borrow across re-entry.
         // Lazy-init the backing arena now that a macro is actually being
         // invoked (see field doc — avoids per-`import()` `mi_heap_new`).
         let bump: *const bun_alloc::Arena =

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -219,10 +219,11 @@ impl MacroContext {
         unsafe { (*(*vm).event_loop()).ensure_waker() };
 
         let javascript_object = self.javascript_object;
-        // SAFETY: `self.bump` is `Option<Arena>` stored inline in this heap-boxed `MacroContext`,
-        // so its address is stable for the box's lifetime. The closure may re-enter
-        // `MacroContext::call` via JS, but re-entry sees `bump` already `Some` and does not move
-        // it. Captured raw so the closure does not extend a `&self` borrow across re-entry.
+        // SAFETY: the closure runs user JS, but same-box re-entry into `MacroContext::call` is
+        // prevented: `MacroModeGuard` above sets `target = BunMacro`, so module loads during the
+        // macro set `is_macro_runtime`, and both visitor `.call()` sites are gated by
+        // `!is_macro_runtime`. `Bun.Transpiler` / bundler workers allocate a fresh box. Captured
+        // raw so the closure does not extend the outer `&mut self` borrow.
         // Lazy-init the backing arena now that a macro is actually being
         // invoked (see field doc — avoids per-`import()` `mi_heap_new`).
         let bump: *const bun_alloc::Arena =

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1830,7 +1830,6 @@ pub mod __gated_printer {
 
             // Record var declarations for module_info. printGlobalBunImportStatement
             // bypasses printDeclStmt/printBinding, so we must record vars explicitly.
-            // reshaped for borrowck — compute names before borrowing module_info.
             if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
                 if !import.star_name_loc.is_empty() {
                     let name = self.name_for_symbol(import.namespace_ref);
@@ -3066,8 +3065,6 @@ pub mod __gated_printer {
                     self.print_space_before_identifier();
                     self.add_source_mapping(expr.loc);
 
-                    // reshaped for borrowck — find the matching index first,
-                    // then drop the immutable iter borrow before printing.
                     let mut found: Option<usize> = None;
                     if let Some(exports) = self.options.commonjs_named_exports {
                         for (idx, value) in exports.values().iter().enumerate() {
@@ -4749,7 +4746,6 @@ pub mod __gated_printer {
                     self.add_source_mapping(binding.loc);
                     self.print_symbol(b.r#ref);
                     if Self::MAY_HAVE_MODULE_INFO {
-                        // reshaped for borrowck — fetch name before borrowing module_info.
                         let local_name = self.name_for_symbol(b.r#ref);
                         if let Some(mi) = self.module_info() {
                             let name_id = mi.str(local_name);
@@ -4905,7 +4901,6 @@ pub mod __gated_printer {
                                                     self.name_for_symbol(id.r#ref),
                                                 ) {
                                                     if Self::MAY_HAVE_MODULE_INFO {
-                                                        // reshaped for borrowck — bump access first.
                                                         let str8 = str.slice(self.bump);
                                                         if let Some(mi) = self.module_info() {
                                                             let name_id = mi.str(str8);
@@ -5485,8 +5480,6 @@ pub mod __gated_printer {
                     self.print_semicolon_after_statement();
 
                     if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
-                        // reshaped for borrowck — re-borrow module_info per item so
-                        // `name_for_symbol` (which needs `&mut self`) can run between uses.
                         let irp_id = {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let id = mi.str(irp);
@@ -6004,9 +5997,6 @@ pub mod __gated_printer {
                     self.print_semicolon_after_statement();
 
                     if Self::MAY_HAVE_MODULE_INFO && self.module_info.is_some() {
-                        // reshaped for borrowck — `module_info()` borrows `&mut self`,
-                        // so we re-borrow it between `name_for_symbol` calls instead of holding
-                        // a single long-lived `mi` across the whole block. `irp_id` is Copy.
                         let import_record_path = &record.path.text;
                         let irp_id = {
                             let mi = self.module_info().expect("infallible: module_info enabled");

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -417,7 +417,6 @@ impl Queue {
             bstr::BStr::new(name)
         );
 
-        // reshaped for borrowck — compaction loop → retain_mut.
         self.map.retain_mut(|module| {
             for pending in module.parse_result.pending_imports.iter() {
                 if pending.tag == bun_resolver::PendingResolutionTag::Resolve {
@@ -478,7 +477,6 @@ impl Queue {
                 .as_slice(),
         );
 
-        // reshaped for borrowck — compaction loop → retain_mut.
         self.map.retain_mut(|module| {
             for pending in module.parse_result.pending_imports.iter() {
                 if resolution_ids.slice()[pending.root_dependency_id as usize] != package_id {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -944,7 +944,6 @@ impl<'a> TablePrinter<'a> {
                 col.name.deref();
             }
         });
-        // reshaped for borrowck — re-borrow through the guard.
         let columns: &mut Vec<Column> = &mut **_deref_names;
 
         // create the first column " " which is always present

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -244,8 +244,6 @@ impl SavedSourceMap {
                 if contains {
                     return Ok(());
                 }
-                // Note: reshaped for borrowck — the lock is
-                // released before returning since no further table access follows.
             }
         }
 
@@ -276,7 +274,6 @@ impl SavedSourceMap {
         use bun_collections::zig_hash_map::MapEntry as Entry;
 
         self.lock();
-        // Note: reshaped for borrowck — explicit unlock paired manually.
 
         // `bun_collections::HashMap` derefs to `std::collections::HashMap`, so
         // the std `entry()` API is used directly.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2369,7 +2369,6 @@ impl VirtualMachine {
                 }
             }
 
-            // Note: reshaped for borrowck — capture raw ptr before &self call.
             let global = self.global;
             let global_ref = self.global();
             let promise = if !self.main_is_html_entrypoint {
@@ -3527,8 +3526,6 @@ impl VirtualMachine {
         }
         // reload_entry_point() stores into pending_internal_promise on every return path.
         let main = self.main;
-        // Note: reshaped for borrowck — copy the `RawSlice` first to avoid
-        // overlapping `&self`/`&mut self` borrows.
         if self.reload_entry_point(main.slice()).is_err() {
             panic!("Failed to reload");
         }
@@ -3778,8 +3775,9 @@ impl VirtualMachine {
         // RAII guard releases on every
         // exit (including the early-return `Occupied` arm).
         let _unlock = self.ref_strings_mutex.lock_guard();
-        // Note: reshaped for borrowck — capture the back-pointer before
-        // `ref_strings.entry()` takes its unique borrow on `self`.
+        // SAFETY: the `*mut VirtualMachine` is stored as `RefString.ctx` for the WTF
+        // external-string finalizer (`clear_ref_string`) invoked later from C; a
+        // `&self`-derived pointer would carry SharedReadOnly provenance.
         let self_ctx = NonNull::new(std::ptr::from_mut::<VirtualMachine>(self).cast::<c_void>());
 
         match self.ref_strings.entry(hash) {
@@ -4518,7 +4516,6 @@ impl VirtualMachine {
             }
         }
 
-        // Note: reshaped for borrowck.
         let global = self.global;
         let main_str = bun_core::String::from_bytes(self.main());
         let promise = jsc::JSModuleLoader::load_and_evaluate_module_ptr(global, Some(&main_str))

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3775,9 +3775,6 @@ impl VirtualMachine {
         // RAII guard releases on every
         // exit (including the early-return `Occupied` arm).
         let _unlock = self.ref_strings_mutex.lock_guard();
-        // SAFETY: the `*mut VirtualMachine` is stored as `RefString.ctx` for the WTF
-        // external-string finalizer (`clear_ref_string`) invoked later from C; a
-        // `&self`-derived pointer would carry SharedReadOnly provenance.
         let self_ctx = NonNull::new(std::ptr::from_mut::<VirtualMachine>(self).cast::<c_void>());
 
         match self.ref_strings.entry(hash) {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -404,7 +404,6 @@ impl EventLoop {
         let this: *mut Self = core::hint::black_box(this);
         // SAFETY: as above.
         unsafe { (*this).exit() };
-        // Note: reshaped for borrowck — `defer this.exit()` moved to tail; no early returns
     }
 
     pub fn run_callback_with_result(
@@ -431,7 +430,6 @@ impl EventLoop {
         let this: *mut Self = core::hint::black_box(this);
         // SAFETY: as above.
         unsafe { (*this).exit() };
-        // Note: reshaped for borrowck — `defer this.exit()` moved to tail
         result
     }
 
@@ -628,8 +626,6 @@ impl EventLoop {
         self.tick_concurrent();
         self.process_gc_timer();
 
-        // Note: reshaped for borrowck — `vm_ref()` is `&'static`, so the
-        // global borrow detaches from `&self` and survives the `&mut self` call.
         let global = self.vm_ref().global();
         let global_vm = self.vm_ref().jsc_vm();
 
@@ -676,7 +672,6 @@ impl EventLoop {
         }
 
         self.vm_ref().suppress_microtask_drain.set(prev);
-        // Note: reshaped for borrowck — `defer vm.suppress_microtask_drain = prev` moved to tail
     }
 
     pub fn enqueue_task(&mut self, task: Task) {

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -1107,9 +1107,6 @@ impl SendQueue {
 
         // optimal case: appending a message without a handle to the end of the queue when the last message also doesn't have a handle and isn't ack/nack
         // this is rare. it will only happen if messages stack up after sending a handle, or if a long message is sent that is waiting for writable
-        // Note: reshaped for borrowck (NLL limitation: early-return of
-        // `&mut self.queue[..]` would otherwise extend the borrow across the
-        // fallback push). Compute the predicate first, then re-borrow.
         let use_last = if handle.is_none() && !self.queue.is_empty() {
             let len = self.queue.len();
             let last = &self.queue[len - 1];
@@ -1891,8 +1888,6 @@ fn on_data2(send_queue: &mut SendQueue, all_data: &[u8]) {
 
     // Decode the message with just the temporary buffer, and if that
     // fails (not enough bytes) then we allocate to .ipc_buffer
-    // Note: reshaped for borrowck — match on raw discriminant pointer to allow
-    // calling &mut self methods on send_queue inside arms.
     match &mut send_queue.incoming {
         IncomingBuffer::Json(_) => {
             // JSON mode: append to buffer (scans only new data for newline),

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1389,7 +1389,6 @@ impl Archiver {
         let mut count: u32 = 0;
         let dir_fd = dir;
 
-        // reshaped for borrowck — ctx is Option<&mut>, rebound as needed
         let mut ctx = ctx;
 
         #[cfg(unix)]
@@ -1781,8 +1780,6 @@ impl Archiver {
                                 owned
                             };
 
-                            // reshaped for borrowck — `plucked_file` is captured by
-                            // the guard tuple; mutate via close_guard.1.
                             let mut close_guard =
                                 scopeguard::guard((file_handle, false), |(fh, plucked)| {
                                     if options.close_handles && !plucked {

--- a/src/md/helpers.rs
+++ b/src/md/helpers.rs
@@ -430,7 +430,6 @@ pub fn generate_slug<'a>(
     let mut out_len: usize = 0;
     let mut prev_hyphen: bool = true; // true to trim leading hyphens
 
-    // reshaped for borrowck — index instead of `for &c in text_items`
     for idx in 0..text_len {
         let c = text_buf[idx];
         if c >= b'A' && c <= b'Z' {

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -773,8 +773,6 @@ impl Parser<'_> {
 
     /// Resolve emphasis delimiters using the CommonMark algorithm.
     pub fn resolve_emphasis_delimiters(&mut self) {
-        // reshaped for borrowck — index directly into self.emph_delims
-        // instead of binding `delims` + `opener` aliases.
         let len = self.emph_delims.len();
         if len == 0 {
             return;

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4096,7 +4096,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let scalar_line = self.token.line;
                     let scalar_tab_after_indent = self.tab_after_indent;
 
-                    // Take it out before scanning.
                     let scalar = match core::mem::replace(
                         &mut self.token.data,
                         TokenData::Eof, // placeholder; overwritten by scan() below

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4096,8 +4096,6 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let scalar_line = self.token.line;
                     let scalar_tab_after_indent = self.tab_after_indent;
 
-                    // reshaped for borrowck — we must hold the scalar
-                    // payload across `self.scan()` which replaces self.token.
                     // Take it out before scanning.
                     let scalar = match core::mem::replace(
                         &mut self.token.data,

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -66,8 +66,6 @@ impl ApplyState {
         }
         match sys::get_fd_path(fd, &mut self.pathbuf) {
             sys::Result::Ok(p) => {
-                // reshaped for borrowck — capture len, drop `p`,
-                // then re-borrow `self.pathbuf` to write the sentinel.
                 let len = p.len();
                 // On Linux `readlink(2)` does not NUL-terminate, so write the
                 // sentinel explicitly (the buffer is zero-initialized but be
@@ -906,7 +904,6 @@ pub fn parse_patch_file(file: &[u8]) -> Result<PatchFile<'_>, ParseErr> {
         }
     }
 
-    // reshaped for borrowck — take ownership of result vec instead of slicing.
     let mut files = mem::take(&mut lines_parser.result);
     patch_file_second_pass(&mut files)
 }
@@ -1154,7 +1151,6 @@ impl<'a> PatchLinesParser<'a> {
     // Drop handles freeing; `reset()` handles the retain-capacity case.
 
     fn reset(&mut self) {
-        // reshaped for borrowck — take result vec, clear it, reinit self.
         let mut result = mem::take(&mut self.result);
         result.clear();
         *self = Self {

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -638,7 +638,6 @@ pub fn relative(from: &[u8], to: &[u8]) -> &'static [u8] {
 pub fn relative_buf_z<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> &'a ZStr {
     let rel = relative_platform_buf::<platform::Auto, true>(buf, from, to);
     let len = rel.len();
-    // reshaped for borrowck — drop `rel` borrow before mutating buf
     buf[len] = 0;
     // SAFETY: buf[len] == 0 written above
     ZStr::from_buf(&buf[..], len)
@@ -666,7 +665,6 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
                 platform_to_posix_in_place::<u8>(normalized);
                 break 'brk &*normalized;
             }
-            // reshaped for borrowck — capture len, drop inner &mut, re-slice
             let path_len =
                 normalize_string_buf::<true, P, true>(from, &mut relative_from_buf[1..]).len();
             if P::P == Platform::Windows {
@@ -698,7 +696,6 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
                 platform_to_posix_in_place::<u8>(normalized);
                 break 'brk &*normalized;
             }
-            // reshaped for borrowck — capture len, drop inner &mut, re-slice
             let path_len =
                 normalize_string_buf::<true, P, true>(to, &mut relative_to_buf[1..]).len();
             if P::P == Platform::Windows {
@@ -1746,9 +1743,6 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
         out += part.len();
     }
 
-    // reshaped for borrowck — stash leading separator into a local
-    // [u8; 8] (max len: NT prefix `\\?\` = 4) so we don't hold a borrow into
-    // temp_buf across the normalize call below.
     let mut leading_buf = [0u8; 8];
     let leading_len: usize = if let Some(i) = P::P.leading_separator_index::<u8>(&temp_buf[0..out])
     {
@@ -1973,7 +1967,6 @@ pub(crate) fn normalize_string_node_t<'a, T: PathChar, P: PlatformT>(
 
     // `normalize_string_generic` handles absolute path cases for windows
     // we should not prefix with /
-    // reshaped for borrowck — track an offset instead of reslicing.
     let buf_off: usize = if P::P == Platform::Windows { 0 } else { 1 };
 
     let separator_t = T::from_u8(P::P.separator());
@@ -2229,9 +2222,6 @@ impl PosixToWinNormalizer {
             if root.len() == 1 {
                 debug_assert!(is_sep_any(root[0]));
                 if strings::is_windows_absolute_path_missing_drive_letter::<u8>(maybe_posix_path) {
-                    // reshaped for borrowck — `getcwd` writes into
-                    // `buf` and returns a borrow of it; capture the lengths we
-                    // need, drop the borrow, then re-slice `buf`.
                     let sr_len = {
                         let cwd = bun_core::getcwd(buf)?;
                         windows_filesystem_root(cwd.as_bytes()).len()
@@ -2277,7 +2267,6 @@ impl PosixToWinNormalizer {
             if root.len() == 1 {
                 debug_assert!(is_sep_any(root[0]));
                 if strings::is_windows_absolute_path_missing_drive_letter::<u8>(maybe_posix_path) {
-                    // reshaped for borrowck — see resolve_cwd above.
                     let sr_len = {
                         let cwd = bun_core::getcwd(buf)?;
                         windows_filesystem_root(cwd.as_bytes()).len()

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -2367,8 +2367,6 @@ pub mod cache {
                 fd
             );
 
-            // reshaped for borrowck — capture `stream` scalar before borrowing
-            // the shared buffer.
             let stream = self.stream;
 
             let contents = match (use_shared_buffer, arena) {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3155,7 +3155,6 @@ impl<'a> Resolver<'a> {
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import
-                                    // NOTE: reshaped for borrowck — see identical note above.
                                     // Resolve against the path "/", then join it with the absolute
                                     // directory path. This is done because ESM package resolution uses
                                     // URLs while our path resolution uses file system paths. We don't
@@ -3872,8 +3871,6 @@ impl<'a> Resolver<'a> {
             None,
             None,
         )?;
-        // NOTE: reshaped for borrowck — `mem::take` the contents (leaving
-        // `Contents::Empty` behind) so `entry` stays whole for the close-guard.
         let entry_contents = core::mem::take(&mut entry.contents);
         let _close_guard = scopeguard::guard(entry, |mut e| {
             let _ = e.close_fd();

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -760,8 +760,6 @@ impl Route {
                 let mut buf: &mut [u8] = &mut route_file_buf[..];
 
                 if !public_dir.is_empty() {
-                    // NOTE: reshaped for borrowck — `buf` already aliases
-                    // route_file_buf[..]; write through it instead of re-borrowing.
                     buf[0] = b'/';
                     buf = &mut buf[1..];
                     buf[..public_dir.len()].copy_from_slice(public_dir);
@@ -806,10 +804,6 @@ impl Route {
             let is_index = name.is_empty();
 
             let mut has_uppercase = false;
-            // NOTE: reshaped for borrowck — both arms intern via DirnameStore
-            // (process-lifetime arena → `&'static`), so the post-if bindings are
-            // 'static and the route_file_buf borrow is dropped before the
-            // abs-path block below needs it mutably.
             let (name, match_name): (&'static [u8], &'static [u8]) = if !name.is_empty() {
                 validation_result = match Pattern::validate(&name[1..], log) {
                     Some(v) => v,
@@ -854,9 +848,6 @@ impl Route {
                 // mutex (the same lock every other `Entry` rewrite path takes).
                 // SAFETY: see fn-level NOTE — read-only reborrow.
                 let _entry_guard = unsafe { &*entry }.mutex.lock_guard();
-                // NOTE: reshaped for borrowck — `defer if (needs_close) file.close()`
-                // becomes a scopeguard owning the Option<File>; `needs_close` is a
-                // Cell so the drop closure can read it while the body still mutates.
                 // The guard is inverted: when the fd belongs to the cache
                 // (`needs_close == false`), `into_raw()` so we do not close
                 // someone else's fd.

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -2014,9 +2014,6 @@ impl BuildArtifact {
 
         {
             formatter.indent_inc();
-            // NOTE: reshaped for borrowck — scopeguard cannot reborrow
-            // `formatter` while it is also borrowed for the body; decrement
-            // after the block instead.
 
             formatter.write_indent(writer)?;
             bun_core::write_pretty!(

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -998,7 +998,6 @@ impl<'a> ParseRenderer<'a> {
         if self.stack.is_empty() {
             return Ok(());
         }
-        // Note: reshaped for borrowck — capture parent.children (Copy JSValue) instead of holding &mut into self.stack.
         let parent_children = self.stack.last().unwrap().children;
 
         match text_type {
@@ -1308,7 +1307,6 @@ impl<'a> JsCallbackRenderer<'a> {
         }
 
         let callback = self.get_block_callback(block_type);
-        // Note: reshaped for borrowck — clone the saved entry (cheap; buffer not used) instead of holding a borrow across method calls.
         let saved = if self.stack.len() > 1 {
             CallbackStackEntry {
                 block_type: self.stack.last().unwrap().block_type,
@@ -1406,9 +1404,6 @@ impl<'a> JsCallbackRenderer<'a> {
         let mut buf = [0u8; 8];
         let decoded =
             md::helpers::decode_entity_to_utf8(entity_text, &mut buf).unwrap_or(entity_text);
-        // Note: reshaped for borrowck — copy the (≤8-byte) decoded slice out of `buf`
-        // before calling &mut self method, to avoid overlapping borrows when the
-        // borrow checker tracks `buf` as borrowed by `decoded`.
         self.append_text_or_raw(decoded)
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4011,7 +4011,10 @@ impl H2FrameParser {
             );
             return data.len();
         };
-        // SAFETY: stream_ptr is a *mut Stream stored in self.streams (heap::alloc); valid for the lifetime of the entry, exclusive access reshaped for borrowck
+        // SAFETY: stream_ptr is a heap::alloc'd *mut Stream stored in self.streams. The dispatch
+        // calls below fire JS that can re-enter the parser and touch self.streams, so holding a
+        // map borrow across them would alias; frees are deferred by dispatch_depth so the entry
+        // stays valid here.
         let mut stream = unsafe { &mut *stream_ptr };
 
         let max_frame_size = self.local_settings.get().max_frame_size;
@@ -4396,7 +4399,10 @@ impl H2FrameParser {
             );
             return data.len();
         };
-        // SAFETY: stream_ptr is a *mut Stream stored in self.streams (heap::alloc); valid for the lifetime of the entry, exclusive access reshaped for borrowck
+        // SAFETY: stream_ptr is a heap::alloc'd *mut Stream stored in self.streams. The dispatch
+        // calls below fire JS that can re-enter the parser and touch self.streams, so holding a
+        // map borrow across them would alias; frees are deferred by dispatch_depth so the entry
+        // stays valid here.
         let stream = unsafe { &mut *stream_ptr };
 
         if frame.length != 4 {
@@ -4558,7 +4564,10 @@ impl H2FrameParser {
             );
             return data.len();
         };
-        // SAFETY: stream_ptr is a *mut Stream stored in self.streams (heap::alloc); valid for the lifetime of the entry, exclusive access reshaped for borrowck
+        // SAFETY: stream_ptr is a heap::alloc'd *mut Stream stored in self.streams. The dispatch
+        // calls below fire JS that can re-enter the parser and touch self.streams, so holding a
+        // map borrow across them would alias; frees are deferred by dispatch_depth so the entry
+        // stays valid here.
         let stream = unsafe { &mut *stream_ptr };
 
         if let Some(content) = self.handle_incomming_payload(data, frame.stream_identifier) {
@@ -4607,7 +4616,10 @@ impl H2FrameParser {
             );
             return Ok(data.len());
         };
-        // SAFETY: stream_ptr is a *mut Stream stored in self.streams (heap::alloc); valid for the lifetime of the entry, exclusive access reshaped for borrowck
+        // SAFETY: stream_ptr is a heap::alloc'd *mut Stream stored in self.streams. The dispatch
+        // calls below fire JS that can re-enter the parser and touch self.streams, so holding a
+        // map borrow across them would alias; frees are deferred by dispatch_depth so the entry
+        // stays valid here.
         let mut stream = unsafe { &mut *stream_ptr };
 
         if !stream.is_waiting_more_headers {
@@ -4731,7 +4743,10 @@ impl H2FrameParser {
             );
             return Ok(data.len());
         };
-        // SAFETY: stream_ptr is a *mut Stream stored in self.streams (heap::alloc); valid for the lifetime of the entry, exclusive access reshaped for borrowck
+        // SAFETY: stream_ptr is a heap::alloc'd *mut Stream stored in self.streams. The dispatch
+        // calls below fire JS that can re-enter the parser and touch self.streams, so holding a
+        // map borrow across them would alias; frees are deferred by dispatch_depth so the entry
+        // stays valid here.
         let mut stream = unsafe { &mut *stream_ptr };
 
         if frame.length > self.local_settings.get().max_frame_size {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -419,7 +419,6 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
             }
         },
     );
-    // Note: reshaped for borrowck — re-borrow through the guard tuple.
     let (abort_signal, terminal_info) = &mut *defer_guard;
 
     // Owned ZBox for `cwd` held here so the `&[u8]` borrow stays valid until
@@ -963,8 +962,6 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
             }
         },
     );
-    // Note: reshaped for borrowck — re-borrow through the guard tuple so the guard
-    // stays armed (runs on every early return) until disarmed by `**should_close_memfd = false` below.
     let (should_close_memfd, stdio) = &mut *memfd_guard;
 
     // "NODE_CHANNEL_FD=" is 16 bytes long, 15 bytes for the number, and 1 byte for the null terminator should be enough/safe

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -190,8 +190,6 @@ impl Stdio {
                 }
             }
 
-            // Note: reshaped for borrowck — `remain` borrows `*self`, so we
-            // must drop it before mutating `self`. Shadowing ends the borrow here.
             let _ = remain;
 
             // Assigning to `*self` drops the previous variant via `Drop`

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1919,7 +1919,6 @@ impl RequestEnsureRouteBundledCtx {
     }
 
     fn on_defer(&mut self, bundle_field: BundleQueueType) -> JsResult<()> {
-        // Note: reshaped for borrowck — captured args before re-borrowing dev
         let route_bundle_index = self.route_bundle_index;
         let kind = self.kind;
         let req = ::core::mem::replace(&mut self.req, ReqOrSaved::Aborted);

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1527,7 +1527,6 @@ impl FrameworkRouter {
                 // serialized on the per-entry `Entry.mutex`.
                 let file = unsafe { &*file_ptr };
                 let base = file.base();
-                // Note: reshaped for borrowck — fetch type fields fresh each iteration.
                 // SAFETY: `Entry::kind` mutates only the entry's lazily-cached kind; `file_ptr`
                 // is the unique live reference to this entry during the scan, and `fs_impl`
                 // points at the process-global FS implementation.

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -453,8 +453,6 @@ impl HotReloadEvent {
                         Some(dev.directory_watchers.watches.values()[watcher_index].first_dep);
 
                     while let Some(index) = it {
-                        // Note: reshaped for borrowck — re-index per iteration instead of
-                        // holding `dep` ref across resolver call + appendFile + freeDependencyIndex.
                         let (source_file_path, specifier, next) = {
                             let dep = &dev.directory_watchers.dependencies[index as usize];
                             (dep.source_file_path, &raw const *dep.specifier, dep.next)
@@ -1302,8 +1300,6 @@ impl DirectoryWatchStore {
             self.dependencies.reserve(1);
         }
 
-        // Note: reshaped for borrowck — capture gop scalars before
-        // calling self methods that need &mut self.
         let gop = self.watches.get_or_put(
             bun_paths::string_paths::without_trailing_slash_windows_path(dir_name_to_watch),
         )?;
@@ -1462,8 +1458,6 @@ impl DirectoryWatchStore {
         let mut watch_index = self.watches.count();
         while watch_index > 0 {
             watch_index -= 1;
-            // Note: reshaped for borrowck — cannot hold &mut entry across
-            // self.free_dependency_index(); walk by index and re-borrow.
             let mut new_chain: Option<u32> = None;
             let mut it: Option<u32> = Some(self.watches.values()[watch_index].first_dep);
             while let Some(index) = it {

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -991,8 +991,6 @@ pub(super) fn build_with_vm(
 
         let route = router.route_ptr(route_index);
         let main_file_route_index = route.file_page.unwrap();
-        // Note: reshaped for borrowck — `pt.output_file()` borrows `pt`
-        // immutably, but `pt.preload_bundled_module()` below needs `&mut pt`.
         // Fetch the output file fresh at each use site instead of binding it.
 
         // Count how many JS+CSS files associated with this route and prepare `pattern`

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -991,7 +991,6 @@ pub(super) fn build_with_vm(
 
         let route = router.route_ptr(route_index);
         let main_file_route_index = route.file_page.unwrap();
-        // Fetch the output file fresh at each use site instead of binding it.
 
         // Count how many JS+CSS files associated with this route and prepare `pattern`
         pattern.prepend_part(route.part);

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -322,10 +322,6 @@ fn collect_packages_for_audit(
         prod_packages = Some(set);
     }
 
-    // Note: reshaped for borrowck — column slices borrow `pm.lockfile`
-    // immutably for the loop, so resolve `root_id` / `prod_packages` (which
-    // need `&mut pm`) above, and split-borrow `pm.options` for the scope lookup
-    // (disjoint from `pm.lockfile`).
     let options = &pm.options;
     let default_url_hash = options.scope.url_hash;
     let packages = pm.lockfile.packages.slice();

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -136,8 +136,6 @@ impl Editor {
                 return Some(editor);
             }
 
-            // Note: reshaped for borrowck — by_fallback_path_for_editor writes a
-            // 'static slice; we widen `out` to accept it via a temporary.
             let mut static_out: &'static [u8] = b"";
             if Self::by_fallback_path_for_editor(editor, Some(&mut static_out)) {
                 *out = static_out;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -917,9 +917,6 @@ fn iterate_bundled_deps(
             while let Some(sub_entry) = scoped_iter.next().ok().flatten() {
                 let entry_name = entry_subpath(_entry_name, sub_entry.name.slice_u8())?;
 
-                // Note: reshaped for borrowck — find
-                // the matching index first, mark it, then call
-                // `add_bundled_dep` with `&mut ctx`.
                 let Some(dep_idx) = ctx.bundled_deps.iter().position(|dep| {
                     debug_assert!(dep.from_root_package_json);
                     strings::eql_long(entry_name.as_bytes(), &dep.name, true)
@@ -949,7 +946,6 @@ fn iterate_bundled_deps(
             }
         } else {
             let entry_name = _entry_name;
-            // Note: reshaped for borrowck — see comment in scoped branch.
             let Some(dep_idx) = ctx.bundled_deps.iter().position(|dep| {
                 debug_assert!(dep.from_root_package_json);
                 strings::eql_long(entry_name, &dep.name, true)
@@ -2553,7 +2549,6 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         package_version,
         &mut dest_buf[..],
     );
-    // Note: reshaped for borrowck — abs_tarball_dest borrows dest_buf
     let abs_tarball_dest_len = abs_tarball_dest.as_bytes().len();
 
     {

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -186,7 +186,6 @@ pub(crate) fn view(
 
     let versions_len: usize;
 
-    // Note: reshaped for borrowck.
     'brk: {
         'from_versions: {
             if let Some(versions_obj) = json.get_object(b"versions") {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1304,7 +1304,6 @@ impl<'a> Repl<'a> {
             // Temporarily re-enable signal delivery so Ctrl+C can interrupt
             // the blocking waitForPromise call
             self.enable_signals_during_wait();
-            // Note: reshaped for borrowck — call disable_signals_during_wait() explicitly on each return path below
 
             // Wait for the promise to settle
             vm.as_mut()
@@ -1607,7 +1606,6 @@ impl<'a> Repl<'a> {
             // owning JSC VM handle for this thread.
             jsc::JSPromise::opaque_mut(promise).set_handled();
             self.enable_signals_during_wait();
-            // Note: reshaped for borrowck — disable_signals_during_wait called on each path
             vm.as_mut()
                 .wait_for_promise(jsc::AnyPromise::Normal(promise));
             if vm.jsc_vm().execution_forbidden() {
@@ -2015,7 +2013,6 @@ impl<'a> Repl<'a> {
                     if self.editor_mode {
                         // Finish editor mode
                         self.print(format_args!("\n"));
-                        // Note: reshaped for borrowck — clone editor_buffer slice before evaluate
                         if !self.editor_buffer.is_empty() {
                             let code = core::mem::take(&mut self.editor_buffer);
                             self.evaluate_and_print(&code);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1033,9 +1033,6 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         }
 
         // ctx → transpiler/resolver option mapping.
-        // reshaped for borrowck — `b` borrows `vm.transpiler`
-        // exclusively; `fail_with_build_error(vm)` needs the whole `vm`, so
-        // capture the defines result, drop `b`, then branch.
         let defines_ok = {
             let b = &mut vm.transpiler;
             Self::wire_transpiler_from_ctx(b, ctx);
@@ -1187,9 +1184,6 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // SAFETY: freshly-allocated heap bytes, never freed (see above).
         vm.set_main(unsafe { &*entry_ptr });
 
-        // reshaped for borrowck — `b` borrows `vm.transpiler`
-        // exclusively; `fail_with_build_error(vm)` needs the whole `vm`, so
-        // capture the defines result, drop `b`, then branch.
         let defines_ok = {
             let b = &mut vm.transpiler;
             Self::wire_transpiler_from_ctx(b, ctx);

--- a/src/runtime/cli/test/ChangedFilesFilter.rs
+++ b/src/runtime/cli/test/ChangedFilesFilter.rs
@@ -281,7 +281,6 @@ pub(crate) fn filter<'a>(
     // affected, or (b) the test file itself is in the changed set (covers
     // test files that failed to enter the graph for any reason).
     let mut write: usize = 0;
-    // reshaped for borrowck — capture len before re-borrowing test_files
     let total = test_files.len();
     debug_assert_eq!(test_files.len(), slot_to_source.len());
     for i in 0..total {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -386,9 +386,6 @@ impl<'a> Scanner<'a> {
                 // Prune ignored directory trees early so we never traverse them.
                 if !self.path_ignore_patterns.is_empty() {
                     let parts: [&[u8]; 2] = [entry.dir, entry.base()];
-                    // reshaped for borrowck — drop the &mut borrow from
-                    // abs_buf and reborrow open_dir_buf immutably so &self methods
-                    // can be called with the slice.
                     let dir_path_len = Self::abs_buf_projected(
                         self.top_level_dir(),
                         &parts,
@@ -423,9 +420,6 @@ impl<'a> Scanner<'a> {
                 }
 
                 let parts: [&[u8]; 2] = [entry.dir, entry.base()];
-                // reshaped for borrowck — drop the &mut borrow from
-                // abs_buf and reborrow open_dir_buf immutably so &self methods
-                // below can be called with the slice.
                 let path_len =
                     Self::abs_buf_projected(self.top_level_dir(), &parts, &mut self.open_dir_buf)
                         .len();

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -162,7 +162,6 @@ pub(crate) fn merge_coverage_fragments<const ENABLE_COLORS: bool>(
             bun_sys::Result::Err(_) => continue,
         };
         let mut cur: Option<usize> = None; // index into by_file; raw &mut would alias across getOrPut
-        // reshaped for borrowck — store index instead of *mut FileCoverage
         for raw in data.split(|b| *b == b'\n') {
             let line = strings::trim_right(raw, b"\r");
             if line.starts_with(b"SF:") {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -667,9 +667,6 @@ fn generate_entry_point(_vm: &VirtualMachine, watch: bool, entry_path: &[u8]) ->
 /// # Safety
 /// `vm` is the live per-thread VM.
 unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JSInternalPromise> {
-    // SAFETY: wait_for_promise/event_loop().tick() re-enter JS which may mutate VM fields;
-    // holding &mut VM across that would alias.
-
     // ── is_in_preload guard ─────────────────────────────────────────────
     // SAFETY: per fn contract — `vm` is the live per-thread VM.
     unsafe { (*vm).is_in_preload = true };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -897,8 +897,6 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
 /// # Safety
 /// `vm` is the live per-thread VM.
 unsafe fn auto_tick(vm: *mut VirtualMachine) {
-    // SAFETY: tick_immediate_tasks/uws loop dispatch JS callbacks that re-enter the VM and its
-    // EventLoop; no stable &mut can span the tick.
     // SAFETY: per fn contract — `vm` is the live per-thread VM.
     let el: *mut bun_jsc::event_loop::EventLoop = unsafe { &*vm }.event_loop;
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
@@ -1059,8 +1057,6 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
 /// # Safety
 /// `vm` is the live per-thread VM.
 unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
-    // SAFETY: same as `auto_tick` above: event-loop tick re-enters JS which mutates
-    // VM/EventLoop; raw per-field deref is required.
     // SAFETY: per fn contract — `vm` is the live per-thread VM.
     let el: *mut bun_jsc::event_loop::EventLoop = unsafe { &*vm }.event_loop;
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -667,11 +667,8 @@ fn generate_entry_point(_vm: &VirtualMachine, watch: bool, entry_path: &[u8]) ->
 /// # Safety
 /// `vm` is the live per-thread VM.
 unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JSInternalPromise> {
-    // Note: reshaped for borrowck — `wait_for_promise` / `event_loop().tick()`
-    // need `&mut VirtualMachine` while we're also iterating `vm.preload` and
-    // touching `vm.transpiler.resolver` / `vm.log`. Dereference per-field via
-    // the raw `vm` ptr; iterate preloads by index (the `Box<[u8]>` payloads are
-    // heap-stable so a raw `*const [u8]` survives the resolver borrow).
+    // SAFETY: wait_for_promise/event_loop().tick() re-enter JS which may mutate VM fields;
+    // holding &mut VM across that would alias.
 
     // ── is_in_preload guard ─────────────────────────────────────────────
     // SAFETY: per fn contract — `vm` is the live per-thread VM.
@@ -900,9 +897,8 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
 /// # Safety
 /// `vm` is the live per-thread VM.
 unsafe fn auto_tick(vm: *mut VirtualMachine) {
-    // Note: reshaped for borrowck — `EventLoop` is a value field of
-    // `VirtualMachine`, so holding `&mut EventLoop` while also touching VM
-    // siblings would alias. Dereference per-field via the raw `vm` ptr.
+    // SAFETY: tick_immediate_tasks/uws loop dispatch JS callbacks that re-enter the VM and its
+    // EventLoop; no stable &mut can span the tick.
     // SAFETY: per fn contract — `vm` is the live per-thread VM.
     let el: *mut bun_jsc::event_loop::EventLoop = unsafe { &*vm }.event_loop;
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
@@ -1063,7 +1059,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
 /// # Safety
 /// `vm` is the live per-thread VM.
 unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
-    // Note: reshaped for borrowck — see `auto_tick` above.
+    // SAFETY: same as `auto_tick` above: event-loop tick re-enters JS which mutates
+    // VM/EventLoop; raw per-field deref is required.
     // SAFETY: per fn contract — `vm` is the live per-thread VM.
     let el: *mut bun_jsc::event_loop::EventLoop = unsafe { &*vm }.event_loop;
     // SAFETY: `el` is the live per-thread event loop (field of `*vm`).
@@ -4200,9 +4197,6 @@ unsafe fn transpile_file(
         }
     };
     // Deinit the blob (if any) on scope exit.
-    // Note: reshaped for borrowck — capture the `is_some()` flag *before*
-    // moving the option into the scopeguard so the `transpile_async` predicate
-    // can still read it without aliasing the guard's `&mut`.
     let had_blob = blob_to_deinit.is_some();
     let _blob_guard = scopeguard::guard(blob_to_deinit, |mut slot| {
         if let Some(mut blob) = slot.take() {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -957,8 +957,6 @@ impl PathLikeExt for PathLike {
                     // SAFETY: buf[4+n] == 0 written above.
                     return ZStr::from_buf(&buf[..], 4 + n);
                 }
-                // reshaped for borrowck — capture the length so
-                // the `Ok` borrow ends at the match, then re-derive.
                 let resolved_len = match bun_paths::resolve_path::PosixToWinNormalizer::resolve_cwd_with_external_buf_z(buf, sliced) {
                     Ok(res) => Some(res.len()),
                     // The cwd root + path don't fit `buf` (UNC cwds can push

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1999,8 +1999,6 @@ where
         ctx_log!("doRenderStream");
         // SAFETY: pair is a stack local threaded through cork user-data.
         let pair = unsafe { &mut *pair };
-        // NOTE: reshaped for borrowck — split the two fields up front so
-        // `this` and `stream` are independent borrows of `*pair`.
         let this: &mut Self = &mut *pair.this;
         let stream = &mut pair.stream;
         debug_assert!(this.server.is_some());
@@ -2034,8 +2032,10 @@ where
                 ..Default::default()
             },
         });
-        // NOTE: reshaped for borrowck — own via raw ptr so `this.sink` and the
-        // local `response_stream` view can coexist with `&mut *this` calls below.
+        // SAFETY: sink field is Option<NonNull> by design (JS GC-owned); assign_to_stream may
+        // synchronously fire on_first_write→handle_first_stream_write(&mut *this) while
+        // the outer frame still holds &mut *response_stream, so Box-in-self + safe
+        // borrow would be aliasing UB.
         let response_stream_ptr = bun_core::heap::into_raw_nn(response_stream_box);
         this.sink = Some(response_stream_ptr);
         // SAFETY: just allocated; sole live mutable view (this.sink only stores the ptr).

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2574,12 +2574,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         Self: ServerPools<SSL, DEBUG>,
     {
         httplog!("listen");
-        // reshaped for borrowck (PORTING.md §Forbidden — aliased
-        // `&mut`). No long-lived `&mut Self` is held across re-derives from
-        // `this`; each use site reborrows fresh and the borrow ends before the
-        // next derive. The serverName / SNI loop extracts raw `(ptr, len)` so
-        // no `&self.config` outlives the per-domain `set_routes()` call.
-        //
         // SAFETY (applies to every `&mut *this` below): `this` was produced by
         // `init()` and is live for this call; only one reference derived from
         // it is alive at a time. Read-only access goes through `this_ref`

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -268,11 +268,6 @@ impl IOReader {
         // memory.
         let _keepalive = self.keepalive();
         self.set_reading(false);
-        // NOTE: reshaped for borrowck — `dispatch_read_chunk`/`run_yield`
-        // both re-derive `state()` (and the interpreter callback may re-enter
-        // `add_reader`/`remove_reader`), so we must NOT hold a long-lived
-        // `&mut State` across the dispatch. Re-derive `state()` per access
-        // instead.
         let mut i = 0usize;
         while i < self.state().readers.len() {
             let r = self.state().readers[i];

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -268,6 +268,10 @@ impl IOReader {
         // memory.
         let _keepalive = self.keepalive();
         self.set_reading(false);
+        // `dispatch_read_chunk`/`run_yield` re-derive `state()` (and the interpreter callback may
+        // re-enter `add_reader`/`remove_reader`). `state()` takes `&self`, so borrowck would
+        // permit a hoisted `&mut State`, but that aliases the inner re-derive. Re-derive per
+        // access instead.
         let mut i = 0usize;
         while i < self.state().readers.len() {
             let r = self.state().readers[i];

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -614,8 +614,6 @@ impl IOWriter {
     }
 
     fn get_buffer_impl(&self) -> &[u8] {
-        // NOTE: reshaped for borrowck — re-derive `state()` after
-        // `skip_dead()` instead of holding one `&mut State` across it.
         {
             let s = self.state();
             if s.writer_idx >= s.writers.len() {
@@ -647,9 +645,6 @@ impl IOWriter {
     /// Advance past `current_writer`, shrinking `buf` if appropriate, and
     /// return the `Yield` for the child's `on_io_writer_chunk` callback.
     fn bump(&self, current_idx: usize) -> Yield {
-        // NOTE: reshaped for borrowck — `skip_dead()` re-derives `state()`,
-        // so we must drop `s` before calling it and re-derive after, otherwise
-        // two `&mut State` are live simultaneously (UB under Stacked Borrows).
         let (is_dead, written, child_ptr) = {
             let s = self.state();
             let w = &s.writers[current_idx];

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -614,6 +614,9 @@ impl IOWriter {
     }
 
     fn get_buffer_impl(&self) -> &[u8] {
+        // `skip_dead()` re-derives `state()` internally. `state()` takes `&self`, so borrowck
+        // would permit holding `s` across it, but that is two live `&mut State` (UB under
+        // Stacked Borrows). Drop `s` first and re-derive after.
         {
             let s = self.state();
             if s.writer_idx >= s.writers.len() {
@@ -645,6 +648,9 @@ impl IOWriter {
     /// Advance past `current_writer`, shrinking `buf` if appropriate, and
     /// return the `Yield` for the child's `on_io_writer_chunk` callback.
     fn bump(&self, current_idx: usize) -> Yield {
+        // `skip_dead()` re-derives `state()` internally. `state()` takes `&self`, so borrowck
+        // would permit holding `s` across it, but that is two live `&mut State` (UB under
+        // Stacked Borrows). Drop `s` first and re-derive after.
         let (is_dead, written, child_ptr) = {
             let s = self.state();
             let w = &s.writers[current_idx];

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -87,8 +87,6 @@ impl Mkdir {
     }
 
     pub(crate) fn next(interp: &Interpreter, cmd: NodeId) -> Yield {
-        // NOTE: reshaped for borrowck — read scalars, drop the borrow,
-        // then act.
         let action = match &mut Self::state_mut(interp, cmd).state {
             State::Idle => panic!("Invalid state"),
             State::Exec(exec) => {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1814,9 +1814,6 @@ impl ShellExecEnv {
     /// `cd -`.
     #[inline]
     pub fn change_prev_cwd(&mut self) -> bun_sys::Result<()> {
-        // Note: reshaped for borrowck — `prev_cwd()` borrows `self`, so
-        // copy into a stack buffer before the `&mut self` call. Bounded by the
-        // ENAMETOOLONG check inside `change_cwd_impl` (same 4 KiB).
         // Use a `[4096]u8` buffer on every platform; do NOT use
         // `bun_paths::PathBuffer` here — on Windows that is ~96 KiB of
         // zero-filled stack, and `change_cwd_impl` stacks another on top.
@@ -1866,8 +1863,6 @@ impl ShellExecEnv {
         } else {
             // `join_z_buf` normalizes `.`/`..` so the stored `$PWD`/`$OLDPWD`
             // strings reflect the resolved path (not `<cwd>/..`).
-            // Note: reshaped for borrowck — capture only the joined length
-            // so the borrow on `buf` is released before stripping below.
             let mut n = {
                 let existing_cwd = self.cwd();
                 bun_paths::resolve_path::join_z_buf::<bun_paths::platform::Auto>(

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -474,7 +474,6 @@ impl Listener {
             }
         };
         if listen_socket.is_null() {
-            // Note: reshaped for borrowck — extract hostname bytes for error formatting
             let hostname_bytes: &[u8] = match &connection {
                 UnixOrHost::Host { host, .. } => host,
                 UnixOrHost::Unix(u) => u,
@@ -1096,9 +1095,6 @@ impl Listener {
             use bun_sys::FdExt as _;
 
             let mut buf = PathBuffer::uninit();
-            // Note: reshaped for borrowck — `normalize_pipe_name` borrows
-            // `buf` for the returned slice; store length and re-borrow after the
-            // `connection` match drops.
             let mut pipe_name_len: Option<usize> = None;
             let is_named_pipe = match &mut connection {
                 // we check if the path is a named pipe otherwise we try to connect using AF_UNIX

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -302,7 +302,6 @@ impl Execution {
         //   kill any dangling processes
         // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
         if let Some(current_group) = self.active_group() {
-            // reshaped for borrowck — capture range, drop &mut group, re-borrow sequences
             let (start, end) = (current_group.sequence_start, current_group.sequence_end);
             let sequences = &self.sequences[start..end];
             if sequences.len() == 1 {

--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -97,7 +97,6 @@ impl Order {
         }
 
         // gather children
-        // reshaped for borrowck — iterate by index since generate_order_sub borrows &mut self.
         let scope_only = current.base.only;
         for i in 0..current.entries.len() {
             if scope_only == Only::Contains && current.entries[i].base().only == Only::No {

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -405,7 +405,6 @@ impl ScopeFunctions {
                     if let Some(filter_regex) = reporter.jest.filter_regex {
                         group_log::log(format_args!("matches_filter begin"));
                         debug_assert!(bun_test.collection.filter_buffer.is_empty());
-                        // reshaped for borrowck — clear at end via explicit call below.
 
                         // SAFETY: active_scope is a valid cursor into root_scope's tree for the lifetime of Collection.
                         let active_scope: &DescribeScope = unsafe { bun_test.collection.active_scope.as_ref() };

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1453,10 +1453,6 @@ impl RefDataValue {
     pub fn sequence<'a>(&self, buntest: &'a mut BunTest) -> Option<&'a mut Execution::ExecutionSequence> {
         let RefDataValue::Execution { group_index, entry_data } = self else { return None };
         let entry_data = (*entry_data)?;
-        // reshaped for borrowck — `ConcurrentGroup::sequences_mut`
-        // borrows `&mut Execution` while `group()` already holds a borrow into
-        // `execution.groups`. Read `(sequence_start, sequence_end)` first, then
-        // index `execution.sequences` directly.
         let group = buntest.execution.groups.get(*group_index)?;
         let (start, end) = (group.sequence_start, group.sequence_end);
         Some(&mut buntest.execution.sequences[start..end][entry_data.sequence_index])

--- a/src/runtime/test_runner/diff/diff_match_patch.rs
+++ b/src/runtime/test_runner/diff/diff_match_patch.rs
@@ -1063,7 +1063,6 @@ pub(crate) fn diff_cleanup_semantic<Unit: DiffUnit>(
     while usize::try_from(pointer).unwrap() < diffs.len() {
         let p = usize::try_from(pointer).unwrap();
         if diffs[p - 1].operation == Operation::Delete && diffs[p].operation == Operation::Insert {
-            // reshaped for borrowck — take owned copies of deletion/insertion
             let deletion: Box<[Unit]> = core::mem::take(&mut diffs[p - 1].text);
             let insertion: Box<[Unit]> = core::mem::take(&mut diffs[p].text);
             let overlap_length1: usize = diff_common_overlap(&deletion, &insertion);

--- a/src/runtime/test_runner/diff/printDiff.rs
+++ b/src/runtime/test_runner/diff/printDiff.rs
@@ -167,7 +167,6 @@ pub fn print_diff_main(
         diff_segments = new_diff_segments;
 
         // Forward pass: unskip segments after non-equal segments
-        // reshaped for borrowck (capture len before mutable slice borrow)
         let len = diff_segments.len();
         for i in 0..len {
             if diff_segments[i].mode != DiffSegmentMode::Equal {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -946,7 +946,6 @@ impl Expect {
         trimmed_buf: &'a mut [u8],
     ) -> TrimResult<'a> {
         debug_assert!(trimmed_buf.len() == str_in.len());
-        // reshaped for borrowck — track dst as an index into trimmed_buf instead of a moving slice
         let mut src = str_in;
         let trimmed_buf_len = trimmed_buf.len();
         let mut dst_idx: usize = 0;
@@ -3095,7 +3094,6 @@ pub mod mock {
     pub(crate) struct AllCallsWithArgsFormatter<'a, 'g> {
         pub global_this: &'g JSGlobalObject,
         pub calls: JSValue,
-        // reshaped for borrowck — Display::fmt takes &self but we need &mut Formatter
         pub formatter: core::cell::RefCell<&'a mut ConsoleObject::Formatter<'g>>,
     }
 
@@ -3157,7 +3155,6 @@ pub mod mock {
     pub(crate) struct AllCallsFormatter<'g, 'f> {
         pub global_this: &'g JSGlobalObject,
         pub returns: JSValue,
-        // reshaped for borrowck — Display::fmt takes &self but we need &mut Formatter
         pub formatter: core::cell::RefCell<&'f mut ConsoleObject::Formatter<'g>>,
     }
 
@@ -3209,7 +3206,6 @@ pub mod mock {
     pub struct SuccessfulReturnsFormatter<'g, 'f> {
         pub global_this: &'g JSGlobalObject,
         pub successful_returns: &'f Vec<JSValue>,
-        // reshaped for borrowck — Display::fmt takes &self but we need &mut Formatter
         pub formatter: core::cell::RefCell<&'f mut ConsoleObject::Formatter<'g>>,
     }
 

--- a/src/runtime/test_runner/expect/toMatchSnapshot.rs
+++ b/src/runtime/test_runner/expect/toMatchSnapshot.rs
@@ -10,9 +10,6 @@ pub(crate) fn to_match_snapshot(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    // reshaped for borrowck — post-match cleanup is expressed by
-    // wrapping `this` in a scopeguard so `post_match` runs on every exit path while we still
-    // deref through the guard for the body.
     let this = scopeguard::guard(this, |this| this.post_match(global));
 
     let this_value = frame.this();

--- a/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
+++ b/src/runtime/test_runner/expect/toThrowErrorMatchingInlineSnapshot.rs
@@ -60,8 +60,6 @@ pub(crate) fn to_throw_error_matching_inline_snapshot(
 
     let expected_slice: Option<&[u8]> = if has_expected { Some(expected.slice()) } else { None };
 
-    // reshaped for borrowck — hoist get_value out so the two &mut self
-    // receivers don't overlap.
     let received = this.get_value(
         global,
         this_value,

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -981,8 +981,6 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
         if tag.cell.is_hidden() {
             return;
         }
-        // reshaped for borrowck — `handle_first_property` needs `&mut *ctx`,
-        // so the split borrows of `ctx.formatter`/`ctx.writer` are taken *after* it.
         if ctx.i == 0 {
             let parent = ctx.parent;
             if Self::handle_first_property(ctx, global_this, parent).is_err() {
@@ -1099,10 +1097,6 @@ impl<'a> Formatter<'a> {
         if self.failed {
             return Ok(());
         }
-        // reshaped for borrowck — `WrappedWriter` borrows both writer_
-        // and &mut self.estimated_line_length; we use a local wrapper and sync
-        // `failed` at scope exit. estimated_line_length is unused by WrappedWriter
-        // methods in this file, so we leave it None here.
         let mut writer = WrappedWriter::new(writer_);
 
         if FORMAT.can_have_circular_references() {

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -977,8 +977,6 @@ impl TimerObjectInternals {
             self.update_flags(|f| f.set_has_accessed_primitive(true));
             let state = crate::jsc_hooks::runtime_state();
             debug_assert!(!state.is_null(), "RuntimeState not installed");
-            // Note: reshaped for borrowck — capture `event_loop_timer` ptr
-            // before borrowing `(*state).timer.maps`.
             let elt = self.event_loop_timer();
             // SAFETY: `state` is the boxed per-thread `RuntimeState`;
             // single-threaded JS heap so no concurrent `&mut` to `.timer.maps`.

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -466,7 +466,6 @@ impl JSValkeyClient {
             args: CommandArgs::Args(&args),
             meta: CommandMeta::default(),
         };
-        // Note: reshaped for borrowck (cmd.meta = cmd.meta.check(&cmd))
         let checked_meta = cmd.meta.check(&cmd);
         cmd.meta = checked_meta;
         // Send command with slices directly

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -579,9 +579,6 @@ impl BlobExt for Blob {
                         // SystemError so the callback has one shape to handle.
                         crate::webcore::__s3_client::S3DownloadResult::NotFound(e)
                         | crate::webcore::__s3_client::S3DownloadResult::Failure(e) => {
-                            // reshaped for borrowck — `t.done` moves
-                            // `t`, so build the SystemError (cloning the path
-                            // out of `t.blob.store`) before the call.
                             let err = bun_jsc::SystemError {
                                 code: BunString::clone_utf8(e.code).into(),
                                 message: BunString::clone_utf8(e.message).into(),

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1285,9 +1285,6 @@ impl Value {
         global: &JSGlobalObject,
     ) -> JsTerminated<()> {
         if let Value::Locked(_) = self {
-            // reshaped for borrowck + E0509 (`Value` has `Drop`) — `mem::take`
-            // the `PendingValue` out (leaves `Locked(default)`, whose Drop is a no-op on
-            // an empty readable), then overwrite with `Error`.
             let mut locked = match self {
                 Value::Locked(l) => core::mem::take(l),
                 _ => unreachable!(),
@@ -1468,7 +1465,6 @@ impl Value {
             _ => {}
         }
 
-        // reshaped for borrowck — re-borrow locked after the early *self = Null path above.
         let Value::Locked(locked) = self else {
             unreachable!()
         };
@@ -1765,8 +1761,6 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         global_object: &JSGlobalObject,
         check: fn(&ReadableStream, &JSGlobalObject) -> bool,
     ) -> bool {
-        // reshaped for borrowck — `get_body_readable_stream` needs `&self`,
-        // so we can't hold a `match` borrow on `get_body_value()` across it.
         match self.get_body_value() {
             Value::Used => true,
             Value::Locked(pending) if !pending.action.is_none() => true,
@@ -1833,7 +1827,6 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 {
                     return Ok(handle_body_already_used(global_object));
                 }
-                // reshaped for borrowck
                 let _ = locked;
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
@@ -2008,7 +2001,6 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         let value = self.get_body_value();
         if let Value::Locked(_locked) = value {
             let owned_readable = self.get_body_readable_stream(global_object);
-            // reshaped for borrowck — re-borrow after self method call.
             let value = self.get_body_value();
             let Value::Locked(locked) = value else {
                 unreachable!()
@@ -2486,7 +2478,6 @@ impl<'a> ValueBufferer<'a> {
             }
         }
 
-        // reshaped for borrowck — re-borrow locked after possible *value = Used above.
         let Value::Locked(locked) = value else {
             unreachable!()
         };

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -595,7 +595,6 @@ impl FileSink {
             return sys::Result::Ok(());
         }
 
-        // reshaped for borrowck — split into a local capture and apply after.
         // R-2: out-params for `bun_io::open_for_writing` are local then `Cell::set`.
         let mut force_sync_out = self.force_sync.get();
         let mut pollable_out = self.pollable.get();
@@ -1468,10 +1467,6 @@ impl FileSink {
 
         self.readable_stream
             .set(readable_stream::Strong::init(*stream, global_this));
-        // reshaped for borrowck — re-derive `signal_ptr` after
-        // assigning `readable_stream`. `JsCell::as_ptr` yields the stable
-        // address of the inner `Signal` (`#[repr(transparent)]` over
-        // `UnsafeCell`).
         // SAFETY: project to `signal.ptr` without forming a reference;
         // `Option<NonNull<c_void>>` is ABI-identical to `*mut c_void` (see
         // const-asserts on `Signal` in streams.rs), so FFI may write the

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -552,10 +552,6 @@ impl Response {
 // ─── getters & header helpers ───────────────────────────────────────────────
 impl Response {
     pub fn header(&self, name: HTTPHeaderName) -> Option<ZigString> {
-        // reshaped for borrowck — `FetchHeaders::fast_get` takes
-        // `&mut self` (FFI writes through an out-param), so we return the
-        // owned `ZigString` instead of a borrowed slice. Callers do
-        // `.slice()` themselves. R-2 escape hatch via `init_mut()`.
         self.init_mut().headers.as_mut()?.fast_get(name)
     }
 

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -571,11 +571,6 @@ impl<'a> CopyFile<'a> {
         let mut dest_buf = PathBuffer::uninit();
 
         loop {
-            // reshaped for borrowck — `slice_z(&'a self, &'a mut buf)`
-            // ties the returned `&ZStr` to `self`, which would conflict with
-            // the `&mut self` borrow `mkdir_if_not_exists` needs below. The
-            // bytes live in `dest_buf`, so capture the length and re-borrow
-            // from the buffer (not `self`) after dropping the first borrow.
             let dest_len = self
                 .destination_file_store
                 .pathlike
@@ -1033,7 +1028,6 @@ impl<'a> CopyFileWindows<'a> {
 
     fn read_write_loop_read(&mut self) -> bun_sys::Result<()> {
         self.read_write_loop.read_buf.clear();
-        // reshaped for borrowck — use the full capacity slice.
         let cap = self.read_write_loop.read_buf.capacity();
         self.read_write_loop.uv_buf = libuv::uv_buf_t {
             len: cap as libuv::ULONG,
@@ -1118,7 +1112,6 @@ extern "C" fn on_read(req: *mut libuv::fs_t) {
 
     let source_fd = this.read_write_loop.source_fd;
     let destination_fd = this.read_write_loop.destination_fd;
-    // reshaped for borrowck — `read_buf.items` is `Vec` len-slice.
     let read_buf = &mut this.read_write_loop.read_buf;
 
     let event_loop = this.event_loop;

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -286,9 +286,8 @@ impl FileCloser for ReadFile {
             let this = unsafe { bun_ptr::callback_ctx::<ReadFile>(ctx.cast()) };
             <ReadFile as FileCloser>::on_io_request_closed(this);
         }
-        // SAFETY: `ctx` is the async io-close callback's *mut Self (on_done re-enters/mutates
-        // self); the hoist before `&mut this.io_poll` is already the minimal safe
-        // ordering.
+        // SAFETY: `ctx` is the async io-close callback's *mut Self; on_done re-enters and
+        // mutates self, so `ptr::from_mut` write provenance is required.
         let ctx = std::ptr::from_mut::<ReadFile>(this).cast::<()>();
         let fd = this.opened_fd;
         io::Action::Close(io::CloseAction {

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -286,8 +286,9 @@ impl FileCloser for ReadFile {
             let this = unsafe { bun_ptr::callback_ctx::<ReadFile>(ctx.cast()) };
             <ReadFile as FileCloser>::on_io_request_closed(this);
         }
-        // reshaped for borrowck — compute the parent raw pointer
-        // before mutably borrowing `io_poll` so the two borrows do not overlap.
+        // SAFETY: `ctx` is the async io-close callback's *mut Self (on_done re-enters/mutates
+        // self); the hoist before `&mut this.io_poll` is already the minimal safe
+        // ordering.
         let ctx = std::ptr::from_mut::<ReadFile>(this).cast::<()>();
         let fd = this.opened_fd;
         io::Action::Close(io::CloseAction {
@@ -595,7 +596,6 @@ impl ReadFile {
 
         let mut this = this;
         let _store = this.store.take().unwrap();
-        // reshaped for borrowck — take buffer out so it survives `drop(this)`.
         let buf = core::mem::take(&mut this.buffer);
 
         // `_store` is dropped at end of scope (= store.deref()).

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -191,8 +191,8 @@ impl FileCloser for WriteFile {
             let this = unsafe { bun_ptr::callback_ctx::<WriteFile>(ctx.cast()) };
             <WriteFile as FileCloser>::on_io_request_closed(this);
         }
-        // SAFETY: `ctx` is the async io-close callback's *mut Self (on_done re-enters/mutates
-        // self); the hoist before `&mut this.io_poll` is the correct ordering.
+        // SAFETY: `ctx` is the async io-close callback's *mut Self; on_done re-enters and
+        // mutates self, so `ptr::from_mut` write provenance is required.
         let ctx = std::ptr::from_mut::<WriteFile>(this).cast::<()>();
         let fd = this.opened_fd;
         io::Action::Close(io::CloseAction {

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -191,8 +191,8 @@ impl FileCloser for WriteFile {
             let this = unsafe { bun_ptr::callback_ctx::<WriteFile>(ctx.cast()) };
             <WriteFile as FileCloser>::on_io_request_closed(this);
         }
-        // reshaped for borrowck — compute the parent raw pointer
-        // before mutably borrowing `io_poll` so the two borrows do not overlap.
+        // SAFETY: `ctx` is the async io-close callback's *mut Self (on_done re-enters/mutates
+        // self); the hoist before `&mut this.io_poll` is the correct ordering.
         let ctx = std::ptr::from_mut::<WriteFile>(this).cast::<()>();
         let fd = this.opened_fd;
         io::Action::Close(io::CloseAction {
@@ -327,8 +327,6 @@ impl WriteFile {
         )
     }
 
-    // reshaped for borrowck — take (off, len) here and re-derive the slice
-    // internally so callers don't hold a borrow of self across the &mut self call.
     pub fn do_write(&mut self, off: usize, len: usize, wrote: &mut usize) -> bool {
         let fd = self.opened_fd;
         debug_assert!(fd != Fd::INVALID);
@@ -543,7 +541,6 @@ impl WriteFile {
     fn do_write_loop_posix(&mut self) {
         while self.state.load(Ordering::Relaxed) == ClosingState::Running as u8 {
             let remain_full = self.bytes_blob.shared_view();
-            // reshaped for borrowck — capture len/offset before mut borrow
             let off = self.total_written.min(remain_full.len());
             let remain_len = remain_full.len() - off;
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1747,7 +1747,6 @@ impl FetchTasklet {
         let metadata = self.metadata.as_ref().unwrap();
         let http_response = &metadata.response;
         self.is_waiting_body = self.result.has_more;
-        // reshaped for borrowck — capture metadata fields before to_body_value() takes &mut self
         let headers = FetchHeaders::create_from_pico_headers(http_response.headers.list);
         let status_code = http_response.status_code as u16;
         // status_text and url must NOT be atomized: the Response can be
@@ -2189,9 +2188,6 @@ impl FetchTasklet {
         if data.is_empty() {
             return ResumableSinkBackpressure::WantMore;
         }
-        // reshaped for borrowck — read sink HWM (Copy) before
-        // borrowing the stream buffer so `self` is unborrowed during the
-        // mutex critical section below.
         let high_water_mark: usize = match self.sink_mut() {
             Some(sink) => sink.high_water_mark() as usize,
             None => 16384,

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -104,9 +104,6 @@ impl S3HttpDownloadStreamingTask {
             _ => true,
         };
 
-        // reshaped for borrowck — `code`/`message` borrow from
-        // `self.reported_response_buffer`, so we compute the chunk after the
-        // borrow scope ends rather than inside the labeled block.
         let chunk: MutableString = 'brk: {
             if failed {
                 if !has_more {

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -345,7 +345,6 @@ impl S3HttpSimpleTask {
             return Ok(());
         }
         debug_assert!(this.result.metadata.is_some());
-        // reshaped for borrowck — borrow response once, dispatch on a copy of `callback`.
         let response = &this.result.metadata.as_ref().unwrap().response;
         match this.callback {
             Callback::Stat(callback) => match response.status_code {

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -1025,8 +1025,6 @@ impl Tag {
         } else {
             let pre_slice = self.pre.slice(slice);
             buf[..pre_slice.len()].copy_from_slice(pre_slice);
-            // reshaped for borrowck —
-            // capture the init args before advancing `buf`.
             pre = SemverString::init(buf, &buf[0..pre_slice.len()]);
             *buf = &mut core::mem::take(buf)[pre_slice.len()..];
         }

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -935,7 +935,6 @@ pub mod semver_string {
             debug_assert!(self.len <= self.cap); // didn't count everything
             debug_assert!(self.ptr.is_some()); // must call allocate first
 
-            // reshaped for borrowck — compute final slice range, then borrow once.
             let start = self.len;
             let end = self.cap;
             {
@@ -959,7 +958,6 @@ pub mod semver_string {
             debug_assert!(self.len <= self.cap); // didn't count everything
             debug_assert!(self.ptr.is_some()); // must call allocate first
 
-            // reshaped for borrowck
             let start = self.len;
             let end = self.cap;
             {
@@ -983,8 +981,6 @@ pub mod semver_string {
             debug_assert!(self.len <= self.cap); // didn't count everything
             debug_assert!(self.ptr.is_some()); // must call allocate first
 
-            // reshaped for borrowck — get_or_put borrows self.string_pool while we also need
-            // &mut self.ptr; capture scalars first, then re-borrow.
             let start = self.len;
             let cap = self.cap;
             let string_entry = self.string_pool.get_or_put(hash).expect("unreachable");

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -766,15 +766,11 @@ impl<'bump> Parser<'bump> {
     /// If you make a subparser and call some fallible functions on it, you need to catch the errors
     /// and call `.continue_from_subparser()`, otherwise errors will not propagate upwards to the parent.
     pub fn make_subparser(&mut self, kind: SubshellKind) -> Parser<'bump> {
-        // reshaped for borrowck — `self.errors` is moved out
-        // via mem::take and restored in continue_from_subparser.
         Parser {
             strpool: self.strpool,
             tokens: self.tokens,
             js_string_ranges: self.js_string_ranges,
             alloc: self.alloc,
-            // reshaped for borrowck — move the
-            // exclusive borrow into the subparser and restore it in continue_from_subparser.
             jsobjs: core::mem::take(&mut self.jsobjs),
             current: self.current,
             errors: core::mem::replace(&mut self.errors, bun_alloc::ArenaVec::new_in(self.alloc)),
@@ -2273,8 +2269,6 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
 
     fn make_sublexer(&mut self, kind: SubShellKind) -> Self {
         log!("[lex] make sublexer");
-        // reshaped for borrowck — move the lists out via mem::take and restore in
-        // continue_from_sublexer.
         let bump = self.strpool.bump();
         let mut sublexer = Self {
             chars: self.chars,
@@ -2290,8 +2284,6 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
             word_start: self.word_start,
             j: self.j,
             delimit_quote: false,
-            // reshaped for borrowck — move the exclusive borrow into the sublexer
-            // and restore it in continue_from_sublexer (avoids aliased &mut).
             string_refs: core::mem::take(&mut self.string_refs),
             jsobjs_len: self.jsobjs_len,
         };

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -1236,8 +1236,6 @@ pub fn from_vlq(vlq: &[u8], input_line_count_hint: u32) -> Result<Box<[u8]>, Fro
         });
     }
 
-    // reshaped for borrowck — capture `builder.count` before borrowing
-    // `builder.finalized` mutably.
     let mapping_count: u64 = builder.count as u64;
     let out = builder.finalize();
     let blob = out.list.as_mut_slice();

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -38,8 +38,6 @@ pub(crate) fn find_source_map(global: &JSGlobalObject, frame: &CallFrame) -> JsR
         return Ok(JSValue::UNDEFINED);
     }
 
-    // reshaped for borrowck — `source_url_slice` borrows `source_url_string`;
-    // explicit deref/deinit calls become Drop on reassignment.
     let mut source_url_string = bun_string_jsc::from_js(source_url_value, global)?;
     let mut source_url_slice = source_url_string.to_utf8();
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1281,13 +1281,6 @@ impl MySQLConnection {
         Ok(())
     }
 
-    // reshaped for borrowck — `request` comes from `self.queue` so
-    // passing `&mut self` alongside `&mut JSMySQLQuery` would alias. `request`
-    // is `&JSMySQLQuery` (R-2: fully interior-mutable, so a shared borrow is
-    // sound across the re-entrant `on_query_result` callback). The statement is
-    // re-fetched via the single-unsafe `request.get_statement()` accessor at
-    // each touch point so no `&mut MySQLStatement` spans the re-entrant
-    // `on_query_result` call (which may itself call `get_statement()`).
     fn handle_result_set_ok(
         &mut self,
         request: &JSMySQLQuery,

--- a/src/sql_jsc/mysql/MySQLRequestQueue.rs
+++ b/src/sql_jsc/mysql/MySQLRequestQueue.rs
@@ -125,9 +125,6 @@ impl MySQLRequestQueue {
         // momentary `Deref` lifetime. All queue mutation below goes through
         // `Cell`/`JsCell` interior mutability — `&Self` is sufficient.
         let queue_ref: ParentRef<Self> = ParentRef::new(&conn_ref.connection.get().queue);
-        // reshaped for borrowck — the cleanup that must run at function exit
-        // became a post-block pass; early returns become
-        // `break 'advance` so cleanup always runs at function exit.
         'advance: {
             let mut offset: usize = 0;
 

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -164,7 +164,6 @@ pub fn decode_binary_value<Context: ReaderContext>(
                         let remaining = w.len();
                         break 'brk &buffer[..32 - remaining];
                     };
-                    // reshaped for borrowck — compute remaining before re-borrowing buffer
                     Ok(SQLDataCell::string(slice))
                 }
                 _ => Err(crate::Error::InvalidBinaryValue),

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -422,9 +422,6 @@ fn parse_array(
                             let mut has_exponent = false;
                             let mut has_negative_sign = false;
                             let mut has_positive_sign = false;
-                            // reshaped for borrowck — cannot mutate `slice` mid-loop while
-                            // iterating it (the Infinity arm). We capture the advance amount and
-                            // apply after the loop.
                             let mut advance_after: Option<usize> = None;
                             for (index, &byte) in slice.iter().enumerate() {
                                 match byte {
@@ -1124,7 +1121,6 @@ fn parse_binary_numeric<'a>(
             result.truncate(end);
         }
     }
-    // reshaped for borrowck — return borrowed slice of `result`
     Ok(PGNummericString::Dynamic(result.as_slice()))
 }
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -623,7 +623,6 @@ impl PostgresSQLConnection {
         if current == Status::Failed {
             return;
         }
-        // reshaped for borrowck — `defer this.updateHasPendingActivity()` moved to explicit calls below.
 
         self.status.set(status);
         self.reset_connection_timeout();
@@ -696,8 +695,6 @@ impl PostgresSQLConnection {
     }
 
     pub fn fail_with_js_value(&self, value: JSValue) {
-        // reshaped for borrowck — `update_has_pending_activity()` + `ref_and_close(value)`
-        // are expanded inline at each return below.
         self.stop_timers();
         if self.status.get() == Status::Failed {
             self.update_has_pending_activity();

--- a/src/sql_jsc/shared/SQLDataCell.rs
+++ b/src/sql_jsc/shared/SQLDataCell.rs
@@ -546,8 +546,6 @@ pub fn dedupe_columns<'a>(
     for name_or_index in columns {
         match &*name_or_index {
             ColumnIdentifier::Name(name) => {
-                // reshaped for borrowck — compute `found_existing` before
-                // mutating `*name_or_index`.
                 let found_existing = seen_fields
                     .get_or_put(name.slice())
                     .unwrap_or_oom()

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1552,8 +1552,6 @@ pub(crate) fn download_to_path(
             // `progress.end()` below is sufficient: no fallible call sits between
             // `refresher.start` and it, so every exit path (including the
             // error returns after it) ends the node exactly once.
-            // Note: reshaped for borrowck — `get_http_proxy_for` borrows
-            // `env` for the proxy URL lifetime; read the bool first.
             let reject_unauthorized = env.get_tls_reject_unauthorized();
             let http_proxy: Option<bun_url::URL<'_>> = env.get_http_proxy_for(&url);
             let progress = refresher.start(b"Downloading", 0);
@@ -1602,8 +1600,6 @@ pub(crate) fn download_to_path(
             }
 
             {
-                // Note: reshaped for borrowck — `refresher.start` borrows
-                // `refresher` mutably; do gunzip work first, drive progress around it.
                 refresher.start(b"Decompressing", 0);
                 let gunzip_result = (|| -> crate::Result<()> {
                     let mut gunzip = bun_zlib::ZlibReaderArrayList::init(

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -218,8 +218,6 @@ impl INotifyWatcher {
         use bun_sys::linux as system;
         use bun_sys::{E, get_errno};
         let mut i: u32 = 0;
-        // reshaped for borrowck — track length instead of borrowing a sub-slice
-        // of self.eventlist_bytes across the whole function.
         let read_len: usize = if let Some(ptr) = self.read_ptr {
             Futex::wait_forever(&self.watch_count, 0);
             i = ptr.i;
@@ -377,8 +375,6 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
         return Ok(());
     }
 
-    // reshaped for borrowck — copy raw event pointers to a local buffer so
-    // `this.platform` borrow ends before we mutably borrow other `this` fields below.
     let events_len = events.len();
     let mut events_buf: [*const Event; max_count] = [core::ptr::null(); max_count];
     events_buf[..events_len].copy_from_slice(events);
@@ -507,7 +503,6 @@ fn process_inotify_event_batch(
         }
 
         if watch_events[i].index == last_event_id {
-            // reshaped for borrowck — split_at_mut to get two disjoint &mut.
             let (head, tail) = watch_events.split_at_mut(i);
             head[last_event_index].merge(tail[0]);
             continue;

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -376,7 +376,6 @@ impl Watcher {
         // So if we just sort the list by the biggest index first, that should be fine
         self.evict_list[0..evict_list_i].sort_by(|a, b| b.cmp(a));
 
-        // reshaped for borrowck — capture fds.len() before loop
         let slice = self.watchlist.slice();
         let fds = slice.items_fd();
         let fds_len = fds.len();

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -444,10 +444,6 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
 
             let n_items = this.watchlist.items_file_path().len();
             for item_idx in 0..n_items {
-                // reshaped for borrowck — `rel` is computed in a scoped
-                // block so the borrows of `this.watchlist` / `this.platform.buf`
-                // are released before we touch `this.watch_events` or hand the
-                // whole `&mut Watcher` to `process_watch_event_batch`.
                 let rel = {
                     let eventpath = &this.platform.buf[..eventpath_len];
                     let path = &this.watchlist.items_file_path()[item_idx];
@@ -518,7 +514,6 @@ fn process_watch_event_batch(this: &mut Watcher, event_count: usize) -> bun_sys:
 
     for i in 0..all_events.len() {
         if all_events[i].index as u32 == last_event_id {
-            // reshaped for borrowck — copy then merge to avoid two &mut into all_events.
             let ev = all_events[i];
             all_events[last_event_index].merge(ev);
             continue;


### PR DESCRIPTION
Part of the `reshaped for borrowck` comment sweep (audit data on [`farm/2a32eccb/borrowck-audit`](https://github.com/oven-sh/bun/tree/farm/2a32eccb/borrowck-audit/docs/dev/borrowck-audit)). This PR handles **bucket A**: the 257 sites where the code is already in optimal safe-Rust form and only the comment needs to change.

## What changed

**A1 (236 sites)**: idiomatic zero-heap-cost patterns (scalar-copy, reborrow, split-borrow, take-replace, index-loop, clone-small, buffer-stash, own-transfer). The comment is deleted; code is unchanged.

**A2 (20 sites)**: raw `*mut Self` dispatch that is *required* for correctness: either the pointer is stored as an FFI callback context that may later free `self`, or the body runs a reentrant JS callback that mutates `self`. A `&self`-derived pointer here would carry `SharedReadOnly` provenance and make the later write/dealloc UB (see `src/CLAUDE.md` "Pointer provenance at FFI boundaries"). The `reshaped for borrowck` note is replaced with a `// SAFETY:` comment stating the provenance/reentrancy invariant so the `unsafe` is self-documenting.

One A1 site (`src/watcher/INotifyWatcher.rs:529`) was already removed on main by #35321, so this PR touches 256 of the 257 audited sites.

## Why

These comments were breadcrumbs from the Zig→Rust port marking spots where code was restructured to satisfy the borrow checker. For the A1 sites the resulting code is just ordinary idiomatic Rust; the comment adds nothing a Rust reader doesn't already see. For the A2 sites the comment was actively misleading: it suggested the raw pointer was a borrow-checker workaround, when it is in fact a correctness requirement that must not be "fixed" into a safe borrow.

## Verification

```
$ rg "reshaped for borrowck" --type rust | wc -l
112    # was 368; remaining are buckets B/C (actual code changes), tracked separately
$ bun bd
[build] done
$ bun run rust:check-all
10 ok, 0 failed, 0 skipped (of 10)
```

Net: `127 files changed, 59 insertions(+), 557 deletions(-)`. No code semantics change.