### PR TITLE
bundler: hoist "use client"/"use server" directives to the top of output

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -50,10 +50,6 @@ pub struct Ast<'a> {
     // `hashbang`/`directives` are slices into source text. `StoreStr` records
     // them under the same lifetime-erased contract as `StoreRef`.
     pub hashbang: StoreStr,
-    /// Top-level directive prologue (`"use strict"`, `"use client"`, ...),
-    /// in source order, deduplicated. These are stripped from `parts` by the
-    /// parser so auto-injected imports can be prepended without displacing the
-    /// prologue; the printer / linker re-emits them ahead of everything else.
     pub directives: StoreSlice<StoreStr>,
     pub parts: PartList<'a>,
     // This list may be mutated later, so we should store the capacity

--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -11,7 +11,7 @@ use bun_collections::{ArrayHashMap, StringArrayHashMap, StringHashMap};
 use crate::runtime;
 use crate::{
     CharFreq, ExportsKind, Expr, InlinedEnumValue, LocRef, NamedExport, NamedImport, Part, Range,
-    Ref, Scope, SlotCounts, StoreStr, Target,
+    Ref, Scope, SlotCounts, StoreSlice, StoreStr, Target,
 };
 
 use crate::part::List as PartList;
@@ -47,10 +47,14 @@ pub struct Ast<'a> {
     /// they can be manipulated efficiently without a full AST traversal
     pub import_records: ImportRecordList<'a>,
 
-    // `hashbang`/`directive` are slices into source text. `StoreStr` records
+    // `hashbang`/`directives` are slices into source text. `StoreStr` records
     // them under the same lifetime-erased contract as `StoreRef`.
     pub hashbang: StoreStr,
-    pub directive: Option<StoreStr>,
+    /// Top-level directive prologue (`"use strict"`, `"use client"`, ...),
+    /// in source order, deduplicated. These are stripped from `parts` by the
+    /// parser so auto-injected imports can be prepended without displacing the
+    /// prologue; the printer / linker re-emits them ahead of everything else.
+    pub directives: StoreSlice<StoreStr>,
     pub parts: PartList<'a>,
     // This list may be mutated later, so we should store the capacity
     pub symbols: SymbolList<'a>,
@@ -109,7 +113,7 @@ impl<'a> Ast<'a> {
             top_level_await_keyword: Range::NONE,
             import_records: ImportRecordList::new_in(arena),
             hashbang: StoreStr::EMPTY,
-            directive: None,
+            directives: StoreSlice::EMPTY,
             parts: PartList::new_in(arena),
             symbols: SymbolList::new_in(arena),
             module_scope: Scope::default(),

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -533,6 +533,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
 
         Ok(crate::BundledAst {
             parts,
+            directives: bun_ast::StoreSlice::EMPTY,
             module_scope: module_scope_value,
             symbols: bun_alloc::vec_from_iter_in(core::mem::take(&mut self.symbols), self.bump),
             exports_ref: Ref::NONE,

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -31,7 +31,7 @@ use bun_ast::import_record;
 use bun_core::strings;
 
 use bun_ast::ast_result::Ast;
-use bun_ast::{CharFreq, ExportsKind, Ref, Scope, SlotCounts, StoreStr, TlaCheck};
+use bun_ast::{CharFreq, ExportsKind, Ref, Scope, SlotCounts, StoreSlice, StoreStr, TlaCheck};
 use bun_ast::{part, symbol};
 
 pub(crate) type CommonJSNamedExports = bun_ast::ast_result::CommonJSNamedExports;
@@ -58,6 +58,7 @@ pub struct BundledAst<'arena> {
     // Ast.hashbang is `StoreStr`; mirror it here so init/to_ast can
     // round-trip.
     pub(crate) hashbang: StoreStr,
+    pub(crate) directives: StoreSlice<StoreStr>,
     pub(crate) parts: part::List<'arena>,
     // See `CssAstRef` doc for the arena drop-order invariant that backs the
     // safe `Deref`.
@@ -105,6 +106,7 @@ bun_collections::multi_array_columns! {
         exports_kind: ExportsKind,
         import_records: import_record::List<'arena>,
         hashbang: StoreStr,
+        directives: StoreSlice<StoreStr>,
         parts: part::List<'arena>,
         css: CssCol,
         url_for_css: &'arena [u8],
@@ -160,6 +162,7 @@ impl<'arena> BundledAst<'arena> {
             exports_kind: ExportsKind::None,
             import_records: import_record::List::new_in(arena),
             hashbang: StoreStr::EMPTY,
+            directives: StoreSlice::EMPTY,
             parts: part::List::new_in(arena),
             css: None,
             url_for_css: b"",
@@ -197,6 +200,7 @@ impl<'arena> BundledAst<'arena> {
             import_records: self.import_records,
 
             hashbang: self.hashbang,
+            directives: self.directives,
             parts: self.parts,
             // This list may be mutated later, so we should store the capacity
             symbols: self.symbols,
@@ -250,14 +254,6 @@ impl<'arena> BundledAst<'arena> {
             commonjs_module_exports_assigned_deoptimized: self
                 .flags
                 .contains(Flags::COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED),
-            directive: if self
-                .flags
-                .contains(Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
-            {
-                Some(StoreStr::new(b"use strict"))
-            } else {
-                None
-            },
             has_import_meta: self.flags.contains(Flags::HAS_IMPORT_META),
             ..Ast::empty_in(arena)
         }
@@ -278,7 +274,10 @@ impl<'arena> BundledAst<'arena> {
         );
         flags.set(
             Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE,
-            ast.directive.is_some_and(|d| d == b"use strict"),
+            ast.directives
+                .slice()
+                .iter()
+                .any(|d| d.slice() == b"use strict"),
         );
         flags.set(Flags::HAS_IMPORT_META, ast.has_import_meta);
 
@@ -291,6 +290,7 @@ impl<'arena> BundledAst<'arena> {
             import_records: ast.import_records,
 
             hashbang: ast.hashbang,
+            directives: ast.directives,
             parts: ast.parts,
             css: None,
             url_for_css: b"",

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -145,9 +145,8 @@ bitflags::bitflags! {
         const FORCE_CJS_TO_ESM = 1 << 4;
         const HAS_LAZY_EXPORT = 1 << 5;
         const COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED = 1 << 6;
-        const HAS_EXPLICIT_USE_STRICT_DIRECTIVE = 1 << 7;
-        const HAS_IMPORT_META = 1 << 8;
-        // _padding: u7 fills the rest
+        const HAS_IMPORT_META = 1 << 7;
+        // _padding: u8 fills the rest
     }
 }
 
@@ -271,13 +270,6 @@ impl<'arena> BundledAst<'arena> {
         flags.set(
             Flags::COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED,
             ast.commonjs_module_exports_assigned_deoptimized,
-        );
-        flags.set(
-            Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE,
-            ast.directives
-                .slice()
-                .iter()
-                .any(|d| d.slice() == b"use strict"),
         );
         flags.set(Flags::HAS_IMPORT_META, ast.has_import_meta);
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -88,11 +88,22 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 }
             }
 
-            let main_stmts_len =
-                stmts.inside_wrapper_prefix.stmts.len() + stmts.inside_wrapper_suffix.len();
+            // The HMR closure body is the module's top level: its directive
+            // prologue goes first (post_process_js_chunk skips directives for
+            // this format).
+            let directives = ast.directives.slice();
+            let main_stmts_len = directives.len()
+                + stmts.inside_wrapper_prefix.stmts.len()
+                + stmts.inside_wrapper_suffix.len();
             let all_stmts_len = main_stmts_len + stmts.outside_wrapper_prefix.len() + 1;
 
             stmts.all_stmts.reserve(all_stmts_len);
+            for directive in directives {
+                stmts.all_stmts.push(Stmt::alloc(
+                    S::Directive { value: *directive },
+                    bun_ast::Loc::EMPTY,
+                ));
+            }
             stmts
                 .all_stmts
                 .extend_from_slice(stmts.inside_wrapper_prefix.stmts.as_slice());

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -88,9 +88,6 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 }
             }
 
-            // The HMR closure body is the module's top level: its directive
-            // prologue goes first (post_process_js_chunk skips directives for
-            // this format).
             let directives = ast.directives.slice();
             let main_stmts_len = directives.len()
                 + stmts.inside_wrapper_prefix.stmts.len()
@@ -281,8 +278,6 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     bun_ast::Loc::EMPTY,
                 ))
                 .expect("unreachable");
-            // Keep later `append_sync_dependency` inserts (init_*() calls)
-            // after the prologue, or the directive stops being one.
             stmts.inside_wrapper_prefix.sync_dependencies_end += 1;
         }
     }

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -270,6 +270,9 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                     bun_ast::Loc::EMPTY,
                 ))
                 .expect("unreachable");
