### PR TITLE
expect: stop toMatchObject/toMatchSnapshot from mutating the received object

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2783,19 +2783,32 @@ impl JSValue {
     }
     /// `JSValue.jestDeepMatch` — `expect(a).toMatchObject(b)` /
     /// snapshot-property-matcher subset comparison.
+    ///
+    /// Side-effect free: neither `self` nor `subset` is mutated. For snapshot
+    /// serialization that needs asymmetric matchers substituted into `self`,
+    /// call [`Self::jest_substitute_asymmetric_matchers`] after a successful
+    /// match.
     pub fn jest_deep_match(
         self,
         subset: JSValue,
         global: &JSGlobalObject,
-        replace_props_with_asymmetric_matchers: bool,
     ) -> JsResult<bool> {
         host_fn::from_js_host_call_generic(global, || {
-            JSC__JSValue__jestDeepMatch(
-                self,
-                subset,
-                global,
-                replace_props_with_asymmetric_matchers,
-            )
+            JSC__JSValue__jestDeepMatch(self, subset, global)
+        })
+    }
+    /// Returns a clone of `self` in which every property that matched an
+    /// asymmetric matcher in `matchers` has been replaced with that matcher,
+    /// so the snapshot formatter records `Any<String>` etc. rather than the
+    /// concrete value. `self` is not mutated. Returns `self` unchanged when
+    /// no substitutions are needed.
+    pub fn jest_substitute_asymmetric_matchers(
+        self,
+        matchers: JSValue,
+        global: &JSGlobalObject,
+    ) -> JsResult<JSValue> {
+        host_fn::from_js_host_call(global, || {
+            Bun__JSValue__substituteAsymmetricMatchers(self, matchers, global)
         })
     }
 
@@ -2907,8 +2920,12 @@ unsafe extern "C" {
         this: JSValue,
         subset: JSValue,
         global: &JSGlobalObject,
-        replace_props: bool,
     ) -> bool;
+    safe fn Bun__JSValue__substituteAsymmetricMatchers(
+        value: JSValue,
+        matchers: JSValue,
+        global: &JSGlobalObject,
+    ) -> JSValue;
     safe fn JSC__JSValue__asBigIntCompare(
         this: JSValue,
         global: &JSGlobalObject,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2782,22 +2782,15 @@ impl JSValue {
         })
     }
     /// `JSValue.jestDeepMatch` — `expect(a).toMatchObject(b)` /
-    /// snapshot-property-matcher subset comparison.
-    ///
-    /// Side-effect free: neither `self` nor `subset` is mutated. For snapshot
-    /// serialization that needs asymmetric matchers substituted into `self`,
-    /// call [`Self::jest_substitute_asymmetric_matchers`] after a successful
-    /// match.
+    /// snapshot-property-matcher subset comparison. Mutates neither side.
     pub fn jest_deep_match(self, subset: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
         host_fn::from_js_host_call_generic(global, || {
             JSC__JSValue__jestDeepMatch(self, subset, global)
         })
     }
-    /// The value `toMatchSnapshot(matchers)` serializes: a clone of `self` with
-    /// each asymmetric matcher that [`Self::jest_deep_match`] checked put in
-    /// place of the property it checked, so the snapshot records `Any<String>`
-    /// etc. rather than the concrete value. `self` is not mutated. Both `self`
-    /// and `matchers` must be objects and `jest_deep_match` must have passed.
+    /// Clone of `self` with the matchers a passing [`Self::jest_deep_match`]
+    /// checked put in place of the properties they matched; what
+    /// `toMatchSnapshot(matchers)` serializes. Both arguments must be objects.
     pub fn jest_substitute_asymmetric_matchers(
         self,
         matchers: JSValue,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2793,10 +2793,11 @@ impl JSValue {
             JSC__JSValue__jestDeepMatch(self, subset, global)
         })
     }
