### PR TITLE
install: fix git dependencies that share one repository

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -248,6 +248,13 @@ type PreallocatedNetworkTasks = HiveArrayFallback<NetworkTask, 128>;
 type ResolveTaskQueue = UnboundedQueue<Task::Task<'static> /* , .next */>;
 
 type RepositoryMap = HashMap<Task::Id, Fd /* , IdentityContext<Task::Id>, 80 */>;
+/// Resolve-task id (git checkout / tarball extract) -> the package that task
+/// appended during the resolve phase. A task's callback queue is drained
+/// exactly once, so a dependency enqueued after that drain must resolve
+/// through this map instead of queueing a callback that nothing will ever
+/// process.
+type AppendedTaskPackageMap =
+    HashMap<Task::Id, PackageID /* , IdentityContext<Task::Id>, 80 */>;
 pub(crate) type FolderResolutionMap =
     HashMap<u64, FolderResolutionEntry /* , IdentityContext<u64>, 80 */>;
 pub(crate) type NpmAliasMap =
@@ -329,6 +336,7 @@ pub struct PackageManager {
     pub manifests: PackageManifestMap,
     pub(crate) folders: FolderResolutionMap,
     pub(crate) git_repositories: RepositoryMap,
+    pub(crate) appended_task_packages: AppendedTaskPackageMap,
 
     pub(crate) network_dedupe_map: crate::network_task::DedupeMap,
     pub(crate) async_network_task_queue: AsyncNetworkTaskQueue,
@@ -1914,6 +1922,7 @@ pub fn init(
         wr!(manifests, PackageManifestMap::default());
         wr!(folders, Default::default());
         wr!(git_repositories, RepositoryMap::default());
+        wr!(appended_task_packages, AppendedTaskPackageMap::default());
         wr!(network_dedupe_map, Default::default());
         wr!(async_network_task_queue, AsyncNetworkTaskQueue::default());
         wr!(network_tarball_batch, thread_pool::Batch::default());
@@ -2346,6 +2355,7 @@ fn init_with_runtime_once(
         wr!(manifests, PackageManifestMap::default());
         wr!(folders, Default::default());
         wr!(git_repositories, RepositoryMap::default());
+        wr!(appended_task_packages, AppendedTaskPackageMap::default());
         wr!(network_dedupe_map, Default::default());
         wr!(async_network_task_queue, AsyncNetworkTaskQueue::default());
         wr!(network_tarball_batch, thread_pool::Batch::default());

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -307,7 +307,6 @@ pub fn enqueue_git_for_checkout(
             clone_id,
             alias,
             &repository,
-            dependency_id,
             &dep,
             resolution,
             None,
@@ -617,6 +616,36 @@ pub unsafe fn enqueue_patch_task_pre(this: &mut PackageManager, task: *mut Patch
 
     this.patch_task_fifo.write_item_assume_capacity(task);
     let _ = this.pending_pre_calc_hashes.fetch_add(1, Ordering::Relaxed);
+}
+
+/// A resolve task's callback queue is drained exactly once. If `task_id`
+/// already completed and appended a package, resolve `id` against it directly:
+/// a context queued now would never be processed. Applies the same
+/// `package_name` / `resolved` fix-up the completion drain applies.
+fn resolve_from_appended_task(
+    this: &mut PackageManager,
+    task_id: Task::Id,
+    id: DependencyID,
+) -> Option<PackageID> {
+    let &pkg_id = this.appended_task_packages.get(&task_id)?;
+    let pkg_name = this.lockfile.packages.items_name()[pkg_id as usize];
+    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id as usize];
+    let v = &mut this.lockfile.buffers.dependencies[id as usize].version;
+    // The buffer row can hold a different tag than the enqueue arm when the
+    // dependency comes from `overrides`.
+    match v.tag {
+        dependency::version::Tag::Git => {
+            let repo = v.git_mut();
+            if pkg_res.tag == ResolutionTag::Git {
+                repo.resolved = pkg_res.git().resolved;
+            }
+            repo.package_name = pkg_name;
+        }
+        dependency::version::Tag::Github => v.github_mut().package_name = pkg_name,
+        dependency::version::Tag::Tarball => v.tarball_mut().package_name = pkg_name,
+        _ => {}
+    }
+    Some(pkg_id)
 }
 
 /// Q: "What do we do with a dependency in a package.json?"
@@ -1218,6 +1247,14 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 
                 let needs_ctx =
                     this.lockfile.buffers.resolutions[id as usize] == invalid_package_id;
+
+                if needs_ctx {
+                    if let Some(pkg_id) = resolve_from_appended_task(this, checkout_id, id) {
+                        success_fn(this, id, pkg_id);
+                        return Ok(());
+                    }
+                }
+
                 let entry = this
                     .task_queue
                     .get_or_put_context(checkout_id, ())
@@ -1273,7 +1310,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 }
 
                 let task =
-                    enqueue_git_clone(this, clone_id, alias, &dep, id, dependency, &res, None);
+                    enqueue_git_clone(this, clone_id, alias, &dep, dependency, &res, None);
                 this.task_batch.push(ThreadPool::Batch::from(task));
             }
             Ok(())
@@ -1302,6 +1339,13 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     bstr::BStr::new(this.lockfile.str(&version.literal)),
                     bstr::BStr::new(&url),
                 );
+            }
+
+            if this.lockfile.buffers.resolutions[id as usize] == invalid_package_id {
+                if let Some(pkg_id) = resolve_from_appended_task(this, task_id, id) {
+                    success_fn(this, id, pkg_id);
+                    return Ok(());
+                }
             }
 
             let ctx = if is_root {
@@ -1502,6 +1546,13 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 );
             }
 
+            if this.lockfile.buffers.resolutions[id as usize] == invalid_package_id {
+                if let Some(pkg_id) = resolve_from_appended_task(this, task_id, id) {
+                    success_fn(this, id, pkg_id);
+                    return Ok(());
+                }
+            }
+
             let ctx = if is_root {
                 TaskCallbackContext::RootDependency(id)
             } else {
@@ -1651,7 +1702,6 @@ fn enqueue_git_clone(
     task_id: Task::Id,
     name: &[u8],
     repository: &Repository,
-    dep_id: DependencyID,
     dependency: &Dependency,
     res: &Resolution,
     // if patched then we need to do apply step after network task is done
@@ -1700,7 +1750,6 @@ fn enqueue_git_clone(
                 )
                 .expect("unreachable"),
                 env: crate::repository::SharedEnv::get(this.env_mut()),
-                dep_id,
                 res: *res,
             }),
         },

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -302,15 +302,7 @@ pub fn enqueue_git_for_checkout(
         }
 
         let dep = this.lockfile.buffers.dependencies[dependency_id as usize].clone();
-        let task = enqueue_git_clone(
-            this,
-            clone_id,
-            alias,
-            &repository,
-            &dep,
-            resolution,
-            None,
-        );
+        let task = enqueue_git_clone(this, clone_id, alias, &repository, &dep, resolution, None);
         this.task_batch.push(ThreadPool::Batch::from(task));
     }
 }
@@ -1309,8 +1301,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     return Ok(());
                 }
 
-                let task =
-                    enqueue_git_clone(this, clone_id, alias, &dep, dependency, &res, None);
+                let task = enqueue_git_clone(this, clone_id, alias, &dep, dependency, &res, None);
                 this.task_batch.push(ThreadPool::Batch::from(task));
             }
             Ok(())

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1227,18 +1227,34 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             }
 
             if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
-                let resolved = Repository::find_commit(
-                    this.env_mut(),
-                    this.log_mut(),
-                    repo_fd,
-                    alias,
-                    this.lockfile.str(&dep.committish),
-                    clone_id,
-                )?;
-                let checkout_id = Task::Id::for_git_checkout(url, &resolved);
-
                 let needs_ctx =
                     this.lockfile.buffers.resolutions[id as usize] == invalid_package_id;
