### PR TITLE
node-fetch: route through node:http when an agent is supplied

### DIFF
--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -184,18 +184,25 @@ function fetchWithAgent(url, init, counter) {
     let agent = init.agent;
     if ($isCallable(agent)) agent = agent.$call(undefined, parsed);
 
-    const method = (init.method || (url instanceof WebRequest && url.method) || "GET").toUpperCase();
+    const isWebRequest = url instanceof WebRequest;
+    const method = (init.method || (isWebRequest && url.method) || "GET").toUpperCase();
     const compress = init.compress !== false;
-    const redirect = init.redirect || "follow";
+    const redirect = init.redirect || (isWebRequest && url.redirect) || "follow";
     const follow = typeof init.follow === "number" ? init.follow : FOLLOW_MAX_DEFAULT;
-    const signal = init.signal;
+    const signal = init.signal ?? (isWebRequest ? url.signal : undefined);
+    if (signal?.aborted) {
+      const err: any = new DOMException("The operation was aborted.", "AbortError");
+      err.type = "aborted";
+      reject(err);
+      return;
+    }
 
-    const headers = new Headers(init.headers || (url instanceof WebRequest && url.headers) || undefined);
+    const headers = new Headers(init.headers || (isWebRequest && url.headers) || undefined);
     if (!headers.has("accept")) headers.set("accept", "*/*");
     if (compress && !headers.has("accept-encoding")) headers.set("accept-encoding", "gzip, deflate, br");
     if (!headers.has("connection") && !agent) headers.set("connection", "close");
 
-    let body = init.body ?? (url instanceof WebRequest ? url.body : null);
+    let body = init.body ?? (isWebRequest ? url.body : null);
     if (body != null && (method === "GET" || method === "HEAD")) {
       reject(new TypeError("Request with GET/HEAD method cannot have body"));
       return;
@@ -241,6 +248,14 @@ function fetchWithAgent(url, init, counter) {
     const removeAbort = () => {
       if (signal) signal.removeEventListener("abort", onAbort);
     };
+    const failRequest = err => {
+      if (settled) return;
+      settled = true;
+      removeAbort();
+      reject(new FetchError(`request to ${href} failed, reason: ${err.message}`, "system", err));
+    };
+    req.on("error", failRequest);
+
     const onAbort = () => {
       const err: any = new DOMException("The operation was aborted.", "AbortError");
       err.type = "aborted";
@@ -251,21 +266,7 @@ function fetchWithAgent(url, init, counter) {
       req.destroy(err);
       if (bodyStream) bodyStream.destroy(err);
     };
-    if (signal) {
-      if (signal.aborted) {
-        onAbort();
-        return;
-      }
-      signal.addEventListener("abort", onAbort, { once: true });
-    }
-
-    const failRequest = err => {
-      if (settled) return;
-      settled = true;
-      removeAbort();
-      reject(new FetchError(`request to ${href} failed, reason: ${err.message}`, "system", err));
-    };
-    req.on("error", failRequest);
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
 
     req.on("response", (res: any) => {
       if (settled) return;
@@ -313,7 +314,7 @@ function fetchWithAgent(url, init, counter) {
             finalize(new FetchError(`maximum redirect reached at: ${href}`, "max-redirect"));
             return;
           }
-          const nextHeaders = new Headers(init.headers || (url instanceof WebRequest && url.headers) || undefined);
+          const nextHeaders = new Headers(init.headers || (isWebRequest && url.headers) || undefined);
           const nextInit: any = { ...init, method, body: init.body, counter: counter + 1, headers: nextHeaders };
           const nextURL = new URL(locationURL);
           if (nextURL.hostname !== parsedHostname || nextURL.protocol !== protocol) {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -324,7 +324,9 @@ function fetchWithAgent(url, init, counter) {
             typeof body === "object" &&
             (typeof (body as any).pipe === "function" || typeof (body as any).getReader === "function")
           ) {
-            finalize(new FetchError("Cannot follow redirect with body being a readable stream", "unsupported-redirect"));
+            finalize(
+              new FetchError("Cannot follow redirect with body being a readable stream", "unsupported-redirect"),
+            );
             return;
           }
           finalize(fetchWithAgent(locationURL, nextInit, counter + 1));

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -189,6 +189,24 @@ function fetchWithAgent(url, init, counter) {
       reject(new TypeError("Request with GET/HEAD method cannot have body"));
       return;
     }
+
+    let blobPromise: Promise<ArrayBuffer> | undefined;
+    if (body != null && typeof body === "object") {
+      if (body instanceof URLSearchParams) {
+        if (!headers.has("content-type")) headers.set("content-type", "application/x-www-form-urlencoded;charset=UTF-8");
+        body = body.toString();
+      } else if (body instanceof FormData) {
+        // Let the native encoder produce the multipart body + boundary.
+        const encoded = new WebResponse(body);
+        const ct = encoded.headers.get("content-type");
+        if (ct && !headers.has("content-type")) headers.set("content-type", ct);
+        blobPromise = encoded.arrayBuffer();
+        body = null;
+      } else if (body instanceof Blob) {
+        const bodyType = body.type;
+        if (bodyType && !headers.has("content-type")) headers.set("content-type", bodyType);
+      }
+    }
     if (body != null && !headers.has("content-length") && !headers.has("transfer-encoding")) {
       if (typeof body === "string") headers.set("content-length", String(Buffer.byteLength(body)));
       else if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
@@ -279,16 +297,17 @@ function fetchWithAgent(url, init, counter) {
             reject(new FetchError(`maximum redirect reached at: ${href}`, "max-redirect"));
             return;
           }
-          const nextInit: any = { ...init, counter: counter + 1 };
+          const nextHeaders = new Headers(init.headers || undefined);
+          const nextInit: any = { ...init, counter: counter + 1, headers: nextHeaders };
           const nextURL = new URL(locationURL);
           if (nextURL.hostname !== parsed.hostname || nextURL.protocol !== parsed.protocol) {
-            const h = new Headers(init.headers || undefined);
-            for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) h.delete(name);
-            nextInit.headers = h;
+            for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) nextHeaders.delete(name);
           }
           if (status === 303 || ((status === 301 || status === 302) && method === "POST")) {
             nextInit.method = "GET";
             nextInit.body = undefined;
+            nextHeaders.delete("content-length");
+            nextHeaders.delete("content-type");
           } else if (body != null && typeof body === "object" && typeof (body as any).pipe === "function") {
             settled = true;
             res.resume();
@@ -332,12 +351,8 @@ function fetchWithAgent(url, init, counter) {
       resolve(response);
     });
 
-    if (body == null) {
-      req.end();
-    } else if (typeof body === "string" || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
-      req.end(body instanceof ArrayBuffer ? new Uint8Array(body) : body);
-    } else if (body instanceof Blob) {
-      body.arrayBuffer().then(
+    const sendBuffered = (p: Promise<ArrayBuffer>) =>
+      p.then(
         buf => req.end(new Uint8Array(buf)),
         err => {
           if (!settled) {
@@ -347,6 +362,15 @@ function fetchWithAgent(url, init, counter) {
           req.destroy(err);
         },
       );
+
+    if (blobPromise) {
+      sendBuffered(blobPromise);
+    } else if (body == null) {
+      req.end();
+    } else if (typeof body === "string" || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+      req.end(body instanceof ArrayBuffer ? new Uint8Array(body) : body);
+    } else if (body instanceof Blob) {
+      sendBuffered(body.arrayBuffer());
     } else if (typeof (body as any).pipe === "function") {
       (body as any).pipe(req);
     } else if (typeof (body as any).getReader === "function") {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -315,7 +315,7 @@ function fetchWithAgent(url, init, counter) {
             return;
           }
           const nextHeaders = new Headers(init.headers || (isWebRequest && url.headers) || undefined);
-          const nextInit: any = { ...init, method, body: init.body, counter: counter + 1, headers: nextHeaders };
+          const nextInit: any = { ...init, method, signal, body: init.body, counter: counter + 1, headers: nextHeaders };
           const nextURL = new URL(locationURL);
           if (nextURL.hostname !== parsedHostname || nextURL.protocol !== protocol) {
             for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) nextHeaders.delete(name);
@@ -341,8 +341,14 @@ function fetchWithAgent(url, init, counter) {
         // redirect === "manual" or no location: fall through and return the 3xx response as-is.
       }
 
+      const nullBody = status === 204 || status === 304 || method === "HEAD";
       const out = new PassThrough();
-      bodyStream = out;
+      // A late onAbort() may destroy `out` with an error after pipeline() has
+      // detached its listener (or when `out` was never consumed); keep a
+      // swallowing listener so that never becomes an uncaught 'error'.
+      out.on("error", () => {});
+      bodyStream = nullBody ? undefined : out;
+      res.once("close", removeAbort);
       out.once("close", removeAbort);
       const pumpErr = (err: any) => {
         if (err) out.destroy(err);
@@ -391,7 +397,7 @@ function fetchWithAgent(url, init, counter) {
         // only accepts 101 / [200, 599], so build with a safe value and
         // patch the real one on top when it falls outside that range.
         const safeStatus = (status >= 200 && status <= 599) || status === 101 ? status : 599;
-        response = new Response(status === 204 || status === 304 || method === "HEAD" ? null : out, {
+        response = new Response(nullBody ? null : out, {
           status: safeStatus,
           statusText: res.statusMessage || "",
           headers: responseHeaders,
@@ -426,8 +432,12 @@ function fetchWithAgent(url, init, counter) {
       sendBuffered(blobPromise);
     } else if (body == null) {
       req.end();
-    } else if (typeof body === "string" || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
-      req.end(body instanceof ArrayBuffer ? new Uint8Array(body) : body);
+    } else if (typeof body === "string" || body instanceof Uint8Array) {
+      req.end(body);
+    } else if (body instanceof ArrayBuffer) {
+      req.end(new Uint8Array(body));
+    } else if (ArrayBuffer.isView(body)) {
+      req.end(new Uint8Array((body as ArrayBufferView).buffer, (body as ArrayBufferView).byteOffset, (body as ArrayBufferView).byteLength));
     } else if (body instanceof Blob) {
       sendBuffered(body.arrayBuffer());
     } else if (typeof (body as any).pipe === "function" || typeof (body as any).getReader === "function") {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -125,6 +125,7 @@ var ResponsePrototype = Response.prototype;
 
 class Request extends WebRequest {
   [kUrl]?: string;
+  agent: any;
 
   constructor(input, init) {
     // node-fetch is relaxed with the URL, for example, it allows "/" as a valid URL.
@@ -136,6 +137,7 @@ class Request extends WebRequest {
     } else {
       super(input, init);
     }
+    this.agent = init?.agent ?? (input != null && typeof input === "object" ? input.agent : undefined);
   }
 
   get url() {
@@ -336,25 +338,48 @@ function fetchWithAgent(url, init, counter) {
       }
 
       const out = new PassThrough();
+      bodyStream = out;
+      out.once("close", removeAbort);
+      const pumpErr = (err: any) => {
+        if (err) out.destroy(err);
+      };
+
       const codings = (responseHeaders.get("content-encoding") || "").toLowerCase();
       let decoder: any;
+      let isDeflate = false;
       if (compress && method !== "HEAD" && status !== 204 && status !== 304) {
         if (codings === "gzip" || codings === "x-gzip")
           decoder = zlib.createGunzip({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
-        else if (codings === "deflate" || codings === "x-deflate")
-          decoder = zlib.createInflate({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
+        else if (codings === "deflate" || codings === "x-deflate") isDeflate = true;
         else if (codings === "br") decoder = zlib.createBrotliDecompress();
-        if (decoder) {
+        if (decoder || isDeflate) {
           responseHeaders.delete("content-encoding");
           responseHeaders.delete("content-length");
         }
       }
-      const chain = decoder ? [res, decoder, out] : [res, out];
-      pipeline(chain, err => {
-        if (err) out.destroy(err);
-      });
-      bodyStream = out;
-      out.once("close", removeAbort);
+      if (isDeflate) {
+        // Some servers send raw deflate (no zlib header) under
+        // Content-Encoding: deflate; node-fetch picks the decoder from the
+        // first byte, so do the same.
+        const raw = new PassThrough();
+        pipeline(res, raw, pumpErr);
+        let chosen = false;
+        const choose = chunk => {
+          if (chosen) return;
+          chosen = true;
+          const zopts = { flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH };
+          const inflate =
+            chunk && (chunk[0] & 0x0f) === 0x08 ? zlib.createInflate(zopts) : zlib.createInflateRaw(zopts);
+          if (chunk) raw.unshift(chunk);
+          pipeline(raw, inflate, out, pumpErr);
+        };
+        raw.once("data", choose);
+        raw.once("end", () => {
+          if (!chosen) out.end();
+        });
+      } else {
+        pipeline(decoder ? [res, decoder, out] : [res, out], pumpErr);
+      }
 
       let response: Response;
       try {
@@ -429,9 +454,11 @@ async function fetch(
 ) {
   // Native fetch has no `agent`; when one is supplied, fall back to the
   // node:http path so custom agents (proxy agents, overridden
-  // createConnection, pooling) are actually used.
-  if (init != null && init.agent != null && init.agent !== false) {
-    return fetchWithAgent(url, init, init.counter || 0);
+  // createConnection, pooling) are actually used. node-fetch also lets the
+  // agent ride on a Request input.
+  const agent = init?.agent ?? (url != null && typeof url === "object" ? url.agent : undefined);
+  if (agent != null && agent !== false) {
+    return fetchWithAgent(url, init == null ? { agent } : init.agent == null ? { ...init, agent } : init, init?.counter || 0);
   }
   // Convert Node.js streams to Web ReadableStream if they don't have Symbol.asyncIterator.
   // This is needed for libraries like `form-data` that use CombinedStream which extends

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -48,7 +48,8 @@ class Response extends WebResponse {
     }
 
     super(body, init);
-    if (init && typeof init.url === "string") this[kUrl] = init.url;
+    const initUrl = init?.url;
+    if (typeof initUrl === "string") this[kUrl] = initUrl;
   }
 
   get url() {
@@ -165,8 +166,9 @@ function fetchWithAgent(url, init, counter) {
       reject(new TypeError(`Only absolute URLs are supported. Received: ${url}`));
       return;
     }
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      reject(new TypeError(`Only HTTP(S) protocols are supported. Received: ${parsed.protocol}`));
+    const protocol = parsed.protocol;
+    if (protocol !== "http:" && protocol !== "https:") {
+      reject(new TypeError(`Only HTTP(S) protocols are supported. Received: ${protocol}`));
       return;
     }
 
@@ -216,7 +218,7 @@ function fetchWithAgent(url, init, counter) {
     }
 
     const requestOpts = {
-      protocol: parsed.protocol,
+      protocol,
       hostname: parsed.hostname,
       port: parsed.port,
       path: parsed.pathname + parsed.search,
@@ -225,7 +227,7 @@ function fetchWithAgent(url, init, counter) {
       agent,
     };
 
-    const send = parsed.protocol === "https:" ? https.request : http.request;
+    const send = protocol === "https:" ? https.request : http.request;
     const req = send(requestOpts);
     let settled = false;
 
@@ -301,7 +303,7 @@ function fetchWithAgent(url, init, counter) {
           const nextHeaders = new Headers(init.headers || undefined);
           const nextInit: any = { ...init, counter: counter + 1, headers: nextHeaders };
           const nextURL = new URL(locationURL);
-          if (nextURL.hostname !== parsed.hostname || nextURL.protocol !== parsed.protocol) {
+          if (nextURL.hostname !== parsed.hostname || nextURL.protocol !== protocol) {
             for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) nextHeaders.delete(name);
           }
           if (status === 303 || ((status === 301 || status === 302) && method === "POST")) {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -458,7 +458,11 @@ async function fetch(
   // agent ride on a Request input.
   const agent = init?.agent ?? (url != null && typeof url === "object" ? url.agent : undefined);
   if (agent != null && agent !== false) {
-    return fetchWithAgent(url, init == null ? { agent } : init.agent == null ? { ...init, agent } : init, init?.counter || 0);
+    return fetchWithAgent(
+      url,
+      init == null ? { agent } : init.agent == null ? { ...init, agent } : init,
+      init?.counter || 0,
+    );
   }
   // Convert Node.js streams to Web ReadableStream if they don't have Symbol.asyncIterator.
   // This is needed for libraries like `form-data` that use CombinedStream which extends

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -254,7 +254,9 @@ function fetchWithAgent(url, init, counter) {
             if (redirect !== "manual") {
               settled = true;
               res.resume();
-              reject(new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, "invalid-redirect"));
+              reject(
+                new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, "invalid-redirect"),
+              );
               return;
             }
           }
@@ -262,7 +264,12 @@ function fetchWithAgent(url, init, counter) {
         if (redirect === "error") {
           settled = true;
           res.resume();
-          reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${href}`, "no-redirect"));
+          reject(
+            new FetchError(
+              `uri requested responds with a redirect, redirect mode is set to error: ${href}`,
+              "no-redirect",
+            ),
+          );
           return;
         }
         if (redirect === "follow" && locationURL !== null) {
@@ -300,8 +307,10 @@ function fetchWithAgent(url, init, counter) {
       const codings = (responseHeaders.get("content-encoding") || "").toLowerCase();
       if (compress && method !== "HEAD" && status !== 204 && status !== 304) {
         let decoder: any;
-        if (codings === "gzip" || codings === "x-gzip") decoder = zlib.createGunzip({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
-        else if (codings === "deflate" || codings === "x-deflate") decoder = zlib.createInflate({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
+        if (codings === "gzip" || codings === "x-gzip")
+          decoder = zlib.createGunzip({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
+        else if (codings === "deflate" || codings === "x-deflate")
+          decoder = zlib.createInflate({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
         else if (codings === "br") decoder = zlib.createBrotliDecompress();
         if (decoder) {
           const out = new PassThrough();

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -72,7 +72,14 @@ class Response extends WebResponse {
   }
 
   clone() {
-    return Object.setPrototypeOf(super.clone(this), ResponsePrototype);
+    const c = Object.setPrototypeOf(super.clone(this), ResponsePrototype);
+    const u = this[kUrl];
+    if (u !== undefined) c[kUrl] = u;
+    for (const name of ["status", "ok", "redirected"]) {
+      const d = Object.getOwnPropertyDescriptor(this, name);
+      if (d) Object.defineProperty(c, name, d);
+    }
+    return c;
   }
 
   async arrayBuffer() {
@@ -219,16 +226,12 @@ function fetchWithAgent(url, init, counter) {
       } else if (body instanceof Blob) headers.set("content-length", String(body.size));
     }
 
+    const { urlToHttpOptions } = require("internal/url");
     const parsedHostname = parsed.hostname;
-    const requestOpts = {
-      protocol,
-      hostname: parsedHostname[0] === "[" ? parsedHostname.slice(1, -1) : parsedHostname,
-      port: parsed.port,
-      path: parsed.pathname + parsed.search,
-      method,
-      headers: headers.toJSON(),
-      agent,
-    };
+    const requestOpts = urlToHttpOptions(parsed);
+    requestOpts.method = method;
+    requestOpts.headers = headers.toJSON();
+    requestOpts.agent = agent;
 
     const send = protocol === "https:" ? https.request : http.request;
     const req = send(requestOpts);
@@ -310,8 +313,8 @@ function fetchWithAgent(url, init, counter) {
             finalize(new FetchError(`maximum redirect reached at: ${href}`, "max-redirect"));
             return;
           }
-          const nextHeaders = new Headers(init.headers || undefined);
-          const nextInit: any = { ...init, counter: counter + 1, headers: nextHeaders };
+          const nextHeaders = new Headers(init.headers || (url instanceof WebRequest && url.headers) || undefined);
+          const nextInit: any = { ...init, method, body: init.body, counter: counter + 1, headers: nextHeaders };
           const nextURL = new URL(locationURL);
           if (nextURL.hostname !== parsedHostname || nextURL.protocol !== protocol) {
             for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) nextHeaders.delete(name);

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -217,9 +217,10 @@ function fetchWithAgent(url, init, counter) {
       } else if (body instanceof Blob) headers.set("content-length", String(body.size));
     }
 
+    const parsedHostname = parsed.hostname;
     const requestOpts = {
       protocol,
-      hostname: parsed.hostname,
+      hostname: parsedHostname[0] === "[" ? parsedHostname.slice(1, -1) : parsedHostname,
       port: parsed.port,
       path: parsed.pathname + parsed.search,
       method,
@@ -230,14 +231,20 @@ function fetchWithAgent(url, init, counter) {
     const send = protocol === "https:" ? https.request : http.request;
     const req = send(requestOpts);
     let settled = false;
+    let bodyStream: any;
 
+    const removeAbort = () => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+    };
     const onAbort = () => {
-      if (settled) return;
-      settled = true;
       const err: any = new DOMException("The operation was aborted.", "AbortError");
       err.type = "aborted";
-      reject(err);
-      req.destroy();
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+      req.destroy(err);
+      if (bodyStream) bodyStream.destroy(err);
     };
     if (signal) {
       if (signal.aborted) {
@@ -247,16 +254,16 @@ function fetchWithAgent(url, init, counter) {
       signal.addEventListener("abort", onAbort, { once: true });
     }
 
-    req.on("error", err => {
+    const failRequest = err => {
       if (settled) return;
       settled = true;
-      if (signal) signal.removeEventListener("abort", onAbort);
+      removeAbort();
       reject(new FetchError(`request to ${href} failed, reason: ${err.message}`, "system", err));
-    });
+    };
+    req.on("error", failRequest);
 
     req.on("response", (res: any) => {
       if (settled) return;
-      if (signal) signal.removeEventListener("abort", onAbort);
 
       const responseHeaders = new Headers();
       const rawHeaders: string[] = res.rawHeaders;
@@ -266,6 +273,13 @@ function fetchWithAgent(url, init, counter) {
 
       const status: number = res.statusCode;
       if (isRedirect(status)) {
+        const finalize = value => {
+          settled = true;
+          removeAbort();
+          res.resume();
+          if (value instanceof Error) reject(value);
+          else resolve(value);
+        };
         const location = responseHeaders.get("location");
         let locationURL: string | null = null;
         if (location !== null) {
@@ -273,9 +287,7 @@ function fetchWithAgent(url, init, counter) {
             locationURL = new URL(location, href).href;
           } catch {
             if (redirect !== "manual") {
-              settled = true;
-              res.resume();
-              reject(
+              finalize(
                 new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, "invalid-redirect"),
               );
               return;
@@ -283,9 +295,7 @@ function fetchWithAgent(url, init, counter) {
           }
         }
         if (redirect === "error") {
-          settled = true;
-          res.resume();
-          reject(
+          finalize(
             new FetchError(
               `uri requested responds with a redirect, redirect mode is set to error: ${href}`,
               "no-redirect",
@@ -295,15 +305,13 @@ function fetchWithAgent(url, init, counter) {
         }
         if (redirect === "follow" && locationURL !== null) {
           if (counter >= follow) {
-            settled = true;
-            res.resume();
-            reject(new FetchError(`maximum redirect reached at: ${href}`, "max-redirect"));
+            finalize(new FetchError(`maximum redirect reached at: ${href}`, "max-redirect"));
             return;
           }
           const nextHeaders = new Headers(init.headers || undefined);
           const nextInit: any = { ...init, counter: counter + 1, headers: nextHeaders };
           const nextURL = new URL(locationURL);
-          if (nextURL.hostname !== parsed.hostname || nextURL.protocol !== protocol) {
+          if (nextURL.hostname !== parsedHostname || nextURL.protocol !== protocol) {
             for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) nextHeaders.delete(name);
           }
           if (status === 303 || ((status === 301 || status === 302) && method === "POST")) {
@@ -311,46 +319,66 @@ function fetchWithAgent(url, init, counter) {
             nextInit.body = undefined;
             nextHeaders.delete("content-length");
             nextHeaders.delete("content-type");
-          } else if (body != null && typeof body === "object" && typeof (body as any).pipe === "function") {
-            settled = true;
-            res.resume();
-            reject(new FetchError("Cannot follow redirect with body being a readable stream", "unsupported-redirect"));
+          } else if (
+            body != null &&
+            typeof body === "object" &&
+            (typeof (body as any).pipe === "function" || typeof (body as any).getReader === "function")
+          ) {
+            finalize(new FetchError("Cannot follow redirect with body being a readable stream", "unsupported-redirect"));
             return;
           }
-          settled = true;
-          res.resume();
-          resolve(fetchWithAgent(locationURL, nextInit, counter + 1));
+          finalize(fetchWithAgent(locationURL, nextInit, counter + 1));
           return;
         }
         // redirect === "manual" or no location: fall through and return the 3xx response as-is.
       }
 
-      let raw: any = res.pipe(new PassThrough());
+      const out = new PassThrough();
       const codings = (responseHeaders.get("content-encoding") || "").toLowerCase();
+      let decoder: any;
       if (compress && method !== "HEAD" && status !== 204 && status !== 304) {
-        let decoder: any;
         if (codings === "gzip" || codings === "x-gzip")
           decoder = zlib.createGunzip({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
         else if (codings === "deflate" || codings === "x-deflate")
           decoder = zlib.createInflate({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
         else if (codings === "br") decoder = zlib.createBrotliDecompress();
         if (decoder) {
-          const out = new PassThrough();
-          pipeline(raw, decoder, out, () => {});
-          raw = out;
           responseHeaders.delete("content-encoding");
           responseHeaders.delete("content-length");
         }
       }
-
-      settled = true;
-      const response = new Response(status === 204 || status === 304 || method === "HEAD" ? null : raw, {
-        status,
-        statusText: res.statusMessage || "",
-        headers: responseHeaders,
-        url: href,
+      const chain = decoder ? [res, decoder, out] : [res, out];
+      pipeline(chain, err => {
+        if (err) out.destroy(err);
       });
-      if (counter > 0) Object.defineProperty(response, "redirected", { value: true, configurable: true });
+      bodyStream = out;
+      out.once("close", removeAbort);
+
+      let response: Response;
+      try {
+        // node-fetch exposes arbitrary status codes; the native constructor
+        // only accepts 101 / [200, 599], so build with a safe value and
+        // patch the real one on top when it falls outside that range.
+        const safeStatus = (status >= 200 && status <= 599) || status === 101 ? status : 599;
+        response = new Response(status === 204 || status === 304 || method === "HEAD" ? null : out, {
+          status: safeStatus,
+          statusText: res.statusMessage || "",
+          headers: responseHeaders,
+          url: href,
+        });
+        if (safeStatus !== status) {
+          Object.defineProperty(response, "status", { value: status, configurable: true });
+          Object.defineProperty(response, "ok", { value: false, configurable: true });
+        }
+        if (counter > 0) Object.defineProperty(response, "redirected", { value: true, configurable: true });
+      } catch (err) {
+        settled = true;
+        removeAbort();
+        res.destroy();
+        reject(err);
+        return;
+      }
+      settled = true;
       resolve(response);
     });
 
@@ -358,10 +386,7 @@ function fetchWithAgent(url, init, counter) {
       p.then(
         buf => req.end(new Uint8Array(buf)),
         err => {
-          if (!settled) {
-            settled = true;
-            reject(new FetchError(`request to ${href} failed, reason: ${err.message}`, "system", err));
-          }
+          failRequest(err);
           req.destroy(err);
         },
       );
@@ -374,10 +399,11 @@ function fetchWithAgent(url, init, counter) {
       req.end(body instanceof ArrayBuffer ? new Uint8Array(body) : body);
     } else if (body instanceof Blob) {
       sendBuffered(body.arrayBuffer());
-    } else if (typeof (body as any).pipe === "function") {
-      (body as any).pipe(req);
-    } else if (typeof (body as any).getReader === "function") {
-      Readable.fromWeb(body as any).pipe(req);
+    } else if (typeof (body as any).pipe === "function" || typeof (body as any).getReader === "function") {
+      const src = typeof (body as any).pipe === "function" ? body : Readable.fromWeb(body as any);
+      pipeline(src, req, err => {
+        if (err) failRequest(err);
+      });
     } else {
       req.end(String(body));
     }

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -315,7 +315,14 @@ function fetchWithAgent(url, init, counter) {
             return;
           }
           const nextHeaders = new Headers(init.headers || (isWebRequest && url.headers) || undefined);
-          const nextInit: any = { ...init, method, signal, body: init.body, counter: counter + 1, headers: nextHeaders };
+          const nextInit: any = {
+            ...init,
+            method,
+            signal,
+            body: init.body,
+            counter: counter + 1,
+            headers: nextHeaders,
+          };
           const nextURL = new URL(locationURL);
           if (nextURL.hostname !== parsedHostname || nextURL.protocol !== protocol) {
             for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) nextHeaders.delete(name);
@@ -437,7 +444,13 @@ function fetchWithAgent(url, init, counter) {
     } else if (body instanceof ArrayBuffer) {
       req.end(new Uint8Array(body));
     } else if (ArrayBuffer.isView(body)) {
-      req.end(new Uint8Array((body as ArrayBufferView).buffer, (body as ArrayBufferView).byteOffset, (body as ArrayBufferView).byteLength));
+      req.end(
+        new Uint8Array(
+          (body as ArrayBufferView).buffer,
+          (body as ArrayBufferView).byteOffset,
+          (body as ArrayBufferView).byteLength,
+        ),
+      );
     } else if (body instanceof Blob) {
       sendBuffered(body.arrayBuffer());
     } else if (typeof (body as any).pipe === "function" || typeof (body as any).getReader === "function") {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -199,6 +199,7 @@ function fetchWithAgent(url, init, counter) {
 
     const headers = new Headers(init.headers || (isWebRequest && url.headers) || undefined);
     if (!headers.has("accept")) headers.set("accept", "*/*");
+    if (!headers.has("user-agent")) headers.set("user-agent", "node-fetch");
     if (compress && !headers.has("accept-encoding")) headers.set("accept-encoding", "gzip, deflate, br");
     if (!headers.has("connection") && !agent) headers.set("connection", "close");
 

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -33,11 +33,13 @@ class Headers extends WebHeaders {
 
 const kHeaders = Symbol("kHeaders");
 const kBody = Symbol("kBody");
+const kUrl = Symbol("kUrl");
 const HeadersPrototype = Headers.prototype;
 
 class Response extends WebResponse {
   [kBody]: any;
   [kHeaders];
+  [kUrl]?: string;
 
   constructor(body, init) {
     const { Readable, Stream } = require("node:stream");
@@ -46,6 +48,11 @@ class Response extends WebResponse {
     }
 
     super(body, init);
+    if (init && typeof init.url === "string") this[kUrl] = init.url;
+  }
+
+  get url() {
+    return this[kUrl] ?? super.url;
   }
 
   get body() {
@@ -115,8 +122,6 @@ class Response extends WebResponse {
 }
 var ResponsePrototype = Response.prototype;
 
-const kUrl = Symbol("kUrl");
-
 class Request extends WebRequest {
   [kUrl]?: string;
 
@@ -137,6 +142,212 @@ class Request extends WebRequest {
   }
 }
 
+const FOLLOW_MAX_DEFAULT = 20;
+
+/**
+ * node-fetch's `agent` option cannot be expressed through native fetch, so when it's
+ * set the request is driven by node:http / node:https (which honour `agent.addRequest`
+ * / `createConnection`). The surface here mirrors what node-fetch itself does.
+ */
+function fetchWithAgent(url, init, counter) {
+  return new Promise((resolve, reject) => {
+    const http = require("node:http");
+    const https = require("node:https");
+    const { Readable, PassThrough, pipeline } = require("node:stream");
+    const zlib = require("node:zlib");
+
+    let href: string;
+    let parsed: URL;
+    try {
+      href = url instanceof WebRequest ? url.url : url instanceof URL ? url.href : String(url);
+      parsed = new URL(href);
+    } catch {
+      reject(new TypeError(`Only absolute URLs are supported. Received: ${url}`));
+      return;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      reject(new TypeError(`Only HTTP(S) protocols are supported. Received: ${parsed.protocol}`));
+      return;
+    }
+
+    let agent = init.agent;
+    if ($isCallable(agent)) agent = agent.$call(undefined, parsed);
+
+    const method = (init.method || (url instanceof WebRequest && url.method) || "GET").toUpperCase();
+    const compress = init.compress !== false;
+    const redirect = init.redirect || "follow";
+    const follow = typeof init.follow === "number" ? init.follow : FOLLOW_MAX_DEFAULT;
+    const signal = init.signal;
+
+    const headers = new Headers(init.headers || (url instanceof WebRequest && url.headers) || undefined);
+    if (!headers.has("accept")) headers.set("accept", "*/*");
+    if (compress && !headers.has("accept-encoding")) headers.set("accept-encoding", "gzip, deflate, br");
+    if (!headers.has("connection") && !agent) headers.set("connection", "close");
+
+    let body = init.body ?? (url instanceof WebRequest ? url.body : null);
+    if (body != null && (method === "GET" || method === "HEAD")) {
+      reject(new TypeError("Request with GET/HEAD method cannot have body"));
+      return;
+    }
+    if (body != null && !headers.has("content-length") && !headers.has("transfer-encoding")) {
+      if (typeof body === "string") headers.set("content-length", String(Buffer.byteLength(body)));
+      else if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+        headers.set("content-length", String((body as ArrayBufferView).byteLength ?? (body as ArrayBuffer).byteLength));
+      } else if (body instanceof Blob) headers.set("content-length", String(body.size));
+    }
+
+    const requestOpts = {
+      protocol: parsed.protocol,
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname + parsed.search,
+      method,
+      headers: headers.toJSON(),
+      agent,
+    };
+
+    const send = parsed.protocol === "https:" ? https.request : http.request;
+    const req = send(requestOpts);
+    let settled = false;
+
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      const err: any = new DOMException("The operation was aborted.", "AbortError");
+      err.type = "aborted";
+      reject(err);
+      req.destroy();
+    };
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+
+    req.on("error", err => {
+      if (settled) return;
+      settled = true;
+      if (signal) signal.removeEventListener("abort", onAbort);
+      reject(new FetchError(`request to ${href} failed, reason: ${err.message}`, "system", err));
+    });
+
+    req.on("response", (res: any) => {
+      if (settled) return;
+      if (signal) signal.removeEventListener("abort", onAbort);
+
+      const responseHeaders = new Headers();
+      const rawHeaders: string[] = res.rawHeaders;
+      for (let i = 0; i < rawHeaders.length; i += 2) {
+        responseHeaders.append(rawHeaders[i], rawHeaders[i + 1]);
+      }
+
+      const status: number = res.statusCode;
+      if (isRedirect(status)) {
+        const location = responseHeaders.get("location");
+        let locationURL: string | null = null;
+        if (location !== null) {
+          try {
+            locationURL = new URL(location, href).href;
+          } catch {
+            if (redirect !== "manual") {
+              settled = true;
+              res.resume();
+              reject(new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, "invalid-redirect"));
+              return;
+            }
+          }
+        }
+        if (redirect === "error") {
+          settled = true;
+          res.resume();
+          reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${href}`, "no-redirect"));
+          return;
+        }
+        if (redirect === "follow" && locationURL !== null) {
+          if (counter >= follow) {
+            settled = true;
+            res.resume();
+            reject(new FetchError(`maximum redirect reached at: ${href}`, "max-redirect"));
+            return;
+          }
+          const nextInit: any = { ...init, counter: counter + 1 };
+          const nextURL = new URL(locationURL);
+          if (nextURL.hostname !== parsed.hostname || nextURL.protocol !== parsed.protocol) {
+            const h = new Headers(init.headers || undefined);
+            for (const name of ["authorization", "www-authenticate", "cookie", "cookie2"]) h.delete(name);
+            nextInit.headers = h;
+          }
+          if (status === 303 || ((status === 301 || status === 302) && method === "POST")) {
+            nextInit.method = "GET";
+            nextInit.body = undefined;
+          } else if (body != null && typeof body === "object" && typeof (body as any).pipe === "function") {
+            settled = true;
+            res.resume();
+            reject(new FetchError("Cannot follow redirect with body being a readable stream", "unsupported-redirect"));
+            return;
+          }
+          settled = true;
+          res.resume();
+          resolve(fetchWithAgent(locationURL, nextInit, counter + 1));
+          return;
+        }
+        // redirect === "manual" or no location: fall through and return the 3xx response as-is.
+      }
+
+      let raw: any = res.pipe(new PassThrough());
+      const codings = (responseHeaders.get("content-encoding") || "").toLowerCase();
+      if (compress && method !== "HEAD" && status !== 204 && status !== 304) {
+        let decoder: any;
+        if (codings === "gzip" || codings === "x-gzip") decoder = zlib.createGunzip({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
+        else if (codings === "deflate" || codings === "x-deflate") decoder = zlib.createInflate({ flush: zlib.Z_SYNC_FLUSH, finishFlush: zlib.Z_SYNC_FLUSH });
+        else if (codings === "br") decoder = zlib.createBrotliDecompress();
+        if (decoder) {
+          const out = new PassThrough();
+          pipeline(raw, decoder, out, () => {});
+          raw = out;
+          responseHeaders.delete("content-encoding");
+          responseHeaders.delete("content-length");
+        }
+      }
+
+      settled = true;
+      const response = new Response(status === 204 || status === 304 || method === "HEAD" ? null : raw, {
+        status,
+        statusText: res.statusMessage || "",
+        headers: responseHeaders,
+        url: href,
+      });
+      if (counter > 0) Object.defineProperty(response, "redirected", { value: true, configurable: true });
+      resolve(response);
+    });
+
+    if (body == null) {
+      req.end();
+    } else if (typeof body === "string" || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+      req.end(body instanceof ArrayBuffer ? new Uint8Array(body) : body);
+    } else if (body instanceof Blob) {
+      body.arrayBuffer().then(
+        buf => req.end(new Uint8Array(buf)),
+        err => {
+          if (!settled) {
+            settled = true;
+            reject(new FetchError(`request to ${href} failed, reason: ${err.message}`, "system", err));
+          }
+          req.destroy(err);
+        },
+      );
+    } else if (typeof (body as any).pipe === "function") {
+      (body as any).pipe(req);
+    } else if (typeof (body as any).getReader === "function") {
+      Readable.fromWeb(body as any).pipe(req);
+    } else {
+      req.end(String(body));
+    }
+  });
+}
+
 /**
  * `node-fetch` works like the browser-fetch API, except it's a little more strict on some features,
  * and uses node streams instead of web streams.
@@ -150,8 +361,14 @@ async function fetch(
   url: any,
 
   // eslint-disable-next-line no-unused-vars
-  init?: RequestInit & { body?: any },
+  init?: RequestInit & { body?: any; agent?: any; compress?: boolean; follow?: number; counter?: number },
 ) {
+  // Native fetch has no `agent`; when one is supplied, fall back to the
+  // node:http path so custom agents (proxy agents, overridden
+  // createConnection, pooling) are actually used.
+  if (init != null && init.agent != null && init.agent !== false) {
+    return fetchWithAgent(url, init, init.counter || 0);
+  }
   // Convert Node.js streams to Web ReadableStream if they don't have Symbol.asyncIterator.
   // This is needed for libraries like `form-data` that use CombinedStream which extends
   // Node.js Stream but doesn't implement Symbol.asyncIterator.

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -193,7 +193,8 @@ function fetchWithAgent(url, init, counter) {
     let blobPromise: Promise<ArrayBuffer> | undefined;
     if (body != null && typeof body === "object") {
       if (body instanceof URLSearchParams) {
-        if (!headers.has("content-type")) headers.set("content-type", "application/x-www-form-urlencoded;charset=UTF-8");
+        if (!headers.has("content-type"))
+          headers.set("content-type", "application/x-www-form-urlencoded;charset=UTF-8");
         body = body.toString();
       } else if (body instanceof FormData) {
         // Let the native encoder produce the multipart body + boundary.

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -450,6 +450,68 @@ describe("node-fetch honours the agent option", () => {
     }
   });
 
+  test("HEAD response releases the abort listener", async () => {
+    const { agent } = makeAgent();
+    let uncaught = 0;
+    const onUncaught = () => uncaught++;
+    process.on("uncaughtException", onUncaught);
+    try {
+      const controller = new AbortController();
+      await withServer(
+        (req, res) => res.end(),
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/`, {
+            agent,
+            method: "HEAD",
+            signal: controller.signal,
+          });
+          expect(res.status).toBe(200);
+          expect(res.body).toBeNull();
+        },
+      );
+      // The request has resolved and the underlying socket is closed; the
+      // abort listener must have been removed and must not throw.
+      await new Promise(r => setImmediate(r));
+      controller.abort();
+      await new Promise(r => setImmediate(r));
+      expect(uncaught).toBe(0);
+    } finally {
+      process.off("uncaughtException", onUncaught);
+      agent.destroy();
+    }
+  });
+
+  test("accepts DataView and non-Uint8Array typed-array bodies", async () => {
+    const { agent } = makeAgent();
+    try {
+      await withServer(
+        (req, res) => {
+          const chunks = [];
+          req.on("data", c => chunks.push(c));
+          req.on("end", () => res.end(Buffer.concat(chunks).toString("hex")));
+        },
+        async port => {
+          const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+          let res = await fetch2(`http://127.0.0.1:${port}/`, {
+            agent,
+            method: "POST",
+            body: new DataView(bytes.buffer),
+          });
+          expect(await res.text()).toBe("deadbeef");
+
+          res = await fetch2(`http://127.0.0.1:${port}/`, {
+            agent,
+            method: "POST",
+            body: new Uint16Array(bytes.buffer),
+          });
+          expect(await res.text()).toBe("deadbeef");
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
+  });
+
   test("rejects cleanly when signal is already aborted", async () => {
     const { agent } = makeAgent();
     let uncaught = 0;

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -450,6 +450,23 @@ describe("node-fetch honours the agent option", () => {
     }
   });
 
+  test("rejects cleanly when signal is already aborted", async () => {
+    const { agent } = makeAgent();
+    let uncaught = 0;
+    const onUncaught = () => uncaught++;
+    process.on("uncaughtException", onUncaught);
+    try {
+      await expect(fetch2("http://127.0.0.1:1/", { agent, signal: AbortSignal.abort() })).rejects.toMatchObject({
+        name: "AbortError",
+      });
+      await new Promise(r => setImmediate(r));
+      expect(uncaught).toBe(0);
+    } finally {
+      process.off("uncaughtException", onUncaught);
+      agent.destroy();
+    }
+  });
+
   test("picks https.request for https: URLs", async () => {
     let calls = 0;
     const agent = new (class extends https.Agent {

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -191,145 +191,202 @@ describe("node-fetch honours the agent option", () => {
 
   test("calls agent.createConnection", async () => {
     const { agent, calls } = makeAgent();
-    await withServer(
-      (req, res) => res.end("ok"),
-      async port => {
-        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
-        expect(await res.text()).toBe("ok");
-        expect(res.status).toBe(200);
-        expect(res.url).toBe(`http://127.0.0.1:${port}/`);
-        expect(res.body).toBeInstanceOf(stream.Readable);
-      },
-    );
-    expect(calls()).toBe(1);
-    agent.destroy();
+    try {
+      await withServer(
+        (req, res) => res.end("ok"),
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
+          expect(await res.text()).toBe("ok");
+          expect(res.status).toBe(200);
+          expect(res.url).toBe(`http://127.0.0.1:${port}/`);
+          expect(res.body).toBeInstanceOf(stream.Readable);
+        },
+      );
+      expect(calls()).toBe(1);
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("agent as a function receives the parsed URL", async () => {
     const { agent, calls } = makeAgent();
-    let receivedHostname;
-    await withServer(
-      (req, res) => res.end("ok"),
-      async port => {
-        const res = await fetch2(`http://127.0.0.1:${port}/`, {
-          agent: parsed => {
-            receivedHostname = parsed.hostname;
-            return agent;
-          },
-        });
-        expect(await res.text()).toBe("ok");
-      },
-    );
-    expect(receivedHostname).toBe("127.0.0.1");
-    expect(calls()).toBe(1);
-    agent.destroy();
+    try {
+      let receivedHostname;
+      await withServer(
+        (req, res) => res.end("ok"),
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/`, {
+            agent: parsed => {
+              receivedHostname = parsed.hostname;
+              return agent;
+            },
+          });
+          expect(await res.text()).toBe("ok");
+        },
+      );
+      expect(receivedHostname).toBe("127.0.0.1");
+      expect(calls()).toBe(1);
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("forwards method, headers and body", async () => {
     const { agent, calls } = makeAgent();
-    await withServer(
-      (req, res) => {
-        let body = "";
-        req.on("data", c => (body += c));
-        req.on("end", () => {
-          res.setHeader("x-echo", req.headers["x-foo"] ?? "");
-          res.end(`${req.method}:${body}`);
-        });
-      },
-      async port => {
-        const res = await fetch2(`http://127.0.0.1:${port}/`, {
-          agent,
-          method: "POST",
-          headers: { "x-foo": "bar" },
-          body: "hello",
-        });
-        expect(await res.text()).toBe("POST:hello");
-        expect(res.headers.get("x-echo")).toBe("bar");
-        expect(res.headers.raw()["x-echo"]).toEqual(["bar"]);
-      },
-    );
-    expect(calls()).toBe(1);
-    agent.destroy();
+    try {
+      await withServer(
+        (req, res) => {
+          let body = "";
+          req.on("data", c => (body += c));
+          req.on("end", () => {
+            res.setHeader("x-echo", req.headers["x-foo"] ?? "");
+            res.end(`${req.method}:${body}`);
+          });
+        },
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/`, {
+            agent,
+            method: "POST",
+            headers: { "x-foo": "bar" },
+            body: "hello",
+          });
+          expect(await res.text()).toBe("POST:hello");
+          expect(res.headers.get("x-echo")).toBe("bar");
+          expect(res.headers.raw()["x-echo"]).toEqual(["bar"]);
+        },
+      );
+      expect(calls()).toBe(1);
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("serialises FormData and URLSearchParams bodies", async () => {
+    const { agent } = makeAgent();
+    try {
+      await withServer(
+        (req, res) => {
+          let body = "";
+          req.on("data", c => (body += c));
+          req.on("end", () => {
+            res.setHeader("x-ct", req.headers["content-type"] ?? "");
+            res.end(body);
+          });
+        },
+        async port => {
+          const fd = new FormData();
+          fd.append("name", "value");
+          let res = await fetch2(`http://127.0.0.1:${port}/`, { agent, method: "POST", body: fd });
+          const ct = res.headers.get("x-ct");
+          expect(ct).toStartWith("multipart/form-data; boundary=");
+          const received = await res.text();
+          expect(received).toContain('name="name"');
+          expect(received).toContain("value");
+
+          const sp = new URLSearchParams({ a: "1", b: "2" });
+          res = await fetch2(`http://127.0.0.1:${port}/`, { agent, method: "POST", body: sp });
+          expect(res.headers.get("x-ct")).toStartWith("application/x-www-form-urlencoded");
+          expect(await res.text()).toBe("a=1&b=2");
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("decompresses gzip responses", async () => {
     const { agent } = makeAgent();
-    await withServer(
-      (req, res) => {
-        res.writeHead(200, { "content-encoding": "gzip" });
-        res.end(zlib.gzipSync("compressed body"));
-      },
-      async port => {
-        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
-        expect(await res.text()).toBe("compressed body");
-      },
-    );
-    agent.destroy();
+    try {
+      await withServer(
+        (req, res) => {
+          res.writeHead(200, { "content-encoding": "gzip" });
+          res.end(zlib.gzipSync("compressed body"));
+        },
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
+          expect(await res.text()).toBe("compressed body");
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("follows redirects through the agent", async () => {
     const { agent, calls } = makeAgent();
-    await withServer(
-      (req, res) => {
-        if (req.url === "/start") {
-          res.writeHead(302, { location: "/end" });
-          res.end();
-        } else {
-          res.end("landed");
-        }
-      },
-      async port => {
-        const res = await fetch2(`http://127.0.0.1:${port}/start`, { agent });
-        expect(await res.text()).toBe("landed");
-        expect(res.status).toBe(200);
-      },
-    );
-    expect(calls()).toBe(2);
-    agent.destroy();
+    try {
+      await withServer(
+        (req, res) => {
+          if (req.url === "/start") {
+            res.writeHead(302, { location: "/end" });
+            res.end();
+          } else {
+            res.end("landed");
+          }
+        },
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/start`, { agent });
+          expect(await res.text()).toBe("landed");
+          expect(res.status).toBe(200);
+        },
+      );
+      expect(calls()).toBe(2);
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("redirect: 'manual' returns the 3xx response", async () => {
     const { agent } = makeAgent();
-    await withServer(
-      (req, res) => {
-        res.writeHead(302, { location: "/elsewhere" });
-        res.end();
-      },
-      async port => {
-        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent, redirect: "manual" });
-        expect(res.status).toBe(302);
-        expect(res.headers.get("location")).toBe("/elsewhere");
-      },
-    );
-    agent.destroy();
+    try {
+      await withServer(
+        (req, res) => {
+          res.writeHead(302, { location: "/elsewhere" });
+          res.end();
+        },
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/`, { agent, redirect: "manual" });
+          expect(res.status).toBe(302);
+          expect(res.headers.get("location")).toBe("/elsewhere");
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("rejects with FetchError on connection failure", async () => {
     const { agent } = makeAgent();
-    // Bind a socket to reserve a port, then close it so nothing is listening.
-    const probe = net.createServer().listen(0);
-    await once(probe, "listening");
-    const port = probe.address().port;
-    await new Promise(r => probe.close(r));
+    try {
+      // Bind a socket to reserve a port, then close it so nothing is listening.
+      const probe = net.createServer().listen(0);
+      await once(probe, "listening");
+      const port = probe.address().port;
+      await new Promise(r => probe.close(r));
 
-    await expect(fetch2(`http://127.0.0.1:${port}/`, { agent })).rejects.toThrow(FetchError);
-    agent.destroy();
+      await expect(fetch2(`http://127.0.0.1:${port}/`, { agent })).rejects.toThrow(FetchError);
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("aborts via signal", async () => {
     const { agent } = makeAgent();
-    await withServer(
-      () => {
-        /* never respond */
-      },
-      async port => {
-        const controller = new AbortController();
-        const p = fetch2(`http://127.0.0.1:${port}/`, { agent, signal: controller.signal });
-        controller.abort();
-        await expect(p).rejects.toMatchObject({ name: "AbortError" });
-      },
-    );
-    agent.destroy();
+    try {
+      await withServer(
+        () => {
+          /* never respond */
+        },
+        async port => {
+          const controller = new AbortController();
+          const p = fetch2(`http://127.0.0.1:${port}/`, { agent, signal: controller.signal });
+          controller.abort();
+          await expect(p).rejects.toMatchObject({ name: "AbortError" });
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
   });
 
   test("picks https.request for https: URLs", async () => {
@@ -348,11 +405,11 @@ describe("node-fetch honours the agent option", () => {
       const port = server.address().port;
       const res = await fetch2(`https://127.0.0.1:${port}/`, { agent });
       expect(await res.text()).toBe("secure");
+      expect(calls).toBe(1);
     } finally {
       server.close();
+      agent.destroy();
     }
-    expect(calls).toBe(1);
-    agent.destroy();
   });
 
   test("tunnels via a CONNECT-proxy agent", async () => {
@@ -374,10 +431,10 @@ describe("node-fetch honours the agent option", () => {
     });
     proxy.listen(0);
     await once(proxy, "listening");
-    const proxyPort = proxy.address().port;
 
     // Agent whose createConnection establishes the tunnel first (what
     // socks-proxy-agent / https-proxy-agent do).
+    const proxyPort = proxy.address().port;
     class TunnelAgent extends http.Agent {
       createConnection(opts, cb) {
         const sock = net.connect(proxyPort, "127.0.0.1", () => {
@@ -389,16 +446,18 @@ describe("node-fetch honours the agent option", () => {
     }
     const agent = new TunnelAgent({ keepAlive: false });
 
-    await withServer(
-      (req, res) => res.end("via proxy"),
-      async port => {
-        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
-        expect(await res.text()).toBe("via proxy");
-        expect(targets).toEqual([`127.0.0.1:${port}`]);
-      },
-    );
-
-    agent.destroy();
-    proxy.close();
+    try {
+      await withServer(
+        (req, res) => res.end("via proxy"),
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
+          expect(await res.text()).toBe("via proxy");
+          expect(targets).toEqual([`127.0.0.1:${port}`]);
+        },
+      );
+    } finally {
+      agent.destroy();
+      proxy.close();
+    }
   });
 });

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -294,19 +294,42 @@ describe("node-fetch honours the agent option", () => {
     }
   });
 
-  test("decompresses gzip responses", async () => {
+  test.each([
+    ["gzip", "gzip", b => zlib.gzipSync(b)],
+    ["deflate (zlib-wrapped)", "deflate", b => zlib.deflateSync(b)],
+    ["deflate (raw)", "deflate", b => zlib.deflateRawSync(b)],
+    ["br", "br", b => zlib.brotliCompressSync(b)],
+  ])("decompresses %s responses", async (_label, enc, encode) => {
     const { agent } = makeAgent();
     try {
       await withServer(
         (req, res) => {
-          res.writeHead(200, { "content-encoding": "gzip" });
-          res.end(zlib.gzipSync("compressed body"));
+          res.writeHead(200, { "content-encoding": enc });
+          res.end(encode("compressed body"));
         },
         async port => {
           const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
           expect(await res.text()).toBe("compressed body");
         },
       );
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("honours the agent carried on a Request input", async () => {
+    const { agent, calls } = makeAgent();
+    try {
+      await withServer(
+        (req, res) => res.end("ok"),
+        async port => {
+          const request = new Request(`http://127.0.0.1:${port}/`, { agent });
+          expect(request.agent).toBe(agent);
+          const res = await fetch2(request);
+          expect(await res.text()).toBe("ok");
+        },
+      );
+      expect(calls()).toBe(1);
     } finally {
       agent.destroy();
     }

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -1,9 +1,15 @@
 import * as vercelFetch from "@vercel/fetch";
 import * as iso from "isomorphic-fetch";
-import fetch2, { fetch, Headers, Request, Response } from "node-fetch";
+import fetch2, { fetch, FetchError, Headers, Request, Response } from "node-fetch";
+import * as http from "node:http";
+import * as https from "node:https";
+import * as net from "node:net";
+import * as zlib from "node:zlib";
+import { once } from "node:events";
 import * as stream from "stream";
 
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { tls as tlsCert } from "harness";
 
 const originalResponse = globalThis.Response;
 const originalRequest = globalThis.Request;
@@ -157,4 +163,242 @@ test("node-fetch request body streams properly", async () => {
   const allData = Buffer.concat(receivedChunks).toString();
   expect(allData).toBe("first chunksecond chunkthird chunk");
   expect(requestBodyComplete).toBe(true);
+});
+
+// https://github.com/oven-sh/bun/issues/5686
+describe("node-fetch honours the agent option", () => {
+  function makeAgent() {
+    let calls = 0;
+    const agent = new (class extends http.Agent {
+      createConnection(opts, cb) {
+        calls++;
+        return net.createConnection(opts, cb);
+      }
+    })({ keepAlive: false });
+    return { agent, calls: () => calls };
+  }
+
+  async function withServer(handler, fn) {
+    const server = http.createServer(handler);
+    server.listen(0);
+    await once(server, "listening");
+    try {
+      await fn(server.address().port);
+    } finally {
+      server.close();
+    }
+  }
+
+  test("calls agent.createConnection", async () => {
+    const { agent, calls } = makeAgent();
+    await withServer(
+      (req, res) => res.end("ok"),
+      async port => {
+        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
+        expect(await res.text()).toBe("ok");
+        expect(res.status).toBe(200);
+        expect(res.url).toBe(`http://127.0.0.1:${port}/`);
+        expect(res.body).toBeInstanceOf(stream.Readable);
+      },
+    );
+    expect(calls()).toBe(1);
+    agent.destroy();
+  });
+
+  test("agent as a function receives the parsed URL", async () => {
+    const { agent, calls } = makeAgent();
+    let receivedHostname;
+    await withServer(
+      (req, res) => res.end("ok"),
+      async port => {
+        const res = await fetch2(`http://127.0.0.1:${port}/`, {
+          agent: parsed => {
+            receivedHostname = parsed.hostname;
+            return agent;
+          },
+        });
+        expect(await res.text()).toBe("ok");
+      },
+    );
+    expect(receivedHostname).toBe("127.0.0.1");
+    expect(calls()).toBe(1);
+    agent.destroy();
+  });
+
+  test("forwards method, headers and body", async () => {
+    const { agent, calls } = makeAgent();
+    await withServer(
+      (req, res) => {
+        let body = "";
+        req.on("data", c => (body += c));
+        req.on("end", () => {
+          res.setHeader("x-echo", req.headers["x-foo"] ?? "");
+          res.end(`${req.method}:${body}`);
+        });
+      },
+      async port => {
+        const res = await fetch2(`http://127.0.0.1:${port}/`, {
+          agent,
+          method: "POST",
+          headers: { "x-foo": "bar" },
+          body: "hello",
+        });
+        expect(await res.text()).toBe("POST:hello");
+        expect(res.headers.get("x-echo")).toBe("bar");
+        expect(res.headers.raw()["x-echo"]).toEqual(["bar"]);
+      },
+    );
+    expect(calls()).toBe(1);
+    agent.destroy();
+  });
+
+  test("decompresses gzip responses", async () => {
+    const { agent } = makeAgent();
+    await withServer(
+      (req, res) => {
+        res.writeHead(200, { "content-encoding": "gzip" });
+        res.end(zlib.gzipSync("compressed body"));
+      },
+      async port => {
+        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
+        expect(await res.text()).toBe("compressed body");
+      },
+    );
+    agent.destroy();
+  });
+
+  test("follows redirects through the agent", async () => {
+    const { agent, calls } = makeAgent();
+    await withServer(
+      (req, res) => {
+        if (req.url === "/start") {
+          res.writeHead(302, { location: "/end" });
+          res.end();
+        } else {
+          res.end("landed");
+        }
+      },
+      async port => {
+        const res = await fetch2(`http://127.0.0.1:${port}/start`, { agent });
+        expect(await res.text()).toBe("landed");
+        expect(res.status).toBe(200);
+      },
+    );
+    expect(calls()).toBe(2);
+    agent.destroy();
+  });
+
+  test("redirect: 'manual' returns the 3xx response", async () => {
+    const { agent } = makeAgent();
+    await withServer(
+      (req, res) => {
+        res.writeHead(302, { location: "/elsewhere" });
+        res.end();
+      },
+      async port => {
+        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent, redirect: "manual" });
+        expect(res.status).toBe(302);
+        expect(res.headers.get("location")).toBe("/elsewhere");
+      },
+    );
+    agent.destroy();
+  });
+
+  test("rejects with FetchError on connection failure", async () => {
+    const { agent } = makeAgent();
+    // Bind a socket to reserve a port, then close it so nothing is listening.
+    const probe = net.createServer().listen(0);
+    await once(probe, "listening");
+    const port = probe.address().port;
+    await new Promise(r => probe.close(r));
+
+    await expect(fetch2(`http://127.0.0.1:${port}/`, { agent })).rejects.toThrow(FetchError);
+    agent.destroy();
+  });
+
+  test("aborts via signal", async () => {
+    const { agent } = makeAgent();
+    await withServer(
+      () => {
+        /* never respond */
+      },
+      async port => {
+        const controller = new AbortController();
+        const p = fetch2(`http://127.0.0.1:${port}/`, { agent, signal: controller.signal });
+        controller.abort();
+        await expect(p).rejects.toMatchObject({ name: "AbortError" });
+      },
+    );
+    agent.destroy();
+  });
+
+  test("picks https.request for https: URLs", async () => {
+    let calls = 0;
+    const agent = new (class extends https.Agent {
+      createConnection(opts, cb) {
+        calls++;
+        return https.Agent.prototype.createConnection.call(this, opts, cb);
+      }
+    })({ keepAlive: false, rejectUnauthorized: false });
+
+    const server = https.createServer({ ...tlsCert }, (req, res) => res.end("secure"));
+    server.listen(0);
+    await once(server, "listening");
+    try {
+      const port = server.address().port;
+      const res = await fetch2(`https://127.0.0.1:${port}/`, { agent });
+      expect(await res.text()).toBe("secure");
+    } finally {
+      server.close();
+    }
+    expect(calls).toBe(1);
+    agent.destroy();
+  });
+
+  test("tunnels via a CONNECT-proxy agent", async () => {
+    // Minimal CONNECT proxy that records every CONNECT target.
+    const targets = [];
+    const proxy = net.createServer(client => {
+      client.once("data", chunk => {
+        const line = chunk.toString().split("\r\n")[0];
+        const [, hostPort] = line.match(/^CONNECT (\S+) HTTP\/1\.1$/);
+        targets.push(hostPort);
+        const [host, port] = hostPort.split(":");
+        const upstream = net.connect(+port, host, () => {
+          client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+          client.pipe(upstream);
+          upstream.pipe(client);
+        });
+        upstream.on("error", () => client.destroy());
+      });
+    });
+    proxy.listen(0);
+    await once(proxy, "listening");
+    const proxyPort = proxy.address().port;
+
+    // Agent whose createConnection establishes the tunnel first (what
+    // socks-proxy-agent / https-proxy-agent do).
+    class TunnelAgent extends http.Agent {
+      createConnection(opts, cb) {
+        const sock = net.connect(proxyPort, "127.0.0.1", () => {
+          sock.write(`CONNECT ${opts.host}:${opts.port} HTTP/1.1\r\n\r\n`);
+          sock.once("data", () => cb(null, sock));
+        });
+        sock.on("error", cb);
+      }
+    }
+    const agent = new TunnelAgent({ keepAlive: false });
+
+    await withServer(
+      (req, res) => res.end("via proxy"),
+      async port => {
+        const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
+        expect(await res.text()).toBe("via proxy");
+        expect(targets).toEqual([`127.0.0.1:${port}`]);
+      },
+    );
+
+    agent.destroy();
+    proxy.close();
+  });
 });

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -412,6 +412,97 @@ describe("node-fetch honours the agent option", () => {
     }
   });
 
+  test("aborts after headers have arrived", async () => {
+    const { agent } = makeAgent();
+    try {
+      let gotHeaders;
+      const headersSent = new Promise(r => (gotHeaders = r));
+      await withServer(
+        (req, res) => {
+          res.writeHead(200);
+          res.write("x");
+          res.flushHeaders();
+          gotHeaders();
+          // never end
+        },
+        async port => {
+          const controller = new AbortController();
+          const res = await fetch2(`http://127.0.0.1:${port}/`, { agent, signal: controller.signal });
+          expect(res.status).toBe(200);
+          await headersSent;
+          const textP = res.text();
+          controller.abort();
+          await expect(textP).rejects.toMatchObject({ name: "AbortError" });
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("strips brackets from IPv6 literal hostnames", async () => {
+    const { agent } = makeAgent();
+    const server = http.createServer((req, res) => res.end("v6"));
+    try {
+      await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "::1", resolve);
+      });
+    } catch (err) {
+      agent.destroy();
+      if (err?.code === "EADDRNOTAVAIL" || err?.code === "EAFNOSUPPORT") return; // no IPv6 loopback in this environment
+      throw err;
+    }
+    try {
+      const port = server.address().port;
+      const res = await fetch2(`http://[::1]:${port}/`, { agent });
+      expect(await res.text()).toBe("v6");
+    } finally {
+      server.close();
+      agent.destroy();
+    }
+  });
+
+  test("accepts status codes outside [200, 599]", async () => {
+    const { agent } = makeAgent();
+    // http.ServerResponse.writeHead rejects 999, so speak raw TCP.
+    const server = net.createServer(sock => {
+      sock.end("HTTP/1.1 999 Custom\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    try {
+      const port = server.address().port;
+      const res = await fetch2(`http://127.0.0.1:${port}/`, { agent });
+      expect(res.status).toBe(999);
+      expect(res.ok).toBe(false);
+      expect(await res.text()).toBe("ok");
+    } finally {
+      server.close();
+      agent.destroy();
+    }
+  });
+
+  test("request body stream error rejects with FetchError", async () => {
+    const { agent } = makeAgent();
+    try {
+      await withServer(
+        (req, res) => {
+          req.resume();
+          req.on("end", () => res.end("ok"));
+        },
+        async port => {
+          const body = new stream.Readable({ read() {} });
+          const p = fetch2(`http://127.0.0.1:${port}/`, { agent, method: "POST", body });
+          body.destroy(new Error("boom"));
+          await expect(p).rejects.toBeInstanceOf(FetchError);
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
+  });
+
   test("tunnels via a CONNECT-proxy agent", async () => {
     // Minimal CONNECT proxy that records every CONNECT target.
     const targets = [];

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -317,6 +317,44 @@ describe("node-fetch honours the agent option", () => {
     }
   });
 
+  test("sends Basic auth from URL userinfo", async () => {
+    const { agent } = makeAgent();
+    try {
+      await withServer(
+        (req, res) => res.end(req.headers.authorization ?? ""),
+        async port => {
+          const res = await fetch2(`http://alice:s%40cret@127.0.0.1:${port}/`, { agent });
+          expect(await res.text()).toBe("Basic " + Buffer.from("alice:s@cret").toString("base64"));
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("clone() preserves url and redirected", async () => {
+    const { agent } = makeAgent();
+    try {
+      await withServer(
+        (req, res) => {
+          if (req.url === "/a") {
+            res.writeHead(302, { location: "/b" });
+            res.end();
+          } else res.end("ok");
+        },
+        async port => {
+          const res = await fetch2(`http://127.0.0.1:${port}/a`, { agent });
+          const c = res.clone();
+          expect(c.url).toBe(res.url);
+          expect(c.redirected).toBe(true);
+          expect(await c.text()).toBe("ok");
+        },
+      );
+    } finally {
+      agent.destroy();
+    }
+  });
+
   test("honours the agent carried on a Request input", async () => {
     const { agent, calls } = makeAgent();
     try {

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -1,11 +1,11 @@
 import * as vercelFetch from "@vercel/fetch";
 import * as iso from "isomorphic-fetch";
 import fetch2, { fetch, FetchError, Headers, Request, Response } from "node-fetch";
+import { once } from "node:events";
 import * as http from "node:http";
 import * as https from "node:https";
 import * as net from "node:net";
 import * as zlib from "node:zlib";
-import { once } from "node:events";
 import * as stream from "stream";
 
 import { afterEach, describe, expect, test } from "bun:test";


### PR DESCRIPTION
Fixes #5686.

## Problem

Bun unconditionally replaces `require("node-fetch")` / `import "node-fetch"` with a thin wrapper around native `fetch`. Native `fetch` has no `agent` option, so the `agent` passed to `node-fetch` was silently dropped and the request went out directly over the network:

```js
import http from "node:http";
import net from "node:net";
import fetch from "node-fetch";

let called = false;
class MyAgent extends http.Agent {
  createConnection(opts, cb) { called = true; return net.createConnection(opts, cb); }
}
await fetch(url, { agent: new MyAgent() });
// node:  called === true
// bun:   called === false   (request bypassed the agent)
```

Anything that relies on `agent.createConnection` to route the socket is affected: `socks-proxy-agent`, `https-proxy-agent`, `http-proxy-agent`, tunneling agents, custom connection pools. There is no user-level opt-out of the override, so installing the real `node-fetch` does not help.

## Fix

When `init.agent` is set (object or function), drive the request with `http.request` / `https.request`, which already honour `agent.addRequest` / `createConnection` in Bun. The result is wrapped back into the shim's `Response` so `headers.raw()`, the node-stream `body`, `.buffer()` and so on keep working. Redirects, gzip/deflate/br decoding, `signal`, and the `agent`-as-function form are handled the same way node-fetch does.

Requests without an `agent` continue to use native `fetch` unchanged.

## Tests

New `describe("node-fetch honours the agent option")` block in `test/js/node/http/node-fetch.test.js` covers `createConnection` being called, agent-as-function, method/headers/body forwarding, gzip decoding, redirect follow/manual, `FetchError` on connection failure, abort via `signal`, https agents, and a CONNECT-tunnel proxy agent.

Fixes #10642
Fixes #22019

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-fetch.test.js
bun test v1.4.0 (440c9202b)

test/js/node/http/node-fetch.test.js:
(pass) node-fetch [22.58ms]
(pass) node-fetch Headers.raw() [8.25ms]
(pass) node-fetch.fetch fetches [48.35ms]
(pass) node-fetch.default fetches [18.54ms]
(pass) node-fetch.default.default fetches [17.88ms]
(pass) isomorphic-fetch.fetch fetches [19.38ms]
(pass) isomorphic-fetch.default.fetch fetches [17.80ms]
(pass) isomorphic-fetch.default fetches [17.12ms]
(pass) @vercel/fetch.default fetches [24.11ms]
(pass) node-fetch uses node streams instead of web streams [314.92ms]
(pass) node-fetch request body streams properly [77.83ms]
200 |           expect(res.status).toBe(200);
201 |           expect(res.url).toBe(`http://127.0.0.1:${port}/`);
202 |           expect(res.body).toBeInstanceOf(stream.Readable);
203 |         },
204 |       );
205 |       expect(calls()).toBe(1);
                            ^
error: expect(received).toBe(expected)

Expected: 1
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/http/node-fetch.te
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (08886c382)

test/js/node/http/node-fetch.test.js:
(pass) node-fetch [5.28ms]
(pass) node-fetch Headers.raw() [1.74ms]
(pass) node-fetch.fetch fetches [18.03ms]
(pass) node-fetch.default fetches [1.40ms]
(pass) node-fetch.default.default fetches [0.78ms]
(pass) isomorphic-fetch.fetch fetches [0.58ms]
(pass) isomorphic-fetch.default.fetch fetches [0.52ms]
(pass) isomorphic-fetch.default fetches [0.47ms]
(pass) @vercel/fetch.default fetches [0.70ms]
(pass) node-fetch uses node streams instead of web streams [15.87ms]
(pass) node-fetch request body streams properly [2.70ms]
(pass) node-fetch honours the agent option > calls agent.createConnection [38.40ms]
(pass) node-fetch honours the agent option > agent as a function receives the parsed URL [5.21ms]
(pass) node-fetch honours the agent option > forwards method, headers and body [7.83ms]
(pass) node-fetch honours the agent option > serialises FormData and URLSearchParams bodies [22.16ms]
(pass) node-fetch honours the agent option > decompresses gzip responses [8.69ms]
(pass) node-fetch honours the agent option > decompresses deflate (zlib-wrapped) responses [7.56ms]
(pass) node-fetch honours t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-fetch.test.js
bun test v1.4.0 (440c9202b)

test/js/node/http/node-fetch.test.js:
(pass) node-fetch [6.59ms]
(pass) node-fetch Headers.raw() [6.17ms]
(pass) node-fetch.fetch fetches [160.25ms]
(pass) node-fetch.default fetches [13.52ms]
(pass) node-fetch.default.default fetches [18.58ms]
(pass) isomorphic-fetch.fetch fetches [18.31ms]
(pass) isomorphic-fetch.default.fetch fetches [17.86ms]
(pass) isomorphic-fetch.default fetches [15.77ms]
(pass) @vercel/fetch.default fetches [26.71ms]
(pass) node-fetch uses node streams instead of web streams [282.21ms]
(pass) node-fetch request body streams properly [88.49ms]
(pass) node-fetch honours the agent option > calls agent.createConnection [1106.16ms]
(pass) node-fetch honours the agent option > agent as a function receives the parsed URL [264.37ms]
(pass) node-fetch honours the agent option > forwards method, headers and body [246.45ms]
(pass) node-fetch honours the agent option > serialises FormData and URLSearchParams bodies [464.75ms]
(pass) node-fetch honours the ag
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1274ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/137] gen cpp.rs (cppbind)
[2/137] gen JS modules (bundle-modules)
Preprocess modules (8496ms)
Bundle modules (118ms)
Postprocesss modules (170ms)
Bundle Functions (791ms)
Generate Code (46ms)

[9.64s] Bundled "src/js" for production
  2124 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[2/137] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/ca
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/node-fetch.ts      | 348 +++++++++++++++++++++-
 test/js/node/http/node-fetch.test.js | 538 ++++++++++++++++++++++++++++++++++-
 2 files changed, 880 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js/thirdparty/node-fetch.ts          15     35      0
test/js/node/http/node-fetch.test.js      4     10      0
```

</details>

<!-- robobun:evidence:end -->