### PR TITLE
test: speed up domjit.test.ts (~3x) and add real assertions

### DIFF
--- a/test/js/bun/jsc/domjit.test.ts
+++ b/test/js/bun/jsc/domjit.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "bun:test";
 import { ptr, read } from "bun:ffi";
 import crypto from "crypto";
 import { statSync } from "fs";
+import { isDebug } from "harness";
 import vm from "node:vm";
 
 const dirStats = statSync(import.meta.dir);
@@ -24,7 +25,11 @@ const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
 // a repeat so the FTLFunctionCall compiled during the previous tier actually
 // executes. 200000 clears the bytecode-scaled thresholdForFTLOptimizeAfterWarmUp
 // for every callback here (FFI's ~1K-bytecode body is the worst case).
-const tiers = [1000, 10000, 200000, 200000];
+// Debug builds can't reach 200K within the default 5s per-test budget; they get
+// DFG coverage here and CI's release/release-ASAN lanes carry FTL.
+const top = isDebug ? 50000 : 200000;
+const tiers = [1000, 10000, top, top];
+const vmIter = isDebug ? 20000 : 100000;
 
 describe("DOMJIT", () => {
   const buf = new Uint8Array(4);
@@ -163,13 +168,14 @@ describe("DOMJIT", () => {
   describe("in NodeVM", () => {
     // "a".repeat is very slow in debug JSC; repros for #13320 used a >1024-byte string.
     const longStr = Buffer.alloc(1030, "a").toString();
-    // One pass at 100000 covers FTL; the old 1000000-iter encoder.encode loop was the
+    // The vm script is a single CodeBlock, so one pass of these loops reaches
+    // FTLForOSREntry mid-run; the old 1000000-iter encoder.encode loop was the
     // single slowest thing in this file under ASAN and added no extra tier coverage.
     const code = `
     const buf = new Uint8Array(4);
     const encoder = new TextEncoder();
     const decoder = new TextDecoder();
-    const iter = 100000;
+    const iter = ${vmIter};
     for (let i = 0; i < iter; i++) performance.now();
     for (let i = 0; i < iter; i++) encoder.encode("test");
     for (let i = 0; i < iter; i++) encoder.encode(longStr);

--- a/test/js/bun/jsc/domjit.test.ts
+++ b/test/js/bun/jsc/domjit.test.ts
@@ -11,6 +11,10 @@ import vm from "node:vm";
 
 const dirStats = statSync(import.meta.dir);
 const buffer = new BigInt64Array(16);
+// non-zero bytes at offset 8 so read.i8 sign-extends and each width decodes a
+// distinct value (read.* must agree with DataView on LE targets)
+new Uint8Array(buffer.buffer).set([0x81, 0x02, 0x03, 0x04], 8);
+const dv = new DataView(buffer.buffer);
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 const encodedTest = new Uint8Array([116, 101, 115, 116]); // "test"
@@ -62,8 +66,10 @@ describe("DOMJIT", () => {
       expect([...buf]).toEqual([116, 101, 115, 116]);
     });
     test(`Crypto.timingSafeEqual x${iter}`, () => {
+      const a = new Uint8Array([1, 2, 3, 4]);
+      const b = new Uint8Array([1, 2, 3, 4]);
       let last = false;
-      for (let i = 0; i < iter; i++) last = crypto.timingSafeEqual(buf, buf);
+      for (let i = 0; i < iter; i++) last = crypto.timingSafeEqual(a, b);
       expect(last).toBe(true);
     });
     test(`Crypto.randomUUID x${iter}`, () => {
@@ -135,18 +141,19 @@ describe("DOMJIT", () => {
       }
       expect(Number.isFinite(ptr(buffer))).toBe(true);
       expect({ intptr, rptr, f64, i64, u64, i8, i16, i32, u8, u16, u32 }).toEqual({
-        intptr: 0,
-        rptr: 0,
-        f64: 0,
-        i64: 0n,
-        u64: 0n,
-        i8: 0,
-        i16: 0,
-        i32: 0,
-        u8: 0,
-        u16: 0,
-        u32: 0,
+        intptr: Number(dv.getBigInt64(8, true)),
+        rptr: Number(dv.getBigUint64(8, true)),
+        f64: dv.getFloat64(8, true),
+        i64: dv.getBigInt64(8, true),
+        u64: dv.getBigUint64(8, true),
+        i8: dv.getInt8(8),
+        i16: dv.getInt16(8, true),
+        i32: dv.getInt32(8, true),
+        u8: dv.getUint8(8),
+        u16: dv.getUint16(8, true),
+        u32: dv.getUint32(8, true),
       });
+      expect(i8).toBe(-127);
     });
   }
 

--- a/test/js/bun/jsc/domjit.test.ts
+++ b/test/js/bun/jsc/domjit.test.ts
@@ -1,6 +1,5 @@
 // exercise DOMJIT-annotated host functions (and host functions that once were)
-// across JIT tiers: baseline (~1K), DFG (~10K), FTL (~100K).
-// JSC defaults: thresholdForOptimizeSoon=1000, thresholdForFTLOptimizeAfterWarmUp=64000.
+// across JIT tiers: baseline/DFG/FTL.
 
 import { describe, expect, test } from "bun:test";
 
@@ -20,29 +19,33 @@ const decoder = new TextDecoder();
 const encodedTest = new Uint8Array([116, 101, 115, 116]); // "test"
 const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-// 100000 is past the FTL warm-up threshold; the old extra 1000000 tier only
-// re-ran FTL steady state and dominated ASAN/debug runtime.
-const tiers = [1000, 10000, 100000];
+// Bun forces useConcurrentJIT=true, so the FTL replacement compiles off-thread
+// and is only installed AFTER a tier's callback returns: the final tier must be
+// a repeat so the FTLFunctionCall compiled during the previous tier actually
+// executes. 200000 clears the bytecode-scaled thresholdForFTLOptimizeAfterWarmUp
+// for every callback here (FFI's ~1K-bytecode body is the worst case).
+const tiers = [1000, 10000, 200000, 200000];
 
 describe("DOMJIT", () => {
   const buf = new Uint8Array(4);
-  for (const iter of tiers) {
-    test(`Buffer.alloc x${iter}`, () => {
+  for (const [n, iter] of tiers.entries()) {
+    const tag = `#${n + 1} x${iter}`;
+    test(`Buffer.alloc ${tag}`, () => {
       let last!: Buffer;
       for (let i = 0; i < iter; i++) last = Buffer.alloc(1);
       expect([last.length, last[0]]).toEqual([1, 0]);
     });
-    test(`Buffer.allocUnsafe x${iter}`, () => {
+    test(`Buffer.allocUnsafe ${tag}`, () => {
       let last!: Buffer;
       for (let i = 0; i < iter; i++) last = Buffer.allocUnsafe(1);
       expect(last.length).toBe(1);
     });
-    test(`Buffer.allocUnsafeSlow x${iter}`, () => {
+    test(`Buffer.allocUnsafeSlow ${tag}`, () => {
       let last!: Buffer;
       for (let i = 0; i < iter; i++) last = Buffer.allocUnsafeSlow(1);
       expect(last.length).toBe(1);
     });
-    test(`Performance.now x${iter}`, () => {
+    test(`Performance.now ${tag}`, () => {
       let prev = performance.now();
       let ok = true;
       let last = prev;
@@ -54,40 +57,40 @@ describe("DOMJIT", () => {
       expect(ok).toBe(true);
       expect(Number.isFinite(last)).toBe(true);
     });
-    test(`TextEncoder.encode x${iter}`, () => {
+    test(`TextEncoder.encode ${tag}`, () => {
       let last!: Uint8Array;
       for (let i = 0; i < iter; i++) last = encoder.encode("test");
       expect([...last]).toEqual([116, 101, 115, 116]);
     });
-    test(`TextEncoder.encodeInto x${iter}`, () => {
+    test(`TextEncoder.encodeInto ${tag}`, () => {
       let last!: TextEncoderEncodeIntoResult;
       for (let i = 0; i < iter; i++) last = encoder.encodeInto("test", buf);
       expect(last).toEqual({ read: 4, written: 4 });
       expect([...buf]).toEqual([116, 101, 115, 116]);
     });
-    test(`Crypto.timingSafeEqual x${iter}`, () => {
+    test(`Crypto.timingSafeEqual ${tag}`, () => {
       const a = new Uint8Array([1, 2, 3, 4]);
       const b = new Uint8Array([1, 2, 3, 4]);
       let last = false;
       for (let i = 0; i < iter; i++) last = crypto.timingSafeEqual(a, b);
       expect(last).toBe(true);
     });
-    test(`Crypto.randomUUID x${iter}`, () => {
+    test(`Crypto.randomUUID ${tag}`, () => {
       let last = "";
       for (let i = 0; i < iter; i++) last = crypto.randomUUID();
       expect(last).toMatch(uuid);
     });
-    test(`Crypto.getRandomValues x${iter}`, () => {
+    test(`Crypto.getRandomValues ${tag}`, () => {
       let last!: Uint8Array;
       for (let i = 0; i < iter; i++) last = crypto.getRandomValues(buf);
       expect(last).toBe(buf);
     });
-    test(`TextDecoder.decode x${iter}`, () => {
+    test(`TextDecoder.decode ${tag}`, () => {
       let last = "";
       for (let i = 0; i < iter; i++) last = decoder.decode(encodedTest);
       expect(last).toBe("test");
     });
-    test(`Stats x${iter}`, () => {
+    test(`Stats ${tag}`, () => {
       let isSymbolicLink!: boolean,
         isSocket!: boolean,
         isFile!: boolean,
@@ -114,7 +117,7 @@ describe("DOMJIT", () => {
         isBlockDevice: false,
       });
     });
-    test(`FFI ptr and read x${iter}`, () => {
+    test(`FFI ptr and read ${tag}`, () => {
       let intptr!: number,
         rptr!: number,
         f64!: number,

--- a/test/js/bun/jsc/domjit.test.ts
+++ b/test/js/bun/jsc/domjit.test.ts
@@ -1,4 +1,6 @@
-// test functions that use DOMJIT
+// exercise DOMJIT-annotated host functions (and host functions that once were)
+// across JIT tiers: baseline (~1K), DFG (~10K), FTL (~100K).
+// JSC defaults: thresholdForOptimizeSoon=1000, thresholdForFTLOptimizeAfterWarmUp=64000.
 
 import { describe, expect, test } from "bun:test";
 
@@ -9,147 +11,180 @@ import vm from "node:vm";
 
 const dirStats = statSync(import.meta.dir);
 const buffer = new BigInt64Array(16);
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const encodedTest = new Uint8Array([116, 101, 115, 116]); // "test"
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+// 100000 is past the FTL warm-up threshold; the old extra 1000000 tier only
+// re-ran FTL steady state and dominated ASAN/debug runtime.
+const tiers = [1000, 10000, 100000];
 
 describe("DOMJIT", () => {
   const buf = new Uint8Array(4);
-  for (let iter of [1000, 10000, 100000, 1000000]) {
-    test("Buffer.alloc", () => {
-      for (let i = 0; i < iter; i++) {
-        Buffer.alloc(1);
-      }
-      expect(true).toBe(true);
+  for (const iter of tiers) {
+    test(`Buffer.alloc x${iter}`, () => {
+      let last!: Buffer;
+      for (let i = 0; i < iter; i++) last = Buffer.alloc(1);
+      expect([last.length, last[0]]).toEqual([1, 0]);
     });
-    test("Buffer.allocUnsafe", () => {
-      for (let i = 0; i < iter; i++) {
-        Buffer.allocUnsafe(1);
-      }
-      expect(true).toBe(true);
+    test(`Buffer.allocUnsafe x${iter}`, () => {
+      let last!: Buffer;
+      for (let i = 0; i < iter; i++) last = Buffer.allocUnsafe(1);
+      expect(last.length).toBe(1);
     });
-    test("Buffer.allocUnsafeSlow", () => {
-      for (let i = 0; i < iter; i++) {
-        Buffer.allocUnsafeSlow(1);
-      }
-      expect(true).toBe(true);
+    test(`Buffer.allocUnsafeSlow x${iter}`, () => {
+      let last!: Buffer;
+      for (let i = 0; i < iter; i++) last = Buffer.allocUnsafeSlow(1);
+      expect(last.length).toBe(1);
     });
-    test("Performance.now", () => {
+    test(`Performance.now x${iter}`, () => {
+      let prev = performance.now();
+      let ok = true;
+      let last = prev;
       for (let i = 0; i < iter; i++) {
-        performance.now();
+        last = performance.now();
+        ok &&= last >= prev;
+        prev = last;
       }
-      expect(true).toBe(true);
+      expect(ok).toBe(true);
+      expect(Number.isFinite(last)).toBe(true);
     });
-    test("TextEncoder.encode", () => {
-      for (let i = 0; i < iter; i++) {
-        new TextEncoder().encode("test");
-      }
-      expect(true).toBe(true);
+    test(`TextEncoder.encode x${iter}`, () => {
+      let last!: Uint8Array;
+      for (let i = 0; i < iter; i++) last = encoder.encode("test");
+      expect([...last]).toEqual([116, 101, 115, 116]);
     });
-    test("TextEncoder.encodeInto", () => {
-      for (let i = 0; i < iter; i++) {
-        new TextEncoder().encodeInto("test", buf);
-      }
-      expect(true).toBe(true);
+    test(`TextEncoder.encodeInto x${iter}`, () => {
+      let last!: TextEncoderEncodeIntoResult;
+      for (let i = 0; i < iter; i++) last = encoder.encodeInto("test", buf);
+      expect(last).toEqual({ read: 4, written: 4 });
+      expect([...buf]).toEqual([116, 101, 115, 116]);
     });
-    test("Crypto.timingSafeEqual", () => {
-      for (let i = 0; i < iter; i++) {
-        crypto.timingSafeEqual(buf, buf);
-      }
-      expect(true).toBe(true);
+    test(`Crypto.timingSafeEqual x${iter}`, () => {
+      let last = false;
+      for (let i = 0; i < iter; i++) last = crypto.timingSafeEqual(buf, buf);
+      expect(last).toBe(true);
     });
-    test("Crypto.randomUUID", () => {
-      for (let i = 0; i < iter; i++) {
-        crypto.randomUUID();
-      }
-      expect(true).toBe(true);
+    test(`Crypto.randomUUID x${iter}`, () => {
+      let last = "";
+      for (let i = 0; i < iter; i++) last = crypto.randomUUID();
+      expect(last).toMatch(uuid);
     });
-    test("Crypto.getRandomValues", () => {
-      for (let i = 0; i < iter; i++) {
-        crypto.getRandomValues(buf);
-      }
-      expect(true).toBe(true);
+    test(`Crypto.getRandomValues x${iter}`, () => {
+      let last!: Uint8Array;
+      for (let i = 0; i < iter; i++) last = crypto.getRandomValues(buf);
+      expect(last).toBe(buf);
     });
-    test("TextDecoder.decode", () => {
-      for (let i = 0; i < iter; i++) {
-        new TextDecoder().decode(buf);
-      }
-      expect(true).toBe(true);
+    test(`TextDecoder.decode x${iter}`, () => {
+      let last = "";
+      for (let i = 0; i < iter; i++) last = decoder.decode(encodedTest);
+      expect(last).toBe("test");
     });
-    test("Stats", () => {
+    test(`Stats x${iter}`, () => {
+      let isSymbolicLink!: boolean,
+        isSocket!: boolean,
+        isFile!: boolean,
+        isFIFO!: boolean,
+        isDirectory!: boolean,
+        isCharacterDevice!: boolean,
+        isBlockDevice!: boolean;
       for (let i = 0; i < iter; i++) {
-        dirStats.isSymbolicLink();
-        dirStats.isSocket();
-        dirStats.isFile();
-        dirStats.isFIFO();
-        dirStats.isDirectory();
-        dirStats.isCharacterDevice();
-        dirStats.isBlockDevice();
+        isSymbolicLink = dirStats.isSymbolicLink();
+        isSocket = dirStats.isSocket();
+        isFile = dirStats.isFile();
+        isFIFO = dirStats.isFIFO();
+        isDirectory = dirStats.isDirectory();
+        isCharacterDevice = dirStats.isCharacterDevice();
+        isBlockDevice = dirStats.isBlockDevice();
       }
-      expect(true).toBe(true);
+      expect({ isSymbolicLink, isSocket, isFile, isFIFO, isDirectory, isCharacterDevice, isBlockDevice }).toEqual({
+        isSymbolicLink: false,
+        isSocket: false,
+        isFile: false,
+        isFIFO: false,
+        isDirectory: true,
+        isCharacterDevice: false,
+        isBlockDevice: false,
+      });
     });
-    test("FFI ptr and read", () => {
+    test(`FFI ptr and read x${iter}`, () => {
+      let intptr!: number,
+        rptr!: number,
+        f64!: number,
+        i64!: bigint,
+        u64!: bigint,
+        i8!: number,
+        i16!: number,
+        i32!: number,
+        u8!: number,
+        u16!: number,
+        u32!: number;
       for (let i = 0; i < iter; i++) {
-        read.intptr(ptr(buffer), 8);
-        read.ptr(ptr(buffer), 8);
-        read.f64(ptr(buffer), 8);
-        read.i64(ptr(buffer), 8);
-        read.u64(ptr(buffer), 8);
-        read.i8(ptr(buffer), 8);
-        read.i16(ptr(buffer), 8);
-        read.i32(ptr(buffer), 8);
-        read.u8(ptr(buffer), 8);
-        read.u16(ptr(buffer), 8);
-        read.u32(ptr(buffer), 8);
+        intptr = read.intptr(ptr(buffer), 8);
+        rptr = read.ptr(ptr(buffer), 8);
+        f64 = read.f64(ptr(buffer), 8);
+        i64 = read.i64(ptr(buffer), 8);
+        u64 = read.u64(ptr(buffer), 8);
+        i8 = read.i8(ptr(buffer), 8);
+        i16 = read.i16(ptr(buffer), 8);
+        i32 = read.i32(ptr(buffer), 8);
+        u8 = read.u8(ptr(buffer), 8);
+        u16 = read.u16(ptr(buffer), 8);
+        u32 = read.u32(ptr(buffer), 8);
       }
-      expect(true).toBe(true);
+      expect(Number.isFinite(ptr(buffer))).toBe(true);
+      expect({ intptr, rptr, f64, i64, u64, i8, i16, i32, u8, u16, u32 }).toEqual({
+        intptr: 0,
+        rptr: 0,
+        f64: 0,
+        i64: 0n,
+        u64: 0n,
+        i8: 0,
+        i16: 0,
+        i32: 0,
+        u8: 0,
+        u16: 0,
+        u32: 0,
+      });
     });
   }
 
   describe("in NodeVM", () => {
+    // "a".repeat is very slow in debug JSC; repros for #13320 used a >1024-byte string.
+    const longStr = Buffer.alloc(1030, "a").toString();
+    // One pass at 100000 covers FTL; the old 1000000-iter encoder.encode loop was the
+    // single slowest thing in this file under ASAN and added no extra tier coverage.
     const code = `
     const buf = new Uint8Array(4);
     const encoder = new TextEncoder();
-    for (let iter of [100000]) {
-      for (let i = 0; i < iter; i++) {
-        performance.now();
-      }
-      for (let i = 0; i < iter; i++) {
-        new TextEncoder().encode("test");
-      }
-      const str = "a".repeat(1030);
-      for (let i = 0; i < 1000000; i++) {
-        const result = encoder.encode(str);
-      }
-      for (let i = 0; i < iter; i++) {
-        new TextEncoder().encodeInto("test", buf);
-      }
-      for (let i = 0; i < iter; i++) {
-        crypto.timingSafeEqual(buf, buf);
-      }
-      for (let i = 0; i < iter; i++) {
-        crypto.randomUUID();
-      }
-      for (let i = 0; i < iter; i++) {
-        crypto.getRandomValues(buf);
-      }
-      for (let i = 0; i < iter; i++) {
-        new TextDecoder().decode(buf);
-      }
-      for (let i = 0; i < iter; i++) {
-        dirStats.isSymbolicLink();
-        dirStats.isSocket();
-        dirStats.isFile();
-        dirStats.isFIFO();
-        dirStats.isDirectory();
-        dirStats.isCharacterDevice();
-        dirStats.isBlockDevice();
-      }
+    const decoder = new TextDecoder();
+    const iter = 100000;
+    for (let i = 0; i < iter; i++) performance.now();
+    for (let i = 0; i < iter; i++) encoder.encode("test");
+    for (let i = 0; i < iter; i++) encoder.encode(longStr);
+    for (let i = 0; i < iter; i++) encoder.encodeInto("test", buf);
+    for (let i = 0; i < iter; i++) crypto.timingSafeEqual(buf, buf);
+    for (let i = 0; i < iter; i++) crypto.randomUUID();
+    for (let i = 0; i < iter; i++) crypto.getRandomValues(buf);
+    for (let i = 0; i < iter; i++) decoder.decode(buf);
+    for (let i = 0; i < iter; i++) {
+      dirStats.isSymbolicLink();
+      dirStats.isSocket();
+      dirStats.isFile();
+      dirStats.isFIFO();
+      dirStats.isDirectory();
+      dirStats.isCharacterDevice();
+      dirStats.isBlockDevice();
     }
     "success";`;
+    const sandbox = { crypto, performance, TextEncoder, TextDecoder, dirStats, longStr };
     test("Script.runInNewContext", () => {
       const script = new vm.Script(code);
-      expect(script.runInNewContext({ crypto, performance, TextEncoder, TextDecoder, dirStats })).toBe("success");
+      expect(script.runInNewContext({ ...sandbox })).toBe("success");
     }, 20_000);
     test("vm.runInNewContext", () => {
-      expect(vm.runInNewContext(code, { crypto, performance, TextEncoder, TextDecoder, dirStats })).toBe("success");
+      expect(vm.runInNewContext(code, { ...sandbox })).toBe("success");
     }, 20_000);
   });
 });


### PR DESCRIPTION
`test/js/bun/jsc/domjit.test.ts` was the slow outlier on x64-asan (29s wall in build #79247), and timed out under a plain `bun bd test` locally.

### What changed

**Iteration tiers.** The main loop ran each host function at `[1000, 10000, 100000, 1000000]`. Replaced with `[1000, 10000, 200000, 200000]` on release builds:

- Bun forces `useConcurrentJIT=true` (`ZigGlobalObject.cpp`), so the FTL replacement compiles off-thread and is only installed after a callback returns. The final tier has to be a repeat so the `FTLFunctionCall` compiled during the previous tier actually executes.
- `thresholdForFTLOptimizeAfterWarmUp=64000` is scaled per `CodeBlock::adjustedCounterValue` by bytecode size; the FFI callback is the largest here and needs roughly 200K to trigger. Two 200K tiers cover trigger and execution for every callback.
- Verified with `BUN_JSC_verboseOSR=1` that every callback's FTL install precedes its `#4` invocation across repeated runs.

411K iterations per function vs the old 1.11M, about 2.7x less work in the hot loops.

Debug builds (`bun bd`) are far too slow per iteration to reach 200K within the default 5s per-test budget, so they use `[1000, 10000, 50000, 50000]` and `vmIter=20000` instead. That covers DFG (where DOMJIT's `CallDOM` node is also emitted); CI's release and release-ASAN lanes carry the FTL coverage. The old file also never reached FTL under `bun bd test` since its 1M tier always timed out at the 5s default.

**vm tests.** The `encoder.encode(1030-byte-string)` loop ran 1000000 iterations for the #13320 regression; reduced to 100000. The vm script's global code is a single CodeBlock that reaches `FTLForOSREntry` mid-run, so 100K is enough there (also verified via `verboseOSR`). Hoisted `TextEncoder`/`TextDecoder` out of the vm hot loops and replaced `"a".repeat(1030)` with `Buffer.alloc(1030, "a").toString()` per test/CLAUDE.md.

**Hoisted encoder/decoder** in the main loops. The DOMJIT signature is on `encode`/`decode`, not the constructor; a fresh `new TextEncoder()` per iteration added allocation overhead without extra coverage. #13320's own repro uses a hoisted encoder.

**Assertions.** Every case previously ended in `expect(true).toBe(true)`. Each now checks the actual return value at that tier: buffer length/content for `Buffer.alloc`, monotonic timestamps for `performance.now`, UTF-8 bytes for `encode`/`decode`, `{read, written}` for `encodeInto`, `true` for `timingSafeEqual` (two distinct equal-content buffers), UUIDv4 shape for `randomUUID`, identity for `getRandomValues`, per-method booleans for `Stats`, and per-width `DataView` agreement (with an explicit `i8 == -127` sign-extension check) for `read.*` against a seeded `[0x81,0x02,0x03,0x04]` pattern. Test names now include a tier index instead of being duplicated.

**Coverage preserved.** Every function the old file exercised is still exercised, in the main process and in both `node:vm` entry points, at FTL on release lanes. Nothing skipped, nothing removed.

### Timings

| build | before | after |
| --- | --- | --- |
| release | 3.64s | 0.84s |
| `bun bd test` (debug+ASAN, default timeout) | 414s, 9 timeouts | 34s, 0 fail |

On CI's release-ASAN lane (about 8x release) this projects to roughly 7s from 29s.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/domjit.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/domjit.test.ts
bun test v1.4.0 (e438e9aad)

test/js/bun/jsc/domjit.test.ts:
(pass) DOMJIT > Buffer.alloc #1 x1000 [11.64ms]
(pass) DOMJIT > Buffer.allocUnsafe #1 x1000 [8.27ms]
(pass) DOMJIT > Buffer.allocUnsafeSlow #1 x1000 [9.18ms]
(pass) DOMJIT > Performance.now #1 x1000 [5.65ms]
(pass) DOMJIT > TextEncoder.encode #1 x1000 [32.71ms]
(pass) DOMJIT > TextEncoder.encodeInto #1 x1000 [23.27ms]
(pass) DOMJIT > Crypto.timingSafeEqual #1 x1000 [8.61ms]
(pass) DOMJIT > Crypto.randomUUID #1 x1000 [12.20ms]
(pass) DOMJIT > Crypto.getRandomValues #1 x1000 [32.31ms]
(pass) DOMJIT > TextDecoder.decode #1 x1000 [38.66ms]
(pass) DOMJIT > Stats #1 x1000 [24.12ms]
(pass) DOMJIT > FFI ptr and read #1 x1000 [53.93ms]
(pass) DOMJIT > Buffer.alloc #2 x10000 [58.08ms]
(pass) DOMJIT > Buffer.allocUnsafe #2 x10000 [57.91ms]
(pass) DOMJIT > Buffer.allocUnsafeSlow #2 x10000 [53.01ms]
(pass) DOMJIT > Performance.now #2 x10000 [7.36ms]
(pass) DOMJIT > TextEncoder.encode #2 x10000 [228.10ms]
(pass) DOMJIT > TextEncoder.encodeInto #2 x10000 [196.10ms]
(pass) DOMJIT > Crypto.timingSafeEqual #2 x10000 [34.66ms]
(pass) DOMJIT > Crypto.randomUUID #2 x10000 [90.20ms]
(pass) DOMJIT > Crypto.getRandomValues #2 x10000 [282.79ms]
(pass) DOMJIT > TextDecoder.decode #2 x10000 [354.74ms]
(pass) DOMJIT > Stats #2 x10000 [188.76ms]
(pass) DOMJIT > FFI ptr and read #2 x10000 [400.97ms]
(pass) DOMJIT > Buffer.alloc #3 x50000 [361.25ms]
(pass) DOMJIT > Buffer.allocUnsafe #3 x50000 [258.84ms]
(pass) DOMJIT > Buffer.allocUnsafeSlow #3 x50000 [263.78ms]
(pass) DOMJIT > Performance.now #3 x50000 [21.00ms]
(pass) DOMJIT > TextEncoder.encode #3 x50000 [1101.71ms]
(pass) DOMJIT > TextEncoder.encodeInto #3 x50000 [935.85ms]
(pass) DOMJIT > Crypto.timingSafeEqual #3 x50000 [173.31ms]
(pass) DOMJIT > Crypto.randomUUID #3 x50000 [417.60ms]
(pass) DOMJIT > Crypto.getRandomValues #3 x50000 [1341.85ms]
(pass) DOMJIT >
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/jsc/domjit.test.ts | 277 ++++++++++++++++++++++++-----------------
 1 file changed, 164 insertions(+), 113 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
test/js/bun/jsc/domjit.test.ts      6     16      0
```

</details>

<!-- robobun:evidence:end -->