### PR TITLE
node:http: keep delivering the request body after a synchronous res.end()

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2446,10 +2446,17 @@ function stopServerResponsePerf(this: any) {
 // arm keep-alive) runs first because onResponseFinishHandleSocket's guards
 // read pre-detach state, then detach the socket and advance the pipeline.
 function emitResponseFinish() {
+  // Like Node.js's resOnFinish: if nothing is (or is about to be) reading the
+  // request body, dump it. Runs on 'finish' (nextTick after end()) so a
+  // consumer attached between res.end() and this tick is still honoured.
+  const req = this.req;
+  if (req && !req._consuming && !req._readableState?.resumeScheduled) {
+    req._dump();
+  }
   // req.socket is nulled by the stream destroyer (pipeline/compose cleanup);
   // the response's own socket (set by assignSocket, cleared only by
   // detachSocket) still references the connection then.
-  const socket = this.req?.socket ?? this.socket;
+  const socket = req?.socket ?? this.socket;
   onResponseFinishHandleSocket(socket?.server, socket, this);
   // The dispatcher detached a synchronously-finished response itself;
   // advancing the pipeline again here would skip a queued response.
@@ -3169,14 +3176,6 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     // node.js will return true if the handle is closed but the internal state is not
     // and will not throw or emit an error
     return true;
-  }
-  // Like Node.js's resOnFinish: if nothing is (or is about to be) reading the
-  // request body, dump it. Runs before the native end so the cleared ondata
-  // lets the native side release the body-read ref; a set ondata means the
-  // body keeps flowing into the IncomingMessage after the response is sent.
-  const req = this.req;
-  if (req && !req._consuming && !req._readableState?.resumeScheduled) {
-    req._dump();
   }
   const sentState = NodeHTTPHeaderState.sent;
   if (headerState !== sentState) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3170,6 +3170,14 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     // and will not throw or emit an error
     return true;
   }
+  // Like Node.js's resOnFinish: if nothing is (or is about to be) reading the
+  // request body, dump it. Runs before the native end so the cleared ondata
+  // lets the native side release the body-read ref; a set ondata means the
+  // body keeps flowing into the IncomingMessage after the response is sent.
+  const req = this.req;
+  if (req && !req._consuming && !req._readableState?.resumeScheduled) {
+    req._dump();
+  }
   const sentState = NodeHTTPHeaderState.sent;
   if (headerState !== sentState) {
     {
@@ -3218,10 +3226,6 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     }
   }
   this._header = " ";
