### PR TITLE
bundler: polyfill the process and Buffer globals for --target browser

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2472,6 +2472,8 @@ pub mod parse_worker {
             output_format == options::Format::InternalBakeDev && !task.source_index.is_runtime();
         opts.features.auto_polyfill_require =
             output_format == options::Format::Esm && !opts.features.hot_module_reloading;
+        opts.features.auto_polyfill_node_globals =
+            topts.polyfill_node_globals && !task.source_index.is_runtime();
         opts.features.react_fast_refresh =
             topts.react_fast_refresh && loader.is_jsx() && !source.path.is_node_module();
         opts.features.react_compiler = if topts.react_compiler.is_enabled()

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2472,8 +2472,14 @@ pub mod parse_worker {
             output_format == options::Format::InternalBakeDev && !task.source_index.is_runtime();
         opts.features.auto_polyfill_require =
             output_format == options::Format::Esm && !opts.features.hot_module_reloading;
-        opts.features.auto_polyfill_node_globals =
-            topts.polyfill_node_globals && !task.source_index.is_runtime();
+        // The HMR wrapper destructures `hmr.imports` for every ESM import, and
+        // `hmr.imports` is only populated for import records the HMR runtime
+        // knows about; a post-visit injected star import isn't wired into that
+        // graph. The dev server also doesn't need this: leave `process` /
+        // `Buffer` as free globals in dev, same as before.
+        opts.features.auto_polyfill_node_globals = topts.polyfill_node_globals
+            && output_format != options::Format::InternalBakeDev
+            && !task.source_index.is_runtime();
         opts.features.react_fast_refresh =
             topts.react_fast_refresh && loader.is_jsx() && !source.path.is_node_module();
         opts.features.react_compiler = if topts.react_compiler.is_enabled()

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -237,6 +237,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub module_ref: Ref,
     pub filename_ref: Ref,
     pub dirname_ref: Ref,
+    pub process_ref: Ref,
+    pub buffer_ref: Ref,
     pub import_meta_ref: Ref,
     pub hmr_api_ref: Ref,
 
@@ -1662,6 +1664,103 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Emit an `import * as <ref> from "<path>"` part for an ambient node
+    /// global (`process`) or, when `alias` is set, `import { <alias> as <ref> } from "<path>"`
+    /// (`Buffer`). The ref was pre-declared by `declare_common_js_symbol` and
+    /// reached by user code, so it already has a non-zero `use_count_estimate`.
+    pub fn generate_node_global_polyfill_import(
+        &mut self,
+        parts: &mut ListManaged<'a, js_ast::Part>,
+        ref_: Ref,
+        import_path: &'static [u8],
+        alias: Option<&'static [u8]>,
+    ) -> Result<(), crate::Error> {
+        let arena = self.arena;
+
+        let import_record_i =
+            self.add_import_record_by_range(ImportKind::Stmt, bun_ast::Range::NONE, import_path);
+
+        let mut declared_symbols = bun_ast::DeclaredSymbolList::default();
+        declared_symbols.ensure_total_capacity(2)?;
+        declared_symbols.append_assume_capacity(DeclaredSymbol {
+            ref_,
+            is_top_level: true,
+        });
+
+        // `declare_common_js_symbol` minted this as `Unbound`; re-kind now that
+        // it is a real binding so later passes don't treat it as a free global.
+        self.symbols[ref_.inner_index() as usize].kind = js_ast::symbol::Kind::Other;
+
+        let import_stmt = if let Some(alias) = alias {
+            let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, import_path);
+            VecExt::append(&mut self.module_scope_mut().generated, namespace_ref);
+            declared_symbols.append_assume_capacity(DeclaredSymbol {
+                ref_: namespace_ref,
+                is_top_level: true,
+            });
+            self.is_import_item.insert(ref_, ());
+            self.named_imports.put(
+                ref_,
+                js_ast::NamedImport {
+                    alias: Some(js_ast::StoreStr::new(alias)),
+                    alias_loc: bun_ast::Loc::default(),
+                    namespace_ref,
+                    import_record_index: import_record_i,
+                    local_parts_with_uses: bun_alloc::AstAlloc::vec(),
+                    alias_is_star: false,
+                    is_exported: false,
+                },
+            )?;
+            let clause_items =
+                arena.alloc_slice_fill_with::<js_ast::ClauseItem, _>(1, |_| js_ast::ClauseItem {
+                    alias: js_ast::StoreStr::new(alias),
+                    original_name: js_ast::StoreStr::new(alias),
+                    alias_loc: bun_ast::Loc::default(),
+                    name: LocRef {
+                        ref_,
+                        loc: bun_ast::Loc::default(),
+                    },
+                });
+            self.s(
+                S::Import {
+                    namespace_ref,
+                    items: clause_items.into(),
+                    import_record_index: import_record_i,
+                    is_single_line: true,
+                    default_name: None,
+                    star_name_loc: bun_ast::Loc::EMPTY,
+                    phase_defer: false,
+                },
+                bun_ast::Loc::default(),
+            )
+        } else {
+            self.import_items_for_namespace
+                .insert(ref_, ImportItemForNamespaceMap::default());
+            self.s(
+                S::Import {
+                    namespace_ref: ref_,
+                    items: bun_ast::StoreSlice::EMPTY,
+                    import_record_index: import_record_i,
+                    is_single_line: true,
+                    default_name: None,
+                    star_name_loc: bun_ast::Loc { start: 0 },
+                    phase_defer: false,
+                },
+                bun_ast::Loc::default(),
+            )
+        };
+
+        let stmts = arena.alloc_slice_fill_with::<Stmt, _>(1, |_| import_stmt);
+        parts.push(js_ast::Part {
+            stmts: stmts.into(),
+            declared_symbols,
+            import_record_indices: js_ast::PartImportRecordIndices::init_one(import_record_i),
+            tag: bun_ast::PartTag::None,
+            ..Default::default()
+        });
+        Ok(())
+    }
+
     pub fn generate_import_stmt_for_bake_response(
         &mut self,
         parts: &mut ListManaged<'a, js_ast::Part>,
@@ -2824,6 +2923,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"__dirname")?;
         self.filename_ref =
             self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"__filename")?;
