### PR TITLE
bun-lambda: format console.log args with util.format instead of Bun.inspect per-arg

### DIFF
--- a/packages/bun-lambda/runtime.ts
+++ b/packages/bun-lambda/runtime.ts
@@ -112,7 +112,7 @@ function formatError(error: unknown): LambdaError {
   }
   return {
     errorType: "Error",
-    errorMessage: Bun.inspect(error),
+    errorMessage: format(error),
   };
 }
 

--- a/packages/bun-lambda/runtime.ts
+++ b/packages/bun-lambda/runtime.ts
@@ -1,5 +1,6 @@
 import { AwsClient } from "aws4fetch";
 import type { Server, ServerWebSocket } from "bun";
+import { format } from "node:util";
 
 type Lambda = {
   fetch: (request: Request, server: Server) => Promise<Response | undefined>;
@@ -22,11 +23,11 @@ function log(level: string, ...args: any[]): void {
   if (!args.length) {
     return;
   }
-  const messages = args.map(arg => Bun.inspect(arg).replace(/\n/g, "\r"));
+  const message = format(...args).replace(/\n/g, "\r");
   if (requestId === undefined) {
-    logger(level, ...messages);
+    logger(`${level} ${message}`);
   } else {
-    logger(level, `RequestId: ${requestId}`, ...messages);
+    logger(`${level} RequestId: ${requestId} ${message}`);
   }
 }
 

--- a/packages/bun-lambda/runtime.ts
+++ b/packages/bun-lambda/runtime.ts
@@ -23,7 +23,7 @@ function log(level: string, ...args: any[]): void {
   if (!args.length) {
     return;
   }
-  const message = format(...args).replace(/\n/g, "\r");
+  const message = format(...args).replace(/\r?\n/g, "\r");
   if (requestId === undefined) {
     logger(`${level} ${message}`);
   } else {

--- a/test/integration/bun-lambda/bun-lambda.test.ts
+++ b/test/integration/bun-lambda/bun-lambda.test.ts
@@ -172,8 +172,10 @@ test.concurrent("console.log formats arguments like Node, not Bun.inspect per-ar
   };
 
   let served = false;
-  const { promise: responded, resolve: markResponded } =
-    Promise.withResolvers<{ unexpected?: string; body?: string }>();
+  const { promise: responded, resolve: markResponded } = Promise.withResolvers<{
+    unexpected?: string;
+    body?: string;
+  }>();
 
   using server = Bun.serve({
     port: 0,

--- a/test/integration/bun-lambda/bun-lambda.test.ts
+++ b/test/integration/bun-lambda/bun-lambda.test.ts
@@ -151,6 +151,7 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
     console.error("payload:", JSON.stringify({ a: 1 }, null, 2));
     console.log("obj:", { a: 1 });
     console.warn("keep %s literal");
+    console.info("crlf:", "a\\r\\nb");
     return new Response("ok");
   },
 };
@@ -216,8 +217,11 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
     stdin: "ignore",
   });
 
+  const stdoutPromise = proc.stdout.text();
+  const stderrPromise = proc.stderr.text();
+  const exitedPromise = proc.exited;
   await responded;
-  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise, exitedPromise]);
 
   expect(stderr).toBe("");
   // Lines from inside the invocation carry the RequestId prefix; the trailing
@@ -229,5 +233,6 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
     'ERROR RequestId: req-1 payload: {\r  "a": 1\r}',
     "INFO RequestId: req-1 obj: { a: 1 }",
     "WARN RequestId: req-1 keep %s literal",
+    "INFO RequestId: req-1 crlf: a\rb",
   ]);
 });

--- a/test/integration/bun-lambda/bun-lambda.test.ts
+++ b/test/integration/bun-lambda/bun-lambda.test.ts
@@ -132,3 +132,102 @@ test("lambda HTTP events cannot override the request authority", async () => {
   expect(v1Url.origin).toBe("https://api.example.com");
   expect(v1Url.pathname).toBe("//attacker.example/reset");
 });
