### PR TITLE
install: link a workspace for a dist-tag the registry cannot satisfy

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2004,6 +2004,30 @@ fn root_workspace_package_id(
     None
 }
 
+pub(crate) fn has_linkable_workspace(this: &PackageManager, name_hash: PackageNameHash) -> bool {
+    this.options.link_workspace_packages && this.lockfile.workspace_paths.contains_key(&name_hash)
+}
+
+/// Fallback for a dist-tag the registry cannot satisfy.
+fn resolve_dist_tag_from_workspace(
+    this: &mut PackageManager,
+    name_hash: PackageNameHash,
+    dependency_id: DependencyID,
+    success_fn: SuccessFn,
+) -> Option<ResolvedPackageResult> {
+    if !has_linkable_workspace(this, name_hash) {
+        return None;
+    }
+    let workspace_package_id = root_workspace_package_id(&this.lockfile, name_hash)?;
+    // make sure verifyResolutions sees this resolution as a valid package id
+    success_fn(this, dependency_id, workspace_package_id);
+    Some(ResolvedPackageResult {
+        package: *this.lockfile.packages.get(workspace_package_id as usize),
+        is_first_time: false,
+        task: None,
+    })
+}
+
 pub(crate) enum ResolvedPackageTask {
     /// Pending network task to schedule
     NetworkTask(*mut NetworkTask),
@@ -2429,6 +2453,15 @@ fn get_or_put_resolved_package(
                 ManifestLoad::LoadFromMemoryFallbackToDisk,
                 needs_ext,
             ) else {
+                if version.tag == dependency::version::Tag::DistTag
+                    && this.network_task_has_failed(Task::Id::for_manifest(name_str))
+                {
+                    if let Some(result) =
+                        resolve_dist_tag_from_workspace(this, name_hash, dependency_id, success_fn)
+                    {
+                        return Ok(Some(result));
+                    }
+                }
                 return Ok(None); // manifest might still be downloading. This feels unreliable.
             };
             let manifest: &Npm::PackageManifest = manifest;
@@ -2527,31 +2560,14 @@ fn get_or_put_resolved_package(
             let find_result = match find_result_opt {
                 Some(r) => r,
                 None => {
-                    'resolve_workspace_from_dist_tag: {
-                        // choose a workspace for a dist_tag only if a version was not found
-                        if version.tag == dependency::version::Tag::DistTag {
-                            let workspace_path = if this.lockfile.workspace_paths.count() > 0 {
-                                this.lockfile.workspace_paths.get(&name_hash)
-                            } else {
-                                None
-                            };
-                            if workspace_path.is_some() {
-                                let Some(workspace_package_id) =
-                                    root_workspace_package_id(&this.lockfile, name_hash)
-                                else {
-                                    break 'resolve_workspace_from_dist_tag;
-                                };
-                                // make sure verifyResolutions sees this resolution as a valid package id
-                                success_fn(this, dependency_id, workspace_package_id);
-                                return Ok(Some(ResolvedPackageResult {
-                                    package: *this
-                                        .lockfile
-                                        .packages
-                                        .get(workspace_package_id as usize),
-                                    is_first_time: false,
-                                    task: None,
-                                }));
-                            }
+                    if version.tag == dependency::version::Tag::DistTag {
+                        if let Some(result) = resolve_dist_tag_from_workspace(
+                            this,
+                            name_hash,
+                            dependency_id,
+                            success_fn,
+                        ) {
+                            return Ok(Some(result));
                         }
                     }
 

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -478,6 +478,35 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         continue;
                     }
 
+                    if response.status_code == 404
+                        && !C::MANIFESTS_ONLY
+                        && enqueue::has_linkable_workspace(
+                            manager,
+                            bun_semver::string::Builder::string_hash(name),
+                        )
+                    {
+                        manager.mark_network_task_failed(task.task_id);
+                        let dependency_list = manager
+                            .task_queue
+                            .get_mut(&task.task_id)
+                            .map(core::mem::take)
+                            .unwrap_or_default();
+                        process_dependency_list_for_ctx::<C>(
+                            manager,
+                            dependency_list,
+                            extract_ctx,
+                            install_peer,
+                        )?;
+                        // A dependent the workspace cannot satisfy re-queues itself here.
+                        if manager
+                            .task_queue
+                            .get(&task.task_id)
+                            .is_none_or(|list| list.is_empty())
+                        {
+                            continue;
+                        }
+                    }
+
                     if manager.is_network_task_required(task.task_id) {
                         bun_ast::add_error_pretty!(
                             manager.log_mut(),

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -278,6 +278,109 @@ test("dependency on same name as workspace and dist-tag", async () => {
   ]);
 });
 
+describe("dist-tag on a workspace name the registry does not have", () => {
+  // `pkg-not-on-registry` is not published to the test registry, so its manifest
+  // request 404s. The workspace member of that name is linked instead (#4830).
+  // A name the registry does have keeps resolving from the registry, see
+  // "dependency on same name as workspace and dist-tag" above.
+  async function setup(packageDir: string, root: Record<string, unknown>, consumerDeps: Record<string, string>) {
+    await Promise.all([
+      write(join(packageDir, "package.json"), JSON.stringify({ name: "root", ...root })),
+      write(
+        join(packageDir, "packages", "lib", "package.json"),
+        JSON.stringify({ name: "pkg-not-on-registry", version: "1.0.0" }),
+      ),
+      write(
+        join(packageDir, "packages", "consumer", "package.json"),
+        JSON.stringify({ name: "consumer", version: "1.0.0", dependencies: consumerDeps }),
+      ),
+    ]);
+  }
+
+  test.concurrent.each(["latest", ""])('"%s" links the workspace', async version => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await setup(packageDir, { workspaces: ["packages/*"] }, { "pkg-not-on-registry": version });
+
+    const { out } = await runBunInstall(env, packageDir);
+    expect(out).toContain("2 packages installed");
+    expect(await file(join(packageDir, "node_modules", "pkg-not-on-registry", "package.json")).json()).toEqual({
+      name: "pkg-not-on-registry",
+      version: "1.0.0",
+    });
+    expect(await exists(join(packageDir, "packages", "consumer", "node_modules"))).toBeFalse();
+    expect(parseLockfile(packageDir)).toMatchNodeModulesAt(packageDir);
+
+    // the resolution round-trips through the saved lockfile
+    await runBunInstall(env, packageDir, { frozenLockfile: true });
+  });
+
+  test.concurrent("aliased dist-tag links the workspace named by the alias target", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await setup(packageDir, { workspaces: ["packages/*"] }, { "lib-alias": "npm:pkg-not-on-registry@latest" });
+
+    const { out } = await runBunInstall(env, packageDir);
+    expect(out).toContain("2 packages installed");
+    expect(await file(join(packageDir, "node_modules", "lib-alias", "package.json")).json()).toEqual({
+      name: "pkg-not-on-registry",
+      version: "1.0.0",
+    });
+  });
+
+  test.concurrent("catalog entry links the workspace", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await setup(
+      packageDir,
+      { workspaces: { packages: ["packages/*"], catalog: { "pkg-not-on-registry": "latest" } } },
+      { "pkg-not-on-registry": "catalog:" },
+    );
+
+    const { out } = await runBunInstall(env, packageDir);
+    expect(out).toContain("2 packages installed");
+    expect(await file(join(packageDir, "node_modules", "pkg-not-on-registry", "package.json")).json()).toEqual({
+      name: "pkg-not-on-registry",
+      version: "1.0.0",
+    });
+  });
+
+  test.concurrent("a range the workspace does not satisfy still reports the 404", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await setup(packageDir, { workspaces: ["packages/*"] }, { "pkg-not-on-registry": "latest" });
+    await write(
+      join(packageDir, "packages", "other", "package.json"),
+      JSON.stringify({ name: "other", version: "1.0.0", dependencies: { "pkg-not-on-registry": "^2.0.0" } }),
+    );
+
+    const { err } = await runBunInstall(env, packageDir, {
+      allowErrors: true,
+      expectedExitCode: 1,
+      savesLockfile: false,
+    });
+    expect(err).toMatch(/GET .*\/pkg-not-on-registry - 404/);
+  });
+
+  test.concurrent("linkWorkspacePackages = false reports the 404", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await setup(packageDir, { workspaces: ["packages/*"] }, { "pkg-not-on-registry": "latest" });
+    await write(
+      join(packageDir, "bunfig.toml"),
+      Bun.TOML.stringify({ install: { linkWorkspacePackages: false, registry: verdaccio.registryUrl() } }),
+    );
+
+    const { err } = await runBunInstall(env, packageDir, {
+      allowErrors: true,
+      expectedExitCode: 1,
+      savesLockfile: false,
+    });
+    expect(err).toMatch(/GET .*\/pkg-not-on-registry - 404/);
+    expect(await exists(join(packageDir, "node_modules", "pkg-not-on-registry"))).toBeFalse();
+  });
+});
+
 test.concurrent("successfully installs workspace when path already exists in node_modules", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;
@@ -2108,6 +2211,48 @@ describe("LinkWorkspacePackages", () => {
 
     // Verify that the dependency linked to the bar package is the workspace version (using the workspace: prefix), not the npm version
     expect(lockfile.packages.find(p => p.id === barDependency?.package_id).resolution.tag).toEqual("workspace");
+  });
+
+  test.concurrent("linkWorkspacePackages = false does not fall back to the workspace for an unknown dist-tag", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    const bunfigPath = await setupWorkspace(packageDir);
+    await Promise.all([
+      write(
+        bunfigPath,
+        Bun.TOML.stringify({
+          install: {
+            linkWorkspacePackages: false,
+            registry: verdaccio.registryUrl(),
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "bar", "package.json"),
+        JSON.stringify({
+          name: "bar",
+          version: "1.0.0",
+          dependencies: {
+            // `no-deps` is on the registry but has no such tag. With linking
+            // enabled this would resolve to the workspace (see the
+            // "kjwoehcojrgjoj" case in "dependency on workspace without version").
+            "no-deps": "kjwoehcojrgjoj",
+          },
+        }),
+      ),
+    ]);
+
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), `-c=${bunfigPath}`, "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await stderr.text();
+    expect(err).toContain('Package "no-deps" with tag "kjwoehcojrgjoj" not found');
+    expect(await exited).toBe(1);
   });
 });
 

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -2213,47 +2213,50 @@ describe("LinkWorkspacePackages", () => {
     expect(lockfile.packages.find(p => p.id === barDependency?.package_id).resolution.tag).toEqual("workspace");
   });
 
