### PR TITLE
GarbageCollectionController: gate the 16 ms nudge on real heap growth

### DIFF
--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -215,26 +215,46 @@ impl GarbageCollectionController {
         self.process_gc_timer_with_heap_size(vm, vm.block_bytes_allocated());
     }
 
+    /// Growth (relative to the post-GC baseline) before we nudge another
+    /// async collection. Bounded so a tiny heap still waits for real work
+    /// and a huge live set does not push RSS several hundred MB past the
+    /// live size between nudges.
+    #[inline]
+    fn growth_threshold(prev: usize) -> usize {
+        const FLOOR: usize = 1024 * 1024;
+        const CEILING: usize = 32 * 1024 * 1024;
+        (prev / 8).clamp(FLOOR, CEILING)
+    }
+
     fn process_gc_timer_with_heap_size(&mut self, vm: &VM, this_heap_size: usize) {
         let prev = self.gc_last_heap_size;
 
         match self.gc_timer_state {
             GCTimerState::RunOnNextTick => {
-                // When memory usage is not stable, run the GC more.
+                // One debounced collect. Go back to Pending rather than
+                // re-arming the 16 ms timer: under sustained allocation the
+                // `!= prev` re-arm made this a collect_async()-every-16 ms
+                // loop, which on a large live heap turns into ~40 % of
+                // main-thread time spent in eden GC pauses. Let Pending's
+                // growth check decide when the next nudge is warranted.
+                self.gc_timer_state = GCTimerState::Pending;
                 if this_heap_size != prev {
-                    self.schedule_gc_timer();
                     self.update_gc_repeat_timer(GcRepeatSetting::Fast);
-                } else {
-                    self.gc_timer_state = GCTimerState::Pending;
                 }
                 vm.collect_async();
                 self.gc_last_heap_size = this_heap_size;
             }
             GCTimerState::Pending => {
-                if this_heap_size != prev {
+                if this_heap_size < prev {
+                    // The async collect we just requested (or a sweep) freed
+                    // blocks. Track the low-water mark so the growth check
+                    // below measures allocation since the post-GC baseline,
+                    // not since the pre-GC peak.
+                    self.gc_last_heap_size = this_heap_size;
+                } else if this_heap_size > prev.saturating_add(Self::growth_threshold(prev)) {
                     self.update_gc_repeat_timer(GcRepeatSetting::Fast);
 
-                    if this_heap_size > prev * 2 {
+                    if this_heap_size > prev.saturating_mul(2) {
                         self.perform_gc();
                     } else {
                         self.schedule_gc_timer();
@@ -242,7 +262,7 @@ impl GarbageCollectionController {
                 }
             }
             GCTimerState::Scheduled => {
-                if this_heap_size > prev * 2 {
+                if this_heap_size > prev.saturating_mul(2) {
                     self.update_gc_repeat_timer(GcRepeatSetting::Fast);
                     self.perform_gc();
                 }

--- a/test/js/bun/http/serve-gc-storm-fixture.ts
+++ b/test/js/bun/http/serve-gc-storm-fixture.ts
@@ -1,0 +1,52 @@
+// Fixture for serve-gc-storm.test.ts. Build a large long-lived heap, serve an
+// allocation-heavy handler under self-generated load for a fixed number of
+// requests, then exit. The parent counts "EdenCollection" in stderr (from
+// BUN_JSC_logGC=1) to measure how many eden GCs the controller requested.
+import { createServer } from "node:http";
+
+const REQUESTS = Number(process.env.REQUESTS ?? 4000);
+const LIVE_RECORDS = Number(process.env.LIVE_RECORDS ?? 100_000);
+const CONCURRENCY = 16;
+
+// ~50 MB of records at the default count. Big enough for each eden pause to
+// be measurable, small enough for an ASAN debug build to construct in a few
+// seconds.
+const pad = Buffer.alloc(64, 120).toString();
+const live = new Map<number, { id: number; name: string; pad: string; meta: { s: number } }>();
+for (let i = 0; i < LIVE_RECORDS; i++) {
+  live.set(i, { id: i, name: "item-" + i, pad, meta: { s: (i * 2654435761) >>> 0 } });
+}
+
+let served = 0;
+const server = createServer((req, res) => {
+  const id = served % LIVE_RECORDS;
+  const related: unknown[] = [];
+  for (let k = 1; k <= 20; k++) {
+    const r = live.get((id + k * 97) % LIVE_RECORDS)!;
+    related.push({ id: r.id, name: r.name, score: r.meta.s });
+  }
+  const body = JSON.stringify({ ok: true, id, related });
+  res.writeHead(200, { "content-type": "application/json", "content-length": Buffer.byteLength(body) });
+  res.end(body);
+  served++;
+});
+
+server.listen(0, async () => {
+  // One sync GC to settle the 40 MB construction before the marker.
+  Bun.gc(true);
+  process.stderr.write("=== LOAD-START ===\n");
+  const { port } = server.address() as import("node:net").AddressInfo;
+  const base = `http://127.0.0.1:${port}/`;
+  let i = 0;
+  const worker = async () => {
+    while (i < REQUESTS) {
+      i++;
+      const r = await fetch(base);
+      await r.arrayBuffer();
+    }
+  };
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  process.stderr.write("=== LOAD-END ===\n");
+  console.log(JSON.stringify({ served, rss: process.memoryUsage().rss }));
+  server.close(() => process.exit(0));
+});

--- a/test/js/bun/http/serve-gc-storm.test.ts
+++ b/test/js/bun/http/serve-gc-storm.test.ts
@@ -6,7 +6,7 @@
 // serving. This test runs a fixed request count against an allocation-heavy
 // handler with a ~50 MB live Map and asserts the controller requested a
 // bounded number of eden collections, not one every few milliseconds.
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug } from "harness";
 import path from "node:path";
 
@@ -14,37 +14,33 @@ import path from "node:path";
 // profiles run the load phase for a few seconds.
 const REQUESTS = isDebug ? 300 : 30000;
 
-test(
-  "node:http server with a large live heap does not trigger an eden GC storm",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "serve-gc-storm-fixture.ts")],
-      env: { ...bunEnv, BUN_JSC_logGC: "1", REQUESTS: String(REQUESTS) },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+test("node:http server with a large live heap does not trigger an eden GC storm", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "serve-gc-storm-fixture.ts")],
+    env: { ...bunEnv, BUN_JSC_logGC: "1", REQUESTS: String(REQUESTS) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toContain('"served":');
-    expect(exitCode).toBe(0);
+  expect(stdout).toContain('"served":');
+  expect(exitCode).toBe(0);
 
-    // Count eden GCs between the load markers only; the heap build and the
-    // explicit Bun.gc() before LOAD-START are not what this test is about.
-    const start = stderr.indexOf("=== LOAD-START ===");
-    const end = stderr.indexOf("=== LOAD-END ===");
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-    const during = stderr.slice(start, end);
-    const edenGCs = (during.match(/EdenCollection/g) ?? []).length;
+  // Count eden GCs between the load markers only; the heap build and the
+  // explicit Bun.gc() before LOAD-START are not what this test is about.
+  const start = stderr.indexOf("=== LOAD-START ===");
+  const end = stderr.indexOf("=== LOAD-END ===");
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  const during = stderr.slice(start, end);
+  const edenGCs = (during.match(/EdenCollection/g) ?? []).length;
 
-    // Before the fix, the 16 ms loop fired an eden GC continuously for the
-    // duration of the load: ~25 collections over a debug build's 300 requests
-    // and ~50-80 over a release build's 30 000. After, the growth-gated nudge
-    // fires on the order of once per several-MB of allocation and measures 2-4
-    // (debug) / 8-12 (release) here. The thresholds sit comfortably between
-    // the two regimes.
-    const limit = isDebug ? 12 : 30;
-    expect(edenGCs).toBeLessThan(limit);
-  },
-  30_000,
-);
+  // Before the fix, the 16 ms loop fired an eden GC continuously for the
+  // duration of the load: ~25 collections over a debug build's 300 requests
+  // and ~50-80 over a release build's 30 000. After, the growth-gated nudge
+  // fires on the order of once per several-MB of allocation and measures 2-4
+  // (debug) / 8-12 (release) here. The thresholds sit comfortably between
+  // the two regimes.
+  const limit = isDebug ? 12 : 30;
+  expect(edenGCs).toBeLessThan(limit);
+}, 30_000);

--- a/test/js/bun/http/serve-gc-storm.test.ts
+++ b/test/js/bun/http/serve-gc-storm.test.ts
@@ -1,0 +1,50 @@
+// Under sustained HTTP load the GarbageCollectionController used to re-arm its
+// 16 ms debounce timer whenever `blockBytesAllocated()` moved at all, so
+// `collect_async()` fired every ~16 ms for as long as requests were arriving.
+// With a large long-lived heap each eden collection has a multi-millisecond
+// pause, and the main thread spent most of its time inside GC instead of
+// serving. This test runs a fixed request count against an allocation-heavy
+// handler with a ~50 MB live Map and asserts the controller requested a
+// bounded number of eden collections, not one every few milliseconds.
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+import path from "node:path";
+
+// Debug + ASAN is 50-100x slower; trade request count for wall time so both
+// profiles run the load phase for a few seconds.
+const REQUESTS = isDebug ? 300 : 30000;
+
+test(
+  "node:http server with a large live heap does not trigger an eden GC storm",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "serve-gc-storm-fixture.ts")],
+      env: { ...bunEnv, BUN_JSC_logGC: "1", REQUESTS: String(REQUESTS) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain('"served":');
+    expect(exitCode).toBe(0);
+
+    // Count eden GCs between the load markers only; the heap build and the
+    // explicit Bun.gc() before LOAD-START are not what this test is about.
+    const start = stderr.indexOf("=== LOAD-START ===");
+    const end = stderr.indexOf("=== LOAD-END ===");
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const during = stderr.slice(start, end);
+    const edenGCs = (during.match(/EdenCollection/g) ?? []).length;
+
+    // Before the fix, the 16 ms loop fired an eden GC continuously for the
+    // duration of the load: ~25 collections over a debug build's 300 requests
+    // and ~50-80 over a release build's 30 000. After, the growth-gated nudge
+    // fires on the order of once per several-MB of allocation and measures 2-4
+    // (debug) / 8-12 (release) here. The thresholds sit comfortably between
+    // the two regimes.
+    const limit = isDebug ? 12 : 30;
+    expect(edenGCs).toBeLessThan(limit);
+  },
+  30_000,
+);


