### PR TITLE
node: cli eval/--print v26 compat fixes (+1 test)

### DIFF
--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -48,6 +48,8 @@ const {
   generateKeyPairSync,
 
   X509Certificate,
+
+  nativeWebCrypto,
 } = $cpp("node_crypto_binding.cpp", "createNodeCryptoBinding");
 
 const {
@@ -130,7 +132,10 @@ function getArrayBufferOrView(buffer, name, encoding?) {
   return buffer;
 }
 
-const crypto = globalThis.crypto;
+// The native WebCrypto object, NOT `globalThis.crypto`: the global is
+// user-replaceable, and in `-e`/`-p` mode it resolves to this very module
+// (node's eval semantics), which would recurse into this initializer.
+const crypto = nativeWebCrypto;
 
 var crypto_exports: any = {};
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4183,29 +4183,67 @@ pub mod formatter {
             writer_: &mut dyn bun_io::Write,
             value: JSValue,
         ) -> JsResult<()> {
+            // `JSPromise` is an `opaque_ffi!` ZST handle; `opaque_mut` is the
+            // centralised non-null deref proof (Tag::Promise ⇒ value is a cell).
+            let promise: &mut JSPromise = JSPromise::opaque_mut(value.encoded() as *mut JSPromise);
+            let status = promise.status();
+
+            // node (util.inspect formatPromise): `Promise { <pending> }`,
+            // `Promise { 42 }`, `Promise { <rejected> reason }`.
+            {
+                let mut writer = WrappedWriter {
+                    ctx: writer_,
+                    failed: false,
+                    estimated_line_length: &mut self.estimated_line_length,
+                };
+                if !self.single_line && writer.good_time_for_a_new_line(self.indent) {
+                    writer.write_all(b"\n");
+                    writer.write_indent(self.indent);
+                }
+
+                writer.write_all(b"Promise { ");
+                match status {
+                    jsc::js_promise::Status::Pending => {
+                        writer.write_all(pfmt!("<r><cyan>", C).as_bytes());
+                        writer.write_all(b"<pending>");
+                        writer.write_all(pfmt!("<r>", C).as_bytes());
+                    }
+                    jsc::js_promise::Status::Fulfilled => {}
+                    jsc::js_promise::Status::Rejected => {
+                        writer.write_all(pfmt!("<r><cyan>", C).as_bytes());
+                        writer.write_all(b"<rejected>");
+                        writer.write_all(pfmt!("<r>", C).as_bytes());
+                        writer.write_all(b" ");
+                    }
+                }
+                if writer.failed {
+                    self.failed = true;
+                    return Ok(());
+                }
+            }
+
+            if !matches!(status, jsc::js_promise::Status::Pending) {
+                let result = promise.result(self.global_this.vm());
+
+                let prev_quote_strings = self.quote_strings;
+                self.quote_strings = true;
+                let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
+                self.depth = self.depth.saturating_add(1);
+                let _d = defer_decrement!(self.depth);
+
+                let mut opts = TagOptions::HIDE_GLOBAL;
+                if self.disable_inspect_custom {
+                    opts |= TagOptions::DISABLE_INSPECT_CUSTOM;
+                }
+                let tag = Tag::get_advanced(result, self.global_this, opts)?;
+                self.format::<C>(tag, writer_, result, self.global_this)?;
+            }
+
             let mut writer = WrappedWriter {
                 ctx: writer_,
                 failed: false,
                 estimated_line_length: &mut self.estimated_line_length,
             };
-            if !self.single_line && writer.good_time_for_a_new_line(self.indent) {
-                writer.write_all(b"\n");
-                writer.write_indent(self.indent);
-            }
-
-            writer.write_all(b"Promise { ");
-            writer.write_all(pfmt!("<r><cyan>", C).as_bytes());
-
-            // `JSPromise` is an `opaque_ffi!` ZST handle; `opaque_ref` is the
-            // centralised non-null deref proof (Tag::Promise ⇒ value is a cell).
-            let promise: &JSPromise = JSPromise::opaque_ref(value.encoded() as *const JSPromise);
-            match promise.status() {
-                jsc::js_promise::Status::Pending => writer.write_all(b"<pending>"),
-                jsc::js_promise::Status::Fulfilled => writer.write_all(b"<resolved>"),
-                jsc::js_promise::Status::Rejected => writer.write_all(b"<rejected>"),
-            }
-
-            writer.write_all(pfmt!("<r>", C).as_bytes());
             writer.write_all(b" }");
             if writer.failed {
                 self.failed = true;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -73,6 +73,14 @@ pub type ExceptionList = Vec<crate::schema_api::JsException>;
 pub struct EntryPointResult {
     pub value: crate::strong::Optional, // jsc.Strong.Optional
     pub cjs_set_value: bool,
+    /// `value` is the internal async-capability promise of a top-level-await
+    /// module (see `EvalGlobalObject::moduleLoaderEvaluate`), not the user's
+    /// completion value — `--print` unwraps it instead of logging it.
+    pub esm_capability: bool,
+    /// `--print` already emitted its output. The print must happen exactly
+    /// once, on the first of event-loop drain or `process.exit()` — mirrors
+    /// node's `runScriptInContext` (beforeExit/exit pair).
+    pub printed: bool,
 }
 
 /// Downstream-compat alias: lib.rs previously exposed `virtual_machine::InitOptions`.
@@ -191,6 +199,9 @@ pub struct VirtualMachine {
     // `transpiler.resolver.standalone_module_graph` without a downcast.
     pub standalone_module_graph: Option<&'static dyn bun_resolver::StandaloneModuleGraph>,
     pub smol: bool,
+    /// `--print` (`bun -p`): [`print_eval_result_if_needed`] logs the
+    /// entry-point completion value on drain or `process.exit()`.
+    pub eval_and_print: bool,
     // LAYERING: real type is `bun_runtime::api::dns::Resolver::Order` (forward
     // dep); stored as its `u8` repr.
     pub dns_result_order: u8,
@@ -1486,6 +1497,89 @@ impl VirtualMachine {
         }
     }
 
+    /// `--print`: log the entry-point completion value exactly once, without
+    /// unwrapping promises — node prints `util.inspect` of the value on the
+    /// first of beforeExit/exit (`runScriptInContext` in
+    /// lib/internal/process/execution.js), so `-p 'Promise.resolve(42)'`
+    /// prints `Promise { 42 }` and a promise still pending when
+    /// `process.exit()` fires prints `Promise { <pending> }`.
+    ///
+    /// Only the CJS eval path takes this route; the ESM top-level-await path
+    /// stores an internal capability promise (see `setEntryPointEvalResultESM`
+    /// in ZigGlobalObject.cpp) that `Run::start` unwraps — node refuses ESM
+    /// `--print` input outright (`ERR_EVAL_ESM_CANNOT_PRINT`), so that
+    /// unwrapping remains a Bun extension.
+    pub fn print_eval_result_if_needed(&mut self) {
+        if !self.eval_and_print
+            || self.entry_point_result.printed
+            || self.entry_point_result.esm_capability
+            || !self.entry_point_result.value.has()
+        {
+            return;
+        }
+        self.entry_point_result.printed = true;
+        let result = self
+            .entry_point_result
+            .value
+            .get()
+            .unwrap_or(JSValue::UNDEFINED);
+
+        // node prints through console.log: a string value is written verbatim,
+        // everything else renders with util.inspect defaults. Bun's native
+        // console formatter deliberately differs from node's inspect, so route
+        // through the node util.inspect port for output parity — except JSX,
+        // a Bun extension node has no rendering for, which keeps the native
+        // console's `<hello>world</hello>` form.
+        if result.is_string() {
+            if let Ok(text) = crate::bun_string_jsc::from_js(result, self.global()) {
+                let utf8 = text.to_utf8();
+                bun_core::Output::println(format_args!("{}", bstr::BStr::new(utf8.slice())));
+                bun_core::Output::flush();
+                return;
+            }
+        }
+        let is_jsx = matches!(
+            crate::console_object::Tag::get_advanced(
+                result,
+                self.global(),
+                crate::console_object::TagOptions::HIDE_GLOBAL,
+            )
+            .map(|r| r.tag.tag()),
+            Ok(crate::console_object::Tag::JSX)
+        );
+        let inspected = if is_jsx {
+            JSValue::ZERO
+        } else {
+            crate::cpp::Bun__inspectEvalResultForPrint(
+                self.global(),
+                result,
+                bun_core::Output::enable_ansi_colors_stdout(),
+            )
+        };
+        if !inspected.is_empty_or_undefined_or_null() && inspected.is_string() {
+            if let Ok(text) = crate::bun_string_jsc::from_js(inspected, self.global()) {
+                let utf8 = text.to_utf8();
+                bun_core::Output::println(format_args!("{}", bstr::BStr::new(utf8.slice())));
+                bun_core::Output::flush();
+                return;
+            }
+        }
+
+        // Fallback (inspect unavailable or threw): the native console formatter.
+        // SAFETY: `&raw const result` is a single live stack slot; a null
+        // `ctype` routes to the per-VM console (stdout).
+        unsafe {
+            crate::console_object::message_with_type_and_level(
+                ::core::ptr::null_mut(),
+                crate::console_object::MessageType::Log,
+                crate::console_object::MessageLevel::Log,
+                self.global(),
+                &raw const result,
+                1,
+            );
+        }
+    }
+
     pub fn on_exit(&mut self) {
         // Write CPU profile if profiling was enabled - do this FIRST before any
         // shutdown begins. Grab the config and null it out to make this
@@ -2113,6 +2207,7 @@ impl VirtualMachine {
             addr_of_mut!((*vm).origin_timer).write(std::time::Instant::now());
             addr_of_mut!((*vm).origin_timestamp).write(get_origin_timestamp());
             addr_of_mut!((*vm).smol).write(opts.smol);
+            addr_of_mut!((*vm).eval_and_print).write(opts.eval_mode);
             // `Option<{CPU,Heap}ProfilerConfig>` are NOT zero-valid: each
             // payload contains a `bool`, and rustc picks that field's invalid
             // range (not the `&[u8]` null-ptr) as the enum niche, so all-zero
@@ -4744,6 +4839,8 @@ impl VirtualMachine {
         self.overridden_main.deinit();
         self.entry_point_result.value.deinit();
         self.entry_point_result.cjs_set_value = false;
+        self.entry_point_result.esm_capability = false;
+        self.entry_point_result.printed = false;
         if let Some(promise) = self.pending_internal_promise {
             if self.pending_internal_promise_is_protected {
                 JSValue::from_cell(promise).unprotect();

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -18,6 +18,12 @@
 #pragma push_macro("assert")
 #undef assert
 
+// For `-e`/`-p` scripts, node exposes every require()-able builtin as a lazy,
+// re-assignable global (addBuiltinLibsToObject in lib/internal/modules/helpers.js).
+// `crypto` is included: node's eval_string.js special-cases code mentioning
+// crypto so the identifier resolves to node:crypto rather than WebCrypto; the
+// CustomValue accessor below has the same effect (and plain assignment
+// replaces it, like node's setReal).
 #define FOREACH_EXPOSED_BUILTIN_IMR(v)     \
     v(ffi,                    Bun::InternalModuleRegistry::BunFFI) \
     v(assert,                 Bun::InternalModuleRegistry::NodeAssert) \
@@ -56,6 +62,7 @@
     v(worker_threads,         Bun::InternalModuleRegistry::NodeWorkerThreads) \
     v(zlib,                   Bun::InternalModuleRegistry::NodeZlib) \
     v(constants,              Bun::InternalModuleRegistry::NodeConstants) \
+    v(crypto,                 Bun::InternalModuleRegistry::NodeCrypto) \
     v(string_decoder,         Bun::InternalModuleRegistry::NodeStringDecoder) \
     v(buffer,                 Bun::InternalModuleRegistry::NodeBuffer) \
     v(jsc,                    Bun::InternalModuleRegistry::BunJSC) \

--- a/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
+++ b/src/jsc/bindings/ExposeNodeModuleGlobals.cpp
@@ -93,6 +93,49 @@ extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__ExposeNodeModuleGlobals(Zig::Global
 #undef PUT_CUSTOM_GETTER_SETTER
 }
 
+// `--print` output: node logs the completion value through console.log, whose
+// rendering is util.inspect with default options. Bun's native console
+// formatter deliberately differs from node's, so `-p` routes its final value
+// through the node util.inspect port for byte-level output parity.
+// Returns the inspected string, or empty (after clearing the exception, like
+// Bun__preExecutionBootstrap above) so the Rust caller can fall back to the
+// native console formatter.
+extern "C" [[ZIG_EXPORT(nothrow)]] JSC::EncodedJSValue Bun__inspectEvalResultForPrint(
+    Zig::GlobalObject* globalObject, JSC::EncodedJSValue encodedValue, bool colors)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSC::JSValue util = globalObject->internalModuleRegistry()->requireId(
+        globalObject, vm, Bun::InternalModuleRegistry::NodeUtil);
+    if (scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        return {};
+    }
+    if (!util.isObject())
+        return {};
+    JSC::JSValue inspect = util.get(globalObject, JSC::Identifier::fromString(vm, "inspect"_s));
+    if (scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        return {};
+    }
+    auto callData = JSC::getCallData(inspect);
+    if (callData.type == JSC::CallData::Type::None)
+        return {};
+    auto* options = JSC::constructEmptyObject(globalObject);
+    options->putDirect(vm, JSC::Identifier::fromString(vm, "colors"_s), JSC::jsBoolean(colors));
+    JSC::MarkedArgumentBuffer args;
+    args.append(JSC::JSValue::decode(encodedValue));
+    args.append(options);
+    JSC::JSValue result = JSC::call(globalObject, inspect, callData, util, args);
+    if (scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        return {};
+    }
+    if (!result.isString())
+        return {};
+    return JSC::JSValue::encode(result);
+}
+
 // Evaluate `internal/process/pre_execution` before any user code runs.
 // Called from VirtualMachine::reload_entry_point when argv carries a
 // Node.js `--trace-*` flag. The registry caches the module, so repeat calls

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3876,7 +3876,7 @@ JSC::JSValue GlobalObject::moduleLoaderEvaluate(JSGlobalObject* lexicalGlobalObj
 }
 
 extern "C" bool Bun__VM__specifierIsEvalEntryPoint(void*, EncodedJSValue);
-extern "C" void Bun__VM__setEntryPointEvalResultESM(void*, EncodedJSValue);
+extern "C" void Bun__VM__setEntryPointEvalResultESM(void*, EncodedJSValue, bool isAsyncCapability);
 
 JSC::JSValue EvalGlobalObject::moduleLoaderEvaluate(JSGlobalObject* lexicalGlobalObject,
     JSModuleLoader* moduleLoader, JSValue key,
@@ -3905,19 +3905,22 @@ JSC::JSValue EvalGlobalObject::moduleLoaderEvaluate(JSGlobalObject* lexicalGloba
         // so we can't rely on a later call to overwrite the captured value.
         //
         // Instead, when the module yielded, capture the async capability's
-        // promise. Its resolution value is the module's final completion
-        // value; the --print loop in run_command.rs already unwraps promises
-        // via asAnyPromise + Bun__onResolveEntryPointResult.
+        // promise (flagged so the --print loop in run_command.rs unwraps it
+        // via asAnyPromise + Bun__onResolveEntryPointResult; a promise that is
+        // itself the completion value is logged verbatim like node does).
         JSC::JSValue valueToStore = result;
+        bool isAsyncCapability = false;
         if (auto* moduleRecord = dynamicDowncast<JSC::AbstractModuleRecord>(moduleRecordValue)) {
             JSC::JSValue state = moduleRecord->internalField(JSC::AbstractModuleRecord::Field::State).get();
             bool moduleYielded = state.isNumber() && state.asNumber() != static_cast<int32_t>(JSC::JSGenerator::State::Executing);
             if (moduleYielded) {
-                if (auto* capability = moduleRecord->asyncCapability())
+                if (auto* capability = moduleRecord->asyncCapability()) {
                     valueToStore = capability;
+                    isAsyncCapability = true;
+                }
             }
         }
-        Bun__VM__setEntryPointEvalResultESM(globalObject->bunVM(), JSValue::encode(valueToStore));
+        Bun__VM__setEntryPointEvalResultESM(globalObject->bunVM(), JSValue::encode(valueToStore), isAsyncCapability);
     }
 
     return result;

--- a/src/jsc/bindings/node/crypto/node_crypto_binding.cpp
+++ b/src/jsc/bindings/node/crypto/node_crypto_binding.cpp
@@ -327,6 +327,13 @@ JSValue createNodeCryptoBinding(Zig::GlobalObject* globalObject)
     VM& vm = globalObject->vm();
     JSObject* obj = constructEmptyObject(globalObject);
 
+    // The native WebCrypto object. node:crypto must not read
+    // `globalThis.crypto` for it: user code can replace that global, and in
+    // `-e`/`-p` mode it IS replaced (with node:crypto itself, matching node's
+    // eval semantics), which would recurse into this module's initializer.
+    obj->putDirect(vm, PropertyName(Identifier::fromString(vm, "nativeWebCrypto"_s)),
+        globalObject->cryptoObject(), 0);
+
     obj->putDirect(vm, PropertyName(Identifier::fromString(vm, "certVerifySpkac"_s)),
         JSFunction::create(vm, globalObject, 1, "verifySpkac"_s, jsCertVerifySpkac, ImplementationVisibility::Public, NoIntrinsic), 0);
     obj->putDirect(vm, PropertyName(Identifier::fromString(vm, "certExportPublicKey"_s)),

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1168,10 +1168,43 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
         }
 
         if let Some(script) = args.option(b"--print") {
-            ctx.runtime_options.eval.script = script.into();
             ctx.runtime_options.eval.eval_and_print = true;
+            if (script == b"-e" || script == b"--eval") && args.option(b"--eval").is_none() {
+                // node's `-p` is a bare flag and `-e` carries the code
+                // (`node -p -e "code"`), but bun's `-p` takes a value, so it
+                // swallows the literal `-e` token and the code lands in the
+                // entrypoint positional. Reclaim it; node consumes it too, so
+                // it must not stay in `positionals` (it would resolve as the
+                // run target and land in `process.argv`).
+                if ctx.positionals.is_empty() {
+                    // node: `node -p -e` → "<execPath>: -e requires an argument"
+                    // on stderr, exit code 9.
+                    let exe: &[u8] = bun_core::self_exe_path()
+                        .map(|p| p.as_bytes())
+                        .unwrap_or(b"bun");
+                    Output::pretty_error(&format_args!(
+                        "{}: -e requires an argument\n",
+                        BStr::new(exe)
+                    ));
+                    Output::flush();
+                    Global::exit(9);
+                }
+                ctx.runtime_options.eval.script = ctx.positionals.remove(0);
+            } else if let Some(code) = script.strip_prefix(b"--eval=") {
+                // `node --print --eval=-42`: the attached-value spelling for
+                // code starting with `-`.
+                ctx.runtime_options.eval.script = code.into();
+            } else {
+                ctx.runtime_options.eval.script = script.into();
+            }
         } else if let Some(script) = args.option(b"--eval") {
             ctx.runtime_options.eval.script = script.into();
+        }
+        // node: an eval expression starting with `-` can be escaped with a
+        // backslash (`node -p "\-42"` prints -42); strip the single leading
+        // backslash before it reaches the parser.
+        if ctx.runtime_options.eval.script.starts_with(b"\\-") {
+            ctx.runtime_options.eval.script = ctx.runtime_options.eval.script[1..].into();
         }
         ctx.runtime_options.if_present = args.flag(b"--if-present");
         ctx.runtime_options.smol = args.flag(b"--smol");

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1575,49 +1575,55 @@ impl Run {
             }
 
             if ctx.runtime_options.eval.eval_and_print {
-                let to_print: JSValue = 'brk: {
-                    let result = vm
-                        .entry_point_result
-                        .value
-                        .get()
-                        .unwrap_or(JSValue::UNDEFINED);
-                    if let Some(promise) = result.as_any_promise() {
-                        match promise.status() {
-                            PromiseStatus::Pending => {
-                                // C-ABI shims are emitted by
-                                // `generate-host-exports.ts` into
-                                // `crate::generated_host_exports` under their
-                                // link name (`Bun__on…EntryPointResult`).
-                                result.then2(
+                if !vm.entry_point_result.esm_capability {
+                    // node semantics: print the completion value verbatim
+                    // (promises included, never unwrapped).
+                    vm.print_eval_result_if_needed();
+                } else {
+                    let to_print: JSValue = 'brk: {
+                        let result = vm
+                            .entry_point_result
+                            .value
+                            .get()
+                            .unwrap_or(JSValue::UNDEFINED);
+                        if let Some(promise) = result.as_any_promise() {
+                            match promise.status() {
+                                PromiseStatus::Pending => {
+                                    // C-ABI shims are emitted by
+                                    // `generate-host-exports.ts` into
+                                    // `crate::generated_host_exports` under their
+                                    // link name (`Bun__on…EntryPointResult`).
+                                    result.then2(
                                     vm.global(),
                                     JSValue::UNDEFINED,
                                     crate::generated_host_exports::Bun__onResolveEntryPointResult,
                                     crate::generated_host_exports::Bun__onRejectEntryPointResult,
                                 );
-                                vm.tick();
-                                vm.auto_tick_active();
-                                while vm.is_event_loop_alive() {
                                     vm.tick();
                                     vm.auto_tick_active();
+                                    while vm.is_event_loop_alive() {
+                                        vm.tick();
+                                        vm.auto_tick_active();
+                                    }
+                                    break 'brk result;
                                 }
-                                break 'brk result;
+                                _ => break 'brk promise.result(vm.jsc_vm()),
                             }
-                            _ => break 'brk promise.result(vm.jsc_vm()),
                         }
+                        result
+                    };
+                    // SAFETY: `vals[..1]` is the single stack `to_print`; null
+                    // `ctype` routes to the VM's stdout/stderr default.
+                    unsafe {
+                        bun_jsc::ConsoleObject::message_with_type_and_level(
+                            ::core::ptr::null_mut(),
+                            bun_jsc::ConsoleObject::MessageType::Log,
+                            bun_jsc::ConsoleObject::MessageLevel::Log,
+                            vm.global(),
+                            &raw const to_print,
+                            1,
+                        );
                     }
-                    result
-                };
-                // SAFETY: `vals[..1]` is the single stack `to_print`; null
-                // `ctype` routes to the VM's stdout/stderr default.
-                unsafe {
-                    bun_jsc::ConsoleObject::message_with_type_and_level(
-                        ::core::ptr::null_mut(),
-                        bun_jsc::ConsoleObject::MessageType::Log,
-                        bun_jsc::ConsoleObject::MessageLevel::Log,
-                        vm.global(),
-                        &raw const to_print,
-                        1,
-                    );
                 }
             }
 

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -108,14 +108,23 @@ pub fn set_override_module_run_main_promise(
 }
 
 /// Exported as `Bun__VM__setEntryPointEvalResultESM`.
+///
+/// `is_async_capability`: `result` is the module's internal async-capability
+/// promise (top-level-await path), not the user-visible completion value, so
+/// `--print` must unwrap it rather than log it.
 // HOST_EXPORT(Bun__VM__setEntryPointEvalResultESM, c)
-pub fn set_entry_point_eval_result_esm(this: &mut VirtualMachine, result: JSValue) {
+pub fn set_entry_point_eval_result_esm(
+    this: &mut VirtualMachine,
+    result: JSValue,
+    is_async_capability: bool,
+) {
     // allow esm evaluate to set value multiple times
     if !this.entry_point_result.cjs_set_value {
         // `global()` returns `&'static`, decoupled from `this` for the
         // disjoint `&mut this.entry_point_result` borrow.
         let global = this.global();
         this.entry_point_result.value.set(global, result);
+        this.entry_point_result.esm_capability = is_async_capability;
     }
 }
 

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -72,6 +72,9 @@ pub extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
             bun_core::Output::flush();
             bun_core::reload_process(should_clear_terminal, false);
         }
+        // node prints the `--print` result from its 'exit' handler even when
+        // the script calls `process.exit()` before a pending promise settles.
+        vm.print_eval_result_if_needed();
         vm.on_exit();
         vm.global_exit();
     }

--- a/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install-registry.test.ts.snap
@@ -1,10 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`auto-install symlinks (and junctions) are created correctly in the install cache 1`] = `
-"{
-  name: "is-number",
-  version: "2.0.0",
-}
+"{ name: 'is-number', version: '2.0.0' }
 "
 `;
 

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -1,6 +1,7 @@
 import { SyncSubprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
+import { inspect } from "util";
 import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep } from "path";
@@ -53,7 +54,13 @@ for (const flag of ["-e", "--print"]) {
         });
 
         expect(stderr.toString("utf8")).toBe("");
-        expect(JSON.parse(stdout.toString("utf8"))).toEqual(expected);
+        // `--print` renders with node's util.inspect (single-quoted strings);
+        // `-e` goes through console.log (double-quoted), which JSON can parse.
+        if (flag === "--print") {
+          expect(stdout.toString("utf8")).toBe(inspect(expected) + "\n");
+        } else {
+          expect(JSON.parse(stdout.toString("utf8"))).toEqual(expected);
+        }
         expect(exitCode).toBe(0);
       }
 

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -1,10 +1,10 @@
 import { SyncSubprocess } from "bun";
 import { describe, expect, test } from "bun:test";
 import { rmSync, writeFileSync } from "fs";
-import { inspect } from "util";
 import { bunEnv, bunExe, isWindows, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { join, sep } from "path";
+import { inspect } from "util";
 
 for (const flag of ["-e", "--print"]) {
   describe(`bun ${flag}`, () => {

--- a/test/js/node/child_process/child_process-node.test.js
+++ b/test/js/node/child_process/child_process-node.test.js
@@ -391,7 +391,8 @@ describe("child_process default options", () => {
     // because the process can exit before the stream is closed and the data is read
     child.stdout.on("close", () => {
       try {
-        expect(response).toContain(`TMPDIR: "${platformTmpDir.replace(/\\/g, "\\\\")}"`);
+        // --print renders through node's util.inspect: single-quoted strings.
+        expect(response).toContain(`TMPDIR: '${platformTmpDir.replace(/\\/g, "\\\\")}'`);
         done();
       } catch (e) {
         done(e);

--- a/test/js/node/test/parallel/test-cli-print-promise.mjs
+++ b/test/js/node/test/parallel/test-cli-print-promise.mjs
@@ -1,0 +1,152 @@
+import { spawnPromisified } from '../common/index.mjs';
+import assert from 'node:assert';
+import { execPath } from 'node:process';
+import { describe, it } from 'node:test';
+
+
+describe('--print with a promise', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  it('should handle directly-fulfilled promises', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'Promise.resolve(42)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { 42 }\n',
+    });
+  });
+
+  it('should handle promises fulfilled after one tick', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'Promise.resolve().then(()=>42)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { 42 }\n',
+    });
+  });
+
+  it('should handle promise that never settles', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'new Promise(()=>{})',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <pending> }\n',
+    });
+  });
+
+  it('should output something if process exits before promise settles', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'setTimeout(process.exit, 100, 0);timers.promises.setTimeout(200)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <pending> }\n',
+    });
+  });
+
+  it('should respect exit code when process exits before promise settles', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'setTimeout(process.exit, 100, 42);timers.promises.setTimeout(200)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 42,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <pending> }\n',
+    });
+  });
+
+  it('should handle rejected promises', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--unhandled-rejections=none',
+      '--print',
+      'Promise.reject(1)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <rejected> 1 }\n',
+    });
+  });
+
+  it('should handle promises that reject after one tick', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--unhandled-rejections=none',
+      '--print',
+      'Promise.resolve().then(()=>Promise.reject(1))',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <rejected> 1 }\n',
+    });
+  });
+
+  it('should handle thenable that resolves', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--unhandled-rejections=none',
+      '--print',
+      '({ then(r) { r(42) } })',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: '{ then: [Function: then] }\n',
+    });
+  });
+
+  it('should handle thenable that rejects', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--unhandled-rejections=none',
+      '--print',
+      '({ then(_, r) { r(42) } })',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: '{ then: [Function: then] }\n',
+    });
+  });
+
+  it('should handle Promise.prototype', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--unhandled-rejections=none',
+      '--print',
+      'Promise.prototype',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Object [Promise] {}\n',
+    });
+  });
+});


