### PR TITLE
node:vm: detach process SIGINT listeners around a breakOnSigint run

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1595,9 +1595,15 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
                     if (signalToContextIdsMap->find(signalNumber) != signalToContextIdsMap->end() && eventEmitter.listenerCount(eventName) == 0) {
 
 #if !OS(WINDOWS)
-                        if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
-                            // Don't uninstall the old handler if it's not the one we installed.
-                            signal(signalNumber, oldHandler);
+                        // Same guard as the add path: the swap-compare below
+                        // goes through SIG_DFL before restoring a foreign
+                        // handler, and a SIGINT in that gap would terminate
+                        // the process instead of interrupting the run.
+                        if (signalNumber != SIGINT || !SigintWatcher::isActive()) {
+                            if (void (*oldHandler)(int) = signal(signalNumber, SIG_DFL); oldHandler != forwardSignal) {
+                                // Don't uninstall the old handler if it's not the one we installed.
+                                signal(signalNumber, oldHandler);
+                            }
                         }
 #else
                         SignalHandleValue signal_handle = signalToContextIdsMap->get(signalNumber);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -62,6 +62,7 @@
 
 #include "AsyncContextFrame.h"
 #include "ErrorCode.h"
+#include "vm/SigintWatcher.h"
 
 #include "napi_handle_scope.h"
 #include "napi_external.h"
@@ -1558,19 +1559,26 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
 #endif
                         };
 #if !OS(WINDOWS)
-                        Bun__ensureSignalHandler();
-                        struct sigaction action;
-                        memset(&action, 0, sizeof(struct sigaction));
+                        // SigintWatcher owns the SIGINT sigaction while a
+                        // breakOnSigint vm run is active; forwarding the
+                        // listener happens when it hands SIGINT back. Installing
+                        // forwardSignal here would make the running script
+                        // uninterruptible.
+                        if (signalNumber != SIGINT || !SigintWatcher::isActive()) {
+                            Bun__ensureSignalHandler();
+                            struct sigaction action;
+                            memset(&action, 0, sizeof(struct sigaction));
 
-                        // Set the handler in the action struct
-                        action.sa_handler = forwardSignal;
+                            // Set the handler in the action struct
+                            action.sa_handler = forwardSignal;
 
-                        // Clear the sa_mask
-                        sigemptyset(&action.sa_mask);
-                        sigaddset(&action.sa_mask, signalNumber);
-                        action.sa_flags = SA_RESTART;
+                            // Clear the sa_mask
+                            sigemptyset(&action.sa_mask);
+                            sigaddset(&action.sa_mask, signalNumber);
+                            action.sa_flags = SA_RESTART;
 
-                        sigaction(signalNumber, &action, nullptr);
+                            sigaction(signalNumber, &action, nullptr);
+                        }
 #else
                         signal_handle.handle = Bun__UVSignalHandle__init(
                             eventEmitter.scriptExecutionContext()->jsGlobalObject(),

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -360,7 +360,11 @@ public:
         if (m_saved.isEmpty())
             return;
         m_emitter = &emitter;
-        m_emitter->removeAllListeners(m_sigint);
+        // Remove from the map directly so onDidChangeListeners does not fire:
+        // the SIGINT entry stays in signalToContextIdsMap, so a mid-run
+        // process.on("SIGINT") takes the contains() early-out instead of
+        // sigaction()-ing forwardSignal over SigintWatcher's handler.
+        m_emitter->eventListenerMap().removeAll(m_sigint);
     }
 
     ~SigintHandlersScope()

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -12,6 +12,7 @@
 
 #include "NodeVMScriptFetcher.h"
 #include "../vm/SigintWatcher.h"
+#include "BunProcess.h"
 
 #include <bit>
 
@@ -328,6 +329,55 @@ void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeou
     }
 }
 
