### PR TITLE
stdin: set O_NONBLOCK on the stdio fd when process.stdin starts reading

### DIFF
--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -485,6 +485,11 @@ extern "C" void Bun__onExit();
 extern "C" int32_t bun_stdio_tty[3];
 #if !OS(WINDOWS)
 static termios termios_to_restore_later[3];
+// F_GETFL snapshot for each stdio fd at startup, or -1 if the fcntl failed.
+// bun_restore_stdio() uses this to restore the O_NONBLOCK bit on exit so a
+// sibling in the same subshell (sharing the pipe file description) does not
+// inherit nonblocking stdin after Bun exits. Mirrors Node's ResetStdio().
+static int bun_stdio_flags[3] = { -1, -1, -1 };
 // Whether Bun itself has modified the termios of each stdio fd during this
 // process's lifetime (e.g. via process.stdin.setRawMode). Used to decide
 // whether the exit-time termios restore should fire when Bun is acting as a
@@ -503,6 +508,26 @@ extern "C" void bun_restore_stdio()
 {
 
 #if !OS(WINDOWS)
+
+    // Restore the O_NONBLOCK bit to its startup value for every stdio fd.
+    // fcntl() is async-signal-safe, so this is fine from onExitSignal.
+    for (int fd = 0; fd < 3; fd++) {
+        if (bun_stdio_flags[fd] < 0)
+            continue;
+        int flags;
+        do
+            flags = fcntl(fd, F_GETFL);
+        while (flags == -1 && errno == EINTR);
+        if (flags == -1)
+            continue;
+        if ((O_NONBLOCK & (flags ^ bun_stdio_flags[fd])) == 0)
+            continue;
+        flags = (flags & ~O_NONBLOCK) | (bun_stdio_flags[fd] & O_NONBLOCK);
+        int err;
+        do
+            err = fcntl(fd, F_SETFL, flags);
+        while (err == -1 && errno == EINTR);
+    }
 
     // Only suppress the restore when Bun is a pipeline producer (stdout is a
     // pipe, not a TTY) and it didn't touch termios itself. That's the #29592
@@ -615,7 +640,13 @@ extern "C" void bun_initialize_process()
         }
     };
 
