### PR TITLE
borrowck cleanup C8: eliminate 10 one-file raw-pointer/alloc workarounds

### DIFF
--- a/src/exe_format/macho.rs
+++ b/src/exe_format/macho.rs
@@ -90,9 +90,7 @@ impl MachoFile {
 
         let mut found_bun = false;
 
-        // reshaped for borrowck — capture base ptr as usize before iterating so we can
-        // compute byte offsets without holding a borrow of self.data across the mutable writes below.
-        let base_addr = self.data.as_ptr() as usize;
+        let lc_base = size_of::<macho::mach_header_64>();
         let mut iter = self.iterator();
 
         while let Some(entry) = iter.next() {
@@ -104,7 +102,7 @@ impl MachoFile {
                         .expect("unreachable");
                     if command.seg_name() == b"__BUN" {
                         if command.nsects > 0 {
-                            let section_offset = entry.data.as_ptr() as usize - base_addr;
+                            let section_offset = lc_base + entry.offset;
                             let sections_base =
                                 section_offset + size_of::<macho::segment_command_64>();
                             let sect_sz = size_of::<macho::section_64>();
@@ -168,11 +166,11 @@ impl MachoFile {
                             }
                         }
                     } else if command.seg_name() == SEG_LINKEDIT {
-                        linkedit_seg_idx = Some(entry.data.as_ptr() as usize - base_addr);
+                        linkedit_seg_idx = Some(lc_base + entry.offset);
                     }
                 }
                 macho::LC::CODE_SIGNATURE => {
-                    code_sign_cmd_idx = Some(entry.data.as_ptr() as usize - base_addr);
+                    code_sign_cmd_idx = Some(lc_base + entry.offset);
                 }
                 _ => {}
             }
@@ -590,7 +588,7 @@ impl MachoSigner {
                 // Store segment info
                 if seg.seg_name() == SEG_LINKEDIT {
                     linkedit_seg = seg;
-                    linkedit_off = cmd.data.as_ptr() as usize - obj.as_ptr() as usize;
+                    linkedit_off = header_size + cmd.offset;
 
                     // Validate linkedit is after text
                     if linkedit_seg.fileoff < text_seg.fileoff + text_seg.filesize {
@@ -617,7 +615,7 @@ impl MachoSigner {
                         .expect("unreachable");
                     sig_off = cs.dataoff as usize;
                     sig_sz = cs.datasize as usize;
-                    cs_cmd_off = cmd.data.as_ptr() as usize - obj.as_ptr() as usize;
+                    cs_cmd_off = header_size + cmd.offset;
                 }
                 _ => {}
             }

--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -470,11 +470,8 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
             )
         };
 
-        // Note: reshaped for borrowck — `path_buf` aliases `self.walker.path_buf`;
-        // capture the raw ptr+len up front so the &mut borrow ends before
-        // `handle_sys_err_with_path` re-borrows `self.walker`.
         let root_path = &root_work_item.path;
-        let (path_buf_ptr, root_path_len) = {
+        let root_path_len = {
             let path_buf: &mut PathBuffer = &mut *self.walker.path_buf;
             if root_path.len() >= path_buf.len() {
                 return Ok(Err(SysError::from_code(
@@ -485,17 +482,12 @@ impl<'a, A: Accessor, const SENTINEL: bool> Iterator<'a, A, SENTINEL> {
             }
             path_buf[0..root_path.len()].copy_from_slice(&root_path[0..root_path.len()]);
             path_buf[root_path.len()] = 0;
-            (path_buf.as_ptr(), root_path.len())
+            root_path.len()
         };
-        // SAFETY: path_buf[root_path_len] == 0 written above; buffer outlives `cwd_fd` open call.
-        let root_path_z = unsafe { ZStr::from_raw(path_buf_ptr, root_path_len) };
+        let root_path_z = ZStr::from_buf(&self.walker.path_buf[..], root_path_len);
         let cwd_fd = match A::open(root_path_z)? {
             Err(err) => {
-                return Ok(Err(self.walker.handle_sys_err_with_path(
-                    &err,
-                    // SAFETY: NUL at index `root_path_len` written above.
-                    unsafe { ZStr::from_raw(path_buf_ptr, root_path_len) },
-                )));
+                return Ok(Err(err.with_path(&self.walker.path_buf[..root_path_len])));
             }
             Ok(fd) => fd,
         };

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -747,9 +747,8 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                         // SAFETY: cross-graph access via `owner()`. We hold
                         // `&mut self` (server_graph); `client_graph` and
                         // `directory_watchers` are disjoint sibling fields.
-                        let (client_graph, directory_watchers) = unsafe {
-                            (&mut (*dev).client_graph, &mut (*dev).directory_watchers)
-                        };
+                        let (client_graph, directory_watchers) =
+                            unsafe { (&mut (*dev).client_graph, &mut (*dev).directory_watchers) };
                         let key = bun_ptr::RawSlice::new(
                             &*self.bundled_files.keys()[file_index.get() as usize],
                         );
@@ -759,8 +758,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                                     "Client graph's SCB was already deleted",
                                 ))
                             });
-                        client_graph
-                            .disconnect_and_delete_file(directory_watchers, client_index);
+                        client_graph.disconnect_and_delete_file(directory_watchers, client_index);
                         self.bundled_files.values_mut()[file_index.get() as usize]
                             .is_client_component_boundary = false;
                         self.dev_incremental_result()

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -507,7 +507,11 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         }
     }
 
