### PR TITLE
worker: inherit bunfig/CLI preloads so runtime plugins work in workers

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -32,6 +32,8 @@ An array of scripts/plugins to execute before running a file or script.
 preload = ["./preload.ts"]
 ```
 
+These scripts also run inside every `Worker` the process creates, so `Bun.plugin` loaders registered here work in worker code. Guard one-time setup with `if (Bun.isMainThread) { ... }`.
+
 ### `jsx`
 
 Configure how Bun handles JSX. You can also set these fields in the `compilerOptions` of your `tsconfig.json`, but `bunfig.toml` supports them for non-TypeScript projects.

--- a/docs/runtime/workers.mdx
+++ b/docs/runtime/workers.mdx
@@ -76,6 +76,8 @@ const worker = new Worker("./worker.ts", {
 });
 ```
 
+Preloads configured via `bunfig.toml` or the `--preload` / `--require` / `--import` CLI flags are automatically inherited by every worker, so `Bun.plugin` registrations made there are available in worker code too. Guard side effects that should only run once with `if (Bun.isMainThread) { ... }`, or pass `execArgv: []` when constructing the worker to opt out of inherited preloads entirely.
+
 ### `blob:` URLs
 
 You can also pass a `blob:` URL to `Worker` to create a worker from a string or other in-memory source.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -402,6 +402,14 @@ declare module "bun" {
      */
     argv?: any[] | undefined;
 
+    /**
+     * List of Node.js CLI options passed to the worker. Sets
+     * `process.execArgv` inside the worker. Passing any value (including `[]`)
+     * also opts the worker out of inheriting preloads configured via
+     * `bunfig.toml` or `--preload` / `--require` / `--import`.
+     */
+    execArgv?: string[] | undefined;
+
     /** If `true` and the first argument is a string, interpret the first argument to the constructor as a script that is executed once the worker is online. */
     // eval?: boolean | undefined;
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -183,12 +183,9 @@ pub struct VirtualMachine {
     /// threads.
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
     pub preload: Vec<Box<[u8]>>,
-    /// The preload list as originally configured (bunfig `preload` + CLI
-    /// `--preload`/`--require`/`--import`). Unlike `preload`, this is never
-    /// cleared after execution, so `WebWorker::create` can copy it into each
-    /// child worker. Set once on the owning thread before any worker is
-    /// spawned and never mutated afterwards, so cross-thread reads from
-    /// `WebWorker::create` (which runs on the parent's thread) need no lock.
+    /// Immutable snapshot of the configured preloads (bunfig + CLI), for
+    /// `WebWorker::create` to copy into child workers. Set once on the
+    /// owning thread before any worker spawns, never mutated afterwards.
     pub initial_preload: Vec<Box<[u8]>>,
     pub unhandled_pending_rejection_to_capture: Option<*mut JSValue>,
     // Note: layering — the concrete `bun_standalone_graph::Graph` lives
@@ -2252,11 +2249,8 @@ impl VirtualMachine {
     }
 
     /// Snapshot `self.preload` into `self.initial_preload` for worker
-    /// inheritance, absolutising `./` / `../` entries against the startup
-    /// `top_level_dir` so a later `process.chdir()` on the main thread does
-    /// not break resolution when the worker's `load_preloads` runs. Absolute
-    /// paths, `node:`/`bun:`/`file://` specifiers and bare package names are
-    /// kept verbatim.
+    /// inheritance. `./` / `../` entries are joined against the startup
+    /// `top_level_dir` so a later `process.chdir()` does not break resolution.
     pub fn seed_initial_preload(&mut self) {
         use bun_paths::{
             is_absolute, is_package_path_not_absolute, path_buffer_pool, resolve_path,
@@ -2266,9 +2260,6 @@ impl VirtualMachine {
             .preload
             .iter()
             .map(|p| {
-                // `is_absolute || is_package_path_not_absolute` is exactly
-                // "not a `./` / `../` relative path", which covers `node:`,
-                // `bun:`, `file://` and bare package names.
                 if is_absolute(p) || is_package_path_not_absolute(p) {
                     return p.clone();
                 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2251,6 +2251,39 @@ impl VirtualMachine {
         self.main = bun_ptr::RawSlice::new(path);
     }
 
+    /// Snapshot `self.preload` into `self.initial_preload` for worker
+    /// inheritance, absolutising `./` / `../` entries against the startup
+    /// `top_level_dir` so a later `process.chdir()` on the main thread does
+    /// not break resolution when the worker's `load_preloads` runs. Absolute
+    /// paths, `node:`/`bun:`/`file://` specifiers and bare package names are
+    /// kept verbatim.
+    pub fn seed_initial_preload(&mut self) {
+        use bun_paths::{is_absolute, is_package_path_not_absolute, path_buffer_pool, resolve_path};
+        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+        self.initial_preload = self
+            .preload
+            .iter()
+            .map(|p| {
+                if is_absolute(p)
+                    || is_package_path_not_absolute(p)
+                    || p.starts_with(b"node:")
+                    || p.starts_with(b"bun:")
+                    || p.starts_with(b"file://")
+                {
+                    return p.clone();
+                }
+                let mut buf = path_buffer_pool::get();
+                resolve_path::join_abs_string_buf::<resolve_path::platform::Auto>(
+                    top_level_dir,
+                    &mut buf[..],
+                    &[p],
+                )
+                .to_vec()
+                .into_boxed_slice()
+            })
+            .collect();
+    }
+
     /// `eventLoop().waitForPromise(promise)` — spin tick/auto_tick until
     /// `promise` settles. Thin forwarder; body lives in
     /// [`crate::event_loop::EventLoop::wait_for_promise`].

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2266,12 +2266,10 @@ impl VirtualMachine {
             .preload
             .iter()
             .map(|p| {
-                if is_absolute(p)
-                    || is_package_path_not_absolute(p)
-                    || p.starts_with(b"node:")
-                    || p.starts_with(b"bun:")
-                    || p.starts_with(b"file://")
-                {
+                // `is_absolute || is_package_path_not_absolute` is exactly
+                // "not a `./` / `../` relative path", which covers `node:`,
+                // `bun:`, `file://` and bare package names.
+                if is_absolute(p) || is_package_path_not_absolute(p) {
                     return p.clone();
                 }
                 let mut buf = path_buffer_pool::get();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -183,6 +183,13 @@ pub struct VirtualMachine {
     /// threads.
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
     pub preload: Vec<Box<[u8]>>,
+    /// The preload list as originally configured (bunfig `preload` + CLI
+    /// `--preload`/`--require`/`--import`). Unlike `preload`, this is never
+    /// cleared after execution, so `WebWorker::create` can copy it into each
+    /// child worker. Set once on the owning thread before any worker is
+    /// spawned and never mutated afterwards, so cross-thread reads from
+    /// `WebWorker::create` (which runs on the parent's thread) need no lock.
+    pub initial_preload: Vec<Box<[u8]>>,
     pub unhandled_pending_rejection_to_capture: Option<*mut JSValue>,
     // Note: layering — the concrete `bun_standalone_graph::Graph` lives
     // in a higher-tier crate. The resolver already broke that cycle with the
@@ -2104,6 +2111,7 @@ impl VirtualMachine {
             // their validity invariants even when len/cap are 0. Write the
             // canonical empty value via `ptr::write` (no Drop of zeroed bytes).
             addr_of_mut!((*vm).preload).write(Vec::new());
+            addr_of_mut!((*vm).initial_preload).write(Vec::new());
             addr_of_mut!((*vm).argv).write(Vec::new());
             addr_of_mut!((*vm).resolved_path_dups).write(Vec::new());
             addr_of_mut!((*vm).macros).write(Default::default());
@@ -4447,6 +4455,7 @@ impl VirtualMachine {
         // time and `load_preloads` clears the boxes but keeps the Vec buffer,
         // so reclaim it here or every Worker leaks it.
         drop(core::mem::take(&mut self.preload));
+        drop(core::mem::take(&mut self.initial_preload));
 
         // SAFETY: this VM is raw-`dealloc`'d (no field `Drop` runs), so
         // `transpiler` is never auto-dropped after `deinit` clears its fields.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2258,7 +2258,9 @@ impl VirtualMachine {
     /// paths, `node:`/`bun:`/`file://` specifiers and bare package names are
     /// kept verbatim.
     pub fn seed_initial_preload(&mut self) {
-        use bun_paths::{is_absolute, is_package_path_not_absolute, path_buffer_pool, resolve_path};
+        use bun_paths::{
+            is_absolute, is_package_path_not_absolute, path_buffer_pool, resolve_path,
+        };
         let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
         self.initial_preload = self
             .preload

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -516,10 +516,19 @@ impl WebWorker {
         // Inherit the parent VM's configured preloads (bunfig `preload` /
         // `--preload` / `--require` / `--import`). `initial_preload` is set
         // once at startup on the parent thread and never mutated, so reading
-        // it here (on that same thread) is race-free. They are left unresolved
-        // because `load_preloads` on the worker thread resolves them against
-        // the same process-global `top_level_dir` the main thread used.
-        let inherited_preloads: Vec<Box<[u8]>> = parent_ref.initial_preload.clone();
+        // it here (on that same thread) is race-free. Relative entries were
+        // absolutised at seed time so a later `process.chdir()` does not break
+        // resolution in `load_preloads`.
+        //
+        // Skipped when the user passed an explicit `execArgv` (including
+        // `execArgv: []`): Node.js puts `--require` in `execArgv` and a worker
+        // that overrides it does not re-run the parent's `--require`, so
+        // `execArgv: []` is the opt-out for inherited preloads.
+        let inherited_preloads: Vec<Box<[u8]>> = if inherit_exec_argv {
+            parent_ref.initial_preload.clone()
+        } else {
+            Vec::new()
+        };
         let mut preloads: Vec<Box<[u8]>> =
             Vec::with_capacity(inherited_preloads.len() + preload_modules_len);
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -516,16 +516,32 @@ impl WebWorker {
         // Inherit the parent VM's configured preloads (bunfig `preload` /
         // `--preload` / `--require` / `--import`). `initial_preload` is set
         // once at startup on the parent thread and never mutated, so reading
-        // it here (on that same thread) is race-free. These are prepended so
-        // plugin registrations are in place before any `{ preload: [...] }`
-        // option modules run; they are left unresolved because `load_preloads`
-        // on the worker thread resolves them against the same process-global
-        // `top_level_dir` the main thread used.
+        // it here (on that same thread) is race-free. They are left unresolved
+        // because `load_preloads` on the worker thread resolves them against
+        // the same process-global `top_level_dir` the main thread used.
         let inherited_preloads: Vec<Box<[u8]>> = parent_ref.initial_preload.clone();
         let mut preloads: Vec<Box<[u8]>> =
             Vec::with_capacity(inherited_preloads.len() + preload_modules_len);
+
+        // For a node:worker_threads Worker the JS wrapper injects
+        // "node:worker_threads" as the first option preload so its bootstrap
+        // (stdio rebinding, process.chdir/abort stubs) runs before user code.
+        // Keep that sentinel first and splice inherited preloads in after it,
+        // so an inherited preload's console.log reaches a captured
+        // `{stdout: true}` stream and process.chdir throws
+        // ERR_WORKER_UNSUPPORTED_OPERATION as Node.js does for --require.
+        let mut option_preloads = preload_modules;
+        if let Some(first) = option_preloads.first() {
+            let first_slice = first.to_utf8();
+            if first_slice.slice() == b"node:worker_threads" {
+                preloads.push(first_slice.slice().to_vec().into_boxed_slice());
+                option_preloads = &option_preloads[1..];
+            }
+        }
+        // Inherited preloads run before user `{ preload: [...] }` entries so
+        // plugin registrations are in place for them.
         preloads.extend(inherited_preloads.iter().cloned());
-        for module in preload_modules {
+        for module in option_preloads {
             let utf8_slice = module.to_utf8();
             // node: builtin specifiers skip the file resolver — the worker-side
             // module loader resolves them. Lets node:worker_threads run its

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -106,6 +106,9 @@ pub struct WebWorker {
     /// Heap-owned by this struct; freed in `destroy()`.
     unresolved_specifier: Box<[u8]>,
     preloads: Vec<Box<[u8]>>,
+    /// Parent VM's `initial_preload`, cloned at `create()` time so `spin()`
+    /// can seed the worker VM's own `initial_preload` for nested workers.
+    inherited_preloads: Vec<Box<[u8]>>,
     /// Owned NUL-terminated bytes.
     name: bun_core::ZBox,
 
@@ -510,7 +513,18 @@ impl WebWorker {
         let preload_modules: &[BunString] =
             unsafe { bun_core::ffi::slice(preload_modules_ptr, preload_modules_len) };
 
-        let mut preloads: Vec<Box<[u8]>> = Vec::with_capacity(preload_modules_len);
+        // Inherit the parent VM's configured preloads (bunfig `preload` /
+        // `--preload` / `--require` / `--import`). `initial_preload` is set
+        // once at startup on the parent thread and never mutated, so reading
+        // it here (on that same thread) is race-free. These are prepended so
+        // plugin registrations are in place before any `{ preload: [...] }`
+        // option modules run; they are left unresolved because `load_preloads`
+        // on the worker thread resolves them against the same process-global
+        // `top_level_dir` the main thread used.
+        let inherited_preloads: Vec<Box<[u8]>> = parent_ref.initial_preload.clone();
+        let mut preloads: Vec<Box<[u8]>> =
+            Vec::with_capacity(inherited_preloads.len() + preload_modules_len);
+        preloads.extend(inherited_preloads.iter().cloned());
         for module in preload_modules {
             let utf8_slice = module.to_utf8();
             // node: builtin specifiers skip the file resolver — the worker-side
@@ -556,6 +570,7 @@ impl WebWorker {
             inherit_exec_argv,
             unresolved_specifier: spec_slice.slice().to_vec().into_boxed_slice(),
             preloads,
+            inherited_preloads,
             name: if name_str.is_empty() {
                 bun_core::ZBox::default()
             } else {
@@ -1044,6 +1059,11 @@ impl WebWorker {
         // `preloads` is owned by `self` (heap `WebWorker` outlives the VM).
         // `preload: Vec<Box<[u8]>>` — clone the boxes (cheap, ≤handful).
         vm.as_mut().preload.clone_from(&self.preloads);
+        // Seed `initial_preload` so workers spawned from this worker inherit
+        // the same bunfig/CLI preload list the main thread saw.
+        vm.as_mut()
+            .initial_preload
+            .clone_from(&self.inherited_preloads);
 
         // Resolve the entry point on the worker thread (the parent only stored
         // the raw specifier). The returned slice is BORROWED — every exit from

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -513,17 +513,9 @@ impl WebWorker {
         let preload_modules: &[BunString] =
             unsafe { bun_core::ffi::slice(preload_modules_ptr, preload_modules_len) };
 
-        // Inherit the parent VM's configured preloads (bunfig `preload` /
-        // `--preload` / `--require` / `--import`). `initial_preload` is set
-        // once at startup on the parent thread and never mutated, so reading
-        // it here (on that same thread) is race-free. Relative entries were
-        // absolutised at seed time so a later `process.chdir()` does not break
-        // resolution in `load_preloads`.
-        //
-        // Skipped when the user passed an explicit `execArgv` (including
-        // `execArgv: []`): Node.js puts `--require` in `execArgv` and a worker
-        // that overrides it does not re-run the parent's `--require`, so
-        // `execArgv: []` is the opt-out for inherited preloads.
+        // Inherit the parent VM's configured preloads (bunfig/CLI), skipped
+        // when the user passed an explicit `execArgv`: Node.js puts
+        // `--require` in `execArgv`, so overriding it is the opt-out.
         let inherited_preloads: Vec<Box<[u8]>> = if inherit_exec_argv {
             parent_ref.initial_preload.clone()
         } else {
@@ -532,13 +524,9 @@ impl WebWorker {
         let mut preloads: Vec<Box<[u8]>> =
             Vec::with_capacity(inherited_preloads.len() + preload_modules_len);
 
-        // For a node:worker_threads Worker the JS wrapper injects
-        // "node:worker_threads" as the first option preload so its bootstrap
-        // (stdio rebinding, process.chdir/abort stubs) runs before user code.
-        // Keep that sentinel first and splice inherited preloads in after it,
-        // so an inherited preload's console.log reaches a captured
-        // `{stdout: true}` stream and process.chdir throws
-        // ERR_WORKER_UNSUPPORTED_OPERATION as Node.js does for --require.
+        // The node:worker_threads JS wrapper injects "node:worker_threads" as
+        // the first option preload so its bootstrap runs before user code;
+        // keep that sentinel first and splice inherited preloads in after it.
         let mut option_preloads = preload_modules;
         if let Some(first) = option_preloads.first() {
             let first_slice = first.to_utf8();

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -126,14 +126,14 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // that bypass Bun's normal module resolver and plugin system.
     vm.regular_event_loop.global = NonNull::new(vm.global);
     vm.event_loop_ref().ensure_waker();
+    // preload/argv are `Vec<Box<[u8]>>`; clone because the VM owns its
+    // fields. Startup-only, so the copies are not hot.
+    vm.preload.clone_from(&ctx.preloads);
+    vm.seed_initial_preload();
+    vm.argv.clone_from(&ctx.passthrough);
+    vm.arena = NonNull::new(&raw mut arena);
     {
         let b = &mut vm.transpiler;
-        // preload/argv are `Vec<Box<[u8]>>`; clone because the VM owns its
-        // fields. Startup-only, so the copies are not hot.
-        vm.preload.clone_from(&ctx.preloads);
-        vm.initial_preload = vm.preload.clone();
-        vm.argv.clone_from(&ctx.passthrough);
-        vm.arena = NonNull::new(&raw mut arena);
         // vm.allocator = arena.arena() — dropped per §Allocators
         // `BundleOptions.install` is `Option<NonNull<_>>`, so no
         // lifetime-extension cast is needed.

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -131,6 +131,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
         // preload/argv are `Vec<Box<[u8]>>`; clone because the VM owns its
         // fields. Startup-only, so the copies are not hot.
         vm.preload.clone_from(&ctx.preloads);
+        vm.initial_preload = vm.preload.clone();
         vm.argv.clone_from(&ctx.passthrough);
         vm.arena = NonNull::new(&raw mut arena);
         // vm.allocator = arena.arena() — dropped per §Allocators

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -89,6 +89,7 @@ impl ReplCommand {
         // SAFETY: vm valid as above; preload/argv are disjoint from `b`'s transpiler borrow.
         unsafe {
             (*vm).preload = core::mem::take(&mut ctx.preloads);
+            (*vm).initial_preload = (*vm).preload.clone();
             (*vm).argv = core::mem::take(&mut ctx.passthrough);
             // `vm.dns_result_order` is a `u8` (see VirtualMachine.rs); set
             // post-init like run_command.rs since InitOptions doesn't carry it.

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -89,7 +89,7 @@ impl ReplCommand {
         // SAFETY: vm valid as above; preload/argv are disjoint from `b`'s transpiler borrow.
         unsafe {
             (*vm).preload = core::mem::take(&mut ctx.preloads);
-            (*vm).initial_preload = (*vm).preload.clone();
+            (*vm).seed_initial_preload();
             (*vm).argv = core::mem::take(&mut ctx.passthrough);
             // `vm.dns_result_order` is a `u8` (see VirtualMachine.rs); set
             // post-init like run_command.rs since InitOptions doesn't carry it.

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -956,6 +956,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // `vm.preload`/`vm.argv` are `Vec<Box<[u8]>>` on both sides;
         // hand the CLI's vectors over wholesale (process-lifetime, never freed).
         vm.preload = std::mem::take(&mut ctx.preloads);
+        vm.initial_preload = vm.preload.clone();
         vm.argv = std::mem::take(&mut ctx.passthrough);
         // `InitOptions` has no `store_fd` field, so set it on the resolver directly.
         vm.transpiler.resolver.store_fd = ctx.debug.hot_reload != cli::command::HotReload::None;
@@ -1176,6 +1177,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         let vm = unsafe { &mut *vm_ptr };
 
         vm.preload = std::mem::take(&mut ctx.preloads);
+        vm.initial_preload = vm.preload.clone();
         vm.argv = std::mem::take(&mut ctx.passthrough);
 
         // `vm.main` is a BACKREF (`*const [u8]`) into `entry_path`'s heap

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -956,7 +956,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         // `vm.preload`/`vm.argv` are `Vec<Box<[u8]>>` on both sides;
         // hand the CLI's vectors over wholesale (process-lifetime, never freed).
         vm.preload = std::mem::take(&mut ctx.preloads);
-        vm.initial_preload = vm.preload.clone();
+        vm.seed_initial_preload();
         vm.argv = std::mem::take(&mut ctx.passthrough);
         // `InitOptions` has no `store_fd` field, so set it on the resolver directly.
         vm.transpiler.resolver.store_fd = ctx.debug.hot_reload != cli::command::HotReload::None;
@@ -1177,7 +1177,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         let vm = unsafe { &mut *vm_ptr };
 
         vm.preload = std::mem::take(&mut ctx.preloads);
-        vm.initial_preload = vm.preload.clone();
+        vm.seed_initial_preload();
         vm.argv = std::mem::take(&mut ctx.passthrough);
 
         // `vm.main` is a BACKREF (`*const [u8]`) into `entry_path`'s heap

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2290,6 +2290,9 @@ impl TestCommand {
         vm.argv = core::mem::take(&mut ctx.passthrough);
         // Clone (not take): build_worker_argv reads ctx.preloads to forward --preload.
         vm.preload = ctx.preloads.clone();
+        // Intentionally NOT setting `vm.initial_preload`: `[test] preload`
+        // entries are test-runner setup (expect.extend, env normalisation,
+        // mocks) that in-process workers spawned from tests should not re-run.
         vm.transpiler.options.rewrite_jest_for_tests = true;
         bun_http::EXPERIMENTAL_HTTP2_CLIENT_FROM_CLI.store(
             ctx.runtime_options.experimental_http2_fetch,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2290,9 +2290,13 @@ impl TestCommand {
         vm.argv = core::mem::take(&mut ctx.passthrough);
         // Clone (not take): build_worker_argv reads ctx.preloads to forward --preload.
         vm.preload = ctx.preloads.clone();
-        // Intentionally NOT setting `vm.initial_preload`: `[test] preload`
-        // entries are test-runner setup (expect.extend, env normalisation,
-        // mocks) that in-process workers spawned from tests should not re-run.
+        // Intentionally NOT seeding `vm.initial_preload` for `bun test`.
+        // `ctx.preloads` here is `[test] preload` from bunfig plus any CLI
+        // `--preload`/`--require`/`--import`; re-running those inside every
+        // in-process Worker a test spawns is surprising (and clobbers
+        // `process.env` for tests that assert a Worker's `env:` option is
+        // exactly what they passed). Spawned-subprocess tests read bunfig
+        // themselves, so they are unaffected.
         vm.transpiler.options.rewrite_jest_for_tests = true;
         bun_http::EXPERIMENTAL_HTTP2_CLIENT_FROM_CLI.store(
             ctx.runtime_options.experimental_http2_fetch,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2290,13 +2290,9 @@ impl TestCommand {
         vm.argv = core::mem::take(&mut ctx.passthrough);
         // Clone (not take): build_worker_argv reads ctx.preloads to forward --preload.
         vm.preload = ctx.preloads.clone();
-        // Intentionally NOT seeding `vm.initial_preload` for `bun test`.
-        // `ctx.preloads` here is `[test] preload` from bunfig plus any CLI
-        // `--preload`/`--require`/`--import`; re-running those inside every
-        // in-process Worker a test spawns is surprising (and clobbers
-        // `process.env` for tests that assert a Worker's `env:` option is
-        // exactly what they passed). Spawned-subprocess tests read bunfig
-        // themselves, so they are unaffected.
+        // `initial_preload` stays empty for `bun test`: re-running
+        // `[test] preload` inside every in-process Worker a test spawns would
+        // clobber `process.env` for worker-env tests.
         vm.transpiler.options.rewrite_jest_for_tests = true;
         bun_http::EXPERIMENTAL_HTTP2_CLIENT_FROM_CLI.store(
             ctx.runtime_options.experimental_http2_fetch,

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -68,6 +68,186 @@ describe("web worker", () => {
       expect(result).toMatch(
         /THIS IS AN ERROR AND THIS PARTICULAR STRING DOESNT APPEAR IN THE SOURCE CODE SO WE KNOW FOR SURE IT SENT THE ACTUAL MESSAGE AND NOT JUST A DUMP OF THE SOURCE CODE AS IT ORIGINALLY WAS/,
       );
+    });
+
+    // https://github.com/oven-sh/bun/issues/5170
+    describe("inherited from bunfig/CLI", () => {
+      const pluginFile = `
+        import { plugin } from "bun";
+        plugin({
+          name: "virtual",
+          setup(build) {
+            build.module("my-virtual-module", () => ({
+              contents: 'export default "from-plugin";',
+              loader: "js",
+            }));
+          },
+        });
+        globalThis.__preloadRan = (globalThis.__preloadRan ?? 0) + 1;
+      `;
+      const workerFile = `
+        import msg from "my-virtual-module";
+        postMessage({ msg, preloadRan: globalThis.__preloadRan });
+      `;
+      const mainFile = `
+        import msg from "my-virtual-module";
+        const worker = new Worker(new URL("./worker.ts", import.meta.url));
+        const result = await new Promise((resolve, reject) => {
+          worker.onmessage = e => resolve(e.data);
+          worker.onerror = e => reject(new Error(e.message));
+        });
+        console.log(JSON.stringify({ main: { msg, preloadRan: globalThis.__preloadRan }, worker: result }));
+        await worker.terminate();
+      `;
+
+      test.concurrent("bunfig preload runs in Web Worker", async () => {
+        using dir = tempDir("worker-bunfig-preload", {
+          "bunfig.toml": `preload = ["./plugin.ts"]`,
+          "plugin.ts": pluginFile,
+          "worker.ts": workerFile,
+          "main.ts": mainFile,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual({
+          main: { msg: "from-plugin", preloadRan: 1 },
+          worker: { msg: "from-plugin", preloadRan: 1 },
+        });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("--preload flag runs in Web Worker", async () => {
+        using dir = tempDir("worker-cli-preload", {
+          "plugin.ts": pluginFile,
+          "worker.ts": workerFile,
+          "main.ts": mainFile,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "--preload", "./plugin.ts", "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual({
+          main: { msg: "from-plugin", preloadRan: 1 },
+          worker: { msg: "from-plugin", preloadRan: 1 },
+        });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("bunfig preload runs in node:worker_threads Worker", async () => {
+        using dir = tempDir("worker-bunfig-preload-wt", {
+          "bunfig.toml": `preload = ["./plugin.ts"]`,
+          "plugin.ts": pluginFile,
+          "worker.ts": `
+            import { parentPort } from "node:worker_threads";
+            import msg from "my-virtual-module";
+            parentPort.postMessage({ msg, preloadRan: globalThis.__preloadRan });
+          `,
+          "main.ts": `
+            import { Worker } from "node:worker_threads";
+            import msg from "my-virtual-module";
+            const worker = new Worker(new URL("./worker.ts", import.meta.url));
+            const result = await new Promise((resolve, reject) => {
+              worker.on("message", resolve);
+              worker.on("error", reject);
+            });
+            console.log(JSON.stringify({ main: { msg, preloadRan: globalThis.__preloadRan }, worker: result }));
+            await worker.terminate();
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual({
+          main: { msg: "from-plugin", preloadRan: 1 },
+          worker: { msg: "from-plugin", preloadRan: 1 },
+        });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("bunfig preload runs in nested Worker", async () => {
+        using dir = tempDir("worker-bunfig-preload-nested", {
+          "bunfig.toml": `preload = ["./plugin.ts"]`,
+          "plugin.ts": pluginFile,
+          "inner.ts": workerFile,
+          "outer.ts": `
+            import msg from "my-virtual-module";
+            const inner = new Worker(new URL("./inner.ts", import.meta.url));
+            const result = await new Promise((resolve, reject) => {
+              inner.onmessage = e => resolve(e.data);
+              inner.onerror = e => reject(new Error(e.message));
+            });
+            postMessage({ outer: { msg, preloadRan: globalThis.__preloadRan }, inner: result });
+            await inner.terminate();
+          `,
+          "main.ts": `
+            const outer = new Worker(new URL("./outer.ts", import.meta.url));
+            const result = await new Promise((resolve, reject) => {
+              outer.onmessage = e => resolve(e.data);
+              outer.onerror = e => reject(new Error(e.message));
+            });
+            console.log(JSON.stringify(result));
+            await outer.terminate();
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual({
+          outer: { msg: "from-plugin", preloadRan: 1 },
+          inner: { msg: "from-plugin", preloadRan: 1 },
+        });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("inherited preload runs before option.preload", async () => {
+        using dir = tempDir("worker-preload-order", {
+          "bunfig.toml": `preload = ["./first.ts"]`,
+          "first.ts": `globalThis.__order = ["bunfig"];`,
+          "second.ts": `globalThis.__order.push("option");`,
+          "worker.ts": `postMessage(globalThis.__order);`,
+          "main.ts": `
+            const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+              preload: [new URL("./second.ts", import.meta.url).href],
+            });
+            const result = await new Promise((resolve, reject) => {
+              worker.onmessage = e => resolve(e.data);
+              worker.onerror = e => reject(new Error(e.message));
+            });
+            console.log(JSON.stringify(result));
+            await worker.terminate();
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual(["bunfig", "option"]);
+        expect(exitCode).toBe(0);
+      });
     });
   });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -225,7 +225,7 @@ describe("web worker", () => {
           using dir = tempDir("worker-preload-wt-order", {
             "bunfig.toml": `preload = ["./setup.ts"]`,
             "setup.ts": `
-              if (!require("node:worker_threads").isMainThread) {
+              if (!Bun.isMainThread) {
                 console.log("from inherited preload");
                 let chdirErr = "no throw";
                 try { process.chdir("/"); } catch (e) { chdirErr = e.code; }
@@ -267,6 +267,77 @@ describe("web worker", () => {
           expect(exitCode).toBe(0);
         },
       );
+
+      test.concurrent("execArgv: [] opts out of inherited preloads", async () => {
+        using dir = tempDir("worker-preload-execargv-optout", {
+          "bunfig.toml": `preload = ["./setup.ts"]`,
+          "setup.ts": `globalThis.__preloadRan = (globalThis.__preloadRan ?? 0) + 1;`,
+          "worker.ts": `
+            require("node:worker_threads").parentPort.postMessage({
+              preloadRan: globalThis.__preloadRan ?? 0,
+            });
+          `,
+          "main.ts": `
+            const { Worker } = require("node:worker_threads");
+            async function run(execArgv) {
+              const w = new Worker(new URL("./worker.ts", import.meta.url),
+                execArgv === undefined ? {} : { execArgv });
+              const r = await new Promise((res, rej) => {
+                w.on("message", res);
+                w.on("error", rej);
+              });
+              await w.terminate();
+              return r.preloadRan;
+            }
+            console.log(JSON.stringify({
+              inherited: await run(undefined),
+              optedOut: await run([]),
+            }));
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual({ inherited: 1, optedOut: 0 });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("inherited preload resolves against startup cwd after process.chdir", async () => {
+        using dir = tempDir("worker-preload-chdir", {
+          "bunfig.toml": `preload = ["./plugin.ts"]`,
+          "plugin.ts": pluginFile,
+          "sub/.keep": "",
+          "worker.ts": workerFile,
+          "main.ts": `
+            import msg from "my-virtual-module";
+            process.chdir("./sub");
+            const worker = new Worker(new URL("./worker.ts", import.meta.url));
+            const result = await new Promise((resolve, reject) => {
+              worker.onmessage = e => resolve(e.data);
+              worker.onerror = e => reject(new Error(e.message));
+            });
+            console.log(JSON.stringify({ worker: result }));
+            await worker.terminate();
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "run", "main.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout.trim())).toEqual({
+          worker: { msg: "from-plugin", preloadRan: 1 },
+        });
+        expect(exitCode).toBe(0);
+      });
 
       test.concurrent("inherited preload runs before option.preload", async () => {
         using dir = tempDir("worker-preload-order", {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -219,6 +219,55 @@ describe("web worker", () => {
         expect(exitCode).toBe(0);
       });
 
+      test.concurrent(
+        "inherited preload runs after node:worker_threads bootstrap (captured stdio, stubbed process)",
+        async () => {
+          using dir = tempDir("worker-preload-wt-order", {
+            "bunfig.toml": `preload = ["./setup.ts"]`,
+            "setup.ts": `
+              if (!require("node:worker_threads").isMainThread) {
+                console.log("from inherited preload");
+                let chdirErr = "no throw";
+                try { process.chdir("/"); } catch (e) { chdirErr = e.code; }
+                globalThis.__chdirErr = chdirErr;
+              }
+            `,
+            "worker.ts": `
+              const { parentPort } = require("node:worker_threads");
+              console.log("from worker entry");
+              parentPort.postMessage({ chdirErr: globalThis.__chdirErr });
+            `,
+            "main.ts": `
+              const { Worker } = require("node:worker_threads");
+              const { once } = require("node:events");
+              const worker = new Worker(new URL("./worker.ts", import.meta.url), { stdout: true });
+              let captured = "";
+              worker.stdout.setEncoding("utf8");
+              worker.stdout.on("data", d => { captured += d; });
+              const [[msg]] = await Promise.all([
+                once(worker, "message"),
+                once(worker.stdout, "end"),
+                once(worker, "exit"),
+              ]);
+              console.log(JSON.stringify({ captured: captured.trim().split("\\n"), chdirErr: msg.chdirErr }));
+            `,
+          });
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "run", "main.ts"],
+            env: bunEnv,
+            cwd: String(dir),
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(JSON.parse(stdout.trim())).toEqual({
+            captured: ["from inherited preload", "from worker entry"],
+            chdirErr: "ERR_WORKER_UNSUPPORTED_OPERATION",
+          });
+          expect(exitCode).toBe(0);
+        },
+      );
+
       test.concurrent("inherited preload runs before option.preload", async () => {
         using dir = tempDir("worker-preload-order", {
           "bunfig.toml": `preload = ["./first.ts"]`,

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -268,6 +268,38 @@ describe("web worker", () => {
         },
       );
 
+      test.concurrent("[test] preload is not inherited by in-process Workers under bun test", async () => {
+        using dir = tempDir("worker-test-preload-no-inherit", {
+          "bunfig.toml": `[test]\npreload = ["./setup.ts"]`,
+          "setup.ts": `globalThis.__fromTestPreload = true;`,
+          "w.ts": `postMessage(globalThis.__fromTestPreload === true);`,
+          "fixture.test.ts": `
+            import { test, expect } from "bun:test";
+            test("worker does not re-run [test] preload", async () => {
+              expect(globalThis.__fromTestPreload).toBe(true);
+              const w = new Worker(new URL("./w.ts", import.meta.url));
+              const got = await new Promise((res, rej) => {
+                w.onmessage = e => res(e.data);
+                w.onerror = e => rej(new Error(e.message));
+              });
+              await w.terminate();
+              expect(got).toBe(false);
+            });
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "test", "fixture.test.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain("1 pass");
+        expect(stderr).toContain("0 fail");
+        expect(exitCode).toBe(0);
+      });
+
       test.concurrent("execArgv: [] opts out of inherited preloads", async () => {
         using dir = tempDir("worker-preload-execargv-optout", {
           "bunfig.toml": `preload = ["./setup.ts"]`,

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -143,25 +143,34 @@ describe("web worker", () => {
         expect(exitCode).toBe(0);
       });
 
-      test.concurrent("bunfig preload runs in node:worker_threads Worker", async () => {
+      test.concurrent("bunfig preload runs in node:worker_threads Worker; execArgv:[] opts out", async () => {
         using dir = tempDir("worker-bunfig-preload-wt", {
           "bunfig.toml": `preload = ["./plugin.ts"]`,
           "plugin.ts": pluginFile,
           "worker.ts": `
-            import { parentPort } from "node:worker_threads";
-            import msg from "my-virtual-module";
-            parentPort.postMessage({ msg, preloadRan: globalThis.__preloadRan });
+            const { parentPort } = require("node:worker_threads");
+            let msg = "no-plugin";
+            try { msg = (await import("my-virtual-module")).default; } catch {}
+            parentPort.postMessage({ msg, preloadRan: globalThis.__preloadRan ?? 0 });
           `,
           "main.ts": `
             import { Worker } from "node:worker_threads";
             import msg from "my-virtual-module";
-            const worker = new Worker(new URL("./worker.ts", import.meta.url));
-            const result = await new Promise((resolve, reject) => {
-              worker.on("message", resolve);
-              worker.on("error", reject);
-            });
-            console.log(JSON.stringify({ main: { msg, preloadRan: globalThis.__preloadRan }, worker: result }));
-            await worker.terminate();
+            async function run(opts) {
+              const w = new Worker(new URL("./worker.ts", import.meta.url), opts);
+              const r = await new Promise((resolve, reject) => {
+                w.on("message", resolve);
+                w.on("error", reject);
+              });
+              await w.terminate();
+              return r;
+            }
+            const [inherited, optedOut] = await Promise.all([run({}), run({ execArgv: [] })]);
+            console.log(JSON.stringify({
+              main: { msg, preloadRan: globalThis.__preloadRan },
+              inherited,
+              optedOut,
+            }));
           `,
         });
         await using proc = Bun.spawn({
@@ -174,10 +183,11 @@ describe("web worker", () => {
         expect(stderr).toBe("");
         expect(JSON.parse(stdout.trim())).toEqual({
           main: { msg: "from-plugin", preloadRan: 1 },
-          worker: { msg: "from-plugin", preloadRan: 1 },
+          inherited: { msg: "from-plugin", preloadRan: 1 },
+          optedOut: { msg: "no-plugin", preloadRan: 0 },
         });
         expect(exitCode).toBe(0);
-      });
+      }, 20_000);
 
       test.concurrent("bunfig preload runs in nested Worker", async () => {
         using dir = tempDir("worker-bunfig-preload-nested", {
@@ -266,6 +276,7 @@ describe("web worker", () => {
           });
           expect(exitCode).toBe(0);
         },
+        20_000,
       );
 
       test.concurrent("[test] preload is not inherited by in-process Workers under bun test", async () => {
@@ -297,45 +308,6 @@ describe("web worker", () => {
         const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         expect(stderr).toContain("1 pass");
         expect(stderr).toContain("0 fail");
-        expect(exitCode).toBe(0);
-      });
-
-      test.concurrent("execArgv: [] opts out of inherited preloads", async () => {
-        using dir = tempDir("worker-preload-execargv-optout", {
-          "bunfig.toml": `preload = ["./setup.ts"]`,
-          "setup.ts": `globalThis.__preloadRan = (globalThis.__preloadRan ?? 0) + 1;`,
-          "worker.ts": `
-            require("node:worker_threads").parentPort.postMessage({
-              preloadRan: globalThis.__preloadRan ?? 0,
-            });
-          `,
-          "main.ts": `
-            const { Worker } = require("node:worker_threads");
-            async function run(execArgv) {
-              const w = new Worker(new URL("./worker.ts", import.meta.url),
-                execArgv === undefined ? {} : { execArgv });
-              const r = await new Promise((res, rej) => {
-                w.on("message", res);
-                w.on("error", rej);
-              });
-              await w.terminate();
-              return r.preloadRan;
-            }
-            console.log(JSON.stringify({
-              inherited: await run(undefined),
-              optedOut: await run([]),
-            }));
-          `,
-        });
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "run", "main.ts"],
-          env: bunEnv,
-          cwd: String(dir),
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(JSON.parse(stdout.trim())).toEqual({ inherited: 1, optedOut: 0 });
         expect(exitCode).toBe(0);
       });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -143,17 +143,19 @@ describe("web worker", () => {
         expect(exitCode).toBe(0);
       });
 
-      test.concurrent("bunfig preload runs in node:worker_threads Worker; execArgv:[] opts out", async () => {
-        using dir = tempDir("worker-bunfig-preload-wt", {
-          "bunfig.toml": `preload = ["./plugin.ts"]`,
-          "plugin.ts": pluginFile,
-          "worker.ts": `
+      test.concurrent(
+        "bunfig preload runs in node:worker_threads Worker; execArgv:[] opts out",
+        async () => {
+          using dir = tempDir("worker-bunfig-preload-wt", {
+            "bunfig.toml": `preload = ["./plugin.ts"]`,
+            "plugin.ts": pluginFile,
+            "worker.ts": `
             const { parentPort } = require("node:worker_threads");
             let msg = "no-plugin";
             try { msg = (await import("my-virtual-module")).default; } catch {}
             parentPort.postMessage({ msg, preloadRan: globalThis.__preloadRan ?? 0 });
           `,
-          "main.ts": `
+            "main.ts": `
             import { Worker } from "node:worker_threads";
             import msg from "my-virtual-module";
             async function run(opts) {
@@ -172,22 +174,24 @@ describe("web worker", () => {
               optedOut,
             }));
           `,
-        });
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "run", "main.ts"],
-          env: bunEnv,
-          cwd: String(dir),
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(JSON.parse(stdout.trim())).toEqual({
-          main: { msg: "from-plugin", preloadRan: 1 },
-          inherited: { msg: "from-plugin", preloadRan: 1 },
-          optedOut: { msg: "no-plugin", preloadRan: 0 },
-        });
-        expect(exitCode).toBe(0);
-      }, 20_000);
+          });
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "run", "main.ts"],
+            env: bunEnv,
+            cwd: String(dir),
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(JSON.parse(stdout.trim())).toEqual({
+            main: { msg: "from-plugin", preloadRan: 1 },
+            inherited: { msg: "from-plugin", preloadRan: 1 },
+            optedOut: { msg: "no-plugin", preloadRan: 0 },
+          });
+          expect(exitCode).toBe(0);
+        },
+        20_000,
+      );
 
       test.concurrent("bunfig preload runs in nested Worker", async () => {
         using dir = tempDir("worker-bunfig-preload-nested", {


### PR DESCRIPTION
Fixes #5170.
Fixes #12608.

## Repro

```toml
# bunfig.toml
preload = ["./plugin.ts"]
```
```ts
// plugin.ts
import { plugin } from "bun";
plugin({
  name: "virtual",
  setup(build) {
    build.module("my-virtual-module", () => ({
      contents: 'export default "from-plugin";', loader: "js",
    }));
  },
});
```
```ts
// main.ts
import msg from "my-virtual-module";
console.log("main:", msg);
const w = new Worker(new URL("./worker.ts", import.meta.url));
w.onerror = e => console.log("worker error:", e.message);
```
```ts
// worker.ts
import msg from "my-virtual-module";
console.log("worker:", msg);
```

Before:
```
main: from-plugin
worker error: error: Cannot find package 'my-virtual-module' from '.../worker.ts'
```

After:
```
main: from-plugin
worker: from-plugin
```

## Cause

`vm.preload` (populated from bunfig `preload` + CLI `--preload`/`--require`/`--import`) is cleared in `load_preloads` once the main thread has run them, so by the time `new Worker()` runs there is nothing left to hand down. The worker's preload list came only from the `{ preload: [...] }` option, so `Bun.plugin` registrations made in a preloaded script never existed in the worker's VM.

## Fix

Keep an immutable `initial_preload` snapshot of the configured list on `VirtualMachine` alongside the consumed `preload`. Relative `./` / `../` entries are joined against the startup `top_level_dir` when the snapshot is taken, so a later `process.chdir()` on the main thread does not break resolution inside the worker.

In `WebWorker::create` (runs on the parent's thread), clone that list into the worker's preload set with this ordering:

1. the `node:worker_threads` bootstrap sentinel (when present), so stdio is rebound and `process.chdir`/`abort` are stubbed before any inherited preload runs, matching Node.js where `--require` runs after the worker bootstrap;
2. inherited bunfig/CLI preloads;
3. any `{ preload: [...] }` option entries.

Each worker seeds its own `initial_preload` from the same list, so nested workers inherit it too.

**Opt-out:** passing an explicit `execArgv` (including `execArgv: []`) suppresses inherited preloads. Node.js puts `--require` in `execArgv` and a worker that overrides it does not re-run the parent's `--require`, so this is the same escape hatch.

`bun test` does not seed `initial_preload`: `ctx.preloads` there is `[test] preload` plus CLI flags, and re-running those inside every in-process Worker a test spawns would clobber `process.env` for the `worker-env` tests that assert a worker's `env:` option is exactly what was passed. Spawned-subprocess tests read bunfig themselves and are unaffected.

Docs updated: `docs/runtime/bunfig.mdx` and `docs/runtime/workers.mdx` now mention worker inheritance and the `Bun.isMainThread` guard / `execArgv: []` opt-out.

## Verification

New tests in `test/js/web/workers/worker.test.ts` under `preload > inherited from bunfig/CLI`:

- bunfig `preload` plugin is available in a Web `Worker`
- `--preload` CLI flag plugin is available in a Web `Worker`
- bunfig `preload` plugin is available in a `node:worker_threads` `Worker`
- bunfig `preload` plugin is available in a nested `Worker` (worker creates worker)
- inherited preload runs after the `node:worker_threads` bootstrap: its `console.log` is captured by `{ stdout: true }` and `process.chdir` throws `ERR_WORKER_UNSUPPORTED_OPERATION`
- `{ execArgv: [] }` opts out of inherited preloads
- inherited preload still resolves after `process.chdir()` on the main thread
- inherited preloads run before `{ preload: [...] }` option entries

All fail on the released build and pass with this change. Existing `worker.test.ts` (33/33), `worker_threads.test.ts` (91/91) and `plugins.test.ts` (35/35) are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/worker.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/1277] gen bindgenv2
[2/1277] fetch zlib
[zlib] up to date
[3/1277] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1277] fetch picohttpparser
[picohttpparser] up to date
[5/1277] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[6/1277] gen BunObject.lut.h
Generating /workspace/bun/build/debug/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[7/1277] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/debug/codegen/ZigGlobalObject.lut.h from /workspace/bun/src/jsc/bindings/ZigGlobalObject.lut.txt
[8/1277] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[9/1277] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingFs.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingFs.cpp
[10
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.32ms]
(pass) web worker > preload > string [43.35ms]
(pass) web worker > preload > array of 2 strings [518.23ms]
(pass) web worker > preload > array of string [6.57ms]
(pass) web worker > preload > error in preload doesn't crash parent [7.27ms]
112 |           env: bunEnv,
113 |           cwd: String(dir),
114 |           stderr: "pipe",
115 |         });
116 |         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
117 |         expect(stderr).toBe("");
                             ^
error: expect(received).toBe(expected)

- ""
+ "1 | 
+ 2 |         import msg from "my-virtual-module";
+ 3 |         const worker = new Worker(new URL("./worker.ts", import.meta.url));
+ 4 |         const result = await new Promise((resolve, reject) = {
+ 5 |           worker.onmessage = e => resolve(e.data);
+ 6 |           worker.onerror = e => reject(new Error(e.message));
+                                                ^
+ error: error: Cannot find package 'my-virtual-module' from '/tmp/worker-bunf
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/worker.test.ts
bun test v1.4.0 (48ff7d043)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [14.99ms]
(pass) web worker > preload > string [163.26ms]
(pass) web worker > preload > array of 2 strings [158.33ms]
(pass) web worker > preload > array of string [147.88ms]
(pass) web worker > preload > error in preload doesn't crash parent [135.30ms]
(pass) web worker > preload > inherited from bunfig/CLI > bunfig preload runs in Web Worker [827.56ms]
(pass) web worker > preload > inherited from bunfig/CLI > --preload flag runs in Web Worker [813.36ms]
(pass) web worker > preload > inherited from bunfig/CLI > bunfig preload runs in nested Worker [1126.40ms]
(pass) web worker > preload > inherited from bunfig/CLI > [test] preload is not inherited by in-process Workers under bun test [650.96ms]
(pass) web worker > preload > inherited from bunfig/CLI > inherited preload resolves against startup cwd after process.chdir [737.89ms]
(pass) web worker > preload > inherited from bunfig/CLI > inher
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     48ff7d0432
  features     baseline

22 deps, 108 codegen, 1171 objects in 1885ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [96.00ms]
[2/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/1234] gen bindgenv2
[4/1234] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [66.00ms]
[5/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [8.00ms]
[6/1234] gen ErrorCode+*.h
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] fetch zlib
[zlib] up to date
[9/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/bunfig.mdx            |   2 +
 docs/runtime/workers.mdx           |   2 +
 packages/bun-types/bun.d.ts        |   8 +
 src/jsc/VirtualMachine.rs          |  33 ++++
 src/jsc/web_worker.rs              |  37 ++++-
 src/runtime/bake/production.rs     |  11 +-
 src/runtime/cli/repl_command.rs    |   1 +
 src/runtime/cli/run_command.rs     |   2 +
 src/runtime/cli/test_command.rs    |   3 +
 test/js/web/workers/worker.test.ts | 310 ++++++++++++++++++++++++++++++++++++-
 10 files changed, 401 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
docs/runtime/bunfig.mdx                 1      1      0
docs/runtime/workers.mdx                1      1      0
packages/bun-types/bun.d.ts             1      1      0
src/jsc/VirtualMachine.rs               6      5      0
src/jsc/web_worker.rs                   9      5      0
src/runtime/bake/production.rs          2      3      0
src/runtime/cli/repl_command.rs         2      3      0
src/runtime/cli/run_command.rs          3      3      0
src/runtime/cli/test_command.rs         4      5      0
test/js/web/workers/worker.test.ts      2      8      0
```

</details>

<!-- robobun:evidence:end -->