### PR TITLE
http: route identity chunked bodies through the multi-packet decode path

### DIFF
--- a/bench/snippets/fetch-chunked-small.mjs
+++ b/bench/snippets/fetch-chunked-small.mjs
@@ -1,0 +1,76 @@
+// Benchmark fetch() decoding small Transfer-Encoding: chunked bodies that
+// arrive with their headers in a single read. Exercises the <=16 KiB
+// dispatch in the HTTP client's chunked-body handler for both identity and
+// gzip Content-Encoding.
+import { bench, group, run } from "../runner.mjs";
+import net from "node:net";
+import zlib from "node:zlib";
+
+function chunked(buf) {
+  return Buffer.concat([
+    Buffer.from(buf.length.toString(16) + "\r\n"),
+    buf,
+    Buffer.from("\r\n0\r\n\r\n"),
+  ]);
+}
+
+function makeReply(body, gzip) {
+  const payload = gzip ? zlib.gzipSync(body, { level: 6 }) : body;
+  return Buffer.concat([
+    Buffer.from(
+      "HTTP/1.1 200 OK\r\n" +
+        "Transfer-Encoding: chunked\r\n" +
+        (gzip ? "Content-Encoding: gzip\r\n" : "") +
+        "Connection: keep-alive\r\n" +
+        "\r\n",
+    ),
+    chunked(payload),
+  ]);
+}
+
+const sizes = [256, 4096, 15 * 1024];
+const bodies = Object.fromEntries(sizes.map(n => [n, Buffer.alloc(n, "x")]));
+const replies = {};
+for (const n of sizes) {
+  replies[`i${n}`] = makeReply(bodies[n], false);
+  replies[`g${n}`] = makeReply(bodies[n], true);
+}
+
+const server = net.createServer(sock => {
+  sock.setNoDelay(true);
+  let pending = Buffer.alloc(0);
+  sock.on("data", chunk => {
+    pending = Buffer.concat([pending, chunk]);
+    while (true) {
+      const end = pending.indexOf("\r\n\r\n");
+      if (end < 0) break;
+      const head = pending.subarray(0, end).toString("latin1");
+      pending = pending.subarray(end + 4);
+      const m = head.match(/^GET \/(\w+)/);
+      sock.write(replies[m[1]]);
+    }
+  });
+});
+
+await new Promise(r => server.listen(0, r));
+const base = `http://127.0.0.1:${server.address().port}`;
+
+// Warm the keep-alive connection so the first iteration doesn't pay connect.
+for (const key of Object.keys(replies)) await fetch(`${base}/${key}`).then(r => r.arrayBuffer());
+
+for (const n of sizes) {
+  group(`chunked ${n}B`, () => {
+    bench("identity → arrayBuffer()", async () => {
+      const r = await fetch(`${base}/i${n}`);
+      await r.arrayBuffer();
+    });
+    bench("gzip → arrayBuffer()", async () => {
+      const r = await fetch(`${base}/g${n}`);
+      await r.arrayBuffer();
+    });
+  });
+}
+
+await run();
+server.close();
+process.exit(0);

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4781,8 +4781,17 @@ impl<'a> HTTPClient<'a> {
         &mut self,
         incoming_data: &[u8],
     ) -> crate::Result<bool> {
+        // The single-packet path decodes into a 16 KiB scratch so a small
+        // compressed body can be handed straight to `decompress_bytes` without
+        // ever allocating `compressed_body`. For identity bodies that shortcut
+        // doesn't exist: scratch copy + `append_slice_exact` is one memcpy more
+        // than `_from_multiple_packets`' append + decode-in-tail + truncate, so
+        // route identity bodies there unconditionally.
         let small_len = 16 * 1024usize;
-        if incoming_data.len() <= small_len && self.state.get_body_buffer().list.is_empty() {
+        if self.state.encoding.is_compressed()
+            && incoming_data.len() <= small_len
+            && self.state.get_body_buffer().list.is_empty()
+        {
             self.handle_response_body_chunked_encoding_from_single_packet(incoming_data)
         } else {
             self.handle_response_body_chunked_encoding_from_multiple_packets(incoming_data)

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -1,6 +1,7 @@
 import { Socket } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, gcTick } from "harness";
+import { randomBytes } from "node:crypto";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
@@ -905,4 +906,54 @@ describe("empty compressed responses", () => {
       }
     });
   }