### PR DESCRIPTION
Part of the node v26.3.0 compat campaign (runner/cli/module slice). Base: `claude/callback-throw-uncaught`.

## What this does

Makes `bun -p` / `bun -e` match node's CLI eval contract, and vendors the upstream test that pins it.

**Vendored & passing:** `test/parallel/test-cli-print-promise.mjs` (all 10 subtests; each fails on the unfixed build).

## Fixes, per commit

1. **console: include the settled value when formatting promises** — `console.log(Promise.resolve(42))` printed `Promise { <resolved> }`, discarding the value. Now `Promise { 42 }` / `Promise { <rejected> reason }`, matching util.inspect and node.

2. **cli: parse node's -p/-e spellings** — `bun -p -e "code"` evaluated the literal string `-e` (bun's `-p` takes a value and swallowed the token; the code landed in the entrypoint positional). Also: `--print --eval=-42`, backslash-escaped expressions (`-p "\-42"`), and node's exact `<execPath>: -e requires an argument` + exit 9.

3. **cli: match node's --print output semantics** — the fixing lines are the new `print_eval_result_if_needed` in VirtualMachine.rs and its two call sites (event-loop drain in run_command.rs, `process.exit()` in node_process.rs):
   - the completion value is printed **verbatim** — a promise renders in whatever state it is in (`Promise { 42 }`, `Promise { <pending> }`), never unwrapped; previously bun printed the unwrapped value;
   - `process.exit()` before the loop drains still prints (node registers the print on beforeExit *and* exit);
   - output renders through the node util.inspect port instead of bun's native console formatter (strings raw, objects single-line, `Object [Promise] {}`), byte-identical to node. JSX keeps bun's native `<hello>world</hello>` rendering, and the top-level-await path keeps unwrapping the internal async-capability promise (node refuses ESM `--print` outright, so that stays a bun extension; it now carries an explicit `esm_capability` flag).
   - `run-eval.test.ts`'s `--print process.argv` assertion updated for the single-quoted inspect rendering (deliberate output change).