+
+test("console.log formats arguments like Node, not Bun.inspect per-arg", async () => {
+  // https://github.com/oven-sh/bun/issues/4826
+  // Bun.inspect("str") wraps the string in quotes and escapes newlines, which
+  // is wrong for console.log: console.log("url:", url) would print
+  //   "url:" "https://..."
+  // instead of
+  //   url: https://...
+  const runtimeSource = await Bun.file(runtimePath).text();
+
+  using dir = tempDir("bun-lambda-log", {
+    "runtime.ts": runtimeSource,
+    "handler.ts": `export default {
+  async fetch(request) {
+    console.log("url:", request.url);
+    console.log("hi %s, you are %d", "bob", 42);
+    console.error("payload:", JSON.stringify({ a: 1 }, null, 2));
+    console.log("obj:", { a: 1 });
+    console.warn("keep %s literal");
+    return new Response("ok");
+  },
+};
+`,
+    "node_modules/aws4fetch/package.json": JSON.stringify({ name: "aws4fetch", version: "1.0.0", main: "index.js" }),
+    "node_modules/aws4fetch/index.js": aws4fetchStub,
+  });
+
+  const event = {
+    version: "2.0",
+    requestContext: {
+      requestId: "req-1",
+      domainName: "api.example.com",
+      http: { method: "GET", path: "/hello" },
+    },
+    headers: {},
+    isBase64Encoded: false,
+  };
+
+  let served = false;
+  const { promise: responded, resolve: markResponded } = Promise.withResolvers<void>();
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/2018-06-01/runtime/invocation/next") {
+        if (served) {
+          // Non-ok status after the single event makes the runtime exit.
+          return new Response(null, { status: 500 });
+        }
+        served = true;
+        return new Response(JSON.stringify(event), {
+          headers: {
+            "Content-Type": "application/json",
+            "Lambda-Runtime-Aws-Request-Id": "req-1",
+            "Lambda-Runtime-Trace-Id": "trace-id",
+            "Lambda-Runtime-Invoked-Function-Arn": "arn:aws:lambda:us-east-1:000000000000:function:test",
+            "Lambda-Runtime-Deadline-Ms": String(Date.now() + 60_000),
+          },
+        });
+      }
+      if (/^\/2018-06-01\/runtime\/invocation\/[^/]+\/response$/.test(url.pathname)) {
+        markResponded();
+        return new Response(null, { status: 202 });
+      }
+      markResponded();
+      return new Response(null, { status: 202 });
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "runtime.ts"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      AWS_LAMBDA_RUNTIME_API: `localhost:${server.port}`,
+      _HANDLER: "handler.fetch",
+      LAMBDA_TASK_ROOT: String(dir),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  await responded;
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // Lines from inside the invocation carry the RequestId prefix; the trailing
+  // ERROR line is the runtime shutting down after the mock server returns 500.
+  const lines = stdout.split("\n").filter(line => line.includes("RequestId: req-1"));
+  expect(lines).toEqual([
+    "INFO RequestId: req-1 url: http://api.example.com/hello",
+    "INFO RequestId: req-1 hi bob, you are 42",
+    'ERROR RequestId: req-1 payload: {\r  "a": 1\r}',
+    "INFO RequestId: req-1 obj: { a: 1 }",
+    "WARN RequestId: req-1 keep %s literal",
+  ]);
+});

--- a/test/integration/bun-lambda/bun-lambda.test.ts
+++ b/test/integration/bun-lambda/bun-lambda.test.ts
@@ -14,7 +14,7 @@ const aws4fetchStub = `export class AwsClient {
 }
 `;
 