+    bool anyFlags = false;
     for (int fd = 0; fd < 3; fd++) {
+        do
+            bun_stdio_flags[fd] = fcntl(fd, F_GETFL);
+        while (bun_stdio_flags[fd] == -1 && errno == EINTR);
+        anyFlags = anyFlags || bun_stdio_flags[fd] >= 0;
+
         int result = isatty(fd);
         if (result == 0) {
             if (errno == EBADF) [[unlikely]] {
@@ -641,8 +672,8 @@ extern "C" void bun_initialize_process()
         close(devNullFd_);
     }
 
-    // Restore TTY state on exit
-    if (anyTTYs) {
+    // Restore TTY state / O_NONBLOCK on signal exit
+    if (anyTTYs || anyFlags) {
         struct sigaction sa;
         memset(&sa, 0, sizeof(sa));
         sigemptyset(&sa.sa_mask);

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -166,11 +166,17 @@ impl Lazy {
                             // nonblocking without touching the file description
                             // shared with the parent shell. Only stdin is swapped
                             // in place; stdout/stderr readers keep using a
-                            // separate fd so the write side's blocking-tty
-                            // contract on fd 1/2 is untouched.
-                            let accmode = sys::get_fcntl_flags(*pl_fd)
-                                .map(|f| f as i32 & sys::O::ACCMODE)
-                                .unwrap_or(sys::O::RDONLY);
+                            // separate read-only fd so the write side's
+                            // blocking-tty contract on fd 1/2 is untouched and a
+                            // `> /dev/tty` (O_WRONLY) fd 1 still yields a
+                            // readable reopened fd.
+                            let accmode = if *pl_fd == Fd::stdin() {
+                                sys::get_fcntl_flags(*pl_fd)
+                                    .map(|f| f as i32 & sys::O::ACCMODE)
+                                    .unwrap_or(sys::O::RDONLY)
+                            } else {
+                                sys::O::RDONLY
+                            };
                             let rc = open_as_nonblocking_tty(pl_fd.native(), accmode);
                             if rc > -1 {
                                 is_nonblocking = true;

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -159,10 +159,20 @@ impl Lazy {
                     'brk: {
                         #[cfg(unix)]
                         {
-                            let rc = open_as_nonblocking_tty(pl_fd.native(), sys::O::RDONLY);
+                            // libuv `uv_tty_init`: reopen the tty with the fd's
+                            // existing access mode so the fresh file description
+                            // keeps O_RDWR when the original had it, then `dup2`
+                            // it back onto the stdio fd. That leaves fd 0 itself
+                            // nonblocking without touching the file description
+                            // shared with the parent shell.
+                            let accmode = sys::get_fcntl_flags(*pl_fd)
+                                .map(|f| f as i32 & sys::O::ACCMODE)
+                                .unwrap_or(sys::O::RDONLY);
+                            let rc = open_as_nonblocking_tty(pl_fd.native(), accmode);
                             if rc > -1 {
                                 is_nonblocking = true;
                                 file.is_atty = Some(true);
+                                let _ = sys::dup2(Fd::from_native(rc), *pl_fd);
                                 break 'brk Fd::from_native(rc);
                             }
                         }
@@ -248,6 +258,18 @@ impl Lazy {
             } else {
                 FileType::File
             };
+
+            // libuv `uv_pipe_open` / `uv_tty_init` set O_NONBLOCK on the adopted
+            // stdio fd. Node exposes that via `process.stdin`: once the stream
+            // is started, `fs.readSync(0, …)` returns EAGAIN instead of blocking
+            // (issue #5305). The tty path above already swapped in a nonblocking
+            // file description; this covers pipe/socket stdio and the tty
+            // fallback when reopening failed.
+            if fd.stdio_tag().is_some() && this.pollable && !is_nonblocking {
+                if sys::set_nonblocking(fd).is_ok() {
+                    is_nonblocking = true;
+                }
+            }
 
             // pretend it's a non-blocking pipe if it's a TTY
             if is_nonblocking && this.file_type != FileType::Socket {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -164,7 +164,10 @@ impl Lazy {
                             // keeps O_RDWR when the original had it, then `dup2`
                             // it back onto the stdio fd. That leaves fd 0 itself
                             // nonblocking without touching the file description
-                            // shared with the parent shell.
+                            // shared with the parent shell. Only stdin is swapped
+                            // in place; stdout/stderr readers keep using a
+                            // separate fd so the write side's blocking-tty
+                            // contract on fd 1/2 is untouched.
                             let accmode = sys::get_fcntl_flags(*pl_fd)
                                 .map(|f| f as i32 & sys::O::ACCMODE)
                                 .unwrap_or(sys::O::RDONLY);
@@ -172,7 +175,9 @@ impl Lazy {
                             if rc > -1 {
                                 is_nonblocking = true;
                                 file.is_atty = Some(true);
-                                let _ = sys::dup2(Fd::from_native(rc), *pl_fd);
+                                if *pl_fd == Fd::stdin() {
+                                    let _ = sys::dup2(Fd::from_native(rc), *pl_fd);
+                                }
                                 break 'brk Fd::from_native(rc);
                             }
                         }
@@ -263,9 +268,11 @@ impl Lazy {
             // stdio fd. Node exposes that via `process.stdin`: once the stream
             // is started, `fs.readSync(0, …)` returns EAGAIN instead of blocking
             // (issue #5305). The tty path above already swapped in a nonblocking
-            // file description; this covers pipe/socket stdio and the tty
-            // fallback when reopening failed.
-            if fd.stdio_tag().is_some() && this.pollable && !is_nonblocking {
+            // file description; this covers pipe/socket stdin and the tty
+            // fallback when reopening failed. Scoped to stdin so a
+            // `Bun.stdout.stream()` reader does not mutate fd 1/2. The startup
+            // O_NONBLOCK bit is restored in `bun_restore_stdio()`.
+            if fd == Fd::stdin() && this.pollable && !is_nonblocking {
                 if sys::set_nonblocking(fd).is_ok() {
                     is_nonblocking = true;
                 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1216,6 +1216,8 @@ pub mod O {
     pub const NOCTTY: i32 = libc::O_NOCTTY;
     #[cfg(windows)]
     pub const NOCTTY: i32 = 0;
+    #[cfg(unix)]
+    pub const ACCMODE: i32 = libc::O_ACCMODE;
     #[cfg(windows)]
     pub const ACCMODE: i32 = 3;
     #[cfg(target_os = "macos")]

--- a/test/js/node/process/stdin/process-stdin-nonblock.test.ts
+++ b/test/js/node/process/stdin/process-stdin-nonblock.test.ts
@@ -5,7 +5,7 @@
 // TTY, return one keystroke at a time) instead of throwing `EAGAIN` like Node.
 // https://github.com/oven-sh/bun/issues/5305
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMacOS, libcPathForDlopen, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isPosix, libcPathForDlopen, tempDir } from "harness";
 import path from "node:path";
 
 // O_NONBLOCK is a Unix fd flag; the Windows stdin path is libuv-backed and

--- a/test/js/node/process/stdin/process-stdin-nonblock.test.ts
+++ b/test/js/node/process/stdin/process-stdin-nonblock.test.ts
@@ -5,7 +5,7 @@
 // TTY, return one keystroke at a time) instead of throwing `EAGAIN` like Node.
 // https://github.com/oven-sh/bun/issues/5305
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, libcPathForDlopen, isPosix, tempDir } from "harness";
 import path from "node:path";
 
 // O_NONBLOCK is a Unix fd flag; the Windows stdin path is libuv-backed and
@@ -143,7 +143,8 @@ test.skipIf(!isPosix)(
   60_000,
 );
 
-test.skipIf(!isPosix)("O_NONBLOCK on pipe stdin is restored when bun exits", async () => {
+// `libcPathForDlopen()` covers glibc/musl/darwin; FreeBSD is not mapped yet.
+test.skipIf(!(isLinux || isMacOS))("O_NONBLOCK on pipe stdin is restored when bun exits", async () => {
   // `producer | { bun; sibling }` share one read-end file description. Node
   // restores its startup O_NONBLOCK bit on the way out (ResetStdio); Bun
   // should too so `sibling` does not inherit a nonblocking stdin.
@@ -152,11 +153,10 @@ test.skipIf(!isPosix)("O_NONBLOCK on pipe stdin is restored when bun exits", asy
     // either way, so probe the O_NONBLOCK bit directly via fcntl(F_GETFL).
     "probe.js": `
       const { dlopen, FFIType } = require("bun:ffi");
-      const lib = process.platform === "darwin" ? "libc.dylib" : "libc.so.6";
-      const { symbols: { fcntl } } = dlopen(lib, {
+      const { symbols: { fcntl } } = dlopen(process.env.LIBC, {
         fcntl: { args: [FFIType.int, FFIType.int, FFIType.int], returns: FFIType.int },
       });
-      const O_NONBLOCK = process.platform === "darwin" ? 0x0004 : 0o4000;
+      const { O_NONBLOCK } = require("node:fs").constants;
       console.log((fcntl(0, 3, 0) & O_NONBLOCK) ? "NONBLOCKING" : "BLOCKING");
     `,
     "middle.js": `process.stdin.resume(); process.exit(0);`,
@@ -164,7 +164,7 @@ test.skipIf(!isPosix)("O_NONBLOCK on pipe stdin is restored when bun exits", asy
 
   await using proc = Bun.spawn({
     cmd: ["sh", "-c", `"$BUN" probe.js && "$BUN" middle.js && "$BUN" probe.js`],
-    env: { ...bunEnv, BUN: bunExe() },
+    env: { ...bunEnv, BUN: bunExe(), LIBC: libcPathForDlopen() },
     cwd: String(dir),
     stdin: "pipe",
     stdout: "pipe",

--- a/test/js/node/process/stdin/process-stdin-nonblock.test.ts
+++ b/test/js/node/process/stdin/process-stdin-nonblock.test.ts
@@ -83,6 +83,101 @@ test.skipIf(!isPosix)("fd 0 is left alone when stdin is a regular file", async (
   expect(exitCode).toBe(0);
 });
 
+test.skipIf(!isPosix)(
+  "tty stdin: fd 0 becomes nonblocking and keeps its access mode",
+  async () => {
+    // Bun.spawn({ terminal }) hands the child a pty slave on fd 0/1/2.
+    // After process.stdin starts, fd 0 should be swapped for a fresh
+    // nonblocking file description with the original O_RDWR access mode, so
+    // fs.writeSync(0, ...) still succeeds and fs.readSync(0, ...) sees EAGAIN.
+    const script = `
+      const fs = require("fs");
+      process.stdin.resume();
+      let write = "ok";
+      try { fs.writeSync(0, "x"); } catch (e) { write = e.code; }
+      // Drain anything the pty already buffered, then the next read must
+      // throw EAGAIN because fd 0 is nonblocking.
+      let read;
+      for (;;) {
+        try {
+          if (fs.readSync(0, Buffer.alloc(256)) === 0) { read = "EOF"; break; }
+        } catch (e) { read = e.code; break; }
+      }
+      process.stdout.write("RESULT " + JSON.stringify({ isTTY: process.stdin.isTTY, write, read }));
+      process.exit(0);
+    `;
+
+    let output = "";
+    const decoder = new TextDecoder();
+    const done = Promise.withResolvers<void>();
+
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      terminal: {
+        cols: 200,
+        rows: 24,
+        data(_t, chunk: Uint8Array) {
+          output += decoder.decode(chunk, { stream: true });
+          if (output.includes("RESULT ") && output.includes("}")) done.resolve();
+        },
+        exit() {
+          done.resolve();
+        },
+      },
+    });
+
+    await Promise.race([done.promise, Bun.sleep(30_000)]);
+    proc.kill();
+    await proc.exited;
+    proc.terminal?.close();
+    output += decoder.decode();
+
+    const stripped = Bun.stripANSI(output).replace(/[\r\n]/g, "");
+    const match = stripped.match(/RESULT (\{[^}]*\})/);
+    if (!match) {
+      throw new Error("child did not emit RESULT; terminal output was: " + JSON.stringify(output));
+    }
+    expect(JSON.parse(match[1])).toEqual({ isTTY: true, write: "ok", read: "EAGAIN" });
+  },
+  60_000,
+);
+
+test.skipIf(!isPosix)("O_NONBLOCK on pipe stdin is restored when bun exits", async () => {
+  // `producer | { bun; sibling }` share one read-end file description. Node
+  // restores its startup O_NONBLOCK bit on the way out (ResetStdio); Bun
+  // should too so `sibling` does not inherit a nonblocking stdin.
+  using dir = tempDir("stdin-nonblock-restore", {
+    // fs.readSync(0) on a pipe whose write end is already closed returns 0
+    // either way, so probe the O_NONBLOCK bit directly via fcntl(F_GETFL).
+    "probe.js": `
+      const { dlopen, FFIType } = require("bun:ffi");
+      const lib = process.platform === "darwin" ? "libc.dylib" : "libc.so.6";
+      const { symbols: { fcntl } } = dlopen(lib, {
+        fcntl: { args: [FFIType.int, FFIType.int, FFIType.int], returns: FFIType.int },
+      });
+      const O_NONBLOCK = process.platform === "darwin" ? 0x0004 : 0o4000;
+      console.log((fcntl(0, 3, 0) & O_NONBLOCK) ? "NONBLOCKING" : "BLOCKING");
+    `,
+    "middle.js": `process.stdin.resume(); process.exit(0);`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: ["sh", "-c", `"$BUN" probe.js && "$BUN" middle.js && "$BUN" probe.js`],
+    env: { ...bunEnv, BUN: bunExe() },
+    cwd: String(dir),
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.stdin.end();
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim().split("\n")).toEqual(["BLOCKING", "BLOCKING"]);
+  expect(exitCode).toBe(0);
+});
+
 test.skipIf(!isPosix)("process.stdin still delivers data over a nonblocking pipe", async () => {
   const script = `
     let got = "";

--- a/test/js/node/process/stdin/process-stdin-nonblock.test.ts
+++ b/test/js/node/process/stdin/process-stdin-nonblock.test.ts
@@ -1,0 +1,109 @@
+// Once `process.stdin` starts reading, Node/libuv put the stdin file
+// descriptor into nonblocking mode (`uv_pipe_open` / `uv_tty_init` both call
+// `uv__nonblock(fd, 1)`). Bun used to leave fd 0 untouched, so a direct
+// `fs.readSync(0, buf)` afterwards would block on an empty pipe (or, on a raw
+// TTY, return one keystroke at a time) instead of throwing `EAGAIN` like Node.
+// https://github.com/oven-sh/bun/issues/5305
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import path from "node:path";
+
+// O_NONBLOCK is a Unix fd flag; the Windows stdin path is libuv-backed and
+// `fs.readSync` there never observes EAGAIN.
+test.skipIf(!isPosix)(
+  "fs.readSync(0) throws EAGAIN once process.stdin is reading (pipe)",
+  async () => {
+    const script = `
+      const fs = require("fs");
+      const readline = require("readline");
+      readline.createInterface({ input: process.stdin, output: process.stdout });
+      try {
+        const n = fs.readSync(0, Buffer.alloc(64));
+        console.log("RETURNED:" + n);
+      } catch (e) {
+        console.log("ERROR:" + e.code);
+      }
+      process.exit(0);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Without the fix the child is parked in a blocking read() on fd 0, so the
+    // only way to distinguish pass from fail is a deadline. Closing stdin would
+    // unblock that read with a 0-byte result, which masks the bug; keeping the
+    // write end open forces the blocking read to stay blocked.
+    const exited = await Promise.race([proc.exited, Bun.sleep(30_000).then(() => "timeout" as const)]);
+    if (exited === "timeout") {
+      proc.kill(9);
+      await proc.exited;
+    }
+
+    const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+
+    expect(stderr).toBe("");
+    expect({ stdout: stdout.trim(), exited }).toEqual({ stdout: "ERROR:EAGAIN", exited: 0 });
+  },
+  60_000,
+);
+
+test.skipIf(!isPosix)("fd 0 is left alone when stdin is a regular file", async () => {
+  // O_NONBLOCK is meaningless on a regular file; the reader should leave the
+  // fd flags untouched so `fs.readSync(0, buf)` keeps returning data.
+  using dir = tempDir("stdin-nonblock-file", {
+    "in.txt": "regular file body\n",
+  });
+
+  const script = `
+    const fs = require("fs");
+    process.stdin.resume();
+    const buf = Buffer.alloc(16);
+    const n = fs.readSync(0, buf);
+    console.log("READ:" + n + ":" + buf.toString("utf8", 0, n));
+    process.exit(0);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdin: Bun.file(path.join(String(dir), "in.txt")),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("READ:16:regular file bod");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(!isPosix)("process.stdin still delivers data over a nonblocking pipe", async () => {
+  const script = `
+    let got = "";
+    process.stdin.on("data", d => (got += d));
+    process.stdin.on("end", () => console.log("GOT:" + got));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  proc.stdin.write("hello world");
+  await proc.stdin.end();
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("GOT:hello world");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #5305.

## Repro

```js
import fs from "fs";
import readline from "readline";
readline.createInterface({ input: process.stdin, output: process.stdout });
console.log(fs.readSync(0, Buffer.alloc(64)));
```

With stdin as a pipe and no data available:

* **Node**: throws `EAGAIN: resource temporarily unavailable, read`
* **Bun before**: blocks forever (or, on a raw TTY, returns 1 byte per keypress)

## Cause

When `process.stdin` starts reading, Node/libuv put fd 0 into nonblocking mode: `uv_pipe_open` calls `uv__nonblock(fd, 1)` directly, and `uv_tty_init` reopens the tty via `ttyname_r`, `dup2`s the fresh file description back onto the stdio fd, then sets `O_NONBLOCK` on it. After that, a direct `fs.readSync(0, buf)` observes a nonblocking fd and surfaces the kernel's `EAGAIN`.

Bun's `FileReader::open_file_blob` left fd 0 untouched. For a tty it opened a separate nonblocking fd and used that for its own reads; for a pipe it used fd 0 as-is and relied on `preadv2(RWF_NOWAIT)` to avoid blocking internally. Either way, fd 0's file description stayed blocking, so any user syscall on fd 0 (`fs.readSync`, `fs.readvSync`) blocked.

## Fix

`open_file_blob` now mirrors libuv for stdin on Unix:

* **tty stdin**: reopen with the fd's existing access mode (so an `O_RDWR` stdin stays writable) and `dup2` the new nonblocking file description back onto fd 0. The reader keeps using the new fd; `Fd::close` already skips fd 0.
* **pipe/socket stdin**: `fcntl(F_SETFL, O_NONBLOCK)` on fd 0 directly, matching `uv_pipe_open`.
* **regular file**: left alone (`pollable` is false).
* **fd 1/2**: left alone so a `Bun.stdout.stream()` reader cannot disturb the write side's blocking-tty contract.

Setting `O_NONBLOCK` on a pipe's file description is visible to any sibling in the same subshell that shares fd 0. Node bounds that by restoring the startup flag bit in `ResetStdio()` on the way out, so `bun_initialize_process` now snapshots `F_GETFL` for each stdio fd and `bun_restore_stdio()` restores the `O_NONBLOCK` bit at exit (and on SIGINT/SIGTERM, for which the handler is now installed whenever a stdio fd was valid at startup rather than only when one was a tty).

As a side effect the stdin pipe reader now takes the `NonblockingPipe` path (`read_pipe`) instead of `read_blocking_pipe`, dropping the per-read `poll()` readiness check.

## Verification

`test/js/node/process/stdin/process-stdin-nonblock.test.ts`:

* pipe stdin: `fs.readSync(0)` throws `EAGAIN` once `process.stdin` is reading (hangs on main)
* regular-file stdin: `fs.readSync(0)` still returns data
* tty stdin (via `Bun.spawn({ terminal })`): fd 0 is nonblocking, `fs.writeSync(0, ...)` still succeeds (access mode preserved), `fs.readSync(0)` throws `EAGAIN` (hangs on main)
* subshell sibling: O_NONBLOCK is restored after Bun exits
* `process.stdin` still delivers data over the now-nonblocking pipe

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/stdin/process-stdin-nonblock.test.ts

<!-- robobun:evidence:end -->