### PR TITLE
test(bundler): consolidate compile-autoload tests (23 compiles -> 11, 71s -> 35s on ASAN)

### DIFF
--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -1,175 +1,149 @@
 import { describe } from "bun:test";
 import { itBundled } from "./expectBundled";
 
+// Each compiled binary reports the full observable autoload state on one line
+// so a single compile can assert dotenv, bunfig (via preload), tsconfig paths,
+// and package.json exports together instead of one flag per compile.
+const probeEntry = /* ts */ `
+  const dyn = (p: string) => import(p).then(m => m.default).catch(() => "off");
+  Promise.all([dyn("@utils/" + "helper"), dyn("runtime-pkg/" + "utils")]).then(([ts, pj]) => {
+    console.log("dotenv=" + (process.env.TEST_VAR ?? "off") + " tsconfig=" + ts + " pkgjson=" + pj);
+  });
+`;
+
+const probeRuntimeFiles = {
+  "/.env": `TEST_VAR=from_dotenv`,
+  "/bunfig.toml": `preload = ["./preload.ts"]\n`,
+  "/preload.ts": `console.log("PRELOAD");`,
+  "/tsconfig.json": JSON.stringify({
+    compilerOptions: { baseUrl: ".", paths: { "@utils/*": ["./src/utils/*"] } },
+  }),
+  "/src/utils/helper.ts": `export default "tsconfig-helper";`,
+  "/node_modules/runtime-pkg/package.json": JSON.stringify({
+    name: "runtime-pkg",
+    exports: { "./utils": "./lib/utils.js" },
+  }),
+  "/node_modules/runtime-pkg/lib/utils.js": `export default "pkg-utils";`,
+};
+
 // Not describe.concurrent: the backend:"cli" cases each spawn a full