+// Node's sigintHandlersWrap (lib/vm.js): a breakOnSigint run detaches the
+// caller's SIGINT listeners beforehand and re-attaches them in `finally`, so
+// they do not fire on the interrupting signal and cannot be removed by the
+// script. Bun's process keeps the once flag in C++ (rawListeners() cannot
+// surface it), so snapshot { callback, isOnce } directly from the listener map
+// instead of round-tripping through JS.
+class SigintHandlersScope {
+    WTF_MAKE_NONCOPYABLE(SigintHandlersScope);
+
+public:
+    explicit SigintHandlersScope(Zig::GlobalObject* zigGlobalObject)
+    {
+        if (!zigGlobalObject || !zigGlobalObject->hasProcessObject())
+            return;
+        auto& vm = zigGlobalObject->vm();
+        m_sigint = JSC::Identifier::fromString(vm, "SIGINT"_s);
+        auto& emitter = zigGlobalObject->processObject()->wrapped();
+        auto* listeners = emitter.eventListenerMap().find(m_sigint);
+        if (!listeners)
+            return;
+        for (auto& registered : *listeners) {
+            if (registered->wasRemoved()) [[unlikely]]
+                continue;
+            // The listener map is what marks the JSEventListener's weak
+            // m_jsFunction; root each callback ourselves while it is detached.
+            m_roots.append(registered->callback().jsFunction());
+            m_saved.append({ registered->callback(), registered->isOnce() });
+        }
+        if (m_saved.isEmpty())
+            return;
+        m_emitter = &emitter;
+        m_emitter->removeAllListeners(m_sigint);
+    }
+
+    ~SigintHandlersScope()
+    {
+        if (!m_emitter)
+            return;
+        for (auto& entry : m_saved)
+            m_emitter->addListener(m_sigint, WTF::move(entry.first), entry.second, false);
+    }
+
+private:
+    WebCore::EventEmitter* m_emitter { nullptr };
+    JSC::Identifier m_sigint;
+    JSC::MarkedArgumentBuffer m_roots;
+    Vector<std::pair<Ref<WebCore::EventListener>, bool>, 2> m_saved;
+};
+
 static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVMScript* script, JSObject* contextifiedObject, JSValue optionsArg, bool allowStringInPlaceOfOptions = false)
 {
     VM& vm = JSC::getVM(globalObject);
@@ -371,6 +421,7 @@ static JSC::EncodedJSValue runInContext(NodeVMGlobalObject* globalObject, NodeVM
     };
 
     if (options.breakOnSigint) {
+        SigintHandlersScope sigintScope(defaultGlobalObject(globalObject));
         auto holder = SigintWatcher::hold(globalObject, script);
         run();
         drainAfterEvaluate();
@@ -437,6 +488,7 @@ JSC_DEFINE_HOST_FUNCTION(scriptRunInThisContext, (JSGlobalObject * globalObject,
     script->setSigintReceived(false);
 
     if (options.breakOnSigint) {
+        SigintHandlersScope sigintScope(defaultGlobalObject(globalObject));
         auto holder = SigintWatcher::hold(globalObject, script);
         vm.ensureTerminationException();
         run();

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -334,7 +334,11 @@ void setupWatchdog(VM& vm, double timeout, double* oldTimeout, double* newTimeou
 // they do not fire on the interrupting signal and cannot be removed by the
 // script. Bun's process keeps the once flag in C++ (rawListeners() cannot
 // surface it), so snapshot { callback, isOnce } directly from the listener map
-// instead of round-tripping through JS.
+// instead of round-tripping through JS. Neither side emits 'removeListener'
+// nor 'newListener' (node's wrapper does): the destructor runs while the
+// script's exception or termination is still pending, so re-entering user JS
+// there is not safe, and the native JSEventEmitter has no removeListener emit
+// on any path anyway.
 class SigintHandlersScope {
     WTF_MAKE_NONCOPYABLE(SigintHandlersScope);
 

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -365,9 +365,10 @@ public:
             return;
         m_emitter = &emitter;
         // Remove from the map directly so onDidChangeListeners does not fire:
-        // the SIGINT entry stays in signalToContextIdsMap, so a mid-run
-        // process.on("SIGINT") takes the contains() early-out instead of
-        // sigaction()-ing forwardSignal over SigintWatcher's handler.
+        // the scope is constructed before SigintWatcher::install(), so the
+        // removal path would otherwise swap SIGINT to SIG_DFL for the gap.
+        // Mid-run process.on("SIGINT") calls are handled separately by the
+        // SigintWatcher::isActive() guard in onDidChangeListeners.
         m_emitter->eventListenerMap().removeAll(m_sigint);
     }
 

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -10,6 +10,15 @@ extern "C" void Bun__ensureSignalHandler();
 
 namespace Bun {
 
+// Separate from m_installed so onDidChangeListeners can ask "does SigintWatcher
+// own the SIGINT sigaction right now?" without constructing the singleton.
+static std::atomic<bool> s_sigintWatcherActive { false };
+
+bool SigintWatcher::isActive()
+{
+    return s_sigintWatcherActive.load(std::memory_order_acquire);
+}
+
 #if OS(WINDOWS)
 static BOOL WindowsCtrlHandler(DWORD signal)
 {
@@ -35,6 +44,7 @@ SigintWatcher::~SigintWatcher()
 
 void SigintWatcher::install()
 {
+    s_sigintWatcherActive.store(true, std::memory_order_release);
 #if OS(WINDOWS)
     SetConsoleCtrlHandler(WindowsCtrlHandler, true);
 #else
@@ -99,6 +109,7 @@ void SigintWatcher::uninstall()
         sigaction(SIGINT, &action, nullptr);
 #endif
 
+        s_sigintWatcherActive.store(false, std::memory_order_release);
         m_semaphore.signal();
         m_thread->waitForCompletion();
     }

--- a/src/jsc/bindings/vm/SigintWatcher.h
+++ b/src/jsc/bindings/vm/SigintWatcher.h
@@ -30,6 +30,8 @@ public:
     void deref();
 
     static SigintWatcher& get();
+    /** True while install() owns the SIGINT disposition. Does not construct the singleton. */
+    static bool isActive();
 
     class GlobalObjectHolder {
     public:

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import {
   compileFunction,
   constants,
@@ -1234,5 +1234,117 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("ab=B ba=A");
     expect(exitCode).toBe(0);
+  });
+});
+
+// Node's sigintHandlersWrap (lib/vm.js): a breakOnSigint run detaches the
+// caller's SIGINT listeners beforehand and re-attaches them afterwards, so the
+// script cannot observe or remove them and they do not fire on the interrupting
+// signal. The delivered-signal case is covered by
+// test/js/node/test/parallel/test-vm-sigint-existing-handler.js.
+describe.concurrent("breakOnSigint saves and restores process SIGINT listeners", () => {
+  async function run(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  const variants: [string, string][] = [
+    ["vm.runInThisContext", `vm.runInThisContext(code, { breakOnSigint: true })`],
+    ["Script#runInThisContext", `new vm.Script(code).runInThisContext({ breakOnSigint: true })`],
+    ["vm.runInContext", `vm.runInContext(code, vm.createContext({ process }), { breakOnSigint: true })`],
+    ["Script#runInContext", `new vm.Script(code).runInContext(vm.createContext({ process }), { breakOnSigint: true })`],
+    ["vm.runInNewContext", `vm.runInNewContext(code, { process }, { breakOnSigint: true })`],
+    ["Script#runInNewContext", `new vm.Script(code).runInNewContext({ process }, { breakOnSigint: true })`],
+  ];
+
+  test.each(variants)("%s: listeners are detached during the run and re-attached after", async (_, call) => {
+    const result = await run(`
+      const vm = require("vm");
+      const before = () => {};
+      process.on("SIGINT", before);
+      const code = 'process.removeAllListeners("SIGINT"); process.listenerCount("SIGINT");';
+      const during = ${call};
+      const after = process.listeners("SIGINT");
+      process.removeAllListeners("SIGINT");
+      console.log(JSON.stringify({ during, restored: after.length === 1 && after[0] === before }));
+    `);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.trim()).toBe(JSON.stringify({ during: 0, restored: true }));
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("a once() listener keeps its once-ness across the run", async () => {
+    const result = await run(`
+      let called = 0;
+      process.once("SIGINT", () => called++);
+      require("vm").runInThisContext("1 + 1", { breakOnSigint: true });
+      process.emit("SIGINT");
+      process.emit("SIGINT");
+      console.log(JSON.stringify({ called, remaining: process.listenerCount("SIGINT") }));
+    `);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.trim()).toBe(JSON.stringify({ called: 1, remaining: 0 }));
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("listeners added inside the run precede the restored ones", async () => {
+    const result = await run(`
+      process.on("SIGINT", function before() {});
+      require("vm").runInThisContext('process.on("SIGINT", function mid() {})', { breakOnSigint: true });
+      const names = process.listeners("SIGINT").map(l => l.name);
+      process.removeAllListeners("SIGINT");
+      console.log(JSON.stringify(names));
+    `);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.trim()).toBe(JSON.stringify(["mid", "before"]));
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("listeners are restored when the script throws", async () => {
+    const result = await run(`
+      const h = () => {};
+      process.on("SIGINT", h);
+      try { require("vm").runInThisContext('throw new Error("boom")', { breakOnSigint: true }); } catch {}
+      const ok = process.listeners("SIGINT").length === 1 && process.listeners("SIGINT")[0] === h;
+      process.removeAllListeners("SIGINT");
+      console.log(JSON.stringify({ restored: ok }));
+    `);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.trim()).toBe(JSON.stringify({ restored: true }));
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("no detaching without breakOnSigint", async () => {
+    const result = await run(`
+      const h = () => {};
+      process.on("SIGINT", h);
+      const during = require("vm").runInThisContext('process.listenerCount("SIGINT")');
+      process.removeAllListeners("SIGINT");
+      console.log(JSON.stringify({ during }));
+    `);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.trim()).toBe(JSON.stringify({ during: 1 }));
+    expect(result.exitCode).toBe(0);
+  });
+
+  // No way to send CTRL_C_EVENT to a child from JS on Windows.
+  test.skipIf(isWindows)("a delivered SIGINT after the run reaches the restored listener", async () => {
+    const result = await run(`
+      process.on("SIGINT", () => { process.stdout.write("listener\\n"); process.exit(0); });
+      require("vm").runInThisContext('process.removeAllListeners("SIGINT")', { breakOnSigint: true });
+      process.kill(process.pid, "SIGINT");
+      setTimeout(() => { process.stdout.write("survived\\n"); process.exit(7); }, 1500);
+    `);
+    expect({ stdout: result.stdout, exitCode: result.exitCode, signalCode: result.signalCode }).toEqual({
+      stdout: "listener\n",
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1333,6 +1333,44 @@ describe.concurrent("breakOnSigint saves and restores process SIGINT listeners",
     expect(result.exitCode).toBe(0);
   });
 
+  // The detach must not let a mid-run process.on("SIGINT") reinstall the
+  // process-level SIGINT sigaction over SigintWatcher's: the script's own
+  // for(;;) must still be interruptible.
+  test.skipIf(isWindows)("a mid-run process.on('SIGINT') does not stop the run being interruptible", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          process.on("SIGINT", () => {});
+          try {
+            require("vm").runInThisContext(
+              'process.on("SIGINT", () => {}); process.send("ready"); for (;;);',
+              { breakOnSigint: true },
+            );
+          } catch (e) {
+            process.stdout.write(e.code + "\\n");
+            process.exit(0);
+          }
+          process.stdout.write("survived\\n");
+          process.exit(7);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      ipc() {
+        proc.kill("SIGINT");
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "ERR_SCRIPT_EXECUTION_INTERRUPTED\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   // No way to send CTRL_C_EVENT to a child from JS on Windows.
   test.skipIf(isWindows)("a delivered SIGINT after the run reaches the restored listener", async () => {
     const result = await run(`

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1342,7 +1342,10 @@ describe.concurrent("breakOnSigint saves and restores process SIGINT listeners",
   // interruptible. onDidChangeListeners skips the sigaction while
   // SigintWatcher::isActive(), so every add/remove permutation is covered.
   const midRunVariants: [string, { before: string; inside: string }][] = [
-    ["pre-run listener + mid-run add", { before: `process.on("SIGINT", () => {});`, inside: `process.on("SIGINT", () => {});` }],
+    [
+      "pre-run listener + mid-run add",
+      { before: `process.on("SIGINT", () => {});`, inside: `process.on("SIGINT", () => {});` },
+    ],
     [
       "pre-run listener + mid-run add, remove, add",
       {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1280,10 +1280,14 @@ describe.concurrent("breakOnSigint saves and restores process SIGINT listeners",
   });
 
   test("a once() listener keeps its once-ness across the run", async () => {
+    // The anonymous listener's only root while detached is the scope's
+    // MarkedArgumentBuffer; force GC during the run so a missing root would
+    // clear the JSEventListener's weak m_jsFunction and the re-added listener
+    // would never fire.
     const result = await run(`
       let called = 0;
       process.once("SIGINT", () => called++);
-      require("vm").runInThisContext("1 + 1", { breakOnSigint: true });
+      require("vm").runInThisContext("for (let i = 0; i < 50; i++) Bun.gc(true);", { breakOnSigint: true });
       process.emit("SIGINT");
       process.emit("SIGINT");
       console.log(JSON.stringify({ called, remaining: process.listenerCount("SIGINT") }));
@@ -1333,43 +1337,67 @@ describe.concurrent("breakOnSigint saves and restores process SIGINT listeners",
     expect(result.exitCode).toBe(0);
   });
 
-  // The detach must not let a mid-run process.on("SIGINT") reinstall the
-  // process-level SIGINT sigaction over SigintWatcher's: the script's own
-  // for(;;) must still be interruptible.
-  test.skipIf(isWindows)("a mid-run process.on('SIGINT') does not stop the run being interruptible", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          process.on("SIGINT", () => {});
-          try {
-            require("vm").runInThisContext(
-              'process.on("SIGINT", () => {}); process.send("ready"); for (;;);',
-              { breakOnSigint: true },
-            );
-          } catch (e) {
-            process.stdout.write(e.code + "\\n");
-            process.exit(0);
-          }
-          process.stdout.write("survived\\n");
-          process.exit(7);
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      ipc() {
-        proc.kill("SIGINT");
+  // A mid-run process.on("SIGINT") must not reinstall the process-level SIGINT
+  // sigaction over SigintWatcher's: the script's own for(;;) must still be
+  // interruptible. onDidChangeListeners skips the sigaction while
+  // SigintWatcher::isActive(), so every add/remove permutation is covered.
+  const midRunVariants: [string, { before: string; inside: string }][] = [
+    ["pre-run listener + mid-run add", { before: `process.on("SIGINT", () => {});`, inside: `process.on("SIGINT", () => {});` }],
+    [
+      "pre-run listener + mid-run add, remove, add",
+      {
+        before: `process.on("SIGINT", () => {});`,
+        inside: `const g = () => {}; process.on("SIGINT", g); process.removeListener("SIGINT", g); process.on("SIGINT", () => {});`,
       },
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "ERR_SCRIPT_EXECUTION_INTERRUPTED\n",
-      stderr: "",
-      exitCode: 0,
-    });
-  });
+    ],
+    ["no pre-run listener + mid-run add", { before: ``, inside: `process.on("SIGINT", () => {});` }],
+  ];
+  test.skipIf(isWindows).each(midRunVariants)(
+    "a mid-run process.on('SIGINT') does not stop the run being interruptible (%s)",
+    async (_, { before, inside }) => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            ${before}
+            try {
+              require("vm").runInThisContext(
+                ${JSON.stringify(inside + ` process.send("ready"); for (;;);`)},
+                { breakOnSigint: true },
+              );
+            } catch (e) {
+              process.stdout.write(e.code + "\\n");
+              process.exit(0);
+            }
+            process.stdout.write("survived\\n");
+            process.exit(7);
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        ipc() {
+          proc.kill("SIGINT");
+          // Hang guard: if the watcher's handler has been overwritten, SIGINT
+          // is queued on the event loop and the child spins forever. Bound the
+          // wait so the assertion below reports a clear failure instead of a
+          // test-level timeout.
+          guard = setTimeout(() => proc.kill("SIGKILL"), 5000);
+        },
+      });
+      let guard: ReturnType<typeof setTimeout> | undefined;
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      clearTimeout(guard);
+      expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+        stdout: "ERR_SCRIPT_EXECUTION_INTERRUPTED\n",
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    },
+    10000,
+  );
 
   // No way to send CTRL_C_EVENT to a child from JS on Windows.
   test.skipIf(isWindows)("a delivered SIGINT after the run reaches the restored listener", async () => {


### PR DESCRIPTION
## Repro

```js
process.on('SIGINT', () => { process.stdout.write("listener\n"); process.exit(0); });
require('vm').runInThisContext('process.removeAllListeners("SIGINT")', { breakOnSigint: true });
process.kill(process.pid, 'SIGINT');
setTimeout(() => { console.log('survived'); process.exit(7); }, 300);
```

| | node | bun before | bun after |
| --- | --- | --- | --- |
| stdout | `listener` | `survived` | `listener` |
| exit | 0 | 7 | 0 |

## Cause

Node wraps `Script.prototype.runIn{This,,New}Context` in [`sigintHandlersWrap`](https://github.com/nodejs/node/blob/v26.3.0/lib/vm.js#L274-L288) when `breakOnSigint && process.listenerCount('SIGINT') > 0`:

```js
function sigintHandlersWrap(fn, thisArg, argsArray) {
  const sigintListeners = process.rawListeners('SIGINT');
  process.removeAllListeners('SIGINT');
  try { return ReflectApply(fn, thisArg, argsArray); }
  finally { for (const l of sigintListeners) process.addListener('SIGINT', l); }
}
```

The caller's SIGINT listeners are detached before the native evaluation and re-attached after, so the script cannot observe or remove them and they do not fire on the interrupting signal. Bun's `Script.prototype.runIn*` are native and call `SigintWatcher::hold` directly (`NodeVMScript.cpp`), so the listener set is visible and mutable from inside the run. The repro's `removeAllListeners('SIGINT')` removes the caller's listener for good; in node it operates on an already-empty set.

The observable divergences, each exercised by a test in `test/js/node/vm/vm.test.ts`:

| during / after a `breakOnSigint` run | node | bun before |
| --- | --- | --- |
| `process.listenerCount('SIGINT')` inside the script | 0 | pre-run count |
| `removeAllListeners('SIGINT')` inside the script | no effect on caller's listeners | removes them |
| listener added inside the script | precedes restored listeners | follows pre-run listeners |

`Module.prototype.evaluate` is not wrapped in node (`lib/internal/vm/module.js`), so the module path is left alone.

## Fix

Node's wrapper relies on `process.rawListeners('SIGINT')` returning `onceWrapper` closures that can be round-tripped through `addListener` without losing their once-ness. Bun's `process` is a native `JSEventEmitter` that stores the once flag on the C++ `SimpleRegisteredEventListener` and returns bare callbacks from `rawListeners()`, so a JS-level port would convert every `once('SIGINT')` listener into a regular one and break `test-vm-sigint-existing-handler.js`.

Instead, add a `SigintHandlersScope` RAII class around the two `SigintWatcher::hold` sites in `NodeVMScript.cpp`. When there are SIGINT listeners it:

- Snapshots `{ callback, isOnce }` from `eventListenerMap()`, rooting each JS callback in a `MarkedArgumentBuffer` (the map is what marks the `JSEventListener`'s weak `m_jsFunction`, so the detached callbacks would otherwise be collectable across the run).
- Removes the SIGINT entry from the map directly, skipping `onDidChangeListeners`. The scope is constructed before `SigintWatcher::install()`, so routing the removal through the listener-change hook would swap the disposition to `SIG_DFL` for the gap.
- Re-adds each saved listener in the destructor through `EventEmitter::addListener` so `onDidChangeListeners` repopulates `signalToContextIdsMap` if the script cleared it. `'newListener'` is not emitted: the destructor runs while the script's exception or termination is still pending, so re-entering user JS there is not safe (and the native `JSEventEmitter` has no `'removeListener'` emit on any path).

Node's `SigintWatchdog` is a thread that does not share the process-wide `sigaction` slot, so `sigintHandlersWrap` never has to worry about a mid-run `process.on('SIGINT')` overwriting it. Bun's `SigintWatcher` and `onDidChangeListeners` both call `sigaction(SIGINT)`, so the script adding its own listener can clobber the watcher's handler and make its own `for(;;)` uninterruptible. This PR adds `SigintWatcher::isActive()` (a file-static atomic, readable without constructing the singleton) and has the SIGINT branch of `onDidChangeListeners`' add path skip the `sigaction` while it is set; `signalToContextIdsMap` is still updated so the state stays consistent. That closes every mid-run add/remove permutation, including the pre-existing "no pre-run listener + mid-run add" hang that was already broken on main.

## Verification

Fourteen tests in `test/js/node/vm/vm.test.ts`. Nine fail against the unfixed build; five pass on both and are there to pin the new scope's own behavior.

```
(fail) {vm.,Script#}runIn{This,,New}Context: listeners are detached during the run and re-attached after  x6
(fail) listeners added inside the run precede the restored ones
(fail) a delivered SIGINT after the run reaches the restored listener
(fail) a mid-run process.on('SIGINT') does not stop the run being interruptible (no pre-run listener + mid-run add)
(pass) a once() listener keeps its once-ness across the run          [+ Bun.gc(true) during the run to pin m_roots]
(pass) listeners are restored when the script throws
(pass) no detaching without breakOnSigint
(pass) a mid-run process.on('SIGINT') ... (pre-run listener + mid-run add)
(pass) a mid-run process.on('SIGINT') ... (pre-run listener + mid-run add, remove, add)
```

All fourteen pass with the fix, and on the debug build:

```
test/js/node/test/parallel/test-vm-sigint.js                    exit=0
test/js/node/test/parallel/test-vm-sigint-existing-handler.js   exit=0
test/js/node/test/sequential/test-vm-break-on-sigint.js         exit=0
test/js/node/test/parallel/test-util-sigint-watchdog.js         exit=0
test/js/node/test/parallel/test-signal-handler.js               exit=0
test/js/node/test/parallel/test-signal-unregister.js            exit=0
```

Related to #35425 (which restores the kernel sigaction after a `breakOnSigint` run). With the scope detaching from the map only, `SigintWatcher::install()` swaps its handler on top of the pre-run `forwardSignal` directly, and the mid-run-remove sibling from the review discussion there resolves to "the scope re-adds the listener and it fires", matching node.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->