+            // Keep later `append_sync_dependency` inserts (init_*() calls)
+            // after the prologue, or the directive stops being one.
+            stmts.inside_wrapper_prefix.sync_dependencies_end += 1;
         }
     }
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -257,21 +257,20 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     // The top-level directive must come first (the non-wrapped case is handled
     // by the chunk generation code, although only for the entry point)
     if flags.wrap != WrapKind::None
-        && ast
-            .flags
-            .contains(AstFlags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE)
-        && !chunk.is_entry_point()
-        && !output_format.is_always_strict_mode()
+        && !c.graph.files.items_entry_point_kind()[source_index].is_entry_point()
     {
-        stmts
-            .inside_wrapper_prefix
-            .append_non_dependency(Stmt::alloc(
-                S::Directive {
-                    value: bun_ast::StoreStr::new(b"use strict"),
-                },
-                bun_ast::Loc::EMPTY,
-            ))
-            .expect("unreachable");
+        for directive in ast.directives.slice() {
+            if directive.slice() == b"use strict" && output_format.is_always_strict_mode() {
+                continue;
+            }
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(Stmt::alloc(
+                    S::Directive { value: *directive },
+                    bun_ast::Loc::EMPTY,
+                ))
+                .expect("unreachable");
+        }
     }
 
     // `convert_stmts_for_chunk` takes `&mut c` inside the loop body, so capture
@@ -280,7 +279,6 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     let parts_live: bun_ptr::BackRef<bun_collections::AutoBitSet> =
         bun_ptr::BackRef::new(&c.graph.parts_live[source_index]);
 
-    // TODO: handle directive
     if namespace_export_part_index >= part_range.part_index_begin
         && namespace_export_part_index < part_range.part_index_end
         && parts_live.is_set(namespace_export_part_index as usize)

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -411,8 +411,7 @@ pub(crate) fn post_process_js_chunk(
     }
 
     // Add the top-level directive if present (but omit "use strict" in ES
