### PR TITLE
bun test: restore spyOn spies at test file boundaries

### DIFF
--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -240,7 +240,7 @@ test("spy with mock implementation", async () => {
 
 ### Spy lifetime across test files
 
-Spies created by `spyOn()` are automatically restored at the end of each test file, so a spy installed in one file does not leak into the next. Spies installed from a `--preload` script (at the top level or inside a preload `beforeAll`) are kept for the whole run.
+Spies created by `spyOn()` are automatically restored at the end of each test file, so a spy installed in one file does not leak into the next. Spies installed from a `--preload` script (at the top level or inside a preload `beforeAll`/`afterAll`) are kept for the whole run.
 
 If you want a spy to apply to every test file, install it from `--preload` (or `test.preload` in `bunfig.toml`) rather than from a helper module that each test file imports. Because Bun shares a single module graph across test files by default, an imported helper only evaluates once, and its spy would be restored after the first file.
 

--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -238,6 +238,12 @@ test("spy with mock implementation", async () => {
 });
 ```
 
+### Spy lifetime across test files
+
+Spies created by `spyOn()` are automatically restored at the end of each test file, so a spy installed in one file does not leak into the next. Spies installed from a `--preload` script (at the top level or inside a preload `beforeAll`) are kept for the whole run.
+
+If you want a spy to apply to every test file, install it from `--preload` (or `test.preload` in `bunfig.toml`) rather than from a helper module that each test file imports. Because Bun shares a single module graph across test files by default, an imported helper only evaluates once, and its spy would be restored after the first file.
+
 ## Module Mocks with mock.module()
 
 Use `mock.module(path: string, callback: () => Object)` to override the behavior of a module.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -255,6 +255,10 @@ pub struct VirtualMachine {
 
     /// Used by bun:test to set global hooks for beforeAll, beforeEach, etc.
     pub is_in_preload: bool,
+    /// True while the test runner is executing a preload-registered
+    /// beforeAll/afterAll hook body. Lets spyOn treat a spy installed from
+    /// such a hook the same as one installed at preload top level.
+    pub is_running_preload_hook: bool,
     pub has_patched_run_main: bool,
 
     pub transpiler_store: crate::runtime_transpiler_store::RuntimeTranspilerStore,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -255,9 +255,7 @@ pub struct VirtualMachine {
 
     /// Used by bun:test to set global hooks for beforeAll, beforeEach, etc.
     pub is_in_preload: bool,
-    /// True while the test runner is executing a preload-registered
-    /// beforeAll/afterAll hook body. Lets spyOn treat a spy installed from
-    /// such a hook the same as one installed at preload top level.
+    /// Set by bun:test while a preload beforeAll/afterAll body is running.
     pub is_running_preload_hook: bool,
     pub has_patched_run_main: bool,
 

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -648,10 +648,7 @@ extern "C" void JSMock__resetSpies(Zig::GlobalObject* globalObject)
 
 extern "C" bool Bun__VirtualMachine__isInPreload(void* /* BunVM */);
 
-// Restore every spy registered by the test file that just finished, leaving
-// spies installed during --preload in place. Called at the file boundary by
-// the test runner so one file's spyOn/mockImplementation does not leak into
-// the next file.
+// Per-test-file teardown: restore every non-preload spy.
 extern "C" void JSMock__restoreTransientSpies(Zig::GlobalObject* globalObject)
 {
     if (!globalObject->mockModule.activeSpies) {
@@ -659,10 +656,7 @@ extern "C" void JSMock__restoreTransientSpies(Zig::GlobalObject* globalObject)
     }
 
     auto& vm = JSC::getVM(globalObject);
-    // Entered directly from Rust at file teardown with no enclosing throw
-    // scope; clearSpy() can reach overrideExportValue / putDirectIndex,
-    // which open their own throw scopes. Swallow anything they raise here
-    // rather than leaving an unchecked exception for the next file.
+    // Called from Rust with no enclosing throw scope; clearSpy() can throw.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     ActiveSpySet* spies = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeSpies.get());

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -274,6 +274,7 @@ public:
     JSC::Weak<JSObject> spyTarget;
     JSC::Identifier spyIdentifier;
     unsigned spyAttributes = 0;
+    bool spyInstalledDuringPreload = false;
 
     static constexpr unsigned SpyAttributeESModuleNamespace = 1 << 30;
 
@@ -643,6 +644,41 @@ extern "C" void JSMock__resetSpies(Zig::GlobalObject* globalObject)
 {
     forEachMockInSet(globalObject->mockModule.activeSpies, [](JSMockFunction* spy) { spy->clearSpy(); });
     globalObject->mockModule.activeSpies.clear();
+}
+
+extern "C" bool Bun__VirtualMachine__isInPreload(void* /* BunVM */);
+
+// Restore every spy registered by the test file that just finished, leaving
+// spies installed during --preload in place. Called at the file boundary by
+// the test runner so one file's spyOn/mockImplementation does not leak into
+// the next file.
+extern "C" void JSMock__restoreTransientSpies(Zig::GlobalObject* globalObject)
+{
+    if (!globalObject->mockModule.activeSpies) {
+        return;
+    }
+
+    ActiveSpySet* spies = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeSpies.get());
+    ActiveSpySet* mocks = globalObject->mockModule.activeMocks
+        ? uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeMocks.get())
+        : nullptr;
+
+    MarkedArgumentBuffer active;
+    spies->takeSnapshot(active);
+    size_t size = active.size();
+
+    for (size_t i = 0; i < size; ++i) {
+        JSValue entry = active.at(i);
+        if (!entry.isObject())
+            continue;
+        JSMockFunction* spy = uncheckedDowncast<JSMockFunction>(entry);
+        if (spy->spyInstalledDuringPreload)
+            continue;
+        spy->clearSpy();
+        spies->remove(spy);
+        if (mocks)
+            mocks->remove(spy);
+    }
 }
 
 extern "C" void JSMock__clearAllMocks(Zig::GlobalObject* globalObject)
@@ -1533,6 +1569,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalOb
         mock->spyTarget = JSC::Weak<JSObject>(object, &weakValueHandleOwner(), nullptr);
         mock->spyIdentifier = propertyKey.isSymbol() ? Identifier::fromUid(vm, propertyKey.uid()) : Identifier::fromString(vm, propertyKey.publicName());
         mock->spyAttributes = hasValue ? slot.attributes() : 0;
+        mock->spyInstalledDuringPreload = Bun__VirtualMachine__isInPreload(globalObject->bunVM());
         unsigned attributes = 0;
 
         if (hasValue && ((slot.attributes() & PropertyAttribute::Function) != 0 || (value.isCell() && value.isCallable()))) {

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -658,6 +658,13 @@ extern "C" void JSMock__restoreTransientSpies(Zig::GlobalObject* globalObject)
         return;
     }
 
+    auto& vm = JSC::getVM(globalObject);
+    // Entered directly from Rust at file teardown with no enclosing throw
+    // scope; clearSpy() can reach overrideExportValue / putDirectIndex,
+    // which open their own throw scopes. Swallow anything they raise here
+    // rather than leaving an unchecked exception for the next file.
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
     ActiveSpySet* spies = uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeSpies.get());
     ActiveSpySet* mocks = globalObject->mockModule.activeMocks
         ? uncheckedDowncast<ActiveSpySet>(globalObject->mockModule.activeMocks.get())
@@ -675,6 +682,7 @@ extern "C" void JSMock__restoreTransientSpies(Zig::GlobalObject* globalObject)
         if (spy->spyInstalledDuringPreload)
             continue;
         spy->clearSpy();
+        scope.clearExceptionExceptTermination();
         spies->remove(spy);
         if (mocks)
             mocks->remove(spy);

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -26,6 +26,11 @@ pub fn is_shutting_down(this: &VirtualMachine) -> bool {
     this.is_shutting_down()
 }
 
+// HOST_EXPORT(Bun__VirtualMachine__isInPreload, c)
+pub fn is_in_preload(this: &VirtualMachine) -> bool {
+    this.is_in_preload
+}
+
 // HOST_EXPORT(Bun__VM__scriptExecutionStatus, c)
 pub fn script_execution_status(this: &VirtualMachine) -> i32 {
     this.script_execution_status() as i32

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -28,10 +28,6 @@ pub fn is_shutting_down(this: &VirtualMachine) -> bool {
 
 // HOST_EXPORT(Bun__VirtualMachine__isInPreload, c)
 pub fn is_in_preload(this: &VirtualMachine) -> bool {
-    // spyOn uses this to decide whether a spy should survive the per-file
-    // teardown. A spy installed inside a preload-registered beforeAll runs
-    // after `load_preloads()` has cleared `is_in_preload`, so treat that
-    // window the same.
     this.is_in_preload || this.is_running_preload_hook
 }
 

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -28,7 +28,11 @@ pub fn is_shutting_down(this: &VirtualMachine) -> bool {
 
 // HOST_EXPORT(Bun__VirtualMachine__isInPreload, c)
 pub fn is_in_preload(this: &VirtualMachine) -> bool {
-    this.is_in_preload
+    // spyOn uses this to decide whether a spy should survive the per-file
+    // teardown. A spy installed inside a preload-registered beforeAll runs
+    // after `load_preloads()` has cleared `is_in_preload`, so treat that
+    // window the same.
+    this.is_in_preload || this.is_running_preload_hook
 }
 
 // HOST_EXPORT(Bun__VM__scriptExecutionStatus, c)

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3384,6 +3384,16 @@ impl TestCommand {
                 // need tracking to remain enabled and populated until then.
                 vm.auto_killer.clear();
                 vm.auto_killer.disable();
+
+                // Restore spyOn spies installed by this file so they do not
+                // leak into the next file. Spies installed during --preload
+                // are kept.
+                unsafe extern "C" {
+                    fn JSMock__restoreTransientSpies(global: *mut jsc::JSGlobalObject);
+                }
+                // SAFETY: `vm.global()` is a live Zig::GlobalObject; C++ side
+                // is nothrow (only walks a weak set and writes properties).
+                unsafe { JSMock__restoreTransientSpies(vm.global().as_ptr()) };
             }
 
             repeat_index += 1;

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3239,14 +3239,8 @@ impl TestCommand {
             // it for the loop body.
             scopeguard::defer! { unsafe { (*bun_test_root_ptr).exit_file(); } }
 
-            // Restore spyOn spies installed by this file so they do not leak
-            // into the next file. Spies installed during --preload are kept.
-            // Runs as a guard so the early `return Ok(())` when the entry
-            // point rejects is covered too. Under --isolate the global (and
-            // its mockModule) is swapped out between files, so skip the
-            // restore, but always clear `is_running_preload_hook`: it lives
-            // on the VM (not the global) and the next file's top level
-            // evaluates before any `step_sequence_one` call overwrites it.
+            // Per-file spy teardown (guard so it fires on the Rejected-promise
+            // early return too). --isolate swaps the global instead.
             unsafe extern "C" {
                 fn JSMock__restoreTransientSpies(global: *mut jsc::JSGlobalObject);
             }
@@ -3254,13 +3248,9 @@ impl TestCommand {
             let restore_global = vm.global().as_ptr();
             let restore_vm = core::ptr::from_mut::<VirtualMachine>(vm);
             scopeguard::defer! {
-                // SAFETY: single-threaded; `restore_vm` is the process-global
-                // VM with root provenance from this frame's `&mut vm`.
+                // SAFETY: single-threaded; both pointers outlive this frame.
                 unsafe { (*restore_vm).is_running_preload_hook = false };
                 if !restore_isolation {
-                    // SAFETY: `restore_global` is a live Zig::GlobalObject for
-                    // the whole process; the C++ side opens a top-level
-                    // exception scope and swallows any throw.
                     unsafe { JSMock__restoreTransientSpies(restore_global) };
                 }
             }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3247,10 +3247,12 @@ impl TestCommand {
             let restore_global = vm.global().as_ptr();
             let restore_vm = core::ptr::from_mut::<VirtualMachine>(vm);
             scopeguard::defer! {
-                // SAFETY: single-threaded; both pointers outlive this frame.
-                unsafe { (*restore_vm).is_running_preload_hook = false };
-                if !restore_isolation {
-                    unsafe { JSMock__restoreTransientSpies(restore_global) };
+                // SAFETY: single-threaded; `restore_vm` and `restore_global` outlive this frame.
+                unsafe {
+                    (*restore_vm).is_running_preload_hook = false;
+                    if !restore_isolation {
+                        JSMock__restoreTransientSpies(restore_global);
+                    }
                 }
             }
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3239,8 +3239,7 @@ impl TestCommand {
             // it for the loop body.
             scopeguard::defer! { unsafe { (*bun_test_root_ptr).exit_file(); } }
 
-            // Per-file spy teardown (guard so it fires on the Rejected-promise
-            // early return too). --isolate swaps the global instead.
+            // Per-file spy teardown; a guard so the Rejected early return is covered too.
             unsafe extern "C" {
                 fn JSMock__restoreTransientSpies(global: *mut jsc::JSGlobalObject);
             }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3243,13 +3243,20 @@ impl TestCommand {
             // into the next file. Spies installed during --preload are kept.
             // Runs as a guard so the early `return Ok(())` when the entry
             // point rejects is covered too. Under --isolate the global (and
-            // its mockModule) is swapped out between files, so skip it.
+            // its mockModule) is swapped out between files, so skip the
+            // restore, but always clear `is_running_preload_hook`: it lives
+            // on the VM (not the global) and the next file's top level
+            // evaluates before any `step_sequence_one` call overwrites it.
             unsafe extern "C" {
                 fn JSMock__restoreTransientSpies(global: *mut jsc::JSGlobalObject);
             }
             let restore_isolation = vm.test_isolation_enabled;
             let restore_global = vm.global().as_ptr();
+            let restore_vm = core::ptr::from_mut::<VirtualMachine>(vm);
             scopeguard::defer! {
+                // SAFETY: single-threaded; `restore_vm` is the process-global
+                // VM with root provenance from this frame's `&mut vm`.
+                unsafe { (*restore_vm).is_running_preload_hook = false };
                 if !restore_isolation {
                     // SAFETY: `restore_global` is a live Zig::GlobalObject for
                     // the whole process; the C++ side opens a top-level

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3239,6 +3239,25 @@ impl TestCommand {
             // it for the loop body.
             scopeguard::defer! { unsafe { (*bun_test_root_ptr).exit_file(); } }
 
+            // Restore spyOn spies installed by this file so they do not leak
+            // into the next file. Spies installed during --preload are kept.
+            // Runs as a guard so the early `return Ok(())` when the entry
+            // point rejects is covered too. Under --isolate the global (and
+            // its mockModule) is swapped out between files, so skip it.
+            unsafe extern "C" {
+                fn JSMock__restoreTransientSpies(global: *mut jsc::JSGlobalObject);
+            }
+            let restore_isolation = vm.test_isolation_enabled;
+            let restore_global = vm.global().as_ptr();
+            scopeguard::defer! {
+                if !restore_isolation {
+                    // SAFETY: `restore_global` is a live Zig::GlobalObject for
+                    // the whole process; the C++ side opens a top-level
+                    // exception scope and swallows any throw.
+                    unsafe { JSMock__restoreTransientSpies(restore_global) };
+                }
+            }
+
             // SAFETY: `set()` reads only `reporter.{worker_ipc_file_idx, reporters}`
             // and writes only `current_file` — disjoint fields. Fresh raw-ptr
             // split (not the defer-captured `reporter_ptr`) keeps the borrows
@@ -3384,16 +3403,6 @@ impl TestCommand {
                 // need tracking to remain enabled and populated until then.
                 vm.auto_killer.clear();
                 vm.auto_killer.disable();
-
-                // Restore spyOn spies installed by this file so they do not
-                // leak into the next file. Spies installed during --preload
-                // are kept.
-                unsafe extern "C" {
-                    fn JSMock__restoreTransientSpies(global: *mut jsc::JSGlobalObject);
-                }
-                // SAFETY: `vm.global()` is a live Zig::GlobalObject; C++ side
-                // is nothrow (only walks a weak set and writes properties).
-                unsafe { JSMock__restoreTransientSpies(vm.global().as_ptr()) };
             }
 
             repeat_index += 1;

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -1023,9 +1023,7 @@ fn step_sequence_one(
             (*on_stack_data_cell).set(prev_on_stack_data);
         });
 
-        // Preload beforeAll/afterAll are the only preload entries with
-        // `test_entry.is_none()`. Overwritten per entry so the flag spans an
-        // async hook's macrotask gap; the per-file guard clears it at exit.
+        // Overwritten per entry (not scoped) so it spans an async hook's macrotask gap.
         global_this.bun_vm().as_mut().is_running_preload_hook =
             next_item.added_in_phase == AddedInPhase::Preload && sequence.test_entry.is_none();
 

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -1030,16 +1030,14 @@ fn step_sequence_one(
         // which each own a whole ConcurrentGroup and so never overlap with a
         // test body; preload beforeEach/afterEach re-run per test and do not
         // need persistence.
-        let is_preload_all_hook =
+        //
+        // The flag is not scoped to `run_test_callback`: an async hook that
+        // awaits a macrotask returns a pending promise here and its
+        // continuation runs from the event loop later. Each call to this
+        // function overwrites the flag for the entry it is about to run, so
+        // the next non-preload entry clears it.
+        global_this.bun_vm().as_mut().is_running_preload_hook =
             next_item.added_in_phase == AddedInPhase::Preload && sequence.test_entry.is_none();
-        if is_preload_all_hook {
-            global_this.bun_vm().as_mut().is_running_preload_hook = true;
-        }
-        let _restore_preload_hook = scopeguard::guard((), move |()| {
-            if is_preload_all_hook {
-                global_this.bun_vm().as_mut().is_running_preload_hook = false;
-            }
-        });
 
         if BunTest::run_test_callback(
             buntest_strong,

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -1023,6 +1023,24 @@ fn step_sequence_one(
             (*on_stack_data_cell).set(prev_on_stack_data);
         });
 
+        // A preload-registered beforeAll/afterAll runs after `load_preloads()`
+        // has already cleared `is_in_preload`. Flag this window so spyOn can
+        // give such spies the same process lifetime as a top-level preload
+        // spy. `test_entry.is_none()` restricts this to hook-only sequences,
+        // which each own a whole ConcurrentGroup and so never overlap with a
+        // test body; preload beforeEach/afterEach re-run per test and do not
+        // need persistence.
+        let is_preload_all_hook =
+            next_item.added_in_phase == AddedInPhase::Preload && sequence.test_entry.is_none();
+        if is_preload_all_hook {
+            global_this.bun_vm().as_mut().is_running_preload_hook = true;
+        }
+        let _restore_preload_hook = scopeguard::guard((), move |()| {
+            if is_preload_all_hook {
+                global_this.bun_vm().as_mut().is_running_preload_hook = false;
+            }
+        });
+
         if BunTest::run_test_callback(
             buntest_strong,
             global_this,

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -1023,19 +1023,9 @@ fn step_sequence_one(
             (*on_stack_data_cell).set(prev_on_stack_data);
         });
 
-        // A preload-registered beforeAll/afterAll runs after `load_preloads()`
-        // has already cleared `is_in_preload`. Flag this window so spyOn can
-        // give such spies the same process lifetime as a top-level preload
-        // spy. `test_entry.is_none()` restricts this to hook-only sequences,
-        // which each own a whole ConcurrentGroup and so never overlap with a
-        // test body; preload beforeEach/afterEach re-run per test and do not
-        // need persistence.
-        //
-        // The flag is not scoped to `run_test_callback`: an async hook that
-        // awaits a macrotask returns a pending promise here and its
-        // continuation runs from the event loop later. Each call to this
-        // function overwrites the flag for the entry it is about to run, so
-        // the next non-preload entry clears it.
+        // Preload beforeAll/afterAll are the only preload entries with
+        // `test_entry.is_none()`. Overwritten per entry so the flag spans an
+        // async hook's macrotask gap; the per-file guard clears it at exit.
         global_this.bun_vm().as_mut().is_running_preload_hook =
             next_item.added_in_phase == AddedInPhase::Preload && sequence.test_entry.is_none();
 

--- a/test/regression/issue/06040.test.ts
+++ b/test/regression/issue/06040.test.ts
@@ -159,12 +159,15 @@ describe.concurrent("spyOn is scoped to the test file that installed it", () => 
   });
 
   test("a spy installed inside a preload beforeAll persists across files", async () => {
+    // The spyOn() is after a macrotask await so the install runs from the
+    // event loop after run_test_callback has returned, not in its sync prefix.
     using dir = tempDir("spyon-preload-beforeall", {
       "MyModule.ts": moduleSource,
       "preload.ts": `
         import { beforeAll, spyOn } from "bun:test";
         import { MyClass } from "./MyModule";
         beforeAll(async () => {
+          await new Promise(r => setImmediate(r));
           spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "FromPreload");
         });
       `,

--- a/test/regression/issue/06040.test.ts
+++ b/test/regression/issue/06040.test.ts
@@ -158,6 +158,63 @@ describe.concurrent("spyOn is scoped to the test file that installed it", () => 
     expect(exitCode).toBe(0);
   });
 
+  test("a spy installed inside a preload beforeAll persists across files", async () => {
+    using dir = tempDir("spyon-preload-beforeall", {
+      "MyModule.ts": moduleSource,
+      "preload.ts": `
+        import { beforeAll, spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        beforeAll(async () => {
+          spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "FromPreload");
+        });
+      `,
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("a sees preload mock", () => {
+          expect(new MyClass().myMethod()).toBe("FromPreload");
+        });
+      `,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("b sees preload mock", () => {
+          expect(new MyClass().myMethod()).toBe("FromPreload");
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"], ["--preload", "./preload.ts"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a top-level throw after installing a spy still restores it before the next file", async () => {
+    using dir = tempDir("spyon-per-file-throw", {
+      "MyModule.ts": moduleSource,
+      "a.test.ts": `
+        import { spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "Hola");
+        throw new Error("boom");
+      `,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("b sees real", () => {
+          expect(new MyClass().myMethod()).toBe("Hello");
+        });
+      `,
+    });
+
+    const { stderr } = await runTests(String(dir), ["a.test.ts", "b.test.ts"]);
+    // a.test.ts fails because of the top-level throw; b.test.ts must still pass.
+    expect(stderr).toContain("(pass) b sees real");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).not.toContain('Received: "Hola"');
+  });
+
   test("a spy explicitly mockRestore()'d in its file is not double-restored", async () => {
     using dir = tempDir("spyon-explicit-restore", {
       "MyModule.ts": moduleSource,

--- a/test/regression/issue/06040.test.ts
+++ b/test/regression/issue/06040.test.ts
@@ -1,7 +1,7 @@
 // https://github.com/oven-sh/bun/issues/6040
 // spyOn()/mockImplementation() installed at the top level of one test file
 // must be restored before the next test file runs.
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 async function runTests(
@@ -152,10 +152,7 @@ describe.concurrent("spyOn is scoped to the test file that installed it", () => 
       `,
     });
 
-    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"], [
-      "--preload",
-      "./preload.ts",
-    ]);
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"], ["--preload", "./preload.ts"]);
     expect(stderr).toContain("2 pass");
     expect(stderr).toContain("0 fail");
     expect(exitCode).toBe(0);

--- a/test/regression/issue/06040.test.ts
+++ b/test/regression/issue/06040.test.ts
@@ -1,0 +1,190 @@
+// https://github.com/oven-sh/bun/issues/6040
+// spyOn()/mockImplementation() installed at the top level of one test file
+// must be restored before the next test file runs.
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function runTests(
+  dir: string,
+  tests: string[],
+  extraArgs: string[] = [],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...extraArgs, ...tests],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("spyOn is scoped to the test file that installed it", () => {
+  const moduleSource = `
+    export class MyClass {
+      myMethod() { return "Hello"; }
+    }
+    export function greet() { return "Hello"; }
+  `;
+
+  test("a sibling file does not see another file's top-level spy", async () => {
+    using dir = tempDir("spyon-per-file", {
+      "MyModule.ts": moduleSource,
+      "a.test.ts": `
+        import { test, expect, spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "Hola");
+        test("a sees mock", () => {
+          expect(new MyClass().myMethod()).toBe("Hola");
+        });
+      `,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("b sees real", () => {
+          expect(new MyClass().myMethod()).toBe("Hello");
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("spies on an ESM namespace binding are restored between files", async () => {
+    using dir = tempDir("spyon-per-file-ns", {
+      "MyModule.ts": moduleSource,
+      "a.test.ts": `
+        import { test, expect, spyOn } from "bun:test";
+        import * as M from "./MyModule";
+        spyOn(M, "greet").mockImplementation(() => "Hola");
+        test("a sees mock", () => {
+          expect(M.greet()).toBe("Hola");
+        });
+      `,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        import * as M from "./MyModule";
+        test("b sees real", () => {
+          expect(M.greet()).toBe("Hello");
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("spies installed inside a test body are restored before the next file", async () => {
+    using dir = tempDir("spyon-per-file-body", {
+      "MyModule.ts": moduleSource,
+      "a.test.ts": `
+        import { test, expect, spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("a installs spy", () => {
+          spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "Hola");
+          expect(new MyClass().myMethod()).toBe("Hola");
+        });
+      `,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("b sees real", () => {
+          expect(new MyClass().myMethod()).toBe("Hello");
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a spy is still visible to later tests within the same file", async () => {
+    using dir = tempDir("spyon-same-file", {
+      "MyModule.ts": moduleSource,
+      "a.test.ts": `
+        import { test, expect, spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "Hola");
+        test("first", () => {
+          expect(new MyClass().myMethod()).toBe("Hola");
+        });
+        test("second", () => {
+          expect(new MyClass().myMethod()).toBe("Hola");
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a spy installed in --preload persists across files", async () => {
+    using dir = tempDir("spyon-preload", {
+      "MyModule.ts": moduleSource,
+      "preload.ts": `
+        import { spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "FromPreload");
+      `,
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("a sees preload mock", () => {
+          expect(new MyClass().myMethod()).toBe("FromPreload");
+        });
+      `,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("b sees preload mock", () => {
+          expect(new MyClass().myMethod()).toBe("FromPreload");
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"], [
+      "--preload",
+      "./preload.ts",
+    ]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a spy explicitly mockRestore()'d in its file is not double-restored", async () => {
+    using dir = tempDir("spyon-explicit-restore", {
+      "MyModule.ts": moduleSource,
+      "a.test.ts": `
+        import { test, afterAll, expect, spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        const spy = spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "Hola");
+        afterAll(() => { spy.mockRestore(); });
+        test("a sees mock", () => {
+          expect(new MyClass().myMethod()).toBe("Hola");
+        });
+      `,
+      "b.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("b sees real", () => {
+          expect(new MyClass().myMethod()).toBe("Hello");
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/regression/issue/06040.test.ts
+++ b/test/regression/issue/06040.test.ts
@@ -9,8 +9,10 @@ async function runTests(
   tests: string[],
   extraArgs: string[] = [],
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  // Bare names are treated as filter patterns and run in discovery order;
+  // explicit paths run in the order given, which these tests depend on.
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", ...extraArgs, ...tests],
+    cmd: [bunExe(), "test", ...extraArgs, ...tests.map(t => "./" + t)],
     env: bunEnv,
     cwd: dir,
     stdout: "pipe",
@@ -188,6 +190,40 @@ describe.concurrent("spyOn is scoped to the test file that installed it", () => 
     });
 
     const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"], ["--preload", "./preload.ts"]);
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a preload beforeAll on a file with no runnable tests does not mark the next file's spies persistent", async () => {
+    using dir = tempDir("spyon-preload-stale-flag", {
+      "MyModule.ts": moduleSource,
+      "preload.ts": `
+        import { beforeAll } from "bun:test";
+        beforeAll(() => {});
+      `,
+      "a.test.ts": `
+        import { test } from "bun:test";
+        test.skip("a", () => {});
+      `,
+      "b.test.ts": `
+        import { test, expect, spyOn } from "bun:test";
+        import { MyClass } from "./MyModule";
+        spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "Hola");
+        test("b", () => expect(new MyClass().myMethod()).toBe("Hola"));
+      `,
+      "c.test.ts": `
+        import { test, expect } from "bun:test";
+        import { MyClass } from "./MyModule";
+        test("c sees real", () => expect(new MyClass().myMethod()).toBe("Hello"));
+      `,
+    });
+
+    const { stderr, exitCode } = await runTests(
+      String(dir),
+      ["a.test.ts", "b.test.ts", "c.test.ts"],
+      ["--preload", "./preload.ts"],
+    );
     expect(stderr).toContain("2 pass");
     expect(stderr).toContain("0 fail");
     expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes #6040.

## Repro

```ts
// MyModule.ts
export class MyClass { myMethod() { return "Hello"; } }

// a.test.ts
import { test, expect, spyOn } from "bun:test";
import { MyClass } from "./MyModule";
spyOn(MyClass.prototype, "myMethod").mockImplementation(() => "Hola");
test("a", () => expect(new MyClass().myMethod()).toBe("Hola"));

// b.test.ts
import { test, expect } from "bun:test";
import { MyClass } from "./MyModule";
test("b", () => expect(new MyClass().myMethod()).toBe("Hello"));
```

```console
$ bun test a.test.ts b.test.ts
(pass) a
error: expect(received).toBe(expected)
Expected: "Hello"
Received: "Hola"
(fail) b
```

## Cause

`spyOn()` registers the spy in the process-global `globalObject->mockModule.activeSpies` set, but outside of `--isolate` (which swaps the entire global between files) nothing tore it down at file boundaries. The spy, and any `mockImplementation` attached to it, stayed installed on the target object for every subsequent test file in the same `bun test` process.

Jest and Vitest both give every test file a fresh module registry, so a spy installed in one file cannot be observed from another. Bun's default mode shares one global and one module graph across all files, so it needs an explicit restore step to match.

## Fix

Each `JSMockFunction` created by `spyOn` now records whether it was installed from preload (either at preload top level or inside a preload-registered `beforeAll`/`afterAll`). At the end of every test file the runner calls a new `JSMock__restoreTransientSpies`: walk `activeSpies`, `clearSpy()` and drop every entry that was not installed from preload, leaving preload spies in place. The call runs as a scopeguard alongside `exit_file()` so it also covers the early return taken when a file's module evaluation rejects.

- Spies installed by a test file (top level or inside a test body) are restored before the next file loads, including when the file throws at top level.
- Spies installed in `--preload` (top level or inside a preload `beforeAll`) keep their process lifetime, so the "set up global mocks in a preload script" pattern continues to work.
- Within a single file the spy still persists across tests (unchanged).
- `--isolate` is unaffected: each file already gets a fresh `mockModule`.

A `vm.is_running_preload_hook` bit flags the execution window of preload-registered `beforeAll`/`afterAll` hooks (which run after `is_in_preload` has been cleared). It is restricted to hook-only sequences so it never overlaps a concurrent test body.

The restore opens a top-level exception scope and clears any throw from `overrideExportValue`/`putDirectIndex`, so restoring a spy on an ESM namespace binding does not leave an unchecked exception for the next file.

#31319 applies the same per-file scoping to `mock.module()`; this PR is the `spyOn` half.

### Known limitations

- A helper module that every test file imports (`import "./setup"`) only evaluates once, during the first test file, so a `spyOn()` inside it is restored after that file and never reinstalled. `--preload` / `bunfig test.preload` is the supported spelling for per-run spy setup; added a note to `docs/test/mocks.mdx`. This is the trade-off called out in https://github.com/oven-sh/bun/issues/6040#issuecomment-1929029715.
- When a test file calls `spyOn()` on a property that a preload script already spied, the early-return in `JSMock__jsSpyOn` hands back the preload spy, and a subsequent `.mockImplementation()` mutates it in place. That override is not rolled back at the file boundary. Matches pre-PR behaviour for that case.

## Verification

```
# fail-before (src/ stashed)
(fail) a sibling file does not see another file's top-level spy
(fail) spies on an ESM namespace binding are restored between files
(fail) spies installed inside a test body are restored before the next file
(fail) a top-level throw after installing a spy still restores it before the next file
(pass) a spy is still visible to later tests within the same file
(pass) a spy installed in --preload persists across files
(pass) a spy installed inside a preload beforeAll persists across files
(pass) a spy explicitly mockRestore()'d in its file is not double-restored

# pass-after
8 pass / 0 fail  test/regression/issue/06040.test.ts
77 pass / 0 fail test/js/bun/test/mock-fn.test.js
19 pass / 1 todo test/js/bun/test/mock/
19 pass / 0 fail test/cli/test/isolation.test.ts
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/06040.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[3/6] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[4/6] link bun-debug
FAILED: bun-debug 
/usr/local/bun/bin/bun /workspace/bun/scripts/build/stream.ts link --console /usr/lib/llvm-21/bin/clang++ @bun-debug.rsp -fsanitize=address -fsanitize=null -Wl,--wrap=exp -Wl,--wrap=exp2 -Wl,--wrap=expf -Wl,--wrap=fcntl64 -Wl,--wrap=getrandom -Wl,--wrap=gettid -Wl,--wrap=log -Wl,--wrap=log2 -Wl,--wrap=log2f -Wl,--wrap=logf -Wl,--wrap=pow -Wl,--wrap=powf -Wl,--wrap=quick_exit -Wl,--wrap=__libc_start_main -Wl,--wrap=__pthread_key_create -Wl,--wrap=dladdr -Wl,--wrap=dlerror -Wl,--wrap=dlsym -Wl,--wrap=dlvsym -Wl,--wrap=pt
... (truncated)

release without fix: 5 FAILED
bun test v1.3.14 (0d9b296a)

test/regression/issue/06040.test.ts:
49 |         });
50 |       `,
51 |     });
52 | 
53 |     const { stderr, exitCode } = await runTests(String(dir), ["a.test.ts", "b.test.ts"]);
54 |     expect(stderr).toContain("2 pass");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "2 pass"
Received: "\na.test.ts:\n(pass) a sees mock [0.10ms]\n\nb.test.ts:\n1 | \n2 |         import { test, expect } from \"bun:test\";\n3 |         import { MyClass } from \"./MyModule\";\n4 |         test(\"b sees real\", () => {\n5 |           expect(new MyClass().myMethod()).toBe(\"Hello\");\n                                               ^\nerror: expect(received).toBe(expected)\n\nExpected: \"Hello\"\nReceived: \"Hola\"\n\n      at <anonymous> (/tmp/spyon-per-file_CZzaDC/b.test.ts:5:44)\n(fail) b sees real [0.19ms]\n\n 1 pass\n 1 fail\n 2 expect() calls\nRan 2 tests across 2 files. [13.00ms]\n"

      at <anonymous> (/workspace/bun/test/regression/issue/06040.test.ts:54:20)
(fail) spyOn is scoped to the test file that installed it > a sibling file does not see another file's top-level spy [20.94ms]
(pass) spyOn is sc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/06040.test.ts"
bun test v1.4.0 (2318e757f)

test/regression/issue/06040.test.ts:
(pass) spyOn is scoped to the test file that installed it > a sibling file does not see another file's top-level spy [349.76ms]
(pass) spyOn is scoped to the test file that installed it > spies on an ESM namespace binding are restored between files [313.05ms]
(pass) spyOn is scoped to the test file that installed it > a spy is still visible to later tests within the same file [312.80ms]
(pass) spyOn is scoped to the test file that installed it > spies installed inside a test body are restored before the next file [349.35ms]
(pass) spyOn is scoped to the test file that installed it > a spy installed in --preload persists across files [339.38ms]
(pass) spyOn is scoped to the test file that installed it > a spy installed inside a preload beforeAll persists across files [340.68ms]
(pass) spyOn is scoped to the test file that installed it > a top-level throw after installing a spy still restores it before the next file [313.69ms]
(pass) s
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2318e757fe
  features     baseline

22 deps, 108 codegen, 1170 objects in 674ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1232] install /workspace/bun
bun install v1.3.14 (0d9b296a)

Checked 124 installs across 170 packages (no changes) [32.00ms]
[2/1232] gen ErrorCode+*.h
[3/1232] install /workspace/bun/packages/bun-error
bun install v1.3.14 (0d9b296a)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1232] gen bindgenv2
[5/1232] install /workspace/bun/src/node-fallbacks
bun install v1.3.14 (0d9b296a)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[6/1232] fetch zlib
[zlib] up to date
[7/1232] fetch tinycc
[tinycc] up to date
[8/1231] fetch picohttpparser
[picohttpparser] up to date
[9/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1231] gen .bind.ts → GeneratedBindings.cpp
[11/1231] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bind
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/test/mocks.mdx                  |   6 +
 src/jsc/VirtualMachine.rs            |   4 +
 src/jsc/bindings/JSMockFunction.cpp  |  45 ++++++
 src/jsc/virtual_machine_exports.rs   |   9 ++
 src/runtime/cli/test_command.rs      |  26 ++++
 src/runtime/test_runner/Execution.rs |  16 ++
 test/regression/issue/06040.test.ts  | 283 +++++++++++++++++++++++++++++++++++
 7 files changed, 389 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
docs/test/mocks.mdx                       1      1      0
src/jsc/VirtualMachine.rs                 3      1      0
src/jsc/bindings/JSMockFunction.cpp       7      4      0
src/jsc/virtual_machine_exports.rs        1      2      0
src/runtime/cli/test_command.rs           4      6      0
src/runtime/test_runner/Execution.rs      8      4      0
test/regression/issue/06040.test.ts       2      7      0
```

</details>

<!-- robobun:evidence:end -->