### PR TITLE
tls: hold the handshake's final flight until on_handshake decides

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -508,7 +508,10 @@ static long BIO_s_custom_ctrl(BIO *bio, int cmd, long num, void *user) {
  * from inside SSL_do_handshake/SSL_read: user JS that writes to or destroys a
  * different TLS socket on the same loop re-points loop_ssl_data->ssl_socket
  * (and may consume the read-input window), and the interrupted handshake's
- * next BIO_write would otherwise land on that other socket's fd. */
+ * next BIO_write would otherwise land on that other socket's fd. The batching
+ * flag is saved-and-zeroed so a close_notify / write on a different socket
+ * reaches that socket's fd via the per-record BIO path instead of appending
+ * to the interrupted handshake's batch buffer. */
 void us_internal_ssl_loop_state_save(void *ssl_ptr, void **out) {
   SSL *ssl = (SSL *)ssl_ptr;
   struct loop_ssl_data *d = (struct loop_ssl_data *)BIO_get_data(SSL_get_wbio(ssl));
@@ -517,6 +520,8 @@ void us_internal_ssl_loop_state_save(void *ssl_ptr, void **out) {
   out[2] = d ? (void *)d->ssl_read_input : NULL;
   out[3] = d ? (void *)(uintptr_t)d->ssl_read_input_length : NULL;
   out[4] = d ? (void *)(uintptr_t)d->ssl_read_input_offset : NULL;
+  out[5] = d ? (void *)(uintptr_t)d->ssl_write_batching : NULL;
+  if (d) d->ssl_write_batching = 0;
 }
 
 void us_internal_ssl_loop_state_restore(void **saved) {
@@ -526,6 +531,7 @@ void us_internal_ssl_loop_state_restore(void **saved) {
   d->ssl_read_input = (char *)saved[2];
   d->ssl_read_input_length = (unsigned int)(uintptr_t)saved[3];
   d->ssl_read_input_offset = (unsigned int)(uintptr_t)saved[4];
+  d->ssl_write_batching = (int)(uintptr_t)saved[5];
 }
 
 static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
@@ -2675,7 +2681,7 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
   struct loop_ssl_data *cb_lsd = (struct loop_ssl_data *)BIO_get_data(SSL_get_wbio(ssl));
   struct us_socket_t *cb_socket = cb_lsd ? cb_lsd->ssl_socket : NULL;
 
-  void *saved_loop_state[5];
+  void *saved_loop_state[6];
   us_internal_ssl_loop_state_save(ssl, saved_loop_state);
   int abort_handshake = 0;
   SSL_CTX *dyn = ls->on_server_name(ls, hostname, &abort_handshake, cb_socket);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -598,6 +598,14 @@ static int ssl_flush_write_batch(struct loop_ssl_data *loop_ssl_data, struct us_
   if (written < 0) written = 0;
   if ((unsigned int)written < len) {
     unsigned int remainder = len - (unsigned int)written;
+    if (loop_ssl_data->ssl_spill_owner) {
+      /* The spill slot is already taken (a re-entrant JS region under
+       * SNI/ALPN produced one for another socket between the entry-time
+       * gate and this flush). Overwriting it would leak and corrupt that
+       * socket's stream; this socket's remainder is undeliverable. */
+      s->ssl_fatal_error = 1;
+      return 0;
+    }
     char *spill = us_malloc(remainder);
     if (!spill) {
       /* Out of memory with ciphertext in flight: the connection cannot stay

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1847,7 +1847,11 @@ static void ssl_update_handshake(struct us_socket_t *s) {
 
   struct loop_ssl_data *loop_ssl_data =
       (struct loop_ssl_data *)s->group->loop->data.ssl_data;
-  int batching = loop_ssl_data && !loop_ssl_data->ssl_write_batching;
+  /* Same gate as us_internal_ssl_write: an occupied spill slot means a later
+   * ssl_flush_write_batch could short-write into it and clobber another
+   * socket's pending ciphertext, so write through per record instead. */
+  int batching = loop_ssl_data && !loop_ssl_data->ssl_write_batching &&
+                 !loop_ssl_data->ssl_spill_owner;
   if (batching) loop_ssl_data->ssl_write_batching = 1;
 
   unsigned char ssl_was_in_use = s->ssl_in_use;
@@ -2089,9 +2093,12 @@ restart:
     /* While the handshake is pending, SSL_read may seal this side's final
      * flight (TLS 1.3 client Finished, TLS 1.2 server Finished). Batch it so
      * ssl_trigger_handshake_success can let the JS on_handshake callback
-     * discard it when verification is rejected. */
+     * discard it when verification is rejected. Same gate as
+     * us_internal_ssl_write: only when the spill slot is free, so a later
+     * flush cannot short-write over another socket's pending spill. */
     int hs_batching = s->ssl_handshake_state == HANDSHAKE_PENDING &&
-                      !loop_ssl_data->ssl_write_batching;
+                      !loop_ssl_data->ssl_write_batching &&
+                      !loop_ssl_data->ssl_spill_owner;
     if (hs_batching) loop_ssl_data->ssl_write_batching = 1;
     unsigned char ssl_was_in_use = s->ssl_in_use;
     s->ssl_in_use = 1;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -110,6 +110,12 @@ struct loop_ssl_data {
   char *ssl_spill;
   unsigned int ssl_spill_len;
   unsigned int ssl_spill_off;
+  /* Set while the spill holds a handshake's final flight that the JS
+   * on_handshake callback may still discard (node's memory-BIO lets destroy()
+   * drop enc_out_ before EncOut flushes it; here the owner's close path frees
+   * the spill without the last-chance drain). Cleared - and the spill drained
+   * normally - once that callback returns without closing the socket. */
+  int ssl_spill_discard_on_close;
 };
 
 enum {
@@ -465,6 +471,7 @@ static inline struct us_ssl_reneg_state_t *us_reneg_state(SSL *ssl) {
 extern void us_internal_socket_raw_shutdown(struct us_socket_t *s);
 
 static void ssl_update_handshake(struct us_socket_t *s);
+static inline int ssl_gone(struct us_socket_t *s);
 
 /* ── BIO plumbing ─────────────────────────────────────────────────────────
  * The same shared mem-BIO pair is reused for every SSL* on a loop. The write
@@ -597,6 +604,7 @@ static int ssl_flush_write_batch(struct loop_ssl_data *loop_ssl_data, struct us_
     loop_ssl_data->ssl_spill_len = remainder;
     loop_ssl_data->ssl_spill_off = 0;
     loop_ssl_data->ssl_spill_owner = s;
+    loop_ssl_data->ssl_spill_discard_on_close = 0;
     return 0;
   }
   return 1;
@@ -616,6 +624,7 @@ static int ssl_drain_spill(struct loop_ssl_data *loop_ssl_data, struct us_socket
     loop_ssl_data->ssl_spill_len = 0;
     loop_ssl_data->ssl_spill_off = 0;
     loop_ssl_data->ssl_spill_owner = NULL;
+    loop_ssl_data->ssl_spill_discard_on_close = 0;
     return 1;
   }
   return 0;
@@ -625,11 +634,19 @@ static int ssl_drain_spill(struct loop_ssl_data *loop_ssl_data, struct us_socket
 static void ssl_release_spill(struct us_loop_t *loop, struct us_socket_t *s) {
   struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)loop->data.ssl_data;
   if (loop_ssl_data && loop_ssl_data->ssl_spill_owner == s) {
-    /* Hard close with ciphertext still spilled: give the kernel one last
-     * chance to take it (it usually can - the spill is bounded small). */
-    ssl_drain_spill(loop_ssl_data, s);
+    if (loop_ssl_data->ssl_spill_discard_on_close) {
+      /* The held handshake flight is being dropped; the peer never saw this
+       * side finish, so any further TLS record (close_notify) would arrive
+       * under keys it has not installed. Suppress them. */
+      s->ssl_fatal_error = 1;
+    } else {
+      /* Hard close with ciphertext still spilled: give the kernel one last
+       * chance to take it (it usually can - the spill is bounded small). */
+      ssl_drain_spill(loop_ssl_data, s);
+    }
   }
   if (loop_ssl_data && loop_ssl_data->ssl_spill_owner == s) {
+    loop_ssl_data->ssl_spill_discard_on_close = 0;
     us_free(loop_ssl_data->ssl_spill);
     loop_ssl_data->ssl_spill = NULL;
     loop_ssl_data->ssl_spill_len = 0;
@@ -1590,6 +1607,54 @@ static void ssl_trigger_handshake(struct us_socket_t *s, int success) {
   us_dispatch_handshake(s, success, verify_error);
 }
 
+/* Dispatch on_handshake(success=1) while the handshake's final flight sits in
+ * the batch buffer. Node's TLSWrap seals handshake records into a memory BIO
+ * and runs JS from the SSL_CB_HANDSHAKE_DONE info callback before EncOut
+ * copies enc_out_ to the TCP stream, so a verify-rejecting client's destroy()
+ * drops that flight and the server's handshake never completes. Here the
+ * batched flight is parked in the spill slot with discard-on-close set: a
+ * close from inside the callback frees it without draining, and any
+ * us_internal_ssl_write the callback issues drains it first so wire order is
+ * preserved when the connection is kept. */
+static void ssl_trigger_handshake_success(struct us_socket_t *s,
+                                          struct loop_ssl_data *loop_ssl_data) {
+  unsigned int len = loop_ssl_data ? loop_ssl_data->ssl_write_batch_len : 0;
+  if (!len || loop_ssl_data->ssl_spill_owner) {
+    if (len) ssl_flush_write_batch(loop_ssl_data, s);
+    ssl_trigger_handshake(s, 1);
+    return;
+  }
+  char *held = us_malloc(len);
+  if (!held) {
+    ssl_flush_write_batch(loop_ssl_data, s);
+    ssl_trigger_handshake(s, 1);
+    return;
+  }
+  memcpy(held, loop_ssl_data->ssl_write_batch, len);
+  loop_ssl_data->ssl_write_batch_len = 0;
+  loop_ssl_data->ssl_spill = held;
+  loop_ssl_data->ssl_spill_len = len;
+  loop_ssl_data->ssl_spill_off = 0;
+  loop_ssl_data->ssl_spill_owner = s;
+  loop_ssl_data->ssl_spill_discard_on_close = 1;
+
+  ssl_trigger_handshake(s, 1);
+
+  if (loop_ssl_data->ssl_spill_owner == s &&
+      loop_ssl_data->ssl_spill_discard_on_close) {
+    loop_ssl_data->ssl_spill_discard_on_close = 0;
+    if (!ssl_gone(s)) {
+      ssl_drain_spill(loop_ssl_data, s);
+    } else {
+      us_free(loop_ssl_data->ssl_spill);
+      loop_ssl_data->ssl_spill = NULL;
+      loop_ssl_data->ssl_spill_len = 0;
+      loop_ssl_data->ssl_spill_off = 0;
+      loop_ssl_data->ssl_spill_owner = NULL;
+    }
+  }
+}
+
 static void ssl_trigger_handshake_econnreset(struct us_socket_t *s) {
   s->ssl_handshake_state = HANDSHAKE_COMPLETED;
   /* A fatal SSL protocol error (wrong version number, bad record, ...) was
@@ -1711,7 +1776,9 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
   if (code == LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN && !reason
       && !s->ssl_close_after_spill && !s->ssl_fatal_error && !us_socket_is_closed(s)) {
     struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
-    if (loop_ssl_data && !ssl_drain_spill(loop_ssl_data, s)) {
+    if (loop_ssl_data && !(loop_ssl_data->ssl_spill_owner == s &&
+                           loop_ssl_data->ssl_spill_discard_on_close) &&
+        !ssl_drain_spill(loop_ssl_data, s)) {
       s->ssl_close_after_spill = 1;
       return s;
     }
@@ -1778,48 +1845,62 @@ static void ssl_update_handshake(struct us_socket_t *s) {
     return;
   }
 
+  struct loop_ssl_data *loop_ssl_data =
+      (struct loop_ssl_data *)s->group->loop->data.ssl_data;
+  int batching = loop_ssl_data && !loop_ssl_data->ssl_write_batching;
+  if (batching) loop_ssl_data->ssl_write_batching = 1;
+
   unsigned char ssl_was_in_use = s->ssl_in_use;
   s->ssl_in_use = 1;
   int result = SSL_do_handshake(s_ssl(s));
   s->ssl_in_use = ssl_was_in_use;
+
+  if (batching) loop_ssl_data->ssl_write_batching = 0;
   if (!ssl_was_in_use && s->ssl_pending_detach) {
     /* A callback run from inside the handshake destroyed this socket; perform
      * the deferred close now and do not touch the SSL again. */
+    if (batching) loop_ssl_data->ssl_write_batch_len = 0;
     s->ssl_pending_detach = 0;
     us_socket_close(s, s->ssl_pending_close_code, NULL);
     return;
   }
 
   if (SSL_get_shutdown(s_ssl(s)) & SSL_RECEIVED_SHUTDOWN) {
+    if (batching) ssl_flush_write_batch(loop_ssl_data, s);
     ssl_close(s, 0, NULL);
     return;
   }
 
-  if (result <= 0) {
-    int err = SSL_get_error(s_ssl(s), result);
-    if (err == SSL_ERROR_PENDING_CERTIFICATE) {
-      /* Suspended by an async SNICallback: stay in HANDSHAKE_PENDING with no
-       * poll re-arm; us_socket_sni_resolve() re-drives the handshake when the
-       * JS resolution arrives. */
-      s->ssl_handshake_state = HANDSHAKE_PENDING;
-      return;
-    }
-    if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
-      if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
-        ssl_park_fatal_reason(s);
-      }
-      ssl_trigger_handshake(s, 0);
-      return;
-    }
-    s->ssl_handshake_state = HANDSHAKE_PENDING;
+  if (result > 0) {
+    ssl_trigger_handshake_success(s, batching ? loop_ssl_data : NULL);
+    if (ssl_gone(s)) return;
     s->ssl_write_wants_read = 1;
-    s->flags.last_write_failed = 1;
     return;
   }
 
-  ssl_trigger_handshake(s, 1);
-  if (ssl_gone(s)) return;
+  /* Non-success paths: the batched records are this round's outbound flight
+   * (ClientHello, server Hello/Cert/Finished, an alert) - send them now so the
+   * peer can progress. */
+  if (batching) ssl_flush_write_batch(loop_ssl_data, s);
+
+  int err = SSL_get_error(s_ssl(s), result);
+  if (err == SSL_ERROR_PENDING_CERTIFICATE) {
+    /* Suspended by an async SNICallback: stay in HANDSHAKE_PENDING with no
+     * poll re-arm; us_socket_sni_resolve() re-drives the handshake when the
+     * JS resolution arrives. */
+    s->ssl_handshake_state = HANDSHAKE_PENDING;
+    return;
+  }
+  if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+    if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
+      ssl_park_fatal_reason(s);
+    }
+    ssl_trigger_handshake(s, 0);
+    return;
+  }
+  s->ssl_handshake_state = HANDSHAKE_PENDING;
   s->ssl_write_wants_read = 1;
+  s->flags.last_write_failed = 1;
 }
 
 /* ── Event hooks (called from loop.c / socket.c when s->ssl != NULL) ────── */
@@ -2005,15 +2086,30 @@ struct us_socket_t *us_internal_ssl_on_data(struct us_socket_t *s, char *data, i
   int read = 0;
 restart:
   while (1) {
+    /* While the handshake is pending, SSL_read may seal this side's final
+     * flight (TLS 1.3 client Finished, TLS 1.2 server Finished). Batch it so
+     * ssl_trigger_handshake_success can let the JS on_handshake callback
+     * discard it when verification is rejected. */
+    int hs_batching = s->ssl_handshake_state == HANDSHAKE_PENDING &&
+                      !loop_ssl_data->ssl_write_batching;
+    if (hs_batching) loop_ssl_data->ssl_write_batching = 1;
     unsigned char ssl_was_in_use = s->ssl_in_use;
     s->ssl_in_use = 1;
     int just_read = SSL_read(s_ssl(s),
                              loop_ssl_data->ssl_read_output + LIBUS_RECV_BUFFER_PADDING + read,
                              LIBUS_RECV_BUFFER_LENGTH - read);
     s->ssl_in_use = ssl_was_in_use;
+    if (hs_batching) {
+      loop_ssl_data->ssl_write_batching = 0;
+      if (!s->ssl || !SSL_is_init_finished(s_ssl(s)) ||
+          s->ssl_handshake_state != HANDSHAKE_PENDING) {
+        ssl_flush_write_batch(loop_ssl_data, s);
+      }
+    }
     if (!ssl_was_in_use && s->ssl_pending_detach) {
       /* A callback run from inside this read destroyed the socket; perform
        * the deferred close now and stop processing. */
+      if (hs_batching) loop_ssl_data->ssl_write_batch_len = 0;
       s->ssl_pending_detach = 0;
       return us_socket_close(s, s->ssl_pending_close_code, NULL);
     }
@@ -2027,6 +2123,7 @@ restart:
        * when the JS resolution arrives. */
       if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE &&
           err != SSL_ERROR_PENDING_CERTIFICATE) {
+        if (hs_batching) ssl_flush_write_batch(loop_ssl_data, s);
         if (err == SSL_ERROR_WANT_RENEGOTIATE) {
           if (ssl_renegotiate(s)) continue;
           if (ssl_gone(s)) return NULL;
@@ -2075,6 +2172,7 @@ restart:
         /* If the BIO still has unread ciphertext at this point, the TLS
          * framing is broken — close. */
         if (loop_ssl_data->ssl_read_input_length) {
+          if (hs_batching) loop_ssl_data->ssl_write_batch_len = 0;
           return ssl_close(s, 0, NULL);
         }
         /* SSL_read drove the handshake to completion but returned no app
@@ -2085,7 +2183,7 @@ restart:
          * loads. The save/restore below makes this safe even if the JS
          * callback writes; with read==0 the buffer is empty anyway. */
         if (s->ssl_handshake_state == HANDSHAKE_PENDING && SSL_is_init_finished(s_ssl(s))) {
-          ssl_trigger_handshake(s, 1);
+          ssl_trigger_handshake_success(s, hs_batching ? loop_ssl_data : NULL);
           if (ssl_gone(s)) return NULL;
           loop_ssl_data->ssl_socket = s;
         }
@@ -2119,7 +2217,7 @@ restart:
       char *saved_input = loop_ssl_data->ssl_read_input;
       unsigned int saved_length = loop_ssl_data->ssl_read_input_length;
       unsigned int saved_offset = loop_ssl_data->ssl_read_input_offset;
-      ssl_trigger_handshake(s, 1);
+      ssl_trigger_handshake_success(s, hs_batching ? loop_ssl_data : NULL);
       if (ssl_gone(s)) return NULL;
       loop_ssl_data->ssl_read_input = saved_input;
       loop_ssl_data->ssl_read_input_length = saved_length;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -448,7 +448,7 @@ int us_raw_root_certs(struct us_cert_string_t **out);
 
 /* Save/restore the per-loop BIO routing state around in-handshake JS
  * callbacks (SNI / ALPN). Defined in crypto/openssl.c. */
-void us_internal_ssl_loop_state_save(void *ssl, void **out5);
-void us_internal_ssl_loop_state_restore(void **saved5);
+void us_internal_ssl_loop_state_save(void *ssl, void **out6);
+void us_internal_ssl_loop_state_restore(void **saved6);
 
 #endif // INTERNAL_H

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -143,7 +143,7 @@ extern "C" fn select_alpn_callback(
             // routing state, and this handshake's next flight would land on
             // that other socket's fd. Snapshot and restore it around every
             // JS-running region.
-            let mut saved_loop_state: [*mut c_void; 5] = [core::ptr::null_mut(); 5];
+            let mut saved_loop_state: [*mut c_void; 6] = [core::ptr::null_mut(); 6];
             tls_socket_functions::ffi::us_internal_ssl_loop_state_save(
                 boringssl_sys::SSL::opaque_ref(ssl),
                 saved_loop_state.as_mut_ptr(),

--- a/src/runtime/socket/tls_socket_functions.rs
+++ b/src/runtime/socket/tls_socket_functions.rs
@@ -179,8 +179,8 @@ pub(super) mod ffi {
         pub(crate) safe fn SSL_get_ex_data(ssl: &SSL, idx: c_int) -> *mut c_void;
         /// Save/restore the per-loop BIO routing state around in-handshake JS
         /// callbacks (defined in usockets' openssl.c).
-        pub(crate) safe fn us_internal_ssl_loop_state_save(ssl: &SSL, out5: *mut *mut c_void);
-        pub(crate) safe fn us_internal_ssl_loop_state_restore(saved5: *mut *mut c_void);
+        pub(crate) safe fn us_internal_ssl_loop_state_save(ssl: &SSL, out6: *mut *mut c_void);
+        pub(crate) safe fn us_internal_ssl_loop_state_restore(saved6: *mut *mut c_void);
         pub(crate) safe fn SSL_renegotiate(ssl: &SSL) -> c_int;
         pub(crate) safe fn SSL_set_renegotiate_mode(
             ssl: &SSL,

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import { readFileSync, realpathSync } from "fs";
-import { tls as cert1, isDebug } from "harness";
+import { bunEnv, bunExe, tls as cert1, isDebug } from "harness";
 import net, { AddressInfo } from "net";
 import { createTest } from "node-harness";
 import { once } from "node:events";
@@ -974,7 +974,6 @@ it("ALPNCallback returning an offered protocol completes the handshake with it",
 // holds that flight until the on_handshake callback returns.
 // Covers test/js/node/test/parallel/test-tls-close-error.js.
 it("client verify-reject prevents the server seeing a completed handshake", async () => {
-  const { bunExe, bunEnv } = require("harness");
   const keys = join(import.meta.dir, "..", "test", "fixtures", "keys");
   const script = `
     const tls = require("tls");
@@ -984,27 +983,32 @@ it("client verify-reject prevents the server seeing a completed handshake", asyn
       cert: fs.readFileSync(${JSON.stringify(join(keys, "agent1-cert.pem"))}),
     });
     let events = [];
+    let serverDone;
     server.on("secureConnection", s => {
       events.push(["secureConnection", s.authorized]);
       s.end();
+      serverDone?.();
     });
-    server.on("tlsClientError", err => events.push(["tlsClientError", err.code ?? err.message]));
-    const dial = rejectUnauthorized =>
-      new Promise(done => {
-        events = [];
-        const c = tls.connect({ port: server.address().port, host: "127.0.0.1", rejectUnauthorized });
-        c.on("secureConnect", () => events.push(["client-secureConnect", c.authorized]));
-        c.on("error", e => events.push(["client-error", e.code ?? e.message]));
+    server.on("tlsClientError", err => {
+      events.push(["tlsClientError", err.code ?? err.message]);
+      serverDone?.();
+    });
+    const dial = async rejectUnauthorized => {
+      events = [];
+      const serverTerminal = new Promise(r => (serverDone = r));
+      const c = tls.connect({ port: server.address().port, host: "127.0.0.1", rejectUnauthorized });
+      c.on("secureConnect", () => events.push(["client-secureConnect", c.authorized]));
+      c.on("error", e => events.push(["client-error", e.code ?? e.message]));
+      const clientClosed = new Promise(r =>
         c.on("close", hadError => {
           events.push(["client-close", hadError]);
-          // Give the server a turn to observe the client's close.
-          setImmediate(() => setImmediate(() => {
-            console.log(JSON.stringify(events));
-            c.destroy();
-            done();
-          }));
-        });
-      });
+          r();
+        }),
+      );
+      await Promise.all([serverTerminal, clientClosed]);
+      console.log(JSON.stringify(events));
+      c.destroy();
+    };
     server.listen(0, "127.0.0.1", async () => {
       await dial(true);
       await dial(false);

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1014,7 +1014,10 @@ it("client verify-reject prevents the server seeing a completed handshake", asyn
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const [reject, allow] = stdout.trim().split("\n").map(l => JSON.parse(l));
+  const [reject, allow] = stdout
+    .trim()
+    .split("\n")
+    .map(l => JSON.parse(l));
 
   // rejectUnauthorized: true (default): client drops, server handshake never
   // completes. Node reports ECONNRESET here.

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -966,6 +966,73 @@ it("ALPNCallback returning an offered protocol completes the handshake with it",
   await once(server, "close");
 });
 
+// When a TLS 1.3 client's certificate verification fails and it tears the
+// connection down (rejectUnauthorized: true), the server must not see a
+// completed handshake. Node's memory-BIO lets the destroy() inside the info
+// callback drop the client's Finished flight before it reaches the wire, so
+// the server reports tlsClientError instead of secureConnection; Bun now
+// holds that flight until the on_handshake callback returns.
+// Covers test/js/node/test/parallel/test-tls-close-error.js.
+it("client verify-reject prevents the server seeing a completed handshake", async () => {
+  const { bunExe, bunEnv } = require("harness");
+  const keys = join(import.meta.dir, "..", "test", "fixtures", "keys");
+  const script = `
+    const tls = require("tls");
+    const fs = require("fs");
+    const server = tls.createServer({
+      key: fs.readFileSync(${JSON.stringify(join(keys, "agent1-key.pem"))}),
+      cert: fs.readFileSync(${JSON.stringify(join(keys, "agent1-cert.pem"))}),
+    });
+    let events = [];
+    server.on("secureConnection", s => {
+      events.push(["secureConnection", s.authorized]);
+      s.end();
+    });
+    server.on("tlsClientError", err => events.push(["tlsClientError", err.code ?? err.message]));
+    const dial = rejectUnauthorized =>
+      new Promise(done => {
+        events = [];
+        const c = tls.connect({ port: server.address().port, host: "127.0.0.1", rejectUnauthorized });
+        c.on("secureConnect", () => events.push(["client-secureConnect", c.authorized]));
+        c.on("error", e => events.push(["client-error", e.code ?? e.message]));
+        c.on("close", hadError => {
+          events.push(["client-close", hadError]);
+          // Give the server a turn to observe the client's close.
+          setImmediate(() => setImmediate(() => {
+            console.log(JSON.stringify(events));
+            c.destroy();
+            done();
+          }));
+        });
+      });
+    server.listen(0, "127.0.0.1", async () => {
+      await dial(true);
+      await dial(false);
+      server.close();
+    });
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [reject, allow] = stdout.trim().split("\n").map(l => JSON.parse(l));
+
+  // rejectUnauthorized: true (default): client drops, server handshake never
+  // completes. Node reports ECONNRESET here.
+  expect(reject).toEqual([
+    ["client-error", "UNABLE_TO_VERIFY_LEAF_SIGNATURE"],
+    ["client-close", true],
+    ["tlsClientError", "ECONNRESET"],
+  ]);
+
+  // rejectUnauthorized: false: client keeps the connection, so its Finished
+  // is sent and the server emits secureConnection. Both sides proceed with
+  // authorized=false.
+  expect(allow).toContainEqual(["secureConnection", false]);
+  expect(allow).toContainEqual(["client-secureConnect", false]);
+  for (const ev of allow) expect(ev[0]).not.toBe("tlsClientError");
+  expect(exitCode).toBe(0);
+});
+
 it("an asynchronous SNICallback suspends the handshake and resumes with the selected context", async () => {
   // The callback resolves on a later tick - the handshake must wait for it
   // (BoringSSL select-certificate retry) instead of falling through to the


### PR DESCRIPTION
### Problem

A `tls.connect()` client whose server-certificate verification fails (`rejectUnauthorized: true` with an untrusted cert) tears the connection down from its on_handshake callback, but the server still sees a completed handshake and emits `'secureConnection'` for a socket that is about to close. Node's server emits `'tlsClientError'` (ECONNRESET) and never `'secureConnection'`.

```
// node: ["client-error","UNABLE_TO_VERIFY_LEAF_SIGNATURE"],["client-close",true],["tlsClientError","ECONNRESET"]
// bun:  ["client-error","UNABLE_TO_VERIFY_LEAF_SIGNATURE"],["client-close",true],["secureConnection",false]
const tls = require('tls');
const s = tls.createServer({key, cert});
s.on('secureConnection', () => ev.push('secureConnection'));
s.on('tlsClientError', e => ev.push(['tlsClientError', e.code]));
s.listen(0, () => tls.connect(s.address().port) /* no ca, rejectUnauthorized defaults to true */);
```

This is a client-side bug: a Bun server talking to a **Node** client already behaves correctly (`tlsClientError`), and a **Node** server talking to a Bun client sees the spurious `secureConnection`. It is TLS-1.3-specific; under TLS 1.2 the server's handshake completes before the client's by protocol design and both runtimes emit `secureConnection` there.

It surfaces as `test/js/node/test/parallel/test-tls-close-error.js` passing only because its `common.mustNotCall()` secureConnection handler's assertion throw is silently routed through the native socket error handler. That blocks wrapping `server.emit('secureConnection', ...)` for uncaughtException routing (the TLS sibling of the `'connection'` wrap in #35347, deferred there and in #29762).

### Cause

Bun's SSL BIO (`BIO_s_custom_write`) writes handshake records straight to the socket fd via `us_socket_raw_write`. When `SSL_read` processes the server's flight and seals the client's Finished, those bytes are already in the kernel send buffer by the time `on_handshake` dispatches. `self.destroy(verifyError)` in `SocketHandlers.handshake` cannot recall them; the server receives Finished and its handshake completes.

Node's `TLSWrap` writes handshake records into a memory BIO (`enc_out_`) and runs JS from the `SSL_CB_HANDSHAKE_DONE` info callback **inside** `SSL_do_handshake`, before `EncOut()` copies `enc_out_` to the underlying stream. `destroy()` there drops the buffer and the server never sees Finished.

### Fix

`packages/bun-usockets/src/crypto/openssl.c`: batch the BIO output around `SSL_do_handshake` and `SSL_read` while the handshake is pending. When the handshake completes, `ssl_trigger_handshake_success` parks the batched flight in the loop's spill slot with a new `ssl_spill_discard_on_close` flag set, then dispatches `on_handshake(success=1)`:

- A close from inside the callback frees the spill without the last-chance drain (and marks the SSL fatal so no `close_notify` is sent under keys the peer has not installed). The peer sees the TCP close mid-handshake and reports ECONNRESET, matching Node.
- A `us_internal_ssl_write` from inside the callback drains the spill first, so the held flight precedes any application data when the connection is kept.
- If the callback returns without closing, the flag is cleared and the spill drains normally.

When the spill slot is already occupied by another socket's partial write, the batch is flushed immediately (the pre-change behaviour) rather than held.

### Verification

New test in `test/js/node/tls/node-tls-server.test.ts` records the exact server-side event sequence for both `rejectUnauthorized: true` (must see `['tlsClientError','ECONNRESET']`, no `secureConnection`) and `rejectUnauthorized: false` (must see `['secureConnection', false]` and the client's `secureConnect`). Output matches Node v26.3.0 exactly; the reject case fails on main with `['secureConnection', false]` in place of `tlsClientError`.

Regression sweeps, failures match main:
- `test/js/node/test/parallel/test-tls-*.js`: 172/175 pass, no diff vs main
- `test/js/node/test/parallel/test-https-*.js`: 58/59, no diff
- `test/js/node/test/parallel/test-http2-*.js` (first 30): no diff
- `test/js/node/http2/node-http2.test.js`: 307 pass / 0 fail
- `test/js/node/tls/*.test.ts`, `test/js/bun/net/socket.test.ts`: only pre-existing failures
- `test/js/node/test/parallel/test-tls-close-error.js`: continues to pass (now for the right reason)