### PR TITLE
esm: don't invoke getters on plain CJS module.exports during import

### DIFF
--- a/docs/runtime/module-resolution.mdx
+++ b/docs/runtime/module-resolution.mdx
@@ -332,7 +332,7 @@ Bun's JavaScript runtime has native support for CommonJS. When Bun's JavaScript 
 
 `module`, `exports`, and `require` are very much like the `module`, `exports`, and `require` in Node.js. These are assigned through a [`with scope`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with) in C++. An internal `Map` stores the `exports` object to handle cyclical `require` calls before the module is fully loaded.
 
-Once the CommonJS module is successfully evaluated, a Synthetic Module Record is created with the `default` ES Module [export set to `module.exports`](https://github.com/oven-sh/bun/blob/9b6913e1a674ceb7f670f917fc355bb8758c6c72/src/bun.js/bindings/CommonJSModuleRecord.cpp#L212-L213) and keys of the `module.exports` object are re-exported as named exports (if the `module.exports` object is an object).
+Once the CommonJS module is successfully evaluated, a Synthetic Module Record is created with the `default` ES Module [export set to `module.exports`](https://github.com/oven-sh/bun/blob/9b6913e1a674ceb7f670f917fc355bb8758c6c72/src/bun.js/bindings/CommonJSModuleRecord.cpp#L212-L213) and the own data properties of the `module.exports` object are re-exported as named exports (if the `module.exports` object is an object). Own accessor properties (getters/setters) on a module that does not set `__esModule` are not re-exported, matching Node.js; access them through the default export instead.
 
 Bun's bundler works differently: it wraps the CommonJS module in a `require_${moduleName}` function which returns the `module.exports` object.
 

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1004,8 +1004,8 @@ void populateESMExports(
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (auto* exports = result.getObject()) {
-        bool hasESModuleMarker = false;
-        if (!ignoreESModuleAnnotation) {
+        bool fileHasESModule = false;
+        {
             PropertySlot slot(exports, PropertySlot::InternalMethodType::VMInquiry, &vm);
             auto has = exports->getPropertySlot(globalObject, esModuleMarker, slot);
             scope.assertNoException();
@@ -1014,11 +1014,12 @@ void populateESMExports(
                 CLEAR_IF_EXCEPTION(scope);
                 if (!value.isUndefinedOrNull()) {
                     if (value.pureToBoolean() == TriState::True) {
-                        hasESModuleMarker = true;
+                        fileHasESModule = true;
                     }
                 }
             }
         }
+        bool hasESModuleMarker = fileHasESModule && !ignoreESModuleAnnotation;
 
         auto* structure = exports->structure();
 
@@ -1122,12 +1123,18 @@ void populateESMExports(
                 RETURN_IF_EXCEPTION(scope, );
                 if (!has) continue;
 
-                // Without __esModule, skip JS accessor properties. Node's
-                // cjs-module-lexer never discovers these for plain CJS, so
-                // it never invokes them; invoking them here triggers user
-                // side effects (e.g. deprecation warnings) at import time.
-                // https://github.com/oven-sh/bun/issues/6747
-                if (slot.isAccessor()) {
+                // When module.exports has no __esModule marker, skip JS
+                // accessor properties instead of invoking them. Reading
+                // them here runs user side effects (deprecation warnings,
+                // lazy requires) before any importer code executes. Node
+                // only reads accessor-backed exports when cjs-module-lexer
+                // statically detected the name via a preceding
+                // `exports.x = ...` sentinel, which runtime enumeration
+                // cannot distinguish; transpiled output that emits such
+                // sentinels also sets __esModule, so gating on
+                // fileHasESModule covers the patterns Node actually
+                // supports. https://github.com/oven-sh/bun/issues/6747
+                if (slot.isAccessor() && !fileHasESModule) {
                     continue;
                 }
 

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1122,6 +1122,15 @@ void populateESMExports(
                 RETURN_IF_EXCEPTION(scope, );
                 if (!has) continue;
 
+                // Without __esModule, skip JS accessor properties. Node's
+                // cjs-module-lexer never discovers these for plain CJS, so
+                // it never invokes them; invoking them here triggers user
+                // side effects (e.g. deprecation warnings) at import time.
+                // https://github.com/oven-sh/bun/issues/6747
+                if (slot.isAccessor()) {
+                    continue;
+                }
+
                 if (slot.attributes() & PropertyAttribute::DontEnum) {
                     // Allow DontEnum properties which are not getter/setters
                     // https://github.com/oven-sh/bun/issues/4432

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1123,17 +1123,9 @@ void populateESMExports(
                 RETURN_IF_EXCEPTION(scope, );
                 if (!has) continue;
 
-                // When module.exports has no __esModule marker, skip JS
-                // accessor properties instead of invoking them. Reading
-                // them here runs user side effects (deprecation warnings,
-                // lazy requires) before any importer code executes. Node
-                // only reads accessor-backed exports when cjs-module-lexer
-                // statically detected the name via a preceding
-                // `exports.x = ...` sentinel, which runtime enumeration
-                // cannot distinguish; transpiled output that emits such
-                // sentinels also sets __esModule, so gating on
-                // fileHasESModule covers the patterns Node actually
-                // supports. https://github.com/oven-sh/bun/issues/6747
+                // Skip JS accessors on plain CJS so importing doesn't run
+                // user side effects. Node's cjs-module-lexer doesn't see
+                // these either. https://github.com/oven-sh/bun/issues/6747
                 if (slot.isAccessor() && !fileHasESModule) {
                     continue;
                 }

--- a/test/cli/run/esm-defineProperty.test.ts
+++ b/test/cli/run/esm-defineProperty.test.ts
@@ -22,18 +22,19 @@ test("shows __esModule if it was exported", () => {
 test("arraylike", () => {
   expect(CJSArrayLike[0]).toBe(0);
   expect(CJSArrayLike[1]).toBe(1);
-  expect(CJSArrayLike[2]).toBe(3);
+  // Accessor-defined own properties (indices 2 and 4) on a plain CJS module
+  // are not exposed as named exports; see issue #6747.
+  expect(CJSArrayLike[2]).toBe(undefined);
+  expect(CJSArrayLike).not.toHaveProperty("2");
   expect(CJSArrayLike[3]).toBe(4);
   expect(CJSArrayLike[4]).toBe(undefined);
-  expect(CJSArrayLike).toHaveProperty("4");
+  expect(CJSArrayLike).not.toHaveProperty("4");
   expect(Object.getOwnPropertyNames(CJSArrayLike)).not.toContain("__esModule");
   expect(Object.getOwnPropertyNames(CJSArrayLike.default)).not.toContain("__esModule");
   expect(Bun.inspect(CJSArrayLike)).toBe(`Module {
   "0": 0,
   "1": 1,
-  "2": 3,
   "3": 4,
-  "4": undefined,
   default: {
     "0": 0,
     "1": 1,

--- a/test/js/bun/resolve/esModule-annotation.test.js
+++ b/test/js/bun/resolve/esModule-annotation.test.js
@@ -112,12 +112,10 @@ describe.concurrent("accessor properties on module.exports", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("with __esModule, getters are still invoked for named exports", async () => {
+  test("without __esModule, a named import of an accessor-backed property is a link-time error", async () => {
     const src = `
-      import * as ns from ${JSON.stringify(join(fixtures, "export-esModule-with-getter.cjs"))};
-      process.stdout.write("imported\\n");
-      process.stdout.write("keys=" + Object.keys(ns).sort().join(",") + "\\n");
-      process.stdout.write("lightBlue=" + ns.lightBlue + "\\n");
+      import { lightBlue } from ${JSON.stringify(join(fixtures, "export-with-getter.cjs"))};
+      console.log(lightBlue);
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--input-type=module", "-e", src],
@@ -126,8 +124,30 @@ describe.concurrent("accessor properties on module.exports", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("GETTER:lightBlue\nimported\nkeys=default,lightBlue,red\nlightBlue=#0ff\n");
-    expect(exitCode).toBe(0);
+    expect(stderr).toContain("SyntaxError");
+    expect(stderr).toContain("'lightBlue'");
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
   });
+
+  for (const dir of ["without-type-module", "with-type-module"]) {
+    test(`with __esModule (${dir}), getters are still invoked for named exports`, async () => {
+      const src = `
+        import * as ns from ${JSON.stringify(join(import.meta.dir, dir, "export-esModule-with-getter.cjs"))};
+        process.stdout.write("imported\\n");
+        process.stdout.write("lightBlue=" + ns.lightBlue + "\\n");
+        process.stdout.write("hasKey=" + Object.keys(ns).includes("lightBlue") + "\\n");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--input-type=module", "-e", src],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("GETTER:lightBlue\nimported\nlightBlue=#0ff\nhasKey=true\n");
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/js/bun/resolve/esModule-annotation.test.js
+++ b/test/js/bun/resolve/esModule-annotation.test.js
@@ -70,7 +70,7 @@ describe('with type: "module"', () => {
 });
 
 // https://github.com/oven-sh/bun/issues/6747
-describe("accessor properties on module.exports", () => {
+describe.concurrent("accessor properties on module.exports", () => {
   const fixtures = join(import.meta.dir, "without-type-module");
 
   test("without __esModule, getters are not invoked or exposed as named exports", async () => {

--- a/test/js/bun/resolve/esModule-annotation.test.js
+++ b/test/js/bun/resolve/esModule-annotation.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 import * as WithTypeModuleExportEsModuleAnnotationMissingDefault from "./with-type-module/export-esModule-annotation-empty.cjs";
 import * as WithTypeModuleExportEsModuleAnnotationNoDefault from "./with-type-module/export-esModule-annotation-no-default.cjs";
 import * as WithTypeModuleExportEsModuleAnnotation from "./with-type-module/export-esModule-annotation.cjs";
@@ -64,5 +66,68 @@ describe('with type: "module"', () => {
       default: true,
     });
     expect(WithTypeModuleExportEsModuleAnnotation.__esModule).toBeTrue();
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/6747
+describe("accessor properties on module.exports", () => {
+  const fixtures = join(import.meta.dir, "without-type-module");
+
+  test("without __esModule, getters are not invoked or exposed as named exports", async () => {
+    const src = `
+      import colors, * as ns from ${JSON.stringify(join(fixtures, "export-with-getter.cjs"))};
+      process.stdout.write("imported\\n");
+      process.stdout.write("keys=" + Object.keys(ns).sort().join(",") + "\\n");
+      process.stdout.write("red=" + ns.red + "\\n");
+      delete colors.lightBlue;
+      process.stdout.write("afterDelete=" + colors.lightBlue + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--input-type=module", "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("imported\nkeys=default,red\nred=#f00\nafterDelete=undefined\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("without __esModule, the getter remains on the default export and still works", async () => {
+    const src = `
+      import colors from ${JSON.stringify(join(fixtures, "export-with-getter.cjs"))};
+      process.stdout.write("imported\\n");
+      process.stdout.write("value=" + colors.lightBlue + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--input-type=module", "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("imported\nGETTER:lightBlue\nvalue=#0ff\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("with __esModule, getters are still invoked for named exports", async () => {
+    const src = `
+      import * as ns from ${JSON.stringify(join(fixtures, "export-esModule-with-getter.cjs"))};
+      process.stdout.write("imported\\n");
+      process.stdout.write("keys=" + Object.keys(ns).sort().join(",") + "\\n");
+      process.stdout.write("lightBlue=" + ns.lightBlue + "\\n");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--input-type=module", "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("GETTER:lightBlue\nimported\nkeys=default,lightBlue,red\nlightBlue=#0ff\n");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/resolve/with-type-module/export-esModule-with-getter.cjs
+++ b/test/js/bun/resolve/with-type-module/export-esModule-with-getter.cjs
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.red = "#f00";
+Object.defineProperty(exports, "lightBlue", {
+  enumerable: true,
+  configurable: true,
+  get: function () {
+    console.log("GETTER:lightBlue");
+    return "#0ff";
+  },
+});

--- a/test/js/bun/resolve/without-type-module/export-esModule-with-getter.cjs
+++ b/test/js/bun/resolve/without-type-module/export-esModule-with-getter.cjs
@@ -1,0 +1,11 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.red = "#f00";
+Object.defineProperty(exports, "lightBlue", {
+  enumerable: true,
+  configurable: true,
+  get: function () {
+    console.log("GETTER:lightBlue");
+    return "#0ff";
+  },
+});

--- a/test/js/bun/resolve/without-type-module/export-with-getter.cjs
+++ b/test/js/bun/resolve/without-type-module/export-with-getter.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  red: "#f00",
+  get lightBlue() {
+    console.log("GETTER:lightBlue");
+    return "#0ff";
+  },
+};

--- a/test/js/third_party/body-parser/express-body-parser-test.test.ts
+++ b/test/js/third_party/body-parser/express-body-parser-test.test.ts
@@ -3,9 +3,9 @@
 // depend on @types/node which conflicts with bun-types
 import bodyParser from "body-parser";
 import { expect, test } from "bun:test";
-const { json } = bodyParser;
 import express, { Application, Request, Response } from "express";
 import net from "net";
+const { json } = bodyParser;
 // Express uses iconv-lite
 test("iconv works", () => {
   var iconv = require("iconv-lite");

--- a/test/js/third_party/body-parser/express-body-parser-test.test.ts
+++ b/test/js/third_party/body-parser/express-body-parser-test.test.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
 // can't use @types/express or @types/body-parser because they
 // depend on @types/node which conflicts with bun-types
-import { json } from "body-parser";
+import bodyParser from "body-parser";
 import { expect, test } from "bun:test";
+const { json } = bodyParser;
 import express, { Application, Request, Response } from "express";
 import net from "net";
 // Express uses iconv-lite


### PR DESCRIPTION
Fixes #6747.

## Repro

```js
// colors.cjs
module.exports = {
  red: '#f00',
  get lightBlue() {
    console.warn('lightBlue has been renamed to sky');
    return '#0ff';
  },
};
```

```js
// index.mjs
import colors from './colors.cjs';
delete colors.lightBlue;
```

Before this change, the deprecation warning fires before the first line of `index.mjs` runs. The `delete` succeeds but is too late to suppress it. Node prints nothing.

The real-world case is `tailwindcss/colors.js`, where `@nuxt/ui` deletes the deprecated color getters immediately after importing, which silences the warnings under Node but not under Bun.

## Cause

`populateESMExports` synthesizes named ESM exports for a CJS module by enumerating own properties of `module.exports` at runtime. When the exports object has accessor properties, the slow enumeration path reads each one via `slot.getValue()`, which invokes the getter.

Node never reads these properties for plain CJS: its static lexer (`cjs-module-lexer`) cannot discover an accessor defined in an object literal or via `Object.defineProperty` unless a preceding `exports.x = ...` data assignment appears in the source, so it never exposes them as named exports and never reads them at import time.

## Fix

When `module.exports` does not carry `__esModule`, skip own accessor properties instead of invoking them. Data properties are still exposed as named exports; the default export is the untouched `module.exports` object, so callers can still reach the getters through it exactly as before.

When `__esModule` is present, nothing changes: transpiled TypeScript/Babel/SWC output defines re-exported bindings as getters on `exports` and expects them to be read once when the synthetic module is created. The `__esModule` check is made against the object itself rather than the pre-squashed `hasESModuleMarker`, so a `.cjs` file inside a `"type": "module"` package keeps its getter-backed re-exports.

## Behavior change

Previously Bun exposed accessor-backed properties of a plain CJS `module.exports` as named ESM exports (a Bun-only extension; Node never did). With this change, `import { x } from 'pkg'` where `x` is defined only as a getter and the module does not set `__esModule` now raises `SyntaxError: Export named 'x' not found`, matching Node. Use the default import instead:

```js
import pkg from 'pkg';
const { x } = pkg;
```

In practice this affects packages such as `body-parser` that define lazy-load getters on a plain CJS exports object. A module that sets `exports.__esModule = true` (all TypeScript/Babel/SWC output) is unaffected. The hand-written pattern `exports.x = void 0; Object.defineProperty(exports, 'x', {get})` without `__esModule` is now skipped as well; no published package in Bun's test dependency set uses that form without also setting `__esModule`.

## Verification

```
$ bun bd test test/js/bun/resolve/esModule-annotation.test.js \
             test/cli/run/esm-defineProperty.test.ts \
             test/js/third_party/body-parser/express-body-parser-test.test.ts
 19 pass
 0 fail
```

With the actual `tailwindcss@3` package, no warnings are emitted on import, matching Node.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/esm-defineProperty.test.ts test/js/bun/resolve/esModule-annotation.test.js test/js/third_party/body-parser/express-body-parser-test.test.ts
bun test v1.4.0 (416b572ce)

test/cli/run/esm-defineProperty.test.ts:
(pass) defineProperty [5.43ms]
(pass) shows __esModule if it was exported [21.89ms]
22 | test("arraylike", () => {
23 |   expect(CJSArrayLike[0]).toBe(0);
24 |   expect(CJSArrayLike[1]).toBe(1);
25 |   // Accessor-defined own properties (indices 2 and 4) on a plain CJS module
26 |   // are not exposed as named exports; see issue #6747.
27 |   expect(CJSArrayLike[2]).toBe(undefined);
                               ^
error: expect(received).toBe(expected)

Expected: undefined
Received: 3

      at <anonymous> (/workspace/bun/test/cli/run/esm-defineProperty.test.ts:27:27)
(fail) arraylike [10.41ms]

test/js/bun/resolve/esModule-annotation.test.js:
(pass) without type: "module" > module.exports = {} [3.80ms]
(pass) without type: "module" > exports.__esModule = true [3.26ms]
(pass) without type: "module" > exports.default
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/run/esm-defineProperty.test.ts:
(pass) defineProperty [0.16ms]
(pass) shows __esModule if it was exported [0.08ms]
22 | test("arraylike", () => {
23 |   expect(CJSArrayLike[0]).toBe(0);
24 |   expect(CJSArrayLike[1]).toBe(1);
25 |   // Accessor-defined own properties (indices 2 and 4) on a plain CJS module
26 |   // are not exposed as named exports; see issue #6747.
27 |   expect(CJSArrayLike[2]).toBe(undefined);
                               ^
error: expect(received).toBe(expected)

Expected: undefined
Received: 3

      at <anonymous> (/workspace/bun/test/cli/run/esm-defineProperty.test.ts:27:27)
(fail) arraylike [0.27ms]

test/js/bun/resolve/esModule-annotation.test.js:
(pass) without type: "module" > module.exports = {} [0.05ms]
(pass) without type: "module" > exports.__esModule = true [0.03ms]
(pass) without type: "module" > exports.default = true; exports.__esModule = true; [0.02ms]
(pass) without type: "module" > exports.default = true; [0.03ms]
(pass) with type: "module" > module.exports = {} [0.02ms]
(pass) with type: "module" > exports.__esModule = true [0.02ms]
(pass) with type: "module" > exports.default = 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/esm-defineProperty.test.ts test/js/bun/resolve/esModule-annotation.test.js test/js/third_party/body-parser/express-body-parser-test.test.ts
bun test v1.4.0 (416b572ce)

test/cli/run/esm-defineProperty.test.ts:
(pass) defineProperty [4.69ms]
(pass) shows __esModule if it was exported [7.55ms]
(pass) arraylike [22.63ms]

test/js/bun/resolve/esModule-annotation.test.js:
(pass) without type: "module" > module.exports = {} [4.25ms]
(pass) without type: "module" > exports.__esModule = true [2.88ms]
(pass) without type: "module" > exports.default = true; exports.__esModule = true; [2.44ms]
(pass) without type: "module" > exports.default = true; [2.27ms]
(pass) with type: "module" > module.exports = {} [2.36ms]
(pass) with type: "module" > exports.__esModule = true [2.38ms]
(pass) with type: "module" > exports.default = true; exports.__esModule = true; [1.96ms]
(pass) with type: "module" > exports.default = true; [2.27ms]
(pass) accessor properties on module.exports > without __esModule, a named import of an accessor-backed proper
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     416b572ce6
  features     baseline

22 deps, 108 codegen, 1171 objects in 5918ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/1234] gen bindgenv2
[3/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[4/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingFs.cpp
[5/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[6/1234] gen ErrorCode+*.h
[7/1234] gen .bind.ts → GeneratedBindings.cpp
[8/1234] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/release/codegen/ZigGlobalObj
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/module-resolution.mdx                 |  2 +-
 src/jsc/bindings/JSCommonJSModule.cpp              | 14 +++-
 test/cli/run/esm-defineProperty.test.ts            |  9 ++-
 test/js/bun/resolve/esModule-annotation.test.js    | 85 ++++++++++++++++++++++
 .../export-esModule-with-getter.cjs                | 11 +++
 .../export-esModule-with-getter.cjs                | 11 +++
 .../without-type-module/export-with-getter.cjs     |  7 ++
 .../body-parser/express-body-parser-test.test.ts   |  3 +-
 8 files changed, 133 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
docs/runtime/module-resolution.mdx                            1      1      0
src/jsc/bindings/JSCommonJSModule.cpp                         5      4      0
test/cli/run/esm-defineProperty.test.ts                       2      1      0
test/js/bun/resolve/esModule-annotation.test.js               3      5      0
…esolve/with-type-module/export-esModule-with-getter.cjs      0      1      0
…lve/without-type-module/export-esModule-with-getter.cjs      0      1      0
…/bun/resolve/without-type-module/export-with-getter.cjs      0      1      0
…hird_party/body-parser/express-body-parser-test.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->