+
+                // An already-resolved dependency (install-phase re-enqueue
+                // after the shared clone finished) is pinned: its install
+                // context is keyed on the stored SHA, and a branch
+                // committish's current tip may differ.
+                let pinned: Option<Vec<u8>> = if needs_ctx {
+                    None
+                } else {
+                    let pkg_id = this.lockfile.buffers.resolutions[id as usize];
+                    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id as usize];
+                    // SAFETY: tag checked — `value.git` is the active union arm.
+                    (pkg_res.tag == ResolutionTag::Git)
+                        .then(|| this.lockfile.str(&pkg_res.git().resolved).to_vec())
+                };
+                let resolved = match pinned {
+                    Some(resolved) => resolved,
+                    None => Repository::find_commit(
+                        this.env_mut(),
+                        this.log_mut(),
+                        repo_fd,
+                        alias,
+                        this.lockfile.str(&dep.committish),
+                        clone_id,
+                    )?,
+                };
+                let checkout_id = Task::Id::for_git_checkout(url, &resolved);
 
                 if needs_ctx {
                     if let Some(pkg_id) = resolve_from_appended_task(this, checkout_id, id) {

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1159,6 +1159,12 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     task.data_extract(),
                     log_level,
                 ) {
+                    // The callback queue below is drained exactly once; record
+                    // the appended package so a dependency enqueued after this
+                    // drain (e.g. the same tarball reached transitively) can
+                    // resolve instead of queueing a callback that nothing will
+                    // ever process.
+                    manager.appended_task_packages.insert(task.id, pkg.meta.id);
                     'handle_pkg: {
                         // In the middle of an install, you could end up needing to downlaod the github tarball for a dependency
                         // We need to make sure we resolve the dependencies first before calling the onExtract callback
@@ -1251,8 +1257,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 let name = clone.name.slice();
                 let url = clone.url.slice();
 
-                manager.git_repositories.insert(task.id, repo_fd);
-
                 if task.status == Task::Status::Fail {
                     let err = task.err.unwrap_or(crate::Error::Failed);
 
@@ -1331,69 +1335,94 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     continue;
                 }
 
+                manager.git_repositories.insert(task.id, repo_fd);
+
                 if C::HAS_ON_EXTRACT && C::IS_PACKAGE_INSTALLER {
                     // Installing!
-                    // this dependency might be something other than a git dependency! only need the name and
-                    // behavior, use the resolution from the task.
-                    let dep_id = clone.dep_id;
-                    // reshaped for borrowck — copy the small `String` handles
-                    // + behavior bit so
-                    // the `&manager.lockfile` borrow doesn't extend across the
-                    // `&mut manager` calls (`has_created_network_task`,
-                    // `enqueue_git_checkout`) below; detach the slice backing
-                    // through `string_buf_ptr` (matching the
-                    // `PackageManifest`-arm `name` detach pattern above).
-                    let (dep_name_handle, is_required) = {
-                        let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
-                        (dep.name, dep.behavior.is_required())
-                    };
-                    // SAFETY: `clone.res.tag == Git` — git-clone tasks are only
-                    // enqueued for git resolutions; `value.git` is the active arm.
-                    let git = *clone.res.git();
-                    // SAFETY: `string_bytes` lives as long as `manager.lockfile`
-                    // and is not reallocated while resolve tasks are draining.
-                    let string_buf = unsafe {
-                        bun_ptr::detach_lifetime(manager.lockfile.buffers.string_bytes.as_slice())
-                    };
-                    let dep_name = dep_name_handle.slice(string_buf);
-                    let committish = git.committish.slice(string_buf);
-                    let repo = git.repo.slice(string_buf);
-
-                    use crate::repository_real::RepositoryExt as _;
-                    let resolved = crate::repository_real::Repository::find_commit(
-                        manager.env_mut(),
-                        manager.log_mut(),
-                        repo_fd,
-                        dep_name,
-                        committish,
-                        task.id,
-                    )?;
-
-                    let checkout_id = Task::Id::for_git_checkout(repo, &resolved);
-
-                    if manager.has_created_network_task(checkout_id, is_required) {
+                    // The clone task is shared by every dependency on this repo
+                    // URL (one queue entry per dependency, typically different
+                    // committishes). Enqueue a checkout for each of them, not
+                    // just the dependency stored on the task, or the rest are
+                    // silently never installed.
+                    let Some(waiters) = manager.task_queue.remove(&task.id) else {
                         continue;
-                    }
+                    };
+                    use crate::repository_real::RepositoryExt as _;
+                    for waiter in waiters.iter() {
+                        let dep_id = match waiter {
+                            bun_install::TaskCallbackContext::Dependency(id) => *id,
+                            _ => continue,
+                        };
+                        // this dependency might be something other than a git
+                        // dependency! only need the name and behavior from it,
+                        // use the resolution from the lockfile.
+                        // reshaped for borrowck — copy the small `String`
+                        // handles + behavior bit so the `&manager.lockfile`
+                        // borrow doesn't extend across the `&mut manager` calls
+                        // (`has_created_network_task`, `enqueue_git_checkout`)
+                        // below; detach the slice backing through
+                        // `string_buf_ptr` (matching the `PackageManifest`-arm
+                        // `name` detach pattern above).
+                        let (dep_name_handle, is_required) = {
+                            let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
+                            (dep.name, dep.behavior.is_required())
+                        };
+                        let pkg_id = manager.lockfile.buffers.resolutions[dep_id as usize];
+                        if pkg_id == INVALID_PACKAGE_ID {
+                            continue;
+                        }
+                        let res = manager.lockfile.packages.items_resolution()[pkg_id as usize];
+                        if res.tag != bun_install::ResolutionTag::Git {
+                            continue;
+                        }
+                        // SAFETY: `res.tag == Git` checked just above —
+                        // `value.git` is the active union arm.
+                        let git = *res.git();
+                        // SAFETY: `string_bytes` lives as long as `manager.lockfile`
+                        // and is not reallocated while resolve tasks are draining.
+                        let string_buf = unsafe {
+                            bun_ptr::detach_lifetime(
+                                manager.lockfile.buffers.string_bytes.as_slice(),
+                            )
+                        };
+                        let dep_name = dep_name_handle.slice(string_buf);
+                        let committish = git.committish.slice(string_buf);
+                        let repo = git.repo.slice(string_buf);
 
-                    // reshaped for borrowck — split nested `&mut manager`.
-                    let queued = enqueue::enqueue_git_checkout(
-                        manager,
-                        checkout_id,
-                        repo_fd,
-                        dep_id,
-                        dep_name,
-                        &clone.res,
-                        &resolved,
-                        None,
-                    );
-                    manager.task_batch.push(ThreadPoolBatch::from(queued));
+                        let resolved = crate::repository_real::Repository::find_commit(
+                            manager.env_mut(),
+                            manager.log_mut(),
+                            repo_fd,
+                            dep_name,
+                            committish,
+                            task.id,
+                        )?;
+
+                        let checkout_id = Task::Id::for_git_checkout(repo, &resolved);
+
+                        if manager.has_created_network_task(checkout_id, is_required) {
+                            continue;
+                        }
+
+                        // reshaped for borrowck — split nested `&mut manager`.
+                        let queued = enqueue::enqueue_git_checkout(
+                            manager,
+                            checkout_id,
+                            repo_fd,
+                            dep_id,
+                            dep_name,
+                            &res,
+                            &resolved,
+                            None,
+                        );
+                        manager.task_batch.push(ThreadPoolBatch::from(queued));
+                    }
                 } else {
                     // Resolving!
-                    let dependency_list_entry = manager
+                    let dependency_list = manager
                         .task_queue
-                        .get_mut(&task.id)
+                        .remove(&task.id)
                         .expect("infallible: task queued");
-                    let dependency_list = core::mem::take(dependency_list_entry);
 
                     process_dependency_list_for_ctx::<C>(
                         manager,
@@ -1483,6 +1512,12 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     task.data_git_checkout(),
                     log_level,
                 ) {
+                    // The callback queue below is drained exactly once; record
+                    // the appended package so a dependency enqueued after this
+                    // drain (e.g. the same repo+commit reached transitively)
+                    // can resolve instead of queueing a callback that nothing
+                    // will ever process.
+                    manager.appended_task_packages.insert(task.id, pkg.meta.id);
                     'handle_pkg: {
                         let any_root = Cell::new(false);
                         let dependency_list: TaskCallbackList = {

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1159,11 +1159,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     task.data_extract(),
                     log_level,
                 ) {
-                    // The callback queue below is drained exactly once; record
-                    // the appended package so a dependency enqueued after this
-                    // drain (e.g. the same tarball reached transitively) can
-                    // resolve instead of queueing a callback that nothing will
-                    // ever process.
+                    // Record the appended package so a later-enqueued dependency
+                    // on this same tarball can resolve; see `AppendedTaskPackageMap`.
                     manager.appended_task_packages.insert(task.id, pkg.meta.id);
                     'handle_pkg: {
                         // In the middle of an install, you could end up needing to downlaod the github tarball for a dependency
@@ -1338,12 +1335,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 manager.git_repositories.insert(task.id, repo_fd);
 
                 if C::HAS_ON_EXTRACT && C::IS_PACKAGE_INSTALLER {
-                    // Installing!
-                    // The clone task is shared by every dependency on this repo
-                    // URL (one queue entry per dependency, typically different
-                    // committishes). Enqueue a checkout for each of them, not
-                    // just the dependency stored on the task, or the rest are
-                    // silently never installed.
+                    // Installing! The clone task is shared by every dependency on
+                    // this repo URL; enqueue a checkout per waiter, not just one.
                     let Some(waiters) = manager.task_queue.remove(&task.id) else {
                         continue;
                     };
@@ -1353,16 +1346,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             bun_install::TaskCallbackContext::Dependency(id) => *id,
                             _ => continue,
                         };
-                        // this dependency might be something other than a git
-                        // dependency! only need the name and behavior from it,
-                        // use the resolution from the lockfile.
-                        // reshaped for borrowck — copy the small `String`
-                        // handles + behavior bit so the `&manager.lockfile`
-                        // borrow doesn't extend across the `&mut manager` calls
-                        // (`has_created_network_task`, `enqueue_git_checkout`)
-                        // below; detach the slice backing through
-                        // `string_buf_ptr` (matching the `PackageManifest`-arm
-                        // `name` detach pattern above).
+                        // reshaped for borrowck — copy the small `String` handles
+                        // so the `&manager.lockfile` borrow doesn't extend across
+                        // the `&mut manager` calls below.
                         let (dep_name_handle, is_required) = {
                             let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
                             (dep.name, dep.behavior.is_required())
@@ -1512,11 +1498,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     task.data_git_checkout(),
                     log_level,
                 ) {
-                    // The callback queue below is drained exactly once; record
-                    // the appended package so a dependency enqueued after this
-                    // drain (e.g. the same repo+commit reached transitively)
-                    // can resolve instead of queueing a callback that nothing
-                    // will ever process.
+                    // Record the appended package so a later-enqueued dependency
+                    // on this same repo+commit can resolve; see `AppendedTaskPackageMap`.
                     manager.appended_task_packages.insert(task.id, pkg.meta.id);
                     'handle_pkg: {
                         let any_root = Cell::new(false);

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1372,9 +1372,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         };
                         let dep_name = dep_name_handle.slice(string_buf);
                         let repo = git.repo.slice(string_buf);
-                        // Use the lockfile's stored SHA: `enqueue_git_for_checkout`
-                        // keyed the install-context entry on it, and a branch
-                        // committish's current tip may differ.
                         let resolved = git.resolved.slice(string_buf);
 
                         let checkout_id = Task::Id::for_git_checkout(repo, resolved);

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1340,7 +1340,6 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let Some(waiters) = manager.task_queue.remove(&task.id) else {
                         continue;
                     };
-                    use crate::repository_real::RepositoryExt as _;
                     for waiter in waiters.iter() {
                         let dep_id = match waiter {
                             bun_install::TaskCallbackContext::Dependency(id) => *id,
@@ -1372,19 +1371,13 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             )
                         };
                         let dep_name = dep_name_handle.slice(string_buf);
-                        let committish = git.committish.slice(string_buf);
                         let repo = git.repo.slice(string_buf);
+                        // Use the lockfile's stored SHA: `enqueue_git_for_checkout`
+                        // keyed the install-context entry on it, and a branch
+                        // committish's current tip may differ.
+                        let resolved = git.resolved.slice(string_buf);
 
-                        let resolved = crate::repository_real::Repository::find_commit(
-                            manager.env_mut(),
-                            manager.log_mut(),
-                            repo_fd,
-                            dep_name,
-                            committish,
-                            task.id,
-                        )?;
-
-                        let checkout_id = Task::Id::for_git_checkout(repo, &resolved);
+                        let checkout_id = Task::Id::for_git_checkout(repo, resolved);
 
                         if manager.has_created_network_task(checkout_id, is_required) {
                             continue;
@@ -1398,7 +1391,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             dep_id,
                             dep_name,
                             &res,
-                            &resolved,
+                            resolved,
                             None,
                         );
                         manager.task_batch.push(ThreadPoolBatch::from(queued));

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -460,6 +460,34 @@ impl<'a> Task<'a> {
                                         break 'body;
                                     }
                                 }
+                            } else if this.status != Status::Fail {
+                                // Neither matcher recognized the URL
+                                // (`file://`, `git://`, ...) and no clone was
+                                // attempted yet; git supports these schemes
+                                // directly, so clone with the URL as written.
+                                // Without this the task would finish with
+                                // `Status::Waiting` and zeroed data, which the
+                                // main thread treats as a successful clone.
+                                match Repository::download(
+                                    req.env,
+                                    &mut this.log,
+                                    // SAFETY: see `manager` decl — short-lived `&mut` at call boundary.
+                                    unsafe { &mut *manager }.get_cache_directory(),
+                                    this.id,
+                                    name,
+                                    url,
+                                    attempt,
+                                ) {
+                                    Ok(d) => d,
+                                    Err(err) => {
+                                        this.err = Some(err);
+                                        this.status = Status::Fail;
+                                        this.data = Data {
+                                            git_clone: ManuallyDrop::new(Fd::invalid()),
+                                        };
+                                        break 'body;
+                                    }
+                                }
                             } else {
                                 break 'body;
                             }
@@ -654,7 +682,6 @@ pub struct GitCloneRequest {
     // `Map` owns its storage; store a
     // `&'static` into the global `Repository.shared_env` instead — see `SharedEnv::get`.
     pub(crate) env: &'static dot_env::Map,
-    pub(crate) dep_id: DependencyID,
     pub(crate) res: Resolution,
 }
 

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -461,13 +461,9 @@ impl<'a> Task<'a> {
                                     }
                                 }
                             } else if this.status != Status::Fail {
-                                // Neither matcher recognized the URL
-                                // (`file://`, `git://`, ...) and no clone was
-                                // attempted yet; git supports these schemes
-                                // directly, so clone with the URL as written.
-                                // Without this the task would finish with
-                                // `Status::Waiting` and zeroed data, which the
-                                // main thread treats as a successful clone.
+                                // Neither matcher recognized the URL (`file://`,
+                                // `git://`, ...); clone with the URL as written
+                                // instead of finishing with zeroed task data.
                                 match Repository::download(
                                     req.env,
                                     &mut this.log,

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -151,172 +151,184 @@ test.concurrent(
 // #8501): a dependency enqueued after its tarball's extract task already
 // completed and drained its callback queue was parked forever and failed
 // with "failed to resolve".
-test.concurrent("installs every tarball-URL dependency that appears directly and transitively", async () => {
-  const letters = "abcdefghijklmnop".split("");
-  using dir = tempDir("tarball-dep-dup", {});
-  const root = String(dir);
-  const tarballs = join(root, "tarballs");
-  mkdirSync(tarballs);
+test.concurrent(
+  "installs every tarball-URL dependency that appears directly and transitively",
+  async () => {
+    const letters = "abcdefghijklmnop".split("");
+    using dir = tempDir("tarball-dep-dup", {});
+    const root = String(dir);
+    const tarballs = join(root, "tarballs");
+    mkdirSync(tarballs);
 
-  await using server = serveStatic(tarballs);
-  const urlOf = (l: string) => `http://localhost:${server.port}/pkg-${l}.tgz`;
+    await using server = serveStatic(tarballs);
+    const urlOf = (l: string) => `http://localhost:${server.port}/pkg-${l}.tgz`;
 
-  // pkg-a re-declares 11 of its siblings as its own dependencies, so those
-  // tarball specs appear both directly (from the project) and transitively.
-  const transitive = Object.fromEntries(letters.slice(1, 12).map(l => [`@scope/pkg-${l}`, urlOf(l)]));
-  for (const l of letters) {
-    const pkgDir = join(root, `work-${l}`, "package");
-    mkdirSync(pkgDir, { recursive: true });
+    // pkg-a re-declares 11 of its siblings as its own dependencies, so those
+    // tarball specs appear both directly (from the project) and transitively.
+    const transitive = Object.fromEntries(letters.slice(1, 12).map(l => [`@scope/pkg-${l}`, urlOf(l)]));
+    for (const l of letters) {
+      const pkgDir = join(root, `work-${l}`, "package");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({
+          name: `@scope/pkg-${l}`,
+          version: "1.0.0",
+          dependencies: l === "a" ? transitive : undefined,
+        }),
+      );
+      writeFileSync(join(pkgDir, "index.js"), `module.exports = ${JSON.stringify(`pkg-${l}`)};\n`);
+      await run(root, ["tar", "-czf", join(tarballs, `pkg-${l}.tgz`), "-C", join(root, `work-${l}`), "package"], "tar");
+    }
+
+    const project = join(root, "project");
+    mkdirSync(project);
     writeFileSync(
-      join(pkgDir, "package.json"),
+      join(project, "package.json"),
       JSON.stringify({
-        name: `@scope/pkg-${l}`,
+        name: "project",
         version: "1.0.0",
-        dependencies: l === "a" ? transitive : undefined,
+        dependencies: Object.fromEntries(letters.map(l => [`@scope/pkg-${l}`, urlOf(l)])),
       }),
     );
-    writeFileSync(join(pkgDir, "index.js"), `module.exports = ${JSON.stringify(`pkg-${l}`)};\n`);
-    await run(root, ["tar", "-czf", join(tarballs, `pkg-${l}.tgz`), "-C", join(root, `work-${l}`), "package"], "tar");
-  }
 
-  const project = join(root, "project");
-  mkdirSync(project);
-  writeFileSync(
-    join(project, "package.json"),
-    JSON.stringify({
-      name: "project",
-      version: "1.0.0",
-      dependencies: Object.fromEntries(letters.map(l => [`@scope/pkg-${l}`, urlOf(l)])),
-    }),
-  );
-
-  // the race depends on threadpool scheduling; two fresh-cache attempts to
-  // make the failure reliable on the unfixed code
-  for (let attempt = 0; attempt < 2; attempt++) {
-    await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
-    const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {});
-    expect(stderr).not.toContain("failed to resolve");
-    expect(stderr).not.toContain("error:");
-    for (const l of letters) {
-      expect(await installedVersionOf(project, `@scope/pkg-${l}`)).toBe(`pkg-${l}`);
+    // the race depends on threadpool scheduling; two fresh-cache attempts to
+    // make the failure reliable on the unfixed code
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
+      const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {});
+      expect(stderr).not.toContain("failed to resolve");
+      expect(stderr).not.toContain("error:");
+      for (const l of letters) {
+        expect(await installedVersionOf(project, `@scope/pkg-${l}`)).toBe(`pkg-${l}`);
+      }
+      expect(exitCode).toBe(0);
     }
-    expect(exitCode).toBe(0);
-  }
-}, 30_000);
+  },
+  30_000,
+);
 
 // issue #11348: same mechanism for `github:` dependencies. The root and a
 // transitive `github:` dependency both request the same `github:owner/repo`
 // spec; the late enqueue lands after the shared extract task already drained
 // its callback queue and was parked forever with "failed to resolve".
-test.concurrent("installs every github: dependency that appears directly and transitively", async () => {
-  const letters = "abcdefgh".split("");
-  using dir = tempDir("github-dep-dup", {});
-  const root = String(dir);
-  const tarballs = join(root, "tarballs");
-  mkdirSync(tarballs);
+test.concurrent(
+  "installs every github: dependency that appears directly and transitively",
+  async () => {
+    const letters = "abcdefgh".split("");
+    using dir = tempDir("github-dep-dup", {});
+    const root = String(dir);
+    const tarballs = join(root, "tarballs");
+    mkdirSync(tarballs);
 
-  // pkg-a re-declares its siblings as its own dependencies, so those
-  // `github:` specs appear both directly (from the project) and transitively.
-  const transitive = Object.fromEntries(letters.slice(1).map(l => [`@scope/pkg-${l}`, `github:scope/pkg-${l}`]));
-  for (const l of letters) {
-    // GitHub tarballs have a top-level `<owner>-<repo>-<sha>` directory; the
-    // extractor reads it as the resolved tag and it becomes the cache key.
-    const top = `scope-pkg-${l}-0000000`;
-    const pkgDir = join(root, `work-${l}`, top);
-    mkdirSync(pkgDir, { recursive: true });
+    // pkg-a re-declares its siblings as its own dependencies, so those
+    // `github:` specs appear both directly (from the project) and transitively.
+    const transitive = Object.fromEntries(letters.slice(1).map(l => [`@scope/pkg-${l}`, `github:scope/pkg-${l}`]));
+    for (const l of letters) {
+      // GitHub tarballs have a top-level `<owner>-<repo>-<sha>` directory; the
+      // extractor reads it as the resolved tag and it becomes the cache key.
+      const top = `scope-pkg-${l}-0000000`;
+      const pkgDir = join(root, `work-${l}`, top);
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({
+          name: `@scope/pkg-${l}`,
+          version: "1.0.0",
+          dependencies: l === "a" ? transitive : undefined,
+        }),
+      );
+      writeFileSync(join(pkgDir, "index.js"), `module.exports = ${JSON.stringify(`pkg-${l}`)};\n`);
+      await run(root, ["tar", "-czf", join(tarballs, `pkg-${l}.tgz`), "-C", join(root, `work-${l}`), top], "tar");
+    }
+
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const match = /^\/repos\/scope\/(pkg-[a-z])\/tarball\/?$/.exec(new URL(req.url).pathname);
+        if (match) return new Response(Bun.file(join(tarballs, `${match[1]}.tgz`)));
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    const project = join(root, "project");
+    mkdirSync(project);
     writeFileSync(
-      join(pkgDir, "package.json"),
+      join(project, "package.json"),
       JSON.stringify({
-        name: `@scope/pkg-${l}`,
+        name: "project",
         version: "1.0.0",
-        dependencies: l === "a" ? transitive : undefined,
+        dependencies: Object.fromEntries(letters.map(l => [`@scope/pkg-${l}`, `github:scope/pkg-${l}`])),
       }),
     );
-    writeFileSync(join(pkgDir, "index.js"), `module.exports = ${JSON.stringify(`pkg-${l}`)};\n`);
-    await run(root, ["tar", "-czf", join(tarballs, `pkg-${l}.tgz`), "-C", join(root, `work-${l}`), top], "tar");
-  }
 
-  await using server = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const match = /^\/repos\/scope\/(pkg-[a-z])\/tarball\/?$/.exec(new URL(req.url).pathname);
-      if (match) return new Response(Bun.file(join(tarballs, `${match[1]}.tgz`)));
-      return new Response("not found", { status: 404 });
-    },
-  });
-
-  const project = join(root, "project");
-  mkdirSync(project);
-  writeFileSync(
-    join(project, "package.json"),
-    JSON.stringify({
-      name: "project",
-      version: "1.0.0",
-      dependencies: Object.fromEntries(letters.map(l => [`@scope/pkg-${l}`, `github:scope/pkg-${l}`])),
-    }),
-  );
-
-  // the race depends on threadpool scheduling; two fresh-cache attempts to
-  // make the failure reliable on the unfixed code
-  for (let attempt = 0; attempt < 2; attempt++) {
-    await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
-    const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {
-      GITHUB_API_URL: `http://localhost:${server.port}`,
-    });
-    expect(stderr).not.toContain("failed to resolve");
-    expect(stderr).not.toContain("error:");
-    for (const l of letters) {
-      expect(await installedVersionOf(project, `@scope/pkg-${l}`)).toBe(`pkg-${l}`);
+    // the race depends on threadpool scheduling; two fresh-cache attempts to
+    // make the failure reliable on the unfixed code
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
+      const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {
+        GITHUB_API_URL: `http://localhost:${server.port}`,
+      });
+      expect(stderr).not.toContain("failed to resolve");
+      expect(stderr).not.toContain("error:");
+      for (const l of letters) {
+        expect(await installedVersionOf(project, `@scope/pkg-${l}`)).toBe(`pkg-${l}`);
+      }
+      expect(exitCode).toBe(0);
     }
