### PR TITLE
bundler: don't emit `export {}` inside unbraced if/while/do bodies

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -450,6 +450,13 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub module_scope_directive_loc: bun_ast::Loc,
     pub is_control_flow_dead: bool,
 
+    /// True while visiting the unbraced body of `if`/`else`/`while`/`do`/`for`
+    /// via `visit_single_stmt`. Those statements don't introduce a lexical
+    /// scope, so `current_scope == module_scope` still holds inside them even
+    /// though the body is not a top-level module statement. Checks that mean
+    /// "is this a direct child of the module stmt list" must also consult this.
+    pub is_inside_single_stmt_body: bool,
+
     /// We must be careful to avoid revisiting nodes that have scopes.
     pub is_revisit_for_substitution: bool,
 
@@ -8777,6 +8784,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             scope_order_to_visit: &[],
             module_scope_directive_loc: bun_ast::Loc::default(),
             is_control_flow_dead: false,
+            is_inside_single_stmt_body: false,
             is_revisit_for_substitution: false,
             method_call_must_be_replaced_with_undefined: false,
             has_non_local_export_declare_inside_namespace: false,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -450,11 +450,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub module_scope_directive_loc: bun_ast::Loc,
     pub is_control_flow_dead: bool,
 
-    /// True while visiting the unbraced body of `if`/`else`/`while`/`do`/`for`
-    /// via `visit_single_stmt`. Those statements don't introduce a lexical
-    /// scope, so `current_scope == module_scope` still holds inside them even
-    /// though the body is not a top-level module statement. Checks that mean
-    /// "is this a direct child of the module stmt list" must also consult this.
+    /// True while `visit_single_stmt` is visiting a non-block body. `if`,
+    /// `else`, `while`, and `do` reach it without pushing a scope, so inside
+    /// their unbraced body `current_scope == module_scope` is still true at
+    /// module level even though the statement is not a top-level module
+    /// statement. `s_expr` consults this together with the scope check to
+    /// gate the CJS→ESM `export {}` rewrite. (`for`/`with`/`label` callers
+    /// push a scope first, and braced bodies take the `visit_single_stmt_block`
+    /// path which also pushes a scope, so this flag is redundant for those.)
     pub is_inside_single_stmt_body: bool,
 
     /// We must be careful to avoid revisiting nodes that have scopes.

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -764,9 +764,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .expect("unreachable");
         }
 
+        let old_is_inside_single_stmt_body = self.is_inside_single_stmt_body;
+        self.is_inside_single_stmt_body = true;
+
         let mut stmts = BumpVec::with_capacity_in(1, self.arena);
         stmts.push(stmt);
         self.visit_stmts(&mut stmts, kind).expect("unreachable");
