### PR TITLE
ws: implement createWebSocketStream

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1575,6 +1575,8 @@ function duplexOnError(err) {
   }
 }
 
+let Duplex;
+
 /**
  * Wraps a `WebSocket` in a duplex stream.
  *
@@ -1588,8 +1590,6 @@ function duplexOnError(err) {
  * @return {Duplex} The duplex stream
  * @public
  */
-let Duplex;
-
 function createWebSocketStream(ws, options) {
   Duplex ??= require("node:stream").Duplex;
   let terminateOnDestroy = true;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -280,7 +280,7 @@ class BunWebSocket extends EventEmitter {
     return ws;
   }
 
-  #on(event, listener) {
+  #ensureForwarder(event) {
     if (event === "unexpected-response" || event === "upgrade" || event === "redirect") {
       emitWarning(event, "ws.WebSocket '" + event + "' event is not implemented in bun");
     }
@@ -322,21 +322,31 @@ class BunWebSocket extends EventEmitter {
         });
       }
     }
-    return super.on(event, listener);
   }
 
   on(event, listener) {
-    return this.#on(event, listener);
+    this.#ensureForwarder(event);
+    return super.on(event, listener);
   }
 
   addListener(event, listener) {
-    return this.#on(event, listener);
+    this.#ensureForwarder(event);
+    return super.on(event, listener);
   }
 
