### PR TITLE
resolver: apply the module/main auto-fallback to jsnext:main

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5530,7 +5530,7 @@ impl<'a> Resolver<'a> {
                                 if let Some(debug) = self.debug_logs.as_mut() {
                                     debug.add_note_fmt(format_args!(
                                         "Resolved to \"{}\" using the \"{}\" field in \"{}\"",
-                                        bstr::BStr::new(auto_main_result.path_pair.primary.text()),
+                                        bstr::BStr::new(out.path_pair.primary.text()),
                                         bstr::BStr::new(key),
                                         bstr::BStr::new(pkg_json.source.path.text)
                                     ));

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5557,9 +5557,8 @@ impl<'a> Resolver<'a> {
                             } else {
                                 if let Some(debug) = self.debug_logs.as_mut() {
                                     debug.add_note_fmt(format_args!(
-                                        "Resolved to \"{}\" using the \"{}\" field in \"{}\"",
+                                        "Resolved to \"{}\" using the \"main\" field in \"{}\"",
                                         bstr::BStr::new(auto_main_result.path_pair.primary.text()),
-                                        bstr::BStr::new(key),
                                         bstr::BStr::new(pkg_json.source.path.text)
                                     ));
                                 }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -5478,7 +5478,13 @@ impl<'a> Resolver<'a> {
                     // use a special per-module automatic algorithm to decide whether to
                     // use "module" or "main" based on whether the package is imported
                     // using "import" or "require".
-                    if auto_main && key == b"module" {
+                    //
+                    // "jsnext:main" is the historical name for "module" (same semantics:
+                    // an ESM entry point) and is in the browser default main-field list,
+                    // so it needs the same fallback or `require("pkg")` on a package
+                    // that only has `jsnext:main` + `main` (e.g. moment) resolves to the
+                    // ESM file and hands back `{ default }` instead of the CJS export.
+                    if auto_main && (key == b"module" || key == b"jsnext:main") {
                         let mut auto_main_result = MatchResult::default();
                         let mut auto_main_found = false;
 
@@ -5523,8 +5529,9 @@ impl<'a> Resolver<'a> {
                             if self.prefer_module_field && kind != ast::ImportKind::Require {
                                 if let Some(debug) = self.debug_logs.as_mut() {
                                     debug.add_note_fmt(format_args!(
-                                        "Resolved to \"{}\" using the \"module\" field in \"{}\"",
+                                        "Resolved to \"{}\" using the \"{}\" field in \"{}\"",
                                         bstr::BStr::new(auto_main_result.path_pair.primary.text()),
+                                        bstr::BStr::new(key),
                                         bstr::BStr::new(pkg_json.source.path.text)
                                     ));
                                     debug.add_note_fmt(format_args!(

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -990,6 +990,90 @@ describe("bundler", () => {
       stdout: "true",
     },
   });
+  itBundled("packagejson/DualPackageHazardJsnextMainRequireOnly", {
+    // https://github.com/oven-sh/bun/issues/5004
+    // "jsnext:main" is the historical name for "module" and is in Bun's
+    // browser default main-field list, so it needs the same require/import
+    // fallback that "module" gets.
+    files: {
+      "/Users/user/project/src/entry.js": `console.log(require('demo-pkg'))`,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "jsnext:main": "./module.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = 'main'`,
+      "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
+    },
+    run: {
+      stdout: "main",
+    },
+  });
+  itBundled("packagejson/DualPackageHazardJsnextMainImportOnly", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg'
+        console.log(value)
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "jsnext:main": "./module.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = 'main'`,
+      "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
+    },
+    run: {
+      stdout: "module",
+    },
+  });
+  itBundled("packagejson/DualPackageHazardJsnextMainImportAndRequireSameFile", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import value from 'demo-pkg'
+        console.log(value, require('demo-pkg'))
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "jsnext:main": "./module.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": `module.exports = 'main'`,
+      "/Users/user/project/node_modules/demo-pkg/module.js": `export default 'module'`,
+    },
+    run: {
+      stdout: "main main",
+    },
+  });
+  itBundled("packagejson/DualPackageHazardJsnextMainRequireFunction", {
+    // https://github.com/oven-sh/bun/issues/5004 — the exact moment.js shape:
+    // CJS entry exports a function, ESM entry `export default`s a function.
+    // require() must get the callable, not `{ default: [Function] }`.
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        const demo = require('demo-pkg');
+        console.log(typeof demo, demo());
+      `,
+      "/Users/user/project/node_modules/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "jsnext:main": "./dist/module.js"
+        }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/main.js": /* js */ `
+        module.exports = function demo() { return 'main' }
+      `,
+      "/Users/user/project/node_modules/demo-pkg/dist/module.js": /* js */ `
+        export default function demo() { return 'module' }
+      `,
+    },
+    run: {
+      stdout: "function main",
+    },
+  });
   itBundled("packagejson/DualPackageHazardModuleFieldNoMainField", {
     files: {
       "/Users/user/project/src/entry.js": /* js */ `


### PR DESCRIPTION
Fixes #5004.

## Repro

`moment`'s package.json has `main` (CJS UMD) and `jsnext:main` (ESM, `export default hooks`), but no `module` field:

```js
// index.js
const moment = require('moment');
console.log(moment().add(5, 'minutes'));
```

```
$ bun build index.js --target browser --outdir dist && bun dist/index.js
TypeError: moment is not a function. (In 'moment()', 'moment' is an instance of Object)
```

The bundle resolved `moment` to `node_modules/moment/dist/moment.js` and the `require()` lowering produced `(init_moment(), __toCommonJS(exports_moment))`, handing back `{ default: [Function], __esModule: true }` instead of the function.

## Cause

The browser target's default main-field order is `["browser", "module", "jsnext:main", "main"]`. moment has no `browser` or `module`, so iteration reaches `jsnext:main` first and resolves to the ESM entry.

For the default main-field order the resolver runs an `auto_main` heuristic: when the winning key is `module` and a `main` also exists, it records the `main` file as the CJS fallback and uses it whenever the import kind is `require` (same behavior as esbuild). The guard was a literal `key == b"module"`, so packages that publish the older `jsnext:main` spelling (which means exactly the same thing) never entered the fallback and `require()` was stuck with the ESM file. esbuild does not ship `jsnext:main` in its defaults at all, which is why it picks `main` here.

## Fix

Match `jsnext:main` in the `auto_main` guard so it gets the same `require → main` fallback as `module`. With the fix:

- `require('moment')` → `node_modules/moment/moment.js` (CJS), callable
- `import moment from 'moment'` → `node_modules/moment/dist/moment.js` (ESM), unchanged
- mixed import + require in the same graph → both resolve to `moment.js`, identical reference (`momentImp === momentReq`), no dual-package hazard

`--target bun` and `--target node` are unaffected since their default orderings list `main` before `jsnext:main`.

## Verification

Four new `DualPackageHazardJsnextMain*` cases in `test/bundler/esbuild/packagejson.test.ts` alongside the existing `module`-based dual-package tests. Three of the four (RequireOnly, ImportAndRequireSameFile, RequireFunction) throw on the system bun and pass on this build; the full `packagejson.test.ts` suite stays green (78 pass, 9 pre-existing todo).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 9 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/packagejson.test.ts
bun test v1.4.0 (f25c9dade)

test/bundler/esbuild/packagejson.test.ts:
(pass) bundler > packagejson/Main [877.39ms]
(pass) bundler > packagejson/trailing-comma [407.70ms]
(pass) bundler > packagejson/BadMain [412.24ms]
(pass) bundler > packagejson/Module [392.66ms]
(pass) bundler > packagejson/BrowserString [398.91ms]
(pass) bundler > packagejson/BrowserMapRelativeToRelative [403.26ms]
(pass) bundler > packagejson/BrowserMapRelativeToModule [409.01ms]
(pass) bundler > packagejson/BrowserMapRelativeDisabled [488.31ms]
(pass) bundler > packagejson/BrowserMapModuleToRelative [417.62ms]
(pass) bundler > packagejson/BrowserMapModuleToModule [467.73ms]
(todo) bundler > packagejson/BrowserMapModuleDisabled
(pass) bundler > packagejson/BrowserMapNativeModuleDisabled [428.45ms]
(pass) bundler > packagejson/BrowserMapAvoidMissing [498.18ms]
(pass) bundler > packagejson/BrowserOverModuleBrowser [734.83ms]
(pass) bundler > packagejson/BrowserOverMainNode [430.18ms]
(pass) bundler > packagejson/BrowserWithMo
... (truncated)

release without fix: 3 failed, 9 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/esbuild/packagejson.test.ts:
(pass) bundler > packagejson/Main [47.47ms]
(pass) bundler > packagejson/trailing-comma [19.22ms]
(pass) bundler > packagejson/BadMain [22.19ms]
(pass) bundler > packagejson/Module [63.18ms]
(pass) bundler > packagejson/BrowserString [20.58ms]
(pass) bundler > packagejson/BrowserMapRelativeToRelative [19.94ms]
(pass) bundler > packagejson/BrowserMapRelativeToModule [41.29ms]
(pass) bundler > packagejson/BrowserMapRelativeDisabled [21.20ms]
(pass) bundler > packagejson/BrowserMapModuleToRelative [65.08ms]
(pass) bundler > packagejson/BrowserMapModuleToModule [21.55ms]
(todo) bundler > packagejson/BrowserMapModuleDisabled
(pass) bundler > packagejson/BrowserMapNativeModuleDisabled [18.88ms]
(pass) bundler > packagejson/BrowserMapAvoidMissing [19.70ms]
(pass) bundler > packagejson/BrowserOverModuleBrowser [20.93ms]
(pass) bundler > packagejson/BrowserOverMainNode [23.64ms]
(pass) bundler > packagejson/BrowserWithModuleBrowser [46.84ms]
(pass) bundler > packagejson/BrowserWithMainNode [20.83ms]
(todo) bundler > packagejson/BrowserNodeModulesNoExt
(todo) bundler > packagejson/BrowserNodeModul
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 9 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/esbuild/packagejson.test.ts
bun test v1.4.0 (f25c9dade)

test/bundler/esbuild/packagejson.test.ts:
(pass) bundler > packagejson/Main [803.78ms]
(pass) bundler > packagejson/trailing-comma [409.29ms]
(pass) bundler > packagejson/BadMain [392.73ms]
(pass) bundler > packagejson/Module [366.87ms]
(pass) bundler > packagejson/BrowserString [381.14ms]
(pass) bundler > packagejson/BrowserMapRelativeToRelative [395.54ms]
(pass) bundler > packagejson/BrowserMapRelativeToModule [405.44ms]
(pass) bundler > packagejson/BrowserMapRelativeDisabled [407.63ms]
(pass) bundler > packagejson/BrowserMapModuleToRelative [412.81ms]
(pass) bundler > packagejson/BrowserMapModuleToModule [429.81ms]
(todo) bundler > packagejson/BrowserMapModuleDisabled
(pass) bundler > packagejson/BrowserMapNativeModuleDisabled [404.56ms]
(pass) bundler > packagejson/BrowserMapAvoidMissing [399.45ms]
(pass) bundler > packagejson/BrowserOverModuleBrowser [409.33ms]
(pass) bundler > packagejson/BrowserOverMainNode [727.33ms]
(pass) bundler > packagejson/BrowserWithMo
... (truncated)

release with fix: 9 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 813ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/3] link bun-profile
[1/3] bun-profile --revision
1.4.0-canary.1+f25c9dade
[3/3] strip bun
[build] done
bun test v1.4.0-canary.1 (f25c9dade)

test/bundler/esbuild/packagejson.test.ts:
(pass) bundler > packagejson/Main [23.48ms]
(pass) bundler > packagejson/trailing-comma [12.41ms]
(pass) bundler > packagejson/BadMain [11.79ms]
(pass) bundler > packagejson/Module [10.90ms]
(pass) bundler > packagejson/BrowserString [11.32ms]
(pass) bundler > packagejson/BrowserMapRelativeToRelative [13.18ms]
(pass) bundler > packagejson/BrowserMapRelativeToModule [13.23ms]
(pass) bundler > packagejson/BrowserMapRelativeDisabled [15.47ms]
(pass) bundler > packagejson/BrowserMapModuleToRelative [15.74ms]
(pass) bundler > packagejson/BrowserMapModuleToModule [14.10ms]
(todo) bundler > packagejson/BrowserMapModuleDisabled
(pass) bundler > packagejson/BrowserMapNativeModuleDisabled [12.63ms]
(pass) bundler > packagejson/BrowserMapAvoidMissing [13.07ms]
(pass) bundler > packagejson/BrowserOverModuleBrowser [15.47ms]
(pass) bund
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/resolver/resolver.rs                 | 16 ++++--
 test/bundler/esbuild/packagejson.test.ts | 84 ++++++++++++++++++++++++++++++++
 2 files changed, 95 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/resolver/resolver.rs                      4      4      0
test/bundler/esbuild/packagejson.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->