-test("lambda HTTP events cannot override the request authority", async () => {
+test.concurrent("lambda HTTP events cannot override the request authority", async () => {
   const runtimeSource = await Bun.file(runtimePath).text();
 
   using dir = tempDir("bun-lambda", {
@@ -133,7 +133,7 @@ test("lambda HTTP events cannot override the request authority", async () => {
   expect(v1Url.pathname).toBe("//attacker.example/reset");
 });
 
-test("console.log formats arguments like Node, not Bun.inspect per-arg", async () => {
+test.concurrent("console.log formats arguments like Node, not Bun.inspect per-arg", async () => {
   // https://github.com/oven-sh/bun/issues/4826
   // Bun.inspect("str") wraps the string in quotes and escapes newlines, which
   // is wrong for console.log: console.log("url:", url) would print
@@ -163,7 +163,7 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
   const event = {
     version: "2.0",
     requestContext: {
-      requestId: "req-1",
+      requestId: "req-log",
       domainName: "api.example.com",
       http: { method: "GET", path: "/hello" },
     },
@@ -172,7 +172,8 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
   };
 
   let served = false;
-  const { promise: responded, resolve: markResponded } = Promise.withResolvers<void>();
+  const { promise: responded, resolve: markResponded } =
+    Promise.withResolvers<{ unexpected?: string; body?: string }>();
 
   using server = Bun.serve({
     port: 0,
@@ -187,7 +188,7 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
         return new Response(JSON.stringify(event), {
           headers: {
             "Content-Type": "application/json",
-            "Lambda-Runtime-Aws-Request-Id": "req-1",
+            "Lambda-Runtime-Aws-Request-Id": "req-log",
             "Lambda-Runtime-Trace-Id": "trace-id",
             "Lambda-Runtime-Invoked-Function-Arn": "arn:aws:lambda:us-east-1:000000000000:function:test",
             "Lambda-Runtime-Deadline-Ms": String(Date.now() + 60_000),
@@ -195,10 +196,11 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
         });
       }
       if (/^\/2018-06-01\/runtime\/invocation\/[^/]+\/response$/.test(url.pathname)) {
-        markResponded();
+        markResponded({});
         return new Response(null, { status: 202 });
       }
-      markResponded();
+      // Anything else (init/invocation errors) surfaces in the assertions below.
+      markResponded({ unexpected: url.pathname, body: await req.text() });
       return new Response(null, { status: 202 });
     },
   });
@@ -220,19 +222,78 @@ test("console.log formats arguments like Node, not Bun.inspect per-arg", async (
   const stdoutPromise = proc.stdout.text();
   const stderrPromise = proc.stderr.text();
   const exitedPromise = proc.exited;
-  await responded;
-  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise, exitedPromise]);
+  const result = await responded;
+  const [stdout, stderr, exitCode] = await Promise.all([stdoutPromise, stderrPromise, exitedPromise]);
 
   expect(stderr).toBe("");
+  expect(result.unexpected).toBeUndefined();
   // Lines from inside the invocation carry the RequestId prefix; the trailing
   // ERROR line is the runtime shutting down after the mock server returns 500.
-  const lines = stdout.split("\n").filter(line => line.includes("RequestId: req-1"));
+  const lines = stdout.split("\n").filter(line => line.includes("RequestId: req-log"));
   expect(lines).toEqual([
-    "INFO RequestId: req-1 url: http://api.example.com/hello",
-    "INFO RequestId: req-1 hi bob, you are 42",
-    'ERROR RequestId: req-1 payload: {\r  "a": 1\r}',
-    "INFO RequestId: req-1 obj: { a: 1 }",
-    "WARN RequestId: req-1 keep %s literal",
-    "INFO RequestId: req-1 crlf: a\rb",
+    "INFO RequestId: req-log url: http://api.example.com/hello",
+    "INFO RequestId: req-log hi bob, you are 42",
+    'ERROR RequestId: req-log payload: {\r  "a": 1\r}',
+    "INFO RequestId: req-log obj: { a: 1 }",
+    "WARN RequestId: req-log keep %s literal",
+    "INFO RequestId: req-log crlf: a\rb",
   ]);
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("init error errorMessage is not wrapped in extra quotes", async () => {
+  // Sibling of #4826: formatError() used Bun.inspect on non-Error causes, so
+  // the runtime's own string diagnostics (e.g. "Function timed out") were sent
+  // to the Lambda error endpoint as "\"Function timed out\"".
+  const runtimeSource = await Bun.file(runtimePath).text();
+
+  using dir = tempDir("bun-lambda-init-error", {
+    "runtime.ts": runtimeSource,
+    // No `fetch` function: init() calls throwError("MethodDoesNotExist", <string>).
+    "handler.ts": `export default {};\n`,
+    "node_modules/aws4fetch/package.json": JSON.stringify({ name: "aws4fetch", version: "1.0.0", main: "index.js" }),
+    "node_modules/aws4fetch/index.js": aws4fetchStub,
+  });
+
+  const { promise: initError, resolve } = Promise.withResolvers<{ pathname: string; body: unknown }>();
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      resolve({ pathname: url.pathname, body: await req.json() });
+      return new Response(null, { status: 202 });
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "runtime.ts"],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      AWS_LAMBDA_RUNTIME_API: `localhost:${server.port}`,
+      _HANDLER: "handler.fetch",
+      LAMBDA_TASK_ROOT: String(dir),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const stdoutPromise = proc.stdout.text();
+  const stderrPromise = proc.stderr.text();
+  const exitedPromise = proc.exited;
+  const { pathname, body } = await initError;
+  const [stdout, stderr, exitCode] = await Promise.all([stdoutPromise, stderrPromise, exitedPromise]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ERROR handler does not have a default export with a function named 'fetch'\n");
+  expect({ pathname, body }).toEqual({
+    pathname: "/2018-06-01/runtime/init/error",
+    body: {
+      errorType: "Error",
+      errorMessage: "handler does not have a default export with a function named 'fetch'",
+    },
+  });
+  expect(exitCode).toBe(1);
 });


### PR DESCRIPTION
Fixes #4826.

## What

`packages/bun-lambda/runtime.ts` overrides `console.log` / `info` / `warn` / `error` / `debug` / `trace` to prepend a level and request id. It previously built the message with

```ts
const messages = args.map(arg => Bun.inspect(arg).replace(/\n/g, "\r"));
logger(level, `RequestId: ${requestId}`, ...messages);
```

`Bun.inspect("str")` wraps the string in quotes and escapes newlines, so inside a Lambda handler

```ts
console.log("url:", request.url);
console.error("payload:", JSON.stringify(obj, null, 2));
```

printed in CloudWatch as

```
INFO RequestId: ... "url:" "https://api.example.com/hello"
ERROR RequestId: ... "payload:" "{\n  \"a\": 1\n}"
```

The inspected strings were also spread back into the original `console.log`, which re-applied `%s`/`%d` substitution to the already-formatted output.

The same `Bun.inspect` call sat in `formatError()`'s non-`Error` branch, so the runtime's own string diagnostics (`"Function timed out"`, `"handler does not have a default export ..."`) were posted to the Lambda `/error` endpoint wrapped in extra quotes.

## Fix

Use `util.format(...args)` (what Node's own `console.log` uses) and pass the fully assembled line as a single argument to the captured logger:

```ts
const message = format(...args).replace(/\r?\n/g, "\r");
logger(`${level} RequestId: ${requestId} ${message}`);
```

String arguments now print unquoted, newlines inside string arguments survive (and are folded to `\r` so CloudWatch keeps one record per call, with CRLF treated as a single break), objects are inspected, and printf specifiers are handled once, the same as Node's Lambda runtime. `formatError()` now uses `format(error)` for the same reason, so there are no `Bun.inspect` callsites left in the layer.

After:

```
INFO RequestId: ... url: https://api.example.com/hello
ERROR RequestId: ... payload: {\r  "a": 1\r}
```

## Verification

Two new integration tests in `test/integration/bun-lambda/bun-lambda.test.ts` spin up a mock Lambda Runtime API and run the real `runtime.ts`:

- one drives a handler that calls `console.log`/`info`/`warn`/`error` with a mix of strings, printf specifiers, multi-line JSON, an object, and a CRLF string, and asserts the exact lines on stdout;
- one points `_HANDLER` at a module with no `fetch` export and asserts the `/runtime/init/error` body has `errorMessage` unquoted.

Both fail on main with the quoted/escaped output shown above and pass with this change. The existing authority test in the file is untouched apart from being marked `test.concurrent` alongside the new ones.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-lambda/bun-lambda.test.ts
bun test v1.4.0 (1e36aad1d)

test/integration/bun-lambda/bun-lambda.test.ts:
287 |   const exitedPromise = proc.exited;
288 |   const { pathname, body } = await initError;
289 |   const [stdout, stderr, exitCode] = await Promise.all([stdoutPromise, stderrPromise, exitedPromise]);
290 | 
291 |   expect(stderr).toBe("");
292 |   expect(stdout).toBe("ERROR handler does not have a default export with a function named 'fetch'\n");
                       ^
error: expect(received).toBe(expected)

- "ERROR handler does not have a default export with a function named 'fetch'
+ "ERROR "handler does not have a default export with a function named 'fetch'"
  "

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/integration/bun-lambda/bun-lambda.test.ts:292:18)
(fail) init error errorMessage is not wrapped in extra quotes [783.88ms]
230 |   expect(stderr).toBe("");
231 |   expect(result.unexpected).toBeUndefined();
232 |   // Lines from inside the invocation carry the RequestId 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/integration/bun-lambda/bun-lambda.test.ts:
230 |   expect(stderr).toBe("");
231 |   expect(result.unexpected).toBeUndefined();
232 |   // Lines from inside the invocation carry the RequestId prefix; the trailing
233 |   // ERROR line is the runtime shutting down after the mock server returns 500.
234 |   const lines = stdout.split("\n").filter(line => line.includes("RequestId: req-log"));
235 |   expect(lines).toEqual([
                      ^
error: expect(received).toEqual(expected)

  [
-   "INFO RequestId: req-log url: http://api.example.com/hello",
-   "INFO RequestId: req-log hi bob, you are 42",
+   "INFO RequestId: req-log "url:" "http://api.example.com/hello"",
+   "INFO RequestId: req-log "hi "bob", you are 42"",
+   "ERROR RequestId: req-log "payload:" "{\n  \"a\": 1\n}"",
    
- "ERROR RequestId: req-log payload: {
-   "a": 1
+ "INFO RequestId: req-log "obj:" {
+   a: 1,
  }"
  ,
-   "INFO RequestId: req-log obj: { a: 1 }",
-   "WARN RequestId: req-log keep %s literal",
-   
- "INFO RequestId: req-log crlf: a
- b"
- ,
+   "WARN RequestId: req-log "keep %s literal"",
+   "INFO RequestId: req-log "crlf:" "a\r\nb""
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-lambda/bun-lambda.test.ts
bun test v1.4.0 (1e36aad1d)

test/integration/bun-lambda/bun-lambda.test.ts:
(pass) init error errorMessage is not wrapped in extra quotes [1187.27ms]
(pass) console.log formats arguments like Node, not Bun.inspect per-arg [1401.61ms]
(pass) lambda HTTP events cannot override the request authority [1567.24ms]

 3 pass
 0 fail
 14 expect() calls
Ran 3 tests across 1 file. [4.36s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1e36aad1da
  features     baseline

22 deps, 108 codegen, 1170 objects in 1163ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [34.00ms]
[2/1233] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1233] gen bindgenv2
[4/1233] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [9.00ms]
[5/1233] gen ErrorCode+*.h
[6/1233] fetch zlib
[zlib] up to date
[7/1233] fetch picohttpparser
[picohttpparser] up to date
[8/1233] fetch tinycc
[tinycc] up to date
[9/1233] gen .bind.ts → GeneratedBindings.cpp
[10/1233] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1233] subst deps/zlib/zlib.h
[12/1233] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Pr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-lambda/runtime.ts                 |   9 +-
 test/integration/bun-lambda/bun-lambda.test.ts | 169 ++++++++++++++++++++++++-
 2 files changed, 173 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
packages/bun-lambda/runtime.ts                      9      8      0
test/integration/bun-lambda/bun-lambda.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->