### PR TITLE
Blob: purify NaN when boxing lastModified so deserialized files never forge a JSValue

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2164,12 +2164,14 @@ impl BlobExt for Blob {
                     resolve_file_stat(store);
                 }
                 // Fresh borrow after possible mutation by `resolve_file_stat`.
-                return JSValue::js_number(store.data_mut().as_file().last_modified as f64);
+                return JSValue::js_number(JSValue::purify_nan(
+                    store.data_mut().as_file().last_modified as f64,
+                ));
             }
         }
 
         if self.is_jsdom_file.get() {
-            return JSValue::js_number(self.last_modified.get());
+            return JSValue::js_number(JSValue::purify_nan(self.last_modified.get()));
         }
 
         JSValue::js_number(jsc::INIT_TIMESTAMP as f64)

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -664,7 +664,12 @@ describe("structuredClone with Blob and File", () => {
         .filter(Boolean)
         .map(l => JSON.parse(l));
       // Two deserialize entry points per payload, all purified to number NaN.
-      expect(lines).toEqual(payloads.flatMap(() => [{ type: "number", isNaN: true }, { type: "number", isNaN: true }]));
+      expect(lines).toEqual(
+        payloads.flatMap(() => [
+          { type: "number", isNaN: true },
+          { type: "number", isNaN: true },
+        ]),
+      );
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -609,6 +609,66 @@ describe("structuredClone with Blob and File", () => {
       });
     });
 
+    test("crafted NaN lastModified deserializes to a number, never a forged JSValue", async () => {
+      // `File`/`Blob` store `lastModified` as a raw f64 on the wire. A crafted
+      // payload can plant any NaN bit pattern there; JSVALUE64 boxing is only
+      // sound for non-NaN or the single canonical NaN, so an impure NaN decodes
+      // as a forged immediate (boolean/undefined/int32) or a cell pointer that
+      // segfaults when touched. The getter must purify every NaN, so a
+      // deserialized `.lastModified` is always a Number. Run in a child: the
+      // pre-fix debug build trips the `!isImpureNaN(d)` assert at boxing time,
+      // and the cell-pointer case segfaults on release.
+      const sentinelBE = Buffer.from([0x3a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f, 0x60, 0x71]);
+      const sentinel = sentinelBE.readDoubleBE(0);
+      const sentinelLE = Buffer.alloc(8);
+      sentinelLE.writeDoubleLE(sentinel, 0);
+      const base = Buffer.from(serialize(new File(["x"], "a.txt", { lastModified: sentinel })));
+      const at = base.indexOf(sentinelLE);
+      expect(at).toBeGreaterThanOrEqual(0);
+
+      const payloads = [
+        "fffe000000000007", // would forge boolean true
+        "fffe00000000000a", // would forge undefined
+        "fffc000012345678", // would forge int32 0x12345678
+        "fffe000000001008", // would forge an unmapped cell pointer -> SEGV
+      ];
+
+      const childScript = `
+        const { serialize, deserialize } = require("bun:jsc");
+        const v8 = require("node:v8");
+        const base = Buffer.from(process.argv[1], "base64");
+        const at = Number(process.argv[2]);
+        const payloads = process.argv[3].split(",");
+        for (const bits of payloads) {
+          const patched = Buffer.from(base);
+          Buffer.from(bits, "hex").reverse().copy(patched, at); // native-endian
+          for (const de of [deserialize, buf => v8.deserialize(Buffer.from(buf))]) {
+            const lm = de(patched).lastModified;
+            // touch it as an object: a forged cell derefs and crashes here.
+            Object.prototype.toString.call(lm);
+            process.stdout.write(JSON.stringify({ type: typeof lm, isNaN: Number.isNaN(lm) }) + "\\n");
+          }
+        }
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", childScript, base.toString("base64"), String(at), payloads.join(",")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const lines = stdout
+        .split("\n")
+        .filter(Boolean)
+        .map(l => JSON.parse(l));
+      // Two deserialize entry points per payload, all purified to number NaN.
+      expect(lines).toEqual(payloads.flatMap(() => [{ type: "number", isNaN: true }, { type: "number", isNaN: true }]));
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
     test("truncated payload at every byte boundary throws cleanly", () => {
       // Every truncation point must surface as a thrown error (never a
       // partially-constructed Blob, never a crash). This is the functional


### PR DESCRIPTION
## What

`File`/`Blob` store `lastModified` as a raw `f64`. The `lastModified` getter boxed that value with `JSValue::js_number(...)` without purifying NaN. The structured-clone deserialize path (`read_float`, a plain `f64::from_ne_bytes`) reads the value straight off the wire, so a crafted `v8.deserialize` / `bun:jsc.deserialize` buffer could plant an impure NaN.

JSVALUE64 boxing is only sound for a non-NaN or the single canonical NaN. Any other NaN bit pattern collides with the tag ranges for `boolean`, `undefined`, `Int32`, and cell pointers, so `.lastModified` (a property that must always be a `Number`) decoded as a forged immediate or a forged cell pointer that segfaults when dereferenced.

The constructor already mapped `NaN` to `0` (#33922), and the generic structured-clone number path already purifies (`jsNumber(purifyNaN(d))`), but the custom `File`/`Blob` tag getter skipped it. This is the same bug class and primitive as #33823/#33824 (`bun:sql` `float8`) in a sink those fixes did not cover.

## Repro (pre-fix)

```js
import { serialize, deserialize } from "bun:jsc";

const sentinelBE = Buffer.from([0x3a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f, 0x60, 0x71]);
const sentinel = sentinelBE.readDoubleBE(0);
const sentinelLE = Buffer.alloc(8);
sentinelLE.writeDoubleLE(sentinel, 0);

const buf = Buffer.from(serialize(new File(["x"], "a.txt", { lastModified: sentinel })));
const at = buf.indexOf(sentinelLE);
Buffer.from("0810000000feffff", "hex").copy(buf, at); // forged unmapped cell pointer

const forged = deserialize(buf).lastModified;
Object.prototype.toString.call(forged); // SEGV
```

```
panic(main thread): Segmentation fault at address 0xFFFFFFFFFFFFFFFF
```

Under a debug + ASAN build the impure NaN trips `ASSERTION FAILED: !isImpureNaN(d)` at the moment `js_number` boxes it.

## Fix

Purify every NaN at both `lastModified` boxing sites in `src/runtime/webcore/Blob.rs`, mirroring the sink-level fix used in #32787 and #33824. `JSValue::purify_nan` already exists. A deserialized `.lastModified` now always reads back as a `Number` (canonical NaN for a planted NaN), never a forged immediate or cell.

## Verification

- New test in `test/js/web/structured-clone-blob-file.test.ts` forges `boolean`, `undefined`, `int32`, and cell-pointer payloads through both `bun:jsc.deserialize` and `v8.deserialize`, asserting each comes back as `number` NaN. It runs in a child process since the pre-fix build crashes.
- Fails on the unfixed build (child aborts at the `!isImpureNaN` assert before producing output), passes with the fix.

Closes #35434

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/structured-clone-blob-file.test.ts

<!-- robobun:evidence:end -->