### PR TITLE
node:http: make http.Server inherit from net.Server

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1,7 +1,7 @@
 // Hardcoded module "node:_http_server"
 const EventEmitter: typeof import("node:events").EventEmitter = require("node:events");
 const { Stream } = require("node:stream");
-const { Socket: NetSocket } = require("node:net");
+const { Socket: NetSocket, Server: NetServer } = require("node:net");
 const {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   chunkExpression,
@@ -276,7 +276,7 @@ function emitRequestCloseNT(self) {
 }
 
 function emitListeningNextTick(self, hostname, port) {
-  if ((self.listening = !!self[serverSymbol])) {
+  if (self[serverSymbol]) {
     // TODO: remove the arguments
     // Note does not pass any arguments.
     self.emit("listening", null, hostname, port);
@@ -301,7 +301,6 @@ function Server(options, callback): void {
   EventEmitter.$call(this);
   this.on("listening", setupConnectionsTracking);
 
-  this.listening = false;
   this._unref = false;
   this.timeout = 0;
   this.maxRequestsPerSocket = 0;
@@ -406,7 +405,18 @@ function Server(options, callback): void {
   if (callback) this.on("request", callback);
   return this;
 }
-$toClass(Server, "Server", EventEmitter);
+$toClass(Server, "Server", NetServer);
+
+// http.Server is backed by Bun.serve (held in [serverSymbol]); net.Server's
+// `listening` getter keys off `_handle`, which http.Server never populates.
+Object.defineProperty(Server.prototype, "listening", {
+  __proto__: null,
+  get() {
+    return !!this[serverSymbol];
+  },
+  configurable: true,
+  enumerable: true,
+});
 
 Server.prototype[kIncomingMessage] = undefined;
 
@@ -478,7 +488,6 @@ Server.prototype.closeAllConnections = function () {
   }
   this[serverSymbol] = undefined;
   clearInterval(this[kConnectionsCheckingInterval]);
-  this.listening = false;
 
   server.stop(true);
 };
@@ -510,7 +519,6 @@ Server.prototype.close = function (optionalCallback?) {
   }
   this[serverSymbol] = undefined;
   if (typeof optionalCallback === "function") setCloseCallback(this, optionalCallback);
-  this.listening = false;
   server.closeIdleConnections();
   server.stop();
   return this;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -24,7 +24,7 @@ import http, {
 } from "node:http";
 import https, { createServer as createHttpsServer } from "node:https";
 import type { AddressInfo } from "node:net";
-import { connect, createServer as createNetServer } from "node:net";
+import net, { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { PassThrough, Writable } from "node:stream";
@@ -143,6 +143,26 @@ describe("node:http", () => {
       expect(listenResponse instanceof Server).toBe(true);
       expect(listenResponse).toBe(server);
       listenResponse.close();
+    });
+
+    // https://github.com/oven-sh/bun/issues/4360
+    it("http.Server inherits from net.Server", async () => {
+      expect(http.Server.prototype instanceof net.Server).toBe(true);
+      expect(net.Server.prototype instanceof http.Server).toBe(false);
+      expect(Object.getPrototypeOf(http.Server.prototype)).toBe(net.Server.prototype);
+      expect(Object.getPrototypeOf(http.Server)).toBe(net.Server);
+
+      const server = createServer();
+      expect(server instanceof http.Server).toBe(true);
+      expect(server instanceof net.Server).toBe(true);
+      expect(server instanceof EventEmitter).toBe(true);
+
+      expect(server.listening).toBe(false);
+      server.listen(0);
+      await once(server, "listening");
+      expect(server.listening).toBe(true);
+      server.close();
+      expect(server.listening).toBe(false);
     });
 
     it("listen callback should be bound to server", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -159,9 +159,12 @@ describe("node:http", () => {
 
       expect(server.listening).toBe(false);
       server.listen(0);
-      await once(server, "listening");
-      expect(server.listening).toBe(true);
-      server.close();
+      try {
+        await once(server, "listening");
+        expect(server.listening).toBe(true);
+      } finally {
+        server.close();
+      }
       expect(server.listening).toBe(false);
     });
 


### PR DESCRIPTION
Fixes #4360

## Repro

```js
console.log(require('node:http').Server.prototype instanceof require('node:net').Server);
// node: true
// bun:  false
```

## Cause

Node's `http.Server` extends `net.Server` (via `ObjectSetPrototypeOf` in [`lib/_http_server.js`](https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js)). Bun's `src/js/node/_http_server.ts` had `$toClass(Server, "Server", EventEmitter)`, so `http.Server` extended `EventEmitter` directly and `server instanceof net.Server` was `false`.

## Fix

Point `http.Server`'s prototype chain at `net.Server` via `$toClass`, the same way `tls.Server` already does in `src/js/node/tls.ts`.

Bun's `http.Server` is backed by `Bun.serve` (kept in a private symbol slot) rather than a net handle. `net.Server.prototype.listening` keys off `this._handle`, which `http.Server` never populates, so a `listening` getter is added to `http.Server.prototype` that keys off the `Bun.serve` instance instead. The now-redundant direct `this.listening = ...` assignments are dropped so they don't collide with the accessor in the strict-mode builtin. All of `http.Server`'s own prototype methods (`listen`, `close`, `address`, `ref`/`unref`, `getConnections`, `[Symbol.asyncDispose]`) already shadow `net.Server`'s, so the `Bun.serve`-backed implementation is unchanged.

Note: making `https.Server` a distinct class that inherits from `tls.Server` is tracked in #24474 with open PRs #31095 and #32435, and is not included here.

## Verification

```
$ bun bd test test/js/node/http/node-http.test.ts -t "inherits from net.Server"
 1 pass, 0 fail

$ USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http.test.ts -t "inherits from net.Server"
 0 pass, 1 fail   # expect(...).toBe(true), received false
```

`test/js/node/test/parallel/test-http-listening.js` and the rest of `test/js/node/http/node-http.test.ts` still pass.