### PR TITLE
js_parser: keep conditional `exports.x` assignments as CJS in the unwrap transform

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -287,6 +287,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub commonjs_named_exports_needs_conversion: u32,
     pub had_commonjs_named_exports_this_visit: bool,
     pub commonjs_replacement_stmts: StmtNodeList,
+    /// True while visiting the single-statement body of an `if`/`else`/loop
+    /// via `visit_single_stmt`. Those bodies share the enclosing scope, so
+    /// `current_scope == module_scope` is not a sufficient "top level" check
+    /// for the CommonJS→ESM rewrite; an `export` clause emitted there would
+    /// land inside the control-flow statement.
+    pub is_inside_single_stmt_body: bool,
 
     pub parse_pass_symbol_uses: ParsePassSymbolUsageType<'a>,
 
@@ -8750,6 +8756,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             commonjs_named_exports_needs_conversion: u32::MAX,
             had_commonjs_named_exports_this_visit: false,
             commonjs_replacement_stmts: js_ast::StmtNodeList::EMPTY,
+            is_inside_single_stmt_body: false,
             parse_pass_symbol_uses: None,
             has_commonjs_export_names: false,
             should_fold_typescript_constant_expressions: false,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -766,7 +766,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut stmts = BumpVec::with_capacity_in(1, self.arena);
         stmts.push(stmt);
+        let old_is_inside_single_stmt_body = self.is_inside_single_stmt_body;
+        self.is_inside_single_stmt_body = true;
         self.visit_stmts(&mut stmts, kind).expect("unreachable");
