### PR TITLE
bun:test: implement jest.resetModules() and vi.resetModules()

### DIFF
--- a/docs/test/mocks.mdx
+++ b/docs/test/mocks.mdx
@@ -470,6 +470,35 @@ test("foo, bar, baz", () => {
 
 Call `mock.restore()` in an `afterEach` block, or in your test preload script, instead of repeating cleanup in every test.
 
+### Reset Modules
+
+`jest.resetModules()` (and its `vi.resetModules()` alias) clears the module registry, the same thing `delete require.cache[id]` does for every loaded module at once, so the next `require()` or dynamic `import()` re-evaluates the module from scratch. This is useful when a module keeps top-level state that should not bleed between tests:
+
+```ts title="test.ts" icon="/icons/typescript.svg"
+import { beforeEach, expect, jest, test } from "bun:test";
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+test("fresh module state", () => {
+  const counter = require("./counter");
+  counter.increment();
+  expect(counter.get()).toBe(1);
+});
+
+test("state is reset", () => {
+  const counter = require("./counter");
+  expect(counter.get()).toBe(0);
+});
+```
+
+Modules imported with a static `import` at the top of the test file are not affected: those bindings were resolved when the file loaded. Only loads that happen after the reset see a fresh copy.
+
+Module mocks registered with `jest.mock()` / `mock.module()` survive `resetModules()` and continue to intercept subsequent loads. The mock factory is not run again: loads after the reset are built from the object the factory returned the first time, so the mock functions inside it keep their recorded calls. (Jest re-runs the factory after `resetModules()`; Vitest does not.)
+
+As with `delete require.cache[id]` in Node.js, a module evicted by the reset still appears in the `module.children` of the module that `require()`d it, so copies created by repeated resets within one file stay in memory until that file finishes. Modules loaded with `import()` are not linked to their importer this way and are collected once nothing references them.
+
 ## Vitest Compatibility
 
 For added compatibility with tests written for Vitest, Bun provides the `vi` object as an alias for parts of the Jest mocking API:
@@ -491,6 +520,7 @@ test("vitest compatibility", () => {
   // vi.restoreAllMocks
   // vi.resetAllMocks
   // vi.clearAllMocks
+  // vi.resetModules
 });
 ```
 

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -91,6 +91,18 @@ declare module "bun:test" {
     function restoreAllMocks(): void;
     function clearAllMocks(): void;
     function resetAllMocks(): void;
+    /**
+     * Clears the module registry (both the ESM registry and `require.cache`),
+     * so the next `require()` or dynamic `import()` of a module evaluates it
+     * again. Useful when a module keeps top-level state that must not leak
+     * between tests.
+     *
+     * Module mocks registered with `jest.mock()` / `mock.module()` stay in
+     * effect, and their factories are not run again.
+     *
+     * Returns the `jest` object for chaining.
+     */
+    function resetModules(): typeof jest;
     function fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
     function setSystemTime(now?: number | Date): void;
     function setTimeout(milliseconds: number): void;
@@ -187,6 +199,13 @@ declare module "bun:test" {
      */
     clearAllMocks: typeof jest.clearAllMocks;
     resetAllMocks: typeof jest.resetAllMocks;
+    /**
+     * Clears the module registry so the next `require()` or dynamic `import()`
+     * of a module evaluates it again. See {@link jest.resetModules}.
+     *
+     * Returns the `vi` object for chaining.
+     */
+    resetModules: () => typeof vi;
     useFakeTimers: typeof jest.useFakeTimers;
     useRealTimers: typeof jest.useRealTimers;
     advanceTimersByTime: typeof jest.advanceTimersByTime;

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -34,6 +34,7 @@ BUN_DECLARE_HOST_FUNCTION(JSMock__jsSetSystemTime);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsRestoreAllMocks);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsClearAllMocks);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsResetAllMocks);
+BUN_DECLARE_HOST_FUNCTION(JSMock__jsResetModules);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsSpyOn);
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsMockFn);
 
@@ -1481,6 +1482,18 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsResetAllMocks, (JSC::JSGlobalObject * globalO
 {
     JSMock__resetAllMocks(uncheckedDowncast<Zig::GlobalObject>(globalObject));
     return JSValue::encode(jsUndefined());
+}
+
+BUN_DEFINE_HOST_FUNCTION(JSMock__jsResetModules, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // jest.mock() registrations live in onLoadPlugins and deliberately survive this.
+    defaultGlobalObject(lexicalGlobalObject)->clearModuleRegistryAndRequireCache();
+    RETURN_IF_EXCEPTION(scope, {});
+
+    return JSValue::encode(callframe->thisValue());
 }
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsSpyOn, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callframe))

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -155,6 +155,7 @@
 #include "streams/JSWritableStreamDefaultController.h"
 #include "streams/JSWritableStreamDefaultWriter.h"
 #include "libusockets.h"
+#include "IsolatedModuleCache.h"
 #include "ModuleLoader.h"
 #include "napi_external.h"
 #include "napi_handle_scope.h"
@@ -3561,16 +3562,27 @@ template void GlobalObject::visitOutputConstraints(JSCell*, SlotVisitor&);
 
 // DEFINE_VISIT_CHILDREN(Zig::GlobalObject);
 
-void GlobalObject::reload()
+void GlobalObject::clearModuleRegistryAndRequireCache()
 {
     auto& vm = this->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     {
         auto* moduleLoader = this->moduleLoader();
+        // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread under cellLock().
         WTF::Locker locker { moduleLoader->cellLock() };
         moduleLoader->clearAll();
     }
+    // --isolate caches transpiled sources by path in front of the file read; those go too.
+    Bun::IsolatedModuleCache::clear(vm);
     this->requireMap()->clear(this);
+    RETURN_IF_EXCEPTION(scope, );
+}
+
+void GlobalObject::reload()
+{
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    this->clearModuleRegistryAndRequireCache();
     RETURN_IF_EXCEPTION(scope, );
 
     // If we run the GC every time, we will never get the SourceProvider cache hit.
@@ -4282,14 +4294,8 @@ void GlobalObject::forbidExecution()
     // Drop the module registry and require() cache so module-level bindings become unreachable
     // for the final collection (their ExternalStringImpl deallocators must run before ~VM).
     {
-        auto* moduleLoader = this->moduleLoader();
-        // JSModuleLoader::visitChildrenImpl iterates these maps on the GC thread under cellLock().
-        WTF::Locker locker { moduleLoader->cellLock() };
-        moduleLoader->clearAll();
-    }
-    {
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        requireMap()->clear(this);
+        clearModuleRegistryAndRequireCache();
         scope.clearException();
     }
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -769,6 +769,7 @@ public:
     size_t reloadCount = 0;
 
     void reload();
+    void clearModuleRegistryAndRequireCache();
 
     JSC::Structure* jsonlParseResultStructure() { return m_jsonlParseResultStructure.get(this); }
     JSC::Structure* pathParsedObjectStructure() { return m_pathParsedObjectStructure.get(this); }

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -418,19 +418,21 @@ pub mod Jest {
         let restore_all_mocks = jsc::JSFunction::create(global_object, "restoreAllMocks", JSMock__jsRestoreAllMocks, 2, Default::default());
         let clear_all_mocks = jsc::JSFunction::create(global_object, "clearAllMocks", JSMock__jsClearAllMocks, 2, Default::default());
         let reset_all_mocks = jsc::JSFunction::create(global_object, "resetAllMocks", JSMock__jsResetAllMocks, 2, Default::default());
+        let reset_modules = jsc::JSFunction::create(global_object, "resetModules", JSMock__jsResetModules, 0, Default::default());
         let mock_module_fn = jsc::JSFunction::create(global_object, "module", JSMock__jsModuleMock, 2, Default::default());
         module.put(global_object, b"mock", mock_fn);
         mock_fn.put(global_object, b"module", mock_module_fn);
         mock_fn.put(global_object, b"restore", restore_all_mocks);
         mock_fn.put(global_object, b"clearAllMocks", clear_all_mocks);
 
-        let jest = JSValue::create_empty_object(global_object, 9 + fake_timers::TIMER_FNS_COUNT);
+        let jest = JSValue::create_empty_object(global_object, 10 + fake_timers::TIMER_FNS_COUNT);
         jest.put(global_object, b"fn", mock_fn);
         jest.put(global_object, b"mock", mock_module_fn);
         jest.put(global_object, b"spyOn", spy_on);
         jest.put(global_object, b"restoreAllMocks", restore_all_mocks);
         jest.put(global_object, b"clearAllMocks", clear_all_mocks);
         jest.put(global_object, b"resetAllMocks", reset_all_mocks);
+        jest.put(global_object, b"resetModules", reset_modules);
         jest.put(global_object, b"setSystemTime", set_system_time);
         jest.put(global_object, b"now", jsc::JSFunction::create(global_object, "now", JSMock__jsNow, 0, Default::default()));
         jest.put(global_object, b"setTimeout", jsc::JSFunction::create(global_object, "setTimeout", __jsc_host_js_set_default_timeout, 1, Default::default()));
@@ -439,13 +441,14 @@ pub mod Jest {
         module.put(global_object, b"spyOn", spy_on);
         module.put(global_object, b"expect", jsc::codegen::js::get_constructor::<Expect>(global_object));
 
-        let vi = JSValue::create_empty_object(global_object, 6 + fake_timers::TIMER_FNS_COUNT);
+        let vi = JSValue::create_empty_object(global_object, 7 + fake_timers::TIMER_FNS_COUNT);
         vi.put(global_object, b"fn", mock_fn);
         vi.put(global_object, b"mock", mock_module_fn);
         vi.put(global_object, b"spyOn", spy_on);
         vi.put(global_object, b"restoreAllMocks", restore_all_mocks);
         vi.put(global_object, b"resetAllMocks", reset_all_mocks);
         vi.put(global_object, b"clearAllMocks", clear_all_mocks);
+        vi.put(global_object, b"resetModules", reset_modules);
         module.put(global_object, b"vi", vi);
 
         fake_timers::put_timers_fns(global_object, jest, vi);
@@ -462,6 +465,7 @@ pub mod Jest {
         pub(crate) fn JSMock__jsRestoreAllMocks(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
         pub(crate) fn JSMock__jsClearAllMocks(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
         pub(crate) fn JSMock__jsResetAllMocks(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
+        pub(crate) fn JSMock__jsResetModules(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
         pub(crate) fn JSMock__jsSpyOn(global: *mut JSGlobalObject, frame: *mut CallFrame) -> JSValue;
     }
 

--- a/test/js/bun/test/jest-reset-modules.test.ts
+++ b/test/js/bun/test/jest-reset-modules.test.ts
@@ -1,0 +1,242 @@
+// https://github.com/oven-sh/bun/issues/5356
+// jest.resetModules is not a function in bun:test
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function runTestFile(prefix: string, files: Record<string, string>, extraArgs: string[] = []) {
+  const testFile = Object.keys(files).find(f => f.endsWith(".test.ts") || f.endsWith(".test.cjs"))!;
+  using dir = tempDir(prefix, files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...extraArgs, testFile],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { output: stdout + stderr, exitCode };
+}
+
+describe.concurrent("jest.resetModules", () => {
+  test("exists and is chainable on jest and vi", async () => {
+    const { output, exitCode } = await runTestFile("jest-reset-modules-exists", {
+      "exists.test.ts": `
+        import { jest, vi, test, expect } from "bun:test";
+
+        test("callable", () => {
+          expect(typeof jest.resetModules).toBe("function");
+          expect(typeof vi.resetModules).toBe("function");
+          expect(jest.resetModules()).toBe(jest);
+          expect(vi.resetModules()).toBe(vi);
+        });
+      `,
+    });
+    expect(output).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("require() returns a fresh module after resetModules()", async () => {
+    const { output, exitCode } = await runTestFile("jest-reset-modules-cjs", {
+      "counter.cjs": `
+        let count = 0;
+        module.exports = {
+          increment: () => ++count,
+          get: () => count,
+        };
+      `,
+      "reset.test.ts": `
+        import { jest, test, expect } from "bun:test";
+
+        test("fresh CJS module after resetModules", () => {
+          const c1 = require("./counter.cjs");
+          c1.increment();
+          c1.increment();
+          expect(c1.get()).toBe(2);
+          expect(require("./counter.cjs")).toBe(c1);
+
+          jest.resetModules();
+
+          const c2 = require("./counter.cjs");
+          expect(c2).not.toBe(c1);
+          expect(c2.get()).toBe(0);
+        });
+      `,
+    });
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("dynamic import() returns a fresh module after resetModules()", async () => {
+    const { output, exitCode } = await runTestFile("jest-reset-modules-esm", {
+      "state.ts": `
+        export const value = { n: 0 };
+      `,
+      "reset.test.ts": `
+        import { jest, test, expect } from "bun:test";
+
+        test("fresh ESM module after resetModules", async () => {
+          const m1 = await import("./state.ts");
+          m1.value.n = 5;
+          const m1b = await import("./state.ts");
+          expect(m1b).toBe(m1);
+          expect(m1b.value.n).toBe(5);
+
+          jest.resetModules();
+
+          const m2 = await import("./state.ts");
+          expect(m2).not.toBe(m1);
+          expect(m2.value.n).toBe(0);
+        });
+      `,
+    });
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("the next load re-reads a file rewritten on disk, also under --isolate", async () => {
+    const files = {
+      "shared.ts": `export const v = "v1";\n`,
+      "reset.test.ts": `
+        import { jest, test, expect } from "bun:test";
+        import { writeFileSync } from "node:fs";
+
+        test("sees the rewritten file after resetModules", async () => {
+          expect((await import("./shared.ts")).v).toBe("v1");
+          writeFileSync(new URL("./shared.ts", import.meta.url), 'export const v = "v2";\\n');
+
+          jest.resetModules();
+
+          expect((await import("./shared.ts")).v).toBe("v2");
+        });
+      `,
+    };
+    const [plain, isolated] = await Promise.all([
+      runTestFile("jest-reset-modules-reread", files),
+      runTestFile("jest-reset-modules-reread-isolate", files, ["--isolate"]),
+    ]);
+    expect(plain.output).toContain("1 pass");
+    expect(plain.output).toContain("0 fail");
+    expect(plain.exitCode).toBe(0);
+    expect(isolated.output).toContain("1 pass");
+    expect(isolated.output).toContain("0 fail");
+    expect(isolated.exitCode).toBe(0);
+  });
+
+  test("module mocks survive resetModules() and the factory is not re-run", async () => {
+    const { output, exitCode } = await runTestFile("jest-reset-modules-mock", {
+      "dep.cjs": `
+        module.exports = { real: true };
+      `,
+      "reset.test.ts": `
+        import { jest, test, expect } from "bun:test";
+
+        test("mock still applied after resetModules", () => {
+          let factoryCalls = 0;
+          jest.mock("./dep.cjs", () => {
+            factoryCalls++;
+            return { real: false, fn: jest.fn() };
+          });
+          const first = require("./dep.cjs");
+          first.fn();
+          expect(first.real).toBe(false);
+          expect(factoryCalls).toBe(1);
+
+          jest.resetModules();
+
+          // The module is rebuilt from the object the factory returned the
+          // first time: same exports, same mock functions, call history intact.
+          const second = require("./dep.cjs");
+          expect(second.real).toBe(false);
+          expect(second.fn).toBe(first.fn);
+          expect(second.fn).toHaveBeenCalledTimes(1);
+          expect(factoryCalls).toBe(1);
+        });
+      `,
+    });
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  // The bounds below follow the other heapStats tests in this directory: they
+  // leave room for the odd object conservative stack scanning keeps alive.
+  test("modules evicted by resetModules() are collectable on the import() path", async () => {
+    const { output, exitCode } = await runTestFile("jest-reset-modules-heap-esm", {
+      "leaf.ts": `
+        export const leaf = {};
+      `,
+      "reset.test.ts": `
+        import { jest, test, expect } from "bun:test";
+        import { heapStats } from "bun:jsc";
+
+        const N = 100;
+        function liveModuleRecords() {
+          Bun.gc(true);
+          Bun.gc(true);
+          return heapStats().objectTypeCounts.ModuleRecord ?? 0;
+        }
+
+        test("import() path", async () => {
+          await import("./leaf.ts");
+          jest.resetModules();
+          const before = liveModuleRecords();
+
+          for (let i = 0; i < N; i++) {
+            await import("./leaf.ts");
+            jest.resetModules();
+          }
+
+          expect(liveModuleRecords() - before).toBeLessThan(N * 0.1);
+        });
+      `,
+    });
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+
+  test("modules evicted by resetModules() stay reachable from the requirer's module.children", async () => {
+    const { output, exitCode } = await runTestFile("jest-reset-modules-heap-cjs", {
+      "leaf.cjs": `
+        module.exports = {};
+      `,
+      "reset.test.cjs": `
+        const { jest, test, expect } = require("bun:test");
+        const { heapStats } = require("bun:jsc");
+
+        const N = 100;
+        function liveModules() {
+          Bun.gc(true);
+          Bun.gc(true);
+          return heapStats().objectTypeCounts.Module ?? 0;
+        }
+
+        test("require() path", () => {
+          require("./leaf.cjs");
+          jest.resetModules();
+          module.children = [];
+          const before = liveModules();
+
+          for (let i = 0; i < N; i++) {
+            require("./leaf.cjs");
+            jest.resetModules();
+          }
+
+          // Same as delete require.cache[id]: the evicted modules are still
+          // listed in the children of the module that required them.
+          expect(module.children.length).toBe(N);
+          expect(liveModules() - before).toBeGreaterThan(N * 0.9);
+
+          // Dropping that list is what lets them go.
+          module.children = [];
+          expect(liveModules() - before).toBeLessThan(N * 0.1);
+        });
+      `,
+    });
+    expect(output).toContain("1 pass");
+    expect(output).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `jest.resetModules()` / `vi.resetModules()` do not exist in `bun:test`; the common `beforeEach(() => jest.resetModules())` pattern fails with `TypeError: jest.resetModules is not a function`.

### Fix
- Adds `jest.resetModules()` and `vi.resetModules()` (`JSMock__jsResetModules` in `JSMockFunction.cpp`, wired in `jest.rs`). Returns `this` for chaining, as in Jest and Vitest.
- The body is a new `GlobalObject::clearModuleRegistryAndRequireCache()`: clears the ESM registry, the `require()` cache, and the `--isolate` source cache. It is the same block `reload()` (`--hot`) and `forbidExecution()` (process exit) already open-coded; both now call it. `forbidExecution()` keeps its top exception scope, so it still swallows the exception `reload()` propagates.
- The `--isolate` source cache is cleared because otherwise the reload under `--isolate` re-evaluates the source transpiled by the previous load instead of re-reading the file. `delete require.cache[id]` already evicts it for the same reason (`CommonJS.ts` `deleteProperty`); verified by building without that line, which fails only the `--isolate` half of the re-read test.
- Module mocks survive: `jest.mock()` / `mock.module()` factories live in `onLoadPlugins`, not in the cleared caches. The factory is not run again: `JSModuleMock::executeOnce` rebuilds later loads from its first result, so mock functions inside keep their calls. Jest re-runs the factory here; Vitest does not. Documented in `docs/test/mocks.mdx` and the `.d.ts`.
- Retention is the `delete require.cache` behaviour, not Jest's: a module evicted by the reset stays listed in the `module.children` of the module that `require()`d it, so copies created by repeated resets in one file live until that file finishes. Making them collectable would mean mutating `module.children` on live modules we do not own (for an ESM test file the requirer is not even in the cache), so this PR keeps the Node behaviour and documents it. `import()`ed modules have no such link and are collected. Both are pinned by heap tests.
- Verified with `bun bd test test/js/bun/test/jest-reset-modules.test.ts` (7 pass; 7 fail on the released binary). `test/cli/test/isolation.test.ts` (23 pass) and `test/cli/hot/hot.test.ts` (12 pass) cover the two converted call sites. `test/integration/bun-types/bun-types.test.ts` passes. `test/js/web/workers/worker.test.ts` has 4 "terminate() races" tests that time out in this container with or without this diff.
- Pre-existing, not changed here: `require()` of an ES module that empties the registry during its own top level (directly or via a dependency, now also by calling `resetModules()` there) throws `require() failed to evaluate module ... internal consistentency error` from the require-of-ESM path in `ZigGlobalObject.cpp`; static `import` and preloads are fine. Same with `delete require.cache[import.meta.path]` on main. Also pre-existing: after any full eviction, the first CJS file loaded through the ESM loader gets `module.id === "."` (`JSCommonJSModule.cpp` keys "is main" on an empty require map). Both have been filed separately.

### Background
- **ESM registry**: JSC's `JSModuleLoader` keeps every evaluated ES module record keyed by resolved path; `import()` of a known key returns the existing namespace. `clearAll()` empties it (taken under `cellLock()` because the GC marks the map concurrently).
- **`requireMap`**: Bun's `require.cache`, a `JSMap` from resolved path to the `JSCommonJSModule` object; `require()` of a known key returns its `exports`.
- **`IsolatedModuleCache`**: under `bun test --isolate` each test file gets a fresh global but shares the VM; this per-VM map caches the transpiled `SourceProvider` per path so the next file does not re-transpile. It sits in front of reading the file, so a registry clear alone still gets the old source.
- **`module.children`**: Node API listing the modules a module has `require()`d. Bun appends to it on every `require()` (`jsFunctionEvaluateCommonJSModule`), and it is a GC root for those modules; assigning `module.children = []` drops it.

Fixes #5356
Fixes #3594

Addresses the `vi.resetModules` item in #31316 (that issue tracks several other gaps and is not closed by this PR).

<details>
<summary>Previous revision</summary>

The first revision extracted the helper from four call sites; #37075 has since removed the ones in `destructOnExit` and `WebWorker__teardownJSCVM` and added `forbidExecution()`, so the helper now replaces the two sites main has. It also did not clear the `--isolate` source cache, and the test file lived under `test/regression/`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-reset-modules.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/test/jest-reset-modules.test.ts:
29 |           expect(jest.resetModules()).toBe(jest);
30 |           expect(vi.resetModules()).toBe(vi);
31 |         });
32 |       `,
33 |     });
34 |     expect(output).toContain("1 pass");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "1 pass"
Received: "bun test v1.4.0-canary.1 (da3851e57)\n\nexists.test.ts:\n1 | \n2 |         import { jest, vi, test, expect } from \"bun:test\";\n3 | \n4 |         test(\"callable\", () => {\n5 |           expect(typeof jest.resetModules).toBe(\"function\");\n                                               ^\nerror: expect(received).toBe(expected)\n\nExpected: \"function\"\nReceived: \"undefined\"\n\n      at <anonymous> (/tmp/jest-reset-modules-exists_0nfTiW/exists.test.ts:5:44)\n(fail) callable [0.36ms]\n\n 0 pass\n 1 fail\n 1 expect() calls\nRan 1 test across 1 file. [9.00ms]\n"

      at <anonymous> (/workspace/bun/test/js/bun/test/jest-reset-modules.test.ts:34:20)
