### PR TITLE
cli: fix UpdateInteractiveCommand crash-report char collision with UnlinkCommand

### DIFF
--- a/src/options_types/command_tag.rs
+++ b/src/options_types/command_tag.rs
@@ -49,7 +49,7 @@ impl Tag {
     /// Used by crash reports.
     ///
     /// This must be kept in sync with https://github.com/oven-sh/bun.report/blob/62601d8aafb9c0d29554dfc3f8854044ec04d367/backend/remap.ts#L10
-    pub fn char(self) -> u8 {
+    pub const fn char(self) -> u8 {
         match self {
             Tag::AddCommand => b'I',
             Tag::AutoCommand => b'a',
@@ -78,7 +78,7 @@ impl Tag {
             Tag::PatchCommand => b'x',
             Tag::PatchCommitCommand => b'z',
             Tag::OutdatedCommand => b'o',
-            Tag::UpdateInteractiveCommand => b'U',
+            Tag::UpdateInteractiveCommand => b'q',
             Tag::PublishCommand => b'k',
             Tag::AuditCommand => b'A',
             Tag::WhyCommand => b'W',
@@ -126,11 +126,62 @@ impl Tag {
     /// tables below can size themselves without naming the trait at every use.
     pub const COUNT: usize = <Self as Enum>::LENGTH;
 
+    /// Every variant, for const iteration (enum_map's `from_usize` is not const).
+    /// The length check in the uniqueness assertion below fails to compile if a
+    /// variant is added here but not in this list.
+    const ALL: [Self; Self::COUNT] = [
+        Self::AddCommand,
+        Self::AutoCommand,
+        Self::BuildCommand,
+        Self::BunxCommand,
+        Self::CreateCommand,
+        Self::DiscordCommand,
+        Self::GetCompletionsCommand,
+        Self::HelpCommand,
+        Self::InitCommand,
+        Self::InfoCommand,
+        Self::InstallCommand,
+        Self::InstallCompletionsCommand,
+        Self::LinkCommand,
+        Self::PackageManagerCommand,
+        Self::RemoveCommand,
+        Self::RunCommand,
+        Self::RunAsNodeCommand,
+        Self::TestCommand,
+        Self::UnlinkCommand,
+        Self::UpdateCommand,
+        Self::UpgradeCommand,
+        Self::ReplCommand,
+        Self::ReservedCommand,
+        Self::ExecCommand,
+        Self::PatchCommand,
+        Self::PatchCommitCommand,
+        Self::OutdatedCommand,
+        Self::UpdateInteractiveCommand,
+        Self::PublishCommand,
+        Self::AuditCommand,
+        Self::WhyCommand,
+        Self::FuzzilliCommand,
+    ];
+
     // Heavy methods that pull in `Arguments` / help text live in the CLI crate.
     // Re-exporting
     // `bun_runtime::cli::Command::{tag_params, tag_print_help}` here would create a
     // crate cycle (cli → options_types → cli).
 }
+
+/// Compile-time proof that every [`Tag::char`] byte is distinct. A collision
+/// here means bun.report cannot tell the two subcommands apart.
+const _: () = {
+    let mut seen = [false; 256];
+    let mut i = 0;
+    while i < Tag::COUNT {
+        let c = Tag::ALL[i].char() as usize;
+        assert!(!seen[c], "Tag::char() collision: two subcommands share a byte");
+        seen[c] = true;
+        i += 1;
+    }
+};
 
 /// `.rodata` flag table indexed by [`Tag`] discriminant. These tables cost zero
 /// init code on the startup path.

--- a/src/options_types/command_tag.rs
+++ b/src/options_types/command_tag.rs
@@ -177,7 +177,10 @@ const _: () = {
     let mut i = 0;
     while i < Tag::COUNT {
         let c = Tag::ALL[i].char() as usize;
-        assert!(!seen[c], "Tag::char() collision: two subcommands share a byte");
+        assert!(
+            !seen[c],
+            "Tag::char() collision: two subcommands share a byte"
+        );
         seen[c] = true;
         i += 1;
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1985,9 +1985,11 @@ where
         // A request that does not name "websocket" in its |Upgrade| token list,
         // or whose |Sec-WebSocket-Key| is not base64 of 16 bytes, is not a
         // WebSocket handshake; fall through so the caller's fetch() can respond.
-        if !upgrade_header.slice().split(|&c| c == b',').any(|t| {
-            strings::eql_case_insensitive_ascii(t.trim_ascii(), b"websocket", true)
-        }) {
+        if !upgrade_header
+            .slice()
+            .split(|&c| c == b',')
+            .any(|t| strings::eql_case_insensitive_ascii(t.trim_ascii(), b"websocket", true))
+        {
             return Ok(JSValue::FALSE);
         }
         if !is_valid_sec_websocket_key(sec_websocket_key_str.slice()) {


### PR DESCRIPTION
### Problem

`Tag::char()` (`src/options_types/command_tag.rs`) maps both `UnlinkCommand` and `UpdateInteractiveCommand` to `b'U'`:

```rust
Tag::UnlinkCommand => b'U',
...
Tag::UpdateInteractiveCommand => b'U',
```

So crash reports from `bun update -i` encode the same command byte as `bun unlink` and are labeled `UnlinkCommand` in bun.report/Sentry. bun.report's `command_map` already has `q: "UpdateInteractiveCommand"`, but bun never emitted `'q'`. The collision has existed since the Zig version (pre-port).

### Fix

- `UpdateInteractiveCommand => b'q'` to match bun.report's decoder.
- Make `char()` a `const fn` and add a compile-time assertion that every byte is distinct, iterating a `Tag::ALL` array sized by `Tag::COUNT` so a forgotten variant also fails to compile.

Reintroducing the `'U'` collision with this patch applied:

```
error[E0080]: evaluation panicked: Tag::char() collision: two subcommands share a byte
```

No bun.report change needed: `'q'` is already in its `command_map`. Old bun builds that still send `'U'` for `update -i` cannot be disambiguated from `unlink` on the backend (same byte on the wire); new builds are unambiguous.

### Verification

- `cargo check -p bun_options_types` (x86_64-linux, aarch64-linux, x86_64-windows): clean
- `cargo clippy -p bun_options_types`: clean
- Assertion verified to fire by temporarily reverting to `b'U'` (E0080 as above)