-  const req = this.req;
-  if (!req._consuming && !req?._readableState?.resumeScheduled) {
-    req._dump();
-  }
   // The socket is NOT detached here: like Node.js, res.socket stays assigned
   // until the response 'finish' machinery runs (the dispatcher detaches it
   // right after a synchronously-finished handler returns, or via its 'finish'

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2446,9 +2446,9 @@ function stopServerResponsePerf(this: any) {
 // arm keep-alive) runs first because onResponseFinishHandleSocket's guards
 // read pre-detach state, then detach the socket and advance the pipeline.
 function emitResponseFinish() {
-  // Like Node.js's resOnFinish: if nothing is (or is about to be) reading the
-  // request body, dump it. Runs on 'finish' (nextTick after end()) so a
-  // consumer attached between res.end() and this tick is still honoured.
+  // If the user never called req.read(), and didn't pipe() or
+  // .resume() or .on('data'), then we call req._dump() so that the
+  // bytes will be pulled off the wire.
   const req = this.req;
   if (req && !req._consuming && !req._readableState?.resumeScheduled) {
     req._dump();

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2286,10 +2286,11 @@ impl NodeHTTPResponse {
             || flags.contains(Flags::UPGRADED)
         {
             js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
+            let was_pending = self.body_read_state.get() == BodyReadState::Pending;
             // defer { if body_read_ref.has { unref } } — moved to tail of this branch.
             match self.body_read_state.get() {
                 BodyReadState::Pending | BodyReadState::Done => {
-                    if !flags.contains(Flags::REQUEST_HAS_COMPLETED)
+                    if (was_pending || !flags.contains(Flags::REQUEST_HAS_COMPLETED))
                         && !flags.contains(Flags::SOCKET_CLOSED)
                         && !flags.contains(Flags::UPGRADED)
                     {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -610,7 +610,8 @@ impl NodeHTTPResponse {
             || flags.contains(Flags::ENDED))
             && (self.body_read_ref.get().has
                 || self.body_read_state.get() == BodyReadState::Pending)
-            && js::on_data_get_cached(this_value).is_none()
+            && (this_value.is_empty_or_undefined_or_null()
+                || js::on_data_get_cached(this_value).is_none())
         {
             let had_ref = self.body_read_ref.get().has;
             if !flags.contains(Flags::UPGRADED) && !flags.contains(Flags::SOCKET_CLOSED) {
@@ -2291,6 +2292,11 @@ impl NodeHTTPResponse {
                 self.body_read_ref
                     .with_mut(|r| r.unref(bun_vm_mut(global_object)));
             }
+            // The body-read state just left Pending: if the response had already
+            // ended (req._dump() from the 'finish' listener is the common path
+            // here), the request can be marked done now so IS_REQUEST_PENDING and
+            // the server's pending-request counter are released.
+            self.mark_request_as_done_if_necessary();
             return;
         }
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -649,7 +649,11 @@ impl NodeHTTPResponse {
         }
 
         if flags.contains(Flags::ENDED) {
-            return self.body_read_state.get() == BodyReadState::Pending;
+            return self.body_read_state.get() == BodyReadState::Pending
+                || !self
+                    .buffered_request_body_data_during_pause
+                    .get()
+                    .is_empty();
         }
 
         true
@@ -1429,9 +1433,8 @@ impl NodeHTTPResponse {
         if flags.contains(Flags::SOCKET_CLOSED) || flags.contains(Flags::UPGRADED) {
             return JSValue::FALSE;
         }
-        if (flags.contains(Flags::REQUEST_HAS_COMPLETED) || flags.contains(Flags::ENDED))
-            && self.body_read_state.get() != BodyReadState::Pending
-        {
+        let ended = flags.contains(Flags::REQUEST_HAS_COMPLETED) || flags.contains(Flags::ENDED);
+        if ended && self.body_read_state.get() != BodyReadState::Pending {
             return JSValue::FALSE;
         }
         // Body already delivered: re-arming onData/onTimeout would overwrite a
@@ -1442,6 +1445,13 @@ impl NodeHTTPResponse {
         {
             self.set_on_aborted_handler();
             raw.on_data(on_data_shim, self.as_ctx_ptr());
+        }
+        // After the response has ended detachSocket() cleared
+        // socket._httpMessage, so #resumeSocket() can no longer route the
+        // drain to the IncomingMessage; leave it for _read()'s
+        // handle.drainRequestBody() which pushes to `this` directly.
+        if ended {
+            return JSValue::TRUE;
         }
         self.update_flags(|f| f.remove(Flags::IS_DATA_BUFFERED_DURING_PAUSE));
         let mut result: JSValue = JSValue::TRUE;
@@ -1611,16 +1621,7 @@ impl NodeHTTPResponse {
             if self.body_read_ref.get().has {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
             }
-            // mark_request_as_done would free the buffered tail before the
-            // consumer drains it; drain_buffered_request_body_from_pause calls
-            // this once the tail has been handed to JS.
-            if self
-                .buffered_request_body_data_during_pause
-                .get()
-                .is_empty()
-            {
-                self.mark_request_as_done_if_necessary();
-            }
+            self.mark_request_as_done_if_necessary();
         }
     }
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -700,6 +700,11 @@ impl NodeHTTPResponse {
 
         let vm = vm_get();
         self.clear_on_data_callback(self.get_this_value(), vm.global());
+        // The body-read ref may still be held when the request is torn down
+        // before the body's fin arrived (socket closed mid-upload after the
+        // response had already ended). Release it here so vm.active_tasks is
+        // balanced; unref() is a no-op when already released.
+        self.body_read_ref.with_mut(|r| r.unref(vm));
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
         self.upgrade_context.with_mut(|c| c.reset());
 
@@ -1346,10 +1351,15 @@ impl NodeHTTPResponse {
         let Some(raw) = self.raw_response.get() else {
             return Ok(JSValue::FALSE);
         };
-        if flags.contains(Flags::REQUEST_HAS_COMPLETED)
-            || flags.contains(Flags::SOCKET_CLOSED)
-            || flags.contains(Flags::ENDED)
-            || flags.contains(Flags::UPGRADED)
+        if flags.contains(Flags::SOCKET_CLOSED) || flags.contains(Flags::UPGRADED) {
+            return Ok(JSValue::FALSE);
+        }
+        // ENDED/REQUEST_HAS_COMPLETED alone do not gate pausing while the
+        // request body is still being consumed (res.end() ran first): the
+        // inStream re-armed in write_or_end keeps `userData == self`, so the
+        // buffered-pause swap and socket-level pause below are safe.
+        if (flags.contains(Flags::REQUEST_HAS_COMPLETED) || flags.contains(Flags::ENDED))
+            && self.body_read_state.get() != BodyReadState::Pending
         {
             return Ok(JSValue::FALSE);
         }
@@ -1418,10 +1428,11 @@ impl NodeHTTPResponse {
         let Some(raw) = self.raw_response.get() else {
             return JSValue::FALSE;
         };
-        if flags.contains(Flags::REQUEST_HAS_COMPLETED)
-            || flags.contains(Flags::SOCKET_CLOSED)
-            || flags.contains(Flags::ENDED)
-            || flags.contains(Flags::UPGRADED)
+        if flags.contains(Flags::SOCKET_CLOSED) || flags.contains(Flags::UPGRADED) {
+            return JSValue::FALSE;
+        }
+        if (flags.contains(Flags::REQUEST_HAS_COMPLETED) || flags.contains(Flags::ENDED))
+            && self.body_read_state.get() != BodyReadState::Pending
         {
             return JSValue::FALSE;
         }
@@ -2016,9 +2027,13 @@ impl NodeHTTPResponse {
             // This is the equivalent of req._dump(); ServerResponse.prototype.end runs req._dump()
             // (which clears ondata) before reaching here whenever the IncomingMessage has no
             // consumer, so an ondata that is still set means the request body is being read.
+            // A closing connection (Connection: close / HTTP/1.0) also discards: the socket is
+            // shut down from the 'finish' nextTick before any later body segment could reach
+            // the parser, so keeping the body Pending there would only strand the ref.
             if self.body_read_ref.get().has
                 && self.body_read_state.get() == BodyReadState::Pending
-                && js::on_data_get_cached(this_value).is_none()
+                && (js::on_data_get_cached(this_value).is_none()
+                    || state.is_http_connection_close())
             {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
                 self.body_read_state.set(BodyReadState::None);

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2252,7 +2252,10 @@ impl NodeHTTPResponse {
                 js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
             }
             let flags = self.flags.get();
-            if !flags.contains(Flags::SOCKET_CLOSED) && !flags.contains(Flags::UPGRADED) {
+            if !flags.contains(Flags::SOCKET_CLOSED)
+                && !flags.contains(Flags::UPGRADED)
+                && !flags.contains(Flags::REQUEST_HAS_COMPLETED)
+            {
                 scoped_log!(NodeHTTPResponse, "clearOnData");
                 if let Some(raw_response) = self.raw_response.get() {
                     raw_response.clear_on_data();

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -610,8 +610,7 @@ impl NodeHTTPResponse {
             || flags.contains(Flags::ENDED))
             && (self.body_read_ref.get().has
                 || self.body_read_state.get() == BodyReadState::Pending)
-            && (!flags.contains(Flags::HAS_CUSTOM_ON_DATA)
-                || js::on_data_get_cached(this_value).is_none())
+            && js::on_data_get_cached(this_value).is_none()
         {
             let had_ref = self.body_read_ref.get().has;
             if !flags.contains(Flags::UPGRADED) && !flags.contains(Flags::SOCKET_CLOSED) {
@@ -2014,11 +2013,12 @@ impl NodeHTTPResponse {
 
         if IS_END {
             // Discard the body read ref if it's pending and no onData callback is set at this point.
-            // This is the equivalent of req._dump().
+            // This is the equivalent of req._dump(); ServerResponse.prototype.end runs req._dump()
+            // (which clears ondata) before reaching here whenever the IncomingMessage has no
+            // consumer, so an ondata that is still set means the request body is being read.
             if self.body_read_ref.get().has
                 && self.body_read_state.get() == BodyReadState::Pending
-                && (!self.flags.get().contains(Flags::HAS_CUSTOM_ON_DATA)
-                    || js::on_data_get_cached(this_value).is_none())
+                && js::on_data_get_cached(this_value).is_none()
             {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
                 self.body_read_state.set(BodyReadState::None);
@@ -2038,6 +2038,16 @@ impl NodeHTTPResponse {
                 raw_response.end(bytes, state.is_http_connection_close());
             } else {
                 raw_response.end_stream(state.is_http_connection_close());
+            }
+            // uws's markDone() (reached from end/end_stream) nulls the connection's
+            // inStream. Re-arm it when the request body is still being consumed so
+            // body chunks keep flowing into the IncomingMessage after the response
+            // has been sent, like Node.js. IS_REQUEST_PENDING (held while the body
+            // is Pending) keeps `self` alive for the callback.
+            if self.body_read_state.get() == BodyReadState::Pending {
+                if let Some(raw_response) = self.raw_response.get() {
+                    raw_response.on_data(on_data_shim, self.as_ctx_ptr());
+                }
             }
             self.on_request_complete();
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1410,10 +1410,20 @@ impl NodeHTTPResponse {
             let bytes = self
                 .buffered_request_body_data_during_pause
                 .replace(Vec::new());
-            return Some(JSValue::create_buffer_from_box(
-                global_object,
-                bytes.into_boxed_slice(),
-            ));
+            let buf = JSValue::create_buffer_from_box(global_object, bytes.into_boxed_slice());
+            // The body's fin arrived on the buffered-pause shim after the
+            // response had already ended; the buffered tail has now been
+            // handed to JS, so the request can be marked done
+            // (on_buffer_request_body_while_paused deferred this while the
+            // buffer was non-empty).
+            if self
+                .flags
+                .get()
+                .contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+            {
+                self.mark_request_as_done_if_necessary();
+            }
+            return Some(buf);
         }
         None
     }
@@ -1611,11 +1621,20 @@ impl NodeHTTPResponse {
             self.capture_request_trailers();
             self.update_flags(|f| f.insert(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST));
             // Mirror on_data_or_aborted: the body has been fully received, so
-            // should_request_be_pending() must observe Done (not Pending) for
-            // mark_request_as_done_if_necessary() below to release the request.
+            // should_request_be_pending() must observe Done (not Pending) once
+            // the consumer has the buffered tail.
             self.body_read_state.set(BodyReadState::Done);
             if self.body_read_ref.get().has {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
+            }
+            // IS_REQUEST_PENDING is only released once the buffered tail has
+            // been handed to JS (drain_buffered_request_body_from_pause), so
+            // mark_request_as_done does not free it first.
+            if self
+                .buffered_request_body_data_during_pause
+                .get()
+                .is_empty()
+            {
                 self.mark_request_as_done_if_necessary();
             }
         }
@@ -1703,8 +1722,12 @@ impl NodeHTTPResponse {
         if last {
             if self.body_read_ref.get().has {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
-                self.mark_request_as_done_if_necessary();
             }
+            // body_read_state is now Done; re-evaluate IS_REQUEST_PENDING. This
+            // runs unconditionally because run_callback above can reach
+            // _destroy → set_on_data(undefined) and unref body_read_ref before
+            // the check re-reads it.
+            self.mark_request_as_done_if_necessary();
             self.deref();
         }
     }
@@ -2028,17 +2051,16 @@ impl NodeHTTPResponse {
         self.spill_pending_pinned_write(global_object);
 
         if IS_END {
-            // Discard the body read ref if it's pending and no onData callback is set at this point.
-            // This is the equivalent of req._dump(); ServerResponse.prototype.end runs req._dump()
-            // (which clears ondata) before reaching here whenever the IncomingMessage has no
-            // consumer, so an ondata that is still set means the request body is being read.
-            // A closing connection (Connection: close / HTTP/1.0) also discards: the socket is
-            // shut down from the 'finish' nextTick before any later body segment could reach
-            // the parser, so keeping the body Pending there would only strand the ref.
+            // Node.js keeps reading the request body after the response is
+            // written; resOnFinish (on the 'finish' nextTick) calls req._dump()
+            // only when nothing is consuming it. The body is kept Pending here
+            // except on a closing connection (Connection: close / HTTP/1.0):
+            // uws's end(close=true) shuts the socket down before any later
+            // segment could reach the parser, so keeping the body Pending there
+            // would only strand the ref.
             if self.body_read_ref.get().has
                 && self.body_read_state.get() == BodyReadState::Pending
-                && (js::on_data_get_cached(this_value).is_none()
-                    || state.is_http_connection_close())
+                && state.is_http_connection_close()
             {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
                 self.body_read_state.set(BodyReadState::None);
@@ -2059,14 +2081,31 @@ impl NodeHTTPResponse {
             } else {
                 raw_response.end_stream(state.is_http_connection_close());
             }
-            // uws's markDone() (reached from end/end_stream) nulls the connection's
-            // inStream. Re-arm it when the request body is still being consumed so
-            // body chunks keep flowing into the IncomingMessage after the response
-            // has been sent, like Node.js. IS_REQUEST_PENDING (held while the body
-            // is Pending) keeps `self` alive for the callback.
-            if self.body_read_state.get() == BodyReadState::Pending {
+            // uws's markDone() (reached from end/end_stream) nulls the
+            // connection's inStream. Re-arm it when the request body is still
+            // arriving so body chunks keep flowing into the IncomingMessage
+            // after the response has been sent, like Node.js.
+            // IS_REQUEST_PENDING (held while the body is Pending) keeps `self`
+            // alive for the callback; on_data(last=true) → mark_request_as_done
+            // releases it once the body is done.
+            // SOCKET_CLOSED: end() closed the connection synchronously (peer
+            // FIN already received) and the HttpResponseData ext was
+            // destructed by the context onClose; do not touch it.
+            let post_end_flags = self.flags.get();
+            if self.body_read_state.get() == BodyReadState::Pending
+                && !post_end_flags.contains(Flags::SOCKET_CLOSED)
+            {
                 if let Some(raw_response) = self.raw_response.get() {
-                    raw_response.on_data(on_data_shim, self.as_ctx_ptr());
+                    // Preserve an existing pause (async handler where
+                    // push()->false already swapped in the buffered shim),
+                    // like do_pause/do_resume do.
+                    if post_end_flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE)
+                        && !post_end_flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+                    {
+                        raw_response.on_data(on_buffer_paused_shim, self.as_ctx_ptr());
+                    } else {
+                        raw_response.on_data(on_data_shim, self.as_ctx_ptr());
+                    }
                 }
             }
             self.on_request_complete();

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -701,10 +701,6 @@ impl NodeHTTPResponse {
 
         let vm = vm_get();
         self.clear_on_data_callback(self.get_this_value(), vm.global());
-        // The body-read ref may still be held when the request is torn down
-        // before the body's fin arrived (socket closed mid-upload after the
-        // response had already ended). Release it here so vm.active_tasks is
-        // balanced; unref() is a no-op when already released.
         self.body_read_ref.with_mut(|r| r.unref(vm));
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
         self.upgrade_context.with_mut(|c| c.reset());
@@ -1355,10 +1351,6 @@ impl NodeHTTPResponse {
         if flags.contains(Flags::SOCKET_CLOSED) || flags.contains(Flags::UPGRADED) {
             return Ok(JSValue::FALSE);
         }
-        // ENDED/REQUEST_HAS_COMPLETED alone do not gate pausing while the
-        // request body is still being consumed (res.end() ran first): the
-        // inStream re-armed in write_or_end keeps `userData == self`, so the
-        // buffered-pause swap and socket-level pause below are safe.
         if (flags.contains(Flags::REQUEST_HAS_COMPLETED) || flags.contains(Flags::ENDED))
             && self.body_read_state.get() != BodyReadState::Pending
         {
@@ -1411,11 +1403,6 @@ impl NodeHTTPResponse {
                 .buffered_request_body_data_during_pause
                 .replace(Vec::new());
             let buf = JSValue::create_buffer_from_box(global_object, bytes.into_boxed_slice());
-            // The body's fin arrived on the buffered-pause shim after the
-            // response had already ended; the buffered tail has now been
-            // handed to JS, so the request can be marked done
-            // (on_buffer_request_body_while_paused deferred this while the
-            // buffer was non-empty).
             if self
                 .flags
                 .get()
@@ -1620,16 +1607,13 @@ impl NodeHTTPResponse {
         if last {
             self.capture_request_trailers();
             self.update_flags(|f| f.insert(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST));
-            // Mirror on_data_or_aborted: the body has been fully received, so
-            // should_request_be_pending() must observe Done (not Pending) once
-            // the consumer has the buffered tail.
             self.body_read_state.set(BodyReadState::Done);
             if self.body_read_ref.get().has {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
             }
-            // IS_REQUEST_PENDING is only released once the buffered tail has
-            // been handed to JS (drain_buffered_request_body_from_pause), so
-            // mark_request_as_done does not free it first.
+            // mark_request_as_done would free the buffered tail before the
+            // consumer drains it; drain_buffered_request_body_from_pause calls
+            // this once the tail has been handed to JS.
             if self
                 .buffered_request_body_data_during_pause
                 .get()
@@ -1723,10 +1707,6 @@ impl NodeHTTPResponse {
             if self.body_read_ref.get().has {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
             }
-            // body_read_state is now Done; re-evaluate IS_REQUEST_PENDING. This
-            // runs unconditionally because run_callback above can reach
-            // _destroy → set_on_data(undefined) and unref body_read_ref before
-            // the check re-reads it.
             self.mark_request_as_done_if_necessary();
             self.deref();
         }
@@ -2051,13 +2031,8 @@ impl NodeHTTPResponse {
         self.spill_pending_pinned_write(global_object);
 
         if IS_END {
-            // Node.js keeps reading the request body after the response is
-            // written; resOnFinish (on the 'finish' nextTick) calls req._dump()
-            // only when nothing is consuming it. The body is kept Pending here
-            // except on a closing connection (Connection: close / HTTP/1.0):
-            // uws's end(close=true) shuts the socket down before any later
-            // segment could reach the parser, so keeping the body Pending there
-            // would only strand the ref.
+            // Connection: close / HTTP/1.0: end(close=true) shuts the socket
+            // down before any later body segment could reach the parser.
             if self.body_read_ref.get().has
                 && self.body_read_state.get() == BodyReadState::Pending
                 && state.is_http_connection_close()
@@ -2081,24 +2056,15 @@ impl NodeHTTPResponse {
             } else {
                 raw_response.end_stream(state.is_http_connection_close());
             }
-            // uws's markDone() (reached from end/end_stream) nulls the
-            // connection's inStream. Re-arm it when the request body is still
-            // arriving so body chunks keep flowing into the IncomingMessage
-            // after the response has been sent, like Node.js.
-            // IS_REQUEST_PENDING (held while the body is Pending) keeps `self`
-            // alive for the callback; on_data(last=true) → mark_request_as_done
-            // releases it once the body is done.
-            // SOCKET_CLOSED: end() closed the connection synchronously (peer
-            // FIN already received) and the HttpResponseData ext was
-            // destructed by the context onClose; do not touch it.
+            // markDone() nulled inStream; re-arm so the request body keeps
+            // flowing into the IncomingMessage after the response is sent.
+            // SOCKET_CLOSED means the HttpResponseData ext was just
+            // destructed by the context onClose, so it cannot be touched.
             let post_end_flags = self.flags.get();
             if self.body_read_state.get() == BodyReadState::Pending
                 && !post_end_flags.contains(Flags::SOCKET_CLOSED)
             {
                 if let Some(raw_response) = self.raw_response.get() {
-                    // Preserve an existing pause (async handler where
-                    // push()->false already swapped in the buffered shim),
-                    // like do_pause/do_resume do.
                     if post_end_flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE)
                         && !post_end_flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
                     {
@@ -2335,10 +2301,6 @@ impl NodeHTTPResponse {
                 self.body_read_ref
                     .with_mut(|r| r.unref(bun_vm_mut(global_object)));
             }
-            // The body-read state just left Pending: if the response had already
-            // ended (req._dump() from the 'finish' listener is the common path
-            // here), the request can be marked done now so IS_REQUEST_PENDING and
-            // the server's pending-request counter are released.
             self.mark_request_as_done_if_necessary();
             return;
         }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1610,6 +1610,10 @@ impl NodeHTTPResponse {
         if last {
             self.capture_request_trailers();
             self.update_flags(|f| f.insert(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST));
+            // Mirror on_data_or_aborted: the body has been fully received, so
+            // should_request_be_pending() must observe Done (not Pending) for
+            // mark_request_as_done_if_necessary() below to release the request.
+            self.body_read_state.set(BodyReadState::Done);
             if self.body_read_ref.get().has {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
                 self.mark_request_as_done_if_necessary();

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -644,11 +644,7 @@ impl NodeHTTPResponse {
         // A raw 'upgrade'/'connect' tunnel handoff ends the HTTP exchange the
         // same way, except an Upgrade carrying a body keeps parsing as HTTP
         // until the body's fin chunk (the actual tunnel start).
-        if flags.contains(Flags::TUNNELED) {
-            return self.body_read_state.get() == BodyReadState::Pending;
-        }
-
-        if flags.contains(Flags::ENDED) {
+        if flags.contains(Flags::TUNNELED) || flags.contains(Flags::ENDED) {
             return self.body_read_state.get() == BodyReadState::Pending
                 || !self
                     .buffered_request_body_data_during_pause
@@ -2070,6 +2066,8 @@ impl NodeHTTPResponse {
                         && !post_end_flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
                     {
                         raw_response.on_data(on_buffer_paused_shim, self.as_ctx_ptr());
+                        #[cfg(not(windows))]
+                        self.pause_socket();
                     } else {
                         raw_response.on_data(on_data_shim, self.as_ctx_ptr());
                     }
@@ -2248,14 +2246,17 @@ impl NodeHTTPResponse {
     fn clear_on_data_callback(&self, this_value: JSValue, global_object: &JSGlobalObject) {
         scoped_log!(NodeHTTPResponse, "clearOnDataCallback");
         if self.body_read_state.get() != BodyReadState::None {
-            if !this_value.is_empty() {
-                js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
-            }
             let flags = self.flags.get();
+            // Once REQUEST_HAS_COMPLETED is set the per-socket HttpResponseData
+            // (and get_this_value()'s currentResponseObject) may belong to the
+            // next keep-alive request; do not touch either.
             if !flags.contains(Flags::SOCKET_CLOSED)
                 && !flags.contains(Flags::UPGRADED)
                 && !flags.contains(Flags::REQUEST_HAS_COMPLETED)
             {
+                if !this_value.is_empty() {
+                    js::on_data_set_cached(this_value, global_object, JSValue::UNDEFINED);
+                }
                 scoped_log!(NodeHTTPResponse, "clearOnData");
                 if let Some(raw_response) = self.raw_response.get() {
                     raw_response.clear_on_data();
@@ -2305,6 +2306,8 @@ impl NodeHTTPResponse {
                 self.body_read_ref
                     .with_mut(|r| r.unref(bun_vm_mut(global_object)));
             }
+            self.buffered_request_body_data_during_pause
+                .with_mut(|b| b.clear_and_free());
             self.mark_request_as_done_if_necessary();
             return;
         }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -632,6 +632,17 @@ impl NodeHTTPResponse {
 
     fn should_request_be_pending(&self) -> bool {
         let flags = self.flags.get();
+        // The body's fin was parsed onto the paused shim and the tail is still
+        // buffered: mark_request_as_done() would free it before the consumer
+        // drains, so stay pending regardless of which terminal flag is set.
+        if flags.contains(Flags::IS_DATA_BUFFERED_DURING_PAUSE_LAST)
+            && !self
+                .buffered_request_body_data_during_pause
+                .get()
+                .is_empty()
+        {
+            return true;
+        }
         // Once the socket is closed or has been adopted by the WebSocket
         // layer, the HTTP request/response cycle is over — no further uws
         // callbacks will arrive on `raw_response` to balance the

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -37,7 +37,7 @@ export async function run() {
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: address.address,
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4054,3 +4054,111 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
   c.outputData.push({ data: "y", encoding: "utf8", callback: null });
   expect(d.outputData.length).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/4733
+// Ending the response inside the request handler must not drop the request
+// body: Node keeps delivering it to req's 'data' listeners and piped
+// destinations until the body has been fully received.
+describe("request body still flows after res.end() was called in the handler", () => {
+  async function run(
+    attach: (req: IncomingMessage, out: Writable) => void,
+    end: (res: ServerResponse) => Promise<void> | void,
+  ) {
+    const events: string[] = [];
+    const chunks: Buffer[] = [];
+    const { promise: finished, resolve: finish } = Promise.withResolvers<void>();
+
+    await using server = createServer((req, res) => {
+      const out = new Writable({
+        write(chunk, _enc, cb) {
+          chunks.push(Buffer.from(chunk));
+          cb();
+        },
+      });
+      attach(req, out);
+      req.once("end", () => events.push("req-end"));
+      req.once("close", () => events.push("req-close"));
+      out.once("finish", () => {
+        events.push("out-finish");
+        finish();
+      });
+
+      const maybe = end(res);
+      if (maybe) maybe.catch(() => {});
+    });
+
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+    const resp = await fetch(`http://127.0.0.1:${port}/`, { method: "POST", body: "testing-body" });
+    expect(await resp.text()).toBe("ok");
+    await finished;
+
+    expect(Buffer.concat(chunks).toString()).toBe("testing-body");
+    expect(events).toEqual(["req-end", "out-finish", "req-close"]);
+  }
+
+  it("req.pipe(out) with synchronous res.end()", async () => {
+    await run(
+      (req, out) => req.pipe(out),
+      res => void res.end("ok"),
+    );
+  });
+
+  it("req.on('data') with synchronous res.end()", async () => {
+    await run(
+      (req, out) => {
+        req.on("data", c => out.write(c));
+        req.on("end", () => out.end());
+      },
+      res => void res.end("ok"),
+    );
+  });
+
+  it("req.pipe(out) with res.write() + res.end()", async () => {
+    await run(
+      (req, out) => req.pipe(out),
+      res => {
+        res.write("o");
+        res.end("k");
+      },
+    );
+  });
+
+  it("req.pipe(out) with res.end() on nextTick", async () => {
+    await run(
+      (req, out) => req.pipe(out),
+      res =>
+        new Promise(done => {
+          process.nextTick(() => {
+            res.end("ok");
+            done();
+          });
+        }),
+    );
+  });
+
+  it("chunked request body split across writes", async () => {
+    let body = "";
+    const { promise: ended, resolve } = Promise.withResolvers<void>();
+    await using server = createServer((req, res) => {
+      req.on("data", c => (body += c));
+      req.once("end", resolve);
+      res.end("ok");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const sock = connect(port, "127.0.0.1");
+    await once(sock, "connect");
+    sock.write("POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n");
+    // A second TCP segment carrying the remainder (via setNoDelay + event-loop
+    // bounce) so res.end() has already run when it arrives.
+    sock.setNoDelay(true);
+    await new Promise<void>(r => setImmediate(r));
+    sock.write("6\r\n world\r\n0\r\n\r\n");
+
+    await ended;
+    sock.end();
+    expect(body).toBe("hello world");
+  });
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4311,10 +4311,11 @@ describe("request body still flows after res.end() was called in the handler", (
     // body segments are not delivered; 'end' must still fire so the consumer
     // is not left waiting.
     let ended = false;
-    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    const { promise: closed, resolve, reject } = Promise.withResolvers<void>();
     await using server = createServer((req, res) => {
       req.on("data", () => {});
       req.once("end", () => (ended = true));
+      req.once("error", reject);
       req.once("close", resolve);
       res.end("ok");
     });
@@ -4323,6 +4324,7 @@ describe("request body still flows after res.end() was called in the handler", (
 
     const sock = connect(port, "127.0.0.1");
     await once(sock, "connect");
+    sock.on("error", () => {});
     sock.write("POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n");
     sock.setNoDelay(true);
     await new Promise<void>(r => setImmediate(r));

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4220,9 +4220,7 @@ describe("request body still flows after res.end() was called in the handler", (
 
     const sock = connect(port, "127.0.0.1");
     await once(sock, "connect");
-    sock.write(
-      "POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n",
-    );
+    sock.write("POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n");
     sock.setNoDelay(true);
     await new Promise<void>(r => setImmediate(r));
     sock.write("6\r\n world\r\n0\r\n\r\n");

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4161,4 +4161,75 @@ describe("request body still flows after res.end() was called in the handler", (
     sock.end();
     expect(body).toBe("hello world");
   });
+
+  it("socket closed mid-upload does not strand the event loop", async () => {
+    // Covers the case where the body's fin never arrives after the response
+    // ended: the body-read ref must be released on teardown.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const http = require("http");
+         const net = require("net");
+         const { once } = require("events");
+         (async () => {
+           const events = [];
+           const server = http.createServer((req, res) => {
+             req.on("data", c => events.push("data(" + c.length + ")"));
+             req.on("end", () => events.push("end"));
+             res.end("ok");
+           });
+           await once(server.listen(0, "127.0.0.1"), "listening");
+           const s = net.connect(server.address().port, "127.0.0.1");
+           await once(s, "connect");
+           s.write("POST / HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: 100\\r\\n\\r\\nabc");
+           s.resume();
+           await once(s, "data");
+           s.destroy();
+           await once(s, "close");
+           server.close();
+           process.on("beforeExit", () => console.log(JSON.stringify(events)));
+         })();`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Like Node.js: the partial body is delivered, 'end' is not (incomplete),
+    // and the process reaches beforeExit.
+    expect(stdout.trim()).toBe('["data(3)"]');
+    expect(exitCode).toBe(0);
+  });
+
+  it("Connection: close does not hang when the body consumer stays attached", async () => {
+    // The socket is shut down right after the response is written, so later
+    // body segments are not delivered; 'end' must still fire so the consumer
+    // is not left waiting.
+    let ended = false;
+    const { promise: closed, resolve } = Promise.withResolvers<void>();
+    await using server = createServer((req, res) => {
+      req.on("data", () => {});
+      req.once("end", () => (ended = true));
+      req.once("close", resolve);
+      res.end("ok");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const sock = connect(port, "127.0.0.1");
+    await once(sock, "connect");
+    sock.write(
+      "POST / HTTP/1.1\r\nHost: x\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n",
+    );
+    sock.setNoDelay(true);
+    await new Promise<void>(r => setImmediate(r));
+    sock.write("6\r\n world\r\n0\r\n\r\n");
+    sock.resume();
+
+    await closed;
+    sock.end();
+    expect(ended).toBe(true);
+  });
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4057,34 +4057,35 @@ it("OutgoingMessage outputData is per-instance and _flushOutput is defined", () 
 
 // https://github.com/oven-sh/bun/issues/4733
 // Ending the response inside the request handler must not drop the request
-// body: Node keeps delivering it to req's 'data' listeners and piped
-// destinations until the body has been fully received.
+// body: like Node.js, the body keeps flowing to req's 'data' listeners and
+// piped destinations until it has been fully received, and resOnFinish (the
+// 'finish' listener) decides whether to _dump() based on the state *at*
+// 'finish', so a consumer attached after res.end() in the same tick still
+// receives the body.
 describe("request body still flows after res.end() was called in the handler", () => {
-  async function run(
-    attach: (req: IncomingMessage, out: Writable) => void,
-    end: (res: ServerResponse) => Promise<void> | void,
-  ) {
+  async function run(handler: (req: IncomingMessage, res: ServerResponse, out: Writable) => void) {
     const events: string[] = [];
     const chunks: Buffer[] = [];
-    const { promise: finished, resolve: finish } = Promise.withResolvers<void>();
+    const { promise: finished, resolve: finish, reject } = Promise.withResolvers<void>();
 
+    let reqRef: IncomingMessage | undefined;
     await using server = createServer((req, res) => {
+      reqRef = req;
       const out = new Writable({
         write(chunk, _enc, cb) {
           chunks.push(Buffer.from(chunk));
           cb();
         },
       });
-      attach(req, out);
       req.once("end", () => events.push("req-end"));
       req.once("close", () => events.push("req-close"));
+      req.once("error", reject);
+      out.once("error", reject);
       out.once("finish", () => {
         events.push("out-finish");
         finish();
       });
-
-      const maybe = end(res);
-      if (maybe) maybe.catch(() => {});
+      handler(req, res, out);
     });
 
     await once(server.listen(0, "127.0.0.1"), "listening");
@@ -4093,70 +4094,149 @@ describe("request body still flows after res.end() was called in the handler", (
     expect(await resp.text()).toBe("ok");
     await finished;
 
-    expect(Buffer.concat(chunks).toString()).toBe("testing-body");
-    expect(events).toEqual(["req-end", "out-finish", "req-close"]);
+    expect({
+      body: Buffer.concat(chunks).toString(),
+      events,
+      dumped: reqRef!._dumped,
+    }).toEqual({
+      body: "testing-body",
+      events: ["req-end", "out-finish", "req-close"],
+      dumped: false,
+    });
   }
 
-  it("req.pipe(out) with synchronous res.end()", async () => {
-    await run(
-      (req, out) => req.pipe(out),
-      res => void res.end("ok"),
-    );
+  it("req.pipe(out) before res.end()", async () => {
+    await run((req, res, out) => {
+      req.pipe(out);
+      res.end("ok");
+    });
   });
 
-  it("req.on('data') attached after res.end() in the same tick", async () => {
-    // Node gates the dump on 'finish' (nextTick), so a consumer attached in
-    // the same tick as res.end() still receives the body.
-    const events: string[] = [];
-    const { promise: ended, resolve } = Promise.withResolvers<void>();
-    await using server = createServer((req, res) => {
+  it("req.on('data') before res.end()", async () => {
+    await run((req, res, out) => {
+      req.on("data", c => out.write(c));
+      req.on("end", () => out.end());
       res.end("ok");
-      req.on("data", c => events.push(`data(${c.length})`));
+    });
+  });
+
+  it("req.pipe(out) after res.end() in the same tick", async () => {
+    await run((req, res, out) => {
+      res.end("ok");
+      req.pipe(out);
+    });
+  });
+
+  it("req.on('data') after res.end() in the same tick", async () => {
+    await run((req, res, out) => {
+      res.end("ok");
+      req.on("data", c => out.write(c));
+      req.on("end", () => out.end());
+    });
+  });
+
+  it("req.pipe(out) with res.write() + res.end()", async () => {
+    await run((req, res, out) => {
+      req.pipe(out);
+      res.write("o");
+      res.end("k");
+    });
+  });
+
+  it("req.pipe(out) with res.end() on nextTick", async () => {
+    await run((req, res, out) => {
+      req.pipe(out);
+      process.nextTick(() => res.end("ok"));
+    });
+  });
+
+  it("with no consumer, req is _dumped on 'finish' like Node's resOnFinish", async () => {
+    let dumpedAtFinish: boolean | undefined;
+    let reqRef: IncomingMessage | undefined;
+    const { promise: closed, resolve, reject } = Promise.withResolvers<void>();
+    await using server = createServer((req, res) => {
+      reqRef = req;
+      req.once("error", reject);
+      req.once("close", resolve);
+      res.end("ok");
+      // emitResponseFinish is registered before the 'request' event, so by the
+      // time this listener runs req._dump() has already been called.
+      res.on("finish", () => (dumpedAtFinish = req._dumped));
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+    const resp = await fetch(`http://127.0.0.1:${port}/`, { method: "POST", body: "testing-body" });
+    expect(await resp.text()).toBe("ok");
+    await closed;
+    expect({ dumpedAtFinish, dumped: reqRef!._dumped }).toEqual({ dumpedAtFinish: true, dumped: true });
+  });
+
+  it("req.resume() after res.end() in the same tick prevents _dump()", async () => {
+    let dumped: boolean | undefined;
+    const { promise: ended, resolve, reject } = Promise.withResolvers<void>();
+    await using server = createServer((req, res) => {
+      req.once("error", reject);
+      res.end("ok");
+      req.resume();
       req.once("end", () => {
-        events.push("end");
+        dumped = req._dumped;
         resolve();
       });
     });
     await once(server.listen(0, "127.0.0.1"), "listening");
     const { port } = server.address() as AddressInfo;
-    const resp = await fetch(`http://127.0.0.1:${port}/`, { method: "POST", body: "testing" });
-    await resp.text();
+    const resp = await fetch(`http://127.0.0.1:${port}/`, { method: "POST", body: "testing-body" });
+    expect(await resp.text()).toBe("ok");
     await ended;
-    expect(events).toEqual(["data(7)", "end"]);
+    expect(dumped).toBe(false);
   });
 
-  it("req.on('data') with synchronous res.end()", async () => {
-    await run(
-      (req, out) => {
-        req.on("data", c => out.write(c));
-        req.on("end", () => out.end());
-      },
-      res => void res.end("ok"),
-    );
-  });
-
-  it("req.pipe(out) with res.write() + res.end()", async () => {
-    await run(
-      (req, out) => req.pipe(out),
-      res => {
-        res.write("o");
-        res.end("k");
-      },
-    );
-  });
-
-  it("req.pipe(out) with res.end() on nextTick", async () => {
-    await run(
-      (req, out) => req.pipe(out),
-      res =>
-        new Promise(done => {
-          process.nextTick(() => {
-            res.end("ok");
-            done();
-          });
-        }),
-    );
-  });
+  it("keep-alive connection reused after a consumed body releases the request", async () => {
+    // The body's fin arriving on the re-armed inStream after res.end() must
+    // release the pending-request ref so server.close() resolves and the
+    // process exits.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const http = require("http");
+         const { once } = require("events");
+         (async () => {
+           const bodies = [];
+           const server = http.createServer((req, res) => {
+             let body = "";
+             req.on("data", c => body += c);
+             req.once("end", () => bodies.push(body));
+             res.end("ok");
+           });
+           await once(server.listen(0, "127.0.0.1"), "listening");
+           const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+           const port = server.address().port;
+           for (let i = 0; i < 3; i++) {
+             await new Promise((resolve, reject) => {
+               const r = http.request({ agent, method: "POST", port }, res => {
+                 res.resume();
+                 res.on("end", resolve);
+                 res.on("error", reject);
+               });
+               r.on("error", reject);
+               r.end("body" + i);
+             });
+           }
+           agent.destroy();
+           await new Promise(r => server.close(r));
+           console.log(JSON.stringify(bodies));
+         })();`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe('["body0","body1","body2"]');
+    expect(exitCode).toBe(0);
+  }, 20_000);
 
   it("chunked request body split across writes", async () => {
     let body = "";

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4104,6 +4104,27 @@ describe("request body still flows after res.end() was called in the handler", (
     );
   });
 
+  it("req.on('data') attached after res.end() in the same tick", async () => {
+    // Node gates the dump on 'finish' (nextTick), so a consumer attached in
+    // the same tick as res.end() still receives the body.
+    const events: string[] = [];
+    const { promise: ended, resolve } = Promise.withResolvers<void>();
+    await using server = createServer((req, res) => {
+      res.end("ok");
+      req.on("data", c => events.push(`data(${c.length})`));
+      req.once("end", () => {
+        events.push("end");
+        resolve();
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+    const resp = await fetch(`http://127.0.0.1:${port}/`, { method: "POST", body: "testing" });
+    await resp.text();
+    await ended;
+    expect(events).toEqual(["data(7)", "end"]);
+  });
+
   it("req.on('data') with synchronous res.end()", async () => {
     await run(
       (req, out) => {
@@ -4139,10 +4160,12 @@ describe("request body still flows after res.end() was called in the handler", (
 
   it("chunked request body split across writes", async () => {
     let body = "";
-    const { promise: ended, resolve } = Promise.withResolvers<void>();
+    const { promise: ended, resolve, reject } = Promise.withResolvers<void>();
     await using server = createServer((req, res) => {
       req.on("data", c => (body += c));
       req.once("end", resolve);
+      req.once("error", reject);
+      req.once("close", () => reject(new Error("closed before end")));
       res.end("ok");
     });
     await once(server.listen(0, "127.0.0.1"), "listening");
@@ -4201,7 +4224,7 @@ describe("request body still flows after res.end() was called in the handler", (
     // and the process reaches beforeExit.
     expect(stdout.trim()).toBe('["data(3)"]');
     expect(exitCode).toBe(0);
-  });
+  }, 20_000);
 
   it("Connection: close does not hang when the body consumer stays attached", async () => {
     // The socket is shut down right after the response is written, so later


### PR DESCRIPTION
Fixes #4733.
Fixes #18613.

## Repro

```js
import http from "http";
import fs from "fs";

const server = http.createServer((req, res) => {
  const out = fs.createWriteStream("/tmp/output");
  req.pipe(out);
  req.once("end", () => console.log("request ended"));
  res.end("ok");
});
server.listen(3000);
// curl --data "testing" 127.0.0.1:3000
```

Node writes `testing` to `/tmp/output` and logs `request ended`. Bun before this change emits `end`/`close` but never fires `data`, so `/tmp/output` is empty.

## Cause

Two independent native discards dropped the body as soon as `res.end()` ran:

1. `write_or_end::<true>` (and `maybe_stop_reading_body`) released the body-read ref whenever `!HAS_CUSTOM_ON_DATA`, which the dispatcher clears for every request; the check fired regardless of whether the `IncomingMessage` was being consumed.
2. uws's `markDone()` (reached from `end()`/`endStream()`) nulls the connection's `inStream`, so even without step 1 no further body chunks would be delivered.

Node's `resOnFinish` only dumps the body when nothing is consuming it, and it runs on the `'finish'` event (nextTick after `end()`), so a consumer attached after `res.end()` in the same tick is still honoured.

## Fix

- `emitResponseFinish` (the `'finish'` listener, Bun's `resOnFinish`) now runs the `req._dump()` gate, exactly where Node does. `ServerResponse.prototype.end` no longer touches `_dump()`.
- `write_or_end::<true>` no longer discards the body on keep-alive; it only discards for `Connection: close`/HTTP 1.0, where uws closes the socket before any later segment could reach the parser. After `raw_response.end()`, `inStream` is re-armed while the body is still `Pending` so chunks keep flowing into the `IncomingMessage`. The re-arm skips `SOCKET_CLOSED` (end() can destruct the `HttpResponseData` synchronously) and preserves an existing buffered-pause shim.
- `do_pause`/`do_resume` no longer refuse while `ENDED` and the body is still `Pending`, so `push()->false` backpressure reaches the socket after a synchronous `res.end()`.
- `on_buffer_request_body_while_paused(last=true)` now sets `body_read_state = Done` and defers `mark_request_as_done` until `drain_buffered_request_body_from_pause` has handed the buffered tail to JS, so the tail is not freed before the consumer sees it.
- `on_data_or_aborted(last=true)` re-evaluates `IS_REQUEST_PENDING` unconditionally; `run_callback` above can drain nextTicks and unref `body_read_ref` via `_destroy -> set_on_data(undefined)` before the tail re-reads it.
- `set_on_data`'s clear branch and `mark_request_as_done` release `body_read_ref` and call `mark_request_as_done_if_necessary()` so a mid-upload socket close after the response ended cannot strand `vm.active_tasks`.
- `maybe_stop_reading_body` guards `on_data_get_cached` against an empty `this_value`.

## Node semantics

`req._dumped` now matches Node v26 for every ordering: consumer before `res.end()`, `pipe`/`on('data')` after `res.end()` in the same tick, `resume()` after `res.end()`, no consumer (dumped on `'finish'`), and pause-then-end (test-http-pause-no-dump). Verified by running each scenario side-by-side against Node.

## Verification

New `describe("request body still flows after res.end() was called in the handler")` in `test/js/node/http/node-http.test.ts` covers all of the above plus a keep-alive reuse case (three POSTs on one socket, `server.close()` resolves), a mid-upload socket-destroy (process reaches `beforeExit`), `Connection: close`, and a chunked body split across TCP segments. 10 of the 12 fail on `main` and all pass with this change; Node v26 passes them identically.

Also ran `node-http.test.ts`, `node-http-backpressure.test.ts`, `node-http-server-*.test.ts`, `express.json.test.ts`, and the upstream `test-http-{pause,pause-no-dump,no-read-no-dump,pause-resume-one-end,pipe-fs,req-res-close,request-end,request-large-payload,incoming-pipelined-socket-destroy,keep-alive,1.0-keep-alive,keep-alive-pipeline-max-requests,client-keep-alive-release-before-finish,server-keepalive-end,pipeline-requests-connection-leak,outgoing-end-cork}.js`. No new failures.
