### PR TITLE
test(websocket): run autobahn cases with a bounded fan-out

### DIFF
--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -126,10 +126,14 @@ describe.skipIf(!isDockerEnabled())("autobahn", () => {
     // waits for the client echo or a closeAfter/killAfter timer, so a bounded
     // fan-out overlaps those waits instead of paying them serially.
     const concurrency = 16;
+    // A broad protocol regression fails every case via the server's
+    // killAfter/closeAfter fallback (seconds each); bailing once we have
+    // plenty to report keeps that path seconds, not minutes.
+    const maxFailures = 20;
     const failures: { case: number; behavior: string }[] = [];
     let cursor = 0;
     async function worker() {
-      while (true) {
+      while (failures.length < maxFailures) {
         const idx = cursor++;
         if (idx >= testCases.length) return;
         const i = testCases[idx];

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { isDockerEnabled } from "harness";
 import * as dockerCompose from "../../../docker/index.ts";
 
@@ -120,32 +120,46 @@ describe.skipIf(!isDockerEnabled())("autobahn", () => {
 
     console.log(`Running ${testCases.length} of ${count} test cases`);
 
-    for (const i of testCases) {
-      if (i > count) continue;
+    // Each case runs on its own WebSocket connection and the fuzzingserver
+    // stores results per (agent, case) pair, so cases are independent and can
+    // overlap. The Twisted reactor is single-threaded but yields while a case
+    // waits for the client echo or a closeAfter/killAfter timer, so a bounded
+    // fan-out overlaps those waits instead of paying them serially.
+    const concurrency = 16;
+    const failures: { case: number; behavior: string }[] = [];
+    let cursor = 0;
+    async function worker() {
+      while (true) {
+        const idx = cursor++;
+        if (idx >= testCases.length) return;
+        const i = testCases[idx];
+        if (i > count) continue;
 
-      // Run test case
-      await runTestCase(i);
-      const result = (await getCaseStatus(i)) as { behavior: string };
-
-      // Check result
-      try {
-        expect(result.behavior).toBeOneOf(["OK", "INFORMATIONAL", "NON-STRICT"]);
-      } catch (e) {
-        // getCaseInfo is only needed for the failure message; fetching it
-        // lazily skips one WebSocket round trip per case on the happy path.
-        let label = `Test case ${i}`;
-        try {
-          const info = (await getCaseInfo(i)) as { id: string; description: string };
-          label = `Test case ${info.id} (${info.description})`;
-        } catch {}
-        throw new Error(`${label} failed: behavior was ${result.behavior}`);
+        await runTestCase(i);
+        const result = (await getCaseStatus(i)) as { behavior: string };
+        if (!["OK", "INFORMATIONAL", "NON-STRICT"].includes(result.behavior)) {
+          failures.push({ case: i, behavior: result.behavior });
+        }
       }
     }
-  }, 300000); // 5 minute timeout
+    await Promise.all(Array.from({ length: concurrency }, worker));
 
-  afterAll(() => {
-    // Container managed by docker-compose, no need to kill
-  });
+    failures.sort((a, b) => a.case - b.case);
+    if (failures.length > 0) {
+      // getCaseInfo is only needed for the failure message; fetching it
+      // lazily skips one WebSocket round trip per case on the happy path.
+      await Promise.all(
+        failures.map(async f => {
+          try {
+            Object.assign(f, (await getCaseInfo(f.case)) as { id: string; description: string });
+          } catch {}
+        }),
+      );
+    }
+    // Surface every failing case at once instead of only the first, and keep
+    // the per-case OK / NON-STRICT / FAILED behavior in the diff output.
+    expect(failures).toEqual([]);
+  }, 300000); // 5 minute timeout
 });
 
 // last test is 13.7.18


### PR DESCRIPTION
## What

`test/js/web/websocket/autobahn.test.ts` is the slowest WebSocket test on the `darwin 26 aarch64` lane at ~31s wall time (build #79247). The file drives the autobahn fuzzingserver one case at a time: for each of the 56 CI-subset cases it opens a `/runCase` WebSocket, echoes to completion, then opens a second `/getCaseStatus` WebSocket, strictly sequentially.

## Why this is safe

The fuzzingserver stores results in a per-connection protocol instance and writes them back as `factory.agents[agent][caseId] = result` (see [`fuzzing.py` logCase](https://github.com/crossbario/autobahn-testsuite/blob/master/autobahntestsuite/autobahntestsuite/fuzzing.py)). `/getCaseStatus` reads that dict via `addResultListener`, which either returns the stored result immediately or parks a one-shot callback that fires when `logCase` runs for that `(agent, caseId)`. Concurrent cases with the same agent and distinct case numbers cannot interfere, and status can be queried in any order relative to case completion.

The Twisted reactor is single-threaded but every case schedules its `closeAfter`/`killAfter` fallback and any chopped writes via `reactor.callLater`, and is idle while waiting for the client to echo. Those idle windows are what the sequential loop pays for end-to-end and what a fan-out overlaps.

## Change

Replace the sequential `for` loop with 16 worker promises that pull from the same case list, each still doing `runTestCase(i)` then `getCaseStatus(i)`. Same cases, same per-case echo protocol, same acceptable-behavior set (`OK` / `INFORMATIONAL` / `NON-STRICT`). Workers stop once 20 failures have accumulated so a broad regression reports in seconds instead of grinding through every server-side `killAfter` timer. Failures are collected, sorted by case number, enriched with id/description, and asserted as `expect(failures).toEqual([])` so a failing run shows every offending case:

```
error: expect(received).toEqual(expected)
- []
+ [
+   { "behavior": "FAILED", "case": 7,  "description": "...", "id": "1.1.7" },
+   { "behavior": "FAILED", "case": 42, "description": "...", "id": "4.2.3" },
+ ]
```

The empty `afterAll` is dropped.

## Timing

Case-loop wall time (from "Running 56 of 517 test cases" to pass) extracted from CI log timestamps, baseline build #79247 vs this PR's build #79562:

| lane | before | after |
|---|---|---|
| debian 13 x64 | 4.90s | 4.35s |
| debian 13 x64-asan | 6.13s | 4.01s |
| ubuntu 25.04 x64 | 4.83s | 3.73s |
| alpine 3.23 x64 | 4.80s | 3.95s |
| darwin 26 aarch64 | ~29s | (sidecar docker unreachable this run) |

On native linux the per-case latency is already small so the overlap buys ~1.1-1.5x; the darwin aarch64 lane runs the amd64-only container under qemu, where each case takes roughly an order of magnitude longer, so the overlap should matter more there. The suite passes unchanged on every lane where docker was available.

No cases skipped, no behaviors added to the accepted set, no hardcoded ports introduced.
