### PR TITLE
module loader: mark has_loaded before transpiler-cache early return

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2652,6 +2652,18 @@ fn transpile_source_code_inner(
                     return Err(crate::Error::ParseError);
                 }
 
+                // Mark the entry point as loaded as soon as it has parsed
+                // successfully, before any of the early `Ok(...)` returns below
+                // (bytecode, empty-cjs, runtime-transpiler-cache hit, etc.).
+                // `has_loaded` is what flips the loader fallback for unknown
+                // extensions (`transpile_file`'s `synchronous_loader` block) from
+                // `Tsx` to `File`; leaving it unset on a cache hit made a second
+                // run of `bun entry.ts` parse `import x from "./a.c"` as JS.
+                if is_main {
+                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                    unsafe { (*jsc_vm).has_loaded = true };
+                }
+
                 let source = &parse_result.source;
 
                 // Raw JSON: hand the source bytes straight to JSC.
@@ -3048,11 +3060,6 @@ fn transpile_source_code_inner(
                         drop(module_info.take());
                     }
                     print_result?;
-                }
-
-                if is_main {
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                    unsafe { (*jsc_vm).has_loaded = true };
                 }
 
                 // `module_info.asDeserialized()`: finalize the

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -231,7 +231,8 @@ describe("transpiler cache", () => {
     // C source as TSX instead of using the file loader.
     writeFileSync(join(temp_dir, "impl.c"), "#include <stdio.h>\nint main() { return 0; }\n");
     // Entry file large enough to be cached, importing an unknown-extension file.
-    const code = 'import src from "./impl.c";\nconsole.log(typeof src === "string" && src.endsWith("impl.c") ? "file-loader-ok" : src);\n';
+    const code =
+      'import src from "./impl.c";\nconsole.log(typeof src === "string" && src.endsWith("impl.c") ? "file-loader-ok" : src);\n';
     writeFileSync(join(temp_dir, "entry.ts"), code + "//" + Buffer.alloc(50 * 1024, "x").toString() + "\n");
 
     const run = (label: string) => {

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -223,6 +223,41 @@ describe("transpiler cache", () => {
     expect(b.stdout == "production 5");
     expect(newCacheCount()).toBe(0);
   });
+  test("cache hit on the entry point does not change loader selection for unknown-extension imports", () => {
+    // The runtime-transpiler-cache early return used to skip marking the VM's
+    // `has_loaded` flag, so on a warm run (>= MINIMUM_CACHE_SIZE entry file
+    // served from cache) an ESM `import x from "./file.c"` fell into the
+    // "potentially the main module" loader fallback and tried to parse the
+    // C source as TSX instead of using the file loader.
+    writeFileSync(join(temp_dir, "impl.c"), "#include <stdio.h>\nint main() { return 0; }\n");
+    // Entry file large enough to be cached, importing an unknown-extension file.
+    const code = 'import src from "./impl.c";\nconsole.log(typeof src === "string" && src.endsWith("impl.c") ? "file-loader-ok" : src);\n';
+    writeFileSync(join(temp_dir, "entry.ts"), code + "//" + Buffer.alloc(50 * 1024, "x").toString() + "\n");
+
+    const run = (label: string) => {
+      const result = Bun.spawnSync({
+        cmd: [bunExe(), "entry.ts"],
+        cwd: temp_dir,
+        env,
+      });
+      const stderr = result.stderr.toString();
+      const stdout = result.stdout.toString().trim();
+      if (!result.success) throw new Error(`${label}: ${stderr}\n${stdout}`);
+      return { stdout, stderr };
+    };
+
+    const cold = run("cold run");
+    expect(cold.stdout).toBe("file-loader-ok");
+    expect(existsSync(cache_dir)).toBeTrue();
+    expect(newCacheCount()).toBe(1);
+
+    // On the warm run the entry point is restored from cache; the `.c` import
+    // must still go through the file loader.
+    const warm = run("warm run (cache hit)");
+    expect(warm.stderr).not.toContain("Unexpected #include");
+    expect(warm.stdout).toBe("file-loader-ok");
+    expect(newCacheCount()).toBe(0);
+  });
   test("--feature flag invalidates cache", () => {
     // feature() can only appear in an if/ternary, so wrap it
     const code = `import { feature } from "bun:bundle";\nif (feature("SUPER_SECRET")) console.log("enabled"); else console.log("disabled");`;


### PR DESCRIPTION
## What

When the entry point is >= 4 KiB (the runtime transpiler cache's `MINIMUM_CACHE_SIZE`) and a cache entry exists for it, an ESM `import x from "./file.c"` (or any other unknown extension) is parsed as TSX instead of going through the file loader. The first run of the program works; every subsequent run fails with:

```
1 | #include <stdio.h>
    ^
error: Unexpected #include
    at .../impl.c:1:1
```

## Repro

```sh
mkdir /tmp/repro && cd /tmp/repro
printf '#include <stdio.h>\n' > impl.c
printf 'import s from "./impl.c"; console.log(typeof s, s);\n//%.0s' {1..5000} > entry.ts
bun entry.ts   # string /tmp/repro/impl.c
bun entry.ts   # error: Unexpected #include at .../impl.c:1:1
```

## Cause

`transpile_source_code_inner` sets `vm.has_loaded = true` only after the printer runs, but several success paths return earlier: the bytecode/already-bundled arm, the empty `.cjs`/`.cts` arm, and the runtime-transpiler-cache hit. On a warm run the cache-hit return fires before `has_loaded` is set.

`transpile_file`'s `synchronous_loader` block uses `has_loaded || is_in_preload` to decide between `Loader::File` (unknown extension inside the module graph) and `Loader::Tsx` ("potentially the main module"). With `has_loaded` still `false`, the `.c` import takes the `Tsx` branch.

## Fix

Move the `has_loaded = true` assignment to immediately after the parse-error check, so every successful parse of the entry point (cache hit or not) sets it before any early return.

## Test

Added a case to `test/cli/run/transpiler-cache.test.ts` that runs a >4 KiB entry importing a `.c` file twice against an isolated cache dir, asserting the file-loader result on both the cold and warm run and that the cache was populated in between.