### PR TITLE
child_process: regression tests for writes to extra stdio pipes (Playwright launch on Windows)

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1883,10 +1883,6 @@ Socket.prototype.connect = function connect(...args) {
       connection = socket;
     }
     if (fd != null) {
-      // Adoption completes inside this call: SocketHandlers.open runs
-      // synchronously, attaches the handle and emits 'connect'. `connecting`
-      // must stay false below, or _write parks every chunk behind a 'connect'
-      // that has already been emitted (child_process stdio[3+] writes were lost).
       doConnect(this._handle, {
         data: this,
         fd: fd,
@@ -1915,6 +1911,9 @@ Socket.prototype.connect = function connect(...args) {
         // attached stays buffered instead of being emitted to nobody.
         if (!this.isPaused()) this.read(0);
       });
+      // An adopted fd is already connected: doConnect() above ran SocketHandlers.open
+      // synchronously, so marking it connecting would park writes behind a 'connect'
+      // that has already been emitted.
       if (fd == null) this.connecting = true;
     }
     if (fd != null) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1883,6 +1883,10 @@ Socket.prototype.connect = function connect(...args) {
       connection = socket;
     }
     if (fd != null) {
+      // Adoption completes inside this call: SocketHandlers.open runs
+      // synchronously, attaches the handle and emits 'connect'. `connecting`
+      // must stay false below, or _write parks every chunk behind a 'connect'
+      // that has already been emitted (child_process stdio[3+] writes were lost).
       doConnect(this._handle, {
         data: this,
         fd: fd,

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1911,9 +1911,7 @@ Socket.prototype.connect = function connect(...args) {
         // attached stays buffered instead of being emitted to nobody.
         if (!this.isPaused()) this.read(0);
       });
-      // An adopted fd is already connected: doConnect() above ran SocketHandlers.open
-      // synchronously, so marking it connecting would park writes behind a 'connect'
-      // that has already been emitted.
+      // An adopted fd was already connected synchronously by doConnect() above.
       if (fd == null) this.connecting = true;
     }
     if (fd != null) {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -582,12 +582,9 @@ describe("spawn()", () => {
     });
 
     // The parent's end of each extra pipe is a net.Socket made with net.connect({ fd }), which adopts
-    // the descriptor synchronously, so it is connected by the time spawn() returns. It used to be
-    // reported as still connecting, which parked every write behind a 'connect' event that had
-    // already been emitted; on Windows nothing flushed them later. Playwright launches browsers
-    // with --remote-debugging-pipe (CDP requests to the browser's fd 3, replies on fd 4), so
-    // chromium.launch() timed out (#15679, #27977); ffmpeg reading an input from pipe:3 never got
-    // any data (#17989).
+    // the descriptor synchronously, so it must be connected and writable as soon as spawn() returns.
+    // The request/reply shape below mirrors Playwright's --remote-debugging-pipe (requests on the
+    // browser's fd 3, replies on fd 4).
     describe("extra pipes (stdio[3+])", () => {
       // The children below read their pipes with blocking fs.readSync loops: the parent-side socket
       // is what is under test, and loading fs streams roughly doubles a debug child's startup time.

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -609,8 +609,9 @@ describe("spawn()", () => {
       }
 
       // Accumulates the socket's output; nextLine() resolves with everything received so far once
-      // one more "\n"-terminated line has arrived, whether it came in one chunk or several.
-      function readLines(socket: Socket) {
+      // one more "\n"-terminated line has arrived, whether it came in one chunk or several, and
+      // rejects if the pipe ends or errors first (i.e. the child died), carrying its stderr.
+      function readLines(socket: Socket, spawned: { readonly stderr: string }) {
         let text = "";
         socket.setEncoding("utf8");
         socket.on("data", chunk => (text += chunk));
@@ -620,12 +621,32 @@ describe("spawn()", () => {
           },
           nextLine() {
             const lines = text.split("\n").length;
-            const { promise, resolve } = Promise.withResolvers<string>();
-            socket.on("data", function onData() {
+            const { promise, resolve, reject } = Promise.withResolvers<string>();
+            const onData = () => {
               if (text.split("\n").length === lines) return;
-              socket.off("data", onData);
+              cleanup();
               resolve(text);
-            });
+            };
+            const onEnd = () => {
+              cleanup();
+              reject(
+                new Error(
+                  `pipe ended before the next line; received ${JSON.stringify(text)}, stderr: ${spawned.stderr}`,
+                ),
+              );
+            };
+            const onError = (err: Error) => {
+              cleanup();
+              reject(err);
+            };
+            const cleanup = () => {
+              socket.off("data", onData);
+              socket.off("end", onEnd);
+              socket.off("error", onError);
+            };
+            socket.on("data", onData);
+            socket.on("end", onEnd);
+            socket.on("error", onError);
             return promise;
           },
         };
@@ -650,7 +671,7 @@ describe("spawn()", () => {
         const replies = child.stdio[4] as Socket;
         expect([connectionState(requests), connectionState(replies)]).toEqual([connected, connected]);
 
-        const received = readLines(replies);
+        const received = readLines(replies, spawned);
         const writeErrors: (Error | null)[] = [];
         // Wait for each reply before sending the next request so the child sees one chunk per write.
         let reply = received.nextLine();
@@ -687,7 +708,7 @@ describe("spawn()", () => {
         const pipe = child.stdio[3] as Socket;
         expect(connectionState(pipe)).toEqual(connected);
 
-        const received = readLines(pipe);
+        const received = readLines(pipe, spawned);
         expect(await received.nextLine()).toBe("ready\n");
         let reply = received.nextLine();
         pipe.write("hello");
@@ -709,7 +730,7 @@ describe("spawn()", () => {
         );
         const { child, exited } = spawned;
         const input = child.stdio[3] as Socket;
-        const received = readLines(child.stdio[4] as Socket);
+        const received = readLines(child.stdio[4] as Socket, spawned);
 
         const size = 1024 * 1024;
         const { promise: written, resolve: onWritten } = Promise.withResolvers<Error | null>();

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { getEventListeners, once, setMaxListeners } from "node:events";
+import type { Socket } from "node:net";
 import { promisify } from "node:util";
 import path from "path";
 const debug = process.env.DEBUG ? console.log : () => {};
@@ -578,6 +579,154 @@ describe("spawn()", () => {
       });
       expect(stdout).toBe("ok\n");
       expect(status).toBe(0);
+    });
+
+    // The parent's end of each extra pipe is a net.Socket made with net.connect({ fd }), which adopts
+    // the descriptor synchronously, so it is connected by the time spawn() returns. It used to be
+    // reported as still connecting, which parked every write behind a 'connect' event that had
+    // already been emitted; on Windows nothing flushed them later. Playwright launches browsers
+    // with --remote-debugging-pipe (CDP requests to the browser's fd 3, replies on fd 4), so
+    // chromium.launch() timed out (#15679, #27977); ffmpeg reading an input from pipe:3 never got
+    // any data (#17989).
+    describe("extra pipes (stdio[3+])", () => {
+      // The children below read their pipes with blocking fs.readSync loops: the parent-side socket
+      // is what is under test, and loading fs streams roughly doubles a debug child's startup time.
+      function spawnWithExtraPipes(script: string, count: number) {
+        const child = spawn(bunExe(), ["-e", script], {
+          env: bunEnv,
+          stdio: ["ignore", "ignore", "pipe", ...Array(count).fill("pipe")],
+        });
+        let stderr = "";
+        child.stderr!.setEncoding("utf8");
+        child.stderr!.on("data", chunk => (stderr += chunk));
+        return {
+          child,
+          exited: once(child, "exit"),
+          get stderr() {
+            return stderr;
+          },
+          [Symbol.dispose]() {
+            child.kill();
+          },
+        };
+      }
+
+      // Accumulates the socket's output; nextLine() resolves with everything received so far once
+      // one more "\n"-terminated line has arrived, whether it came in one chunk or several.
+      function readLines(socket: Socket) {
+        let text = "";
+        socket.setEncoding("utf8");
+        socket.on("data", chunk => (text += chunk));
+        return {
+          get text() {
+            return text;
+          },
+          nextLine() {
+            const lines = text.split("\n").length;
+            const { promise, resolve } = Promise.withResolvers<string>();
+            socket.on("data", function onData() {
+              if (text.split("\n").length === lines) return;
+              socket.off("data", onData);
+              resolve(text);
+            });
+            return promise;
+          },
+        };
+      }
+
+      const connectionState = (socket: Socket) => ({
+        connecting: socket.connecting,
+        pending: socket.pending,
+        readyState: socket.readyState,
+      });
+      const connected = { connecting: false, pending: false, readyState: "open" };
+
+      it("are connected when spawn() returns and deliver requests on stdio[3] with replies on stdio[4]", async () => {
+        using spawned = spawnWithExtraPipes(
+          `const fs = require("fs"), buf = Buffer.alloc(1024);
+           for (let n; (n = fs.readSync(3, buf)) > 0; ) fs.writeSync(4, "reply:" + buf.toString("utf8", 0, n) + "\\n");
+           fs.writeSync(4, "eof\\n");`,
+          2,
+        );
+        const { child, exited } = spawned;
+        const requests = child.stdio[3] as Socket;
+        const replies = child.stdio[4] as Socket;
+        expect([connectionState(requests), connectionState(replies)]).toEqual([connected, connected]);
+
+        const received = readLines(replies);
+        const writeErrors: (Error | null)[] = [];
+        // Wait for each reply before sending the next request so the child sees one chunk per write.
+        let reply = received.nextLine();
+        requests.write("Target.getTargets", err => writeErrors.push(err ?? null));
+        expect(await reply).toBe("reply:Target.getTargets\n");
+        reply = received.nextLine();
+        requests.write("Browser.close", err => writeErrors.push(err ?? null));
+        expect(await reply).toBe("reply:Target.getTargets\nreply:Browser.close\n");
+
+        const repliesEnded = once(replies, "end");
+        requests.end();
+        await repliesEnded;
+        const [exitCode] = await exited;
+        expect({ received: received.text, writeErrors, stderr: spawned.stderr, exitCode }).toEqual({
+          received: "reply:Target.getTargets\nreply:Browser.close\neof\n",
+          writeErrors: [null, null],
+          stderr: "",
+          exitCode: 0,
+        });
+      });
+
+      it("carry both directions over a single pipe", async () => {
+        using spawned = spawnWithExtraPipes(
+          `const fs = require("fs"), buf = Buffer.alloc(1024);
+           fs.writeSync(3, "ready\\n");
+           for (let n; (n = fs.readSync(3, buf)) > 0; ) {
+             const request = buf.toString("utf8", 0, n);
+             fs.writeSync(3, "reply:" + request + "\\n");
+             if (request === "bye") break;
+           }`,
+          1,
+        );
+        const { child, exited } = spawned;
+        const pipe = child.stdio[3] as Socket;
+        expect(connectionState(pipe)).toEqual(connected);
+
+        const received = readLines(pipe);
+        expect(await received.nextLine()).toBe("ready\n");
+        let reply = received.nextLine();
+        pipe.write("hello");
+        expect(await reply).toBe("ready\nreply:hello\n");
+        reply = received.nextLine();
+        pipe.write("bye");
+        expect(await reply).toBe("ready\nreply:hello\nreply:bye\n");
+        const [exitCode] = await exited;
+        expect({ stderr: spawned.stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+      });
+
+      it("deliver a write larger than the pipe buffer", async () => {
+        using spawned = spawnWithExtraPipes(
+          `const fs = require("fs"), buf = Buffer.alloc(65536);
+           let bytes = 0;
+           for (let n; (n = fs.readSync(3, buf)) > 0; ) bytes += n;
+           fs.writeSync(4, bytes + "\\n");`,
+          2,
+        );
+        const { child, exited } = spawned;
+        const input = child.stdio[3] as Socket;
+        const received = readLines(child.stdio[4] as Socket);
+
+        const size = 1024 * 1024;
+        const { promise: written, resolve: onWritten } = Promise.withResolvers<Error | null>();
+        const total = received.nextLine();
+        input.write(Buffer.alloc(size, "x"), err => onWritten(err ?? null));
+        input.end();
+        const [exitCode] = await exited;
+        expect({ total: await total, writeError: await written, stderr: spawned.stderr, exitCode }).toEqual({
+          total: `${size}\n`,
+          writeError: null,
+          stderr: "",
+          exitCode: 0,
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### What

Regression tests for writes to extra `child_process` stdio pipes (`child.stdio[3]`, `[4]`, ...), which is what Playwright's `chromium.launch()` depends on (CDP goes to the browser's fd 3 via `--remote-debugging-pipe`), plus a one-line note on the `fd == null` guard in `Socket.prototype.connect` that the tests pin down.

The fix itself landed in #31829: `connect()` no longer sets `connecting = true` on the fd path ([net.ts](https://github.com/oven-sh/bun/blob/626034fda078bbc6a9e1a2099e12854154ef236d/src/js/node/net.ts#L1914)). This PR was rebased on top of it, so the earlier one-line change is gone and what remains is the coverage, which main does not have.

### Bug

`child_process` wraps each extra pipe in `net.connect({ fd })`. Adopting the fd completes synchronously (`SocketHandlers.open` attaches the handle and emits `'connect'` before `doConnect()` returns), but `connect()` then set `connecting = true`, so `_write` parked every chunk in `_pendingData` behind a `'connect'` that had already fired. On POSIX a later native drain happened to flush it; on Windows named pipes nothing did, so parent to child writes on extra stdio were silently dropped. `chromium.launch()` timed out (#15679, #27977) and ffmpeg never received its `pipe:3` input (#17989).

```js
// bun 1.3.14 on Windows: connecting = true, write callback never fires, child never gets "ping"
const child = spawn(process.execPath, ["child.mjs"], { stdio: ["ignore", "inherit", "inherit", "pipe", "pipe"] });
child.stdio[3].write("ping\n");
```

### Tests (`spawn() > stdio > extra pipes (stdio[3+])` in `child_process.test.ts`)

- sockets report `{ connecting: false, pending: false, readyState: "open" }` as soon as `spawn()` returns; two requests written to `stdio[3]` come back on `stdio[4]` with their write callbacks, and `end()` reaches the child as EOF
- both directions over a single extra pipe
- a 1 MiB write (bigger than any platform's pipe buffer) is delivered in full

Results:

| | Linux | Windows x64 |
| --- | --- | --- |
| bun 1.3.14 / main before #31829 | first two fail on the state assertion | all three fail (the writes never arrive; the third times out) |
| main with #31829 (`bun bd` on Linux, `1.4.0-canary.1+626034fda` on Windows) | 3 pass | 3 pass, stable across 20+ runs |

End to end on the same Windows machine with `playwright@1.62.1`, running Playwright under Bun: `chromium.launch()` times out on 1.3.14 and on `1.4.0-canary.1+626034fda` launches in about 135ms, `page.evaluate()` returns, and `browser.close()` completes. Details and scripts are in the comments on #15679 / #27977 / #17989.

Supersedes #31445 and #31932 (same diagnosis; their authors are credited in the commit).

Fixes #15679
Fixes #27977
Fixes #17989

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->