+  prependListener(event, listener) {
+    this.#ensureForwarder(event);
+    return super.prependListener(event, listener);
+  }
+
+  // EventEmitter.prototype.once() / prependOnceListener() call this.on() /
+  // this.prependListener(), which reach #ensureForwarder above.
   once(event, listener) {
-    // EventEmitter.prototype.once() calls this.on(), which reaches #on and
-    // registers the native forwarder once per event type.
     return super.once(event, listener);
+  }
+
+  prependOnceListener(event, listener) {
+    return super.prependOnceListener(event, listener);
   }
 
   send(data, opts, cb) {
@@ -950,6 +960,8 @@ class BunWebSocketMocked extends EventEmitter {
       // not connected yet
       this.#enquedMessages.push([data, opts?.compress, cb]);
       this.#bufferedAmount += data.length;
+    } else {
+      return sendAfterClose(this.#state, cb);
     }
   }
 
@@ -1570,8 +1582,10 @@ function duplexOnError(err) {
  * @return {Duplex} The duplex stream
  * @public
  */
+let Duplex;
+
 function createWebSocketStream(ws, options) {
-  const { Duplex } = require("node:stream");
+  Duplex ??= require("node:stream").Duplex;
   let terminateOnDestroy = true;
 
   const duplex = new Duplex({

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -339,15 +339,9 @@ class BunWebSocket extends EventEmitter {
     return super.prependListener(event, listener);
   }
 
-  // EventEmitter.prototype.once() / prependOnceListener() call this.on() /
-  // this.prependListener(), which reach #ensureForwarder above.
-  once(event, listener) {
-    return super.once(event, listener);
-  }
-
-  prependOnceListener(event, listener) {
-    return super.prependOnceListener(event, listener);
-  }
+  // once() / prependOnceListener() are inherited: EventEmitter.prototype.once
+  // calls this.on() and prependOnceListener calls this.prependListener(), both
+  // of which reach #ensureForwarder above.
 
   send(data, opts, cb) {
     if ($isCallable(opts)) {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -10,7 +10,6 @@ const ReadyState_CLOSED = 3;
 
 const EventEmitter = require("node:events");
 const http = require("node:http");
-const onceObject = { once: true };
 const kBunInternals = Symbol.for("::bunternal::");
 const readyStates = ["CONNECTING", "OPEN", "CLOSING", "CLOSED"];
 
@@ -281,89 +280,63 @@ class BunWebSocket extends EventEmitter {
     return ws;
   }
 
-  #onOrOnce(event, listener, once) {
+  #on(event, listener) {
     if (event === "unexpected-response" || event === "upgrade" || event === "redirect") {
       emitWarning(event, "ws.WebSocket '" + event + "' event is not implemented in bun");
     }
     const mask = 1 << eventIds[event];
-    const hasPersistentListener = mask && (this.#eventId & mask) === mask;
-    // Add a native listener if:
-    // 1. For `on()`: no native listener exists yet (will be persistent)
-    // 2. For `once()`: no persistent `on()` listener exists (otherwise the persistent one forwards events)
-    //    If only `once()` listeners exist, each needs its own native listener since they auto-remove
-    if (mask && !hasPersistentListener) {
-      // Only set the eventId bit for persistent `on` listeners, not for `once`
-      if (!once) {
-        this.#eventId |= mask;
-      }
+    if (mask && (this.#eventId & mask) === 0) {
+      this.#eventId |= mask;
       if (event === "open") {
-        this.#ws.addEventListener(
-          "open",
-          () => {
-            this.emit("open");
-          },
-          once,
-        );
+        this.#ws.addEventListener("open", () => {
+          this.emit("open");
+        });
       } else if (event === "close") {
-        this.#ws.addEventListener(
-          "close",
-          ({ code, reason, wasClean }) => {
-            this.emit("close", code, reason, wasClean);
-          },
-          once,
-        );
+        this.#ws.addEventListener("close", ({ code, reason, wasClean }) => {
+          this.emit("close", code, reason, wasClean);
+        });
       } else if (event === "message") {
-        this.#ws.addEventListener(
-          "message",
-          ({ data }) => {
-            const isBinary = typeof data !== "string";
-            if (isBinary) {
-              this.emit("message", this.#fragments ? [data] : data, isBinary);
-            } else {
-              let encoded = encoder.encode(data);
-              if (this.#binaryType !== "arraybuffer") {
-                encoded = Buffer.from(encoded.buffer, encoded.byteOffset, encoded.byteLength);
-              }
-              this.emit("message", this.#fragments ? [encoded] : encoded, isBinary);
+        this.#ws.addEventListener("message", ({ data }) => {
+          const isBinary = typeof data !== "string";
+          if (isBinary) {
+            this.emit("message", this.#fragments ? [data] : data, isBinary);
+          } else {
+            let encoded = encoder.encode(data);
+            if (this.#binaryType !== "arraybuffer") {
+              encoded = Buffer.from(encoded.buffer, encoded.byteOffset, encoded.byteLength);
             }
-          },
-          once,
-        );
+            this.emit("message", this.#fragments ? [encoded] : encoded, isBinary);
+          }
+        });
       } else if (event === "error") {
-        this.#ws.addEventListener(
-          "error",
-          err => {
-            this.emit("error", err);
-          },
-          once,
-        );
+        this.#ws.addEventListener("error", err => {
+          this.emit("error", err);
+        });
       } else if (event === "ping") {
-        this.#ws.addEventListener(
-          "ping",
-          ({ data }) => {
-            this.emit("ping", data);
-          },
-          once,
-        );
+        this.#ws.addEventListener("ping", ({ data }) => {
+          this.emit("ping", data);
+        });
       } else if (event === "pong") {
-        this.#ws.addEventListener(
-          "pong",
-          ({ data }) => {
-            this.emit("pong", data);
-          },
-          once,
-        );
+        this.#ws.addEventListener("pong", ({ data }) => {
+          this.emit("pong", data);
+        });
       }
     }
-    return once ? super.once(event, listener) : super.on(event, listener);
+    return super.on(event, listener);
   }
 
   on(event, listener) {
-    return this.#onOrOnce(event, listener, undefined);
+    return this.#on(event, listener);
+  }
+
+  addListener(event, listener) {
+    return this.#on(event, listener);
   }
 
   once(event, listener) {
-    return this.#onOrOnce(event, listener, onceObject);
+    // EventEmitter.prototype.once() calls this.on(), which reaches #on and
+    // registers the native forwarder once per event type.
+    return super.once(event, listener);
   }
 
   send(data, opts, cb) {
@@ -1566,9 +1539,120 @@ class Receiver {
   }
 }
 
