### PR TITLE
crash_handler: tag JSC JIT-pool frames instead of discarding them

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -23,6 +23,9 @@
 #![allow(internal_features)]
 #![allow(nonstandard_style, static_mut_refs, unexpected_cfgs)]
 #![warn(unused_must_use)]
+
+extern crate alloc;
+
 #[path = "CPUFeatures.rs"]
 pub mod cpu_features;
 
@@ -2553,10 +2556,9 @@ mod draft {
 
     struct StackLine {
         address: i32,
-        // None -> from bun.exe
-        object: Option<Box<[u8]>>,
-        // Box<[u8]> rather than a borrowed slice into caller's `name_bytes`,
-        // since the only caller writes into a stack buffer and the value is consumed immediately.
+        /// `None` → from bun.exe. `Cow` so static labels (`b"JIT"`) encode
+        /// without touching the allocator; only the Windows DLL path owns.
+        object: Option<alloc::borrow::Cow<'static, [u8]>>,
     }
 
     impl StackLine {
@@ -2571,7 +2573,7 @@ mod draft {
                 let _ = name_bytes;
                 return Some(StackLine {
                     address: offset as i32,
-                    object: Some(Box::<[u8]>::from(&b"JIT"[..])),
+                    object: Some(alloc::borrow::Cow::Borrowed(b"JIT")),
                 });
             }
             #[cfg(windows)]
@@ -2598,8 +2600,8 @@ mod draft {
                         // or bare drive prefix, so `basename_windows`'s
                         // stripping is a no-op on this domain.
                         let basename = bun_paths::basename_windows(name);
-                        Some(Box::<[u8]>::from(
-                            &*strings::convert_utf16_to_utf8_in_buffer(name_bytes, basename),
+                        Some(alloc::borrow::Cow::Owned(
+                            strings::convert_utf16_to_utf8_in_buffer(name_bytes, basename).to_vec(),
                         ))
                     } else {
                         None
@@ -2875,12 +2877,13 @@ mod draft {
         Ok(())
     }
 
-    /// `bun:internal-for-testing` hook: what module label would the
-    /// trace-string encoder give this address. `None` → encoded as `_`;
-    /// `Some(None)` → bun's own image; `Some(Some(name))` → named object.
-    pub fn stack_line_object_for_testing(addr: usize) -> Option<Option<Box<[u8]>>> {
+    /// `bun:internal-for-testing` hook: the `(address, object)` the
+    /// trace-string encoder would record for this PC. `None` → encoded as `_`.
+    pub fn stack_line_for_testing(
+        addr: usize,
+    ) -> Option<(i32, Option<alloc::borrow::Cow<'static, [u8]>>)> {
         let mut name_bytes: [u8; 1024] = [0; 1024];
-        StackLine::from_address(addr, &mut name_bytes).map(|l| l.object)
+        StackLine::from_address(addr, &mut name_bytes).map(|l| (l.address, l.object))
     }
 
     pub fn write_u64_as_two_vlqs(writer: &mut impl Write, addr: usize) -> crate::Result<()> {
@@ -3414,6 +3417,11 @@ mod draft {
             let Some(line) = StackLine::from_address(addr, &mut name_bytes) else {
                 continue;
             };
+            // `--exe` is bun's own image; a foreign-object offset (system
+            // DLL or JIT pool) would symbolize against the wrong binary.
+            if line.object.is_some() {
+                continue;
+            }
             argv.push(format!("0x{:X}", line.address).into_bytes());
         }
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -526,11 +526,16 @@ mod draft {
     // that `bun_runtime` populates at startup (the full `Cli` stays in
     // `bun_runtime::cli`, a higher-tier crate).
     pub mod cli_state {
-        use core::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+        use core::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
 
         static MAIN_THREAD_ID: AtomicU64 = AtomicU64::new(0);
         /// 0 = unset → encoded as `_` in the trace string.
         static CMD_CHAR: AtomicU8 = AtomicU8::new(0);
+        /// JSC's fixed executable-memory pool `[start, end)`. Written once from
+        /// C++ (`JSCInitialize`) after `JSC::initialize()`; zero = unset (JIT
+        /// disabled or not yet initialized).
+        static JIT_POOL_START: AtomicUsize = AtomicUsize::new(0);
+        static JIT_POOL_END: AtomicUsize = AtomicUsize::new(0);
 
         pub fn set_main_thread_id(id: u64) {
             MAIN_THREAD_ID.store(id, Ordering::Relaxed);
@@ -552,6 +557,30 @@ mod draft {
                 0 => None,
                 c => Some(c),
             }
+        }
+
+        pub(crate) fn set_jit_pool_range(start: usize, end: usize) {
+            JIT_POOL_START.store(start, Ordering::Relaxed);
+            JIT_POOL_END.store(end, Ordering::Relaxed);
+        }
+
+        pub fn jit_pool_range() -> (usize, usize) {
+            (
+                JIT_POOL_START.load(Ordering::Relaxed),
+                JIT_POOL_END.load(Ordering::Relaxed),
+            )
+        }
+
+        /// JSC's `isJITPC`: `g_jscConfig.startExecutableMemory <= pc <
+        /// g_jscConfig.endExecutableMemory`. Returns the offset into the pool
+        /// so the trace-string encoder has a stable (ASLR-independent) value.
+        pub(crate) fn jit_pool_offset(addr: usize) -> Option<usize> {
+            let start = JIT_POOL_START.load(Ordering::Relaxed);
+            if start == 0 {
+                return None;
+            }
+            let end = JIT_POOL_END.load(Ordering::Relaxed);
+            (start <= addr && addr < end).then(|| addr - start)
         }
     }
 
@@ -2210,6 +2239,15 @@ mod draft {
     #[unsafe(no_mangle)]
     pub(crate) static Bun__reported_memory_size: AtomicUsize = AtomicUsize::new(0);
 
+    /// Called from C++ `JSCInitialize` once `JSC::initialize()` has reserved
+    /// the fixed executable-memory pool; mirrors
+    /// `g_jscConfig.{start,end}ExecutableMemory` so `StackLine::from_address`
+    /// can tag JIT frames without linking against JSC.
+    #[unsafe(no_mangle)]
+    pub(crate) extern "C" fn Bun__setJITPoolRange(start: usize, end: usize) {
+        cli_state::set_jit_pool_range(start, end);
+    }
+
     pub fn print_metadata(writer: &mut impl Write) -> crate::Result<()> {
         #[cfg(debug_assertions)]
         {
@@ -2524,6 +2562,18 @@ mod draft {
     impl StackLine {
         /// `None` implies the trace is not known.
         pub(crate) fn from_address(addr: usize, name_bytes: &mut [u8]) -> Option<StackLine> {
+            // JSC's JIT pool (Baseline/DFG/FTL/Wasm/Yarr) is a single
+            // VirtualAlloc/mmap reservation, not a loaded image, so the
+            // per-platform module lookup below can never find it. Classify it
+            // here so the trace string records the frame (as a pool offset)
+            // instead of discarding the captured PC as `_`.
+            if let Some(offset) = cli_state::jit_pool_offset(addr) {
+                let _ = name_bytes;
+                return Some(StackLine {
+                    address: offset as i32,
+                    object: Some(Box::<[u8]>::from(&b"JIT"[..])),
+                });
+            }
             #[cfg(windows)]
             {
                 let module = bun_sys::windows::get_module_handle_from_address(addr)?;
@@ -2823,6 +2873,14 @@ mod draft {
             writer.write_all(b"/view")?;
         }
         Ok(())
+    }
+
+    /// `bun:internal-for-testing` hook: what module label would the
+    /// trace-string encoder give this address. `None` → encoded as `_`;
+    /// `Some(None)` → bun's own image; `Some(Some(name))` → named object.
+    pub fn stack_line_object_for_testing(addr: usize) -> Option<Option<Box<[u8]>>> {
+        let mut name_bytes: [u8; 1024] = [0; 1024];
+        StackLine::from_address(addr, &mut name_bytes).map(|l| l.object)
     }
 
     pub fn write_u64_as_two_vlqs(writer: &mut impl Write, addr: usize) -> crate::Result<()> {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -107,6 +107,8 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   abort: () => void;
   trap: () => void;
   raiseIgnoringPanicHandler: () => void;
+  jitPoolRange: () => [number, number];
+  stackLine: (addr: number) => { address: number; object: string | null } | undefined;
 };
 
 export const upgrade_test_helpers = $rust("upgrade_command.rs", "upgrade_js_bindings.generate") as {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -278,8 +278,9 @@ extern "C" unsigned getJSCBytecodeCacheVersion()
 extern "C" void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject*);
 #endif
 
-#if OS(WINDOWS) && (CPU(X86_64) || CPU(ARM64))
 #include <JavaScriptCore/ExecutableAllocator.h>
+extern "C" void Bun__setJITPoolRange(uintptr_t start, uintptr_t end);
+#if OS(WINDOWS) && (CPU(X86_64) || CPU(ARM64))
 extern "C" long Bun__crashHandlerFromJSCFrame(void*, void*, void*, void*);
 #endif
 
@@ -363,6 +364,14 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             JSC::Options::assertOptionsAreCoherent();
         }); // end JSC::initialize lambda
 
+#if ENABLE(JIT)
+        // Mirror g_jscConfig.{start,end}ExecutableMemory so the crash handler
+        // can tag JIT frames (the pool is a bare VirtualAlloc/mmap, not a
+        // loaded image, so module lookup cannot classify it).
+        Bun__setJITPoolRange(
+            JSC::startOfFixedExecutableMemoryPool<uintptr_t>(),
+            JSC::endOfFixedExecutableMemoryPool<uintptr_t>());
+#endif
 #if OS(WINDOWS) && (CPU(X86_64) || CPU(ARM64))
         // JSC::initialize() registered unwind info + a language-specific SEH
         // handler for the JIT pool. Route that handler to the crash reporter

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -33,7 +33,7 @@ pub mod js_bindings {
                 __jsc_host_js_raise_ignoring_panic_handler,
             ),
             ("jitPoolRange", __jsc_host_js_jit_pool_range),
-            ("stackLineObject", __jsc_host_js_stack_line_object),
+            ("stackLine", __jsc_host_js_stack_line),
         ];
         let obj = JSValue::create_empty_object(global, ENTRIES.len());
         for &(name, func) in ENTRIES {
@@ -215,35 +215,41 @@ pub mod js_bindings {
         _frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let (start, end) = crash_handler::cli_state::jit_pool_range();
+        // User-space addresses are <2^48 on every supported arch, so a double
+        // is exact; matches `getMachOImageZeroOffset`'s number return and
+        // avoids `JSBigInt::tryCreateFrom`'s throw scope.
         let arr = JSValue::create_empty_array(global, 2)?;
-        arr.put_index(
-            global,
-            0,
-            JSValue::from_uint64_no_truncate(global, start as u64),
-        )?;
-        arr.put_index(
-            global,
-            1,
-            JSValue::from_uint64_no_truncate(global, end as u64),
-        )?;
+        arr.put_index(global, 0, JSValue::js_number_from_uint64(start as u64))?;
+        arr.put_index(global, 1, JSValue::js_number_from_uint64(end as u64))?;
         Ok(arr)
     }
 
     /// Returns what the crash-report encoder would record for an address:
-    /// `undefined` → unknown (encoded as `_`), `null` → bun's own image,
-    /// `"<name>"` → named object (system DLL, `"JIT"`, …).
+    /// `undefined` → unknown (encoded as `_`); otherwise `{ address, object }`
+    /// where `object` is `null` for bun's own image, or the name (system DLL,
+    /// `"JIT"`, …).
     #[bun_jsc::host_fn]
-    pub(crate) fn js_stack_line_object(
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
+    pub(crate) fn js_stack_line(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         let [addr] = frame.arguments_as_array::<1>();
         let addr = addr.to_uint64_no_truncate() as usize;
-        Ok(match crash_handler::stack_line_object_for_testing(addr) {
-            None => JSValue::UNDEFINED,
-            Some(None) => JSValue::NULL,
-            Some(Some(name)) => BunString::clone_utf8(&name).transfer_to_js(global)?,
-        })
+        let Some((address, object)) = crash_handler::stack_line_for_testing(addr) else {
+            return Ok(JSValue::UNDEFINED);
+        };
+        let obj = JSValue::create_empty_object(global, 2);
+        obj.put(
+            global,
+            "address",
+            JSValue::js_number_from_int64(address as i64),
+        );
+        obj.put(
+            global,
+            "object",
+            match object {
+                None => JSValue::NULL,
+                Some(name) => BunString::clone_utf8(&name).transfer_to_js(global)?,
+            },
+        );
+        Ok(obj)
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -216,8 +216,16 @@ pub mod js_bindings {
     ) -> JsResult<JSValue> {
         let (start, end) = crash_handler::cli_state::jit_pool_range();
         let arr = JSValue::create_empty_array(global, 2)?;
-        arr.put_index(global, 0, JSValue::from_uint64_no_truncate(global, start as u64))?;
-        arr.put_index(global, 1, JSValue::from_uint64_no_truncate(global, end as u64))?;
+        arr.put_index(
+            global,
+            0,
+            JSValue::from_uint64_no_truncate(global, start as u64),
+        )?;
+        arr.put_index(
+            global,
+            1,
+            JSValue::from_uint64_no_truncate(global, end as u64),
+        )?;
         Ok(arr)
     }
 

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -32,6 +32,8 @@ pub mod js_bindings {
                 "raiseIgnoringPanicHandler",
                 __jsc_host_js_raise_ignoring_panic_handler,
             ),
+            ("jitPoolRange", __jsc_host_js_jit_pool_range),
+            ("stackLineObject", __jsc_host_js_stack_line_object),
         ];
         let obj = JSValue::create_empty_object(global, ENTRIES.len());
         for &(name, func) in ENTRIES {
@@ -205,6 +207,35 @@ pub mod js_bindings {
     ) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         Global::raise_ignoring_panic_handler(bun_core::SignalCode::SIGSEGV);
+    }
+
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_jit_pool_range(
+        global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let (start, end) = crash_handler::cli_state::jit_pool_range();
+        let arr = JSValue::create_empty_array(global, 2)?;
+        arr.put_index(global, 0, JSValue::from_uint64_no_truncate(global, start as u64))?;
+        arr.put_index(global, 1, JSValue::from_uint64_no_truncate(global, end as u64))?;
+        Ok(arr)
+    }
+
+    /// Returns what the crash-report encoder would record for an address:
+    /// `undefined` → unknown (encoded as `_`), `null` → bun's own image,
+    /// `"<name>"` → named object (system DLL, `"JIT"`, …).
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_stack_line_object(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let [addr] = frame.arguments_as_array::<1>();
+        let addr = addr.to_uint64_no_truncate() as usize;
+        Ok(match crash_handler::stack_line_object_for_testing(addr) {
+            None => JSValue::UNDEFINED,
+            Some(None) => JSValue::NULL,
+            Some(Some(name)) => BunString::clone_utf8(&name).transfer_to_js(global)?,
+        })
     }
 
     #[bun_jsc::host_fn]

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -2,7 +2,7 @@ import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs } from "harness";
 import path from "path";
-const { getMachOImageZeroOffset } = crash_handler;
+const { getMachOImageZeroOffset, jitPoolRange, stackLineObject } = crash_handler;
 
 // CI sets BUN_CRASH_REPORT_URL so unexpected crashes are captured; these
 // deliberate crashes must not upload there or the runner pins them on the
@@ -12,6 +12,28 @@ const noReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPO
 // On Linux, debug builds symbolize crash traces by spawning llvm-symbolizer;
 // without it the fallback printer has no Rust symbol names to assert on.
 const hasSymbolizer = !!(Bun.which("llvm-symbolizer") || Bun.which("llvm-symbolizer-21"));
+
+// The crash-report trace-string encoder used to throw away any captured PC
+// that `GetModuleHandleExW`/`dl_iterate_phdr`/`_dyld_get_image_header` cannot
+// map to a loaded image. JSC's JIT pool is a bare VirtualAlloc/mmap (not an
+// image), so JIT frames were encoded as the single byte `_` and bun.report
+// rendered them as `pkg:"?" addr:0x0000`. ~16% of Windows crash events in
+// the week before this change had ≥1 such frame.
+test("JIT pool addresses are tagged in crash-report frames", () => {
+  const [start, end] = jitPoolRange();
+  // JSCInitialize calls Bun__setJITPoolRange after JSC::initialize(); the
+  // test runner has already brought up a VM, so the pool must be registered.
+  expect(start).toBeGreaterThan(0n);
+  expect(end).toBeGreaterThan(start);
+
+  // A PC inside the pool is now encoded with object "JIT" (reusing the
+  // existing foreign-module slot, so bun.report needs no decoder change).
+  expect(stackLineObject(start)).toBe("JIT");
+  expect(stackLineObject(end - 1n)).toBe("JIT");
+  // Boundaries: end is exclusive, and 0 is never a valid PC.
+  expect(stackLineObject(end)).not.toBe("JIT");
+  expect(stackLineObject(0n)).toBeUndefined();
+});
 
 test.if(isDebug && isLinux && hasSymbolizer)(
   "crash trace starts at the crash site, not inside the crash handler",

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -2,7 +2,7 @@ import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs } from "harness";
 import path from "path";
-const { getMachOImageZeroOffset, jitPoolRange, stackLineObject } = crash_handler;
+const { getMachOImageZeroOffset, jitPoolRange, stackLine } = crash_handler;
 
 // CI sets BUN_CRASH_REPORT_URL so unexpected crashes are captured; these
 // deliberate crashes must not upload there or the runner pins them on the
@@ -17,22 +17,24 @@ const hasSymbolizer = !!(Bun.which("llvm-symbolizer") || Bun.which("llvm-symboli
 // that `GetModuleHandleExW`/`dl_iterate_phdr`/`_dyld_get_image_header` cannot
 // map to a loaded image. JSC's JIT pool is a bare VirtualAlloc/mmap (not an
 // image), so JIT frames were encoded as the single byte `_` and bun.report
-// rendered them as `pkg:"?" addr:0x0000`. ~16% of Windows crash events in
-// the week before this change had ≥1 such frame.
+// rendered them as `pkg:"?" addr:0x0000`.
 test("JIT pool addresses are tagged in crash-report frames", () => {
   const [start, end] = jitPoolRange();
   // JSCInitialize calls Bun__setJITPoolRange after JSC::initialize(); the
   // test runner has already brought up a VM, so the pool must be registered.
-  expect(start).toBeGreaterThan(0n);
+  expect(start).toBeGreaterThan(0);
   expect(end).toBeGreaterThan(start);
 
   // A PC inside the pool is now encoded with object "JIT" (reusing the
-  // existing foreign-module slot, so bun.report needs no decoder change).
-  expect(stackLineObject(start)).toBe("JIT");
-  expect(stackLineObject(end - 1n)).toBe("JIT");
+  // existing foreign-module slot, so bun.report needs no decoder change) and
+  // address = offset-into-pool so the value is stable across ASLR.
+  expect(stackLine(start)).toEqual({ object: "JIT", address: 0 });
+  expect(stackLine(start + 0x100)).toEqual({ object: "JIT", address: 0x100 });
+  // `| 0` mirrors the Rust `offset as i32` wrap for a hypothetical >2GB pool.
+  expect(stackLine(end - 1)).toEqual({ object: "JIT", address: (end - start - 1) | 0 });
   // Boundaries: end is exclusive, and 0 is never a valid PC.
-  expect(stackLineObject(end)).not.toBe("JIT");
-  expect(stackLineObject(0n)).toBeUndefined();
+  expect(stackLine(end)?.object).not.toBe("JIT");
+  expect(stackLine(0)).toBeUndefined();
 });
 
 test.if(isDebug && isLinux && hasSymbolizer)(


### PR DESCRIPTION
## Problem

`StackLine::from_address` (src/crash_handler/lib.rs) discards any captured PC it cannot map to a loaded image: on Windows `GetModuleHandleExW(FROM_ADDRESS)`, on Linux `dl_iterate_phdr`, on macOS the `_dyld` image walk. The encoder writes a single `_` for those frames and the raw address is thrown away; bun.report renders them as `pkg:\"?\" addr:0x0000`.

JSC's fixed executable-memory pool (Baseline/DFG/FTL/Wasm/Yarr, plus host-call thunks) is a bare `VirtualAlloc`/`mmap` reservation, not a loaded image, so every JIT frame hits that path. In Sentry, 9,122 of 58,414 Windows crash events over the last 7 days (~16%) carried at least one such blank frame; e.g. [BUN-2PYE](https://bun-p9.sentry.io/issues/7375905670/) events on `1.4.0-canary+892b1dabc` show 19/20 frames as `pkg:\"?\" addr:0x0000` for a user running JIT'd code with `process_dlopen`.

## Fix

Mirror `g_jscConfig.{start,end}ExecutableMemory` (JSC's `isJITPC` bounds) into the crash handler via a new `Bun__setJITPoolRange` called once from `JSCInitialize` after `JSC::initialize()`. `StackLine::from_address` range-checks each PC against it before the per-platform image lookup (two pointer compares, no locks, no allocation). A match is encoded with `object: \"JIT\"` and `address` = offset into the pool, which reuses the existing foreign-module trace-string slot (`VLQ(1) + VLQ(len) + name + VLQ(addr)`), so bun.report needs no decoder change and will render `pkg:\"JIT\" addr:0x<offset>`.

Pool bounds live in `cli_state` alongside `CMD_CHAR`/`MAIN_THREAD_ID` (same write-once-from-a-higher-tier-crate pattern as #31688).

## Verification

New cross-platform test in `test/cli/run/run-crash-handler.test.ts` via two `bun:internal-for-testing` hooks (`jitPoolRange()`, `stackLineObject(addr)`):

```
$ USE_SYSTEM_BUN=1 bun test test/cli/run/run-crash-handler.test.ts -t 'JIT pool'
(fail) JIT pool addresses are tagged in crash-report frames
  TypeError: jitPoolRange is not a function

$ bun bd test test/cli/run/run-crash-handler.test.ts -t 'JIT pool'
(pass) JIT pool addresses are tagged in crash-report frames [4.42ms]
```

Full `run-crash-handler.test.ts`: 15 pass / 8 skip / 0 fail. `crash-report-command-char.test.ts`: 3 pass. `bun run rust:check-all`: 10/10 targets clean.

Deriving JIT tier / JS function name from the PC (via `VMInspector::codeBlockForMachinePC` or a `vm.topCallFrame` walk) is a larger follow-up.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->