### PR TITLE
bundler: tolerate unresolved optional peerDependencies (NestJS --compile)

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1515,10 +1515,7 @@ pub mod bv2_impl {
         unsafe { (*p).into_static() }
     }
 
-    /// An unresolvable `require()` / `require.resolve()` / `import()` of a package
-    /// that the importer's own package.json marks optional in `peerDependenciesMeta`
-    /// is downgraded to a runtime throw, like a `require()` inside `try/catch`.
-    /// Static `import` cannot be deferred to runtime, so it is not included.
+    /// Only import kinds whose failure can be deferred to a runtime throw qualify.
     fn is_missing_optional_peer(
         resolver: &mut _resolver::Resolver<'_>,
         source_dir: &[u8],

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1515,6 +1515,36 @@ pub mod bv2_impl {
         unsafe { (*p).into_static() }
     }
 
+    /// Whether an unresolvable `specifier` imported from `source_dir` is a
+    /// package the importer's own package.json declares under
+    /// `peerDependenciesMeta` with `"optional": true`.
+    ///
+    /// Packages reference such peers through helpers like NestJS's
+    /// `optionalRequire(name, () => require(name))`, which catch the
+    /// `MODULE_NOT_FOUND` at runtime but hide the `require` from the parser's
+    /// try/catch detection. When this returns true the caller treats the record
+    /// as if it were inside a try/catch: the bundle succeeds and the call is
+    /// printed as a runtime throw. Static `import` statements are excluded
+    /// because they cannot be deferred to runtime.
+    fn is_missing_optional_peer(
+        resolver: &mut _resolver::Resolver<'_>,
+        source_dir: &[u8],
+        specifier: &[u8],
+        kind: ImportKind,
+    ) -> bool {
+        if !matches!(
+            kind,
+            ImportKind::Require | ImportKind::RequireResolve | ImportKind::Dynamic
+        ) || !is_package_path(specifier)
+        {
+            return false;
+        }
+        resolver
+            .read_dir_info_ignore_error(source_dir)
+            .and_then(|dir| dir.enclosing_package_json)
+            .is_some_and(|pkg| pkg.is_optional_peer_dependency(specifier))
+    }
+
     // Unified with the canonical definitions at the parent module level (this
     // avoids two distinct nominal `BundleV2`/`PendingImport`/`BakeOptions` types
     // that previously caused widespread "expected `BundleV2`, found `BundleV2`"
@@ -2368,6 +2398,15 @@ pub mod bv2_impl {
                             }
                         }
 
+                        let missing_optional_peer = err == _resolver::Error::ModuleNotFound
+                            && is_missing_optional_peer(
+                                // SAFETY: see `transpiler` note above.
+                                &mut unsafe { &mut *transpiler }.resolver,
+                                source_dir,
+                                &import_record.specifier,
+                                import_record.kind,
+                            );
+
                         let handles_import_errors;
                         // reshaped for borrowck — `log_for_resolution_failures` borrows
                         // `&mut self`; the returned log is backed by either a DevServer-owned slot or
