### PR TITLE
prompt/alert/confirm: force cooked stdin during the blocking line read

### DIFF
--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -6,6 +6,62 @@ use bun_core::Output;
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::zig_string::ZigString;
 
+/// RAII guard that forces stdin into canonical ("cooked") mode for the
+/// duration of a blocking line read and restores whatever termios were in
+/// effect afterwards.
+///
+/// `node:readline` (and anything else that calls `setRawMode(true)`) clears
+/// `ICANON`, `ECHO`, `ISIG` and `ICRNL`. While in that state, Enter delivers a
+/// bare `\r`, typed characters are not echoed, and Ctrl+C is not translated to
+/// `SIGINT`. `alert`/`confirm`/`prompt` all do a blocking read that waits for
+/// `\n`, so without this guard they hang with no visible feedback.
+///
+/// On non-TTY stdin `tcgetattr` fails and the guard is inert, so piped input
+/// keeps its existing behaviour.
+#[cfg(unix)]
+struct CookedStdinGuard {
+    saved: Option<libc::termios>,
+}
+
+#[cfg(unix)]
+impl CookedStdinGuard {
+    fn new() -> Self {
+        let saved = match bun_sys::posix::tcgetattr(0) {
+            Ok(orig) => {
+                let mut cooked = orig;
+                cooked.c_iflag |= libc::ICRNL;
+                cooked.c_lflag |= libc::ICANON | libc::ECHO | libc::ISIG | libc::IEXTEN;
+                match bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Drain, &cooked) {
+                    Ok(()) => Some(orig),
+                    Err(_) => None,
+                }
+            }
+            Err(_) => None,
+        };
+        Self { saved }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for CookedStdinGuard {
+    fn drop(&mut self) {
+        if let Some(orig) = self.saved.as_ref() {
+            let _ = bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Drain, orig);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+struct CookedStdinGuard;
+
+#[cfg(not(unix))]
+impl CookedStdinGuard {
+    #[inline]
+    fn new() -> Self {
+        Self
+    }
+}
+
 /// https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-alert
 #[bun_jsc::host_fn(export = "WebCore__alert")]
 fn alert(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
@@ -47,6 +103,8 @@ fn alert(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // 6. Invoke WebDriver BiDi user prompt opened with this, "alert", and message.
     // *  Not pertinent to use their complex system in a server context.
     Output::flush();
+
+    let _cooked = CookedStdinGuard::new();
 
     // 7. Optionally, pause while waiting for the user to acknowledge the message.
     let mut reader = Output::stdin_reader();
@@ -101,6 +159,8 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // 5. Invoke WebDriver BiDi user prompt opened with this, "confirm", and message.
     // *  Not relevant in a server context.
     Output::flush();
+
+    let _cooked = CookedStdinGuard::new();
 
     // 6. Pause until the user responds either positively or negatively.
     let mut reader = Output::stdin_reader();
@@ -293,13 +353,17 @@ pub mod prompt {
         // *  Not relevant in a server context.
         Output::flush();
 
+        let _cooked = CookedStdinGuard::new();
+
         // unset `ENABLE_VIRTUAL_TERMINAL_INPUT` on windows. This prevents backspace from
         // deleting the entire line
         #[cfg(windows)]
         let _restore =
             bun_sys::windows::StdinModeGuard::set(bun_sys::windows::UpdateStdioModeFlagsOpts {
+                set: bun_sys::windows::ENABLE_LINE_INPUT
+                    | bun_sys::windows::ENABLE_ECHO_INPUT
+                    | bun_sys::windows::ENABLE_PROCESSED_INPUT,
                 unset: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
-                ..Default::default()
             });
 
         // 7. Pause while waiting for the user's response.

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -16,6 +16,11 @@ use bun_jsc::zig_string::ZigString;
 /// `SIGINT`. `alert`/`confirm`/`prompt` all do a blocking read that waits for
 /// `\n`, so without this guard they hang with no visible feedback.
 ///
+/// The guard must be installed before the prompt text is written: the line
+/// discipline applies `ICRNL` at receive time, so a `\r` that arrives in the
+/// window between the prompt becoming visible and `tcsetattr` applying stays a
+/// `\r` in the input queue and the canonical read never sees a line.
+///
 /// On non-TTY stdin `tcgetattr` fails and the guard is inert, so piped input
 /// keeps its existing behaviour.
 #[cfg(unix)]
@@ -31,7 +36,7 @@ impl CookedStdinGuard {
                 let mut cooked = orig;
                 cooked.c_iflag |= libc::ICRNL;
                 cooked.c_lflag |= libc::ICANON | libc::ECHO | libc::ISIG | libc::IEXTEN;
-                match bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Drain, &cooked) {
+                match bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Now, &cooked) {
                     Ok(()) => Some(orig),
                     Err(_) => None,
                 }
@@ -46,7 +51,7 @@ impl CookedStdinGuard {
 impl Drop for CookedStdinGuard {
     fn drop(&mut self) {
         if let Some(orig) = self.saved.as_ref() {
-            let _ = bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Drain, orig);
+            let _ = bun_sys::posix::tcsetattr(0, bun_sys::posix::TCSA::Now, orig);
         }
     }
 }
@@ -94,6 +99,8 @@ fn alert(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let output = Output::writer();
     let has_message = !arguments.is_empty();
 
+    let _cooked = CookedStdinGuard::new();
+
     // 2. If the method was invoked with no arguments, then let message be the empty string; otherwise, let message be the method's first argument.
     if has_message {
         let message = arguments[0].to_slice(global)?;
@@ -129,8 +136,6 @@ fn alert(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // *  Not pertinent to use their complex system in a server context.
     Output::flush();
 
-    let _cooked = CookedStdinGuard::new();
-
     // 7. Optionally, pause while waiting for the user to acknowledge the message.
     let mut reader = Output::stdin_reader();
     loop {
@@ -151,6 +156,8 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let arguments = frame.arguments();
     let output = Output::writer();
     let has_message = !arguments.is_empty();
+
+    let _cooked = CookedStdinGuard::new();
 
     if has_message {
         // 2. Set message to the result of normalizing newlines given message.
@@ -184,8 +191,6 @@ fn confirm(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     // 5. Invoke WebDriver BiDi user prompt opened with this, "confirm", and message.
     // *  Not relevant in a server context.
     Output::flush();
-
-    let _cooked = CookedStdinGuard::new();
 
     // 6. Pause until the user responds either positively or negatively.
     let mut reader = Output::stdin_reader();
@@ -327,6 +332,8 @@ pub mod prompt {
             JSValue::NULL
         };
 
+        let _cooked = CookedStdinGuard::new();
+
         if has_message {
             // 2. Set message to the result of normalizing newlines given message.
             // *  Not pertinent to a server runtime so we will just let the terminal handle this.
@@ -377,8 +384,6 @@ pub mod prompt {
         // 6. Invoke WebDriver BiDi user prompt opened with this, "prompt" and message.
         // *  Not relevant in a server context.
         Output::flush();
-
-        let _cooked = CookedStdinGuard::new();
 
         // 7. Pause while waiting for the user's response.
         // `bun.Output.buffered_stdin.reader()` — process-global 4 KiB buffered stdin.

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -51,10 +51,31 @@ impl Drop for CookedStdinGuard {
     }
 }
 
-#[cfg(not(unix))]
+/// Windows equivalent of the cooked-mode guard: re-enable line input, echo and
+/// Ctrl+C processing on the console and clear `ENABLE_VIRTUAL_TERMINAL_INPUT`
+/// so Backspace edits the line instead of arriving as an escape sequence.
+/// `StdinModeGuard` is inert when stdin is not a console.
+#[cfg(windows)]
+struct CookedStdinGuard(#[allow(dead_code)] bun_sys::windows::StdinModeGuard);
+
+#[cfg(windows)]
+impl CookedStdinGuard {
+    fn new() -> Self {
+        Self(bun_sys::windows::StdinModeGuard::set(
+            bun_sys::windows::UpdateStdioModeFlagsOpts {
+                set: bun_sys::windows::ENABLE_LINE_INPUT
+                    | bun_sys::windows::ENABLE_ECHO_INPUT
+                    | bun_sys::windows::ENABLE_PROCESSED_INPUT,
+                unset: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
+            },
+        ))
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
 struct CookedStdinGuard;
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 impl CookedStdinGuard {
     #[inline]
     fn new() -> Self {
@@ -354,17 +375,6 @@ pub mod prompt {
         Output::flush();
 
         let _cooked = CookedStdinGuard::new();
-
-        // unset `ENABLE_VIRTUAL_TERMINAL_INPUT` on windows. This prevents backspace from
-        // deleting the entire line
-        #[cfg(windows)]
-        let _restore =
-            bun_sys::windows::StdinModeGuard::set(bun_sys::windows::UpdateStdioModeFlagsOpts {
-                set: bun_sys::windows::ENABLE_LINE_INPUT
-                    | bun_sys::windows::ENABLE_ECHO_INPUT
-                    | bun_sys::windows::ENABLE_PROCESSED_INPUT,
-                unset: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
-            });
 
         // 7. Pause while waiting for the user's response.
         // `bun.Output.buffered_stdin.reader()` — process-global 4 KiB buffered stdin.

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -56,19 +56,23 @@ impl Drop for CookedStdinGuard {
 /// so Backspace edits the line instead of arriving as an escape sequence.
 /// `StdinModeGuard` is inert when stdin is not a console.
 #[cfg(windows)]
-struct CookedStdinGuard(#[allow(dead_code)] bun_sys::windows::StdinModeGuard);
+struct CookedStdinGuard {
+    _guard: bun_sys::windows::StdinModeGuard,
+}
 
 #[cfg(windows)]
 impl CookedStdinGuard {
     fn new() -> Self {
-        Self(bun_sys::windows::StdinModeGuard::set(
-            bun_sys::windows::UpdateStdioModeFlagsOpts {
-                set: bun_sys::windows::ENABLE_LINE_INPUT
-                    | bun_sys::windows::ENABLE_ECHO_INPUT
-                    | bun_sys::windows::ENABLE_PROCESSED_INPUT,
-                unset: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
-            },
-        ))
+        Self {
+            _guard: bun_sys::windows::StdinModeGuard::set(
+                bun_sys::windows::UpdateStdioModeFlagsOpts {
+                    set: bun_sys::windows::ENABLE_LINE_INPUT
+                        | bun_sys::windows::ENABLE_ECHO_INPUT
+                        | bun_sys::windows::ENABLE_PROCESSED_INPUT,
+                    unset: bun_sys::windows::ENABLE_VIRTUAL_TERMINAL_INPUT,
+                },
+            ),
+        }
     }
 }
 

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -6,23 +6,12 @@ use bun_core::Output;
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::zig_string::ZigString;
 
-/// RAII guard that forces stdin into canonical ("cooked") mode for the
-/// duration of a blocking line read and restores whatever termios were in
-/// effect afterwards.
-///
-/// `node:readline` (and anything else that calls `setRawMode(true)`) clears
-/// `ICANON`, `ECHO`, `ISIG` and `ICRNL`. While in that state, Enter delivers a
-/// bare `\r`, typed characters are not echoed, and Ctrl+C is not translated to
-/// `SIGINT`. `alert`/`confirm`/`prompt` all do a blocking read that waits for
-/// `\n`, so without this guard they hang with no visible feedback.
-///
-/// The guard must be installed before the prompt text is written: the line
-/// discipline applies `ICRNL` at receive time, so a `\r` that arrives in the
-/// window between the prompt becoming visible and `tcsetattr` applying stays a
-/// `\r` in the input queue and the canonical read never sees a line.
-///
-/// On non-TTY stdin `tcgetattr` fails and the guard is inert, so piped input
-/// keeps its existing behaviour.
+/// Force stdin into canonical mode for `alert`/`confirm`/`prompt`'s blocking
+/// line read and restore whatever termios were in effect on drop, so they work
+/// when `node:readline`/`bun repl` has put the tty in raw mode (#5267). Must
+/// be installed *before* the prompt text is written: n_tty applies `ICRNL` at
+/// receive time, so a `\r` that lands before `tcsetattr` stays a `\r` and the
+/// canonical read never sees a line. Inert on non-tty stdin.
 #[cfg(unix)]
 struct CookedStdinGuard {
     saved: Option<libc::termios>,
@@ -56,10 +45,6 @@ impl Drop for CookedStdinGuard {
     }
 }
 
-/// Windows equivalent of the cooked-mode guard: re-enable line input, echo and
-/// Ctrl+C processing on the console and clear `ENABLE_VIRTUAL_TERMINAL_INPUT`
-/// so Backspace edits the line instead of arriving as an escape sequence.
-/// `StdinModeGuard` is inert when stdin is not a console.
 #[cfg(windows)]
 struct CookedStdinGuard {
     _guard: bun_sys::windows::StdinModeGuard,

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1175,6 +1175,32 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       await waitFor(/\n\s*2\b/);
     });
   });
+
+  // https://github.com/oven-sh/bun/issues/27542, https://github.com/oven-sh/bun/issues/5267
+  // The REPL keeps stdin in raw mode while evaluating, so without a cooked-mode
+  // guard inside alert/confirm/prompt pressing Enter delivers a bare CR and the
+  // blocking LF read never returns.
+  test("alert/confirm/prompt return when called from the REPL", async () => {
+    await withTerminalRepl(async ({ send, waitFor }) => {
+      send("prompt('name?')\n");
+      await waitFor("name? ");
+      send("alice\r");
+      await waitFor(/['"]alice['"]/);
+
+      send("confirm('ok?')\n");
+      await waitFor("[y/N]");
+      send("y\r");
+      await waitFor("true");
+
+      send("alert('bye')\n");
+      await waitFor("[Enter]");
+      send("\r");
+      // Back at the prompt and still able to evaluate.
+      await waitFor(/\u276f|> /);
+      send("41 + 1\n");
+      await waitFor("42");
+    });
+  });
 });
 
 // History file written on REPL exit must be owner-only (0600), since it can

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -383,28 +383,28 @@ test.skipIf(isWindows)("alert/confirm/prompt work while readline has stdin in ra
       if (out.includes(waiters[i].marker)) waiters.splice(i, 1)[0].resolve();
     }
   };
-  const exited = Promise.withResolvers();
-  const waitFor = marker =>
-    Promise.race([
-      new Promise(resolve => {
-        waiters.push({ marker, resolve });
-        pump();
-      }),
-      exited.promise.then(() =>
-        Promise.reject(new Error("child exited before " + JSON.stringify(marker) + "; out=" + JSON.stringify(out))),
-      ),
-    ]);
-
   await using terminal = new Bun.Terminal({
     data(_t, chunk) {
       out += decoder.decode(chunk, { stream: true });
       pump();
     },
-    exit() {
-      exited.resolve();
-    },
   });
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", childSrc], env: bunEnv, terminal });
+  // A child that dies early must reject the pending waitFor rather than hang
+  // it. A pre-constructed Bun.Terminal does not fire its exit() callback on
+  // child exit, so key this off the process itself.
+  proc.exited.then(code => {
+    for (const w of waiters.splice(0)) {
+      w.reject(
+        new Error("child exited (" + code + ") before " + JSON.stringify(w.marker) + "; out=" + JSON.stringify(out)),
+      );
+    }
+  });
+  const waitFor = marker =>
+    new Promise((resolve, reject) => {
+      waiters.push({ marker, resolve, reject });
+      pump();
+    });
 
   await waitFor("rl1? ");
   terminal.write("first\r");

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -438,7 +438,6 @@ test.skipIf(isWindows)(
     const flat = Bun.stripANSI(out).replace(/\r/g, "");
     expect(flat).toContain("name? alice");
   },
-  20_000,
 );
 
 test("globalThis.self = 123 works", () => {

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -392,8 +392,11 @@ test.skipIf(isWindows)("alert/confirm/prompt work while readline has stdin in ra
   await using proc = Bun.spawn({ cmd: [bunExe(), "-e", childSrc], env: bunEnv, terminal });
   // A child that dies early must reject the pending waitFor rather than hang
   // it. A pre-constructed Bun.Terminal does not fire its exit() callback on
-  // child exit, so key this off the process itself.
+  // child exit, so key this off the process itself. A clean exit is left to
+  // the data callback (the final PTY read can arrive after the pidfd event in
+  // the same poll batch, so rejecting on code 0 would race the success path).
   proc.exited.then(code => {
+    if (code === 0) return;
     for (const w of waiters.splice(0)) {
       w.reject(
         new Error("child exited (" + code + ") before " + JSON.stringify(w.marker) + "; out=" + JSON.stringify(out)),

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -352,6 +352,91 @@ test("confirm (no) windows newline", async () => {
   expect(await proc.stderr.text()).toBe("No\n");
 });
 
+// https://github.com/oven-sh/bun/issues/5267
+// readline puts the TTY into raw mode (no ICANON, no ECHO, no ICRNL), so
+// Enter delivers a bare CR and typed input is invisible. alert/confirm/prompt
+// must temporarily restore cooked mode so the blocking line read sees LF and
+// the user can see what they typed, then put raw mode back for readline.
+test.skipIf(isWindows)("alert/confirm/prompt work while readline has stdin in raw mode", async () => {
+  const childSrc = `
+    const readline = require("node:readline");
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const ask = q => new Promise(resolve => rl.question(q, resolve));
+    const say = s => process.stdout.write(s + "\\n");
+    (async () => {
+      say("RL1 " + JSON.stringify(await ask("rl1? ")));
+      say("PROMPT " + JSON.stringify(prompt("name?")));
+      say("CONFIRM " + JSON.stringify(confirm("ok?")));
+      alert("bye");
+      say("ALERT done");
+      say("ISRAW " + process.stdin.isRaw);
+      say("RL2 " + JSON.stringify(await ask("rl2? ")));
+      rl.close();
+      process.exit(0);
+    })().catch(e => { say("ERR " + e.message); process.exit(1); });
+  `;
+
+  const decoder = new TextDecoder();
+  let out = "";
+  const waiters = [];
+  const pump = () => {
+    for (let i = waiters.length - 1; i >= 0; i--) {
+      if (out.includes(waiters[i].marker)) waiters.splice(i, 1)[0].resolve();
+    }
+  };
+  const exited = Promise.withResolvers();
+  const waitFor = marker =>
+    Promise.race([
+      new Promise(resolve => {
+        waiters.push({ marker, resolve });
+        pump();
+      }),
+      exited.promise.then(() =>
+        Promise.reject(new Error("child exited before " + JSON.stringify(marker) + "; out=" + JSON.stringify(out))),
+      ),
+    ]);
+
+  await using terminal = new Bun.Terminal({
+    data(_t, chunk) {
+      out += decoder.decode(chunk, { stream: true });
+      pump();
+    },
+    exit() {
+      exited.resolve();
+    },
+  });
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", childSrc], env: bunEnv, terminal });
+
+  await waitFor("rl1? ");
+  terminal.write("first\r");
+  await waitFor('RL1 "first"');
+
+  await waitFor("name?");
+  terminal.write("alice\r");
+  await waitFor('PROMPT "alice"');
+
+  await waitFor("ok?");
+  terminal.write("y\r");
+  await waitFor("CONFIRM true");
+
+  await waitFor("[Enter]");
+  terminal.write("\r");
+  await waitFor("ALERT done");
+
+  // Raw mode must have been restored so readline keeps working.
+  await waitFor("ISRAW true");
+  await waitFor("rl2? ");
+  terminal.write("second\r");
+  await waitFor('RL2 "second"');
+
+  await proc.exited;
+
+  // Echo must have been on during prompt(): the characters we typed should be
+  // visible between the prompt text and the PROMPT result line.
+  const flat = Bun.stripANSI(out).replace(/\r/g, "");
+  expect(flat).toContain("name? alice");
+}, 20_000);
+
 test("globalThis.self = 123 works", () => {
   expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toMatchObject({
     configurable: true,

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -357,10 +357,8 @@ test("confirm (no) windows newline", async () => {
 // Enter delivers a bare CR and typed input is invisible. alert/confirm/prompt
 // must temporarily restore cooked mode so the blocking line read sees LF and
 // the user can see what they typed, then put raw mode back for readline.
-test.skipIf(isWindows)(
-  "alert/confirm/prompt work while readline has stdin in raw mode",
-  async () => {
-    const childSrc = `
+test.skipIf(isWindows)("alert/confirm/prompt work while readline has stdin in raw mode", async () => {
+  const childSrc = `
     const readline = require("node:readline");
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     const ask = q => new Promise(resolve => rl.question(q, resolve));
@@ -371,74 +369,75 @@ test.skipIf(isWindows)(
       say("CONFIRM " + JSON.stringify(confirm("ok?")));
       alert("bye");
       say("ALERT done");
-      say("ISRAW " + process.stdin.isRaw);
       say("RL2 " + JSON.stringify(await ask("rl2? ")));
       rl.close();
       process.exit(0);
     })().catch(e => { say("ERR " + e.message); process.exit(1); });
   `;
 
-    const decoder = new TextDecoder();
-    let out = "";
-    const waiters = [];
-    const pump = () => {
-      for (let i = waiters.length - 1; i >= 0; i--) {
-        if (out.includes(waiters[i].marker)) waiters.splice(i, 1)[0].resolve();
-      }
-    };
-    const exited = Promise.withResolvers();
-    const waitFor = marker =>
-      Promise.race([
-        new Promise(resolve => {
-          waiters.push({ marker, resolve });
-          pump();
-        }),
-        exited.promise.then(() =>
-          Promise.reject(new Error("child exited before " + JSON.stringify(marker) + "; out=" + JSON.stringify(out))),
-        ),
-      ]);
-
-    await using terminal = new Bun.Terminal({
-      data(_t, chunk) {
-        out += decoder.decode(chunk, { stream: true });
+  const decoder = new TextDecoder();
+  let out = "";
+  const waiters = [];
+  const pump = () => {
+    for (let i = waiters.length - 1; i >= 0; i--) {
+      if (out.includes(waiters[i].marker)) waiters.splice(i, 1)[0].resolve();
+    }
+  };
+  const exited = Promise.withResolvers();
+  const waitFor = marker =>
+    Promise.race([
+      new Promise(resolve => {
+        waiters.push({ marker, resolve });
         pump();
-      },
-      exit() {
-        exited.resolve();
-      },
-    });
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", childSrc], env: bunEnv, terminal });
+      }),
+      exited.promise.then(() =>
+        Promise.reject(new Error("child exited before " + JSON.stringify(marker) + "; out=" + JSON.stringify(out))),
+      ),
+    ]);
 
-    await waitFor("rl1? ");
-    terminal.write("first\r");
-    await waitFor('RL1 "first"');
+  await using terminal = new Bun.Terminal({
+    data(_t, chunk) {
+      out += decoder.decode(chunk, { stream: true });
+      pump();
+    },
+    exit() {
+      exited.resolve();
+    },
+  });
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", childSrc], env: bunEnv, terminal });
 
-    await waitFor("name?");
-    terminal.write("alice\r");
-    await waitFor('PROMPT "alice"');
+  await waitFor("rl1? ");
+  terminal.write("first\r");
+  await waitFor('RL1 "first"');
 
-    await waitFor("ok?");
-    terminal.write("y\r");
-    await waitFor("CONFIRM true");
+  await waitFor("name?");
+  terminal.write("alice\r");
+  await waitFor('PROMPT "alice"');
 
-    await waitFor("[Enter]");
-    terminal.write("\r");
-    await waitFor("ALERT done");
+  await waitFor("ok?");
+  terminal.write("y\r");
+  await waitFor("CONFIRM true");
 
-    // Raw mode must have been restored so readline keeps working.
-    await waitFor("ISRAW true");
-    await waitFor("rl2? ");
-    terminal.write("second\r");
-    await waitFor('RL2 "second"');
+  await waitFor("[Enter]");
+  terminal.write("\r");
+  await waitFor("ALERT done");
 
-    await proc.exited;
+  await waitFor("rl2? ");
+  terminal.write("second\r");
+  await waitFor('RL2 "second"');
 
-    // Echo must have been on during prompt(): the characters we typed should be
-    // visible between the prompt text and the PROMPT result line.
-    const flat = Bun.stripANSI(out).replace(/\r/g, "");
-    expect(flat).toContain("name? alice");
-  },
-);
+  await proc.exited;
+
+  const flat = Bun.stripANSI(out).replace(/\r/g, "");
+  // Echo must have been on during prompt(): the characters we typed should be
+  // visible between the prompt text and the PROMPT result line.
+  expect(flat).toContain("name? alice");
+  // Raw mode must have been restored for readline: if the guard left stdin
+  // cooked the kernel would echo "second" in addition to readline's own echo,
+  // so it would appear twice between the second prompt and the result line.
+  const rl2 = flat.slice(flat.indexOf("rl2? "), flat.indexOf('RL2 "second"'));
+  expect(rl2.split("second").length - 1).toBe(1);
+});
 
 test("globalThis.self = 123 works", () => {
   expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toMatchObject({

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -395,16 +395,15 @@ test.skipIf(isWindows)("alert/confirm/prompt work while readline has stdin in ra
   // child exit, so key this off the process itself. A clean exit is left to
   // the data callback (the final PTY read can arrive after the pidfd event in
   // the same poll batch, so rejecting on code 0 would race the success path).
+  let childExitError;
   proc.exited.then(code => {
     if (code === 0) return;
-    for (const w of waiters.splice(0)) {
-      w.reject(
-        new Error("child exited (" + code + ") before " + JSON.stringify(w.marker) + "; out=" + JSON.stringify(out)),
-      );
-    }
+    childExitError = new Error("child exited (" + code + ") before expected output; out=" + JSON.stringify(out));
+    for (const w of waiters.splice(0)) w.reject(childExitError);
   });
   const waitFor = marker =>
     new Promise((resolve, reject) => {
+      if (childExitError) return reject(childExitError);
       waiters.push({ marker, resolve, reject });
       pump();
     });

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -357,8 +357,10 @@ test("confirm (no) windows newline", async () => {
 // Enter delivers a bare CR and typed input is invisible. alert/confirm/prompt
 // must temporarily restore cooked mode so the blocking line read sees LF and
 // the user can see what they typed, then put raw mode back for readline.
-test.skipIf(isWindows)("alert/confirm/prompt work while readline has stdin in raw mode", async () => {
-  const childSrc = `
+test.skipIf(isWindows)(
+  "alert/confirm/prompt work while readline has stdin in raw mode",
+  async () => {
+    const childSrc = `
     const readline = require("node:readline");
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     const ask = q => new Promise(resolve => rl.question(q, resolve));
@@ -376,66 +378,68 @@ test.skipIf(isWindows)("alert/confirm/prompt work while readline has stdin in ra
     })().catch(e => { say("ERR " + e.message); process.exit(1); });
   `;
 
-  const decoder = new TextDecoder();
-  let out = "";
-  const waiters = [];
-  const pump = () => {
-    for (let i = waiters.length - 1; i >= 0; i--) {
-      if (out.includes(waiters[i].marker)) waiters.splice(i, 1)[0].resolve();
-    }
-  };
-  const exited = Promise.withResolvers();
-  const waitFor = marker =>
-    Promise.race([
-      new Promise(resolve => {
-        waiters.push({ marker, resolve });
+    const decoder = new TextDecoder();
+    let out = "";
+    const waiters = [];
+    const pump = () => {
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        if (out.includes(waiters[i].marker)) waiters.splice(i, 1)[0].resolve();
+      }
+    };
+    const exited = Promise.withResolvers();
+    const waitFor = marker =>
+      Promise.race([
+        new Promise(resolve => {
+          waiters.push({ marker, resolve });
+          pump();
+        }),
+        exited.promise.then(() =>
+          Promise.reject(new Error("child exited before " + JSON.stringify(marker) + "; out=" + JSON.stringify(out))),
+        ),
+      ]);
+
+    await using terminal = new Bun.Terminal({
+      data(_t, chunk) {
+        out += decoder.decode(chunk, { stream: true });
         pump();
-      }),
-      exited.promise.then(() =>
-        Promise.reject(new Error("child exited before " + JSON.stringify(marker) + "; out=" + JSON.stringify(out))),
-      ),
-    ]);
+      },
+      exit() {
+        exited.resolve();
+      },
+    });
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", childSrc], env: bunEnv, terminal });
 
-  await using terminal = new Bun.Terminal({
-    data(_t, chunk) {
-      out += decoder.decode(chunk, { stream: true });
-      pump();
-    },
-    exit() {
-      exited.resolve();
-    },
-  });
-  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", childSrc], env: bunEnv, terminal });
+    await waitFor("rl1? ");
+    terminal.write("first\r");
+    await waitFor('RL1 "first"');
 
-  await waitFor("rl1? ");
-  terminal.write("first\r");
-  await waitFor('RL1 "first"');
+    await waitFor("name?");
+    terminal.write("alice\r");
+    await waitFor('PROMPT "alice"');
 
-  await waitFor("name?");
-  terminal.write("alice\r");
-  await waitFor('PROMPT "alice"');
+    await waitFor("ok?");
+    terminal.write("y\r");
+    await waitFor("CONFIRM true");
 
-  await waitFor("ok?");
-  terminal.write("y\r");
-  await waitFor("CONFIRM true");
+    await waitFor("[Enter]");
+    terminal.write("\r");
+    await waitFor("ALERT done");
 
-  await waitFor("[Enter]");
-  terminal.write("\r");
-  await waitFor("ALERT done");
+    // Raw mode must have been restored so readline keeps working.
+    await waitFor("ISRAW true");
+    await waitFor("rl2? ");
+    terminal.write("second\r");
+    await waitFor('RL2 "second"');
 
-  // Raw mode must have been restored so readline keeps working.
-  await waitFor("ISRAW true");
-  await waitFor("rl2? ");
-  terminal.write("second\r");
-  await waitFor('RL2 "second"');
+    await proc.exited;
 
-  await proc.exited;
-
-  // Echo must have been on during prompt(): the characters we typed should be
-  // visible between the prompt text and the PROMPT result line.
-  const flat = Bun.stripANSI(out).replace(/\r/g, "");
-  expect(flat).toContain("name? alice");
-}, 20_000);
+    // Echo must have been on during prompt(): the characters we typed should be
+    // visible between the prompt text and the PROMPT result line.
+    const flat = Bun.stripANSI(out).replace(/\r/g, "");
+    expect(flat).toContain("name? alice");
+  },
+  20_000,
+);
 
 test("globalThis.self = 123 works", () => {
   expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toMatchObject({


### PR DESCRIPTION
## What does this PR do?

Fixes #5267
Fixes #27542

`node:readline`, `bun repl`, and anything else that calls `setRawMode(true)` clear `ICANON`, `ECHO`, `ISIG` and `ICRNL` on the tty. While the tty is in that state:

- Enter delivers a bare `\r` (no CR→LF translation)
- typed characters are not echoed
- Ctrl+C is not translated into `SIGINT`

`alert()`, `confirm()` and `prompt()` all block on a read that waits for `\n`, so calling any of them from inside a readline callback (or from `bun repl`) appeared to hang with no visible input and no way to interrupt.

### Repro

```js
const rl = require("node:readline").createInterface({ input: process.stdin, output: process.stdout });
rl.question("rl? ", () => {
  const name = prompt("Name?"); // hung: nothing echoed, Enter ignored, Ctrl+C ignored
  console.log(name);
  rl.close();
});
```

### Fix

Wrap each dialog in an RAII `CookedStdinGuard` that, on POSIX,

1. saves the current termios with `tcgetattr`,
2. OR's in `ICANON | ECHO | ISIG | IEXTEN` and `ICRNL`,
3. applies with `tcsetattr(TCSANOW)`, and
4. restores the saved termios on drop.

The guard is installed *before* the prompt text is written: the line discipline applies `ICRNL` at receive time, so a `\r` that arrives between the prompt becoming visible and `tcsetattr` running stays a `\r` in the input queue and the canonical read never sees a line.

`tcgetattr` fails on non-tty stdin, so piped input keeps its existing behaviour (the guard is inert). After the read, whatever mode the caller had installed (raw for readline/repl) is put back exactly as it was, so readline keeps working.

On Windows the same guard wraps `StdinModeGuard` with `ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT` set and `ENABLE_VIRTUAL_TERMINAL_INPUT` cleared, applied to all three functions (previously only `prompt()` touched console mode, and only to clear the VT-input flag). The guard is inert when stdin is not a console.

### Why this fix rather than accepting `\r`

An earlier attempt (#27544) taught the readers to accept a bare `\r`. That unblocks Enter but leaves the user typing blind (no echo, no line editing) and unable to Ctrl+C. Restoring cooked mode for the duration of the read fixes all three at once and is exactly what a user expects from a dialog-style prompt.

## How did you verify your code works?

- `test/js/web/web-globals.test.js`: a PTY-backed test drives readline → `prompt()` → `confirm()` → `alert()` → readline again and asserts that each call returns the typed value, the typed characters are echoed, and raw mode is observably restored afterwards (readline's echo of the second answer appears exactly once; if the guard left stdin cooked the kernel would echo it too).
- `test/js/bun/repl/repl.test.ts`: a `withTerminalRepl` test types `prompt(...)`, `confirm(...)` and `alert(...)` at the REPL prompt and asserts each returns and the REPL keeps evaluating.
- Both tests time out on an unpatched build and pass with the fix. The existing piped-stdin `confirm` tests in `web-globals.test.js` continue to pass on Linux and Windows.

The PTY tests are POSIX-only; the Windows REPL terminal suite is already `todoIf(isWindows)`, and the existing piped-stdin tests verify the Windows guard is inert on non-console stdin.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts test/js/web/web-globals.test.js

<!-- robobun:evidence:end -->