+
+        if self.options.features.auto_polyfill_node_globals {
+            // `Kind::Unbound` so the `process.env.NODE_ENV` / `process.browser`
+            // dot-defines (which only match unbound roots) keep firing. The
+            // post-visit pass rewrites the kind before emitting the import.
+            self.process_ref =
+                self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"process")?;
+            self.buffer_ref =
+                self.declare_common_js_symbol(js_ast::symbol::Kind::Unbound, b"Buffer")?;
+        }
 
         if self.options.features.inject_jest_globals {
             self.jest.test =
@@ -8728,6 +8837,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             module_ref: Ref::NONE,
             filename_ref: Ref::NONE,
             dirname_ref: Ref::NONE,
+            process_ref: Ref::NONE,
+            buffer_ref: Ref::NONE,
             import_meta_ref: Ref::NONE,
             hmr_api_ref: Ref::NONE,
             response_ref: Ref::NONE,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -189,6 +189,7 @@ impl<'a> Options<'a> {
                 set_breakpoint_on_first_line: f.set_breakpoint_on_first_line,
                 trim_unused_imports: f.trim_unused_imports,
                 auto_polyfill_require: f.auto_polyfill_require,
+                auto_polyfill_node_globals: f.auto_polyfill_node_globals,
                 replace_exports: Default::default(),
                 dont_bundle_twice: f.dont_bundle_twice,
                 unwrap_commonjs_packages: f.unwrap_commonjs_packages,
@@ -2141,6 +2142,29 @@ impl<'a> Parser<'a> {
                     },
                 ],
             )?;
