### PR TITLE
dotenv: expose auto-loaded .env values as non-enumerable on process.env

### DIFF
--- a/docs/guides/runtime/read-env.mdx
+++ b/docs/guides/runtime/read-env.mdx
@@ -20,7 +20,7 @@ Bun.env.API_TOKEN; // => "secret"
 
 ---
 
-To print all currently-set environment variables, run `bun --print process.env`.
+To print all currently-set environment variables, run `bun --print process.env`. Values auto-loaded from `.env` files are non-enumerable and do not appear here; use `bun --print 'Object.getOwnPropertyNames(process.env)'` to list every key.
 
 ```sh terminal icon="terminal"
 bun --print process.env

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -143,7 +143,7 @@ Bun reads `.env` files automatically, so `dotenv` and `dotenv-expand` are unnece
 
 Values that Bun auto-loads from `.env` files are readable via `process.env.NAME` but are **not enumerable**: `Object.keys(process.env)`, `for..in`, and `{ ...process.env }` list only variables from the OS environment and from explicit `--env-file` arguments. This keeps `process.env` enumeration Node-compatible so tools with their own `.env.{mode}` loading (such as Vite's `loadEnv`) do not mistake Bun's auto-loaded values for shell-provided overrides. Assigning to such a key from JavaScript promotes it to an enumerable own property. `Object.getOwnPropertyNames(process.env)` lists all keys including the auto-loaded ones.
 
-Default inherited environments (`Bun.spawn` with no `env`, `child_process` with no `options.env`, `Bun.$`, and `worker_threads`) still receive auto-loaded values. Once a `worker_threads` `SHARE_ENV` tree is founded, `process.env` becomes a shared string map and auto-loaded values enumerate like any other entry on the threads in that tree.
+Default inherited environments (`Bun.spawn` with no `env`, `child_process` with no `options.env`, `Bun.$`, `worker_threads`, `cluster.fork`, and the WASI runner) still receive auto-loaded values. Once a `worker_threads` `SHARE_ENV` tree is founded, `process.env` becomes a shared string map and auto-loaded values enumerate like any other entry on the threads in that tree.
 
 ## Reading environment variables
 

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -139,6 +139,10 @@ process.env.BAR; // => "hello$FOO"
 
 Bun reads `.env` files automatically, so `dotenv` and `dotenv-expand` are unnecessary.
 
+### Enumeration
+
+Values that Bun auto-loads from `.env` files are readable via `process.env.NAME` but are **not enumerable**: `Object.keys(process.env)`, `for..in`, and `{ ...process.env }` list only variables from the OS environment and from explicit `--env-file` arguments. This keeps `process.env` enumeration Node-compatible so tools with their own `.env.{mode}` loading (such as Vite's `loadEnv`) do not mistake Bun's auto-loaded values for shell-provided overrides. Assigning to such a key from JavaScript promotes it to an enumerable own property.
+
 ## Reading environment variables
 
 Read the current environment variables from `process.env`.

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -141,7 +141,9 @@ Bun reads `.env` files automatically, so `dotenv` and `dotenv-expand` are unnece
 
 ### Enumeration
 
-Values that Bun auto-loads from `.env` files are readable via `process.env.NAME` but are **not enumerable**: `Object.keys(process.env)`, `for..in`, and `{ ...process.env }` list only variables from the OS environment and from explicit `--env-file` arguments. This keeps `process.env` enumeration Node-compatible so tools with their own `.env.{mode}` loading (such as Vite's `loadEnv`) do not mistake Bun's auto-loaded values for shell-provided overrides. Assigning to such a key from JavaScript promotes it to an enumerable own property.
+Values that Bun auto-loads from `.env` files are readable via `process.env.NAME` but are **not enumerable**: `Object.keys(process.env)`, `for..in`, and `{ ...process.env }` list only variables from the OS environment and from explicit `--env-file` arguments. This keeps `process.env` enumeration Node-compatible so tools with their own `.env.{mode}` loading (such as Vite's `loadEnv`) do not mistake Bun's auto-loaded values for shell-provided overrides. Assigning to such a key from JavaScript promotes it to an enumerable own property. `Object.getOwnPropertyNames(process.env)` lists all keys including the auto-loaded ones.
+
+Default inherited environments (`Bun.spawn` with no `env`, `child_process` with no `options.env`, `Bun.$`, and `worker_threads`) still receive auto-loaded values. Once a `worker_threads` `SHARE_ENV` tree is founded, `process.env` becomes a shared string map and auto-loaded values enumerate like any other entry on the threads in that tree.
 
 ## Reading environment variables
 

--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -160,7 +160,7 @@ Bun.env.API_TOKEN; // => "secret"
 import.meta.env.API_TOKEN; // => "secret"
 ```
 
-To print all currently-set environment variables, run `bun --print process.env`.
+To print all currently-set environment variables, run `bun --print process.env`. This lists variables from the OS environment and explicit `--env-file` arguments; values auto-loaded from `.env` files are [non-enumerable](#enumeration) and do not appear here. Use `bun --print 'Object.getOwnPropertyNames(process.env)'` to list every key including auto-loaded ones.
 
 ```sh
 bun --print process.env

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -615,7 +615,11 @@ impl Loader {
         // `Source.contents: &'static [u8]` lifetime constraint (callers like
         // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
-        Parser::parse_bytes::<OVERWRITE, false, EXPAND, false>(str, &mut self.map, &mut value_buffer)
+        Parser::parse_bytes::<OVERWRITE, false, EXPAND, false>(
+            str,
+            &mut self.map,
+            &mut value_buffer,
+        )
     }
 
     pub fn load<D: DirEntryProbe + ?Sized>(

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -449,6 +449,7 @@ impl Loader {
                 *cxx_gop.key_ptr = Box::<[u8]>::from(&**cxx_gop.key_ptr);
                 *cxx_gop.value_ptr = HashTableValue {
                     value: ccache_path.clone(),
+                    conditional: false,
                 };
             }
             let c_gop = self
@@ -456,7 +457,10 @@ impl Loader {
                 .get_or_put_without_value(b"CMAKE_C_COMPILER_LAUNCHER")?;
             if !c_gop.found_existing {
                 *c_gop.key_ptr = Box::<[u8]>::from(&**c_gop.key_ptr);
-                *c_gop.value_ptr = HashTableValue { value: ccache_path };
+                *c_gop.value_ptr = HashTableValue {
+                    value: ccache_path,
+                    conditional: false,
+                };
             }
         }
         Ok(())
@@ -611,7 +615,7 @@ impl Loader {
         // `Source.contents: &'static [u8]` lifetime constraint (callers like
         // `node:util.parseEnv` pass JS-owned non-'static buffers).
         let mut value_buffer: Vec<u8> = Vec::new();
-        Parser::parse_bytes::<OVERWRITE, false, EXPAND>(str, &mut self.map, &mut value_buffer)
+        Parser::parse_bytes::<OVERWRITE, false, EXPAND, false>(str, &mut self.map, &mut value_buffer)
     }
 
     pub fn load<D: DirEntryProbe + ?Sized>(
@@ -870,7 +874,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                Parser::parse_bytes::<OVERRIDE, false, true, true>(
+                    &buf,
+                    &mut self.map,
+                    value_buffer,
+                )?;
             }
         }
 
@@ -917,7 +925,11 @@ impl Loader {
                 }
             }
             ReadEnvFile::Bytes(buf) => {
-                Parser::parse_bytes::<OVERRIDE, false, true>(&buf, &mut self.map, value_buffer)?;
+                Parser::parse_bytes::<OVERRIDE, false, true, false>(
+                    &buf,
+                    &mut self.map,
+                    value_buffer,
+                )?;
             }
         }
 
@@ -1207,7 +1219,12 @@ impl<'a> Parser<'a> {
         Ok(Some(self.value_buffer.as_slice()))
     }
 
-    fn _parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
+    fn _parse<
+        const OVERRIDE: bool,
+        const IS_PROCESS: bool,
+        const EXPAND: bool,
+        const CONDITIONAL: bool,
+    >(
         &mut self,
         map: &mut Map,
     ) -> Result<(), AllocError> {
@@ -1231,7 +1248,10 @@ impl<'a> Parser<'a> {
                 }
                 // else: previous value freed by Drop on assignment below
             }
