### PR TITLE
resolver: hint at tsconfig paths / Bun.plugin when a $-prefixed or ~/ import fails to resolve

### DIFF
--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -150,9 +150,10 @@ impl ResolveMessage {
         Box::new([bun_ast::range_data(
             None,
             bun_ast::Range::NONE,
-            b"This looks like a path alias. Bun does not read vite.config.js; \
-              configure the alias in tsconfig.json \"paths\", or register it with \
-              Bun.plugin / mock.module.",
+            b"This looks like a path alias. Bun's resolver does not read bundler \
+              config (vite.config.*, svelte.config.*, nuxt.config.*). Check the \
+              alias is under \"paths\" in tsconfig.json or jsconfig.json and that \
+              its target exists, or register it with Bun.plugin / mock.module.",
         )])
     }
 

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -130,6 +130,34 @@ impl ResolveMessage {
         Ok(JSValue::from(0_i32))
     }
 
+    /// A follow-up note for ModuleNotFound when the specifier looks like a
+    /// framework/bundler path alias (e.g. SvelteKit's `$app/*`, Nuxt's `~/*`).
+    /// These are commonly set up by a Vite plugin rather than tsconfig `paths`,
+    /// so Bun's resolver (and Node's) cannot see them.
+    pub fn notes_for_module_not_found(specifier: &[u8]) -> Box<[bun_ast::Data]> {
+        let looks_like_alias = match specifier.first() {
+            // `$` is not a valid leading byte for an npm package name, so any
+            // `$...` specifier that reached ModuleNotFound is almost certainly
+            // a path alias (SvelteKit uses `$app/*`, `$env/*`, `$lib/*`).
+            Some(b'$') => true,
+            // `~/` and `~~/` are Nuxt/Vite conventions for srcDir/rootDir.
+            Some(b'~') => {
+                matches!(specifier.get(1), Some(b'/')) || specifier.starts_with(b"~~/")
+            }
+            _ => false,
+        };
+        if !looks_like_alias {
+            return Box::default();
+        }
+        Box::new([bun_ast::range_data(
+            None,
+            bun_ast::Range::NONE,
+            b"This looks like a path alias. Bun does not read vite.config.js; \
+              configure the alias in tsconfig.json \"paths\", or register it with \
+              Bun.plugin / mock.module.",
+        )])
+    }
+
     pub fn fmt(
         specifier: &[u8],
         referrer: &[u8],

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -141,9 +141,7 @@ impl ResolveMessage {
             // a path alias (SvelteKit uses `$app/*`, `$env/*`, `$lib/*`).
             Some(b'$') => true,
             // `~/` and `~~/` are Nuxt/Vite conventions for srcDir/rootDir.
-            Some(b'~') => {
-                matches!(specifier.get(1), Some(b'/')) || specifier.starts_with(b"~~/")
-            }
+            Some(b'~') => matches!(specifier.get(1), Some(b'/')) || specifier.starts_with(b"~~/"),
             _ => false,
         };
         if !looks_like_alias {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4356,6 +4356,9 @@ impl VirtualMachine {
                             import_kind,
                             err: bun_ast::Error::ModuleNotFound,
                         }),
+                        notes: crate::ResolveMessage::notes_for_module_not_found(
+                            specifier_utf8.slice(),
+                        ),
                         ..Default::default()
                     }
                 });

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5225,6 +5225,7 @@ unsafe fn resolve_hook(
                     import_kind,
                     err: bun_ast::Error::ModuleNotFound,
                 }),
