### PR TITLE
bundler: tree-shake the automatic JSX runtime import when all JSX is dead

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2844,6 +2844,32 @@ impl<'a> LinkerContext<'a> {
                 }
             }
 
+            // The automatic JSX runtime import is synthesized by the parser; it
+            // exists only so lowered JSX can reference `jsx`/`jsxDEV`/etc. If no
+            // live part references those symbols the import must not be kept
+            // "for its side effects": the user never wrote it, and keeping it
+            // would bundle (or externally import) React for JSX that was
+            // entirely dead code. Liveness of the JSX import source, when it is
+            // actually needed, is established via part.dependencies (step 6
+            // wires the wrapper_ref/__toESM dependency onto this part), so
+            // skipping the side-effect scan here is safe.
+            if part.tag == bun_ast::PartTag::JsxImport {
+                if !can_be_removed_if_unused
+                    || (!part.force_tree_shaking
+                        && !self.options.tree_shaking
+                        && ctx.entry_point_kinds[source_index as usize].is_entry_point())
+                {
+                    let part_index = u32::try_from(part_index).expect("int cast");
+                    if !ctx.parts_live[source_index as usize].is_set(part_index as usize) {
+                        ctx.worklist.push(TreeShakeWork::Part {
+                            part_index,
+                            source_index,
+                        });
+                    }
+                }
+                continue;
+            }
+
             // Also include any statement-level imports
             for &import_index in part.import_record_indices.iter() {
                 let record = &ctx.import_records[source_index as usize][import_index as usize];

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1760,6 +1760,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         additional_stmt: Option<Stmt>,
         prefix: &'static [u8],
         is_internal: bool,
+        tag: bun_ast::PartTag,
     ) -> Result<(), crate::Error>
     where
         I: AsRef<[<Sym as GenerateImportSymbols>::Key]>,
@@ -1883,11 +1884,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // This import is placed in a part before the main code, however
         // the bundler ends up re-ordering this to be after... The order
         // does not matter as ESM imports are always hoisted.
+        //
+        // The JSX auto-import only exists to provide `jsx`/`jsxs`/`jsxDEV`/
+        // `Fragment`/`createElement` to lowered JSX. When every JSX call is
+        // tree-shaken, nothing references this part's declared symbols and the
+        // import itself should disappear: the user never wrote it, so keeping
+        // it "for side effects" pulls in React for code the user never asked
+        // to run. See mark_file_live_step for the matching JsxImport skip.
+        let is_jsx = tag == bun_ast::PartTag::JsxImport;
         parts.push(js_ast::Part {
             stmts: stmts.into(),
             declared_symbols,
             import_record_indices: js_ast::PartImportRecordIndices::init_one(import_record_i),
-            tag: bun_ast::PartTag::Runtime,
+            tag,
+            can_be_removed_if_unused: is_jsx,
+            force_tree_shaking: is_jsx,
             ..Default::default()
         });
         Ok(())

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1984,6 +1984,7 @@ impl<'a> Parser<'a> {
                     None,
                     b"import_",
                     true,
+                    js_ast::PartTag::Runtime,
                 )
                 .expect("unreachable");
             }
@@ -2016,6 +2017,7 @@ impl<'a> Parser<'a> {
                     None,
                     b"",
                     false,
+                    js_ast::PartTag::JsxImport,
                 )
                 .expect("unreachable");
             }
@@ -2030,6 +2032,7 @@ impl<'a> Parser<'a> {
                     None,
                     b"",
                     false,
+                    js_ast::PartTag::JsxImport,
                 )
                 .expect("unreachable");
             }

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -949,6 +949,24 @@ describe("bundler", () => {
       },
     });
 
+    // With jsx.sideEffects: true the lowered calls carry no pure annotation,
+    // so even otherwise-unused JSX keeps the call and therefore the import.
+    itBundledDevAndProd("jsx/AutoImportKeptWhenJsxSideEffectsTrue", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          const unused = <div>dead</div>;
+          export default 'hi';
+        `,
+      },
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic", sideEffects: true },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).toMatch(/from\s*"react\/jsx-(dev-)?runtime"/);
+        expect(file).toMatch(/jsx(DEV)?\(/);
+      },
+    });
+
     itBundledDevAndProd("jsx/AutoImportKeptWhenJsxUsedExternal", {
       files: {
         "/index.tsx": /* tsx */ `

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -923,4 +923,162 @@ describe("bundler", () => {
       },
     });
   });
