### PR TITLE
inspector: enumerate module-scope bindings in Debugger.paused scope chain

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-336-eaf21fc7";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/inspect/debugger-scopes.test.ts
+++ b/test/cli/inspect/debugger-scopes.test.ts
@@ -9,7 +9,8 @@
 // `debugger;` statement.
 
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { isASAN, isDebug, tempDir } from "harness";
+import { enableAndWaitForDebuggerPause, spawnInspectorWS } from "./inspector-ws-helper";
 
 type Scope = {
   type: string;
@@ -26,155 +27,51 @@ type InspectResult = {
 async function inspectAtDebugger(files: Record<string, string>, entry: string): Promise<InspectResult> {
   using dir = tempDir("debugger-scopes", files);
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--inspect-wait=ws://127.0.0.1:0/scopes", entry],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  await using session = await spawnInspectorWS({ args: [entry], cwd: String(dir), urlPath: "/scopes" });
+  const { send, proc } = session;
 
-  // Drain stderr and extract the inspector WebSocket URL from the banner.
-  let stderrBuf = "";
-  let stderrLineBuf = "";
-  const { promise: urlPromise, resolve: urlResolve, reject: urlReject } = Promise.withResolvers<URL>();
-  let urlFound = false;
-  (async () => {
-    const decoder = new TextDecoder();
-    for await (const chunk of proc.stderr as ReadableStream<Uint8Array>) {
-      const text = decoder.decode(chunk);
-      stderrBuf += text;
-      if (urlFound) continue;
-      stderrLineBuf += text;
-      const lines = stderrLineBuf.split("\n");
-      stderrLineBuf = lines.pop() ?? "";
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          const u = new URL(trimmed);
-          if (u.protocol === "ws:" || u.protocol === "wss:") {
-            urlFound = true;
-            urlResolve(u);
-            break;
-          }
-        } catch {}
-      }
+  const paused = await enableAndWaitForDebuggerPause(session);
+  expect(paused.reason).toBe("DebuggerStatement");
+  const frame = paused.callFrames[0];
+  const scopeChain: Scope[] = frame.scopeChain;
+
+  const scopeProperties: string[][] = [];
+  for (const scope of scopeChain) {
+    // The global scope is very large and irrelevant here.
+    if (scope.type === "global") {
+      scopeProperties.push(["<global>"]);
+      continue;
     }
-    if (!urlFound) urlReject(new Error(`inspector URL not found in stderr: ${JSON.stringify(stderrBuf)}`));
-  })().catch(err => {
-    if (!urlFound) urlReject(err);
-  });
-
-  const url = await urlPromise;
-  const ws = new WebSocket(url);
-  try {
-    await new Promise<void>((resolve, reject) => {
-      ws.addEventListener("open", () => resolve(), { once: true });
-      ws.addEventListener("error", e => reject(new Error("WebSocket error", { cause: e })), { once: true });
-      ws.addEventListener("close", e => reject(new Error("WebSocket closed", { cause: e })), { once: true });
+    const { properties } = await send("Runtime.getDisplayableProperties", {
+      objectId: scope.object.objectId,
     });
-
-    type Waiter = { resolve: (value: any) => void; reject: (error: Error) => void };
-    let nextId = 1;
-    const pending = new Map<number, Waiter>();
-    const eventWaiters = new Map<string, Waiter>();
-    let closeError: Error | undefined;
-
-    const failAll = (error: Error) => {
-      if (closeError) return;
-      closeError = error;
-      for (const w of pending.values()) w.reject(error);
-      pending.clear();
-      for (const w of eventWaiters.values()) w.reject(error);
-      eventWaiters.clear();
-    };
-    ws.addEventListener("error", e => failAll(new Error("WebSocket error", { cause: e })));
-    ws.addEventListener("close", e => failAll(new Error(`WebSocket closed (${e.code})`, { cause: e })));
-
-    ws.addEventListener("message", ev => {
-      const msg = JSON.parse(String(ev.data));
-      if (typeof msg.id === "number") {
-        const w = pending.get(msg.id);
-        if (w) {
-          pending.delete(msg.id);
-          if (msg.error) w.reject(new Error(JSON.stringify(msg.error)));
-          else w.resolve(msg.result);
-        }
-      } else if (typeof msg.method === "string") {
-        const w = eventWaiters.get(msg.method);
-        if (w) {
-          eventWaiters.delete(msg.method);
-          w.resolve(msg.params);
-        }
-      }
-    });
-
-    const send = (method: string, params: Record<string, unknown> = {}) =>
-      new Promise<any>((resolve, reject) => {
-        if (closeError) return reject(closeError);
-        const id = nextId++;
-        pending.set(id, { resolve, reject });
-        ws.send(JSON.stringify({ id, method, params }));
-      });
-
-    const waitForEvent = (method: string) =>
-      new Promise<any>((resolve, reject) => {
-        if (closeError) return reject(closeError);
-        eventWaiters.set(method, { resolve, reject });
-      });
-
-    await Promise.all([
-      send("Inspector.enable"),
-      send("Debugger.enable"),
-      send("Debugger.setBreakpointsActive", { active: true }),
-      send("Debugger.setPauseOnDebuggerStatements", { enabled: true }),
-    ]);
-
-    const pausedPromise = waitForEvent("Debugger.paused");
-    send("Inspector.initialized").catch(() => {});
-
-    const paused = await pausedPromise;
-    expect(paused.reason).toBe("DebuggerStatement");
-    const frame = paused.callFrames[0];
-    const scopeChain: Scope[] = frame.scopeChain;
-
-    const scopeProperties: string[][] = [];
-    for (const scope of scopeChain) {
-      // The global scope is very large and irrelevant here.
-      if (scope.type === "global") {
-        scopeProperties.push(["<global>"]);
-        continue;
-      }
-      const { properties } = await send("Runtime.getDisplayableProperties", {
-        objectId: scope.object.objectId,
-      });
-      scopeProperties.push((properties as Array<{ name: string }>).map(p => p.name).sort());
-    }
-
-    await send("Debugger.resume");
-
-    // The debuggee keeps its event loop alive while the inspector connection
-    // is open, so close before awaiting exit.
-    ws.close();
-
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout).toContain("reached-end");
-    expect(exitCode).toBe(0);
-
-    return {
-      functionName: frame.functionName,
-      scopeChain,
-      scopeProperties,
-    };
-  } finally {
-    try {
-      ws.close();
-    } catch {}
+    scopeProperties.push((properties as Array<{ name: string }>).map(p => p.name).sort());
   }
+
+  await send("Debugger.resume");
+
+  // The debuggee keeps its event loop alive while the inspector connection is
+  // open, so close before awaiting exit.
+  session.close();
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toContain("reached-end");
+  expect(exitCode).toBe(0);
+
+  return {
+    functionName: frame.functionName,
+    scopeChain,
+    scopeProperties,
+  };
 }
 
-describe("Debugger.paused module scope chain", () => {
+// The WebSocket inspector transport is unreliable under the CI release-ASAN
+// build (test/expectations.txt quarantines cli/inspect/inspect.test.ts there
+// for the same reason): the debuggee drops the socket with code 1006 shortly
+// after accept. Skip on that lane only. The local `bun bd` debug build also
+// has ASAN enabled but does not exhibit this, so keep running there (isDebug)
+// so the fail-before / pass-after proof is observable.
+describe.skipIf(isASAN && !isDebug).concurrent("Debugger.paused module scope chain", () => {
   test("ESM top-level let/const/var/function appear in the module scope", async () => {
     const { functionName, scopeChain, scopeProperties } = await inspectAtDebugger(
       {

--- a/test/cli/inspect/debugger-scopes.test.ts
+++ b/test/cli/inspect/debugger-scopes.test.ts
@@ -1,0 +1,256 @@
+// https://github.com/oven-sh/bun/issues/5958
+//
+// When paused inside an ES module's top level (`module code`), the scope chain
+// should include the module's own let/const/var/function bindings. Previously
+// JSModuleEnvironment only enumerated import entries and omitted its own
+// symbol-table bindings, so the Inspector reported the module scope as
+// `empty: true` and `Runtime.getDisplayableProperties` returned no locals.
+// That meant VS Code's Variables pane was blank when stopped on a top-level
+// `debugger;` statement.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+type Scope = {
+  type: string;
+  empty?: boolean;
+  object: { objectId: string };
+};
+
+type InspectResult = {
+  functionName: string;
+  scopeChain: Scope[];
+  scopeProperties: string[][];
+};
+
+async function inspectAtDebugger(files: Record<string, string>, entry: string): Promise<InspectResult> {
+  using dir = tempDir("debugger-scopes", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--inspect-wait=ws://127.0.0.1:0/scopes", entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Drain stderr and extract the inspector WebSocket URL from the banner.
+  let stderrBuf = "";
+  let stderrLineBuf = "";
+  const { promise: urlPromise, resolve: urlResolve, reject: urlReject } = Promise.withResolvers<URL>();
+  let urlFound = false;
+  (async () => {
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr as ReadableStream<Uint8Array>) {
+      const text = decoder.decode(chunk);
+      stderrBuf += text;
+      if (urlFound) continue;
+      stderrLineBuf += text;
+      const lines = stderrLineBuf.split("\n");
+      stderrLineBuf = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const u = new URL(trimmed);
+          if (u.protocol === "ws:" || u.protocol === "wss:") {
+            urlFound = true;
+            urlResolve(u);
+            break;
+          }
+        } catch {}
+      }
+    }
+    if (!urlFound) urlReject(new Error(`inspector URL not found in stderr: ${JSON.stringify(stderrBuf)}`));
+  })().catch(err => {
+    if (!urlFound) urlReject(err);
+  });
+
+  const url = await urlPromise;
+  const ws = new WebSocket(url);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener("error", e => reject(new Error("WebSocket error", { cause: e })), { once: true });
+      ws.addEventListener("close", e => reject(new Error("WebSocket closed", { cause: e })), { once: true });
+    });
+
+    type Waiter = { resolve: (value: any) => void; reject: (error: Error) => void };
+    let nextId = 1;
+    const pending = new Map<number, Waiter>();
+    const eventWaiters = new Map<string, Waiter>();
+    let closeError: Error | undefined;
+
+    const failAll = (error: Error) => {
+      if (closeError) return;
+      closeError = error;
+      for (const w of pending.values()) w.reject(error);
+      pending.clear();
+      for (const w of eventWaiters.values()) w.reject(error);
+      eventWaiters.clear();
+    };
+    ws.addEventListener("error", e => failAll(new Error("WebSocket error", { cause: e })));
+    ws.addEventListener("close", e => failAll(new Error(`WebSocket closed (${e.code})`, { cause: e })));
+
+    ws.addEventListener("message", ev => {
+      const msg = JSON.parse(String(ev.data));
+      if (typeof msg.id === "number") {
+        const w = pending.get(msg.id);
+        if (w) {
+          pending.delete(msg.id);
+          if (msg.error) w.reject(new Error(JSON.stringify(msg.error)));
+          else w.resolve(msg.result);
+        }
+      } else if (typeof msg.method === "string") {
+        const w = eventWaiters.get(msg.method);
+        if (w) {
+          eventWaiters.delete(msg.method);
+          w.resolve(msg.params);
+        }
+      }
+    });
+
+    const send = (method: string, params: Record<string, unknown> = {}) =>
+      new Promise<any>((resolve, reject) => {
+        if (closeError) return reject(closeError);
+        const id = nextId++;
+        pending.set(id, { resolve, reject });
+        ws.send(JSON.stringify({ id, method, params }));
+      });
+
+    const waitForEvent = (method: string) =>
+      new Promise<any>((resolve, reject) => {
+        if (closeError) return reject(closeError);
+        eventWaiters.set(method, { resolve, reject });
+      });
+
+    await Promise.all([
+      send("Inspector.enable"),
+      send("Debugger.enable"),
+      send("Debugger.setBreakpointsActive", { active: true }),
+      send("Debugger.setPauseOnDebuggerStatements", { enabled: true }),
+    ]);
+
+    const pausedPromise = waitForEvent("Debugger.paused");
+    send("Inspector.initialized").catch(() => {});
+
+    const paused = await pausedPromise;
+    expect(paused.reason).toBe("DebuggerStatement");
+    const frame = paused.callFrames[0];
+    const scopeChain: Scope[] = frame.scopeChain;
+
+    const scopeProperties: string[][] = [];
+    for (const scope of scopeChain) {
+      // The global scope is very large and irrelevant here.
+      if (scope.type === "global") {
+        scopeProperties.push(["<global>"]);
+        continue;
+      }
+      const { properties } = await send("Runtime.getDisplayableProperties", {
+        objectId: scope.object.objectId,
+      });
+      scopeProperties.push((properties as Array<{ name: string }>).map(p => p.name).sort());
+    }
+
+    await send("Debugger.resume");
+
+    // The debuggee keeps its event loop alive while the inspector connection
+    // is open, so close before awaiting exit.
+    ws.close();
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toContain("reached-end");
+    expect(exitCode).toBe(0);
+
+    return {
+      functionName: frame.functionName,
+      scopeChain,
+      scopeProperties,
+    };
+  } finally {
+    try {
+      ws.close();
+    } catch {}
+  }
+}
+
+describe("Debugger.paused module scope chain", () => {
+  test("ESM top-level let/const/var/function appear in the module scope", async () => {
+    const { functionName, scopeChain, scopeProperties } = await inspectAtDebugger(
+      {
+        "index.mjs": `
+let a = 3;
+const b = 4;
+var c = 5;
+function d() {}
+debugger;
+console.log("reached-end", a, b, c, d);
+export {};
+`,
+      },
+      "index.mjs",
+    );
+
+    expect(functionName).toBe("module code");
+
+    // The first entry in the scope chain is the module environment. It must not
+    // be reported as empty, and enumerating it must yield the module's own
+    // bindings. Without the fix this scope arrives as { empty: true } with zero
+    // properties.
+    expect(scopeChain[0].type).toBe("closure");
+    expect(scopeChain[0].empty).not.toBe(true);
+    expect(scopeProperties[0]).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("ESM with named import shows both the import and local bindings", async () => {
+    const { functionName, scopeChain, scopeProperties } = await inspectAtDebugger(
+      {
+        "dep.mjs": `export const imported = 42;\n`,
+        "index.mjs": `
+import { imported } from "./dep.mjs";
+let localLet = 1;
+const localConst = 2;
+debugger;
+console.log("reached-end", imported, localLet, localConst);
+`,
+      },
+      "index.mjs",
+    );
+
+    expect(functionName).toBe("module code");
+    expect(scopeChain[0].type).toBe("closure");
+    expect(scopeChain[0].empty).not.toBe(true);
+    // Previously only "imported" was listed; local bindings were missing.
+    expect(scopeProperties[0]).toEqual(["imported", "localConst", "localLet"]);
+  });
+
+  test("CommonJS module wrapper scope chain still lists top-level bindings", async () => {
+    const { functionName, scopeChain, scopeProperties } = await inspectAtDebugger(
+      {
+        "index.cjs": `
+"use strict";
+let a = 3;
+var c = 5;
+debugger;
+console.log("reached-end", a, c, module.id);
+`,
+      },
+      "index.cjs",
+    );
+
+    // CJS is executed inside Bun's (function (exports, require, module, ...) { ... })
+    // wrapper, so the top frame is the anonymous wrapper function rather than
+    // "module code".
+    expect(functionName).not.toBe("module code");
+
+    // The wrapper's lexical scope carries `a`; its var scope carries `c` and
+    // the wrapper parameters.
+    expect(scopeChain[0].type).toBe("closure");
+    expect(scopeProperties[0]).toEqual(["a"]);
+
+    expect(scopeChain[1].type).toBe("closure");
+    expect(scopeProperties[1]).toEqual(
+      expect.arrayContaining(["__dirname", "__filename", "c", "exports", "module", "require"]),
+    );
+  });
+});

--- a/test/cli/inspect/inspector-ws-helper.ts
+++ b/test/cli/inspect/inspector-ws-helper.ts
@@ -1,0 +1,174 @@
+// Shared helper for tests that drive a debuggee via the WebSocket inspector
+// transport (`--inspect-wait=ws://127.0.0.1:0/...`). Spawns the child, parses
+// the inspector banner from stderr for the WebSocket URL, connects, and returns
+// thin `send` / `waitForEvent` helpers over the JSC inspector protocol.
+//
+// Call `[Symbol.asyncDispose]()` (or use `await using`) when done; it closes
+// the socket first so the debuggee's event loop is released, then awaits exit.
+
+import type { Subprocess } from "bun";
+import { bunEnv, bunExe } from "harness";
+
+type Waiter = { resolve: (value: any) => void; reject: (error: Error) => void };
+
+export type InspectorSessionWS = {
+  readonly proc: Subprocess<"ignore", "pipe", "pipe">;
+  readonly ws: WebSocket;
+  readonly stderr: () => string;
+  send: (method: string, params?: Record<string, unknown>) => Promise<any>;
+  waitForEvent: (method: string) => Promise<any>;
+  close: () => void;
+  [Symbol.asyncDispose]: () => Promise<void>;
+};
+
+export async function spawnInspectorWS(options: {
+  args: string[];
+  cwd?: string;
+  urlPath?: string;
+  env?: Record<string, string | undefined>;
+}): Promise<InspectorSessionWS> {
+  const { args, cwd, urlPath = "/bun-inspector", env = bunEnv } = options;
+
+  const proc = Bun.spawn({
+    cmd: [bunExe(), `--inspect-wait=ws://127.0.0.1:0${urlPath}`, ...args],
+    env,
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Drain stderr in the background so it never back-pressures the child, and
+  // pull the WebSocket URL from the inspector banner. Only scan complete
+  // (newline-terminated) lines so a chunk boundary can't split the URL.
+  let stderrBuf = "";
+  let stderrLineBuf = "";
+  const { promise: urlPromise, resolve: urlResolve, reject: urlReject } = Promise.withResolvers<URL>();
+  let urlFound = false;
+  (async () => {
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stderr as ReadableStream<Uint8Array>) {
+      const text = decoder.decode(chunk);
+      stderrBuf += text;
+      if (urlFound) continue;
+      stderrLineBuf += text;
+      const lines = stderrLineBuf.split("\n");
+      stderrLineBuf = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const u = new URL(trimmed);
+          if (u.protocol === "ws:" || u.protocol === "wss:") {
+            urlFound = true;
+            urlResolve(u);
+            break;
+          }
+        } catch {}
+      }
+    }
+    if (!urlFound) urlReject(new Error(`inspector URL not found before child stderr closed: ${JSON.stringify(stderrBuf)}`));
+  })().catch(err => {
+    if (!urlFound) urlReject(err);
+  });
+
+  let ws: WebSocket;
+  try {
+    const url = await urlPromise;
+    ws = new WebSocket(url);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener("error", e => reject(new Error("WebSocket error", { cause: e })), { once: true });
+      ws.addEventListener("close", e => reject(new Error("WebSocket closed", { cause: e })), { once: true });
+    });
+  } catch (err) {
+    proc.kill();
+    await proc.exited;
+    throw err;
+  }
+
+  let nextId = 1;
+  const pending = new Map<number, Waiter>();
+  const eventWaiters = new Map<string, Waiter>();
+  let closeError: Error | undefined;
+
+  const failAll = (error: Error) => {
+    if (closeError) return;
+    closeError = error;
+    for (const w of pending.values()) w.reject(error);
+    pending.clear();
+    for (const w of eventWaiters.values()) w.reject(error);
+    eventWaiters.clear();
+  };
+  ws.addEventListener("error", e => failAll(new Error("WebSocket error", { cause: e })));
+  ws.addEventListener("close", e => failAll(new Error(`WebSocket closed (${e.code})`, { cause: e })));
+
+  ws.addEventListener("message", ev => {
+    const msg = JSON.parse(String(ev.data));
+    if (typeof msg.id === "number") {
+      const w = pending.get(msg.id);
+      if (w) {
+        pending.delete(msg.id);
+        if (msg.error) w.reject(new Error(JSON.stringify(msg.error)));
+        else w.resolve(msg.result);
+      }
+    } else if (typeof msg.method === "string") {
+      const w = eventWaiters.get(msg.method);
+      if (w) {
+        eventWaiters.delete(msg.method);
+        w.resolve(msg.params);
+      }
+    }
+  });
+
+  const send = (method: string, params: Record<string, unknown> = {}) =>
+    new Promise<any>((resolve, reject) => {
+      if (closeError) return reject(closeError);
+      const id = nextId++;
+      pending.set(id, { resolve, reject });
+      ws.send(JSON.stringify({ id, method, params }));
+    });
+
+  const waitForEvent = (method: string) =>
+    new Promise<any>((resolve, reject) => {
+      if (closeError) return reject(closeError);
+      eventWaiters.set(method, { resolve, reject });
+    });
+
+  const close = () => {
+    try {
+      ws.close();
+    } catch {}
+  };
+
+  return {
+    proc,
+    ws,
+    stderr: () => stderrBuf,
+    send,
+    waitForEvent,
+    close,
+    async [Symbol.asyncDispose]() {
+      close();
+      proc.kill();
+      await proc.exited;
+    },
+  };
+}
+
+/**
+ * Enable the inspector + debugger, opt into pausing on `debugger;` statements,
+ * and release `--inspect-wait`. Resolves with the first `Debugger.paused`
+ * event's params.
+ */
+export async function enableAndWaitForDebuggerPause(session: InspectorSessionWS): Promise<any> {
+  const { send, waitForEvent } = session;
+  await Promise.all([
+    send("Inspector.enable"),
+    send("Debugger.enable"),
+    send("Debugger.setBreakpointsActive", { active: true }),
+    send("Debugger.setPauseOnDebuggerStatements", { enabled: true }),
+  ]);
+  const pausedPromise = waitForEvent("Debugger.paused");
+  send("Inspector.initialized").catch(() => {});
+  return pausedPromise;
+}

--- a/test/regression/issue/21654/21654.test.ts
+++ b/test/regression/issue/21654/21654.test.ts
@@ -7,7 +7,8 @@
 // child process consumed very little CPU time while paused.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { isASAN, tempDir } from "harness";
+import { enableAndWaitForDebuggerPause, spawnInspectorWS } from "../../../cli/inspect/inspector-ws-helper";
 
 // The WebSocket inspector transport is known to be unreliable under the CI
 // ASAN build (see test/expectations.txt: `cli/inspect/inspect.test.ts`), so
@@ -32,125 +33,11 @@ test.skipIf(isASAN)(
     `,
     });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--inspect-wait=ws://127.0.0.1:0/bun21654", "index.js"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+    await using session = await spawnInspectorWS({ args: ["index.js"], cwd: String(dir), urlPath: "/bun21654" });
+    const { send, proc, stderr } = session;
 
-    // Drain stderr in the background so it never back-pressures the child, and
-    // pull the WebSocket URL from the inspector banner. Only scan complete
-    // (newline-terminated) lines so a chunk boundary can't yield a truncated
-    // URL.
-    let stderrBuf = "";
-    let stderrLineBuf = "";
-    const { promise: urlPromise, resolve: urlResolve, reject: urlReject } = Promise.withResolvers<URL>();
-    let urlFound = false;
-    (async () => {
-      const decoder = new TextDecoder();
-      for await (const chunk of proc.stderr as ReadableStream<Uint8Array>) {
-        const text = decoder.decode(chunk);
-        stderrBuf += text;
-        if (!urlFound) {
-          stderrLineBuf += text;
-          const lines = stderrLineBuf.split("\n");
-          stderrLineBuf = lines.pop() ?? "";
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-            try {
-              const u = new URL(trimmed);
-              if (u.protocol === "ws:" || u.protocol === "wss:") {
-                urlFound = true;
-                urlResolve(u);
-                break;
-              }
-            } catch {}
-          }
-        }
-      }
-      if (!urlFound) {
-        urlReject(new Error(`Inspector URL not found before child stderr closed: ${JSON.stringify(stderrBuf)}`));
-      }
-    })().catch(err => {
-      if (!urlFound) urlReject(err);
-    });
-
-    const url = await urlPromise;
-
-    const ws = new WebSocket(url);
     try {
-      await new Promise<void>((resolve, reject) => {
-        ws.addEventListener("open", () => resolve(), { once: true });
-        ws.addEventListener("error", e => reject(new Error("WebSocket error", { cause: e })), { once: true });
-        ws.addEventListener("close", e => reject(new Error("WebSocket closed", { cause: e })), { once: true });
-      });
-
-      let nextId = 1;
-      type Waiter = { resolve: (value: any) => void; reject: (error: Error) => void };
-      const pending = new Map<number, Waiter>();
-      const eventWaiters = new Map<string, Waiter>();
-      let closeError: Error | undefined;
-
-      const failAll = (error: Error) => {
-        if (closeError) return;
-        closeError = error;
-        for (const w of pending.values()) w.reject(error);
-        pending.clear();
-        for (const w of eventWaiters.values()) w.reject(error);
-        eventWaiters.clear();
-      };
-      ws.addEventListener("error", e => failAll(new Error("WebSocket error", { cause: e })));
-      ws.addEventListener("close", e => failAll(new Error(`WebSocket closed (${e.code})`, { cause: e })));
-
-      ws.addEventListener("message", ev => {
-        const msg = JSON.parse(String(ev.data));
-        if (typeof msg.id === "number") {
-          const w = pending.get(msg.id);
-          if (w) {
-            pending.delete(msg.id);
-            w.resolve(msg);
-          }
-        } else if (typeof msg.method === "string") {
-          const w = eventWaiters.get(msg.method);
-          if (w) {
-            eventWaiters.delete(msg.method);
-            w.resolve(msg.params);
-          }
-        }
-      });
-
-      const send = (method: string, params: Record<string, unknown> = {}) =>
-        new Promise<any>((resolve, reject) => {
-          if (closeError) return reject(closeError);
-          const id = nextId++;
-          pending.set(id, { resolve, reject });
-          ws.send(JSON.stringify({ id, method, params }));
-        });
-
-      const waitForEvent = (method: string) =>
-        new Promise<any>((resolve, reject) => {
-          if (closeError) return reject(closeError);
-          eventWaiters.set(method, { resolve, reject });
-        });
-
-      // Enable the debugger and opt into pausing on `debugger;` statements.
-      // Wait for the responses so we know the JS thread has fully processed
-      // them before we send `Inspector.initialized`, which releases
-      // --inspect-wait and lets the script begin executing.
-      await Promise.all([
-        send("Inspector.enable"),
-        send("Debugger.enable"),
-        send("Debugger.setBreakpointsActive", { active: true }),
-        send("Debugger.setPauseOnDebuggerStatements", { enabled: true }),
-      ]);
-
-      const pausedPromise = waitForEvent("Debugger.paused");
-      send("Inspector.initialized").catch(() => {});
-
-      const paused = await pausedPromise;
+      const paused = await enableAndWaitForDebuggerPause(session);
       expect(paused.reason).toBe("DebuggerStatement");
 
       // Stay paused. In the buggy implementation this busy-loops at 100% CPU.
@@ -162,7 +49,7 @@ test.skipIf(isASAN)(
       const rtStart = performance.now();
       const evalResult = await send("Runtime.evaluate", { expression: "1 + 1" });
       const roundTripMs = performance.now() - rtStart;
-      expect(evalResult?.result?.result?.value).toBe(2);
+      expect(evalResult?.result?.value).toBe(2);
 
       await send("Debugger.resume");
 
@@ -174,7 +61,7 @@ test.skipIf(isASAN)(
         .find(l => l.startsWith("{"));
       if (!line) {
         throw new Error(
-          `No JSON output from child; stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderrBuf)}`,
+          `No JSON output from child; stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr())}`,
         );
       }
 
@@ -205,13 +92,9 @@ test.skipIf(isASAN)(
       throw new Error(
         `${err instanceof Error ? err.message : String(err)}\n` +
           `  child exit: ${exitCode}\n` +
-          `  child stderr: ${JSON.stringify(stderrBuf)}`,
+          `  child stderr: ${JSON.stringify(stderr())}`,
         { cause: err },
       );
-    } finally {
-      try {
-        ws.close();
-      } catch {}
     }
   },
   30000,


### PR DESCRIPTION
### What does this PR do?

Fixes #5958, fixes #14242: when paused at a `debugger;` statement in the top level of an ES module, the debugger's Variables pane is empty. Module-scope `let`/`const`/`var`/`function` declarations never appear in any scope.

Picks up oven-sh/WebKit#336 via `WEBKIT_VERSION` and adds a protocol-level regression test.

### Repro

```js
// index.mjs
let a = 3;
const b = 4;
debugger;
console.log(a, b);
```

Attach a debugger and stop at the `debugger;` statement. Before this change, `Debugger.paused` reports:

```
scopeChain[0]  type=closure  empty=true   properties=[]
```

so VS Code shows nothing under Locals. After:

```
scopeChain[0]  type=closure  empty=false  properties=["a","b"]
```

Node.js (V8) reports the same bindings for the equivalent program (under scope `type=module`), so this brings Bun in line with `node --inspect`.

### Cause

JSC wraps the module scope object in a `DebuggerScope`, whose `getOwnPropertyNames` forwards to the wrapped `JSModuleEnvironment`. That class overrides `getOwnSpecialPropertyNames` to add `importEntries()` local names, but never chains to `JSLexicalEnvironment::getOwnSpecialPropertyNames`, which is where the symbol-table walk (the module's own declarations) lives. `InjectedScriptSource.js` therefore sees zero own keys, sets `empty: true`, and `Runtime.getDisplayableProperties` returns only the imports.

CJS files were never affected: Bun runs them inside a `(function (exports, require, module, __filename, __dirname) { ... })` wrapper, so top-level bindings live in an ordinary `JSLexicalEnvironment`.

### Fix

oven-sh/WebKit#336 has `JSModuleEnvironment::getOwnSpecialPropertyNames` chain to `Base` after adding the import entries, so the symbol-table bindings are enumerated too. `Single` imports are not duplicated (they are not stored in this module's symbol table), and the private parser names (`*starNamespace`, `@meta`) are symbols and are already filtered by the base implementation.

This is the only commit between the previous pin (`549170099226`) and the new one.

### Verification

`test/cli/inspect/debugger-scopes.test.ts` spawns a debuggee under `--inspect-wait`, stops at a top-level `debugger;`, and asserts on `scopeChain[0]` and the `Runtime.getDisplayableProperties` result for three shapes: plain ESM, ESM with a named import, and CJS.

```
# previous WebKit (549170099226)
$ bun bd --webkit-version=549170099226f816a4b204ea1d8fa102fb79eefa test test/cli/inspect/debugger-scopes.test.ts
(fail) ESM top-level let/const/var/function appear in the module scope
(fail) ESM with named import shows both the import and local bindings
(pass) CommonJS module wrapper scope chain still lists top-level bindings
 1 pass  2 fail

# this PR's WebKit
$ bun bd test test/cli/inspect/debugger-scopes.test.ts
(pass) ESM top-level let/const/var/function appear in the module scope
(pass) ESM with named import shows both the import and local bindings
(pass) CommonJS module wrapper scope chain still lists top-level bindings
 3 pass  0 fail
```

> [!NOTE]
> `WEBKIT_VERSION` currently points at the preview build `autobuild-preview-pr-336-eaf21fc7`. Once oven-sh/WebKit#336 merges, it should be bumped to the merge commit's `autobuild-<sha>` before this PR lands.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 2 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/inspect/debugger-scopes.test.ts' 'test/regression/issue/21654/21654.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/inspect/debugger-scopes.test.ts "test/regression/issue/21654/21654.test.ts"
bun test v1.4.0 (78240b65e)

test/cli/inspect/debugger-scopes.test.ts:
(pass) Debugger.paused module scope chain > ESM top-level let/const/var/function appear in the module scope [854.32ms]
(pass) Debugger.paused module scope chain > CommonJS module wrapper scope chain still lists top-level bindings [829.78ms]
(pass) Debugger.paused module scope chain > ESM with named import shows both the import and local bindings [863.87ms]

test/regression/issue/21654/21654.test.ts:
(skip) does not spin at 100% CPU while paused at a breakpoint

 3 pass
 1 skip
 0 fail
 22 expect() calls
Ran 4 tests across 2 files. [3.24s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts              |   2 +-
 test/cli/inspect/debugger-scopes.test.ts  | 153 ++++++++++++++++++++++++++
 test/cli/inspect/inspector-ws-helper.ts   | 174 ++++++++++++++++++++++++++++++
 test/regression/issue/21654/21654.test.ts | 133 ++---------------------
 4 files changed, 336 insertions(+), 126 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
scripts/build/deps/webkit.ts                   1      1      0
test/cli/inspect/debugger-scopes.test.ts       3     12      0
test/cli/inspect/inspector-ws-helper.ts        0      1      0
test/regression/issue/21654/21654.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->