+                notes: ResolveMessage::notes_for_module_not_found(specifier_utf8.slice()),
                 ..Default::default()
             }
         };

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -110,7 +110,7 @@ describe("ResolveMessage", () => {
   // are bundler aliases usually configured in vite.config.js, which Bun's
   // resolver does not read. The error should carry a note pointing at
   // tsconfig paths / Bun.plugin so people aren't left guessing.
-  describe("path-alias hint on ModuleNotFound", () => {
+  describe.concurrent("path-alias hint on ModuleNotFound", () => {
     const hint = "This looks like a path alias";
 
     it.each(["$app/environment", "$env/dynamic/private", "~/components/Foo", "~~/server/util"])(
@@ -126,7 +126,7 @@ describe("ResolveMessage", () => {
         expect(stdout).toBe("");
         expect(stderr).toContain(`Cannot find module '${specifier}'`);
         expect(stderr).toContain(hint);
-        expect(stderr).toContain('tsconfig.json "paths"');
+        expect(stderr).toContain("tsconfig.json or jsconfig.json");
         expect(exitCode).toBe(1);
       },
     );

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -122,11 +122,7 @@ describe("ResolveMessage", () => {
           stderr: "pipe",
           stdout: "pipe",
         });
-        const [stdout, stderr, exitCode] = await Promise.all([
-          proc.stdout.text(),
-          proc.stderr.text(),
-          proc.exited,
-        ]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect(stdout).toBe("");
         expect(stderr).toContain(`Cannot find module '${specifier}'`);
         expect(stderr).toContain(hint);
@@ -144,11 +140,7 @@ describe("ResolveMessage", () => {
           stderr: "pipe",
           stdout: "pipe",
         });
-        const [stdout, stderr, exitCode] = await Promise.all([
-          proc.stdout.text(),
-          proc.stderr.text(),
-          proc.exited,
-        ]);
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect(stdout).toBe("");
         expect(stderr).not.toContain(hint);
         expect(exitCode).toBe(1);

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -106,6 +106,68 @@ describe("ResolveMessage", () => {
     expect(log.specifier).toBe("./na\u00efve-missing.js");
   });
 
+  // #5541 / #10712 — `$app/*`, `$env/*` (SvelteKit) and `~/`, `~~/` (Nuxt)
+  // are bundler aliases usually configured in vite.config.js, which Bun's
+  // resolver does not read. The error should carry a note pointing at
+  // tsconfig paths / Bun.plugin so people aren't left guessing.
+  describe("path-alias hint on ModuleNotFound", () => {
+    const hint = "This looks like a path alias";
+
+    it.each(["$app/environment", "$env/dynamic/private", "~/components/Foo", "~~/server/util"])(
+      "prints a note for '%s'",
+      async specifier => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", `await import(${JSON.stringify(specifier)})`],
+          env: bunEnv,
+          stderr: "pipe",
+          stdout: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          proc.stdout.text(),
+          proc.stderr.text(),
+          proc.exited,
+        ]);
+        expect(stdout).toBe("");
+        expect(stderr).toContain(`Cannot find module '${specifier}'`);
+        expect(stderr).toContain(hint);
+        expect(stderr).toContain('tsconfig.json "paths"');
+        expect(exitCode).toBe(1);
+      },
+    );
+
+    it.each(["totally-nonexistent-xyz-pkg", "~something", "./local-missing.ts", "@scope/missing"])(
+      "does NOT print a note for '%s'",
+      async specifier => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", `await import(${JSON.stringify(specifier)})`],
+          env: bunEnv,
+          stderr: "pipe",
+          stdout: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([
+          proc.stdout.text(),
+          proc.stderr.text(),
+          proc.exited,
+        ]);
+        expect(stdout).toBe("");
+        expect(stderr).not.toContain(hint);
+        expect(exitCode).toBe(1);
+      },
+    );
+
+    it("note is not part of .message", async () => {
+      let err: any;
+      try {
+        await import("$app/environment");
+        expect.unreachable();
+      } catch (e) {
+        err = e;
+      }
+      expect(err.message).toContain("Cannot find module '$app/environment'");
+      expect(err.message).not.toContain(hint);
+    });
+  });
+
   it("invalid data URL import", async () => {
     expect(async () => {
       // @ts-ignore


### PR DESCRIPTION
## What

When `bun` / `bun test` fails to resolve a specifier that starts with `$` (SvelteKit's `$app/*`, `$env/*`, `$lib/*`, ...) or `~/` / `~~/` (Nuxt), it now prints a follow-up note:

```
error: Cannot find module '$app/environment' from '/.../src/index.test.js'

note: This looks like a path alias. Bun's resolver does not read bundler config (vite.config.*, svelte.config.*, nuxt.config.*). Check the alias is under "paths" in tsconfig.json or jsconfig.json and that its target exists, or register it with Bun.plugin / mock.module.
```

The note is attached via `Msg.notes` and only affects the printed diagnostic; `e.message`, `e.code`, `e.specifier`, etc. are unchanged.

## Why

`$app/*` and friends are aliases set up by a framework's Vite plugin. Bun's runtime resolver follows Node resolution + tsconfig/jsconfig `paths` and does not read `vite.config.js` (Node can't resolve these either), so resolution legitimately fails. But the bare `Cannot find module '$app/environment'` leaves people thinking Bun is broken; #5541 and #10712 have been open since 2023 with steady "me too"s, and the [working remedies](https://github.com/oven-sh/bun/issues/5541#issuecomment-2009374200) (tsconfig `paths`, `Bun.plugin`, `mock.module`) aren't discoverable from the error.

A `$`-prefixed specifier is never a valid npm package name, so ModuleNotFound on one is almost certainly a path alias. `~/` and `~~/` are narrow enough to be safe (bare `~foo` is not matched).

Making these imports work out of the box would mean either running the Vite plugin or hard-coding per-framework aliases (fragile, and SvelteKit's `$app/*` modules also depend on Vite `define`s, so an alias alone doesn't make them run). A diagnostic note is the honest fix.

## How

`ResolveMessage::notes_for_module_not_found(specifier)` returns a one-element `notes` array for matching prefixes and `Box::default()` otherwise. The two runtime resolve-error call sites (`VirtualMachine::resolve_maybe_needs_trailing_slash` and the module-loader hook in `jsc_hooks.rs`) populate `Msg.notes` from it.

The note deliberately:
- names several bundler configs (vite/svelte/nuxt.config.*) rather than only `vite.config.js`, since the `~/` branch targets Nuxt projects that have no `vite.config.js`;
- mentions `jsconfig.json` as well as `tsconfig.json` (the #5541 repro is a JS SvelteKit template);
- says "check the alias is under paths and that its target exists" rather than "add it", because the note also fires when a `$lib/*` mapping already exists but the target file is missing.

## Tests

`test/js/bun/resolve/resolve-error.test.ts` gains a `path-alias hint on ModuleNotFound` block: four positive cases, four negative cases, and a check that `.message` is untouched.

Refs #5541, #10712.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->