-// `bun build --compile` link (hundreds of MB on disk) and running eight of
+// `bun build --compile` link (hundreds of MB on disk) and running several of
 // those at once SIGTERMs on the linux lanes. expectBundled already forces
 // backend:"api" cases to it.serial, so only the CLI cases would overlap.
 describe("bundler", () => {
-  // Test that .env files are loaded by default in standalone executables
-  itBundled("compile/AutoloadDotenvDefault", {
+  // Defaults: dotenv/bunfig on, tsconfig/package.json off. A second run
+  // proves shell env vars take precedence over .env.
+  itBundled("compile/AutoloadDefaults", {
     compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_dotenv",
-      setCwd: true,
-    },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: [
+      { stdout: "PRELOAD\ndotenv=from_dotenv tsconfig=off pkgjson=off", setCwd: true },
+      {
+        stdout: "PRELOAD\ndotenv=from_shell tsconfig=off pkgjson=off",
+        setCwd: true,
+        env: { TEST_VAR: "from_shell" },
+      },
+    ],
   });
 
-  // Test that .env files can be disabled with autoloadDotenv: false
-  itBundled("compile/AutoloadDotenvDisabled", {
-    compile: {
-      autoloadDotenv: false,
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "not found",
-      setCwd: true,
-    },
+  // autoloadDotenv:false leaves bunfig's default (on) untouched; pair it with
+  // autoloadTsconfig:true so one compile exercises both flags independently.
+  itBundled("compile/AutoloadDotenvDisabledTsconfigEnabled", {
+    compile: { autoloadDotenv: false, autoloadTsconfig: true },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "PRELOAD\ndotenv=off tsconfig=tsconfig-helper pkgjson=off", setCwd: true },
   });
 
-  // Test that .env files can be explicitly enabled with autoloadDotenv: true
-  itBundled("compile/AutoloadDotenvEnabledExplicitly", {
+  // autoloadBunfig:false leaves dotenv's default (on) untouched; pair it with
+  // autoloadPackageJson:true so one compile exercises both flags independently.
+  itBundled("compile/AutoloadBunfigDisabledPackageJsonEnabled", {
+    compile: { autoloadBunfig: false, autoloadPackageJson: true },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "dotenv=from_dotenv tsconfig=off pkgjson=pkg-utils", setCwd: true },
+  });
+
+  // Every flag explicitly true.
+  itBundled("compile/AutoloadAllEnabled", {
     compile: {
       autoloadDotenv: true,
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_dotenv",
-      setCwd: true,
-    },
-  });
-
-  // Test that process environment variables take precedence over .env files
-  itBundled("compile/AutoloadDotenvWithExistingEnv", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_shell",
-      setCwd: true,
-      env: {
-        TEST_VAR: "from_shell",
-      },
-    },
-  });
-
-  // Test that bunfig.toml is loaded by default (preload is executed)
-  itBundled("compile/AutoloadBunfigDefault", {
-    compile: true,
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "PRELOAD\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that bunfig.toml can be disabled with autoloadBunfig: false
-  itBundled("compile/AutoloadBunfigDisabled", {
-    compile: {
-      autoloadBunfig: false,
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      // When bunfig is disabled, preload should NOT execute
-      stdout: "ENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that bunfig.toml can be explicitly enabled with autoloadBunfig: true
-  itBundled("compile/AutoloadBunfigEnabled", {
-    compile: {
       autoloadBunfig: true,
+      autoloadTsconfig: true,
+      autoloadPackageJson: true,
     },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
     run: {
-      stdout: "PRELOAD\nENTRY",
+      stdout: "PRELOAD\ndotenv=from_dotenv tsconfig=tsconfig-helper pkgjson=pkg-utils",
       setCwd: true,
     },
   });
 
-  // Test CLI backend with autoloadDotenv: false
-  itBundled("compile/AutoloadDotenvDisabledCLI", {
+  // Every flag explicitly false.
+  itBundled("compile/AutoloadAllDisabled", {
     compile: {
       autoloadDotenv: false,
+      autoloadBunfig: false,
+      autoloadTsconfig: false,
+      autoloadPackageJson: false,
     },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "dotenv=off tsconfig=off pkgjson=off", setCwd: true },
+  });
+
+  // Regression test for #25640: autoloadBunfig:false must be honoured when
+  // execArgv is present. The probe also asserts execArgv does not disturb the
+  // other three autoload defaults.
+  itBundled("compile/AutoloadBunfigDisabledWithExecArgv", {
+    compile: { autoloadBunfig: false, execArgv: ["--smol"] },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "dotenv=from_dotenv tsconfig=off pkgjson=off", setCwd: true },
+  });
+
+  itBundled("compile/AutoloadBunfigEnabledWithExecArgv", {
+    compile: { autoloadBunfig: true, execArgv: ["--smol"] },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "PRELOAD\ndotenv=from_dotenv tsconfig=off pkgjson=off", setCwd: true },
+  });
+
+  // CLI backend: exercise each --compile-autoload-* flag at least once. The
+  // pairs mirror the API tests above so the same independence checks apply.
+  itBundled("compile/AutoloadDotenvDisabledTsconfigEnabledCLI", {
+    compile: { autoloadDotenv: false, autoloadTsconfig: true },
     backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "not found",
-      setCwd: true,
-    },
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "PRELOAD\ndotenv=off tsconfig=tsconfig-helper pkgjson=off", setCwd: true },
+  });
+
+  itBundled("compile/AutoloadBunfigDisabledPackageJsonEnabledCLI", {
+    compile: { autoloadBunfig: false, autoloadPackageJson: true },
+    backend: "cli",
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "dotenv=from_dotenv tsconfig=off pkgjson=pkg-utils", setCwd: true },
+  });
+
+  itBundled("compile/AutoloadDotenvBunfigEnabledCLI", {
+    compile: { autoloadDotenv: true, autoloadBunfig: true },
+    backend: "cli",
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "PRELOAD\ndotenv=from_dotenv tsconfig=off pkgjson=off", setCwd: true },
+  });
+
+  // CLI regression test for #25640.
+  itBundled("compile/AutoloadBunfigDisabledWithExecArgvCLI", {
+    compile: { autoloadBunfig: false, execArgv: ["--smol"] },
+    backend: "cli",
+    files: { "/entry.ts": probeEntry },
+    runtimeFiles: probeRuntimeFiles,
+    run: { stdout: "dotenv=from_dotenv tsconfig=off pkgjson=off", setCwd: true },
   });
 
   // Regression test: standalone workers must not load .env when autoloadDotenv is disabled
@@ -184,6 +158,7 @@ console.log("PRELOAD");
 
         rmSync("./worker.ts", { force: true });
 
+        console.log("main=" + (process.env.TEST_VAR ?? "off"));
         const worker = new Worker("./worker.ts");
         console.log(await new Promise(resolve => {
           worker.onmessage = event => resolve(event.data);
@@ -191,7 +166,7 @@ console.log("PRELOAD");
         worker.terminate();
       `,
       "/worker.ts": /* js */ `
-        postMessage(process.env.TEST_VAR || "not found");
+        postMessage("worker=" + (process.env.TEST_VAR ?? "off"));
       `,
     },
     entryPointsRaw: ["./entry.ts", "./worker.ts"],
@@ -200,411 +175,8 @@ console.log("PRELOAD");
       "/.env": `TEST_VAR=from_dotenv`,
     },
     run: {
-      stdout: "not found",
+      stdout: "main=off\nworker=off",
       file: "dist/out",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadDotenv: true
-  itBundled("compile/AutoloadDotenvEnabledCLI", {
-    compile: {
-      autoloadDotenv: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-    },
-    run: {
-      stdout: "from_dotenv",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadBunfig: false
-  itBundled("compile/AutoloadBunfigDisabledCLI", {
-    compile: {
-      autoloadBunfig: false,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "ENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadBunfig: true
-  itBundled("compile/AutoloadBunfigEnabledCLI", {
-    compile: {
-      autoloadBunfig: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "PRELOAD\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadTsconfig: true using tsconfig paths
-  itBundled("compile/AutoloadTsconfigPathsCLI", {
-    compile: {
-      autoloadTsconfig: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* ts */ `
-        const modulePath = "@lib/" + "mymodule";
-        import(modulePath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@lib/*": ["./lib/*"],
-          },
-        },
-      }),
-      "/lib/mymodule.ts": `export default "mymodule-from-cli-tsconfig";`,
-    },
-    run: {
-      stdout: "mymodule-from-cli-tsconfig",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend with autoloadPackageJson: true using package.json exports
-  itBundled("compile/AutoloadPackageJsonExportsCLI", {
-    compile: {
-      autoloadPackageJson: true,
-    },
-    backend: "cli",
-    files: {
-      "/entry.js": /* js */ `
-        const pkgName = "cli-pkg";
-        const subpath = "feature";
-        import(pkgName + "/" + subpath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/node_modules/cli-pkg/package.json": JSON.stringify({
-        name: "cli-pkg",
-        exports: {
-          "./feature": "./features/main.js",
-        },
-      }),
-      "/node_modules/cli-pkg/features/main.js": `export default "feature-from-cli-package-exports";`,
-    },
-    run: {
-      stdout: "feature-from-cli-package-exports",
-      setCwd: true,
-    },
-  });
-
-  // Test CLI backend for autoloadBunfig: false with execArgv (regression test for #25640)
-  itBundled("compile/AutoloadBunfigDisabledWithExecArgvCLI", {
-    compile: {
-      autoloadBunfig: false,
-      execArgv: ["--smol"],
-    },
-    backend: "cli",
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "ENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that both flags can be disabled together without interference
-  itBundled("compile/AutoloadBothDisabled", {
-    compile: {
-      autoloadDotenv: false,
-      autoloadBunfig: false,
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log(process.env.TEST_VAR || "not found");
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/.env": `TEST_VAR=from_dotenv`,
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "not found\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that tsconfig.json paths are loaded at runtime when autoloadTsconfig: true
-  // Uses a dynamic import path that the bundler cannot resolve at compile time
-  itBundled("compile/AutoloadTsconfigPathsEnabled", {
-    compile: {
-      autoloadTsconfig: true,
-    },
-    files: {
-      "/entry.ts": /* ts */ `
-        // Use a dynamic path that can't be resolved at compile time
-        // This forces runtime resolution using the runtime tsconfig.json
-        const modulePath = "@utils/" + "helper";
-        import(modulePath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@utils/*": ["./src/utils/*"],
-          },
-        },
-      }),
-      "/src/utils/helper.ts": `export default "helper-from-tsconfig-paths";`,
-    },
-    run: {
-      stdout: "helper-from-tsconfig-paths",
-      setCwd: true,
-    },
-  });
-
-  // Test that tsconfig.json paths are NOT loaded when autoloadTsconfig: false (default)
-  // The import should fail because @utils/helper cannot be resolved without tsconfig paths
-  itBundled("compile/AutoloadTsconfigPathsDisabled", {
-    compile: {
-      autoloadTsconfig: false,
-    },
-    files: {
-      "/entry.ts": /* ts */ `
-        // Without runtime tsconfig.json, @utils/helper cannot be resolved
-        const modulePath = "@utils/" + "helper";
-        import(modulePath)
-          .then(m => console.log(m.default))
-          .catch(() => console.log("import-failed-as-expected"));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@utils/*": ["./src/utils/*"],
-          },
-        },
-      }),
-      "/src/utils/helper.ts": `export default "helper-from-tsconfig-paths";`,
-    },
-    run: {
-      stdout: "import-failed-as-expected",
-      setCwd: true,
-    },
-  });
-
-  // Test that package.json exports are loaded at runtime when autoloadPackageJson: true
-  // Uses a dynamic import path that the bundler cannot resolve at compile time
-  itBundled("compile/AutoloadPackageJsonExportsEnabled", {
-    compile: {
-      autoloadPackageJson: true,
-    },
-    files: {
-      "/entry.js": /* js */ `
-        // Use a dynamic path that can't be resolved at compile time
-        const pkgName = "my-runtime-pkg";
-        const subpath = "utils";
-        import(pkgName + "/" + subpath)
-          .then(m => console.log(m.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/node_modules/my-runtime-pkg/package.json": JSON.stringify({
-        name: "my-runtime-pkg",
-        exports: {
-          "./utils": "./lib/utilities.js",
-        },
-      }),
-      "/node_modules/my-runtime-pkg/lib/utilities.js": `export default "utilities-from-package-exports";`,
-    },
-    run: {
-      stdout: "utilities-from-package-exports",
-      setCwd: true,
-    },
-  });
-
-  // Test that package.json exports are NOT loaded when autoloadPackageJson: false (default)
-  // The import should fail because my-runtime-pkg/utils cannot be resolved without package.json exports
-  itBundled("compile/AutoloadPackageJsonExportsDisabled", {
-    compile: {
-      autoloadPackageJson: false,
-    },
-    files: {
-      "/entry.js": /* js */ `
-        // Without runtime package.json, my-runtime-pkg/utils cannot be resolved
-        const pkgName = "my-runtime-pkg";
-        const subpath = "utils";
-        import(pkgName + "/" + subpath)
-          .then(m => console.log(m.default))
-          .catch(() => console.log("import-failed-as-expected"));
-      `,
-    },
-    runtimeFiles: {
-      "/node_modules/my-runtime-pkg/package.json": JSON.stringify({
-        name: "my-runtime-pkg",
-        exports: {
-          "./utils": "./lib/utilities.js",
-        },
-      }),
-      "/node_modules/my-runtime-pkg/lib/utilities.js": `export default "utilities-from-package-exports";`,
-    },
-    run: {
-      stdout: "import-failed-as-expected",
-      setCwd: true,
-    },
-  });
-
-  // Test that autoloadBunfig: false works with execArgv (regression test for #25640)
-  // When execArgv is present, bunfig should still be disabled if autoloadBunfig: false
-  itBundled("compile/AutoloadBunfigDisabledWithExecArgv", {
-    compile: {
-      autoloadBunfig: false,
-      execArgv: ["--smol"],
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      // When bunfig is disabled, preload should NOT execute even with execArgv
-      stdout: "ENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that autoloadBunfig: true with execArgv still loads bunfig
-  itBundled("compile/AutoloadBunfigEnabledWithExecArgv", {
-    compile: {
-      autoloadBunfig: true,
-      execArgv: ["--smol"],
-    },
-    files: {
-      "/entry.ts": /* js */ `
-        console.log("ENTRY");
-      `,
-    },
-    runtimeFiles: {
-      "/bunfig.toml": `
-preload = ["./preload.ts"]
-      `,
-      "/preload.ts": `
-console.log("PRELOAD");
-      `,
-    },
-    run: {
-      stdout: "PRELOAD\nENTRY",
-      setCwd: true,
-    },
-  });
-
-  // Test that both tsconfig and package.json can be enabled together
-  itBundled("compile/AutoloadBothTsconfigAndPackageJson", {
-    compile: {
-      autoloadTsconfig: true,
-      autoloadPackageJson: true,
-    },
-    files: {
-      "/entry.ts": /* ts */ `
-        // Both imports require runtime config files
-        const tsconfigPath = "@utils/" + "helper";
-        const pkgPath = "runtime-pkg/" + "utils";
-        Promise.all([import(tsconfigPath), import(pkgPath)])
-          .then(([helper, utils]) => console.log(helper.default + " " + utils.default))
-          .catch(e => console.log("import-failed: " + e.message));
-      `,
-    },
-    runtimeFiles: {
-      "/tsconfig.json": JSON.stringify({
-        compilerOptions: {
-          baseUrl: ".",
-          paths: {
-            "@utils/*": ["./src/utils/*"],
-          },
-        },
-      }),
-      "/src/utils/helper.ts": `export default "tsconfig-helper";`,
-      "/node_modules/runtime-pkg/package.json": JSON.stringify({
-        name: "runtime-pkg",
-        exports: {
-          "./utils": "./lib/utils.js",
-        },
-      }),
-      "/node_modules/runtime-pkg/lib/utils.js": `export default "package-utils";`,
-    },
-    run: {
-      stdout: "tsconfig-helper package-utils",
       setCwd: true,
     },
   });

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -113,8 +113,11 @@ describe("bundler", () => {
 
   // CLI backend: exercise each --compile-autoload-* flag at least once. The
   // pairs mirror the API tests above so the same independence checks apply.
+  // autoloadBunfig:true and autoloadDotenv:true below are defaults, so they
+  // cannot be behaviorally distinguished from omitting the flag; they are
+  // passed here only to keep parity with the old suite's CLI flag coverage.
   itBundled("compile/AutoloadDotenvDisabledTsconfigEnabledCLI", {
-    compile: { autoloadDotenv: false, autoloadTsconfig: true },
+    compile: { autoloadDotenv: false, autoloadBunfig: true, autoloadTsconfig: true },
     backend: "cli",
     files: { "/entry.ts": probeEntry },
     runtimeFiles: probeRuntimeFiles,
@@ -122,19 +125,11 @@ describe("bundler", () => {
   });
 
   itBundled("compile/AutoloadBunfigDisabledPackageJsonEnabledCLI", {
-    compile: { autoloadBunfig: false, autoloadPackageJson: true },
+    compile: { autoloadDotenv: true, autoloadBunfig: false, autoloadPackageJson: true },
     backend: "cli",
     files: { "/entry.ts": probeEntry },
     runtimeFiles: probeRuntimeFiles,
     run: { stdout: "dotenv=from_dotenv tsconfig=off pkgjson=pkg-utils", setCwd: true },
-  });
-
-  itBundled("compile/AutoloadDotenvBunfigEnabledCLI", {
-    compile: { autoloadDotenv: true, autoloadBunfig: true },
-    backend: "cli",
-    files: { "/entry.ts": probeEntry },
-    runtimeFiles: probeRuntimeFiles,
-    run: { stdout: "PRELOAD\ndotenv=from_dotenv tsconfig=off pkgjson=off", setCwd: true },
   });
 
   // CLI regression test for #25640.


### PR DESCRIPTION
## What does this PR do?

`test/bundler/bundler_compile_autoload.test.ts` compiled 23 standalone binaries, each to assert a single `autoload*` flag. The link step dominates each test (~3s on debug+ASAN), so the file was ~30s on the debian-13 x64-asan lane (build #79247) and 71s locally on debug+ASAN.

This replaces the per-flag entry scripts with one shared probe that reports all four observable autoload behaviors on one line:

```
dotenv=<value> tsconfig=<value> pkgjson=<value>
```

preceded by `PRELOAD` when bunfig is loaded. Every compile now asserts the full state, so the flag-combination matrix collapses to 11 compiles while still exercising every flag in every state (default / explicit `true` / explicit `false`) across both the `Bun.build()` API and `bun build --compile` CLI paths. Flag pairs are chosen to also prove independence, e.g. `{ autoloadDotenv: false, autoloadTsconfig: true }` asserts bunfig's default is untouched and package.json's default is untouched in the same run.

### Coverage

| Original test | Now covered by |
| --- | --- |
| `AutoloadDotenvDefault`, `AutoloadBunfigDefault` | `AutoloadDefaults` run[0] |
| `AutoloadDotenvWithExistingEnv` | `AutoloadDefaults` run[1] |
| `AutoloadDotenvDisabled`, `AutoloadTsconfigPathsEnabled` | `AutoloadDotenvDisabledTsconfigEnabled` |
| `AutoloadBunfigDisabled`, `AutoloadPackageJsonExportsEnabled` | `AutoloadBunfigDisabledPackageJsonEnabled` |
| `AutoloadDotenvEnabledExplicitly`, `AutoloadBunfigEnabled`, `AutoloadBothTsconfigAndPackageJson` | `AutoloadAllEnabled` |
| `AutoloadBothDisabled`, `AutoloadTsconfigPathsDisabled`, `AutoloadPackageJsonExportsDisabled` | `AutoloadAllDisabled` |
| `AutoloadBunfigDisabledWithExecArgv` | kept |
| `AutoloadBunfigEnabledWithExecArgv` | kept |
| `AutoloadDotenvDisabledCLI`, `AutoloadBunfigEnabledCLI`, `AutoloadTsconfigPathsCLI` | `AutoloadDotenvDisabledTsconfigEnabledCLI` |
| `AutoloadDotenvEnabledCLI`, `AutoloadBunfigDisabledCLI`, `AutoloadPackageJsonExportsCLI` | `AutoloadBunfigDisabledPackageJsonEnabledCLI` |
| `AutoloadBunfigDisabledWithExecArgvCLI` | kept |
| `AutoloadDotenvDisabledWorkerCLI` | kept (now also asserts main thread does not load .env) |

No test is skipped or deleted without replacement; every `--compile-autoload-*` CLI flag and every `compile.autoload*` API option is still passed through `expectBundled` at least once in each boolean state. Note `--compile-autoload-dotenv` and `--compile-autoload-bunfig` set their options to the default (`true`), so a positive-form CLI test cannot behaviorally distinguish them from passing no flag; they are folded into the two CLI cases whose stdout already asserts the enabled state rather than spending a dedicated compile (this was equally true of the original suite's `AutoloadDotenvEnabledCLI` / `AutoloadBunfigEnabledCLI`).

### Assertion strength

Each test now asserts all four autoload outcomes instead of one. The two `execArgv` tests, for example, previously only checked bunfig; they now also assert `execArgv` does not disturb the dotenv/tsconfig/package.json defaults. The worker test previously only checked the worker thread; it now asserts the main thread too.

## How did you verify your code works?

Timed locally on debug+ASAN:

```
before: Ran 23 tests across 1 file. [71.02s]
after:  Ran 11 tests across 1 file. [35.11s]
```

Also verified against a release build (all pass).

This is a test-only change: no `src/**` modifications, so the before/after behavior is identical on any recent build.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/bundler_compile_autoload.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/bundler_compile_autoload.test.ts
bun test v1.4.0 (ce1d8cc9f)

test/bundler/bundler_compile_autoload.test.ts:
(pass) bundler > compile/AutoloadDefaults [3444.18ms]
(pass) bundler > compile/AutoloadDotenvDisabledTsconfigEnabled [2689.19ms]
(pass) bundler > compile/AutoloadBunfigDisabledPackageJsonEnabled [3018.68ms]
(pass) bundler > compile/AutoloadAllEnabled [2631.23ms]
(pass) bundler > compile/AutoloadAllDisabled [2871.67ms]
(pass) bundler > compile/AutoloadBunfigDisabledWithExecArgv [2578.13ms]
(pass) bundler > compile/AutoloadBunfigEnabledWithExecArgv [3274.07ms]
(pass) bundler > compile/AutoloadDotenvDisabledTsconfigEnabledCLI [2949.47ms]
(pass) bundler > compile/AutoloadBunfigDisabledPackageJsonEnabledCLI [2837.23ms]
(pass) bundler > compile/AutoloadBunfigDisabledWithExecArgvCLI [2865.90ms]
(pass) bundler > compile/AutoloadDotenvDisabledWorkerCLI [3672.26ms]

 11 pass
 0 fail
 12 expect() calls
Ran 11 tests across 1 file. [35.59s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bundler/bundler_compile_autoload.test.ts | 661 +++++---------------------
 1 file changed, 114 insertions(+), 547 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/bundler/bundler_compile_autoload.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

The test file ran 23 separate `bun build --compile` invocations that each asserted only one of four autoload behaviors, so most of the wall time was redundant compilation. The fix replaces them with 11 tests that compile a shared probe entry emitting all four autoload states on one line, letting each compile assert the full matrix and pairing flag combinations to prove independence. This halves the compile count and runtime while mapping every original assertion to an equivalent or stronger check.

<!-- robobun:evidence:end -->