+        }
+
+        if p.options.features.auto_polyfill_node_globals {
+            if !p.process_ref.is_empty()
+                && p.symbols.as_slice()[p.process_ref.inner_index() as usize].use_count_estimate > 0
+            {
+                p.generate_node_global_polyfill_import(
+                    &mut before,
+                    p.process_ref,
+                    b"node:process",
+                    None,
+                )?;
+            }
+            if !p.buffer_ref.is_empty()
+                && p.symbols.as_slice()[p.buffer_ref.inner_index() as usize].use_count_estimate > 0
+            {
+                p.generate_node_global_polyfill_import(
+                    &mut before,
+                    p.buffer_ref,
+                    b"node:buffer",
+                    Some(b"Buffer"),
+                )?;
+            }
         }
 
         // Bake: transform global `Response` to use `import { Response } from 'bun:app'`

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -219,6 +219,12 @@ pub mod Runtime {
         /// Allow runtime usage of require(), converting `require` into `__require`
         pub auto_polyfill_require: bool,
 
+        /// When bundling for the browser, inject `import * as process from "node:process"`
+        /// and `import { Buffer } from "node:buffer"` for any unbound `process` / `Buffer`
+        /// global, the same way `__dirname` / `__filename` are inlined. The resolver maps
+        /// those specifiers to the embedded browser polyfills via `polyfill_node_globals`.
+        pub auto_polyfill_node_globals: bool,
+
         pub replace_exports: ReplaceableExportMap,
 
         /// Scan for '// @bun' at the top of this file, halting a parse if it is
@@ -300,6 +306,7 @@ pub mod Runtime {
                 set_breakpoint_on_first_line: false,
                 trim_unused_imports: false,
                 auto_polyfill_require: false,
+                auto_polyfill_node_globals: false,
                 replace_exports: ReplaceableExportMap::default(),
                 dont_bundle_twice: false,
                 unwrap_commonjs_packages: &[],

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1207,6 +1207,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return;
                 }
 
+                // `typeof process` / `typeof Buffer` on its own is a
+                // feature-detection guard. Don't let it count toward the
+                // auto-polyfill injection; otherwise a lone `typeof Buffer`
+                // pulls in the whole Buffer polyfill just to answer "function".
+                // If some other expression in the file *does* use the global,
+                // the ref is the same symbol and this `typeof` will see the
+                // polyfill at runtime.
+                if p.options.features.auto_polyfill_node_globals
+                    && e_
+                        .flags
+                        .contains(E::UnaryFlags::WAS_ORIGINALLY_TYPEOF_IDENTIFIER)
+                {
+                    if let Data::EIdentifier(id) = e_.value.data {
+                        if (!p.process_ref.is_empty() && id.ref_.eql(p.process_ref))
+                            || (!p.buffer_ref.is_empty() && id.ref_.eql(p.buffer_ref))
+                        {
+                            p.ignore_usage(id.ref_);
+                        }
+                    }
+                }
+
                 if let Some(typeof_) = SideEffects::typeof_(&e_.value.data) {
                     *e = p.new_expr(
                         E::String {

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -82,6 +82,116 @@ describe("bundler", () => {
       api.expectFile("out.js").not.toInclude("import ");
     },
   });
+  itBundled("browser/NodeGlobalProcess#5894", {
+    files: {
+      "/entry.js": /* js */ `
+        if (typeof process !== "object") throw new Error("typeof process: " + typeof process);
+        if (typeof process.nextTick !== "function") throw new Error("typeof process.nextTick: " + typeof process.nextTick);
+        if (process.browser !== true) throw new Error("process.browser: " + process.browser);
+        if (process.cwd() !== "/") throw new Error("process.cwd(): " + process.cwd());
+        process.nextTick(() => console.log("tick"));
+        console.log("ok " + process.title);
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "ok browser\ntick",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toInclude("import ");
+      // The polyfill was bundled in: a bare `process` global would be a
+      // ReferenceError in a real browser.
+      expect(out).toInclude("node:process");
+      expect(out).toMatch(/\btitle\s*=\s*"browser"/);
+    },
+  });
+  itBundled("browser/NodeGlobalBuffer", {
+    files: {
+      "/entry.js": /* js */ `
+        if (typeof Buffer !== "function") throw new Error("typeof Buffer: " + typeof Buffer);
+        const buf = Buffer.from("hello");
+        console.log(buf.toString("base64"), Buffer.isBuffer(buf));
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "aGVsbG8= true",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toInclude("import ");
+      expect(out).toInclude("node:buffer");
+      expect(out).not.toMatch(/\bBuffer\.from\(/);
+    },
+  });
+  itBundled("browser/NodeGlobalProcessNotInjectedForTargetBun", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(typeof process.nextTick);
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toInclude("node:process");
+      expect(out).not.toInclude("exports_process");
+      expect(out).toInclude("typeof process.nextTick");
+    },
+  });
+  itBundled("browser/NodeGlobalProcessNotInjectedWhenShadowed", {
+    files: {
+      "/entry.js": /* js */ `
+        const process = { nextTick: "shadowed" };
+        const Buffer = { from: "shadowed" };
+        console.log(process.nextTick, Buffer.from);
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "shadowed shadowed",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toInclude("node:process");
+      expect(out).not.toInclude("node:buffer");
+      expect(out).not.toInclude("browser polyfill");
+    },
+  });
+  itBundled("browser/NodeGlobalProcessNotInjectedForDefinesOnly", {
+    files: {
+      "/entry.js": /* js */ `
+        // Every reference is covered by a default define, so no polyfill is needed.
+        console.log(typeof process.env.NODE_ENV, process.browser);
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "string true",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toInclude("node:process");
+      expect(out).not.toInclude("exports_process");
+    },
+  });
+  itBundled("browser/NodeGlobalProcessUserDefineWins", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(process.nextTick);
+      `,
+    },
+    target: "browser",
+    define: { process: '{"nextTick":"fromDefine"}' },
+    run: {
+      stdout: "fromDefine",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toInclude("node:process");
+      expect(out).not.toInclude("exports_process");
+    },
+  });
   itBundled("browser/NodeFS", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -192,6 +192,55 @@ describe("bundler", () => {
       expect(out).not.toInclude("exports_process");
     },
   });
+  itBundled("browser/NodeGlobalProcessNotInjectedForTypeofOnly", {
+    files: {
+      "/entry.js": /* js */ `
+        // A lone typeof guard is feature detection; don't pull in the polyfill.
+        console.log(typeof process, typeof Buffer);
+      `,
+    },
+    target: "browser",
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toInclude("node:process");
+      expect(out).not.toInclude("node:buffer");
+      expect(out).toInclude("typeof process");
+      expect(out).toInclude("typeof Buffer");
+    },
+  });
+  itBundled("browser/NodeGlobalProcessTypeofWithRealUse", {
+    files: {
+      "/entry.js": /* js */ `
+        // typeof guard plus a real use: the real use pulls in the polyfill,
+        // and the typeof then sees it.
+        if (typeof process !== "object") throw new Error("typeof process: " + typeof process);
+        process.nextTick(() => console.log("tick"));
+        console.log("ok");
+      `,
+    },
+    target: "browser",
+    run: {
+      stdout: "ok\ntick",
+    },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toInclude("node:process");
+    },
+  });
+  itBundled("browser/NodeGlobalProcessPackagesExternal", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(process.nextTick);
+      `,
+    },
+    target: "browser",
+    packages: "external",
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      // With --packages external the injected import stays external, same as
+      // a user-written `import * as process from "node:process"` would.
+      expect(out).toMatch(/import\s*\*\s*as\s+process\s+from\s*"node:process"/);
+    },
+  });
   itBundled("browser/NodeFS", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2870,9 +2870,14 @@ for (const backend of ["api", "cli"] as const) {
       },
       target: "browser",
       backend,
-      capture: ["process.env.ARBITRARY"],
+      // `process` now resolves to the browser polyfill namespace; the point of
+      // this test is that the host env value is *not* inlined into the bundle.
+      capture: ["exports_process.env.ARBITRARY"],
       env: {
         ARBITRARY: "secret environment stuff!",
+      },
+      onAfterBundle(api) {
+        api.expectFile("/out.js").not.toContain("secret environment stuff!");
       },
     });
   });

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -285,8 +285,10 @@ env = "BUN_PUBLIC_*"
       const js = await jsResponse.text();
       expect(js).not.toContain("process.env.BUN_PUBLIC_FOO");
       expect(js).toContain('console.log("bar")');
