### PR TITLE
util: styleText handles inspect.colors added after first call; getCallSites captures Error

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -20,6 +20,7 @@ const parseEnv = $newRustFunction("node_util_binding.rs", "parseEnv", 1);
 const NumberIsSafeInteger = Number.isSafeInteger;
 const ObjectKeys = Object.keys;
 const ObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
+var Error = globalThis.Error;
 const { uncurryThis, SafeMap } = require("internal/primordials");
 const RegExpPrototypeExec = uncurryThis(RegExp.prototype.exec);
 
@@ -245,6 +246,17 @@ function getHexStyleCache() {
   return hexStyleCache;
 }
 
+function buildStyleEntry(codes) {
+  const openNum = codes[0];
+  const closeNum = codes[1];
+  return {
+    __proto__: null,
+    openSeq: kEscape + openNum + kEscapeEnd,
+    closeSeq: kEscape + closeNum + kEscapeEnd,
+    keepClose: openNum === kDimCode || openNum === kBoldCode,
+  };
+}
+
 function getStyleCache() {
   if (styleCache === undefined) {
     styleCache = { __proto__: null };
@@ -252,14 +264,7 @@ function getStyleCache() {
     for (const key of ObjectGetOwnPropertyNames(colors)) {
       const codes = colors[key];
       if (codes) {
-        const openNum = codes[0];
-        const closeNum = codes[1];
-        styleCache[key] = {
-          __proto__: null,
-          openSeq: kEscape + openNum + kEscapeEnd,
-          closeSeq: kEscape + closeNum + kEscapeEnd,
-          keepClose: openNum === kDimCode || openNum === kBoldCode,
-        };
+        styleCache[key] = buildStyleEntry(codes);
       }
     }
   }
@@ -388,9 +393,16 @@ function styleText(format, text, options) {
       continue;
     }
 
-    const style = cache[key];
+    let style = cache[key];
     if (style === undefined) {
-      validateOneOf(key, "format", ObjectGetOwnPropertyNames(inspect.colors));
+      // inspect.colors is user-mutable; a key added after the cache was
+      // populated is looked up live and cached on first use.
+      const codes = inspect.colors[key];
+      if (codes == null) {
+        validateOneOf(key, "format", ObjectGetOwnPropertyNames(inspect.colors));
+      }
+      style = buildStyleEntry(codes);
+      cache[key] = style;
     }
     openCodes += style.openSeq;
     closeCodes = style.closeSeq + closeCodes;

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -21,6 +21,7 @@ const NumberIsSafeInteger = Number.isSafeInteger;
 const ObjectKeys = Object.keys;
 const ObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
 var Error = globalThis.Error;
+const ErrorCaptureStackTrace = Error.captureStackTrace;
 const { uncurryThis, SafeMap } = require("internal/primordials");
 const RegExpPrototypeExec = uncurryThis(RegExp.prototype.exec);
 
@@ -479,7 +480,7 @@ function getCallSites(frameCount = 10, options) {
     try {
       Error.stackTraceLimit = frameCount;
     } catch {}
-    Error.captureStackTrace(target, getCallSites);
+    ErrorCaptureStackTrace(target, getCallSites);
     return target.stack;
   } finally {
     Error.prepareStackTrace = savedPrepareStackTrace;

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -23,7 +23,7 @@
 
 import assert from "assert";
 import { describe, expect, it } from "bun:test";
-import "harness";
+import { bunEnv, bunExe } from "harness";
 import util from "util";
 // const context = require('vm').runInNewContext; // TODO: Use a vm polyfill
 
@@ -432,6 +432,32 @@ describe("util", () => {
     assert.strictEqual(util.styleText("red", "test", { validateStream: false }), "\u001b[31mtest\u001b[39m");
   });
 
+  // inspect.colors is user-mutable; styleText must see keys added after its
+  // internal cache was first populated instead of crashing on the stale cache.
+  it.concurrent("styleText accepts inspect.colors entries added after first call", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const util = require("node:util");
+         util.styleText("red", "x", { validateStream: false });
+         util.inspect.colors.myColor = [95, 39];
+         const single = util.styleText("myColor", "x", { validateStream: false });
+         const array = util.styleText(["bold", "myColor"], "x", { validateStream: false });
+         process.stdout.write(JSON.stringify({ single, array }));`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      single: "\u001b[95mx\u001b[39m",
+      array: "\u001b[1m\u001b[95mx\u001b[39m\u001b[22m",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   describe("getCallSites", () => {
     it("restores Error state when stackTraceLimit is non-writable", () => {
       const desc = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit");
@@ -446,6 +472,26 @@ describe("util", () => {
         Object.defineProperty(Error, "stackTraceLimit", desc);
         Error.prepareStackTrace = savedPrepare;
       }
+    });
+
+    it.concurrent("is unaffected by user replacing globalThis.Error", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const util = require("node:util");
+           globalThis.Error = undefined;
+           function outer() { return util.getCallSites(5); }
+           const sites = outer();
+           process.stdout.write(JSON.stringify(sites.map(s => s.functionName)));`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toContain("outer");
+      expect(exitCode).toBe(0);
     });
 
     it("each frame has the node v26 shape", () => {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -474,12 +474,13 @@ describe("util", () => {
       }
     });
 
-    it.concurrent("is unaffected by user replacing globalThis.Error", async () => {
+    it.concurrent("is unaffected by user tampering with the Error global", async () => {
       await using proc = Bun.spawn({
         cmd: [
           bunExe(),
           "-e",
           `const util = require("node:util");
+           delete Error.captureStackTrace;
            globalThis.Error = undefined;
            function outer() { return util.getCallSites(5); }
            const sites = outer();


### PR DESCRIPTION
## What

Two follow-up fixes to #34434 in `src/js/node/util.ts`.

### styleText: cache miss on user-added color

```js
const util = require("node:util");
util.styleText("red", "x", { validateStream: false }); // populates cache
util.inspect.colors.myColor = [95, 39];
util.styleText("myColor", "x", { validateStream: false });
// TypeError: undefined is not an object (evaluating 'style.openSeq')
```

`getStyleCache()` snapshots `inspect.colors` once, but the unknown-key path validates against the live `ObjectGetOwnPropertyNames(inspect.colors)` and then unconditionally reads `style.openSeq`. A color added after the cache was built passes validation and then crashes. Before #34434 the lookup was always live so user-added colors worked.

Fix: on cache miss, read the live `inspect.colors[key]` and build/cache the entry. Invalid names still hit `validateOneOf` and throw `ERR_INVALID_ARG_VALUE`; mutated or deleted built-in entries continue to resolve from the cache, matching Node v26.3.0.

### getCallSites: bare global `Error`

```js
const util = require("node:util");
globalThis.Error = undefined;
util.getCallSites(5);
// TypeError: undefined is not an object
```

Node's implementation goes through an internal binding and is unaffected by the `Error` global. We implement it over `Error.prepareStackTrace`/`captureStackTrace`, so replacing `globalThis.Error` broke it. Capture `Error` at module load, the same pattern `child_process.ts` already uses.

The `Object.freeze(Error)` case still throws because we must assign `Error.prepareStackTrace`; matching Node there would need a native call-site binding.

The handoff also flagged the `Buffer.from` call in `hexToRgb`, but `Buffer` is already in the codegen `globalsToPrefix` list and is rewritten to the private intrinsic at build time, so it is unaffected by `globalThis.Buffer` tampering (verified).

## Tests

Added two subprocess tests in `test/js/node/util/util.test.js` covering the added-color path and the replaced-`Error` path. Both fail on main and pass with this change; the rest of the file (210 tests) and `test-util-getcallsites-preparestacktrace.js` continue to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
bun test v1.4.0 (8222b8617)

test/js/node/util/util.test.js:
(pass) util > toUSVString [4.60ms]
(pass) util > inherits [5.35ms]
(pass) util > isArray > all cases [7.02ms]
(pass) util > isRegExp > all cases [3.75ms]
(pass) util > isDate > all cases [155.48ms]
(pass) util > isError > all cases [15.33ms]
(pass) util > isObject > all cases [3.92ms]
(pass) util > isPrimitive > all cases [8.11ms]
(pass) util > isBuffer > all cases [3.40ms]
(pass) util > _extend > all cases [7.65ms]
(pass) util > isBoolean > all cases [2.69ms]
(pass) util > isNull > all cases [2.83ms]
(pass) util > isUndefined > all cases [2.88ms]
(pass) util > isNullOrUndefined > all cases [2.75ms]
(pass) util > isNumber > all cases [2.79ms]
(pass) util > isString > all cases [2.54ms]
(pass) util > isSymbol > all cases [2.58ms]
(pass) util > isFunction > all cases [3.08ms]
(pass) util > types.isNativeError > all cases [4.28ms]
(pass) util > TextEncoder > is same as global TextEncoder [1.21ms]
(pass) util > TextDecoder > is same as global TextDe
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (38c513d34)

test/js/node/util/util.test.js:
(pass) util > toUSVString [0.10ms]
(pass) util > inherits [0.12ms]
(pass) util > isArray > all cases [0.10ms]
(pass) util > isRegExp > all cases [0.05ms]
(pass) util > isDate > all cases [5.43ms]
(pass) util > isError > all cases [0.23ms]
(pass) util > isObject > all cases [0.05ms]
(pass) util > isPrimitive > all cases [0.12ms]
(pass) util > isBuffer > all cases [0.04ms]
(pass) util > _extend > all cases [0.09ms]
(pass) util > isBoolean > all cases [0.02ms]
(pass) util > isNull > all cases [0.02ms]
(pass) util > isUndefined > all cases [0.04ms]
(pass) util > isNullOrUndefined > all cases [0.02ms]
(pass) util > isNumber > all cases [0.02ms]
(pass) util > isString > all cases [0.02ms]
(pass) util > isSymbol > all cases [0.02ms]
(pass) util > isFunction > all cases [0.03ms]
(pass) util > types.isNativeError > all cases [0.04ms]
(pass) util > TextEncoder > is same as global TextEncoder [0.01ms]
(pass) util > TextDecoder > is same as global TextDecoder [0.01ms]
(pass) util > format [0.22ms]
(pass) util > formatWithOptions [1.45ms]
(pass) util > styleText hex colors > parses 6-digit hex [0.52ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/util/util.test.js
bun test v1.4.0 (8222b8617)

test/js/node/util/util.test.js:
(pass) util > toUSVString [4.49ms]
(pass) util > inherits [5.04ms]
(pass) util > isArray > all cases [7.03ms]
(pass) util > isRegExp > all cases [4.01ms]
(pass) util > isDate > all cases [154.51ms]
(pass) util > isError > all cases [14.94ms]
(pass) util > isObject > all cases [3.93ms]
(pass) util > isPrimitive > all cases [8.51ms]
(pass) util > isBuffer > all cases [3.48ms]
(pass) util > _extend > all cases [7.74ms]
(pass) util > isBoolean > all cases [2.62ms]
(pass) util > isNull > all cases [2.87ms]
(pass) util > isUndefined > all cases [2.87ms]
(pass) util > isNullOrUndefined > all cases [2.74ms]
(pass) util > isNumber > all cases [2.87ms]
(pass) util > isString > all cases [2.58ms]
(pass) util > isSymbol > all cases [2.54ms]
(pass) util > isFunction > all cases [3.07ms]
(pass) util > types.isNativeError > all cases [4.36ms]
(pass) util > TextEncoder > is same as global TextEncoder [1.17ms]
(pass) util > TextDecoder > is same as global TextDe
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 634ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7441ms)
Bundle modules (44ms)
Postprocesss modules (120ms)
Bundle Functions (662ms)
Generate Code (14ms)

[8.30s] Bundled "src/js" for production
  2113 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 19.57s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+8222b8617
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (8222b8617)

test/js/node/util/util.test.js:
(pass) util > toUSVString [0.10ms]
(pass) util > inherits [0.12ms]
(pass) util > isArray > all cases [0.12ms]
(pass) util > isRegExp > all cases [0.05ms]
(pass) util > isDate > all cases [5.70ms]
(pass) util > isEr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/util.ts            | 35 ++++++++++++++++++++----------
 test/js/node/util/util.test.js | 49 +++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 72 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/js/node/util.ts                 3      6      0
test/js/node/util/util.test.js      4      4      0
```

</details>

<!-- robobun:evidence:end -->