-    expect(exitCode).toBe(0);
-  }
-}, 30_000);
+  },
+  30_000,
+);
 
 // issue #35420 bug 2: installing from a complete lockfile with a cold cache
 // only checked out the single dependency stored on the shared clone task; the
 // other branches of the same repo were silently skipped with exit code 0.
-test.concurrent("installs every git dependency from a lockfile on a cold cache when deps share one repo", async () => {
-  using dir = tempDir("git-dep-lockfile", {});
-  const root = String(dir);
+test.concurrent(
+  "installs every git dependency from a lockfile on a cold cache when deps share one repo",
+  async () => {
+    using dir = tempDir("git-dep-lockfile", {});
+    const root = String(dir);
 
-  await using server = serveStatic(root);
-  const repoUrl = `git+http://localhost:${server.port}/shared-repo.git`;
-  await makeSharedRepo(root, [
-    { name: "@scope/pkg-m", branch: "pkg-m" },
-    { name: "@scope/pkg-n", branch: "pkg-n" },
-  ]);
+    await using server = serveStatic(root);
+    const repoUrl = `git+http://localhost:${server.port}/shared-repo.git`;
+    await makeSharedRepo(root, [
+      { name: "@scope/pkg-m", branch: "pkg-m" },
+      { name: "@scope/pkg-n", branch: "pkg-n" },
+    ]);
 
-  const project = join(root, "project");
-  mkdirSync(project);
-  writeFileSync(
-    join(project, "package.json"),
-    JSON.stringify({
-      name: "project",
-      version: "1.0.0",
-      dependencies: {
-        "@scope/pkg-m": `${repoUrl}#pkg-m`,
-        "@scope/pkg-n": `${repoUrl}#pkg-n`,
-      },
-    }),
-  );
+    const project = join(root, "project");
+    mkdirSync(project);
+    writeFileSync(
+      join(project, "package.json"),
+      JSON.stringify({
+        name: "project",
+        version: "1.0.0",
+        dependencies: {
+          "@scope/pkg-m": `${repoUrl}#pkg-m`,
+          "@scope/pkg-n": `${repoUrl}#pkg-n`,
+        },
+      }),
+    );
 
-  // fresh install to produce a complete lockfile
-  {
-    const { stderr, exitCode } = await runInstall(project, join(root, "cache-warm"), {});
+    // fresh install to produce a complete lockfile
+    {
+      const { stderr, exitCode } = await runInstall(project, join(root, "cache-warm"), {});
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
+      expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
+    }
+
+    // simulate a fresh machine: keep bun.lock, drop node_modules + cache
+    await Bun.$`rm -rf ${join(project, "node_modules")}`;
+    const { stderr, exitCode } = await runInstall(project, join(root, "cache-cold"), {}, "--frozen-lockfile");
     expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
     expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
     expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
-  }
-
-  // simulate a fresh machine: keep bun.lock, drop node_modules + cache
-  await Bun.$`rm -rf ${join(project, "node_modules")}`;
-  const { stderr, exitCode } = await runInstall(project, join(root, "cache-cold"), {}, "--frozen-lockfile");
-  expect(stderr).not.toContain("error:");
-  expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
-  expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
-  expect(exitCode).toBe(0);
-}, 30_000);
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
 
 // issue #35420 bug 3: `git+file://` dependencies never cloned at all — the
 // clone task recognized neither an https nor an ssh URL and finished without

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -330,6 +330,70 @@ test.concurrent(
   30_000,
 );
 
+// With the isolated linker, a cold-cache frozen install re-enqueues each
+// dependency after the shared clone completes; the checkout id was derived
+// from the branch committish's current tip instead of the lockfile's pinned
+// SHA, so a branch that moved after the lockfile was written installed the
+// wrong commit and stranded the store's install context.
+test.concurrent(
+  "isolated linker installs the locked commit from a cold cache after the branch moves",
+  async () => {
+    using dir = tempDir("git-dep-iso-moved", {});
+    const root = String(dir);
+
+    await using server = serveStatic(root);
+    const repoUrl = `git+http://localhost:${server.port}/shared-repo.git`;
+    const bare = await makeSharedRepo(root, [
+      { name: "@scope/pkg-m", branch: "pkg-m" },
+      { name: "@scope/pkg-n", branch: "pkg-n" },
+    ]);
+
+    const project = join(root, "project");
+    mkdirSync(project);
+    writeFileSync(
+      join(project, "package.json"),
+      JSON.stringify({
+        name: "project",
+        version: "1.0.0",
+        dependencies: {
+          "@scope/pkg-m": `${repoUrl}#pkg-m`,
+          "@scope/pkg-n": `${repoUrl}#pkg-n`,
+        },
+      }),
+    );
+
+    // fresh install to produce a complete lockfile
+    {
+      const { stderr, exitCode } = await runInstall(project, join(root, "cache-warm"), {}, "--linker=isolated");
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    // move pkg-m past the locked commit
+    const work = join(root, "work");
+    await git(work, "checkout", "-q", "pkg-m");
+    writeFileSync(join(work, "index.js"), `module.exports = "pkg-m-v2";\n`);
+    await git(work, "commit", "-aqm", "v2", "--no-gpg-sign");
+    await git(work, "push", "-q", bare, "pkg-m");
+    await git(bare, "update-server-info");
+
+    // cold cache from the lockfile: must install the locked commit, not the tip
+    await Bun.$`rm -rf ${join(project, "node_modules")}`;
+    const { stderr, exitCode } = await runInstall(
+      project,
+      join(root, "cache-cold"),
+      {},
+      "--frozen-lockfile",
+      "--linker=isolated",
+    );
+    expect(stderr).not.toContain("error:");
+    expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
+    expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);
+
 // issue #35420 bug 3: `git+file://` dependencies never cloned at all — the
 // clone task recognized neither an https nor an ssh URL and finished without
 // running git, leaving a poisoned repo handle behind.

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -1,0 +1,346 @@
+// Tests for installing git dependencies that live in ONE repository as
+// multiple branches (issue #35420), `git+file://` dependencies, and
+// tarball-URL / `github:` dependencies that appear both directly and
+// transitively (issues #10915, #8501, #11348, #28284). Everything is local:
+// a bare repo on disk (served over git's dumb HTTP protocol by Bun.serve
+// when an http URL is needed) or static tarballs.
+import { expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+import { pathToFileURL } from "url";
+
+const gitEnv = {
+  ...bunEnv,
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+async function run(cwd: string, cmd: string[], what: string) {
+  await using proc = Bun.spawn({ cmd, cwd, env: gitEnv, stdout: "ignore", stderr: "pipe" });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    throw new Error(`${what} failed in ${cwd}:\n${stderr}`);
+  }
+}
+
+function git(cwd: string, ...args: string[]) {
+  return run(cwd, ["git", ...args], `git ${args.join(" ")}`);
+}
+
+interface BranchPackage {
+  name: string;
+  branch: string;
+  dependencies?: Record<string, string>;
+}
+
+// Creates `<root>/shared-repo.git`, a bare repo with one orphan branch per
+// package, and prepares it for serving over dumb HTTP.
+async function makeSharedRepo(root: string, packages: BranchPackage[]): Promise<string> {
+  const bare = join(root, "shared-repo.git");
+  const work = join(root, "work");
+  await git(root, "init", "-q", "--bare", "shared-repo.git");
+  mkdirSync(work);
+  await git(work, "init", "-q");
+  for (const pkg of packages) {
+    await git(work, "checkout", "-q", "--orphan", pkg.branch);
+    writeFileSync(
+      join(work, "package.json"),
+      JSON.stringify({ name: pkg.name, version: "1.0.0", dependencies: pkg.dependencies }, null, 2),
+    );
+    writeFileSync(join(work, "index.js"), `module.exports = ${JSON.stringify(pkg.branch)};\n`);
+    await git(work, "add", "-A");
+    await git(work, "commit", "-q", "-m", pkg.branch, "--no-gpg-sign");
+    await git(work, "push", "-q", bare, pkg.branch);
+  }
+  // dumb HTTP clients read the static files this generates
+  await git(bare, "update-server-info");
+  return bare;
+}
+
+function serveStatic(root: string) {
+  return Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const file = Bun.file(join(root, new URL(req.url).pathname));
+      return (await file.exists()) ? new Response(file) : new Response("not found", { status: 404 });
+    },
+  });
+}
+
+async function runInstall(cwd: string, cacheDir: string, extraEnv: Record<string, string>, ...args: string[]) {
+  const env = { ...gitEnv, ...extraEnv, BUN_INSTALL_CACHE_DIR: cacheDir };
+  // Set on ASAN CI lanes; it arms a subreaper around internal git spawns that
+  // SIGKILLs concurrent clone tasks (see #33982). This test exercises install
+  // task bookkeeping, not orphan reaping.
+  delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", ...args],
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+async function installedVersionOf(dir: string, name: string): Promise<string | null> {
+  const file = Bun.file(join(dir, "node_modules", name, "index.js"));
+  if (!(await file.exists())) return null;
+  const text = await file.text();
+  return JSON.parse(text.slice(text.indexOf("=") + 1, text.lastIndexOf(";")));
+}
+
+// issue #35420 bug 1: with no lockfile and a cold cache, dependencies that
+// appear both directly and transitively (same repo URL + committish) raced
+// against the shared clone/checkout tasks and failed with "failed to resolve".
+test.concurrent(
+  "installs every git dependency when many branches of one repo appear directly and transitively",
+  async () => {
+    const letters = "abcdefghijklmnop".split("");
+    using dir = tempDir("git-dep-dup", {});
+    const root = String(dir);
+
+    await using server = serveStatic(root);
+    const repoUrl = `git+http://localhost:${server.port}/shared-repo.git`;
+
+    // pkg-a re-declares 11 of its siblings as its own dependencies, so those
+    // specs appear both directly (from the project) and transitively.
+    const transitive = Object.fromEntries(letters.slice(1, 12).map(l => [`@scope/pkg-${l}`, `${repoUrl}#pkg-${l}`]));
+    await makeSharedRepo(
+      root,
+      letters.map(l => ({
+        name: `@scope/pkg-${l}`,
+        branch: `pkg-${l}`,
+        dependencies: l === "a" ? transitive : undefined,
+      })),
+    );
+
+    const project = join(root, "project");
+    mkdirSync(project);
+    writeFileSync(
+      join(project, "package.json"),
+      JSON.stringify({
+        name: "project",
+        version: "1.0.0",
+        dependencies: Object.fromEntries(letters.map(l => [`@scope/pkg-${l}`, `${repoUrl}#pkg-${l}`])),
+      }),
+    );
+
+    // the race depends on threadpool scheduling; two fresh-cache attempts to
+    // make the failure reliable on the unfixed code
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
+      const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {});
+      expect(stderr).not.toContain("failed to resolve");
+      expect(stderr).not.toContain("error:");
+      for (const l of letters) {
+        expect(await installedVersionOf(project, `@scope/pkg-${l}`)).toBe(`pkg-${l}`);
+      }
+      expect(exitCode).toBe(0);
+    }
+  },
+  30_000,
+);
+
+// same mechanism as above but for tarball-URL dependencies (issues #10915,
+// #8501): a dependency enqueued after its tarball's extract task already
+// completed and drained its callback queue was parked forever and failed
+// with "failed to resolve".
+test.concurrent("installs every tarball-URL dependency that appears directly and transitively", async () => {
+  const letters = "abcdefghijklmnop".split("");
+  using dir = tempDir("tarball-dep-dup", {});
+  const root = String(dir);
+  const tarballs = join(root, "tarballs");
+  mkdirSync(tarballs);
+
+  await using server = serveStatic(tarballs);
+  const urlOf = (l: string) => `http://localhost:${server.port}/pkg-${l}.tgz`;
+
+  // pkg-a re-declares 11 of its siblings as its own dependencies, so those
+  // tarball specs appear both directly (from the project) and transitively.
+  const transitive = Object.fromEntries(letters.slice(1, 12).map(l => [`@scope/pkg-${l}`, urlOf(l)]));
+  for (const l of letters) {
+    const pkgDir = join(root, `work-${l}`, "package");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: `@scope/pkg-${l}`,
+        version: "1.0.0",
+        dependencies: l === "a" ? transitive : undefined,
+      }),
+    );
+    writeFileSync(join(pkgDir, "index.js"), `module.exports = ${JSON.stringify(`pkg-${l}`)};\n`);
+    await run(root, ["tar", "-czf", join(tarballs, `pkg-${l}.tgz`), "-C", join(root, `work-${l}`), "package"], "tar");
+  }
+
+  const project = join(root, "project");
+  mkdirSync(project);
+  writeFileSync(
+    join(project, "package.json"),
+    JSON.stringify({
+      name: "project",
+      version: "1.0.0",
+      dependencies: Object.fromEntries(letters.map(l => [`@scope/pkg-${l}`, urlOf(l)])),
+    }),
+  );
+
+  // the race depends on threadpool scheduling; two fresh-cache attempts to
+  // make the failure reliable on the unfixed code
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
+    const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {});
+    expect(stderr).not.toContain("failed to resolve");
+    expect(stderr).not.toContain("error:");
+    for (const l of letters) {
+      expect(await installedVersionOf(project, `@scope/pkg-${l}`)).toBe(`pkg-${l}`);
+    }
+    expect(exitCode).toBe(0);
+  }
+}, 30_000);
+
+// issue #11348: same mechanism for `github:` dependencies. The root and a
+// transitive `github:` dependency both request the same `github:owner/repo`
+// spec; the late enqueue lands after the shared extract task already drained
+// its callback queue and was parked forever with "failed to resolve".
+test.concurrent("installs every github: dependency that appears directly and transitively", async () => {
+  const letters = "abcdefgh".split("");
+  using dir = tempDir("github-dep-dup", {});
+  const root = String(dir);
+  const tarballs = join(root, "tarballs");
+  mkdirSync(tarballs);
+
+  // pkg-a re-declares its siblings as its own dependencies, so those
+  // `github:` specs appear both directly (from the project) and transitively.
+  const transitive = Object.fromEntries(letters.slice(1).map(l => [`@scope/pkg-${l}`, `github:scope/pkg-${l}`]));
+  for (const l of letters) {
+    // GitHub tarballs have a top-level `<owner>-<repo>-<sha>` directory; the
+    // extractor reads it as the resolved tag and it becomes the cache key.
+    const top = `scope-pkg-${l}-0000000`;
+    const pkgDir = join(root, `work-${l}`, top);
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: `@scope/pkg-${l}`,
+        version: "1.0.0",
+        dependencies: l === "a" ? transitive : undefined,
+      }),
+    );
+    writeFileSync(join(pkgDir, "index.js"), `module.exports = ${JSON.stringify(`pkg-${l}`)};\n`);
+    await run(root, ["tar", "-czf", join(tarballs, `pkg-${l}.tgz`), "-C", join(root, `work-${l}`), top], "tar");
+  }
+
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const match = /^\/repos\/scope\/(pkg-[a-z])\/tarball\/?$/.exec(new URL(req.url).pathname);
+      if (match) return new Response(Bun.file(join(tarballs, `${match[1]}.tgz`)));
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  const project = join(root, "project");
+  mkdirSync(project);
+  writeFileSync(
+    join(project, "package.json"),
+    JSON.stringify({
+      name: "project",
+      version: "1.0.0",
+      dependencies: Object.fromEntries(letters.map(l => [`@scope/pkg-${l}`, `github:scope/pkg-${l}`])),
+    }),
+  );
+
+  // the race depends on threadpool scheduling; two fresh-cache attempts to
+  // make the failure reliable on the unfixed code
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
+    const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {
+      GITHUB_API_URL: `http://localhost:${server.port}`,
+    });
+    expect(stderr).not.toContain("failed to resolve");
+    expect(stderr).not.toContain("error:");
+    for (const l of letters) {
+      expect(await installedVersionOf(project, `@scope/pkg-${l}`)).toBe(`pkg-${l}`);
+    }
+    expect(exitCode).toBe(0);
+  }
+}, 30_000);
+
+// issue #35420 bug 2: installing from a complete lockfile with a cold cache
+// only checked out the single dependency stored on the shared clone task; the
+// other branches of the same repo were silently skipped with exit code 0.
+test.concurrent("installs every git dependency from a lockfile on a cold cache when deps share one repo", async () => {
+  using dir = tempDir("git-dep-lockfile", {});
+  const root = String(dir);
+
+  await using server = serveStatic(root);
+  const repoUrl = `git+http://localhost:${server.port}/shared-repo.git`;
+  await makeSharedRepo(root, [
+    { name: "@scope/pkg-m", branch: "pkg-m" },
+    { name: "@scope/pkg-n", branch: "pkg-n" },
+  ]);
+
+  const project = join(root, "project");
+  mkdirSync(project);
+  writeFileSync(
+    join(project, "package.json"),
+    JSON.stringify({
+      name: "project",
+      version: "1.0.0",
+      dependencies: {
+        "@scope/pkg-m": `${repoUrl}#pkg-m`,
+        "@scope/pkg-n": `${repoUrl}#pkg-n`,
+      },
+    }),
+  );
+
+  // fresh install to produce a complete lockfile
+  {
+    const { stderr, exitCode } = await runInstall(project, join(root, "cache-warm"), {});
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
+    expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
+  }
+
+  // simulate a fresh machine: keep bun.lock, drop node_modules + cache
+  await Bun.$`rm -rf ${join(project, "node_modules")}`;
+  const { stderr, exitCode } = await runInstall(project, join(root, "cache-cold"), {}, "--frozen-lockfile");
+  expect(stderr).not.toContain("error:");
+  expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
+  expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
+  expect(exitCode).toBe(0);
+}, 30_000);
+
+// issue #35420 bug 3: `git+file://` dependencies never cloned at all — the
+// clone task recognized neither an https nor an ssh URL and finished without
+// running git, leaving a poisoned repo handle behind.
+test.concurrent("installs a git+file:// dependency", async () => {
+  using dir = tempDir("git-dep-file", {});
+  const root = String(dir);
+  const bare = await makeSharedRepo(root, [{ name: "@scope/pkg-b", branch: "pkg-b" }]);
+
+  const project = join(root, "project");
+  mkdirSync(project);
+  writeFileSync(
+    join(project, "package.json"),
+    JSON.stringify({
+      name: "project",
+      version: "1.0.0",
+      dependencies: {
+        "@scope/pkg-b": `git+${pathToFileURL(bare)}#pkg-b`,
+      },
+    }),
+  );
+
+  const { stderr, exitCode } = await runInstall(project, join(root, "cache"), {});
+  expect(stderr).not.toContain("error:");
+  expect(await installedVersionOf(project, "@scope/pkg-b")).toBe("pkg-b");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -334,65 +334,68 @@ test.concurrent(
 // dependency after the shared clone completes; the checkout id was derived
 // from the branch committish's current tip instead of the lockfile's pinned
 // SHA, so a branch that moved after the lockfile was written installed the
-// wrong commit and stranded the store's install context.
-test.concurrent(
-  "isolated linker installs the locked commit from a cold cache after the branch moves",
-  async () => {
-    using dir = tempDir("git-dep-iso-moved", {});
-    const root = String(dir);
+// wrong commit and stranded the install context. The hoisted linker had the
+// same mismatch in its clone-completion waiter loop.
+for (const linker of ["hoisted", "isolated"] as const) {
+  test.concurrent(
+    `${linker} linker installs the locked commit from a cold cache after the branch moves`,
+    async () => {
+      using dir = tempDir(`git-dep-${linker}-moved`, {});
+      const root = String(dir);
 
-    await using server = serveStatic(root);
-    const repoUrl = `git+http://localhost:${server.port}/shared-repo.git`;
-    const bare = await makeSharedRepo(root, [
-      { name: "@scope/pkg-m", branch: "pkg-m" },
-      { name: "@scope/pkg-n", branch: "pkg-n" },
-    ]);
+      await using server = serveStatic(root);
+      const repoUrl = `git+http://localhost:${server.port}/shared-repo.git`;
+      const bare = await makeSharedRepo(root, [
+        { name: "@scope/pkg-m", branch: "pkg-m" },
+        { name: "@scope/pkg-n", branch: "pkg-n" },
+      ]);
 
-    const project = join(root, "project");
-    mkdirSync(project);
-    writeFileSync(
-      join(project, "package.json"),
-      JSON.stringify({
-        name: "project",
-        version: "1.0.0",
-        dependencies: {
-          "@scope/pkg-m": `${repoUrl}#pkg-m`,
-          "@scope/pkg-n": `${repoUrl}#pkg-n`,
-        },
-      }),
-    );
+      const project = join(root, "project");
+      mkdirSync(project);
+      writeFileSync(
+        join(project, "package.json"),
+        JSON.stringify({
+          name: "project",
+          version: "1.0.0",
+          dependencies: {
+            "@scope/pkg-m": `${repoUrl}#pkg-m`,
+            "@scope/pkg-n": `${repoUrl}#pkg-n`,
+          },
+        }),
+      );
 
-    // fresh install to produce a complete lockfile
-    {
-      const { stderr, exitCode } = await runInstall(project, join(root, "cache-warm"), {}, "--linker=isolated");
+      // fresh install to produce a complete lockfile
+      {
+        const { stderr, exitCode } = await runInstall(project, join(root, "cache-warm"), {}, `--linker=${linker}`);
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+      }
+
+      // move pkg-m past the locked commit
+      const work = join(root, "work");
+      await git(work, "checkout", "-q", "pkg-m");
+      writeFileSync(join(work, "index.js"), `module.exports = "pkg-m-v2";\n`);
+      await git(work, "commit", "-aqm", "v2", "--no-gpg-sign");
+      await git(work, "push", "-q", bare, "pkg-m");
+      await git(bare, "update-server-info");
+
+      // cold cache from the lockfile: must install the locked commit, not the tip
+      await Bun.$`rm -rf ${join(project, "node_modules")}`;
+      const { stderr, exitCode } = await runInstall(
+        project,
+        join(root, "cache-cold"),
+        {},
+        "--frozen-lockfile",
+        `--linker=${linker}`,
+      );
       expect(stderr).not.toContain("error:");
+      expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
+      expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
       expect(exitCode).toBe(0);
-    }
-
-    // move pkg-m past the locked commit
-    const work = join(root, "work");
-    await git(work, "checkout", "-q", "pkg-m");
-    writeFileSync(join(work, "index.js"), `module.exports = "pkg-m-v2";\n`);
-    await git(work, "commit", "-aqm", "v2", "--no-gpg-sign");
-    await git(work, "push", "-q", bare, "pkg-m");
-    await git(bare, "update-server-info");
-
-    // cold cache from the lockfile: must install the locked commit, not the tip
-    await Bun.$`rm -rf ${join(project, "node_modules")}`;
-    const { stderr, exitCode } = await runInstall(
-      project,
-      join(root, "cache-cold"),
-      {},
-      "--frozen-lockfile",
-      "--linker=isolated",
-    );
-    expect(stderr).not.toContain("error:");
-    expect(await installedVersionOf(project, "@scope/pkg-m")).toBe("pkg-m");
-    expect(await installedVersionOf(project, "@scope/pkg-n")).toBe("pkg-n");
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+    },
+    30_000,
+  );
+}
 
 // issue #35420 bug 3: `git+file://` dependencies never cloned at all — the
 // clone task recognized neither an https nor an ssh URL and finished without


### PR DESCRIPTION
### What does this PR do?

Fixes #35420
Fixes #10915
Fixes #8501
Fixes #28284
Fixes #11348

When several git dependencies point at different branches of one repository (`git+ssh://host/repo.git#branch-a`, `...#branch-b`, ...), they share a single git-clone task whose callback queue holds one entry per dependency. Three bugs around that sharing, all reproducible locally with a bare repo (no network):

## Bug 1: install from a complete lockfile on a cold cache silently skips packages

`bun install --frozen-lockfile` with a cold cache installed only one of N git deps sharing a repo, printed `N packages installed`, and exited 0. Re-running recovered roughly one package per attempt (`error: InstallFailed cloning repository`).

Cause: in the hoisted installer, the clone-completion handler in `runTasks.rs` only processed `clone.dep_id`, the single dependency stored on the task, and enqueued one checkout. Every other dependency queued on the shared clone was dropped on the floor.

Fix: drain the clone task's whole callback queue and enqueue a checkout per waiting dependency (deduped by checkout id).

## Bug 2: resolve phase fails with `failed to resolve` for specs that appear both directly and transitively

With no lockfile, a project whose git deps are also re-declared by one of the packages (same URL + committish strings) deterministically errored with `error: <pkg>@git+... failed to resolve` for a varying subset of the duplicated specs.

Cause: a git checkout's callback queue is drained exactly once, when its completion is processed. A duplicate dependency enqueued after that drain (checkout completions for siblings land in the same task batch, before the deferred dependency-list flush runs) pushed a callback nothing would ever process, so its resolution slot stayed invalid. The in-memory fast path could not catch it because first-time git deps hash an empty `package_name`.

Fix: record which package each completed checkout appended (`git_checkout_packages` map) and resolve late arrivals against it directly, applying the same `resolved`/`package_name` fix-up the drain applies.

## Bug 2b: the same parked-callback bug in the tarball extract path

The mechanism behind bug 2 is not git-specific. `github:` and tarball-URL dependencies that appear both directly and transitively park the late dependency on an already-drained extract task the same way (#8501, #10915, #28284). Reproduced locally with tarball URLs (16 packages, one re-declaring 11 siblings: `failed to resolve` in 4 of 5 runs) and with the #8501 repro (`bun add github:angular/cli-builds#21fd54b0...` fails on canary with `error: @angular-devkit/core@github:angular/angular-devkit-core-builds#910531a failed to resolve`, installs all 230 packages with this change).

Fix: the completed-checkout map generalizes to every extract task that appends a package; the github and tarball enqueue arms consult it like the git arm does.

## Bug 3: `git+file://` dependencies never clone

`dependency.rs` accepts `git+file:` as a git dependency, but the clone task recognized neither an https nor an ssh URL and finished without running git, with `Status::Waiting` and zeroed task data that the main thread treated as a successful clone. The zeroed fd then poisoned `git_repositories`, so every later dependency on that repo ran `git log` against a nonexistent directory (`fatal: cannot change to '.../<id>.git'`).

Fixes: clone with the URL as written when neither matcher recognizes it (git supports `file://` and `git://` natively), and only insert the repo fd into `git_repositories` on clone success so a failed clone can be retried instead of poisoning the map.

### How did you verify your code works?

`test/cli/install/bun-install-git-deps.test.ts` (new): a local bare repo with orphan branches, served over git's dumb HTTP protocol by `Bun.serve` (`git update-server-info` + static files), so no network is involved.

- fresh resolve with 16 branches of one repo where one branch re-declares 11 siblings: previously `failed to resolve`, now all 16 install
- the same direct+transitive shape with tarball-URL dependencies (static `.tgz` files served by `Bun.serve`): previously `failed to resolve`, now all 16 install
- the #8501 shape with `github:` specifiers (a single `github:` direct dependency whose own `github:` dependencies overlap, via `GITHUB_API_URL` pointed at a local `Bun.serve`): previously `error: @scope/pkg-b@github:scope/pkg-b#v1 failed to resolve`, now all 17 install
- install from a complete lockfile on a cold cache with 2 branches of one repo: previously 1 of 2 installed with exit 0, now both install
- `git+file://` dependency: previously `error: no commit matching ... (but repository exists)`, now installs

All five tests fail on bun 1.4.0-canary and on an unfixed debug build, and pass with this change (hoisted and isolated linkers both verified manually for the 16-branch scenario). The real-world #8501 repro (`bun add github:angular/cli-builds#21fd54b0...`) was also verified directly: canary fails with `error: @angular-devkit/core@github:angular/angular-devkit-core-builds#910531a failed to resolve`, this change installs all 230 packages.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-git-deps.test.ts
bun test v1.4.0 (7cb3e38e2)

test/cli/install/bun-install-git-deps.test.ts:
267 |     for (let attempt = 0; attempt < 2; attempt++) {
268 |       await Bun.$`rm -rf ${join(project, "node_modules")} ${join(project, "bun.lock")} ${join(root, "cache-" + attempt)}`;
269 |       const { stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {
270 |         GITHUB_API_URL: `http://localhost:${server.port}`,
271 |       });
272 |       expect(stderr).not.toContain("failed to resolve");
                               ^
error: expect(received).not.toContain(expected)

Expected to not contain: "failed to resolve"
Received: "Resolving dependencies\nResolved, downloaded and extracted [16]\nerror: @scope/pkg-b@github:scope/pkg-b failed to resolve\nerror: @scope/pkg-c@github:scope/pkg-c failed to resolve\nerror: @scope/pkg-d@github:scope/pkg-d failed to resolve\nerror: @scope/pkg-e@github:scope/pkg-e failed to resolve\nerror: @scope/pkg-f@github:scope/pkg-f failed to resolve\nerro
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (bdc3d0c59)

test/cli/install/bun-install-git-deps.test.ts:
(pass) installs a git+file:// dependency [2938.47ms]
(pass) installs every tarball-URL dependency that appears directly and transitively [4298.95ms]
(pass) hoisted linker installs the locked commit from a cold cache after the branch moves [4681.54ms]
(pass) isolated linker installs the locked commit from a cold cache after the branch moves [5467.40ms]
(pass) installs every git dependency from a lockfile on a cold cache when deps share one repo [6974.04ms]
(pass) installs every github: dependency that appears directly and transitively [9879.09ms]
(pass) installs every git dependency when many branches of one repo appear directly and transitively [11749.51ms]

 7 pass
 0 fail
 121 expect() calls
Ran 7 tests across 1 file. [12.10s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-install-git-deps.test.ts
bun test v1.4.0 (7cb3e38e2)

test/cli/install/bun-install-git-deps.test.ts:
(pass) installs every github: dependency that appears directly and transitively [2397.48ms]
(pass) installs every git dependency from a lockfile on a cold cache when deps share one repo [2809.97ms]
(pass) hoisted linker installs the locked commit from a cold cache after the branch moves [2988.58ms]
(pass) installs every tarball-URL dependency that appears directly and transitively [3591.59ms]
(pass) installs a git+file:// dependency [1656.40ms]
(pass) isolated linker installs the locked commit from a cold cache after the branch moves [3365.00ms]
(pass) installs every git dependency when many branches of one repo appear directly and transitively [10147.36ms]

 7 pass
 0 fail
 121 expect() calls
Ran 7 tests across 1 file. [15.77s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1598ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] gen cpp.rs (cppbind)
[2/52] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/52] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      |  10 +
 .../PackageManager/PackageManagerEnqueue.rs        | 104 +++--
 src/install/PackageManager/runTasks.rs             | 118 +++---
 src/install/PackageManagerTask.rs                  |  25 +-
 test/cli/install/bun-install-git-deps.test.ts      | 425 +++++++++++++++++++++
 5 files changed, 602 insertions(+), 80 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager.rs                            4      4      0
src/install/PackageManager/PackageManagerEnqueue.rs      9      9      0
src/install/PackageManager/runTasks.rs                   5      5      0
src/install/PackageManagerTask.rs                        1      1      0
test/cli/install/bun-install-git-deps.test.ts            5      8      0
```

</details>

<!-- robobun:evidence:end -->