### PR TITLE
Bun.spawn: report Subprocess.resourceUsage().maxRSS in bytes on every platform

### DIFF
--- a/src/runtime/api/bun/subprocess/ResourceUsage.rs
+++ b/src/runtime/api/bun/subprocess/ResourceUsage.rs
@@ -39,7 +39,7 @@ impl ResourceUsage {
 
     #[bun_jsc::host_fn(getter)]
     pub fn get_max_rss(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.maxrss_())
+        JSValue::js_number(this.rusage.maxrss_bytes())
     }
 
     #[bun_jsc::host_fn(getter)]

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -135,7 +135,7 @@ pub fn uv_getrusage(process: &mut bun_libuv_sys::uv_process_t) -> WinRusage {
     let Ok(memory) = bun_sys::windows::GetProcessMemoryInfo(process_pid) else {
         return usage_info;
     };
-    usage_info.maxrss = (memory.PeakWorkingSetSize / 1024) as u64;
+    usage_info.maxrss = memory.PeakWorkingSetSize as u64;
 
     usage_info
 }
@@ -162,7 +162,11 @@ pub trait RusageFields {
     fn utime_usec(&self) -> i64;
     fn stime_sec(&self) -> i64;
     fn stime_usec(&self) -> i64;
-    fn maxrss_(&self) -> f64;
+    /// Peak resident set size in **bytes**. `getrusage(2)` reports `ru_maxrss`
+    /// in kilobytes on Linux and the BSDs but in bytes on Darwin, and Windows'
+    /// `PeakWorkingSetSize` is bytes; the impls normalize so the JS-facing
+    /// `Subprocess.resourceUsage().maxRSS` is bytes on every platform.
+    fn maxrss_bytes(&self) -> f64;
     fn ixrss_(&self) -> f64;
     fn nswap_(&self) -> f64;
     fn inblock_(&self) -> f64;
@@ -195,8 +199,17 @@ impl RusageFields for libc::rusage {
         self.ru_stime.tv_usec as i64
     }
     #[inline]
-    fn maxrss_(&self) -> f64 {
-        self.ru_maxrss as f64
+    fn maxrss_bytes(&self) -> f64 {
+        // Darwin's `ru_maxrss` is bytes; every other Unix (Linux, *BSD,
+        // Solaris) reports kilobytes.
+        #[cfg(target_vendor = "apple")]
+        {
+            self.ru_maxrss as f64
+        }
+        #[cfg(not(target_vendor = "apple"))]
+        {
+            self.ru_maxrss as f64 * 1024.0
+        }
     }
     #[inline]
     fn ixrss_(&self) -> f64 {
@@ -254,7 +267,7 @@ impl RusageFields for WinRusage {
         self.stime.usec
     }
     #[inline]
-    fn maxrss_(&self) -> f64 {
+    fn maxrss_bytes(&self) -> f64 {
         self.maxrss as f64
     }
     // These counters do not exist on Windows — always zero.

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1403,3 +1403,45 @@ describe("uid/gid", () => {
     expect(thrown?.code).toBe("EPERM");
   });
 });
+
+describe("resourceUsage", () => {
+  // getrusage(2) reports ru_maxrss in kilobytes on Linux/BSD but in bytes on
+  // Darwin; Windows' PeakWorkingSetSize is bytes. Bun.ResourceUsage documents
+  // maxRSS in bytes, so the implementation must normalize. A child that faults
+  // in 64 MiB of pages must report at least 64 MiB of peak RSS in bytes, not
+  // the raw ~65 000 kilobyte figure Linux hands back.
+  const MiB = 1024 * 1024;
+  const touch64MiB =
+    "const a=new Uint8Array(64*1024*1024); for(let i=0;i<a.length;i+=4096)a[i]=1; process.stdout.write('t')";
+
+  it("spawn: maxRSS is reported in bytes", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", touch64MiB],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("t");
+    const usage = proc.resourceUsage()!;
+    expect(usage.maxRSS).toBeGreaterThanOrEqual(64 * MiB);
+    expect(usage.maxRSS).toBeLessThan(8 * 1024 * MiB);
+    expect(exitCode).toBe(0);
+  });
+
+  it("spawnSync: maxRSS is reported in bytes", () => {
+    const result = spawnSync({
+      cmd: [bunExe(), "-e", touch64MiB],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.stderr.toString()).toBe("");
+    expect(result.stdout.toString()).toBe("t");
+    const usage = result.resourceUsage!;
+    expect(usage.maxRSS).toBeGreaterThanOrEqual(64 * MiB);
+    expect(usage.maxRSS).toBeLessThan(8 * 1024 * MiB);
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`Bun.ResourceUsage` in `packages/bun-types/bun.d.ts` documents `maxRSS` as "The maximum resident set size (in bytes)", and `docs/runtime/child-process.mdx` prints `${usage.maxRSS} bytes`. The implementation returned the raw platform value instead: kilobytes on Linux (raw `ru_maxrss` from `getrusage(2)`), kilobytes on Windows (`PeakWorkingSetSize / 1024`), bytes on macOS (Darwin's `ru_maxrss` is bytes). So the value was both 1024x off from its documented unit on Linux/Windows and inconsistent across platforms.

```js
const big = Bun.spawn([process.execPath, "-e",
  "const a=new Uint8Array(300<<20); for(let i=0;i<a.length;i+=4096)a[i]=1; process.stdout.write('t')"], { stdout: "pipe" });
await new Response(big.stdout).text(); await big.exited;
console.log(big.resourceUsage().maxRSS);
// Linux:  342508        (kilobytes; docs say bytes, so maxRSS/1048576 "MiB" shows 0)
// macOS:  ~350000000    (bytes)
```

## Cause

`RusageFields::maxrss_()` in `src/spawn_sys/spawn_process.rs` returned `ru_maxrss as f64` on every Unix without normalizing for Darwin's divergent unit, and the Windows path stored `PeakWorkingSetSize / 1024` into `WinRusage.maxrss`.

## Fix

Rename the accessor to `maxrss_bytes()` and make it return bytes on every platform: multiply by 1024 on non-Apple Unix, store `PeakWorkingSetSize` undivided on Windows, pass Darwin's value through unchanged. The JS-facing getter in `ResourceUsage.rs` calls the renamed accessor. `process.resourceUsage().maxRSS` (the Node-compat path in `BunProcess.cpp`, which reads `rusage.ru_maxrss` directly and which Node documents as kilobytes) is unchanged.

## Verification

New `describe("resourceUsage")` block in `test/js/bun/spawn/spawn.test.ts` spawns a child that faults in 64 MiB of pages and asserts `maxRSS >= 64 MiB` and `< 8 GiB` for both `spawn().resourceUsage()` and `spawnSync().resourceUsage`. On the released binary the Linux value is ~109 000 (kilobytes) and both assertions fail; with this change both pass.

Related: #32255 covers the `cpuTime` BigInt face of the same published-contract family.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->