-  test.concurrent("linkWorkspacePackages = false does not fall back to the workspace for an unknown dist-tag", async () => {
-    using ctx = await setupTest();
-    const { packageDir, env } = ctx;
-    const bunfigPath = await setupWorkspace(packageDir);
-    await Promise.all([
-      write(
-        bunfigPath,
-        Bun.TOML.stringify({
-          install: {
-            linkWorkspacePackages: false,
-            registry: verdaccio.registryUrl(),
-          },
-        }),
-      ),
-      write(
-        join(packageDir, "packages", "bar", "package.json"),
-        JSON.stringify({
-          name: "bar",
-          version: "1.0.0",
-          dependencies: {
-            // `no-deps` is on the registry but has no such tag. With linking
-            // enabled this would resolve to the workspace (see the
-            // "kjwoehcojrgjoj" case in "dependency on workspace without version").
-            "no-deps": "kjwoehcojrgjoj",
-          },
-        }),
-      ),
-    ]);
+  test.concurrent(
+    "linkWorkspacePackages = false does not fall back to the workspace for an unknown dist-tag",
+    async () => {
+      using ctx = await setupTest();
+      const { packageDir, env } = ctx;
+      const bunfigPath = await setupWorkspace(packageDir);
+      await Promise.all([
+        write(
+          bunfigPath,
+          Bun.TOML.stringify({
+            install: {
+              linkWorkspacePackages: false,
+              registry: verdaccio.registryUrl(),
+            },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "bar", "package.json"),
+          JSON.stringify({
+            name: "bar",
+            version: "1.0.0",
+            dependencies: {
+              // `no-deps` is on the registry but has no such tag. With linking
+              // enabled this would resolve to the workspace (see the
+              // "kjwoehcojrgjoj" case in "dependency on workspace without version").
+              "no-deps": "kjwoehcojrgjoj",
+            },
+          }),
+        ),
+      ]);
 
-    const { stderr, exited } = spawn({
-      cmd: [bunExe(), `-c=${bunfigPath}`, "install"],
-      cwd: packageDir,
-      stdout: "ignore",
-      stderr: "pipe",
-      env,
-    });
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), `-c=${bunfigPath}`, "install"],
+        cwd: packageDir,
+        stdout: "ignore",
+        stderr: "pipe",
+        env,
+      });
 
-    const err = await stderr.text();
-    expect(err).toContain('Package "no-deps" with tag "kjwoehcojrgjoj" not found');
-    expect(await exited).toBe(1);
-  });
+      const err = await stderr.text();
+      expect(err).toContain('Package "no-deps" with tag "kjwoehcojrgjoj" not found');
+      expect(await exited).toBe(1);
+    },
+  );
 });
 
 test("matching workspace devDependency and npm peerDependency", async () => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1880,6 +1880,7 @@ export class VerdaccioRegistry {
   configPath: string;
   packagesPath: string;
   users: Record<string, string> = {};
+  stopping = false;
 
   constructor(opts?: { configPath?: string; packagesPath?: string; verbose?: boolean }) {
     this.port = randomPort();
@@ -1915,6 +1916,7 @@ export class VerdaccioRegistry {
     });
 
     this.process.on("exit", (code, signal) => {
+      if (this.stopping && code === null && signal === "SIGTERM") return;
       if (code !== 0) {
         console.error(`Verdaccio exited with code ${code} and signal ${signal}`);
       } else {
@@ -1937,7 +1939,9 @@ export class VerdaccioRegistry {
 
   stop() {
     rmSync(join(dirname(this.configPath), "htpasswd"), { force: true });
-    this.process?.kill(0);
+    this.stopping = true;
+    // kill(0) is a liveness probe and leaves the server running until the test process exits.
+    this.process?.kill();
   }
 
   /**


### PR DESCRIPTION
### Problem
- In a workspace, a member depending on a sibling by name with `"latest"` (or `""`) fails to install when that name is not published: `bun install` requests the manifest, the registry returns 404, and the install errors with `GET .../<name> - 404` even though a workspace of that name exists (#4830).
- `get_or_put_resolved_package` (`PackageManagerEnqueue.rs`) already falls back to the workspace when the manifest exists but lacks the tag (#10959). When there is no manifest at all, the 404 handler in `runTasks.rs` logs the error and the waiting dependents are never resolved, so the fallback is never reached.
- The same-name-and-published case (`"no-deps": "latest"` where `no-deps` is both a workspace and a registry package) is unchanged: it resolves from the registry, as #10959 decided. That keeps the existing `dependency on same name as workspace and dist-tag` test and its snapshot as they are, and keeps `bun add`, `bun update --latest`, committed lockfiles and `--frozen-lockfile` behaving as on main.

### Fix
- `runTasks.rs`: on a manifest 404 for a name that has a linkable workspace (`linkWorkspacePackages` on, name in `workspace_paths`), mark the manifest task failed and re-run the dependents queued on it instead of logging. If any dependent could not be satisfied by the workspace it re-queues itself on the same task id, and the 404 is then reported exactly as before.
- `PackageManagerEnqueue.rs`: when the manifest lookup misses and the manifest task has failed, a `DistTag` dependency takes the existing tag-missing fallback (extracted into `resolve_dist_tag_from_workspace`, built on `root_workspace_package_id` from #37669). Both fallback sites are now gated on `linkWorkspacePackages`; before, the manifest-present arm ignored the option.
- Only `DistTag` is affected. Ranges still fail: a range on an unpublished name is a user error on main and stays one. Whatever reaches `get_or_put_resolved_package` as a `DistTag` follows the rule, so a catalog entry or an `npm:<workspace>@latest` alias whose target is an unpublished workspace also links (both tested).
- Why this is the right rule: it only changes an install that failed before, so no existing resolution moves; the published same-name question from #10959 is left alone.

### Verification
`test/cli/install/bun-workspaces.test.ts`, new `describe("dist-tag on a workspace name the registry does not have")`:
- `"latest"` / `""` link the workspace and the result survives `--frozen-lockfile`
- `npm:<workspace>@latest` alias links it
- `catalog:` entry whose value is `latest` links it
- a second member with `^2.0.0` on the same name still gets the 404
- `linkWorkspacePackages = false` still gets the 404

and in `describe("LinkWorkspacePackages")`:
- `linkWorkspacePackages = false` with a tag the manifest lacks now errors instead of linking (the manifest-present arm previously ignored the option).

Without the `src/` change the five linking/option tests fail and the two 404 tests pass; with it the file passes (71/71). `bun-install-registry`, `bun-add`, `bun-lock`, `catalogs` and `isolated-install` pass locally.

The first commit is a separate harness fix: `VerdaccioRegistry.stop()` used `kill(0)`, a liveness probe, so every registry-using file left its server running until process exit. It now sends SIGTERM; the exit listener stays and only suppresses that expected exit.

### Background
- A dist-tag dependency (`"latest"`, `"beta"`, `""`) is resolved by fetching the package manifest and reading `dist-tags`, unlike a semver range which is matched against the workspace's own version first in `parse_dependency`.
- Dependents waiting on a manifest are queued under `Task::Id::for_manifest(name)` in `task_queue`; when the manifest arrives they are re-run through `process_dependency_list`. This change re-runs them on a 404 as well.
- `network_dedupe_map` tracks whether a network task failed; `get_or_put_resolved_package` uses that to tell "manifest missing because it 404ed" from "manifest still downloading".

Fixes #4830