(fail) jest.resetModules > exists and is chainable on jest and vi [35.07ms]
60 |           expect(c2).not.toBe(c1);
61 |           exp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/jest-reset-modules.test.ts
bun test v1.4.0 (0a01d33e8)

test/js/bun/test/jest-reset-modules.test.ts:
(pass) jest.resetModules > exists and is chainable on jest and vi [640.57ms]
(pass) jest.resetModules > require() returns a fresh module after resetModules() [621.63ms]
(pass) jest.resetModules > dynamic import() returns a fresh module after resetModules() [658.53ms]
(pass) jest.resetModules > module mocks survive resetModules() and the factory is not re-run [596.61ms]
(pass) jest.resetModules > the next load re-reads a file rewritten on disk, also under --isolate [1320.39ms]
(pass) jest.resetModules > modules evicted by resetModules() are collectable on the import() path [1327.57ms]
(pass) jest.resetModules > modules evicted by resetModules() stay reachable from the requirer's module.children [1306.04ms]

 7 pass
 0 fail
 23 expect() calls
Ran 7 tests across 1 file. [6.78s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0a01d33e83
  features     baseline

22 deps, 107 codegen, 1176 objects in 1826ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[4/1238] gen .bind.ts → GeneratedBindings.cpp
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[9/1237] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/test/mocks.mdx                         |  30 ++++
 packages/bun-types/test.d.ts                |  19 +++
 src/jsc/bindings/JSMockFunction.cpp         |  13 ++
 src/jsc/bindings/ZigGlobalObject.cpp        |  22 ++-
 src/jsc/bindings/ZigGlobalObject.h          |   1 +
 src/runtime/test_runner/jest.rs             |   8 +-
 test/js/bun/test/jest-reset-modules.test.ts | 242 ++++++++++++++++++++++++++++
 7 files changed, 325 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
docs/test/mocks.mdx                              3      4      0
packages/bun-types/test.d.ts                     3      5      0
src/jsc/bindings/JSMockFunction.cpp              5      9      0
src/jsc/bindings/ZigGlobalObject.cpp             6      7      0
src/jsc/bindings/ZigGlobalObject.h               2      1      0
src/runtime/test_runner/jest.rs                  2      4      0
test/js/bun/test/jest-reset-modules.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->