### PR DESCRIPTION
## Summary

Under sustained HTTP load Bun's `GarbageCollectionController` was requesting an eden GC roughly every 16 ms for as long as requests were arriving. With a small heap that is harmless (each eden cycle is well under a millisecond), but with a large long-lived heap (an in-memory cache, a big Map, a warmed ORM) each eden collection costs several milliseconds of main-thread pause. At a 150 MB live set that was ~40 % of wall time and made `node:http` / `Bun.serve` with an allocation-heavy handler run at roughly half of Node.js.

## Root cause

`process_gc_timer_with_heap_size` is called on every request completion (`on_request_complete`) and on every event-loop tick. Its `RunOnNextTick` arm called `vm.collect_async()` and, whenever `block_bytes_allocated() != prev` (which under any allocation is always, because that value moves in 16 KB block increments), re-armed the 16 ms one-shot. So the state machine locked into `Scheduled -> (16 ms) -> RunOnNextTick -> collect + re-arm -> Scheduled -> ...` for the lifetime of the load.

`BUN_JSC_logGC=1` on the server shows it directly: at 150 MB live, ~45 eden collections per second, each with `ca=` (bytes allocated since the last GC) in the hundreds-of-KB range and a `~530 MB` eden threshold, i.e. none of them were allocation-triggered; all came from our explicit `collectAsync()` nudge.

