### PR TITLE
moduleLoaderFetch: drop GCOwnedDataScope before transpiling so promise macros don't trip the sweeper assert

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3794,11 +3794,16 @@ JSC::JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
 
     auto moduleKeyJS = key.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    auto moduleKey = moduleKeyJS->value(globalObject);
+    // Copy into an owned String instead of holding the GCOwnedDataScope that value() returns.
+    // fetchESMSourceCode* below may transpile a module that invokes a promise-returning macro,
+    // which spins the event loop via wait_for_promise; IncrementalSweeper can then fire with
+    // vm().entryScope unset and trip ASSERT(!m_topGCOwnedDataScope). The String copy is a
+    // refcount bump on the impl, so moduleKeyBun below borrows safely for the function's scope.
+    String moduleKey = moduleKeyJS->value(globalObject);
     if (scope.exception()) [[unlikely]]
         return rejectedInternalPromise(globalObject, scope.exception()->value());
 
-    if (moduleKey->endsWith(".node"_s)) {
+    if (moduleKey.endsWith(".node"_s)) {
         return rejectedInternalPromise(globalObject, createTypeError(globalObject, "To load Node-API modules, use require() or process.dlopen instead of import."_s));
     }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3794,11 +3794,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
 
     auto moduleKeyJS = key.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    // Copy into an owned String instead of holding the GCOwnedDataScope that value() returns.
-    // fetchESMSourceCode* below may transpile a module that invokes a promise-returning macro,
-    // which spins the event loop via wait_for_promise; IncrementalSweeper can then fire with
-    // vm().entryScope unset and trip ASSERT(!m_topGCOwnedDataScope). The String copy is a
-    // refcount bump on the impl, so moduleKeyBun below borrows safely for the function's scope.
+    // Owned String, not GCOwnedDataScope: fetchESMSourceCode* may spin the event loop (promise-returning macros) and trip IncrementalSweeper's !m_topGCOwnedDataScope assert.
     String moduleKey = moduleKeyJS->value(globalObject);
     if (scope.exception()) [[unlikely]]
         return rejectedInternalPromise(globalObject, scope.exception()->value());

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -139,9 +139,11 @@ test("ireturnapromise", async () => {
 // ASSERT(!m_topGCOwnedDataScope) in Heap::clearConcurrentRetainedDataIfPossible aborted.
 // The Bun.gc(true) inside the macro schedules the sweeper; the setTimeout gives the sweeper
 // timer time to become due while wait_for_promise loops.
-test.skipIf(!isDebug && !isASAN)("promise-returning macro does not trip the GCOwnedDataScope sweeper assertion", async () => {
-  using dir = tempDir("macro-promise-sweeper", {
-    "macro.ts": `
+test.skipIf(!isDebug && !isASAN)(
+  "promise-returning macro does not trip the GCOwnedDataScope sweeper assertion",
+  async () => {
+    using dir = tempDir("macro-promise-sweeper", {
+      "macro.ts": `
       export async function delayed() {
         Bun.gc(true);
         const { promise, resolve } = Promise.withResolvers();
@@ -149,26 +151,27 @@ test.skipIf(!isDebug && !isASAN)("promise-returning macro does not trip the GCOw
         return promise;
       }
     `,
-    "entry.test.ts": `
+      "entry.test.ts": `
       import { delayed } from "./macro.ts" with { type: "macro" };
       import { test, expect } from "bun:test";
       test("macro promise", () => { expect(delayed()).toBe("ok"); });
     `,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "entry.test.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toMatchObject({
-    stderr: expect.not.stringContaining("m_topGCOwnedDataScope"),
-    exitCode: 0,
-    signalCode: null,
-  });
-});
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "entry.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toMatchObject({
+      stderr: expect.not.stringContaining("m_topGCOwnedDataScope"),
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+);
 
 // A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside
 // JSC__JSValue__putToPropertyKey take a path that can throw, so the binding must check for

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,6 +1,6 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import defaultMacro, {
@@ -135,11 +135,11 @@ test("ireturnapromise", async () => {
 
 // moduleLoaderFetch held a GCOwnedDataScope across Bun__transpileFile. When a macro returned a
 // pending Promise, the macro runner spun the event loop (wait_for_promise), JSC's
-// IncrementalSweeper fired with no VMEntryScope on the stack, and the debug-only
+// IncrementalSweeper fired with no VMEntryScope on the stack, and the ASSERT_ENABLED-only
 // ASSERT(!m_topGCOwnedDataScope) in Heap::clearConcurrentRetainedDataIfPossible aborted.
 // The Bun.gc(true) inside the macro schedules the sweeper; the setTimeout gives the sweeper
 // timer time to become due while wait_for_promise loops.
-test.skipIf(!isDebug)("promise-returning macro does not trip the GCOwnedDataScope sweeper assertion", async () => {
+test.skipIf(!isDebug && !isASAN)("promise-returning macro does not trip the GCOwnedDataScope sweeper assertion", async () => {
   using dir = tempDir("macro-promise-sweeper", {
     "macro.ts": `
       export async function delayed() {

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,6 +1,6 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import defaultMacro, {
@@ -131,6 +131,43 @@ test("namespace import", () => {
 
 test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
+});
+
+// moduleLoaderFetch held a GCOwnedDataScope across Bun__transpileFile. When a macro returned a
+// pending Promise, the macro runner spun the event loop (wait_for_promise), JSC's
+// IncrementalSweeper fired with no VMEntryScope on the stack, and the debug-only
+// ASSERT(!m_topGCOwnedDataScope) in Heap::clearConcurrentRetainedDataIfPossible aborted.
+// The Bun.gc(true) inside the macro schedules the sweeper; the setTimeout gives the sweeper
+// timer time to become due while wait_for_promise loops.
+test.skipIf(!isDebug)("promise-returning macro does not trip the GCOwnedDataScope sweeper assertion", async () => {
+  using dir = tempDir("macro-promise-sweeper", {
+    "macro.ts": `
+      export async function delayed() {
+        Bun.gc(true);
+        const { promise, resolve } = Promise.withResolvers();
+        setTimeout(() => resolve("ok"), 200);
+        return promise;
+      }
+    `,
+    "entry.test.ts": `
+      import { delayed } from "./macro.ts" with { type: "macro" };
+      import { test, expect } from "bun:test";
+      test("macro promise", () => { expect(delayed()).toBe("ok"); });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "entry.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toMatchObject({
+    stderr: expect.not.stringContaining("m_topGCOwnedDataScope"),
+    exitCode: 0,
+    signalCode: null,
+  });
 });
 
 // A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside


### PR DESCRIPTION
## What

`bun bd test test/bundler/transpiler` was intermittently aborting under debug/ASAN with:

```
ASSERTION FAILED: !m_topGCOwnedDataScope
vendor/WebKit/Source/JavaScriptCore/heap/Heap.cpp(1261) : void JSC::Heap::clearConcurrentRetainedDataIfPossible()
```

right after the `[macro] call ...` lines for `macro-test.test.ts`.

## Cause

`Zig::GlobalObject::moduleLoaderFetch` did

```cpp
auto moduleKey = moduleKeyJS->value(globalObject);   // GCOwnedDataScope<const String&>
...
Bun::fetchESMSourceCodeAsync(... &moduleKeyBun ...); // transpiles the module
```

`JSString::value()` returns a `GCOwnedDataScope<const String&>`, which in `ASSERT_ENABLED` builds registers itself as `heap.m_topGCOwnedDataScope`. `fetchESMSourceCode*` ends up in `Bun__transpileFile`, and when the module being transpiled invokes a **promise-returning macro** (`ireturnapromise` in the suite), `Run::coerce` calls `wait_for_promise`, which spins the event loop. `auto_tick` drains JSC's `JSRunLoopTimer`, which fires `IncrementalSweeper::doWork` → `clearConcurrentRetainedDataIfPossible`:

```cpp
if (vm().entryScope) [[unlikely]] return;
ASSERT(!m_topGCOwnedDataScope);
```

`moduleLoaderFetch` is reached from `JSModuleLoader::loadModule` (the C++ loader), not from a JS call, so `vm().entryScope` is null and the assert fires. gdb confirms the dangling scope address sits inside `moduleLoaderFetch`'s frame.

This is an `ASSERT_ENABLED`-only failure. The `m_topGCOwnedDataScope` tracking is compiled out in release, and the module key arrives from `identifierToJSValue` as an already-atom string, so `swapToAtomString` never runs on it and its impl never lands in the retained-strings vector the sweeper clears; there is no release-mode UAF for this particular caller.

The scope-holding `auto moduleKey = moduleKeyJS->value(globalObject)` was introduced in #18266 (previously `key.toWTFString()` returned an owned `String`); the assertion only landed in a later WebKit bump, which is why it surfaced now.

## Fix

Bind to an owned `String` instead:

```cpp
String moduleKey = moduleKeyJS->value(globalObject);
```

The temporary `GCOwnedDataScope` is destroyed at the end of the full-expression and clears `m_topGCOwnedDataScope` before any transpile runs. `String`'s copy is just a `StringImpl` refcount bump, so `Bun::toString(moduleKey)` still borrows the same impl for the lifetime of the function.

## Test

Added an `ASSERT_ENABLED`-gated regression in `test/bundler/transpiler/macro-test.test.ts` that spawns `bun test` on a two-file fixture where the macro calls `Bun.gc(true)` (to schedule the sweeper) and resolves via `setTimeout(..., 200)` (so the sweeper timer comes due inside `wait_for_promise`). Before this change the child aborts with the assertion; after, it exits 0. The full `test/bundler/transpiler` directory now passes 10/10 runs.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.0 (5f4f9206a)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (5f4f9206a)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.03ms]
(pass) latin1 string [0.01ms]
(pass) ascii string
(pass) type coercion [0.05ms]
(pass) escaping [0.18ms]
(pass) utf16 string
(pass) import aliases [0.02ms]
(pass) default import
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.07ms]
(skip) promise-returning macro does not trip the GCOwnedDataScope sweeper assertion
(pass) object argument with a sparse numeric key [8.69ms]
(pass) --no-macros > bun build --no-macros refuses to run macros [4.69ms]
(pass) --no-macros > Bun.build({ macros: false }) refuses to run macros [9.22ms]
(pass) --no-macros > bun build without --no-macros still runs macros [26.15ms]

 14 pass
 1 skip
 0 fail
 81 expect() calls
Ran 15 tests across 1 file. [277.00ms]
__F:0:S:1
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-test.test.ts
bun test v1.4.0 (5f4f9206a)

test/bundler/transpiler/macro-test.test.ts:
[macro] call escapeHTML
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call identity
[macro] call escape
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] call addStrings
[macro] c
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 665ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+5f4f9206a
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (5f4f9206a)

test/bundler/transpiler/macro-test.test.ts:
(pass) bun builtins can be used in macros [0.03ms]
(pass) latin1 string [0.01ms]
(pass) ascii string
(pass) type coercion [0.05ms]
(pass) escaping [0.15ms]
(pass) utf16 string
(pass) import aliases [0.02ms]
(pass) default import
(pass) namespace import [0.02ms]
(pass) ireturnapromise [0.19ms]
(skip) promise-returning macro does not trip the GCOwnedDataScope sweeper assertion
(pass) object argument with a sparse numeric key [8.89ms]
(pass) --no-macros > bun build --no-macros refuses to run macros [4.40ms]
(pass) --no-macros > Bun.build({ macros: false }) refuses to run macros [8.55ms]
(pass) --no-macros > bun build without --no-macros still runs macros [21.95ms]

 14 pass
 1 skip
 0 fail
 81 expect() calls
Ran 15 tests across 1 file. [303.00ms]
__F:0:S:1
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp       |  5 ++--
 test/bundler/transpiler/macro-test.test.ts | 42 +++++++++++++++++++++++++++++-
 2 files changed, 44 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 2 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp            3      3      0
test/bundler/transpiler/macro-test.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->