### PR TITLE
node:domain: return the callback's value from bind() and intercept()

### DIFF
--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -34,26 +34,49 @@ domain.createDomain = domain.create = function () {
     emitter.removeListener("error", emitError);
   };
   d.bind = function (fn) {
-    return function () {
-      var args = Array.prototype.slice.$call(arguments);
+    function runBound() {
+      d.enter();
       try {
-        fn.$apply(null, args);
+        return fn.$apply(this, arguments);
       } catch (err) {
         emitError(err);
+      } finally {
+        d.exit();
       }
-    };
+    }
+    ObjectDefineProperty(runBound, "domain", {
+      __proto__: null,
+      configurable: true,
+      enumerable: false,
+      value: d,
+      writable: true,
+    });
+    return runBound;
   };
   d.intercept = function (fn) {
-    return function (err) {
-      if (err) {
+    return function runIntercepted() {
+      var er = arguments[0];
+      if (er && er instanceof Error) {
+        er.domainBound = fn;
+        er.domainThrown = false;
+        ObjectDefineProperty(er, "domain", {
+          __proto__: null,
+          configurable: true,
+          enumerable: false,
+          value: d,
+          writable: true,
+        });
+        d.emit("error", er);
+        return;
+      }
+      var args = Array.prototype.slice.$call(arguments, 1);
+      d.enter();
+      try {
+        return fn.$apply(this, args);
+      } catch (err) {
         emitError(err);
-      } else {
-        var args = Array.prototype.slice.$call(arguments, 1);
-        try {
-          fn.$apply(null, args);
-        } catch (err) {
-          emitError(err);
-        }
+      } finally {
+        d.exit();
       }
     };
   };

--- a/src/js/node/domain.ts
+++ b/src/js/node/domain.ts
@@ -27,6 +27,21 @@ domain.createDomain = domain.create = function () {
     d.emit("error", e);
   }
 
+  // Node lets a throw from fn propagate and catches it later via
+  // process._fatalException's domain hook; Bun has no such hook yet, so the
+  // catch here stands in for it. The return value and `this` forwarding match
+  // Node exactly.
+  function runInDomain(thisArg, fn, args) {
+    d.enter();
+    try {
+      return fn.$apply(thisArg, args);
+    } catch (err) {
+      emitError(err);
+    } finally {
+      d.exit();
+    }
+  }
+
   d.add = function (emitter) {
     emitter.on("error", emitError);
   };
@@ -35,14 +50,7 @@ domain.createDomain = domain.create = function () {
   };
   d.bind = function (fn) {
     function runBound() {
-      d.enter();
-      try {
-        return fn.$apply(this, arguments);
-      } catch (err) {
-        emitError(err);
-      } finally {
-        d.exit();
-      }
+      return runInDomain(this, fn, arguments);
     }
     ObjectDefineProperty(runBound, "domain", {
       __proto__: null,
@@ -69,26 +77,11 @@ domain.createDomain = domain.create = function () {
         d.emit("error", er);
         return;
       }
-      var args = Array.prototype.slice.$call(arguments, 1);
-      d.enter();
-      try {
-        return fn.$apply(this, args);
-      } catch (err) {
-        emitError(err);
-      } finally {
-        d.exit();
-      }
+      return runInDomain(this, fn, Array.prototype.slice.$call(arguments, 1));
     };
   };
   d.run = function (fn, ...args) {
-    this.enter();
-    try {
-      return fn.$apply(this, args);
-    } catch (err) {
-      emitError(err);
-    } finally {
-      this.exit();
-    }
+    return runInDomain(this, fn, args);
   };
   d.dispose = function () {
     this.removeAllListeners();

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -35,20 +35,6 @@ describe("domain.bind()", () => {
     const bound = d.bind(() => {});
     expect((bound as any).domain).toBe(d);
   });
-
-  test("routes a thrown error to the domain's 'error' listener", () => {
-    const d = domain.create();
-    let caught;
-    d.on("error", (e: any) => {
-      caught = e;
-    });
-    const bound = d.bind(() => {
-      throw new Error("boom");
-    });
-    expect(bound()).toBeUndefined();
-    expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toBe("boom");
-  });
 });
 
 describe("domain.intercept()", () => {
@@ -99,10 +85,12 @@ describe("domain.intercept()", () => {
   test("makes the domain active while the callback runs", () => {
     const d = domain.create();
     let inside;
+    expect(process.domain == null).toBe(true);
     d.intercept(() => {
       inside = process.domain;
     })(null);
     expect(inside).toBe(d);
+    expect(process.domain == null).toBe(true);
   });
 });
 

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import domain from "node:domain";
 

--- a/test/js/node/domain/domain.test.ts
+++ b/test/js/node/domain/domain.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import domain from "node:domain";
+
+describe("domain.bind()", () => {
+  test("returns the callback's return value", () => {
+    const d = domain.create();
+    const bound = d.bind(() => 42);
+    expect(bound()).toBe(42);
+  });
+
+  test("forwards the caller's this and arguments", () => {
+    const d = domain.create();
+    const receiver = { tag: "rx" };
+    const bound = d.bind(function (this: any, a: number, b: number) {
+      return [this, a, b];
+    });
+    expect(bound.call(receiver, 1, 2)).toEqual([receiver, 1, 2]);
+  });
+
+  test("makes the domain active while the callback runs", () => {
+    const d = domain.create();
+    let inside;
+    const bound = d.bind(() => {
+      inside = process.domain;
+    });
+    expect(process.domain == null).toBe(true);
+    bound();
+    expect(inside).toBe(d);
+    expect(process.domain == null).toBe(true);
+  });
+
+  test("sets .domain on the returned function", () => {
+    const d = domain.create();
+    const bound = d.bind(() => {});
+    expect((bound as any).domain).toBe(d);
+  });
+
+  test("routes a thrown error to the domain's 'error' listener", () => {
+    const d = domain.create();
+    let caught;
+    d.on("error", (e: any) => {
+      caught = e;
+    });
+    const bound = d.bind(() => {
+      throw new Error("boom");
+    });
+    expect(bound()).toBeUndefined();
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("boom");
+  });
+});
+
+describe("domain.intercept()", () => {
+  test("returns the callback's return value", () => {
+    const d = domain.create();
+    const intercepted = d.intercept(() => 99);
+    expect(intercepted(null)).toBe(99);
+  });
+
+  test("drops the leading (error) argument before invoking the callback", () => {
+    const d = domain.create();
+    const receiver = { tag: "rx" };
+    const intercepted = d.intercept(function (this: any, ...args: unknown[]) {
+      return [this, ...args];
+    });
+    expect(intercepted.call(receiver, null, 1, 2)).toEqual([receiver, 1, 2]);
+  });
+
+  test("emits on the domain when the first argument is an Error", () => {
+    const d = domain.create();
+    let caught: any;
+    d.on("error", (e: any) => {
+      caught = e;
+    });
+    const fn = (..._args: unknown[]) => {
+      throw new Error("should not run");
+    };
+    const intercepted = d.intercept(fn);
+    const err = new Error("boom");
+    expect(intercepted(err, 1, 2)).toBeUndefined();
+    expect(caught).toBe(err);
+    expect(caught.domain).toBe(d);
+    expect(caught.domainBound).toBe(fn);
+    expect(caught.domainThrown).toBe(false);
+  });
+
+  test("does not treat a truthy non-Error first argument as an error", () => {
+    const d = domain.create();
+    let caught;
+    d.on("error", (e: any) => {
+      caught = e;
+    });
+    const intercepted = d.intercept((...args: unknown[]) => args);
+    expect(intercepted("not-an-error", 1, 2)).toEqual([1, 2]);
+    expect(caught).toBeUndefined();
+  });
+
+  test("makes the domain active while the callback runs", () => {
+    const d = domain.create();
+    let inside;
+    d.intercept(() => {
+      inside = process.domain;
+    })(null);
+    expect(inside).toBe(d);
+  });
+});
+
+describe("domain.run()", () => {
+  test("returns the callback's return value and forwards arguments", () => {
+    const d = domain.create();
+    expect(
+      d.run(function (this: any, a: string) {
+        return [this === d, a];
+      }, "x"),
+    ).toEqual([true, "x"]);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/5923
+// https://github.com/oven-sh/bun/issues/24287
+// gulp's async-done wraps each task via d.bind(task) and inspects the return
+// value to decide whether it got a promise/stream/observable back. When bind()
+// dropped the return value the promise was never awaited and gulp reported
+// "Did you forget to signal async completion?".
+test.concurrent("async-done style: d.bind(fn)() surfaces a returned promise", async () => {
+  const src = `
+    const domain = require("node:domain");
+
+    function asyncDone(fn, cb) {
+      const d = domain.create();
+      d.once("error", cb);
+      const bound = d.bind(fn);
+      const result = bound(cb);
+      if (result && typeof result.then === "function") {
+        result.then(r => cb(null, r), cb);
+      }
+    }
+
+    asyncDone(
+      () => Promise.resolve("task-value"),
+      (err, res) => {
+        if (err) {
+          console.log("ERR", err && err.message);
+        } else {
+          console.log("DONE", res);
+        }
+      },
+    );
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("DONE task-value");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What does this PR do?

`d.bind(fn)` and `d.intercept(fn)` returned wrappers that called `fn` but dropped its return value (and invoked it with `this === null` instead of the caller's receiver).

gulp's [`async-done`](https://github.com/gulpjs/async-done/blob/v1.3.2/index.js#L35-L80) wraps every task via `d.bind(task)` and inspects the return value to decide whether it got back a promise, stream, or observable. Because `bind()` swallowed the return value, the task's promise was never awaited and gulp immediately reported:

```
[20:30:03] Starting 'clean'...
[20:30:03] The following tasks did not complete: default, clean
[20:30:03] Did you forget to signal async completion?
```

## Fix

Both wrappers now match Node for the pieces `async-done` depends on:

- enter/exit the domain around the call
- forward the caller's `this` and arguments
- **return** the callback's result
- `bind()` sets `.domain` on the returned function
- `intercept()` only diverts to the domain's `'error'` listener when the first argument is an `Error` instance (previously any truthy value), and tags the error with `domainBound` / `domainThrown` / `domain` the way Node does

The enter/apply/exit body is now a single `runInDomain()` helper that `bind`, `intercept`, and `run` all delegate to. The helper still catches a synchronous throw and routes it to the domain's `'error'` listener; Node lets the throw propagate and catches it later via the `process._fatalException` domain hook, which Bun does not have yet. That is pre-existing shim behaviour and outside the scope of this change.

## How did you verify your code works?

`test/js/node/domain/domain.test.ts` covers the return value, receiver forwarding, active-domain-during-call, `.domain` property, the `Error`-vs-truthy intercept branch, and an `async-done`-shaped integration case. Every assertion was cross-checked against Node v26.3.0.

With a gulp 4 project (`gulp.series(del, gulp.src().pipe(gulp.dest()))`):

```
# before
$ bun --bun x gulp
[..] The following tasks did not complete: default, clean
[..] Did you forget to signal async completion?

# after
$ bun-debug --bun x gulp
[..] Finished 'clean' after 503 ms
[..] Finished 'copy' after 1.51 s
[..] Finished 'default' after 2.08 s
```

Fixes #5923
Fixes #24287

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domain/domain.test.ts
bun test v1.4.0 (c4e09f268)

test/js/node/domain/domain.test.ts:
4 | 
5 | describe("domain.bind()", () => {
6 |   test("returns the callback's return value", () => {
7 |     const d = domain.create();
8 |     const bound = d.bind(() => 42);
9 |     expect(bound()).toBe(42);
                        ^
error: expect(received).toBe(expected)

Expected: 42
Received: undefined

      at <anonymous> (/workspace/bun/test/js/node/domain/domain.test.ts:9:21)
(fail) domain.bind() > returns the callback's return value [136.88ms]
13 |     const d = domain.create();
14 |     const receiver = { tag: "rx" };
15 |     const bound = d.bind(function (this: any, a: number, b: number) {
16 |       return [this, a, b];
17 |     });
18 |     expect(bound.call(receiver, 1, 2)).toEqual([receiver, 1, 2]);
                                            ^
error: expect(received).toEqual(expected)

- [
-   {
-     "tag": "rx",
-   },
-   1,
-   2,
- ]
+ undefined

- Expected  - 7
+ Received  + 1

      at <anonymous> (/workspace/bun
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/domain/domain.test.ts:
4 | 
5 | describe("domain.bind()", () => {
6 |   test("returns the callback's return value", () => {
7 |     const d = domain.create();
8 |     const bound = d.bind(() => 42);
9 |     expect(bound()).toBe(42);
                        ^
error: expect(received).toBe(expected)

Expected: 42
Received: undefined

      at <anonymous> (/workspace/bun/test/js/node/domain/domain.test.ts:9:21)
(fail) domain.bind() > returns the callback's return value [0.56ms]
13 |     const d = domain.create();
14 |     const receiver = { tag: "rx" };
15 |     const bound = d.bind(function (this: any, a: number, b: number) {
16 |       return [this, a, b];
17 |     });
18 |     expect(bound.call(receiver, 1, 2)).toEqual([receiver, 1, 2]);
                                            ^
error: expect(received).toEqual(expected)

- [
-   {
-     "tag": "rx",
-   },
-   1,
-   2,
- ]
+ undefined

- Expected  - 7
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/domain/domain.test.ts:18:40)
(fail) domain.bind() > forwards the caller's this and arguments [0.36ms]
24 |     const bound = d.bind(() => {
25 |   
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/domain/domain.test.ts
bun test v1.4.0 (c4e09f268)

test/js/node/domain/domain.test.ts:
(pass) domain.bind() > returns the callback's return value [42.61ms]
(pass) domain.bind() > forwards the caller's this and arguments [9.52ms]
(pass) domain.bind() > makes the domain active while the callback runs [9.35ms]
(pass) domain.bind() > sets .domain on the returned function [3.76ms]
(pass) domain.intercept() > returns the callback's return value [11.28ms]
(pass) domain.intercept() > drops the leading (error) argument before invoking the callback [6.63ms]
(pass) domain.intercept() > emits on the domain when the first argument is an Error [22.51ms]
(pass) domain.intercept() > does not treat a truthy non-Error first argument as an error [7.22ms]
(pass) domain.intercept() > makes the domain active while the callback runs [8.90ms]
(pass) domain.run() > returns the callback's return value and forwards arguments [9.59ms]
(pass) async-done style: d.bind(fn)() surfaces a returned promise [739.41ms]

 11 pass
 0 fail
 22 expect() calls
Ran
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 998ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (12842ms)
Bundle modules (80ms)
Postprocesss modules (184ms)
Bundle Functions (1010ms)
Generate Code (34ms)

[14.17s] Bundled "src/js" for production
  2113 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 10s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+c4e09f268
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (c4e09f268)

test/js/node/domain/domain.test.ts:
(pass) domain.bind() > returns the callback's return value [1.68ms]
(pass) domain.bind() > forwards the caller's this and arguments [0.12ms]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/domain.ts              |  68 ++++++++++-------
 test/js/node/domain/domain.test.ts | 150 +++++++++++++++++++++++++++++++++++++
 2 files changed, 192 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/js/node/domain.ts                   2      2      0
test/js/node/domain/domain.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->