### PR TITLE
test(install): fix yarn-lock-migration yarn-cli-repo case under debug+ASAN

### DIFF
--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1369,7 +1369,12 @@ describe("bun pm migrate for existing yarn.lock", () => {
         stdin: "ignore",
       });
 
-      const exitCode = await migrateResult.exited;
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(migrateResult.stdout).text(),
+        new Response(migrateResult.stderr).text(),
+        migrateResult.exited,
+      ]);
+
       expect(exitCode).toBe(0);
       expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
 

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isDebug, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 describe("yarn.lock migration basic", () => {
@@ -1348,30 +1348,36 @@ describe("bun pm migrate for existing yarn.lock", () => {
     "yarn-stuff",
     "yarn-stuff/abbrev-link-target",
   ];
-  test.each(folders)("%s", async folder => {
-    const packageJsonContent = await Bun.file(join(import.meta.dir, "yarn", folder, "package.json")).text();
-    const yarnLockContent = await Bun.file(join(import.meta.dir, "yarn", folder, "yarn.lock")).text();
+  // yarn-cli-repo is yarn's own lockfile (~8k lines) and needs more than the 5s default under debug+ASAN.
+  test.each(folders)(
+    "%s",
+    async folder => {
+      const packageJsonContent = await Bun.file(join(import.meta.dir, "yarn", folder, "package.json")).text();
+      const yarnLockContent = await Bun.file(join(import.meta.dir, "yarn", folder, "yarn.lock")).text();
 
-    const tempDir = tempDirWithFiles("yarn-lock-migration-", {
-      "package.json": packageJsonContent,
-      "yarn.lock": yarnLockContent,
-    });
+      const tempDir = tempDirWithFiles("yarn-lock-migration-", {
+        "package.json": packageJsonContent,
+        "yarn.lock": yarnLockContent,
+      });
 
-    const migrateResult = Bun.spawn({
-      cmd: [bunExe(), "pm", "migrate", "-f"],
-      cwd: tempDir,
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
-    });
+      const migrateResult = Bun.spawn({
+        cmd: [bunExe(), "pm", "migrate", "-f"],
+        cwd: tempDir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
 
-    expect(migrateResult.exited).resolves.toBe(0);
-    expect(Bun.file(join(tempDir, "bun.lock")).exists()).resolves.toBe(true);
+      const exitCode = await migrateResult.exited;
+      expect(exitCode).toBe(0);
+      expect(fs.existsSync(join(tempDir, "bun.lock"))).toBe(true);
 
-    const bunLockContent = await Bun.file(join(tempDir, "bun.lock")).text();
-    expect(bunLockContent).toMatchSnapshot(folder);
-  });
+      const bunLockContent = await Bun.file(join(tempDir, "bun.lock")).text();
+      expect(bunLockContent).toMatchSnapshot(folder);
+    },
+    isDebug ? 60_000 : undefined,
+  );
 
   test("yarn.lock with packages that have os/cpu requirements", async () => {
     const tempDir = tempDirWithFiles("yarn-migration-os-cpu", {


### PR DESCRIPTION
## What

`bun bd test test/cli/install/migration/yarn-lock-migration.test.ts -t yarn-cli-repo` fails on main under debug+ASAN:

```
(fail) bun pm migrate for existing yarn.lock > yarn-cli-repo [5090.95ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
error: expect(received).toBe(expected)
Expected: 0
Received: 143
      at yarn-lock-migration.test.ts:1369
```

Passes under release (`USE_SYSTEM_BUN=1`, ~700ms).

## Why

Two issues compound:

1. The `test.each` body called `expect(migrateResult.exited).resolves.toBe(0)` and `expect(...exists()).resolves.toBe(true)` without `await`, leaving the assertions as floating promises that race the rest of the test body.
2. The `yarn-cli-repo` fixture is yarn's own ~8k-line `yarn.lock`. `bun pm migrate` on it takes ~5-8s under debug+ASAN locally, over the 5s default test timeout. The runner times out, kills the child with SIGTERM, and the floating `.resolves.toBe(0)` later fires with `143` as an unhandled error between tests.

   About half of that wall time is `populate_manifest_cache` fetching ~900 package manifests from registry.npmjs.org to enrich the migrated lockfile with bin/os/cpu metadata (added in #23143); the other half is the ASAN slowdown on parsing/printing. Pointing the registry at a dead address brings debug down to ~4.2s, but that changes the snapshot (drops all `"bin"` entries) and the network dependency is file-wide, so it's left as-is here.

## Fix

- Await the subprocess exit and drain stdout/stderr concurrently via `Promise.all`, matching the pattern used by the other tests in this file.
- Give this parameterised block a 60s timeout when running a debug build (`isDebug ? 60_000 : undefined`). Release builds keep the 5s default.

The `await` portion overlaps with the broader sweep in #33279; this PR is the minimal change to get this specific case green under `bun bd`.

## Verification

```
# before (main, debug+ASAN)
(fail) bun pm migrate for existing yarn.lock > yarn-cli-repo   # timeout + exit 143

# after (debug+ASAN)
(pass) bun pm migrate for existing yarn.lock > yarn-cli-repo [5486.04ms]
... 16 pass, 0 fail

# after (release)
(pass) bun pm migrate for existing yarn.lock > yarn-cli-repo [722.60ms]
... 16 pass, 0 fail
```

Test-only change; no `src/` diff.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/migration/yarn-lock-migration.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/migration/yarn-lock-migration.test.ts
bun test v1.4.0 (95e73e229)

test/cli/install/migration/yarn-lock-migration.test.ts:
(pass) yarn.lock migration basic > simple yarn.lock migration produces correct bun.lock [364.65ms]
(pass) yarn.lock migration basic > yarn.lock with packages containing long build tags [1659.48ms]
(pass) yarn.lock migration basic > yarn.lock with extremely long build tags (regression test) [379.84ms]
(pass) yarn.lock migration basic > complex yarn.lock with multiple dependencies and versions [2670.61ms]
(pass) yarn.lock migration basic > yarn.lock with npm aliases [1253.04ms]
(pass) yarn.lock migration basic > yarn.lock with resolutions [653.92ms]
(pass) yarn.lock migration basic > yarn.lock with workspace dependencies [397.28ms]
(pass) yarn.lock migration basic > yarn.lock with scoped packages and parent/child relationships [427.71ms]
(pass) yarn.lock migration basic > migration with realistic complex yarn.lock [2105.93ms]
(pass) bun pm migrate for existing yarn.lock > yarn-cli-repo [5042.37ms]
(pass) bun pm migrate for existing yarn.lock > yarn-lock-mkdirp [355.78ms]
(pass) bun pm migrate for existing yarn.lock > yarn-lock-mkdirp-file-dep [202.21ms]
(pass) bun pm migrate for existing yarn.lock > yarn-lock-mkdirp-no-resolved [408.64ms]
(pass) bun pm migrate for existing yarn.lock > yarn-stuff [459.54ms]
(pass) bun pm migrate for existing yarn.lock > yarn-stuff/abbrev-link-target [135.46ms]
(pass) bun pm migrate for existing yarn.lock > yarn.lock with packages that have os/cpu requirements [695.09ms]

 16 pass
 0 fail
 14 snapshots, 70 expect() calls
Ran 16 tests across 1 file. [19.46s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../install/migration/yarn-lock-migration.test.ts  | 61 +++++++++++++---------
 1 file changed, 36 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
test/cli/install/migration/yarn-lock-migration.test.ts      5      7      0
```

</details>

<!-- robobun:evidence:end -->