-    pub(super) fn disconnect_and_delete_file(&mut self, file_index: FileIndex<SIDE>) {
+    pub(super) fn disconnect_and_delete_file(
+        &mut self,
+        directory_watchers: &mut super::DirectoryWatchStore,
+        file_index: FileIndex<SIDE>,
+    ) {
         debug_assert!(self.first_dep[file_index.get() as usize].is_none()); // must have no dependencies
 
         // Disconnect all imports.
@@ -522,21 +526,8 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
 
         // DirectoryWatchStore.Dep.source_file_path borrows this key; remove
         // any such dependencies before freeing it so they do not dangle.
-        {
-            // Note: reshaped for borrowck — re-derive the key slice via raw
-            // ptr so the `&mut DevServer.directory_watchers` borrow does not
-            // overlap the `&mut self.bundled_files` borrow.
-            let key_ptr: *const [u8] =
-                &raw const *self.bundled_files.keys()[file_index.get() as usize];
-            // SAFETY: see `owner()`; touches `directory_watchers` sibling only,
-            // and `key_ptr` points into `bundled_files` which is not mutated
-            // by `remove_dependencies_for_file`.
-            unsafe {
-                (*self.owner())
-                    .directory_watchers
-                    .remove_dependencies_for_file(&*key_ptr);
-            }
-        }
+        directory_watchers
+            .remove_dependencies_for_file(&self.bundled_files.keys()[file_index.get() as usize]);
 
         // Free the key string and tombstone the slot. Cannot swap-remove since
         // FrameworkRouter / SerializedFailure hold FileIndices into this graph.
@@ -754,9 +745,11 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                         .is_client_component_boundary
                     {
                         // SAFETY: cross-graph access via `owner()`. We hold
-                        // `&mut self` (server_graph); `client_graph` is a
-                        // disjoint sibling field.
-                        let client_graph = unsafe { &mut (*dev).client_graph };
+                        // `&mut self` (server_graph); `client_graph` and
+                        // `directory_watchers` are disjoint sibling fields.
+                        let (client_graph, directory_watchers) = unsafe {
+                            (&mut (*dev).client_graph, &mut (*dev).directory_watchers)
+                        };
                         let key = bun_ptr::RawSlice::new(
                             &*self.bundled_files.keys()[file_index.get() as usize],
                         );
@@ -766,7 +759,8 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                                     "Client graph's SCB was already deleted",
                                 ))
                             });
-                        client_graph.disconnect_and_delete_file(client_index);
+                        client_graph
+                            .disconnect_and_delete_file(directory_watchers, client_index);
                         self.bundled_files.values_mut()[file_index.get() as usize]
                             .is_client_component_boundary = false;
                         self.dev_incremental_result()

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -217,9 +217,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // LIFO order — under the API lock, before the VM is destroyed.
     let mut pt = PerThread::placeholder(vm_ptr);
 