+});
+
+// The <=16 KiB chunked-body dispatcher routes identity bodies through the
+// append + decode-in-tail path and compressed bodies through the scratch
+// decode path. These pin both paths for a body that fits in one read.
+describe("small chunked body decode", () => {
+  function chunked(buf: Buffer): Buffer {
+    return Buffer.concat([Buffer.from(buf.length.toString(16) + "\r\n"), buf, Buffer.from("\r\n0\r\n\r\n")]);
+  }
+
+  async function serve(extraHeader: string, body: Buffer, expected: Buffer): Promise<void> {
+    const reply = Buffer.concat([
+      Buffer.from(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n" + extraHeader + "\r\n",
+      ),
+      chunked(body),
+    ]);
+    const sockets = new Set<import("node:net").Socket>();
+    const server = createNetServer(sock => {
+      sockets.add(sock);
+      sock.on("close", () => sockets.delete(sock));
+      sock.on("error", () => {});
+      sock.once("data", () => sock.write(reply));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(res.status).toBe(200);
+      expect(Buffer.from(await res.arrayBuffer()).equals(expected)).toBe(true);
+    } finally {
+      for (const s of sockets) s.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  for (const n of [1, 4096, 15 * 1024]) {
+    const body = Buffer.alloc(n, "x");
+    it.concurrent(`identity ${n}B`, () => serve("", body, body));
+  }
+
+  // One compressed case as the unchanged-path control; randomBytes keeps the
+  // compressed size near the input size so the test exercises the 16 KiB gate
+  // with a multi-KiB payload rather than a ~50 B gzipped run of 'x'.
+  const raw = randomBytes(4096);
+  const gz = gzipSync(raw, { level: 6 });
+  it.concurrent(`gzip ${gz.length}B compressed`, () => serve("Content-Encoding: gzip\r\n", gz, raw));
 });

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -918,9 +918,7 @@ describe("small chunked body decode", () => {
 
   async function serve(extraHeader: string, body: Buffer, expected: Buffer): Promise<void> {
     const reply = Buffer.concat([
-      Buffer.from(
-        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n" + extraHeader + "\r\n",
-      ),
+      Buffer.from("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n" + extraHeader + "\r\n"),
       chunked(body),
     ]);
     const sockets = new Set<import("node:net").Socket>();

--- a/test/js/web/fetch/fetch-retry-chunked.test.ts
+++ b/test/js/web/fetch/fetch-retry-chunked.test.ts
@@ -4,9 +4,10 @@
 // body_out_str == None state itself is not deterministically reachable from
 // fetch().
 
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
+import zlib from "node:zlib";
 
 // The server drops every third request without responding, so the client
 // that adopted the pooled socket observes on_close with response_stage ==
@@ -57,5 +58,70 @@ test("chunked uncompressed body over a retried keep-alive connection", async () 
   } finally {
     for (const s of sockets) s.destroy();
     await new Promise<void>(r => server.close(() => r()));
+  }
+});
+
+// The <=16 KiB chunked-body dispatcher routes identity bodies through the
+// append + decode-in-tail path and compressed bodies through the scratch
+// decode path. These pin both paths for a body that fits in one read and for
+// one that is split so the first read yields -2 (needs more data).
+describe("small chunked body decode", () => {
+  function chunked(buf: Buffer): Buffer {
+    return Buffer.concat([Buffer.from(buf.length.toString(16) + "\r\n"), buf, Buffer.from("\r\n0\r\n\r\n")]);
+  }
+
+  async function serve(reply: Buffer, fn: (url: string) => Promise<void>): Promise<void> {
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer(sock => {
+      sockets.add(sock);
+      sock.on("close", () => sockets.delete(sock));
+      sock.on("error", () => {});
+      sock.once("data", () => sock.write(reply));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as AddressInfo;
+    try {
+      await fn(`http://127.0.0.1:${port}/`);
+    } finally {
+      for (const s of sockets) s.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  function reply(body: Buffer, extraHeader: string): Buffer {
+    return Buffer.concat([
+      Buffer.from(
+        "HTTP/1.1 200 OK\r\n" +
+          "Transfer-Encoding: chunked\r\n" +
+          "Connection: keep-alive\r\n" +
+          extraHeader +
+          "\r\n",
+      ),
+      chunked(body),
+    ]);
+  }
+
+  for (const n of [1, 256, 4096, 15 * 1024]) {
+    const body = Buffer.alloc(n, "x");
+    const gz = zlib.gzipSync(body, { level: 6 });
+
+    test.concurrent(`identity ${n}B`, async () => {
+      await serve(reply(body, ""), async url => {
+        const res = await fetch(url);
+        expect(res.status).toBe(200);
+        expect(Buffer.from(await res.arrayBuffer()).equals(body)).toBe(true);
+      });
+    });
+
+    test.concurrent(`gzip ${n}B`, async () => {
+      await serve(reply(gz, "Content-Encoding: gzip\r\n"), async url => {
+        const res = await fetch(url);
+        expect(res.status).toBe(200);
+        expect(Buffer.from(await res.arrayBuffer()).equals(body)).toBe(true);
+      });
+    });
   }
 });

--- a/test/js/web/fetch/fetch-retry-chunked.test.ts
+++ b/test/js/web/fetch/fetch-retry-chunked.test.ts
@@ -63,8 +63,7 @@ test("chunked uncompressed body over a retried keep-alive connection", async () 
 
 // The <=16 KiB chunked-body dispatcher routes identity bodies through the
 // append + decode-in-tail path and compressed bodies through the scratch
-// decode path. These pin both paths for a body that fits in one read and for
-// one that is split so the first read yields -2 (needs more data).
+// decode path. These pin both paths for a body that fits in one read.
 describe("small chunked body decode", () => {
   function chunked(buf: Buffer): Buffer {
     return Buffer.concat([Buffer.from(buf.length.toString(16) + "\r\n"), buf, Buffer.from("\r\n0\r\n\r\n")]);

--- a/test/js/web/fetch/fetch-retry-chunked.test.ts
+++ b/test/js/web/fetch/fetch-retry-chunked.test.ts
@@ -94,11 +94,7 @@ describe("small chunked body decode", () => {
   function reply(body: Buffer, extraHeader: string): Buffer {
     return Buffer.concat([
       Buffer.from(
-        "HTTP/1.1 200 OK\r\n" +
-          "Transfer-Encoding: chunked\r\n" +
-          "Connection: keep-alive\r\n" +
-          extraHeader +
-          "\r\n",
+        "HTTP/1.1 200 OK\r\n" + "Transfer-Encoding: chunked\r\n" + "Connection: keep-alive\r\n" + extraHeader + "\r\n",
       ),
       chunked(body),
     ]);

--- a/test/js/web/fetch/fetch-retry-chunked.test.ts
+++ b/test/js/web/fetch/fetch-retry-chunked.test.ts
@@ -4,10 +4,9 @@
 // body_out_str == None state itself is not deterministically reachable from
 // fetch().
 
-import { describe, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import type { AddressInfo } from "node:net";
 import net from "node:net";
-import zlib from "node:zlib";
 
 // The server drops every third request without responding, so the client
 // that adopted the pooled socket observes on_close with response_stage ==
@@ -58,65 +57,5 @@ test("chunked uncompressed body over a retried keep-alive connection", async () 
   } finally {
     for (const s of sockets) s.destroy();
     await new Promise<void>(r => server.close(() => r()));
-  }
-});
-
-// The <=16 KiB chunked-body dispatcher routes identity bodies through the
-// append + decode-in-tail path and compressed bodies through the scratch
-// decode path. These pin both paths for a body that fits in one read.
-describe("small chunked body decode", () => {
-  function chunked(buf: Buffer): Buffer {
-    return Buffer.concat([Buffer.from(buf.length.toString(16) + "\r\n"), buf, Buffer.from("\r\n0\r\n\r\n")]);
-  }
-
-  async function serve(reply: Buffer, fn: (url: string) => Promise<void>): Promise<void> {
-    const sockets = new Set<net.Socket>();
-    const server = net.createServer(sock => {
-      sockets.add(sock);
-      sock.on("close", () => sockets.delete(sock));
-      sock.on("error", () => {});
-      sock.once("data", () => sock.write(reply));
-    });
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const { port } = server.address() as AddressInfo;
-    try {
-      await fn(`http://127.0.0.1:${port}/`);
-    } finally {
-      for (const s of sockets) s.destroy();
-      await new Promise<void>(r => server.close(() => r()));
-    }
-  }
-
-  function reply(body: Buffer, extraHeader: string): Buffer {
-    return Buffer.concat([
-      Buffer.from(
-        "HTTP/1.1 200 OK\r\n" + "Transfer-Encoding: chunked\r\n" + "Connection: keep-alive\r\n" + extraHeader + "\r\n",
-      ),
-      chunked(body),
-    ]);
-  }
-
-  for (const n of [1, 256, 4096, 15 * 1024]) {
-    const body = Buffer.alloc(n, "x");
-    const gz = zlib.gzipSync(body, { level: 6 });
-
-    test.concurrent(`identity ${n}B`, async () => {
-      await serve(reply(body, ""), async url => {
-        const res = await fetch(url);
-        expect(res.status).toBe(200);
-        expect(Buffer.from(await res.arrayBuffer()).equals(body)).toBe(true);
-      });
-    });
-
-    test.concurrent(`gzip ${n}B`, async () => {
-      await serve(reply(gz, "Content-Encoding: gzip\r\n"), async url => {
-        const res = await fetch(url);
-        expect(res.status).toBe(200);
-        expect(Buffer.from(await res.arrayBuffer()).equals(body)).toBe(true);
-      });
-    });
   }
 });


### PR DESCRIPTION
Follow-up to the review note in https://github.com/oven-sh/bun/pull/35373#issuecomment-5066571946.

## What changes

`handle_response_body_chunked_encoding` now takes the `_from_single_packet` branch only when `encoding.is_compressed()`. Identity-encoded chunked bodies of any size go through `_from_multiple_packets`.

## Why

`_from_single_packet` decodes the raw chunked bytes into a 16 KiB scratch buffer and then, on the Done path, calls `handle_response_body_from_single_packet`:

- compressed: `decompress_bytes(scratch, body_out, true)`. The compressed bytes never touch `compressed_body`, so that allocation is skipped entirely. This is the reason the scratch path exists.
- identity: `body_out.append_slice_exact(scratch)`. That is a second memcpy on top of the scratch copy.

`_from_multiple_packets` does `body_out.append_slice(incoming)` + `phr_decode_chunked` in the tail + `truncate`. For identity bodies that is one memcpy into the final destination and no scratch.

The `-2` (needs more data) case is the same shape: single-packet does scratch copy + `append_slice_exact`; multi-packet does `append_slice` + decode-in-tail. One memcpy fewer.

Redirect handling is unchanged: `_from_multiple_packets` already runs for identity chunked bodies above 16 KiB, and `progress_update` / `state.reset()` discard any bytes decoded into `body_out_str` before the redirect fires.

## Bench

`bench/snippets/fetch-chunked-small.mjs` (new) serves 256 B / 4 KiB / 15 KiB chunked bodies over a keep-alive `net` socket under both identity and gzip encodings, headers and body written in one `sock.write()`. Path-dispatch counters added during verification confirmed the identity cases enter `_from_multiple_packets` and the gzip cases still enter `_from_single_packet`.

Release build, 8 alternating A/B runs, min-of-8 avg-per-iter:

| size | encoding | before | after | delta |
| ---: | --- | ---: | ---: | ---: |
| 256 B | identity | 38.41 µs | 38.43 µs | +0.02 µs |
| 256 B | gzip | 38.08 µs | 38.04 µs | -0.04 µs |
| 4096 B | identity | 39.56 µs | 39.80 µs | +0.24 µs |
| 4096 B | gzip | 46.49 µs | 46.44 µs | -0.05 µs |
| 15360 B | identity | 47.61 µs | 48.16 µs | +0.55 µs |
| 15360 B | gzip | 64.67 µs | 66.70 µs | +2.03 µs |

Run-to-run spread on the same binary is ~40 µs (CPU frequency swings on a shared host), so all of the above is noise; the medians go both directions by similar amounts. The avoided memcpy is at most 16 KiB (~1.5 µs) against a ~38-48 µs localhost round-trip, which is below the variance floor of a loopback `fetch()` bench. No regression in any measured case.

So: the operation-count win is real (one memcpy instead of two, no scratch touch) but not observable at the `fetch()` level. Leaving the dispatch gated on `is_compressed()` regardless because it makes the single-packet path's purpose explicit and costs nothing; happy to close if that's preferred.

## Tests

`test/js/web/fetch/fetch-gzip.test.ts` gains a `small chunked body decode` block: identity at 1 B / 4 KiB / 15 KiB plus one gzip control (randomBytes so the compressed payload is actually ~4 KiB rather than a ~50 B gzipped run of the same byte). These are regression guards for the newly-routed identity path; they pass on `main` and here by construction since the change is behaviour-preserving.

```
bun bd test fetch-gzip.test.ts fetch-retry-chunked.test.ts         75 pass
bun bd test fetch-proxy-connect-tunnel-split-envelope.test.ts fetch-redirect.test.ts   16 pass
```
