### PR TITLE
spawnSync: buffer ReadableStream/Response stdin on the main loop instead of throwing

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -956,16 +956,12 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
             };
             let stream_value = stream.value;
             stream_value.ensure_still_alive();
-            let bytes_result = global_this.readable_stream_to_bytes(stream_value);
-            if global_this.has_exception() {
-                return Err(JsError::Thrown);
-            }
+            let bytes_result = jsc::from_js_host_call(global_this, || {
+                global_this.readable_stream_to_bytes(stream_value)
+            })?;
             let bytes_value = match bytes_result.as_any_promise() {
                 Some(promise) => {
                     jsc_vm.wait_for_promise(promise);
-                    if global_this.has_exception() {
-                        return Err(JsError::Thrown);
-                    }
                     match promise.unwrap(global_this.vm(), jsc::js_promise::UnwrapMode::MarkHandled)
                     {
                         jsc::js_promise::Unwrapped::Fulfilled(v) => v,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -942,6 +942,13 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
         // or run microtasks, so a ReadableStream stdin (e.g. a streaming fetch
         // Response body) would never progress there. Drain it to bytes on the
         // main event loop before entering the isolated loop.
+        //
+        // `timeout`/`signal` are wired up only after the child is spawned, so
+        // this drain is unbounded (Node's `timeout` is child runtime only; the
+        // `stdin: await res.arrayBuffer()` workaround has the same hang).
+        // Bound a network body at its source: `fetch(url, { signal:
+        // AbortSignal.timeout(n) })` fires here because `wait_for_promise`
+        // ticks the main loop.
         if matches!(stdio[0], Stdio::ReadableStream(_)) {
             let Stdio::ReadableStream(stream) = core::mem::replace(&mut stdio[0], Stdio::Ignore)
             else {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -959,8 +959,7 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                     if global_this.has_exception() {
                         return Err(JsError::Thrown);
                     }
-                    match promise
-                        .unwrap(global_this.vm(), jsc::js_promise::UnwrapMode::MarkHandled)
+                    match promise.unwrap(global_this.vm(), jsc::js_promise::UnwrapMode::MarkHandled)
                     {
                         jsc::js_promise::Unwrapped::Fulfilled(v) => v,
                         jsc::js_promise::Unwrapped::Rejected(err) => {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -938,17 +938,10 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     let _ = &inherited_env_storage;
 
     if IS_SYNC {
-        // spawnSync runs on an isolated uws loop that cannot receive HTTP data
-        // or run microtasks, so a ReadableStream stdin (e.g. a streaming fetch
-        // Response body) would never progress there. Drain it to bytes on the
-        // main event loop before entering the isolated loop.
-        //
-        // `timeout`/`signal` are wired up only after the child is spawned, so
-        // this drain is unbounded (Node's `timeout` is child runtime only; the
-        // `stdin: await res.arrayBuffer()` workaround has the same hang).
-        // Bound a network body at its source: `fetch(url, { signal:
-        // AbortSignal.timeout(n) })` fires here because `wait_for_promise`
-        // ticks the main loop.
+        // The isolated uws loop cannot receive HTTP data or run microtasks,
+        // so drain a streaming stdin to bytes on the main loop first.
+        // `timeout`/`signal` do not bound this drain (Node's `timeout` is
+        // child runtime only).
         if matches!(stdio[0], Stdio::ReadableStream(_)) {
             let Stdio::ReadableStream(stream) = core::mem::replace(&mut stdio[0], Stdio::Ignore)
             else {

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -937,6 +937,59 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     }
     let _ = &inherited_env_storage;
 
+    if IS_SYNC {
+        // spawnSync runs on an isolated uws loop that cannot receive HTTP data
+        // or run microtasks, so a ReadableStream stdin (e.g. a streaming fetch
+        // Response body) would never progress there. Drain it to bytes on the
+        // main event loop before entering the isolated loop.
+        if matches!(stdio[0], Stdio::ReadableStream(_)) {
+            let Stdio::ReadableStream(stream) = core::mem::replace(&mut stdio[0], Stdio::Ignore)
+            else {
+                unreachable!()
+            };
+            let stream_value = stream.value;
+            stream_value.ensure_still_alive();
+            let bytes_result = global_this.readable_stream_to_bytes(stream_value);
+            if global_this.has_exception() {
+                return Err(JsError::Thrown);
+            }
+            let bytes_value = match bytes_result.as_any_promise() {
+                Some(promise) => {
+                    jsc_vm.wait_for_promise(promise);
+                    if global_this.has_exception() {
+                        return Err(JsError::Thrown);
+                    }
+                    match promise
+                        .unwrap(global_this.vm(), jsc::js_promise::UnwrapMode::MarkHandled)
+                    {
+                        jsc::js_promise::Unwrapped::Fulfilled(v) => v,
+                        jsc::js_promise::Unwrapped::Rejected(err) => {
+                            return Err(global_this.throw_value(err));
+                        }
+                        jsc::js_promise::Unwrapped::Pending => {
+                            return Err(global_this.throw_invalid_arguments(format_args!(
+                                "stdin ReadableStream did not settle before spawnSync"
+                            )));
+                        }
+                    }
+                }
+                None => bytes_result,
+            };
+            bytes_value.ensure_still_alive();
+            match bytes_value.as_array_buffer(global_this) {
+                Some(ab) if !ab.byte_slice().is_empty() => {
+                    stdio[0] = Stdio::ArrayBuffer(jsc::array_buffer::ArrayBufferStrong {
+                        array_buffer: ab,
+                        held: jsc::StrongOptional::create(bytes_value, global_this),
+                    });
+                }
+                _ => {
+                    stdio[0] = Stdio::Ignore;
+                }
+            }
+        }
+    }
+
     for fd_index in 0..stdio.len() {
         if stdio[fd_index].can_use_memfd() {
             if stdio[fd_index].use_memfd(fd_index as u32) {

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -390,10 +390,6 @@ impl Stdio {
                         .throw());
                 }
 
-                // For spawnSync, the stream is drained to bytes on the main
-                // event loop before the isolated loop is entered (the isolated
-                // loop cannot receive HTTP data or run microtasks). See
-                // `spawn_maybe_sync`.
                 *out_stdio = Stdio::ReadableStream(stream);
             }
         }

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -326,7 +326,6 @@ impl Stdio {
         global: &JSGlobalObject,
         i: i32,
         body: &mut webcore::body::Value,
-        is_sync: bool,
     ) -> JsResult<()> {
         body.to_blob_if_possible();
 
@@ -356,12 +355,6 @@ impl Stdio {
             | webcore::body::Value::WTFStringImpl(_)
             | webcore::body::Value::InternalBlob(_) => unreachable!(),
             webcore::body::Value::Locked(_) => {
-                if is_sync {
-                    return Err(global.throw_invalid_arguments(format_args!(
-                        "ReadableStream cannot be used in sync mode"
-                    )));
-                }
-
                 match i {
                     0 => {}
                     1 => {
@@ -397,6 +390,10 @@ impl Stdio {
                         .throw());
                 }
 
+                // For spawnSync, the stream is drained to bytes on the main
+                // event loop before the isolated loop is entered (the isolated
+                // loop cannot receive HTTP data or run microtasks). See
+                // `spawn_maybe_sync`.
                 *out_stdio = Stdio::ReadableStream(stream);
             }
         }
@@ -507,9 +504,9 @@ impl Stdio {
             // `value` is on the stack. `dupe()` only bumps the store refcount.
             return out_stdio.extract_blob(global, webcore::blob::Any::Blob(blob.dupe()), i);
         } else if let Some(req) = value.as_class_ref::<webcore::Request>() {
-            return Self::extract_body_value(out_stdio, global, i, req.get_body_value(), is_sync);
+            return Self::extract_body_value(out_stdio, global, i, req.get_body_value());
         } else if let Some(res) = value.as_class_ref::<webcore::Response>() {
-            return Self::extract_body_value(out_stdio, global, i, res.get_body_value(), is_sync);
+            return Self::extract_body_value(out_stdio, global, i, res.get_body_value());
         }
 
         if let Some(stream_) = webcore::ReadableStream::from_js(value, global)? {
@@ -529,7 +526,7 @@ impl Stdio {
                 }
             };
 
-            if is_sync {
+            if is_sync && i != 0 {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "'{}' ReadableStream cannot be used in sync mode",
                     bstr::BStr::new(name),

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts
@@ -1,23 +1,173 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunExe } from "harness";
+import { bunEnv, bunExe } from "harness";
+
+const childScript = `let n = 0; for await (const c of process.stdin) n += c.length; process.stdout.write("n=" + n);`;
 
 describe("spawnSync with ReadableStream stdin", () => {
-  test("spawnSync should throw", () => {
+  test("JS-authored ReadableStream is buffered before spawn", () => {
     const stream = new ReadableStream({
       async start(controller) {
         await 42;
-        controller.enqueue("test data");
+        controller.enqueue(new TextEncoder().encode("test data"));
         controller.close();
+      },
+    });
+
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", childScript],
+      stdin: stream,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString()).toBe("n=9");
+    expect(exitCode).toBe(0);
+  });
+
+  test("ReadableStream with multiple async chunks", () => {
+    let pulls = 0;
+    const stream = new ReadableStream({
+      async pull(controller) {
+        await Promise.resolve();
+        if (pulls++ === 4) return controller.close();
+        controller.enqueue(new Uint8Array(16).fill(97));
+      },
+    });
+
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", childScript],
+      stdin: stream,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString()).toBe("n=64");
+    expect(exitCode).toBe(0);
+  });
+
+  test("ReadableStream that errors rejects the spawnSync call", () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+        controller.error(new Error("boom from stream"));
       },
     });
 
     expect(() =>
       spawnSync({
-        cmd: [bunExe()],
+        cmd: [bunExe(), "-e", childScript],
         stdin: stream,
         stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
       }),
-    ).toThrowErrorMatchingInlineSnapshot(`"'stdin' ReadableStream cannot be used in sync mode"`);
+    ).toThrow("boom from stream");
+  });
+
+  test("empty ReadableStream", () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", childScript],
+      stdin: stream,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString()).toBe("n=0");
+    expect(exitCode).toBe(0);
+  });
+
+  test("stdout/stderr ReadableStream still rejected in sync mode", () => {
+    const stream = new ReadableStream({ start: c => c.close() });
+    expect(() =>
+      spawnSync({
+        cmd: [bunExe(), "-e", ""],
+        stdout: stream as any,
+        env: bunEnv,
+      }),
+    ).toThrow(/ReadableStream cannot be used in sync mode/);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/5991
+describe("spawnSync with streaming fetch Response stdin", () => {
+  async function makeServer(totalBytes: number, chunk = 32 * 1024) {
+    return Bun.serve({
+      port: 0,
+      async fetch() {
+        let sent = 0;
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(c: any) {
+              const buf = Buffer.alloc(chunk, "a");
+              while (sent < totalBytes) {
+                const n = Math.min(chunk, totalBytes - sent);
+                c.write(buf.subarray(0, n));
+                await c.flush();
+                sent += n;
+              }
+              c.close();
+            },
+          }),
+        );
+      },
+    });
+  }
+
+  test("Response whose body is still arriving", async () => {
+    const total = 128 * 1024;
+    await using server = await makeServer(total);
+    const res = await fetch(server.url);
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", childScript],
+      stdin: res,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString()).toBe(`n=${total}`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("res.body (ReadableStream) directly", async () => {
+    const total = 64 * 1024;
+    await using server = await makeServer(total);
+    const res = await fetch(server.url);
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", childScript],
+      stdin: res.body!,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    expect(stderr.toString()).toBe("");
+    expect(stdout.toString()).toBe(`n=${total}`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("Response whose body has been consumed throws", async () => {
+    await using server = await makeServer(1024, 1024);
+    const res = await fetch(server.url);
+    await res.arrayBuffer();
+    expect(() =>
+      spawnSync({
+        cmd: [bunExe(), "-e", childScript],
+        stdin: res,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: bunEnv,
+      }),
+    ).toThrow(/already.*used/i);
   });
 });

--- a/test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts
@@ -86,6 +86,43 @@ describe("spawnSync with ReadableStream stdin", () => {
     expect(exitCode).toBe(0);
   });
 
+  // The stdin drain runs on the main event loop (before the child is
+  // spawned and before the isolated loop is entered), so queued microtasks
+  // fire while the stream is being buffered. This is the same as if the
+  // caller had written `const b = await res.bytes(); spawnSync({ stdin: b
+  // })`. The isolated-loop invariants (no microtasks/timers while the child
+  // runs) still hold because the child has not started yet. Timers may also
+  // fire if the drain reaches `auto_tick()` (e.g. for a network body), but
+  // that is not deterministic for a pure-microtask stream so only the
+  // microtask is asserted here.
+  test("main-loop microtasks run during the pre-spawn stdin drain", () => {
+    let microtask: "before" | "during" | undefined;
+    let inSpawnSync = false;
+    queueMicrotask(() => {
+      microtask = inSpawnSync ? "during" : "before";
+    });
+    let pulls = 0;
+    const stream = new ReadableStream({
+      async pull(c) {
+        await Promise.resolve();
+        if (pulls++ === 0) return c.enqueue(new TextEncoder().encode("x"));
+        c.close();
+      },
+    });
+    inSpawnSync = true;
+    const { stdout, exitCode } = spawnSync({
+      cmd: [bunExe(), "-e", childScript],
+      stdin: stream,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    inSpawnSync = false;
+    expect(microtask).toBe("during");
+    expect(stdout.toString()).toBe("n=1");
+    expect(exitCode).toBe(0);
+  });
+
   test("stdout/stderr ReadableStream still rejected in sync mode", () => {
     const stream = new ReadableStream({ start: c => c.close() });
     expect(() =>

--- a/test/regression/issue/05991.test.ts
+++ b/test/regression/issue/05991.test.ts
@@ -1,0 +1,48 @@
+// https://github.com/oven-sh/bun/issues/5991
+// spawnSync with a streaming fetch Response as stdin threw
+// "ReadableStream cannot be used in sync mode" (and before that, truncated
+// the body). It should buffer the body and deliver all of it to the child.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("spawnSync stdin: streaming fetch Response delivers the full body", async () => {
+  const total = 256 * 1024;
+  await using server = Bun.serve({
+    port: 0,
+    fetch() {
+      let sent = 0;
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          async pull(c: any) {
+            const chunk = Buffer.alloc(64 * 1024, "x");
+            while (sent < total) {
+              c.write(chunk);
+              await c.flush();
+              sent += chunk.length;
+            }
+            c.close();
+          },
+        }),
+        { headers: { "Content-Type": "application/octet-stream" } },
+      );
+    },
+  });
+
+  const res = await fetch(server.url);
+  const { stdout, stderr, exitCode } = Bun.spawnSync({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let n = 0; for await (const c of process.stdin) n += c.length; process.stdout.write(String(n));`,
+    ],
+    stdin: res,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+
+  expect(stderr.toString()).toBe("");
+  expect(stdout.toString()).toBe(String(total));
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`Bun.spawnSync({ stdin: await fetch(url) })` threw `TypeError: ReadableStream cannot be used in sync mode` whenever the fetch body was still arriving (i.e. not synchronously convertible to a blob). The same happened for `stdin: res.body` and for any JS-authored `ReadableStream`. This is the primary pattern from #5991 (pipe a download into `tar`), and it used to work before spawnSync gained its isolated event loop.

## Repro

```js
await using server = Bun.serve({
  port: 0,
  fetch: () => new Response(new ReadableStream({
    type: "direct",
    async pull(c) { c.write(Buffer.alloc(128 * 1024)); await c.flush(); c.close(); },
  })),
});
const res = await fetch(server.url);
Bun.spawnSync(["wc", "-c"], { stdin: res });
// TypeError: ReadableStream cannot be used in sync mode
```

## Cause

`Stdio::extract`/`extract_body_value` rejected any `ReadableStream` stdin when `is_sync` was set. spawnSync's wait loop runs on an isolated `uws::Loop` that neither receives HTTP data from the main loop nor drains microtasks, so a streaming body cannot be pumped concurrently with the child the way async `Bun.spawn` does.

## Fix

Let a `ReadableStream` stdin through in sync mode, then in `spawn_maybe_sync` (before the isolated event loop is prepared and before the child is spawned) drain it to a `Uint8Array` via `readable_stream_to_bytes` + `wait_for_promise` on the main event loop. The buffered bytes go through the existing `Stdio::ArrayBuffer`/memfd path, so the child sees the full body on stdin. A stream that errors rejects `spawnSync` with the stream's error. `stdout`/`stderr` ReadableStreams are still rejected in sync mode.

Two trade-offs, both the same as the `stdin: await res.bytes()` workaround a user would write today:
- The whole body is held in memory before the child starts.
- The drain ticks the main event loop, so queued microtasks (and timers if `auto_tick()` is reached) run before the child is spawned. The isolated-loop invariants (no microtasks/timers while the child is running) still hold because the child has not started yet. Pinned by a test.
- `timeout`/`signal` apply to child runtime only (matching Node). A stalled network body can be bounded at the source with `fetch(url, { signal: AbortSignal.timeout(n) })`, which fires during the drain.

## Verification

`test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts` now covers: JS-authored pull/start streams, an erroring stream, an empty stream, main-loop microtasks running during the drain, the stdout/stderr sync rejection, a streaming fetch `Response`, `res.body` directly, and an already-consumed body. `test/regression/issue/05991.test.ts` is the issue-shaped fetch repro.

Before: 7 of 9 sync tests fail with `ReadableStream cannot be used in sync mode`; the regression test fails the same way.
After: all 9 sync tests and the regression test pass; `spawnSync.test.ts`, `spawn-stdin-readable-stream.test.ts`, `spawnsync-no-microtask-drain.test.ts`, and `spawnsync-isolated-event-loop.test.ts` are unchanged.

Fixes #5991

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts "test/regression/issue/05991.test.ts"
bun test v1.4.0 (350c59251)

test/regression/issue/05991.test.ts:
28 |       );
29 |     },
30 |   });
31 | 
32 |   const res = await fetch(server.url);
33 |   const { stdout, stderr, exitCode } = Bun.spawnSync({
                                                ^
TypeError: ReadableStream cannot be used in sync mode
 code: "ERR_INVALID_ARG_TYPE"

      at <anonymous> (/workspace/bun/test/regression/issue/05991.test.ts:33:44)
(fail) spawnSync stdin: streaming fetch Response delivers the full body [79.98ms]

test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts:
12 |         controller.enqueue(new TextEncoder().encode("test data"));
13 |         controller.close();
14 |       },
15 |     });
16 | 
17 |     const { stdout, stderr, exitCode } = spawnSync({
                                              ^
TypeError: 'stdin' ReadableStream cannot be used in sync mode
      at <anonymous> (/workspace/bun/test/js/bun/spawn/spawn-stdin-readable-s
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/regression/issue/05991.test.ts:
28 |       );
29 |     },
30 |   });
31 | 
32 |   const res = await fetch(server.url);
33 |   const { stdout, stderr, exitCode } = Bun.spawnSync({
                                                ^
TypeError: ReadableStream cannot be used in sync mode
 code: "ERR_INVALID_ARG_TYPE"

      at <anonymous> (/workspace/bun/test/regression/issue/05991.test.ts:33:44)
(fail) spawnSync stdin: streaming fetch Response delivers the full body [3.93ms]

test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts:
12 |         controller.enqueue(new TextEncoder().encode("test data"));
13 |         controller.close();
14 |       },
15 |     });
16 | 
17 |     const { stdout, stderr, exitCode } = spawnSync({
                                              ^
TypeError: 'stdin' ReadableStream cannot be used in sync mode
      at <anonymous> (/workspace/bun/test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts:17:42)
(fail) spawnSync with ReadableStream stdin > JS-authored ReadableStream is buffered before spawn [0.59ms]
34 |         if (pulls++ === 4) return controller.close();
35 |         controller.enqueue
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts "test/regression/issue/05991.test.ts"
bun test v1.4.0 (350c59251)

test/regression/issue/05991.test.ts:
(pass) spawnSync stdin: streaming fetch Response delivers the full body [1475.03ms]

test/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts:
(pass) spawnSync with ReadableStream stdin > JS-authored ReadableStream is buffered before spawn [1396.56ms]
(pass) spawnSync with ReadableStream stdin > ReadableStream with multiple async chunks [1408.77ms]
(pass) spawnSync with ReadableStream stdin > ReadableStream that errors rejects the spawnSync call [8.99ms]
(pass) spawnSync with ReadableStream stdin > empty ReadableStream [1354.26ms]
(pass) spawnSync with ReadableStream stdin > main-loop microtasks run during the pre-spawn stdin drain [1413.89ms]
(pass) spawnSync with ReadableStream stdin > stdout/stderr ReadableStream still rejected in sync mode [9.92ms]
(pass) spawnSync with streaming fetch Response stdin > Response whose body is still arriving [1457.70ms]
(pass) spawnSync w
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     350c592514
  features     baseline

22 deps, 108 codegen, 1170 objects in 834ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [32.00ms]
[2/1233] gen ErrorCode+*.h
[3/1233] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1233] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[5/1233] gen bindgenv2
[6/1233] fetch tinycc
[tinycc] up to date
[7/1233] fetch picohttpparser
[picohttpparser] up to date
[8/1233] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1233] gen .bind.ts → GeneratedBindings.cpp
[10/1233] fetch zlib
[zlib] up to date
[11/1233] subst deps/libjpeg-turbo/jconfig.h
[12/1233] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/js_bun_spawn_bindings.rs       |  59 ++++++
 src/runtime/api/bun/spawn/stdio.rs                 |  17 +-
 .../spawn/spawn-stdin-readable-stream-sync.test.ts | 197 ++++++++++++++++++++-
 test/regression/issue/05991.test.ts                |  48 +++++
 4 files changed, 306 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/api/bun/js_bun_spawn_bindings.rs                  7      2      0
src/runtime/api/bun/spawn/stdio.rs                            3      6      0
…t/js/bun/spawn/spawn-stdin-readable-stream-sync.test.ts      1      4      0
test/regression/issue/05991.test.ts                           0      1      0
```

</details>

<!-- robobun:evidence:end -->