### PR TITLE
test(http): run nested-cork scenarios in-process instead of one subprocess each

### DIFF
--- a/test/js/node/http/node-http-nested-cork.test.ts
+++ b/test/js/node/http/node-http-nested-cork.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 
 // Security test: with two cork slots that can be stolen/evicted, a bug in slot
 // bookkeeping could cause bytes meant for socket A to land in socket B's
@@ -9,313 +11,301 @@ import { bunEnv, bunExe } from "harness";
 // concurrent requests using every yield primitive (microtask, macrotask, mixed)
 // to maximize slot churn. Every chunk is tagged [reqId:chunkIdx] and responses
 // are validated byte-for-byte so a single foreign byte fails the test.
+//
+// All cases run in-process and concurrently, so every server's sockets compete
+// for the same two process-wide cork slots — strictly more contention than the
+// original one-subprocess-per-case version.
 
 const N = 32;
 const CHUNKS = 8;
 
-const harness = `
-  const N = ${N};
-  const CHUNKS = ${CHUNKS};
-
-  // Chain-await: each request resolves the previous one's promise, forcing
-  // microtask resumption while a newer request holds a cork slot.
-  let pending, count = 0;
-  async function chainAwait() {
+// Chain-await barrier: each incoming request resolves the previous request's
+// promise, so handlers resume via microtask while a newer request holds a cork
+// slot. Returns a fresh barrier per server so concurrent tests don't interfere.
+function makeChainAwait() {
+  let pending: PromiseWithResolvers<void> | undefined;
+  let count = 0;
+  return async function chainAwait() {
     count++;
-    if (pending) { const p = pending; pending = Promise.withResolvers(); p.resolve(); }
-    else pending = Promise.withResolvers();
+    if (pending) {
+      const p = pending;
+      pending = Promise.withResolvers();
+      p.resolve();
+    } else {
+      pending = Promise.withResolvers();
+    }
     if (count === N) pending.resolve();
     await pending.promise;
-  }
+  };
+}
 
-  // Mixed yield: alternates microtask and macrotask to hit both the
-  // drainMicrotasks path and the event loop tick path.
-  async function yieldMixed(c) {
-    if (c % 3 === 0) await 42;              // microtask (awaiting non-thenable)
-    else if (c % 3 === 1) await Bun.sleep(0); // macrotask
-    else { await 42; await 42; }            // double microtask
-  }
+// Mixed yield: alternates microtask and macrotask to hit both the
+// drainMicrotasks path and the event loop tick path. Awaiting a non-thenable
+// is a pure microtask; Bun.sleep(0) is a macrotask; the third arm doubles the
+// microtask to widen the resume window.
+async function yieldMixed(c: number) {
+  if (c % 3 === 0) return await 42;
+  if (c % 3 === 1) return await Bun.sleep(0);
+  await 42;
+  await 42;
+}
 
-  async function validate(makeUrl) {
-    const results = await Promise.all(
-      Array.from({ length: N }, async (_, i) => {
-        const r = await fetch(makeUrl(i));
-        const body = await r.text();
-        const headerId = r.headers.get("x-id");
-        let expected = "";
-        for (let c = 0; c < CHUNKS; c++) expected += "[" + i + ":" + c + "]";
-        expected += "[" + i + ":end]";
-        if (body !== expected) return { i, ok: false, reason: "body", got: body, want: expected };
-        if (headerId !== String(i)) return { i, ok: false, reason: "header", got: headerId };
-        return { i, ok: true };
-      })
-    );
-    const bad = results.filter(r => !r.ok);
-    console.log(bad.length ? "FAIL " + JSON.stringify(bad.slice(0, 3)) : "PASS " + results.length);
-  }
-`;
+function expectedBody(i: number, pad = "") {
+  let s = "";
+  for (let c = 0; c < CHUNKS; c++) s += `[${i}:${c}]${pad}`;
+  return s + `[${i}:end]`;
+}
 
