### PR TITLE
run: shim npm/npx alongside node in the --bun PATH dir

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1083,12 +1083,16 @@ fn configure_env_for_scripts_run(
                 .load_node_js_config(paths_fs, node_path_z.as_ref())?;
         } else {
             'brk: {
-                let current_path = this.env().get(b"PATH").unwrap_or(b"");
+                let current_path: Vec<u8> = this.env().get(b"PATH").unwrap_or(b"").to_vec();
                 let mut path_var: Vec<u8> = Vec::with_capacity(current_path.len());
-                path_var.extend_from_slice(current_path);
+                path_var.extend_from_slice(&current_path);
                 let mut bun_path: &[u8] = b"";
-                if RunCommand::create_fake_temporary_node_executable(&mut path_var, &mut bun_path)
-                    .is_err()
+                if RunCommand::create_fake_temporary_node_executable(
+                    &mut path_var,
+                    &mut bun_path,
+                    &current_path,
+                )
+                .is_err()
                 {
                     break 'brk;
                 }

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -631,10 +631,8 @@ impl RunCommand {
             }
 
             let mut which_buf = bun_paths::PathBuffer::uninit();
-            let need_npm =
-                bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
-            let need_npx =
-                bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
+            let need_npm = bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
+            let need_npx = bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
 
             for (dest, wanted) in [
                 (NODE_LINK, true),
@@ -752,10 +750,8 @@ impl RunCommand {
             }
 
             let mut which_buf = bun_paths::PathBuffer::uninit();
-            let need_npm =
-                bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
-            let need_npx =
-                bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
+            let need_npm = bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
+            let need_npx = bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
 
             let image_path = win::exe_path_w();
             for (name, wanted) in [

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -500,8 +500,11 @@ impl RunCommand {
         .as_deref()
     }
 
-    /// Symlinks/hardlinks the running bun binary as
-    /// `node` + `bun` inside a temp dir and prepends that dir to `path`.
+    /// Symlinks/hardlinks the running bun binary as `node` + `bun` inside a
+    /// temp dir and prepends that dir to `path`. Also links `npm` + `npx`
+    /// there *only when* they are not already resolvable in `original_path`,
+    /// so the shim is a fallback on bun-only hosts and never shadows a real
+    /// npm under `--bun`.
     ///
     /// `#[cold]`: only reached on the `bun run <script>` / lifecycle-script
     /// slow path, never on plain `bun foo.js` startup. Forcing it into
@@ -512,6 +515,7 @@ impl RunCommand {
     pub fn create_fake_temporary_node_executable(
         path: &mut Vec<u8>,
         optional_bun_path: &mut &[u8],
+        original_path: &[u8],
     ) -> Result<(), crate::Error> {
         // If we are already running as "node", the path should exist
         if PRETEND_TO_BE_NODE.load(core::sync::atomic::Ordering::Relaxed) {
@@ -626,7 +630,24 @@ impl RunCommand {
                 Err(_) => return Ok(()),
             }
 
-            for dest in [NODE_LINK, BUN_LINK, NPM_LINK, NPX_LINK] {
+            let mut which_buf = bun_paths::PathBuffer::uninit();
+            let need_npm =
+                bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
+            let need_npx =
+                bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
+
+            for (dest, wanted) in [
+                (NODE_LINK, true),
+                (BUN_LINK, true),
+                (NPM_LINK, need_npm),
+                (NPX_LINK, need_npx),
+            ] {
+                if !wanted {
+                    // A real one exists in PATH. Remove any stale shim left by
+                    // a previous run so it can't shadow the real binary.
+                    let _ = bun_sys::unlink(dest);
+                    continue;
+                }
                 let mut replaced = false;
                 loop {
                     match bun_sys::symlink(argv0_z, dest) {
@@ -730,13 +751,22 @@ impl RunCommand {
                 let _ = bun_sys::Dir::cwd().make_dir(&dir_slice_u8);
             }
 
+            let mut which_buf = bun_paths::PathBuffer::uninit();
+            let need_npm =
+                bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
+            let need_npx =
+                bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
+
             let image_path = win::exe_path_w();
-            for name in [
-                strings::w!("\\node.exe\0"),
-                strings::w!("\\bun.exe\0"),
-                strings::w!("\\npm.exe\0"),
-                strings::w!("\\npx.exe\0"),
+            for (name, wanted) in [
+                (strings::w!("\\node.exe\0"), true),
+                (strings::w!("\\bun.exe\0"), true),
+                (strings::w!("\\npm.exe\0"), need_npm),
+                (strings::w!("\\npx.exe\0"), need_npx),
             ] {
+                if !wanted {
+                    continue;
+                }
                 target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);
                 // `target_path_buffer` is mutated in place between FFI calls
                 // (the dir-NUL/backslash toggle below).

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -754,11 +754,27 @@ impl RunCommand {
             let need_npx = bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
 
             let image_path = win::exe_path_w();
-            for (name, wanted) in [
-                (strings::w!("\\node.exe\0"), true),
-                (strings::w!("\\bun.exe\0"), true),
-                (strings::w!("\\npm.exe\0"), need_npm),
-                (strings::w!("\\npx.exe\0"), need_npx),
+            for (name, stale_name, wanted) in [
+                (
+                    strings::w!("\\node.exe\0"),
+                    strings::w!("\\node.exe.stale\0"),
+                    true,
+                ),
+                (
+                    strings::w!("\\bun.exe\0"),
+                    strings::w!("\\bun.exe.stale\0"),
+                    true,
+                ),
+                (
+                    strings::w!("\\npm.exe\0"),
+                    strings::w!("\\npm.exe.stale\0"),
+                    need_npm,
+                ),
+                (
+                    strings::w!("\\npx.exe\0"),
+                    strings::w!("\\npx.exe.stale\0"),
+                    need_npx,
+                ),
             ] {
                 if !wanted {
                     // A real one exists in PATH. Remove any stale shim left by
@@ -770,7 +786,26 @@ impl RunCommand {
                         &target_path_buffer[..],
                         dir_slice_len + name.len() - 1,
                     );
-                    let _ = bun_sys::unlink_w(path_w);
+                    if bun_sys::unlink_w(path_w).is_err() {
+                        // Deleting fails with ERROR_ACCESS_DENIED while the
+                        // link's image is mapped by a running process (the
+                        // link targets this very binary). A mapped image can
+                        // still be renamed, and `npm.exe.stale` never matches
+                        // PATH resolution, so rename it out of the way.
+                        let mut stale_buf = bun_paths::w_path_buffer_pool::get();
+                        stale_buf[..dir_slice_len]
+                            .copy_from_slice(&target_path_buffer[..dir_slice_len]);
+                        stale_buf[dir_slice_len..][..stale_name.len()].copy_from_slice(stale_name);
+                        // SAFETY: both paths are NUL-terminated (the name
+                        // literals end in NUL).
+                        let _ = unsafe {
+                            win::kernel32::MoveFileExW(
+                                target_path_buffer.as_ptr(),
+                                stale_buf.as_ptr(),
+                                win::MOVEFILE_REPLACE_EXISTING,
+                            )
+                        };
+                    }
                     continue;
                 }
                 target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -500,11 +500,8 @@ impl RunCommand {
         .as_deref()
     }
 
-    /// Symlinks/hardlinks the running bun binary as `node` + `bun` inside a
-    /// temp dir and prepends that dir to `path`. Also links `npm` + `npx`
-    /// there *only when* they are not already resolvable in `original_path`,
-    /// so the shim is a fallback on bun-only hosts and never shadows a real
-    /// npm under `--bun`.
+    /// Symlinks/hardlinks the running bun binary as
+    /// `node` + `bun` inside a temp dir and prepends that dir to `path`.
     ///
     /// `#[cold]`: only reached on the `bun run <script>` / lifecycle-script
     /// slow path, never on plain `bun foo.js` startup. Forcing it into
@@ -631,10 +628,6 @@ impl RunCommand {
             }
 
             let mut which_buf = bun_paths::PathBuffer::uninit();
-            // A nested `--bun` inherits a PATH with `BUN_NODE_DIR` already
-            // prepended, so a probe hit inside the shim dir is our own link,
-            // not a real npm; treating it as real would delete the only npm
-            // on PATH mid-script.
             let mut real_in_path = |bin: &[u8]| -> bool {
                 bun_which::which(&mut which_buf, original_path, b".", bin).is_some_and(|p| {
                     !bun_core::strings::starts_with(p.as_bytes(), Self::BUN_NODE_DIR.as_bytes())
@@ -650,8 +643,6 @@ impl RunCommand {
                 (NPX_LINK, need_npx),
             ] {
                 if !wanted {
-                    // A real one exists in PATH. Remove any stale shim left by
-                    // a previous run so it can't shadow the real binary.
                     let _ = bun_sys::unlink(dest);
                     continue;
                 }
@@ -759,9 +750,6 @@ impl RunCommand {
             }
 
             let mut which_buf = bun_paths::PathBuffer::uninit();
-            // Same nested-`--bun` guard as the POSIX arm: a probe hit inside
-            // the shim dir is our own hardlink, not a real npm. Compare
-            // case-insensitively; Windows paths are.
             let shim_dir_utf8 = bun_core::strings::to_utf8_alloc_with_type(
                 &target_path_buffer[prefix.len()..dir_slice_len],
             );
@@ -802,11 +790,9 @@ impl RunCommand {
                 ),
             ] {
                 if !wanted {
-                    // A real one exists in PATH. Remove any stale shim left by
-                    // a previous run so it can't shadow the real binary (the
-                    // shim dir persists across runs and is prepended to PATH).
                     target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);
-                    // `name` ends in NUL, so the written path is NUL-terminated.
+                    // SAFETY: `name` ends in NUL, so the written path is
+                    // NUL-terminated.
                     let path_w = bun_core::WStr::from_buf(
                         &target_path_buffer[..],
                         dir_slice_len + name.len() - 1,
@@ -817,12 +803,6 @@ impl RunCommand {
                             bun_sys::E::EPERM | bun_sys::E::EACCES | bun_sys::E::EBUSY
                         )
                     {
-                        // Deleting fails while the link's image is mapped by a
-                        // running process (the link targets this very binary).
-                        // A mapped image can still be renamed, and
-                        // `npm.exe.stale` never matches PATH resolution, so
-                        // rename it out of the way. Other errors (ENOENT: no
-                        // stale link) need no fallback.
                         let mut stale_buf = bun_paths::w_path_buffer_pool::get();
                         stale_buf[..dir_slice_len]
                             .copy_from_slice(&target_path_buffer[..dir_slice_len]);

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -811,12 +811,18 @@ impl RunCommand {
                         &target_path_buffer[..],
                         dir_slice_len + name.len() - 1,
                     );
-                    if bun_sys::unlink_w(path_w).is_err() {
-                        // Deleting fails with ERROR_ACCESS_DENIED while the
-                        // link's image is mapped by a running process (the
-                        // link targets this very binary). A mapped image can
-                        // still be renamed, and `npm.exe.stale` never matches
-                        // PATH resolution, so rename it out of the way.
+                    if let Err(e) = bun_sys::unlink_w(path_w)
+                        && matches!(
+                            e.get_errno(),
+                            bun_sys::E::EPERM | bun_sys::E::EACCES | bun_sys::E::EBUSY
+                        )
+                    {
+                        // Deleting fails while the link's image is mapped by a
+                        // running process (the link targets this very binary).
+                        // A mapped image can still be renamed, and
+                        // `npm.exe.stale` never matches PATH resolution, so
+                        // rename it out of the way. Other errors (ENOENT: no
+                        // stale link) need no fallback.
                         let mut stale_buf = bun_paths::w_path_buffer_pool::get();
                         stale_buf[..dir_slice_len]
                             .copy_from_slice(&target_path_buffer[..dir_slice_len]);

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -593,6 +593,16 @@ impl RunCommand {
                 // SAFETY: literal ends in NUL; len excludes it.
                 ZStr::from_static(B)
             };
+            const NPM_LINK: &ZStr = {
+                const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "/npm\0").as_bytes();
+                // SAFETY: literal ends in NUL; len excludes it.
+                ZStr::from_static(B)
+            };
+            const NPX_LINK: &ZStr = {
+                const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "/npx\0").as_bytes();
+                // SAFETY: literal ends in NUL; len excludes it.
+                ZStr::from_static(B)
+            };
             const DIR_Z: &ZStr = {
                 const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "\0").as_bytes();
                 // SAFETY: literal ends in NUL; len excludes it.
@@ -616,7 +626,7 @@ impl RunCommand {
                 Err(_) => return Ok(()),
             }
 
-            for dest in [NODE_LINK, BUN_LINK] {
+            for dest in [NODE_LINK, BUN_LINK, NPM_LINK, NPX_LINK] {
                 let mut replaced = false;
                 loop {
                     match bun_sys::symlink(argv0_z, dest) {
@@ -721,7 +731,12 @@ impl RunCommand {
             }
 
             let image_path = win::exe_path_w();
-            for name in [strings::w!("\\node.exe\0"), strings::w!("\\bun.exe\0")] {
+            for name in [
+                strings::w!("\\node.exe\0"),
+                strings::w!("\\bun.exe\0"),
+                strings::w!("\\npm.exe\0"),
+                strings::w!("\\npx.exe\0"),
+            ] {
                 target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);
                 // `target_path_buffer` is mutated in place between FFI calls
                 // (the dir-NUL/backslash toggle below).

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -761,6 +761,16 @@ impl RunCommand {
                 (strings::w!("\\npx.exe\0"), need_npx),
             ] {
                 if !wanted {
+                    // A real one exists in PATH. Remove any stale shim left by
+                    // a previous run so it can't shadow the real binary (the
+                    // shim dir persists across runs and is prepended to PATH).
+                    target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);
+                    // `name` ends in NUL, so the written path is NUL-terminated.
+                    let path_w = bun_core::WStr::from_buf(
+                        &target_path_buffer[..],
+                        dir_slice_len + name.len() - 1,
+                    );
+                    let _ = bun_sys::unlink_w(path_w);
                     continue;
                 }
                 target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -631,8 +631,17 @@ impl RunCommand {
             }
 
             let mut which_buf = bun_paths::PathBuffer::uninit();
-            let need_npm = bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
-            let need_npx = bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
+            // A nested `--bun` inherits a PATH with `BUN_NODE_DIR` already
+            // prepended, so a probe hit inside the shim dir is our own link,
+            // not a real npm; treating it as real would delete the only npm
+            // on PATH mid-script.
+            let mut real_in_path = |bin: &[u8]| -> bool {
+                bun_which::which(&mut which_buf, original_path, b".", bin).is_some_and(|p| {
+                    !bun_core::strings::starts_with(p.as_bytes(), Self::BUN_NODE_DIR.as_bytes())
+                })
+            };
+            let need_npm = !real_in_path(b"npm");
+            let need_npx = !real_in_path(b"npx");
 
             for (dest, wanted) in [
                 (NODE_LINK, true),
@@ -750,8 +759,24 @@ impl RunCommand {
             }
 
             let mut which_buf = bun_paths::PathBuffer::uninit();
-            let need_npm = bun_which::which(&mut which_buf, original_path, b".", b"npm").is_none();
-            let need_npx = bun_which::which(&mut which_buf, original_path, b".", b"npx").is_none();
+            // Same nested-`--bun` guard as the POSIX arm: a probe hit inside
+            // the shim dir is our own hardlink, not a real npm. Compare
+            // case-insensitively; Windows paths are.
+            let shim_dir_utf8 = bun_core::strings::to_utf8_alloc_with_type(
+                &target_path_buffer[prefix.len()..dir_slice_len],
+            );
+            let mut real_in_path = |bin: &[u8]| -> bool {
+                bun_which::which(&mut which_buf, original_path, b".", bin).is_some_and(|p| {
+                    let pb = p.as_bytes();
+                    !(pb.len() >= shim_dir_utf8.len()
+                        && strings::eql_case_insensitive_asciii_check_length(
+                            &pb[..shim_dir_utf8.len()],
+                            &shim_dir_utf8,
+                        ))
+                })
+            };
+            let need_npm = !real_in_path(b"npm");
+            let need_npx = !real_in_path(b"npx");
 
             let image_path = win::exe_path_w();
             for (name, stale_name, wanted) in [

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -629,9 +629,14 @@ impl RunCommand {
 
             let mut which_buf = bun_paths::PathBuffer::uninit();
             let mut real_in_path = |bin: &[u8]| -> bool {
-                bun_which::which(&mut which_buf, original_path, b".", bin).is_some_and(|p| {
-                    !bun_core::strings::starts_with(p.as_bytes(), Self::BUN_NODE_DIR.as_bytes())
-                })
+                bun_which::which(&mut which_buf, b"node_modules/.bin", b".", bin).is_some()
+                    || bun_which::which(&mut which_buf, original_path, b".", bin).is_some_and(|p| {
+                        let pb = p.as_bytes();
+                        let dir = Self::BUN_NODE_DIR.as_bytes();
+                        !(pb.len() > dir.len()
+                            && pb[dir.len()] == b'/'
+                            && bun_core::strings::starts_with(pb, dir))
+                    })
             };
             let need_npm = !real_in_path(b"npm");
             let need_npx = !real_in_path(b"npx");
@@ -754,14 +759,16 @@ impl RunCommand {
                 &target_path_buffer[prefix.len()..dir_slice_len],
             );
             let mut real_in_path = |bin: &[u8]| -> bool {
-                bun_which::which(&mut which_buf, original_path, b".", bin).is_some_and(|p| {
-                    let pb = p.as_bytes();
-                    !(pb.len() >= shim_dir_utf8.len()
-                        && strings::eql_case_insensitive_asciii_check_length(
-                            &pb[..shim_dir_utf8.len()],
-                            &shim_dir_utf8,
-                        ))
-                })
+                bun_which::which(&mut which_buf, b"node_modules/.bin", b".", bin).is_some()
+                    || bun_which::which(&mut which_buf, original_path, b".", bin).is_some_and(|p| {
+                        let pb = p.as_bytes();
+                        !(pb.len() > shim_dir_utf8.len()
+                            && matches!(pb[shim_dir_utf8.len()], b'\\' | b'/')
+                            && strings::eql_case_insensitive_asciii_check_length(
+                                &pb[..shim_dir_utf8.len()],
+                                &shim_dir_utf8,
+                            ))
+                    })
             };
             let need_npm = !real_in_path(b"npm");
             let need_npx = !real_in_path(b"npx");

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1200,7 +1200,57 @@ pub mod command {
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"x" | b"create")) {
             hoisted.clear();
         }
-        if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"run" | b"init")) {
+        if matches!(
+            sub_bytes,
+            Some(
+                b"i" | b"isntall"
+                    | b"in"
+                    | b"ins"
+                    | b"inst"
+                    | b"insta"
+                    | b"instal"
+                    | b"install"
+                    | b"ci"
+                    | b"clean-install"
+                    | b"ic"
+                    | b"install-clean"
+                    | b"isntall-clean"
+                    | b"update"
+                    | b"upgrade"
+                    | b"up"
+                    | b"udpate"
+                    | b"outdated"
+                    | b"add"
+                    | b"a"
+                    | b"remove"
+                    | b"r"
+                    | b"rm"
+                    | b"uninstall"
+                    | b"link"
+                    | b"unlink"
+                    | b"ls"
+                    | b"la"
+                    | b"ll"
+                    | b"list"
+            )
+        ) {
+            let drop_colliding_shorts = |v: &mut Vec<&'static ZStr>| {
+                let mut past_separator = false;
+                v.retain(|a| {
+                    let b = a.as_bytes();
+                    if b == b"--" {
+                        past_separator = true;
+                    }
+                    past_separator || !matches!(b, b"-p" | b"-y" | b"-d")
+                });
+            };
+            drop_colliding_shorts(&mut pre_subcommand_flags);
+            drop_colliding_shorts(&mut tail);
+        }
+        if matches!(
+            mapped.first().map(|z| z.as_bytes()),
+            Some(b"run" | b"init" | b"x" | b"pm")
+        ) {
             for a in pre_subcommand_flags.drain(..) {
                 if matches!(a.as_bytes(), b"--if-present" | b"--silent") {
                     hoisted.push(a);

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -906,9 +906,17 @@ pub mod command {
     #[derive(Clone, Copy)]
     enum NpmFlag {
         Drop,
+        /// Copied through together with its value (bun accepts the npm
+        /// spelling for the mapped subcommand).
+        Keep,
         Rename(&'static bun_core::ZStr),
     }
 
+    /// Classify a value-taking npm flag. Returns `None` for anything that is
+    /// not a recognized value-taking npm flag (positionals, boolean flags,
+    /// bun's own flags). The advance over argv (flag plus separate value) is
+    /// the same whichever variant comes back, so a scan that only needs the
+    /// subcommand position can pass empty `keep`/`renames`.
     #[cold]
     fn translate_npm_value_flag(
         arg: &[u8],
@@ -929,7 +937,7 @@ pub mod command {
             return None;
         };
         if keep.contains(&name) {
-            return None;
+            return Some(NpmFlag::Keep);
         }
         if let Some(&(_, to)) = renames.iter().find(|(n, _)| *n == name) {
             return Some(NpmFlag::Rename(to));
@@ -939,6 +947,22 @@ pub mod command {
             b"prefix" => Some(NpmFlag::Rename(zstr!("--cwd"))),
             _ if NPM_VALUE_FLAGS_IGNORED.binary_search(&name).is_ok() => Some(NpmFlag::Drop),
             _ => None,
+        }
+    }
+
+    /// npm's boolean `--save-*` dependency-group flags under bun's spelling.
+    /// These take no value, so they are rewritten in place; bun's clap parser
+    /// would otherwise skip the npm spelling silently and e.g.
+    /// `npm install --save-dev typescript` would land in `"dependencies"`.
+    #[cold]
+    fn rename_npm_bool_flag(arg: &'static bun_core::ZStr) -> &'static bun_core::ZStr {
+        use bun_core::zstr;
+        match arg.as_bytes() {
+            b"--save-dev" => zstr!("--dev"),
+            b"--save-exact" => zstr!("--exact"),
+            b"--save-optional" => zstr!("--optional"),
+            b"--save-peer" => zstr!("--peer"),
+            _ => arg,
         }
     }
 
@@ -1002,35 +1026,57 @@ pub mod command {
                         && argv
                             .get(i + 1)
                             .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
-                    if let NpmFlag::Rename(new_name) = tr {
-                        hoisted.push(new_name);
-                        if let Some(eq) = eq {
-                            let with_nul = a.as_bytes_with_nul();
-                            hoisted.push(ZStr::from_static(&with_nul[eq as usize + 1..]));
-                        } else if consumes_next {
-                            hoisted.push(argv[i + 1]);
+                    match tr {
+                        NpmFlag::Drop => {}
+                        // Hoisted, not in place: before the subcommand the
+                        // flag's value would be taken for the subcommand by
+                        // `which()`'s leading-flag skip.
+                        NpmFlag::Keep => {
+                            hoisted.push(a);
+                            if consumes_next {
+                                hoisted.push(argv[i + 1]);
+                            }
+                        }
+                        NpmFlag::Rename(new_name) => {
+                            hoisted.push(new_name);
+                            if let Some(eq) = eq {
+                                let with_nul = a.as_bytes_with_nul();
+                                hoisted.push(ZStr::from_static(&with_nul[eq as usize + 1..]));
+                            } else if consumes_next {
+                                hoisted.push(argv[i + 1]);
+                            }
                         }
                     }
                     i += if consumes_next { 2 } else { 1 };
                     continue;
                 }
-                tail.push(a);
+                tail.push(rename_npm_bool_flag(a));
                 i += 1;
             }
             argv.len()
         }
 
-        let mut hoisted: Vec<&'static ZStr> = Vec::new();
-        let mut pre_subcommand_flags: Vec<&'static ZStr> = Vec::new();
-        let sub_idx = copy_translating_npm_flags(
-            argv,
-            &mut pre_subcommand_flags,
-            &mut hoisted,
-            1,
-            true,
-            &[],
-            &[],
-        );
+        // npm accepts config flags in any position, so the subcommand (and
+        // with it the keep/rename decision) must be known before the
+        // pre-subcommand flags are processed: `npm --tag beta publish` keeps
+        // `--tag beta` only because `publish` is found first. The scan
+        // advances over value flags exactly like `copy_translating_npm_flags`.
+        let sub_idx = {
+            let mut i = 1;
+            while i < argv.len() {
+                let ab = argv[i].as_bytes();
+                if ab == b"--" || ab.first() != Some(&b'-') {
+                    break;
+                }
+                let consumes_next = translate_npm_value_flag(ab, &[], &[]).is_some()
+                    && !strings::contains_char(ab, b'=')
+                    && argv
+                        .get(i + 1)
+                        .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
+                i += if consumes_next { 2 } else { 1 };
+            }
+            i
+        };
         let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
         let sub_bytes = subcommand.map(|z| z.as_bytes());
         let rest_start = sub_idx + usize::from(sub_idx < argv.len());
@@ -1038,6 +1084,32 @@ pub mod command {
             .iter()
             .take_while(|a| a.as_bytes() != b"--")
             .any(|a| a.as_bytes().first() != Some(&b'-'));
+
+        // npm flags bun's own parser accepts for the mapped subcommand must
+        // reach it instead of being dropped, either as-is (`keep`) or under
+        // bun's spelling (`renames`).
+        let (keep, renames): (&[&[u8]], &[(&[u8], &ZStr)]) = match sub_bytes {
+            Some(b"publish") => (&[b"access", b"otp", b"tag"], &[]),
+            Some(b"version" | b"verison") => (&[b"message"], &[]),
+            Some(b"pack") => (&[], &[(b"pack-destination", zstr!("--destination"))]),
+            _ => (&[], &[]),
+        };
+
+        let mut hoisted: Vec<&'static ZStr> = Vec::new();
+        let mut pre_subcommand_flags: Vec<&'static ZStr> = Vec::new();
+        let first_pass_end = copy_translating_npm_flags(
+            argv,
+            &mut pre_subcommand_flags,
+            &mut hoisted,
+            1,
+            true,
+            keep,
+            renames,
+        );
+        debug_assert_eq!(
+            first_pass_end, sub_idx,
+            "subcommand prescan must advance exactly like the copy pass"
+        );
 
         let mut mapped: Vec<&'static ZStr> = Vec::with_capacity(2);
         match sub_bytes {
@@ -1079,29 +1151,30 @@ pub mod command {
                 mapped.push(zstr!("install"));
             }
             Some(b"ls" | b"la" | b"ll") => mapped.push(zstr!("list")),
-            Some(b"view" | b"show") => mapped.push(zstr!("info")),
+            Some(b"view" | b"show" | b"v") => mapped.push(zstr!("info")),
+            // npm spells dependency-update as `upgrade`/`up`/`udpate` too;
+            // bare `upgrade` would dispatch bun's self-upgrader.
+            Some(b"upgrade" | b"up" | b"udpate") => mapped.push(zstr!("update")),
+            // `c` is npm's alias for `config`; bare `c` would dispatch
+            // `bun create`.
+            Some(b"c") => mapped.push(zstr!("config")),
             Some(b"version" | b"verison") => {
                 mapped.push(zstr!("pm"));
                 mapped.push(zstr!("version"));
             }
-            // Likewise `npm pack` is `bun pm pack`.
+            // Likewise `npm pack` / `npm cache` are `bun pm pack` / `pm cache`.
             Some(b"pack") => {
                 mapped.push(zstr!("pm"));
                 mapped.push(zstr!("pack"));
+            }
+            Some(b"cache") => {
+                mapped.push(zstr!("pm"));
+                mapped.push(zstr!("cache"));
             }
             Some(_) => mapped.push(*subcommand.unwrap()),
             None => {}
         }
 
-        // npm flags bun's own parser accepts for the mapped subcommand must
-        // reach it instead of being dropped, either as-is (`keep`) or under
-        // bun's spelling (`renames`).
-        let (keep, renames): (&[&[u8]], &[(&[u8], &ZStr)]) = match sub_bytes {
-            Some(b"publish") => (&[b"access", b"otp", b"tag"], &[]),
-            Some(b"version" | b"verison") => (&[b"message"], &[]),
-            Some(b"pack") => (&[], &[(b"pack-destination", zstr!("--destination"))]),
-            _ => (&[], &[]),
-        };
         let mut tail: Vec<&'static ZStr> =
             Vec::with_capacity(argv.len().saturating_sub(rest_start));
         copy_translating_npm_flags(

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -871,7 +871,9 @@ pub mod command {
     const NPM_VALUE_FLAGS_IGNORED: &[&[u8]] = &[
         b"access",
         b"before",
+        b"ca",
         b"cache",
+        b"cafile",
         b"depth",
         b"editor",
         b"fetch-retries",
@@ -880,6 +882,8 @@ pub mod command {
         b"fetch-retry-mintimeout",
         b"fetch-timeout",
         b"globalconfig",
+        b"https-proxy",
+        b"include",
         b"init-author-email",
         b"init-author-name",
         b"init-author-url",
@@ -893,8 +897,12 @@ pub mod command {
         b"maxsockets",
         b"message",
         b"node-options",
+        b"noproxy",
+        b"omit",
         b"otp",
         b"pack-destination",
+        b"proxy",
+        b"registry",
         b"script-shell",
         b"searchexclude",
         b"searchlimit",
@@ -962,8 +970,12 @@ pub mod command {
         match arg.as_bytes() {
             b"--save-dev" => zstr!("--dev"),
             b"--save-exact" => zstr!("--exact"),
-            b"--save-optional" => zstr!("--optional"),
+            b"--save-optional" | b"-O" => zstr!("--optional"),
             b"--save-peer" => zstr!("--peer"),
+            // npm's -P/--save-prod mean "save to dependencies", bun's
+            // default; bun's own -P means --prod (skip devDependencies), so
+            // map to the no-op --save. (-D and -E match bun's shorts.)
+            b"-P" | b"--save-prod" => zstr!("--save"),
             _ => arg,
         }
     }
@@ -1097,15 +1109,28 @@ pub mod command {
         // `--filter` would not consume its value and the workspace name would
         // leak as a positional.
         let (keep, renames): (&[&[u8]], &[(&[u8], &ZStr)]) = match sub_bytes {
-            Some(b"publish") => (&[b"access", b"otp", b"tag"], &[]),
+            Some(b"publish") => (
+                &[b"access", b"ca", b"cafile", b"otp", b"registry", b"tag"],
+                &[],
+            ),
             Some(b"version" | b"verison") => (&[b"message"], &[]),
             Some(b"pack") => (&[], &[(b"pack-destination", zstr!("--destination"))]),
+            // The script runner accepts --filter but none of the npm
+            // config flags.
             Some(
                 b"test" | b"t" | b"tst" | b"start" | b"stop" | b"restart" | b"run-script" | b"rum"
-                | b"urn" | b"run" | b"i" | b"isntall" | b"in" | b"ins" | b"inst" | b"insta"
-                | b"instal" | b"install" | b"ci" | b"clean-install" | b"ic" | b"install-clean"
-                | b"isntall-clean" | b"update" | b"upgrade" | b"up" | b"udpate" | b"outdated",
+                | b"urn" | b"run",
             ) => (&[], &[(b"workspace", zstr!("--filter"))]),
+            // The install-family parsers accept --filter plus these npm
+            // config flags as spelled.
+            Some(
+                b"i" | b"isntall" | b"in" | b"ins" | b"inst" | b"insta" | b"instal" | b"install"
+                | b"ci" | b"clean-install" | b"ic" | b"install-clean" | b"isntall-clean"
+                | b"update" | b"upgrade" | b"up" | b"udpate" | b"outdated",
+            ) => (
+                &[b"ca", b"cafile", b"omit", b"registry"],
+                &[(b"workspace", zstr!("--filter"))],
+            ),
             _ => (&[], &[]),
         };
 
@@ -1166,10 +1191,13 @@ pub mod command {
             // Decided from `tail`, where value-flags are already consumed, so
             // e.g. `--loglevel`'s value is not mistaken for an initializer.
             Some(b"init" | b"create" | b"innit") => {
-                let has_initializer = tail
-                    .iter()
-                    .take_while(|a| a.as_bytes() != b"--")
-                    .any(|a| a.as_bytes().first() != Some(&b'-'));
+                // Everything after `--` is positional in npm, so the scan
+                // does not stop there: `npm init -- x` still names a
+                // template.
+                let has_initializer = tail.iter().any(|a| {
+                    let b = a.as_bytes();
+                    b != b"--" && b.first() != Some(&b'-')
+                });
                 mapped.push(if has_initializer {
                     zstr!("create")
                 } else {
@@ -1213,6 +1241,25 @@ pub mod command {
         // subcommands mapped to them.
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"x" | b"create")) {
             hoisted.clear();
+        }
+        // npm consumes its remaining config flags (e.g. `-y`) anywhere
+        // before `--`, and `bun create` rejects flags it does not know, so
+        // for the create mapping keep only positionals up to `--`;
+        // everything after `--` is forwarded to the create-* package.
+        if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"create")) {
+            pre_subcommand_flags.clear();
+            let mut past_separator = false;
+            tail.retain(|a| {
+                let b = a.as_bytes();
+                if past_separator {
+                    return true;
+                }
+                if b == b"--" {
+                    past_separator = true;
+                    return true;
+                }
+                b.first() != Some(&b'-')
+            });
         }
 
         let mut out: Vec<&'static ZStr> = Vec::with_capacity(
@@ -2257,7 +2304,10 @@ pub mod command {
             while remainder_i < remainder.len() && positional_i < positionals.len() {
                 let slice = strings::trim(remainder[remainder_i].as_bytes(), b" \t\n");
                 if !slice.is_empty() {
-                    if !strings::has_prefix(slice, b"--") {
+                    // Like the bunx parser, a token starting with `-` is
+                    // never a positional: `bun create -y foo` must not take
+                    // `-y` for the template name.
+                    if slice[0] != b'-' {
                         if positional_i == 1 {
                             template_name_start = remainder_i + 2;
                         }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -847,6 +847,178 @@ pub mod command {
         }
     }
 
+    // `is_npm`/`is_npx` compare the basename exactly so `pnpm`/`pnpx` (and
+    // anything else ending in "npm"/"npx") are not caught.
+    pub(crate) fn is_npm(argv0: &[u8]) -> bool {
+        let base = bun_paths::basename(argv0);
+        base == b"npm" || (cfg!(windows) && base == b"npm.exe")
+    }
+
+    pub(crate) fn is_npx(argv0: &[u8]) -> bool {
+        let base = bun_paths::basename(argv0);
+        base == b"npx" || (cfg!(windows) && base == b"npx.exe")
+    }
+
+    /// npm long options that take a separate value argument and have no bun
+    /// equivalent. When bun is invoked as `npm` via the `--bun` shim these are
+    /// dropped together with their value so the value is not mistaken for a
+    /// positional (e.g. `npm install --loglevel error react` must not try to
+    /// install a package called `error`). Kept sorted for `binary_search`.
+    const NPM_VALUE_FLAGS_IGNORED: &[&[u8]] = &[
+        b"access",
+        b"before",
+        b"cache",
+        b"depth",
+        b"editor",
+        b"fetch-retries",
+        b"fetch-retry-factor",
+        b"fetch-retry-maxtimeout",
+        b"fetch-retry-mintimeout",
+        b"fetch-timeout",
+        b"globalconfig",
+        b"init-author-email",
+        b"init-author-name",
+        b"init-author-url",
+        b"init-license",
+        b"init-module",
+        b"init-version",
+        b"location",
+        b"loglevel",
+        b"logs-dir",
+        b"logs-max",
+        b"maxsockets",
+        b"message",
+        b"node-options",
+        b"otp",
+        b"pack-destination",
+        b"prefix",
+        b"script-shell",
+        b"searchexclude",
+        b"searchlimit",
+        b"searchopts",
+        b"searchstaleness",
+        b"tag",
+        b"userconfig",
+        b"viewer",
+        b"workspace",
+    ];
+
+    #[cold]
+    fn is_npm_ignored_value_flag(arg: &[u8]) -> bool {
+        if let Some(name) = arg.strip_prefix(b"--") {
+            let name = match strings::index_of_char(name, b'=') {
+                Some(eq) => &name[..eq as usize],
+                None => name,
+            };
+            return NPM_VALUE_FLAGS_IGNORED.binary_search(&name).is_ok();
+        }
+        arg == b"-w" || arg.starts_with(b"-w=")
+    }
+
+    /// Rewrite argv when bun is invoked as `npm` (via the `--bun` shim dir) so
+    /// the rest of the CLI can dispatch it as a normal bun invocation.
+    /// Best-effort: subcommands bun has no equivalent for fall through
+    /// unchanged.
+    ///
+    /// # Safety
+    /// Single-threaded CLI startup; stores into the process-global argv slot.
+    #[cold]
+    #[inline(never)]
+    unsafe fn translate_npm_argv() {
+        use bun_core::{ZStr, zstr};
+        debug_assert!(
+            NPM_VALUE_FLAGS_IGNORED.is_sorted(),
+            "NPM_VALUE_FLAGS_IGNORED must be sorted for binary_search"
+        );
+
+        let argv = bun::argv().as_slice();
+        let mut out: Vec<&'static ZStr> = Vec::with_capacity(argv.len() + 1);
+        let Some(&argv0) = argv.first() else { return };
+        out.push(argv0);
+
+        // Copy argv[from..] into `out`, dropping npm-only value-taking flags
+        // (and their separate value). Stops at the first positional when
+        // `stop_at_positional` is set and returns its index; otherwise copies
+        // through to the end, returning `argv.len()`. A bare `--` ends flag
+        // processing either way.
+        let copy_dropping_npm_flags =
+            |out: &mut Vec<&'static ZStr>, from: usize, stop_at_positional: bool| -> usize {
+                let mut i = from;
+                while i < argv.len() {
+                    let a = argv[i];
+                    let ab = a.as_bytes();
+                    if ab == b"--" {
+                        if !stop_at_positional {
+                            out.extend_from_slice(&argv[i..]);
+                        }
+                        return i;
+                    }
+                    if ab.first() != Some(&b'-') {
+                        if stop_at_positional {
+                            return i;
+                        }
+                        out.push(a);
+                        i += 1;
+                        continue;
+                    }
+                    if is_npm_ignored_value_flag(ab) {
+                        let consumes_next = !strings::contains_char(ab, b'=')
+                            && argv
+                                .get(i + 1)
+                                .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
+                        i += if consumes_next { 2 } else { 1 };
+                        continue;
+                    }
+                    out.push(a);
+                    i += 1;
+                }
+                argv.len()
+            };
+
+        let sub_idx = copy_dropping_npm_flags(&mut out, 1, true);
+        let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
+        let rest_start = sub_idx + usize::from(sub_idx < argv.len());
+
+        match subcommand.map(|z| z.as_bytes()) {
+            // npm's lifecycle shortcuts run the package.json script; map to
+            // `bun run <name>` so `npm test` does not invoke bun's test runner.
+            Some(b"test" | b"t" | b"tst") => {
+                out.push(zstr!("run"));
+                out.push(zstr!("test"));
+            }
+            Some(b"start") => {
+                out.push(zstr!("run"));
+                out.push(zstr!("start"));
+            }
+            Some(b"stop") => {
+                out.push(zstr!("run"));
+                out.push(zstr!("stop"));
+            }
+            Some(b"restart") => {
+                out.push(zstr!("run"));
+                out.push(zstr!("restart"));
+            }
+            Some(b"run-script" | b"rum" | b"urn") => out.push(zstr!("run")),
+            Some(b"clean-install" | b"ic" | b"install-clean" | b"isntall-clean") => {
+                out.push(zstr!("ci"));
+            }
+            Some(b"i" | b"isntall" | b"in" | b"ins" | b"inst" | b"insta" | b"instal") => {
+                out.push(zstr!("install"));
+            }
+            Some(b"ls" | b"la" | b"ll") => out.push(zstr!("list")),
+            Some(b"view" | b"show") => out.push(zstr!("info")),
+            Some(_) => out.push(*subcommand.unwrap()),
+            None => {}
+        }
+
+        copy_dropping_npm_flags(&mut out, rest_start, false);
+
+        static SLOT: std::sync::OnceLock<Box<[&'static ZStr]>> = std::sync::OnceLock::new();
+        let stored = SLOT.get_or_init(move || out.into_boxed_slice());
+        // SAFETY: per fn contract — single-threaded startup.
+        unsafe { bun::set_argv(stored) };
+    }
+
     /// Cheap argv prescan for the dominant `bun <path>` / `bun .` shape.
     ///
     /// `which()` classifies any first positional that isn't one of the ~40
@@ -943,8 +1115,35 @@ pub mod command {
             return Tag::RunAsNodeCommand;
         }
 
+        if is_npx(argv0) {
+            // SAFETY: single-threaded startup
+            IS_BUNX_EXE.store(true, core::sync::atomic::Ordering::Relaxed);
+            return Tag::BunxCommand;
+        }
+
+        let as_npm = is_npm(argv0);
+        let (argv, mut iter) = if as_npm {
+            bun_clap::streaming::WARN_ON_UNRECOGNIZED_FLAG
+                .store(false, core::sync::atomic::Ordering::Relaxed);
+            // SAFETY: single-threaded startup; rewrites the process-global argv
+            // view. Fall through to the normal subcommand matcher on the
+            // rewritten argv so `npm install` / `npm run` / etc. dispatch to
+            // the same Tag a direct `bun` invocation would.
+            unsafe { translate_npm_argv() };
+            let argv = bun::argv();
+            let mut iter = argv.iter();
+            let _ = iter.next();
+            (argv, iter)
+        } else {
+            (argv, iter)
+        };
+
         let Some(mut first_arg_name) = iter.next() else {
-            return Tag::AutoCommand;
+            return if as_npm {
+                Tag::HelpCommand
+            } else {
+                Tag::AutoCommand
+            };
         };
         while !first_arg_name.is_empty()
             && first_arg_name[0] == b'-'
@@ -1232,7 +1431,7 @@ pub mod command {
         {
             let argv = bun::argv();
             let argv0 = argv.get(0).map(bun_core::ZStr::as_bytes).unwrap_or(b"");
-            if !is_node(argv0) && !is_bun_x(argv0) {
+            if !is_node(argv0) && !is_bun_x(argv0) && !is_npx(argv0) {
                 if argv.len() == 2 {
                     match argv.get(1).map(bun_core::ZStr::as_bytes) {
                         Some(b"-v" | b"--version") => print_version_and_exit(),
@@ -1241,40 +1440,42 @@ pub mod command {
                     }
                 }
 
-                let empty_eval = match argv.len() {
-                    2 => matches!(
-                        argv.get(1).map(bun_core::ZStr::as_bytes),
-                        Some(b"-e=" | b"-p=" | b"--eval=" | b"--print=")
-                    ),
-                    3 => {
-                        argv.get(2).is_some_and(|a| a.as_bytes().is_empty())
-                            && matches!(
-                                argv.get(1).map(bun_core::ZStr::as_bytes),
-                                Some(b"-e" | b"-p" | b"--eval" | b"--print")
-                            )
+                if !is_npm(argv0) {
+                    let empty_eval = match argv.len() {
+                        2 => matches!(
+                            argv.get(1).map(bun_core::ZStr::as_bytes),
+                            Some(b"-e=" | b"-p=" | b"--eval=" | b"--print=")
+                        ),
+                        3 => {
+                            argv.get(2).is_some_and(|a| a.as_bytes().is_empty())
+                                && matches!(
+                                    argv.get(1).map(bun_core::ZStr::as_bytes),
+                                    Some(b"-e" | b"-p" | b"--eval" | b"--print")
+                                )
+                        }
+                        _ => false,
+                    };
+                    if empty_eval {
+                        Output::flush();
+                        return HelpCommand::exec();
                     }
-                    _ => false,
-                };
-                if empty_eval {
-                    Output::flush();
-                    return HelpCommand::exec();
-                }
 
-                // `bun <path>` / `bun .` — the dominant run shape. argv[1] is
-                // path-shaped (`looks_like_run_entrypoint`), which no
-                // subcommand keyword can be, so `which()` would unambiguously
-                // return `Tag::AutoCommand`; short-circuit straight to that
-                // arm so a plain `bun <file>` never decodes the subcommand
-                // classifier (`which()` + its `RootCommandMatcher` keyword
-                // table / rodata) or walks the per-tag dispatch `match` below.
-                // Dispatches to exactly the arm `which()` would have selected,
-                // so config loading / arg parsing / passthrough are unchanged.
-                if argv
-                    .get(1)
-                    .map(bun_core::ZStr::as_bytes)
-                    .is_some_and(looks_like_run_entrypoint)
-                {
-                    return exec_auto_or_run(Tag::AutoCommand, log);
+                    // `bun <path>` / `bun .` — the dominant run shape. argv[1] is
+                    // path-shaped (`looks_like_run_entrypoint`), which no
+                    // subcommand keyword can be, so `which()` would unambiguously
+                    // return `Tag::AutoCommand`; short-circuit straight to that
+                    // arm so a plain `bun <file>` never decodes the subcommand
+                    // classifier (`which()` + its `RootCommandMatcher` keyword
+                    // table / rodata) or walks the per-tag dispatch `match` below.
+                    // Dispatches to exactly the arm `which()` would have selected,
+                    // so config loading / arg parsing / passthrough are unchanged.
+                    if argv
+                        .get(1)
+                        .map(bun_core::ZStr::as_bytes)
+                        .is_some_and(looks_like_run_entrypoint)
+                    {
+                        return exec_auto_or_run(Tag::AutoCommand, log);
+                    }
                 }
             }
         }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -892,6 +892,7 @@ pub mod command {
         b"pack-destination",
         b"proxy",
         b"registry",
+        b"scope",
         b"script-shell",
         b"searchexclude",
         b"searchlimit",
@@ -953,6 +954,35 @@ pub mod command {
             b"-P" | b"--save-prod" => zstr!("--save"),
             _ => arg,
         }
+    }
+
+    /// npm flags that never take a value from the following token, so
+    /// dropping them must not consume it.
+    #[cold]
+    fn is_npm_bool_flag(arg: &[u8]) -> bool {
+        strings::has_prefix_comptime(arg, b"--no-")
+            || matches!(
+                arg,
+                b"-y"
+                    | b"--yes"
+                    | b"-s"
+                    | b"-q"
+                    | b"-d"
+                    | b"-dd"
+                    | b"-ddd"
+                    | b"-p"
+                    | b"-g"
+                    | b"--global"
+                    | b"--json"
+                    | b"--long"
+                    | b"--parseable"
+                    | b"--ignore-scripts"
+                    | b"--foreground-scripts"
+                    | b"--include-workspace-root"
+                    | b"--workspaces"
+                    | b"--if-present"
+                    | b"--silent"
+            )
     }
 
     #[cold]
@@ -1173,6 +1203,8 @@ pub mod command {
                     if matches!(b, b"--if-present" | b"--silent") {
                         hoisted.push(a);
                         i += 1;
+                    } else if is_npm_bool_flag(b) {
+                        i += 1;
                     } else {
                         let consumes_next = !strings::contains_char(b, b'=')
                             && tail.get(i + 1).is_some_and(|n| {
@@ -1190,18 +1222,29 @@ pub mod command {
         }
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"create")) {
             pre_subcommand_flags.clear();
-            let mut past_separator = false;
-            tail.retain(|a| {
+            let mut new_tail: Vec<&'static ZStr> = Vec::with_capacity(tail.len());
+            let mut i = 0;
+            while i < tail.len() {
+                let a = tail[i];
                 let b = a.as_bytes();
-                if past_separator {
-                    return true;
-                }
                 if b == b"--" {
-                    past_separator = true;
-                    return true;
+                    new_tail.extend_from_slice(&tail[i..]);
+                    break;
                 }
-                b.first() != Some(&b'-')
-            });
+                if b.first() == Some(&b'-') {
+                    let consumes_next = !is_npm_bool_flag(b)
+                        && !strings::contains_char(b, b'=')
+                        && tail.get(i + 1).is_some_and(|n| {
+                            let nb = n.as_bytes();
+                            nb != b"--" && nb.first() != Some(&b'-')
+                        });
+                    i += if consumes_next { 2 } else { 1 };
+                    continue;
+                }
+                new_tail.push(a);
+                i += 1;
+            }
+            tail = new_tail;
         }
 
         let mut out: Vec<&'static ZStr> = Vec::with_capacity(

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -847,8 +847,6 @@ pub mod command {
         }
     }
 
-    // `is_npm`/`is_npx` compare the basename exactly so `pnpm`/`pnpx` (and
-    // anything else ending in "npm"/"npx") are not caught.
     pub(crate) fn is_npm(argv0: &[u8]) -> bool {
         let base = bun_paths::basename(argv0);
         base == b"npm" || (cfg!(windows) && base == b"npm.exe")
@@ -859,15 +857,6 @@ pub mod command {
         base == b"npx" || (cfg!(windows) && base == b"npx.exe")
     }
 
-    /// npm long options that take a separate value argument and have no bun
-    /// equivalent. When bun is invoked as `npm` via the shim these are dropped
-    /// together with their value so the value is not mistaken for a positional
-    /// (e.g. `npm install --loglevel error react` must not try to install a
-    /// package called `error`). Options that change the *target* of the
-    /// operation are translated instead of dropped where bun can express
-    /// them: `--prefix` always (`--cwd`), `--workspace` only for subcommands
-    /// whose parser accepts `--filter`; see `translate_npm_value_flag` and
-    /// the per-subcommand `renames`. Kept sorted for `binary_search`.
     const NPM_VALUE_FLAGS_IGNORED: &[&[u8]] = &[
         b"access",
         b"before",
@@ -917,17 +906,10 @@ pub mod command {
     #[derive(Clone, Copy)]
     enum NpmFlag {
         Drop,
-        /// Copied through together with its value (bun accepts the npm
-        /// spelling for the mapped subcommand).
         Keep,
         Rename(&'static bun_core::ZStr),
     }
 
-    /// Classify a value-taking npm flag. Returns `None` for anything that is
-    /// not a recognized value-taking npm flag (positionals, boolean flags,
-    /// bun's own flags). The advance over argv (flag plus separate value) is
-    /// the same whichever variant comes back, so a scan that only needs the
-    /// subcommand position can pass empty `keep`/`renames`.
     #[cold]
     fn translate_npm_value_flag(
         arg: &[u8],
@@ -960,10 +942,6 @@ pub mod command {
         }
     }
 
-    /// npm's boolean `--save-*` dependency-group flags under bun's spelling.
-    /// These take no value, so they are rewritten in place; bun's clap parser
-    /// would otherwise skip the npm spelling silently and e.g.
-    /// `npm install --save-dev typescript` would land in `"dependencies"`.
     #[cold]
     fn rename_npm_bool_flag(arg: &'static bun_core::ZStr) -> &'static bun_core::ZStr {
         use bun_core::zstr;
@@ -972,19 +950,11 @@ pub mod command {
             b"--save-exact" => zstr!("--exact"),
             b"--save-optional" | b"-O" => zstr!("--optional"),
             b"--save-peer" => zstr!("--peer"),
-            // npm's -P/--save-prod mean "save to dependencies", bun's
-            // default; bun's own -P means --prod (skip devDependencies), so
-            // map to the no-op --save. (-D and -E match bun's shorts.)
             b"-P" | b"--save-prod" => zstr!("--save"),
             _ => arg,
         }
     }
 
-    /// Rewrite argv when bun is invoked as `npm` (via the `--bun` shim dir) so
-    /// the rest of the CLI can dispatch it as a normal bun invocation.
-    /// Best-effort: subcommands bun has no equivalent for fall through
-    /// unchanged.
-    ///
     /// # Safety
     /// Single-threaded CLI startup; stores into the process-global argv slot.
     #[cold]
@@ -999,14 +969,6 @@ pub mod command {
         let argv = bun::argv().as_slice();
         let Some(&argv0) = argv.first() else { return };
 
-        // Copy `argv[from..]` into `tail`, dropping npm-only value-taking
-        // flags (with their separate value) and renaming
-        // `--workspace`/`--prefix` to their bun spellings into `hoisted`.
-        // Renamed flags are hoisted before the subcommand so `bun run`'s
-        // stop-after-first-positional does not pass them through to the
-        // script. Stops at the first positional when `stop_at_positional` is
-        // set and returns its index; otherwise copies to the end. A bare `--`
-        // ends flag processing either way.
         fn copy_translating_npm_flags(
             argv: &[&'static ZStr],
             tail: &mut Vec<&'static ZStr>,
@@ -1042,9 +1004,6 @@ pub mod command {
                             .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
                     match tr {
                         NpmFlag::Drop => {}
-                        // Hoisted, not in place: before the subcommand the
-                        // flag's value would be taken for the subcommand by
-                        // `which()`'s leading-flag skip.
                         NpmFlag::Keep => {
                             hoisted.push(a);
                             if consumes_next {
@@ -1070,11 +1029,6 @@ pub mod command {
             argv.len()
         }
 
-        // npm accepts config flags in any position, so the subcommand (and
-        // with it the keep/rename decision) must be known before the
-        // pre-subcommand flags are processed: `npm --tag beta publish` keeps
-        // `--tag beta` only because `publish` is found first. The scan
-        // advances over value flags exactly like `copy_translating_npm_flags`.
         let scan_end = {
             let mut i = 1;
             while i < argv.len() {
@@ -1091,23 +1045,12 @@ pub mod command {
             }
             i
         };
-        // npm treats a leading `--` as end-of-options but still takes the
-        // next token as the subcommand: `npm -- upgrade` is `npm upgrade`.
-        // Without this skip the raw token would bypass the mapping and e.g.
-        // `upgrade` would dispatch bun's self-upgrader.
         let sub_idx =
             scan_end + usize::from(argv.get(scan_end).is_some_and(|a| a.as_bytes() == b"--"));
         let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
         let sub_bytes = subcommand.map(|z| z.as_bytes());
         let rest_start = sub_idx + usize::from(sub_idx < argv.len());
 
-        // npm flags bun's own parser accepts for the mapped subcommand must
-        // reach it instead of being dropped, either as-is (`keep`) or under
-        // bun's spelling (`renames`). `--workspace` becomes `--filter` only
-        // where the mapped command parses `--filter` (run scripts, install,
-        // update, outdated); elsewhere it stays dropped, since an unknown
-        // `--filter` would not consume its value and the workspace name would
-        // leak as a positional.
         let (keep, renames): (&[&[u8]], &[(&[u8], &ZStr)]) = match sub_bytes {
             Some(b"publish") => (
                 &[b"access", b"ca", b"cafile", b"otp", b"registry", b"tag"],
@@ -1115,14 +1058,10 @@ pub mod command {
             ),
             Some(b"version" | b"verison") => (&[b"message"], &[]),
             Some(b"pack") => (&[], &[(b"pack-destination", zstr!("--destination"))]),
-            // The script runner accepts --filter but none of the npm
-            // config flags.
             Some(
                 b"test" | b"t" | b"tst" | b"start" | b"stop" | b"restart" | b"run-script" | b"rum"
                 | b"urn" | b"run",
             ) => (&[], &[(b"workspace", zstr!("--filter"))]),
-            // The install-family parsers accept --filter plus these npm
-            // config flags as spelled.
             Some(
                 b"i" | b"isntall" | b"in" | b"ins" | b"inst" | b"insta" | b"instal" | b"install"
                 | b"ci" | b"clean-install" | b"ic" | b"install-clean" | b"isntall-clean"
@@ -1164,8 +1103,6 @@ pub mod command {
 
         let mut mapped: Vec<&'static ZStr> = Vec::with_capacity(2);
         match sub_bytes {
-            // npm's lifecycle shortcuts run the package.json script; map to
-            // `bun run <name>` so `npm test` does not invoke bun's test runner.
             Some(b"test" | b"t" | b"tst") => {
                 mapped.push(zstr!("run"));
                 mapped.push(zstr!("test"));
@@ -1183,17 +1120,8 @@ pub mod command {
                 mapped.push(zstr!("restart"));
             }
             Some(b"run-script" | b"rum" | b"urn") => mapped.push(zstr!("run")),
-            // npm ≥7's `npm exec` is what `npx` delegates to; bun's own `exec`
-            // is a shell-script runner.
             Some(b"exec") => mapped.push(zstr!("x")),
-            // `npm init <x>` / `npm create <x>` ≡ `npx create-<x>`. Bare
-            // `npm init` scaffolds a package.json, same as `bun init`.
-            // Decided from `tail`, where value-flags are already consumed, so
-            // e.g. `--loglevel`'s value is not mistaken for an initializer.
             Some(b"init" | b"create" | b"innit") => {
-                // Everything after `--` is positional in npm, so the scan
-                // does not stop there: `npm init -- x` still names a
-                // template.
                 let has_initializer = tail.iter().any(|a| {
                     let b = a.as_bytes();
                     b != b"--" && b.first() != Some(&b'-')
@@ -1212,17 +1140,12 @@ pub mod command {
             }
             Some(b"ls" | b"la" | b"ll") => mapped.push(zstr!("list")),
             Some(b"view" | b"show" | b"v") => mapped.push(zstr!("info")),
-            // npm spells dependency-update as `upgrade`/`up`/`udpate` too;
-            // bare `upgrade` would dispatch bun's self-upgrader.
             Some(b"upgrade" | b"up" | b"udpate") => mapped.push(zstr!("update")),
-            // `c` is npm's alias for `config`; bare `c` would dispatch
-            // `bun create`.
             Some(b"c") => mapped.push(zstr!("config")),
             Some(b"version" | b"verison") => {
                 mapped.push(zstr!("pm"));
                 mapped.push(zstr!("version"));
             }
-            // Likewise `npm pack` / `npm cache` are `bun pm pack` / `pm cache`.
             Some(b"pack") => {
                 mapped.push(zstr!("pm"));
                 mapped.push(zstr!("pack"));
@@ -1235,17 +1158,9 @@ pub mod command {
             None => {}
         }
 
-        // The bunx and `bun create` parsers skip flags they do not know
-        // without consuming their value, so a hoisted `--cwd <dir>` would
-        // become the package or template name; drop renamed flags for the
-        // subcommands mapped to them.
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"x" | b"create")) {
             hoisted.clear();
         }
-        // npm consumes its remaining config flags (e.g. `-y`) anywhere
-        // before `--`, and `bun create` rejects flags it does not know, so
-        // for the create mapping keep only positionals up to `--`;
-        // everything after `--` is forwarded to the create-* package.
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"create")) {
             pre_subcommand_flags.clear();
             let mut past_separator = false;
@@ -1267,10 +1182,6 @@ pub mod command {
         );
         out.push(argv0);
         out.extend_from_slice(&pre_subcommand_flags);
-        // Hoisted flags go right after the first mapped token: `bun run`
-        // forwards everything after the script name to the script, so for the
-        // lifecycle shortcuts (`mapped = ["run", "test"]`) they must land
-        // between "run" and the script name.
         if let Some((first, rest_mapped)) = mapped.split_first() {
             out.push(*first);
             out.extend_from_slice(&hoisted);
@@ -1286,14 +1197,6 @@ pub mod command {
         unsafe { bun::set_argv(stored) };
     }
 
-    /// Rewrite argv when bun is invoked as `npx` via the shim. Since npm 7
-    /// `npx` accepts the same config flags as `npm`, so the npm-only
-    /// value-taking flags (plus npx's `-c`/`--call`) are dropped up to the
-    /// first positional; everything from the package name on belongs to the
-    /// executed package and is copied verbatim. Flags `translate_npm_argv`
-    /// would rename are dropped too: the bunx parser has no equivalent and
-    /// would take the stray value for the package name.
-    ///
     /// # Safety
     /// Single-threaded CLI startup; stores into the process-global argv slot.
     #[cold]
@@ -2304,9 +2207,6 @@ pub mod command {
             while remainder_i < remainder.len() && positional_i < positionals.len() {
                 let slice = strings::trim(remainder[remainder_i].as_bytes(), b" \t\n");
                 if !slice.is_empty() {
-                    // Like the bunx parser, a token starting with `-` is
-                    // never a positional: `bun create -y foo` must not take
-                    // `-y` for the template name.
                     if slice[0] != b'-' {
                         if positional_i == 1 {
                             template_name_start = remainder_i + 2;

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1160,22 +1160,33 @@ pub mod command {
             hoisted.clear();
         }
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"run")) {
-            let mut past_separator = false;
-            tail.retain(|a| {
+            let mut new_tail: Vec<&'static ZStr> = Vec::with_capacity(tail.len());
+            let mut i = 0;
+            while i < tail.len() {
+                let a = tail[i];
                 let b = a.as_bytes();
-                if past_separator {
-                    return true;
-                }
                 if b == b"--" {
-                    past_separator = true;
-                    return true;
+                    new_tail.extend_from_slice(&tail[i..]);
+                    break;
                 }
                 if b.first() == Some(&b'-') {
-                    hoisted.push(a);
-                    return false;
+                    if matches!(b, b"--if-present" | b"--silent") {
+                        hoisted.push(a);
+                        i += 1;
+                    } else {
+                        let consumes_next = !strings::contains_char(b, b'=')
+                            && tail.get(i + 1).is_some_and(|n| {
+                                let nb = n.as_bytes();
+                                nb != b"--" && nb.first() != Some(&b'-')
+                            });
+                        i += if consumes_next { 2 } else { 1 };
+                    }
+                    continue;
                 }
-                true
-            });
+                new_tail.push(a);
+                i += 1;
+            }
+            tail = new_tail;
         }
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"create")) {
             pre_subcommand_flags.clear();

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -864,8 +864,10 @@ pub mod command {
     /// together with their value so the value is not mistaken for a positional
     /// (e.g. `npm install --loglevel error react` must not try to install a
     /// package called `error`). Options that change the *target* of the
-    /// operation (`--workspace`/`--prefix`) are translated instead; see
-    /// `translate_npm_value_flag`. Kept sorted for `binary_search`.
+    /// operation are translated instead of dropped where bun can express
+    /// them: `--prefix` always (`--cwd`), `--workspace` only for subcommands
+    /// whose parser accepts `--filter`; see `translate_npm_value_flag` and
+    /// the per-subcommand `renames`. Kept sorted for `binary_search`.
     const NPM_VALUE_FLAGS_IGNORED: &[&[u8]] = &[
         b"access",
         b"before",
@@ -901,6 +903,7 @@ pub mod command {
         b"tag",
         b"userconfig",
         b"viewer",
+        b"workspace",
     ];
 
     #[derive(Clone, Copy)]
@@ -943,7 +946,6 @@ pub mod command {
             return Some(NpmFlag::Rename(to));
         }
         match name {
-            b"workspace" => Some(NpmFlag::Rename(zstr!("--filter"))),
             b"prefix" => Some(NpmFlag::Rename(zstr!("--cwd"))),
             _ if NPM_VALUE_FLAGS_IGNORED.binary_search(&name).is_ok() => Some(NpmFlag::Drop),
             _ => None,
@@ -1083,11 +1085,21 @@ pub mod command {
 
         // npm flags bun's own parser accepts for the mapped subcommand must
         // reach it instead of being dropped, either as-is (`keep`) or under
-        // bun's spelling (`renames`).
+        // bun's spelling (`renames`). `--workspace` becomes `--filter` only
+        // where the mapped command parses `--filter` (run scripts, install,
+        // update, outdated); elsewhere it stays dropped, since an unknown
+        // `--filter` would not consume its value and the workspace name would
+        // leak as a positional.
         let (keep, renames): (&[&[u8]], &[(&[u8], &ZStr)]) = match sub_bytes {
             Some(b"publish") => (&[b"access", b"otp", b"tag"], &[]),
             Some(b"version" | b"verison") => (&[b"message"], &[]),
             Some(b"pack") => (&[], &[(b"pack-destination", zstr!("--destination"))]),
+            Some(
+                b"test" | b"t" | b"tst" | b"start" | b"stop" | b"restart" | b"run-script" | b"rum"
+                | b"urn" | b"run" | b"i" | b"isntall" | b"in" | b"ins" | b"inst" | b"insta"
+                | b"instal" | b"install" | b"ci" | b"clean-install" | b"ic" | b"install-clean"
+                | b"isntall-clean" | b"update" | b"upgrade" | b"up" | b"udpate" | b"outdated",
+            ) => (&[], &[(b"workspace", zstr!("--filter"))]),
             _ => (&[], &[]),
         };
 
@@ -1189,10 +1201,11 @@ pub mod command {
             None => {}
         }
 
-        // The bunx parser skips flags it does not know without consuming
-        // their value, so a hoisted `--cwd <dir>` would make `<dir>` the
-        // package name; drop renamed flags for the bunx-mapped subcommands.
-        if matches!(sub_bytes, Some(b"exec" | b"x")) {
+        // The bunx and `bun create` parsers skip flags they do not know
+        // without consuming their value, so a hoisted `--cwd <dir>` would
+        // become the package or template name; drop renamed flags for the
+        // subcommands mapped to them.
+        if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"x" | b"create")) {
             hoisted.clear();
         }
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1257,6 +1257,34 @@ pub mod command {
                 }
             }
         }
+        if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"x")) {
+            let mut new_tail: Vec<&'static ZStr> = Vec::with_capacity(tail.len());
+            let mut i = 0;
+            while i < tail.len() {
+                let a = tail[i];
+                let b = a.as_bytes();
+                if b == b"--" {
+                    new_tail.extend_from_slice(&tail[i..]);
+                    break;
+                }
+                if b == b"-c" || b == b"--call" || b.starts_with(b"--call=") {
+                    let consumes_next = !strings::contains_char(b, b'=')
+                        && tail.get(i + 1).is_some_and(|n| {
+                            let nb = n.as_bytes();
+                            nb != b"--" && nb.first() != Some(&b'-')
+                        });
+                    i += if consumes_next { 2 } else { 1 };
+                    continue;
+                }
+                if b != b"--silent" && is_npm_bool_flag(b) {
+                    i += 1;
+                    continue;
+                }
+                new_tail.push(a);
+                i += 1;
+            }
+            tail = new_tail;
+        }
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"run")) {
             let mut new_tail: Vec<&'static ZStr> = Vec::with_capacity(tail.len());
             let mut i = 0;

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -927,6 +927,8 @@ pub mod command {
             b"workspace"
         } else if arg == b"-C" || arg.starts_with(b"-C=") {
             b"prefix"
+        } else if arg == b"-m" || arg.starts_with(b"-m=") {
+            b"message"
         } else {
             return None;
         };
@@ -972,6 +974,7 @@ pub mod command {
                     | b"-g"
                     | b"--global"
                     | b"--json"
+                    | b"-l"
                     | b"--long"
                     | b"--parseable"
                     | b"--ignore-scripts"
@@ -1241,7 +1244,7 @@ pub mod command {
                     if b == b"--" {
                         past_separator = true;
                     }
-                    past_separator || !matches!(b, b"-p" | b"-y" | b"-d")
+                    past_separator || !matches!(b, b"-p" | b"-y" | b"-d" | b"-dd" | b"-ddd")
                 });
             };
             drop_colliding_shorts(&mut pre_subcommand_flags);

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -910,7 +910,7 @@ pub mod command {
     }
 
     #[cold]
-    fn translate_npm_value_flag(arg: &[u8]) -> Option<NpmFlag> {
+    fn translate_npm_value_flag(arg: &[u8], keep: &[&[u8]]) -> Option<NpmFlag> {
         use bun_core::zstr;
         let name: &[u8] = if let Some(long) = arg.strip_prefix(b"--") {
             match strings::index_of_char(long, b'=') {
@@ -924,6 +924,9 @@ pub mod command {
         } else {
             return None;
         };
+        if keep.contains(&name) {
+            return None;
+        }
         match name {
             b"workspace" => Some(NpmFlag::Rename(zstr!("--filter"))),
             b"prefix" => Some(NpmFlag::Rename(zstr!("--cwd"))),
@@ -965,6 +968,7 @@ pub mod command {
             hoisted: &mut Vec<&'static ZStr>,
             from: usize,
             stop_at_positional: bool,
+            keep: &[&[u8]],
         ) -> usize {
             let mut i = from;
             while i < argv.len() {
@@ -984,7 +988,7 @@ pub mod command {
                     i += 1;
                     continue;
                 }
-                if let Some(tr) = translate_npm_value_flag(ab) {
+                if let Some(tr) = translate_npm_value_flag(ab, keep) {
                     let eq = strings::index_of_char(ab, b'=');
                     let consumes_next = eq.is_none()
                         && argv
@@ -1011,8 +1015,9 @@ pub mod command {
         let mut hoisted: Vec<&'static ZStr> = Vec::new();
         let mut pre_subcommand_flags: Vec<&'static ZStr> = Vec::new();
         let sub_idx =
-            copy_translating_npm_flags(argv, &mut pre_subcommand_flags, &mut hoisted, 1, true);
+            copy_translating_npm_flags(argv, &mut pre_subcommand_flags, &mut hoisted, 1, true, &[]);
         let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
+        let sub_bytes = subcommand.map(|z| z.as_bytes());
         let rest_start = sub_idx + usize::from(sub_idx < argv.len());
         let has_positional_after = argv[rest_start..]
             .iter()
@@ -1020,7 +1025,7 @@ pub mod command {
             .any(|a| a.as_bytes().first() != Some(&b'-'));
 
         let mut mapped: Vec<&'static ZStr> = Vec::with_capacity(2);
-        match subcommand.map(|z| z.as_bytes()) {
+        match sub_bytes {
             // npm's lifecycle shortcuts run the package.json script; map to
             // `bun run <name>` so `npm test` does not invoke bun's test runner.
             Some(b"test" | b"t" | b"tst") => {
@@ -1060,12 +1065,23 @@ pub mod command {
             }
             Some(b"ls" | b"la" | b"ll") => mapped.push(zstr!("list")),
             Some(b"view" | b"show") => mapped.push(zstr!("info")),
+            Some(b"version" | b"verison") => {
+                mapped.push(zstr!("pm"));
+                mapped.push(zstr!("version"));
+            }
             Some(_) => mapped.push(*subcommand.unwrap()),
             None => {}
         }
 
+        // npm flags bun's own parser accepts for the mapped subcommand must
+        // reach it instead of being dropped.
+        let keep: &[&[u8]] = match sub_bytes {
+            Some(b"publish") => &[b"access", b"otp", b"tag"],
+            Some(b"version" | b"verison") => &[b"message"],
+            _ => &[],
+        };
         let mut tail: Vec<&'static ZStr> = Vec::with_capacity(argv.len().saturating_sub(rest_start));
-        copy_translating_npm_flags(argv, &mut tail, &mut hoisted, rest_start, false);
+        copy_translating_npm_flags(argv, &mut tail, &mut hoisted, rest_start, false, keep);
 
         let mut out: Vec<&'static ZStr> = Vec::with_capacity(
             1 + pre_subcommand_flags.len() + mapped.len() + hoisted.len() + tail.len(),

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -910,7 +910,11 @@ pub mod command {
     }
 
     #[cold]
-    fn translate_npm_value_flag(arg: &[u8], keep: &[&[u8]]) -> Option<NpmFlag> {
+    fn translate_npm_value_flag(
+        arg: &[u8],
+        keep: &[&[u8]],
+        renames: &[(&[u8], &'static bun_core::ZStr)],
+    ) -> Option<NpmFlag> {
         use bun_core::zstr;
         let name: &[u8] = if let Some(long) = arg.strip_prefix(b"--") {
             match strings::index_of_char(long, b'=') {
@@ -926,6 +930,9 @@ pub mod command {
         };
         if keep.contains(&name) {
             return None;
+        }
+        if let Some(&(_, to)) = renames.iter().find(|(n, _)| *n == name) {
+            return Some(NpmFlag::Rename(to));
         }
         match name {
             b"workspace" => Some(NpmFlag::Rename(zstr!("--filter"))),
@@ -969,6 +976,7 @@ pub mod command {
             from: usize,
             stop_at_positional: bool,
             keep: &[&[u8]],
+            renames: &[(&[u8], &'static ZStr)],
         ) -> usize {
             let mut i = from;
             while i < argv.len() {
@@ -988,7 +996,7 @@ pub mod command {
                     i += 1;
                     continue;
                 }
-                if let Some(tr) = translate_npm_value_flag(ab, keep) {
+                if let Some(tr) = translate_npm_value_flag(ab, keep, renames) {
                     let eq = strings::index_of_char(ab, b'=');
                     let consumes_next = eq.is_none()
                         && argv
@@ -1014,8 +1022,15 @@ pub mod command {
 
         let mut hoisted: Vec<&'static ZStr> = Vec::new();
         let mut pre_subcommand_flags: Vec<&'static ZStr> = Vec::new();
-        let sub_idx =
-            copy_translating_npm_flags(argv, &mut pre_subcommand_flags, &mut hoisted, 1, true, &[]);
+        let sub_idx = copy_translating_npm_flags(
+            argv,
+            &mut pre_subcommand_flags,
+            &mut hoisted,
+            1,
+            true,
+            &[],
+            &[],
+        );
         let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
         let sub_bytes = subcommand.map(|z| z.as_bytes());
         let rest_start = sub_idx + usize::from(sub_idx < argv.len());
@@ -1069,29 +1084,111 @@ pub mod command {
                 mapped.push(zstr!("pm"));
                 mapped.push(zstr!("version"));
             }
+            // Likewise `npm pack` is `bun pm pack`.
+            Some(b"pack") => {
+                mapped.push(zstr!("pm"));
+                mapped.push(zstr!("pack"));
+            }
             Some(_) => mapped.push(*subcommand.unwrap()),
             None => {}
         }
 
         // npm flags bun's own parser accepts for the mapped subcommand must
-        // reach it instead of being dropped.
-        let keep: &[&[u8]] = match sub_bytes {
-            Some(b"publish") => &[b"access", b"otp", b"tag"],
-            Some(b"version" | b"verison") => &[b"message"],
-            _ => &[],
+        // reach it instead of being dropped, either as-is (`keep`) or under
+        // bun's spelling (`renames`).
+        let (keep, renames): (&[&[u8]], &[(&[u8], &ZStr)]) = match sub_bytes {
+            Some(b"publish") => (&[b"access", b"otp", b"tag"], &[]),
+            Some(b"version" | b"verison") => (&[b"message"], &[]),
+            Some(b"pack") => (&[], &[(b"pack-destination", zstr!("--destination"))]),
+            _ => (&[], &[]),
         };
         let mut tail: Vec<&'static ZStr> =
             Vec::with_capacity(argv.len().saturating_sub(rest_start));
-        copy_translating_npm_flags(argv, &mut tail, &mut hoisted, rest_start, false, keep);
+        copy_translating_npm_flags(
+            argv,
+            &mut tail,
+            &mut hoisted,
+            rest_start,
+            false,
+            keep,
+            renames,
+        );
+
+        // The bunx parser skips flags it does not know without consuming
+        // their value, so a hoisted `--cwd <dir>` would make `<dir>` the
+        // package name; drop renamed flags for the bunx-mapped subcommands.
+        if matches!(sub_bytes, Some(b"exec" | b"x")) {
+            hoisted.clear();
+        }
 
         let mut out: Vec<&'static ZStr> = Vec::with_capacity(
             1 + pre_subcommand_flags.len() + mapped.len() + hoisted.len() + tail.len(),
         );
         out.push(argv0);
         out.extend_from_slice(&pre_subcommand_flags);
-        out.extend_from_slice(&mapped);
-        out.extend_from_slice(&hoisted);
+        // Hoisted flags go right after the first mapped token: `bun run`
+        // forwards everything after the script name to the script, so for the
+        // lifecycle shortcuts (`mapped = ["run", "test"]`) they must land
+        // between "run" and the script name.
+        if let Some((first, rest_mapped)) = mapped.split_first() {
+            out.push(*first);
+            out.extend_from_slice(&hoisted);
+            out.extend_from_slice(rest_mapped);
+        } else {
+            out.extend_from_slice(&hoisted);
+        }
         out.extend_from_slice(&tail);
+
+        static SLOT: std::sync::OnceLock<Box<[&'static ZStr]>> = std::sync::OnceLock::new();
+        let stored = SLOT.get_or_init(move || out.into_boxed_slice());
+        // SAFETY: per fn contract — single-threaded startup.
+        unsafe { bun::set_argv(stored) };
+    }
+
+    /// Rewrite argv when bun is invoked as `npx` via the shim. Since npm 7
+    /// `npx` accepts the same config flags as `npm`, so the npm-only
+    /// value-taking flags (plus npx's `-c`/`--call`) are dropped up to the
+    /// first positional; everything from the package name on belongs to the
+    /// executed package and is copied verbatim. Flags `translate_npm_argv`
+    /// would rename are dropped too: the bunx parser has no equivalent and
+    /// would take the stray value for the package name.
+    ///
+    /// # Safety
+    /// Single-threaded CLI startup; stores into the process-global argv slot.
+    #[cold]
+    #[inline(never)]
+    unsafe fn translate_npx_argv() {
+        use bun_core::ZStr;
+        let argv = bun::argv().as_slice();
+        let Some(&argv0) = argv.first() else { return };
+        let mut out: Vec<&'static ZStr> = Vec::with_capacity(argv.len());
+        out.push(argv0);
+        let mut i = 1;
+        while i < argv.len() {
+            let a = argv[i];
+            let ab = a.as_bytes();
+            if ab.first() != Some(&b'-') || ab == b"--" {
+                break;
+            }
+            if ab == b"-c"
+                || ab == b"--call"
+                || ab.starts_with(b"--call=")
+                || translate_npm_value_flag(ab, &[], &[]).is_some()
+            {
+                let consumes_next = !strings::contains_char(ab, b'=')
+                    && argv
+                        .get(i + 1)
+                        .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
+                i += if consumes_next { 2 } else { 1 };
+                continue;
+            }
+            out.push(a);
+            i += 1;
+        }
+        if out.len() == i {
+            return;
+        }
+        out.extend_from_slice(&argv[i..]);
 
         static SLOT: std::sync::OnceLock<Box<[&'static ZStr]>> = std::sync::OnceLock::new();
         let stored = SLOT.get_or_init(move || out.into_boxed_slice());
@@ -1196,6 +1293,9 @@ pub mod command {
         }
 
         if is_npx(argv0) {
+            // SAFETY: single-threaded startup; rewrites the process-global
+            // argv view.
+            unsafe { translate_npx_argv() };
             // SAFETY: single-threaded startup
             IS_BUNX_EXE.store(true, core::sync::atomic::Ordering::Relaxed);
             return Tag::BunxCommand;

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1080,10 +1080,6 @@ pub mod command {
         let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
         let sub_bytes = subcommand.map(|z| z.as_bytes());
         let rest_start = sub_idx + usize::from(sub_idx < argv.len());
-        let has_positional_after = argv[rest_start..]
-            .iter()
-            .take_while(|a| a.as_bytes() != b"--")
-            .any(|a| a.as_bytes().first() != Some(&b'-'));
 
         // npm flags bun's own parser accepts for the mapped subcommand must
         // reach it instead of being dropped, either as-is (`keep`) or under
@@ -1109,6 +1105,18 @@ pub mod command {
         debug_assert_eq!(
             first_pass_end, sub_idx,
             "subcommand prescan must advance exactly like the copy pass"
+        );
+
+        let mut tail: Vec<&'static ZStr> =
+            Vec::with_capacity(argv.len().saturating_sub(rest_start));
+        copy_translating_npm_flags(
+            argv,
+            &mut tail,
+            &mut hoisted,
+            rest_start,
+            false,
+            keep,
+            renames,
         );
 
         let mut mapped: Vec<&'static ZStr> = Vec::with_capacity(2);
@@ -1137,8 +1145,14 @@ pub mod command {
             Some(b"exec") => mapped.push(zstr!("x")),
             // `npm init <x>` / `npm create <x>` ≡ `npx create-<x>`. Bare
             // `npm init` scaffolds a package.json, same as `bun init`.
+            // Decided from `tail`, where value-flags are already consumed, so
+            // e.g. `--loglevel`'s value is not mistaken for an initializer.
             Some(b"init" | b"create" | b"innit") => {
-                mapped.push(if has_positional_after {
+                let has_initializer = tail
+                    .iter()
+                    .take_while(|a| a.as_bytes() != b"--")
+                    .any(|a| a.as_bytes().first() != Some(&b'-'));
+                mapped.push(if has_initializer {
                     zstr!("create")
                 } else {
                     zstr!("init")
@@ -1174,18 +1188,6 @@ pub mod command {
             Some(_) => mapped.push(*subcommand.unwrap()),
             None => {}
         }
-
-        let mut tail: Vec<&'static ZStr> =
-            Vec::with_capacity(argv.len().saturating_sub(rest_start));
-        copy_translating_npm_flags(
-            argv,
-            &mut tail,
-            &mut hoisted,
-            rest_start,
-            false,
-            keep,
-            renames,
-        );
 
         // The bunx parser skips flags it does not know without consuming
         // their value, so a hoisted `--cwd <dir>` would make `<dir>` the

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1210,15 +1210,23 @@ pub mod command {
             if ab.first() != Some(&b'-') || ab == b"--" {
                 break;
             }
+            let consumes_next = !strings::contains_char(ab, b'=')
+                && argv
+                    .get(i + 1)
+                    .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
+            if ab == b"-p" || ab == b"--package" || ab.starts_with(b"--package=") {
+                out.push(a);
+                if consumes_next {
+                    out.push(argv[i + 1]);
+                }
+                i += if consumes_next { 2 } else { 1 };
+                continue;
+            }
             if ab == b"-c"
                 || ab == b"--call"
                 || ab.starts_with(b"--call=")
                 || translate_npm_value_flag(ab, &[], &[]).is_some()
             {
-                let consumes_next = !strings::contains_char(ab, b'=')
-                    && argv
-                        .get(i + 1)
-                        .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
                 i += if consumes_next { 2 } else { 1 };
                 continue;
             }

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1159,6 +1159,24 @@ pub mod command {
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"x" | b"create")) {
             hoisted.clear();
         }
+        if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"run")) {
+            let mut past_separator = false;
+            tail.retain(|a| {
+                let b = a.as_bytes();
+                if past_separator {
+                    return true;
+                }
+                if b == b"--" {
+                    past_separator = true;
+                    return true;
+                }
+                if b.first() == Some(&b'-') {
+                    hoisted.push(a);
+                    return false;
+                }
+                true
+            });
+        }
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"create")) {
             pre_subcommand_flags.clear();
             let mut past_separator = false;

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1080,7 +1080,8 @@ pub mod command {
             Some(b"version" | b"verison") => &[b"message"],
             _ => &[],
         };
-        let mut tail: Vec<&'static ZStr> = Vec::with_capacity(argv.len().saturating_sub(rest_start));
+        let mut tail: Vec<&'static ZStr> =
+            Vec::with_capacity(argv.len().saturating_sub(rest_start));
         copy_translating_npm_flags(argv, &mut tail, &mut hoisted, rest_start, false, keep);
 
         let mut out: Vec<&'static ZStr> = Vec::with_capacity(

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -956,8 +956,6 @@ pub mod command {
         }
     }
 
-    /// npm flags that never take a value from the following token, so
-    /// dropping them must not consume it.
     #[cold]
     fn is_npm_bool_flag(arg: &[u8]) -> bool {
         strings::has_prefix_comptime(arg, b"--no-")

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -860,10 +860,12 @@ pub mod command {
     }
 
     /// npm long options that take a separate value argument and have no bun
-    /// equivalent. When bun is invoked as `npm` via the `--bun` shim these are
-    /// dropped together with their value so the value is not mistaken for a
-    /// positional (e.g. `npm install --loglevel error react` must not try to
-    /// install a package called `error`). Kept sorted for `binary_search`.
+    /// equivalent. When bun is invoked as `npm` via the shim these are dropped
+    /// together with their value so the value is not mistaken for a positional
+    /// (e.g. `npm install --loglevel error react` must not try to install a
+    /// package called `error`). Options that change the *target* of the
+    /// operation (`--workspace`/`--prefix`) are translated instead; see
+    /// `translate_npm_value_flag`. Kept sorted for `binary_search`.
     const NPM_VALUE_FLAGS_IGNORED: &[&[u8]] = &[
         b"access",
         b"before",
@@ -891,7 +893,6 @@ pub mod command {
         b"node-options",
         b"otp",
         b"pack-destination",
-        b"prefix",
         b"script-shell",
         b"searchexclude",
         b"searchlimit",
@@ -900,19 +901,35 @@ pub mod command {
         b"tag",
         b"userconfig",
         b"viewer",
-        b"workspace",
     ];
 
+    #[derive(Clone, Copy)]
+    enum NpmFlag {
+        Drop,
+        Rename(&'static bun_core::ZStr),
+    }
+
     #[cold]
-    fn is_npm_ignored_value_flag(arg: &[u8]) -> bool {
-        if let Some(name) = arg.strip_prefix(b"--") {
-            let name = match strings::index_of_char(name, b'=') {
-                Some(eq) => &name[..eq as usize],
-                None => name,
-            };
-            return NPM_VALUE_FLAGS_IGNORED.binary_search(&name).is_ok();
+    fn translate_npm_value_flag(arg: &[u8]) -> Option<NpmFlag> {
+        use bun_core::zstr;
+        let name: &[u8] = if let Some(long) = arg.strip_prefix(b"--") {
+            match strings::index_of_char(long, b'=') {
+                Some(eq) => &long[..eq as usize],
+                None => long,
+            }
+        } else if arg == b"-w" || arg.starts_with(b"-w=") {
+            b"workspace"
+        } else if arg == b"-C" || arg.starts_with(b"-C=") {
+            b"prefix"
+        } else {
+            return None;
+        };
+        match name {
+            b"workspace" => Some(NpmFlag::Rename(zstr!("--filter"))),
+            b"prefix" => Some(NpmFlag::Rename(zstr!("--cwd"))),
+            _ if NPM_VALUE_FLAGS_IGNORED.binary_search(&name).is_ok() => Some(NpmFlag::Drop),
+            _ => None,
         }
-        arg == b"-w" || arg.starts_with(b"-w=")
     }
 
     /// Rewrite argv when bun is invoked as `npm` (via the `--bun` shim dir) so
@@ -932,86 +949,132 @@ pub mod command {
         );
 
         let argv = bun::argv().as_slice();
-        let mut out: Vec<&'static ZStr> = Vec::with_capacity(argv.len() + 1);
         let Some(&argv0) = argv.first() else { return };
-        out.push(argv0);
 
-        // Copy argv[from..] into `out`, dropping npm-only value-taking flags
-        // (and their separate value). Stops at the first positional when
-        // `stop_at_positional` is set and returns its index; otherwise copies
-        // through to the end, returning `argv.len()`. A bare `--` ends flag
-        // processing either way.
-        let copy_dropping_npm_flags =
-            |out: &mut Vec<&'static ZStr>, from: usize, stop_at_positional: bool| -> usize {
-                let mut i = from;
-                while i < argv.len() {
-                    let a = argv[i];
-                    let ab = a.as_bytes();
-                    if ab == b"--" {
-                        if !stop_at_positional {
-                            out.extend_from_slice(&argv[i..]);
-                        }
+        // Copy `argv[from..]` into `tail`, dropping npm-only value-taking
+        // flags (with their separate value) and renaming
+        // `--workspace`/`--prefix` to their bun spellings into `hoisted`.
+        // Renamed flags are hoisted before the subcommand so `bun run`'s
+        // stop-after-first-positional does not pass them through to the
+        // script. Stops at the first positional when `stop_at_positional` is
+        // set and returns its index; otherwise copies to the end. A bare `--`
+        // ends flag processing either way.
+        fn copy_translating_npm_flags(
+            argv: &[&'static ZStr],
+            tail: &mut Vec<&'static ZStr>,
+            hoisted: &mut Vec<&'static ZStr>,
+            from: usize,
+            stop_at_positional: bool,
+        ) -> usize {
+            let mut i = from;
+            while i < argv.len() {
+                let a = argv[i];
+                let ab = a.as_bytes();
+                if ab == b"--" {
+                    if !stop_at_positional {
+                        tail.extend_from_slice(&argv[i..]);
+                    }
+                    return i;
+                }
+                if ab.first() != Some(&b'-') {
+                    if stop_at_positional {
                         return i;
                     }
-                    if ab.first() != Some(&b'-') {
-                        if stop_at_positional {
-                            return i;
-                        }
-                        out.push(a);
-                        i += 1;
-                        continue;
-                    }
-                    if is_npm_ignored_value_flag(ab) {
-                        let consumes_next = !strings::contains_char(ab, b'=')
-                            && argv
-                                .get(i + 1)
-                                .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
-                        i += if consumes_next { 2 } else { 1 };
-                        continue;
-                    }
-                    out.push(a);
+                    tail.push(a);
                     i += 1;
+                    continue;
                 }
-                argv.len()
-            };
+                if let Some(tr) = translate_npm_value_flag(ab) {
+                    let eq = strings::index_of_char(ab, b'=');
+                    let consumes_next = eq.is_none()
+                        && argv
+                            .get(i + 1)
+                            .is_some_and(|n| n.as_bytes().first() != Some(&b'-'));
+                    if let NpmFlag::Rename(new_name) = tr {
+                        hoisted.push(new_name);
+                        if let Some(eq) = eq {
+                            let with_nul = a.as_bytes_with_nul();
+                            hoisted.push(ZStr::from_static(&with_nul[eq as usize + 1..]));
+                        } else if consumes_next {
+                            hoisted.push(argv[i + 1]);
+                        }
+                    }
+                    i += if consumes_next { 2 } else { 1 };
+                    continue;
+                }
+                tail.push(a);
+                i += 1;
+            }
+            argv.len()
+        }
 
-        let sub_idx = copy_dropping_npm_flags(&mut out, 1, true);
+        let mut hoisted: Vec<&'static ZStr> = Vec::new();
+        let mut pre_subcommand_flags: Vec<&'static ZStr> = Vec::new();
+        let sub_idx =
+            copy_translating_npm_flags(argv, &mut pre_subcommand_flags, &mut hoisted, 1, true);
         let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
         let rest_start = sub_idx + usize::from(sub_idx < argv.len());
+        let has_positional_after = argv[rest_start..]
+            .iter()
+            .take_while(|a| a.as_bytes() != b"--")
+            .any(|a| a.as_bytes().first() != Some(&b'-'));
 
+        let mut mapped: Vec<&'static ZStr> = Vec::with_capacity(2);
         match subcommand.map(|z| z.as_bytes()) {
             // npm's lifecycle shortcuts run the package.json script; map to
             // `bun run <name>` so `npm test` does not invoke bun's test runner.
             Some(b"test" | b"t" | b"tst") => {
-                out.push(zstr!("run"));
-                out.push(zstr!("test"));
+                mapped.push(zstr!("run"));
+                mapped.push(zstr!("test"));
             }
             Some(b"start") => {
-                out.push(zstr!("run"));
-                out.push(zstr!("start"));
+                mapped.push(zstr!("run"));
+                mapped.push(zstr!("start"));
             }
             Some(b"stop") => {
-                out.push(zstr!("run"));
-                out.push(zstr!("stop"));
+                mapped.push(zstr!("run"));
+                mapped.push(zstr!("stop"));
             }
             Some(b"restart") => {
-                out.push(zstr!("run"));
-                out.push(zstr!("restart"));
+                mapped.push(zstr!("run"));
+                mapped.push(zstr!("restart"));
             }
-            Some(b"run-script" | b"rum" | b"urn") => out.push(zstr!("run")),
+            Some(b"run-script" | b"rum" | b"urn") => mapped.push(zstr!("run")),
+            // npm ≥7's `npm exec` is what `npx` delegates to; bun's own `exec`
+            // is a shell-script runner.
+            Some(b"exec") => mapped.push(zstr!("x")),
+            // `npm init <x>` / `npm create <x>` ≡ `npx create-<x>`. Bare
+            // `npm init` scaffolds a package.json, same as `bun init`.
+            Some(b"init" | b"create" | b"innit") => {
+                mapped.push(if has_positional_after {
+                    zstr!("create")
+                } else {
+                    zstr!("init")
+                });
+            }
             Some(b"clean-install" | b"ic" | b"install-clean" | b"isntall-clean") => {
-                out.push(zstr!("ci"));
+                mapped.push(zstr!("ci"));
             }
             Some(b"i" | b"isntall" | b"in" | b"ins" | b"inst" | b"insta" | b"instal") => {
-                out.push(zstr!("install"));
+                mapped.push(zstr!("install"));
             }
-            Some(b"ls" | b"la" | b"ll") => out.push(zstr!("list")),
-            Some(b"view" | b"show") => out.push(zstr!("info")),
-            Some(_) => out.push(*subcommand.unwrap()),
+            Some(b"ls" | b"la" | b"ll") => mapped.push(zstr!("list")),
+            Some(b"view" | b"show") => mapped.push(zstr!("info")),
+            Some(_) => mapped.push(*subcommand.unwrap()),
             None => {}
         }
 
-        copy_dropping_npm_flags(&mut out, rest_start, false);
+        let mut tail: Vec<&'static ZStr> = Vec::with_capacity(argv.len().saturating_sub(rest_start));
+        copy_translating_npm_flags(argv, &mut tail, &mut hoisted, rest_start, false);
+
+        let mut out: Vec<&'static ZStr> = Vec::with_capacity(
+            1 + pre_subcommand_flags.len() + mapped.len() + hoisted.len() + tail.len(),
+        );
+        out.push(argv0);
+        out.extend_from_slice(&pre_subcommand_flags);
+        out.extend_from_slice(&mapped);
+        out.extend_from_slice(&hoisted);
+        out.extend_from_slice(&tail);
 
         static SLOT: std::sync::OnceLock<Box<[&'static ZStr]>> = std::sync::OnceLock::new();
         let stored = SLOT.get_or_init(move || out.into_boxed_slice());

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -955,8 +955,6 @@ pub mod command {
         }
     }
 
-    /// # Safety
-    /// Single-threaded CLI startup; stores into the process-global argv slot.
     #[cold]
     #[inline(never)]
     unsafe fn translate_npm_argv() {
@@ -1197,8 +1195,6 @@ pub mod command {
         unsafe { bun::set_argv(stored) };
     }
 
-    /// # Safety
-    /// Single-threaded CLI startup; stores into the process-global argv slot.
     #[cold]
     #[inline(never)]
     unsafe fn translate_npx_argv() {

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -980,6 +980,19 @@ pub mod command {
                     | b"--workspaces"
                     | b"--if-present"
                     | b"--silent"
+                    | b"-f"
+                    | b"--force"
+                    | b"--dry-run"
+                    | b"--offline"
+                    | b"--prefer-offline"
+                    | b"--prefer-online"
+                    | b"--legacy-peer-deps"
+                    | b"--strict-peer-deps"
+                    | b"--save"
+                    | b"--audit"
+                    | b"--fund"
+                    | b"--package-lock-only"
+                    | b"--production"
             )
     }
 
@@ -1187,6 +1200,13 @@ pub mod command {
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"x" | b"create")) {
             hoisted.clear();
         }
+        if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"run" | b"init")) {
+            for a in pre_subcommand_flags.drain(..) {
+                if matches!(a.as_bytes(), b"--if-present" | b"--silent") {
+                    hoisted.push(a);
+                }
+            }
+        }
         if matches!(mapped.first().map(|z| z.as_bytes()), Some(b"run")) {
             let mut new_tail: Vec<&'static ZStr> = Vec::with_capacity(tail.len());
             let mut i = 0;
@@ -1298,6 +1318,10 @@ pub mod command {
                 || translate_npm_value_flag(ab, &[], &[]).is_some()
             {
                 i += if consumes_next { 2 } else { 1 };
+                continue;
+            }
+            if ab != b"--silent" && is_npm_bool_flag(ab) {
+                i += 1;
                 continue;
             }
             out.push(a);

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1063,7 +1063,7 @@ pub mod command {
         // pre-subcommand flags are processed: `npm --tag beta publish` keeps
         // `--tag beta` only because `publish` is found first. The scan
         // advances over value flags exactly like `copy_translating_npm_flags`.
-        let sub_idx = {
+        let scan_end = {
             let mut i = 1;
             while i < argv.len() {
                 let ab = argv[i].as_bytes();
@@ -1079,6 +1079,12 @@ pub mod command {
             }
             i
         };
+        // npm treats a leading `--` as end-of-options but still takes the
+        // next token as the subcommand: `npm -- upgrade` is `npm upgrade`.
+        // Without this skip the raw token would bypass the mapping and e.g.
+        // `upgrade` would dispatch bun's self-upgrader.
+        let sub_idx =
+            scan_end + usize::from(argv.get(scan_end).is_some_and(|a| a.as_bytes() == b"--"));
         let subcommand = argv.get(sub_idx).filter(|a| a.as_bytes() != b"--");
         let sub_bytes = subcommand.map(|z| z.as_bytes());
         let rest_start = sub_idx + usize::from(sub_idx < argv.len());
@@ -1115,7 +1121,7 @@ pub mod command {
             renames,
         );
         debug_assert_eq!(
-            first_pass_end, sub_idx,
+            first_pass_end, scan_end,
             "subcommand prescan must advance exactly like the copy pass"
         );
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1873,9 +1873,14 @@ impl RunCommand {
     pub fn create_fake_temporary_node_executable(
         path: &mut Vec<u8>,
         optional_bun_path: &mut &[u8],
+        original_path: &[u8],
     ) -> crate::Result<()> {
-        bun_install::RunCommand::create_fake_temporary_node_executable(path, optional_bun_path)
-            .map_err(Into::into)
+        bun_install::RunCommand::create_fake_temporary_node_executable(
+            path,
+            optional_bun_path,
+            original_path,
+        )
+        .map_err(Into::into)
     }
 
     /// Prepends workspace
@@ -1986,6 +1991,7 @@ impl RunCommand {
             match Self::create_fake_temporary_node_executable(
                 &mut new_path,
                 &mut optional_bun_self_path,
+                &path,
             ) {
                 Ok(()) => {}
                 Err(crate::Error::Alloc(bun_alloc::AllocError)) => bun_core::out_of_memory(),

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -167,10 +167,39 @@ describe("fake npm/npx cli", () => {
         // before any network request.
         "bunfig.toml": `[install]\nregistry = { url = "http://127.0.0.1:1/", token = "fake" }\n`,
       });
-      const r = await fakePmRun(String(dir), "npm", ["publish", "--dry-run", "--tag", "beta", "--access", "public"]);
+      // `--tag` before the subcommand pins that the keep list applies to
+      // pre-subcommand flags too; npm accepts config flags in any position.
+      const r = await fakePmRun(String(dir), "npm", ["--tag", "beta", "publish", "--dry-run", "--access", "public"]);
       expect(r.stdout).toContain("Tag: beta");
       expect(r.stdout).toContain("Access: public");
       expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm upgrade dispatches as bun update, not bun's self-upgrader", async () => {
+      using dir = tempDir("fake-npm-upgrade", { "package.json": "{}" });
+      const r = await fakePmRun(String(dir), "npm", ["upgrade", "--help"]);
+      expect(r.stdout).toContain("bun update");
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm cache dispatches as bun pm cache", async () => {
+      using dir = tempDir("fake-npm-cache", { "package.json": "{}" });
+      const r = await fakePmRun(String(dir), "npm", ["cache"]);
+      expect(r.stdout.trim()).not.toBe("");
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm install --save-dev writes to devDependencies", async () => {
+      using dir = tempDir("fake-npm-savedev", {
+        "package.json": JSON.stringify({ name: "root", version: "1.0.0" }),
+        "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      const r = await fakePmRun(String(dir), "npm", ["install", "--save-dev", "./dep"]);
+      expect(r.exitCode).toBe(0);
+      const pkg = JSON.parse(await Bun.file(join(String(dir), "package.json")).text());
+      expect(pkg.devDependencies).toEqual({ dep: "./dep" });
+      expect(pkg.dependencies).toBeUndefined();
     });
 
     test.concurrent("npm version dispatches as bun pm version", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -91,6 +91,33 @@ describe("fake npm/npx cli", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("does not shadow a vendored node_modules/.bin npm", async () => {
+    using dir = tempDir("fake-npm-binshadow", {
+      "package.json": JSON.stringify({
+        name: "fake-npm-binshadow",
+        scripts: { go: `${bunExe()} spawn-npm.js` },
+      }),
+      "spawn-npm.js": spawnNpmFixture,
+      "node_modules/.bin/placeholder": "",
+    });
+    for (const name of ["npm", "npx"]) {
+      const f = join(String(dir), "node_modules", ".bin", name + (isWindows ? ".cmd" : ""));
+      writeFileSync(f, isWindows ? `@echo BIN-${name}\r\n` : `#!/bin/sh\necho BIN-${name}\n`);
+      if (!isWindows) chmodSync(f, 0o755);
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--bun", "run", "go"],
+      cwd: String(dir),
+      env: stripEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim().split("\n")).toEqual(["npm OK BIN-npm", "npx OK BIN-npx"]);
+    expect(exitCode).toBe(0);
+  });
+
   // When invoked via argv[0] == "npm" / "npx", bun must recognize itself and
   // behave as its package manager / bunx, not try to run a file called
   // "install" or "some-pkg".
@@ -404,6 +431,25 @@ describe("fake npm/npx cli", () => {
       const short = await fakePmRun(String(dir), "npm", ["run", "-s", "go"]);
       expect(short.stdout).toContain("ARGS:");
       expect(short.exitCode).toBe(0);
+      const force = await fakePmRun(String(dir), "npm", ["run", "--force", "go"]);
+      expect(force.stdout).toContain("ARGS:");
+      expect(force.exitCode).toBe(0);
+      // npm shorts before the subcommand must not reach bun's parser, where
+      // -d means --define and would consume "run".
+      const pre = await fakePmRun(String(dir), "npm", ["-d", "run", "go"]);
+      expect(pre.stdout).toContain("ARGS:");
+      expect(pre.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm -y init does not scaffold into a folder named init", async () => {
+      using dir = tempDir("fake-npm-yinit", {
+        "package.json": "{}",
+        // init runs an install afterwards; keep it off the network.
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      await fakePmRun(String(dir), "npm", ["-y", "init"]);
+      expect(existsSync(join(String(dir), "init"))).toBe(false);
+      expect(existsSync(join(String(dir), "index.ts"))).toBe(true);
     });
 
     test.concurrent("-- stops flag translation", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -328,6 +328,13 @@ describe("fake npm/npx cli", () => {
       const ws = await fakePmRun(String(dir), "npm", ["init", "nonexistent-template", "-w", "client"]);
       expect(ws.stdout + ws.stderr).toContain("create-nonexistent-template");
       expect(ws.stdout + ws.stderr).not.toContain("create-client");
+    });
+
+    test.concurrent("npm init separators and boolean flags do not leak into the template", async () => {
+      using dir = tempDir("fake-npm-init-sep", {
+        "package.json": "{}",
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
       // Everything after `--` is positional in npm, so it still names a
       // template, and a short boolean flag is not one.
       const dd = await fakePmRun(String(dir), "npm", ["init", "--", "nonexistent-template"]);
@@ -335,6 +342,10 @@ describe("fake npm/npx cli", () => {
       const y = await fakePmRun(String(dir), "npm", ["init", "-y", "nonexistent-template"]);
       expect(y.stdout + y.stderr).toContain("create-nonexistent-template");
       expect(y.stdout + y.stderr).not.toContain("create--y");
+      // `--scope` takes a value; it must not become the template.
+      const scoped = await fakePmRun(String(dir), "npm", ["init", "--scope", "@myorg", "nonexistent-template"]);
+      expect(scoped.stdout + scoped.stderr).toContain("create-nonexistent-template");
+      expect(scoped.stdout + scoped.stderr).not.toContain("@myorg");
     });
 
     test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", async () => {
@@ -389,6 +400,10 @@ describe("fake npm/npx cli", () => {
       expect(pair.stdout).toContain("ARGS:");
       expect(pair.stdout).not.toContain("3000");
       expect(pair.exitCode).toBe(0);
+      // A boolean npm flag before the script name must not eat it.
+      const short = await fakePmRun(String(dir), "npm", ["run", "-s", "go"]);
+      expect(short.stdout).toContain("ARGS:");
+      expect(short.exitCode).toBe(0);
     });
 
     test.concurrent("-- stops flag translation", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -219,6 +219,11 @@ describe("fake npm/npx cli", () => {
       const r = await fakePmRun(String(dir), "npm", ["pack", "--pack-destination", "./tarballs"]);
       expect(r.exitCode).toBe(0);
       expect(existsSync(join(String(dir), "tarballs", "fake-npm-pack-1.0.0.tgz"))).toBe(true);
+      // `-w` is dropped here (bun pm pack has no --filter); the workspace
+      // name must not leak into the pm subcommand position.
+      const ws = await fakePmRun(String(dir), "npm", ["pack", "-w", "whatever"]);
+      expect(ws.exitCode).toBe(0);
+      expect(existsSync(join(String(dir), "fake-npm-pack-1.0.0.tgz"))).toBe(true);
     });
 
     test.concurrent("npm --version prints a version", async () => {
@@ -265,6 +270,12 @@ describe("fake npm/npx cli", () => {
       // A value-flag's value is not an initializer.
       const flags = await fakePmRun(String(dir), "npm", ["init", "--loglevel", "error", "--help"]);
       expect(flags.stdout + flags.stderr).toContain("bun init");
+      // `-w client` must not become the template: `bun create`'s scanner
+      // takes the first non-flag token, so translated flags are not hoisted
+      // into it.
+      const ws = await fakePmRun(String(dir), "npm", ["init", "nonexistent-template", "-w", "client"]);
+      expect(ws.stdout + ws.stderr).toContain("create-nonexistent-template");
+      expect(ws.stdout + ws.stderr).not.toContain("create-client");
     });
 
     test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -144,7 +144,7 @@ describe("fake npm/npx cli", () => {
       return { stdout, stderr, exitCode };
     }
 
-    test.concurrent("npm test runs the package.json script, not bun's test runner", async () => {
+    test("npm test runs the package.json script, not bun's test runner", async () => {
       using dir = tempDir("fake-npm-test", {
         "package.json": JSON.stringify({ scripts: { test: "echo TEST-SCRIPT-RAN" } }),
       });
@@ -154,7 +154,7 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm start / npm run <script> run the package.json script", async () => {
+    test("npm start / npm run <script> run the package.json script", async () => {
       using dir = tempDir("fake-npm-start", {
         "package.json": JSON.stringify({ scripts: { start: "echo STARTED", other: "echo OTHER" } }),
       });
@@ -162,7 +162,7 @@ describe("fake npm/npx cli", () => {
       expect((await fakePmRun(String(dir), "npm", ["run", "other"])).stdout).toContain("OTHER");
     });
 
-    test.concurrent("npm install drops npm-only value-taking flags", async () => {
+    test("npm install drops npm-only value-taking flags", async () => {
       using dir = tempDir("fake-npm-install", {
         "package.json": JSON.stringify({ name: "p", version: "0.0.0" }),
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
@@ -187,7 +187,7 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm publish keeps --tag/--access/--otp", async () => {
+    test("npm publish keeps --tag/--access/--otp", async () => {
       using dir = tempDir("fake-npm-publish", {
         "package.json": JSON.stringify({ name: "fake-npm-publish", version: "1.2.3" }),
         // A token so publish gets past the auth check; --dry-run stops
@@ -202,7 +202,7 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm upgrade dispatches as bun update, not bun's self-upgrader", async () => {
+    test("npm upgrade dispatches as bun update, not bun's self-upgrader", async () => {
       using dir = tempDir("fake-npm-upgrade", { "package.json": "{}" });
       const r = await fakePmRun(String(dir), "npm", ["upgrade", "--help"]);
       expect(r.stdout).toContain("bun update");
@@ -214,7 +214,7 @@ describe("fake npm/npx cli", () => {
       expect(dd.exitCode).toBe(0);
     });
 
-    test.concurrent("npm cache dispatches as bun pm cache", async () => {
+    test("npm cache dispatches as bun pm cache", async () => {
       using dir = tempDir("fake-npm-cache", { "package.json": "{}" });
       const r = await fakePmRun(String(dir), "npm", ["cache"]);
       // `bun pm cache` prints the cache directory path.
@@ -222,7 +222,7 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm install --save-dev writes to devDependencies", async () => {
+    test("npm install --save-dev writes to devDependencies", async () => {
       using dir = tempDir("fake-npm-savedev", {
         "package.json": JSON.stringify({ name: "root", version: "1.0.0" }),
         "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
@@ -240,7 +240,7 @@ describe("fake npm/npx cli", () => {
       expect(pkg.dependencies).toBeUndefined();
     });
 
-    test.concurrent("npm install -P does not enable bun's production mode", async () => {
+    test("npm install -P does not enable bun's production mode", async () => {
       using dir = tempDir("fake-npm-saveprod", {
         "package.json": JSON.stringify({
           name: "root",
@@ -257,7 +257,7 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm config value flags before the subcommand do not eat it", async () => {
+    test("npm config value flags before the subcommand do not eat it", async () => {
       using dir = tempDir("fake-npm-preflag", {
         "package.json": JSON.stringify({ name: "p", version: "0.0.0" }),
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
@@ -269,7 +269,7 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm version dispatches as bun pm version", async () => {
+    test("npm version dispatches as bun pm version", async () => {
       using dir = tempDir("fake-npm-version", {
         "package.json": JSON.stringify({ name: "fake-npm-version", version: "1.2.3" }),
       });
@@ -279,7 +279,7 @@ describe("fake npm/npx cli", () => {
       expect(JSON.parse(await Bun.file(join(String(dir), "package.json")).text()).version).toBe("1.2.4");
     });
 
-    test.concurrent("npm pack dispatches as bun pm pack, rewriting --pack-destination", async () => {
+    test("npm pack dispatches as bun pm pack, rewriting --pack-destination", async () => {
       using dir = tempDir("fake-npm-pack", {
         "package.json": JSON.stringify({ name: "fake-npm-pack", version: "1.0.0" }),
       });
@@ -293,20 +293,43 @@ describe("fake npm/npx cli", () => {
       expect(existsSync(join(String(dir), "fake-npm-pack-1.0.0.tgz"))).toBe(true);
     });
 
-    test.concurrent("npm --version prints a version", async () => {
+    test("npm --version prints a version", async () => {
       using dir = tempDir("fake-npm-ver", { "package.json": "{}" });
       const r = await fakePmRun(String(dir), "npm", ["--version"]);
       expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npx / npm exec dispatch as bunx", async () => {
+    test("npx / npm exec dispatch as bunx", async () => {
       using dir = tempDir("fake-npx", { "package.json": "{}" });
       expect((await fakePmRun(String(dir), "npx", ["--help"])).stderr).toContain("Usage: bunx");
       expect((await fakePmRun(String(dir), "npm", ["exec", "--help"])).stderr).toContain("Usage: bunx");
+      // npm's -p before the subcommand must not become bunx's --package,
+      // which would take the mapped "x" token for the package name.
+      expect((await fakePmRun(String(dir), "npm", ["-p", "exec", "--help"])).stderr).toContain("Usage: bunx");
     });
 
-    test.concurrent("npx drops npm config flags before the package name", async () => {
+    test("npm lowercase shorts are not bun's production/yarn flags", async () => {
+      using dir = tempDir("fake-npm-shorts", {
+        "package.json": JSON.stringify({
+          name: "root",
+          version: "1.0.0",
+          devDependencies: { dep: "./dep" },
+        }),
+        "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      // npm's -p is --parseable, not bun's --production.
+      const r = await fakePmRun(String(dir), "npm", ["install", "-p"]);
+      expect(existsSync(join(String(dir), "node_modules", "dep"))).toBe(true);
+      expect(r.exitCode).toBe(0);
+      // npm's -y is --yes, not bun's --yarn.
+      const y = await fakePmRun(String(dir), "npm", ["-y", "install"]);
+      expect(existsSync(join(String(dir), "yarn.lock"))).toBe(false);
+      expect(y.exitCode).toBe(0);
+    });
+
+    test("npx drops npm config flags before the package name", async () => {
       using dir = tempDir("fake-npx-flags", {
         "package.json": "{}",
         // `error` must not be taken for the package name; the registry
@@ -323,7 +346,7 @@ describe("fake npm/npx cli", () => {
       expect(pkg.stdout + pkg.stderr).toContain("you must specify the binary");
     });
 
-    test.concurrent("npm init <x> / npm create <x> dispatch as bun create, not bun init", async () => {
+    test("npm init <x> / npm create <x> dispatch as bun create, not bun init", async () => {
       using dir = tempDir("fake-npm-init", {
         "package.json": "{}",
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
@@ -341,7 +364,7 @@ describe("fake npm/npx cli", () => {
       expect(bare.stdout + bare.stderr).toContain("bun init");
     });
 
-    test.concurrent("npm init flags do not leak into the template name", async () => {
+    test("npm init flags do not leak into the template name", async () => {
       using dir = tempDir("fake-npm-init-flags", {
         "package.json": "{}",
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
@@ -357,7 +380,7 @@ describe("fake npm/npx cli", () => {
       expect(ws.stdout + ws.stderr).not.toContain("create-client");
     });
 
-    test.concurrent("npm init separators and boolean flags do not leak into the template", async () => {
+    test("npm init separators and boolean flags do not leak into the template", async () => {
       using dir = tempDir("fake-npm-init-sep", {
         "package.json": "{}",
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
@@ -369,13 +392,19 @@ describe("fake npm/npx cli", () => {
       const y = await fakePmRun(String(dir), "npm", ["init", "-y", "nonexistent-template"]);
       expect(y.stdout + y.stderr).toContain("create-nonexistent-template");
       expect(y.stdout + y.stderr).not.toContain("create--y");
-      // `--scope` takes a value; it must not become the template.
+    });
+
+    test("npm init --scope's value does not become the template", async () => {
+      using dir = tempDir("fake-npm-init-scope", {
+        "package.json": "{}",
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
       const scoped = await fakePmRun(String(dir), "npm", ["init", "--scope", "@myorg", "nonexistent-template"]);
       expect(scoped.stdout + scoped.stderr).toContain("create-nonexistent-template");
       expect(scoped.stdout + scoped.stderr).not.toContain("@myorg");
     });
 
-    test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", async () => {
+    test("npm run -w <pkg> / --prefix <dir> are translated, not dropped", async () => {
       using dir = tempDir("fake-npm-ws", {
         "package.json": JSON.stringify({
           name: "root",
@@ -396,7 +425,7 @@ describe("fake npm/npx cli", () => {
       expect(r3.stdout).toContain("FROM-A");
     });
 
-    test.concurrent("npm test --prefix <dir> runs the script in that directory", async () => {
+    test("npm test --prefix <dir> runs the script in that directory", async () => {
       using dir = tempDir("fake-npm-test-prefix", {
         "package.json": JSON.stringify({ name: "root" }),
         "client/package.json": JSON.stringify({ name: "client", scripts: { test: "echo CLIENT-TEST" } }),
@@ -408,7 +437,7 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm run flags after the script name are npm's, not the script's", async () => {
+    test("npm run flags after the script name are npm's, not the script's", async () => {
       using dir = tempDir("fake-npm-postflag", {
         "package.json": JSON.stringify({ name: "p", scripts: { go: "echo ARGS:" } }),
       });
@@ -421,8 +450,14 @@ describe("fake npm/npx cli", () => {
       // missing script exits 0.
       const ip = await fakePmRun(String(dir), "npm", ["run", "missing-script", "--if-present"]);
       expect(ip.exitCode).toBe(0);
-      // An unknown config flag consumes its value like npm's parser does;
-      // neither may shift the script name or reach the script.
+    });
+
+    test("npm run value flags consume their value like npm's parser", async () => {
+      using dir = tempDir("fake-npm-pairflag", {
+        "package.json": JSON.stringify({ name: "p", scripts: { go: "echo ARGS:" } }),
+      });
+      // Neither the flag nor its value may shift the script name or reach
+      // the script.
       const pair = await fakePmRun(String(dir), "npm", ["run", "go", "--port", "3000"]);
       expect(pair.stdout).toContain("ARGS:");
       expect(pair.stdout).not.toContain("3000");
@@ -431,6 +466,12 @@ describe("fake npm/npx cli", () => {
       const short = await fakePmRun(String(dir), "npm", ["run", "-s", "go"]);
       expect(short.stdout).toContain("ARGS:");
       expect(short.exitCode).toBe(0);
+    });
+
+    test("npm run boolean flags do not eat the script name", async () => {
+      using dir = tempDir("fake-npm-boolflag", {
+        "package.json": JSON.stringify({ name: "p", scripts: { go: "echo ARGS:" } }),
+      });
       const force = await fakePmRun(String(dir), "npm", ["run", "--force", "go"]);
       expect(force.stdout).toContain("ARGS:");
       expect(force.exitCode).toBe(0);
@@ -441,7 +482,7 @@ describe("fake npm/npx cli", () => {
       expect(pre.exitCode).toBe(0);
     });
 
-    test.concurrent("npm -y init does not scaffold into a folder named init", async () => {
+    test("npm -y init does not scaffold into a folder named init", async () => {
       using dir = tempDir("fake-npm-yinit", {
         "package.json": "{}",
         // init runs an install afterwards; keep it off the network.
@@ -452,7 +493,7 @@ describe("fake npm/npx cli", () => {
       expect(existsSync(join(String(dir), "index.ts"))).toBe(true);
     });
 
-    test.concurrent("-- stops flag translation", async () => {
+    test("-- stops flag translation", async () => {
       using dir = tempDir("fake-npm-dd", {
         "package.json": JSON.stringify({ scripts: { go: "echo ARGS:" } }),
       });
@@ -460,7 +501,7 @@ describe("fake npm/npx cli", () => {
       expect(r.stdout).toContain("ARGS: --loglevel error");
     });
 
-    test.concurrent("pnpm as argv0 is not treated as npm", async () => {
+    test("pnpm as argv0 is not treated as npm", async () => {
       using dir = tempDir("fake-pnpm", {
         "package.json": JSON.stringify({ scripts: { test: "echo SHOULD-NOT-RUN" } }),
       });

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -180,12 +180,18 @@ describe("fake npm/npx cli", () => {
       const r = await fakePmRun(String(dir), "npm", ["upgrade", "--help"]);
       expect(r.stdout).toContain("bun update");
       expect(r.exitCode).toBe(0);
+      // A leading `--` still names the subcommand in npm, so the mapping
+      // must apply to it too.
+      const dd = await fakePmRun(String(dir), "npm", ["--", "upgrade", "--help"]);
+      expect(dd.stdout).toContain("bun update");
+      expect(dd.exitCode).toBe(0);
     });
 
     test.concurrent("npm cache dispatches as bun pm cache", async () => {
       using dir = tempDir("fake-npm-cache", { "package.json": "{}" });
       const r = await fakePmRun(String(dir), "npm", ["cache"]);
-      expect(r.stdout.trim()).not.toBe("");
+      // `bun pm cache` prints the cache directory path.
+      expect(existsSync(r.stdout.trim())).toBe(true);
       expect(r.exitCode).toBe(0);
     });
 

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { chmodSync, copyFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/5995
@@ -95,48 +95,54 @@ describe("fake npm/npx cli", () => {
   // behave as its package manager / bunx, not try to run a file called
   // "install" or "some-pkg".
   describe("argv[0] dispatch", () => {
-    function fakePmRun(dir: string, argv0: "npm" | "npx", args: string[]) {
+    function linkAs(dir: string, argv0: string): string {
       const link = join(dir, argv0 + (isWindows ? ".exe" : ""));
-      try {
+      // A test may invoke the same link several times in the same dir.
+      if (!existsSync(link)) {
         if (isWindows) copyFileSync(bunExe(), link);
         else symlinkSync(bunExe(), link);
-      } catch {}
-      const r = Bun.spawnSync({
-        cmd: [link, ...args],
+      }
+      return link;
+    }
+
+    async function fakePmRun(dir: string, argv0: "npm" | "npx" | "pnpm", args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [linkAs(dir, argv0), ...args],
         cwd: dir,
         env: bunEnv,
         stderr: "pipe",
         stdout: "pipe",
       });
-      return { stdout: r.stdout.toString("utf8"), stderr: r.stderr.toString("utf8"), exitCode: r.exitCode };
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
     }
 
-    test.concurrent("npm test runs the package.json script, not bun's test runner", () => {
+    test.concurrent("npm test runs the package.json script, not bun's test runner", async () => {
       using dir = tempDir("fake-npm-test", {
         "package.json": JSON.stringify({ scripts: { test: "echo TEST-SCRIPT-RAN" } }),
       });
-      const r = fakePmRun(String(dir), "npm", ["test"]);
+      const r = await fakePmRun(String(dir), "npm", ["test"]);
       expect(r.stdout).toContain("TEST-SCRIPT-RAN");
       expect(r.stdout).not.toContain("bun test v");
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm start / npm run <script> run the package.json script", () => {
+    test.concurrent("npm start / npm run <script> run the package.json script", async () => {
       using dir = tempDir("fake-npm-start", {
         "package.json": JSON.stringify({ scripts: { start: "echo STARTED", other: "echo OTHER" } }),
       });
-      expect(fakePmRun(String(dir), "npm", ["start"]).stdout).toContain("STARTED");
-      expect(fakePmRun(String(dir), "npm", ["run", "other"]).stdout).toContain("OTHER");
+      expect((await fakePmRun(String(dir), "npm", ["start"])).stdout).toContain("STARTED");
+      expect((await fakePmRun(String(dir), "npm", ["run", "other"])).stdout).toContain("OTHER");
     });
 
-    test.concurrent("npm install drops npm-only value-taking flags", () => {
+    test.concurrent("npm install drops npm-only value-taking flags", async () => {
       using dir = tempDir("fake-npm-install", {
         "package.json": JSON.stringify({ name: "p", version: "0.0.0" }),
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
       });
       // create-react-app's invocation shape. The `error` and `silent` tokens
       // are values for `--loglevel`/`--logs-dir`, not packages to install.
-      const r = fakePmRun(String(dir), "npm", [
+      const r = await fakePmRun(String(dir), "npm", [
         "install",
         "--no-audit",
         "--save",
@@ -154,20 +160,64 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npm --version prints a version", () => {
+    test.concurrent("npm publish keeps --tag/--access/--otp", async () => {
+      using dir = tempDir("fake-npm-publish", {
+        "package.json": JSON.stringify({ name: "fake-npm-publish", version: "1.2.3" }),
+        // A token so publish gets past the auth check; --dry-run stops
+        // before any network request.
+        "bunfig.toml": `[install]\nregistry = { url = "http://127.0.0.1:1/", token = "fake" }\n`,
+      });
+      const r = await fakePmRun(String(dir), "npm", ["publish", "--dry-run", "--tag", "beta", "--access", "public"]);
+      expect(r.stdout).toContain("Tag: beta");
+      expect(r.stdout).toContain("Access: public");
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm version dispatches as bun pm version", async () => {
+      using dir = tempDir("fake-npm-version", {
+        "package.json": JSON.stringify({ name: "fake-npm-version", version: "1.2.3" }),
+      });
+      const r = await fakePmRun(String(dir), "npm", ["version", "patch", "--no-git-tag-version"]);
+      expect(r.stdout).toContain("v1.2.4");
+      expect(r.exitCode).toBe(0);
+      expect(JSON.parse(await Bun.file(join(String(dir), "package.json")).text()).version).toBe("1.2.4");
+    });
+
+    test.concurrent("npm pack dispatches as bun pm pack, rewriting --pack-destination", async () => {
+      using dir = tempDir("fake-npm-pack", {
+        "package.json": JSON.stringify({ name: "fake-npm-pack", version: "1.0.0" }),
+      });
+      const r = await fakePmRun(String(dir), "npm", ["pack", "--pack-destination", "./tarballs"]);
+      expect(r.exitCode).toBe(0);
+      expect(existsSync(join(String(dir), "tarballs", "fake-npm-pack-1.0.0.tgz"))).toBe(true);
+    });
+
+    test.concurrent("npm --version prints a version", async () => {
       using dir = tempDir("fake-npm-ver", { "package.json": "{}" });
-      const r = fakePmRun(String(dir), "npm", ["--version"]);
+      const r = await fakePmRun(String(dir), "npm", ["--version"]);
       expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npx / npm exec dispatch as bunx", () => {
+    test.concurrent("npx / npm exec dispatch as bunx", async () => {
       using dir = tempDir("fake-npx", { "package.json": "{}" });
-      expect(fakePmRun(String(dir), "npx", ["--help"]).stderr).toContain("Usage: bunx");
-      expect(fakePmRun(String(dir), "npm", ["exec", "--help"]).stderr).toContain("Usage: bunx");
+      expect((await fakePmRun(String(dir), "npx", ["--help"])).stderr).toContain("Usage: bunx");
+      expect((await fakePmRun(String(dir), "npm", ["exec", "--help"])).stderr).toContain("Usage: bunx");
     });
 
-    test.concurrent("npm init <x> / npm create <x> dispatch as bun create, not bun init", () => {
+    test.concurrent("npx drops npm config flags before the package name", async () => {
+      using dir = tempDir("fake-npx-flags", {
+        "package.json": "{}",
+        // `error` must not be taken for the package name; the registry
+        // override keeps an unfixed bun from reaching the network.
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      const r = await fakePmRun(String(dir), "npx", ["--loglevel", "error", "--version"]);
+      expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm init <x> / npm create <x> dispatch as bun create, not bun init", async () => {
       using dir = tempDir("fake-npm-init", {
         "package.json": "{}",
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
@@ -176,16 +226,16 @@ describe("fake npm/npx cli", () => {
       // registry that fails fast without scaffolding anything. `bun init
       // <name>` would instead mkdir `<name>/` and write index.ts into it.
       for (const cmd of ["init", "create"]) {
-        const r = fakePmRun(String(dir), "npm", [cmd, "nonexistent-template"]);
+        const r = await fakePmRun(String(dir), "npm", [cmd, "nonexistent-template"]);
         expect(r.stdout + r.stderr).toContain("create-nonexistent-template");
         expect(r.stdout + r.stderr).not.toContain("index.ts");
       }
       // Bare `npm init` still means `bun init`.
-      const bare = fakePmRun(String(dir), "npm", ["init", "--help"]);
+      const bare = await fakePmRun(String(dir), "npm", ["init", "--help"]);
       expect(bare.stdout + bare.stderr).toContain("bun init");
     });
 
-    test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", () => {
+    test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", async () => {
       using dir = tempDir("fake-npm-ws", {
         "package.json": JSON.stringify({
           name: "root",
@@ -194,38 +244,46 @@ describe("fake npm/npx cli", () => {
         }),
         "packages/a/package.json": JSON.stringify({ name: "a", scripts: { go: "echo FROM-A" } }),
       });
-      const r = fakePmRun(String(dir), "npm", ["run", "go", "-w", "a"]);
+      const r = await fakePmRun(String(dir), "npm", ["run", "go", "-w", "a"]);
       expect(r.stdout).toContain("FROM-A");
       expect(r.stdout).not.toContain("ROOT");
 
-      const r2 = fakePmRun(String(dir), "npm", ["run", "go", "--workspace=a"]);
+      const r2 = await fakePmRun(String(dir), "npm", ["run", "go", "--workspace=a"]);
       expect(r2.stdout).toContain("FROM-A");
 
       // `--prefix` → `--cwd`
-      const r3 = fakePmRun(String(dir), "npm", ["--prefix", join(String(dir), "packages", "a"), "run", "go"]);
+      const r3 = await fakePmRun(String(dir), "npm", ["--prefix", join(String(dir), "packages", "a"), "run", "go"]);
       expect(r3.stdout).toContain("FROM-A");
     });
 
-    test.concurrent("-- stops flag translation", () => {
+    test.concurrent("npm test --prefix <dir> runs the script in that directory", async () => {
+      using dir = tempDir("fake-npm-test-prefix", {
+        "package.json": JSON.stringify({ name: "root" }),
+        "client/package.json": JSON.stringify({ name: "client", scripts: { test: "echo CLIENT-TEST" } }),
+      });
+      // The translated --cwd must land between `run` and the script name;
+      // anything after the script name is forwarded to the script.
+      const r = await fakePmRun(String(dir), "npm", ["test", "--prefix", "./client"]);
+      expect(r.stdout).toContain("CLIENT-TEST");
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("-- stops flag translation", async () => {
       using dir = tempDir("fake-npm-dd", {
         "package.json": JSON.stringify({ scripts: { go: "echo ARGS:" } }),
       });
-      const r = fakePmRun(String(dir), "npm", ["run", "go", "--", "--loglevel", "error"]);
+      const r = await fakePmRun(String(dir), "npm", ["run", "go", "--", "--loglevel", "error"]);
       expect(r.stdout).toContain("ARGS: --loglevel error");
     });
 
-    test.concurrent("pnpm as argv0 is not treated as npm", () => {
+    test.concurrent("pnpm as argv0 is not treated as npm", async () => {
       using dir = tempDir("fake-pnpm", {
         "package.json": JSON.stringify({ scripts: { test: "echo SHOULD-NOT-RUN" } }),
       });
-      const link = join(String(dir), "pnpm" + (isWindows ? ".exe" : ""));
-      try {
-        if (isWindows) copyFileSync(bunExe(), link);
-        else symlinkSync(bunExe(), link);
-      } catch {}
-      const r = Bun.spawnSync({ cmd: [link, "test"], cwd: String(dir), env: bunEnv });
+      const r = await fakePmRun(String(dir), "pnpm", ["test"]);
       // falls through to bun's own `test` command, not `run test`
-      expect(r.stdout.toString()).not.toContain("SHOULD-NOT-RUN");
+      expect(r.stdout).toContain("bun test v");
+      expect(r.stdout).not.toContain("SHOULD-NOT-RUN");
     });
   });
 });

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -277,6 +277,10 @@ describe("fake npm/npx cli", () => {
       expect(r.stdout).toContain("v1.2.4");
       expect(r.exitCode).toBe(0);
       expect(JSON.parse(await Bun.file(join(String(dir), "package.json")).text()).version).toBe("1.2.4");
+      // npm's -m shorthand takes a value; it must not eat the subcommand.
+      const m = await fakePmRun(String(dir), "npm", ["-m", "a message", "version", "patch", "--no-git-tag-version"]);
+      expect(m.stdout).toContain("v1.2.5");
+      expect(m.exitCode).toBe(0);
     });
 
     test("npm pack dispatches as bun pm pack, rewriting --pack-destination", async () => {
@@ -319,6 +323,7 @@ describe("fake npm/npx cli", () => {
           devDependencies: { dep: "./dep" },
         }),
         "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+        "dep2/package.json": JSON.stringify({ name: "dep2", version: "1.0.0" }),
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
       });
       // npm's -p is --parseable, not bun's --production.
@@ -329,6 +334,11 @@ describe("fake npm/npx cli", () => {
       const y = await fakePmRun(String(dir), "npm", ["-y", "install"]);
       expect(existsSync(join(String(dir), "yarn.lock"))).toBe(false);
       expect(y.exitCode).toBe(0);
+      // npm's -dd is a loglevel shorthand, not a chained bun -d -d (--dev).
+      const dd = await fakePmRun(String(dir), "npm", ["install", "-dd", "./dep2"]);
+      expect(dd.exitCode).toBe(0);
+      const pkg = JSON.parse(await Bun.file(join(String(dir), "package.json")).text());
+      expect(pkg.dependencies).toEqual({ dep2: "./dep2" });
     });
 
     test("npx drops npm config flags before the package name", async () => {
@@ -482,6 +492,10 @@ describe("fake npm/npx cli", () => {
       const pre = await fakePmRun(String(dir), "npm", ["-d", "run", "go"]);
       expect(pre.stdout).toContain("ARGS:");
       expect(pre.exitCode).toBe(0);
+      // npm's -l (--long) is boolean and must not pair with the script name.
+      const l = await fakePmRun(String(dir), "npm", ["run", "-l", "go"]);
+      expect(l.stdout).toContain("ARGS:");
+      expect(l.exitCode).toBe(0);
     });
 
     test("npm -y init does not scaffold into a folder named init", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { copyFileSync, symlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/5995
+// With `--bun`, the shim directory that provides a `node` symlink to bun also
+// provides `npm` and `npx`, so scripts and tools that spawn `npm`/`npx` via
+// child_process work when neither is installed on the host.
+describe("fake npm/npx cli", () => {
+  // A PATH that contains no node/npm/npx: just the dir of the bun-under-test.
+  // `bun run` locates a shell via hardcoded fallbacks when PATH has none; on
+  // Windows, System32 is needed for cmd.exe.
+  const barePATH = isWindows
+    ? [dirname(bunExe()), process.env.SystemRoot + "\\System32", process.env.SystemRoot].join(";")
+    : dirname(bunExe());
+  const stripEnv = {
+    ...bunEnv,
+    PATH: barePATH,
+    Path: undefined,
+    npm_execpath: undefined,
+    npm_node_execpath: undefined,
+    NODE: undefined,
+  };
+
+  async function runScript(dir: string, name: string, extraArgs: string[] = []) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--bun", "run", name, ...extraArgs],
+      cwd: dir,
+      env: stripEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("child_process.spawn('npm'|'npx') resolves via the shim when not in PATH", async () => {
+    using dir = tempDir("fake-npm-spawn", {
+      "package.json": JSON.stringify({
+        name: "fake-npm-spawn",
+        scripts: { go: `${bunExe()} spawn-npm.js` },
+      }),
+      "spawn-npm.js": `
+        const { spawnSync } = require("child_process");
+        for (const cmd of ["npm", "npx"]) {
+          const r = spawnSync(cmd, ["--version"], { encoding: "utf8", shell: ${isWindows} });
+          if (r.error) {
+            console.log(cmd + " ERR " + (r.error.code || r.error.message));
+          } else {
+            console.log(cmd + " OK " + r.stdout.trim());
+          }
+        }
+      `,
+    });
+
+    const { stdout, stderr, exitCode } = await runScript(String(dir), "go");
+    expect(stderr).not.toContain("ENOENT");
+    expect(stdout.trim().split("\n")).toEqual([
+      expect.stringMatching(/^npm OK \d+\.\d+\.\d+/),
+      expect.stringMatching(/^npx OK \d+\.\d+\.\d+/),
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  // When invoked via argv[0] == "npm" / "npx", bun must recognize itself and
+  // behave as its package manager / bunx, not try to run a file called
+  // "install" or "some-pkg".
+  describe("argv[0] dispatch", () => {
+    function fakePmRun(dir: string, argv0: "npm" | "npx", args: string[]) {
+      const link = join(dir, argv0 + (isWindows ? ".exe" : ""));
+      try {
+        if (isWindows) copyFileSync(bunExe(), link);
+        else symlinkSync(bunExe(), link);
+      } catch {}
+      const r = Bun.spawnSync({
+        cmd: [link, ...args],
+        cwd: dir,
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      return { stdout: r.stdout.toString("utf8"), stderr: r.stderr.toString("utf8"), exitCode: r.exitCode };
+    }
+
+    test.concurrent("npm test runs the package.json script, not bun's test runner", () => {
+      using dir = tempDir("fake-npm-test", {
+        "package.json": JSON.stringify({ scripts: { test: "echo TEST-SCRIPT-RAN" } }),
+      });
+      const r = fakePmRun(String(dir), "npm", ["test"]);
+      expect(r.stdout).toContain("TEST-SCRIPT-RAN");
+      expect(r.stdout).not.toContain("bun test v");
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm start / npm run <script> run the package.json script", () => {
+      using dir = tempDir("fake-npm-start", {
+        "package.json": JSON.stringify({ scripts: { start: "echo STARTED", other: "echo OTHER" } }),
+      });
+      expect(fakePmRun(String(dir), "npm", ["start"]).stdout).toContain("STARTED");
+      expect(fakePmRun(String(dir), "npm", ["run", "other"]).stdout).toContain("OTHER");
+    });
+
+    test.concurrent("npm install drops npm-only value-taking flags", () => {
+      using dir = tempDir("fake-npm-install", {
+        "package.json": JSON.stringify({ name: "p", version: "0.0.0" }),
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      // create-react-app's invocation shape. The `error` and `silent` tokens
+      // are values for `--loglevel`/`--logs-dir`, not packages to install.
+      const r = fakePmRun(String(dir), "npm", [
+        "install",
+        "--no-audit",
+        "--save",
+        "--save-exact",
+        "--loglevel",
+        "error",
+        "--logs-dir",
+        "silent",
+        "--dry-run",
+      ]);
+      // It ran as `bun install` (no positionals), not `bun add error silent`.
+      expect(r.stdout).toContain("bun install");
+      expect(r.stdout).not.toContain("bun add");
+      expect(r.stdout + r.stderr).not.toMatch(/\berror\b.*@/);
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm --version prints a version", () => {
+      using dir = tempDir("fake-npm-ver", { "package.json": "{}" });
+      const r = fakePmRun(String(dir), "npm", ["--version"]);
+      expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npx dispatches as bunx", () => {
+      using dir = tempDir("fake-npx", { "package.json": "{}" });
+      const r = fakePmRun(String(dir), "npx", ["--help"]);
+      expect(r.stdout + r.stderr).toContain("Usage: bunx");
+    });
+
+    test.concurrent("pnpm as argv0 is not treated as npm", () => {
+      using dir = tempDir("fake-pnpm", {
+        "package.json": JSON.stringify({ scripts: { test: "echo SHOULD-NOT-RUN" } }),
+      });
+      const link = join(String(dir), "pnpm" + (isWindows ? ".exe" : ""));
+      try {
+        if (isWindows) copyFileSync(bunExe(), link);
+        else symlinkSync(bunExe(), link);
+      } catch {}
+      const r = Bun.spawnSync({ cmd: [link, "test"], cwd: String(dir), env: bunEnv });
+      // falls through to bun's own `test` command, not `run test`
+      expect(r.stdout.toString()).not.toContain("SHOULD-NOT-RUN");
+    });
+  });
+});

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -262,6 +262,9 @@ describe("fake npm/npx cli", () => {
       // Bare `npm init` still means `bun init`.
       const bare = await fakePmRun(String(dir), "npm", ["init", "--help"]);
       expect(bare.stdout + bare.stderr).toContain("bun init");
+      // A value-flag's value is not an initializer.
+      const flags = await fakePmRun(String(dir), "npm", ["init", "--loglevel", "error", "--help"]);
+      expect(flags.stdout + flags.stderr).toContain("bun init");
     });
 
     test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -307,6 +307,8 @@ describe("fake npm/npx cli", () => {
       // npm's -p before the subcommand must not become bunx's --package,
       // which would take the mapped "x" token for the package name.
       expect((await fakePmRun(String(dir), "npm", ["-p", "exec", "--help"])).stderr).toContain("Usage: bunx");
+      // After the subcommand too: npm's -p is --parseable, not --package.
+      expect((await fakePmRun(String(dir), "npm", ["exec", "-p", "--help"])).stderr).toContain("Usage: bunx");
     });
 
     test("npm lowercase shorts are not bun's production/yarn flags", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { copyFileSync, symlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/5995
 // With `--bun`, the shim directory that provides a `node` symlink to bun also

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -199,13 +199,47 @@ describe("fake npm/npx cli", () => {
       using dir = tempDir("fake-npm-savedev", {
         "package.json": JSON.stringify({ name: "root", version: "1.0.0" }),
         "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+        "dep2/package.json": JSON.stringify({ name: "dep2", version: "1.0.0" }),
         "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
       });
       const r = await fakePmRun(String(dir), "npm", ["install", "--save-dev", "./dep"]);
       expect(r.exitCode).toBe(0);
+      // npm's `-O` short means --save-optional.
+      const r2 = await fakePmRun(String(dir), "npm", ["install", "-O", "./dep2"]);
+      expect(r2.exitCode).toBe(0);
       const pkg = JSON.parse(await Bun.file(join(String(dir), "package.json")).text());
       expect(pkg.devDependencies).toEqual({ dep: "./dep" });
+      expect(pkg.optionalDependencies).toEqual({ dep2: "./dep2" });
       expect(pkg.dependencies).toBeUndefined();
+    });
+
+    test.concurrent("npm install -P does not enable bun's production mode", async () => {
+      using dir = tempDir("fake-npm-saveprod", {
+        "package.json": JSON.stringify({
+          name: "root",
+          version: "1.0.0",
+          devDependencies: { dep: "./dep" },
+        }),
+        "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      // npm's -P is --save-prod, a no-op default; bun's own -P is --prod,
+      // which would skip devDependencies.
+      const r = await fakePmRun(String(dir), "npm", ["install", "-P"]);
+      expect(existsSync(join(String(dir), "node_modules", "dep"))).toBe(true);
+      expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm config value flags before the subcommand do not eat it", async () => {
+      using dir = tempDir("fake-npm-preflag", {
+        "package.json": JSON.stringify({ name: "p", version: "0.0.0" }),
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      // `dev` is --omit's value, not the subcommand; --omit itself is a
+      // flag bun install accepts and must reach it.
+      const r = await fakePmRun(String(dir), "npm", ["--omit", "dev", "install", "--dry-run"]);
+      expect(r.stdout).toContain("bun install");
+      expect(r.exitCode).toBe(0);
     });
 
     test.concurrent("npm version dispatches as bun pm version", async () => {
@@ -282,6 +316,13 @@ describe("fake npm/npx cli", () => {
       const ws = await fakePmRun(String(dir), "npm", ["init", "nonexistent-template", "-w", "client"]);
       expect(ws.stdout + ws.stderr).toContain("create-nonexistent-template");
       expect(ws.stdout + ws.stderr).not.toContain("create-client");
+      // Everything after `--` is positional in npm, so it still names a
+      // template, and a short boolean flag is not one.
+      const dd = await fakePmRun(String(dir), "npm", ["init", "--", "nonexistent-template"]);
+      expect(dd.stdout + dd.stderr).toContain("create-nonexistent-template");
+      const y = await fakePmRun(String(dir), "npm", ["init", "-y", "nonexistent-template"]);
+      expect(y.stdout + y.stderr).toContain("create-nonexistent-template");
+      expect(y.stdout + y.stderr).not.toContain("create--y");
     });
 
     test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -289,6 +289,11 @@ describe("fake npm/npx cli", () => {
       const r = await fakePmRun(String(dir), "npx", ["--loglevel", "error", "--version"]);
       expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
       expect(r.exitCode).toBe(0);
+      // `--package <pkg>` is bunx's own value flag; config flags after it
+      // must still be stripped so their value is not taken for the binary
+      // name, which makes bunx ask for one.
+      const pkg = await fakePmRun(String(dir), "npx", ["--package", "some-pkg", "--loglevel", "error"]);
+      expect(pkg.stdout + pkg.stderr).toContain("you must specify the binary");
     });
 
     test.concurrent("npm init <x> / npm create <x> dispatch as bun create, not bun init", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -383,6 +383,12 @@ describe("fake npm/npx cli", () => {
       // missing script exits 0.
       const ip = await fakePmRun(String(dir), "npm", ["run", "missing-script", "--if-present"]);
       expect(ip.exitCode).toBe(0);
+      // An unknown config flag consumes its value like npm's parser does;
+      // neither may shift the script name or reach the script.
+      const pair = await fakePmRun(String(dir), "npm", ["run", "go", "--port", "3000"]);
+      expect(pair.stdout).toContain("ARGS:");
+      expect(pair.stdout).not.toContain("3000");
+      expect(pair.exitCode).toBe(0);
     });
 
     test.concurrent("-- stops flag translation", async () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
-import { copyFileSync, symlinkSync } from "node:fs";
+import { chmodSync, copyFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/5995
-// With `--bun`, the shim directory that provides a `node` symlink to bun also
-// provides `npm` and `npx`, so scripts and tools that spawn `npm`/`npx` via
-// child_process work when neither is installed on the host.
+// The shim directory that provides a `node` symlink to bun for `--bun` / hosts
+// without node also provides `npm` and `npx` fallbacks, so tools that spawn
+// `npm`/`npx` via child_process work on a bun-only host.
 describe("fake npm/npx cli", () => {
   // A PATH that contains no node/npm/npx: just the dir of the bun-under-test.
   // `bun run` locates a shell via hardcoded fallbacks when PATH has none; on
@@ -23,43 +23,71 @@ describe("fake npm/npx cli", () => {
     NODE: undefined,
   };
 
-  async function runScript(dir: string, name: string, extraArgs: string[] = []) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--bun", "run", name, ...extraArgs],
-      cwd: dir,
-      env: stripEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
-  }
+  const spawnNpmFixture = `
+    const { spawnSync } = require("child_process");
+    for (const cmd of ["npm", "npx"]) {
+      const r = spawnSync(cmd, ["--version"], { encoding: "utf8", shell: ${isWindows} });
+      if (r.error) {
+        console.log(cmd + " ERR " + (r.error.code || r.error.message));
+      } else {
+        console.log(cmd + " OK " + r.stdout.trim());
+      }
+    }
+  `;
 
-  test.concurrent("child_process.spawn('npm'|'npx') resolves via the shim when not in PATH", async () => {
+  // The shim directory is shared (`/tmp/bun-node-*`), so the two tests that
+  // exercise its creation cannot run concurrently with each other (or with
+  // anything else that passes `--bun` with a different PATH).
+  test("child_process.spawn('npm'|'npx') resolves via the shim when not in PATH", async () => {
     using dir = tempDir("fake-npm-spawn", {
       "package.json": JSON.stringify({
         name: "fake-npm-spawn",
         scripts: { go: `${bunExe()} spawn-npm.js` },
       }),
-      "spawn-npm.js": `
-        const { spawnSync } = require("child_process");
-        for (const cmd of ["npm", "npx"]) {
-          const r = spawnSync(cmd, ["--version"], { encoding: "utf8", shell: ${isWindows} });
-          if (r.error) {
-            console.log(cmd + " ERR " + (r.error.code || r.error.message));
-          } else {
-            console.log(cmd + " OK " + r.stdout.trim());
-          }
-        }
-      `,
+      "spawn-npm.js": spawnNpmFixture,
     });
 
-    const { stdout, stderr, exitCode } = await runScript(String(dir), "go");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--bun", "run", "go"],
+      cwd: String(dir),
+      env: stripEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("ENOENT");
     expect(stdout.trim().split("\n")).toEqual([
       expect.stringMatching(/^npm OK \d+\.\d+\.\d+/),
       expect.stringMatching(/^npx OK \d+\.\d+\.\d+/),
     ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("does not shadow a real npm in PATH under --bun", async () => {
+    using dir = tempDir("fake-npm-noshadow", {
+      "package.json": JSON.stringify({
+        name: "fake-npm-noshadow",
+        scripts: { go: `${bunExe()} spawn-npm.js` },
+      }),
+      "spawn-npm.js": spawnNpmFixture,
+      "fakebin/placeholder": "",
+    });
+    for (const name of ["npm", "npx"]) {
+      const f = join(String(dir), "fakebin", name + (isWindows ? ".cmd" : ""));
+      writeFileSync(f, isWindows ? `@echo REAL-${name}\r\n` : `#!/bin/sh\necho REAL-${name}\n`);
+      if (!isWindows) chmodSync(f, 0o755);
+    }
+    const sep = isWindows ? ";" : ":";
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--bun", "run", "go"],
+      cwd: String(dir),
+      env: { ...stripEnv, PATH: barePATH + sep + join(String(dir), "fakebin") },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim().split("\n")).toEqual(["npm OK REAL-npm", "npx OK REAL-npx"]);
     expect(exitCode).toBe(0);
   });
 
@@ -133,10 +161,57 @@ describe("fake npm/npx cli", () => {
       expect(r.exitCode).toBe(0);
     });
 
-    test.concurrent("npx dispatches as bunx", () => {
+    test.concurrent("npx / npm exec dispatch as bunx", () => {
       using dir = tempDir("fake-npx", { "package.json": "{}" });
-      const r = fakePmRun(String(dir), "npx", ["--help"]);
-      expect(r.stdout + r.stderr).toContain("Usage: bunx");
+      expect(fakePmRun(String(dir), "npx", ["--help"]).stderr).toContain("Usage: bunx");
+      expect(fakePmRun(String(dir), "npm", ["exec", "--help"]).stderr).toContain("Usage: bunx");
+    });
+
+    test.concurrent("npm init <x> / npm create <x> dispatch as bun create, not bun init", () => {
+      using dir = tempDir("fake-npm-init", {
+        "package.json": "{}",
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
+      // `bun create <name>` runs `bunx create-<name>`; with an unreachable
+      // registry that fails fast without scaffolding anything. `bun init
+      // <name>` would instead mkdir `<name>/` and write index.ts into it.
+      for (const cmd of ["init", "create"]) {
+        const r = fakePmRun(String(dir), "npm", [cmd, "nonexistent-template"]);
+        expect(r.stdout + r.stderr).toContain("create-nonexistent-template");
+        expect(r.stdout + r.stderr).not.toContain("index.ts");
+      }
+      // Bare `npm init` still means `bun init`.
+      const bare = fakePmRun(String(dir), "npm", ["init", "--help"]);
+      expect(bare.stdout + bare.stderr).toContain("bun init");
+    });
+
+    test.concurrent("npm run -w <pkg> / --prefix <dir> are translated, not dropped", () => {
+      using dir = tempDir("fake-npm-ws", {
+        "package.json": JSON.stringify({
+          name: "root",
+          workspaces: ["packages/*"],
+          scripts: { go: "echo ROOT" },
+        }),
+        "packages/a/package.json": JSON.stringify({ name: "a", scripts: { go: "echo FROM-A" } }),
+      });
+      const r = fakePmRun(String(dir), "npm", ["run", "go", "-w", "a"]);
+      expect(r.stdout).toContain("FROM-A");
+      expect(r.stdout).not.toContain("ROOT");
+
+      const r2 = fakePmRun(String(dir), "npm", ["run", "go", "--workspace=a"]);
+      expect(r2.stdout).toContain("FROM-A");
+
+      // `--prefix` → `--cwd`
+      const r3 = fakePmRun(String(dir), "npm", ["--prefix", join(String(dir), "packages", "a"), "run", "go"]);
+      expect(r3.stdout).toContain("FROM-A");
+    });
+
+    test.concurrent("-- stops flag translation", () => {
+      using dir = tempDir("fake-npm-dd", {
+        "package.json": JSON.stringify({ scripts: { go: "echo ARGS:" } }),
+      });
+      const r = fakePmRun(String(dir), "npm", ["run", "go", "--", "--loglevel", "error"]);
+      expect(r.stdout).toContain("ARGS: --loglevel error");
     });
 
     test.concurrent("pnpm as argv0 is not treated as npm", () => {

--- a/test/cli/run/as-npm.test.ts
+++ b/test/cli/run/as-npm.test.ts
@@ -312,6 +312,13 @@ describe("fake npm/npx cli", () => {
       // Bare `npm init` still means `bun init`.
       const bare = await fakePmRun(String(dir), "npm", ["init", "--help"]);
       expect(bare.stdout + bare.stderr).toContain("bun init");
+    });
+
+    test.concurrent("npm init flags do not leak into the template name", async () => {
+      using dir = tempDir("fake-npm-init-flags", {
+        "package.json": "{}",
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:1/nope"\n`,
+      });
       // A value-flag's value is not an initializer.
       const flags = await fakePmRun(String(dir), "npm", ["init", "--loglevel", "error", "--help"]);
       expect(flags.stdout + flags.stderr).toContain("bun init");
@@ -361,6 +368,21 @@ describe("fake npm/npx cli", () => {
       const r = await fakePmRun(String(dir), "npm", ["test", "--prefix", "./client"]);
       expect(r.stdout).toContain("CLIENT-TEST");
       expect(r.exitCode).toBe(0);
+    });
+
+    test.concurrent("npm run flags after the script name are npm's, not the script's", async () => {
+      using dir = tempDir("fake-npm-postflag", {
+        "package.json": JSON.stringify({ name: "p", scripts: { go: "echo ARGS:" } }),
+      });
+      // npm consumes config flags anywhere before `--`; only args after `--`
+      // reach the script.
+      const r = await fakePmRun(String(dir), "npm", ["run", "go", "--silent"]);
+      expect(r.stdout).not.toContain("ARGS: --silent");
+      expect(r.exitCode).toBe(0);
+      // `--if-present` after the script name must reach bun run, so a
+      // missing script exits 0.
+      const ip = await fakePmRun(String(dir), "npm", ["run", "missing-script", "--if-present"]);
+      expect(ip.exitCode).toBe(0);
     });
 
     test.concurrent("-- stops flag translation", async () => {


### PR DESCRIPTION
Fixes #5995
Fixes #14773

## Repro

On a host with no `npm`/`npx` in `PATH`:

```console
$ bun create react-app my-app
...
TypeError: Executable not found in $PATH: "npm"
      at spawn (node:child_process:721:8)
      at spawn (.../cross-spawn/index.js:12:24)
      at .../create-react-app/createReactApp.js:383:19
```

Minimal form:

```js
// package.json: { "scripts": { "go": "node check.js" } }
// check.js:
require('child_process').spawnSync('npm', ['--version']); // ENOENT
```

`bun --bun run go` (or `bun run go` on a host without node) fails to find `npm`.

## Cause

When `--bun` is passed or `node` is not in `PATH`, `RunCommand::create_fake_temporary_node_executable` (src/install/lib.rs) creates a temp dir with `node` and `bun` links at the running bun binary and prepends it to `PATH`, so scripts that spawn `node` get bun. Scripts that spawn `npm` or `npx` via `child_process` (as create-react-app and many scaffolding tools do) still see `ENOENT` on a bun-only host. The existing `replace_package_manager_run` rewrite only touches package.json script *strings*, not `spawn('npm', ...)` calls from JavaScript.

## Fix

Add `npm` and `npx` links to the same shim dir, **only when they are not already resolvable in the original `PATH`**. A host with a real npm is unaffected (`--bun` keeps meaning "symlink node", nothing more); a bun-only host gets a best-effort shim instead of ENOENT. A stale shim link left by a previous run is removed when a real npm is present so it can never shadow.

Teach the CLI entry point to recognize those argv0 basenames:

- `argv0 == npx` dispatches as `bunx`.
- `argv0 == npm` rewrites argv into the equivalent `bun` invocation and falls through to the normal subcommand matcher:
  - npm lifecycle shortcuts `test`/`t`/`tst`/`start`/`stop`/`restart` become `run <name>`, so `npm test` runs the package.json `test` script rather than bun's test runner.
  - `npm exec` dispatches as `bun x` (bun's own `exec` is a shell-script runner); `npm init <x>`/`npm create <x>` dispatch as `bun create <x>`; bare `npm init` stays `bun init`; `npm version` dispatches as `bun pm version`; npm's install/ci/run/ls/view aliases are mapped.
  - npm-only value-taking options (`--loglevel`, `--userconfig`, `--script-shell`, ...) are dropped together with their value so the value is not mis-parsed as a positional. Otherwise `npm install --no-audit --save --save-exact --loglevel error react` (create-react-app's exact invocation) would try to install a package named `error`.
  - `--workspace`/`-w` is translated to `--filter` and `--prefix`/`-C` to `--cwd`, hoisted after the mapped subcommand so `bun run`'s stop-after-first-positional does not pass them through to the script. `--tag`/`--access`/`--otp` are kept for `publish` and `--message` for `version`, where bun accepts them.

The basename check is exact so `pnpm`/`pnpx` are not caught. Unknown npm boolean flags are silently dropped as before, and subcommands with no bun equivalent pass through unchanged.

## Verification

New `test/cli/run/as-npm.test.ts`:

- `spawn('npm'|'npx', ['--version'])` from inside a `--bun run` script with no npm in `PATH` resolves via the shim (the #5995 failure)
- with a real `npm`/`npx` on `PATH`, `--bun run` does *not* shadow it
- `npm test` runs the package.json script, not bun's test runner
- `npm install --no-audit --save --save-exact --loglevel error --logs-dir silent --dry-run` runs as `bun install` with no positionals
- `npx --help` / `npm exec --help` show bunx usage
- `npm init <x>` / `npm create <x>` dispatch as `bun create`, bare `npm init` as `bun init`
- `npm run go -w pkg` / `--workspace=pkg` / `--prefix dir` reach the right workspace
- `--` stops flag translation
- `pnpm` as argv0 is *not* translated

Six of the eleven tests fail on the current binary; all pass with the change. `test/cli/run/as-node.test.ts` and `test/cli/install/bun-run.test.ts` are unchanged and continue to pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/as-npm.test.ts

<!-- robobun:evidence:end -->