-    /// Returns a clone of `self` in which every property that matched an
-    /// asymmetric matcher in `matchers` has been replaced with that matcher,
-    /// so the snapshot formatter records `Any<String>` etc. rather than the
-    /// concrete value. `self` is not mutated.
+    /// The value `toMatchSnapshot(matchers)` serializes: a clone of `self` with
+    /// each asymmetric matcher that [`Self::jest_deep_match`] checked put in
+    /// place of the property it checked, so the snapshot records `Any<String>`
+    /// etc. rather than the concrete value. `self` is not mutated. Both `self`
+    /// and `matchers` must be objects and `jest_deep_match` must have passed.
     pub fn jest_substitute_asymmetric_matchers(
         self,
         matchers: JSValue,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2788,11 +2788,7 @@ impl JSValue {
     /// serialization that needs asymmetric matchers substituted into `self`,
     /// call [`Self::jest_substitute_asymmetric_matchers`] after a successful
     /// match.
-    pub fn jest_deep_match(
-        self,
-        subset: JSValue,
-        global: &JSGlobalObject,
-    ) -> JsResult<bool> {
+    pub fn jest_deep_match(self, subset: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
         host_fn::from_js_host_call_generic(global, || {
             JSC__JSValue__jestDeepMatch(self, subset, global)
         })

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2796,8 +2796,7 @@ impl JSValue {
     /// Returns a clone of `self` in which every property that matched an
     /// asymmetric matcher in `matchers` has been replaced with that matcher,
     /// so the snapshot formatter records `Any<String>` etc. rather than the
-    /// concrete value. `self` is not mutated. Returns `self` unchanged when
-    /// no substitutions are needed.
+    /// concrete value. `self` is not mutated.
     pub fn jest_substitute_asymmetric_matchers(
         self,
         matchers: JSValue,

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -730,10 +730,9 @@ JSC_DEFINE_HOST_FUNCTION(functionBunDeepMatch, (JSGlobalObject * globalObject, J
         return {};
     }
 
-    std::set<EncodedJSValue> objVisited;
-    std::set<EncodedJSValue> subsetVisited;
+    DeepMatchSeenPairs seenPairs;
     MarkedArgumentBuffer gcBuffer;
-    bool match = Bun__deepMatch</* enableAsymmetricMatchers */ false>(object, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false);
+    bool match = Bun__deepMatch</* enableAsymmetricMatchers */ false>(object, subset, &seenPairs, globalObject, scope, &gcBuffer, false);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsBoolean(match));
 }

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -733,7 +733,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBunDeepMatch, (JSGlobalObject * globalObject, J
     std::set<EncodedJSValue> objVisited;
     std::set<EncodedJSValue> subsetVisited;
     MarkedArgumentBuffer gcBuffer;
-    bool match = Bun__deepMatch</* enableAsymmetricMatchers */ false>(object, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false, false);
+    bool match = Bun__deepMatch</* enableAsymmetricMatchers */ false>(object, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsBoolean(match));
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2214,7 +2214,9 @@ bool Bun__deepMatch(
 
         if constexpr (enableAsymmetricMatchers) {
             if (subsetPropCell && subsetPropCell->type() == JSC::JSType(JSDOMWrapperType)) {
-                switch (matchAsymmetricMatcher(globalObject, subsetProp, prop, throwScope)) {
+                auto result = matchAsymmetricMatcher(globalObject, subsetProp, prop, throwScope);
+                RETURN_IF_EXCEPTION(throwScope, false);
+                switch (result) {
                 case AsymmetricMatcherResult::FAIL:
                     return false;
                 case AsymmetricMatcherResult::PASS:
@@ -2224,7 +2226,9 @@ bool Bun__deepMatch(
                     break;
                 }
             } else if (propCell && propCell->type() == JSC::JSType(JSDOMWrapperType)) {
-                switch (matchAsymmetricMatcher(globalObject, prop, subsetProp, throwScope)) {
+                auto result = matchAsymmetricMatcher(globalObject, prop, subsetProp, throwScope);
+                RETURN_IF_EXCEPTION(throwScope, false);
+                switch (result) {
                 case AsymmetricMatcherResult::FAIL:
                     return false;
                 case AsymmetricMatcherResult::PASS:
@@ -2283,6 +2287,9 @@ inline bool deepEqualsWrapperImpl(JSC::EncodedJSValue a, JSC::EncodedJSValue b, 
     RELEASE_AND_RETURN(scope, result);
 }
 
+// Keep this list in sync with the dispatch in
+// `matchAsymmetricMatcherAndGetFlags`; that function is the source of truth
+// for which cell types are asymmetric matchers.
 bool isAsymmetricMatcher(JSValue v)
 {
     if (!v.isCell()) return false;
@@ -2337,18 +2344,26 @@ JSValue substituteAsymmetricMatchersImpl(
     JSObject* cloned = nullptr;
     auto ensureCloned = [&]() -> bool {
         if (cloned) return true;
-        if (isArray(globalObject, value)) {
+        bool valueIsArray = isArray(globalObject, value);
+        if (throwScope.exception()) return false;
+        if (valueIsArray) {
             unsigned len = valueObj->getArrayLength();
             cloned = JSC::constructEmptyArray(globalObject, nullptr, len);
         } else {
-            cloned = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype());
+            // Preserve the original's prototype so the snapshot formatter keeps
+            // the class-name prefix (e.g. `User { ... }`).
+            JSValue proto = valueObj->getPrototype(globalObject);
+            if (throwScope.exception()) return false;
+            JSObject* protoObj = proto.isObject() ? proto.getObject() : globalObject->objectPrototype();
+            cloned = JSC::constructEmptyObject(globalObject, protoObj);
         }
         if (throwScope.exception()) return false;
         gcBuffer.append(cloned);
-        // Shallow-copy so the snapshot retains every original property; the
-        // substitutions below overwrite individual entries.
+        // Copy own properties (including non-enumerable) so the snapshot sees
+        // the same property set that `forEachPropertyOrdered` would on the
+        // original; substitutions below overwrite individual entries.
         PropertyNameArrayBuilder valueProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
-        valueObj->getPropertyNames(globalObject, valueProps, DontEnumPropertiesMode::Exclude);
+        valueObj->methodTable()->getOwnPropertyNames(valueObj, globalObject, valueProps, DontEnumPropertiesMode::Include);
         if (throwScope.exception()) return false;
         for (const auto& p : valueProps) {
             JSValue v = valueObj->getIfPropertyExists(globalObject, p);
@@ -2382,6 +2397,7 @@ JSValue substituteAsymmetricMatchersImpl(
         RETURN_IF_EXCEPTION(throwScope, value);
     }
 
+    seen.erase(JSValue::encode(value));
     return cloned ? JSValue(cloned) : value;
 }
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2325,8 +2325,9 @@ struct AsymmetricMatcherSubstitution {
     std::set<EncodedJSValue> matcherPath;
 
     // nullptr for kinds the formatter renders from internal state rather than
-    // from properties (Date, RegExp, Map, Set, boxed primitives, ...): a
-    // matcher on one of those was never visible, so the original is used.
+    // from properties (Date, RegExp, Map, Set, boxed primitives, matcher
+    // instances, ...): a matcher on one of those was never visible, so the
+    // original is used.
     JSObject* cloneFor(JSObject* received)
     {
         auto& vm = globalObject->vm();
@@ -2344,6 +2345,8 @@ struct AsymmetricMatcherSubstitution {
             JSC::JSType type = received->type();
             bool rendersOwnProperties = type == JSC::FinalObjectType || type == JSC::ObjectType || type == JSC::JSType(JSDOMWrapperType) || type == JSC::JSType(JSEventType);
             if (!rendersOwnProperties && type != JSC::ErrorInstanceType) return nullptr;
+            // A matcher instance is a JSDOMWrapper too, but prints as itself (`Any<String>`).
+            if (isAsymmetricMatcher(received)) return nullptr;
 
             // The formatter takes the class name (or Error name) from the prototype.
             JSValue proto = received->getPrototype(globalObject);
@@ -2419,64 +2422,62 @@ struct AsymmetricMatcherSubstitution {
         }
     }
 
+    // Returns what to serialize in place of `received`.
     JSValue run(JSObject* received, JSObject* matchers)
     {
-        JSValue result = substitute(received, matchers);
+        substitute(received, matchers);
         RETURN_IF_EXCEPTION(throwScope, {});
         redirectToClones();
         RETURN_IF_EXCEPTION(throwScope, {});
-        return result;
+        auto rootClone = clones.find(JSValue::encode(received));
+        return rootClone == clones.end() ? received : rootClone->second;
     }
 
-    // Returns what to serialize in place of `received`.
-    JSValue substitute(JSObject* received, JSObject* matchers)
+    void substitute(JSObject* received, JSObject* matchers)
     {
-        if (received == matchers) return received;
+        if (received == matchers) return;
 
         JSObject* clone = cloneFor(received);
-        RETURN_IF_EXCEPTION(throwScope, received);
-        if (!clone) return received;
+        RETURN_IF_EXCEPTION(throwScope, );
+        if (!clone) return;
 
         PropertyNameArrayBuilder names(globalObject->vm(), PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
         matchers->getPropertyNames(globalObject, names, DontEnumPropertiesMode::Exclude);
-        RETURN_IF_EXCEPTION(throwScope, received);
+        RETURN_IF_EXCEPTION(throwScope, );
 
         for (const auto& name : names) {
             JSValue receivedProp = received->getIfPropertyExists(globalObject, name);
-            RETURN_IF_EXCEPTION(throwScope, received);
+            RETURN_IF_EXCEPTION(throwScope, );
             if (receivedProp.isEmpty()) continue;
             JSValue matcherProp = matchers->get(globalObject, name);
-            RETURN_IF_EXCEPTION(throwScope, received);
+            RETURN_IF_EXCEPTION(throwScope, );
             gcBuffer.append(receivedProp);
             gcBuffer.append(matcherProp);
 
-            JSValue replacement;
             if (isAsymmetricMatcher(matcherProp)) {
-                replacement = matcherProp;
-            } else if (isAsymmetricMatcher(receivedProp) || !receivedProp.isObject() || !matcherProp.isObject()) {
-                // Compared as a whole; a received-side matcher already prints as one.
+                clone->putDirectMayBeIndex(globalObject, name, matcherProp);
+                RETURN_IF_EXCEPTION(throwScope, );
                 continue;
-            } else {
-                auto onReceivedPath = receivedPath.insert(JSValue::encode(receivedProp));
-                auto onMatcherPath = matcherPath.insert(JSValue::encode(matcherProp));
-                if (!onReceivedPath.second || !onMatcherPath.second) {
-                    // Cycle: deepMatch checked nothing below here.
-                    if (onReceivedPath.second) receivedPath.erase(onReceivedPath.first);
-                    if (onMatcherPath.second) matcherPath.erase(onMatcherPath.first);
-                    continue;
-                }
-                replacement = substitute(receivedProp.getObject(), matcherProp.getObject());
-                receivedPath.erase(JSValue::encode(receivedProp));
-                matcherPath.erase(JSValue::encode(matcherProp));
-                RETURN_IF_EXCEPTION(throwScope, received);
-                if (replacement == receivedProp) continue;
             }
+            // Compared as a whole; a received-side matcher already prints as one.
+            if (isAsymmetricMatcher(receivedProp) || !receivedProp.isObject() || !matcherProp.isObject()) continue;
 
-            clone->putDirectMayBeIndex(globalObject, name, replacement);
-            RETURN_IF_EXCEPTION(throwScope, received);
+            auto onReceivedPath = receivedPath.insert(JSValue::encode(receivedProp));
+            auto onMatcherPath = matcherPath.insert(JSValue::encode(matcherProp));
+            if (!onReceivedPath.second || !onMatcherPath.second) {
+                // Cycle: deepMatch checked nothing below here.
+                if (onReceivedPath.second) receivedPath.erase(onReceivedPath.first);
+                if (onMatcherPath.second) matcherPath.erase(onMatcherPath.first);
+                continue;
+            }
+            // Nothing is put on `clone` for this key: whichever copied property
+            // holds the child (this key, or the field behind a getter) is pointed
+            // at the child's clone by redirectToClones.
+            substitute(receivedProp.getObject(), matcherProp.getObject());
+            receivedPath.erase(JSValue::encode(receivedProp));
+            matcherPath.erase(JSValue::encode(matcherProp));
+            RETURN_IF_EXCEPTION(throwScope, );
         }
-
-        return clone;
     }
 };
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2417,13 +2417,18 @@ struct AsymmetricMatcherSubstitution {
 
     void substitute(JSObject* received, JSObject* matchers)
     {
+        auto& vm = globalObject->vm();
+        if (!vm.isSafeToRecurse()) [[unlikely]] {
+            throwStackOverflowError(globalObject, throwScope);
+            return;
+        }
         if (received == matchers) return;
 
         JSObject* clone = cloneFor(received);
         RETURN_IF_EXCEPTION(throwScope, );
         if (!clone) return;
 
-        PropertyNameArrayBuilder names(globalObject->vm(), PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+        PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
         matchers->getPropertyNames(globalObject, names, DontEnumPropertiesMode::Exclude);
         RETURN_IF_EXCEPTION(throwScope, );
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2318,8 +2318,7 @@ struct AsymmetricMatcherSubstitution {
     JSGlobalObject* globalObject;
     ThrowScope& throwScope;
     MarkedArgumentBuffer& gcBuffer;
-    // One clone per received object, so shared objects and back-references
-    // (the formatter's [Circular] is identity-based) render as they did.
+    // One clone per received object (see redirectToClones).
     std::unordered_map<EncodedJSValue, JSObject*> clones;
     // deepMatch's seen sets.
     std::set<EncodedJSValue> receivedPath;
@@ -2343,7 +2342,7 @@ struct AsymmetricMatcherSubstitution {
             clone = JSC::constructEmptyArray(globalObject, nullptr, received->getArrayLength());
         } else {
             JSC::JSType type = received->type();
-            bool rendersOwnProperties = type == JSC::FinalObjectType || type == JSC::ObjectType || type == JSC::JSType(JSDOMWrapperType);
+            bool rendersOwnProperties = type == JSC::FinalObjectType || type == JSC::ObjectType || type == JSC::JSType(JSDOMWrapperType) || type == JSC::JSType(JSEventType);
             if (!rendersOwnProperties && type != JSC::ErrorInstanceType) return nullptr;
 
             // The formatter takes the class name (or Error name) from the prototype.
@@ -2380,10 +2379,6 @@ struct AsymmetricMatcherSubstitution {
             JSValue v = slot.getValue(globalObject, name);
             RETURN_IF_EXCEPTION(throwScope, nullptr);
             if (v.isEmpty()) continue;
-            if (v.isCell()) {
-                auto cloned = clones.find(JSValue::encode(v));
-                if (cloned != clones.end()) v = cloned->second;
-            }
             unsigned attributes = slot.attributes() & PropertyAttribute::DontEnum;
             if (std::optional<uint32_t> index = parseIndex(name))
                 clone->putDirectIndex(globalObject, index.value(), v, attributes, PutDirectIndexLikePutDirect);
@@ -2392,6 +2387,45 @@ struct AsymmetricMatcherSubstitution {
             RETURN_IF_EXCEPTION(throwScope, nullptr);
         }
         return clone;
+    }
+
+    // The copies above still point at the originals of objects that were
+    // cloned later in the walk (a back-reference, a shared object, the field
+    // behind a getter). Point them at the clones so each object renders one way.
+    void redirectToClones()
+    {
+        auto& vm = globalObject->vm();
+        for (const auto& [original, clone] : clones) {
+            PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+            clone->methodTable()->getOwnPropertyNames(clone, globalObject, names, DontEnumPropertiesMode::Include);
+            RETURN_IF_EXCEPTION(throwScope, );
+            for (const auto& name : names) {
+                JSC::PropertySlot slot(clone, PropertySlot::InternalMethodType::Get);
+                bool hasProperty = clone->methodTable()->getOwnPropertySlot(clone, globalObject, name, slot);
+                RETURN_IF_EXCEPTION(throwScope, );
+                if (!hasProperty || slot.isAccessor()) continue;
+                JSValue v = slot.getValue(globalObject, name);
+                RETURN_IF_EXCEPTION(throwScope, );
+                if (!v.isCell()) continue;
+                auto target = clones.find(JSValue::encode(v));
+                if (target == clones.end()) continue;
+                unsigned attributes = slot.attributes() & PropertyAttribute::DontEnum;
+                if (std::optional<uint32_t> index = parseIndex(name))
+                    clone->putDirectIndex(globalObject, index.value(), target->second, attributes, PutDirectIndexLikePutDirect);
+                else
+                    clone->putDirect(vm, name, target->second, attributes);
+                RETURN_IF_EXCEPTION(throwScope, );
+            }
+        }
+    }
+
+    JSValue run(JSObject* received, JSObject* matchers)
+    {
+        JSValue result = substitute(received, matchers);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        redirectToClones();
+        RETURN_IF_EXCEPTION(throwScope, {});
+        return result;
     }
 
     // Returns what to serialize in place of `received`.
@@ -3472,7 +3506,7 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__substituteAsymmetricMatchers(JSC::E
     ThrowScope scope = DECLARE_THROW_SCOPE(globalObject->vm());
     MarkedArgumentBuffer gcBuffer;
     AsymmetricMatcherSubstitution substitution { globalObject, scope, gcBuffer };
-    JSValue result = substitution.substitute(received, matchers);
+    JSValue result = substitution.run(received, matchers);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(result);
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -257,7 +257,6 @@ template bool Bun__deepMatch<true>(
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining);
 
 template bool Bun__deepMatch<false>(
@@ -268,7 +267,6 @@ template bool Bun__deepMatch<false>(
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining);
 
 extern "C" bool Expect_readFlagsAndProcessPromise(JSC::EncodedJSValue instanceValue, JSC::JSGlobalObject* globalObject, ExpectFlags* flags, JSC::EncodedJSValue* value, AsymmetricMatcherConstructorType* constructorType);
@@ -554,7 +552,7 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                 // SAFETY: visited property sets are not required when
                 // `enableAsymmetricMatchers` and `isMatchingObjectContaining`
                 // are both true
-                bool match = Bun__deepMatch<true>(otherProp, nullptr, patternObject, nullptr, globalObject, throwScope, nullptr, false, true);
+                bool match = Bun__deepMatch<true>(otherProp, nullptr, patternObject, nullptr, globalObject, throwScope, nullptr, true);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                 if (match) {
                     return AsymmetricMatcherResult::PASS;
@@ -2148,7 +2146,6 @@ template bool Bun__deepEquals<true, false, false, true>(JSC::JSGlobalObject*, JS
  * @param globalObject
  * @param throwScope
  * @param gcBuffer
- * @param replacePropsWithAsymmetricMatchers
  * @param isMatchingObjectContaining
  *
  * @return true
@@ -2163,7 +2160,6 @@ bool Bun__deepMatch(
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining)
 {
 
@@ -2222,10 +2218,6 @@ bool Bun__deepMatch(
                 case AsymmetricMatcherResult::FAIL:
                     return false;
                 case AsymmetricMatcherResult::PASS:
-                    if (replacePropsWithAsymmetricMatchers) {
-                        obj->putDirectMayBeIndex(globalObject, property, subsetProp);
-                        RETURN_IF_EXCEPTION(throwScope, false);
-                    }
                     // continue to next subset prop
                     continue;
                 case AsymmetricMatcherResult::NOT_MATCHER:
@@ -2236,10 +2228,6 @@ bool Bun__deepMatch(
                 case AsymmetricMatcherResult::FAIL:
                     return false;
                 case AsymmetricMatcherResult::PASS:
-                    if (replacePropsWithAsymmetricMatchers) {
-                        subsetObj->putDirectMayBeIndex(globalObject, property, prop);
-                        RETURN_IF_EXCEPTION(throwScope, false);
-                    }
                     // continue to next subset prop
                     continue;
                 case AsymmetricMatcherResult::NOT_MATCHER:
@@ -2268,7 +2256,7 @@ bool Bun__deepMatch(
                 gcBuffer->append(subsetProp);
                 // property cycle detected
                 if (!didInsertProp.second || !didInsertSubset.second) continue;
-                bool matched = Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, replacePropsWithAsymmetricMatchers, isMatchingObjectContaining);
+                bool matched = Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, isMatchingObjectContaining);
                 RETURN_IF_EXCEPTION(throwScope, false);
                 if (!matched) return false;
             }
@@ -2293,6 +2281,108 @@ inline bool deepEqualsWrapperImpl(JSC::EncodedJSValue a, JSC::EncodedJSValue b, 
     MarkedArgumentBuffer args;
     bool result = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(global, JSC::JSValue::decode(a), JSC::JSValue::decode(b), args, stack, scope, true);
     RELEASE_AND_RETURN(scope, result);
+}
+
+bool isAsymmetricMatcher(JSValue v)
+{
+    if (!v.isCell()) return false;
+    JSCell* cell = v.asCell();
+    if (cell->type() != JSC::JSType(JSDOMWrapperType)) return false;
+    return dynamicDowncast<JSExpectAnything>(cell)
+        || dynamicDowncast<JSExpectAny>(cell)
+        || dynamicDowncast<JSExpectStringContaining>(cell)
+        || dynamicDowncast<JSExpectStringMatching>(cell)
+        || dynamicDowncast<JSExpectArrayContaining>(cell)
+        || dynamicDowncast<JSExpectObjectContaining>(cell)
+        || dynamicDowncast<JSExpectCloseTo>(cell)
+        || dynamicDowncast<JSExpectCustomAsymmetricMatcher>(cell);
+}
+
+// Walks `value` and `matchers` in parallel and returns a clone of `value` with
+// any asymmetric matchers from `matchers` substituted in place of the matching
+// `value` properties. If no substitutions are needed the original `value` is
+// returned unchanged (no allocation). Cycles in `value` short-circuit by
+// returning the original reference at the cycle point.
+//
+// Used by snapshot serialization so property matchers like `expect.any(Date)`
+// show up as `Any<Date>` in the saved snapshot without mutating the user's
+// object. Replaces the old `replacePropsWithAsymmetricMatchers` side effect of
+// `Bun__deepMatch` (issue #3521).
+JSValue substituteAsymmetricMatchersImpl(
+    JSGlobalObject* globalObject,
+    ThrowScope& throwScope,
+    JSValue value,
+    JSValue matchers,
+    std::set<EncodedJSValue>& seen,
+    MarkedArgumentBuffer& gcBuffer)
+{
+    if (isAsymmetricMatcher(matchers)) {
+        return matchers;
+    }
+    if (!value.isObject() || !matchers.isObject()) {
+        return value;
+    }
+
+    auto inserted = seen.insert(JSValue::encode(value));
+    if (!inserted.second) return value;
+
+    auto& vm = globalObject->vm();
+    JSObject* valueObj = value.getObject();
+    JSObject* matchersObj = matchers.getObject();
+
+    PropertyNameArrayBuilder matcherProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+    matchersObj->getPropertyNames(globalObject, matcherProps, DontEnumPropertiesMode::Exclude);
+    RETURN_IF_EXCEPTION(throwScope, value);
+
+    JSObject* cloned = nullptr;
+    auto ensureCloned = [&]() -> bool {
+        if (cloned) return true;
+        if (isArray(globalObject, value)) {
+            unsigned len = valueObj->getArrayLength();
+            cloned = JSC::constructEmptyArray(globalObject, nullptr, len);
+        } else {
+            cloned = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype());
+        }
+        if (throwScope.exception()) return false;
+        gcBuffer.append(cloned);
+        // Shallow-copy so the snapshot retains every original property; the
+        // substitutions below overwrite individual entries.
+        PropertyNameArrayBuilder valueProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+        valueObj->getPropertyNames(globalObject, valueProps, DontEnumPropertiesMode::Exclude);
+        if (throwScope.exception()) return false;
+        for (const auto& p : valueProps) {
+            JSValue v = valueObj->getIfPropertyExists(globalObject, p);
+            if (throwScope.exception()) return false;
+            if (v.isEmpty()) continue;
+            cloned->putDirectMayBeIndex(globalObject, p, v);
+            if (throwScope.exception()) return false;
+        }
+        return true;
+    };
+
+    for (const auto& property : matcherProps) {
+        JSValue valueProp = valueObj->getIfPropertyExists(globalObject, property);
+        RETURN_IF_EXCEPTION(throwScope, value);
+        if (valueProp.isEmpty()) continue;
+
+        JSValue matcherProp = matchersObj->get(globalObject, property);
+        RETURN_IF_EXCEPTION(throwScope, value);
+
+        gcBuffer.append(valueProp);
+        gcBuffer.append(matcherProp);
+
+        JSValue substituted = substituteAsymmetricMatchersImpl(globalObject, throwScope, valueProp, matcherProp, seen, gcBuffer);
+        RETURN_IF_EXCEPTION(throwScope, value);
+
+        if (substituted == valueProp) continue;
+
+        gcBuffer.append(substituted);
+        if (!ensureCloned()) return value;
+        cloned->putDirectMayBeIndex(globalObject, property, substituted);
+        RETURN_IF_EXCEPTION(throwScope, value);
+    }
+
+    return cloned ? JSValue(cloned) : value;
 }
 }
 
@@ -3298,7 +3388,7 @@ bool Bun__deepEqualsNodeStrictSkipProto(JSC::EncodedJSValue JSValue0, JSC::Encod
 
 #undef IMPL_DEEP_EQUALS_WRAPPER
 
-bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject, bool replacePropsWithAsymmetricMatchers)
+bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject)
 {
     JSValue obj = JSValue::decode(JSValue0);
     JSValue subset = JSValue::decode(JSValue1);
@@ -3308,7 +3398,20 @@ bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSVal
     std::set<EncodedJSValue> objVisited;
     std::set<EncodedJSValue> subsetVisited;
     MarkedArgumentBuffer gcBuffer;
-    RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, replacePropsWithAsymmetricMatchers, false));
+    RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false));
+}
+
+extern "C" JSC::EncodedJSValue Bun__JSValue__substituteAsymmetricMatchers(JSC::EncodedJSValue valueEncoded, JSC::EncodedJSValue matchersEncoded, JSC::JSGlobalObject* globalObject)
+{
+    JSValue value = JSValue::decode(valueEncoded);
+    JSValue matchers = JSValue::decode(matchersEncoded);
+
+    ThrowScope scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    std::set<EncodedJSValue> seen;
+    MarkedArgumentBuffer gcBuffer;
+    JSValue result = substituteAsymmetricMatchersImpl(globalObject, scope, value, matchers, seen, gcBuffer);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(result);
 }
 
 extern "C" bool Bun__JSValue__isAsyncContextFrame(JSC::EncodedJSValue value)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2309,7 +2309,7 @@ bool isAsymmetricMatcher(JSValue v)
 // any asymmetric matchers from `matchers` substituted in place of the matching
 // `value` properties. If no substitutions are needed the original `value` is
 // returned unchanged (no allocation). Cycles in `value` short-circuit by
-// returning the original reference at the cycle point.
+// returning the clone (or original) for the ancestor.
 //
 // Used by snapshot serialization so property matchers like `expect.any(Date)`
 // show up as `Any<Date>` in the saved snapshot without mutating the user's
@@ -2320,7 +2320,7 @@ JSValue substituteAsymmetricMatchersImpl(
     ThrowScope& throwScope,
     JSValue value,
     JSValue matchers,
-    std::set<EncodedJSValue>& seen,
+    std::unordered_map<EncodedJSValue, JSObject*>& ancestors,
     MarkedArgumentBuffer& gcBuffer)
 {
     if (isAsymmetricMatcher(matchers)) {
@@ -2330,12 +2330,27 @@ JSValue substituteAsymmetricMatchersImpl(
         return value;
     }
 
-    auto inserted = seen.insert(JSValue::encode(value));
-    if (!inserted.second) return value;
+    auto [entry, inserted] = ancestors.emplace(JSValue::encode(value), nullptr);
+    if (!inserted) {
+        JSObject* ancestorClone = entry->second;
+        return ancestorClone ? JSValue(ancestorClone) : value;
+    }
 
     auto& vm = globalObject->vm();
     JSObject* valueObj = value.getObject();
     JSObject* matchersObj = matchers.getObject();
+
+    bool valueIsArray = isArray(globalObject, value);
+    RETURN_IF_EXCEPTION(throwScope, value);
+    // The snapshot formatter dispatches on the cell's JSType. A JSFinalObject
+    // clone cannot stand in for ErrorInstance/JSDate/RegExpObject/JSMap/etc.,
+    // whose snapshot rendering does not enumerate own properties anyway, so
+    // the substituted matcher was never visible in the snapshot for those
+    // types under the old in-place mutation either.
+    if (!valueIsArray && valueObj->type() != JSC::FinalObjectType && valueObj->type() != JSC::ObjectType) {
+        ancestors.erase(JSValue::encode(value));
+        return value;
+    }
 
     PropertyNameArrayBuilder matcherProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
     matchersObj->getPropertyNames(globalObject, matcherProps, DontEnumPropertiesMode::Exclude);
@@ -2344,8 +2359,6 @@ JSValue substituteAsymmetricMatchersImpl(
     JSObject* cloned = nullptr;
     auto ensureCloned = [&]() -> bool {
         if (cloned) return true;
-        bool valueIsArray = isArray(globalObject, value);
-        if (throwScope.exception()) return false;
         if (valueIsArray) {
             unsigned len = valueObj->getArrayLength();
             cloned = JSC::constructEmptyArray(globalObject, nullptr, len);
@@ -2359,9 +2372,12 @@ JSValue substituteAsymmetricMatchersImpl(
         }
         if (throwScope.exception()) return false;
         gcBuffer.append(cloned);
+        ancestors[JSValue::encode(value)] = cloned;
         // Copy own properties (including non-enumerable) so the snapshot sees
         // the same property set that `forEachPropertyOrdered` would on the
-        // original; substitutions below overwrite individual entries.
+        // original; substitutions below overwrite individual entries. Rewrite
+        // back-references to cloned ancestors so [Circular] detection in the
+        // formatter still fires at the same nesting level as on the original.
         PropertyNameArrayBuilder valueProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
         valueObj->methodTable()->getOwnPropertyNames(valueObj, globalObject, valueProps, DontEnumPropertiesMode::Include);
         if (throwScope.exception()) return false;
@@ -2369,6 +2385,10 @@ JSValue substituteAsymmetricMatchersImpl(
             JSValue v = valueObj->getIfPropertyExists(globalObject, p);
             if (throwScope.exception()) return false;
             if (v.isEmpty()) continue;
+            if (v.isCell()) {
+                auto found = ancestors.find(JSValue::encode(v));
+                if (found != ancestors.end() && found->second) v = JSValue(found->second);
+            }
             cloned->putDirectMayBeIndex(globalObject, p, v);
             if (throwScope.exception()) return false;
         }
@@ -2386,7 +2406,7 @@ JSValue substituteAsymmetricMatchersImpl(
         gcBuffer.append(valueProp);
         gcBuffer.append(matcherProp);
 
-        JSValue substituted = substituteAsymmetricMatchersImpl(globalObject, throwScope, valueProp, matcherProp, seen, gcBuffer);
+        JSValue substituted = substituteAsymmetricMatchersImpl(globalObject, throwScope, valueProp, matcherProp, ancestors, gcBuffer);
         RETURN_IF_EXCEPTION(throwScope, value);
 
         if (substituted == valueProp) continue;
@@ -2397,7 +2417,7 @@ JSValue substituteAsymmetricMatchersImpl(
         RETURN_IF_EXCEPTION(throwScope, value);
     }
 
-    seen.erase(JSValue::encode(value));
+    ancestors.erase(JSValue::encode(value));
     return cloned ? JSValue(cloned) : value;
 }
 }
@@ -3423,9 +3443,9 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__substituteAsymmetricMatchers(JSC::E
     JSValue matchers = JSValue::decode(matchersEncoded);
 
     ThrowScope scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    std::set<EncodedJSValue> seen;
+    std::unordered_map<EncodedJSValue, JSObject*> ancestors;
     MarkedArgumentBuffer gcBuffer;
-    JSValue result = substituteAsymmetricMatchersImpl(globalObject, scope, value, matchers, seen, gcBuffer);
+    JSValue result = substituteAsymmetricMatchersImpl(globalObject, scope, value, matchers, ancestors, gcBuffer);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(result);
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2307,9 +2307,9 @@ bool isAsymmetricMatcher(JSValue v)
 
 // Walks `value` and `matchers` in parallel and returns a clone of `value` with
 // any asymmetric matchers from `matchers` substituted in place of the matching
-// `value` properties. If no substitutions are needed the original `value` is
-// returned unchanged (no allocation). Cycles in `value` short-circuit by
-// returning the clone (or original) for the ancestor.
+// `value` properties. A clone is produced for every plain-object/array node on
+// the matcher path; other values (primitives, Error/Date/Map/Set/etc.) are
+// returned unchanged. Cycles in `value` resolve to the ancestor's clone.
 //
 // Used by snapshot serialization so property matchers like `expect.any(Date)`
 // show up as `Any<Date>` in the saved snapshot without mutating the user's
@@ -2352,48 +2352,58 @@ JSValue substituteAsymmetricMatchersImpl(
         return value;
     }
 
+    // Allocate the clone up front and record it in `ancestors` before
+    // recursing, so a back-reference at any depth resolves to the clone and
+    // the formatter's identity-based [Circular] check fires at the same level
+    // it would on the original.
+    JSObject* cloned;
+    if (valueIsArray) {
+        unsigned len = valueObj->getArrayLength();
+        cloned = JSC::constructEmptyArray(globalObject, nullptr, len);
+    } else {
+        // Preserve the original's prototype so the snapshot formatter keeps
+        // the class-name prefix (e.g. `User { ... }`).
+        JSValue proto = valueObj->getPrototype(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, value);
+        JSObject* protoObj = proto.isObject() ? proto.getObject() : globalObject->objectPrototype();
+        cloned = JSC::constructEmptyObject(globalObject, protoObj);
+    }
+    RETURN_IF_EXCEPTION(throwScope, value);
+    gcBuffer.append(cloned);
+    ancestors[JSValue::encode(value)] = cloned;
+
+    // Shallow-copy own properties using the same slot discipline as
+    // `JSC__JSValue__forEachPropertyOrdered` (which the snapshot formatter
+    // drives): accessor slots are taken via `getPureResult()` so user getters
+    // are not invoked and render as the GetterSetter cell, matching the
+    // pre-substitution output. Back-references are rewritten via `ancestors`.
+    PropertyNameArrayBuilder valueProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+    valueObj->methodTable()->getOwnPropertyNames(valueObj, globalObject, valueProps, DontEnumPropertiesMode::Include);
+    RETURN_IF_EXCEPTION(throwScope, value);
+    for (const auto& p : valueProps) {
+        JSC::PropertySlot slot(valueObj, PropertySlot::InternalMethodType::Get);
+        bool hasProperty = valueObj->methodTable()->getOwnPropertySlot(valueObj, globalObject, p, slot);
+        RETURN_IF_EXCEPTION(throwScope, value);
+        if (!hasProperty) continue;
+        if (slot.isAccessor()) {
+            cloned->putDirectAccessor(globalObject, p, slot.getterSetter(), slot.attributes());
+            RETURN_IF_EXCEPTION(throwScope, value);
+            continue;
+        }
+        JSValue v = slot.getValue(globalObject, p);
+        RETURN_IF_EXCEPTION(throwScope, value);
+        if (v.isEmpty()) continue;
+        if (v.isCell()) {
+            auto found = ancestors.find(JSValue::encode(v));
+            if (found != ancestors.end() && found->second) v = JSValue(found->second);
+        }
+        cloned->putDirectMayBeIndex(globalObject, p, v);
+        RETURN_IF_EXCEPTION(throwScope, value);
+    }
+
     PropertyNameArrayBuilder matcherProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
     matchersObj->getPropertyNames(globalObject, matcherProps, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(throwScope, value);
-
-    JSObject* cloned = nullptr;
-    auto ensureCloned = [&]() -> bool {
-        if (cloned) return true;
-        if (valueIsArray) {
-            unsigned len = valueObj->getArrayLength();
-            cloned = JSC::constructEmptyArray(globalObject, nullptr, len);
-        } else {
-            // Preserve the original's prototype so the snapshot formatter keeps
-            // the class-name prefix (e.g. `User { ... }`).
-            JSValue proto = valueObj->getPrototype(globalObject);
-            if (throwScope.exception()) return false;
-            JSObject* protoObj = proto.isObject() ? proto.getObject() : globalObject->objectPrototype();
-            cloned = JSC::constructEmptyObject(globalObject, protoObj);
-        }
-        if (throwScope.exception()) return false;
-        gcBuffer.append(cloned);
-        ancestors[JSValue::encode(value)] = cloned;
-        // Copy own properties (including non-enumerable) so the snapshot sees
-        // the same property set that `forEachPropertyOrdered` would on the
-        // original; substitutions below overwrite individual entries. Rewrite
-        // back-references to cloned ancestors so [Circular] detection in the
-        // formatter still fires at the same nesting level as on the original.
-        PropertyNameArrayBuilder valueProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
-        valueObj->methodTable()->getOwnPropertyNames(valueObj, globalObject, valueProps, DontEnumPropertiesMode::Include);
-        if (throwScope.exception()) return false;
-        for (const auto& p : valueProps) {
-            JSValue v = valueObj->getIfPropertyExists(globalObject, p);
-            if (throwScope.exception()) return false;
-            if (v.isEmpty()) continue;
-            if (v.isCell()) {
-                auto found = ancestors.find(JSValue::encode(v));
-                if (found != ancestors.end() && found->second) v = JSValue(found->second);
-            }
-            cloned->putDirectMayBeIndex(globalObject, p, v);
-            if (throwScope.exception()) return false;
-        }
-        return true;
-    };
 
     for (const auto& property : matcherProps) {
         JSValue valueProp = valueObj->getIfPropertyExists(globalObject, property);
@@ -2412,13 +2422,12 @@ JSValue substituteAsymmetricMatchersImpl(
         if (substituted == valueProp) continue;
 
         gcBuffer.append(substituted);
-        if (!ensureCloned()) return value;
         cloned->putDirectMayBeIndex(globalObject, property, substituted);
         RETURN_IF_EXCEPTION(throwScope, value);
     }
 
     ancestors.erase(JSValue::encode(value));
-    return cloned ? JSValue(cloned) : value;
+    return JSValue(cloned);
 }
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2325,9 +2325,7 @@ struct AsymmetricMatcherSubstitution {
     std::set<EncodedJSValue> matcherPath;
 
     // nullptr for kinds the formatter renders from internal state rather than
-    // from properties (Date, RegExp, Map, Set, boxed primitives, matcher
-    // instances, ...): a matcher on one of those was never visible, so the
-    // original is used.
+    // from properties (Date, Map, ...): a matcher put on one of those is invisible.
     JSObject* cloneFor(JSObject* received)
     {
         auto& vm = globalObject->vm();
@@ -2470,9 +2468,7 @@ struct AsymmetricMatcherSubstitution {
                 if (onMatcherPath.second) matcherPath.erase(onMatcherPath.first);
                 continue;
             }
-            // Nothing is put on `clone` for this key: whichever copied property
-            // holds the child (this key, or the field behind a getter) is pointed
-            // at the child's clone by redirectToClones.
+            // redirectToClones repoints the copied reference to the child at its clone.
             substitute(receivedProp.getObject(), matcherProp.getObject());
             receivedPath.erase(JSValue::encode(receivedProp));
             matcherPath.erase(JSValue::encode(matcherProp));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2397,7 +2397,11 @@ JSValue substituteAsymmetricMatchersImpl(
             auto found = ancestors.find(JSValue::encode(v));
             if (found != ancestors.end() && found->second) v = JSValue(found->second);
         }
-        cloned->putDirectMayBeIndex(globalObject, p, v);
+        unsigned attrs = slot.attributes() & PropertyAttribute::DontEnum;
+        if (std::optional<uint32_t> index = parseIndex(p))
+            cloned->putDirectIndex(globalObject, index.value(), v, attrs, PutDirectIndexLikePutDirect);
+        else
+            cloned->putDirect(vm, p, v, attrs);
         RETURN_IF_EXCEPTION(throwScope, value);
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -251,9 +251,8 @@ enum class AsymmetricMatcherConstructorType : int8_t {
 // Ensure we instantiate the true and false variants of this function
 template bool Bun__deepMatch<true>(
     JSValue objValue,
-    std::set<EncodedJSValue>* seenObjProperties,
     JSValue subsetValue,
-    std::set<EncodedJSValue>* seenSubsetProperties,
+    DeepMatchSeenPairs* seenPairs,
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
@@ -261,9 +260,8 @@ template bool Bun__deepMatch<true>(
 
 template bool Bun__deepMatch<false>(
     JSValue objValue,
-    std::set<EncodedJSValue>* seenObjProperties,
     JSValue subsetValue,
-    std::set<EncodedJSValue>* seenSubsetProperties,
+    DeepMatchSeenPairs* seenPairs,
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
@@ -552,7 +550,7 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
                 // SAFETY: visited property sets are not required when
                 // `enableAsymmetricMatchers` and `isMatchingObjectContaining`
                 // are both true
-                bool match = Bun__deepMatch<true>(otherProp, nullptr, patternObject, nullptr, globalObject, throwScope, nullptr, true);
+                bool match = Bun__deepMatch<true>(otherProp, patternObject, nullptr, globalObject, throwScope, nullptr, true);
                 RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                 if (match) {
                     return AsymmetricMatcherResult::PASS;
@@ -2129,10 +2127,9 @@ template bool Bun__deepEquals<true, false, false, true>(JSC::JSGlobalObject*, JS
  * @brief `Bun.deepMatch(a, b)`
  *
  * @note
- * The sets recording already visited properties (`seenObjProperties`,
- * `seenSubsetProperties`, and `gcBuffer`) aren not needed when both
- * `enableAsymmetricMatchers` and `isMatchingObjectContaining` are true. In
- * this case, it is safe to pass a `nullptr`.
+ * `seenPairs` and `gcBuffer` are not needed when both `enableAsymmetricMatchers`
+ * and `isMatchingObjectContaining` are true. In this case, it is safe to pass a
+ * `nullptr`.
  *
  * `gcBuffer` ensures JSC's stack scan does not come up empty-handed and free
  * properties currently within those stacks. Likely unnecessary, but better to
@@ -2140,9 +2137,8 @@ template bool Bun__deepEquals<true, false, false, true>(JSC::JSGlobalObject*, JS
  *
  * @tparam enableAsymmetricMatchers
  * @param objValue
- * @param seenObjProperties objects of `objValue` on the current recursion path (cycle guard).
  * @param subsetValue
- * @param seenSubsetProperties objects of `subsetValue` on the current recursion path (cycle guard).
+ * @param seenPairs a (object, subset) pair met again is a cycle, or was already checked, and is skipped; an object is still checked against every other subset object it is paired with.
  * @param globalObject
  * @param throwScope
  * @param gcBuffer
@@ -2154,9 +2150,8 @@ template bool Bun__deepEquals<true, false, false, true>(JSC::JSGlobalObject*, JS
 template<bool enableAsymmetricMatchers>
 bool Bun__deepMatch(
     JSValue objValue,
-    std::set<EncodedJSValue>* seenObjProperties,
     JSValue subsetValue,
-    std::set<EncodedJSValue>* seenSubsetProperties,
+    DeepMatchSeenPairs* seenPairs,
     JSGlobalObject* globalObject,
     ThrowScope& throwScope,
     MarkedArgumentBuffer* gcBuffer,
@@ -2251,23 +2246,13 @@ bool Bun__deepMatch(
                 RETURN_IF_EXCEPTION(throwScope, false);
                 if (!eql) return false;
             } else {
-                ASSERT(seenObjProperties != nullptr);
-                ASSERT(seenSubsetProperties != nullptr);
+                ASSERT(seenPairs != nullptr);
                 ASSERT(gcBuffer != nullptr);
                 gcBuffer->append(prop);
                 gcBuffer->append(subsetProp);
-                // The seen sets track the current path only, so a sub-object
-                // reached through two properties is checked at both.
-                auto didInsertProp = seenObjProperties->insert(JSC::JSValue::encode(prop));
-                auto didInsertSubset = seenSubsetProperties->insert(JSC::JSValue::encode(subsetProp));
-                if (!didInsertProp.second || !didInsertSubset.second) {
-                    if (didInsertProp.second) seenObjProperties->erase(didInsertProp.first);
-                    if (didInsertSubset.second) seenSubsetProperties->erase(didInsertSubset.first);
-                    continue;
-                }
-                bool matched = Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, isMatchingObjectContaining);
-                seenObjProperties->erase(JSC::JSValue::encode(prop));
-                seenSubsetProperties->erase(JSC::JSValue::encode(subsetProp));
+                // Met again: a cycle, or already checked. A new pairing of a shared object is still checked.
+                if (!seenPairs->insert({ JSC::JSValue::encode(prop), JSC::JSValue::encode(subsetProp) }).second) continue;
+                bool matched = Bun__deepMatch<enableAsymmetricMatchers>(prop, subsetProp, seenPairs, globalObject, throwScope, gcBuffer, isMatchingObjectContaining);
                 RETURN_IF_EXCEPTION(throwScope, false);
                 if (!matched) return false;
             }
@@ -2312,7 +2297,7 @@ bool isAsymmetricMatcher(JSValue v)
 
 // Builds the value `toMatchSnapshot(propertyMatchers)` serializes: the walk
 // `Bun__deepMatch<true>` just made over (received, matchers), replayed with the
-// same enumeration and cycle rules, writing each matcher it checked onto a
+// same enumeration and seen-pair rules, writing each matcher it checked onto a
 // clone of the received object at that position.
 struct AsymmetricMatcherSubstitution {
     JSGlobalObject* globalObject;
@@ -2320,9 +2305,8 @@ struct AsymmetricMatcherSubstitution {
     MarkedArgumentBuffer& gcBuffer;
     // One clone per received object (see redirectToClones).
     std::unordered_map<EncodedJSValue, JSObject*> clones;
-    // deepMatch's seen sets.
-    std::set<EncodedJSValue> receivedPath;
-    std::set<EncodedJSValue> matcherPath;
+    // deepMatch's seen pairs.
+    DeepMatchSeenPairs seenPairs;
 
     // nullptr for kinds the formatter renders from internal state rather than
     // from properties (Date, Map, ...): a matcher put on one of those is invisible.
@@ -2460,18 +2444,10 @@ struct AsymmetricMatcherSubstitution {
             // Compared as a whole; a received-side matcher already prints as one.
             if (isAsymmetricMatcher(receivedProp) || !receivedProp.isObject() || !matcherProp.isObject()) continue;
 
-            auto onReceivedPath = receivedPath.insert(JSValue::encode(receivedProp));
-            auto onMatcherPath = matcherPath.insert(JSValue::encode(matcherProp));
-            if (!onReceivedPath.second || !onMatcherPath.second) {
-                // Cycle: deepMatch checked nothing below here.
-                if (onReceivedPath.second) receivedPath.erase(onReceivedPath.first);
-                if (onMatcherPath.second) matcherPath.erase(onMatcherPath.first);
-                continue;
-            }
+            // Skipped by deepMatch too (a cycle, or a pair it had already checked).
+            if (!seenPairs.insert({ JSValue::encode(receivedProp), JSValue::encode(matcherProp) }).second) continue;
             // redirectToClones repoints the copied reference to the child at its clone.
             substitute(receivedProp.getObject(), matcherProp.getObject());
-            receivedPath.erase(JSValue::encode(receivedProp));
-            matcherPath.erase(JSValue::encode(matcherProp));
             RETURN_IF_EXCEPTION(throwScope, );
         }
     }
@@ -3487,10 +3463,9 @@ bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSVal
 
     ThrowScope scope = DECLARE_THROW_SCOPE(globalObject->vm());
 
-    std::set<EncodedJSValue> objVisited;
-    std::set<EncodedJSValue> subsetVisited;
+    DeepMatchSeenPairs seenPairs;
     MarkedArgumentBuffer gcBuffer;
-    RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false));
+    RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, subset, &seenPairs, globalObject, scope, &gcBuffer, false));
 }
 
 // Call after `JSC__JSValue__jestDeepMatch(received, matchers)` passed; both are objects.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2256,10 +2256,8 @@ bool Bun__deepMatch(
                 ASSERT(gcBuffer != nullptr);
                 gcBuffer->append(prop);
                 gcBuffer->append(subsetProp);
-                // The seen sets hold the objects on the current recursion path
-                // (like Jest's subsetEquality), so a shared sub-object reached
-                // from two different properties is checked at both and only a
-                // genuine cycle is skipped.
+                // The seen sets track the current path only, so a sub-object
+                // reached through two properties is checked at both.
                 auto didInsertProp = seenObjProperties->insert(JSC::JSValue::encode(prop));
                 auto didInsertSubset = seenSubsetProperties->insert(JSC::JSValue::encode(subsetProp));
                 if (!didInsertProp.second || !didInsertSubset.second) {
@@ -2296,9 +2294,7 @@ inline bool deepEqualsWrapperImpl(JSC::EncodedJSValue a, JSC::EncodedJSValue b, 
     RELEASE_AND_RETURN(scope, result);
 }
 
-// Keep this list in sync with the dispatch in
-// `matchAsymmetricMatcherAndGetFlags`; that function is the source of truth
-// for which cell types are asymmetric matchers.
+// Same type list as `matchAsymmetricMatcherAndGetFlags`.
 bool isAsymmetricMatcher(JSValue v)
 {
     if (!v.isCell()) return false;
@@ -2314,29 +2310,24 @@ bool isAsymmetricMatcher(JSValue v)
         || dynamicDowncast<JSExpectCustomAsymmetricMatcher>(cell);
 }
 
-// State for `substituteAsymmetricMatchers`: produces the value that
-// `toMatchSnapshot(propertyMatchers)` serializes. It re-walks `received` and
-// `propertyMatchers` exactly the way `Bun__deepMatch<true>` just did (same
-// property enumeration, same recursion and cycle rules) and records every
-// matcher that walk checked on a clone of the received object at that
-// position, so the received object itself is never written to.
+// Builds the value `toMatchSnapshot(propertyMatchers)` serializes: the walk
+// `Bun__deepMatch<true>` just made over (received, matchers), replayed with the
+// same enumeration and cycle rules, writing each matcher it checked onto a
+// clone of the received object at that position.
 struct AsymmetricMatcherSubstitution {
     JSGlobalObject* globalObject;
     ThrowScope& throwScope;
     MarkedArgumentBuffer& gcBuffer;
-    // One clone per received object for the whole walk, so an object reached
-    // through several properties renders the same everywhere and a reference
-    // back to it renders as [Circular] exactly where the original did.
+    // One clone per received object, so shared objects and back-references
+    // (the formatter's [Circular] is identity-based) render as they did.
     std::unordered_map<EncodedJSValue, JSObject*> clones;
-    // The two recursion paths, mirroring deepMatch's seen sets.
+    // deepMatch's seen sets.
     std::set<EncodedJSValue> receivedPath;
     std::set<EncodedJSValue> matcherPath;
 
-    // Returns the clone standing in for `received`, or nullptr when the
-    // snapshot formatter does not render this kind of object from the
-    // properties a matcher can land on (Date, RegExp, Map, Set, boxed
-    // primitives, ...). For those the original renders the same as the
-    // mutated object used to, so it is serialized as-is.
+    // nullptr for kinds the formatter renders from internal state rather than
+    // from properties (Date, RegExp, Map, Set, boxed primitives, ...): a
+    // matcher on one of those was never visible, so the original is used.
     JSObject* cloneFor(JSObject* received)
     {
         auto& vm = globalObject->vm();
@@ -2355,14 +2346,11 @@ struct AsymmetricMatcherSubstitution {
             bool rendersOwnProperties = type == JSC::FinalObjectType || type == JSC::ObjectType || type == JSC::JSType(JSDOMWrapperType);
             if (!rendersOwnProperties && type != JSC::ErrorInstanceType) return nullptr;
 
-            // Same prototype as the original: the formatter derives the
-            // `ClassName {` prefix (and an Error's name) from the prototype
-            // chain, not from the cell type.
+            // The formatter takes the class name (or Error name) from the prototype.
             JSValue proto = received->getPrototype(globalObject);
             RETURN_IF_EXCEPTION(throwScope, nullptr);
             if (type == JSC::ErrorInstanceType) {
-                // Errors render as `[Name: message]`, so the clone has to stay
-                // an ErrorInstance for a matcher on `message` to show up.
+                // Rendered as `[Name: message]`, which needs an ErrorInstance cell.
                 clone = JSC::ErrorInstance::create(vm, JSC::ErrorInstance::createStructure(vm, globalObject, proto), String(), JSValue(), nullptr, JSC::TypeNothing, JSC::ErrorType::Error, false);
             } else if (proto.isObject()) {
                 clone = JSC::constructEmptyObject(globalObject, proto.getObject());
@@ -2406,8 +2394,7 @@ struct AsymmetricMatcherSubstitution {
         return clone;
     }
 
-    // `received` and `matchers` are objects that deepMatch compared against
-    // each other. Returns what should be serialized in place of `received`.
+    // Returns what to serialize in place of `received`.
     JSValue substitute(JSObject* received, JSObject* matchers)
     {
         if (received == matchers) return received;
@@ -2433,15 +2420,13 @@ struct AsymmetricMatcherSubstitution {
             if (isAsymmetricMatcher(matcherProp)) {
                 replacement = matcherProp;
             } else if (isAsymmetricMatcher(receivedProp) || !receivedProp.isObject() || !matcherProp.isObject()) {
-                // Compared as a whole by deepMatch, and a matcher on the
-                // received side already prints as a matcher: nothing to
-                // substitute.
+                // Compared as a whole; a received-side matcher already prints as one.
                 continue;
             } else {
                 auto onReceivedPath = receivedPath.insert(JSValue::encode(receivedProp));
                 auto onMatcherPath = matcherPath.insert(JSValue::encode(matcherProp));
                 if (!onReceivedPath.second || !onMatcherPath.second) {
-                    // deepMatch stopped at this cycle without checking below it.
+                    // Cycle: deepMatch checked nothing below here.
                     if (onReceivedPath.second) receivedPath.erase(onReceivedPath.first);
                     if (onMatcherPath.second) matcherPath.erase(onMatcherPath.first);
                     continue;
@@ -3477,8 +3462,7 @@ bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSVal
     RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false));
 }
 
-// Only valid after `JSC__JSValue__jestDeepMatch(received, matchers)` returned
-// true; both arguments must be objects.
+// Call after `JSC__JSValue__jestDeepMatch(received, matchers)` passed; both are objects.
 extern "C" JSC::EncodedJSValue Bun__JSValue__substituteAsymmetricMatchers(JSC::EncodedJSValue receivedEncoded, JSC::EncodedJSValue matchersEncoded, JSC::JSGlobalObject* globalObject)
 {
     JSObject* received = JSValue::decode(receivedEncoded).getObject();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2140,9 +2140,9 @@ template bool Bun__deepEquals<true, false, false, true>(JSC::JSGlobalObject*, JS
  *
  * @tparam enableAsymmetricMatchers
  * @param objValue
- * @param seenObjProperties already visited properties of `objValue`.
+ * @param seenObjProperties objects of `objValue` on the current recursion path (cycle guard).
  * @param subsetValue
- * @param seenSubsetProperties already visited properties of `subsetValue`.
+ * @param seenSubsetProperties objects of `subsetValue` on the current recursion path (cycle guard).
  * @param globalObject
  * @param throwScope
  * @param gcBuffer
@@ -2254,13 +2254,22 @@ bool Bun__deepMatch(
                 ASSERT(seenObjProperties != nullptr);
                 ASSERT(seenSubsetProperties != nullptr);
                 ASSERT(gcBuffer != nullptr);
-                auto didInsertProp = seenObjProperties->insert(JSC::JSValue::encode(prop));
-                auto didInsertSubset = seenSubsetProperties->insert(JSC::JSValue::encode(subsetProp));
                 gcBuffer->append(prop);
                 gcBuffer->append(subsetProp);
-                // property cycle detected
-                if (!didInsertProp.second || !didInsertSubset.second) continue;
+                // The seen sets hold the objects on the current recursion path
+                // (like Jest's subsetEquality), so a shared sub-object reached
+                // from two different properties is checked at both and only a
+                // genuine cycle is skipped.
+                auto didInsertProp = seenObjProperties->insert(JSC::JSValue::encode(prop));
+                auto didInsertSubset = seenSubsetProperties->insert(JSC::JSValue::encode(subsetProp));
+                if (!didInsertProp.second || !didInsertSubset.second) {
+                    if (didInsertProp.second) seenObjProperties->erase(didInsertProp.first);
+                    if (didInsertSubset.second) seenSubsetProperties->erase(didInsertSubset.first);
+                    continue;
+                }
                 bool matched = Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, isMatchingObjectContaining);
+                seenObjProperties->erase(JSC::JSValue::encode(prop));
+                seenSubsetProperties->erase(JSC::JSValue::encode(subsetProp));
                 RETURN_IF_EXCEPTION(throwScope, false);
                 if (!matched) return false;
             }
@@ -2305,134 +2314,152 @@ bool isAsymmetricMatcher(JSValue v)
         || dynamicDowncast<JSExpectCustomAsymmetricMatcher>(cell);
 }
 
-// Walks `value` and `matchers` in parallel and returns a clone of `value` with
-// any asymmetric matchers from `matchers` substituted in place of the matching
-// `value` properties. A clone is produced for every plain-object/array node on
-// the matcher path; other values (primitives, Error/Date/Map/Set/etc.) are
-// returned unchanged. Cycles in `value` resolve to the ancestor's clone.
-//
-// Used by snapshot serialization so property matchers like `expect.any(Date)`
-// show up as `Any<Date>` in the saved snapshot without mutating the user's
-// object. Replaces the old `replacePropsWithAsymmetricMatchers` side effect of
-// `Bun__deepMatch` (issue #3521).
-JSValue substituteAsymmetricMatchersImpl(
-    JSGlobalObject* globalObject,
-    ThrowScope& throwScope,
-    JSValue value,
-    JSValue matchers,
-    std::unordered_map<EncodedJSValue, JSObject*>& ancestors,
-    MarkedArgumentBuffer& gcBuffer)
-{
-    if (isAsymmetricMatcher(matchers)) {
-        return matchers;
-    }
-    if (!value.isObject() || !matchers.isObject()) {
-        return value;
-    }
+// State for `substituteAsymmetricMatchers`: produces the value that
+// `toMatchSnapshot(propertyMatchers)` serializes. It re-walks `received` and
+// `propertyMatchers` exactly the way `Bun__deepMatch<true>` just did (same
+// property enumeration, same recursion and cycle rules) and records every
+// matcher that walk checked on a clone of the received object at that
+// position, so the received object itself is never written to.
+struct AsymmetricMatcherSubstitution {
+    JSGlobalObject* globalObject;
+    ThrowScope& throwScope;
+    MarkedArgumentBuffer& gcBuffer;
+    // One clone per received object for the whole walk, so an object reached
+    // through several properties renders the same everywhere and a reference
+    // back to it renders as [Circular] exactly where the original did.
+    std::unordered_map<EncodedJSValue, JSObject*> clones;
+    // The two recursion paths, mirroring deepMatch's seen sets.
+    std::set<EncodedJSValue> receivedPath;
+    std::set<EncodedJSValue> matcherPath;
 
-    auto [entry, inserted] = ancestors.emplace(JSValue::encode(value), nullptr);
-    if (!inserted) {
-        JSObject* ancestorClone = entry->second;
-        return ancestorClone ? JSValue(ancestorClone) : value;
-    }
+    // Returns the clone standing in for `received`, or nullptr when the
+    // snapshot formatter does not render this kind of object from the
+    // properties a matcher can land on (Date, RegExp, Map, Set, boxed
+    // primitives, ...). For those the original renders the same as the
+    // mutated object used to, so it is serialized as-is.
+    JSObject* cloneFor(JSObject* received)
+    {
+        auto& vm = globalObject->vm();
+        auto existing = clones.find(JSValue::encode(received));
+        if (existing != clones.end()) return existing->second;
 
-    auto& vm = globalObject->vm();
-    JSObject* valueObj = value.getObject();
-    JSObject* matchersObj = matchers.getObject();
+        bool receivedIsArray = isArray(globalObject, received);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-    bool valueIsArray = isArray(globalObject, value);
-    RETURN_IF_EXCEPTION(throwScope, value);
-    // The snapshot formatter dispatches on the cell's JSType. A JSFinalObject
-    // clone cannot stand in for ErrorInstance/JSDate/RegExpObject/JSMap/etc.,
-    // whose snapshot rendering does not enumerate own properties anyway, so
-    // the substituted matcher was never visible in the snapshot for those
-    // types under the old in-place mutation either.
-    if (!valueIsArray && valueObj->type() != JSC::FinalObjectType && valueObj->type() != JSC::ObjectType) {
-        ancestors.erase(JSValue::encode(value));
-        return value;
-    }
+        JSObject* clone = nullptr;
+        if (receivedIsArray) {
+            // The formatter renders arrays from their indices only.
+            clone = JSC::constructEmptyArray(globalObject, nullptr, received->getArrayLength());
+        } else {
+            JSC::JSType type = received->type();
+            bool rendersOwnProperties = type == JSC::FinalObjectType || type == JSC::ObjectType || type == JSC::JSType(JSDOMWrapperType);
+            if (!rendersOwnProperties && type != JSC::ErrorInstanceType) return nullptr;
 
-    // Allocate the clone up front and record it in `ancestors` before
-    // recursing, so a back-reference at any depth resolves to the clone and
-    // the formatter's identity-based [Circular] check fires at the same level
-    // it would on the original.
-    JSObject* cloned;
-    if (valueIsArray) {
-        unsigned len = valueObj->getArrayLength();
-        cloned = JSC::constructEmptyArray(globalObject, nullptr, len);
-    } else {
-        // Preserve the original's prototype so the snapshot formatter keeps
-        // the class-name prefix (e.g. `User { ... }`).
-        JSValue proto = valueObj->getPrototype(globalObject);
-        RETURN_IF_EXCEPTION(throwScope, value);
-        JSObject* protoObj = proto.isObject() ? proto.getObject() : globalObject->objectPrototype();
-        cloned = JSC::constructEmptyObject(globalObject, protoObj);
-    }
-    RETURN_IF_EXCEPTION(throwScope, value);
-    gcBuffer.append(cloned);
-    ancestors[JSValue::encode(value)] = cloned;
-
-    // Shallow-copy own properties using the same slot discipline as
-    // `JSC__JSValue__forEachPropertyOrdered` (which the snapshot formatter
-    // drives): accessor slots are taken via `getPureResult()` so user getters
-    // are not invoked and render as the GetterSetter cell, matching the
-    // pre-substitution output. Back-references are rewritten via `ancestors`.
-    PropertyNameArrayBuilder valueProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
-    valueObj->methodTable()->getOwnPropertyNames(valueObj, globalObject, valueProps, DontEnumPropertiesMode::Include);
-    RETURN_IF_EXCEPTION(throwScope, value);
-    for (const auto& p : valueProps) {
-        JSC::PropertySlot slot(valueObj, PropertySlot::InternalMethodType::Get);
-        bool hasProperty = valueObj->methodTable()->getOwnPropertySlot(valueObj, globalObject, p, slot);
-        RETURN_IF_EXCEPTION(throwScope, value);
-        if (!hasProperty) continue;
-        if (slot.isAccessor()) {
-            cloned->putDirectAccessor(globalObject, p, slot.getterSetter(), slot.attributes());
-            RETURN_IF_EXCEPTION(throwScope, value);
-            continue;
+            // Same prototype as the original: the formatter derives the
+            // `ClassName {` prefix (and an Error's name) from the prototype
+            // chain, not from the cell type.
+            JSValue proto = received->getPrototype(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
+            if (type == JSC::ErrorInstanceType) {
+                // Errors render as `[Name: message]`, so the clone has to stay
+                // an ErrorInstance for a matcher on `message` to show up.
+                clone = JSC::ErrorInstance::create(vm, JSC::ErrorInstance::createStructure(vm, globalObject, proto), String(), JSValue(), nullptr, JSC::TypeNothing, JSC::ErrorType::Error, false);
+            } else if (proto.isObject()) {
+                clone = JSC::constructEmptyObject(globalObject, proto.getObject());
+            } else {
+                clone = JSC::constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
+            }
         }
-        JSValue v = slot.getValue(globalObject, p);
-        RETURN_IF_EXCEPTION(throwScope, value);
-        if (v.isEmpty()) continue;
-        if (v.isCell()) {
-            auto found = ancestors.find(JSValue::encode(v));
-            if (found != ancestors.end() && found->second) v = JSValue(found->second);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
+        gcBuffer.append(clone);
+        clones.emplace(JSValue::encode(received), clone);
+
+        PropertyNameArrayBuilder names(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Exclude);
+        received->methodTable()->getOwnPropertyNames(received, globalObject, names, DontEnumPropertiesMode::Include);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
+        for (const auto& name : names) {
+            if (receivedIsArray && name == vm.propertyNames->length) continue;
+            JSC::PropertySlot slot(received, PropertySlot::InternalMethodType::Get);
+            bool hasProperty = received->methodTable()->getOwnPropertySlot(received, globalObject, name, slot);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
+            if (!hasProperty) continue;
+            // Accessors are copied as accessors so user getters do not run.
+            if (slot.isAccessor()) {
+                clone->putDirectAccessor(globalObject, name, slot.getterSetter(), slot.attributes());
+                RETURN_IF_EXCEPTION(throwScope, nullptr);
+                continue;
+            }
+            JSValue v = slot.getValue(globalObject, name);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
+            if (v.isEmpty()) continue;
+            if (v.isCell()) {
+                auto cloned = clones.find(JSValue::encode(v));
+                if (cloned != clones.end()) v = cloned->second;
+            }
+            unsigned attributes = slot.attributes() & PropertyAttribute::DontEnum;
+            if (std::optional<uint32_t> index = parseIndex(name))
+                clone->putDirectIndex(globalObject, index.value(), v, attributes, PutDirectIndexLikePutDirect);
+            else
+                clone->putDirect(vm, name, v, attributes);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
         }
-        unsigned attrs = slot.attributes() & PropertyAttribute::DontEnum;
-        if (std::optional<uint32_t> index = parseIndex(p))
-            cloned->putDirectIndex(globalObject, index.value(), v, attrs, PutDirectIndexLikePutDirect);
-        else
-            cloned->putDirect(vm, p, v, attrs);
-        RETURN_IF_EXCEPTION(throwScope, value);
+        return clone;
     }
 
-    PropertyNameArrayBuilder matcherProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
-    matchersObj->getPropertyNames(globalObject, matcherProps, DontEnumPropertiesMode::Exclude);
-    RETURN_IF_EXCEPTION(throwScope, value);
+    // `received` and `matchers` are objects that deepMatch compared against
+    // each other. Returns what should be serialized in place of `received`.
+    JSValue substitute(JSObject* received, JSObject* matchers)
+    {
+        if (received == matchers) return received;
 
-    for (const auto& property : matcherProps) {
-        JSValue valueProp = valueObj->getIfPropertyExists(globalObject, property);
-        RETURN_IF_EXCEPTION(throwScope, value);
-        if (valueProp.isEmpty()) continue;
+        JSObject* clone = cloneFor(received);
+        RETURN_IF_EXCEPTION(throwScope, received);
+        if (!clone) return received;
 
-        JSValue matcherProp = matchersObj->get(globalObject, property);
-        RETURN_IF_EXCEPTION(throwScope, value);
+        PropertyNameArrayBuilder names(globalObject->vm(), PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
+        matchers->getPropertyNames(globalObject, names, DontEnumPropertiesMode::Exclude);
+        RETURN_IF_EXCEPTION(throwScope, received);
 
-        gcBuffer.append(valueProp);
-        gcBuffer.append(matcherProp);
+        for (const auto& name : names) {
+            JSValue receivedProp = received->getIfPropertyExists(globalObject, name);
+            RETURN_IF_EXCEPTION(throwScope, received);
+            if (receivedProp.isEmpty()) continue;
+            JSValue matcherProp = matchers->get(globalObject, name);
+            RETURN_IF_EXCEPTION(throwScope, received);
+            gcBuffer.append(receivedProp);
+            gcBuffer.append(matcherProp);
 
-        JSValue substituted = substituteAsymmetricMatchersImpl(globalObject, throwScope, valueProp, matcherProp, ancestors, gcBuffer);
-        RETURN_IF_EXCEPTION(throwScope, value);
+            JSValue replacement;
+            if (isAsymmetricMatcher(matcherProp)) {
+                replacement = matcherProp;
+            } else if (isAsymmetricMatcher(receivedProp) || !receivedProp.isObject() || !matcherProp.isObject()) {
+                // Compared as a whole by deepMatch, and a matcher on the
+                // received side already prints as a matcher: nothing to
+                // substitute.
+                continue;
+            } else {
+                auto onReceivedPath = receivedPath.insert(JSValue::encode(receivedProp));
+                auto onMatcherPath = matcherPath.insert(JSValue::encode(matcherProp));
+                if (!onReceivedPath.second || !onMatcherPath.second) {
+                    // deepMatch stopped at this cycle without checking below it.
+                    if (onReceivedPath.second) receivedPath.erase(onReceivedPath.first);
+                    if (onMatcherPath.second) matcherPath.erase(onMatcherPath.first);
+                    continue;
+                }
+                replacement = substitute(receivedProp.getObject(), matcherProp.getObject());
+                receivedPath.erase(JSValue::encode(receivedProp));
+                matcherPath.erase(JSValue::encode(matcherProp));
+                RETURN_IF_EXCEPTION(throwScope, received);
+                if (replacement == receivedProp) continue;
+            }
 
-        if (substituted == valueProp) continue;
+            clone->putDirectMayBeIndex(globalObject, name, replacement);
+            RETURN_IF_EXCEPTION(throwScope, received);
+        }
 
-        gcBuffer.append(substituted);
-        cloned->putDirectMayBeIndex(globalObject, property, substituted);
-        RETURN_IF_EXCEPTION(throwScope, value);
+        return clone;
     }
-
-    ancestors.erase(JSValue::encode(value));
-    return JSValue(cloned);
-}
+};
 }
 
 extern "C" {
@@ -3450,15 +3477,18 @@ bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSVal
     RELEASE_AND_RETURN(scope, Bun__deepMatch<true>(obj, &objVisited, subset, &subsetVisited, globalObject, scope, &gcBuffer, false));
 }
 
-extern "C" JSC::EncodedJSValue Bun__JSValue__substituteAsymmetricMatchers(JSC::EncodedJSValue valueEncoded, JSC::EncodedJSValue matchersEncoded, JSC::JSGlobalObject* globalObject)
+// Only valid after `JSC__JSValue__jestDeepMatch(received, matchers)` returned
+// true; both arguments must be objects.
+extern "C" JSC::EncodedJSValue Bun__JSValue__substituteAsymmetricMatchers(JSC::EncodedJSValue receivedEncoded, JSC::EncodedJSValue matchersEncoded, JSC::JSGlobalObject* globalObject)
 {
-    JSValue value = JSValue::decode(valueEncoded);
-    JSValue matchers = JSValue::decode(matchersEncoded);
+    JSObject* received = JSValue::decode(receivedEncoded).getObject();
+    JSObject* matchers = JSValue::decode(matchersEncoded).getObject();
+    ASSERT(received && matchers);
 
     ThrowScope scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    std::unordered_map<EncodedJSValue, JSObject*> ancestors;
     MarkedArgumentBuffer gcBuffer;
-    JSValue result = substituteAsymmetricMatchersImpl(globalObject, scope, value, matchers, ancestors, gcBuffer);
+    AsymmetricMatcherSubstitution substitution { globalObject, scope, gcBuffer };
+    JSValue result = substitution.substitute(received, matchers);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(result);
 }

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -436,9 +436,9 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JS
  *
  * @tparam enableAsymmetricMatchers
  * @param objValue
- * @param seenObjProperties already visited properties of `objValue`.
+ * @param seenObjProperties objects of `objValue` on the current recursion path (cycle guard).
  * @param subsetValue
- * @param seenSubsetProperties already visited properties of `subsetValue`.
+ * @param seenSubsetProperties objects of `subsetValue` on the current recursion path (cycle guard).
  * @param globalObject
  * @param Scope
  * @param gcBuffer

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -442,7 +442,6 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JS
  * @param globalObject
  * @param Scope
  * @param gcBuffer
- * @param replacePropsWithAsymmetricMatchers
  * @param isMatchingObjectContaining
  *
  * @return true
@@ -457,7 +456,6 @@ bool Bun__deepMatch(
     JSC::JSGlobalObject* globalObject,
     JSC::ThrowScope& throwScope,
     JSC::MarkedArgumentBuffer* gcBuffer,
-    bool replacePropsWithAsymmetricMatchers,
     bool isMatchingObjectContaining);
 
 extern "C" void Bun__remapStackFramePositions(void*, ZigStackFrame*, size_t);

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -416,6 +416,9 @@ extern "C" void Bun__EventLoop__runCallback2(JSC::JSGlobalObject* global, JSC::E
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity = false>
 bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JSValue v2, JSC::MarkedArgumentBuffer&, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, JSC::ThrowScope& scope, bool addToStack);
 
+/// (object, subset) pairs `Bun__deepMatch` has recursed into.
+using DeepMatchSeenPairs = std::set<std::pair<JSC::EncodedJSValue, JSC::EncodedJSValue>>;
+
 /**
  * @brief `Bun.deepMatch(a, b)`
  *
@@ -424,8 +427,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JS
  * if either `object` or `subset` are not `JSCCell`.
  *
  * @note
- * The sets recording already visited properties (`seenObjProperties` and
- * `seenSubsetProperties`) aren not needed when both `enableAsymmetricMatchers`
+ * `seenPairs` and `gcBuffer` are not needed when both `enableAsymmetricMatchers`
  * and `isMatchingObjectContaining` are true. In this case, it is safe to pass a
  * `nullptr`.
  *
@@ -436,9 +438,8 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JS
  *
  * @tparam enableAsymmetricMatchers
  * @param objValue
- * @param seenObjProperties objects of `objValue` on the current recursion path (cycle guard).
  * @param subsetValue
- * @param seenSubsetProperties objects of `subsetValue` on the current recursion path (cycle guard).
+ * @param seenPairs a (object, subset) pair met again is a cycle, or was already checked, and is skipped; an object is still checked against every other subset object it is paired with.
  * @param globalObject
  * @param Scope
  * @param gcBuffer
@@ -450,9 +451,8 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSC::JSValue v1, JSC::JS
 template<bool enableAsymmetricMatchers>
 bool Bun__deepMatch(
     JSC::JSValue object,
-    std::set<JSC::EncodedJSValue>* seenObjProperties,
     JSC::JSValue subset,
-    std::set<JSC::EncodedJSValue>* seenSubsetProperties,
+    DeepMatchSeenPairs* seenPairs,
     JSC::JSGlobalObject* globalObject,
     JSC::ThrowScope& throwScope,
     JSC::MarkedArgumentBuffer* gcBuffer,

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -261,7 +261,7 @@ CPP_DECL bool JSC__JSValue__isSymbol(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isTerminationException(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isUInt32AsAnyInt(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__jestDeepEquals(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
-CPP_DECL bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2, bool arg3);
+CPP_DECL bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
 CPP_DECL bool JSC__JSValue__jestStrictDeepEquals(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* arg2);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__jsNumberFromChar(unsigned char arg0);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__jsNumberFromDouble(double arg0);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1146,6 +1146,8 @@ impl Expect {
         pretty_value: &mut impl bun_io::Write,
         fn_name: &'static str,
     ) -> JsResult<()> {
+        let mut snapshot_value = value;
+
         if let Some(_prop_matchers) = property_matchers {
             if !value.is_object() {
                 let signature = Self::get_signature(fn_name, "<green>properties<r><d>, <r>hint", false);
@@ -1154,7 +1156,7 @@ impl Expect {
 
             let prop_matchers = _prop_matchers;
 
-            if !value.jest_deep_match(prop_matchers, global_this, true)? {
+            if !value.jest_deep_match(prop_matchers, global_this)? {
                 // TODO: print diff with properties from propertyMatchers
                 let signature = Self::get_signature(fn_name, "<green>propertyMatchers<r>", false);
                 let mut formatter = ConsoleObject::Formatter::new(global_this);
@@ -1164,9 +1166,11 @@ impl Expect {
                     value.to_fmt(&mut formatter),
                 ).map(drop);
             }
+
+            snapshot_value = value.jest_substitute_asymmetric_matchers(prop_matchers, global_this)?;
         }
 
-        if value.jest_snapshot_pretty_format(pretty_value, global_this).is_err() {
+        if snapshot_value.jest_snapshot_pretty_format(pretty_value, global_this).is_err() {
             let mut formatter = ConsoleObject::Formatter::new(global_this);
             return Err(global_this.throw(format_args!(
                 "Failed to pretty format value: {}",

--- a/src/runtime/test_runner/expect/toMatchObject.rs
+++ b/src/runtime/test_runner/expect/toMatchObject.rs
@@ -30,7 +30,7 @@ pub(crate) fn to_match_object(
 
     let property_matchers = args[0];
 
-    let mut pass = received_object.jest_deep_match(property_matchers, global, true)?;
+    let mut pass = received_object.jest_deep_match(property_matchers, global)?;
 
     if not {
         pass = !pass;

--- a/test/js/bun/test/expect-stack-overflow-crash.test.ts
+++ b/test/js/bun/test/expect-stack-overflow-crash.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // Regression test: calling expect matchers after catching a stack overflow
 // should not crash with a releaseAssertNoException assertion failure.
@@ -54,5 +54,39 @@ try {
 
   expect(stdout).toBe("true Maximum call stack size exceeded.\n");
   expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+// toMatchSnapshot(propertyMatchers) walks the same chain twice: the match,
+// then the substitution of the matchers into the recorded value. Both must
+// stop with RangeError.
+test("toMatchSnapshot() with property matchers throws RangeError on deeply nested objects instead of crashing", async () => {
+  using dir = tempDir("snapshot-deep-matchers", {
+    "deep.test.ts": `import { expect, test } from "bun:test";
+test("deep", () => {
+  let a = {}, b = {};
+  const ra = a, rb = b;
+  for (let i = 0; i < 100000; i++) { a.x = {}; b.x = {}; a = a.x; b = b.x; }
+  try {
+    expect(ra).toMatchSnapshot(rb);
+    console.log("no throw");
+  } catch (e) {
+    console.log(e instanceof RangeError, e.message);
+  }
+});
+`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "deep.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("true Maximum call stack size exceeded.\n");
+  expect(stderr).toContain("1 pass");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/expect-stack-overflow-crash.test.ts
+++ b/test/js/bun/test/expect-stack-overflow-crash.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 // Regression test: calling expect matchers after catching a stack overflow
 // should not crash with a releaseAssertNoException assertion failure.
@@ -54,39 +54,5 @@ try {
 
   expect(stdout).toBe("true Maximum call stack size exceeded.\n");
   expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-});
-
-// toMatchSnapshot(propertyMatchers) walks the same chain twice: the match,
-// then the substitution of the matchers into the recorded value. Both must
-// stop with RangeError.
-test("toMatchSnapshot() with property matchers throws RangeError on deeply nested objects instead of crashing", async () => {
-  using dir = tempDir("snapshot-deep-matchers", {
-    "deep.test.ts": `import { expect, test } from "bun:test";
-test("deep", () => {
-  let a = {}, b = {};
-  const ra = a, rb = b;
-  for (let i = 0; i < 100000; i++) { a.x = {}; b.x = {}; a = a.x; b = b.x; }
-  try {
-    expect(ra).toMatchSnapshot(rb);
-    console.log("no throw");
-  } catch (e) {
-    console.log(e instanceof RangeError, e.message);
-  }
-});
-`,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "deep.test.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stdout).toContain("true Maximum call stack size exceeded.\n");
-  expect(stderr).toContain("1 pass");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3573,6 +3573,32 @@ describe("expect()", () => {
       expect(a1).not.toMatchObject({ 1: 1 });
       expect(a1).toMatchObject(a1);
     });
+
+    // https://github.com/oven-sh/bun/issues/3521
+    test("does not mutate the received object when an asymmetric matcher matches", () => {
+      const obj = { foo: "foo", bar: "bar" };
+      expect(obj).toMatchObject({ bar: expect.any(String) });
+      expect(obj).toEqual({ foo: "foo", bar: "bar" });
+      expect(obj).toMatchObject({ bar: expect.any(String) });
+      expect(obj.bar).toBe("bar");
+
+      const nested = { a: { b: { c: 42 } }, d: "keep" };
+      expect(nested).toMatchObject({ a: { b: { c: expect.any(Number) } } });
+      expect(nested).toEqual({ a: { b: { c: 42 } }, d: "keep" });
+
+      const arr = { list: [1, "two", 3] };
+      expect(arr).toMatchObject({ list: [1, expect.any(String), 3] });
+      expect(arr).toEqual({ list: [1, "two", 3] });
+
+      // The expected/subset side must also be left alone when the received
+      // side carries the asymmetric matcher.
+      const matcherSentinel = expect.any(String);
+      const matchersFirst = { a: matcherSentinel };
+      const subset = { a: "hello" };
+      expect(matchersFirst).toMatchObject(subset);
+      expect(matchersFirst.a).toBe(matcherSentinel);
+      expect(subset.a).toBe("hello");
+    });
   });
 
   describe("toMatch()", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3598,6 +3598,10 @@ describe("expect()", () => {
       expect(matchersFirst).toMatchObject(subset);
       expect(matchersFirst.a).toBe(matcherSentinel);
       expect(subset.a).toBe("hello");
+
+      const frozen = Object.freeze({ foo: "foo", bar: "bar" });
+      expect(frozen).toMatchObject({ bar: expect.any(String) });
+      expect(frozen.bar).toBe("bar");
     });
   });
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3575,20 +3575,22 @@ describe("expect()", () => {
     });
 
     // https://github.com/oven-sh/bun/issues/3521
+    // toEqual accepts an asymmetric matcher on either side, so every check
+    // below reads the leaf that would have been overwritten and uses toBe.
     test("does not mutate the received object when an asymmetric matcher matches", () => {
       const obj = { foo: "foo", bar: "bar" };
       expect(obj).toMatchObject({ bar: expect.any(String) });
-      expect(obj).toEqual({ foo: "foo", bar: "bar" });
+      expect(obj.bar).toBe("bar");
       expect(obj).toMatchObject({ bar: expect.any(String) });
       expect(obj.bar).toBe("bar");
 
       const nested = { a: { b: { c: 42 } }, d: "keep" };
       expect(nested).toMatchObject({ a: { b: { c: expect.any(Number) } } });
-      expect(nested).toEqual({ a: { b: { c: 42 } }, d: "keep" });
+      expect(nested.a.b.c).toBe(42);
 
       const arr = { list: [1, "two", 3] };
       expect(arr).toMatchObject({ list: [1, expect.any(String), 3] });
-      expect(arr).toEqual({ list: [1, "two", 3] });
+      expect(arr.list[1]).toBe("two");
 
       // The expected/subset side must also be left alone when the received
       // side carries the asymmetric matcher.
@@ -3602,6 +3604,25 @@ describe("expect()", () => {
       const frozen = Object.freeze({ foo: "foo", bar: "bar" });
       expect(frozen).toMatchObject({ bar: expect.any(String) });
       expect(frozen.bar).toBe("bar");
+    });
+
+    test("checks an object reached through more than one property at every position", () => {
+      const shared = { x: 1 };
+      const dag = { a: shared, b: shared };
+      expect(dag).toMatchObject({ a: { x: expect.any(Number) }, b: { x: expect.any(Number) } });
+      expect(dag).not.toMatchObject({ a: { x: expect.any(Number) }, b: { x: expect.any(String) } });
+
+      const m = { id: expect.any(Number) };
+      expect([{ id: 1 }, { id: 2 }, { id: 3 }]).toMatchObject([m, m, m]);
+      expect([{ id: 1 }, { id: "oops" }, { id: 3 }]).not.toMatchObject([m, m, m]);
+
+      // Genuine cycles on either side still terminate.
+      const cyclic = { x: 1 };
+      cyclic.self = cyclic;
+      const cyclicMatcher = { x: expect.any(Number) };
+      cyclicMatcher.self = cyclicMatcher;
+      expect(cyclic).toMatchObject(cyclicMatcher);
+      expect(cyclic).toMatchObject({ self: { self: { x: expect.any(Number) } } });
     });
   });
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3623,6 +3623,22 @@ describe("expect()", () => {
       cyclicMatcher.self = cyclicMatcher;
       expect(cyclic).toMatchObject(cyclicMatcher);
       expect(cyclic).toMatchObject({ self: { self: { x: expect.any(Number) } } });
+
+      // A cycle on one side does not skip what the other side still asks for.
+      expect(cyclic).not.toMatchObject({ self: { self: { x: expect.any(String) } } });
+      expect({ x: 1, self: { x: 1, self: { x: 1 } } }).not.toMatchObject(cyclicMatcher);
+
+      // Objects shared at every level of both sides are checked once per pair.
+      let value = { leaf: 1 };
+      let pattern = { leaf: expect.any(Number) };
+      let wrongPattern = { leaf: expect.any(String) };
+      for (let i = 0; i < 64; i++) {
+        value = { a: value, b: value };
+        pattern = { a: pattern, b: pattern };
+        wrongPattern = { a: wrongPattern, b: wrongPattern };
+      }
+      expect(value).toMatchObject(pattern);
+      expect(value).not.toMatchObject(wrongPattern);
     });
   });
 

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -85,3 +85,21 @@ exports[`property matchers do not mutate the received object 1`] = `
   "when": Any<Date>,
 }
 `;
+
+exports[`property matchers preserve class name and handle shared references 1`] = `
+User {
+  "id": Any<Number>,
+  "name": "alice",
+}
+`;
+
+exports[`property matchers preserve class name and handle shared references 2`] = `
+{
+  "a": {
+    "x": Any<Number>,
+  },
+  "b": {
+    "x": Any<Number>,
+  },
+}
+`;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -1,11 +1,5 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`toMatchSnapshot errors should throw if arguments are in the wrong order: right spot 1`] = `
-{
-  "a": "oops",
-}
-`;
-
 exports[`it will create a snapshot file if it doesn't exist 1`] = `
 {
   "a": {
@@ -79,6 +73,11 @@ exports[`it will create a snapshot file if it doesn't exist 7`] = `
 exports[`property matchers do not mutate the received object 1`] = `
 {
   "id": Any<Number>,
+  "list": [
+    1,
+    Any<String>,
+    3,
+  ],
   "nested": {
     "name": Any<String>,
   },
@@ -101,5 +100,11 @@ exports[`property matchers preserve class name and handle shared references 2`] 
   "b": {
     "x": Any<Number>,
   },
+}
+`;
+
+exports[`toMatchSnapshot errors should throw if arguments are in the wrong order: right spot 1`] = `
+{
+  "a": "oops",
 }
 `;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -103,6 +103,15 @@ exports[`property matchers preserve class name and handle shared references 2`] 
 }
 `;
 
+exports[`property matchers preserve class name and handle shared references 3`] = `
+{
+  "id": Any<Number>,
+  "self": [Circular],
+}
+`;
+
+exports[`property matchers preserve class name and handle shared references 4`] = `[Error: boom]`;
+
 exports[`toMatchSnapshot errors should throw if arguments are in the wrong order: right spot 1`] = `
 {
   "a": "oops",

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -75,3 +75,13 @@ exports[`it will create a snapshot file if it doesn't exist 7`] = `
   "j": Any<RegExp>,
 }
 `;
+
+exports[`property matchers do not mutate the received object 1`] = `
+{
+  "id": Any<Number>,
+  "nested": {
+    "name": Any<String>,
+  },
+  "when": Any<Date>,
+}
+`;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -117,3 +117,19 @@ exports[`toMatchSnapshot errors should throw if arguments are in the wrong order
   "a": "oops",
 }
 `;
+
+exports[`property matchers preserve class name and handle shared references 5`] = `
+{
+  "id": Any<Number>,
+  "ts": [native code],
+}
+`;
+
+exports[`property matchers preserve class name and handle shared references 6`] = `
+{
+  "inner": {
+    "id": Any<Number>,
+    "parent": [Circular],
+  },
+}
+`;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -187,13 +187,21 @@ MessageEvent {
 }
 `;
 
-exports[`a matcher checked through a getter is recorded under the getter and on the object behind it 1`] = `
+exports[`snapshot records the matchers that were checked 9`] = `Any<String>`;
+
+exports[`a matcher object checked through a getter is recorded on the object behind it 1`] = `
 Wrapper {
   "_user": {
     "name": Any<String>,
   },
-  "user": {
+}
+`;
+
+exports[`a matcher object checked through a getter is recorded on the object behind it 2`] = `
+{
+  "_user": {
     "name": Any<String>,
   },
+  "user": [native code],
 }
 `;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -172,3 +172,28 @@ Headers {
   "append": Any<Function>,
 }
 `;
+
+exports[`snapshot records the matchers that were checked 7`] = `Event 
+Event {
+  "isTrusted": false,
+  "timeStamp": Any<Number>,
+}
+`;
+
+exports[`snapshot records the matchers that were checked 8`] = `MessageEvent 
+MessageEvent {
+  "data": Any<String>,
+  "isTrusted": false,
+}
+`;
+
+exports[`a matcher checked through a getter is recorded under the getter and on the object behind it 1`] = `
+Wrapper {
+  "_user": {
+    "name": Any<String>,
+  },
+  "user": {
+    "name": Any<String>,
+  },
+}
+`;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -189,6 +189,21 @@ MessageEvent {
 
 exports[`snapshot records the matchers that were checked 9`] = `Any<String>`;
 
+exports[`snapshot records the matchers that were checked 10`] = `
+{
+  "current": {
+    "id": Any<Number>,
+  },
+  "log": [
+    {
+      "user": {
+        "id": 7,
+      },
+    },
+  ],
+}
+`;
+
 exports[`a matcher object checked through a getter is recorded on the object behind it 1`] = `
 Wrapper {
   "_user": {

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -133,3 +133,42 @@ exports[`property matchers preserve class name and handle shared references 6`] 
   },
 }
 `;
+
+exports[`snapshot records the matchers that were checked 1`] = `
+{
+  "a": 1,
+}
+`;
+
+exports[`snapshot records the matchers that were checked 2`] = `
+{
+  "a": 1,
+}
+`;
+
+exports[`snapshot records the matchers that were checked 3`] = `
+{
+  "a": {
+    "x": Any<Number>,
+    "y": Any<String>,
+  },
+  "b": {
+    "x": Any<Number>,
+    "y": Any<String>,
+  },
+}
+`;
+
+exports[`snapshot records the matchers that were checked 4`] = `
+{
+  "id": Any<Number>,
+}
+`;
+
+exports[`snapshot records the matchers that were checked 5`] = `[TypeError: [object ExpectAny]]`;
+
+exports[`snapshot records the matchers that were checked 6`] = `Headers 
+Headers {
+  "append": Any<Function>,
+}
+`;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap
@@ -204,6 +204,13 @@ exports[`snapshot records the matchers that were checked 10`] = `
 }
 `;
 
+exports[`snapshot records the matchers that were checked 11`] = `
+{
+  "id": Any<Number>,
+  "self": [Circular],
+}
+`;
+
 exports[`a matcher object checked through a getter is recorded on the object behind it 1`] = `
 Wrapper {
   "_user": {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -154,9 +154,14 @@ test("snapshot records the matchers that were checked", () => {
   const message = new MessageEvent("message", { data: "hi" });
   expect(message).toMatchSnapshot({ data: expect.any(String) });
   expect(message.data).toBe("hi");
+
+  // A received value that is itself a matcher still prints as that matcher.
+  expect(expect.any(String)).toMatchSnapshot({});
 });
 
-test("a matcher checked through a getter is recorded under the getter and on the object behind it", () => {
+// The matcher is recorded on the object the getter returns, which the snapshot
+// shows under the field that holds it; the getter itself is left as it was.
+test("a matcher object checked through a getter is recorded on the object behind it", () => {
   class Wrapper {
     _user: { name: string };
     constructor() {
@@ -170,6 +175,16 @@ test("a matcher checked through a getter is recorded under the getter and on the
   expect(wrapper).toMatchSnapshot({ user: { name: expect.any(String) } });
   expect(wrapper._user.name).toBe("alice");
   expect(Object.hasOwn(wrapper, "user")).toBe(false);
+
+  const withOwnGetter = {
+    _user: { name: "bob" },
+    get user() {
+      return this._user;
+    },
+  };
+  expect(withOwnGetter).toMatchSnapshot({ user: { name: expect.any(String) } });
+  expect(withOwnGetter._user.name).toBe("bob");
+  expect(Object.getOwnPropertyDescriptor(withOwnGetter, "user")!.get).toBeFunction();
 });
 
 describe("toMatchSnapshot errors", () => {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -33,6 +33,20 @@ test("ArrayBuffer values are serialized like typed arrays", () => {
   `);
 });
 
+// https://github.com/oven-sh/bun/issues/3521
+test("property matchers do not mutate the received object", () => {
+  const date = new Date(0);
+  const obj = { id: 42, when: date, nested: { name: "abc" } };
+  expect(obj).toMatchSnapshot({
+    id: expect.any(Number),
+    when: expect.any(Date),
+    nested: { name: expect.any(String) },
+  });
+  expect(obj.id).toBe(42);
+  expect(obj.when).toBe(date);
+  expect(obj.nested.name).toBe("abc");
+});
+
 describe("toMatchSnapshot errors", () => {
   it("should throw if property matchers exist and received is not an object", () => {
     expect(() => {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -83,6 +83,25 @@ test("property matchers preserve class name and handle shared references", () =>
   err.code = "E_FOO";
   expect(err).toMatchSnapshot({ code: expect.any(String) });
   expect(err.code).toBe("E_FOO");
+
+  let getterCalls = 0;
+  const withGetter = {
+    id: 1,
+    get ts() {
+      getterCalls++;
+      return Date.now();
+    },
+  };
+  expect(withGetter).toMatchSnapshot({ id: expect.any(Number) });
+  expect(withGetter.id).toBe(1);
+  expect(getterCalls).toBe(0);
+
+  const inner: any = { id: 1 };
+  const outer: any = { inner };
+  inner.parent = outer;
+  expect(outer).toMatchSnapshot({ inner: { id: expect.any(Number) } });
+  expect(inner.id).toBe(1);
+  expect(inner.parent).toBe(outer);
 });
 
 describe("toMatchSnapshot errors", () => {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -47,6 +47,31 @@ test("property matchers do not mutate the received object", () => {
   expect(obj.nested.name).toBe("abc");
 });
 
+test("property matchers preserve class name and handle shared references", () => {
+  class User {
+    id: number;
+    name: string;
+    constructor() {
+      this.id = 1;
+      this.name = "alice";
+    }
+  }
+  const user = new User();
+  expect(user).toMatchSnapshot({ id: expect.any(Number) });
+  expect(user.id).toBe(1);
+  expect(user).toBeInstanceOf(User);
+
+  const shared = { x: 1 };
+  const dag = { a: shared, b: shared };
+  expect(dag).toMatchSnapshot({
+    a: { x: expect.any(Number) },
+    b: { x: expect.any(Number) },
+  });
+  expect(dag.a).toBe(shared);
+  expect(dag.b).toBe(shared);
+  expect(shared.x).toBe(1);
+});
+
 describe("toMatchSnapshot errors", () => {
   it("should throw if property matchers exist and received is not an object", () => {
     expect(() => {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -157,6 +157,13 @@ test("snapshot records the matchers that were checked", () => {
 
   // A received value that is itself a matcher still prints as that matcher.
   expect(expect.any(String)).toMatchSnapshot({});
+
+  // A shared object referenced again from inside an object the matchers did
+  // not walk keeps its real values there (as in Jest; the in-place mutation
+  // used to show the matcher at both places).
+  const user = { id: 7 };
+  expect({ current: user, log: [{ user }] }).toMatchSnapshot({ current: { id: expect.any(Number) } });
+  expect(user.id).toBe(7);
 });
 
 // The matcher is recorded on the object the getter returns, which the snapshot

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -72,6 +72,17 @@ test("property matchers preserve class name and handle shared references", () =>
   expect(dag.a).toBe(shared);
   expect(dag.b).toBe(shared);
   expect(shared.x).toBe(1);
+
+  const cyclic: any = { id: 1 };
+  cyclic.self = cyclic;
+  expect(cyclic).toMatchSnapshot({ id: expect.any(Number) });
+  expect(cyclic.id).toBe(1);
+  expect(cyclic.self).toBe(cyclic);
+
+  const err: any = new Error("boom");
+  err.code = "E_FOO";
+  expect(err).toMatchSnapshot({ code: expect.any(String) });
+  expect(err.code).toBe("E_FOO");
 });
 
 describe("toMatchSnapshot errors", () => {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -164,6 +164,13 @@ test("snapshot records the matchers that were checked", () => {
   const user = { id: 7 };
   expect({ current: user, log: [{ user }] }).toMatchSnapshot({ current: { id: expect.any(Number) } });
   expect(user.id).toBe(7);
+
+  // A cyclic received object is checked against every matcher object it is
+  // paired with, so a matcher one lap into the cycle is checked and recorded.
+  const ring: any = { id: 1 };
+  ring.self = ring;
+  expect(ring).toMatchSnapshot({ self: { self: { id: expect.any(Number) } } });
+  expect(ring.id).toBe(1);
 });
 
 // The matcher is recorded on the object the getter returns, which the snapshot

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -143,6 +143,33 @@ test("snapshot records the matchers that were checked", () => {
   expect(headers).toMatchSnapshot({ append: expect.any(Function) });
   expect(Object.hasOwn(headers, "append")).toBe(false);
   expect(headers.get("x-a")).toBe("1");
+
+  const event = new Event("x");
+  expect(event).toMatchSnapshot({ timeStamp: expect.any(Number) });
+  expect(Object.hasOwn(event, "timeStamp")).toBe(false);
+  expect(typeof event.timeStamp).toBe("number");
+
+  // Events with a dedicated rendering (message/error) fall back to the
+  // by-properties rendering once a matcher is recorded on them.
+  const message = new MessageEvent("message", { data: "hi" });
+  expect(message).toMatchSnapshot({ data: expect.any(String) });
+  expect(message.data).toBe("hi");
+});
+
+test("a matcher checked through a getter is recorded under the getter and on the object behind it", () => {
+  class Wrapper {
+    _user: { name: string };
+    constructor() {
+      this._user = { name: "alice" };
+    }
+    get user() {
+      return this._user;
+    }
+  }
+  const wrapper = new Wrapper();
+  expect(wrapper).toMatchSnapshot({ user: { name: expect.any(String) } });
+  expect(wrapper._user.name).toBe("alice");
+  expect(Object.hasOwn(wrapper, "user")).toBe(false);
 });
 
 describe("toMatchSnapshot errors", () => {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -36,15 +36,17 @@ test("ArrayBuffer values are serialized like typed arrays", () => {
 // https://github.com/oven-sh/bun/issues/3521
 test("property matchers do not mutate the received object", () => {
   const date = new Date(0);
-  const obj = { id: 42, when: date, nested: { name: "abc" } };
+  const obj = { id: 42, when: date, nested: { name: "abc" }, list: [1, "two", 3] };
   expect(obj).toMatchSnapshot({
     id: expect.any(Number),
     when: expect.any(Date),
     nested: { name: expect.any(String) },
+    list: [1, expect.any(String), 3],
   });
   expect(obj.id).toBe(42);
   expect(obj.when).toBe(date);
   expect(obj.nested.name).toBe("abc");
+  expect(obj.list).toEqual([1, "two", 3]);
 });
 
 test("property matchers preserve class name and handle shared references", () => {

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -46,7 +46,7 @@ test("property matchers do not mutate the received object", () => {
   expect(obj.id).toBe(42);
   expect(obj.when).toBe(date);
   expect(obj.nested.name).toBe("abc");
-  expect(obj.list).toEqual([1, "two", 3]);
+  expect(obj.list[1]).toBe("two");
 });
 
 test("property matchers preserve class name and handle shared references", () => {
@@ -102,6 +102,47 @@ test("property matchers preserve class name and handle shared references", () =>
   expect(outer).toMatchSnapshot({ inner: { id: expect.any(Number) } });
   expect(inner.id).toBe(1);
   expect(inner.parent).toBe(outer);
+});
+
+// The recorded snapshot must show exactly the matchers the property-matcher
+// check looked at, in the same places they were looked at.
+test("snapshot records the matchers that were checked", () => {
+  // The propertyMatchers argument itself is never matched against the
+  // received value, so it must not replace the snapshot.
+  const plain = { a: 1 };
+  expect(plain).toMatchSnapshot(expect.any(Object));
+  expect(plain).toMatchSnapshot(expect.any(Array));
+
+  // One received object checked through two properties, with a different
+  // matcher at each: it is a single object, so it records the same everywhere.
+  const shared = { x: 1, y: "s" };
+  expect({ a: shared, b: shared }).toMatchSnapshot({
+    a: { x: expect.any(Number) },
+    b: { y: expect.any(String) },
+  });
+  expect(shared.x).toBe(1);
+  expect(shared.y).toBe("s");
+
+  // A matcher on a key the received object implements as a getter.
+  const withGetter = {
+    get id() {
+      return 7;
+    },
+  };
+  expect(withGetter).toMatchSnapshot({ id: expect.any(Number) });
+  expect(withGetter.id).toBe(7);
+
+  // Errors render as [Name: message], so a matcher on message is visible
+  // through the message's string form.
+  const err = new TypeError("boom");
+  expect(err).toMatchSnapshot({ message: expect.any(String) });
+  expect(err.message).toBe("boom");
+
+  // Instances of native classes render by own properties like plain objects.
+  const headers = new Headers({ "x-a": "1" });
+  expect(headers).toMatchSnapshot({ append: expect.any(Function) });
+  expect(Object.hasOwn(headers, "append")).toBe(false);
+  expect(headers.get("x-a")).toBe("1");
 });
 
 describe("toMatchSnapshot errors", () => {


### PR DESCRIPTION
Fixes #3521.

### Problem
- `expect(obj).toMatchObject({ bar: expect.any(String) })` overwrote `obj.bar` with the `Any<String>` matcher object; `toMatchSnapshot` / `toMatchInlineSnapshot` with property matchers did the same to the received value.
- Cause: `Bun__deepMatch` (src/jsc/bindings/bindings.cpp) had a `replacePropsWithAsymmetricMatchers` mode that called `putDirectMayBeIndex` on the received object whenever a matcher passed. It existed so the snapshot formatter would see `Any<String>` in place of the real value; `toMatchObject` also passed `true` and got the mutation for nothing.
- Related: the cycle guard in `Bun__deepMatch` was a per-call set that never shrank, so an object reached through two properties, or one matcher object used at several array positions, was only checked at its first occurrence. `expect([{id: 1}, {id: "oops"}, {id: 3}]).toMatchObject([m, m, m])` with `m = { id: expect.any(Number) }` passed. This matters here because the snapshot must only show matchers that were actually checked.

### Fix
- `Bun__deepMatch` no longer writes to either object; the parameter is gone. `toMatchObject` needs nothing else: on pass it returns `undefined`, on fail the diff uses the real values.
- Its cycle guard is now one set of (received object, matcher object) pairs instead of a set per side. A pair met again is either a cycle or a re-visit whose verdict is already known, and is skipped; any new pairing is checked. So a shared object or a reused matcher object is checked at every position, a cycle on one side no longer skips what the other side still asks for (`expect(ring).toMatchObject({ self: { self: { id: expect.any(String) } } })` used to pass without looking at `id`; the verdicts now agree with Jest), and the work is bounded by the number of distinct pairs. (The previous revision erased the per-side entries after recursing instead, which checks everything but is exponential when both sides share objects at every level.) This also applies to `Bun.deepMatch`.
- New `Bun__JSValue__substituteAsymmetricMatchers` (`AsymmetricMatcherSubstitution` in bindings.cpp), called by `match_and_fmt_snapshot` after the match passed. It builds the value the formatter serializes in three steps:
  - `substitute` walks received/matchers with the same enumeration, recursion rules and pair set as `Bun__deepMatch`. The first time it reaches a received object it makes a clone of it (`cloneFor`: same prototype, own properties copied, accessors copied as accessors so getters are not invoked, `DontEnum` preserved); one clone per received object for the whole walk. The only thing it writes is a matcher that deepMatch checked, put onto the clone at that key. When the matcher side is an object it just recurses, so a matcher object reached through a getter or an inherited property records on the child and adds no key to the parent, as the in-place write did.
  - `redirectToClones` then repoints every copied property that still holds an original at that original's clone. This covers own data properties holding a child, the field behind a getter, shared objects reached through a property the matchers did not walk, and back-references, which render as `[Circular]` at the same depth as before because the formatter's circular check is by identity.
  - `run` returns the clone of the root, or the root itself if nothing was cloned.
  - `substitute` starts with the same `isSafeToRecurse()` check that #40363 gave `Bun__deepMatch`. It is defensive: deepMatch walks the same pairs first and throws first on every chain tried (a 2000 deep Error chain passes both walks on the debug build, 2100 throws in deepMatch), so no test can reach it on its own.
- Which objects get cloned follows the formatter's dispatch (`pretty_format.rs`), so the clone renders the way the mutated original did:
  - Plain objects, native class instances (`JSDOMWrapperType`) and events (`JSEventType`) become ordinary objects with the same prototype: the formatter renders all of these by own properties and takes the `ClassName {` prefix from the prototype chain, so e.g. `Headers { "append": Any<Function> }` and `Event { "isTrusted": false, "timeStamp": Any<Number> }` record byte-for-byte as before.
  - Errors become an `ErrorInstance` with the same prototype, since the formatter renders them as `[Name: message]`; a matcher on `message` records as `[TypeError: [object ExpectAny]]`, as before.
  - Arrays become arrays (the formatter renders indices only).
  - Everything else is serialized as-is: Date, RegExp, Map, Set, boxed primitives, typed arrays and so on are rendered from internal state, so a matcher on them was never visible, and a received value that is itself a matcher instance prints as that matcher (`Any<String>`). A received-side matcher below the root is left alone for the same reason.
  - The `propertyMatchers` argument itself is only walked, never substituted, so `toMatchSnapshot(expect.any(Object))` still records the received object (deepMatch never compares the root against anything).
- Three output changes relative to main, each pinned in `bun-snapshots.test.ts`:
  - Positions the old guard skipped are now checked, so their matchers are recorded: a shared object or a reused matcher object records every matcher checked on it (previously only the first path's), and a matcher one lap into a cyclic received object (`ring` with `{ self: { self: { id: expect.any(Number) } } }`) records `"id": Any<Number>` where main recorded the real value.
  - The few native classes and events with a dedicated rendering (`Response`, `Request`, `Blob`, `FormData`, timers, `MessageEvent`, `ErrorEvent`) record as `Name { "prop": Matcher }` when a property matcher targets one of their properties, instead of the dedicated rendering with the matcher hidden. Pinned with `MessageEvent`.
  - A shared object referenced again from inside an object the matchers did not walk (`{ current: user, log: [{ user }] }` with a matcher under `current`) records its real values at that second place; the mutation showed the matcher there too. The redirect pass only rewrites properties of cloned objects, and `log` was never walked. Jest records the same thing; a reference held directly by a walked object (`{ a: user, b: user }`) still records as on main.
- Verified:
  - `test/js/bun/test/expect.test.js` (`toMatchObject`): the no-mutation test asserts the overwritten leaves with `toBe`; new test for shared object, reused matcher object, cycles on both sides, a cycle on one side only (both directions), and objects shared at all 64 levels of both sides. Both tests fail on main.
  - `test/js/bun/test/snapshot-tests/bun-snapshots.test.ts`: no-mutation, class name, shared object, self and parent cycles, matcher one lap into a cycle, getter on a non-matcher key and on a matcher key, matcher object behind a prototype getter and behind an own getter, `Error.code`, `Error.message`, root matcher argument, root received matcher, shared object behind an unwalked object, `Headers`, `Event`, `MessageEvent`. The file fails on main.
  - Twenty further shapes (getter variants, inherited data property, private fields, null prototype, sparse arrays, array expandos, symbol and non-enumerable keys, nested class instances, Error with nested object, Map expando, objectContaining/stringContaining/arrayContaining) were recorded with a release bun without this change and with this build; the only difference is the reused-matcher-object shape listed above.
  - `expect.test.js`, `snapshot-tests/`, `expect-extend`, `spyMatchers`, `jest-extended`, `bun-object/deep-match.spec.ts`, `expect-stack-overflow-crash.test.ts` pass on the debug build; `bun-snapshots.test.ts` also under `BUN_JSC_validateExceptionChecks=1`.

### Background
- Asymmetric matcher: the object returned by `expect.any(X)`, `expect.stringContaining(...)` etc. It is a Bun native class instance (`JSDOMWrapperType` cell); `matchAsymmetricMatcherAndGetFlags` decides whether a value is one and whether it matches. The snapshot formatter prints one as `Any<X>`, `StringContaining "..."`, and so on.
- Property matchers: the optional first argument of `toMatchSnapshot` / `toMatchInlineSnapshot`. The received value is first checked against it with `Bun__deepMatch` (subset match, matchers allowed), then the snapshot is written with the matchers in place of the matched values so it stays stable across runs.
- `Bun__deepMatch` is the shared subset matcher behind `toMatchObject`, snapshot property matchers and `Bun.deepMatch`. It enumerates the matcher object's enumerable properties, and for each one either runs the matcher, recurses when both sides are objects, or compares with `SameValue`.
- The snapshot formatter (`src/runtime/test_runner/pretty_format.rs`) dispatches on the cell's `JSType`: plain objects, native class instances and events print their own properties with a class-name prefix derived from the prototype chain, arrays print their indices, errors print `[Name: message]`, and types such as Date or Map print from internal state. That dispatch is what decides which kind of clone can stand in for the original.

<details>
<summary>Earlier revisions of this PR</summary>

The first version returned the received object unchanged when no substitution happened and only cloned plain objects; review found that this dropped class-name prefixes, skipped matchers on shared objects, invoked getters while copying, silently ignored matchers on native class instances, events and `Error.message`, let a matcher passed as the whole `propertyMatchers` argument replace the snapshot, and substituted at positions deepMatch never checked. A later revision put the child's clone onto the parent clone under the matcher key, which added an own key where the received object only had a getter or an inherited property; the redirect pass now handles the child reference and the put is limited to matchers. The clone is allocated as soon as an object is reached, so there is no lazy path. The deepMatch guard went from two per-call sets (main) to two path-scoped sets (checks everything, exponential on objects shared at every level of both sides) to the pair set described above.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect.test.js:
(pass) expect() > () [337.27ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.77ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.50ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.27ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.31ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.28ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.29ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.27ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.27ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.30ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.39ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.51ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.73ms]
(pass) expect() > 
... (truncated)

release without fix: 2 skipped
bun test v1.4.1-canary.1 (0b8865fe4)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.59ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.02ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.02ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect.test.js test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect.test.js:
(pass) expect() > () [336.63ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.72ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.47ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.32ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.27ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.29ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.27ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.26ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.29ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.26ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.48ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.51ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.72ms]
(pass) expect() > 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 712ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[2/124] gen cpp.rs (cppbind)
[2/124] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSValue.rs                                 |  32 +--
 src/jsc/bindings/BunObject.cpp                     |   5 +-
 src/jsc/bindings/bindings.cpp                      | 253 +++++++++++++++++----
 src/jsc/bindings/headers-handwritten.h             |  14 +-
 src/jsc/bindings/headers.h                         |   2 +-
 src/runtime/test_runner/expect.rs                  |   8 +-
 src/runtime/test_runner/expect/toMatchObject.rs    |   2 +-
 test/js/bun/test/expect.test.js                    |  67 ++++++
 .../__snapshots__/bun-snapshots.test.ts.snap       | 164 ++++++++++++-
 .../bun/test/snapshot-tests/bun-snapshots.test.ts  | 168 ++++++++++++++
 10 files changed, 643 insertions(+), 72 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/JSValue.rs                                            0      0      0
src/jsc/bindings/BunObject.cpp                                1      1      0
src/jsc/bindings/bindings.cpp                                12     18      0
src/jsc/bindings/headers-handwritten.h                        1      1      0
src/jsc/bindings/headers.h                                    0      0      0
src/runtime/test_runner/expect.rs                             0      0      0
src/runtime/test_runner/expect/toMatchObject.rs               0      0      0
test/js/bun/test/expect.test.js                               1      1      0
…snapshot-tests/__snapshots__/bun-snapshots.test.ts.snap      4      5      0
test/js/bun/test/snapshot-tests/bun-snapshots.test.ts         6      8      0
```

</details>

<!-- robobun:evidence:end -->


