### PR TITLE
tsconfig: stop forcing the Solid JSX runtime for jsxImportSource: "solid-js"

### DIFF
--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -480,11 +480,6 @@ impl TSConfigJSON {
             // Parse "jsxImportSource"
             if let Some(jsx_prop) = jsx_import_source_v {
                 if let Some(str) = jsx_prop.as_str() {
-                    if str.len() >= b"solid-js".len() && &str[..b"solid-js".len()] == b"solid-js" {
-                        result.jsx.runtime = options::jsx::Runtime::Solid;
-                        result.jsx_flags.insert(JsxField::Runtime);
-                    }
-
                     result.jsx.package_name = str.to_vec().into();
                     result.jsx.set_import_source();
                     result.jsx_flags.insert(JsxField::ImportSource);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2030,6 +2030,38 @@ export default <>hi</>
     expect(fragment.includes("var JSXFrag = foo.frag,")).toBe(true);
   });
 
+  // https://github.com/oven-sh/bun/issues/3528
+  describe('tsconfig jsxImportSource uses the automatic runtime for any package', () => {
+    for (const pkg of ["solid-js", "preact", "@emotion/react"]) {
+      it(`"${pkg}"`, async () => {
+        for (const tsconfig of [
+          { compilerOptions: { jsx: "react-jsx", jsxImportSource: pkg } },
+          JSON.stringify({ compilerOptions: { jsx: "react-jsx", jsxImportSource: pkg } }),
+        ]) {
+          const bun = new Bun.Transpiler({ loader: "tsx", autoImportJSX: true, tsconfig });
+          for (const out of [
+            bun.transformSync(`export default <div>hi</div>`),
+            await bun.transform(`export default <div>hi</div>`),
+          ]) {
+            expect(out).not.toContain("React.createElement");
+            expect(out).toContain(`"${pkg}/jsx-`);
+          }
+        }
+      });
+    }
+
+    it("does not require jsx to be set alongside jsxImportSource", () => {
+      const bun = new Bun.Transpiler({
+        loader: "tsx",
+        autoImportJSX: true,
+        tsconfig: { compilerOptions: { jsxImportSource: "solid-js" } },
+      });
+      const out = bun.transformSync(`export default <div>hi</div>`);
+      expect(out).not.toContain("React.createElement");
+      expect(out).toContain(`"solid-js/jsx-`);
+    });
+  });
+
   it('logLevel: "error" throws', () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2031,7 +2031,7 @@ export default <>hi</>
   });
 
   // https://github.com/oven-sh/bun/issues/3528