+
+        self.is_inside_single_stmt_body = old_is_inside_single_stmt_body;
 
         if has_if_scope {
             self.pop_scope();

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1362,7 +1362,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             && (p.options.features.minify_syntax && data.value.is_primitive_literal());
         p.stmt_expr_value = data.value.data;
 
-        let is_top_level = p.current_scope == p.module_scope;
+        let is_top_level = p.current_scope == p.module_scope && !p.is_inside_single_stmt_body;
         if p.should_unwrap_common_js_to_esm() {
             p.commonjs_named_exports_needs_conversion = if is_top_level {
                 u32::MAX

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -392,4 +392,113 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
+  // https://github.com/oven-sh/bun/issues/4565
+  // `exports.x = ...` as the unbraced body of if/while/do/else must not be
+  // converted to `var $x = ...; export { $x as x };` because `export` is only
+  // valid at the top level of a module.
+  const noNestedExport = (api: { readFile(path: string): string }) => {
+    // Before the fix, the output contained `export { $x as x };` nested inside
+    // a block, which is a syntax error. Any indented `export {` is wrong here.
+    expect(api.readFile("out.js")).not.toMatch(/^\s+export\s*\{/m);
+  };
+  itBundled("cjs2esm/ExportsAssignInSingleStmtIf#4565", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.js';
+        console.log(JSON.stringify([lib.always, lib.cond]));
+      `,
+      "/lib.js": /* js */ `
+        exports.always = 1;
+        if (process.env.NEVER_SET_4565) exports.cond = 2;
+      `,
+    },
+    onAfterBundle: noNestedExport,
+    run: { stdout: "[1,null]" },
+  });
+  itBundled("cjs2esm/ExportsAssignInSingleStmtElse", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.js';
+        console.log(JSON.stringify([lib.a, lib.b]));
+      `,
+      "/lib.js": /* js */ `
+        exports.a = 1;
+        if (process.env.NEVER_SET_4565) void 0;
+        else exports.b = 2;
+      `,
+    },
+    onAfterBundle: noNestedExport,
+    run: { stdout: "[1,2]" },
+  });
+  itBundled("cjs2esm/ExportsAssignInSingleStmtWhile", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.js';
+        console.log(JSON.stringify([lib.a, lib.b]));
+      `,
+      "/lib.js": /* js */ `
+        exports.a = 1;
+        let i = 0;
+        while (i++ < 1) exports.b = 2;
+      `,
+    },
+    onAfterBundle: noNestedExport,
+    run: { stdout: "[1,2]" },
+  });
+  itBundled("cjs2esm/ExportsAssignInSingleStmtDoWhile", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.js';
+        console.log(JSON.stringify([lib.a, lib.b]));
+      `,
+      "/lib.js": /* js */ `
+        exports.a = 1;
+        do exports.b = 2; while (false);
+      `,
+    },
+    onAfterBundle: noNestedExport,
+    run: { stdout: "[1,2]" },
+  });
+  itBundled("cjs2esm/ModuleExportsAssignInSingleStmtIf", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.js';
+        console.log(JSON.stringify([lib.a, lib.b]));
+      `,
+      "/lib.js": /* js */ `
+        module.exports.a = 1;
+        if (process.env.NEVER_SET_4565) module.exports.b = 2;
+      `,
+    },
+    onAfterBundle: noNestedExport,
+    run: { stdout: "[1,null]" },
+  });
+  itBundled("cjs2esm/ExportsAssignInNestedSingleStmtIf", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from './lib.js';
+        console.log(JSON.stringify([lib.a, lib.b]));
+      `,
+      "/lib.js": /* js */ `
+        exports.a = 1;
+        if (!process.env.NEVER_SET_4565) if (!process.env.NEVER_SET_4565) exports.b = 2;
+      `,
+    },
+    onAfterBundle: noNestedExport,
+    run: { stdout: "[1,2]" },
+  });
+  itBundled("cjs2esm/ExportsAssignTopLevelStillConverts", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a, b } from './lib.js';
+        console.log(JSON.stringify([a, b]));
+      `,
+      "/lib.js": /* js */ `
+        exports.a = 1;
+        exports.b = 2;
+      `,
+    },
+    cjs2esm: true,
+    run: { stdout: "[1,2]" },
+  });
 });


### PR DESCRIPTION
Fixes #4565. Fixes #7024. Fixes #10880.

## Problem

Bundling a CommonJS file that assigns to `exports.foo` as the unbraced body of `if`/`else`/`while`/`do` produces syntactically invalid output:

```sh
$ echo 'if (x) exports.bar = 1;' > in.js
$ bun build in.js
if (x) {
  var $bar = 1;
  export { $bar as bar };   // SyntaxError: 'export' only allowed at top level
}
```

This is what breaks `bun build node_modules/uglify-js/tools/node.js`, which contains `if (+process.env["UGLIFY_BUG_REPORT"]) exports.minify = function(...) {...};`.

## Cause

The CJS→ESM conversion in `s_expr` rewrites a top-level `exports.x = v` expression statement to `var $x = v; export { $x as x };`. It gates this on `p.current_scope == p.module_scope`.

`if`, `while`, and `do` don't introduce a lexical scope in JavaScript (correctly: `var` declarations inside them hoist to the enclosing function/module). So when the parser visits the unbraced body of a module-level `if` via `visit_single_stmt`, `current_scope` is still `module_scope`, the gate passes, and the conversion fires inside the body. `stmts_to_single_stmt` then wraps the resulting `[SLocal, SExportClause]` pair in a block.

The braced form `if (x) { exports.bar = 1; }` was already correct because `SBlock` pushes a block scope.

## Fix

Track when we're visiting a single-statement control-flow body (`is_inside_single_stmt_body`, saved/restored in `visit_single_stmt`) and include it in the `is_top_level` check in `s_expr`. This makes the unbraced case behave exactly like the already-correct braced case: the conditional assignment leaves `needs_decl` set, which causes the file to fall back to `__commonJS` wrapping instead of per-export ESM conversion.

`for`/`for-in`/`for-of`/`with`/`label` were already unaffected because their visit handlers push a scope before visiting the body.

## Verification

With the fix, `bun build --target=node node_modules/uglify-js/tools/node.js` produces valid JS that runs cleanly under Node.

Added tests in `test/bundler/bundler_cjs2esm.test.ts` covering `if`, `else`, `while`, `do`, nested `if`, and the `module.exports.x` variant. Each test asserts the bundle has no indented `export {` and that it runs with the correct output. A separate test confirms plain top-level `exports.x = ...` still converts without the `__commonJS` wrapper.