4. **crypto: resolve `crypto` to node:crypto in -e/-p scripts** — node's eval entry makes the `crypto` identifier the node:crypto module (`node -p "crypto.randomBytes(16)"` works); bun's eval-mode builtin globals covered every module except crypto. Also stops node:crypto reading `globalThis.crypto` for its webcrypto export (it now gets the native WebCrypto object from the binding) — that read was user-tamperable and recursed once the eval accessor existed. Non-eval scripts are unaffected.

## How verified

- `test-cli-print-promise.mjs` 10/10 CI-style, 3 consecutive runs; fails without the fixes.
- `test/cli/run/run-eval.test.ts` 33/33 (covers the TLA `-p '(await 1) + 1'` extension, JSX printing, `process._eval`, argv).
- `test/js/web/console/` 10/10, `test/js/node/crypto/crypto-random.test.ts` 22/22, vendored `test-global-webcrypto.js` / `test-crypto-subtle-zero-length.js` / `test-webcrypto-cryptokey-clone-transfer.js` all pass (webcrypto identity in non-eval mode unchanged).
- `test-cli-eval.js` is **not** vendored: the -p/-e and crypto blocks now pass but other sections still fail (fork/execArgv parity, beforeExit/exit print ordering with console.log reviving the loop, etc.).

## Slice triage (for the tracker)

Investigated but not fixed here, with owners where known: the `--test` CLI-mode runner tests are blocked on #34515/#35395/#35404 (not in this base); node:test coverage tests need the unimplemented coverage feature; `run({isolation:'none'})` tests are implemented in #34515; module-loading-globalpaths is implemented by #35124; SourceMap method fidelity overlaps #35123; watch-mode files are blocked on `--watch` restart parity; the two `import source` vm tests need JSC source-phase import support; `test-vm-dynamic-import-callback-missing-flag.js` would require gating bun's flagless vm dynamic-import support behind `--experimental-vm-modules` (needs a decision).
