### PR TITLE
install: replace *mut PackageManager self-aliasing with disjoint field borrows

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -39,6 +39,18 @@ pub(crate) fn filename_store_appender() -> FilenameStoreAppender<'static> {
     FilenameStoreAppender(FileSystem::instance().filename_store())
 }
 
+/// Intern `bytes` into the global filename store (inline when it fits) and
+/// return the `StringOrTinyString` handle. Convenience for callers that need
+/// to release a lockfile/manifest borrow before a `&mut PackageManager` call.
+#[inline]
+pub(crate) fn intern_in_filename_store(bytes: &[u8]) -> bun_core::strings::StringOrTinyString {
+    bun_core::strings::StringOrTinyString::init_append_if_needed(
+        bytes,
+        &mut filename_store_appender(),
+    )
+    .expect("unreachable")
+}
+
 pub struct NetworkTask {
     // Self-referential: borrows `url_buf` / leaked header content owned by
     // sibling fields, so the lifetime is erased to `'static`.

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -902,12 +902,21 @@ impl NetworkTask {
     /// Release any streaming-extraction resources that were never used because
     /// the request errored before a drain was scheduled. Called on the main
     /// thread from `runTasks` when falling back to the buffered path.
-    pub fn discard_unused_streaming_state(&mut self, manager: &mut PackageManager) {
-        debug_assert!(!self.streaming_committed);
-        if let Some(stream) = self.tarball_stream.take() {
+    ///
+    /// Implemented as an associated fn over the disjoint fields it touches so
+    /// `runTasks` can hold `&mut self.callback` (via the `Extract` match arm)
+    /// across the call.
+    pub fn discard_unused_streaming_state(
+        streaming_committed: bool,
+        tarball_stream: &mut Option<Box<TarballStream>>,
+        streaming_extract_task: &mut *mut crate::package_manager_task::Task<'static>,
+        preallocated_resolve_tasks: &mut crate::package_manager_real::PreallocatedTaskStore,
+    ) {
+        debug_assert!(!streaming_committed);
+        if let Some(stream) = tarball_stream.take() {
             drop(stream);
         }
-        if !self.streaming_extract_task.is_null() {
+        if !streaming_extract_task.is_null() {
             // ARENA: returned to `preallocated_resolve_tasks` pool, not freed.
             // SAFETY: `streaming_extract_task` was obtained from this same
             // `preallocated_resolve_tasks` pool via `get()` and is not aliased
@@ -915,23 +924,28 @@ impl NetworkTask {
             // slot — the Task was fully initialized via
             // `enqueue::create_extract_task_for_streaming` so this is sound.
             unsafe {
-                manager
-                    .preallocated_resolve_tasks
-                    .put(self.streaming_extract_task);
+                preallocated_resolve_tasks.put(*streaming_extract_task);
             }
-            self.streaming_extract_task = ptr::null_mut();
+            *streaming_extract_task = ptr::null_mut();
         }
     }
 
     /// Prepare this task for another HTTP attempt (used by retry logic when
     /// streaming extraction never started). Keeps the stream allocation so the
     /// retry can still benefit from streaming.
-    pub fn reset_streaming_for_retry(&mut self) {
-        debug_assert!(!self.streaming_committed);
-        if let Some(stream) = self.tarball_stream.as_deref_mut() {
+    ///
+    /// Implemented as an associated fn over the disjoint fields it touches so
+    /// `runTasks` can hold `&mut self.callback` across the call.
+    pub fn reset_streaming_for_retry(
+        streaming_committed: bool,
+        tarball_stream: &mut Option<Box<TarballStream>>,
+        response: &mut HTTPClientResult,
+    ) {
+        debug_assert!(!streaming_committed);
+        if let Some(stream) = tarball_stream.as_deref_mut() {
             stream.reset_for_retry();
         }
-        self.response = HTTPClientResult::default();
+        *response = HTTPClientResult::default();
     }
 
     /// Initialize a freshly-vended pool slot in place — a full struct overwrite

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1161,16 +1161,14 @@ impl<'a> PackageInstaller<'a> {
         pkg_name: String,
         resolution: &Resolution,
     ) {
-        // reshaped for borrowck — `string_bytes` is not mutated during install,
-        // so capture a raw slice once to avoid repeatedly re-borrowing `self.lockfile`
-        // across `&mut self` method calls below.
-        // SAFETY: `buffers.string_bytes` is append-only and never freed
-        // for the lifetime of this `PackageInstaller`.
-        let string_buf_ptr =
-            bun_ptr::RawSlice::new(self.lockfile().buffers.string_bytes.as_slice());
+        // `lockfile()` returns `&'a Lockfile` (tied to the struct lifetime, not
+        // `&self`), so this slice is held safely across `&mut self` calls below.
+        // `buffers.string_bytes` is append-only and never freed for the
+        // lifetime of this `PackageInstaller`.
+        let string_buf: &'a [u8] = self.lockfile().buffers.string_bytes.as_slice();
         macro_rules! string_buf {
             () => {
-                string_buf_ptr.slice()
+                string_buf
             };
         }
 
@@ -1521,7 +1519,7 @@ impl<'a> PackageInstaller<'a> {
                         package_manager::enqueue_git_for_checkout(
                             self.manager_mut(),
                             dependency_id,
-                            alias.slice(string_buf!()),
+                            alias,
                             resolution,
                             context,
                             download_patch_hash,
@@ -1556,7 +1554,7 @@ impl<'a> PackageInstaller<'a> {
                             self.manager_mut(),
                             dependency_id,
                             package_id,
-                            alias.slice(string_buf!()),
+                            alias,
                             resolution,
                             context,
                         );

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -264,7 +264,7 @@ pub(crate) type TaskCallbackList = Vec<TaskCallbackContext>;
 pub(crate) type TaskDependencyQueue =
     HashMap<Task::Id, TaskCallbackList /* , IdentityContext<Task::Id>, 80 */>;
 
-type PreallocatedTaskStore = HiveArrayFallback<Task::Task<'static>, 64>;
+pub(crate) type PreallocatedTaskStore = HiveArrayFallback<Task::Task<'static>, 64>;
 type PreallocatedNetworkTasks = HiveArrayFallback<NetworkTask, 128>;
 type ResolveTaskQueue = UnboundedQueue<Task::Task<'static> /* , .next */>;
 

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -53,12 +53,11 @@ fn copy_property(p: &G::Property) -> G::Property {
 }
 
 pub(crate) fn edit_patched_dependencies(
-    manager: &mut PackageManager,
+    arena: &bun_alloc::Arena,
     package_json: &mut Expr,
     patch_key: &[u8],
     patchfile_path: &[u8],
 ) -> Result<(), bun_alloc::AllocError> {
-    let arena = &manager.ast_arena;
     // const pkg_to_patch = manager.
     let mut patched_dependencies = E::Object::default();
     if let Some(query) = package_json.as_property(b"patchedDependencies") {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1,5 +1,4 @@
 use crate::lockfile::package::PackageColumns as _;
-use bun_ptr::detach_lifetime;
 use core::mem::ManuallyDrop;
 use core::sync::atomic::Ordering;
 
@@ -213,12 +212,8 @@ pub fn enqueue_tarball_for_download(
         patch_name_and_version_hash,
         crate::network_task::Authorization::NoAuthorization,
     )? {
-        // reshaped for borrowck — `task: &mut NetworkTask` borrows
-        // `*this` (pool slot); reborrow as raw so `this.network_tarball_batch`
-        // is reachable.
-        let task: *mut NetworkTask = task;
         // SAFETY: `task` is the unique handle to a freshly-vended pool slot.
-        unsafe { (*task).schedule(&mut this.network_tarball_batch) };
+        unsafe { (*task.as_ptr()).schedule(&mut this.network_tarball_batch) };
         if this.network_tarball_batch.len > 0 {
             let _ = this.schedule_tasks();
         }
@@ -230,20 +225,13 @@ pub fn enqueue_tarball_for_reading(
     this: &mut PackageManager,
     dependency_id: DependencyID,
     package_id: PackageID,
-    alias: &[u8],
+    alias: SemverString,
     resolution: &Resolution,
     task_context: TaskCallbackContext,
 ) {
-    // reshaped for borrowck — `path` borrows
-    // `this.lockfile.buffers.string_bytes`; detach the slice lifetime so the
-    // `&mut PackageManager` reborrow for `enqueue_local_tarball` below does
-    // not conflict.
-    // SAFETY: caller passes `resolution.tag == LocalTarball`; the
-    // `local_tarball` arm is the active union field. `string_bytes` is not
-    // resized in this fn — `enqueue_local_tarball` copies `path` into the
-    // filename store before any append.
-    let path = this.lockfile.str_detached(resolution.local_tarball());
-    let task_id = Task::Id::for_tarball(path);
+    // Caller passes `resolution.tag == LocalTarball`.
+    let path_str: SemverString = *resolution.local_tarball();
+    let task_id = Task::Id::for_tarball(this.lockfile.str(&path_str));
     let task_queue = this.task_queue.get_or_put(task_id).expect("unreachable");
     if !task_queue.found_existing {
         *task_queue.value_ptr = TaskCallbackList::default();
@@ -262,7 +250,7 @@ pub fn enqueue_tarball_for_reading(
         task_id,
         dependency_id,
         alias,
-        path,
+        path_str,
         resolution,
         &integrity,
     );
@@ -272,25 +260,23 @@ pub fn enqueue_tarball_for_reading(
 pub fn enqueue_git_for_checkout(
     this: &mut PackageManager,
     dependency_id: DependencyID,
-    alias: &[u8],
+    alias: SemverString,
     resolution: &Resolution,
     task_context: TaskCallbackContext,
     patch_name_and_version_hash: Option<u64>,
 ) {
-    // SAFETY: caller passes `resolution.tag == Git`; the `git` arm is the
-    // active union field. Copy out so the value no longer borrows
-    // `*resolution` while `*this` is mutably reborrowed below.
+    // Caller passes `resolution.tag == Git`; copy out so the value no longer
+    // borrows `*resolution` while `*this` is mutably reborrowed below.
     let repository: Repository = *resolution.git();
-    // reshaped for borrowck — `url`/`resolved` borrow
-    // `this.lockfile.buffers.string_bytes`; detach the slice lifetimes so the
-    // `&mut PackageManager` reborrows for the enqueue callees below do not
-    // conflict.
-    // SAFETY: the enqueue callees copy these slices into the filename store
-    // and never resize `string_bytes` while they are live.
-    let url = this.lockfile.str_detached(&repository.repo);
-    let clone_id = Task::Id::for_git_clone(url);
-    let resolved = this.lockfile.str_detached(&repository.resolved);
-    let checkout_id = Task::Id::for_git_checkout(url, resolved);
+    let (clone_id, checkout_id) = {
+        let buf = this.lockfile.buffers.string_bytes.as_slice();
+        let url = repository.repo.slice(buf);
+        let resolved = repository.resolved.slice(buf);
+        (
+            Task::Id::for_git_clone(url),
+            Task::Id::for_git_checkout(url, resolved),
+        )
+    };
     let checkout_queue = this
         .task_queue
         .get_or_put(checkout_id)
@@ -306,6 +292,14 @@ pub fn enqueue_git_for_checkout(
     }
 
     if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
+        // `enqueue_git_checkout` copies `resolved` into the filename store
+        // before taking `&mut *this`; do that copy here so the
+        // `this.lockfile` borrow ends before the call.
+        let resolved_tiny = StringOrTinyString::init_append_if_needed(
+            this.lockfile.str(&repository.resolved),
+            &mut crate::network_task::filename_store_appender(),
+        )
+        .expect("unreachable");
         let task = enqueue_git_checkout(
             this,
             checkout_id,
@@ -313,7 +307,7 @@ pub fn enqueue_git_for_checkout(
             dependency_id,
             alias,
             resolution,
-            resolved,
+            resolved_tiny.slice(),
             patch_name_and_version_hash,
         );
         this.task_batch.push(ThreadPool::Batch::from(task));
@@ -422,10 +416,8 @@ pub fn enqueue_package_for_download(
         patch_name_and_version_hash,
         crate::network_task::Authorization::AllowAuthorization,
     )? {
-        // reshaped for borrowck — see `enqueue_tarball_for_download`.
-        let task: *mut NetworkTask = task;
         // SAFETY: `task` is the unique handle to a freshly-vended pool slot.
-        unsafe { (*task).schedule(&mut this.network_tarball_batch) };
+        unsafe { (*task.as_ptr()).schedule(&mut this.network_tarball_batch) };
         if this.network_tarball_batch.len > 0 {
             let _ = this.schedule_tasks();
         }
@@ -992,16 +984,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             );
                         }
                     } else if version.tag.is_npm() {
-                        // reshaped for borrowck — `name_str` borrows
-                        // `this.lockfile.buffers.string_bytes`. Route the whole
-                        // branch through a raw root so the slice and the
-                        // `&mut PackageManager` calls below can coexist.
-                        // Snapshot the manifest disk-cache scalars while we
-                        // still hold `&mut this` exclusively — taking it via
-                        // `&mut *this_ptr` after `name_str`/`scope` exist
-                        // would pop their borrow-stack tags under SB.
                         let cache_ctx = this.manifest_disk_cache_ctx();
-                        let this_ptr: *mut PackageManager = this;
                         // Owned copy: `get_or_put_resolved_package_with_find_result`
                         // below appends to `string_bytes` (and may reallocate it),
                         // and `name_str` is still read afterwards on the
@@ -1032,26 +1015,16 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     this.options.minimum_release_age_ms.is_some();
                                 if this.options.enable.manifest_cache() {
                                     let mut expired = false;
-                                    // SAFETY: `this_ptr` is the live exclusive
-                                    // borrow's address; `options` is disjoint
-                                    // from `manifests`.
-                                    let scope: *const crate::npm::registry::Scope =
-                                        unsafe { &(*this_ptr).options }
-                                            .scope_for_package_name(&name_str);
-                                    // SAFETY: `manifests` projected from
-                                    // `this_ptr`; `cache_ctx` was snapshotted
-                                    // before `this_ptr` so the lookup holds
-                                    // only this disjoint field borrow.
-                                    if let Some(manifest) = unsafe {
-                                        (*this_ptr).manifests.by_name_hash_allow_expired(
+                                    if let Some(manifest) =
+                                        this.manifests.by_name_hash_allow_expired(
                                             cache_ctx,
-                                            &*scope,
+                                            this.options.scope_for_package_name(&name_str),
                                             name_hash,
                                             Some(&mut expired),
                                             ManifestLoad::LoadFromMemoryFallbackToDisk,
                                             needs_extended_manifest,
                                         )
-                                    } {
+                                    {
                                         loaded_manifest = Some(manifest.clone());
 
                                         // If it's an exact package version already living in the cache
@@ -1099,27 +1072,19 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                         return Ok(());
                                                     }
                                                 }
-                                                // reshaped for borrowck — `find_result`
-                                                // borrows `loaded_manifest`; route the manifest
-                                                // through a `BackRef` so the `&mut PackageManager`
-                                                // call below doesn't conflict. `loaded_manifest`
-                                                // is owned by this stack frame and not touched
-                                                // until the call returns.
-                                                let manifest_ref = bun_ptr::BackRef::new(
-                                                    loaded_manifest.as_ref().unwrap(),
-                                                );
+                                                let find_result_version = find_result.version;
+                                                let find_result_package = *find_result.package;
                                                 if let Some(new_resolve_result) =
                                                     get_or_put_resolved_package_with_find_result(
-                                                        // SAFETY: see `this_ptr` note above.
-                                                        unsafe { &mut *this_ptr },
+                                                        this,
                                                         name_hash,
                                                         name,
                                                         dependency,
                                                         &version,
                                                         id,
                                                         dependency.behavior,
-                                                        manifest_ref.get(),
-                                                        find_result,
+                                                        find_result_version,
+                                                        find_result_package,
                                                         install_peer,
                                                         success_fn,
                                                     )
@@ -1160,15 +1125,19 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 // defaulted field (callback is uninitialized and
                                 // overwritten by `for_manifest`).
                                 unsafe {
-                                    NetworkTask::write_init(network_task, task_id, this_ptr, None);
+                                    NetworkTask::write_init(
+                                        network_task,
+                                        task_id,
+                                        std::ptr::from_mut(this),
+                                        None,
+                                    );
                                 }
 
-                                let scope = this.scope_for_package_name(&name_str);
                                 // SAFETY: network_task points to a valid initialized NetworkTask slot
                                 unsafe {
                                     (*network_task).for_manifest(
                                         &name_str,
-                                        scope,
+                                        this.scope_for_package_name(&name_str),
                                         loaded_manifest.as_ref(),
                                         dependency.behavior.is_optional(),
                                         needs_extended_manifest,
@@ -1208,15 +1177,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 return Ok(());
             }
 
-            // reshaped for borrowck — `alias`/`url` borrow
-            // `this.lockfile.buffers.string_bytes`; detach the slice
-            // lifetimes so the `&mut PackageManager` reborrows for the
-            // enqueue callees below do not conflict.
-            // SAFETY: `string_bytes` is not resized in this branch; the
-            // enqueue callees copy the slices into the filename store.
-            let alias = this.lockfile.str_detached(&dependency.name);
-            let url = this.lockfile.str_detached(&dep.repo);
-            let clone_id = Task::Id::for_git_clone(url);
+            let alias: SemverString = dependency.name;
+            let clone_id = Task::Id::for_git_clone(this.lockfile.str(&dep.repo));
             let ctx = if is_root {
                 TaskCallbackContext::RootDependency(id)
             } else {
@@ -1231,7 +1193,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     <&'static str>::from(version.tag),
                     bstr::BStr::new(this.lockfile.str(&name)),
                     bstr::BStr::new(this.lockfile.str(&version.literal)),
-                    bstr::BStr::new(url),
+                    bstr::BStr::new(this.lockfile.str(&dep.repo)),
                 );
             }
 
@@ -1240,11 +1202,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     this.env_mut(),
                     this.log_mut(),
                     repo_fd,
-                    alias,
+                    this.lockfile.str(&alias),
                     this.lockfile.str(&dep.committish),
                     clone_id,
                 )?;
-                let checkout_id = Task::Id::for_git_checkout(url, &resolved);
+                let checkout_id =
+                    Task::Id::for_git_checkout(this.lockfile.str(&dep.repo), &resolved);
 
                 let needs_ctx =
                     this.lockfile.buffers.resolutions[id as usize] == invalid_package_id;
@@ -1375,9 +1338,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 None,
                 crate::network_task::Authorization::NoAuthorization,
             )? {
-                // reshaped for borrowck — see `enqueue_tarball_for_download`.
-                let nt: *mut NetworkTask = network_task;
-                enqueue_network_task(this, nt);
+                enqueue_network_task(this, network_task.as_ptr());
             }
             Ok(())
         }
@@ -1507,18 +1468,11 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 return Ok(());
             }
 
-            // reshaped for borrowck — `url` borrows `string_bytes`;
-            // detach the slice lifetime so the `&mut PackageManager` reborrows
-            // for the enqueue callees below do not conflict.
-            // SAFETY: the enqueue callees copy `url` into the filename store
-            // before any `string_bytes` resize.
-            let url = unsafe {
-                detach_lifetime(match &tarball.uri {
-                    dependency::tarball::Uri::Local(path) => this.lockfile.str(path),
-                    dependency::tarball::Uri::Remote(url) => this.lockfile.str(url),
-                })
+            let url_str: SemverString = match &tarball.uri {
+                dependency::tarball::Uri::Local(path) => *path,
+                dependency::tarball::Uri::Remote(url) => *url,
             };
-            let task_id = Task::Id::for_tarball(url);
+            let task_id = Task::Id::for_tarball(this.lockfile.str(&url_str));
 
             if cfg!(debug_assertions) {
                 bun_output::scoped_log!(
@@ -1528,7 +1482,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     <&'static str>::from(version.tag),
                     bstr::BStr::new(this.lockfile.str(&name)),
                     bstr::BStr::new(this.lockfile.str(&version.literal)),
-                    bstr::BStr::new(url),
+                    bstr::BStr::new(this.lockfile.str(&url_str)),
                 );
             }
 
@@ -1537,7 +1491,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else {
                 TaskCallbackContext::Dependency(id)
             };
-            // reshaped for borrowck — scope `entry` tightly.
             {
                 let entry = this
                     .task_queue
@@ -1562,45 +1515,43 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         return Ok(());
                     }
 
-                    // SAFETY: `string_bytes` is not resized before
-                    // `enqueue_local_tarball` copies `dep_name` into the
-                    // filename store.
-                    let dep_name = this.lockfile.str_detached(&dependency.name);
                     let task = enqueue_local_tarball(
                         this,
                         task_id,
                         id,
-                        dep_name,
-                        url,
+                        dependency.name,
+                        url_str,
                         &res,
                         &Integrity::default(),
                     );
                     this.task_batch.push(ThreadPool::Batch::from(task));
                 }
                 dependency::tarball::Uri::Remote(_) => {
-                    // `generate_network_task_for_tarball` returns
-                    // `&'a mut NetworkTask` tied to `this`; coerce to `*mut`
-                    // immediately so the `&mut *this` borrow ends before
-                    // `enqueue_network_task(this, …)` reborrows it (NLL).
-                    let network_task: Option<*mut NetworkTask> =
-                        run_tasks::generate_network_task_for_tarball(
-                            this,
-                            task_id,
-                            url,
-                            dependency.behavior.is_required(),
-                            id,
-                            &Package {
-                                name: dependency.name,
-                                name_hash: dependency.name_hash,
-                                resolution: res,
-                                ..Package::default()
-                            },
-                            None,
-                            crate::network_task::Authorization::NoAuthorization,
-                        )?
-                        .map(std::ptr::from_mut::<NetworkTask>);
-                    if let Some(network_task) = network_task {
-                        enqueue_network_task(this, network_task);
+                    // Copy into the filename store (no heap alloc; where
+                    // `generate_network_task_for_tarball` would copy it
+                    // anyway) so the slice no longer borrows
+                    // `this.lockfile` across the `&mut this` call.
+                    let url_tiny = StringOrTinyString::init_append_if_needed(
+                        this.lockfile.str(&url_str),
+                        &mut crate::network_task::filename_store_appender(),
+                    )
+                    .expect("unreachable");
+                    if let Some(network_task) = run_tasks::generate_network_task_for_tarball(
+                        this,
+                        task_id,
+                        url_tiny.slice(),
+                        dependency.behavior.is_required(),
+                        id,
+                        &Package {
+                            name: dependency.name,
+                            name_hash: dependency.name_hash,
+                            resolution: res,
+                            ..Package::default()
+                        },
+                        None,
+                        crate::network_task::Authorization::NoAuthorization,
+                    )? {
+                        enqueue_network_task(this, network_task.as_ptr());
                     }
                 }
             }
@@ -1679,7 +1630,7 @@ pub fn create_extract_task_for_streaming(
 fn enqueue_git_clone(
     this: &mut PackageManager,
     task_id: Task::Id,
-    name: &[u8],
+    name: SemverString,
     repository: &Repository,
     dep_id: DependencyID,
     dependency: &Dependency,
@@ -1698,6 +1649,9 @@ fn enqueue_git_clone(
     // from package.json, leaving the hash only in
     // `patched_dependencies_to_remove`. Install the package unpatched instead
     // of panicking.
+    //
+    // All lockfile-backed slices are copied into the filename store before
+    // any `&mut *this` use so the lockfile borrow is scoped.
     let patch = patch_name_and_version_hash.and_then(|h| {
         Some((
             h,
@@ -1707,6 +1661,26 @@ fn enqueue_git_clone(
                 .patchfile_hash()?,
         ))
     });
+    let (name_tiny, url_tiny, patch_pkg_id) = {
+        let lf = &*this.lockfile;
+        let mut store = crate::network_task::filename_store_appender();
+        (
+            StringOrTinyString::init_append_if_needed(lf.str(&name), &mut store)
+                .expect("unreachable"),
+            StringOrTinyString::init_append_if_needed(lf.str(&repository.repo), &mut store)
+                .expect("unreachable"),
+            patch.map(|_| {
+                match lf
+                    .package_index
+                    .get(&dependency.name_hash)
+                    .unwrap_or_else(|| panic!("Package not found"))
+                {
+                    PackageIndexEntry::Id(p) => *p,
+                    PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
+                }
+            }),
+        )
+    };
     let value = Task::Task {
         // `this` is a live `&mut PackageManager`; the task is owned by
         // `this.preallocated_resolve_tasks` and never outlives the manager.
@@ -1719,16 +1693,8 @@ fn enqueue_git_clone(
         tag: crate::package_manager_task::Tag::GitClone,
         request: crate::package_manager_task::Request {
             git_clone: ManuallyDrop::new(crate::package_manager_task::GitCloneRequest {
-                name: StringOrTinyString::init_append_if_needed(
-                    name,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-                url: StringOrTinyString::init_append_if_needed(
-                    this.lockfile.str(&repository.repo),
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
+                name: name_tiny,
+                url: url_tiny,
                 env: crate::repository::SharedEnv::get(this.env_mut()),
                 dep_id,
                 res: *res,
@@ -1736,17 +1702,7 @@ fn enqueue_git_clone(
         },
         id: task_id,
         apply_patch_task: if let Some((h, patch_hash)) = patch {
-            let dep = dependency;
-            let pkg_id = match this
-                .lockfile
-                .package_index
-                .get(&dep.name_hash)
-                .unwrap_or_else(|| panic!("Package not found"))
-            {
-                PackageIndexEntry::Id(p) => *p,
-                PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
-            };
-            let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
+            let pt = PatchTask::new_apply_patch_hash(this, patch_pkg_id.unwrap(), patch_hash, h);
             // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
             let mut pt = unsafe { bun_core::heap::take(pt) };
             pt.callback.apply_mut().task_id = Some(task_id);
@@ -1766,7 +1722,7 @@ pub fn enqueue_git_checkout(
     task_id: Task::Id,
     dir: Fd,
     dependency_id: DependencyID,
-    name: &[u8],
+    name: SemverString,
     resolution: &Resolution,
     resolved: &[u8],
     // if patched then we need to do apply step after network task is done
@@ -1777,6 +1733,9 @@ pub fn enqueue_git_checkout(
     // from package.json, leaving the hash only in
     // `patched_dependencies_to_remove`. Install the package unpatched instead
     // of panicking.
+    //
+    // All lockfile-backed slices are copied into the filename store before
+    // any `&mut *this` use so the lockfile borrow is scoped.
     let patch = patch_name_and_version_hash.and_then(|h| {
         Some((
             h,
@@ -1786,6 +1745,29 @@ pub fn enqueue_git_checkout(
                 .patchfile_hash()?,
         ))
     });
+    let (name_tiny, url_tiny, resolved_tiny, patch_pkg_id) = {
+        let lf = &*this.lockfile;
+        let mut store = crate::network_task::filename_store_appender();
+        (
+            StringOrTinyString::init_append_if_needed(lf.str(&name), &mut store)
+                .expect("unreachable"),
+            // `resolution.tag == Git` for the git-checkout path.
+            StringOrTinyString::init_append_if_needed(lf.str(&resolution.git().repo), &mut store)
+                .expect("unreachable"),
+            StringOrTinyString::init_append_if_needed(resolved, &mut store).expect("unreachable"),
+            patch.map(|_| {
+                let dep_name_hash = lf.buffers.dependencies[dependency_id as usize].name_hash;
+                match lf
+                    .package_index
+                    .get(&dep_name_hash)
+                    .unwrap_or_else(|| panic!("Package not found"))
+                {
+                    PackageIndexEntry::Id(p) => *p,
+                    PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
+                }
+            }),
+        )
+    };
     // SAFETY: `this` is a live `&mut PackageManager`.
     let task_value = unsafe {
         Task::Task {
@@ -1799,38 +1781,15 @@ pub fn enqueue_git_checkout(
                     repo_dir: dir,
                     resolution: *resolution,
                     dependency_id,
-                    name: StringOrTinyString::init_append_if_needed(
-                        name,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    url: StringOrTinyString::init_append_if_needed(
-                        // `resolution.tag == Git` for the git-checkout path.
-                        this.lockfile.str(&resolution.git().repo),
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    resolved: StringOrTinyString::init_append_if_needed(
-                        resolved,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
+                    name: name_tiny,
+                    url: url_tiny,
+                    resolved: resolved_tiny,
                     env: crate::repository::SharedEnv::get(this.env_mut()),
                 }),
             },
             apply_patch_task: if let Some((h, patch_hash)) = patch {
-                let dep_name_hash =
-                    this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
-                let pkg_id = match this
-                    .lockfile
-                    .package_index
-                    .get(&dep_name_hash)
-                    .unwrap_or_else(|| panic!("Package not found"))
-                {
-                    PackageIndexEntry::Id(p) => *p,
-                    PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
-                };
-                let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
+                let pt =
+                    PatchTask::new_apply_patch_hash(this, patch_pkg_id.unwrap(), patch_hash, h);
                 // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
                 let mut pt = bun_core::heap::take(pt);
                 pt.callback.apply_mut().task_id = Some(task_id);
@@ -1851,8 +1810,8 @@ fn enqueue_local_tarball(
     this: &mut PackageManager,
     task_id: Task::Id,
     dependency_id: DependencyID,
-    name: &[u8],
-    path: &[u8],
+    name: SemverString,
+    path_str: SemverString,
     resolution: &Resolution,
     integrity: &Integrity,
 ) -> *mut ThreadPool::Task {
@@ -1861,36 +1820,56 @@ fn enqueue_local_tarball(
     // `lockfile.packages` / `lockfile.buffers.string_bytes`: those buffers
     // can be reallocated concurrently by the main thread while processing
     // other dependencies (e.g. `appendPackage` / `StringBuilder.allocate`
-    // in `Package.fromNPM`).
+    // in `Package.fromNPM`). This function itself never grows
+    // `string_bytes`, so re-slicing `name`/`path_str` against it below is
+    // stable.
+    //
+    // Copy every lockfile-backed slice into the filename store before taking
+    // `&mut *this` for the `Task` literal.
     let mut abs_buf = PathBuffer::uninit();
-    let (tarball_path, normalize): (&[u8], bool) = 'tarball_path: {
-        let workspace_pkg_id = this
-            .lockfile
-            .get_workspace_pkg_if_workspace_dep(dependency_id);
-        if workspace_pkg_id == invalid_package_id {
-            break 'tarball_path (path, true);
-        }
+    let (name_tiny, url_tiny, tarball_path_tiny, normalize) = {
+        let buf = this.lockfile.buffers.string_bytes.as_slice();
+        let path = path_str.slice(buf);
+        let (tarball_path, normalize): (&[u8], bool) = 'tarball_path: {
+            let workspace_pkg_id = this
+                .lockfile
+                .get_workspace_pkg_if_workspace_dep(dependency_id);
+            if workspace_pkg_id == invalid_package_id {
+                break 'tarball_path (path, true);
+            }
 
-        let workspace_res = this.lockfile.packages.items_resolution()[workspace_pkg_id as usize];
-        if workspace_res.tag != ResolutionTag::Workspace {
-            break 'tarball_path (path, true);
-        }
+            let workspace_res =
+                this.lockfile.packages.items_resolution()[workspace_pkg_id as usize];
+            if workspace_res.tag != ResolutionTag::Workspace {
+                break 'tarball_path (path, true);
+            }
 
-        // Construct an absolute path to the tarball.
-        // Normally tarball paths are always relative to the root directory, but if a
-        // workspace depends on a tarball path, it should be relative to the workspace.
-        let workspace_str = *workspace_res.workspace();
-        let workspace_path = workspace_str.slice(this.lockfile.buffers.string_bytes.as_slice());
-        let joined = Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-            FileSystem::instance().top_level_dir(),
-            &mut abs_buf,
-            &[workspace_path, path],
-        );
-        break 'tarball_path (joined, false);
+            // Construct an absolute path to the tarball.
+            // Normally tarball paths are always relative to the root directory, but if a
+            // workspace depends on a tarball path, it should be relative to the workspace.
+            let workspace_str = *workspace_res.workspace();
+            let workspace_path = workspace_str.slice(buf);
+            let joined = Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                FileSystem::instance().top_level_dir(),
+                &mut abs_buf,
+                &[workspace_path, path],
+            );
+            break 'tarball_path (joined, false);
+        };
+
+        let mut store = crate::network_task::filename_store_appender();
+        (
+            StringOrTinyString::init_append_if_needed(name.slice(buf), &mut store)
+                .expect("unreachable"),
+            StringOrTinyString::init_append_if_needed(path, &mut store).expect("unreachable"),
+            StringOrTinyString::init_append_if_needed(tarball_path, &mut store)
+                .expect("unreachable"),
+            normalize,
+        )
     };
 
     // Build the `Task` value *before* claiming a hive slot — the `.expect()`s
-    // below can unwind, and `Task` carries drop glue. See `enqueue_git_clone`.
+    // above can unwind, and `Task` carries drop glue. See `enqueue_git_clone`.
     let value = Task::Task {
         // `this` is a live `&mut PackageManager`; the task is owned by
         // `this.preallocated_resolve_tasks` and never outlives the manager.
@@ -1905,11 +1884,7 @@ fn enqueue_local_tarball(
             local_tarball: ManuallyDrop::new(crate::package_manager_task::LocalTarballRequest {
                 tarball: ExtractTarball {
                     package_manager: bun_ptr::BackRef::new(this),
-                    name: StringOrTinyString::init_append_if_needed(
-                        name,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
+                    name: name_tiny,
                     resolution: *resolution,
                     // `ExtractTarball::{cache_dir,temp_dir}` are borrowed views — the
                     // descriptors are owned by the `PackageManager` singleton and the
@@ -1918,19 +1893,11 @@ fn enqueue_local_tarball(
                     temp_dir: get_temporary_directory(this).handle.fd(),
                     dependency_id,
                     integrity: *integrity,
-                    url: StringOrTinyString::init_append_if_needed(
-                        path,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
+                    url: url_tiny,
                     skip_verify: false,
                     in_trusted_dependencies: false,
                 },
-                tarball_path: StringOrTinyString::init_append_if_needed(
-                    tarball_path,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
+                tarball_path: tarball_path_tiny,
                 normalize,
             }),
         },
@@ -1985,6 +1952,12 @@ pub(crate) struct ResolvedPackageResult {
     pub task: Option<ResolvedPackageTask>,
 }
 
+/// Takes `find_result_package` by value (240-byte POD) instead of
+/// `Npm::FindResult<'_>` so callers can release their borrow of
+/// `this.manifests` before handing us `&mut PackageManager`. The manifest
+/// itself is re-borrowed here via disjoint field access on `this.manifests`
+/// (both call sites have already populated the map entry via
+/// `by_name_hash[_allow_expired]`).
 fn get_or_put_resolved_package_with_find_result(
     this: &mut PackageManager,
     name_hash: PackageNameHash,
@@ -1993,28 +1966,23 @@ fn get_or_put_resolved_package_with_find_result(
     version: &dependency::Version,
     dependency_id: DependencyID,
     behavior: Behavior,
-    manifest: &Npm::PackageManifest,
-    find_result: Npm::FindResult,
+    find_result_version: Semver::Version,
+    find_result_package: Npm::PackageVersion,
     install_peer: bool,
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
-    // reshaped for borrowck — `is_root_dependency(&self, &mut PackageManager, …)`
-    // borrows `this.lockfile` and `this` at once. Split via raw root.
-    let should_update = {
-        let this_ptr: *mut PackageManager = this;
-        // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
-        // `manager.workspace_package_json_cache` only — disjoint from
-        // `manager.lockfile`.
-        this.to_update
-            // If updating, only update packages in the current workspace
-            && unsafe { &*(*this_ptr).lockfile }
-                .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id)
-            // no need to do a look up if update requests are empty (`bun update` with no args)
-            && (this.update_requests.is_empty()
-                || this.updating_packages.contains(
-                    dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),
-                ))
-    };
+    let should_update = this.to_update
+        // If updating, only update packages in the current workspace
+        && this.lockfile.is_root_dependency(
+            &mut this.root_package_id,
+            this.workspace_name_hash,
+            dependency_id,
+        )
+        // no need to do a look up if update requests are empty (`bun update` with no args)
+        && (this.update_requests.is_empty()
+            || this.updating_packages.contains(
+                dependency.name.slice(this.lockfile.buffers.string_bytes.as_slice()),
+            ));
 
     // Was this package already allocated? Let's reuse the existing one.
     //
@@ -2043,8 +2011,8 @@ fn get_or_put_resolved_package_with_find_result(
             Some(version)
         },
         &Resolution::init(ResolutionTagged::Npm(ResolutionNpmValue {
-            version: find_result.version,
-            url: find_result.package.tarball_url.value,
+            version: find_result_version,
+            url: find_result_package.tarball_url.value,
         })),
     ) {
         success_fn(this, dependency_id, id);
@@ -2057,133 +2025,141 @@ fn get_or_put_resolved_package_with_find_result(
         return Ok(None);
     }
 
-    // appendPackage sets the PackageID on the package
-    // reshaped for borrowck — `from_npm` takes both `&mut PackageManager`
-    // and `&mut Lockfile`, which alias through `this.lockfile`. Split via raw root.
-    let this_ptr: *mut PackageManager = this;
-    // SAFETY: `from_npm` reads `pm` fields disjoint from `pm.lockfile` (options /
-    // updating_packages), so the raw-pointer split does not alias.
-    let package = unsafe { &mut *(*this_ptr).lockfile }.append_package(&Package::from_npm(
-        unsafe { &mut *this_ptr },
-        unsafe { &mut *(*this_ptr).lockfile },
-        this.log_mut(),
-        manifest,
-        find_result.version,
-        find_result.package,
-        Features::NPM,
-    )?)?;
+    // appendPackage sets the PackageID on the package. `from_npm` reads the
+    // manifest but only writes `lockfile` and `known_npm_aliases`, so borrow
+    // `this.manifests` immutably alongside those disjoint `&mut` field
+    // borrows. The tarball URL is copied out of the manifest here as well so
+    // the `this.manifests` borrow ends before the whole-`&mut this` calls in
+    // the preinstall match below.
+    let (new_pkg, tarball_url_tiny) = {
+        let log = this.log_mut();
+        let manifest = this
+            .manifests
+            .loaded_by_name_hash(name_hash)
+            .expect("manifest was just loaded by caller");
+        (
+            Package::from_npm(
+                &mut this.known_npm_aliases,
+                &mut this.lockfile,
+                log,
+                manifest,
+                find_result_version,
+                &find_result_package,
+                Features::NPM,
+            )?,
+            StringOrTinyString::init_append_if_needed(
+                manifest.str(&find_result_package.tarball_url),
+                &mut crate::network_task::filename_store_appender(),
+            )
+            .expect("unreachable"),
+        )
+    };
+    let package = this.lockfile.append_package(&new_pkg)?;
 
     debug_assert!(package.meta.id != invalid_package_id);
     // Record exact-version pins so `Lockfile::get_package_id`'s
     // order-independence guard can tell them apart from range-resolved
     // entries (which it treats as network-order artefacts).
     if version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact() {
-        // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here;
-        // `lockfile.exact_pinned` is disjoint from `package` (returned
-        // by-value above).
-        unsafe { &mut *(*this_ptr).lockfile }.mark_exact_pin(package.meta.id);
+        this.lockfile.mark_exact_pin(package.meta.id);
     }
-    // Use scopeguard so success_fn runs on every
-    // return below (including the `?` paths). The guard owns the raw pointer so the
-    // `this` reborrow below doesn't conflict with the closure capture.
-    let mut guard = scopeguard::guard((this_ptr, package.meta.id), |(this_ptr, pkg_id)| {
-        // SAFETY: `this_ptr` came from the live exclusive `this` borrow; the
-        // guard fires after all reborrows of `this` below have ended.
-        success_fn(unsafe { &mut *this_ptr }, dependency_id, pkg_id);
-    });
-    // SAFETY: see above — sole live `&mut PackageManager` until scope exit.
-    let this: &mut PackageManager = unsafe { &mut *guard.0 };
-    // The scopeguard runs on ALL exits, never disarmed.
 
-    // non-null if the package is in "patchedDependencies"
-    let mut name_and_version_hash: Option<u64> = None;
-    let mut patchfile_hash: Option<u64> = None;
+    // `success_fn` must run on every return below (including `?`), so wrap
+    // the rest in an immediately-called closure and run `success_fn` on its
+    // way out.
+    let pkg_meta_id = package.meta.id;
+    let result = (|| {
+        // non-null if the package is in "patchedDependencies"
+        let mut name_and_version_hash: Option<u64> = None;
+        let mut patchfile_hash: Option<u64> = None;
 
-    let result = match determine_preinstall_state(
-        this,
-        &package,
-        &mut name_and_version_hash,
-        &mut patchfile_hash,
-    ) {
-        // Is this package already in the cache?
-        // We don't need to download the tarball, but we should enqueue dependencies
-        install::PreinstallState::Done => Some(ResolvedPackageResult {
-            package,
-            is_first_time: true,
-            task: None,
-        }),
-        // Do we need to download the tarball?
-        install::PreinstallState::Extract => 'extract: {
-            // Skip tarball download when prefetch_resolved_tarballs is disabled (e.g., --lockfile-only)
-            if !this
-                .options
-                .do_
-                .contains(crate::package_manager_real::options::Do::PREFETCH_RESOLVED_TARBALLS)
-            {
-                break 'extract Some(ResolvedPackageResult {
+        let result =
+            match determine_preinstall_state(
+                this,
+                &package,
+                &mut name_and_version_hash,
+                &mut patchfile_hash,
+            ) {
+                // Is this package already in the cache?
+                // We don't need to download the tarball, but we should enqueue dependencies
+                install::PreinstallState::Done => Some(ResolvedPackageResult {
                     package,
                     is_first_time: true,
                     task: None,
-                });
-            }
+                }),
+                // Do we need to download the tarball?
+                install::PreinstallState::Extract => 'extract: {
+                    // Skip tarball download when prefetch_resolved_tarballs is disabled (e.g., --lockfile-only)
+                    if !this.options.do_.contains(
+                        crate::package_manager_real::options::Do::PREFETCH_RESOLVED_TARBALLS,
+                    ) {
+                        break 'extract Some(ResolvedPackageResult {
+                            package,
+                            is_first_time: true,
+                            task: None,
+                        });
+                    }
 
-            let task_id = Task::Id::for_npm_package(
-                this.lockfile.str(&name),
-                package.resolution.npm().version,
-            );
-            debug_assert!(!this.network_dedupe_map.contains(&task_id));
+                    let task_id = Task::Id::for_npm_package(
+                        this.lockfile.str(&name),
+                        package.resolution.npm().version,
+                    );
+                    debug_assert!(!this.network_dedupe_map.contains(&task_id));
 
-            break 'extract Some(ResolvedPackageResult {
-                package,
-                is_first_time: true,
-                task: Some(ResolvedPackageTask::NetworkTask(
-                    run_tasks::generate_network_task_for_tarball(
-                        this,
-                        task_id,
-                        manifest.str(&find_result.package.tarball_url),
-                        behavior.is_required(),
-                        dependency_id,
-                        &package,
-                        name_and_version_hash,
-                        // its npm.
-                        crate::network_task::Authorization::AllowAuthorization,
-                    )?
-                    .expect("unreachable"),
-                )),
-            });
-        }
-        install::PreinstallState::CalcPatchHash => Some(ResolvedPackageResult {
-            package,
-            is_first_time: true,
-            task: Some(ResolvedPackageTask::PatchTask(
-                PatchTask::new_calc_patch_hash(
-                    this,
-                    name_and_version_hash.unwrap(),
-                    Some(EnqueueAfterState {
-                        pkg_id: package.meta.id,
-                        dependency_id,
-                        url: Box::<[u8]>::from(manifest.str(&find_result.package.tarball_url)),
-                    }),
-                ),
-            )),
-        }),
-        install::PreinstallState::ApplyPatch => Some(ResolvedPackageResult {
-            package,
-            is_first_time: true,
-            task: Some(ResolvedPackageTask::PatchTask(
-                PatchTask::new_apply_patch_hash(
-                    this,
-                    package.meta.id,
-                    patchfile_hash.unwrap(),
-                    name_and_version_hash.unwrap(),
-                ),
-            )),
-        }),
-        _ => unreachable!(),
-    };
+                    break 'extract Some(ResolvedPackageResult {
+                        package,
+                        is_first_time: true,
+                        task: Some(ResolvedPackageTask::NetworkTask(
+                            run_tasks::generate_network_task_for_tarball(
+                                this,
+                                task_id,
+                                tarball_url_tiny.slice(),
+                                behavior.is_required(),
+                                dependency_id,
+                                &package,
+                                name_and_version_hash,
+                                // its npm.
+                                crate::network_task::Authorization::AllowAuthorization,
+                            )?
+                            .expect("unreachable")
+                            .as_ptr(),
+                        )),
+                    });
+                }
+                install::PreinstallState::CalcPatchHash => Some(ResolvedPackageResult {
+                    package,
+                    is_first_time: true,
+                    task: Some(ResolvedPackageTask::PatchTask(
+                        PatchTask::new_calc_patch_hash(
+                            this,
+                            name_and_version_hash.unwrap(),
+                            Some(EnqueueAfterState {
+                                pkg_id: package.meta.id,
+                                dependency_id,
+                                url: Box::<[u8]>::from(tarball_url_tiny.slice()),
+                            }),
+                        ),
+                    )),
+                }),
+                install::PreinstallState::ApplyPatch => Some(ResolvedPackageResult {
+                    package,
+                    is_first_time: true,
+                    task: Some(ResolvedPackageTask::PatchTask(
+                        PatchTask::new_apply_patch_hash(
+                            this,
+                            package.meta.id,
+                            patchfile_hash.unwrap(),
+                            name_and_version_hash.unwrap(),
+                        ),
+                    )),
+                }),
+                _ => unreachable!(),
+            };
 
-    Ok(result)
-    // `guard` drops here → success_fn(this, dependency_id, package.meta.id)
+        Ok(result)
+    })();
+    success_fn(this, dependency_id, pkg_meta_id);
+    result
 }
 
 fn get_or_put_resolved_package(
@@ -2364,35 +2340,18 @@ fn get_or_put_resolved_package(
                 }
             }
 
-            // Resolve the version from the loaded NPM manifest
-            // reshaped for borrowck — `name_str`/`manifest` borrow
-            // `*this`; route through a raw root so the `&mut PackageManager`
-            // calls below can coexist.
-            // Snapshot the disk-fallback scalars *before* establishing
-            // `this_ptr`: `manifest_disk_cache_ctx` takes `&mut self`, and
-            // materializing `&mut *this_ptr` after `name_str`/`scope` are
-            // derived from it would pop their borrow-stack tags under SB.
+            // Resolve the version from the loaded NPM manifest.
+            //
+            // `cache_ctx` snapshots the disk-fallback scalars so `by_name_hash`
+            // only needs `&mut this.manifests`; `scope` borrows
+            // `this.options`, `name_str` borrows `this.lockfile` — all
+            // disjoint fields.
             let cache_ctx = this.manifest_disk_cache_ctx();
             let needs_ext = this.options.minimum_release_age_ms.is_some();
-            let this_ptr: *mut PackageManager = this;
-            // SAFETY: `string_bytes` is not resized between here and the
-            // `find_result` lookup; `manifest` lives in `this.manifests` and
-            // is only read. Detach the slice lifetime so `name_str` does not
-            // borrow `*this`.
-            let name_str = this.lockfile.str_detached(&name);
-
-            let scope = bun_ptr::BackRef::new(
-                // SAFETY: `this_ptr` is the live exclusive `this` borrow; `options`
-                // is read-only here and disjoint from the `manifests` mutation below.
-                unsafe { &(*this_ptr).options }.scope_for_package_name(name_str),
-            );
-            // SAFETY: `manifests` projected from `this_ptr`; the lookup holds
-            // only that disjoint field borrow alongside the shared `options`
-            // / `lockfile` projections above. `scope` points into
-            // `(*this_ptr).options`, disjoint from `manifests`.
-            let Some(manifest) = (unsafe { &mut (*this_ptr).manifests }).by_name_hash(
+            let Some(manifest) = this.manifests.by_name_hash(
                 cache_ctx,
-                scope.get(),
+                this.options
+                    .scope_for_package_name(this.lockfile.str(&name)),
                 name_hash,
                 ManifestLoad::LoadFromMemoryFallbackToDisk,
                 needs_ext,
@@ -2529,22 +2488,22 @@ fn get_or_put_resolved_package(
                 }
             };
 
-            // reshaped for borrowck — `manifest`/`find_result`
-            // borrow `this.manifests`; detach via `BackRef` so the `&mut *this`
-            // call can proceed (`this.manifests` is not mutated by the callee).
-            let manifest_ref: bun_ptr::BackRef<Npm::PackageManifest> =
-                bun_ptr::BackRef::new(manifest);
+            // Copy the 240-byte POD `PackageVersion` out so `find_result` no
+            // longer borrows `manifest` (and thus `this.manifests`); the
+            // callee re-borrows the manifest via a disjoint `&this.manifests`
+            // alongside the `&mut this.lockfile`/`known_npm_aliases` writes.
+            let find_result_version = find_result.version;
+            let find_result_package = *find_result.package;
             get_or_put_resolved_package_with_find_result(
-                // SAFETY: see `this_ptr` note above.
-                unsafe { &mut *this_ptr },
+                this,
                 name_hash,
                 name,
                 dependency,
                 version,
                 dependency_id,
                 behavior,
-                manifest_ref.get(),
-                find_result,
+                find_result_version,
+                find_result_package,
                 install_peer,
                 success_fn,
             )
@@ -2555,34 +2514,36 @@ fn get_or_put_resolved_package(
             let res: FolderResolutionValue = 'res: {
                 if this.lockfile.is_workspace_dependency(dependency_id) {
                     // relative to cwd
-                    // reshaped for borrowck — `folder_path` borrows
-                    // `string_bytes`; detach the slice lifetime so the
-                    // `&mut PackageManager` reborrow for `get_or_put` below
-                    // does not conflict.
-                    // SAFETY: `get_or_put` copies `folder_path_abs` into the
-                    // lockfile string buffer before any other mutation.
-                    let folder_path = this.lockfile.str_detached(&folder);
+                    //
+                    // Copy the folder path out of `string_bytes` into `buf2`
+                    // so the `&this.lockfile` borrow ends before the
+                    // `&mut PackageManager` reborrow for `get_or_put`.
                     let mut buf2 = PathBuffer::uninit();
-                    let folder_path_abs = if bun_paths::is_absolute(folder_path) {
-                        folder_path
-                    } else {
-                        Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                            FileSystem::instance().top_level_dir(),
-                            &mut buf2,
-                            &[folder_path],
-                        )
-                        // break :blk Path.joinAbsStringBuf(
-                        //     strings.withoutSuffixComptime(this.original_package_json_path, "package.json"),
-                        //     &buf2,
-                        //     &[_]string{folder_path},
-                        //     .auto,
-                        // );
+                    let folder_path_len = {
+                        let folder_path = this.lockfile.str(&folder);
+                        if bun_paths::is_absolute(folder_path) {
+                            buf2[..folder_path.len()].copy_from_slice(folder_path);
+                            folder_path.len()
+                        } else {
+                            Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                                FileSystem::instance().top_level_dir(),
+                                &mut buf2,
+                                &[folder_path],
+                            )
+                            // break :blk Path.joinAbsStringBuf(
+                            //     strings.withoutSuffixComptime(this.original_package_json_path, "package.json"),
+                            //     &buf2,
+                            //     &[_]string{folder_path},
+                            //     .auto,
+                            // );
+                            .len()
+                        }
                     };
 
                     break 'res FolderResolution::get_or_put(
                         GlobalOrRelative::Relative(dependency::version::Tag::Folder),
                         version,
-                        folder_path_abs,
+                        &buf2[..folder_path_len],
                         this,
                     );
                 }
@@ -2667,28 +2628,29 @@ fn get_or_put_resolved_package(
                 .get(&name_hash)
                 .copied()
                 .unwrap_or_else(|| *version.workspace());
-            // reshaped for borrowck — `workspace_path` may borrow
-            // `string_bytes`; detach the slice lifetime so the
-            // `&mut PackageManager` reborrow for `get_or_put` below does not
-            // conflict.
-            // SAFETY: `get_or_put` copies `workspace_path_u8` into the
-            // lockfile string buffer before any other mutation.
-            let workspace_path = this.lockfile.str_detached(&workspace_path_raw);
+            // Copy the workspace path out of `string_bytes` into `buf2` so
+            // the `&this.lockfile` borrow ends before the `&mut
+            // PackageManager` reborrow for `get_or_put`.
             let mut buf2 = PathBuffer::uninit();
-            let workspace_path_u8 = if bun_paths::is_absolute(workspace_path) {
-                workspace_path
-            } else {
-                Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                    FileSystem::instance().top_level_dir(),
-                    &mut buf2,
-                    &[workspace_path],
-                )
+            let workspace_path_len = {
+                let workspace_path = this.lockfile.str(&workspace_path_raw);
+                if bun_paths::is_absolute(workspace_path) {
+                    buf2[..workspace_path.len()].copy_from_slice(workspace_path);
+                    workspace_path.len()
+                } else {
+                    Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                        FileSystem::instance().top_level_dir(),
+                        &mut buf2,
+                        &[workspace_path],
+                    )
+                    .len()
+                }
             };
 
             let res = FolderResolution::get_or_put(
                 GlobalOrRelative::Relative(dependency::version::Tag::Workspace),
                 version,
-                workspace_path_u8,
+                &buf2[..workspace_path_len],
                 this,
             );
 
@@ -2712,22 +2674,27 @@ fn get_or_put_resolved_package(
             }
         }
         dependency::version::Tag::Symlink => {
-            // reshaped for borrowck — `link_dir` / `symlink_path`
-            // borrow into `*this`; detach their lifetimes so the
-            // `&mut PackageManager` reborrow for `get_or_put` does not
-            // conflict.
-            // SAFETY: `global_link_dir_path` returns a slice into the lazily-
-            // initialized `PackageManager.global_link_dir_path` (a `Box<[u8]>`
-            // set once and never freed); `get_or_put` copies `symlink_path`
-            // into the lockfile string buffer before any other mutation.
             // `version.tag == Symlink`.
-            let link_dir =
-                unsafe { detach_lifetime(package_manager_real::global_link_dir_path(this)) };
-            let symlink_path = this.lockfile.str_detached(version.symlink());
+            //
+            // Copy `link_dir` and the symlink target out of `*this` into
+            // local buffers so neither borrow overlaps the `&mut
+            // PackageManager` reborrow for `get_or_put`.
+            let mut link_buf = PathBuffer::uninit();
+            let mut path_buf = PathBuffer::uninit();
+            let link_len = {
+                let link_dir = package_manager_real::global_link_dir_path(this);
+                link_buf[..link_dir.len()].copy_from_slice(link_dir);
+                link_dir.len()
+            };
+            let path_len = {
+                let symlink_path = this.lockfile.str(version.symlink());
+                path_buf[..symlink_path.len()].copy_from_slice(symlink_path);
+                symlink_path.len()
+            };
             let res = FolderResolution::get_or_put(
-                GlobalOrRelative::Global(link_dir),
+                GlobalOrRelative::Global(&link_buf[..link_len]),
                 version,
-                symlink_path,
+                &path_buf[..path_len],
                 this,
             );
 
@@ -2802,7 +2769,7 @@ impl PackageManager {
         &mut self,
         dependency_id: DependencyID,
         package_id: PackageID,
-        alias: &[u8],
+        alias: SemverString,
         resolution: &Resolution,
         task_context: TaskCallbackContext,
     ) {
@@ -2820,7 +2787,7 @@ impl PackageManager {
     pub fn enqueue_git_for_checkout(
         &mut self,
         dependency_id: DependencyID,
-        alias: &[u8],
+        alias: SemverString,
         resolution: &Resolution,
         task_context: TaskCallbackContext,
         patch_name_and_version_hash: Option<u64>,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1084,7 +1084,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                         id,
                                                         dependency.behavior,
                                                         find_result_version,
-                                                        find_result_package,
+                                                        &find_result_package,
                                                         install_peer,
                                                         success_fn,
                                                     )
@@ -1952,8 +1952,8 @@ pub(crate) struct ResolvedPackageResult {
     pub task: Option<ResolvedPackageTask>,
 }
 
-/// Takes `find_result_package` by value (240-byte POD) instead of
-/// `Npm::FindResult<'_>` so callers can release their borrow of
+/// `find_result_package` points at a caller-owned stack copy instead of the
+/// `Npm::FindResult<'_>` borrow so callers can release their borrow of
 /// `this.manifests` before handing us `&mut PackageManager`. The manifest
 /// itself is re-borrowed here via disjoint field access on `this.manifests`
 /// (both call sites have already populated the map entry via
@@ -1967,7 +1967,7 @@ fn get_or_put_resolved_package_with_find_result(
     dependency_id: DependencyID,
     behavior: Behavior,
     find_result_version: Semver::Version,
-    find_result_package: Npm::PackageVersion,
+    find_result_package: &Npm::PackageVersion,
     install_peer: bool,
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
@@ -2028,31 +2028,22 @@ fn get_or_put_resolved_package_with_find_result(
     // appendPackage sets the PackageID on the package. `from_npm` reads the
     // manifest but only writes `lockfile` and `known_npm_aliases`, so borrow
     // `this.manifests` immutably alongside those disjoint `&mut` field
-    // borrows. The tarball URL is copied out of the manifest here as well so
-    // the `this.manifests` borrow ends before the whole-`&mut this` calls in
-    // the preinstall match below.
-    let (new_pkg, tarball_url_tiny) = {
+    // borrows.
+    let new_pkg = {
         let log = this.log_mut();
         let manifest = this
             .manifests
             .loaded_by_name_hash(name_hash)
             .expect("manifest was just loaded by caller");
-        (
-            Package::from_npm(
-                &mut this.known_npm_aliases,
-                &mut this.lockfile,
-                log,
-                manifest,
-                find_result_version,
-                &find_result_package,
-                Features::NPM,
-            )?,
-            StringOrTinyString::init_append_if_needed(
-                manifest.str(&find_result_package.tarball_url),
-                &mut crate::network_task::filename_store_appender(),
-            )
-            .expect("unreachable"),
-        )
+        Package::from_npm(
+            &mut this.known_npm_aliases,
+            &mut this.lockfile,
+            log,
+            manifest,
+            find_result_version,
+            find_result_package,
+            Features::NPM,
+        )?
     };
     let package = this.lockfile.append_package(&new_pkg)?;
 
@@ -2069,6 +2060,20 @@ fn get_or_put_resolved_package_with_find_result(
     // way out.
     let pkg_meta_id = package.meta.id;
     let result = (|| {
+        // Lazily copy the tarball URL out of `this.manifests` into the
+        // filename store (only the Extract/CalcPatchHash arms need it), then
+        // release the `&this.manifests` borrow before the whole-`&mut this`
+        // calls.
+        let tarball_url_tiny = |this: &PackageManager| {
+            StringOrTinyString::init_append_if_needed(
+                this.manifests
+                    .loaded_by_name_hash(name_hash)
+                    .expect("manifest was just loaded by caller")
+                    .str(&find_result_package.tarball_url),
+                &mut crate::network_task::filename_store_appender(),
+            )
+            .expect("unreachable")
+        };
         // non-null if the package is in "patchedDependencies"
         let mut name_and_version_hash: Option<u64> = None;
         let mut patchfile_hash: Option<u64> = None;
@@ -2106,6 +2111,7 @@ fn get_or_put_resolved_package_with_find_result(
                     );
                     debug_assert!(!this.network_dedupe_map.contains(&task_id));
 
+                    let url_tiny = tarball_url_tiny(this);
                     break 'extract Some(ResolvedPackageResult {
                         package,
                         is_first_time: true,
@@ -2113,7 +2119,7 @@ fn get_or_put_resolved_package_with_find_result(
                             run_tasks::generate_network_task_for_tarball(
                                 this,
                                 task_id,
-                                tarball_url_tiny.slice(),
+                                url_tiny.slice(),
                                 behavior.is_required(),
                                 dependency_id,
                                 &package,
@@ -2136,7 +2142,7 @@ fn get_or_put_resolved_package_with_find_result(
                             Some(EnqueueAfterState {
                                 pkg_id: package.meta.id,
                                 dependency_id,
-                                url: Box::<[u8]>::from(tarball_url_tiny.slice()),
+                                url: Box::<[u8]>::from(tarball_url_tiny(this).slice()),
                             }),
                         ),
                     )),
@@ -2503,7 +2509,7 @@ fn get_or_put_resolved_package(
                 dependency_id,
                 behavior,
                 find_result_version,
-                find_result_package,
+                &find_result_package,
                 install_peer,
                 success_fn,
             )

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -205,7 +205,7 @@ pub fn enqueue_tarball_for_download(
     if let Some(task) = run_tasks::generate_network_task_for_tarball(
         this,
         task_id,
-        url,
+        crate::network_task::intern_in_filename_store(url),
         is_required,
         dependency_id,
         &package,
@@ -406,7 +406,7 @@ pub fn enqueue_package_for_download(
     if let Some(task) = run_tasks::generate_network_task_for_tarball(
         this,
         task_id,
-        url,
+        crate::network_task::intern_in_filename_store(url),
         is_required,
         dependency_id,
         &package,
@@ -1327,7 +1327,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             if let Some(network_task) = run_tasks::generate_network_task_for_tarball(
                 this,
                 task_id,
-                &url,
+                crate::network_task::intern_in_filename_store(&url),
                 dependency.behavior.is_required(),
                 id,
                 &Package {
@@ -1528,20 +1528,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     this.task_batch.push(ThreadPool::Batch::from(task));
                 }
                 dependency::tarball::Uri::Remote(_) => {
-                    // Stage the URL in a stack buffer so the `this.lockfile`
-                    // borrow ends before the `&mut this` call;
-                    // `generate_network_task_for_tarball` interns it into the
-                    // filename store once.
-                    let mut url_buf = bun_paths::path_buffer_pool::get();
-                    let url_len = {
-                        let url = this.lockfile.str(&url_str);
-                        url_buf[..url.len()].copy_from_slice(url);
-                        url.len()
-                    };
+                    let url_tiny =
+                        crate::network_task::intern_in_filename_store(this.lockfile.str(&url_str));
                     if let Some(network_task) = run_tasks::generate_network_task_for_tarball(
                         this,
                         task_id,
-                        &url_buf[..url_len],
+                        url_tiny,
                         dependency.behavior.is_required(),
                         id,
                         &Package {
@@ -2099,20 +2091,12 @@ fn get_or_put_resolved_package_with_find_result(
                     );
                     debug_assert!(!this.network_dedupe_map.contains(&task_id));
 
-                    // Stage the URL in a pooled stack buffer so the
-                    // `&this.manifests` borrow ends before the `&mut this`
-                    // call; `generate_network_task_for_tarball` interns it
-                    // into the filename store.
-                    let mut url_buf = bun_paths::path_buffer_pool::get();
-                    let url_len = {
-                        let url = this
-                            .manifests
+                    let url_tiny = crate::network_task::intern_in_filename_store(
+                        this.manifests
                             .loaded_by_name_hash(name_hash)
                             .expect("manifest was just loaded by caller")
-                            .str(&find_result_package.tarball_url);
-                        url_buf[..url.len()].copy_from_slice(url);
-                        url.len()
-                    };
+                            .str(&find_result_package.tarball_url),
+                    );
                     break 'extract Some(ResolvedPackageResult {
                         package,
                         is_first_time: true,
@@ -2120,7 +2104,7 @@ fn get_or_put_resolved_package_with_find_result(
                             run_tasks::generate_network_task_for_tarball(
                                 this,
                                 task_id,
-                                &url_buf[..url_len],
+                                url_tiny,
                                 behavior.is_required(),
                                 dependency_id,
                                 &package,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -292,9 +292,6 @@ pub fn enqueue_git_for_checkout(
     }
 
     if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
-        // `enqueue_git_checkout` copies `resolved` into the filename store
-        // before taking `&mut *this`; do that copy here so the
-        // `this.lockfile` borrow ends before the call.
         let resolved_tiny = StringOrTinyString::init_append_if_needed(
             this.lockfile.str(&repository.resolved),
             &mut crate::network_task::filename_store_appender(),
@@ -307,7 +304,7 @@ pub fn enqueue_git_for_checkout(
             dependency_id,
             alias,
             resolution,
-            resolved_tiny.slice(),
+            resolved_tiny,
             patch_name_and_version_hash,
         );
         this.task_batch.push(ThreadPool::Batch::from(task));
@@ -1240,7 +1237,11 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     id,
                     alias,
                     &res,
-                    &resolved,
+                    StringOrTinyString::init_append_if_needed(
+                        &resolved,
+                        &mut crate::network_task::filename_store_appender(),
+                    )
+                    .expect("unreachable"),
                     None,
                 );
                 this.task_batch.push(ThreadPool::Batch::from(task));
@@ -1527,19 +1528,20 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     this.task_batch.push(ThreadPool::Batch::from(task));
                 }
                 dependency::tarball::Uri::Remote(_) => {
-                    // Copy into the filename store (no heap alloc; where
-                    // `generate_network_task_for_tarball` would copy it
-                    // anyway) so the slice no longer borrows
-                    // `this.lockfile` across the `&mut this` call.
-                    let url_tiny = StringOrTinyString::init_append_if_needed(
-                        this.lockfile.str(&url_str),
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable");
+                    // Stage the URL in a stack buffer so the `this.lockfile`
+                    // borrow ends before the `&mut this` call;
+                    // `generate_network_task_for_tarball` interns it into the
+                    // filename store once.
+                    let mut url_buf = bun_paths::path_buffer_pool::get();
+                    let url_len = {
+                        let url = this.lockfile.str(&url_str);
+                        url_buf[..url.len()].copy_from_slice(url);
+                        url.len()
+                    };
                     if let Some(network_task) = run_tasks::generate_network_task_for_tarball(
                         this,
                         task_id,
-                        url_tiny.slice(),
+                        &url_buf[..url_len],
                         dependency.behavior.is_required(),
                         id,
                         &Package {
@@ -1724,7 +1726,7 @@ pub fn enqueue_git_checkout(
     dependency_id: DependencyID,
     name: SemverString,
     resolution: &Resolution,
-    resolved: &[u8],
+    resolved: StringOrTinyString,
     // if patched then we need to do apply step after network task is done
     patch_name_and_version_hash: Option<u64>,
 ) -> *mut ThreadPool::Task {
@@ -1754,7 +1756,7 @@ pub fn enqueue_git_checkout(
             // `resolution.tag == Git` for the git-checkout path.
             StringOrTinyString::init_append_if_needed(lf.str(&resolution.git().repo), &mut store)
                 .expect("unreachable"),
-            StringOrTinyString::init_append_if_needed(resolved, &mut store).expect("unreachable"),
+            resolved,
             patch.map(|_| {
                 let dep_name_hash = lf.buffers.dependencies[dependency_id as usize].name_hash;
                 match lf
@@ -2060,20 +2062,6 @@ fn get_or_put_resolved_package_with_find_result(
     // way out.
     let pkg_meta_id = package.meta.id;
     let result = (|| {
-        // Lazily copy the tarball URL out of `this.manifests` into the
-        // filename store (only the Extract/CalcPatchHash arms need it), then
-        // release the `&this.manifests` borrow before the whole-`&mut this`
-        // calls.
-        let tarball_url_tiny = |this: &PackageManager| {
-            StringOrTinyString::init_append_if_needed(
-                this.manifests
-                    .loaded_by_name_hash(name_hash)
-                    .expect("manifest was just loaded by caller")
-                    .str(&find_result_package.tarball_url),
-                &mut crate::network_task::filename_store_appender(),
-            )
-            .expect("unreachable")
-        };
         // non-null if the package is in "patchedDependencies"
         let mut name_and_version_hash: Option<u64> = None;
         let mut patchfile_hash: Option<u64> = None;
@@ -2111,7 +2099,20 @@ fn get_or_put_resolved_package_with_find_result(
                     );
                     debug_assert!(!this.network_dedupe_map.contains(&task_id));
 
-                    let url_tiny = tarball_url_tiny(this);
+                    // Stage the URL in a pooled stack buffer so the
+                    // `&this.manifests` borrow ends before the `&mut this`
+                    // call; `generate_network_task_for_tarball` interns it
+                    // into the filename store.
+                    let mut url_buf = bun_paths::path_buffer_pool::get();
+                    let url_len = {
+                        let url = this
+                            .manifests
+                            .loaded_by_name_hash(name_hash)
+                            .expect("manifest was just loaded by caller")
+                            .str(&find_result_package.tarball_url);
+                        url_buf[..url.len()].copy_from_slice(url);
+                        url.len()
+                    };
                     break 'extract Some(ResolvedPackageResult {
                         package,
                         is_first_time: true,
@@ -2119,7 +2120,7 @@ fn get_or_put_resolved_package_with_find_result(
                             run_tasks::generate_network_task_for_tarball(
                                 this,
                                 task_id,
-                                url_tiny.slice(),
+                                &url_buf[..url_len],
                                 behavior.is_required(),
                                 dependency_id,
                                 &package,
@@ -2142,7 +2143,12 @@ fn get_or_put_resolved_package_with_find_result(
                             Some(EnqueueAfterState {
                                 pkg_id: package.meta.id,
                                 dependency_id,
-                                url: Box::<[u8]>::from(tarball_url_tiny(this).slice()),
+                                url: Box::<[u8]>::from(
+                                    this.manifests
+                                        .loaded_by_name_hash(name_hash)
+                                        .expect("manifest was just loaded by caller")
+                                        .str(&find_result_package.tarball_url),
+                                ),
                             }),
                         ),
                     )),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -292,11 +292,8 @@ pub fn enqueue_git_for_checkout(
     }
 
     if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
-        let resolved_tiny = StringOrTinyString::init_append_if_needed(
-            this.lockfile.str(&repository.resolved),
-            &mut crate::network_task::filename_store_appender(),
-        )
-        .expect("unreachable");
+        let resolved_tiny =
+            crate::network_task::intern_in_filename_store(this.lockfile.str(&repository.resolved));
         let task = enqueue_git_checkout(
             this,
             checkout_id,
@@ -1237,11 +1234,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     id,
                     alias,
                     &res,
-                    StringOrTinyString::init_append_if_needed(
-                        &resolved,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
+                    crate::network_task::intern_in_filename_store(&resolved),
                     None,
                 );
                 this.task_batch.push(ThreadPool::Batch::from(task));

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -41,6 +41,51 @@ pub fn assign_root_resolution(
     this.assign_root_resolution(dependency_id, package_id)
 }
 
+/// Free fn over the disjoint fields `Tree::print` can supply, so the tree
+/// printer doesn't need `&mut PackageManager` while `Printer` holds
+/// `&lockfile`/`&options`.
+pub fn format_later_version_in_cache<'a>(
+    manifests: &'a mut crate::PackageManifestMap,
+    options: &super::Options,
+    lockfile: &crate::lockfile_real::Lockfile,
+    name_hash: PackageNameHash,
+    resolution: &Resolution,
+) -> Option<semver::version::Formatter<'a, u64>> {
+    match resolution.tag {
+        ResolutionTag::Npm => {
+            let npm_version = resolution.npm().version;
+            if npm_version.tag.has_pre() {
+                // TODO:
+                return None;
+            }
+
+            let manifest = manifests.by_name_hash_in_memory(name_hash)?;
+
+            if let Some(latest_version) = manifest
+                .find_by_dist_tag_with_filter(
+                    b"latest",
+                    options.minimum_release_age_ms,
+                    options.minimum_release_age_excludes,
+                )
+                .unwrap()
+            {
+                if latest_version.version.order(
+                    npm_version,
+                    &manifest.string_buf,
+                    lockfile.buffers.string_bytes.as_slice(),
+                ) != core::cmp::Ordering::Greater
+                {
+                    return None;
+                }
+                return Some(latest_version.version.fmt(&manifest.string_buf));
+            }
+
+            None
+        }
+        _ => None,
+    }
+}
+
 impl PackageManager {
     pub fn format_later_version_in_cache(
         &mut self,
@@ -51,46 +96,13 @@ impl PackageManager {
         // The `.load_from_memory` arm never reads scope; keep the param for
         // signature parity.
         let _ = package_name;
-        match resolution.tag {
-            ResolutionTag::Npm => {
-                let npm_version = resolution.npm().version;
-                if npm_version.tag.has_pre() {
-                    // TODO:
-                    return None;
-                }
-
-                // reshaped for borrowck —
-                // `this.manifests.byNameHash(this, …, .load_from_memory, …)`
-                // would require simultaneous `&mut self.manifests`
-                // (receiver) and `&mut self` (arg). The memory-only path touches
-                // nothing on `PackageManager` besides the map, so use the
-                // disjoint-borrow helper and read `self.options` / `self.lockfile`
-                // alongside the held `&mut self.manifests` field borrow.
-                let manifest = self.manifests.by_name_hash_in_memory(name_hash)?;
-
-                if let Some(latest_version) = manifest
-                    .find_by_dist_tag_with_filter(
-                        b"latest",
-                        self.options.minimum_release_age_ms,
-                        self.options.minimum_release_age_excludes,
-                    )
-                    .unwrap()
-                {
-                    if latest_version.version.order(
-                        npm_version,
-                        &manifest.string_buf,
-                        self.lockfile.buffers.string_bytes.as_slice(),
-                    ) != core::cmp::Ordering::Greater
-                    {
-                        return None;
-                    }
-                    return Some(latest_version.version.fmt(&manifest.string_buf));
-                }
-
-                None
-            }
-            _ => None,
-        }
+        format_later_version_in_cache(
+            &mut self.manifests,
+            &self.options,
+            &self.lockfile,
+            name_hash,
+            resolution,
+        )
     }
 
     pub fn scope_for_package_name(&self, name: &[u8]) -> &npm::registry::Scope {

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -87,24 +87,6 @@ pub fn format_later_version_in_cache<'a>(
 }
 
 impl PackageManager {
-    pub fn format_later_version_in_cache(
-        &mut self,
-        package_name: &[u8],
-        name_hash: PackageNameHash,
-        resolution: &Resolution,
-    ) -> Option<semver::version::Formatter<'_, u64>> {
-        // The `.load_from_memory` arm never reads scope; keep the param for
-        // signature parity.
-        let _ = package_name;
-        format_later_version_in_cache(
-            &mut self.manifests,
-            &self.options,
-            &self.lockfile,
-            name_hash,
-            resolution,
-        )
-    }
-
     pub fn scope_for_package_name(&self, name: &[u8]) -> &npm::registry::Scope {
         self.options.scope_for_package_name(name)
     }

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -63,31 +63,23 @@ fn start_manifest_task(
     }
     manager.start_progress_bar_if_none();
 
-    // reshaped for borrowck — `get_network_task()`
-    // borrows `&mut manager.preallocated_network_tasks`, so compute everything
-    // that needs `&manager` *before* taking that borrow, then populate the pool
-    // slot through a raw pointer (matches `runTasks::generate_network_task_for_tarball`).
-    let scope = bun_ptr::BackRef::new(manager.scope_for_package_name(pkg_name));
-    // Backref address only — stored, not dereffed in this function.
-    let manager_backref: *mut PackageManager = manager;
-
-    // Take the pool slot as a raw pointer so borrowck releases `manager` for the
-    // `enqueue_network_task` tail.
+    // Take the pool slot as a raw pointer (the pool API is pointer-based) so
+    // the `manager` borrow is released before `enqueue_network_task`.
     let net_ptr: *mut NetworkTask = run_tasks::get_network_task(manager);
     // `write_init` is a full struct overwrite that resets every other field to
     // its struct default. The slot may be uninitialized (heap fallback) or
     // stale (reused hive slot).
     // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
     // other alias exists until we hand it to `enqueue_network_task`.
-    unsafe { NetworkTask::write_init(net_ptr, task_id, manager_backref, None) };
+    unsafe { NetworkTask::write_init(net_ptr, task_id, std::ptr::from_mut(manager), None) };
     // SAFETY: `write_init` populated every field with a drop-safe value;
     // `unsafe_http_client` is `MaybeUninit` and overwritten by `for_manifest`.
-    let task = unsafe { &mut *net_ptr };
-    // `scope` points into `manager.options` which is not mutated by
-    // `for_manifest` (it only writes the pool slot and `manager.log`).
-    task.for_manifest(
+    // `for_manifest` writes only the pool slot (disjoint from every `manager`
+    // field) and `manager.log` (a raw pointer to CLI-scope storage), so
+    // `scope`'s `&manager.options` borrow can coexist.
+    unsafe { &mut *net_ptr }.for_manifest(
         pkg_name,
-        scope.get(),
+        manager.scope_for_package_name(pkg_name),
         None,
         is_optional,
         needs_extended_manifest,

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -64,9 +64,11 @@ pub fn install_with_manager(
         }
     }
 
-    // reshaped for borrowck — `loadFromCwd` needs `manager`, `manager.lockfile`,
-    // and `manager.log` simultaneously. Route through a single
-    // raw provenance root so the three reborrows share a tag.
+    // reshaped for borrowck — `LoadResult<'a>` holds `&'a mut Lockfile`
+    // (== `manager.lockfile`) and is used alongside `manager` below, so this
+    // has to go through `load_lockfile_from_cwd`'s raw-ptr split. Dropping
+    // `LoadResultOk.lockfile` (callers already own `manager.lockfile`) would
+    // remove the alias but touches the yarn/pnpm/npm migration constructors.
     let load_result: lockfile::LoadResult = if manager.options.do_.load_lockfile() {
         let mgr: *mut PackageManager = manager;
         // SAFETY: `mgr` is the sole provenance root; `lockfile`, `*mgr`, and
@@ -1104,30 +1106,17 @@ fn print_summary_tree(
     install_summary: &PackageInstallSummary,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
-    // reshaped for borrowck — `Printer` borrows
-    // `this.lockfile` / `this.options` while `this` (the
-    // PackageManager) is also passed to `Tree::print`. Route through a single `*mut
-    // PackageManager` provenance root and reborrow disjoint fields
-    // through it: `Tree::print` only reads
-    // `manager.{updating_packages, workspace_name_hash}` and writes
-    // `manager.track_installed_bin`, none of which overlap `lockfile` /
-    // `options` / `update_requests`.
-    let mgr: *mut PackageManager = this;
-    // `mgr` is the sole provenance root from here through the `Tree::print`
-    // call; the `Printer` reborrows shared `lockfile` / `options` /
-    // `update_requests`, and the `&mut *mgr` passed to `Tree::print` only
-    // touches disjoint `PackageManager` fields. Wrapped once as `ParentRef`
-    // so the three read-only field reborrows go through safe `Deref`
-    // instead of three per-site raw projections. Safe `From<NonNull>`
-    // construction — `mgr` was just derived from `&mut *this`.
-    let mgr_ref = bun_ptr::ParentRef::<PackageManager>::from(
-        core::ptr::NonNull::new(mgr).expect("derived from &mut, non-null"),
-    );
     let printer = Printer {
-        lockfile: &mgr_ref.lockfile,
-        options: &mgr_ref.options,
-        updates: &mgr_ref.update_requests,
+        lockfile: &this.lockfile,
+        options: &this.options,
+        updates: &this.update_requests,
         successfully_installed: install_summary.successfully_installed.as_ref(),
+    };
+    let mut ctx = LockfilePrinter::Tree::TreePrintCtx {
+        updating_packages: &this.updating_packages,
+        workspace_name_hash: this.workspace_name_hash,
+        track_installed_bin: &mut this.track_installed_bin,
+        manifests: &mut this.manifests,
     };
 
     Output::flush();
@@ -1137,23 +1126,9 @@ fn print_summary_tree(
     let writer = Output::writer_buffered();
     // Runtime bool → const-generic dispatch.
     if Output::enable_ansi_colors_stdout() {
-        LockfilePrinter::Tree::print::<_, true>(
-            &printer,
-            // SAFETY: `mgr` is the sole provenance root; `Tree::print` writes only fields
-            // disjoint from `printer`'s shared `lockfile`/`options`/`update_requests` borrows.
-            unsafe { &mut *mgr },
-            writer,
-            log_level,
-        )?;
+        LockfilePrinter::Tree::print::<_, true>(&printer, &mut ctx, writer, log_level)?;
     } else {
-        LockfilePrinter::Tree::print::<_, false>(
-            &printer,
-            // SAFETY: `mgr` is the sole provenance root; `Tree::print` writes only fields
-            // disjoint from `printer`'s shared `lockfile`/`options`/`update_requests` borrows.
-            unsafe { &mut *mgr },
-            writer,
-            log_level,
-        )?;
+        LockfilePrinter::Tree::print::<_, false>(&printer, &mut ctx, writer, log_level)?;
     }
     Ok(())
 }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1751,7 +1751,7 @@ pub fn network_task_has_failed(this: &PackageManager, task_id: Task::Id) -> bool
 pub fn generate_network_task_for_tarball(
     this: &mut PackageManager,
     task_id: Task::Id,
-    url: &[u8],
+    url: strings::StringOrTinyString,
     is_required: bool,
     dependency_id: DependencyID,
     package: &Package,
@@ -1842,11 +1842,7 @@ pub fn generate_network_task_for_tarball(
         skip_verify: false,
         in_trusted_dependencies: this.lockfile.in_trusted_dependencies(pkg_name),
         integrity: package.meta.integrity,
-        url: strings::StringOrTinyString::init_append_if_needed(
-            url,
-            &mut crate::network_task::filename_store_appender(),
-        )
-        .expect("unreachable"),
+        url,
     };
 
     network_task.for_tarball(extract_tarball, scope, authorization)?;

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1,5 +1,6 @@
 use crate::lockfile::package::PackageColumns as _;
 use core::cell::Cell;
+use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 use std::io::Write as _;
 
@@ -615,18 +616,10 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 manager.task_batch.push(ThreadPoolBatch::from(queued));
             }
             NetworkTaskCallback::Extract(extract) => {
-                // reshaped for borrowck — `extract` borrows
-                // `task.callback`; the body also calls `&mut self` methods on
-                // `task` (`reset_streaming_for_retry`,
-                // `discard_unused_streaming_state`) which only touch disjoint
-                // fields. Detach via raw pointer (mirroring the
-                // `PackageManifest` arm above) so those calls don't overlap.
-                let extract_ptr: *mut ExtractTarball = extract;
-                // SAFETY: `extract` lives in `task.callback`, which outlives
-                // this match arm; the methods called on `task` below never
-                // touch `task.callback` (see `NetworkTask::reset_streaming_*`
-                // / `discard_unused_streaming_state`).
-                let extract = unsafe { &mut *extract_ptr };
+                // `extract` borrows `task.callback`; the streaming helpers
+                // below are associated fns over disjoint `task.*` fields so
+                // the borrow can stay live.
+                //
                 // Streaming extraction never pushes its NetworkTask to
                 // `async_network_task_queue` once committed — the
                 // extract Task published by `TarballStream.finish()`
@@ -665,7 +658,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         // Streaming never committed (asserted above), so
                         // the pre-allocated stream is safe to reuse for
                         // the retry attempt.
-                        task.reset_streaming_for_retry();
+                        NetworkTask::reset_streaming_for_retry(
+                            task.streaming_committed,
+                            &mut task.tarball_stream,
+                            &mut task.response,
+                        );
                         enqueue::enqueue_network_task(manager, task_ptr);
 
                         if manager.options.log_level.is_verbose() {
@@ -693,7 +690,12 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 // pre-created Task goes back to the pool and the stream
                 // buffers are freed. The buffered `enqueueExtractNPMPackage`
                 // path below allocates its own Task.
-                task.discard_unused_streaming_state(manager);
+                NetworkTask::discard_unused_streaming_state(
+                    task.streaming_committed,
+                    &mut task.tarball_stream,
+                    &mut task.streaming_extract_task,
+                    &mut manager.preallocated_resolve_tasks,
+                );
 
                 let Some(metadata) = task.response.metadata.as_ref() else {
                     let err = task
@@ -1336,52 +1338,40 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     // this dependency might be something other than a git dependency! only need the name and
                     // behavior, use the resolution from the task.
                     let dep_id = clone.dep_id;
-                    // reshaped for borrowck — copy the small `String` handles
-                    // + behavior bit so
-                    // the `&manager.lockfile` borrow doesn't extend across the
-                    // `&mut manager` calls (`has_created_network_task`,
-                    // `enqueue_git_checkout`) below; detach the slice backing
-                    // through `string_buf_ptr` (matching the
-                    // `PackageManifest`-arm `name` detach pattern above).
+                    // Copy the small `String` handles + behavior bit so the
+                    // `&manager.lockfile` borrow doesn't extend across the
+                    // `&mut manager` calls below.
                     let (dep_name_handle, is_required) = {
                         let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
                         (dep.name, dep.behavior.is_required())
                     };
-                    // SAFETY: `clone.res.tag == Git` — git-clone tasks are only
+                    // `clone.res.tag == Git` — git-clone tasks are only
                     // enqueued for git resolutions; `value.git` is the active arm.
                     let git = *clone.res.git();
-                    // SAFETY: `string_bytes` lives as long as `manager.lockfile`
-                    // and is not reallocated while resolve tasks are draining.
-                    let string_buf = unsafe {
-                        bun_ptr::detach_lifetime(manager.lockfile.buffers.string_bytes.as_slice())
-                    };
-                    let dep_name = dep_name_handle.slice(string_buf);
-                    let committish = git.committish.slice(string_buf);
-                    let repo = git.repo.slice(string_buf);
 
                     use crate::repository_real::RepositoryExt as _;
                     let resolved = crate::repository_real::Repository::find_commit(
                         manager.env_mut(),
                         manager.log_mut(),
                         repo_fd,
-                        dep_name,
-                        committish,
+                        manager.lockfile.str(&dep_name_handle),
+                        manager.lockfile.str(&git.committish),
                         task.id,
                     )?;
 
-                    let checkout_id = Task::Id::for_git_checkout(repo, &resolved);
+                    let checkout_id =
+                        Task::Id::for_git_checkout(manager.lockfile.str(&git.repo), &resolved);
 
                     if manager.has_created_network_task(checkout_id, is_required) {
                         continue;
                     }
 
-                    // reshaped for borrowck — split nested `&mut manager`.
                     let queued = enqueue::enqueue_git_checkout(
                         manager,
                         checkout_id,
                         repo_fd,
                         dep_id,
-                        dep_name,
+                        dep_name_handle,
                         &clone.res,
                         &resolved,
                         None,
@@ -1754,8 +1744,8 @@ pub fn network_task_has_failed(this: &PackageManager, task_id: Task::Id) -> bool
         .is_some_and(|e| e.failed)
 }
 
-pub fn generate_network_task_for_tarball<'a>(
-    this: &'a mut PackageManager,
+pub fn generate_network_task_for_tarball(
+    this: &mut PackageManager,
     task_id: Task::Id,
     url: &[u8],
     is_required: bool,
@@ -1763,7 +1753,7 @@ pub fn generate_network_task_for_tarball<'a>(
     package: &Package,
     patch_name_and_version_hash: Option<u64>,
     authorization: Authorization,
-) -> Result<Option<&'a mut NetworkTask>, ForTarballError> {
+) -> Result<Option<NonNull<NetworkTask>>, ForTarballError> {
     if has_created_network_task(this, task_id, is_required) {
         return Ok(None);
     }
@@ -1892,9 +1882,10 @@ pub fn generate_network_task_for_tarball<'a>(
         }
     }
 
-    // SAFETY: final reborrow of the pool slot for the caller; `net_ptr` is the
-    // sole live handle (see above) and outlives nothing past this return.
-    Ok(Some(unsafe { &mut *net_ptr }))
+    // `net_ptr` is the sole live handle to the freshly-vended pool slot; return
+    // it by pointer so the caller can schedule it alongside other `&mut
+    // PackageManager` borrows without overlapping `this`.
+    Ok(Some(NonNull::new(net_ptr).expect("pool slot is non-null")))
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1373,11 +1373,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         dep_id,
                         dep_name_handle,
                         &clone.res,
-                        strings::StringOrTinyString::init_append_if_needed(
-                            &resolved,
-                            &mut crate::network_task::filename_store_appender(),
-                        )
-                        .expect("unreachable"),
+                        crate::network_task::intern_in_filename_store(&resolved),
                         None,
                     );
                     manager.task_batch.push(ThreadPoolBatch::from(queued));

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1373,7 +1373,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         dep_id,
                         dep_name_handle,
                         &clone.res,
-                        &resolved,
+                        strings::StringOrTinyString::init_append_if_needed(
+                            &resolved,
+                            &mut crate::network_task::filename_store_appender(),
+                        )
+                        .expect("unreachable"),
                         None,
                     );
                     manager.task_batch.push(ThreadPoolBatch::from(queued));

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -122,59 +122,54 @@ fn update_package_json_and_install_with_manager_with_updates(
         Global::crash();
     }
 
-    // reshaped for borrowck — `get_with_path` returns `&mut MapEntry`
-    // borrowed from `manager.workspace_package_json_cache`, but we then need
-    // `&mut *manager` for `PackageJSONEditor::edit` / `do_patch_commit` while still
-    // holding the entry. Demote to `*mut MapEntry` and re-
-    // borrow at point of use. The cache map is not mutated again until the
-    // next `get_with_path` call below, so the pointer remains valid.
-    let current_package_json_ptr: *mut MapEntry =
-        match manager.workspace_package_json_cache.get_with_path(
-            manager.log_mut(),
-            manager.original_package_json_path.as_bytes(),
-            GetJSONOptions {
-                guess_indentation: true,
-                ..Default::default()
-            },
-        ) {
-            GetResult::ParseErr(err) => {
-                let _ = manager
-                    .log_mut()
-                    .print(std::ptr::from_mut(Output::error_writer()));
-                Output::err_generic(
-                    "failed to parse package.json \"{s}\": {s}",
-                    (
-                        BStr::new(manager.original_package_json_path.as_bytes()),
-                        err.name(),
-                    ),
-                );
-                Global::crash();
-            }
-            GetResult::ReadErr(err) => {
-                Output::err_generic(
-                    "failed to read package.json \"{s}\": {s}",
-                    (
-                        BStr::new(manager.original_package_json_path.as_bytes()),
-                        err.name(),
-                    ),
-                );
-                Global::crash();
-            }
-            GetResult::Entry(entry) => core::ptr::from_mut(entry),
-        };
-    // SAFETY: see note above — pointer into `manager.workspace_package_json_cache`,
-    // valid until the next `get_with_path`. No `&mut manager.workspace_package_json_cache`
-    // is taken across this borrow; `PackageJSONEditor` and `do_patch_commit` touch only
-    // disjoint manager fields.
-    let current_package_json: &mut MapEntry = unsafe { &mut *current_package_json_ptr };
-    let mut current_package_json_root: bun_ast::Expr = current_package_json.root;
-    let current_package_json_indent = current_package_json.indentation;
-
-    // If there originally was a newline at the end of their package.json, preserve it
-    // so that we don't cause unnecessary diffs in their git history.
-    // https://github.com/oven-sh/bun/issues/1375
-    let preserve_trailing_newline_at_eof_for_package_json =
-        current_package_json.source.contents.last() == Some(&b'\n');
+    // `get_with_path` caches the parsed entry keyed by path, so we can scope
+    // this borrow to the reads, release it for the `&mut manager` work below,
+    // and re-borrow the same cached entry (no re-read/re-parse) when we need
+    // to write `source.contents` / `reparse_root` afterwards.
+    let (
+        mut current_package_json_root,
+        current_package_json_indent,
+        preserve_trailing_newline_at_eof_for_package_json,
+    ) = match manager.workspace_package_json_cache.get_with_path(
+        manager.log_mut(),
+        manager.original_package_json_path.as_bytes(),
+        GetJSONOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    ) {
+        GetResult::ParseErr(err) => {
+            let _ = manager
+                .log_mut()
+                .print(std::ptr::from_mut(Output::error_writer()));
+            Output::err_generic(
+                "failed to parse package.json \"{s}\": {s}",
+                (
+                    BStr::new(manager.original_package_json_path.as_bytes()),
+                    err.name(),
+                ),
+            );
+            Global::crash();
+        }
+        GetResult::ReadErr(err) => {
+            Output::err_generic(
+                "failed to read package.json \"{s}\": {s}",
+                (
+                    BStr::new(manager.original_package_json_path.as_bytes()),
+                    err.name(),
+                ),
+            );
+            Global::crash();
+        }
+        // If there originally was a newline at the end of their package.json,
+        // preserve it so that we don't cause unnecessary diffs in their git
+        // history. https://github.com/oven-sh/bun/issues/1375
+        GetResult::Entry(entry) => (
+            entry.root,
+            entry.indentation,
+            entry.source.contents.last() == Some(&b'\n'),
+        ),
+    };
 
     if subcommand == Subcommand::Remove {
         if !current_package_json_root.data.is_e_object() {
@@ -346,7 +341,7 @@ fn update_package_json_and_install_with_manager_with_updates(
                         not_in_workspace_root = Some(stuff);
                     } else {
                         PackageJSONEditor::edit_patched_dependencies(
-                            manager,
+                            &manager.ast_arena,
                             &mut current_package_json_root,
                             &stuff.patch_key,
                             &stuff.patchfile_path,
@@ -359,10 +354,28 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     manager.to_update = subcommand == Subcommand::Update;
 
-    // reshaped for borrowck — the field is owning
-    // (`Box<[UpdateRequest]>`), so we transfer ownership here and re-borrow from
-    // `manager.update_requests` after `install_with_manager` (which is the only writer).
+    // The field is owning (`Box<[UpdateRequest]>`), so transfer ownership here
+    // and re-borrow from `manager.update_requests` after `install_with_manager`
+    // (which is the only writer).
     manager.update_requests = updates.into_boxed_slice();
+
+    // Re-borrow the (now-cached) entry for the `source` read/write and
+    // `reparse_root` below; `manager` is only touched via
+    // `original_package_json_path` (disjoint field) and `log_mut()` (raw
+    // pointer, detached lifetime) for the remainder of this span.
+    let log = manager.log_mut();
+    let current_package_json = manager
+        .workspace_package_json_cache
+        .get_with_path(
+            log,
+            manager.original_package_json_path.as_bytes(),
+            GetJSONOptions {
+                guess_indentation: true,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .expect("entry was cached by the first get_with_path above");
 
     let mut buffer_writer = js_printer::BufferWriter::init();
     buffer_writer.buffer.list.reserve(
@@ -411,7 +424,7 @@ fn update_package_json_and_install_with_manager_with_updates(
     // (`current_package_json_root`), so re-parse the
     // printed source so the cached AST (consumed by `FolderResolver` for workspace
     // members during `install_with_manager`) reflects the new dependency list.
-    if let Err(err) = current_package_json.reparse_root(manager.log_mut()) {
+    if let Err(err) = current_package_json.reparse_root(log) {
         bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name(),);
         Global::crash();
     }
@@ -432,49 +445,43 @@ fn update_package_json_and_install_with_manager_with_updates(
         root_package_json_path_buf[root_package_json_path_len] = 0;
         let root_package_json_path = &root_package_json_path_buf[..root_package_json_path_len];
 
-        // The lifetime of this pointer is only valid until the next call to `getWithPath`, which can happen after this scope.
+        // The lifetime of this borrow is only valid until the next call to
+        // `getWithPath`, which can happen after this scope.
         // https://github.com/oven-sh/bun/issues/12288
-        // reshaped for borrowck — see `current_package_json_ptr` above.
-        let root_package_json_ptr: *mut MapEntry =
-            match manager.workspace_package_json_cache.get_with_path(
-                manager.log_mut(),
-                root_package_json_path,
-                GetJSONOptions {
-                    guess_indentation: true,
-                    ..Default::default()
-                },
-            ) {
-                GetResult::ParseErr(err) => {
-                    let _ = manager
-                        .log_mut()
-                        .print(std::ptr::from_mut(Output::error_writer()));
-                    Output::err_generic(
-                        "failed to parse package.json \"{s}\": {s}",
-                        (BStr::new(root_package_json_path), err.name()),
-                    );
-                    Global::crash();
-                }
-                GetResult::ReadErr(err) => {
-                    Output::err_generic(
-                        "failed to read package.json \"{s}\": {s}",
-                        (
-                            BStr::new(manager.original_package_json_path.as_bytes()),
-                            err.name(),
-                        ),
-                    );
-                    Global::crash();
-                }
-                GetResult::Entry(entry) => core::ptr::from_mut(entry),
-            };
-        // SAFETY: pointer into `manager.workspace_package_json_cache`, valid until the
-        // next `get_with_path` (after this block). `edit_patched_dependencies` touches
-        // only disjoint manager fields.
-        let root_package_json: &mut MapEntry = unsafe { &mut *root_package_json_ptr };
+        let root_log = manager.log_mut();
+        let root_package_json = match manager.workspace_package_json_cache.get_with_path(
+            root_log,
+            root_package_json_path,
+            GetJSONOptions {
+                guess_indentation: true,
+                ..Default::default()
+            },
+        ) {
+            GetResult::ParseErr(err) => {
+                let _ = root_log.print(std::ptr::from_mut(Output::error_writer()));
+                Output::err_generic(
+                    "failed to parse package.json \"{s}\": {s}",
+                    (BStr::new(root_package_json_path), err.name()),
+                );
+                Global::crash();
+            }
+            GetResult::ReadErr(err) => {
+                Output::err_generic(
+                    "failed to read package.json \"{s}\": {s}",
+                    (
+                        BStr::new(manager.original_package_json_path.as_bytes()),
+                        err.name(),
+                    ),
+                );
+                Global::crash();
+            }
+            GetResult::Entry(entry) => entry,
+        };
 
         if let Some(stuff) = &not_in_workspace_root {
             let mut root_package_json_root: bun_ast::Expr = root_package_json.root;
             PackageJSONEditor::edit_patched_dependencies(
-                manager,
+                &manager.ast_arena,
                 &mut root_package_json_root,
                 &stuff.patch_key,
                 &stuff.patchfile_path,
@@ -977,4 +984,4 @@ impl fmt::Display for MoreInstructions<'_> {
 use super::TrackInstalledBin;
 use super::options::{Do, LogLevel, PatchFeatures};
 use super::package_json_editor::EditOptions;
-use super::workspace_package_json_cache::{GetJSONOptions, GetResult, MapEntry};
+use super::workspace_package_json_cache::{GetJSONOptions, GetResult};

--- a/src/install/PackageManifestMap.rs
+++ b/src/install/PackageManifestMap.rs
@@ -115,6 +115,18 @@ impl PackageManifestMap {
         }
     }
 
+    /// Shared-borrow variant of [`by_name_hash_in_memory`] that also yields an
+    /// `Expired` entry. For callers that have already ensured the entry is
+    /// loaded (via [`by_name_hash`]/[`by_name_hash_allow_expired`]) and now
+    /// want to hold `&PackageManifest` alongside `&mut` borrows of other
+    /// `PackageManager` fields.
+    pub fn loaded_by_name_hash(&self, name_hash: PackageNameHash) -> Option<&npm::PackageManifest> {
+        match self.hash_map.get(&name_hash)? {
+            Value::Manifest(m) | Value::Expired(m) => Some(m),
+            Value::NotFound => None,
+        }
+    }
+
     pub fn by_name_allow_expired(
         &mut self,
         ctx: DiskCacheCtx,

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -1184,6 +1184,27 @@ pub fn parse<'a, 'b>(
     log: impl Into<Option<&'a mut bun_ast::Log>>,
     manager: impl Into<Option<&'b mut PackageManager>>,
 ) -> Option<Version> {
+    parse_with_registry(
+        alias,
+        alias_hash,
+        dependency,
+        sliced,
+        log,
+        manager.into().map(|m| m as &mut dyn NpmAliasRegistry),
+    )
+}
+
+/// [`parse`] for callers that have already split-borrowed the
+/// `PackageManager` and can only hand over the alias map (or another
+/// `NpmAliasRegistry` impl) as a disjoint field.
+pub fn parse_with_registry<'a>(
+    alias: String,
+    alias_hash: impl Into<Option<PackageNameHash>>,
+    dependency: &[u8],
+    sliced: &SlicedString,
+    log: impl Into<Option<&'a mut bun_ast::Log>>,
+    registry: Option<&mut dyn NpmAliasRegistry>,
+) -> Option<Version> {
     let dep = strings::trim_left(dependency, b" \t\n\r");
     parse_with_tag(
         alias,
@@ -1192,7 +1213,7 @@ pub fn parse<'a, 'b>(
         Tag::infer(dep),
         sliced,
         log.into(),
-        manager.into().map(|m| m as &mut dyn NpmAliasRegistry),
+        registry,
     )
 }
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2455,7 +2455,7 @@ pub(crate) fn install_isolated_packages(
                         ResolutionTag::Git => {
                             installer.manager_mut().enqueue_git_for_checkout(
                                 dep_id,
-                                dep.name.slice(string_buf),
+                                dep.name,
                                 &pkg_res,
                                 ctx,
                                 patch_info.name_and_version_hash(),
@@ -2512,11 +2512,7 @@ pub(crate) fn install_isolated_packages(
                         }
                         ResolutionTag::LocalTarball => {
                             installer.manager_mut().enqueue_tarball_for_reading(
-                                dep_id,
-                                pkg_id,
-                                dep.name.slice(string_buf),
-                                &pkg_res,
-                                ctx,
+                                dep_id, pkg_id, dep.name, &pkg_res, ctx,
                             );
                         }
                         ResolutionTag::RemoteTarball => {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -871,11 +871,17 @@ impl Lockfile {
     }
 
     /// Is this a direct dependency of the workspace the install is taking place in?
-    pub fn is_root_dependency(&self, manager: &mut PackageManager, id: DependencyID) -> bool {
-        // `RootPackageId::get` caches into `manager`.
-        let root_id = manager
-            .root_package_id
-            .get(self, manager.workspace_name_hash);
+    ///
+    /// Takes the two `PackageManager` fields it reads instead of a full
+    /// `&mut PackageManager` so callers can hold `&self` (a borrow of
+    /// `manager.lockfile`) alongside the call.
+    pub fn is_root_dependency(
+        &self,
+        root_package_id: &mut crate::package_manager_real::RootPackageId,
+        workspace_name_hash: Option<PackageNameHash>,
+        id: DependencyID,
+    ) -> bool {
+        let root_id = root_package_id.get(self, workspace_name_hash);
         self.packages.items_dependencies()[root_id as usize].contains(id)
     }
 
@@ -1991,26 +1997,6 @@ impl Lockfile {
     #[inline]
     pub fn str<'a, T: bun_semver::Slicable>(&'a self, slicable: &'a T) -> &'a [u8] {
         slicable.slice(self.buffers.string_bytes.as_slice())
-    }
-
-    /// [`str`](Self::str) with the borrow detached from `self`.
-    ///
-    /// The install pipeline frequently needs to read a string out of
-    /// `buffers.string_bytes` and then call back into `&mut PackageManager`
-    /// (which owns the `Lockfile`). The caller would otherwise have to write
-    /// `unsafe { detach_lifetime(self.str(x)) }` at
-    /// every site. Consolidating that here keeps the SAFETY argument in one
-    /// place.
-    ///
-    /// SAFETY (internal): `string_bytes` is append-only for the lifetime of a
-    /// resolve/enqueue pass and is never reallocated while a detached slice is
-    /// live. The returned slice must not outlive the
-    /// `Lockfile`.
-    #[inline]
-    pub fn str_detached<'a, T: bun_semver::Slicable>(&self, slicable: &T) -> &'a [u8] {
-        // SAFETY: see doc comment — same invariant every prior call site
-        // already relied on via `bun_ptr::detach_lifetime`.
-        unsafe { bun_ptr::detach_lifetime(slicable.slice(self.buffers.string_bytes.as_slice())) }
     }
 
     /// Construct an empty Lockfile value in place.

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -627,7 +627,7 @@ impl Package<u64> {
     }
 
     pub fn from_npm(
-        pm: &mut PackageManager,
+        known_npm_aliases: &mut crate::package_manager_real::NpmAliasMap,
         lockfile: &mut Lockfile,
         log: &mut bun_ast::Log,
         manifest: &Npm::PackageManifest,
@@ -804,13 +804,13 @@ impl Package<u64> {
                         name: name.value,
                         name_hash: name.hash,
                         behavior,
-                        version: Dependency::parse(
+                        version: crate::dependency::parse_with_registry(
                             name.value,
                             Some(name.hash),
                             sliced.slice,
                             &sliced,
                             Some(&mut *log),
-                            Some(&mut *pm),
+                            Some(&mut *known_npm_aliases),
                         )
                         .unwrap_or_default(),
                     };

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -298,7 +298,6 @@ where
     let resolution: Resolution = packages_slice.items_resolution()[package_id as usize];
     let name = dependency.name.slice(string_buf);
 
-    let _ = packages_slice.items_name()[package_id as usize].slice(string_buf);
     if let Some(later_version_fmt) =
         crate::package_manager::package_manager_resolution::format_later_version_in_cache(
             manager.manifests,

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -3,16 +3,27 @@ use bun_io::Write;
 use bun_semver as semver;
 
 use crate::lockfile_real::package::PackageColumns as _;
-use crate::package_manager_real::TrackInstalledBin;
+use crate::package_manager_real::{PackageUpdateInfo, TrackInstalledBin};
 use bun_core::fmt::PathSep;
 use bun_install::lockfile::{Printer, package::Meta as PackageMeta};
 use bun_install::{
-    self as install, Bin, Dependency, DependencyID, INVALID_PACKAGE_ID, PackageID, PackageManager,
-    PackageNameHash, Resolution, bin, resolution,
+    self as install, Bin, Dependency, DependencyID, INVALID_PACKAGE_ID, PackageID, PackageNameHash,
+    Resolution, bin, resolution,
 };
 use bun_sys::Fd;
 
 type Bitset = DynamicBitSet;
+
+/// Disjoint `PackageManager` fields that the tree printer mutates/reads,
+/// passed alongside `Printer` (which already borrows `lockfile`/`options`/
+/// `update_requests` immutably) so [`print`] never needs `&mut
+/// PackageManager`.
+pub struct TreePrintCtx<'a> {
+    pub updating_packages: &'a bun_collections::StringArrayHashMap<PackageUpdateInfo>,
+    pub workspace_name_hash: Option<PackageNameHash>,
+    pub track_installed_bin: &'a mut TrackInstalledBin,
+    pub manifests: &'a mut crate::PackageManifestMap,
+}
 
 fn print_installed_workspace_section<
     W,
@@ -20,7 +31,7 @@ fn print_installed_workspace_section<
     const PRINT_SECTION_HEADER: bool,
 >(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &mut TreePrintCtx<'_>,
     writer: &mut W,
     workspace_package_id: PackageID,
     installed: &Bitset,
@@ -163,7 +174,7 @@ enum ShouldPrintPackageInstallResult<'a> {
 
 fn should_print_package_install<'a>(
     this: &Printer,
-    manager: &'a PackageManager,
+    manager: &'a TreePrintCtx<'_>,
     dep_id: DependencyID,
     installed: &Bitset,
     id_map: Option<&mut [DependencyID]>,
@@ -274,7 +285,7 @@ where
 
 fn print_installed_package<W, const ENABLE_ANSI_COLORS: bool>(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &mut TreePrintCtx<'_>,
     dependency: &Dependency,
     package_id: PackageID,
     writer: &mut W,
@@ -287,9 +298,15 @@ where
     let resolution: Resolution = packages_slice.items_resolution()[package_id as usize];
     let name = dependency.name.slice(string_buf);
 
-    let package_name = packages_slice.items_name()[package_id as usize].slice(string_buf);
+    let _ = packages_slice.items_name()[package_id as usize].slice(string_buf);
     if let Some(later_version_fmt) =
-        manager.format_later_version_in_cache(package_name, dependency.name_hash, &resolution)
+        crate::package_manager::package_manager_resolution::format_later_version_in_cache(
+            manager.manifests,
+            this.options,
+            this.lockfile,
+            dependency.name_hash,
+            &resolution,
+        )
     {
         if ENABLE_ANSI_COLORS {
             write!(
@@ -338,7 +355,7 @@ where
 /// - Prints a leading and trailing blank newline with diffs
 pub fn print<W, const ENABLE_ANSI_COLORS: bool>(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &mut TreePrintCtx<'_>,
     writer: &mut W,
     log_level: install::package_manager::Options::LogLevel,
 ) -> Result<(), crate::Error>
@@ -545,7 +562,7 @@ where
                 }
 
                 {
-                    if matches!(manager.track_installed_bin, TrackInstalledBin::Pending) {
+                    if matches!(*manager.track_installed_bin, TrackInstalledBin::Pending) {
                         // `bin_name`'s borrow of `iterator.buf` must end before
                         // the loop's `iterator.next()`.
                         if let Some(bin_name) = iterator.next().unwrap_or(None) {
@@ -558,7 +575,7 @@ where
                                 bstr::BStr::new(&owned[..]),
                             )?;
 
-                            manager.track_installed_bin = TrackInstalledBin::Basename(owned);
+                            *manager.track_installed_bin = TrackInstalledBin::Basename(owned);
                         }
                     }
 

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -354,7 +354,7 @@ impl PatchTask {
                             manager,
                             // TODO: not just npm package
                             task_id,
-                            url,
+                            crate::network_task::intern_in_filename_store(url),
                             is_required,
                             dep_id,
                             &pkg_again,

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -366,7 +366,8 @@ impl PatchTask {
                                 _ => Authorization::NoAuthorization,
                             },
                         )?
-                        .unwrap_or_else(|| unreachable!());
+                        .unwrap_or_else(|| unreachable!())
+                        .as_ptr();
                     if manager.get_preinstall_state(pkg_meta_id) == PreinstallState::Extract {
                         manager.set_preinstall_state(pkg_meta_id, PreinstallState::Extracting);
                         package_manager::enqueue_network_task(manager, network_task);


### PR DESCRIPTION
Part of the bucket-C borrowck cleanup (`docs/dev/borrowck-audit/bucket-C-involved-*.txt` on `farm/2a32eccb/borrowck-audit`): the 25 sites in `src/install/` that used `*mut PackageManager` + `unsafe` reborrows, `Lockfile::str_detached`, or `BackRef` wrappers to hold a `&lockfile` / `&options` / `&[u8]` slice across a `&mut PackageManager` call. This PR eliminates 21 of them by splitting the hot `&mut self` methods into associated fns over disjoint field refs and by passing `SemverString` handles (Copy) into callees that copy the slice out before mutating anything else. No heap allocations are added; in every case the bytes were already being copied into the filename store or a stack `PathBuffer`, just later.

## Why

These sites all encode the same invariant ("`string_bytes` / `manifests` is not mutated by this callee") in `unsafe` instead of in signatures. The resulting `*mut PackageManager` roots are sound only under a single provenance chain and are exactly the shape that turns into a Stacked-Borrows violation the moment a `&mut *this` is formed in the wrong order. Moving each invariant into a type-level disjoint borrow lets borrowck verify it and deletes the `SAFETY:` boilerplate.

## What changed

**`PackageManagerEnqueue.rs` (15 sites)**
- `generate_network_task_for_tarball` returns `Option<NonNull<NetworkTask>>` instead of `Option<&'a mut NetworkTask>`; the six callers schedule the pool slot without overlapping `&mut this`.
- `enqueue_local_tarball` / `enqueue_git_clone` / `enqueue_git_checkout` take `SemverString` handles and copy every lockfile-backed slice into the filename store before taking `&mut *this`. Callers no longer pre-slice with `str_detached`.
- `Lockfile::is_root_dependency` takes `&mut RootPackageId` + `workspace_name_hash` instead of `&mut PackageManager` (its only two reads).
- `Package::from_npm` takes `&mut NpmAliasMap` instead of `&mut PackageManager` (its only use was `Dependency::parse` -> `NpmAliasRegistry`). Added `dependency::parse_with_registry` for split-borrow callers.
- `get_or_put_resolved_package_with_find_result` takes the 240-byte POD `PackageVersion` by value (releasing the caller's `&this.manifests` borrow) and re-borrows the manifest internally via disjoint `&this.manifests` alongside `&mut this.lockfile` / `&mut this.known_npm_aliases`. The deferred `success_fn` moved from a `this_ptr`-capturing `scopeguard` to an immediately-called closure.
- The npm / dist-tag manifest lookup uses direct disjoint field borrows (`this.manifests` / `this.options` / `this.lockfile`) instead of `*mut PackageManager` projections.
- Folder / Workspace / Symlink `FolderResolution::get_or_put` callers copy paths into local `PathBuffer`s so the `&this.lockfile` / `&this.global_link_dir_path` borrow ends before the `&mut this` call.

**`runTasks.rs`, `PopulateManifestCache.rs`**
- `NetworkTask::{reset_streaming_for_retry, discard_unused_streaming_state}` are associated fns over the disjoint task fields so the `Extract` match arm can hold `&mut task.callback` across them.
- `start_manifest_task` populates the pool slot inline alongside a direct `&manager.options` scope lookup (no `BackRef`).
- The git-clone resolve-task arm re-slices via `manager.lockfile.str` per use instead of a detached `string_buf`.

**`install_with_manager.rs`, `updatePackageJSONAndInstall.rs`, `tree_printer.rs`**
- `Tree::print` takes a `TreePrintCtx` of the four disjoint `PackageManager` fields it touches; `format_later_version_in_cache` split into a free fn over `(manifests, options, lockfile)`.
- `update_package_json_and_install_with_manager_with_updates` scopes the first workspace-cache lookup to the three scalars it reads and re-borrows the cached entry (same map key, no re-read) after the `&mut manager` edit pass. `edit_patched_dependencies` takes `&Arena` instead of `&mut PackageManager`.

**`PackageInstaller.rs`**
- `install_package_with_name_and_resolution` binds `string_buf` as `&'a [u8]` (the `lockfile()` accessor already returns `&'a Lockfile`) instead of a `RawSlice`.

`Lockfile::str_detached` is removed (no remaining callers). Added `PackageManifestMap::loaded_by_name_hash(&self)` for the immutable re-borrow.

## Not in this change

Four sites need a deeper signature refactor that touches several external callers/types and would balloon this diff; they keep their `reshaped for borrowck` comment with the follow-up spelled out in place:

- `install_with_manager.rs:67` `load_from_cwd`: `LoadResultOk<'a>` holds `&'a mut Lockfile`, so any `&mut manager` call with a live `LoadResult` aliases by construction. Dropping that field (callers already own `manager.lockfile`) is the fix but touches the yarn/pnpm/npm migration constructors.
- `patchPackage.rs:1205` `tree::Iterator` `.to_vec()` in a cold `bun patch` path; fixing requires a `tree::Iterator` path accessor plus `pkg_info_for_name_and_version` returning a borrow through 4 callers.
- `PackageInstaller.rs:719` `package_name.clone()` for the spawn error message; fixing requires `spawn_package_lifecycle_scripts` to hand the `ScriptsList` back on `Err` (5 callers).
- `PackageInstaller.rs:1288` `PackageInstall` holding `&self.node_modules` across `increment_tree_install_count(&mut self)`; fixing requires `PackageInstall` to stop storing `node_modules` / `lockfile` and thread them to its methods (~10 signatures in `PackageInstall.rs`).

## Verification

`cargo check -p bun_install` clean. `bun bd test test/cli/install/{bun-install,bun-add,bun-update,bun-remove,bun-pm,bun-workspaces,bun-link,bun-install-patch,bun-install-streaming-extract,bun-install-retry}.test.ts` has zero regressions against HEAD (failures present are the pre-existing external-network gitlab/bitbucket tests and the lifecycle-script `ensureTempNodeGypScript` / `node -p` container-PATH failures that also fail on HEAD).

Net: -12 lines across 17 files.