### PR TITLE
path: reserved Windows device names in normalize; domain and debuglog parity (+4 tests)

### DIFF
--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -27,6 +27,32 @@ domain.createDomain = domain.create = function () {
     d.emit("error", e);
   }
 
+  // Node routes a *thrown* error through Domain.prototype._errorHandler, which
+  // leaves the domain before running the handler and clears the stack after it,
+  // because an uncaught exception ends the tick.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/domain.js#L218-L300
+  function handleThrown(e) {
+    if (typeof e === "object" && e !== null) {
+      ObjectDefineProperty(e, "domain", {
+        __proto__: null,
+        configurable: true,
+        enumerable: false,
+        value: d,
+        writable: true,
+      });
+      e.domainThrown = true;
+    }
+    // Pop adjacent duplicates of this domain so the handler does not run
+    // inside the domain that raised.
+    while (domain.active === d) d.exit();
+    try {
+      d.emit("error", e);
+    } finally {
+      stack.length = 0;
+      domain.active = process.domain = null;
+    }
+  }
+
   d.add = function (emitter) {
     emitter.on("error", emitError);
   };
@@ -39,7 +65,7 @@ domain.createDomain = domain.create = function () {
       try {
         fn.$apply(null, args);
       } catch (err) {
-        emitError(err);
+        handleThrown(err);
       }
     };
   };
@@ -52,7 +78,7 @@ domain.createDomain = domain.create = function () {
         try {
           fn.$apply(null, args);
         } catch (err) {
-          emitError(err);
+          handleThrown(err);
         }
       }
     };
