### PR TITLE
perf: drop per-iteration heap allocs at 7 reshaped-for-borrowck sites

### DIFF
--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -206,22 +206,19 @@ impl DefineExt for Define {
     ) -> Result<(), bun_alloc::AllocError> {
         let key = global[global.len() - 1];
         let parts: Vec<Box<[u8]>> = global.iter().map(|p| Box::<[u8]>::from(*p)).collect();
-        // reshaped for borrowck — getOrPut split into entry-style match.
         if let Some(existing) = self.dots.get_mut(key) {
-            let mut list: Vec<DotDefine> = Vec::with_capacity(existing.len() + 1);
-            list.extend_from_slice(existing);
-            list.push(DotDefine {
+            existing.push(DotDefine {
                 parts,
                 data: value_define.clone(),
             });
-            // The old value is freed by Vec drop on assign.
-            *existing = list;
         } else {
-            let list: Vec<DotDefine> = vec![DotDefine {
-                parts,
-                data: value_define.clone(),
-            }];
-            self.dots.put_assume_capacity(key, list);
+            self.dots.put_assume_capacity(
+                key,
+                vec![DotDefine {
+                    parts,
+                    data: value_define.clone(),
+                }],
+            );
         }
         Ok(())
     }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -110,12 +110,13 @@ pub fn enqueue_dependency_list(
         let dependencies = &mut lockfile.buffers.dependencies;
         let mut peer_i: usize = 0;
         while dependencies[peer_i].behavior.is_peer() {
+            let peer_name_hash = dependencies[peer_i].name_hash;
             let mut dep_i: usize = (end - 1) as usize;
             while !dependencies[dep_i].behavior.is_peer() {
                 if !dependencies[dep_i].behavior.is_dev()
-                    && dependencies[peer_i].name_hash == dependencies[dep_i].name_hash
+                    && dependencies[dep_i].name_hash == peer_name_hash
                 {
-                    dependencies.swap(peer_i, begin as usize);
+                    dependencies[peer_i] = dependencies[begin as usize].clone();
                     begin += 1;
                     break;
                 }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -107,20 +107,22 @@ pub fn enqueue_dependency_list(
     // if dependency is peer and is going to be installed
     // through "dependencies", skip it
     if end - begin > 1 && lockfile.buffers.dependencies[0].behavior.is_peer() {
-        let dependencies = &mut lockfile.buffers.dependencies;
         let mut peer_i: usize = 0;
-        while dependencies[peer_i].behavior.is_peer() {
-            let peer_name_hash = dependencies[peer_i].name_hash;
+        // reshaped for borrowck — index into the slice instead of holding &mut across loop
+        while lockfile.buffers.dependencies[peer_i].behavior.is_peer() {
             let mut dep_i: usize = (end - 1) as usize;
-            while !dependencies[dep_i].behavior.is_peer() {
-                if !dependencies[dep_i].behavior.is_dev()
-                    && dependencies[dep_i].name_hash == peer_name_hash
-                {
-                    dependencies[peer_i] = dependencies[begin as usize].clone();
-                    begin += 1;
-                    break;
+            let mut dep = lockfile.buffers.dependencies[dep_i].clone();
+            while !dep.behavior.is_peer() {
+                if !dep.behavior.is_dev() {
+                    if lockfile.buffers.dependencies[peer_i].name_hash == dep.name_hash {
+                        lockfile.buffers.dependencies[peer_i] =
+                            lockfile.buffers.dependencies[begin as usize].clone();
+                        begin += 1;
+                        break;
+                    }
                 }
                 dep_i -= 1;
+                dep = lockfile.buffers.dependencies[dep_i].clone();
             }
             peer_i += 1;
             if peer_i == end as usize {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -107,22 +107,19 @@ pub fn enqueue_dependency_list(
     // if dependency is peer and is going to be installed
     // through "dependencies", skip it
     if end - begin > 1 && lockfile.buffers.dependencies[0].behavior.is_peer() {
+        let dependencies = &mut lockfile.buffers.dependencies;
         let mut peer_i: usize = 0;
-        // reshaped for borrowck — index into the slice instead of holding &mut across loop
-        while lockfile.buffers.dependencies[peer_i].behavior.is_peer() {
+        while dependencies[peer_i].behavior.is_peer() {
             let mut dep_i: usize = (end - 1) as usize;
-            let mut dep = lockfile.buffers.dependencies[dep_i].clone();
-            while !dep.behavior.is_peer() {
-                if !dep.behavior.is_dev() {
-                    if lockfile.buffers.dependencies[peer_i].name_hash == dep.name_hash {
-                        lockfile.buffers.dependencies[peer_i] =
-                            lockfile.buffers.dependencies[begin as usize].clone();
-                        begin += 1;
-                        break;
-                    }
+            while !dependencies[dep_i].behavior.is_peer() {
+                if !dependencies[dep_i].behavior.is_dev()
+                    && dependencies[peer_i].name_hash == dependencies[dep_i].name_hash
+                {
+                    dependencies.swap(peer_i, begin as usize);
+                    begin += 1;
+                    break;
                 }
                 dep_i -= 1;
-                dep = lockfile.buffers.dependencies[dep_i].clone();
             }
             peer_i += 1;
             if peer_i == end as usize {

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1381,7 +1381,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 let found_entry_idx: Option<usize> = yarn_lock
                     .entries
                     .iter()
-                    .position(|e| e.specs.iter().any(|s| *s == dep_spec.as_slice()));
+                    .position(|e| e.specs.contains(&dep_spec.as_slice()));
 
                 if let Some(found_entry_idx) = found_entry_idx {
                     let dep_entry_specs = &yarn_lock.entries[found_entry_idx].specs;

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1378,25 +1378,13 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 )
                 .expect("unreachable");
 
-                // reshaped for borrowck — find_entry_by_spec via index search
-                // instead of returning &mut to avoid overlapping borrow with the loop below.
-                let dep_entry_specs: Option<Vec<&[u8]>> = {
-                    let mut found: Option<Vec<&[u8]>> = None;
-                    for e in yarn_lock.entries.iter() {
-                        for entry_spec in e.specs.iter() {
-                            if *entry_spec == dep_spec.as_slice() {
-                                found = Some(e.specs.clone());
-                                break;
-                            }
-                        }
-                        if found.is_some() {
-                            break;
-                        }
-                    }
-                    found
-                };
+                let found_entry_idx: Option<usize> = yarn_lock
+                    .entries
+                    .iter()
+                    .position(|e| e.specs.iter().any(|s| *s == dep_spec.as_slice()));
 
-                if let Some(dep_entry_specs) = dep_entry_specs {
+                if let Some(found_entry_idx) = found_entry_idx {
+                    let dep_entry_specs = &yarn_lock.entries[found_entry_idx].specs;
                     for (idx, e) in yarn_lock.entries.iter().enumerate() {
                         let mut found = false;
                         for spec in e.specs.iter() {

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -535,8 +535,6 @@ pub mod defines {
                 }
                 parts.push(Box::from(tail));
 
-                let mut initial_values: &[DotDefine] = &[];
-                // Note: reshaped for borrowck — getOrPut split into get/insert.
                 if let Some(existing) = self.dots.get_mut(tail) {
                     for part in existing.iter_mut() {
                         if are_parts_equal(&part.parts, &parts) {
@@ -544,15 +542,12 @@ pub mod defines {
                             return Ok(());
                         }
                     }
-                    initial_values = existing.as_slice();
+                    existing.push(DotDefine { data: value, parts });
+                    return Ok(());
                 }
 
-                let mut list: Vec<DotDefine> = Vec::with_capacity(initial_values.len() + 1);
-                if !initial_values.is_empty() {
-                    list.extend_from_slice(initial_values);
-                }
-                list.push(DotDefine { data: value, parts });
-                self.dots.put_assume_capacity(tail, list);
+                self.dots
+                    .put_assume_capacity(tail, vec![DotDefine { data: value, parts }]);
             } else {
                 // e.g. IS_BROWSER
                 self.identifiers.put_assume_capacity(key, value);

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -190,15 +190,15 @@ impl Seq {
 
         Self::state_mut(interp, cmd).state = State::Done;
         if needs_io {
-            Self::state_mut(interp, cmd).buf = out;
             let safeguard = Builtin::of(interp, cmd).stdout.needs_io().unwrap();
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            // NOTE: reshaped for borrowck — clone the slice so the &mut
-            // on stdout doesn't alias `buf`.
-            let buf = Self::state_mut(interp, cmd).buf.clone();
-            return Builtin::of_mut(interp, cmd)
+            // enqueue copies into the IOWriter's buffer, so `out` can be moved into
+            // state afterward instead of stored-then-cloned.
+            let y = Builtin::of_mut(interp, cmd)
                 .stdout
-                .enqueue(child, &buf, safeguard);
+                .enqueue(child, &out, safeguard);
+            Self::state_mut(interp, cmd).buf = out;
+            return y;
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
         Builtin::done(interp, cmd, 0)

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -15,7 +15,6 @@ enum State {
 
 pub struct Seq {
     state: State,
-    buf: Vec<u8>,
     start: f32,
     end: f32,
     increment: f32,
@@ -29,7 +28,6 @@ impl Default for Seq {
     fn default() -> Self {
         Self {
             state: State::Idle,
-            buf: Vec::new(),
             start: 1.0,
             end: 1.0,
             increment: 1.0,
@@ -192,13 +190,9 @@ impl Seq {
         if needs_io {
             let safeguard = Builtin::of(interp, cmd).stdout.needs_io().unwrap();
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            // enqueue copies into the IOWriter's buffer, so `out` can be moved into
-            // state afterward instead of stored-then-cloned.
-            let y = Builtin::of_mut(interp, cmd)
+            return Builtin::of_mut(interp, cmd)
                 .stdout
                 .enqueue(child, &out, safeguard);
-            Self::state_mut(interp, cmd).buf = out;
-            return y;
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
         Builtin::done(interp, cmd, 0)

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -623,9 +623,6 @@ unsafe fn expand_nested(
                 }
                 ast::GroupAtoms::Single(ast::Atom::Expansion(expansion)) => {
                     let length = out[usize::from(out_key)].len();
-                    // reshaped for borrowck — snapshot prefix once.
-                    // PERF: extra Vec alloc for prefix snapshot — profile if hot.
-                    let prefix: Vec<u8> = out[usize::from(out_key)][..length].to_vec();
                     let variants = expansion.variants;
                     let variants_len = variants.len();
                     for j in 0..variants_len {
@@ -636,7 +633,11 @@ unsafe fn expand_nested(
                             out_key
                         } else {
                             let new_key = *out_key_counter;
-                            out[usize::from(new_key)].extend_from_slice(&prefix);
+                            // new_key > out_key always (counter is bumped past out_key before
+                            // any recursion into it), and the j==0 recursion only appends to
+                            // out[out_key], so its [..length] prefix is stable.
+                            let (lo, hi) = out.split_at_mut(usize::from(new_key));
+                            hi[0].extend_from_slice(&lo[usize::from(out_key)][..length]);
                             *out_key_counter += 1;
                             new_key
                         };
@@ -673,8 +674,6 @@ unsafe fn expand_nested(
                 }
                 ast::Atom::Expansion(expansion) => {
                     let length = out[usize::from(out_key)].len();
-                    // reshaped for borrowck — see above.
-                    let prefix: Vec<u8> = out[usize::from(out_key)][..length].to_vec();
                     let variants = expansion.variants;
                     let variants_len = variants.len();
                     for j in 0..variants_len {
@@ -685,7 +684,8 @@ unsafe fn expand_nested(
                             out_key
                         } else {
                             let new_key = *out_key_counter;
-                            out[usize::from(new_key)].extend_from_slice(&prefix);
+                            let (lo, hi) = out.split_at_mut(usize::from(new_key));
+                            hi[0].extend_from_slice(&lo[usize::from(out_key)][..length]);
                             *out_key_counter += 1;
                             new_key
                         };
@@ -742,14 +742,15 @@ fn expand_flat(
                 let skip_over_idx = variants[variants.len() - 1].end();
 
                 let starting_len = out[usize::from(out_key)].len();
-                // reshaped for borrowck — snapshot prefix once.
-                let prefix: Vec<u8> = out[usize::from(out_key)][..starting_len].to_vec();
                 for (i, variant) in variants.iter().enumerate() {
                     let new_key = if i == 0 {
                         out_key
                     } else {
                         let new_key = *out_key_counter;
-                        out[usize::from(new_key)].extend_from_slice(&prefix);
+                        // new_key > out_key always; the i==0 recursion only appends to
+                        // out[out_key], so its [..starting_len] prefix is stable.
+                        let (lo, hi) = out.split_at_mut(usize::from(new_key));
+                        hi[0].extend_from_slice(&lo[usize::from(out_key)][..starting_len]);
                         *out_key_counter += 1;
                         new_key
                     };

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -161,10 +161,13 @@ test.skipIf(!isASAN)("seq piped to an fd does not clone its output buffer before
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const deltaBytes = parseInt(stdout.trim(), 10);
+  const rawDelta = stdout.trim();
+  expect(rawDelta).toMatch(/^\d+$/);
+  const deltaBytes = Number(rawDelta);
   // Output is 31_688_895 bytes. With the fix the child's RSS grows by
   // ~128-134 MB (rendered Vec capacity + IOWriter's copy + ASAN shadow);
   // without it the extra clone pushes it to ~170 MB.
+  expect(deltaBytes).toBeGreaterThan(0);
   expect(deltaBytes).toBeLessThan(152 * 1024 * 1024);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -140,9 +140,9 @@ describe("seq without stdout", async () => {
 // Regression guard: the fd-output path used to build the full output into a
 // local Vec, store it into state, then clone the stored Vec to hand to
 // BuiltinIO::enqueue (which itself copies into IOWriter's buffer). That is a
-// full-output-sized clone on top of the two copies that must exist, so peak
-// RSS was ~3x the output instead of ~2x. ASAN-gated because release mimalloc
-// does not retain freed pages the way ASAN's allocator does.
+// full-output-sized clone on top of the copy that must exist, so peak RSS was
+// ~3x the output instead of ~2x. ASAN-gated because release mimalloc does not
+// retain freed pages the way ASAN's allocator does.
 test.skipIf(!isASAN)("seq piped to an fd does not clone its output buffer before enqueue", async () => {
   // 100-byte separator keeps the output large (~32 MB) with only 300k
   // iterations, so the child finishes in ~1s under ASAN.
@@ -162,9 +162,9 @@ test.skipIf(!isASAN)("seq piped to an fd does not clone its output buffer before
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const deltaBytes = parseInt(stdout.trim(), 10);
-  // Output is 31_888_894 bytes. With the fix the child's RSS grows by ~134 MB
-  // (rendered Vec capacity + IOWriter's copy + ASAN shadow); without it the
-  // extra clone pushes it to ~170 MB.
+  // Output is 31_688_895 bytes. With the fix the child's RSS grows by
+  // ~128-134 MB (rendered Vec capacity + IOWriter's copy + ASAN shadow);
+  // without it the extra clone pushes it to ~170 MB.
   expect(deltaBytes).toBeLessThan(152 * 1024 * 1024);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
 import { createTestBuilder } from "../test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -135,3 +136,38 @@ describe("seq without stdout", async () => {
     .stderr("")
     .runAsTest("works basic down without stdout");
 });
+
+// Regression guard: the fd-output path used to build the full output into a
+// local Vec, store it into state, then clone the stored Vec to hand to
+// BuiltinIO::enqueue (which itself copies into IOWriter's buffer). For
+// `seq 1 4000000` that is a ~30 MB clone on top of the two copies that must
+// exist, so peak RSS was ~3x the output instead of ~2x. The clone was only
+// observable under ASAN (which does not return freed pages to the OS as
+// eagerly as mimalloc), so this test is ASAN-gated.
+test.skipIf(!isASAN)(
+  "seq piped to an fd does not clone its output buffer before enqueue",
+  async () => {
+    const N = 4_000_000;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `await Bun.$\`seq 1 10 > /dev/null\`;` +
+          `const b = process.memoryUsage().rss;` +
+          `await Bun.$\`seq 1 ${N} > /dev/null\`;` +
+          `console.log(process.memoryUsage().rss - b);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const deltaBytes = parseInt(stdout.trim(), 10);
+    // `seq 1 4000000` renders 30_888_896 bytes. With the fix the child's RSS
+    // grows by ~106 MB (rendered Vec capacity + IOWriter's copy + ASAN shadow);
+    // without it the extra clone pushes it to ~143 MB.
+    expect(deltaBytes).toBeLessThan(128 * 1024 * 1024);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -139,35 +139,32 @@ describe("seq without stdout", async () => {
 
 // Regression guard: the fd-output path used to build the full output into a
 // local Vec, store it into state, then clone the stored Vec to hand to
-// BuiltinIO::enqueue (which itself copies into IOWriter's buffer). For
-// `seq 1 4000000` that is a ~30 MB clone on top of the two copies that must
-// exist, so peak RSS was ~3x the output instead of ~2x. The clone was only
-// observable under ASAN (which does not return freed pages to the OS as
-// eagerly as mimalloc), so this test is ASAN-gated.
-test.skipIf(!isASAN)(
-  "seq piped to an fd does not clone its output buffer before enqueue",
-  async () => {
-    const N = 4_000_000;
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
+// BuiltinIO::enqueue (which itself copies into IOWriter's buffer). That is a
+// full-output-sized clone on top of the two copies that must exist, so peak
+// RSS was ~3x the output instead of ~2x. ASAN-gated because release mimalloc
+// does not retain freed pages the way ASAN's allocator does.
+test.skipIf(!isASAN)("seq piped to an fd does not clone its output buffer before enqueue", async () => {
+  // 100-byte separator keeps the output large (~32 MB) with only 300k
+  // iterations, so the child finishes in ~1s under ASAN.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const sep = Buffer.alloc(100, "x").toString();` +
         `await Bun.$\`seq 1 10 > /dev/null\`;` +
-          `const b = process.memoryUsage().rss;` +
-          `await Bun.$\`seq 1 ${N} > /dev/null\`;` +
-          `console.log(process.memoryUsage().rss - b);`,
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const deltaBytes = parseInt(stdout.trim(), 10);
-    // `seq 1 4000000` renders 30_888_896 bytes. With the fix the child's RSS
-    // grows by ~106 MB (rendered Vec capacity + IOWriter's copy + ASAN shadow);
-    // without it the extra clone pushes it to ~143 MB.
-    expect(deltaBytes).toBeLessThan(128 * 1024 * 1024);
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+        `const b = process.memoryUsage().rss;` +
+        `await Bun.$\`seq -s \${sep} 1 300000 > /dev/null\`;` +
+        `console.log(process.memoryUsage().rss - b);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const deltaBytes = parseInt(stdout.trim(), 10);
+  // Output is 31_888_894 bytes. With the fix the child's RSS grows by ~134 MB
+  // (rendered Vec capacity + IOWriter's copy + ASAN shadow); without it the
+  // extra clone pushes it to ~170 MB.
+  expect(deltaBytes).toBeLessThan(152 * 1024 * 1024);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Seven sites marked `reshaped for borrowck` were reshaped by adding a per-iteration heap alloc, turning an O(n) loop into O(n²) clone work or adding a full-buffer clone on a hot path. Each fix is a local restructure that removes the alloc without changing behavior or any signature.

| Site | Old shape | Fix |
|---|---|---|
| `src/bundler/defines.rs` `insert_global` | `get_mut` arm builds fresh `Vec<DotDefine>`, `extend_from_slice` from existing, push, reassign → O(n²) `DotDefine` clones over the globals table | `existing.push(..)` in place |
| `src/js_parser/lib.rs` `Define::insert` | same rebuild+reassign per insert | push in the `Some` arm and return; `put` a 1-element vec in the `None` arm |
| `src/install/yarn.rs` migrate | clones the matching entry's `specs: Vec<&[u8]>` per dependency edge | store `Option<usize>` entry index, borrow `&yarn_lock.entries[idx].specs` (all borrows are shared) |
| `src/shell_parser/braces.rs` `expand_nested` (×2) and `expand_flat` | `out[out_key][..len].to_vec()` snapshot per expansion frame | `out.split_at_mut(new_key)` then `hi[0].extend_from_slice(&lo[out_key][..len])`. `new_key > out_key` always holds (counter is bumped past `out_key` before any recursion into it), and the `j==0` recursion only appends to `out[out_key]` so its `[..len]` prefix is stable |
| `src/runtime/shell/builtin/seq.rs` `do_` | stores rendered output into state, clones it, enqueues the clone | `stdout.enqueue(child, &out, ..)` (enqueue copies into IOWriter's buffer), then let `out` drop. The `Seq.buf` field's only reader was that clone, so the field is removed too |

The `reshaped for borrowck` comment is deleted at each site.

An eighth site in `PackageManagerEnqueue.rs::enqueue_dependency_list` was in the original list but is dropped from this PR: the peer-skip block it sits in has been unreachable since #21059 flipped `Behavior::cmp` to sort peers last (the block's gate checks `dependencies[0].is_peer()` and the inner loop's `!is_peer()` guard together require peers both first and last). Optimizing dead code adds no value; deleting the block is a separate change.

## Why this is correct

Each change is a local restructure that preserves the sequence of writes:

- `Define::insert_global` / `Define::insert`: pushing in place produces the same final Vec as clone-extend-push-reassign, just without the intermediate.
- yarn migrate: the outer loop, the spec search, and the follow-up loop all take shared borrows of `yarn_lock.entries`, so re-borrowing `entries[idx].specs` coexists with them.
- braces: `out_key_counter` is monotonically increasing and is bumped past `out_key` before any recursion into a new key, so `new_key > out_key` holds for every `j>0` / `i>0` iteration; recursion only appends to `out[out_key]`, so re-reading its `[..len]` prefix each iteration yields the same bytes as the snapshot did.
- seq: `IOWriter::enqueue` does `s.buf.extend_from_slice(buf)` and records `buf.len()`, so the caller's slice need not outlive the call. `state.state = Done` is already set before the enqueue, which is the only field `on_io_writer_chunk` reads; `Seq.buf` has no remaining reader and is dropped along with its `Default` init.

## Verification

```
$ bun bd test test/js/bun/shell/commands/seq.test.ts
 32 pass, 0 fail
$ bun bd test test/js/bun/shell/brace.test.ts test/js/bun/shell/bunshell.test.ts
 454 pass, 2 skip, 83 todo, 0 fail
$ bun bd test test/bundler/transpiler/transpiler.test.js -t define
 2 pass, 1 todo, 0 fail
$ bun bd test test/cli/install/migration/yarn-lock-migration.test.ts
 15 pass, 1 fail (yarn-cli-repo, pre-existing on main under ASAN: the test
 does not await its .resolves assertion so the spawned migrate is SIGTERMed
 by the test timeout; fails identically with src/ stashed)
```

The new RSS test in `seq.test.ts` is the fail-before proof: `seq -s <100-byte sep> 1 300000` renders 31,688,895 bytes; with the fix the child's RSS grows by ~128-134 MB (rendered Vec capacity + IOWriter's copy + ASAN shadow), without it the extra clone pushes it to ~170 MB. Threshold 152 MB; `skipIf(!isASAN)` because release mimalloc does not retain freed pages the same way.

The other six sites have no user-observable behavior delta to demonstrate (they remove clone work whose output was bit-identical), so the fail-before proof rides on the seq site; the existing suites above exercise the restructured code paths for correctness.

These sites are the perf-priority subset of the wider `reshaped for borrowck` audit; the remaining bucket-B cleanup will rebase over this.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/seq.test.ts
bun test v1.4.0 (229f6d31f)

test/js/bun/shell/commands/seq.test.ts:
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage [62.21ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -w flag given [16.37ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only --fixed-width flag given [12.44ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -s flag given [5.81ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -t flag given [15.08ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only flags given [5.45ms]
seq: option requires an argument -- s
(pass) seq > tests -s [13.75ms]
seq: option requires an argument -- t
(pass) seq > tests -s [5.04ms]
0
1
2
3
4
5
(pass) seq > work
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (d9e749f7f)

test/js/bun/shell/commands/seq.test.ts:
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage [1.12ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -w flag given [0.15ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only --fixed-width flag given [0.14ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -s flag given [0.10ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -t flag given [0.07ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only flags given [0.07ms]
seq: option requires an argument -- s
(pass) seq > tests -s [0.07ms]
seq: option requires an argument -- t
(pass) seq > tests -s [0.07ms]
0
1
2
3
4
5
(pass) seq > works basic up [0.10ms]
5
4
3
2
1
0
(pass) seq > works basic down [0.07ms]
0,1,2,3,4,5,(pass) seq > -s works inline [0.06ms]
0,1,2,3,4,5,(pass) seq > -s works separate [0.0
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/seq.test.ts
bun test v1.4.0 (229f6d31f)

test/js/bun/shell/commands/seq.test.ts:
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage [61.63ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -w flag given [16.72ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only --fixed-width flag given [12.21ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -s flag given [4.95ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only -t flag given [12.81ms]
usage: seq [-w] [-f format] [-s string] [-t string] [first [incr]] last
(pass) seq > prints usage when only flags given [5.33ms]
seq: option requires an argument -- s
(pass) seq > tests -s [12.80ms]
seq: option requires an argument -- t
(pass) seq > tests -s [4.85ms]
0
1
2
3
4
5
(pass) seq > work
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 728ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/defines.rs                 | 19 +++++++----------
 src/install/yarn.rs                    | 24 ++++++---------------
 src/js_parser/lib.rs                   | 13 ++++--------
 src/runtime/shell/builtin/seq.rs       |  8 +------
 src/shell_parser/braces.rs             | 21 ++++++++++---------
 test/js/bun/shell/commands/seq.test.ts | 38 +++++++++++++++++++++++++++++++++-
 6 files changed, 67 insertions(+), 56 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/bundler/defines.rs                      1      1      0
src/install/yarn.rs                         2      2      0
src/js_parser/lib.rs                        1      1      0
src/runtime/shell/builtin/seq.rs            2      2      0
src/shell_parser/braces.rs                  1      1      0
test/js/bun/shell/commands/seq.test.ts      4      6      0
```

</details>

<!-- robobun:evidence:end -->