@@ -2387,6 +2426,11 @@ pub mod bv2_impl {
                                     [import_record.importer_source_index as usize]
                                     .as_mut_slice()
                                     [import_record.import_record_index as usize];
+                            if missing_optional_peer {
+                                record
+                                    .flags
+                                    .insert(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
+                            }
                             handles_import_errors = record
                                 .flags
                                 .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
@@ -6296,6 +6340,17 @@ pub mod bv2_impl {
 
                             if err == _resolver::Error::ModuleNotFound {
                                 let add_error = bun_ast::Log::add_resolve_error_with_text_dupe;
+
+                                if is_missing_optional_peer(
+                                    &mut transpiler.resolver,
+                                    source_dir,
+                                    import_record.path.text,
+                                    import_record.kind,
+                                ) {
+                                    import_record
+                                        .flags
+                                        .insert(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
+                                }
 
                                 if !import_record
                                     .flags

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1515,17 +1515,10 @@ pub mod bv2_impl {
         unsafe { (*p).into_static() }
     }
 
-    /// Whether an unresolvable `specifier` imported from `source_dir` is a
-    /// package the importer's own package.json declares under
-    /// `peerDependenciesMeta` with `"optional": true`.
-    ///
-    /// Packages reference such peers through helpers like NestJS's
-    /// `optionalRequire(name, () => require(name))`, which catch the
-    /// `MODULE_NOT_FOUND` at runtime but hide the `require` from the parser's
-    /// try/catch detection. When this returns true the caller treats the record
-    /// as if it were inside a try/catch: the bundle succeeds and the call is
-    /// printed as a runtime throw. Static `import` statements are excluded
-    /// because they cannot be deferred to runtime.
+    /// An unresolvable `require()` / `require.resolve()` / `import()` of a package
+    /// that the importer's own package.json marks optional in `peerDependenciesMeta`
+    /// is downgraded to a runtime throw, like a `require()` inside `try/catch`.
+    /// Static `import` cannot be deferred to runtime, so it is not included.
     fn is_missing_optional_peer(
         resolver: &mut _resolver::Resolver<'_>,
         source_dir: &[u8],

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -124,6 +124,10 @@ pub struct PackageJSON {
 
     pub(crate) exports: Option<ExportsMap>,
     pub(crate) imports: Option<ExportsMap>,
+
+    /// Package names listed in `peerDependenciesMeta` with `"optional": true`.
+    /// Read by the bundler via [`PackageJSON::is_optional_peer_dependency`].
+    pub(crate) optional_peer_dependencies: Box<[Box<[u8]>]>,
 }
 
 // hand-rolled `Default` because `#[derive(Default)]` would zero
@@ -151,6 +155,7 @@ impl Default for PackageJSON {
             browser_map: BrowserMap::default(),
             exports: None,
             imports: None,
+            optional_peer_dependencies: Box::default(),
         }
     }
 }
@@ -207,6 +212,19 @@ impl PackageJSON {
         let mut normalized = path.to_vec();
         bun_paths::slashes_to_posix_in_place(&mut normalized[..]);
         Ok(normalized)
+    }
+
+    /// Is the package named by `specifier` (a bare specifier such as `"pkg"`,
+    /// `"pkg/sub"` or `"@scope/pkg/sub"`) listed in this package.json's
+    /// `peerDependenciesMeta` with `"optional": true`?
+    pub fn is_optional_peer_dependency(&self, specifier: &[u8]) -> bool {
+        if self.optional_peer_dependencies.is_empty() {
+            return false;
+        }
+        let name = Package::parse_name(specifier).unwrap_or(specifier);
+        self.optional_peer_dependencies
+            .iter()
+            .any(|peer| strings::eql(peer, name))
     }
 }
 
@@ -512,6 +530,7 @@ impl PackageJSON {
             side_effects: SideEffects::Unspecified,
             exports: None,
             imports: None,
+            optional_peer_dependencies: Box::default(),
         };
         // shadow as `&Source`; the owned value is reconstructed at the bottom
         // (Source isn't `Clone`).
@@ -674,6 +693,27 @@ impl PackageJSON {
         if let Some(imports_prop) = json.as_property(b"imports") {
             if let Some(imports_map) = ExportsMap::parse(json_source, r_log, imports_prop.expr) {
                 package_json.imports = Some(imports_map);
+            }
+        }
+
+        if let Some(meta_prop) = json.as_property(b"peerDependenciesMeta") {
+            if let js_ast::ExprData::EObjectJSON(meta_obj) = &meta_prop.expr.data {
+                let names: Vec<Box<[u8]>> = meta_obj
+                    .get()
+                    .properties()
+                    .iter()
+                    .filter(|prop| {
+                        !prop.key.slice().is_empty()
+                            && prop.value.as_object().is_some_and(|entry| {
+                                matches!(
+                                    entry.get(b"optional"),
+                                    Some(js_ast::E::JsonValue::Boolean(true))
+                                )
+                            })
+                    })
+                    .map(|prop| Box::from(prop.key.slice()))
+                    .collect();
+                package_json.optional_peer_dependencies = names.into_boxed_slice();
             }
         }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -125,8 +125,7 @@ pub struct PackageJSON {
     pub(crate) exports: Option<ExportsMap>,
     pub(crate) imports: Option<ExportsMap>,
 
-    /// Package names listed in `peerDependenciesMeta` with `"optional": true`.
-    /// Read by the bundler via [`PackageJSON::is_optional_peer_dependency`].
+    /// `peerDependenciesMeta` entries with `"optional": true`.
     pub(crate) optional_peer_dependencies: Box<[Box<[u8]>]>,
 }
 
@@ -214,9 +213,7 @@ impl PackageJSON {
         Ok(normalized)
     }
 
-    /// Is the package named by `specifier` (a bare specifier such as `"pkg"`,
-    /// `"pkg/sub"` or `"@scope/pkg/sub"`) listed in this package.json's
-    /// `peerDependenciesMeta` with `"optional": true`?
+    /// `specifier` is a bare specifier; its subpath, if any, is ignored.
     pub fn is_optional_peer_dependency(&self, specifier: &[u8]) -> bool {
         if self.optional_peer_dependencies.is_empty() {
             return false;

--- a/test/bundler/bundler_optional_peer.test.ts
+++ b/test/bundler/bundler_optional_peer.test.ts
@@ -1,0 +1,307 @@
+import { describe } from "bun:test";
+import { itBundled } from "./expectBundled";
+
+// When a package declares an optional peer dependency via `peerDependenciesMeta`
+// and that peer is not installed, `require()` / `import()` / `require.resolve()`
+// calls that reference it from inside the package should not fail the build.
+// Instead the call is replaced with a runtime throw, matching how Node behaves
+// (throws MODULE_NOT_FOUND, which the package's own try/catch helper handles).
+//
+// https://github.com/oven-sh/bun/issues/4803
+
+describe("bundler", () => {
+  // The NestJS pattern: optionalRequire("x", () => require("x")). The require
+  // call is inside an arrow function (not lexically inside try/catch), so the
+  // bundler cannot infer that it is guarded from syntax alone.
+  itBundled("optional-peer/MissingOptionalPeerInArrowCallback", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require("lib");
+        console.log(lib.value);
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependencies": { "missing-peer": "*" },
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        function optionalRequire(name, fn) {
+          try { return fn ? fn() : require(name); } catch { return "fallback"; }
+        }
+        exports.value = optionalRequire("missing-peer", () => require("missing-peer"));
+      `,
+    },
+    target: "bun",
+    run: { stdout: "fallback" },
+  });
+
+  // Bare `require()` outside any try/catch. The build must still succeed and
+  // the throw must happen at runtime only when the call is reached.
+  itBundled("optional-peer/MissingOptionalPeerBareRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require("lib");
+        console.log("used=" + lib.used);
+        let threw = false;
+        try { lib.load(); } catch (e) { threw = e instanceof Error; }
+        console.log("threw=" + threw);
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        exports.used = false;
+        exports.load = function () {
+          exports.used = true;
+          return require("missing-peer");
+        };
+      `,
+    },
+    target: "bun",
+    run: { stdout: "used=false\nthrew=true" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain("Cannot require module ");
+    },
+  });
+
+  itBundled("optional-peer/MissingOptionalPeerScopedSubpath", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require("lib");
+        let threw = false;
+        try { lib.load(); } catch (e) { threw = e instanceof Error; }
+        console.log("threw=" + threw);
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependencies": { "@scope/missing": "*" },
+          "peerDependenciesMeta": { "@scope/missing": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        exports.load = function () {
+          return require("@scope/missing/deep/path");
+        };
+      `,
+    },
+    target: "bun",
+    run: { stdout: "threw=true" },
+  });
+
+  itBundled("optional-peer/MissingOptionalPeerRequireResolve", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require("lib");
+        let threw = false;
+        try { lib.where(); } catch { threw = true; }
+        console.log("threw=" + threw);
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        exports.where = function () {
+          return require.resolve("missing-peer");
+        };
+      `,
+    },
+    target: "bun",
+    run: { stdout: "threw=true" },
+  });
+
+  // Dynamic `import()` of a missing optional peer is left as an external call
+  // in the output; it rejects at runtime rather than being lowered to a throw
+  // shim (same output as `--external missing-peer`).
+  itBundled("optional-peer/MissingOptionalPeerDynamicImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from "lib";
+        const result = await lib().then(() => "ok", () => "rejected");
+        console.log(result);
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        module.exports = function () {
+          return import("missing-peer");
+        };
+      `,
+    },
+    target: "bun",
+    run: { stdout: "rejected" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain(`import("missing-peer")`);
+    },
+  });
+
+  // The same onResolve-plugin fallback path (plugin returns undefined, bundler
+  // falls through to the resolver) should behave identically.
+  itBundled("optional-peer/MissingOptionalPeerThroughPluginFallback", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require("lib");
+        let threw = false;
+        try { lib.load(); } catch (e) { threw = e instanceof Error; }
+        console.log("threw=" + threw);
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        exports.load = function () {
+          return require("missing-peer");
+        };
+      `,
+    },
+    target: "bun",
+    plugins(builder) {
+      builder.onResolve({ filter: /^missing-peer$/ }, () => undefined);
+    },
+    run: { stdout: "threw=true" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain("Cannot require module ");
+    },
+  });
+
+  // `peerDependenciesMeta` in the app's own package.json applies to its own
+  // files the same way it would inside node_modules.
+  itBundled("optional-peer/AppRootOptionalPeer", {
+    files: {
+      "/entry.js": /* js */ `
+        exports.load = function () { return require("missing-peer"); };
+        let threw = false;
+        try { exports.load(); } catch (e) { threw = e instanceof Error; }
+        console.log("threw=" + threw);
+      `,
+      "/package.json": /* json */ `
+        {
+          "name": "app",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+    },
+    target: "bun",
+    run: { stdout: "threw=true" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain("Cannot require module ");
+    },
+  });
+
+  // A peer that is installed resolves normally; being listed as optional does
+  // not shadow the real module.
+  itBundled("optional-peer/InstalledOptionalPeerResolves", {
+    files: {
+      "/entry.js": /* js */ `
+        const lib = require("lib");
+        console.log(lib.value);
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependenciesMeta": { "present-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        exports.value = require("present-peer");
+      `,
+      "/node_modules/present-peer/package.json": /* json */ `
+        { "name": "present-peer" }
+      `,
+      "/node_modules/present-peer/index.js": /* js */ `
+        module.exports = "present";
+      `,
+    },
+    target: "bun",
+    run: { stdout: "present" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toContain("Cannot require module ");
+    },
+  });
+
+  // Optional-peer handling only looks at the nearest enclosing package.json.
+  // A require from the app (not from inside the package) still errors.
+  itBundled("optional-peer/OnlyAppliesInsideOwningPackage", {
+    files: {
+      "/entry.js": /* js */ `
+        require("missing-peer");
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/entry.js": [`Could not resolve: "missing-peer". Maybe you need to "bun install"?`],
+    },
+  });
+
+  // `peerDependenciesMeta` without `"optional": true` (or with a non-true value)
+  // does not suppress the error.
+  itBundled("optional-peer/NonOptionalMetaStillErrors", {
+    files: {
+      "/entry.js": /* js */ `
+        require("lib");
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "peerDependenciesMeta": {
+            "missing-peer": { "optional": false },
+            "other-peer": {}
+          }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        require("missing-peer");
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/node_modules/lib/index.js": [`Could not resolve: "missing-peer". Maybe you need to "bun install"?`],
+    },
+  });
+
+  // Static ESM `import` statements cannot defer their error to runtime (the
+  // binding is hoisted), so they keep erroring at build time.
+  itBundled("optional-peer/ESMImportStillErrors", {
+    files: {
+      "/entry.js": /* js */ `
+        import "lib";
+      `,
+      "/node_modules/lib/package.json": /* json */ `
+        {
+          "name": "lib",
+          "type": "module",
+          "peerDependenciesMeta": { "missing-peer": { "optional": true } }
+        }
+      `,
+      "/node_modules/lib/index.js": /* js */ `
+        import peer from "missing-peer";
+        export default peer;
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/node_modules/lib/index.js": [`Could not resolve: "missing-peer". Maybe you need to "bun install"?`],
+    },
+  });
+});


### PR DESCRIPTION
Fixes #4803. Fixes #11836. Fixes #14611.

### Problem

- `bun build --compile src/main.ts` on a hello-world NestJS v10 app fails with eight errors of the form `Could not resolve: "@nestjs/microservices". Maybe you need to "bun install"?` (also `@nestjs/websockets/socket-module`, `class-validator`, `class-transformer`). Every one of these is declared by the importing package under `peerDependenciesMeta` with `"optional": true`.
- NestJS references those peers as `optionalRequire(name, () => require(name))` (`@nestjs/core/helpers/optional-require.js`). The `require` sits inside an arrow function, not lexically inside a `try`, so the parser's try/catch detection (`try_body_count` in `src/js_parser`) never sets `HANDLES_IMPORT_ERRORS`, and the two resolve-failure branches in `src/bundler/bundle_v2.rs` log a hard error.
- The resolver never read `peerDependenciesMeta`, so nothing could tell the bundler the package itself expects the module to be absent.

### Fix

- `src/resolver/package_json.rs`: parse `peerDependenciesMeta`, keep the names with `"optional": true`, and expose `PackageJSON::is_optional_peer_dependency(specifier)` (strips the subpath with the existing `Package::parse_name`).
- `src/bundler/bundle_v2.rs`: one helper, `is_missing_optional_peer`, called from both `ModuleNotFound` branches (`run_resolver`, the onResolve-plugin fallback, and `resolve_import_records`, the main path). For a `require` / `require.resolve` / `import()` of a bare specifier whose importing directory's enclosing package.json lists it as an optional peer, it sets `HANDLES_IMPORT_ERRORS` on the record before the error check, so no error is logged.
- Why this is correct: those branches already mark the record `is_disabled` and `WAS_UNRESOLVED`, so adding `HANDLES_IMPORT_ERRORS` makes the printer emit exactly what it emits for `try { require(x) } catch {}` today: `(()=>{throw new Error("Cannot require module "+"x")})()`. At runtime the package's own catch handles it, which is what happens under `bun run` and Node. Static `import` statements are excluded (they cannot be deferred) and still fail the build.
- Why the check is in the bundler and not the resolver: the resolver is shared with the runtime module loader. Returning a synthetic result from it would change `bun run` behavior (it would skip the dir-cache bust and retry that makes "require, install, require again" work). The resolver half of this PR is therefore only the parse plus a query method; `Resolver::resolve` is untouched. Verified the runtime retry scenario prints `MODULE_NOT_FOUND peer-installed` with this build, same as main.
- Verification:
  - `test/bundler/bundler_optional_peer.test.ts` (11 cases): arrow-callback require (the NestJS shape), bare `require`, `require.resolve`, `import()`, scoped subpath, the plugin fallback branch, app-root package.json; plus guards that an installed optional peer still resolves, a require from outside the owning package still errors, `optional: false` / missing `optional` still errors, and a static `import` still errors. 7 fail on the current release, all 11 pass with this change.
  - Hello-world NestJS `bun build --compile`: 8 `Could not resolve` errors on the release binary; bundles 754 modules and the binary starts the app with this build.
  - `bundler_edgecase` (including the #35659 try/catch and disabled-path cases), `bundler_allow_unresolved`, `bundler_cjs`, `esbuild/packagejson` pass.

### Background

- `peerDependenciesMeta`: package.json field where a package marks some of its `peerDependencies` as `{ "optional": true }`, meaning the package works without them installed and is written to handle the `require` throwing.
- `HANDLES_IMPORT_ERRORS`: import-record flag the parser sets on a `require` / `require.resolve` / `import()` lexically inside a `try` (or, since #35659, a `catch`) body; the bundler then downgrades an unresolvable specifier from a build error to a runtime throw.
- `WAS_UNRESOLVED` (#35659): flag set at the resolve-failure sites so the printer can tell "resolution failed" apart from "intentionally disabled" (`"browser": { "x": false }`); the throw shim is only printed when both it and `HANDLES_IMPORT_ERRORS` are set. This PR sets the second flag at a site where the first is already set.
- `enclosing_package_json`: the nearest named package.json above a directory, cached on the resolver's `DirInfo` for that directory. For `node_modules/@nestjs/common/pipes/validation.pipe.js` it is `@nestjs/common/package.json`.

<details>
<summary>Earlier revision</summary>

The first version of this PR did the check inside `Resolver::check_package_path`, returning a disabled path plus a `ResultFlags::IS_MISSING_OPTIONAL_PEER` bit that the bundler translated into `HANDLES_IMPORT_ERRORS`. Review pointed out that (a) after #35659 landed, the bundler branch that consumed the flag never set `WAS_UNRESOLVED`, so the throw shim would no longer be printed, and (b) the resolver is shared with the runtime, so the synthetic result changed `bun run` semantics and needed a `custom_dir_paths` guard. Moving the check into the bundler's existing failure branches removed the resolver arm, the result flag, the guard, and the runtime regression test that only existed to pin the guard.

</details>