@@ -62,7 +88,7 @@ domain.createDomain = domain.create = function () {
     try {
       return fn.$apply(this, args);
     } catch (err) {
-      emitError(err);
+      handleThrown(err);
     } finally {
       this.exit();
     }
@@ -80,7 +106,10 @@ domain.createDomain = domain.create = function () {
     const index = stack.lastIndexOf(this);
     if (index === -1) return this;
     stack.splice(index, stack.length);
-    domain.active = process.domain = stack.length ? stack[stack.length - 1] : null;
+    // Node leaves `undefined` behind when the stack empties; only the
+    // uncaught-exception path resets it to null.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/domain.js#L313-L323
+    domain.active = process.domain = stack.length ? stack[stack.length - 1] : undefined;
     return this;
   };
   return d;

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -39,6 +39,7 @@ const format = utl.format;
 const stripVTControlCharacters = utl.stripVTControlCharacters;
 
 var debugs = {};
+const ObjectDefineProperty = Object.defineProperty;
 var debugEnvRegex = /^$/;
 const NODE_DEBUG = process.env.NODE_DEBUG;
 if (NODE_DEBUG) {
@@ -66,21 +67,68 @@ function emitWarningIfNeeded(set) {
   }
 }
 
-function debuglog(set) {
-  set = set.toUpperCase();
+function debuglogImpl(enabled, set) {
   if (!debugs[set]) {
-    if (debugEnvRegex.test(set)) {
-      var pid = process.pid;
+    if (enabled) {
+      const pid = process.pid;
       emitWarningIfNeeded(set);
-      debugs[set] = function () {
-        var msg = format.$apply(cjs_exports, arguments);
+      debugs[set] = function debug() {
+        const msg = format.$apply(cjs_exports, arguments);
         console.error("%s %d: %s", set, pid, msg);
       };
     } else {
-      debugs[set] = function () {};
+      debugs[set] = function debug() {};
     }
   }
   return debugs[set];
+}
+
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/util/debuglog.js#L86-L138
+function debuglog(set, cb) {
+  let enabled;
+  function init() {
+    set = set.toUpperCase();
+    enabled = debugEnvRegex.test(set);
+  }
+
+  // The section is resolved on the first call, not here, so that a `debuglog`
+  // taken at module load still sees a later `process.pid`.
+  let debug = function (...args) {
+    init();
+    debug = debuglogImpl(enabled, set);
+    if (typeof cb === "function") {
+      ObjectDefineProperty(debug, "enabled", {
+        __proto__: null,
+        get() {
+          return enabled;
+        },
+        configurable: true,
+        enumerable: true,
+      });
+      cb(debug);
+    }
+    return debug(...args);
+  };
+
+  let test = function () {
+    init();
+    test = () => enabled;
+    return enabled;
+  };
+
+  const logger = function (...args) {
+    if (enabled === false) return;
+    return debug(...args);
+  };
+  ObjectDefineProperty(logger, "enabled", {
+    __proto__: null,
+    get() {
+      return test();
+    },
+    configurable: true,
+    enumerable: true,
+  });
+  return logger;
 }
 
 function isBoolean(arg) {

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -992,7 +992,10 @@ const CHAR_SUPERSCRIPT_THREE: u32 = 0xb3;
 /// a reserved DOS device name? A missing colon reproduces JS `slice(0, -1)`,
 /// which drops the final character ("PRNX" is treated as "PRN").
 /// https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L81-L84
-pub(crate) fn is_windows_reserved_name_t<T: PathCharCwd>(path: &[T], colon_index: Option<usize>) -> bool {
+pub(crate) fn is_windows_reserved_name_t<T: PathCharCwd>(
+    path: &[T],
+    colon_index: Option<usize>,
+) -> bool {
     let end = match colon_index {
         Some(index) => index,
         None => match path.len().checked_sub(1) {
@@ -1010,7 +1013,9 @@ pub(crate) fn is_windows_reserved_name_t<T: PathCharCwd>(path: &[T], colon_index
         name[2].to_ascii_upper().as_u32(),
     ];
     let matches = |candidate: &[u8]| {
-        head[0] == candidate[0] as u32 && head[1] == candidate[1] as u32 && head[2] == candidate[2] as u32
+        head[0] == candidate[0] as u32
+            && head[1] == candidate[1] as u32
+            && head[2] == candidate[2] as u32
     };
     if name.len() == 3 {
         return WINDOWS_RESERVED_NAMES.iter().any(|n| matches(n));
@@ -1028,7 +1033,9 @@ pub(crate) fn is_windows_reserved_name_t<T: PathCharCwd>(path: &[T], colon_index
             (b'1' as u32..=b'9' as u32).contains(&c) || is_superscript_digit(c)
         }
         // UTF-8 paths carry the superscripts as their two-byte encoding.
-        [lead, trail] => !T::IS_U16 && lead.as_u32() == 0xc2 && is_superscript_digit(trail.as_u32()),
+        [lead, trail] => {
+            !T::IS_U16 && lead.as_u32() == 0xc2 && is_superscript_digit(trail.as_u32())
+        }
         _ => false,
     }
 }
@@ -1920,7 +1927,8 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
                         j += 1;
                     }
                     if first_part.len() == 1
-                        && (first_part[0].eq_ascii(CHAR_DOT) || first_part[0].eq_ascii(CHAR_QUESTION_MARK))
+                        && (first_part[0].eq_ascii(CHAR_DOT)
+                            || first_part[0].eq_ascii(CHAR_QUESTION_MARK))
                     {
                         // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
                         // Translated from the following JS code:
@@ -1944,7 +1952,10 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
                                     // device = `\\?\${possibleDevice}`
                                     buf[2] = T::from_u8(CHAR_QUESTION_MARK);
                                     buf[3] = T::from_u8(CHAR_BACKWARD_SLASH);
-                                    memmove(&mut buf[4..4 + possible_device.len()], possible_device);
+                                    memmove(
+                                        &mut buf[4..4 + possible_device.len()],
+                                        possible_device,
+                                    );
                                     device_len = Some(4 + possible_device.len());
                                     root_end = 4 + possible_device.len();
                                 }
@@ -2067,7 +2078,10 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
                     needs_dot_prefix = true;
                     break;
                 }
-                index = path[i + 1..].iter().position(|c| c.eq_ascii(CHAR_COLON)).map(|k| i + 1 + k);
+                index = path[i + 1..]
+                    .iter()
+                    .position(|c| c.eq_ascii(CHAR_COLON))
+                    .map(|k| i + 1 + k);
             }
         }
     }

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -979,6 +979,65 @@ pub(crate) fn is_windows_device_root_t<T: PathCharCwd>(byte: T) -> bool {
     (b'A' as u32 <= c && c <= b'Z' as u32) || (b'a' as u32 <= c && c <= b'z' as u32)
 }
 
+/// Reserved DOS device names. `COM`/`LPT` also have superscript digit forms
+/// (U+00B9, U+00B2, U+00B3), which Windows treats the same as 1/2/3.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L73-L79
+const WINDOWS_RESERVED_NAMES: [&[u8]; 4] = [b"CON", b"PRN", b"AUX", b"NUL"];
+const WINDOWS_RESERVED_DEVICE_PREFIXES: [&[u8]; 2] = [b"COM", b"LPT"];
+const CHAR_SUPERSCRIPT_ONE: u32 = 0xb9;
+const CHAR_SUPERSCRIPT_TWO: u32 = 0xb2;
+const CHAR_SUPERSCRIPT_THREE: u32 = 0xb3;
+
+/// `isWindowsReservedName(path, colonIndex)`: is everything before `colon_index`
+/// a reserved DOS device name? A missing colon reproduces JS `slice(0, -1)`,
+/// which drops the final character ("PRNX" is treated as "PRN").
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L81-L84
+pub(crate) fn is_windows_reserved_name_t<T: PathCharCwd>(path: &[T], colon_index: Option<usize>) -> bool {
+    let end = match colon_index {
+        Some(index) => index,
+        None => match path.len().checked_sub(1) {
+            Some(end) => end,
+            None => return false,
+        },
+    };
+    let name = &path[..end.min(path.len())];
+    if name.len() < 3 {
+        return false;
+    }
+    let head = [
+        name[0].to_ascii_upper().as_u32(),
+        name[1].to_ascii_upper().as_u32(),
+        name[2].to_ascii_upper().as_u32(),
+    ];
+    let matches = |candidate: &[u8]| {
+        head[0] == candidate[0] as u32 && head[1] == candidate[1] as u32 && head[2] == candidate[2] as u32
+    };
+    if name.len() == 3 {
+        return WINDOWS_RESERVED_NAMES.iter().any(|n| matches(n));
+    }
+    if !WINDOWS_RESERVED_DEVICE_PREFIXES.iter().any(|n| matches(n)) {
+        return false;
+    }
+    let is_superscript_digit = |c: u32| {
+        c == CHAR_SUPERSCRIPT_ONE || c == CHAR_SUPERSCRIPT_TWO || c == CHAR_SUPERSCRIPT_THREE
+    };
+    match &name[3..] {
+        // COM1 .. COM9, and the UTF-16 spelling of COM¹ / COM² / COM³.
+        [digit] => {
+            let c = digit.as_u32();
+            (b'1' as u32..=b'9' as u32).contains(&c) || is_superscript_digit(c)
+        }
+        // UTF-8 paths carry the superscripts as their two-byte encoding.
+        [lead, trail] => !T::IS_U16 && lead.as_u32() == 0xc2 && is_superscript_digit(trail.as_u32()),
+        _ => false,
+    }
+}
+
+/// Index of the first `:` in `path`, mirroring `StringPrototypeIndexOf(path, ':')`.
+fn index_of_colon_t<T: PathCharCwd>(path: &[T]) -> Option<usize> {
+    path.iter().position(|c| c.eq_ascii(CHAR_COLON))
+}
+
 /// Based on Node v21.6.1 path.posix.isAbsolute:
 /// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L1159
 #[inline]
@@ -1860,7 +1919,38 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
                     while j < len && !is_sep_t(path[j]) {
                         j += 1;
                     }
-                    if j == len {
+                    if first_part.len() == 1
+                        && (first_part[0].eq_ascii(CHAR_DOT) || first_part[0].eq_ascii(CHAR_QUESTION_MARK))
+                    {
+                        // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                        // Translated from the following JS code:
+                        //   device = `\\\\${firstPart}`;
+                        //   rootEnd = 4;
+                        buf[0] = T::from_u8(CHAR_BACKWARD_SLASH);
+                        buf[1] = T::from_u8(CHAR_BACKWARD_SLASH);
+                        buf[2] = first_part[0];
+                        // `device` stops before the separator; the absolute-path
+                        // branch below writes it back in front of the tail.
+                        device_len = Some(3);
+                        root_end = 4;
+                        // Special case: handle \\?\COM1: or similar reserved device paths.
+                        if let Some(colon_index) = index_of_colon_t(path) {
+                            if colon_index + 1 >= 4 && colon_index < len {
+                                let possible_device = &path[4..colon_index + 1];
+                                if is_windows_reserved_name_t(
+                                    possible_device,
+                                    possible_device.len().checked_sub(1),
+                                ) {
+                                    // device = `\\?\${possibleDevice}`
+                                    buf[2] = T::from_u8(CHAR_QUESTION_MARK);
+                                    buf[3] = T::from_u8(CHAR_BACKWARD_SLASH);
+                                    memmove(&mut buf[4..4 + possible_device.len()], possible_device);
+                                    device_len = Some(4 + possible_device.len());
+                                    root_end = 4 + possible_device.len();
+                                }
+                            }
+                        }
+                    } else if j == len {
                         // We matched a UNC root only
                         // Return the normalized version of the UNC root since there
                         // is nothing left to process
@@ -1883,8 +1973,7 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
                         buf_size += 1;
                         buf[buf_offset] = T::from_u8(CHAR_BACKWARD_SLASH);
                         return &buf[0..buf_size];
-                    }
-                    if j != last {
+                    } else if j != last {
                         // We matched a UNC root with leftovers
 
                         // Translated from the following JS code:
@@ -1924,6 +2013,15 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
             _is_absolute = true;
             root_end = 3;
         }
+    } else if let Some(colon_index) = index_of_colon_t(path) {
+        // A reserved device name is its own root, so `CON:..\..\foo` cannot
+        // climb out of it.
+        // https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L438-L441
+        if colon_index > 0 && is_windows_reserved_name_t(path, Some(colon_index)) {
+            memmove(&mut buf[0..colon_index + 1], &path[0..colon_index + 1]);
+            device_len = Some(colon_index + 1);
+            root_end = colon_index + 1;
+        }
     }
 
     buf_offset = device_len.unwrap_or(0) + (_is_absolute as usize);
@@ -1951,6 +2049,35 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
     }
 
     buf_size = buf_offset + tail_len;
+
+    let colon_index = index_of_colon_t(path);
+    // If the original path was not absolute and we could not resolve it relative
+    // to a particular device, make sure the tail cannot be read back as an
+    // absolute path. See CVE-2024-36139.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L455-L471
+    let mut needs_dot_prefix = false;
+    if !_is_absolute && device_len.is_none() && colon_index.is_some() {
+        let tail = &buf[buf_offset..buf_size];
+        if tail.len() >= 2 && is_windows_device_root_t(tail[0]) && tail[1].eq_ascii(CHAR_COLON) {
+            needs_dot_prefix = true;
+        } else {
+            let mut index = colon_index;
+            while let Some(i) = index {
+                if i == len - 1 || is_sep_t(path[i + 1]) {
+                    needs_dot_prefix = true;
+                    break;
+                }
+                index = path[i + 1..].iter().position(|c| c.eq_ascii(CHAR_COLON)).map(|k| i + 1 + k);
+            }
+        }
+    }
+    // A reserved device name keeps its device in the result, but the whole path
+    // is made explicitly relative.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L472-L475
+    if is_windows_reserved_name_t(path, colon_index) {
+        needs_dot_prefix = true;
+    }
+
     // Translated from the following JS code:
     //   if (device === undefined) {
     //     return isAbsolute ? `\\${tail}` : tail;
@@ -1960,6 +2087,15 @@ pub(crate) fn normalize_windows_t<'a, T: PathCharCwd>(path: &[T], buf: &'a mut [
         buf_offset -= 1;
         // Prepend the separator.
         buf[buf_offset] = T::from_u8(CHAR_BACKWARD_SLASH);
+    }
+
+    if needs_dot_prefix {
+        // `.\` in front of the device and tail. The caller reserves two extra
+        // slots in `buf` for exactly this.
+        buf.copy_within(0..buf_size, 2);
+        buf[0] = T::from_u8(CHAR_DOT);
+        buf[1] = T::from_u8(CHAR_BACKWARD_SLASH);
+        buf_size += 2;
     }
     &buf[0..buf_size]
 }
@@ -1987,8 +2123,9 @@ pub(crate) fn normalize_js_t<T: PathCharCwd>(
     path: &[T],
 ) -> JsResult<JSValue> {
     let buf_len = path.len().max(path_size::<T>());
-    // +1 for null terminator
-    let mut scratch = PathScratch::<T>::new(pool, buf_len + 1);
+    // +1 for null terminator, +2 for the `.\\` a reserved device name or a
+    // CVE-2024-36139 relative path prepends to the result.
+    let mut scratch = PathScratch::<T>::new(pool, buf_len + 3);
     let buf = scratch.slice();
     if is_windows {
         normalize_windows_js_t(global_object, path, buf)

--- a/test/js/node/path/normalize.test.js
+++ b/test/js/node/path/normalize.test.js
@@ -74,6 +74,40 @@ describe("path.normalize", () => {
     assert.strictEqual(path.posix.normalize("/bb../../x"), "/x");
   });
 
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L438-L475
+  test("win32 reserved device names", () => {
+    // A reserved name is its own root and the result is made explicitly relative.
+    assert.strictEqual(path.win32.normalize("CON:"), ".\\CON:.");
+    assert.strictEqual(path.win32.normalize("con:"), ".\\con:.");
+    assert.strictEqual(path.win32.normalize("CON:foo"), ".\\CON:foo");
+    assert.strictEqual(path.win32.normalize("CON:..\\..\\foo"), ".\\CON:..\\..\\foo");
+    assert.strictEqual(path.win32.normalize("AUX:/foo\\bar/baz"), ".\\AUX:foo\\bar\\baz");
+    assert.strictEqual(path.win32.normalize("LPT9:"), ".\\LPT9:.");
+    assert.strictEqual(path.win32.normalize("COM\u00b9:"), ".\\COM\u00b9:.");
+    assert.strictEqual(path.win32.normalize("LPT\u00b3:"), ".\\LPT\u00b3:.");
+    // JS `slice(0, -1)` drops the last character when there is no colon.
+    assert.strictEqual(path.win32.normalize("PRNX"), ".\\PRNX");
+    // Not reserved.
+    assert.strictEqual(path.win32.normalize("CON"), "CON");
+    assert.strictEqual(path.win32.normalize("COM10:"), ".\\COM10:");
+    assert.strictEqual(path.win32.normalize("CONNINGTOWER:"), ".\\CONNINGTOWER:");
+    assert.strictEqual(path.win32.normalize("C:\\COM9"), "C:\\COM9");
+    // Reserved names after a UNC share are left alone.
+    assert.strictEqual(path.win32.normalize("\\\\server\\share\\COM1:"), "\\\\server\\share\\COM1:");
+    // Device roots.
+    assert.strictEqual(path.win32.normalize("\\\\?\\COM1:"), "\\\\?\\COM1:\\");
+    assert.strictEqual(path.win32.normalize("\\\\.\\PHYSICALDRIVE0"), "\\\\.\\PHYSICALDRIVE0");
+  });
+
+  // A relative path must not come back as something Windows reads as absolute.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/path.js#L455-L471 (CVE-2024-36139)
+  test("win32 relative paths containing a colon", () => {
+    assert.strictEqual(path.win32.normalize("foo:/bar"), ".\\foo:\\bar");
+    assert.strictEqual(path.win32.normalize("foo:"), ".\\foo:");
+    assert.strictEqual(path.win32.normalize("foo:bar"), "foo:bar");
+    assert.strictEqual(path.win32.normalize("x:y/z"), "x:y\\z");
+  });
+
   test("very long paths", () => {
     // Regression test: buffer overflow with paths longer than PATH_SIZE
     // This used to panic with "index out of bounds" because the buffer

--- a/test/js/node/test/parallel/test-path-win32-normalize-device-names.js
+++ b/test/js/node/test/parallel/test-path-win32-normalize-device-names.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+
+if (!common.isWindows) {
+  common.skip('Windows only');
+}
+
+const normalizeDeviceNameTests = [
+  // UNC paths: \\server\share\... is a Windows UNC path, where 'server' is the network server name and 'share'
+  // is the shared folder. These are used for network file access and are subject to reserved device name
+  // checks after the share.
+  { input: '\\\\server\\share\\COM1:', expected: '\\\\server\\share\\COM1:' },
+  { input: '\\\\server\\share\\PRN:', expected: '\\\\server\\share\\PRN:' },
+  { input: '\\\\server\\share\\AUX:', expected: '\\\\server\\share\\AUX:' },
+  { input: '\\\\server\\share\\LPT1:', expected: '\\\\server\\share\\LPT1:' },
+  { input: '\\\\server\\share\\COM1:\\foo\\bar', expected: '\\\\server\\share\\COM1:\\foo\\bar' },
+  { input: '\\\\server\\share\\path\\COM1:', expected: '\\\\server\\share\\path\\COM1:' },
+  { input: '\\\\server\\share\\COM1:..\\..\\..\\..\\Windows', expected: '\\\\server\\share\\Windows' },
+  { input: '\\\\server\\share\\path\\to\\LPT9:..\\..\\..\\..\\..\\..\\..\\..\\..\\file.txt',
+    expected: '\\\\server\\share\\file.txt' },
+
+  { input: 'CON', expected: 'CON' },
+  { input: 'con', expected: 'con' },
+  { input: 'CON:', expected: '.\\CON:.' },
+  { input: 'con:', expected: '.\\con:.' },
+  { input: 'CON:.', expected: '.\\CON:.' },
+  { input: 'coN:', expected: '.\\coN:.' },
+  { input: 'LPT9.foo', expected: 'LPT9.foo' },
+  { input: 'COM9:', expected: '.\\COM9:.' },
+  { input: 'COM9.', expected: '.\\COM9.' },
+  { input: 'C:COM9', expected: 'C:COM9' },
+  { input: 'C:\\COM9', expected: 'C:\\COM9' },
+  { input: 'CON:./foo', expected: '.\\CON:foo' },
+  { input: 'CON:/foo', expected: '.\\CON:foo' },
+  { input: 'CON:../foo', expected: '.\\CON:..\\foo' },
+  { input: 'CON:/../foo', expected: '.\\CON:..\\foo' },
+  { input: 'CON:./././foo', expected: '.\\CON:foo' },
+  { input: 'CON:..', expected: '.\\CON:..' },
+  { input: 'CON:..\\', expected: '.\\CON:..\\' },
+  { input: 'CON:..\\..', expected: '.\\CON:..\\..' },
+  { input: 'CON:..\\..\\', expected: '.\\CON:..\\..\\' },
+  { input: 'CON:..\\..\\foo', expected: '.\\CON:..\\..\\foo' },
+  { input: 'CON:..\\..\\foo\\', expected: '.\\CON:..\\..\\foo\\' },
+  { input: 'CON:..\\..\\foo\\bar', expected: '.\\CON:..\\..\\foo\\bar' },
+  { input: 'CON:..\\..\\foo\\bar\\', expected: '.\\CON:..\\..\\foo\\bar\\' },
+  { input: 'COM1:a:b:c', expected: '.\\COM1:a:b:c' },
+  { input: 'COM1:a:b:c/', expected: '.\\COM1:a:b:c\\' },
+  { input: 'c:lpt1', expected: 'c:lpt1' },
+  { input: 'c:\\lpt1', expected: 'c:\\lpt1' },
+
+  // Reserved device names with path traversal
+  { input: 'CON:.\\..\\..\\foo', expected: '.\\CON:..\\..\\foo' },
+  { input: 'PRN:.\\..\\bar', expected: '.\\PRN:..\\bar' },
+  { input: 'AUX:/../../baz', expected: '.\\AUX:..\\..\\baz' },
+
+  { input: 'COM1:', expected: '.\\COM1:.' },
+  { input: 'COM9:', expected: '.\\COM9:.' },
+  { input: 'COM¹:', expected: '.\\COM¹:.' },
+  { input: 'COM²:', expected: '.\\COM²:.' },
+  { input: 'COM³:', expected: '.\\COM³:.' },
+  { input: 'COM1:.\\..\\..\\foo', expected: '.\\COM1:..\\..\\foo' },
+  { input: 'COM¹:.\\..\\..\\foo', expected: '.\\COM¹:..\\..\\foo' },
+  { input: 'LPT1:', expected: '.\\LPT1:.' },
+  { input: 'LPT¹:', expected: '.\\LPT¹:.' },
+  { input: 'LPT²:', expected: '.\\LPT²:.' },
+  { input: 'LPT³:', expected: '.\\LPT³:.' },
+  { input: 'LPT9:', expected: '.\\LPT9:.' },
+  { input: 'LPT1:.\\..\\..\\foo', expected: '.\\LPT1:..\\..\\foo' },
+  { input: 'LPT¹:.\\..\\..\\foo', expected: '.\\LPT¹:..\\..\\foo' },
+  { input: 'LpT5:/another/path', expected: '.\\LpT5:another\\path' },
+
+  { input: 'C:\\foo', expected: 'C:\\foo' },
+  { input: 'D:bar', expected: 'D:bar' },
+
+  { input: 'CON', expected: 'CON' },
+  { input: 'CON.TXT', expected: 'CON.TXT' },
+  { input: 'COM10:', expected: '.\\COM10:' },
+  { input: 'LPT10:', expected: '.\\LPT10:' },
+  { input: 'CONNINGTOWER:', expected: '.\\CONNINGTOWER:' },
+  { input: 'AUXILIARYDEVICE:', expected: '.\\AUXILIARYDEVICE:' },
+  { input: 'NULLED:', expected: '.\\NULLED:' },
+  { input: 'PRNINTER:', expected: '.\\PRNINTER:' },
+
+  { input: 'CON:\\..\\..\\windows\\system32', expected: '.\\CON:..\\..\\windows\\system32' },
+  { input: 'PRN:.././../etc/passwd', expected: '.\\PRN:..\\..\\etc\\passwd' },
+
+  // Test with trailing slashes
+  { input: 'CON:\\', expected: '.\\CON:.\\' },
+  { input: 'COM1:\\foo\\bar\\', expected: '.\\COM1:foo\\bar\\' },
+
+  // Test cases from original vulnerability reports or similar scenarios
+  { input: 'COM1:.\\..\\..\\foo.js', expected: '.\\COM1:..\\..\\foo.js' },
+  { input: 'LPT1:.\\..\\..\\another.txt', expected: '.\\LPT1:..\\..\\another.txt' },
+  // UNC paths
+  { input: '\\\\?\\COM1:.\\..\\..\\foo2.js', expected: '\\\\?\\COM1:\\foo2.js' },
+
+  // Paths with device names not at the beginning
+  { input: 'C:\\CON', expected: 'C:\\CON' },
+  { input: 'C:\\path\\to\\COM1:', expected: 'C:\\path\\to\\COM1:' },
+
+  // Device name followed by multiple colons
+  { input: 'CON::', expected: '.\\CON::' },
+  { input: 'COM1:::foo', expected: '.\\COM1:::foo' },
+
+  // Device name with mixed path separators
+  { input: 'AUX:/foo\\bar/baz', expected: '.\\AUX:foo\\bar\\baz' },
+];
+
+for (const { input, expected } of normalizeDeviceNameTests) {
+  const actual = path.win32.normalize(input);
+  assert.strictEqual(actual, expected,
+                     `path.win32.normalize(${JSON.stringify(input)}) === ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
+}
+
+assert.strictEqual(path.win32.normalize('CON:foo/../bar'), '.\\CON:bar');
+
+// This should NOT be prefixed because 'c:' is treated as a drive letter.
+assert.strictEqual(path.win32.normalize('c:COM1:'), 'c:COM1:');

--- a/test/js/node/test/parallel/test-pipe-unref.js
+++ b/test/js/node/test/parallel/test-pipe-unref.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+const net = require('net');
+const assert = require('assert');
+const { fork } = require('child_process');
+
+// This test should end immediately after `unref` is called
+// The pipe will stay open as Node.js completes, thus run in a child process
+// so that tmpdir can be cleaned up.
+
+const tmpdir = require('../common/tmpdir');
+
+if (process.argv[2] !== 'child') {
+  // Parent
+  tmpdir.refresh();
+
+  // Run test
+  const child = fork(__filename, ['child'], { stdio: 'inherit' });
+  child.on('exit', common.mustCall(function(code) {
+    assert.strictEqual(code, 0);
+  }));
+
+  return;
+}
+
+// Child
+const s = net.Server();
+s.listen(common.PIPE);
+s.unref();

--- a/test/js/node/test/parallel/test-stdout-close-catch.js
+++ b/test/js/node/test/parallel/test-stdout-close-catch.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child_process = require('child_process');
+const fixtures = require('../common/fixtures');
+const { getSystemErrorName } = require('util');
+
+const testScript = fixtures.path('catch-stdout-error.js');
+
+const child = child_process.exec(
+  ...common.escapePOSIXShell`"${process.execPath}" "${testScript}" | "${process.execPath}" -pe "process.stdin.on('data' , () => process.exit(1))"`
+);
+let output = '';
+
+child.stderr.on('data', function(c) {
+  output += c;
+});
+
+
+child.on('close', common.mustCall(function(code) {
+  output = JSON.parse(output);
+
+  assert.strictEqual(output.code, 'EPIPE');
+  assert.strictEqual(getSystemErrorName(output.errno), 'EPIPE');
+  assert.strictEqual(output.syscall, 'write');
+  console.log('ok');
+}));

--- a/test/js/node/test/parallel/test-timers-reset-process-domain-on-throw.js
+++ b/test/js/node/test/parallel/test-timers-reset-process-domain-on-throw.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// This test makes sure that when throwing from within a timer's callback,
+// its active domain at the time of the throw is not the process' active domain
+// for the next timers that need to be processed on the same turn of the event
+// loop.
+
+const common = require('../common');
+const assert = require('assert');
+const domain = require('domain');
+
+// Use the same timeout value so that both timers' callbacks are called during
+// the same invocation of the underlying native timer's callback (listOnTimeout
+// in lib/timers.js).
+setTimeout(err, 50);
+setTimeout(common.mustCall(secondTimer), 50);
+
+function err() {
+  const d = domain.create();
+  d.on('error', handleDomainError);
+  d.run(err2);
+
+  function err2() {
+    // This function doesn't exist, and throws an error as a result.
+    err3(); // eslint-disable-line no-undef
+  }
+
+  function handleDomainError(e) {
+    assert.strictEqual(e.domain, d);
+    // Domains' error handlers are called outside of their domain's context, so
+    // we're not expecting any active domain here.
+    assert.strictEqual(process.domain, undefined);
+  }
+}
+
+function secondTimer() {
+  // secondTimer was scheduled before any domain had been created, so its
+  // callback should not have any active domain set when it runs.
+  if (process.domain !== null) {
+    console.log('process.domain should be null in this timer callback, but is:',
+                process.domain);
+    // Do not use assert here, as it throws errors and if a domain with an error
+    // handler is active, then asserting wouldn't make the test fail.
+    process.exit(1);
+  }
+}

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -23,7 +23,7 @@
 
 import assert from "assert";
 import { describe, expect, it } from "bun:test";
-import "harness";
+import { bunEnv, bunExe } from "harness";
 import util from "util";
 // const context = require('vm').runInNewContext; // TODO: Use a vm polyfill
 
@@ -434,5 +434,51 @@ describe("util", () => {
 describe("util.parseEnv", () => {
   it("accepts a String object without crashing", () => {
     expect(util.parseEnv(new String("FOO=bar"))).toEqual({ FOO: "bar" });
+  });
+});
+
+// https://nodejs.org/docs/latest-v26.x/api/util.html#utildebuglogsection-callback
+describe("util.debuglog", () => {
+  const script = `
+    const assert = require("node:assert");
+    const util = require("node:util");
+    let inner = null;
+    const debug = util.debuglog(process.argv[1], cb => { inner = cb; });
+    assert.strictEqual(typeof Object.getOwnPropertyDescriptor(debug, "enabled").get, "function");
+    assert.strictEqual(inner, null, "the callback runs on the first call, not at creation");
+    debug("hello %s", "world");
+    assert.strictEqual(typeof inner, "function");
+    assert.strictEqual(typeof Object.getOwnPropertyDescriptor(inner, "enabled").get, "function");
+    console.log(JSON.stringify({ outer: debug.enabled, inner: inner.enabled }));
+  `;
+
+  async function run(section, nodeDebug) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script, section],
+      env: { ...bunEnv, NODE_DEBUG: nodeDebug },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  it("exposes `enabled` and passes the real logger to the callback", async () => {
+    const cases = [
+      ["tud", "foo,tud,bar", true],
+      ["tud", "foo,bar", false],
+      ["test-abc", "test-*", true],
+      // A section name is matched literally: `$` and `.` are not regexp syntax.
+      ["f.oo", "f$oo", false],
+    ];
+    const results = await Promise.all(cases.map(([section, env]) => run(section, env)));
+    for (let i = 0; i < cases.length; i++) {
+      const [section, env, expected] = cases[i];
+      expect({ section, env, stdout: results[i].stdout, exitCode: results[i].exitCode }).toEqual({
+        section,
+        env,
+        stdout: JSON.stringify({ outer: expected, inner: expected }),
+        exitCode: 0,
+      });
+    }
   });
 });


### PR DESCRIPTION
Stacked on #34660 — review that first. This branch is based on `claude/callback-throw-uncaught`, not `main`.

**Upstream tests added: 4.**

Part of the Node v26.3.0 sweep. Four upstream test files are vendored and three runtime gaps are closed. Every vendored file was canary-checked (a copy with a `throw` appended must make the run fail) so nothing here is a silent pass.

## Runtime changes

**1. `path.win32.normalize()` handles reserved DOS device names** (`src/runtime/node/path.rs`)

Bun's port predates two upstream changes:

- Reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1`-`COM9`, `LPT1`-`LPT9`, plus the superscript `COM¹`/`LPT³` spellings) form their own root and make the result explicitly relative: `CON:` was returned unchanged, Node returns `.\CON:.`. Without this, `CON:..\..\foo` could climb out of what the caller treated as a device path.
- A relative path containing a colon is prefixed with `.\` so Windows cannot read it back as device-relative — CVE-2024-36139. `foo:/bar` was returned as `foo:\bar`, Node returns `.\foo:\bar`.
- `\\.\` and `\\?\` device roots are now recognized, including the `\\?\COM1:` special case. `\\.\PHYSICALDRIVE0` previously gained a spurious separator.

The reserved-name list is matched in both representations: a UTF-8 path carries `¹` as `C2 B9`, a UTF-16 path as a single unit. `normalize_js_t` now reserves two extra slots for the `.\` prefix.

**2. `node:domain` runs a thrown error's handler outside the domain** (`src/js/node/domain.ts`)

A throw inside `d.run()` went straight to the `error` handler with the domain still active, so `process.domain` was the domain itself. Node's `_errorHandler` exits the domain first (`process.domain` is `undefined` in the handler) and clears the stack afterwards (`null` for the rest of the tick). `Domain.prototype.exit` also leaves `undefined`, not `null`, when the stack empties. `bind()` and `intercept()` take the same path.

**3. `util.debuglog(section, callback)`** (`src/js/node/util.ts`)

The documented second argument was ignored and the returned logger had no `enabled` property. Both now match `lib/internal/util/debuglog.js`: the callback receives the real logger on the first call (whether or not the section is enabled), and `enabled` is a getter on both functions.

## Tests

Vendored verbatim from Node v26.3.0:

| file | status |
| --- | --- |
| `test-pipe-unref.js` | already passed on the base branch — canary-verified real |
| `test-stdout-close-catch.js` | already passed on the base branch — canary-verified real |
| `test-timers-reset-process-domain-on-throw.js` | needs change 2 |
| `test-path-win32-normalize-device-names.js` | needs change 1 |

`test-path-win32-normalize-device-names.js` gates on `common.isWindows`, so it skips on the Linux lane and runs for real on the Windows lane. Since I cannot run Windows here, I verified the implementation directly: the file's 76-case table, re-pointed at `path.win32`, passes on Linux, and the same expectations are asserted on every platform by the new cases in `test/js/node/path/normalize.test.js`.

Bun-side tests (these run everywhere):
- `test/js/node/path/normalize.test.js` — reserved device names, the superscript spellings, UNC and `\\?\`/`\\.\` device roots, and the CVE-2024-36139 colon cases.
- `test/js/node/util/util.test.js` — `debuglog`'s callback and `enabled`, including that section names are matched literally (`f$oo` must not match `f.oo`).

Both fail on a build without these changes. The four vendored domain tests already in the tree still pass.

`test/expectations.txt` is untouched.

## The rest of the 38, and what stopped each one

All were run against this build (`bun test` for the `node:test` files, matching the CI runner).

**Silent passes on the base — deliberately not vendored.** `test-node-output-eval.mjs` and `test-util-getcallsites.js` both skip with `Requires Amaro`: they need `module.stripTypeScriptTypes`, which another agent is implementing. `test-module-subpath-import-long-path.js` skips as Windows-specific and exercises >260-character path handling I cannot verify from Linux.

**Needs a feature Bun does not have.**
- `test-quotaexceedederror.js` — no `QuotaExceededError` global (WebIDL's DOMException replacement, with `quota`/`requested`).
- `test-sea-get-asset-keys.js` — no `node:sea`.
- `test-webstream-structured-clone-no-leftovers.mjs` — `structuredClone` cannot transfer a `ReadableStream` (`DataCloneError`).
- `test-vfs.js` — module resolution does not consult monkey-patched `fs`/`Module._stat`, so a userland VFS under `process.execPath` is not resolvable.
- `test-sync-io-option.js` (`--trace-sync-io`), `test-stack-size-limit.js` (`--stack-size`), `test-openssl-ca-options.js` (`--use-bundled-ca`/`--use-openssl-ca` and their exit code 9), `test-throw-undefined-or-null-traced.mjs` (`--trace-uncaught`) — CLI flags Bun does not implement; the last three also assert Node's exact stderr text.
- `test-process-binding-internalbinding-allowlist.js` — `process.binding()` would have to return objects for ~20 internal modules Bun does not expose.
- `test-warn-sigprof.js` — needs `--inspect` on its own process, which Bun's runner does not pass.

**Node's output format, which Bun deliberately differs on.**
- `test-unhandled-exception-rethrow-error.js` — expects `Error: boom` and exit code 7; Bun prints its own `error: boom` report.
- `test-node-output-console.mjs`, `test-node-output-vm.mjs` — snapshot Node's uncaught-error layout (`test.vm:1`, the source line, `Node.js *`); Bun prints `error: …` plus a version banner. The vendored `assertSnapshot.js` helper is also an older adapted copy.
- `test-util-debug.js` — the child half passes with change 3, but the parent re-runs every case with colors, and Node v26 turned `util.inspect.styles.regexp` into a syntax-highlighting *function*. Matching its per-character coloring is an `util.inspect` feature, not a debuglog one.

**Reads Node's own source tree**: `test-process-versions.js` (`deps/acorn/.../package.json`), `test-npm-install.js` (`deps/npm`), `test-release-changelog.js` (`CHANGELOG.md`, `src/node_version.h`), `test-without-async-context-frame.mjs` (spawns `tools/test.py`).

**Other.**
- `test-require-extensions-same-filename-as-dir.js` — Bun resolves `.../three.js` to the directory named `three.js` rather than the file. A real resolver bug, but in the resolver's file-vs-directory precedence, which I did not want to change under a sweep.
- `test-next-tick-error-spin.js` — an error thrown inside `domain.run()` is caught synchronously in Bun, so a `nextTick` chain that re-throws never yields and `setImmediate` never runs; Node unwinds through the uncaught-exception path. Fixing it means giving `node:domain` real uncaught-exception integration.
- `test-strace-openat-openssl.js` — Bun's startup opens `/sys/kernel/mm/transparent_hugepage/enabled` (mimalloc), which the test's allowlist forbids.
- `test-setproctitle.js` — assigning `process.title` does not change the title `ps` reports.
- `test-module-loading.js` — expects the DEP0128 "invalid main entry" warning.
- `test-process-env-sideeffects.js` — inspector `Runtime.evaluate` ignores `throwOnSideEffect`.
- `test-x509-escaping.js` — `X509Certificate.infoAccess` parsing differs from Node's.
- `test-watch-mode-worker.mjs`, `test-watch-mode-restart-esm-loading-error.mjs`, `test-http-regr-gh-2928.js` — time out; not diagnosed.
- `parallel/testcfg.py` — Node's Python test-runner config, not a test.

## Cross-cutting bug found while triaging

Importing a CJS module from ESM **invokes every getter on `module.exports`**; Node uses `cjs-module-lexer` and never calls them.

```js
// cjs.cjs
module.exports = { get foo() { console.log("GETTER CALLED"); return 1; } };
// main.mjs
import m from "./cjs.cjs";   // node: silent.  bun: prints GETTER CALLED
```

This is why `test-startup-empty-regexp-statics.mjs` fails: importing the test harness runs its lazy `hasOpenSSL`/`hasIPv6` getters, which leave `RegExp.$_` populated. Bun's own startup is clean — a bare `.mjs` file sees empty statics. Site is `src/jsc/bindings/JSCommonJSModule.cpp` (`slot.getValue(...)` while building `exportValues`). Not fixed here: making named exports lazy is a module-loader change, and dropping accessor properties from the named exports would break code that imports them today.
