### PR TITLE
jsx: stop forcing the removed Solid runtime for jsxImportSource: "solid-js"

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -986,7 +986,10 @@ pub(crate) fn to_parser_jsx_pragma(
     mut p: crate::options_impl::jsx::Pragma,
 ) -> js_ast::parser::options::JSX::Pragma {
     use crate::options_impl::jsx::Runtime;
-    if p.runtime == Runtime::_None {
+    // `Solid` is a leftover from the removed Solid.js transform (88538b7c2c);
+    // the parser only distinguishes Automatic vs Classic, and any other value
+    // would fall through to `React.createElement`.
+    if matches!(p.runtime, Runtime::_None | Runtime::Solid) {
         p.runtime = Runtime::Automatic;
     }
     p

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -480,11 +480,6 @@ impl TSConfigJSON {
             // Parse "jsxImportSource"
             if let Some(jsx_prop) = jsx_import_source_v {
                 if let Some(str) = jsx_prop.as_str() {
-                    if str.len() >= b"solid-js".len() && &str[..b"solid-js".len()] == b"solid-js" {
-                        result.jsx.runtime = options::jsx::Runtime::Solid;
-                        result.jsx_flags.insert(JsxField::Runtime);
-                    }
-
                     result.jsx.package_name = str.to_vec().into();
                     result.jsx.set_import_source();
                     result.jsx_flags.insert(JsxField::ImportSource);

--- a/test/bundler/esbuild/tsconfig.test.ts
+++ b/test/bundler/esbuild/tsconfig.test.ts
@@ -627,6 +627,49 @@ describe("bundler", () => {
       api.expectFile("/Users/user/project/out.js").toContain(`from "notreact/jsx-dev-runtime`);
     },
   });
+  // https://github.com/oven-sh/bun/issues/5429 - jsxImportSource: "solid-js" must use the
+  // automatic runtime with the configured package, same as any other import source.
+  itBundled("tsconfig/ReactJSXSolid", {
+    files: {
+      "/Users/user/project/entry.tsx": `console.log(<><div/><div/></>)`,
+      "/Users/user/project/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "react-jsx",
+            "jsxImportSource": "solid-js"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    env: {
+      NODE_ENV: "production",
+    },
+    external: ["solid-js"],
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").toContain(`from "solid-js/jsx-runtime`);
+      api.expectFile("/Users/user/project/out.js").not.toContain("React.createElement");
+    },
+  });
+  itBundled("tsconfig/PreserveImportSourceSolid", {
+    files: {
+      "/Users/user/project/entry.tsx": `export const Button = () => <button>test</button>;`,
+      "/Users/user/project/tsconfig.json": /* json */ `
+        {
+          "compilerOptions": {
+            "jsx": "preserve",
+            "jsxImportSource": "solid-js"
+          }
+        }
+      `,
+    },
+    outfile: "/Users/user/project/out.js",
+    external: ["solid-js"],
+    onAfterBundle(api) {
+      api.expectFile("/Users/user/project/out.js").not.toContain("React.createElement");
+      api.expectFile("/Users/user/project/out.js").toContain("solid-js/jsx-");
+    },
+  });
   itBundled("tsconfig/ReactJSXDev", {
     files: {
       "/Users/user/project/entry.tsx": `console.log(<><div/><div/></>)`,


### PR DESCRIPTION
Fixes #5429
Fixes #3528

## Problem

With a tsconfig like

```json
{
  "compilerOptions": {
    "jsx": "preserve",
    "jsxImportSource": "solid-js"
  }
}
```

`bun build` and `bun run` emit `React.createElement(...)` instead of using the automatic runtime with `solid-js` as the import source. This breaks every SolidJS project out of the box:

```
$ bun run app.tsx
ReferenceError: React is not defined
```

The same tsconfig with `"jsxImportSource": "preact"` (or any other package) works correctly and imports from `preact/jsx-dev-runtime`.

## Cause

`tsconfig_json.rs` special-cased any `jsxImportSource` starting with `"solid-js"` to `Runtime::Solid`, a value left over from the Solid.js JSX transform that was removed in 88538b7c2c ("Deprecate very incomplete Solid.js JSX transform"). The parser only recognises `Automatic` vs `Classic` (`visit_expr.rs`), so `Solid` silently fell through to the classic transform and emitted `React.createElement` with the default `React` factory, ignoring the configured import source entirely.

Because the override ran *after* the `"jsx"` field was processed, it also clobbered an explicit `"jsx": "react-jsx"`.

## Fix

* Drop the `solid-js` prefix override in `tsconfig_json.rs` so `"jsxImportSource": "solid-js"` is treated like any other import source (automatic runtime, importing from `solid-js/jsx-runtime` / `solid-js/jsx-dev-runtime`). This matches esbuild and TypeScript.
* Fold the vestigial `Runtime::Solid` to `Automatic` in `to_parser_jsx_pragma`, so `--jsx-runtime=solid` and bunfig `jsx = "solid"` no longer degrade to `React.createElement` either.

After:

```js
// bun build index.tsx --external="*"
import { jsx } from "solid-js/jsx-runtime";
var Button = () => /* @__PURE__ */ jsx("button", { children: "test" });
```

`solid-js` ships both `jsx-runtime` and `jsx-dev-runtime` entry points, so this runs. It is not the optimised Solid compilation (that needs `babel-preset-solid` via a plugin, e.g. `bun-plugin-solid`), but it is the correct generic behaviour for `jsxImportSource` and no longer references an undefined `React` global.

## Verification

New `tsconfig/ReactJSXSolid` and `tsconfig/PreserveImportSourceSolid` cases in `test/bundler/esbuild/tsconfig.test.ts` cover both tsconfig shapes from the issue. They fail on current `bun` (emit `React.createElement`) and pass with this change. `bundler_jsx.test.ts`, `esbuild/tsconfig.test.ts`, `transpiler.test.js`, and `jsx-tsconfig-react-jsx.test.ts` pass unchanged.