-  describe('tsconfig jsxImportSource uses the automatic runtime for any package', () => {
+  describe("tsconfig jsxImportSource uses the automatic runtime for any package", () => {
     for (const pkg of ["solid-js", "preact", "@emotion/react"]) {
       it(`"${pkg}"`, async () => {
         for (const tsconfig of [

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2032,33 +2032,28 @@ export default <>hi</>
 
   // https://github.com/oven-sh/bun/issues/3528
   describe("tsconfig jsxImportSource uses the automatic runtime for any package", () => {
+    const cases = [];
     for (const pkg of ["solid-js", "preact", "@emotion/react"]) {
-      it(`"${pkg}"`, async () => {
-        for (const tsconfig of [
-          { compilerOptions: { jsx: "react-jsx", jsxImportSource: pkg } },
-          JSON.stringify({ compilerOptions: { jsx: "react-jsx", jsxImportSource: pkg } }),
-        ]) {
-          const bun = new Bun.Transpiler({ loader: "tsx", autoImportJSX: true, tsconfig });
-          for (const out of [
-            bun.transformSync(`export default <div>hi</div>`),
-            await bun.transform(`export default <div>hi</div>`),
-          ]) {
-            expect(out).not.toContain("React.createElement");
-            expect(out).toContain(`"${pkg}/jsx-`);
-          }
+      for (const jsx of ["react-jsx", "unset"]) {
+        for (const form of ["object", "string"]) {
+          cases.push([pkg, jsx, form]);
         }
-      });
+      }
     }
 
-    it("does not require jsx to be set alongside jsxImportSource", () => {
-      const bun = new Bun.Transpiler({
-        loader: "tsx",
-        autoImportJSX: true,
-        tsconfig: { compilerOptions: { jsxImportSource: "solid-js" } },
-      });
-      const out = bun.transformSync(`export default <div>hi</div>`);
-      expect(out).not.toContain("React.createElement");
-      expect(out).toContain(`"solid-js/jsx-`);
+    it.each(cases)('"%s" (jsx: %s, tsconfig as %s)', async (pkg, jsx, form) => {
+      const compilerOptions = jsx === "unset" ? { jsxImportSource: pkg } : { jsx, jsxImportSource: pkg };
+      const tsconfig = form === "string" ? JSON.stringify({ compilerOptions }) : { compilerOptions };
+      const bun = new Bun.Transpiler({ loader: "tsx", autoImportJSX: true, tsconfig });
+      const input = `export default <div>hi</div>`;
+
+      for (const out of [bun.transformSync(input), await bun.transform(input)]) {
+        expect(out).not.toContain("React.createElement");
+        const runtime = out.match(/^import \{ (jsx|jsxDEV) as (\w+) \} from "(.+?)";/m);
+        expect(runtime).not.toBeNull();
+        expect(runtime[3]).toMatch(new RegExp(`^${pkg}/jsx-(dev-)?runtime$`));
+        expect(out).toContain(`${runtime[2]}("div"`);
+      }
     });
   });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2034,7 +2034,7 @@ export default <>hi</>
   describe("tsconfig jsxImportSource uses the automatic runtime for any package", () => {
     const cases = [];
     for (const pkg of ["solid-js", "preact", "@emotion/react"]) {
-      for (const jsx of ["react-jsx", "unset"]) {
+      for (const jsx of ["react-jsx", "preserve", "unset"]) {
         for (const form of ["object", "string"]) {
           cases.push([pkg, jsx, form]);
         }


### PR DESCRIPTION
Fixes #3528.

## Repro

```ts
const transpiler = new Bun.Transpiler({
  loader: "tsx",
  tsconfig: {
    compilerOptions: { jsx: "react-jsx", jsxImportSource: "solid-js" },
  },
});
console.log(transpiler.transformSync(`export default <div>hi</div>`));
```

```
// before
export default React.createElement("div", null, "hi");

// after
export default jsx_w77yafs4("div", { children: "hi" });
```

The same shape reproduces with `bun build` and a `tsconfig.json` on disk, and with the `{ jsx: "preserve", jsxImportSource: "solid-js" }` shape that SolidJS project templates ship.

## Cause

`TSConfigJSON::parse` special-cased `jsxImportSource` values that start with `"solid-js"` and set `jsx.runtime = Runtime::Solid`. The JSX visitor has no Solid path; it normalizes any non-`Automatic` runtime to `Classic` (`src/js_parser/visit/visit_expr.rs`), so the transform fell back to `React.createElement` regardless of the import source the user asked for. Every other `jsxImportSource` value (preact, @emotion/react, the `shim` package used in the existing test) already produced the automatic-runtime output.

## Fix

Drop the special case so `"solid-js"` is treated like any other `jsxImportSource`: the package name is recorded and `solid-js/jsx-runtime` / `solid-js/jsx-dev-runtime` are derived, with the runtime left to `compilerOptions.jsx`. This matches what TypeScript emits for the same options.

The `Runtime::Solid` enum variant itself is left in place (still reachable via `--jsx-runtime=solid` and bunfig `jsx: "solid"`); removing it is a separate change.

## Verification

New `it.each` block in `test/bundler/transpiler/transpiler.test.js` covers the 18-case matrix of `pkg ∈ {solid-js, preact, @emotion/react} × jsx ∈ {react-jsx, preserve, unset} × tsconfig ∈ {object, string}`, each driving both `transformSync` and async `transform`. Every case asserts that no `React.createElement` call is emitted and that the `import { jsx|jsxDEV as <alias> } from "<pkg>/jsx-(dev-)?runtime"` statement is present and the emitted call uses that alias. On `main` the six `solid-js` rows fail with `React.createElement`; with this change all 18 pass.

Regression sweep (no new failures): `test/bundler/transpiler/transpiler.test.js`, `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`, `test/bundler/bundler_jsx.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (2d918ac1a)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.97ms]
(pass) Bun.Transpiler > normalizes \r\n [10.09ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [7.20ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [12.80ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.92ms]
(pass) Bun.Transpiler > property access inlining > works [4.25ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.87ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [32.70ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [5.18ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [4.65ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [14.59ms]
(pass) Bun.Transpiler > TypeScript > context
... (truncated)

release without fix: 20 failed, 22 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.25ms]
(pass) Bun.Transpiler > normalizes \r\n [0.31ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.23ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.25ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.06ms]
(pass) Bun.Transpiler > property access inlining > works [0.05ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.05ms]
141 |     });
142 |     it("bails out on optional-chain index into enum", () => {
143 |       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
144 |       const lastLine = out => out.trimEnd().split("\n").at(-1);
145 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo["A"];', false))).toBe("export let y = 0 /* A */;");
146 |       expect(lastLine(ts.parsed(pre + 'export let y = Foo?.["A"];', false))).toBe('export let y = Foo?.["A"];');
                                                                                   ^
error: expect(received).toBe(expected)

Expected: "export let y = F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.0 (2d918ac1a)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [8.48ms]
(pass) Bun.Transpiler > normalizes \r\n [10.65ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [7.56ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [13.21ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.90ms]
(pass) Bun.Transpiler > property access inlining > works [4.75ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.92ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [34.77ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [5.57ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when parsing typescript fails [4.82ms]
(pass) Bun.Transpiler > TypeScript > reports Expected ":" for a conditional expression missing its colon [15.44ms]
(pass) Bun.Transpiler > TypeScript > context
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1033ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/tsconfig_json.rs              |  5 -----
 test/bundler/transpiler/transpiler.test.js | 27 +++++++++++++++++++++++++++
 2 files changed, 27 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/resolver/tsconfig_json.rs                   2      1      0
test/bundler/transpiler/transpiler.test.js      3      4      0
```

</details>

<!-- robobun:evidence:end -->