-            *entry.value_ptr = HashTableValue { value: value_owned };
+            *entry.value_ptr = HashTableValue {
+                value: value_owned,
+                conditional: CONDITIONAL,
+            };
         }
         if !IS_PROCESS && EXPAND {
             // borrowck — index-based iteration: clone the value bytes, run
@@ -1243,9 +1263,7 @@ impl<'a> Parser<'a> {
             while idx < total {
                 let current: Box<[u8]> = Box::from(&*map.map.values()[idx].value);
                 if let Some(expanded) = self.expand_value(map, &current)? {
-                    map.map.values_mut()[idx] = HashTableValue {
-                        value: Box::from(expanded),
-                    };
+                    map.map.values_mut()[idx].value = Box::from(expanded);
                 }
                 idx += 1;
             }
@@ -1258,7 +1276,12 @@ impl<'a> Parser<'a> {
     /// Same as [`parse`] but takes the source bytes directly. Exists so
     /// `load_env_file*` can parse a transient `Vec<u8>` without constructing a
     /// `bun_ast::Source` (whose `contents` field is currently `&'static [u8]`).
-    pub(crate) fn parse_bytes<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(
+    pub(crate) fn parse_bytes<
+        const OVERRIDE: bool,
+        const IS_PROCESS: bool,
+        const EXPAND: bool,
+        const CONDITIONAL: bool,
+    >(
         src: &[u8],
         map: &mut Map,
         value_buffer: &mut Vec<u8>,
@@ -1272,7 +1295,7 @@ impl<'a> Parser<'a> {
             src: strings::without_utf8_bom(src),
             value_buffer,
         };
-        parser._parse::<OVERRIDE, IS_PROCESS, EXPAND>(map)
+        parser._parse::<OVERRIDE, IS_PROCESS, EXPAND, CONDITIONAL>(map)
     }
 }
 
@@ -1281,6 +1304,13 @@ pub struct HashTableValue {
     // `Box<[u8]>` is owned-by-default, trading some copies for uniform
     // ownership.
     pub value: Box<[u8]>,
+    /// Set for keys that exist only because Bun auto-discovered a `.env*` file,
+    /// not because the OS environment, `--env-file`, or an explicit `put()`
+    /// supplied them. `createEnvironmentVariablesMap` adds these with
+    /// `DontEnum` so tooling that re-reads `.env.{mode}` itself (Vite's
+    /// `loadEnv`, dotenv-flow, etc.) does not mistake them for process-level
+    /// overrides when enumerating `process.env`.
+    pub conditional: bool,
 }
 
 // On Windows, environment variables are case-insensitive. So we use a case-insensitive hash map.
@@ -1411,6 +1441,7 @@ impl Map {
             key,
             HashTableValue {
                 value: Box::from(value),
+                conditional: false,
             },
         )
     }
@@ -1428,6 +1459,7 @@ impl Map {
             key,
             HashTableValue {
                 value: Box::from(value),
+                conditional: false,
             },
         );
     }
@@ -1437,6 +1469,7 @@ impl Map {
         let gop = self.map.get_or_put(key)?;
         *gop.value_ptr = HashTableValue {
             value: Box::from(value),
+            conditional: false,
         };
         if !gop.found_existing {
             *gop.key_ptr = Box::from(key);
@@ -1471,6 +1504,7 @@ impl Map {
             key,
             HashTableValue {
                 value: Box::from(value),
+                conditional: false,
             },
         )?;
         Ok(())

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1050,6 +1050,7 @@ fn configure_env_for_scripts_run(
             value: Box::<[u8]>::from(strings::without_trailing_slash(
                 FileSystem::instance().top_level_dir(),
             )),
+            conditional: false,
         };
     }
 

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -71,6 +71,7 @@ impl IniTestingAPIs {
                     &keyslice,
                     dotenv::map::Entry {
                         value: slice.into_boxed_slice(),
+                        conditional: false,
                     },
                 )?;
             }

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -453,9 +453,6 @@ export function windowsEnv(
   //
   // it throws "Cannot convert a Symbol value to a string"
 
-  // envMapList now includes auto-loaded .env keys (DontEnum on internalEnv) so
-  // getOwnPropertyNames can see them; inspection and toJSON mirror Object.keys
-  // by skipping keys whose storage property is non-enumerable.
   const enumerableView = () => {
     let o = {};
     for (let k of envMapList) {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -453,24 +453,24 @@ export function windowsEnv(
   //
   // it throws "Cannot convert a Symbol value to a string"
 
-  (internalEnv as any)[Bun.inspect.custom] = () => {
+  // envMapList now includes auto-loaded .env keys (DontEnum on internalEnv) so
+  // getOwnPropertyNames can see them; inspection and toJSON mirror Object.keys
+  // by skipping keys whose storage property is non-enumerable.
+  const enumerableView = () => {
     let o = {};
     for (let k of envMapList) {
-      o[k] = internalEnv[k.toUpperCase()];
+      const up = k.toUpperCase();
+      if ($Object.getOwnPropertyDescriptor(internalEnv, up)?.enumerable) {
+        o[k] = internalEnv[up];
+      }
     }
     return o;
   };
-
-  (internalEnv as any).toJSON = () => {
-    // Mirror enumeration: original-case key names, case-insensitive values.
-    // Spreading internalEnv directly would leak the canonical UPPERCASE
-    // storage keys into JSON.stringify(process.env) and IPC env echoes.
-    let o = {};
-    for (let k of envMapList) {
-      o[k] = internalEnv[k.toUpperCase()];
-    }
-    return o;
-  };
+  (internalEnv as any)[Bun.inspect.custom] = enumerableView;
+  // Mirror enumeration: original-case key names, case-insensitive values.
+  // Spreading internalEnv directly would leak the canonical UPPERCASE
+  // storage keys into JSON.stringify(process.env) and IPC env echoes.
+  (internalEnv as any).toJSON = enumerableView;
 
   return new Proxy(internalEnv, {
     get(_, p) {

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -505,8 +505,10 @@ export function windowsEnv(
       }
       if (internalEnv[k] !== value) {
         editWindowsEnvVar(k, value);
-        internalEnv[k] = value;
       }
+      // Unconditional so a same-value write to a DontEnum auto-loaded .env key
+      // still promotes it to an enumerable data property via the custom setter.
+      internalEnv[k] = value;
       return true;
     },
     has(_, p) {
@@ -530,7 +532,10 @@ export function windowsEnv(
     defineProperty(_, p, attributes) {
       const k = String(p).toUpperCase();
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
-      if (!(k in internalEnv) && !envMapList.includes(p)) {
+      // Gate on envMapList membership, not `k in internalEnv`: DontEnum
+      // auto-loaded .env keys and the always-present TZ/proxy accessors are
+      // own properties of internalEnv while correctly absent from envMapList.
+      if (!envMapList.includes(p) && !envMapList.some(x => x.toUpperCase() === k)) {
         envMapList.push(p);
       }
       editWindowsEnvVar(k, internalEnv[k]);

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -532,9 +532,9 @@ export function windowsEnv(
     defineProperty(_, p, attributes) {
       const k = String(p).toUpperCase();
       $assert(typeof p === "string"); // proxy is only string and symbol. the symbol would have thrown by now
-      // Gate on envMapList membership, not `k in internalEnv`: DontEnum
-      // auto-loaded .env keys and the always-present TZ/proxy accessors are
-      // own properties of internalEnv while correctly absent from envMapList.
+      // Gate on envMapList membership, not `k in internalEnv`: the
+      // always-present TZ/proxy accessors are own properties of internalEnv
+      // while correctly absent from envMapList.
       if (!envMapList.includes(p) && !envMapList.some(x => x.toUpperCase() === k)) {
         envMapList.push(p);
       }

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -161,7 +161,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
         newEnv = defaultEnv;
       }
 
-      this.#args!.setEnv(newEnv);
+      this.#args!.setEnv(newEnv === originalDefaultEnv ? snapshotProcessEnv(newEnv) : newEnv);
       return this;
     }
 

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -253,6 +253,18 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
   const originalDefaultEnv = defaultEnv;
   var defaultCwd: string | undefined = undefined;
 
+  // Auto-loaded .env values are DontEnum on process.env; setEnv iterates
+  // enumerable-only. Snapshot via getOwnPropertyNames so $`cmd` keeps
+  // inheriting both .env values and runtime process.env mutations.
+  function snapshotProcessEnv(env) {
+    const out = {};
+    for (const key of $Object.getOwnPropertyNames(env)) {
+      const v = env[key];
+      if (v !== undefined && typeof v !== "function") out[key] = v;
+    }
+    return out;
+  }
+
   const cwdSymbol = Symbol("cwd");
   const envSymbol = Symbol("env");
   const throwsSymbol = Symbol("throws");
@@ -309,7 +321,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
     // cwd must be set before env or else it will be injected into env as "PWD=/"
     if (cwd) parsed_shell_script.setCwd(cwd);
-    if (env) parsed_shell_script.setEnv(env);
+    if (env) parsed_shell_script.setEnv(env === originalDefaultEnv ? snapshotProcessEnv(env) : env);
 
     return new ShellPromise(parsed_shell_script, throws);
   };
@@ -329,7 +341,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
 
       // cwd must be set before env or else it will be injected into env as "PWD=/"
       if (cwd) parsed_shell_script.setCwd(cwd);
-      if (env) parsed_shell_script.setEnv(env);
+      if (env) parsed_shell_script.setEnv(env === originalDefaultEnv ? snapshotProcessEnv(env) : env);
 
       return new ShellPromise(parsed_shell_script, throws);
     };

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -253,9 +253,6 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
   const originalDefaultEnv = defaultEnv;
   var defaultCwd: string | undefined = undefined;
 
-  // Auto-loaded .env values are DontEnum on process.env; setEnv iterates
-  // enumerable-only. Snapshot via getOwnPropertyNames so $`cmd` keeps
-  // inheriting both .env values and runtime process.env mutations.
   function snapshotProcessEnv(env) {
     const out = {};
     for (const key of $Object.getOwnPropertyNames(env)) {

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -78,7 +78,14 @@ function setupSettingsNT(settings) {
 }
 
 function createWorkerProcess(id, env) {
-  const workerEnv = { ...process.env, ...env, NODE_UNIQUE_ID: `${id}` };
+  // Auto-loaded .env values are DontEnum on process.env; spread would drop
+  // them. getOwnPropertyNames includes them so workers inherit .env values.
+  const workerEnv = {};
+  for (const k of $Object.getOwnPropertyNames(process.env)) {
+    const v = process.env[k];
+    if (v !== undefined && typeof v !== "function") workerEnv[k] = v;
+  }
+  Object.assign(workerEnv, env, { NODE_UNIQUE_ID: `${id}` });
   const execArgv = [...cluster.settings.execArgv];
 
   // if (cluster.settings.inspectPort === null) {

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -78,8 +78,6 @@ function setupSettingsNT(settings) {
 }
 
 function createWorkerProcess(id, env) {
-  // Auto-loaded .env values are DontEnum on process.env; spread would drop
-  // them. getOwnPropertyNames includes them so workers inherit .env values.
   const workerEnv = {};
   for (const k of $Object.getOwnPropertyNames(process.env)) {
     const v = process.env[k];

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1020,8 +1020,16 @@ function normalizeSpawnArguments(file, args, options) {
   // copyProcessEnvToEnv(env, "NODE_V8_COVERAGE", options.env);
 
   let envKeys: string[] = [];
-  for (const key in env) {
-    ArrayPrototypePush.$call(envKeys, key);
+  if (env === process.env) {
+    // Auto-loaded .env values are DontEnum on process.env; getOwnPropertyNames
+    // includes them (and runtime mutations) so children keep inheriting both.
+    for (const key of $Object.getOwnPropertyNames(env)) {
+      ArrayPrototypePush.$call(envKeys, key);
+    }
+  } else {
+    for (const key in env) {
+      ArrayPrototypePush.$call(envKeys, key);
+    }
   }
 
   if (process.platform === "win32") {

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1021,8 +1021,6 @@ function normalizeSpawnArguments(file, args, options) {
 
   let envKeys: string[] = [];
   if (env === process.env) {
-    // Auto-loaded .env values are DontEnum on process.env; getOwnPropertyNames
-    // includes them (and runtime mutations) so children keep inheriting both.
     for (const key of $Object.getOwnPropertyNames(env)) {
       ArrayPrototypePush.$call(envKeys, key);
     }

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -473,10 +473,24 @@ async function runOneFile(
   reporter.enqueue({ __proto__: null, ...fileNode });
   reporter.dequeue({ __proto__: null, ...fileNode });
 
+  // Auto-loaded .env values are DontEnum on process.env; spread would drop
+  // them. getOwnPropertyNames includes them so child tests inherit .env values.
+  const baseEnv: Record<string, string> = {};
+  if (opts.env) {
+    Object.assign(baseEnv, opts.env);
+  } else {
+    for (const k of $Object.getOwnPropertyNames(process.env)) {
+      const v = process.env[k];
+      if (v !== undefined && typeof v !== "function") baseEnv[k] = v;
+    }
+  }
+  baseEnv.BUN_TEST_DRAIN_EVENT_LOOP = "1";
+  baseEnv[kRunChildEnv] = kRunChildEnvValue;
+
   const proc = Bun.spawn({
     cmd: args,
     cwd: opts.cwd as string,
-    env: { ...(opts.env ?? process.env), BUN_TEST_DRAIN_EVENT_LOOP: "1", [kRunChildEnv]: kRunChildEnvValue },
+    env: baseEnv,
     stdout: "pipe",
     stderr: "pipe",
     signal: opts.signal,

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -473,11 +473,10 @@ async function runOneFile(
   reporter.enqueue({ __proto__: null, ...fileNode });
   reporter.dequeue({ __proto__: null, ...fileNode });
 
-  // Auto-loaded .env values are DontEnum on process.env; spread would drop
-  // them. getOwnPropertyNames includes them so child tests inherit .env values.
   const baseEnv: Record<string, string> = {};
-  if (opts.env) {
-    Object.assign(baseEnv, opts.env);
+  const optsEnv = opts.env;
+  if (optsEnv) {
+    Object.assign(baseEnv, optsEnv);
   } else {
     for (const k of $Object.getOwnPropertyNames(process.env)) {
       const v = process.env[k];

--- a/src/js/wasi-runner.js
+++ b/src/js/wasi-runner.js
@@ -19,8 +19,6 @@ var {
   WASM_USE_ASYNC_INIT = "1",
 } = process.env;
 
-// Auto-loaded .env values are DontEnum on process.env; WASI's environ_get
-// enumerates via Object.entries, so snapshot via getOwnPropertyNames here.
 var env = {};
 for (const k of Object.getOwnPropertyNames(process.env)) {
   const v = process.env[k];

--- a/src/js/wasi-runner.js
+++ b/src/js/wasi-runner.js
@@ -19,7 +19,13 @@ var {
   WASM_USE_ASYNC_INIT = "1",
 } = process.env;
 
-var env = process.env;
+// Auto-loaded .env values are DontEnum on process.env; WASI's environ_get
+// enumerates via Object.entries, so snapshot via getOwnPropertyNames here.
+var env = {};
+for (const k of Object.getOwnPropertyNames(process.env)) {
+  const v = process.env[k];
+  if (v !== undefined && typeof v !== "function") env[k] = v;
+}
 if (WASM_ENV_STR?.length) {
   env = JSON.parse(WASM_ENV_STR);
 }

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -721,8 +721,11 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
         RETURN_IF_EXCEPTION(scope, nullptr);
     }
 
+    // Include DontEnum so auto-loaded .env values (conditional CustomAccessors)
+    // and the always-present TZ/TLS/proxy accessors are seeded; values that read
+    // as undefined or callable are filtered below.
     JSC::PropertyNameArrayBuilder keys(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
-    envObject->methodTable()->getOwnPropertyNames(envObject, globalObject, keys, JSC::DontEnumPropertiesMode::Exclude);
+    envObject->methodTable()->getOwnPropertyNames(envObject, globalObject, keys, JSC::DontEnumPropertiesMode::Include);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Seed unconditionally: this thread's env is the new tree's initial contents.
@@ -730,6 +733,9 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     for (const auto& key : keys) {
         JSValue value = envObject->get(globalObject, key);
         RETURN_IF_EXCEPTION(scope, nullptr);
+        // DontEnum accessors for unset special vars (TZ, TLS, proxy) read undefined.
+        if (value.isUndefined())
+            continue;
         // Windows' process.env Proxy owns an enumerable `toJSON`; it is not an env var.
         if (value.isCallable())
             continue;
@@ -839,20 +845,23 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
             RETURN_IF_EXCEPTION(scope, {});
         }
 #endif
+        // hasXXX gates whether the post-loop CustomAccessor is installed
+        // enumerable; a .env-only value (conditional) stays DontEnum by leaving
+        // hasXXX false.
         if (name == TZ) {
-            hasTZ = true;
+            if (!conditional) hasTZ = true;
             continue;
         }
         if (name == NODE_TLS_REJECT_UNAUTHORIZED) {
-            hasNodeTLSRejectUnauthorized = true;
+            if (!conditional) hasNodeTLSRejectUnauthorized = true;
             continue;
         }
         if (name == BUN_CONFIG_VERBOSE_FETCH) {
-            hasBunConfigVerboseFetch = true;
+            if (!conditional) hasBunConfigVerboseFetch = true;
             continue;
         }
         if (auto idx = isProxyVar(name)) {
-            hasProxyVar[*idx] = true;
+            if (!conditional) hasProxyVar[*idx] = true;
             continue;
         }
         ASSERT(len > 0);
@@ -872,7 +881,8 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
                 if (Bun__getEnvValue(globalObject, &nameStr, &valueString)) {
                     JSValue value = jsString(vm, Zig::toStringCopy(valueString));
                     RETURN_IF_EXCEPTION(scope, {});
-                    object->putDirectIndex(globalObject, *index, value, 0, PutDirectIndexLikePutDirect);
+                    unsigned indexAttrs = conditional ? static_cast<unsigned>(JSC::PropertyAttribute::DontEnum) : 0;
+                    object->putDirectIndex(globalObject, *index, value, indexAttrs, PutDirectIndexLikePutDirect);
                     RETURN_IF_EXCEPTION(scope, {});
                 }
                 continue;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -28,6 +28,7 @@ using namespace JSC;
 
 extern "C" size_t Bun__getEnvCount(JSGlobalObject* globalObject, void** list_ptr);
 extern "C" size_t Bun__getEnvKey(void* list, size_t index, unsigned char** out);
+extern "C" bool Bun__isEnvKeyConditional(JSGlobalObject* globalObject, size_t index);
 
 extern "C" bool Bun__getEnvValue(JSGlobalObject* globalObject, const ZigString* name, ZigString* value);
 extern "C" bool Bun__getEnvValueBunString(JSGlobalObject* globalObject, const BunString* name, BunString* value);
@@ -59,6 +60,32 @@ JSC_DEFINE_CUSTOM_GETTER(jsGetterEnvironmentVariable, (JSGlobalObject * globalOb
     JSValue result = jsString(vm, Zig::toStringCopy(value));
     thisObject->putDirect(vm, propertyName, result, 0);
     return JSValue::encode(result);
+}
+
+// Non-caching variant for keys auto-loaded from `.env*` files. Installed as a
+// CustomAccessor with DontEnum so enumerating process.env matches Node's
+// OS-only view; the accessor stays in place until user code writes to the key
+// (jsSetterEnvironmentVariable promotes to an enumerable data property).
+JSC_DEFINE_CUSTOM_GETTER(jsGetterConditionalEnvironmentVariable, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    ZigString name = toZigString(propertyName.publicName());
+    ZigString value = { nullptr, 0 };
+
+    if (name.len == 0) [[unlikely]]
+        return JSValue::encode(jsUndefined());
+
+    if (!Bun__getEnvValue(globalObject, &name, &value)) {
+        return JSValue::encode(jsUndefined());
+    }
+
+    return JSValue::encode(jsString(vm, Zig::toStringCopy(value)));
 }
 
 JSC_DEFINE_CUSTOM_SETTER(jsSetterEnvironmentVariable, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, PropertyName propertyName))
@@ -759,7 +786,7 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     }
 
 #if OS(WINDOWS)
-    JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);
+    JSArray* keyArray = constructEmptyArray(globalObject, nullptr, 0);
     RETURN_IF_EXCEPTION(scope, {});
 #endif
 
@@ -795,15 +822,22 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     };
 
     auto* cached_getter_setter = JSC::CustomGetterSetter::create(vm, jsGetterEnvironmentVariable, nullptr);
+    auto* conditional_getter_setter = JSC::CustomGetterSetter::create(vm, jsGetterConditionalEnvironmentVariable, jsSetterEnvironmentVariable);
     auto* proxy_getter_setter = JSC::CustomGetterSetter::create(vm, jsGetterProxyEnvironmentVariable, jsSetterProxyEnvironmentVariable);
 
     for (size_t i = 0; i < count; i++) {
         unsigned char* chars;
         size_t len = Bun__getEnvKey(list, i, &chars);
+        bool conditional = Bun__isEnvKeyConditional(globalObject, i);
         // We can't really trust that the OS gives us valid UTF-8
         auto name = String::fromUTF8ReplacingInvalidSequences(std::span { chars, len });
 #if OS(WINDOWS)
-        keyArray->putByIndexInline(globalObject, (unsigned)i, jsString(vm, name), false);
+        // keyArray backs the Windows Proxy's ownKeys() trap; skip conditional
+        // keys to keep DontEnum semantics through the Proxy.
+        if (!conditional) {
+            keyArray->push(globalObject, jsString(vm, name));
+            RETURN_IF_EXCEPTION(scope, {});
+        }
 #endif
         if (name == TZ) {
             hasTZ = true;
@@ -849,7 +883,18 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
         // time) and then sets it onto the object, subsequent calls to the
         // getter will not go through the getter and instead will just do the
         // property lookup.
-        object->putDirectCustomAccessor(vm, identifier, cached_getter_setter, JSC::PropertyAttribute::CustomValue | 0);
+        //
+        // Keys that exist only because Bun auto-discovered a `.env*` file are
+        // added `DontEnum` so `Object.keys`/`for..in`/`{ ...process.env }` match
+        // Node's OS-only view. Direct reads still work; `jsSetterEnvironmentVariable`
+        // promotes to an enumerable data property on first write.
+        if (conditional) {
+            object->putDirectCustomAccessor(vm, identifier, conditional_getter_setter,
+                JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DontEnum | 0);
+        } else {
+            object->putDirectCustomAccessor(vm, identifier, cached_getter_setter,
+                JSC::PropertyAttribute::CustomValue | 0);
+        }
     }
 
     unsigned int TZAttrs = JSC::PropertyAttribute::CustomAccessor | 0;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -46,8 +46,8 @@ using namespace WebCore;
 JSObject* unwrapProcessEnvProxy(JSObject* envObject)
 {
 #if OS(WINDOWS)
-    if (auto* proxy = jsDynamicCast<JSC::ProxyObject*>(envObject)) {
-        if (auto* target = proxy->target()) return target;
+    if (envObject->type() == JSC::ProxyObjectType) {
+        if (auto* target = static_cast<JSC::ProxyObject*>(envObject)->target()) return target;
     }
 #endif
     return envObject;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -860,9 +860,9 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
             RETURN_IF_EXCEPTION(scope, {});
         }
 #endif
-        // hasXXX gates whether the post-loop CustomAccessor is installed
+        // The has* flags gate whether the post-loop CustomAccessor is installed
         // enumerable; a .env-only value (conditional) stays DontEnum by leaving
-        // hasXXX false.
+        // the flag false.
         if (name == TZ) {
             if (!conditional) hasTZ = true;
             continue;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -18,6 +18,7 @@
 #include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/PropertyDescriptor.h>
+#include <JavaScriptCore/ProxyObject.h>
 #include "BunProcess.h"
 #include "ScriptExecutionContext.h"
 #include "SharedEnvStore.h"
@@ -37,6 +38,20 @@ extern "C" void Bun__setEnvValue(JSGlobalObject* globalObject, const BunString* 
 namespace Bun {
 
 using namespace WebCore;
+
+// On Windows process.env is a Proxy whose ownKeys trap returns envMapList,
+// which by design excludes DontEnum auto-loaded .env keys. Snapshot and
+// SHARE_ENV seeding want the target so DontEnumPropertiesMode::Include sees
+// those keys; pass-through on POSIX.
+JSObject* unwrapProcessEnvProxy(JSObject* envObject)
+{
+#if OS(WINDOWS)
+    if (auto* proxy = jsDynamicCast<JSC::ProxyObject*>(envObject)) {
+        if (auto* target = proxy->target()) return target;
+    }
+#endif
+    return envObject;
+}
 
 JSC_DEFINE_CUSTOM_GETTER(jsGetterEnvironmentVariable, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
@@ -715,7 +730,7 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
 
     // Founding a new tree. processEnvObject() forces the lazy init so the OS
     // environment is captured before the swap below.
-    JSObject* envObject = globalObject->processEnvObject();
+    JSObject* envObject = unwrapProcessEnvProxy(globalObject->processEnvObject());
     if (!envObject->staticPropertiesReified()) {
         envObject->reifyAllStaticProperties(globalObject);
         RETURN_IF_EXCEPTION(scope, nullptr);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -18,7 +18,6 @@
 #include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/PropertyDescriptor.h>
-#include <JavaScriptCore/ProxyObject.h>
 #include "BunProcess.h"
 #include "ScriptExecutionContext.h"
 #include "SharedEnvStore.h"
@@ -38,20 +37,6 @@ extern "C" void Bun__setEnvValue(JSGlobalObject* globalObject, const BunString* 
 namespace Bun {
 
 using namespace WebCore;
-
-// On Windows process.env is a Proxy whose ownKeys trap returns envMapList,
-// which by design excludes DontEnum auto-loaded .env keys. Snapshot and
-// SHARE_ENV seeding want the target so DontEnumPropertiesMode::Include sees
-// those keys; pass-through on POSIX.
-JSObject* unwrapProcessEnvProxy(JSObject* envObject)
-{
-#if OS(WINDOWS)
-    if (envObject->type() == JSC::ProxyObjectType) {
-        if (auto* target = static_cast<JSC::ProxyObject*>(envObject)->target()) return target;
-    }
-#endif
-    return envObject;
-}
 
 JSC_DEFINE_CUSTOM_GETTER(jsGetterEnvironmentVariable, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
 {
@@ -730,7 +715,7 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
 
     // Founding a new tree. processEnvObject() forces the lazy init so the OS
     // environment is captured before the swap below.
-    JSObject* envObject = unwrapProcessEnvProxy(globalObject->processEnvObject());
+    JSObject* envObject = globalObject->processEnvObject();
     if (!envObject->staticPropertiesReified()) {
         envObject->reifyAllStaticProperties(globalObject);
         RETURN_IF_EXCEPTION(scope, nullptr);
@@ -853,12 +838,12 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
         // We can't really trust that the OS gives us valid UTF-8
         auto name = String::fromUTF8ReplacingInvalidSequences(std::span { chars, len });
 #if OS(WINDOWS)
-        // keyArray backs the Windows Proxy's ownKeys() trap; skip conditional
-        // keys to keep DontEnum semantics through the Proxy.
-        if (!conditional) {
-            keyArray->push(globalObject, jsString(vm, name));
-            RETURN_IF_EXCEPTION(scope, {});
-        }
+        // keyArray backs the Windows Proxy's ownKeys() trap. Include conditional
+        // keys so Object.getOwnPropertyNames sees them; Object.keys / for..in /
+        // spread still filter them out via the getOwnPropertyDescriptor trap,
+        // which reflects internalEnv's DontEnum accessor.
+        keyArray->push(globalObject, jsString(vm, name));
+        RETURN_IF_EXCEPTION(scope, {});
 #endif
         // The has* flags gate whether the post-loop CustomAccessor is installed
         // enumerable; a .env-only value (conditional) stays DontEnum by leaving

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -13,6 +13,11 @@ namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
+// Windows' process.env is a Proxy over internalEnv; snapshotting wants the
+// target so DontEnum keys (auto-loaded .env values) are visible. Pass-through
+// on POSIX.
+JSC::JSObject* unwrapProcessEnvProxy(JSC::JSObject* envObject);
+
 // worker_threads SHARE_ENV: a `process.env` whose reads/writes/enumeration go
 // through the SharedEnvStore of the tree its global belongs to.
 JSC::JSValue createSharedEnvironmentVariablesMap(Zig::GlobalObject* globalObject);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -13,11 +13,6 @@ namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
-// Windows' process.env is a Proxy over internalEnv; snapshotting wants the
-// target so DontEnum keys (auto-loaded .env values) are visible. Pass-through
-// on POSIX.
-JSC::JSObject* unwrapProcessEnvProxy(JSC::JSObject* envObject);
-
 // worker_threads SHARE_ENV: a `process.env` whose reads/writes/enumeration go
 // through the SharedEnvStore of the tree its global belongs to.
 JSC::JSValue createSharedEnvironmentVariablesMap(Zig::GlobalObject* globalObject);

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -267,21 +267,34 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
                 return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "options.env"_s, "object or one of undefined, null, or worker_threads.SHARE_ENV"_s, envValue);
             }
             JSObject* envObject = nullptr;
+            bool isProcessEnv = false;
 
             if (envValue && envValue.isCell()) {
                 envObject = dynamicDowncast<JSC::JSObject>(envValue);
+                isProcessEnv = globalObject->m_processEnvObject.isInitialized()
+                    && envObject == globalObject->processEnvObject();
             } else if (globalObject->m_processEnvObject.isInitialized()) {
                 envObject = globalObject->processEnvObject();
+                isProcessEnv = true;
             }
 
             if (envObject) {
+                // process.env carries DontEnum accessors for auto-loaded .env
+                // values and the always-present TZ/TLS/proxy vars. Unwrap the
+                // Windows Proxy and include DontEnum when snapshotting it so
+                // workers keep seeing .env values; user-provided env objects
+                // stay Exclude so their DontEnum properties are not leaked.
+                if (isProcessEnv) {
+                    envObject = Bun::unwrapProcessEnvProxy(envObject);
+                }
                 if (!envObject->staticPropertiesReified()) {
                     envObject->reifyAllStaticProperties(globalObject);
                     RETURN_IF_EXCEPTION(throwScope, {});
                 }
 
                 JSC::PropertyNameArrayBuilder keys(vm, JSC::PropertyNameMode::Strings, JSC::PrivateSymbolMode::Exclude);
-                envObject->methodTable()->getOwnPropertyNames(envObject, lexicalGlobalObject, keys, JSC::DontEnumPropertiesMode::Exclude);
+                envObject->methodTable()->getOwnPropertyNames(envObject, lexicalGlobalObject, keys,
+                    isProcessEnv ? JSC::DontEnumPropertiesMode::Include : JSC::DontEnumPropertiesMode::Exclude);
                 RETURN_IF_EXCEPTION(throwScope, {});
 
                 HashMap<String, String> env;
@@ -289,6 +302,12 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
                 for (const auto& key : keys) {
                     JSValue value = envObject->get(lexicalGlobalObject, key);
                     RETURN_IF_EXCEPTION(throwScope, {});
+                    if (isProcessEnv) {
+                        if (value.isUndefined())
+                            continue;
+                        if (value.isCallable())
+                            continue;
+                    }
                     String str = value.toWTFString(lexicalGlobalObject).isolatedCopy();
                     RETURN_IF_EXCEPTION(throwScope, {});
                     env.add(key.impl()->isolatedCopy(), str);

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -280,13 +280,13 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
 
             if (envObject) {
                 // process.env carries DontEnum accessors for auto-loaded .env
-                // values and the always-present TZ/TLS/proxy vars. Unwrap the
-                // Windows Proxy and include DontEnum when snapshotting it so
-                // workers keep seeing .env values; user-provided env objects
-                // stay Exclude so their DontEnum properties are not leaked.
-                if (isProcessEnv) {
-                    envObject = Bun::unwrapProcessEnvProxy(envObject);
-                }
+                // values and the always-present TZ/TLS/proxy vars; include
+                // DontEnum when snapshotting it so workers keep seeing .env
+                // values. On Windows the Proxy's ownKeys trap lists those keys
+                // in their original case and the descriptor trap reports them
+                // non-enumerable, so Include sees them without an unwrap.
+                // User-provided env objects stay Exclude so their DontEnum
+                // properties are not leaked.
                 if (!envObject->staticPropertiesReified()) {
                     envObject->reifyAllStaticProperties(globalObject);
                     RETURN_IF_EXCEPTION(throwScope, {});

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2152,6 +2152,25 @@ pub mod environment_variables {
         item.len()
     }
 
+    /// Whether the env entry at index `i` came only from an auto-discovered
+    /// `.env*` file. `createEnvironmentVariablesMap` marks such keys `DontEnum`
+    /// so `process.env` enumeration matches Node's (OS-only) view.
+    ///
+    /// # Safety
+    /// Same contract as `Bun__getEnvKey`: `i` must be less than the count
+    /// returned by `Bun__getEnvCount` for the same `globalObject`, with no map
+    /// mutation in between.
+    #[unsafe(no_mangle)]
+    pub(crate) unsafe extern "C" fn Bun__isEnvKeyConditional(
+        global_object: &JSGlobalObject,
+        i: usize,
+    ) -> bool {
+        let bun_vm = global_object.bun_vm().as_mut();
+        let values = bun_vm.env_loader().map.map.values();
+        debug_assert!(i < values.len());
+        values[i].conditional
+    }
+
     #[unsafe(no_mangle)]
     pub(crate) extern "C" fn Bun__getEnvValue(
         global_object: &JSGlobalObject,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2327,6 +2327,7 @@ impl TestCommand {
             *node_env_entry.key_ptr = Box::<[u8]>::from(&**node_env_entry.key_ptr);
             *node_env_entry.value_ptr = DotEnv::HashTableValue {
                 value: Box::<[u8]>::from(b"test" as &[u8]),
+                conditional: false,
             };
         }
 

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -329,6 +329,21 @@ describe("dotenv priority", () => {
     expect(stdout).toBe("secret\nsecret");
   });
 
+  test("auto-loaded .env values survive child_process default env inheritance", () => {
+    const dir = tempDirWithFiles("dotenv-cp", {
+      ".env": "AUTO_FROM_FILE=secret\n",
+      "child.js": `console.log(process.env.AUTO_FROM_FILE, process.env.USER_MUTATION);`,
+      "index.ts": `
+        process.env.USER_MUTATION = "from-js";
+        const { execFileSync } = require("child_process");
+        const out = execFileSync(process.execPath, ["child.js"], { encoding: "utf8" });
+        console.log(out.trim());
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("secret from-js");
+  });
+
   test("auto-loaded .env values survive the default worker env snapshot", () => {
     const dir = tempDirWithFiles("dotenv-worker-snap", {
       ".env": "AUTO_FROM_FILE=secret\n",

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -314,11 +314,13 @@ describe("dotenv priority", () => {
   // Worker/subprocess-spawning tests below are slow under debug+ASAN.
   const spawnTimeout = (isDebug || isASAN ? 6 : 1) * 5000;
 
-  test("auto-loaded .env values survive founding a SHARE_ENV worker tree", () => {
-    const dir = tempDirWithFiles("dotenv-share-env", {
-      ".env": "AUTO_FROM_FILE=secret\n",
-      "worker.js": `process.exit(0);`,
-      "index.ts": `
+  test(
+    "auto-loaded .env values survive founding a SHARE_ENV worker tree",
+    () => {
+      const dir = tempDirWithFiles("dotenv-share-env", {
+        ".env": "AUTO_FROM_FILE=secret\n",
+        "worker.js": `process.exit(0);`,
+        "index.ts": `
         const { Worker, SHARE_ENV } = require("worker_threads");
         console.log(process.env.AUTO_FROM_FILE);
         const w = new Worker("./worker.js", { env: SHARE_ENV });
@@ -327,30 +329,36 @@ describe("dotenv priority", () => {
           process.exit(0);
         });
       `,
-    });
-    const { stdout } = bunRun(`${dir}/index.ts`);
-    expect(stdout).toBe("secret\nsecret");
-  }, spawnTimeout);
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`);
+      expect(stdout).toBe("secret\nsecret");
+    },
+    spawnTimeout,
+  );
 
-  test("auto-loaded .env values survive child_process default env inheritance", () => {
-    const dir = tempDirWithFiles("dotenv-cp", {
-      ".env": "AUTO_FROM_FILE=secret\n",
-      "sub/child.js": `
+  test(
+    "auto-loaded .env values survive child_process default env inheritance",
+    () => {
+      const dir = tempDirWithFiles("dotenv-cp", {
+        ".env": "AUTO_FROM_FILE=secret\n",
+        "sub/child.js": `
         // enumerable=true iff the value arrived via the OS env block; false if
         // the child re-auto-loaded it from a .env file in cwd.
         const d = Object.getOwnPropertyDescriptor(process.env, "AUTO_FROM_FILE");
         console.log(process.env.AUTO_FROM_FILE, d?.enumerable, process.env.USER_MUTATION);
       `,
-      "index.ts": `
+        "index.ts": `
         process.env.USER_MUTATION = "from-js";
         const { execFileSync } = require("child_process");
         const out = execFileSync(process.execPath, ["child.js"], { cwd: "sub", encoding: "utf8" });
         console.log(out.trim());
       `,
-    });
-    const { stdout } = bunRun(`${dir}/index.ts`);
-    expect(stdout).toBe("secret true from-js");
-  }, spawnTimeout);
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`);
+      expect(stdout).toBe("secret true from-js");
+    },
+    spawnTimeout,
+  );
 
   test("auto-loaded .env values survive Bun.$ default env inheritance", () => {
     const dir = tempDirWithFiles("dotenv-shell", {
@@ -367,11 +375,13 @@ describe("dotenv priority", () => {
     expect(stdout).toBe("secret from-js\nsecret");
   });
 
-  test("auto-loaded .env values survive cluster.fork default env inheritance", () => {
-    const dir = tempDirWithFiles("dotenv-cluster", {
-      ".env": "AUTO_FROM_FILE=secret\n",
-      "sub/.keep": "",
-      "index.ts": `
+  test(
+    "auto-loaded .env values survive cluster.fork default env inheritance",
+    () => {
+      const dir = tempDirWithFiles("dotenv-cluster", {
+        ".env": "AUTO_FROM_FILE=secret\n",
+        "sub/.keep": "",
+        "index.ts": `
         const cluster = require("cluster");
         if (cluster.isPrimary) {
           cluster.setupPrimary({ cwd: "sub", exec: __filename });
@@ -382,25 +392,31 @@ describe("dotenv priority", () => {
           process.exit(0);
         }
       `,
-    });
-    const { stdout } = bunRun(`${dir}/index.ts`);
-    expect(stdout).toBe("secret true");
-  }, spawnTimeout);
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`);
+      expect(stdout).toBe("secret true");
+    },
+    spawnTimeout,
+  );
 
-  test("auto-loaded .env values survive the default worker env snapshot", () => {
-    const dir = tempDirWithFiles("dotenv-worker-snap", {
-      ".env": "AUTO_FROM_FILE=secret\n",
-      "worker.js": `require("worker_threads").parentPort.postMessage(process.env.AUTO_FROM_FILE);`,
-      "index.ts": `
+  test(
+    "auto-loaded .env values survive the default worker env snapshot",
+    () => {
+      const dir = tempDirWithFiles("dotenv-worker-snap", {
+        ".env": "AUTO_FROM_FILE=secret\n",
+        "worker.js": `require("worker_threads").parentPort.postMessage(process.env.AUTO_FROM_FILE);`,
+        "index.ts": `
         const { Worker } = require("worker_threads");
         void process.env.PATH;
         const w = new Worker("./worker.js", {});
         w.on("message", (m) => { console.log(process.env.AUTO_FROM_FILE, m); process.exit(0); });
       `,
-    });
-    const { stdout } = bunRun(`${dir}/index.ts`);
-    expect(stdout).toBe("secret secret");
-  }, spawnTimeout);
+      });
+      const { stdout } = bunRun(`${dir}/index.ts`);
+      expect(stdout).toBe("secret secret");
+    },
+    spawnTimeout,
+  );
 
   test("auto-loaded special-cased env keys are not enumerable", () => {
     const dir = tempDirWithFiles("dotenv-special", {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -332,12 +332,30 @@ describe("dotenv priority", () => {
   test("auto-loaded .env values survive child_process default env inheritance", () => {
     const dir = tempDirWithFiles("dotenv-cp", {
       ".env": "AUTO_FROM_FILE=secret\n",
-      "child.js": `console.log(process.env.AUTO_FROM_FILE, process.env.USER_MUTATION);`,
+      "sub/child.js": `
+        // enumerable=true iff the value arrived via the OS env block; false if
+        // the child re-auto-loaded it from a .env file in cwd.
+        const d = Object.getOwnPropertyDescriptor(process.env, "AUTO_FROM_FILE");
+        console.log(process.env.AUTO_FROM_FILE, d?.enumerable, process.env.USER_MUTATION);
+      `,
       "index.ts": `
         process.env.USER_MUTATION = "from-js";
         const { execFileSync } = require("child_process");
-        const out = execFileSync(process.execPath, ["child.js"], { encoding: "utf8" });
+        const out = execFileSync(process.execPath, ["child.js"], { cwd: "sub", encoding: "utf8" });
         console.log(out.trim());
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("secret true from-js");
+  });
+
+  test("auto-loaded .env values survive Bun.$ default env inheritance", () => {
+    const dir = tempDirWithFiles("dotenv-shell", {
+      ".env": "AUTO_FROM_FILE=secret\n",
+      "index.ts": `
+        process.env.USER_MUTATION = "from-js";
+        const echo = await Bun.$\`echo \${{raw: "$AUTO_FROM_FILE $USER_MUTATION"}}\`.text();
+        console.log(echo.trim());
       `,
     });
     const { stdout } = bunRun(`${dir}/index.ts`);

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -311,6 +311,9 @@ describe("dotenv priority", () => {
     expect(result.stdout.toString("utf8").trim()).toBe("true");
   });
 
+  // Worker/subprocess-spawning tests below are slow under debug+ASAN.
+  const spawnTimeout = (isDebug || isASAN ? 6 : 1) * 5000;
+
   test("auto-loaded .env values survive founding a SHARE_ENV worker tree", () => {
     const dir = tempDirWithFiles("dotenv-share-env", {
       ".env": "AUTO_FROM_FILE=secret\n",
@@ -327,7 +330,7 @@ describe("dotenv priority", () => {
     });
     const { stdout } = bunRun(`${dir}/index.ts`);
     expect(stdout).toBe("secret\nsecret");
-  });
+  }, spawnTimeout);
 
   test("auto-loaded .env values survive child_process default env inheritance", () => {
     const dir = tempDirWithFiles("dotenv-cp", {
@@ -347,7 +350,7 @@ describe("dotenv priority", () => {
     });
     const { stdout } = bunRun(`${dir}/index.ts`);
     expect(stdout).toBe("secret true from-js");
-  });
+  }, spawnTimeout);
 
   test("auto-loaded .env values survive Bun.$ default env inheritance", () => {
     const dir = tempDirWithFiles("dotenv-shell", {
@@ -356,11 +359,33 @@ describe("dotenv priority", () => {
         process.env.USER_MUTATION = "from-js";
         const echo = await Bun.$\`echo \${{raw: "$AUTO_FROM_FILE $USER_MUTATION"}}\`.text();
         console.log(echo.trim());
+        const reset = await Bun.$\`echo \${{raw: "$AUTO_FROM_FILE"}}\`.env(undefined).text();
+        console.log(reset.trim());
       `,
     });
     const { stdout } = bunRun(`${dir}/index.ts`);
-    expect(stdout).toBe("secret from-js");
+    expect(stdout).toBe("secret from-js\nsecret");
   });
+
+  test("auto-loaded .env values survive cluster.fork default env inheritance", () => {
+    const dir = tempDirWithFiles("dotenv-cluster", {
+      ".env": "AUTO_FROM_FILE=secret\n",
+      "sub/.keep": "",
+      "index.ts": `
+        const cluster = require("cluster");
+        if (cluster.isPrimary) {
+          cluster.setupPrimary({ cwd: "sub", exec: __filename });
+          cluster.fork().on("exit", () => process.exit(0));
+        } else {
+          const d = Object.getOwnPropertyDescriptor(process.env, "AUTO_FROM_FILE");
+          console.log(process.env.AUTO_FROM_FILE, d?.enumerable);
+          process.exit(0);
+        }
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("secret true");
+  }, spawnTimeout);
 
   test("auto-loaded .env values survive the default worker env snapshot", () => {
     const dir = tempDirWithFiles("dotenv-worker-snap", {
@@ -375,7 +400,7 @@ describe("dotenv priority", () => {
     });
     const { stdout } = bunRun(`${dir}/index.ts`);
     expect(stdout).toBe("secret secret");
-  });
+  }, spawnTimeout);
 
   test("auto-loaded special-cased env keys are not enumerable", () => {
     const dir = tempDirWithFiles("dotenv-special", {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -310,6 +310,44 @@ describe("dotenv priority", () => {
     });
     expect(result.stdout.toString("utf8").trim()).toBe("true");
   });
+
+  test("auto-loaded .env values survive founding a SHARE_ENV worker tree", () => {
+    const dir = tempDirWithFiles("dotenv-share-env", {
+      ".env": "AUTO_FROM_FILE=secret\n",
+      "worker.js": `process.exit(0);`,
+      "index.ts": `
+        const { Worker, SHARE_ENV } = require("worker_threads");
+        console.log(process.env.AUTO_FROM_FILE);
+        const w = new Worker("./worker.js", { env: SHARE_ENV });
+        w.on("exit", () => {
+          console.log(process.env.AUTO_FROM_FILE);
+          process.exit(0);
+        });
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("secret\nsecret");
+  });
+
+  test("auto-loaded special-cased env keys are not enumerable", () => {
+    const dir = tempDirWithFiles("dotenv-special", {
+      ".env": "HTTP_PROXY=http://p:1\nTZ=UTC\n123=num\n",
+      "index.ts": `
+        const keys = Object.keys(process.env);
+        console.log(JSON.stringify({
+          proxy: { read: process.env.HTTP_PROXY, listed: keys.includes("HTTP_PROXY") },
+          tz: { read: process.env.TZ, listed: keys.includes("TZ") },
+          num: { read: process.env[123], listed: keys.includes("123") },
+        }));
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, { HTTP_PROXY: undefined, TZ: undefined });
+    expect(JSON.parse(stdout)).toEqual({
+      proxy: { read: "http://p:1", listed: false },
+      tz: { read: "UTC", listed: false },
+      num: { read: "num", listed: false },
+    });
+  });
 });
 
 test(".env colon assign", () => {
@@ -730,7 +768,12 @@ describe("--env-file", () => {
   });
 
   test("empty string disables default dotenv behavior", () => {
-    expect(bunRun(["--env-file=''"]).stdout).toBe("");
+    // auto-loaded .env values are non-enumerable (see #6338), so check via direct access rather than Object.entries.
+    const result = Bun.spawnSync([bunExe(), "--env-file=''", "-e", "console.log(process.env.BUNTEST_DOTENV)"], {
+      cwd: dir,
+      env: { ...bunEnv, NODE_ENV: undefined },
+    });
+    expect(result.stdout.toString("utf8").trim()).toBe("undefined");
   });
 
   test("should correctly ignore invalid values and parse the rest", () => {
@@ -739,8 +782,12 @@ describe("--env-file", () => {
   });
 
   test("should ignore a file that doesn't exist", () => {
-    const res = bunRun(["--env-file=.env.nonexisting"]);
-    expect(res.stdout).toBe("");
+    // auto-loaded .env values are non-enumerable (see #6338), so check via direct access rather than Object.entries.
+    const result = Bun.spawnSync(
+      [bunExe(), "--env-file=.env.nonexisting", "-e", "console.log(process.env.BUNTEST_DOTENV)"],
+      { cwd: dir, env: { ...bunEnv, NODE_ENV: undefined } },
+    );
+    expect(result.stdout.toString("utf8").trim()).toBe("undefined");
   });
 });
 

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -329,6 +329,21 @@ describe("dotenv priority", () => {
     expect(stdout).toBe("secret\nsecret");
   });
 
+  test("auto-loaded .env values survive the default worker env snapshot", () => {
+    const dir = tempDirWithFiles("dotenv-worker-snap", {
+      ".env": "AUTO_FROM_FILE=secret\n",
+      "worker.js": `require("worker_threads").parentPort.postMessage(process.env.AUTO_FROM_FILE);`,
+      "index.ts": `
+        const { Worker } = require("worker_threads");
+        void process.env.PATH;
+        const w = new Worker("./worker.js", {});
+        w.on("message", (m) => { console.log(process.env.AUTO_FROM_FILE, m); process.exit(0); });
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("secret secret");
+  });
+
   test("auto-loaded special-cased env keys are not enumerable", () => {
     const dir = tempDirWithFiles("dotenv-special", {
       ".env": "HTTP_PROXY=http://p:1\nTZ=UTC\n123=num\n",

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -222,6 +222,94 @@ describe("dotenv priority", () => {
     const { stdout: stdout_test } = bunTest(`${dir}/index.test.ts`, {});
     expect(stdout_test).toBe(`bun test ${Bun.version_with_sha}\n` + ".env.test");
   });
+
+  // https://github.com/oven-sh/bun/issues/6338
+  test("auto-loaded .env values are not enumerable on process.env", () => {
+    const dir = tempDirWithFiles("dotenv-enum", {
+      ".env": "AUTO_FROM_FILE=from-file\nBOTH=from-file\n",
+      "index.ts": `
+        const d = Object.getOwnPropertyDescriptor(process.env, "AUTO_FROM_FILE");
+        console.log(JSON.stringify({
+          read: process.env.AUTO_FROM_FILE,
+          inOp: "AUTO_FROM_FILE" in process.env,
+          hasOwn: Object.hasOwn(process.env, "AUTO_FROM_FILE"),
+          enumerable: d?.enumerable,
+          keys: Object.keys(process.env).includes("AUTO_FROM_FILE"),
+          spread: "AUTO_FROM_FILE" in { ...process.env },
+          both: Object.getOwnPropertyDescriptor(process.env, "BOTH")?.enumerable,
+        }));
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`, { BOTH: "from-process" });
+    expect(JSON.parse(stdout)).toEqual({
+      read: "from-file",
+      inOp: true,
+      hasOwn: true,
+      enumerable: false,
+      keys: false,
+      spread: false,
+      // BOTH came from the OS env, so it stays enumerable even though .env also defines it.
+      both: true,
+    });
+  });
+
+  // https://github.com/oven-sh/bun/issues/6338
+  test("auto-loaded .env values do not shadow mode-specific dotenv loaders", () => {
+    // Mirrors Vite's loadEnv(): parse .env.{mode} then let enumerable
+    // process.env keys override. Under Node process.env has no .env entries,
+    // so .env.production wins; Bun must behave the same.
+    const dir = tempDirWithFiles("dotenv-loadEnv", {
+      ".env": "PUBLICPATH=/\n",
+      ".env.production": "PUBLICPATH=/app\n",
+      "index.ts": `
+        import fs from "fs";
+        import path from "path";
+        const parsed: Record<string, string> = {};
+        for (const f of [".env", ".env.production"]) {
+          for (const line of fs.readFileSync(path.join(process.cwd(), f), "utf8").split("\\n")) {
+            const m = line.match(/^([^=]+)=(.*)$/);
+            if (m) parsed[m[1]] = m[2];
+          }
+        }
+        const processEnv = { ...process.env };
+        for (const key of Object.keys(parsed)) {
+          if (processEnv[key] !== undefined) parsed[key] = processEnv[key]!;
+        }
+        for (const key in process.env) {
+          if (key in parsed) parsed[key] = process.env[key]!;
+        }
+        console.log(parsed.PUBLICPATH);
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("/app");
+  });
+
+  test("writing to an auto-loaded .env key makes it enumerable", () => {
+    const dir = tempDirWithFiles("dotenv-write", {
+      ".env": "AUTO_FROM_FILE=from-file\n",
+      "index.ts": `
+        console.log(Object.keys(process.env).includes("AUTO_FROM_FILE"));
+        process.env.AUTO_FROM_FILE = "from-js";
+        console.log(Object.keys(process.env).includes("AUTO_FROM_FILE"));
+        console.log(process.env.AUTO_FROM_FILE);
+      `,
+    });
+    const { stdout } = bunRun(`${dir}/index.ts`);
+    expect(stdout).toBe("false\ntrue\nfrom-js");
+  });
+
+  test("--env-file values stay enumerable on process.env", () => {
+    const dir = tempDirWithFiles("dotenv-explicit", {
+      ".env.custom": "EXPLICIT_FROM_FILE=1\n",
+      "index.ts": `console.log(Object.keys(process.env).includes("EXPLICIT_FROM_FILE"));`,
+    });
+    const result = Bun.spawnSync([bunExe(), "--env-file", ".env.custom", "index.ts"], {
+      cwd: dir,
+      env: { ...bunEnv, NODE_ENV: undefined },
+    });
+    expect(result.stdout.toString("utf8").trim()).toBe("true");
+  });
 });
 
 test(".env colon assign", () => {
@@ -633,7 +721,12 @@ describe("--env-file", () => {
 
   test("when arg missing, fallback to default dotenv behavior", () => {
     // if --env-file missing, it should fallback to the default builtin behavior (.env, .env.production, etc.)
-    expect(bunRun([]).stdout).toBe("BUNTEST_DOTENV=1");
+    // auto-loaded .env values are non-enumerable (see #6338), so check via direct access rather than Object.entries.
+    const result = Bun.spawnSync([bunExe(), "-e", "console.log(process.env.BUNTEST_DOTENV)"], {
+      cwd: dir,
+      env: { ...bunEnv, NODE_ENV: undefined },
+    });
+    expect(result.stdout.toString("utf8").trim()).toBe("1");
   });
 
   test("empty string disables default dotenv behavior", () => {


### PR DESCRIPTION
## What

Values that Bun auto-discovers in `.env` / `.env.local` / `.env.{NODE_ENV}` are now installed on `process.env` as non-enumerable accessor properties. Direct reads (`process.env.FOO`, `'FOO' in process.env`, `Object.hasOwn(process.env, 'FOO')`) still work, but `Object.keys(process.env)`, `for..in`, and `{ ...process.env }` no longer list them.

`--env-file` values and OS env vars stay enumerable. Assigning to a conditional key from JS promotes it to an enumerable data property. `Bun.spawn`'s default inherited environment (no `env` option) still includes `.env` values via the loader map.

## Repro

```sh
d=$(mktemp -d); cd $d
printf 'PUBLICPATH=/\n'    > .env
printf 'PUBLICPATH=/app\n' > .env.production
cat > check.js <<'JS'
import { loadEnv } from 'vite';
console.log(loadEnv('production', process.cwd(), '').PUBLICPATH);
JS
bun add vite >/dev/null
node check.js   # /app
bun  check.js   # before: /   after: /app
```

## Cause

Bun's auto-loaded `.env` values were indistinguishable from OS environment variables on `process.env`. Vite's `loadEnv()` (and dotenv-expand) follow the standard dotenv convention that existing `process.env` entries take priority over file values; both probe that via `{ ...process.env }` and `for (const key in process.env)`. When Bun runs without `NODE_ENV` set it defaults to the development file set, so `.env` lands in `process.env.PUBLICPATH`, and Vite then refuses to let `.env.production` override what it believes is a shell-provided value.

## Fix

- `HashTableValue` regains a `conditional: bool`, set only by `load_default_files` (the auto-discovered `.env*` files). `load_process`, `--env-file`, and programmatic `put()` keep `conditional = false`.
- A new `Bun__isEnvKeyConditional` FFI exposes the flag to C++.
- `createEnvironmentVariablesMap` installs conditional keys as `CustomAccessor | DontEnum` with a non-caching getter and the existing `jsSetterEnvironmentVariable` so a JS write promotes to an enumerable data property. The Windows Proxy's key array skips conditional keys to keep `ownKeys()` consistent.
- Docs updated to describe the enumeration behaviour.

The `--env-file` describe block's "fallback to default dotenv behavior" test is updated to check via direct read instead of `Object.entries`; its intent (auto `.env` loading still happens without `--env-file`) is preserved.

## Why this is correct

Under Node, `process.env` enumeration only ever yields OS environment variables, so any tool that treats enumerable `process.env` keys as "real env wins" works by construction. This change brings Bun's enumeration in line with that contract while keeping the ergonomic `process.env.FOO` read that Bun's auto-loading exists for. The earlier `conditional` field that #9689 removed was only consulted by the script-runner's subprocess env block; this revives it for the in-process `process.env` object instead, which is the layer the Vite conflict actually lives in.

## Behavior change

`Object.keys(process.env)` / `{ ...process.env }` no longer include values that came *only* from an auto-discovered `.env*` file. This is an observable change; see the updated docs in `docs/runtime/environment-variables.mdx`. `Bun.spawn` with the default (unspecified) `env` still inherits everything.

## Verification

```
bun bd test test/cli/run/env.test.ts test/cli/run/no-envfile.test.ts
# 104 pass, 1 skip, 2 todo, 0 fail
```

Fixes #6338
Fixes #13614
Fixes #22496

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->