-async function run(script: string) {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", harness + script],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(stdout.trim()).toBe(`PASS ${N}`);
-  expect(exitCode).toBe(0);
+type Result = { i: number; header: string | null; body: string };
+
+async function validate(makeUrl: (i: number) => string, pad = "") {
+  const results: Result[] = await Promise.all(
+    Array.from({ length: N }, async (_, i) => {
+      const r = await fetch(makeUrl(i));
+      return { i, header: r.headers.get("x-id"), body: await r.text() };
+    }),
+  );
+  // One structural assertion so a single foreign byte anywhere fails with a
+  // diff that names the offending request.
+  expect(results).toEqual(Array.from({ length: N }, (_, i) => ({ i, header: String(i), body: expectedBody(i, pad) })));
+}
+
+async function withNodeServer(
+  handler: (req: import("http").IncomingMessage, res: import("http").ServerResponse) => void,
+  fn: (port: number) => Promise<void>,
+) {
+  const server = createServer(handler);
+  server.listen(0);
+  await once(server, "listening");
+  try {
+    await fn((server.address() as AddressInfo).port);
+  } finally {
+    server.close();
+  }
 }
 
 describe.concurrent("cork buffer: no cross-socket data bleed", () => {
   // Attack 1: write, yield, write — slot held with data across yield.
   // Another request resumes during the yield and tries to steal/use our slot.
   test("node:http — write then mixed yield then write (slot held with data)", async () => {
-    await run(`
-      import { createServer } from "node:http";
-      const server = createServer(async (req, res) => {
-        const id = req.url.slice(1);
+    const chainAwait = makeChainAwait();
+    await withNodeServer(
+      async (req, res) => {
+        const id = req.url!.slice(1);
         await chainAwait();
         res.writeHead(200, { "x-id": id });
         for (let c = 0; c < CHUNKS; c++) {
-          res.write("[" + id + ":" + c + "]");
+          res.write(`[${id}:${c}]`);
           await yieldMixed(c);
         }
-        res.end("[" + id + ":end]");
-      }).listen(0, async () => {
-        await validate(i => "http://localhost:" + server.address().port + "/" + i);
-        server.close();
-      });
-    `);
+        res.end(`[${id}:end]`);
+      },
+      port => validate(i => `http://localhost:${port}/${i}`),
+    );
   });
 
   // Attack 2: yield BEFORE each write. Our slot is empty (stealable) at every
   // yield point, then we try to write after someone may have taken it.
   test("node:http — yield then write (empty slot stolen, must re-acquire)", async () => {
-    await run(`
-      import { createServer } from "node:http";
-      const server = createServer(async (req, res) => {
-        const id = req.url.slice(1);
+    const chainAwait = makeChainAwait();
+    await withNodeServer(
+      async (req, res) => {
+        const id = req.url!.slice(1);
         await chainAwait();
         res.writeHead(200, { "x-id": id });
         for (let c = 0; c < CHUNKS; c++) {
           await yieldMixed(c);
-          res.write("[" + id + ":" + c + "]");
+          res.write(`[${id}:${c}]`);
         }
-        res.end("[" + id + ":end]");
-      }).listen(0, async () => {
-        await validate(i => "http://localhost:" + server.address().port + "/" + i);
-        server.close();
-      });
-    `);
+        res.end(`[${id}:end]`);
+      },
+      port => validate(i => `http://localhost:${port}/${i}`),
+    );
   });
 
   // Attack 3: rapid microtask churn — every chunk yields twice via await 42.
   // Maximizes the number of slot-steal opportunities per request.
   test("node:http — double microtask between every chunk", async () => {
-    await run(`
-      import { createServer } from "node:http";
-      const server = createServer(async (req, res) => {
-        const id = req.url.slice(1);
+    const chainAwait = makeChainAwait();
+    await withNodeServer(
+      async (req, res) => {
+        const id = req.url!.slice(1);
         await chainAwait();
         res.writeHead(200, { "x-id": id });
         for (let c = 0; c < CHUNKS; c++) {
-          res.write("[" + id + ":" + c + "]");
+          res.write(`[${id}:${c}]`);
           await 42;
           await 42;
         }
-        res.end("[" + id + ":end]");
-      }).listen(0, async () => {
-        await validate(i => "http://localhost:" + server.address().port + "/" + i);
-        server.close();
-      });
-    `);
+        res.end(`[${id}:end]`);
+      },
+      port => validate(i => `http://localhost:${port}/${i}`),
+    );
   });
 
   // Attack 4: write several chunks, yield, write more. Tests that partial
   // buffered data survives slot eviction and doesn't leak into the evictor.
   test("node:http — burst write, yield, burst write", async () => {
-    await run(`
-      import { createServer } from "node:http";
-      const server = createServer(async (req, res) => {
-        const id = req.url.slice(1);
+    const chainAwait = makeChainAwait();
+    await withNodeServer(
+      async (req, res) => {
+        const id = req.url!.slice(1);
         await chainAwait();
         res.writeHead(200, { "x-id": id });
         const half = CHUNKS >> 1;
-        for (let c = 0; c < half; c++) res.write("[" + id + ":" + c + "]");
+        for (let c = 0; c < half; c++) res.write(`[${id}:${c}]`);
         await Bun.sleep(0);
-        for (let c = half; c < CHUNKS; c++) res.write("[" + id + ":" + c + "]");
-        res.end("[" + id + ":end]");
-      }).listen(0, async () => {
-        await validate(i => "http://localhost:" + server.address().port + "/" + i);
-        server.close();
-      });
-    `);
+        for (let c = half; c < CHUNKS; c++) res.write(`[${id}:${c}]`);
+        res.end(`[${id}:end]`);
+      },
+      port => validate(i => `http://localhost:${port}/${i}`),
+    );
   });
 
   // Attack 5: Bun.serve buffered Response — the whole body is one string,
   // but the interleaved awaits before returning stress slot allocation for
   // the headers + body write.
   test("Bun.serve — buffered Response with await before return", async () => {
-    await run(`
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const id = new URL(req.url).pathname.slice(1);
-          await chainAwait();
-          await 42;
-          await Bun.sleep(0);
-          let body = "";
-          for (let c = 0; c < CHUNKS; c++) body += "[" + id + ":" + c + "]";
-          body += "[" + id + ":end]";
-          return new Response(body, { headers: { "x-id": id } });
-        },
-      });
-      await validate(i => "http://localhost:" + server.port + "/" + i);
-      server.stop(true);
-    `);
+    const chainAwait = makeChainAwait();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const id = new URL(req.url).pathname.slice(1);
+        await chainAwait();
+        await 42;
+        await Bun.sleep(0);
+        return new Response(expectedBody(+id), { headers: { "x-id": id } });
+      },
+    });
+    await validate(i => `http://localhost:${server.port}/${i}`);
   });
 
   // Attack 6: type:"direct" with write+yield per chunk. Direct streams write
   // straight to the socket via the cork path.
   test('Bun.serve — type:"direct" write then mixed yield', async () => {
-    await run(`
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const id = new URL(req.url).pathname.slice(1);
-          await chainAwait();
-          return new Response(new ReadableStream({
+    const chainAwait = makeChainAwait();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const id = new URL(req.url).pathname.slice(1);
+        await chainAwait();
+        return new Response(
+          new ReadableStream({
             type: "direct",
             async pull(ctrl) {
               for (let c = 0; c < CHUNKS; c++) {
-                ctrl.write("[" + id + ":" + c + "]");
+                ctrl.write(`[${id}:${c}]`);
                 await yieldMixed(c);
               }
-              ctrl.write("[" + id + ":end]");
+              ctrl.write(`[${id}:end]`);
               await ctrl.end();
             },
-          }), { headers: { "x-id": id } });
-        },
-      });
-      await validate(i => "http://localhost:" + server.port + "/" + i);
-      server.stop(true);
-    `);
+          }),
+          { headers: { "x-id": id } },
+        );
+      },
+    });
+    await validate(i => `http://localhost:${server.port}/${i}`);
   });
 
   // Attack 7: type:"direct" yield then write. Slot is empty at yield, we must
   // re-cork before each write.
   test('Bun.serve — type:"direct" yield then write', async () => {
-    await run(`
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const id = new URL(req.url).pathname.slice(1);
-          await chainAwait();
-          return new Response(new ReadableStream({
+    const chainAwait = makeChainAwait();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const id = new URL(req.url).pathname.slice(1);
+        await chainAwait();
+        return new Response(
+          new ReadableStream({
             type: "direct",
             async pull(ctrl) {
               for (let c = 0; c < CHUNKS; c++) {
                 await yieldMixed(c);
-                ctrl.write("[" + id + ":" + c + "]");
+                ctrl.write(`[${id}:${c}]`);
               }
-              ctrl.write("[" + id + ":end]");
+              ctrl.write(`[${id}:end]`);
               await ctrl.end();
             },
-          }), { headers: { "x-id": id } });
-        },
-      });
-      await validate(i => "http://localhost:" + server.port + "/" + i);
-      server.stop(true);
-    `);
+          }),
+          { headers: { "x-id": id } },
+        );
+      },
+    });
+    await validate(i => `http://localhost:${server.port}/${i}`);
   });
 
   // Attack 8: type:"direct" burst + flush + yield + burst. Explicit flush
   // mid-stream exercises the uncork/recork path.
   test('Bun.serve — type:"direct" burst, flush, yield, burst', async () => {
-    await run(`
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const id = new URL(req.url).pathname.slice(1);
-          await chainAwait();
-          return new Response(new ReadableStream({
+    const chainAwait = makeChainAwait();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const id = new URL(req.url).pathname.slice(1);
+        await chainAwait();
+        return new Response(
+          new ReadableStream({
             type: "direct",
             async pull(ctrl) {
               const half = CHUNKS >> 1;
-              for (let c = 0; c < half; c++) ctrl.write("[" + id + ":" + c + "]");
+              for (let c = 0; c < half; c++) ctrl.write(`[${id}:${c}]`);
               await ctrl.flush();
               await Bun.sleep(0);
-              for (let c = half; c < CHUNKS; c++) ctrl.write("[" + id + ":" + c + "]");
-              ctrl.write("[" + id + ":end]");
+              for (let c = half; c < CHUNKS; c++) ctrl.write(`[${id}:${c}]`);
+              ctrl.write(`[${id}:end]`);
               await ctrl.end();
             },
-          }), { headers: { "x-id": id } });
-        },
-      });
-      await validate(i => "http://localhost:" + server.port + "/" + i);
-      server.stop(true);
-    `);
+          }),
+          { headers: { "x-id": id } },
+        );
+      },
+    });
+    await validate(i => `http://localhost:${server.port}/${i}`);
   });
 
   // Attack 9: async generator with mixed yields — every other chunk uses a
   // different yield primitive.
   test("Bun.serve — async generator mixed yield per chunk", async () => {
-    await run(`
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const id = new URL(req.url).pathname.slice(1);
-          await chainAwait();
-          async function* gen() {
-            for (let c = 0; c < CHUNKS; c++) {
-              yield "[" + id + ":" + c + "]";
-              await yieldMixed(c);
-            }
-            yield "[" + id + ":end]";
+    const chainAwait = makeChainAwait();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const id = new URL(req.url).pathname.slice(1);
+        await chainAwait();
+        async function* gen() {
+          for (let c = 0; c < CHUNKS; c++) {
+            yield `[${id}:${c}]`;
+            await yieldMixed(c);
           }
-          return new Response(gen(), { headers: { "x-id": id } });
-        },
-      });
-      await validate(i => "http://localhost:" + server.port + "/" + i);
-      server.stop(true);
-    `);
+          yield `[${id}:end]`;
+        }
+        return new Response(gen(), { headers: { "x-id": id } });
+      },
+    });
+    await validate(i => `http://localhost:${server.port}/${i}`);
   });
 
   // Attack 10: node:http with large chunks near the 16KB cork buffer boundary.
   // If offset math is wrong, a large chunk could overflow into the adjacent
   // slot's buffer.
   test("node:http — large chunks near cork buffer boundary", async () => {
-    await run(`
-      import { createServer } from "node:http";
-      // ~2KB per chunk * 8 chunks = ~16KB total, hovering at cork buffer size
-      const pad = Buffer.alloc(2000, 0x2e).toString(); // "."
-      const server = createServer(async (req, res) => {
-        const id = req.url.slice(1);
+    // ~2KB per chunk * 8 chunks = ~16KB total, hovering at cork buffer size
+    const pad = Buffer.alloc(2000, 0x2e).toString(); // "."
+    const chainAwait = makeChainAwait();
+    await withNodeServer(
+      async (req, res) => {
+        const id = req.url!.slice(1);
         await chainAwait();
         res.writeHead(200, { "x-id": id });
         for (let c = 0; c < CHUNKS; c++) {
-          res.write("[" + id + ":" + c + "]" + pad);
+          res.write(`[${id}:${c}]${pad}`);
           await 42;
         }
-        res.end("[" + id + ":end]");
-      }).listen(0, async () => {
-        const results = await Promise.all(
-          Array.from({ length: N }, async (_, i) => {
-            const r = await fetch("http://localhost:" + server.address().port + "/" + i);
-            const body = await r.text();
-            let expected = "";
-            for (let c = 0; c < CHUNKS; c++) expected += "[" + i + ":" + c + "]" + pad;
-            expected += "[" + i + ":end]";
-            return body === expected && r.headers.get("x-id") === String(i)
-              ? { i, ok: true }
-              : { i, ok: false, got: body.slice(0, 100), want: expected.slice(0, 100) };
-          })
-        );
-        const bad = results.filter(r => !r.ok);
-        console.log(bad.length ? "FAIL " + JSON.stringify(bad.slice(0, 3)) : "PASS " + results.length);
-        server.close();
-      });
-    `);
+        res.end(`[${id}:end]`);
+      },
+      port => validate(i => `http://localhost:${port}/${i}`, pad),
+    );
   });
 });

