### PR TITLE
cli: add --disallow-code-generation-from-strings (+1 node v26 test)

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3211,6 +3211,17 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void JSC__JSGlobalObject__addGc(JSC::JSGlobal
     globalObject->putDirectNativeFunction(vm, globalObject, JSC::Identifier::fromString(vm, "gc"_s), 0, functionJsGc, ImplementationVisibility::Public, JSC::NoIntrinsic, PropertyAttribute::DontEnum | 0);
 }
 
+/// `--disallow-code-generation-from-strings`. V8's flag makes both `eval()` and
+/// the `Function` constructor throw `EvalError: Code generation from strings
+/// disallowed for this context`; JSC's `setEvalEnabled` gates the same two
+/// entry points and throws the same error type, so the message is spelled to
+/// match V8's verbatim. node:vm's `codeGeneration: { strings: false }` already
+/// uses this mechanism (NodeVM.cpp).
+extern "C" [[ZIG_EXPORT(nothrow)]] void JSC__JSGlobalObject__disallowCodeGenerationFromStrings(JSC::JSGlobalObject* globalObject)
+{
+    globalObject->setEvalEnabled(false, "Code generation from strings disallowed for this context"_s);
+}
+
 extern "C" [[ZIG_EXPORT(nothrow)]] double JSC__JSGlobalObject__jsDateNow(JSC::JSGlobalObject* globalObject)
 {
     return globalObject->jsDateNow();

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -547,6 +547,10 @@ pub struct RuntimeOptions {
     /// `--expose-gc` makes `globalThis.gc()` available. Added for Node
     /// compatibility.
     pub expose_gc: bool,
+    /// `--disallow-code-generation-from-strings` makes `eval()` and the
+    /// `Function` constructor throw `EvalError`, matching the V8 flag node
+    /// exposes under the same name.
+    pub disallow_code_generation_from_strings: bool,
     pub preserve_symlinks_main: bool,
     pub console_depth: Option<u16>,
     pub cron_title: Box<[u8]>,
@@ -609,6 +613,7 @@ impl Default for RuntimeOptions {
             experimental_http3_fetch: false,
             dns_result_order: Box::from(&b"verbatim"[..]),
             expose_gc: false,
+            disallow_code_generation_from_strings: false,
             preserve_symlinks_main: false,
             console_depth: None,
             cron_title: Box::default(),

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -259,6 +259,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
         "--expose-gc                       Expose gc() on the global object. Has no effect on Bun.gc()."
     ),
     parse_param!(
+        "--disallow-code-generation-from-strings  Make eval() and new Function() throw EvalError."
+    ),
+    parse_param!(
         "--no-deprecation                  Suppress all reporting of the custom deprecation."
     ),
     parse_param!(
@@ -1179,6 +1182,8 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         ctx.runtime_options.experimental_http2_fetch = args.flag(b"--experimental-http2-fetch");
         ctx.runtime_options.experimental_http3_fetch = args.flag(b"--experimental-http3-fetch");
         ctx.runtime_options.expose_gc = args.flag(b"--expose-gc");
+        ctx.runtime_options.disallow_code_generation_from_strings =
+            args.flag(b"--disallow-code-generation-from-strings");
         if args.flag(b"--expose-internals") {
             // Same gate the env var `BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING`
             // sets (VirtualMachine::configure_from_env): allows resolving

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1316,7 +1316,9 @@ impl Run {
         unsafe extern "C" {
             fn Bun__ExposeNodeModuleGlobals(global: *const JSGlobalObject);
             fn JSC__JSGlobalObject__addGc(global: *const JSGlobalObject);
-            fn JSC__JSGlobalObject__disallowCodeGenerationFromStrings(global: *const JSGlobalObject);
+            fn JSC__JSGlobalObject__disallowCodeGenerationFromStrings(
+                global: *const JSGlobalObject,
+            );
         }
         // SAFETY: `self.vm`/`self.ctx` are process-lifetime; written by
         // `boot()` before the API-lock trampoline runs.

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1316,6 +1316,7 @@ impl Run {
         unsafe extern "C" {
             fn Bun__ExposeNodeModuleGlobals(global: *const JSGlobalObject);
             fn JSC__JSGlobalObject__addGc(global: *const JSGlobalObject);
+            fn JSC__JSGlobalObject__disallowCodeGenerationFromStrings(global: *const JSGlobalObject);
         }
         // SAFETY: `self.vm`/`self.ctx` are process-lifetime; written by
         // `boot()` before the API-lock trampoline runs.
@@ -1329,6 +1330,10 @@ impl Run {
         if ro.expose_gc {
             // SAFETY: FFI; `vm.global` is live for the VM lifetime.
             unsafe { JSC__JSGlobalObject__addGc(vm.global) };
+        }
+        if ro.disallow_code_generation_from_strings {
+            // SAFETY: FFI; `vm.global` is live for the VM lifetime.
+            unsafe { JSC__JSGlobalObject__disallowCodeGenerationFromStrings(vm.global) };
         }
     }
 

--- a/test/js/node/test/parallel/test-eval-disallow-code-generation-from-strings.js
+++ b/test/js/node/test/parallel/test-eval-disallow-code-generation-from-strings.js
@@ -1,0 +1,9 @@
+// Flags: --disallow-code-generation-from-strings
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Verify that v8 option --disallow-code-generation-from-strings is still
+// respected
+assert.throws(() => eval('"eval"'), EvalError);


### PR DESCRIPTION
Adds `--disallow-code-generation-from-strings` and vendors the upstream test it unblocks.

Stacked on #34660 — review that first.

## What this adds

Node exposes V8's `--disallow-code-generation-from-strings`: with it, `eval()` and the `Function`
constructor throw `EvalError: Code generation from strings disallowed for this context`. Bun
accepted the flag on the command line and then ignored it, so `eval()` kept working.

JSC has the same switch. `JSGlobalObject::setEvalEnabled(false, message)` gates both `eval()` and
the `Function` constructor and throws `EvalError` with the message the embedder supplies — and
`node:vm`'s `codeGeneration: { strings: false }` already drives it (`NodeVM.cpp`). I checked the
behaviour before writing any code:

```js
const ctx = vm.createContext({}, { codeGeneration: { strings: false } });
vm.runInContext('eval("1")', ctx);              // EvalError: Code generation from strings disallowed for this context
vm.runInContext('new Function("return 1")', ctx); // EvalError: Code generation from strings disallowed for this context
```

That is V8's message verbatim, so the flag is four small edits reusing the existing mechanism: the
option field, the `parse_param!` entry, one `extern "C"` calling `setEvalEnabled`, and one call in
`add_conditional_globals()` next to `--expose-gc`.

Applies to the main thread only, like the other entries in `add_conditional_globals()`.

## Verification

`parallel/test-eval-disallow-code-generation-from-strings.js`, byte-identical to `nodejs/node` at
`v26.3.0`, run three times one-process-per-file the way CI runs vendored tests — 3/3 exit 0. It is
not a skip: `common` re-spawns it as a child process with the flag (`NOTE: The test started as a
child_process using these flags: [ '--disallow-code-generation-from-strings' ]`) and the assertion
executes.

Directly:

```
$ bun -e 'console.log(eval("1+1"))'
2
$ bun --disallow-code-generation-from-strings -e 'try { eval("1") } catch (e) { console.log(e.name + ": " + e.message) }'
EvalError: Code generation from strings disallowed for this context
$ bun --disallow-code-generation-from-strings -e 'try { new Function("return 1") } catch (e) { console.log(e.name) }'
EvalError
```

Regression sweep on the same build: 45/45 vendored `test-vm-*`, `test-eval*`, `test-cli-*`,
`test-process-argv*` and `test-repl-*` files pass. `test/expectations.txt` is untouched.

## Two bugs found while triaging this cluster

Neither is fixed here; both are real and worth their own work.

### 1. http2 sessions are retained after explicit destruction

`parallel/test-h2leak-destroy-session-on-socket-ended.js` registers a `FinalizationRegistry` on each
`Http2Session`, then on the server's `end` event does `socket.destroy()`,
`firstServerStream.session.destroy()`, drops its reference and runs `globalThis.gc()` twice on the
next `setImmediate`. The callback never fires, so the session is still reachable.

This is **not** an `--expose-gc` gap — the test reaches and executes both `gc()` calls, printing
`secureConnection`, `stream...`, `Draining setImmediate after writing` and `false` before failing on
the unfired registry callback. Something holds the session alive past an explicit `destroy()`, which
affects long-lived h2 servers, not just this test.

### 2. `url.fileURLToPath()` silently returns `""` for non-UTF-8 percent-escapes

```js
const u = new URL('file:///tmp/%82%A0%82%A2%82%A4');   // Shift-JIS bytes
require('url').fileURLToPath(u)         // Bun: ""            node: throws URIError
require('fs').writeFileSync(u, 'x')     // Bun: ERR_INVALID_ARG_VALUE "URL must be a non-empty \"file:\" path"
require('url').fileURLToPathBuffer(u)   // correct on both: <Buffer 2f 74 6d 70 2f 82 a0 82 a2 82 a4>
```

Node reaches this through `decodeURIComponent()` in `getPathFromURLPosix`
([lib/internal/url.js](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/url.js)) and throws
`URIError`. Bun produces an empty path instead, and the misleading `ERR_INVALID_ARG_VALUE` from
`writeFileSync` is a downstream symptom of that empty string, not the real cause.

`WTF::URL::fileSystemPath()` returns a null string in this case; the null is currently dropped. The
four sites:

- `src/jsc/bindings/bindings.cpp` `WebCore__DOMURL__fileSystemPath()` (~2371) — add an error code
  for the null result alongside the existing 1/2/3
- `src/jsc/DOMURL.rs` `ToFileSystemPathError` (~20) — matching variant
- `src/runtime/node/types.rs` (~1196) — the fs `PathLike` throw site, which today reports
  `ERR_INVALID_ARG_VALUE` off an `is_empty()` check
- `src/jsc/bindings/BunObject.cpp` `functionFileURLToPath()` (~904) — same null check after
  `url.fileSystemPath()`

It also needs a way to throw a plain `URIError` from Rust, which does not exist yet (`ctx.err()`
only produces Node `ERR_*` codes). Blocks `parallel/test-fileurltopathbuffer.js`; note
`fileURLToPathBuffer` itself is already correct.

## Rest of the cluster, and why each is not here

19 files were triaged against this base; 1 landed. The remainder, grouped:

**Handed to the http/https server cluster owner** (isolated repro at
`test-http-raw-headers.js`): the node:http server drops the incoming chunked-body trailer section
whenever the handler ends the response before the request body has been read.
`req.rawTrailers === []`; if the handler waits for the request's `end` first, trailers are correct.
Everything else already matches node — Bun's client emits trailers on the wire correctly (including
four duplicate-case trailers), the server emits `res.addTrailers()` correctly, and the client parses
response trailers correctly including the `"a, b, c, d"` duplicate-name join. Only server-side
incoming capture is affected.

**V8 internals**
- `test-http-same-map.js` — `%DebugPrint` / `%HaveSameMap` natives.
- `test-freeze-intrinsics.js` — `--frozen-intrinsics`.

**Permission model** (owned elsewhere)
- `test-ffi-missing-build.js`, `test-dotenv-node-options.js`.

**Inspector**
- `test-domain-dep0097.js` (`inspector.open()` + the DEP0097 warning),
  `test-esm-loader-hooks-inspect-brk.js` (`NodeRuntime` domain + loader worker).

**Depends on another branch**
- `test-messageport-hasref.js` — needs the MESSAGEPORT `async_hooks` `init` emission from #35366
  (a different stack), plus per-port `hasRef()` tracking through `ref()`/`unref()`/listener attach.
  Not reimplemented here.
- `test-is-internal-thread.mjs` — `node:test`'s `describe` outside `bun test`, plus
  `worker_threads.isInternalThread`.

**Engine/structural**
- `test-domexception-subclass.js` — `Error.isError(new DOMException(...))` is `false` in Bun
  (`instanceof Error` is `true`); DOMException has no `[[ErrorData]]`, which is a WebCore/JSC
  structural change.

**Networking, not yet sized**
- `test-http-server-unconsume.js` — re-attaching a `data` listener to `req.socket` after the
  response yields `''` instead of the unconsumed bytes.
- `test-https-timeout-server.js` — `handshakeTimeout` never fires, so the test hangs (20s timeout).
- `test-double-tls-client.js` — TLS over an existing TLS socket (`tls.connect({ socket })`) resets.
- `test-https-resume-after-renew.js` — `server._sharedCreds.context.enableTicketKeyCallback()`.
- `test-force-repl-with-eval.js` — `bun -i -e 'console.log("42")'` prints `42` but not the `> `
  prompt, so `-i` does not force the REPL alongside `-e`.