+        self.is_inside_single_stmt_body = old_is_inside_single_stmt_body;
 
         if has_if_scope {
             self.pop_scope();

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1363,8 +1363,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.stmt_expr_value = data.value.data;
 
         let is_top_level = p.current_scope == p.module_scope;
+        // `if`/`else`/`while`/`do` single-statement bodies share the module
+        // scope, but a `var $x; export { $x }` rewrite there would sit inside
+        // the control-flow statement (invalid) and would unconditionally
+        // export a conditionally-assigned value. Treat them as non-top-level.
+        let is_top_level_cjs_to_esm = is_top_level && !p.is_inside_single_stmt_body;
         if p.should_unwrap_common_js_to_esm() {
-            p.commonjs_named_exports_needs_conversion = if is_top_level {
+            p.commonjs_named_exports_needs_conversion = if is_top_level_cjs_to_esm {
                 u32::MAX
             } else {
                 p.commonjs_named_exports_needs_conversion
@@ -1402,7 +1407,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data.value = simplified;
 
         if p.should_unwrap_common_js_to_esm() {
-            if is_top_level {
+            if is_top_level_cjs_to_esm {
                 if matches!(data.value.data, js_ast::ExprData::EBinary(_)) {
                     let to_convert = p.commonjs_named_exports_needs_conversion;
                     if to_convert != u32::MAX {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -233,6 +233,94 @@ describe("bundler", () => {
       stdout: "development",
     },
   });
+  // https://github.com/oven-sh/bun/issues/7024
+  // `exports.foo = ...` as the single-statement body of an if/else/while/do-while
+  // shares the module scope, so the CJS→ESM rewrite used to emit
+  // `export { $foo as foo }` inside the control-flow statement, which is a
+  // SyntaxError. These must stay wrapped.
+  itBundled("cjs2esm/ExportsAssignedInIfBodyIssue7024", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require('lib');
+        console.log(typeof lib.minify);
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        if (+process.env["UGLIFY_BUG_REPORT"]) exports.minify = function(files, options) {
+          return { code: "bug report" };
+        };
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toContain("export { $minify as minify }");
+      expect(out).toContain("exports.minify = function");
+    },
+    run: [
+      { env: { UGLIFY_BUG_REPORT: "1" }, stdout: "function" },
+      { env: { UGLIFY_BUG_REPORT: "0" }, stdout: "undefined" },
+    ],
+  });
+  itBundled("cjs2esm/ExportsAssignedInControlFlowBody", {
+    files: {
+      "/entry.js": /* js */ `
+        globalThis.YES = true;
+        const s_if = require('./s_if.js');
+        const s_else = require('./s_else.js');
+        const s_while = require('./s_while.js');
+        const s_dowhile = require('./s_dowhile.js');
+        const s_nested = require('./s_nested.js');
+        const s_module = require('./s_module.js');
+        console.log(JSON.stringify({ s_if, s_else, s_while, s_dowhile, s_nested, s_module }));
+      `,
+      "/s_if.js": /* js */ `
+        if (globalThis.YES) exports.foo = "if";
+      `,
+      "/s_else.js": /* js */ `
+        if (!globalThis.YES) throw 1;
+        else exports.foo = "else";
+      `,
+      "/s_while.js": /* js */ `
+        var i = 0;
+        while (i++ < 1) exports.foo = "while";
+      `,
+      "/s_dowhile.js": /* js */ `
+        do exports.foo = "do-while"; while (0);
+      `,
+      "/s_nested.js": /* js */ `
+        if (globalThis.YES) if (globalThis.YES) exports.foo = "nested";
+      `,
+      "/s_module.js": /* js */ `
+        if (globalThis.YES) module.exports.foo = "module";
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("out.js")).not.toContain("export { $foo as foo }");
+    },
+    run: {
+      stdout:
+        '{"s_if":{"foo":"if"},"s_else":{"foo":"else"},"s_while":{"foo":"while"},"s_dowhile":{"foo":"do-while"},"s_nested":{"foo":"nested"},"s_module":{"foo":"module"}}',
+    },
+  });
+  itBundled("cjs2esm/ExportsAssignedInIfBodyDeoptsSiblings", {
+    files: {
+      "/entry.js": /* js */ `
+        globalThis.YES = true;
+        const lib = require('lib');
+        console.log(JSON.stringify(lib));
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        exports.a = 1;
+        if (globalThis.YES) exports.b = 2;
+        exports.c = 3;
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("out.js")).not.toContain("export { $b as b }");
+    },
+    run: {
+      stdout: '{"a":1,"b":2,"c":3}',
+    },
+  });
   itBundled("cjs2esm/UnwrappedModuleRequireAssigned", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
## What does this PR do?

Fixes #7024.
Fixes #4565.
Fixes #10880.

### Repro

```js
// node_modules/uglify-js/tools/node.js (reduced)
if (+process.env["UGLIFY_BUG_REPORT"]) exports.minify = function(files, options) {
  return { code: "bug report" };
};
```

`bun build` emitted:

```js
if (+process.env["UGLIFY_BUG_REPORT"]) {
  var $minify = function(files, options) {
    return { code: "bug report" };
  };

  export { $minify as minify };
}
```

An `export` clause inside a block is a syntax error, so any bundle that pulled in `uglify-js` (or any CJS module with the same shape) failed to run. The bug also applied to `else`, `while`, `do`-`while`, and `module.exports.x` in the same position.

### Cause

The CJS→ESM unwrap in `s_expr` gated its `var $x; export { $x as x }` rewrite on `current_scope == module_scope`. The parser (correctly) does not push a scope for the single-statement body of `if`/`else`/`while`/`do`-`while`, so that check was satisfied inside those bodies and the rewrite fired as if the assignment were a top-level module statement.

Writing the body with explicit braces already worked: `s_block` pushes a scope, the rewrite is skipped, `needs_decl` stays set for the entry in `commonjs_named_exports`, and the post-visit pass in `parse_entry.rs` deoptimises the module back to a `__commonJS` wrapper.

### Fix

Track whether we are currently visiting a single-statement body (`visit_single_stmt`) and require that flag to be clear in addition to the scope check before performing the rewrite. The conditional assignment then follows the same path as the braced form: the named export keeps `needs_decl = true`, the module deopts, and the output stays wrapped as CommonJS. Unconditional top-level `exports.x = …` statements are unaffected and continue to be unwrapped to ESM.

esbuild keeps such modules wrapped as well.

### How did you verify your code works?

New tests in `test/bundler/bundler_cjs2esm.test.ts` cover the uglify-js repro plus `else`, `while`, `do`-`while`, nested `if`, `module.exports.x`, and a mix of conditional and unconditional assignments, asserting both the bundle text and its runtime output.