### PR TITLE
install: load bunfig before resolving globalDir for -g installs

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1481,10 +1481,8 @@ pub fn init(
     subcommand: Subcommand,
 ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
     if cli.global {
-        // `[install] globalDir` determines where we fchdir to, so the config must be
-        // loaded before that chdir. For non-global installs, loading stays deferred
-        // until after the package.json walk (below) so `bunfig.toml` resolves next to
-        // `package.json`.
+        // `[install] globalDir` decides where we fchdir, so bunfig is read before it here
+        // and after the package.json walk (below) otherwise.
         ::bun_bunfig::arguments::load_config(
             bun_options_types::command_tag::Tag::InstallCommand,
             cli.config,

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1481,6 +1481,16 @@ pub fn init(
     subcommand: Subcommand,
 ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
     if cli.global {
+        // `[install] globalDir` determines where we fchdir to, so the config must be
+        // loaded before that chdir. For non-global installs, loading stays deferred
+        // until after the package.json walk (below) so `bunfig.toml` resolves next to
+        // `package.json`.
+        ::bun_bunfig::arguments::load_config(
+            bun_options_types::command_tag::Tag::InstallCommand,
+            cli.config,
+            ctx,
+        )?;
+
         // Non-consuming peek: `ctx.install` is
         // `Option<Box<BunInstall>>` borrowed via `&mut ContextData`; reborrow with
         // `as_deref()` so the boxed config remains in `ctx` for the
@@ -1830,11 +1840,13 @@ pub fn init(
     // `loadConfig` was moved down into `bun_bunfig`
     // (MOVE_DOWN b0) so install can call it directly — no fn-pointer hook.
     // (`::`-qualified because `crate::bun_bunfig` is a legacy local shim mod.)
-    ::bun_bunfig::arguments::load_config(
-        bun_options_types::command_tag::Tag::InstallCommand,
-        cli.config,
-        ctx,
-    )?;
+    if !cli.global {
+        ::bun_bunfig::arguments::load_config(
+            bun_options_types::command_tag::Tag::InstallCommand,
+            cli.config,
+            ctx,
+        )?;
+    }
     // SAFETY: main-thread global
     unsafe {
         let tld = fs.top_level_dir();

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1481,8 +1481,6 @@ pub fn init(
     subcommand: Subcommand,
 ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
     if cli.global {
-        // `[install] globalDir` decides where we fchdir, so bunfig is read before it here
-        // and after the package.json walk (below) otherwise.
         ::bun_bunfig::arguments::load_config(
             bun_options_types::command_tag::Tag::InstallCommand,
             cli.config,

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1,8 +1,18 @@
 import type { BunLockFile } from "bun";
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { existsSync } from "fs";
 import { access, appendFile, copyFile, mkdir, readlink, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toBeValidBin, toBeWorkspaceLink, toHaveBins } from "harness";
+import {
+  bunExe,
+  bunEnv as env,
+  readdirSorted,
+  tempDir,
+  tmpdirSync,
+  toBeValidBin,
+  toBeWorkspaceLink,
+  toHaveBins,
+} from "harness";
 import { join, relative, resolve } from "path";
 import {
   check_npm_auth_type,
@@ -2934,5 +2944,81 @@ it("bun add --trust keeps the new package when another --trust package is alread
       "a-scripted": "file:./a-scripted",
       "b-scripted": "file:./b-scripted",
     },
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/4553
+// `-g` used to chdir into the default global directory before any bunfig was read,
+// so `[install] globalDir` was ignored no matter which file it came from.
+describe("bun add -g honors [install] globalDir from bunfig", () => {
+  const projectPackageJson = JSON.stringify({ name: "project", version: "0.0.1" });
+
+  type ConfigSource = { file: string; args?: string[]; env?: Record<string, string> };
+  const configSources: Record<string, (root: string) => ConfigSource> = {
+    "--config=<path>": root => ({
+      file: join(root, "config.toml"),
+      args: [`--config=${join(root, "config.toml")}`],
+    }),
+    "$HOME/.bunfig.toml": root => ({ file: join(root, "home", ".bunfig.toml") }),
+    "$XDG_CONFIG_HOME/.bunfig.toml": root => ({
+      file: join(root, "xdg", ".bunfig.toml"),
+      env: { XDG_CONFIG_HOME: join(root, "xdg") },
+    }),
+    "./bunfig.toml of the directory bun add -g runs in": root => ({ file: join(root, "project", "bunfig.toml") }),
+  };
+
+  it.each(Object.keys(configSources))("via %s", async sourceName => {
+    using dir = tempDir("add-g-globaldir", {
+      "home/.keep": "",
+      "xdg/.keep": "",
+      "project/package.json": projectPackageJson,
+      "custom-global/package.json": JSON.stringify({ name: "custom-global" }),
+      "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+    });
+    const root = String(dir);
+    const home = join(root, "home");
+    const project = join(root, "project");
+    const customGlobal = join(root, "custom-global");
+    const source = configSources[sourceName](root);
+    await writeFile(
+      source.file,
+      `[install]\nglobalDir = ${JSON.stringify(customGlobal)}\nglobalBinDir = ${JSON.stringify(join(root, "custom-bin"))}\n`,
+    );
+
+    const testEnv: Record<string, string> = { ...(env as Record<string, string>), HOME: home, USERPROFILE: home };
+    for (const key of [
+      "BUN_INSTALL",
+      "BUN_INSTALL_GLOBAL_DIR",
+      "BUN_INSTALL_BIN",
+      "XDG_CONFIG_HOME",
+      "XDG_CACHE_HOME",
+    ]) {
+      delete testEnv[key];
+    }
+    Object.assign(testEnv, source.env);
+
+    await using proc = spawn({
+      cmd: [bunExe(), "add", "-g", `file:${join(root, "dep")}`, ...(source.args ?? [])],
+      cwd: project,
+      env: testEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed dep@");
+    expect({
+      globalDependencies: Object.keys((await file(join(customGlobal, "package.json")).json()).dependencies ?? {}),
+      installedIntoGlobalDir: existsSync(join(customGlobal, "node_modules", "dep", "package.json")),
+      defaultGlobalDirCreated: existsSync(join(home, ".bun", "install", "global")),
+      projectPackageJson: await file(join(project, "package.json")).text(),
+    }).toEqual({
+      globalDependencies: ["dep"],
+      installedIntoGlobalDir: true,
+      defaultGlobalDirCreated: false,
+      projectPackageJson,
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #4553.
Fixes #12886.

### Problem
- `[install] globalDir` in bunfig is ignored by every `-g` command (`bun add/install/remove/update -g`, `bun pm ls -g`, ...): packages always land in the default `~/.bun/install/global`. `globalBinDir` from the same file is honored, and `BUN_INSTALL_GLOBAL_DIR` works.
- `PackageManager::init()` (`src/install/PackageManager.rs`) opens the global directory from `ctx.install.global_dir` and `fchdir`s into it at the top of the function, but `load_config` (which populates `ctx.install` from bunfig) only runs further down, after the package.json walk. On the `-g` path `ctx.install` is therefore still `None` when the directory is chosen.
- `globalBinDir` works because `setup_global_dir` reads it after `load_config` has run.
- This is a regression from 2023: the config used to be loaded while parsing the install CLI arguments, before the global directory was opened. #2834 moved it after the package.json walk (so `bunfig.toml` resolves next to `package.json`), which broke the `-g` case.

### Fix
- When `cli.global` is set, call `load_config` before resolving the global directory, and skip the later call. Non-global installs are unchanged: they still load config after the package.json walk.
- For `-g`, the auto-loaded `./bunfig.toml` (and a relative `--config=` path) now resolve against the directory the command was run from instead of against the default global directory, which is what happened before #2834.
- Verified with `test/cli/install/bun-add.test.ts` ("bun add -g honors [install] globalDir from bunfig"): four cases setting `globalDir` via `--config=<path>`, `$HOME/.bunfig.toml`, `$XDG_CONFIG_HOME/.bunfig.toml`, and `./bunfig.toml` of the invocation directory. Each asserts the configured directory receives the dependency, the default `~/.bun/install/global` is never created, and the project's `package.json` is untouched. All four fail on bun 1.4.0 and pass with this change.
- Also ran the `-g` tests in `bun-update`, `bun-install-registry`, `bun-prune`, `bun-add-filter` and `bun-add-catalog`, plus the full `bun-add.test.ts`.

### Background
- bunfig is loaded from two places for install commands: the user-level file (`$XDG_CONFIG_HOME/.bunfig.toml`, else `$HOME/.bunfig.toml`) and the project-level `bunfig.toml` (or the `--config=` path). `bun_bunfig::arguments::load_config` loads both and writes the `[install]` table into `ctx.install`.
- `open_global_dir` picks the global directory in this order: `BUN_INSTALL_GLOBAL_DIR`, the bunfig `globalDir`, `$BUN_INSTALL/install/global`, `~/.bun/install/global`. `PackageManager::init` chdirs into that directory so the rest of the install treats it like a normal project.

<details>
<summary>Repro</summary>

```sh
T=$(mktemp -d); export HOME=$T/home XDG_CONFIG_HOME=$T/xdg; unset BUN_INSTALL BUN_INSTALL_GLOBAL_DIR
mkdir -p $HOME $XDG_CONFIG_HOME $T/gdir $T/proj
printf '[install]\nglobalDir = "%s"\nglobalBinDir = "%s"\n' $T/gdir $T/gbin > $XDG_CONFIG_HOME/.bunfig.toml
cd $T/proj && echo '{"name":"proj"}' > package.json
bun add -g is-number@7.0.0
ls $T/gdir/node_modules                    # before: No such file or directory
ls $HOME/.bun/install/global/node_modules  # before: is-number (went to the default)
ls -d $T/gbin                              # exists either way: globalBinDir from the same file is honored
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->