-      expect(js).toContain("process.env.BUN_PRIVATE_FOO");
-      expect(js).not.toContain('console.log("baz")');
+      // `process` now resolves to the browser polyfill namespace in the output;
+      // the point of this check is that the private value is not inlined.
+      expect(js).toContain(".env.BUN_PRIVATE_FOO");
+      expect(js).not.toContain("baz");
       expect(js).toContain('document.getElementById("message")');
     }
   } finally {


### PR DESCRIPTION
Fixes #5894

### Repro

```sh
echo 'console.log(typeof process.nextTick)' > a.js
bun build a.js --target browser
```

```js
// a.js
console.log(typeof process.nextTick);
```

`process` is left as a free global, so the bundle throws `ReferenceError: process is not defined` in a real browser. `require("process")` and `import "node:process"` already resolve to the embedded browser polyfill; only the bare-global form is missing. Same for `Buffer`. browserify and webpack (via ProvidePlugin) both inject these automatically.

This also breaks several of the node-fallback polyfills themselves: `path.resolve()` references `process.cwd()` as a bare global, so a `--target browser` bundle that does nothing but `import { resolve } from "path"` throws the same ReferenceError.

### Cause

`polyfill_node_globals` only lives on the resolver: it maps the `process` / `buffer` *specifiers* to `src/node-fallbacks/{process,buffer}.js`. Nothing in the parser rewrites an unbound `process` / `Buffer` identifier into an import, the way `__dirname` / `__filename` are already inlined.

### Fix

Add a parser feature flag `auto_polyfill_node_globals`, wired from the existing `polyfill_node_globals` bundler option (set for `target == Browser`). Use the same ambient-symbol pattern as `__dirname` / the jest-globals injection:

- `declare_common_js_symbol(Unbound, "process" / "Buffer")` before visit so `find_symbol` reaches it.
- After visit, if `use_count_estimate > 0`, emit `import * as process from "node:process"` / `import { Buffer } from "node:buffer"` as a new part. The resolver already routes those specifiers to the embedded polyfills.

The symbol stays `Unbound` during visit so the `process.env.NODE_ENV` / `process.browser` dot-defines keep firing (they only match unbound roots), and a local `const process = ...` or a user `--define process=...` still win: the ambient ref's use count stays zero and nothing is injected.

Scope limits:

- **`--target bun` / `--target node`** are unaffected (`polyfill_node_globals` is false there).
- **`--format=internal_bake_dev` (bake dev server / HMR)** is gated off, matching `auto_polyfill_require` one line above: the HMR runtime wraps each module's ESM imports through `hmr.imports`, and a post-visit injected import record isn't wired into that graph.
- **`typeof process` / `typeof Buffer` on its own** does not count as a use. A file whose only reference is a feature-detection guard like `typeof Buffer !== "undefined"` doesn't pull in the 52 KB Buffer polyfill. A file that also has a real use (e.g. `Buffer.from(...)`) does get the polyfill, and its `typeof` expressions then see it. This mirrors the existing `typeof require` handling.
- **`--packages external`** keeps the injected import external (`import * as process from "node:process"` in the output), same as a user-written `import "node:process"` would be. A downstream bundler can handle it.

### Verification

New tests in `test/bundler/bundler_browser.test.ts` (the first four fail on the released binary):

- `browser/NodeGlobalProcess#5894`, `browser/NodeGlobalBuffer`: bare `process` / `Buffer` reach the polyfill, bundle runs.
- `browser/NodeGlobalProcessTypeofWithRealUse`: typeof guard plus a real use sees the polyfill.
- `browser/NodeGlobalProcessPackagesExternal`: injected import stays external under `--packages external`.
- `browser/NodeGlobalProcessNotInjectedForTargetBun`, `...WhenShadowed`, `...ForDefinesOnly`, `...UserDefineWins`, `...ForTypeofOnly`: the polyfill is *not* pulled in when it shouldn't be.

Updated `edgecase/ProcessEnvArbitrary` and `bun-serve-html-entry.test.ts` to account for `process` now resolving to the polyfill namespace; their actual assertions (host env values are not inlined) are unchanged and checked directly.

```
bun bd test test/bundler/bundler_browser.test.ts                   # 22 pass
bun bd test test/bundler/bundler_edgecase.test.ts                  # 117 pass
bun bd test test/bundler/esbuild/default.test.ts                   # 151 pass
bun bd test test/bake/dev/react-spa.test.ts ssg-pages-router.test.ts  # 15 pass
```

Manually verified the bundled output of `process.nextTick(...)` + `Buffer.from(...)` runs correctly under Node with no bun globals, and that `import { resolve } from "path"` with `--target browser` no longer throws.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->