-    // modules because all ES modules are automatically in strict mode).
-    // InternalBakeDev re-inserts directives inside each module closure instead.
+    // modules because all ES modules are automatically in strict mode)
     if chunk.is_entry_point() && output_format != options::OutputFormat::InternalBakeDev {
         let directives = c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
         let newline: &[u8] = if c.options.minify_whitespace {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -412,12 +412,25 @@ pub(crate) fn post_process_js_chunk(
 
     // Add the top-level directive if present (but omit "use strict" in ES
     // modules because all ES modules are automatically in strict mode)
-    if chunk.is_entry_point() && !output_format.is_always_strict_mode() {
-        let flags = c.graph.ast.items_flags()[chunk.entry_point.source_index() as usize];
-
-        if flags.contains(crate::bundled_ast::Flags::HAS_EXPLICIT_USE_STRICT_DIRECTIVE) {
-            j.push_static(b"\"use strict\";\n");
-            line_offset.advance(b"\"use strict\";\n");
+    if chunk.is_entry_point() {
+        let directives =
+            c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
+        let newline: &[u8] = if c.options.minify_whitespace {
+            b""
+        } else {
+            b"\n"
+        };
+        for directive in directives.slice() {
+            if directive.slice() == b"use strict" && output_format.is_always_strict_mode() {
+                continue;
+            }
+            let mut quoted = MutableString::default();
+            bun_core::quote_for_json(directive.slice(), &mut quoted, false)?;
+            quoted.append_slice(b";")?;
+            quoted.append_slice(newline)?;
+            let quoted = quoted.take_slice().into_boxed_slice();
+            line_offset.advance(&quoted);
+            j.push_owned(quoted);
             newline_before_comment = true;
         }
     }

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -411,8 +411,9 @@ pub(crate) fn post_process_js_chunk(
     }
 
     // Add the top-level directive if present (but omit "use strict" in ES
-    // modules because all ES modules are automatically in strict mode)
-    if chunk.is_entry_point() {
+    // modules because all ES modules are automatically in strict mode).
+    // InternalBakeDev re-inserts directives inside each module closure instead.
+    if chunk.is_entry_point() && output_format != options::OutputFormat::InternalBakeDev {
         let directives = c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
         let newline: &[u8] = if c.options.minify_whitespace {
             b""

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -424,7 +424,8 @@ pub(crate) fn post_process_js_chunk(
                 continue;
             }
             let mut quoted = MutableString::default();
-            bun_core::quote_for_json(directive.slice(), &mut quoted, false)?;
+            // Bun-target output must be ASCII-only, matching the chunk printer.
+            bun_core::quote_for_json(directive.slice(), &mut quoted, is_bun)?;
             quoted.append_slice(b";")?;
             quoted.append_slice(newline)?;
             let quoted = quoted.take_slice().into_boxed_slice();

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -413,8 +413,7 @@ pub(crate) fn post_process_js_chunk(
     // Add the top-level directive if present (but omit "use strict" in ES
     // modules because all ES modules are automatically in strict mode)
     if chunk.is_entry_point() {
-        let directives =
-            c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
+        let directives = c.graph.ast.items_directives()[chunk.entry_point.source_index() as usize];
         let newline: &[u8] = if c.options.minify_whitespace {
             b""
         } else {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8136,10 +8136,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             {
                 let mut remaining_stmts = &mut stmts_to_copy[..];
                 for directive in prologue {
-                    remaining_stmts[0] = self.s(
-                        S::Directive { value: *directive },
-                        self.module_scope_directive_loc,
-                    );
+                    // Only "use strict" has a recorded source location.
+                    let loc = if directive.slice() == b"use strict" {
+                        self.module_scope_directive_loc
+                    } else {
+                        bun_ast::Loc::EMPTY
+                    };
+                    remaining_stmts[0] = self.s(S::Directive { value: *directive }, loc);
                     remaining_stmts = &mut remaining_stmts[1..];
                 }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8123,9 +8123,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 total_stmts_count += part.stmts.len();
             }
 
-            // The wrapper function body is the module's top level: re-insert
-            // the directive prologue there instead of printing it outside the
-            // wrapper (the program completion value must stay the wrapper).
             let prologue = directives.slice();
             directives = bun_ast::StoreSlice::EMPTY;
 
@@ -8136,7 +8133,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             {
                 let mut remaining_stmts = &mut stmts_to_copy[..];
                 for directive in prologue {
-                    // Only "use strict" has a recorded source location.
                     let loc = if directive.slice() == b"use strict" {
                         self.module_scope_directive_loc
                     } else {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7800,7 +7800,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         exports_kind: js_ast::ExportsKind,
         wrap_mode: WrapMode,
         hashbang: &'a [u8],
-        directives: bun_ast::StoreSlice<bun_ast::StoreStr>,
+        mut directives: bun_ast::StoreSlice<bun_ast::StoreStr>,
     ) -> Result<Box<js_ast::Ast<'a>>, crate::Error> {
         use crate::lower::lower_esm_exports_hmr::ConvertESMExportsForHmr;
         use crate::scan::scan_imports::ImportScanner;
@@ -8123,23 +8123,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 total_stmts_count += part.stmts.len();
             }
 
-            let preserve_strict_mode = self.module_scope().strict_mode
-                == js_ast::StrictModeKind::ExplicitStrictMode
-                && !(parts.len() > 0
-                    && parts[0].stmts.len() > 0
-                    && matches!(parts[0].stmts[0].data, js_ast::StmtData::SDirective(_)));
+            // The wrapper function body is the module's top level: re-insert
+            // the directive prologue there instead of printing it outside the
+            // wrapper (the program completion value must stay the wrapper).
+            let prologue = directives.slice();
+            directives = bun_ast::StoreSlice::EMPTY;
 
-            total_stmts_count += usize::from(preserve_strict_mode);
+            total_stmts_count += prologue.len();
 
             // Stmt is not Default; fill with `Stmt::empty()`.
             let stmts_to_copy = arena.alloc_slice_fill_with(total_stmts_count, |_| Stmt::empty());
             {
                 let mut remaining_stmts = &mut stmts_to_copy[..];
-                if preserve_strict_mode {
+                for directive in prologue {
                     remaining_stmts[0] = self.s(
-                        S::Directive {
-                            value: b"use strict".into(),
-                        },
+                        S::Directive { value: *directive },
                         self.module_scope_directive_loc,
                     );
                     remaining_stmts = &mut remaining_stmts[1..];

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7800,6 +7800,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         exports_kind: js_ast::ExportsKind,
         wrap_mode: WrapMode,
         hashbang: &'a [u8],
+        directives: bun_ast::StoreSlice<bun_ast::StoreStr>,
     ) -> Result<Box<js_ast::Ast<'a>>, crate::Error> {
         use crate::lower::lower_esm_exports_hmr::ConvertESMExportsForHmr;
         use crate::scan::scan_imports::ImportScanner;
@@ -8282,7 +8283,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let char_freq: Option<js_ast::CharFreq> = self.compute_character_frequency();
 
-        let module_scope_strict = self.module_scope().strict_mode;
         // Scope is not `Clone` (Vec/HashMap members), so move it out and leave
         // a default in `*self.module_scope`. `to_ast` is terminal — the parser
         // does not touch `module_scope` afterwards.
@@ -8340,11 +8340,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             export_keyword: self.esm_export_keyword,
             top_level_symbols_to_parts,
             char_freq,
-            directive: if module_scope_strict == js_ast::StrictModeKind::ExplicitStrictMode {
-                Some(bun_ast::StoreStr::new(b"use strict"))
-            } else {
-                None
-            },
+            directives,
             nested_scope_slot_counts,
 
             require_ref,

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1486,11 +1486,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                     StrictModeKind::ExplicitStrictMode;
                                 if p.current_scope == p.module_scope {
                                     p.module_scope_directive_loc = stmt.loc;
-                                    // At module scope, keep "use strict" as an
-                                    // SDirective like other directives so the
-                                    // prologue list preserves source order; it
-                                    // is stripped into `Ast.directives` before
-                                    // the visit pass.
                                     stmt = Stmt::alloc(
                                         S::Directive {
                                             value: bun_ast::StoreStr::new(b"use strict"),

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1481,12 +1481,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             is_directive_prologue = true;
 
                             if str_.eql_comptime(b"use strict") {
-                                skip = true;
                                 // Track "use strict" directives
                                 p.current_scope_mut().strict_mode =
                                     StrictModeKind::ExplicitStrictMode;
                                 if p.current_scope == p.module_scope {
                                     p.module_scope_directive_loc = stmt.loc;
+                                    // At module scope, keep "use strict" as an
+                                    // SDirective like other directives so the
+                                    // prologue list preserves source order; it
+                                    // is stripped into `Ast.directives` before
+                                    // the visit pass.
+                                    stmt = Stmt::alloc(
+                                        S::Directive {
+                                            value: bun_ast::StoreStr::new(b"use strict"),
+                                        },
+                                        stmt.loc,
+                                    );
+                                } else {
+                                    skip = true;
                                 }
                             } else if str_.eql_comptime(b"use asm") && !p.options.repl_mode {
                                 // In the REPL the directive stays a string

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -628,6 +628,7 @@ impl<'a> Parser<'a> {
             exports_kind,
             WrapMode::None,
             b"",
+            bun_ast::StoreSlice::EMPTY,
         )?))
     }
 }
@@ -896,6 +897,38 @@ impl<'a> Parser<'a> {
                 import_bindings,
             )));
         }
+
+        // Strip the leading directive prologue from `stmts` and record it on
+        // the AST so the printer / linker can emit it ahead of auto-injected
+        // parts (JSX runtime import, runtime helpers, `before`-hoisted imports).
+        // https://github.com/oven-sh/bun/issues/6854
+        let mut prologue_len = 0usize;
+        for stmt in stmts.iter() {
+            if matches!(stmt.data, js_ast::StmtData::SDirective(_)) {
+                prologue_len += 1;
+            } else {
+                break;
+            }
+        }
+        let directives: bun_ast::StoreSlice<bun_ast::StoreStr> = if prologue_len == 0 {
+            bun_ast::StoreSlice::EMPTY
+        } else {
+            let mut list = BumpVec::<bun_ast::StoreStr>::with_capacity_in(prologue_len, p.arena);
+            for stmt in stmts[..prologue_len].iter() {
+                let js_ast::StmtData::SDirective(d) = &stmt.data else {
+                    unreachable!()
+                };
+                if !list.iter().any(|e| e.slice() == d.value.slice()) {
+                    list.push(d.value);
+                }
+            }
+            bun_ast::StoreSlice::from_bump(list)
+        };
+        let stmts: &'a mut [Stmt] = if prologue_len > 0 {
+            &mut stmts[prologue_len..]
+        } else {
+            stmts
+        };
 
         let mut before = BumpVec::<js_ast::Part>::new_in(p.arena);
         let mut after = BumpVec::<js_ast::Part>::new_in(p.arena);
@@ -2170,7 +2203,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let ast = p.to_ast(&mut parts, exports_kind, wrap_mode, hashbang)?;
+        let ast = p.to_ast(&mut parts, exports_kind, wrap_mode, hashbang, directives)?;
 
         if reject_import_statements {
             // An empty range marks a parser-generated record, like the JSX runtime import.

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -902,30 +902,49 @@ impl<'a> Parser<'a> {
         // the AST so the printer / linker can emit it ahead of auto-injected
         // parts (JSX runtime import, runtime helpers, `before`-hoisted imports).
         // https://github.com/oven-sh/bun/issues/6854
+        // Preserved legal comments (`/*! ... */`, `//! ...`) become SComment
+        // statements ahead of the statement they precede, so they are part of
+        // the leading run without terminating the prologue. The REPL treats
+        // directives as expressions (a bare string is a completion value), so
+        // leave them in place there.
         let mut prologue_len = 0usize;
-        for stmt in stmts.iter() {
-            if matches!(stmt.data, js_ast::StmtData::SDirective(_)) {
-                prologue_len += 1;
-            } else {
-                break;
+        let mut directive_count = 0usize;
+        if !p.options.repl_mode {
+            for stmt in stmts.iter() {
+                match stmt.data {
+                    js_ast::StmtData::SDirective(_) => {
+                        prologue_len += 1;
+                        directive_count += 1;
+                    }
+                    js_ast::StmtData::SComment(_) => prologue_len += 1,
+                    _ => break,
+                }
             }
         }
-        let directives: bun_ast::StoreSlice<bun_ast::StoreStr> = if prologue_len == 0 {
+        let directives: bun_ast::StoreSlice<bun_ast::StoreStr> = if directive_count == 0 {
             bun_ast::StoreSlice::EMPTY
         } else {
-            let mut list = BumpVec::<bun_ast::StoreStr>::with_capacity_in(prologue_len, p.arena);
+            let mut list = BumpVec::<bun_ast::StoreStr>::with_capacity_in(directive_count, p.arena);
             for stmt in stmts[..prologue_len].iter() {
-                let js_ast::StmtData::SDirective(d) = &stmt.data else {
-                    unreachable!()
-                };
-                if !list.iter().any(|e| e.slice() == d.value.slice()) {
-                    list.push(d.value);
+                if let js_ast::StmtData::SDirective(d) = &stmt.data {
+                    if !list.iter().any(|e| e.slice() == d.value.slice()) {
+                        list.push(d.value);
+                    }
                 }
             }
             bun_ast::StoreSlice::from_bump(list)
         };
-        let stmts: &'a mut [Stmt] = if prologue_len > 0 {
-            &mut stmts[prologue_len..]
+        let stmts: &'a mut [Stmt] = if directive_count > 0 {
+            // Compact the comments to the end of the prologue prefix
+            // (preserving their order), then drop the directive slots.
+            let mut j = prologue_len;
+            for i in (0..prologue_len).rev() {
+                if matches!(stmts[i].data, js_ast::StmtData::SComment(_)) {
+                    j -= 1;
+                    stmts[j] = stmts[i];
+                }
+            }
+            &mut stmts[directive_count..]
         } else {
             stmts
         };

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -898,15 +898,6 @@ impl<'a> Parser<'a> {
             )));
         }
 
-        // Strip the leading directive prologue from `stmts` and record it on
-        // the AST so the printer / linker can emit it ahead of auto-injected
-        // parts (JSX runtime import, runtime helpers, `before`-hoisted imports).
-        // https://github.com/oven-sh/bun/issues/6854
-        // Preserved legal comments (`/*! ... */`, `//! ...`) become SComment
-        // statements ahead of the statement they precede, so they are part of
-        // the leading run without terminating the prologue. The REPL treats
-        // directives as expressions (a bare string is a completion value), so
-        // leave them in place there.
         let mut prologue_len = 0usize;
         let mut directive_count = 0usize;
         if !p.options.repl_mode {
@@ -935,8 +926,6 @@ impl<'a> Parser<'a> {
             bun_ast::StoreSlice::from_bump(list)
         };
         let stmts: &'a mut [Stmt] = if directive_count > 0 {
-            // Compact the comments to the end of the prologue prefix
-            // (preserving their order), then drop the directive slots.
             let mut j = prologue_len;
             for i in (0..prologue_len).rev() {
                 if matches!(stmts[i].data, js_ast::StmtData::SComment(_)) {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1760,9 +1760,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 StmtData::SEmpty(_) => continue,
 
                 StmtData::SDirective(_) => {
-                    // Only a function body has a directive prologue. In other
-                    // block bodies the string is a side-effect-free expression
-                    // statement, so minify drops it.
                     if kind == StmtsKind::FnBody {
                         output.push(stmt);
                     }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1759,8 +1759,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match stmt.data {
                 StmtData::SEmpty(_) => continue,
 
-                // skip directives for now
-                StmtData::SDirective(_) => continue,
+                StmtData::SDirective(_) => {
+                    output.push(stmt);
+                    continue;
+                }
 
                 StmtData::SLocal(local) => {
                     // Merge adjacent local statements

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1760,7 +1760,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 StmtData::SEmpty(_) => continue,
 
                 StmtData::SDirective(_) => {
-                    output.push(stmt);
+                    // Only a function body has a directive prologue. In other
+                    // block bodies the string is a side-effect-free expression
+                    // statement, so minify drops it.
+                    if kind == StmtsKind::FnBody {
+                        output.push(stmt);
+                    }
                     continue;
                 }
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7679,6 +7679,13 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     }
     printer.binary_expression_stack = Vec::new();
 
+    for directive in tree.directives.slice() {
+        printer.print_indent();
+        printer.print_string_literal_utf8(directive.slice(), false);
+        printer.print(b";");
+        printer.print_newline();
+    }
+
     if !printer.options.bundling
         && tree.uses_require_ref
         && tree.exports_kind == js_ast::ExportsKind::Esm

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7685,6 +7685,7 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         printer.print(b";");
         printer.print_newline();
     }
+    printer.writer.get_error()?;
 
     if !printer.options.bundling
         && tree.uses_require_ref

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,9 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: Top-level directive prologue is hoisted ahead of auto-injected
+/// parts (JSX runtime import, `var {require}=import.meta`). #6854.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -129,6 +129,8 @@ fn collect_body_directives(stmts: &[Stmt]) -> Vec<&[u8]> {
     for s in stmts {
         match &s.data {
             StmtData::SDirective(d) => out.push(d.value.slice()),
+            // Preserved legal comments don't terminate the prologue.
+            StmtData::SComment(_) => continue,
             _ => break,
         }
     }

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -460,10 +460,10 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "52c1e0868de8da5d8bf4b89d68afbd027f3c64fdce490cd46800674b0de3f0c1",
+          "js": "7cf9dd3d8bc03517a212eed923d3d3f8d856d53cd6d7fd915af776f50e645dd3",
           "jsc": {
-            "bytes": 1999232,
-            "sha256": "a6043ef5e8aaae25c9581e6802fc2508f0b7b2fb0681be536768f9d09ef4cac6",
+            "bytes": 2004632,
+            "sha256": "3bf715e72f2789878902f0d3bbaa6668d6f6fd0627cc15415ed16ee24235a6b5",
           },
         },
         "bun build --bytecode --minify features.js": {
@@ -488,10 +488,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode all.js": {
-          "js": "46d723ea07e5e2d8db673a51fec52b3248edcd3e216029f243d8172244f7cd2c",
+          "js": "73f27a1414b26406c14a9d4c95cc8a5eb7271fad3792bfc020d39df02e7cf907",
           "jsc": {
-            "bytes": 2178792,
-            "sha256": "c5d1eaae5c4d198b1f8e0d768bb41502162081c75b67249032e66a2b95e26ec1",
+            "bytes": 2184416,
+            "sha256": "3d1f952144dcd37335b757b12b5a8cfa9497ad7d14cc8fbe37ff9cf5f822b088",
           },
         },
         "bun build --bytecode big.js": {
@@ -509,10 +509,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode happy-dom/lib/index.js": {
-          "js": "148f0d3e4baf485281725f859deb3e717a6da25a4a08de9af288d5ef54b6414b",
+          "js": "f7873071421bccffe16fbadc85101e62ca1c10839ef3c6bb9c752ecd7f7f3b3a",
           "jsc": {
-            "bytes": 2528840,
-            "sha256": "d68b260282a74f545c15b5a3b812b69cb4e828972f85c5de60f8307b73c43e57",
+            "bytes": 2528864,
+            "sha256": "05d8e99e966ef0cf9bf07e86baadb47d926cc33d494dd61140259d83b039d15a",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
@@ -523,10 +523,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode libraries.js": {
-          "js": "e685164a8316f60b665bc3d47e42b4623cfe7385f87310e655478a50ecd8f959",
+          "js": "bfac43a2b4c87364807617387203fcfbf65ac7dd9ac01a7d044bdd15781df49d",
           "jsc": {
-            "bytes": 23806352,
-            "sha256": "5f23309532d868e1c985d568207c92b77a7f3974e5c6c3f37b21accf7d429327",
+            "bytes": 23874144,
+            "sha256": "b950f7985eb2c8f6ab4fbeecdf32c803daab464a800255be98c55253cd56b941",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -537,10 +537,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode react-dom/cjs/react-dom.development.js": {
-          "js": "e2cf34c8eb6f5952a33ca91e3949b28786349cf97ea3fbf0b3b8500dbccd4860",
+          "js": "54451a126f78d48cafb01c7c3e9e459bf0f2821d084ed15d29adccfdf2d06875",
           "jsc": {
-            "bytes": 980080,
-            "sha256": "32fa8492ad9fdf3ea31395756898d556df9dc6bdfbac9bba07bcafa748ab38ca",
+            "bytes": 980088,
+            "sha256": "56e259fd06b1fba8ed7dcc1aef8d785a39b4190e45a67479851932c6bbef3b9a",
           },
         },
         "bun build --bytecode records.js": {
@@ -565,10 +565,10 @@ describe("bytecode cache portability", () => {
           },
         },
         "bun build --bytecode undici/index.js": {
-          "js": "d0bd3791e7c8f77a06814429d5d95cb26a06baaa3c135502bcd3e984310f1d2c",
+          "js": "7ebc1a93fd924da1107ea2c12bc0a684686717fb6e382ba90d34bd3f1a9062c3",
           "jsc": {
-            "bytes": 937000,
-            "sha256": "d7cff4df84668b14987703bcd950a6753a574cf48e4372e4fe8779f747c0ed89",
+            "bytes": 937032,
+            "sha256": "ecb2f5eb5472bd2fbd8ab08cf64494afa66a5cb74f352cb26c543f0a32b96a79",
           },
         },
         "vm.Script big.js": {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -761,8 +761,11 @@ describe("bundler", () => {
     format: "cjs",
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
-      // The wrapped dependency keeps its own "use strict" inside the closure
-      expect(out).toMatch(/__commonJS\(function\(exports[^)]*\) \{\s*"use strict";/);
+      // The wrapped dependency keeps its own "use strict" inside the closure:
+      // it must appear after the runtime helpers (not hoisted to the top) and
+      // as the first statement of the closure body.
+      expect(out.indexOf('"use strict"')).toBeGreaterThan(out.indexOf("require_dep"));
+      expect(out).toMatch(/\{\s*"use strict";\s*exports/);
     },
   });
   itBundled("edgecase/DCEVarRedeclarationIssue2815", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -655,6 +655,31 @@ describe("bundler", () => {
       const out = api.readFile("/out.js");
       // Must come before "var __commonJS = ..." runtime helpers
       expect(out).toStartWith('"use client";\n');
+      expect(out.indexOf('"use client"')).toBeLessThan(out.indexOf("__commonJS"));
+    },
+  });
+  itBundled("edgecase/DirectiveInsideBakeDevModuleClosure", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        "use potato";
+        import { x } from "./dep.js";
+        console.log(x);
+      `,
+      "/dep.js": /* js */ `
+        "use tomato";
+        export const x = 1;
+        console.log("dep loaded");
+      `,
+    },
+    format: "internal_bake_dev",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // Each module closure keeps its own directive prologue first; the chunk
+      // itself gets no top-level copy in this format.
+      expect(out).toMatch(/\{\s*"use strict";\s*"use potato";/);
+      expect(out).toMatch(/\{\s*"use tomato";/);
+      expect(out).not.toMatch(/^"use strict";/);
     },
   });
   itBundled("edgecase/DirectiveFromEntryOnlyWhenBundling", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -730,6 +730,25 @@ describe("bundler", () => {
       expect(api.readFile("/out.js")).toMatch(/(?:async\s+)?function\s+action\s*\(\)\s*\{\s*"use server";/);
     },
   });
+  itBundled("edgecase/DirectiveLikeStringInNestedBlockMinified", {
+    files: {
+      "/entry.js": /* js */ `
+        export function f() {
+          try {
+            "debug label";
+            g();
+          } catch {}
+        }
+        function g() {}
+      `,
+    },
+    minifySyntax: true,
+    onAfterBundle(api) {
+      // Only a function body has a directive prologue; a leading string in any
+      // other block is a side-effect-free expression and minify drops it.
+      expect(api.readFile("/out.js")).not.toContain("debug label");
+    },
+  });
   itBundled("edgecase/DirectiveMultipleDedup", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -784,6 +784,31 @@ describe("bundler", () => {
       expect(out).toMatch(/\{\s*"use strict";\s*exports/);
     },
   });
+  itBundled("edgecase/DirectiveBeforeInitCallsInWrappedDep", {
+    files: {
+      "/entry.js": /* js */ `
+        const { a } = require("./a.js");
+        const { x } = require("./b.js");
+        console.log(a, x);
+      `,
+      "/a.js": /* js */ `
+        "use strict";
+        import { x } from "./b.js";
+        export const a = x;
+      `,
+      "/b.js": /* js */ `
+        export const x = 1;
+        console.log("b loaded");
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // a.js's wrapper body must keep its directive prologue first: the
+      // injected init_b() dependency call goes after it, not before.
+      expect(out).toMatch(/__esm\(\(\) => \{\s*"use strict";\s*init_b\(\)/);
+    },
+  });
   itBundled("edgecase/DCEVarRedeclarationIssue2815", {
     todo: true,
     files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -623,6 +623,22 @@ describe("bundler", () => {
       expect([...out.matchAll(/"use client"/g)]).toHaveLength(1);
     },
   });
+  itBundled("edgecase/DirectiveAfterLegalCommentHoisted", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        /*! @license MIT */
+        "use client";
+        export function Button() { return <div>Click</div>; }
+      `,
+    },
+    external: ["react", "react-dom", "react/jsx-dev-runtime", "react/jsx-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // A preserved legal comment does not terminate the directive prologue
+      expect(out).toStartWith('"use client";\n');
+      expect(out).toContain("@license MIT");
+    },
+  });
   itBundled("edgecase/DirectiveHoistedAboveRuntimeHelpers", {
     files: {
       "/entry.tsx": /* tsx */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -607,6 +607,164 @@ describe("bundler", () => {
       `,
     },
   });
+  // https://github.com/oven-sh/bun/issues/6854
+  itBundled("edgecase/DirectiveHoistedAboveJSXImport", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        "use client";
+        export function Button() { return <div>Click</div>; }
+      `,
+    },
+    external: ["react", "react-dom", "react/jsx-dev-runtime", "react/jsx-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toStartWith('"use client";\n');
+      // Only one copy of the directive should be emitted
+      expect([...out.matchAll(/"use client"/g)]).toHaveLength(1);
+    },
+  });
+  itBundled("edgecase/DirectiveHoistedAboveRuntimeHelpers", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        "use client";
+        const mod = require("./cjs.cjs");
+        export function C() { return <div>{mod.x}</div>; }
+      `,
+      "/cjs.cjs": /* js */ `
+        module.exports = { x: 42 };
+      `,
+    },
+    external: ["react", "react-dom", "react/jsx-dev-runtime", "react/jsx-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // Must come before "var __commonJS = ..." runtime helpers
+      expect(out).toStartWith('"use client";\n');
+    },
+  });
+  itBundled("edgecase/DirectiveFromEntryOnlyWhenBundling", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        "use client";
+        import { S } from "./dep.jsx";
+        export function M() { return <S />; }
+      `,
+      "/dep.jsx": /* jsx */ `
+        "use server";
+        export function S() { return <div />; }
+      `,
+    },
+    external: ["react", "react-dom", "react/jsx-dev-runtime", "react/jsx-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toStartWith('"use client";\n');
+      // The dep's directive is dropped once bundled into a flat ESM chunk
+      expect(out).not.toContain('"use server"');
+    },
+  });
+  itBundled("edgecase/DirectivePreservedUnderMinify", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        "use client";
+        export function Button() { return <div>Click</div>; }
+      `,
+    },
+    external: ["react", "react-dom", "react/jsx-dev-runtime", "react/jsx-runtime"],
+    minifySyntax: true,
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('"use client";');
+    },
+  });
+  itBundled("edgecase/DirectiveFunctionBodyPreservedUnderMinify", {
+    files: {
+      "/entry.js": /* js */ `
+        export async function action() {
+          "use server";
+          return 1;
+        }
+      `,
+    },
+    minifySyntax: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toContain('"use server"');
+    },
+  });
+  itBundled("edgecase/DirectiveMultipleDedup", {
+    files: {
+      "/entry.js": /* js */ `
+        "use client";
+        "use potato";
+        "use client";
+        export const a = 1;
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toStartWith('"use client";\n"use potato";\n');
+      expect([...out.matchAll(/"use client"/g)]).toHaveLength(1);
+    },
+  });
+  itBundled("edgecase/DirectiveWithBannerAndHashbang", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        "use client";
+        export function A() { return <div />; }
+      `,
+    },
+    external: ["react", "react-dom", "react/jsx-dev-runtime", "react/jsx-runtime"],
+    banner: "#!/usr/bin/env node\n/* banner */",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toStartWith('#!/usr/bin/env node\n/* banner */\n"use client";\n');
+    },
+  });
+  itBundled("edgecase/DirectiveUseStrictKeptForCJS", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        "use client";
+        exports.a = 1;
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toStartWith('"use strict";\n"use client";\n');
+    },
+  });
+  itBundled("edgecase/DirectiveHoistedCJSWrappedEntry", {
+    files: {
+      "/entry.js": /* js */ `
+        "use strict";
+        "use client";
+        console.log(this);
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // CJS wrapping sinks the entry into a closure; the directive must still
+      // be hoisted above the "var __commonJS = ..." runtime helper.
+      expect(out).toStartWith('"use client";\n');
+      expect(out).toContain("__commonJS");
+    },
+  });
+  itBundled("edgecase/DirectiveInsideWrappedDep", {
+    files: {
+      "/entry.js": /* js */ `
+        const dep = require("./dep.js");
+        console.log(dep.a);
+      `,
+      "/dep.js": /* js */ `
+        "use strict";
+        exports.a = this;
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The wrapped dependency keeps its own "use strict" inside the closure
+      expect(out).toMatch(/__commonJS\(function\(exports[^)]*\) \{\s*"use strict";/);
+    },
+  });
   itBundled("edgecase/DCEVarRedeclarationIssue2815", {
     todo: true,
     files: {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -727,7 +727,7 @@ describe("bundler", () => {
     },
     minifySyntax: true,
     onAfterBundle(api) {
-      expect(api.readFile("/out.js")).toContain('"use server"');
+      expect(api.readFile("/out.js")).toMatch(/(?:async\s+)?function\s+action\s*\(\)\s*\{\s*"use server";/);
     },
   });
   itBundled("edgecase/DirectiveMultipleDedup", {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2657,7 +2657,6 @@ describe.concurrent("bundler", () => {
     minifySyntax: true,
     minifyWhitespace: true,
     bundling: false,
-    todo: true,
     onAfterBundle(api) {
       assert(api.readFile("/out.js").includes('"use strict";'), '"use strict"; was emitted');
     },

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4670,13 +4670,14 @@ console.log("boop");
 `,
     );
   });
-  it("does not preserve use strict (for now)", () => {
+  it("preserves use strict", () => {
     expect(
       new Bun.Transpiler().transformSync(`"use strict";
   console.log("boop");
   `),
     ).toBe(
-      `console.log("boop");
+      `"use strict";
+console.log("boop");
 `,
     );
   });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -46,25 +46,25 @@ describe.concurrent("run-cjs", () => {
   });
 
   test('"use strict" still applies inside the CJS module wrapper', async () => {
-    const dir = tmpdirSync();
-    mkdirSync(dir, { recursive: true });
-    await Bun.write(
-      join(dir, "strict.cjs"),
-      `"use strict";
+    using dir = tempDir("run-cjs-strict", {
+      "strict.cjs": `"use strict";
 try {
   undeclared = 1;
   console.log("sloppy");
 } catch (e) {
   console.log(e.constructor.name);
 }`,
-    );
+    });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), join(dir, "strict.cjs")],
-      cwd: dir,
+      cmd: [bunExe(), join(String(dir), "strict.cjs")],
+      cwd: String(dir),
       env: bunEnv,
       stdout: "pipe",
+      stderr: "pipe",
     });
-    const stdout = await proc.stdout.text();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toEqual("ReferenceError\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -44,4 +44,27 @@ describe.concurrent("run-cjs", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "custom-loader\n", exitCode: 0 });
   });
+
+  test('"use strict" still applies inside the CJS module wrapper', async () => {
+    const dir = tmpdirSync();
+    mkdirSync(dir, { recursive: true });
+    await Bun.write(
+      join(dir, "strict.cjs"),
+      `"use strict";
+try {
+  undeclared = 1;
+  console.log("sloppy");
+} catch (e) {
+  console.log(e.constructor.name);
+}`,
+    );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(dir, "strict.cjs")],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+    });
+    const stdout = await proc.stdout.text();
+    expect(stdout).toEqual("ReferenceError\n");
+  });
 });

--- a/test/regression/issue/06854.test.ts
+++ b/test/regression/issue/06854.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/6854
+// "use client"/"use server" directives must stay at the top of the output,
+// ahead of auto-injected JSX runtime imports and bundler runtime helpers.
+
+test.concurrent('"use client" stays above the JSX runtime import in --no-bundle', async () => {
+  using dir = tempDir("issue-6854-nobundle", {
+    "input.jsx": `"use client";\nexport function Button() { return <div>Click</div>; }`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "input.jsx"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toStartWith('"use client";\n');
+  expect(stdout.indexOf('"use client"')).toBeLessThan(stdout.indexOf("react/jsx"));
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent('"use client" stays above the JSX runtime import with --no-bundle --minify', async () => {
+  using dir = tempDir("issue-6854-nobundle-min", {
+    "input.jsx": `"use client";\nexport function Button() { return <div>Click</div>; }`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "--minify", "input.jsx"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toStartWith('"use client";');
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent('"use client" is hoisted above bundler runtime helpers', async () => {
+  using dir = tempDir("issue-6854-bundle", {
+    "entry.tsx": `"use client";\nconst mod = require("./cjs.cjs");\nexport function C() { return <div>{mod.x}</div>; }`,
+    "cjs.cjs": `module.exports = { x: 42 };`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "build",
+      "entry.tsx",
+      "--external",
+      "react",
+      "--external",
+      "react/jsx-dev-runtime",
+      "--external",
+      "react/jsx-runtime",
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toStartWith('"use client";\n');
+  expect(stdout.indexOf('"use client"')).toBeLessThan(stdout.indexOf("__commonJS"));
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/06854.test.ts
+++ b/test/regression/issue/06854.test.ts
@@ -33,6 +33,7 @@ test.concurrent('"use client" stays above the JSX runtime import with --no-bundl
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout).toStartWith('"use client";');
+  expect(stdout.indexOf('"use client"')).toBeLessThan(stdout.indexOf("react/jsx"));
   expect(exitCode).toBe(0);
 });
 

--- a/test/regression/issue/06854.test.ts
+++ b/test/regression/issue/06854.test.ts
@@ -38,6 +38,23 @@ test.concurrent('"use client" stays above the JSX runtime import with --no-bundl
   expect(exitCode).toBe(0);
 });
 
+test.concurrent('"use client" is hoisted past a preserved legal comment in --no-bundle', async () => {
+  using dir = tempDir("issue-6854-nobundle-lic", {
+    "input.jsx": `/*! @license MIT */\n"use client";\nexport function Button() { return <div>Click</div>; }`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--no-bundle", "input.jsx"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toStartWith('"use client";\n');
+  expect(stdout).toContain("@license MIT");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent('"use client" is hoisted above bundler runtime helpers', async () => {
   using dir = tempDir("issue-6854-bundle", {
     "entry.tsx": `"use client";\nconst mod = require("./cjs.cjs");\nexport function C() { return <div>{mod.x}</div>; }`,

--- a/test/regression/issue/06854.test.ts
+++ b/test/regression/issue/06854.test.ts
@@ -2,8 +2,6 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/6854
-// "use client"/"use server" directives must stay at the top of the output,
-// ahead of auto-injected JSX runtime imports and bundler runtime helpers.
 
 test.concurrent('"use client" stays above the JSX runtime import in --no-bundle', async () => {
   using dir = tempDir("issue-6854-nobundle", {


### PR DESCRIPTION
Fixes #6854.

### Repro

```jsx
// entry.jsx
"use client";
export function Button() { return <div/>; }
```

```
$ bun build --no-bundle entry.jsx
import { jsxDEV } from "react/jsx-dev-runtime";   // <- injected import first
"use client";                                     // <- directive no longer a prologue
...
```

The same thing happens when bundling: the `var __commonJS = ...` runtime helpers and hoisted imports from every module in the chunk land before the directive, so Next.js / the React compiler reject the output with `The "use client" directive must be placed before other expressions`.

Under `--minify`, the directive was dropped entirely by the minify-syntax pass.

### Cause

The parser converts prologue strings other than `"use strict"` into `SDirective` statements and leaves them in the top-level statement list. Auto-injected parts (JSX runtime import, runtime-helper import, `before`-hoisted user imports, `var {require}=import.meta`) are then prepended ahead of them, and the bundler's chunk writer only special-cases `"use strict"`. The minify-syntax merge pass additionally had `StmtData::SDirective(_) => continue`.

### Fix

- `Ast.directive: Option<StoreStr>` is now `Ast.directives: StoreSlice<StoreStr>` (arena-owned, source order, deduplicated). `BundledAst` round-trips it; the old `HAS_EXPLICIT_USE_STRICT_DIRECTIVE` bitflag is removed.
- `parse_stmts_up_to` now leaves a module-scope `"use strict"` in the statement list as an `SDirective` alongside other directives so source order is preserved. The strict-mode flag on the scope is unchanged.
- `_parse` strips the leading `SDirective` prologue from `stmts` before the parts loop and passes it to `to_ast`, so the visit/append-part pipeline never sees module-level directives and auto-injected parts can be prepended freely.
- `print_ast` / `print_common_js` emit `tree.directives` before any other output.
- `post_process_js_chunk` emits the entry point's directives at the top of each chunk (after hashbang / `// @bun` / banner), skipping `"use strict"` for output formats that are already strict. `generate_code_for_file_in_chunk_js` emits a wrapped non-entry file's directives inside its wrapper (and now gates on the *file's* entry-point kind rather than the chunk's, matching esbuild).
- The minify-syntax merge pass keeps `SDirective` statements. Module-level ones are gone before visiting, so this only affects function-body directives (`"use server"` inside an action), which are now preserved under `--minify`.

This matches esbuild: entry-point directives hoist to the top of the chunk, non-entry directives are dropped from flat ESM output and kept inside wrapped closures, `"use strict"` is omitted for ESM output.

### After

```
$ bun build --no-bundle entry.jsx
"use client";
import { jsxDEV } from "react/jsx-dev-runtime";
...
$ bun build entry.tsx --external react ...
"use client";
var __commonJS = ...
...
```

### Verification

New bundler tests in `test/bundler/bundler_edgecase.test.ts` cover JSX-import hoist, runtime-helper hoist, entry-vs-dep directive selection, minify (both top-level and function-body), dedup, hashbang+banner ordering, CJS `"use strict"` ordering, CJS-wrapped entry hoisting and wrapped-dep `"use strict"`. `test/regression/issue/06854.test.ts` covers the `--no-bundle` CLI paths. The previously `todo` `default/UseStrictDirectiveMinifyNoBundle` now passes and is enabled. All existing bundler / transpiler suites pass unchanged.


### Rebase notes

Rebased onto main after the dead-code sweep (#39732) and the module-loader cache changes landed. Resolutions:
- `print_common_js` was deleted on main as dead code. The directive emit it carried is gone with it. The live paths (`print_ast`, the linker chunk paths) keep theirs.
- `RuntimeTranspilerCache` `EXPECTED_VERSION` moved to 28 (main took 24 through 27).
- `BundledAst` fields are `pub(crate)` on main now. `directives` follows.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 12 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts, test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->