-    // Note: reshaped for borrowck — `pt.vm` already borrows `*vm`, so pass
-    // the raw VM pointer and re-borrow inside.
-    match build_with_vm(ctx, &cwd, vm_ptr, &mut pt) {
+    match build_with_vm(ctx, &cwd, &mut pt) {
         Ok(()) => {}
         Err(crate::Error::JSError) => {
             // SAFETY: vm.global is live for VM lifetime.
@@ -286,11 +284,12 @@ pub(super) fn write_sourcemap_to_disk(
 pub(super) fn build_with_vm(
     ctx: Context,
     cwd: &[u8],
-    vm_ptr: *mut VirtualMachine,
     pt: &mut PerThread,
 ) -> crate::Result<()> {
-    // SAFETY: vm_ptr is the live per-thread VM passed from build_command;
-    // exclusive access on this thread for the duration of the call.
+    // `pt.vm` is the live per-thread VM's BackRef set in `build_command`;
+    // `as_ptr()` is `Copy` and does not borrow `pt`.
+    let vm_ptr: *mut VirtualMachine = pt.vm.as_ptr();
+    // SAFETY: exclusive access on this thread for the duration of the call.
     let vm = unsafe { &mut *vm_ptr };
     // Load and evaluate the configuration module. `global()` returns
     // `&'static`, decoupled from `vm` so later `&mut vm` reborrows are allowed.

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -281,11 +281,7 @@ pub(super) fn write_sourcemap_to_disk(
     Ok(())
 }
 
-pub(super) fn build_with_vm(
-    ctx: Context,
-    cwd: &[u8],
-    pt: &mut PerThread,
-) -> crate::Result<()> {
+pub(super) fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<()> {
     // `pt.vm` is the live per-thread VM's BackRef set in `build_command`;
     // `as_ptr()` is `Copy` and does not borrow `pt`.
     let vm_ptr: *mut VirtualMachine = pt.vm.as_ptr();

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1061,11 +1061,7 @@ fn add_bundled_dep(
                             }
                         };
 
-                        let json = match JSON::parse_package_json_utf8(
-                            &source,
-                            log,
-                            pack_bump(),
-                        ) {
+                        let json = match JSON::parse_package_json_utf8(&source, log, pack_bump()) {
                             Ok(j) => j,
                             Err(_) => break 'root_depth,
                         };

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -846,12 +846,14 @@ fn entry_name_z<'a>(entry_name: &[u8], entry_subpath: &'a ZStr) -> &'a ZStr {
 // ───────────────────────────────────────────────────────────────────────────
 
 fn iterate_bundled_deps(
-    ctx: &mut Context<'_>,
+    bundled_deps: &mut Vec<BundledDep>,
+    stats: &mut Stats,
+    log: &mut bun_ast::Log,
     root_dir: &Dir,
     log_level: LogLevel,
 ) -> Result<PackQueue, AllocError> {
     let mut bundled_pack_queue = new_pack_queue();
-    if ctx.bundled_deps.is_empty() {
+    if bundled_deps.is_empty() {
         return Ok(bundled_pack_queue);
     }
 
@@ -917,10 +919,7 @@ fn iterate_bundled_deps(
             while let Some(sub_entry) = scoped_iter.next().ok().flatten() {
                 let entry_name = entry_subpath(_entry_name, sub_entry.name.slice_u8())?;
 
-                // Note: reshaped for borrowck — find
-                // the matching index first, mark it, then call
-                // `add_bundled_dep` with `&mut ctx`.
-                let Some(dep_idx) = ctx.bundled_deps.iter().position(|dep| {
+                let Some(dep) = bundled_deps.iter_mut().find(|dep| {
                     debug_assert!(dep.from_root_package_json);
                     strings::eql_long(entry_name.as_bytes(), &dep.name, true)
                 }) else {
@@ -930,7 +929,7 @@ fn iterate_bundled_deps(
                 let entry_subpath_ = entry_subpath(b"node_modules", entry_name.as_bytes())?;
 
                 let dedupe_entry = dedupe.get_or_put(entry_subpath_.as_bytes())?;
-                ctx.bundled_deps[dep_idx].was_packed = true;
+                dep.was_packed = true;
                 if dedupe_entry.found_existing {
                     // already got to it in `add_bundled_dep` below
                     continue;
@@ -938,7 +937,8 @@ fn iterate_bundled_deps(
 
                 let subdir = open_subdir(&dir, entry_name.as_bytes(), &entry_subpath_);
                 add_bundled_dep(
-                    ctx,
+                    stats,
+                    log,
                     root_dir,
                     DirInfo(subdir, entry_subpath_.as_bytes().into(), 2),
                     &mut bundled_pack_queue,
@@ -949,8 +949,7 @@ fn iterate_bundled_deps(
             }
         } else {
             let entry_name = _entry_name;
-            // Note: reshaped for borrowck — see comment in scoped branch.
-            let Some(dep_idx) = ctx.bundled_deps.iter().position(|dep| {
+            let Some(dep) = bundled_deps.iter_mut().find(|dep| {
                 debug_assert!(dep.from_root_package_json);
                 strings::eql_long(entry_name, &dep.name, true)
             }) else {
@@ -960,7 +959,7 @@ fn iterate_bundled_deps(
             let entry_subpath_ = entry_subpath(b"node_modules", entry_name)?;
 
             let dedupe_entry = dedupe.get_or_put(entry_subpath_.as_bytes())?;
-            ctx.bundled_deps[dep_idx].was_packed = true;
+            dep.was_packed = true;
             if dedupe_entry.found_existing {
                 // already got to it in `add_bundled_dep` below
                 continue;
@@ -968,7 +967,8 @@ fn iterate_bundled_deps(
 
             let subdir = open_subdir(&dir, entry_name, &entry_subpath_);
             add_bundled_dep(
-                ctx,
+                stats,
+                log,
                 root_dir,
                 DirInfo(subdir, entry_subpath_.as_bytes().into(), 2),
                 &mut bundled_pack_queue,
@@ -989,14 +989,15 @@ fn iterate_bundled_deps(
             dir_subpath
         };
 
-        ctx.bundled_deps.push(BundledDep {
+        bundled_deps.push(BundledDep {
             name: Box::from(dep_name),
             from_root_package_json: false,
             was_packed: true,
         });
 
         add_bundled_dep(
-            ctx,
+            stats,
+            log,
             root_dir,
             bundled_dir_info,
             &mut bundled_pack_queue,
@@ -1010,7 +1011,8 @@ fn iterate_bundled_deps(
 }
 
 fn add_bundled_dep(
-    ctx: &mut Context<'_>,
+    stats: &mut Stats,
+    log: &mut bun_ast::Log,
     root_dir: &Dir,
     bundled_dir_info: DirInfo,
     bundled_pack_queue: &mut PackQueue,
@@ -1018,7 +1020,7 @@ fn add_bundled_dep(
     additional_bundled_deps: &mut Vec<DirInfo>,
     log_level: LogLevel,
 ) -> Result<(), AllocError> {
-    ctx.stats.bundled_deps += 1;
+    stats.bundled_deps += 1;
 
     let bundled_root_depth = bundled_dir_info.2;
 
@@ -1061,7 +1063,7 @@ fn add_bundled_dep(
 
                         let json = match JSON::parse_package_json_utf8(
                             &source,
-                            pm_log(ctx.manager),
+                            log,
                             pack_bump(),
                         ) {
                             Ok(j) => j,
@@ -1904,18 +1906,11 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     ctx: &mut Context<'_>,
     abs_package_json_path: &ZStr,
 ) -> Result<PackReturn<'static, FOR_PUBLISH>, PackError<FOR_PUBLISH>> {
-    // Note: reshaped for borrowck —
-    // `ctx`-whole calls (`run_lifecycle_script(ctx, …)`,
-    // `iterate_bundled_deps(ctx, …)`) overlap the manager borrow.
-    // Round-trip the field through a raw
-    // pointer so the long-lived `manager` reborrow is decoupled from `ctx`;
-    // every interleaved `ctx` access touches disjoint fields (`command_ctx`,
-    // `bundled_deps`, `stats`) or only reads `manager` via `pm_*` helpers.
+    // Raw pointer for the `pm_workspace_cache`/`pm_log` disjoint-field
+    // projections and the `'static` lifetime extension when returning
+    // `Publish::Context`.
     let manager_ptr: *mut PackageManager = &raw mut *ctx.manager;
-    // SAFETY: `ctx.manager` is the sole `&mut PackageManager`; CLI is
-    // single-threaded and no callee retains a conflicting borrow.
-    let manager: &mut PackageManager = unsafe { &mut *manager_ptr };
-    let log_level = manager.options.log_level;
+    let log_level = ctx.manager.options.log_level;
     let bump = pack_bump();
     // Note: `workspace_package_json_cache` and `log` are disjoint fields on
     // `PackageManager`; route through raw-pointer field projections so the
@@ -1950,14 +1945,14 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
 
     if FOR_PUBLISH {
         if let Some(config) = json.root.get(b"publishConfig") {
-            if manager.options.publish_config.tag.is_empty() {
+            if ctx.manager.options.publish_config.tag.is_empty() {
                 if let Some(tag) = config.get_string_cloned(bump, b"tag")? {
-                    manager.options.publish_config.tag = tag;
+                    ctx.manager.options.publish_config.tag = tag;
                 }
             }
-            if manager.options.publish_config.access.is_none() {
+            if ctx.manager.options.publish_config.access.is_none() {
                 if let Some((access, _)) = config.get_string(bump, b"access")? {
-                    manager.options.publish_config.access =
+                    ctx.manager.options.publish_config.access =
                         match bun_install::Access::from_str(access) {
                             Some(a) => Some(a),
                             None => {
@@ -1985,7 +1980,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     if FOR_PUBLISH {
         let is_scoped = bun_install::dependency::is_scoped_package_name(package_name)
             .map_err(|_| PackError::InvalidPackageName)?;
-        if let Some(access) = manager.options.publish_config.access {
+        if let Some(access) = ctx.manager.options.publish_config.access {
             if access == bun_install::Access::Restricted && !is_scoped {
                 return Err(PackError::RestrictedUnscopedPackage);
             }
@@ -2024,8 +2019,8 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     if let Err(err) = RunCommand::configure_env_for_run(
         &mut *ctx.command_ctx,
         &mut this_transpiler,
-        Some(pm_env(manager)),
-        manager.options.log_level != LogLevel::Silent,
+        Some(pm_env(ctx.manager)),
+        ctx.manager.options.log_level != LogLevel::Silent,
         false,
     ) {
         if matches!(err, crate::Error::Alloc(_)) {
@@ -2063,7 +2058,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     // raw pointer so `run_package_script_foreground` can `&mut` it without
     // conflicting with our `&Transpiler` borrow.
     let transpiler_env: *mut bun_dotenv::Loader = this_transpiler.env;
-    manager.env_mut().map.put(b"npm_command", b"pack")?;
+    ctx.manager.env_mut().map.put(b"npm_command", b"pack")?;
 
     let (postpack_script, publish_script, postpublish_script, ran_scripts): (
         Option<Box<[u8]>>,
@@ -2072,7 +2067,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         bool,
     ) = 'post_scripts: {
         // --ignore-scripts
-        if !pm_run_scripts(manager) {
+        if !pm_run_scripts(ctx.manager) {
             break 'post_scripts (None, None, None, false);
         }
 
@@ -2091,12 +2086,12 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 if let Some(prepublish_only) = prepublish_only_script_str.as_string(bump) {
                     did_run_scripts = true;
                     run_lifecycle_script(
-                        ctx,
+                        ctx.command_ctx,
                         prepublish_only,
                         b"prepublishOnly",
                         abs_workspace_path,
                         transpiler_env,
-                        manager.options.log_level == LogLevel::Silent,
+                        ctx.manager.options.log_level == LogLevel::Silent,
                     )?;
                 }
             }
@@ -2106,12 +2101,12 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             if let Some(prepack_script_str) = prepack_script.as_string(bump) {
                 did_run_scripts = true;
                 run_lifecycle_script(
-                    ctx,
+                    ctx.command_ctx,
                     prepack_script_str,
                     b"prepack",
                     abs_workspace_path,
                     transpiler_env,
-                    manager.options.log_level == LogLevel::Silent,
+                    ctx.manager.options.log_level == LogLevel::Silent,
                 )?;
             }
         }
@@ -2120,12 +2115,12 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             if let Some(prepare_script_str) = prepare_script.as_string(bump) {
                 did_run_scripts = true;
                 run_lifecycle_script(
-                    ctx,
+                    ctx.command_ctx,
                     prepare_script_str,
                     b"prepare",
                     abs_workspace_path,
                     transpiler_env,
-                    manager.options.log_level == LogLevel::Silent,
+                    ctx.manager.options.log_level == LogLevel::Silent,
                 )?;
             }
         }
@@ -2386,12 +2381,18 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         }
     }
 
-    let mut bundled_pack_queue = iterate_bundled_deps(ctx, &root_dir, log_level)?;
+    let mut bundled_pack_queue = iterate_bundled_deps(
+        &mut ctx.bundled_deps,
+        &mut ctx.stats,
+        pm_log(manager_ptr),
+        &root_dir,
+        log_level,
+    )?;
 
     // +1 for package.json
     ctx.stats.total_files = pack_queue.count() + bundled_pack_queue.count() + 1;
 
-    if opt_dry_run(manager) {
+    if opt_dry_run(ctx.manager) {
         // don't create the tarball, but run scripts if they exist
 
         print_archived_files_and_packages::<true>(
@@ -2402,7 +2403,9 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         );
 
         if !FOR_PUBLISH {
-            if opt_pack_destination(manager).is_empty() && opt_pack_filename(manager).is_empty() {
+            if opt_pack_destination(ctx.manager).is_empty()
+                && opt_pack_filename(ctx.manager).is_empty()
+            {
                 Context::print_tarball_path(
                     fmt_tarball_filename(
                         package_name,
@@ -2432,12 +2435,12 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
 
         if let Some(postpack_script_str) = &postpack_script {
             run_lifecycle_script(
-                ctx,
+                ctx.command_ctx,
                 postpack_script_str,
                 b"postpack",
                 abs_workspace_path,
-                pm_env(manager),
-                manager.options.log_level == LogLevel::Silent,
+                pm_env(ctx.manager),
+                ctx.manager.options.log_level == LogLevel::Silent,
             )?;
         }
 
@@ -2506,7 +2509,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
 
     // default is 9
     // https://github.com/npm/cli/blob/ec105f400281a5bfd17885de1ea3d54d0c231b27/node_modules/pacote/lib/util/tar-create-options.js#L12
-    let compression_level: &[u8] = opt_pack_gzip_level(manager).unwrap_or(b"9");
+    let compression_level: &[u8] = opt_pack_gzip_level(ctx.manager).unwrap_or(b"9");
     write!(&mut print_buf, "{}\x00", bstr::BStr::new(compression_level)).expect("OOM");
     // SAFETY: print_buf[compression_level.len()] == 0 written above
     let level_z = ZStr::from_buf(&print_buf[..], compression_level.len());
@@ -2878,7 +2881,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         // the JSON itself), so the copy doesn't need to flow back into `json.root`.
         let mut root_full = json.root;
         Some(Publish::PublishCommand::normalized_package(
-            manager,
+            ctx.manager,
             package_name,
             package_version,
             &mut root_full,
@@ -2899,7 +2902,8 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     );
 
     if !FOR_PUBLISH {
-        if opt_pack_destination(manager).is_empty() && opt_pack_filename(manager).is_empty() {
+        if opt_pack_destination(ctx.manager).is_empty() && opt_pack_filename(ctx.manager).is_empty()
+        {
             Context::print_tarball_path(
                 fmt_tarball_filename(package_name, package_version, TarballNameStyle::Normalize),
                 log_level,
@@ -2918,12 +2922,12 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     if let Some(postpack_script_str) = &postpack_script {
         bun_core::pretty!("\n");
         run_lifecycle_script(
-            ctx,
+            ctx.command_ctx,
             postpack_script_str,
             b"postpack",
             abs_workspace_path,
-            pm_env(manager),
-            manager.options.log_level == LogLevel::Silent,
+            pm_env(ctx.manager),
+            ctx.manager.options.log_level == LogLevel::Silent,
         )?;
     }
 
@@ -2957,19 +2961,13 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
 // Note: hoisted from repeated inline blocks to avoid 5x duplication of the
 // same `match err { MissingShell, OutOfMemory }` arms. Behavior identical.
 fn run_lifecycle_script<const FOR_PUBLISH: bool>(
-    ctx: &Context<'_>,
+    command_ctx: &mut Command::ContextData,
     script: &[u8],
     name: &[u8],
     abs_workspace_path: &[u8],
     env: *mut bun_dotenv::Loader,
     silent: bool,
 ) -> Result<(), PackError<FOR_PUBLISH>> {
-    // Note: `ctx.command_ctx` and `env` are reborrowed via raw pointer
-    // because `run_package_script_foreground` needs `&mut`
-    // for `env.map.put()` while `ctx` only holds `&Context`.
-    // SAFETY: both are process-lifetime singletons; no concurrent `&mut` exists
-    // while a lifecycle script runs (single-threaded CLI dispatch).
-    let command_ctx = unsafe { &mut *std::ptr::from_ref(ctx.command_ctx).cast_mut() };
     let use_system_shell = command_ctx.debug.use_system_shell;
     match RunCommand::run_package_script_foreground(
         command_ctx,

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2054,10 +2054,6 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         // not repeated.
         unsafe { (*transpiler_for_deinit).deinit() };
     }
-    // `Transpiler::env` is a process-singleton `*mut` (set by `init`); pass as
-    // raw pointer so `run_package_script_foreground` can `&mut` it without
-    // conflicting with our `&Transpiler` borrow.
-    let transpiler_env: *mut bun_dotenv::Loader = this_transpiler.env;
     ctx.manager.env_mut().map.put(b"npm_command", b"pack")?;
 
     let (postpack_script, publish_script, postpublish_script, ran_scripts): (
@@ -2090,7 +2086,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                         prepublish_only,
                         b"prepublishOnly",
                         abs_workspace_path,
-                        transpiler_env,
+                        ctx.manager.env_mut(),
                         ctx.manager.options.log_level == LogLevel::Silent,
                     )?;
                 }
@@ -2105,7 +2101,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     prepack_script_str,
                     b"prepack",
                     abs_workspace_path,
-                    transpiler_env,
+                    ctx.manager.env_mut(),
                     ctx.manager.options.log_level == LogLevel::Silent,
                 )?;
             }
@@ -2119,7 +2115,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     prepare_script_str,
                     b"prepare",
                     abs_workspace_path,
-                    transpiler_env,
+                    ctx.manager.env_mut(),
                     ctx.manager.options.log_level == LogLevel::Silent,
                 )?;
             }
@@ -2439,7 +2435,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 postpack_script_str,
                 b"postpack",
                 abs_workspace_path,
-                pm_env(ctx.manager),
+                ctx.manager.env_mut(),
                 ctx.manager.options.log_level == LogLevel::Silent,
             )?;
         }
@@ -2926,7 +2922,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             postpack_script_str,
             b"postpack",
             abs_workspace_path,
-            pm_env(ctx.manager),
+            ctx.manager.env_mut(),
             ctx.manager.options.log_level == LogLevel::Silent,
         )?;
     }
@@ -2965,7 +2961,7 @@ fn run_lifecycle_script<const FOR_PUBLISH: bool>(
     script: &[u8],
     name: &[u8],
     abs_workspace_path: &[u8],
-    env: *mut bun_dotenv::Loader,
+    env: &mut bun_dotenv::Loader,
     silent: bool,
 ) -> Result<(), PackError<FOR_PUBLISH>> {
     let use_system_shell = command_ctx.debug.use_system_shell;
@@ -2974,9 +2970,7 @@ fn run_lifecycle_script<const FOR_PUBLISH: bool>(
         script,
         name,
         abs_workspace_path,
-        // SAFETY: `env` is non-null (set by `PackageManager::init` /
-        // `configure_env_for_run`).
-        unsafe { &mut *env },
+        env,
         &[],
         silent,
         use_system_shell,

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -29,11 +29,7 @@ pub(crate) fn view(
         // Extremely best effort.
         if spec_ == b"." || spec_ == b"" {
             if strings::is_npm_package_name(&manager.root_package_json_name_at_time_of_init) {
-                // Note: reshaped for borrowck — copy into the function-scope
-                // bump so `name` doesn't keep `manager` borrowed across the
-                // `&mut self` calls (`http_proxy`, `tls_reject_unauthorized`) below.
-                break 'brk &*bump
-                    .alloc_slice_copy(&manager.root_package_json_name_at_time_of_init);
+                break 'brk &manager.root_package_json_name_at_time_of_init;
             }
 
             // Try our best to get the package.json name they meant
@@ -72,10 +68,7 @@ pub(crate) fn view(
         break 'brk spec_;
     });
 
-    // Note: reshaped for borrowck — clone the registry scope so it doesn't
-    // keep `manager` borrowed across `http_proxy` / `tls_reject_unauthorized`
-    // (`&mut self`) below; matches `outdated_command` / `update_interactive_command`.
-    let scope = manager.scope_for_package_name(name).clone();
+    let scope = manager.scope_for_package_name(name);
 
     let mut url_buf = PathBuffer::uninit();
     let encoded_name = buf_print(
@@ -161,7 +154,7 @@ pub(crate) fn view(
 
     // Parse the existing JSON response into a PackageManifest using the now-public parse function
     let parsed_manifest = match PackageManifest::parse(
-        &scope,
+        scope,
         &mut log,
         response_buf.list.as_slice(),
         name,

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -29,7 +29,6 @@ pub struct Scanner<'a> {
     pub test_files: Vec<Interned>,
     pub fs: *mut FileSystem,
     pub open_dir_buf: PathBuffer,
-    pub scan_dir_buf: PathBuffer,
     pub options: &'a BundleOptions<'a>,
     pub has_iterated: bool,
     pub search_count: usize,
@@ -90,7 +89,6 @@ impl<'a> Scanner<'a> {
             fs: transpiler.fs,
             test_files: results,
             open_dir_buf: PathBuffer::uninit(),
-            scan_dir_buf: PathBuffer::uninit(),
             has_iterated: false,
             search_count: 0,
         })
@@ -130,16 +128,9 @@ impl<'a> Scanner<'a> {
     }
 
     pub fn scan(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
-        let parts: [&[u8]; 2] = [self.fs().top_level_dir, path_literal];
-        // reshaped for borrowck — abs_buf's return keeps a &mut borrow
-        // of scan_dir_buf alive across the &mut self calls below. Capture only the
-        // length, then reconstruct a detached slice from the raw buffer pointer.
-        let path_len = self.fs().abs_buf(&parts, &mut self.scan_dir_buf).len();
-        // SAFETY: scan_dir_buf is not written again for the remainder of this
-        // function — read_dir_with_name/next() only touch open_dir_buf — so the
-        // bytes at [0, path_len) remain valid while `path` is live.
-        let path: &[u8] =
-            unsafe { core::slice::from_raw_parts(self.scan_dir_buf.0.as_ptr(), path_len) };
+        let mut scan_dir_buf = PathBuffer::uninit();
+        let parts: [&[u8]; 2] = [self.top_level_dir(), path_literal];
+        let path: &[u8] = Self::abs_buf_projected(self.top_level_dir(), &parts, &mut scan_dir_buf);
 
         let root = self
             .read_dir_with_name(path, None)

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -477,45 +477,34 @@ impl ReadFile {
         }
     }
 
-    /// Returns a raw `(ptr, len)` into either `stack_buffer` or
-    /// `self.buffer`'s spare capacity. Raw (not `&mut [u8]`) so the caller in
-    /// `do_read_loop` can carry it across the `&mut self` `do_read` call
-    /// without two live `&mut` covering overlapping memory (Stacked-Borrows
-    /// UB). The slice is materialised only at the syscall boundary.
+    /// Pick the read target: `buffer`'s spare capacity if it is at least as
+    /// large as `stack_buffer`, otherwise `stack_buffer`; capped by
+    /// `max_length - read_off`.
     #[cfg(not(windows))]
-    fn remaining_buffer(&mut self, stack_buffer: &mut [u8]) -> (*mut u8, usize) {
-        // `spare_capacity_mut()` is the safe spelling of
-        // `as_mut_ptr().add(len) .. as_mut_ptr().add(cap)`; we immediately
-        // decay it to a raw `(ptr, len)` so the borrow does not outlive this
-        // call (the caller carries the raw pair across `&mut self`).
-        let spare = self.buffer.spare_capacity_mut();
-        let (ptr, len) = if spare.len() < stack_buffer.len() {
-            (stack_buffer.as_mut_ptr(), stack_buffer.len())
+    fn remaining_buffer<'a>(
+        buffer: &'a mut Vec<u8>,
+        stack_buffer: &'a mut [u8],
+        max_length: SizeType,
+        read_off: SizeType,
+    ) -> &'a mut [u8] {
+        let cap = (max_length.saturating_sub(read_off)) as usize;
+        let spare = buffer.spare_capacity_mut();
+        if spare.len() < stack_buffer.len() {
+            let n = stack_buffer.len().min(cap);
+            &mut stack_buffer[..n]
         } else {
-            (spare.as_mut_ptr().cast::<u8>(), spare.len())
-        };
-        let cap = len.min((self.max_length.saturating_sub(self.read_off)) as usize);
-        (ptr, cap)
+            let n = spare.len().min(cap);
+            // SAFETY: `spare` is `&mut [MaybeUninit<u8>]` over the Vec's spare
+            // capacity. The bytes are only written by the `read()`/`recv()`
+            // syscall below and `commit_spare` advances `len` by exactly the
+            // kernel-reported initialized count; no uninit byte is ever read.
+            unsafe { core::slice::from_raw_parts_mut(spare.as_mut_ptr().cast::<u8>(), n) }
+        }
     }
 
-    /// `buffer` is passed raw because it may point into `self.buffer`'s spare
-    /// capacity; holding it as `&mut [u8]` alongside `&mut self` would be two
-    /// live `&mut` to overlapping memory. `do_read` never touches
-    /// `self.buffer`, so the disjoint access is sound — we just keep the
-    /// pointer raw across the `&mut self` borrow and materialise the slice
-    /// only for the syscall.
-    pub fn do_read(
-        &mut self,
-        buffer: (*mut u8, usize),
-        read_len: &mut usize,
-        retry: &mut bool,
-    ) -> bool {
+    /// Never touches `self.buffer`; the caller moves it out for the duration.
+    pub fn do_read(&mut self, buf: &mut [u8], read_len: &mut usize, retry: &mut bool) -> bool {
         let result: bun_sys::Result<usize> = 'brk: {
-            // SAFETY: `buffer.0` points at either a stack array or this Vec's
-            // spare capacity (write-valid via `as_mut_ptr()`); both are
-            // exclusively owned by the caller for `buffer.1` bytes and outlive
-            // this call. We never access `self.buffer` here, so no aliasing.
-            let buf = unsafe { core::slice::from_raw_parts_mut(buffer.0, buffer.1) };
             if bun_sys::S::ISSOCK(self.file_store.mode) {
                 break 'brk bun_sys::recv_non_block(self.opened_fd, buf);
             }
@@ -806,39 +795,44 @@ impl ReadFile {
             // syscall, and avoids the `MaybeUninit<u8>` → `&mut [u8]` cast (uninit
             // bytes behind a `&[u8]` is technically UB even when never read).
             let mut stack_buffer = [0u8; 64 * 1024];
+            // `do_read` never touches `self.buffer`; move it out so the read
+            // target slice (which may point into its spare capacity) can be
+            // held as a safe `&mut [u8]` across the `&mut self` call.
+            let mut buffer = core::mem::take(&mut self.buffer);
             while self.state.load(Ordering::Relaxed) == ClosingState::Running as u8 {
-                // reshaped for borrowck — keep the read target as a raw
-                // (ptr, len) across the `&mut self` `do_read` call; no `&mut [u8]`
-                // to `self.buffer`'s spare capacity is ever live alongside
-                // `&mut self`.
-                let stack_ptr = stack_buffer.as_mut_ptr();
-                let (buf_ptr, buf_len) = self.remaining_buffer(&mut stack_buffer);
+                let use_stack =
+                    buffer.capacity() - buffer.len() < stack_buffer.len();
+                let buf = Self::remaining_buffer(
+                    &mut buffer,
+                    &mut stack_buffer,
+                    self.max_length,
+                    self.read_off,
+                );
 
-                if buf_len > 0 && self.errno.is_none() && !self.read_eof {
+                if !buf.is_empty() && self.errno.is_none() && !self.read_eof {
                     let mut read_amount: usize = 0;
                     let mut retry = false;
-                    let continue_reading =
-                        self.do_read((buf_ptr, buf_len), &mut read_amount, &mut retry);
+                    let continue_reading = self.do_read(buf, &mut read_amount, &mut retry);
 
                     // We might read into the stack buffer, so we need to copy it into the heap.
-                    if buf_ptr == stack_ptr {
+                    if use_stack {
                         // `do_read` wrote `read_amount` initialized bytes at
                         // `stack_buffer[..read_amount]`; the stack array is live
                         // for this iteration.
                         let read = &stack_buffer[..read_amount];
-                        if self.buffer.capacity() == 0 {
+                        if buffer.capacity() == 0 {
                             // We need to allocate a new buffer
                             // In this case, we want to use `ensureTotalCapacityPrecise` so that it's an exact amount
                             // We want to avoid over-allocating incase it's a large amount of data sent in a single chunk followed by a 0 byte chunk.
-                            self.buffer.reserve_exact(read.len());
+                            buffer.reserve_exact(read.len());
                         } else {
-                            self.buffer.reserve(read.len());
+                            buffer.reserve(read.len());
                         }
-                        self.buffer.extend_from_slice(read);
+                        buffer.extend_from_slice(read);
                     } else {
                         // record the amount of data read
                         // SAFETY: read() wrote `read_amount` initialized bytes into spare capacity.
-                        unsafe { bun_core::vec::commit_spare(&mut self.buffer, read_amount) };
+                        unsafe { bun_core::vec::commit_spare(&mut buffer, read_amount) };
                     }
                     // - If they DID set a max length, we should stop
                     //   reading after that.
@@ -846,7 +840,7 @@ impl ReadFile {
                     // - If they DID NOT set a max_length, then it will
                     //   be Blob.max_size which is an impossibly large
                     //   amount to read.
-                    if !self.read_eof && self.buffer.len() >= self.max_length as usize {
+                    if !self.read_eof && buffer.len() >= self.max_length as usize {
                         break;
                     }
 
@@ -883,6 +877,7 @@ impl ReadFile {
                             }
                         }
                         self.read_eof = false;
+                        self.buffer = buffer;
                         self.wait_for_readable();
 
                         return;
@@ -895,6 +890,7 @@ impl ReadFile {
                 // -- We are done reading.
                 break;
             }
+            self.buffer = buffer;
 
             if self.system_error.is_some() {
                 self.buffer = Vec::new(); // clearAndFree

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -479,26 +479,30 @@ impl ReadFile {
 
     /// Pick the read target: `buffer`'s spare capacity if it is at least as
     /// large as `stack_buffer`, otherwise `stack_buffer`; capped by
-    /// `max_length - read_off`.
+    /// `max_length - read_off`. Returns `(use_stack, target)` so the caller
+    /// keys its `extend_from_slice`/`commit_spare` decision off the same
+    /// branch taken here.
     #[cfg(not(windows))]
     fn remaining_buffer<'a>(
         buffer: &'a mut Vec<u8>,
         stack_buffer: &'a mut [u8],
         max_length: SizeType,
         read_off: SizeType,
-    ) -> &'a mut [u8] {
+    ) -> (bool, &'a mut [u8]) {
         let cap = (max_length.saturating_sub(read_off)) as usize;
         let spare = buffer.spare_capacity_mut();
         if spare.len() < stack_buffer.len() {
             let n = stack_buffer.len().min(cap);
-            &mut stack_buffer[..n]
+            (true, &mut stack_buffer[..n])
         } else {
             let n = spare.len().min(cap);
             // SAFETY: `spare` is `&mut [MaybeUninit<u8>]` over the Vec's spare
             // capacity. The bytes are only written by the `read()`/`recv()`
             // syscall below and `commit_spare` advances `len` by exactly the
             // kernel-reported initialized count; no uninit byte is ever read.
-            unsafe { core::slice::from_raw_parts_mut(spare.as_mut_ptr().cast::<u8>(), n) }
+            let target =
+                unsafe { core::slice::from_raw_parts_mut(spare.as_mut_ptr().cast::<u8>(), n) };
+            (false, target)
         }
     }
 
@@ -800,9 +804,7 @@ impl ReadFile {
             // held as a safe `&mut [u8]` across the `&mut self` call.
             let mut buffer = core::mem::take(&mut self.buffer);
             while self.state.load(Ordering::Relaxed) == ClosingState::Running as u8 {
-                let use_stack =
-                    buffer.capacity() - buffer.len() < stack_buffer.len();
-                let buf = Self::remaining_buffer(
+                let (use_stack, buf) = Self::remaining_buffer(
                     &mut buffer,
                     &mut stack_buffer,
                     self.max_length,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6001,6 +6001,9 @@ pub mod macho {
     pub struct LoadCommand {
         pub hdr: load_command,
         pub data: RawSlice,
+        /// Byte offset of this command within the buffer passed to
+        /// `LoadCommandIterator::new`.
+        pub offset: usize,
     }
     impl LoadCommand {
         #[inline]
@@ -6035,6 +6038,7 @@ pub mod macho {
         index: u32,
         buf_ptr: *const u8,
         buf_len: usize,
+        offset: usize,
     }
     impl LoadCommandIterator {
         /// `buffer` must remain live (no realloc/free) for the lifetime of the
@@ -6046,6 +6050,7 @@ pub mod macho {
                 index: 0,
                 buf_ptr: buffer.as_ptr(),
                 buf_len: buffer.len(),
+                offset: 0,
             }
         }
 
@@ -6070,10 +6075,12 @@ pub mod macho {
                     ptr: self.buf_ptr,
                     len: cmdsize,
                 },
+                offset: self.offset,
             };
             // SAFETY: advancing within the original buffer; bounds checked above.
             self.buf_ptr = unsafe { self.buf_ptr.add(cmdsize) };
             self.buf_len -= cmdsize;
+            self.offset += cmdsize;
             self.index += 1;
             Some(lc)
         }

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -384,10 +384,6 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
     events_buf[..events_len].copy_from_slice(events);
     let events = &events_buf[..events_len];
 
-    // reshaped for borrowck — copy the (small) column to a local Vec
-    // so the borrow of `this.watchlist` ends before we mutably borrow other
-    // `this` fields inside the batching loop below.
-    //
     // The snapshot is taken locked. `on_file_update` may evict watchlist entries via
     // `remove_at_index` + `flush_evictions` (the dir-event path appends *and*
     // evicts the matched file watch). The enqueued reload then re-imports the
@@ -398,10 +394,12 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
     // 128 `max_count` batch size, so the dir-event-only batch is common) the
     // unlocked read raced the realloc and the process occasionally died with
     // a non-zero exit code. Snapshot under the same mutex `add_file` takes.
-    let eventlist_index: Vec<EventListIndex> = {
+    {
         let _guard = this.mutex.lock_guard();
-        this.watchlist.items_eventlist_index().to_vec()
-    };
+        this.eventlist_index_scratch.clear();
+        this.eventlist_index_scratch
+            .extend_from_slice(this.watchlist.items_eventlist_index());
+    }
 
     let mut event_id: usize = 0;
     let mut events_processed: usize = 0;
@@ -441,7 +439,8 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                 }
             }
 
-            let idx = match eventlist_index
+            let idx = match this
+                .eventlist_index_scratch
                 .iter()
                 .position(|&x| x == event.watch_descriptor)
             {

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -124,6 +124,11 @@ pub struct Watcher {
     pub evict_list: [WatchItemIndex; MAX_EVICTION_COUNT],
     pub evict_list_i: WatchItemIndex,
 
+    /// Scratch snapshot of `watchlist.eventlist_index` used by
+    /// `watch_loop_cycle`; owned by the watcher thread.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub eventlist_index_scratch: Vec<platform::EventListIndex>,
+
     pub ctx: *mut (),
     pub on_file_update: fn(*mut (), &mut [WatchEvent], &[ChangedFilePath], &WatchList),
     pub on_error: fn(*mut (), sys::Error),
@@ -198,6 +203,8 @@ impl Watcher {
             close_descriptors: bun_core::AtomicCell::new(false),
             evict_list: [0; MAX_EVICTION_COUNT],
             evict_list_i: 0,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            eventlist_index_scratch: Vec::new(),
             thread_lock: ThreadLock::init_unlocked(),
         });
 

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,7 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
+import { tempDir } from "harness";
 import { tmpdir } from "node:os";
+import path from "node:path";
 
 it("offset should work in Bun.file() #4963", async () => {
   const filename = tmpdir() + "/bun.test.offset.txt";
@@ -8,4 +10,47 @@ it("offset should work in Bun.file() #4963", async () => {
   const slice = file.slice(2, file.size);
   const contents = await slice.text();
   expect(contents).toBe("ntents");
+});
+
+// do_read_loop picks its read target per iteration: the 64 KB stack buffer
+// when self.buffer's spare capacity is smaller, otherwise the Vec's spare
+// capacity directly. Cover both branches plus the max_length cap so the
+// branch selection and the commit_spare path stay tied to the same decision.
+describe("Bun.file read-loop target selection", () => {
+  function pattern(size: number, seed: number) {
+    const out = Buffer.alloc(size);
+    for (let i = 0; i < size; i++) out[i] = (i * seed + 7) & 0xff;
+    return out;
+  }
+
+  it.each([
+    ["small file (stack-buffer path)", 1024],
+    ["64 KB boundary", 64 * 1024],
+    ["large file (spare-capacity path)", 256 * 1024 + 17],
+  ] as const)("%s", async (_label, size) => {
+    const bytes = pattern(size, 131);
+    using dir = tempDir("bun-file-read-target", {});
+    const p = path.join(String(dir), "data.bin");
+    await Bun.write(p, bytes);
+
+    const buf = new Uint8Array(await Bun.file(p).arrayBuffer());
+    expect(buf.length).toBe(size);
+    expect(Bun.hash(buf)).toBe(Bun.hash(bytes));
+  });
+
+  it("slice(offset, end) honours max_length across the stack/spare split", async () => {
+    const size = 256 * 1024;
+    const bytes = pattern(size, 97);
+    using dir = tempDir("bun-file-read-slice", {});
+    const p = path.join(String(dir), "data.bin");
+    await Bun.write(p, bytes);
+
+    // 70_000 bytes: larger than one stack-buffer fill, smaller than the whole
+    // file, and not a multiple of 64 KB.
+    const start = 10;
+    const end = 70_010;
+    const buf = new Uint8Array(await Bun.file(p).slice(start, end).arrayBuffer());
+    expect(buf.length).toBe(end - start);
+    expect(Bun.hash(buf)).toBe(Bun.hash(bytes.subarray(start, end)));
+  });
 });


### PR DESCRIPTION
Part of the `reshaped for borrowck` audit (docs on `farm/2a32eccb/borrowck-audit`). This batch covers 10 independent one-file sites from bucket C that each needed a small signature change or a new field.

## Why

These sites used raw-pointer laundering or per-iteration heap allocation to satisfy the borrow checker during the Zig→Rust port. Each is now in its idiomatic form: disjoint-field borrows, safe slice construction, or an amortized scratch buffer.

## Changes

| site | before | after |
|---|---|---|
| `exe_format/macho.rs:93` | `as_ptr() as usize - base_addr` offset math | `LoadCommandIterator` yields each command's byte `offset`; callers add `size_of::<mach_header_64>()` |
| `glob/GlobWalker.rs:473` | captured `path_buf` raw ptr+len → `unsafe ZStr::from_raw` | write NUL into `self.path_buf`, `ZStr::from_buf` safely; error path calls `err.with_path(&self.path_buf[..len])` directly |
| `bake/dev_server/incremental_graph.rs:526` | `*const [u8]` key + `(*self.owner()).directory_watchers` | `disconnect_and_delete_file` takes `&mut DirectoryWatchStore` from the caller |
| `bake/production.rs:221` | separate `vm_ptr: *mut VirtualMachine` param | derive from `pt.vm.as_ptr()` (the `BackRef` is already set by the caller) |
| `cli/pack_command.rs:1907` | laundered `&mut *manager_ptr` held across whole-`ctx` calls | `run_lifecycle_script`/`iterate_bundled_deps`/`add_bundled_dep` take the disjoint ctx fields they touch; `pack()` reborrows `ctx.manager` per use; `run_lifecycle_script` takes `env: &mut Loader` (matching `pm_version_command`) |
| `cli/pm_view_command.rs:32,75` | bump-copy of package name + `Scope::clone()` because `http_proxy`/`tls_reject_unauthorized` were `&mut self` | those became `&self` in #35320; borrow directly |
| `cli/test/Scanner.rs:134` | `unsafe from_raw_parts(scan_dir_buf.as_ptr(), len)` | `scan_dir_buf` was only used in `scan()`; make it a local so the path slice does not borrow `self` |
| `webcore/blob/read_file.rs:808` | raw `(*mut u8, usize)` read target carried across `&mut self` | `mem::take(&mut self.buffer)` for the loop (`do_read` never touches it); `remaining_buffer` returns `(use_stack, &mut [u8])`; `do_read` takes `&mut [u8]` |
| `watcher/INotifyWatcher.rs:388` | `Vec<EventListIndex>` allocated per cycle | scratch `Vec` field on `Watcher`, `clear()` + `extend_from_slice()` under the mutex (the snapshot itself is required: JS thread may realloc the MultiArrayList backing) |

Net: -30 lines, 7 `unsafe` blocks removed, 1 per-cycle allocation amortized, 2 cold-path allocs dropped.

## Verification

```
bun run rust:check-all               # all 10 targets ok (cfg-gated code spans linux/windows/macos)
bun bd test test/js/bun/glob/scan.test.ts           # 194 pass
bun bd test test/cli/hot/watch-many-dirs.test.ts    # pass (INotify path)
bun bd test test/cli/test/bun-test.test.ts          # 76 pass incl. scanner tests
bun bd test test/cli/install/bun-pack.test.ts       # 76 pass incl. lifecycle scripts
bun bd test test/js/bun/util/bun-file-read.test.ts  # 5 pass (read_file path, new coverage)
bun bd test test/bundler/bundler_compile.test.ts    # 60 pass incl. macho bounds test
```

## On fail-before testing

This is a behavior-preserving refactor batch: each site swaps a raw-pointer launder or per-iteration allocation for an equivalent disjoint-field borrow, so there is no input on which the before/after builds produce different output. `test/js/bun/util/bun-file-read.test.ts` gained explicit coverage of both `do_read_loop` read-target branches (stack buffer vs spare capacity) and the `max_length` cap, pinning the `commit_spare` invariant to `remaining_buffer`'s returned decision; it passes on main as well, as expected for a behavior-preserving change.

Precedent for src-only borrowck-cleanup PRs: #35321, #34791, #34795, #31075, #31057, #31070.
