### PR TITLE
install: delete dead peer-skip block in enqueue_dependency_list

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -98,40 +98,10 @@ pub fn enqueue_dependency_list(
     this.task_queue
         .ensure_unused_capacity(dependencies_list.len as usize)
         .expect("unreachable");
-    let lockfile = &mut *this.lockfile;
 
     // Step 1. Go through main dependencies
-    let mut begin = dependencies_list.off;
     let end = dependencies_list.off.saturating_add(dependencies_list.len);
-
-    // if dependency is peer and is going to be installed
-    // through "dependencies", skip it
-    if end - begin > 1 && lockfile.buffers.dependencies[0].behavior.is_peer() {
-        let mut peer_i: usize = 0;
-        // reshaped for borrowck — index into the slice instead of holding &mut across loop
-        while lockfile.buffers.dependencies[peer_i].behavior.is_peer() {
-            let mut dep_i: usize = (end - 1) as usize;
-            let mut dep = lockfile.buffers.dependencies[dep_i].clone();
-            while !dep.behavior.is_peer() {
-                if !dep.behavior.is_dev() {
-                    if lockfile.buffers.dependencies[peer_i].name_hash == dep.name_hash {
-                        lockfile.buffers.dependencies[peer_i] =
-                            lockfile.buffers.dependencies[begin as usize].clone();
-                        begin += 1;
-                        break;
-                    }
-                }
-                dep_i -= 1;
-                dep = lockfile.buffers.dependencies[dep_i].clone();
-            }
-            peer_i += 1;
-            if peer_i == end as usize {
-                break;
-            }
-        }
-    }
-
-    let mut i = begin;
+    let mut i = dependencies_list.off;
 
     // we have to be very careful with pointers here
     while i < end {

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -160,7 +160,7 @@ impl DependencyExt for Dependency {
     }
 
     /// Sorting order for dependencies is:
-    /// 1. [ `peerDependencies`, `optionalDependencies`, `devDependencies`, `dependencies` ]
+    /// 1. [ `workspaces`, `devDependencies`, `optionalDependencies`, `dependencies`, `peerDependencies` ]
     /// 2. name ASC
     /// "name" must be ASC so that later, when we rebuild the lockfile
     /// we insert it back in reverse order without an extra sorting pass

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -548,7 +548,7 @@ impl Clone for Dependency {
 
 impl Dependency {
     /// Sorting order for dependencies is:
-    /// 1. [`peerDependencies`, `optionalDependencies`, `devDependencies`, `dependencies`]
+    /// 1. [`workspaces`, `devDependencies`, `optionalDependencies`, `dependencies`, `peerDependencies`]
     /// 2. name ASC
     /// "name" must be ASC so that later, when we rebuild the lockfile, we
     /// insert it back in reverse order without an extra sorting pass.


### PR DESCRIPTION
### What

Delete the peer-skip compaction block at the top of `enqueue_dependency_list`, and fix the two doc comments on `Dependency::is_less_than` that still describe the pre-#21059 sort order.

### Why this block is dead

The block was added in `05781dd91e` (#6396, Oct 2023) when `Behavior::cmp` sorted peer dependencies to the **front** of every slice. Its structure relies on that: it gates on the first entry being a peer, walks `peer_i` forward through the peer prefix, and for each one walks `dep_i` backward from `end-1` through the non-peer tail looking for a same-named regular dependency.

`2bc75a87f4` (#21059, Jul 2025) flipped `Behavior::cmp` to `workspace < dev < optional < prod < peer`, i.e. peers now sort **last**. All three callers hand this function peers-last slices:

| caller | slice source | peer placement |
| --- | --- | --- |
| `install_with_manager.rs:1589` | `root.parse()` → `parse_with_json_impl` | sorted at `Package.rs:2863` by `Behavior::cmp` |
| `PackageManagerResolution.rs:236,241` | `folder_resolver::get_or_put` → `parse_with_json_impl` | same sort |
| `AsyncModule.rs:579` | `Package::from_npm` | groups appended `dependencies, dev, optional, peer` (`Package.rs:644-658`), no sort |

So the gate `dependencies[begin].is_peer()` can only hold when every entry in `[begin, end)` is a peer (peers are the tail). Then `dependencies[end-1]` is a peer too, the inner `while !dep.behavior.is_peer()` is false on entry, and the body never runs.

The duplicate-name dedup the block was built for is handled at parse time now: `Package::from_npm` skips a peer/dev/optional whose `name_hash` matches an earlier dependency (`Package.rs:748-767`), and `parse_with_json_impl` has the `duplicate_checker_map` path.

The block also indexed `lockfile.buffers.dependencies[0]` and started `peer_i` at absolute `0` while `begin`/`end`/`dep_i` were relative to `dependencies_list.off`, so had it been reachable from the `off > 0` auto-install callers it would have written into root's dependency slots. That is moot now, but it is why the block was flagged in the first place.

### Verification

Empirical dead-code check: replaced the inner-loop entry with `panic!()` and ran `bun bd test test/cli/install/bun-install.test.ts` (193 tests). Zero hits; the only failures were the bitbucket/gitlab network tests that fail without egress. In particular `should prefer dependencies over peerDependencies of the same name` passes without entering the block (the prod dep sorts to index 0, so the `is_peer()` gate is false).

With the block deleted:

- `bun bd test test/cli/install/bun-install.test.ts -t peer` (8 pass)
- `bun bd test test/cli/run/run-autoinstall.test.ts test/cli/run/autoinstall-cached-manifest.test.ts` (13 pass)

### Related

#35370 reached the same dead-code conclusion and reverted its perf change to this file; this PR does the deletion it deferred.