+
+  // https://github.com/oven-sh/bun/issues/6858
+  // The automatic JSX runtime import is synthesized by the bundler. When every
+  // JSX expression in a file is tree-shaken, nothing references the generated
+  // `jsx`/`jsxDEV`/`Fragment` bindings and the import itself should disappear
+  // instead of being kept "for side effects" and dragging React into the bundle.
+  describe("autoImportTreeShaking", () => {
+    itBundledDevAndProd("jsx/AutoImportDroppedWhenJsxUnusedExternal", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          const unused = <div>dead</div>;
+          export default 'hi';
+        `,
+      },
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic" },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).not.toContain("react/jsx-runtime");
+        expect(file).not.toContain("react/jsx-dev-runtime");
+        expect(file).not.toContain("jsxDEV");
+        expect(file).not.toContain("jsx(");
+        expect(file).not.toContain("unused");
+      },
+    });
+
+    itBundledDevAndProd("jsx/AutoImportKeptWhenJsxUsedExternal", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          const unused = <div>dead</div>;
+          export const live = <span>live</span>;
+        `,
+      },
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic" },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).toMatch(/from\s*"react\/jsx-(dev-)?runtime"/);
+        expect(file).toContain("live");
+        expect(file).not.toContain("unused");
+      },
+    });
+
+    itBundledDevAndProd("jsx/AutoImportDroppedFragUnusedExternal", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          const unused = <><a/><b/></>;
+          export default 1;
+        `,
+      },
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic" },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).not.toContain("react");
+        expect(file).not.toContain("Fragment");
+        expect(file).not.toContain("unused");
+      },
+    });
+
+    // CommonJS JSX source with no "sideEffects" field: previously the
+    // auto-import forced the whole module into the bundle even though the JSX
+    // was dead code.
+    itBundled("jsx/AutoImportDroppedWhenJsxUnusedBundledCjs", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          const unused = <div>dead</div>;
+          console.log('only-this');
+        `,
+        "/node_modules/react/package.json": JSON.stringify({
+          name: "react",
+          exports: {
+            "./jsx-runtime": "./jsx-runtime.js",
+            "./jsx-dev-runtime": "./jsx-dev-runtime.js",
+          },
+        }),
+        "/node_modules/react/jsx-runtime.js": /* js */ `
+          console.log('JSX_RUNTIME_SIDE_EFFECT');
+          exports.jsx = function (type, props) { return { type, props }; };
+          exports.jsxs = exports.jsx;
+          exports.Fragment = 'F';
+        `,
+        "/node_modules/react/jsx-dev-runtime.js": /* js */ `
+          console.log('JSX_RUNTIME_SIDE_EFFECT');
+          exports.jsxDEV = function (type, props) { return { type, props }; };
+          exports.Fragment = 'F';
+        `,
+      },
+      target: "bun",
+      jsx: { runtime: "automatic" },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).not.toContain("JSX_RUNTIME_SIDE_EFFECT");
+        expect(file).not.toContain("jsx-runtime");
+        expect(file).not.toContain("unused");
+      },
+      run: { stdout: "only-this" },
+    });
+
+    // Same CJS source, but the JSX is actually used: the JSX source must still
+    // be bundled and its top-level code must still run.
+    itBundled("jsx/AutoImportKeptWhenJsxUsedBundledCjs", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          const el = <div>live</div>;
+          console.log(JSON.stringify(el));
+        `,
+        "/node_modules/react/package.json": JSON.stringify({
+          name: "react",
+          exports: {
+            "./jsx-runtime": "./jsx-runtime.js",
+            "./jsx-dev-runtime": "./jsx-dev-runtime.js",
+          },
+        }),
+        "/node_modules/react/jsx-runtime.js": /* js */ `
+          console.log('JSX_RUNTIME_SIDE_EFFECT');
+          exports.jsx = function (type, props) { return { type: type, props: props }; };
+          exports.jsxs = exports.jsx;
+          exports.Fragment = 'F';
+        `,
+        "/node_modules/react/jsx-dev-runtime.js": /* js */ `
+          console.log('JSX_RUNTIME_SIDE_EFFECT');
+          exports.jsxDEV = function (type, props) { return { type: type, props: props }; };
+          exports.Fragment = 'F';
+        `,
+      },
+      target: "bun",
+      jsx: { runtime: "automatic" },
+      run: {
+        stdout: `JSX_RUNTIME_SIDE_EFFECT\n{"type":"div","props":{"children":"live"}}`,
+      },
+    });
+
+    // Two entry modules: one where JSX survives, one where it is all dead.
+    // The JSX source must be bundled (for the live entry) without leaking an
+    // extra import into the dead entry's chunk.
+    itBundled("jsx/AutoImportMixedEntries", {
+      files: {
+        "/live.tsx": /* tsx */ `
+          export const el = <div>live</div>;
+        `,
+        "/dead.tsx": /* tsx */ `
+          const unused = <div>dead</div>;
+          export default 'dead-entry';
+        `,
+      },
+      entryPoints: ["/live.tsx", "/dead.tsx"],
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic" },
+      onAfterBundle(api) {
+        const live = api.readFile("out/live.js");
+        const dead = api.readFile("out/dead.js");
+        expect(live).toMatch(/from\s*"react\/jsx-(dev-)?runtime"/);
+        expect(dead).not.toContain("react");
+        expect(dead).not.toContain("unused");
+      },
+    });
+  });
 });

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1056,6 +1056,78 @@ describe("bundler", () => {
       },
     });
 
+    // key-after-spread falls back to `createElement` from the bare JSX package,
+    // which is a second synthesized JsxImport part. When the only reference is
+    // inside a dead function, that import must go too.
+    itBundled("jsx/AutoImportDroppedCreateElementDeadFunction", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          function dead() {
+            const p = {};
+            return <div {...p} key="k" />;
+          }
+          export default 'hi';
+        `,
+      },
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic" },
+      bundleWarnings: {
+        "/index.tsx": ['"key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.'],
+      },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).not.toContain("createElement");
+        expect(file).not.toContain('"react"');
+        expect(file).not.toContain("react/jsx");
+        expect(file).not.toContain("dead");
+      },
+    });
+
+    // JSX that only appears under a compile-time-false branch is dropped by
+    // define-DCE before tree-shaking runs. The synthesized import must follow.
+    itBundled("jsx/AutoImportDroppedDefineDeadBranch", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          if (process.env.DEBUG) {
+            console.log(<div/>);
+          }
+          console.log('only-this');
+        `,
+      },
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic" },
+      define: { "process.env.DEBUG": "false" },
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).not.toContain("react");
+        expect(file).not.toContain("jsxDEV");
+      },
+    });
+
+    // React Compiler can hoist a callback that contains the file's only JSX
+    // into a separate top-level function. The original component's part still
+    // carries the jsx symbol use that was recorded while visiting the
+    // unhoisted body, so the JSX import must remain live.
+    itBundled("jsx/AutoImportKeptReactCompilerOutlined", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          import { useMemo } from "react";
+          export function Live({items}) {
+            const mapped = useMemo(() => items.map(x => <li key={x}>{x}</li>), [items]);
+            return mapped;
+          }
+        `,
+      },
+      external: ["react", "react/*"],
+      jsx: { runtime: "automatic" },
+      reactCompiler: true,
+      onAfterBundle(api) {
+        const file = api.readFile("out.js");
+        expect(file).toMatch(/from\s*"react\/jsx-(dev-)?runtime"/);
+        expect(file).toMatch(/jsx(DEV)?\(/);
+      },
+    });
+
     // Two entry modules: one where JSX survives, one where it is all dead.
     // The JSX source must be bundled (for the live entry) without leaking an
     // extra import into the dead entry's chunk.

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -815,7 +815,7 @@ function expectBundled(
               jsx.factory && ["--jsx-factory", jsx.factory],
               jsx.fragment && ["--jsx-fragment", jsx.fragment],
               jsx.importSource && ["--jsx-import-source", jsx.importSource],
-              jsx.side_effects && ["--jsx-side-effects"],
+              jsx.sideEffects && ["--jsx-side-effects"],
               dotenv && ["--env", dotenv],
               // metafile && `--manifest=${metafile}`,
               sourceMap && `--sourcemap=${sourceMap}`,


### PR DESCRIPTION
### What does this PR do?

Fixes #6858.

When the automatic JSX runtime is active, the parser injects an import like

```js
import { jsxDEV } from "react/jsx-dev-runtime";
```

so the lowered `jsxDEV("div", ...)` calls have a binding. If every JSX expression in a file is dead code (for example `const unused = <div/>;` where `unused` is never referenced), the bundler tree-shakes the `jsxDEV(...)` calls but previously still kept the import, because the synthesized Part was emitted with `can_be_removed_if_unused: false` and the linker's side-effect-import scan forced it live. With `--external react` the output carried a stray `import { jsxDEV } from "react/jsx-dev-runtime"`; with React bundled it pulled the entire `react` package (1k+ lines) into a bundle that contains no JSX at runtime.

#### Repro
```tsx
// test.tsx
const myElement = <div>hello</div>;
export default 'hi';
```
```sh
bun build test.tsx --external react
```

Before:
```js
import { jsxDEV } from "react/jsx-dev-runtime";
var test_default = "hi";
export { test_default as default };
```
After:
```js
var test_default = "hi";
export { test_default as default };
```

#### Why is removing the import correct?

The import is not user code; the bundler synthesized it to service JSX calls. If no JSX survives tree-shaking, the file is semantically identical to one with no JSX at all, which would not have received the import in the first place. The user has no expectation of the JSX runtime module's side effects from code they never wrote.

esbuild currently keeps the import in the same scenario, but only because its synthesized part takes the same default. There is no correctness reason to keep it; Babel/SWC/TypeScript all only emit the import when JSX is present in their output, and a bundler that knows all JSX has been eliminated can do the same.

#### How

- Tag the synthesized JSX import Part as `PartTag::JsxImport` (the tag already existed, unused) with `can_be_removed_if_unused: true` and `force_tree_shaking: true`.
- In `mark_file_live_step`, skip the side-effect-import scan for `JsxImport` parts so an external or side-effect-carrying JSX source does not force the part live.

When JSX *is* used, the part is still pulled in via `part.dependencies`: the using part depends on the import part through `top_level_symbols_to_parts`, and step 6 of `scanImportsAndExports` wires the import part to the JSX source's wrapper via `generate_symbol_import_and_use`, so bundled CJS JSX sources (the real `react` case) are still included and run their top-level code.

### How did you verify your code works?

New tests in `test/bundler/bundler_jsx.test.ts` cover, in both dev and prod:

- external JSX source, all JSX dead: import dropped
- external JSX source, JSX live: import kept
- external JSX source, fragment-only dead JSX: import dropped
- bundled CJS JSX source with no `sideEffects` field, all JSX dead: source not bundled (previously the whole module was bundled); `run` check confirms only the entry's own code executes
- bundled CJS JSX source, JSX live: source still bundled, its top-level side effect still runs, `jsxDEV` still produces the expected element
- two entry points, one with live JSX and one with dead JSX: only the live entry's chunk carries the import

The three "kept when used" cases guard against regressing the existing behavior; the rest fail before this change and pass after.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts
bun test v1.4.0 (3a48234f7)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1123.89ms]
(pass) bundler > jsx/AutomaticProd [728.01ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [1023.39ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [642.75ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [707.43ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [712.50ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [366.16ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [321.87ms]
(pass) bundler > jsx/ClassicDev [703.39ms]
(pass) bundler > jsx/ClassicProd [671.10ms]
(pass) bundler > jsx/ClassicPragmaDev [655.65ms]
(pass) bundler > jsx/ClassicPragmaProd [656.52ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [695.85ms]
(pass) bundler > jsx/FactoryProd [770.54ms]
(pass) bundler > jsx/FactoryImportDe
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (3a48234f7)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [25.54ms]
(pass) bundler > jsx/AutomaticProd [13.59ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [13.42ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [14.40ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [13.69ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [13.74ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [6.73ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [5.75ms]
(pass) bundler > jsx/ClassicDev [13.36ms]
(pass) bundler > jsx/ClassicProd [14.08ms]
(pass) bundler > jsx/ClassicPragmaDev [12.78ms]
(pass) bundler > jsx/ClassicPragmaProd [13.04ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [15.78ms]
(pass) bundler > jsx/FactoryProd [14.36ms]
(pass) bundler > jsx/FactoryImportDev [13.63ms]
(pass) bundler > jsx/FactoryImportProd [15.17ms]
(pass) bundler > jsx/FactoryImportExplicitReactDefaultDev [7.78ms]
(pass) bundler > jsx/FactoryImportExplicitReact
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts
bun test v1.4.0 (3a48234f7)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1395.61ms]
(pass) bundler > jsx/AutomaticProd [851.05ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [839.66ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [1195.33ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [1262.29ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [1282.84ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [377.60ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [321.89ms]
(pass) bundler > jsx/ClassicDev [870.04ms]
(pass) bundler > jsx/ClassicProd [746.73ms]
(pass) bundler > jsx/ClassicPragmaDev [681.71ms]
(pass) bundler > jsx/ClassicPragmaProd [658.91ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [673.08ms]
(pass) bundler > jsx/FactoryProd [1395.38ms]
(pass) bundler > jsx/FactoryImpor
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1452ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/135] gen cpp.rs (cppbind)
[1/135] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs       |  26 ++++
 src/js_parser/p.rs                 |  13 +-
 src/js_parser/parse/parse_entry.rs |   3 +
 test/bundler/bundler_jsx.test.ts   | 248 +++++++++++++++++++++++++++++++++++++
 test/bundler/expectBundled.ts      |   2 +-
 5 files changed, 290 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/bundler/LinkerContext.rs            1      0      0
src/js_parser/p.rs                      0      0      0
src/js_parser/parse/parse_entry.rs      0      0      0
test/bundler/bundler_jsx.test.ts        3      7      0
test/bundler/expectBundled.ts           1      7      0
```

</details>

**root cause** · written by the author bot

The bug was that the parser always synthesizes the automatic JSX runtime import (for example `import { jsx } from "react/jsx-runtime"`), and the bundler treated it like a user-written import, so the import and its target module survived bundling even when every JSX expression in the file was eliminated as dead code. The fix tags these synthesized import parts as `JsxImport` in `generate_import_stmt`, marking them removable if unused and eligible for forced tree shaking, and teaches `mark_file_live_step` in the linker to skip the side-effect-import liveness scan for such parts so their liven…

<!-- robobun:evidence:end -->