### PR TITLE
node-fallbacks: route the stream polyfill's process shim to require('process') and forward nextTick args

### DIFF
--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -41,6 +41,11 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
         .replaceAll("__require(", "require(")
         .replaceAll("import.meta.url", "''")
         .replaceAll("createRequire", "")
+        // --define=global:globalThis has already run, so the bundled text
+        // contains `globalThis.process` (e.g. from the `process` npm package's
+        // index.js). Rewrite both forms to the `node:process` polyfill so the
+        // output does not depend on a real `globalThis.process` in the browser.
+        .replaceAll("globalThis.process", "require('process')")
         .replaceAll("global.process", "require('process')")
         .trim();
 

--- a/src/node-fallbacks/build-fallbacks.ts
+++ b/src/node-fallbacks/build-fallbacks.ts
@@ -41,12 +41,12 @@ for (let fileIndex = 0; fileIndex < allFiles.length; fileIndex++) {
         .replaceAll("__require(", "require(")
         .replaceAll("import.meta.url", "''")
         .replaceAll("createRequire", "")
-        // --define=global:globalThis has already run, so the bundled text
-        // contains `globalThis.process` (e.g. from the `process` npm package's
-        // index.js). Rewrite both forms to the `node:process` polyfill so the
-        // output does not depend on a real `globalThis.process` in the browser.
+        // --define=global:globalThis has already run, so any `global.process`
+        // in the bundled sources (e.g. the `process` npm package's index.js)
+        // is `globalThis.process` by the time it reaches here. Rewrite it to
+        // the `node:process` polyfill so the output does not depend on a real
+        // `globalThis.process` existing in the browser.
         .replaceAll("globalThis.process", "require('process')")
-        .replaceAll("global.process", "require('process')")
         .trim();
 
       while (outfile.startsWith("import{")) {

--- a/src/node-fallbacks/process.js
+++ b/src/node-fallbacks/process.js
@@ -32,7 +32,7 @@ function drainQueue() {
     while (++queueIndex < len) {
       if (currentQueue) {
         var item = currentQueue[queueIndex];
-        item.fun.apply(null, item.array);
+        item.fun.apply(null, item.args);
       }
     }
     queueIndex = -1;

--- a/test/bundler/bundler_browser.test.ts
+++ b/test/bundler/bundler_browser.test.ts
@@ -101,6 +101,59 @@ describe("bundler", () => {
       api.expectFile("out.js").not.toInclude("import ");
     },
   });
+  itBundled("browser/NodeStreamWithoutGlobalProcess", {
+    files: {
+      "/entry.js": /* js */ `
+        import { Readable } from "node:stream";
+        const r = Readable.from(["a", "b"]);
+        const chunks = [];
+        globalThis.DONE = new Promise((resolve, reject) => {
+          r.on("data", d => chunks.push(d));
+          r.on("end", () => resolve("got:" + chunks.join(",")));
+          r.on("error", reject);
+        });
+      `,
+    },
+    target: "browser",
+    runtimeFiles: {
+      "/exec.js": /* js */ `
+        // Simulate a browser: no global process object.
+        delete globalThis.process;
+        await import("./out.js");
+        console.log(await globalThis.DONE);
+      `,
+    },
+    run: {
+      file: "/exec.js",
+      stdout: "got:a,b",
+    },
+    onAfterBundle(api) {
+      api.expectFile("out.js").not.toInclude("import ");
+      api.expectFile("out.js").not.toInclude("globalThis.process");
+    },
+  });
+  itBundled("browser/NodeProcessNextTickForwardsArgs", {
+    files: {
+      "/entry.js": /* js */ `
+        import { nextTick } from "node:process";
+        globalThis.DONE = new Promise(resolve => {
+          nextTick((a, b, c) => resolve(a + b + c), "x", "y", "z");
+        });
+      `,
+    },
+    target: "browser",
+    runtimeFiles: {
+      "/exec.js": /* js */ `
+        delete globalThis.process;
+        await import("./out.js");
+        console.log(await globalThis.DONE);
+      `,
+    },
+    run: {
+      file: "/exec.js",
+      stdout: "xyz",
+    },
+  });
   itBundled("browser/NodeTTY", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Repro

```sh
cat > t.js <<'JS'
import { Readable } from "stream";
const r = Readable.from(["a"]);
r.on("data", () => {});
JS
bun build t.js --target browser --outfile out.js
node -e 'delete globalThis.process; import("./out.js")'
# TypeError: Cannot read properties of undefined (reading 'nextTick')
```

The browser `node:stream` polyfill is unusable in an environment without a real `globalThis.process` (i.e. an actual browser).

### Cause

`readable-stream` depends on the `process` npm package, whose `index.js` is just `module.exports = global.process`. `build-fallbacks.ts` bundles with `--define=global:globalThis`, so that becomes `module.exports = globalThis.process` in the output. The post-processing step then does `.replaceAll("global.process", "require('process')")`, which no longer matches because the define already ran. The embedded `stream.js` therefore ships `module2.exports = globalThis.process` as its process shim, and every `process.nextTick` inside the stream implementation reads `undefined`.

Once that routed to the `node:process` polyfill, a second pre-existing bug surfaced: the polyfill's `nextTick` pushes `{ fun, args }` onto the queue, but `drainQueue` reads `item.array`, so every callback was invoked with zero arguments. This broke `Readable`'s `resume_(stream, state)` the moment the first bug was fixed.

### Fix

- `build-fallbacks.ts`: also rewrite `globalThis.process` to `require('process')`, so the stream (and crypto) polyfills pull in the browser `node:process` polyfill instead of the host global.
- `process.js`: read `item.args` in `drainQueue`, matching what `nextTick` pushes.

### Verification

New tests in `test/bundler/bundler_browser.test.ts`:

- `browser/NodeStreamWithoutGlobalProcess` bundles a `Readable.from()` consumer for `--target browser`, asserts the output contains no `globalThis.process`, and runs it after `delete globalThis.process`. Before this change the bundle throws `undefined is not an object (evaluating 'process.nextTick')`.
- `browser/NodeProcessNextTickForwardsArgs` checks that `nextTick(cb, a, b, c)` forwards its extra arguments. Before this change the callback receives `undefined, undefined, undefined` and the test prints `NaN`.

```
bun bd test test/bundler/bundler_browser.test.ts   # 15 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.0 (a30ba1d52)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [2022.50ms]
(pass) bundler > browser/NodeBuffer#12272 [993.73ms]
(pass) bundler > browser/NodeFS [505.18ms]
127 |       file: "/exec.js",
128 |       stdout: "got:a,b",
129 |     },
130 |     onAfterBundle(api) {
131 |       api.expectFile("out.js").not.toInclude("import ");
132 |       api.expectFile("out.js").not.toInclude("globalThis.process");
                                         ^
error: expect(received).not.toInclude(expected)

Expected to not include: "globalThis.process"
Received: "var __create = Object.create;\nvar __getProtoOf = Object.getPrototypeOf;\nvar __defProp = Object.defineProperty;\nvar __getOwnPropNames = Object.getOwnPropertyNames;\nvar __getOwnPropDesc = Object.getOwnPropertyDescriptor;\nvar __hasOwnProp = Object.prototype.hasOwnProperty;\nfunction __accessProp(key) {\n  return this[key];\n}\nvar __toESMCache_node;\nvar __toESMCache_esm;\nvar __toESM = (mod, isNodeMo
... (truncated)

release without fix: 2 skipped
bun test v1.4.0-canary.1 (ac9962ca6)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [45.05ms]
(pass) bundler > browser/NodeBuffer#12272 [28.22ms]
(pass) bundler > browser/NodeFS [15.14ms]
(pass) bundler > browser/NodeStreamWithoutGlobalProcess [58.29ms]
(pass) bundler > browser/NodeProcessNextTickForwardsArgs [18.55ms]
(pass) bundler > browser/NodeTTY [14.61ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [18.75ms]
(pass) bundler > browser/NodePolyfills [223.76ms]
(todo) bundler > browser/NodePolyfillExternal
(skip) bundler > browser/BunPolyfill
(pass) bundler > browser/ImportBunError [4.41ms]
(pass) bundler > browser/BunPolyfillExternal [9.40ms]
(pass) bundler > browser/ImportNonExistentNodeBuiltinShouldError [2.59ms]
(pass) bundler > browser/ImportNonExistentWithoutNodePrefix [3.01ms]
(pass) bundler > browser/TargetNodeNonExistentBuiltinShouldBeExternal [4.32ms]
(pass) bundler > browser/AwaitUsingStatement [15.92ms]
(pass) bundler > browser/UsingStatement [15.90ms]

 15 pass
 1 skip
 1 todo
 0 fail
 18 expect() calls
Ran 17 tests across 1 file. [738.00ms]
__F:0:S:2
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_browser.test.ts
bun test v1.4.0 (a30ba1d52)

test/bundler/bundler_browser.test.ts:
(pass) bundler > browser/NodeBuffer#21522 [1461.13ms]
(pass) bundler > browser/NodeBuffer#12272 [731.30ms]
(pass) bundler > browser/NodeFS [405.95ms]
(pass) bundler > browser/NodeStreamWithoutGlobalProcess [2021.72ms]
(pass) bundler > browser/NodeProcessNextTickForwardsArgs [570.84ms]
(pass) bundler > browser/NodeTTY [455.99ms]
(pass) bundler > browser/NodeUrlProtocolTablesIgnorePrototype [838.07ms]
(pass) bundler > browser/NodePolyfills [7899.96ms]
(todo) bundler > browser/NodePolyfillExternal
(skip) bundler > browser/BunPolyfill
(pass) bundler > browser/ImportBunError [124.76ms]
(pass) bundler > browser/BunPolyfillExternal [513.45ms]
(pass) bundler > browser/ImportNonExistentNodeBuiltinShouldError [76.94ms]
(pass) bundler > browser/ImportNonExistentWithoutNodePrefix [74.01ms]
(pass) bundler > browser/TargetNodeNonExistentBuiltinShouldBeExternal [93.80ms]
(pass) bundler > browser/AwaitUsingStatement [395.78ms]
(pass) bundler > brows
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 894ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] cc obj/packages/bun-usockets/src/context.c.o
[2/136] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[3/136] cc obj/packages/bun-usockets/src/bsd.c.o
[4/136] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[5/136] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[6/136] cc obj/packages/bun-usockets/src/loop.c.o
[7/136] cc obj/packages/bun-usockets/src/socket.c.o
[8/136] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[9/136] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[10/136] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[11/136] cc obj/src/jsc/bindings/uv-posix-polyfills.c.o
[12/136] cc obj/src/jsc/bindings/uv-posix-stubs.c.o
[13/136] cc obj/packages/bun-usockets/src/fault_inject.c.o
[14/136] cc obj/packages/bun-usockets/src/udp.c.o
[15/136] cc obj/packages/bun-usockets/src/quic.c.o
[16/136] cc obj/vendor/picohttpparser/picohttpparser.c.o
[17/136] gen cpp.rs (cppbind)
[18/136] gen node-fallbacks/*.js
[18/136] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/node-fallbacks/build-fallbacks.ts |  7 ++++-
 src/node-fallbacks/process.js         |  2 +-
 test/bundler/bundler_browser.test.ts  | 53 +++++++++++++++++++++++++++++++++++
 3 files changed, 60 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/node-fallbacks/build-fallbacks.ts      2      3      0
src/node-fallbacks/process.js              1      1      0
test/bundler/bundler_browser.test.ts       3      3      0
```

</details>

<!-- robobun:evidence:end -->