--- a/test/js/node/http/node-http-nested-cork.test.ts
+++ b/test/js/node/http/node-http-nested-cork.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { createServer } from "node:http";
 import { once } from "node:events";
+import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 
 // Security test: with two cork slots that can be stolen/evicted, a bug in slot


### PR DESCRIPTION
## What

`test/js/node/http/node-http-nested-cork.test.ts` was the slow file on debian 13 x64-asan (31s wall in build #79247). Its ten scenarios each spawned their own `bun -e` subprocess; under `describe.concurrent` on an ASAN shard that is ten ASAN processes competing for the runner's cores and memory.

This runs the identical handlers and the identical 32-request / 8-chunk validation inside the test process instead of in subprocesses. No scenario is removed, skipped, or narrowed; `N=32` and `CHUNKS=8` are unchanged.

## Why this is safe for the thing the test guards

The cork slots are per-`LoopData`, i.e. per thread (`packages/bun-uws/src/LoopData.h` `CorkSlot corkSlots[2]`). `node:http` is backed by `Bun.serve`, so all ten servers on the main thread share the same two slots. In-process under `describe.concurrent` that is 320 sockets competing for 2 slots, versus 32 per isolated subprocess before: strictly more eviction pressure on the bookkeeping #28615 added, not less.

Each scenario still has its own `chainAwait` barrier (now a factory returning a fresh closure) so per-scenario interleaving is unchanged.

## Assertions

Before, the subprocess computed the result and the outer test asserted `stdout == "PASS 32"`. Now `validate()` asserts directly:

```ts
expect(results).toEqual(
  Array.from({ length: N }, (_, i) => ({ i, header: String(i), body: expectedBody(i, pad) })),
);
```

so a single cross-socket byte fails with a diff that names the offending request's id, header, and body. The large-chunk boundary case goes through the same helper instead of its own inline loop.

## Timing

**debian 13 x64-asan CI shard** (the lane this was about):

| | build | time |
|-|-|-|
| before | [#79247](https://buildkite.com/bun/bun/builds/79247) | 31.17s |
| after | [#79542](https://buildkite.com/bun/bun/builds/79542) | 523ms |

**Local `bun bd test` (debug+ASAN)**, three runs each at `df84f8db1`:

| | run 1 | run 2 | run 3 |
|-|-|-|-|
| before | 8.43s | 8.41s | 8.40s |
| after | 6.26s | 6.46s | 6.36s |

The local delta understates the CI win because the CI shard's cost was ten concurrent ASAN processes fighting for shared cores, which this container reproduces poorly.

All 10 tests pass on all lanes.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http/node-http-nested-cork.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/http/node-http-nested-cork.test.ts
bun test v1.4.0 (b85134656)

test/js/node/http/node-http-nested-cork.test.ts:
(pass) cork buffer: no cross-socket data bleed > Bun.serve — buffered Response with await before return [304.37ms]
(pass) cork buffer: no cross-socket data bleed > node:http — double microtask between every chunk [2062.67ms]
(pass) cork buffer: no cross-socket data bleed > node:http — burst write, yield, burst write [2087.12ms]
(pass) cork buffer: no cross-socket data bleed > Bun.serve — type:"direct" burst, flush, yield, burst [392.71ms]
(pass) cork buffer: no cross-socket data bleed > node:http — write then mixed yield then write (slot held with data) [2998.46ms]
(pass) cork buffer: no cross-socket data bleed > node:http — yield then write (empty slot stolen, must re-acquire) [2938.26ms]
(pass) cork buffer: no cross-socket data bleed > Bun.serve — type:"direct" write then mixed yield [2579.49ms]
(pass) cork buffer: no cross-socket data bleed > Bun.serve — type:"direct" yield then write [990.51ms]
(pass) cork buffer: no cross-socket data bleed > Bun.serve — async generator mixed yield per chunk [840.25ms]
(pass) cork buffer: no cross-socket data bleed > node:http — large chunks near cork buffer boundary [488.35ms]

 10 pass
 0 fail
 10 expect() calls
Ran 10 tests across 1 file. [6.69s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/http/node-http-nested-cork.test.ts | 388 ++++++++++++------------
 1 file changed, 189 insertions(+), 199 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/js/node/http/node-http-nested-cork.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->