## Fix

Break the loop and make the nudge proportional to actual growth:

- `RunOnNextTick` now collects once and drops back to `Pending` instead of re-arming the 16 ms timer.
- `Pending` only re-arms after the heap has grown by `clamp(prev/8, 1 MiB, 32 MiB)` past its post-GC low-water mark (it tracks the low-water mark so the threshold is measured from the post-collect baseline, not the pre-collect peak).
- The `prev * 2` immediate-collect fast path and the 1 s / 30 s repeating timer are unchanged.

This keeps the controller's original purpose (bound RSS between JSC's own very lax allocation thresholds) while letting JSC's allocation-based trigger do its job under steady load.

## Measurements

Allocation-heavy handler (20 small objects + `JSON.stringify(~1 KB)` per request, 150 MB live `Map`), server pinned to 4 cores, separate loadgen cores, 10 s @ 64 concurrent, median of 3 reps, linux-x64, release builds at `028f7a3b5`:

| | Node v26.3.0 | main | this PR | vs main |
|---|---|---|---|---|
| `node:http` | 18.8 k rps | 12.6 k rps | **21.4 k rps** | +70 % |
| fastify | 17.7 k rps | 12.0 k rps | **18.0 k rps** | +50 % |
| express | 12.2 k rps | 8.4 k rps | **13.2 k rps** | +57 % |
| `Bun.serve` (direct) | n/a | 17.0 k rps | **31.4 k rps** | +85 % |
| eden GCs / 10 s | n/a | ~530 | ~33 | |
| peak RSS | 369 MB | 320 MB | 392 MB | +72 MB |

At a 1 MB live set (the typical hello-world benchmark) throughput is unchanged; the storm never cost much there because each eden GC was sub-millisecond.

The RSS increase is the expected trade-off: the 32 MiB ceiling plus block granularity between nudges. It is bounded and does not grow with run length.

## Test

`test/js/bun/http/serve-gc-storm.test.ts` spawns a `node:http` server with a ~50 MB live `Map`, drives a fixed request count at it from the same process, and counts `EdenCollection` entries in the `BUN_JSC_logGC=1` output between `LOAD-START`/`LOAD-END` markers. Before: ~20 (debug) / ~50-80 (release). After: 2-4 / 8-12. Asserts well between.