### PR TITLE
test(proxy-stress): return deadPort()'s bind(0) port, not the connect-autobound one

### DIFF
--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -712,34 +712,42 @@ export interface DeadPort {
  * A port on 127.0.0.1 that refuses connections for as long as the returned
  * handle is alive.
  *
- * The port is held as the *local* side of a live TCP connection: bound, so
- * the kernel's ephemeral allocator will not hand it to a concurrent
- * `listen(0)`, and not listening, so `connect()` to it is refused. Do not
- * simplify to bind-then-close: that frees the port into exactly the pool
- * `listen(0)` draws from, and a sibling `test.concurrent` will take it.
+ * The returned port is the `bind(0)`-allocated listening port of a server
+ * that has since stopped listening but whose one accepted connection is
+ * still established. That keeps the port in the kernel's bind hash with a
+ * `bind()`-style `fastreuse >= 0` bucket, which BOTH the ephemeral
+ * `listen(0)` allocator and the connect-time `__inet_hash_connect`
+ * allocator skip. Nothing is listening on it, so `connect()` is refused.
+ *
+ * Do not return the client-side local port of the held connection: that
+ * port was allocated by `connect()` (`fastreuse == -1`), which
+ * `__inet_hash_connect` WILL consider for reuse, and on Linux a later
+ * `connect(127.0.0.1:P)` can be assigned source port P and self-connect
+ * (observed as ~1/10000, surfacing as `Malformed_HTTP_Response` because the
+ * client reads back its own CONNECT line).
  */
 export async function deadPort(): Promise<DeadPort> {
-  let accepted: net.Socket | undefined;
+  let accepted!: net.Socket;
+  const acceptedP = Promise.withResolvers<void>();
   const sink = net.createServer(s => {
     accepted = s;
     s.on("error", () => {});
+    acceptedP.resolve();
   });
   sink.listen(0, "127.0.0.1");
   await once(sink, "listening");
-  const holder = net.connect({ host: "127.0.0.1", port: (sink.address() as net.AddressInfo).port });
+  const port = (sink.address() as net.AddressInfo).port;
+  const holder = net.connect({ host: "127.0.0.1", port });
   holder.on("error", () => {});
   await once(holder, "connect");
-  const port = (holder.address() as net.AddressInfo).port;
-  // `sink` has served its purpose (giving `holder` something to connect to);
-  // stop accepting so its listening port can be recycled. The established
-  // connection — and with it `holder`'s local-port binding — survives
-  // server.close().
+  await acceptedP.promise;
+  // Stop listening; `accepted` (and `holder`) keep the port bound.
   sink.close();
   return {
     port,
     [Symbol.dispose]() {
       holder.destroy();
-      accepted?.destroy();
+      accepted.destroy();
     },
   };
 }


### PR DESCRIPTION
## Problem

`proxy-stress-errors.test.ts` flaked in CI on 5461e9d4c with:

```
error: expect(received).toMatch(expected)
Expected substring or pattern: /ECONNREFUSED|ConnectionRefused/
Received: "Malformed_HTTP_Response"
✗ proxy unreachable > proxy port refused, https origin
```

Reproduced locally at 1/2000 full-file runs.

## Cause

#35269 changed `deadPort()` to hold a live TCP connection and return `holder.address().port`, the client-side local port, so a concurrent `listen(0)` can't steal it. That works for `listen(0)`, but the port was allocated by `connect()`, which gives its `inet_bind_bucket` the `fastreuse == -1` marker. Linux's connect-time port allocator (`__inet_hash_connect`) only checks 4-tuple uniqueness for such ports, so a later `connect(127.0.0.1:P)` can itself be assigned source port P. On loopback that is a TCP self-connect: the fetch client's proxy connection succeeds, it writes `CONNECT host:port HTTP/1.1...`, reads those same bytes back, and picohttp reports `Malformed_HTTP_Response`.

A standalone `net.connect` probe against the current `deadPort()` hits this in ~3/30000 attempts.

## Fix

Return the server-side (`sink`) port instead. It was allocated by `bind(0)`, so its bucket has `fastreuse >= 0` and `__inet_hash_connect` skips it entirely, ruling out self-connect. The `accepted` socket (kept alive after `server.close()`) keeps the port in the bind hash without `SO_REUSEADDR`, so `listen(0)` still can't pick it either. Also wait for the server's `'connection'` event before closing it so `accepted` is guaranteed to exist.

## Verification

```
# before
full file, release:                   1 / 2000 runs hit Malformed_HTTP_Response
net.connect probe:                    3 / 30000 self-connects

# after
full file, release:                   0 / 2000 runs
-t "unreachable|proxy port refused":  0 / 3000 runs
net.connect probe:                    0 / 30000 self-connects
listen(0) churn alongside probe:      0 / 30000 collisions
bun bd (ASAN), all proxy-stress-*:    841 pass / 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->