### PR TITLE
Object.seal/freeze: take the JSObject fast path for arrays and indexed objects

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-337-e4f1d0d0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### Problem

`Object.seal` / `Object.freeze` on a `JSArray` (or a plain object with indexed properties) always fall through to JSC's generic `SetIntegrityLevel` loop, which per element allocates an `Identifier`, dispatches through the method table, and runs the full `defineOwnProperty` descriptor validation. For the #6360 benchmark (2000 arrays, avg 1000 elements) that costs ~460ms for `seal` and ~530ms for `freeze`, vs ~3ms in Node/V8:

```
$ bun repro.js
[22.96ms] test-nonoptimized
[476.77ms] test-optimized   # the Object.seal path
```

### Fix

[oven-sh/WebKit#337](https://github.com/oven-sh/WebKit/pull/337) adds bulk `seal()` / `freeze()` to `SparseArrayValueMap` (mirroring `PropertyTable::seal/freeze`), teaches `JSObject::seal/freeze` to apply it to the sparse map after `enterDictionaryIndexingMode`, freezes `JSArray` "length" from the same place, and widens the `objectConstructorSeal` / `objectConstructorFreeze` fast-path gate from `is<JSFinalObject> && !hasIndexedProperties` to `is<JSFinalObject> || isJSArray`.

`isJSArray` matches only exact `ArrayType`, so `DerivedArrayType` subclasses and every receiver with overridden `[[DefineOwnProperty]]` / `[[PreventExtensions]]` (e.g. `Proxy`) still take the generic observable loop.

### Results (x86_64, release, local WebKit build)

2000 iterations, `new Array(i).fill(i)`:

|                         | before | after  | node 26 |
|-------------------------|--------|--------|---------|
| `Object.seal(arr)`      | 462 ms |  89 ms |  3.6 ms |
| `Object.freeze(arr)`    | 530 ms |  98 ms |  3.2 ms |
| `preventExtensions(arr)`| 102 ms | 102 ms |  4.3 ms |
| baseline (fill only)    |   5 ms |   4 ms |  3.9 ms |

The remaining ~90ms is `enterDictionaryIndexingMode` itself (contiguous → `ArrayStorage` vector → `SparseArrayValueMap`); V8 keeps a contiguous sealed/frozen elements kind and so never pays for a sparse-map conversion. That is a larger change.

### Verification

The WebKit PR carries `JSTests/stress/object-seal-freeze-array-fast-path.js` covering descriptor attributes on dense / holey / accessor-bearing / named-prop-bearing arrays and plain objects, `length` writability, seal-after-preventExtensions, freeze-after-seal, idempotence, strict-mode throw semantics, and that a `Proxy` target still observes the `preventExtensions` / `ownKeys` / `defineProperty` traps.

All 279 test262 tests under `built-ins/Object/{seal,freeze,isSealed,isFrozen,preventExtensions}` and the pre-existing `JSTests/stress/*{seal,freeze,frozen}*` pass.

There is no Bun-side test proof for this change: the diff is `WEBKIT_VERSION` only (the fix lives in JavaScriptCore) and the new fast path is semantically identical to the generic loop, so a correctness test passes with and without the fix. Before/after numbers above are from a local `--webkit=local` release build.

### Also in this range (oven-sh/WebKit 54917009..e4f1d0d0)

- [oven-sh/WebKit#328](https://github.com/oven-sh/WebKit/pull/328) inspector: release throw scope before tail-calling impl in injected-script prototype host functions (bun side: #35333)
- [oven-sh/WebKit#317](https://github.com/oven-sh/WebKit/pull/317) LiteralParser: throw RangeError on OOM when copying a JSON string value (bun side: #35194)

> [!NOTE]
> CI will fail until the [`autobuild-preview-pr-337-e4f1d0d0`](https://github.com/oven-sh/WebKit/releases) artifacts finish building.

Fixes #6360.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->