-var createWebSocketStream = _ws => {
-  throw new Error("Not supported yet in Bun");
-};
+function emitClose(stream) {
+  stream.emit("close");
+}
+
+function duplexOnEnd() {
+  if (!this.destroyed && this._writableState.finished) {
+    this.destroy();
+  }
+}
+
+function duplexOnError(err) {
+  this.removeListener("error", duplexOnError);
+  this.destroy();
+  if (this.listenerCount("error") === 0) {
+    this.emit("error", err);
+  }
+}
+
+/**
+ * Wraps a `WebSocket` in a duplex stream.
+ *
+ * Ported from https://github.com/websockets/ws/blob/master/lib/stream.js with
+ * adaptations for Bun's `ws` shim: the shim has no `_socket` and `pause()` /
+ * `resume()` are no-ops, so backpressure from the readable side is absorbed by
+ * the Duplex internal buffer instead of pausing the underlying socket.
+ *
+ * @param {WebSocket} ws The `WebSocket` to wrap
+ * @param {Object} [options] The options for the `Duplex` constructor
+ * @return {Duplex} The duplex stream
+ * @public
+ */
+function createWebSocketStream(ws, options) {
+  const { Duplex } = require("node:stream");
+  let terminateOnDestroy = true;
+
+  const duplex = new Duplex({
+    ...options,
+    autoDestroy: false,
+    emitClose: false,
+    objectMode: false,
+    writableObjectMode: false,
+  });
+
+  ws.on("message", function message(msg, isBinary) {
+    const data = !isBinary && duplex._readableState.objectMode ? msg.toString() : msg;
+
+    duplex.push(data);
+  });
+
+  ws.once("error", function error(err) {
+    if (duplex.destroyed) return;
+
+    terminateOnDestroy = false;
+    duplex.destroy(err);
+  });
+
+  ws.once("close", function close() {
+    if (duplex.destroyed) return;
+
+    duplex.push(null);
+  });
+
+  duplex._destroy = function (err, callback) {
+    if (ws.readyState === ws.CLOSED) {
+      callback(err);
+      process.nextTick(emitClose, duplex);
+      return;
+    }
+
+    let called = false;
+
+    ws.once("error", function error(err) {
+      called = true;
+      callback(err);
+    });
+
+    ws.once("close", function close() {
+      if (!called) callback(err);
+      process.nextTick(emitClose, duplex);
+    });
+
+    if (terminateOnDestroy) ws.terminate();
+  };
+
+  duplex._final = function (callback) {
+    if (ws.readyState === ws.CONNECTING) {
+      ws.once("open", function open() {
+        duplex._final(callback);
+      });
+      return;
+    }
+
+    callback();
+    if (ws.readyState === ws.OPEN) ws.close();
+    if (duplex._readableState.endEmitted) duplex.destroy();
+  };
+
+  duplex._read = function () {};
+
+  duplex._write = function (chunk, encoding, callback) {
+    if (ws.readyState === ws.CONNECTING) {
+      ws.once("open", function open() {
+        duplex._write(chunk, encoding, callback);
+      });
+      return;
+    }
+
+    ws.send(chunk, callback);
+  };
+
+  duplex.on("end", duplexOnEnd);
+  duplex.on("error", duplexOnError);
+  return duplex;
+}
 
 export default Object.assign(BunWebSocket, {
   createWebSocketStream,

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -870,6 +870,13 @@ class BunWebSocketMocked extends EventEmitter {
     this.#state = ReadyState_CLOSED;
     this.#ws = null;
 
+    const queued = this.#enquedMessages;
+    if (queued.length) {
+      this.#enquedMessages = [];
+      this.#bufferedAmount = 0;
+      for (const [, , cb] of queued) sendAfterClose(ReadyState_CLOSED, cb);
+    }
+
     this.emit("close", code, reason);
   }
 

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -355,6 +355,11 @@ class BunWebSocket extends EventEmitter {
       opts = undefined;
     }
 
+    const state = this.#ws.readyState;
+    if (state !== ReadyState_OPEN && state !== ReadyState_CONNECTING) {
+      return sendAfterClose(state, cb);
+    }
+
     try {
       this.#ws.send(normalizeData(data, opts), opts?.compress);
     } catch (error) {

--- a/test/js/first_party/ws/ws-create-websocket-stream.test.ts
+++ b/test/js/first_party/ws/ws-create-websocket-stream.test.ts
@@ -179,6 +179,20 @@ describe("createWebSocketStream", () => {
     expect((err as Error).message).toMatch(/not open/i);
   });
 
+  it("errors the write callback when the client-side WebSocket has closed", async () => {
+    const url = await serve(ws => ws.close());
+    const ws = connect(url);
+    const duplex = createWebSocketStream(ws);
+    duplex.on("error", () => {});
+    duplex.resume();
+    await once(ws, "close");
+
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    duplex.write("too late", err => (err ? resolve(err) : reject(new Error("expected an error"))));
+    const err = await promise;
+    expect((err as Error).message).toMatch(/not open/i);
+  });
+
   it("forces objectMode and writableObjectMode to false", async () => {
     const url = await serve(() => {});
     const ws = connect(url);
@@ -189,6 +203,26 @@ describe("createWebSocketStream", () => {
     duplex.on("error", () => {});
 
     expect((duplex as Duplex & { _writableState: { objectMode: boolean } })._writableState.objectMode).toBe(false);
+  });
+});
+
+describe("BunWebSocket listener entry points register the native forwarder", () => {
+  it("addListener('message') as the only listener receives frames", async () => {
+    const url = await serve(ws => ws.send("via addListener"));
+    const ws = connect(url);
+    const { promise, resolve } = Promise.withResolvers<Buffer>();
+    ws.addListener("message", msg => resolve(msg as Buffer));
+    const msg = await promise;
+    expect(msg.toString()).toBe("via addListener");
+  });
+
+  it("prependListener('message') as the only listener receives frames", async () => {
+    const url = await serve(ws => ws.send("via prependListener"));
+    const ws = connect(url);
+    const { promise, resolve } = Promise.withResolvers<Buffer>();
+    ws.prependListener("message", msg => resolve(msg as Buffer));
+    const msg = await promise;
+    expect(msg.toString()).toBe("via prependListener");
   });
 });
 

--- a/test/js/first_party/ws/ws-create-websocket-stream.test.ts
+++ b/test/js/first_party/ws/ws-create-websocket-stream.test.ts
@@ -160,6 +160,25 @@ describe("createWebSocketStream", () => {
     expect(msg.toString()).toBe("echo:ping");
   });
 
+  it("errors the write callback when the server-side peer has closed", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>();
+    const url = await serve(ws => {
+      const duplex = createWebSocketStream(ws);
+      duplex.on("error", () => {});
+      duplex.resume();
+      ws.on("close", () => {
+        duplex.write("too late", err => (err ? resolve(err) : reject(new Error("expected an error"))));
+      });
+    });
+
+    const ws = connect(url);
+    await once(ws, "open");
+    ws.terminate();
+
+    const err = await promise;
+    expect((err as Error).message).toMatch(/not open/i);
+  });
+
   it("forces objectMode and writableObjectMode to false", async () => {
     const url = await serve(() => {});
     const ws = connect(url);

--- a/test/js/first_party/ws/ws-create-websocket-stream.test.ts
+++ b/test/js/first_party/ws/ws-create-websocket-stream.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { once } from "node:events";
+import type { Duplex } from "node:stream";
+import { createWebSocketStream, WebSocket, WebSocketServer } from "ws";
+
+const servers: WebSocketServer[] = [];
+const sockets: WebSocket[] = [];
+
+afterEach(() => {
+  for (const ws of sockets.splice(0)) ws.terminate();
+  for (const wss of servers.splice(0)) wss.close();
+});
+
+async function serve(handler: (ws: WebSocket) => void) {
+  const wss = new WebSocketServer({ port: 0 });
+  servers.push(wss);
+  wss.on("connection", handler);
+  await once(wss, "listening");
+  return `ws://127.0.0.1:${(wss.address() as import("net").AddressInfo).port}`;
+}
+
+function connect(url: string) {
+  const ws = new WebSocket(url);
+  sockets.push(ws);
+  return ws;
+}
+
+describe("createWebSocketStream", () => {
+  it("returns a Duplex that round-trips data", async () => {
+    const url = await serve(ws => {
+      ws.on("message", msg => ws.send(msg));
+    });
+
+    const ws = connect(url);
+    const duplex = createWebSocketStream(ws);
+    expect(typeof duplex.write).toBe("function");
+    expect(typeof duplex.read).toBe("function");
+
+    const chunks: Buffer[] = [];
+    duplex.on("data", chunk => chunks.push(chunk));
+
+    await once(ws, "open");
+    duplex.write("hello");
+
+    while (chunks.length === 0) await once(duplex, "data");
+    expect(Buffer.concat(chunks).toString()).toBe("hello");
+  });
+
+  it("queues writes issued before the socket opens", async () => {
+    const received: string[] = [];
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const url = await serve(ws => {
+      ws.on("message", msg => {
+        received.push(msg.toString());
+        if (received.length === 2) resolve();
+      });
+    });
+
+    const ws = connect(url);
+    // readyState is CONNECTING here; _write must defer until 'open'.
+    const duplex = createWebSocketStream(ws);
+    duplex.write("first");
+    duplex.write("second");
+
+    await promise;
+    expect(received).toEqual(["first", "second"]);
+  });
+
+  it("pushes null and emits 'end' when the WebSocket closes", async () => {
+    const url = await serve(ws => {
+      ws.send("bye");
+      ws.close();
+    });
+
+    const ws = connect(url);
+    const duplex = createWebSocketStream(ws);
+
+    const chunks: Buffer[] = [];
+    duplex.on("data", chunk => chunks.push(chunk));
+    await once(duplex, "end");
+
+    expect(Buffer.concat(chunks).toString()).toBe("bye");
+  });
+
+  it("closes the WebSocket when the stream ends", async () => {
+    const serverClose = Promise.withResolvers<number>();
+    const url = await serve(ws => {
+      ws.on("close", code => serverClose.resolve(code));
+    });
+
+    const ws = connect(url);
+    const duplex = createWebSocketStream(ws);
+    const duplexClose = once(duplex, "close");
+    duplex.resume();
+    duplex.end();
+
+    expect(await serverClose.promise).toBe(1000);
+    await duplexClose;
+    expect(duplex.destroyed).toBe(true);
+  });
+
+  it("terminates the WebSocket when the stream is destroyed", async () => {
+    const serverClose = Promise.withResolvers<void>();
+    const url = await serve(ws => {
+      ws.on("close", () => serverClose.resolve());
+    });
+
+    const ws = connect(url);
+    await once(ws, "open");
+    const duplex = createWebSocketStream(ws);
+    const duplexClose = once(duplex, "close");
+    duplex.destroy();
+
+    await serverClose.promise;
+    await duplexClose;
+    expect(ws.readyState).toBe(WebSocket.CLOSED);
+  });
+
+  it("forwards WebSocket errors to the duplex", async () => {
+    // Connect to a port nothing is listening on.
+    const ws = connect("ws://127.0.0.1:1");
+    const duplex = createWebSocketStream(ws);
+
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+    duplex.on("error", resolve);
+    const err = await promise;
+    expect(err).toBeTruthy();
+    expect(duplex.destroyed).toBe(true);
+  });
+
+  it("passes readableObjectMode through and delivers text as strings", async () => {
+    const url = await serve(ws => {
+      ws.send("plain text");
+    });
+
+    const ws = connect(url);
+    const duplex = createWebSocketStream(ws, { readableObjectMode: true });
+
+    const [chunk] = await once(duplex, "data");
+    expect(typeof chunk).toBe("string");
+    expect(chunk).toBe("plain text");
+  });
+
+  it("wraps a server-side WebSocket", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers<Buffer>();
+    const url = await serve(ws => {
+      const duplex = createWebSocketStream(ws);
+      duplex.on("error", reject);
+      duplex.on("data", chunk => {
+        duplex.write(Buffer.concat([Buffer.from("echo:"), chunk]));
+      });
+    });
+
+    const ws = connect(url);
+    await once(ws, "open");
+    ws.send("ping");
+    ws.on("message", msg => resolve(msg as Buffer));
+
+    const msg = await promise;
+    expect(msg.toString()).toBe("echo:ping");
+  });
+
+  it("forces objectMode and writableObjectMode to false", async () => {
+    const url = await serve(() => {});
+    const ws = connect(url);
+    const duplex = createWebSocketStream(ws, {
+      objectMode: true,
+      writableObjectMode: true,
+    } as unknown as import("node:stream").DuplexOptions);
+    duplex.on("error", () => {});
+
+    expect((duplex as Duplex & { _writableState: { objectMode: boolean } })._writableState.objectMode).toBe(false);
+  });
+});
+
+// Previously `ws.once(event, fn)` registered the native forwarder twice
+// (super.once -> this.on -> #on), so a single native event produced two
+// EventEmitter emissions. createWebSocketStream depends on once("error")
+// behaving like npm ws.
+it("ws.once('error') fires exactly once per native error", async () => {
+  const ws = new WebSocket("ws://127.0.0.1:1");
+  sockets.push(ws);
+
+  let emits = 0;
+  const origEmit = ws.emit;
+  ws.emit = function (ev: string, ...args: unknown[]) {
+    if (ev === "error") emits++;
+    return origEmit.call(this, ev, ...args);
+  } as typeof ws.emit;
+
+  const { promise, resolve } = Promise.withResolvers<void>();
+  ws.once("error", () => {});
+  ws.once("close", () => resolve());
+  await promise;
+
+  expect(emits).toBe(1);
+});


### PR DESCRIPTION
## What does this PR do?

Implements `createWebSocketStream` in Bun's `ws` shim so packages that wrap a WebSocket in a Node `Duplex` (mqtt.js, `@atproto/sync`, Prisma Pulse) work without throwing `Not supported yet in Bun`.

Fixes #4568.

### Reproduction

```js
import WebSocket, { createWebSocketStream } from "ws";
const ws = new WebSocket(url);
const duplex = createWebSocketStream(ws);
// before: Error: Not supported yet in Bun
// after:  a Duplex that reads/writes over the socket
```

### Implementation

Ports [`lib/stream.js`](https://github.com/websockets/ws/blob/master/lib/stream.js) from the upstream `ws` package, with two adaptations for the shim:

- The shim has no `_socket`, so `_final()` closes the WebSocket directly and lets the `close` event push `null`, instead of waiting on `_socket._writableState.finished`.
- `pause()`/`resume()` are no-ops in the shim, so readable-side backpressure is absorbed by the Duplex internal buffer instead of pausing the underlying socket.

Everything else (`_write` deferral while `CONNECTING`, `_destroy` terminating and waiting for `close`, `autoDestroy: false` + manual `close` emission, `readableObjectMode` passthrough for text frames, `duplexOnEnd`/`duplexOnError`) follows upstream exactly.

### `once()` double-registration fix

While wiring this up, the stream's `ws.once("error", ...)` path kept throwing `Unhandled error` on a failed connection. Root cause: `BunWebSocket.once()` called `#onOrOnce(..., {once:true})`, which registered a native `addEventListener` forwarder, then called `super.once()`. `EventEmitter.prototype.once` internally calls `this.on()`, which is `BunWebSocket`'s overridden `on`, which registered a *second* persistent native forwarder. One native error event then produced two `emit("error")` calls; the second had zero listeners and threw.

`once()` now delegates straight to `super.once()` and lets the `on()` override do the native hookup via the existing bitmask (so the forwarder is still registered exactly once per event type). `addListener()` is overridden to match `on()`. The now-dead `once` branch of `#onOrOnce` is dropped.

## How did you verify your code works?

New test file `test/js/first_party/ws/ws-create-websocket-stream.test.ts` covers:
- round-trip read/write through an echo server
- writes issued while `CONNECTING` are deferred until `open`
- ws `close` -> `push(null)` -> duplex `end`
- duplex `end()` -> ws `close` -> duplex `close`
- duplex `destroy()` -> ws `terminate` -> duplex `close`
- ws connection error -> duplex `error` + `destroyed`
- `readableObjectMode: true` delivers text frames as strings
- wrapping a server-side `WebSocketServer` socket
- `objectMode`/`writableObjectMode` forced to `false` (matches upstream)
- `ws.once("error")` emits exactly once per native error

```
=== USE_SYSTEM_BUN=1 (before) ===
 0 pass  10 fail
error: Not supported yet in Bun
      at createWebSocketStream (ws:1004:14)

=== bun bd (after) ===
 10 pass  0 fail
```

Existing suites unchanged: `test/js/first_party/ws/ws.test.ts` (45 pass), `test/regression/issue/26358.test.ts` (`ws.once()` multiple calls, 4 pass), `test/js/first_party/ws/ws-syscall-fault.test.ts`, `test/js/web/websocket/websocket-client.test.ts`, `test/js/node/http/node-http-with-ws.test.ts`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws-create-websocket-stream.test.ts
bun test v1.4.0 (dc7482afc)

test/js/first_party/ws/ws-create-websocket-stream.test.ts:
1196 | class Receiver {
1197 |   constructor() {
1198 |     throw new Error("Not supported yet in Bun");
1199 |   }
1200 | }
1201 |   throw new Error("Not supported yet in Bun");
               ^
error: Not supported yet in Bun
      at createWebSocketStream (ws:1201:9)
      at <anonymous> (/workspace/bun/test/js/first_party/ws/ws-create-websocket-stream.test.ts:35:20)
(fail) createWebSocketStream > returns a Duplex that round-trips data [156.67ms]
1196 | class Receiver {
1197 |   constructor() {
1198 |     throw new Error("Not supported yet in Bun");
1199 |   }
1200 | }
1201 |   throw new Error("Not supported yet in Bun");
               ^
error: Not supported yet in Bun
      at createWebSocketStream (ws:1201:9)
      at <anonymous> (/workspace/bun/test/js/first_party/ws/ws-create-websocket-stream.test.ts:61:20)
(fail) createWebSocketStream > queues writes issued before the socket opens [6
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cbacb1248)

test/js/first_party/ws/ws-create-websocket-stream.test.ts:
(pass) createWebSocketStream > returns a Duplex that round-trips data [12.85ms]
(pass) createWebSocketStream > queues writes issued before the socket opens [4.02ms]
(pass) createWebSocketStream > pushes null and emits 'end' when the WebSocket closes [2.86ms]
(pass) createWebSocketStream > closes the WebSocket when the stream ends [3.15ms]
(pass) createWebSocketStream > terminates the WebSocket when the stream is destroyed [2.67ms]
(pass) createWebSocketStream > forwards WebSocket errors to the duplex [0.55ms]
(pass) createWebSocketStream > passes readableObjectMode through and delivers text as strings [2.73ms]
(pass) createWebSocketStream > wraps a server-side WebSocket [3.16ms]
(pass) createWebSocketStream > errors the write callback when the server-side peer has closed [2.96ms]
(pass) createWebSocketStream > errors the write callback when the client-side WebSocket has closed [2.04ms]
(pass) createWebSocketStream > forces objectMode and writableObjectMode to false [2.05ms]
(pass) BunWebSocket listener entry points register the native forwarder > addListener('message') a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws-create-websocket-stream.test.ts
bun test v1.4.0 (dc7482afc)

test/js/first_party/ws/ws-create-websocket-stream.test.ts:
(pass) createWebSocketStream > returns a Duplex that round-trips data [483.88ms]
(pass) createWebSocketStream > queues writes issued before the socket opens [142.26ms]
(pass) createWebSocketStream > pushes null and emits 'end' when the WebSocket closes [103.73ms]
(pass) createWebSocketStream > closes the WebSocket when the stream ends [111.84ms]
(pass) createWebSocketStream > terminates the WebSocket when the stream is destroyed [92.15ms]
(pass) createWebSocketStream > forwards WebSocket errors to the duplex [40.37ms]
(pass) createWebSocketStream > passes readableObjectMode through and delivers text as strings [94.53ms]
(pass) createWebSocketStream > wraps a server-side WebSocket [90.01ms]
(pass) createWebSocketStream > errors the write callback when the server-side peer has closed [108.57ms]
(pass) createWebSocketStream > errors the write callback when the client-side WebSocket has closed [8
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 812ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7771ms)
Bundle modules (32ms)
Postprocesss modules (203ms)
Bundle Functions (814ms)
Generate Code (27ms)

[8.87s] Bundled "src/js" for production
  2115 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/ws.js                            | 242 ++++++++++++++------
 .../ws/ws-create-websocket-stream.test.ts          | 250 +++++++++++++++++++++
 2 files changed, 423 insertions(+), 69 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/thirdparty/ws.js                                       6     12      0
…st/js/first_party/ws/ws-create-websocket-stream.test.ts      1      7      0
```

</details>

<!-- robobun:evidence:end -->