### PR TITLE
jsc: JIT simple fixed-width regex lookbehinds

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-338-1ab8e590";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-338-1ab8e590";
+export const WEBKIT_VERSION = "autobuild-preview-pr-338-4d098549";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/yarr-jit-lookbehind.test.ts
+++ b/test/js/bun/jsc/yarr-jit-lookbehind.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// YARR used to refuse to JIT any pattern that contained a lookbehind assertion, so
+// a large alternation like the isbot user-agent matcher dropped entirely into the
+// bytecode interpreter because of four tiny `(?<! ...)` assertions. That made the
+// whole match orders of magnitude slower than V8. The JIT now compiles lookbehinds
+// whose body can be flattened into a bounded set of fixed-width alternatives by
+// reading characters at negative offsets from the assertion anchor; anything more
+// complex still falls back cleanly to the interpreter.
+//
+// https://github.com/oven-sh/bun/issues/5197
+// https://bugs.webkit.org/show_bug.cgi?id=258706
+
+describe("lookbehind JIT correctness", () => {
+  // Each [pattern, input, expected] triplet is checked both before and after the regex
+  // has been executed enough times to cross the JIT threshold.
+  const cases: Array<[RegExp, string, string | null]> = [
+    [/(?<! cu)bot/, "mybot", "bot"],
+    [/(?<! cu)bot/, "my cubot", null],
+    [/(?<! cu)bot/, "bot", "bot"],
+    [/(?<! cu)bot/, "cubot", "bot"],
+    [/(?<! cu)bot/, " cubot", null],
+    [/(?<! cu)bot/, " cubotbot", "bot"],
+    [/(?<=cu)bot/, "cubot", "bot"],
+    [/(?<=cu)bot/, "mybot", null],
+    [/(?<=cu)bot/, "bot", null],
+    [/(?<=cu)bot/, "xxcubot", "bot"],
+    [/(?<!abc|de)X/, "abcX", null],
+    [/(?<!abc|de)X/, "deX", null],
+    [/(?<!abc|de)X/, "zzX", "X"],
+    [/(?<!abc|de)X/, "X", "X"],
+    [/(?<!abc|de)X/, "bcX", "X"],
+    [/(?<!abc|de)X/, "xdeX", null],
+    [/(?<!abc|de)X/, "xabcX", null],
+    [/(?<=abc|de)X/, "abcX", "X"],
+    [/(?<=abc|de)X/, "deX", "X"],
+    [/(?<=abc|de)X/, "zzX", null],
+    [/(?<=abc|de)X/, "adeXabcX", "X"],
+    [/(?<!(?:lib))http/, "libhttp", null],
+    [/(?<!(?:lib))http/, "xxxhttp", "http"],
+    [/(?<!(?:lib))http/, "http", "http"],
+    [/(?<!(?:lib))http/, "alibhttp", null],
+    [/(?<! (?:channel\/|google\/))google/, " channel/google", null],
+    [/(?<! (?:channel\/|google\/))google/, "xxxxxxx channel/google", null],
+    [/(?<! (?:channel\/|google\/))google/, "xxxxxxxx google/google", "google"],
+    [/(?<! (?:channel\/|google\/))google/, "google", "google"],
+    [/(?<! ya(?:yandex)?)search/, " yasearch", null],
+    [/(?<! ya(?:yandex)?)search/, " yayandexsearch", null],
+    [/(?<! ya(?:yandex)?)search/, "zzzsearch", "search"],
+    [/(?<! ya(?:yandex)?)search/, "search", "search"],
+    [/(?<! ya(?:yandex)?)search/, "yayandexsearch", "search"],
+    [/(?<! ya(?:yandex)?)search/, "xxx yasearch", null],
+    [/(?<! ya(?:yandex)?)search/, "xxx yayandexsearch", null],
+    [/(?<![0-9])px/, "10px", null],
+    [/(?<![0-9])px/, "apx", "px"],
+    [/(?<![0-9])px/, "px", "px"],
+    [/(?<![0-9])px/, "x10px", null],
+    [/a(?<!xa)b/, "xab", null],
+    [/a(?<!xa)b/, "yab", "ab"],
+    [/a(?<!xa)b/, "ab", "ab"],
+    [/a(?<!xa)b/, "xxab", null],
+    [/(?<!ABC)d/i, "abcd", null],
+    [/(?<!ABC)d/i, "xyzd", "d"],
+    [/(?<!ABC)d/i, "AbCd", null],
+    [/(?<=[a-z])X/, "aX", "X"],
+    [/(?<=[a-z])X/, "9X", null],
+    [/(?<!\d)px/, "5px", null],
+    [/(?<!\d)px/, "xpx", "px"],
+    [/(?<!a)(?<!b)c/, "ac", null],
+    [/(?<!a)(?<!b)c/, "bc", null],
+    [/(?<!a)(?<!b)c/, "xc", "c"],
+    [/(?<=a)(?<=.a)b/, "xab", "b"],
+    [/(?<=a)(?<=.a)b/, "ab", null],
+    [/ab(?<!ab)/, "ab", null],
+    [/ab(?<!cd)/, "ab", "ab"],
+    [/(?<!\s)word/, " word", null],
+    [/(?<!\s)word/, "xword", "word"],
+    [/foo(?<!x)bar/, "foobar", "foobar"],
+    [/foo(?<!o)bar/, "foobar", null],
+    [/(?<!a|bb|ccc)d/, "ad", null],
+    [/(?<!a|bb|ccc)d/, "bbd", null],
+    [/(?<!a|bb|ccc)d/, "cccd", null],
+    [/(?<!a|bb|ccc)d/, "xd", "d"],
+    [/(?<!a|bb|ccc)d/, "bd", "d"],
+    [/(?<!a|bb|ccc)d/, "ccd", "d"],
+    [/x|(?<!a)y/, "ay", null],
+    [/x|(?<!a)y/, "by", "y"],
+    [/x|(?<!a)y/, "x", "x"],
+    [/(?<!ab)c/, "\u00ffabc", null],
+    [/(?<!ab)c/, "\u00ffxxc", "c"],
+    [/(?<!\u00e9)x/, "\u00e9x", null],
+    [/(?<!\u00e9)x/, "ax", "x"],
+    // Patterns below must fall back to the interpreter; they still need to work.
+    [/(?<!a)b/u, "ab", null],
+    [/(?<!a)b/u, "xb", "b"],
+    [/(?<=a+)b/, "aaab", "b"],
+    [/(?<=a+)b/, "b", null],
+    [/(?<=a{2,3})b/, "aab", "b"],
+    [/(?<=a{2,3})b/, "ab", null],
+    [/(?<=(x))y/, "xy", "y"],
+    [/(?<=(x))y/, "zy", null],
+  ];
+
+  test.each(cases)("%p on %p", (re, input, expected) => {
+    const m = re.exec(input);
+    if (expected === null) {
+      expect(m).toBeNull();
+    } else {
+      expect(m?.[0]).toBe(expected);
+    }
+  });
+
+  test("warmed-up JIT path", () => {
+    for (const [re, input, expected] of cases) {
+      // Push the regex past the JIT threshold, then verify again.
+      for (let i = 0; i < 8; i++) re.test("\u0000");
+      const m = re.exec(input);
+      if (expected === null) {
+        expect(m).toBeNull();
+      } else {
+        expect(m?.[0]).toBe(expected);
+      }
+    }
+  });
+
+  test("capture outside lookbehind", () => {
+    const m = /(?<!x)(bot)/.exec("mybot");
+    expect([m?.[0], m?.[1], m?.index]).toEqual(["bot", "bot", 2]);
+  });
+
+  test("global replace", () => {
+    expect("foobar cubar".replace(/(?<!cu)bar/g, "X")).toBe("fooX cubar");
+  });
+});
+
+// The headline symptom from #5197: the isbot user-agent regex. Before the fix the
+// whole pattern ran in the interpreter because of four simple `(?<! ...)` assertions,
+// while the same pattern without them was JIT-compiled. We time both shapes and assert
+// the lookbehind variant is not orders of magnitude slower than the plain one, which
+// holds independent of build type.
+test("isbot-style regex with lookbehinds is not orders of magnitude slower than without", async () => {
+  const script = `
+    const browser = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    const crawler = "Mozilla/5.0 (compatible; AhrefsBot/7.0; +xxxx://ahrefs.example/robot/)";
+    function bench(re) {
+      re.test("warmup"); re.test("warmup");
+      const t0 = performance.now();
+      let c = 0;
+      for (let i = 0; i < 200; i++) {
+        c += re.test(browser);
+        c += re.test(crawler);
+      }
+      return { c, dt: performance.now() - t0 };
+    }
+    // Identical alternation; the first form guards four alternatives with lookbehinds.
+    const reLB = /^axios\\/|^php|^postman|^python|^wget|^yandex|appinsights|archive|bluecoat drtr|(?<! cu)bot|browsex|capture|catch|check|chromeframe|cloud|crawl|download|feed|ghost|(?<! (?:channel\\/|google\\/))google(?!(app|\\/google| pixel))|headlesschrome\\/|(?<!(?:lib))http|httrack|hydra|images|java(?!;)|library|manager|monitor|nutch|optimize|pagespeed|perl|phantom|pingdom|preview|proxy|reader|rss|scan|scrape|(?<! ya(?:yandex)?)search|server|sogou|spider|torrent|uuurl|wappalyzer|wordpress|zgrab/;
+    const rePlain = /^axios\\/|^php|^postman|^python|^wget|^yandex|appinsights|archive|bluecoat drtr|bot|browsex|capture|catch|check|chromeframe|cloud|crawl|download|feed|ghost|google(?!(app|\\/google| pixel))|headlesschrome\\/|http|httrack|hydra|images|java(?!;)|library|manager|monitor|nutch|optimize|pagespeed|perl|phantom|pingdom|preview|proxy|reader|rss|scan|scrape|search|server|sogou|spider|torrent|uuurl|wappalyzer|wordpress|zgrab/;
+    const lb = bench(reLB);
+    const plain = bench(rePlain);
+    process.stdout.write(JSON.stringify({ lb, plain }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+  const { lb, plain } = JSON.parse(stdout);
+  // Both inputs match the crawler string once per iteration.
+  expect({ lb: lb.c, plain: plain.c }).toEqual({ lb: 200, plain: 200 });
+  // Without the JIT lookbehind support the ratio is roughly 50x on release and 30x on
+  // debug builds; with it the two patterns run within a small constant factor of each
+  // other. 10x leaves ample slack for noise without admitting the interpreter path.
+  const ratio = lb.dt / Math.max(plain.dt, 1);
+  expect(ratio).toBeLessThan(10);
+});

--- a/test/js/bun/jsc/yarr-jit-lookbehind.test.ts
+++ b/test/js/bun/jsc/yarr-jit-lookbehind.test.ts
@@ -91,6 +91,38 @@ describe("lookbehind JIT correctness", () => {
     [/(?<!ab)c/, "\u00ffxxc", "c"],
     [/(?<!\u00e9)x/, "\u00e9x", null],
     [/(?<!\u00e9)x/, "ax", "x"],
+    // 16-bit input strings (code points above U+00FF force Char16 storage).
+    [/(?<!ab)c/, "\u0100abc", null],
+    [/(?<!ab)c/, "\u0100xxc", "c"],
+    [/(?<!\u0101)x/, "\u0101x", null],
+    [/(?<!\u0101)x/, "a\u0100x", "x"],
+    [/(?<![0-9])px/, "\u010010px", null],
+    [/(?<![0-9])px/, "\u0100apx", "px"],
+    [/(?<=\u0101\u0102)x/, "\u0101\u0102x", "x"],
+    [/(?<=\u0101\u0102)x/, "\u0101\u0103x", null],
+    // Lookbehind inside a lookahead.
+    [/x(?=(?<!x)y)y/, "xy", null],
+    [/x(?=(?<!a)y)y/, "xy", "xy"],
+    [/(?=(?<=a)b)b/, "ab", "b"],
+    [/(?=(?<=a)b)b/, "xb", null],
+    [/z(?=a(?<!za)b)ab/, "zab", null],
+    [/z(?=a(?<!ya)b)ab/, "zab", "zab"],
+    [/(?=(?<!ab|c)d)d/, "abd", null],
+    [/(?=(?<!ab|c)d)d/, "xd", "d"],
+    [/(?=ab(?<!xab)c)abc/, "xabc", null],
+    [/(?=ab(?<!xab)c)abc/, "yabc", "abc"],
+    [/(?<!)X/, "aX", null],
+    [/(?<=)X/, "aX", "X"],
+    [/(?=(?<!a)b)/, "xb", ""],
+    [/(?=(?<!a)b)/, "ab", null],
+    [/((?<!a)b)+/, "xbbb", "bbb"],
+    [/((?<!a)b)+/, "abbb", "bb"],
+    [/(?<![^a])b/, "ab", "b"],
+    [/(?<![^a])b/, "xb", null],
+    [/(?<![^a])b/, "b", "b"],
+    [/(?<!.)b/, "ab", null],
+    [/(?<!.)b/, "b", "b"],
+    [/(?<!.)b/, "\nb", "b"],
     // Patterns below must fall back to the interpreter; they still need to work.
     [/(?<!a)b/u, "ab", null],
     [/(?<!a)b/u, "xb", "b"],
@@ -111,10 +143,10 @@ describe("lookbehind JIT correctness", () => {
     }
   });
 
-  test("warmed-up JIT path", () => {
+  test("16-bit MatchOnly path", () => {
     for (const [re, input, expected] of cases) {
-      // Push the regex past the JIT threshold, then verify again.
-      for (let i = 0; i < 8; i++) re.test("\u0000");
+      // Force compilation of the Char16 match-only body before the assertion below.
+      re.test("\u0100");
       const m = re.exec(input);
       if (expected === null) {
         expect(m).toBeNull();


### PR DESCRIPTION
Fixes #5197.

## Problem

The isbot user-agent regex (and any large alternation guarded by a small `(?<! ...)` assertion) fell entirely into the YARR bytecode interpreter because the JIT bailed on any pattern with `m_containsLookbehinds` set, making `.test()` ~300x slower than Node:

```
$ node benchmark.mjs
263487 lines processed
took 201 ms

$ bun run benchmark.mjs
263487 lines processed
took 65417 ms
```

The isbot pattern has ~200 literal alternatives; only four of them use a lookbehind, and all four are small fixed-width negative assertions like `(?<! cu)bot` or `(?<!(?:lib))http`. Their mere presence forced the other ~196 alternatives into the interpreter.

## Fix

WebKit change oven-sh/WebKit#338 teaches YarrJIT to compile lookbehinds whose body reduces to a bounded set of fixed-width flat alternatives (`PatternCharacter` / one-character `CharacterClass` terms, optionally behind non-capturing groups or `{0,1}` quantifiers) by reading characters at known negative offsets from the assertion anchor, reusing the existing forward term generators with `checkedOffset` set to the alternative width. Anything that cannot be flattened (captures, backreferences, unbounded quantifiers, nested assertions, surrogate decoding) still sets `JITFailureReason::Lookbehind` and takes the interpreter path as before.

This PR bumps `WEBKIT_VERSION` to that preview build and adds:

* 82 correctness cases covering positive/negative lookbehinds, alternation, nested groups, optional groups, character classes, ignoreCase, 16-bit input, mid-alternative placement, and the interpreter-fallback shapes (`/u`, `a+`, captures).
* A ratio benchmark that times an isbot-shaped pattern against the same alternation with the four lookbehinds removed. Both should JIT and run within a small constant factor of each other. Before this change the ratio is ~50x; after it is ~1x.

<details>
<summary>Before/after</summary>

```
=== FAIL-BEFORE: debug bun (prebuilt webkit) ===
error: expect(received).toBeLessThan(expected)
Expected: < 10
Received: 51.456771433655796
(fail) isbot-style regex with lookbehinds is not orders of magnitude slower than without [2120.60ms]

=== PASS-AFTER: debug bun (local WebKit with fix) ===
(pass) isbot-style regex with lookbehinds is not orders of magnitude slower than without
 87 pass, 0 fail
```

isbot 10k user-agent sample (debug+ASAN jsc): 30.7s interpreter vs 1.08s JIT, identical match count.
</details>

## Why this is correct

Every accepted term inside the lookbehind is fixed-count with width 1, so the order in which those terms are checked is not observable: a flat alternative either matches the N characters immediately preceding the anchor or it does not, and the assertion consumes no input and contains no captures, so forward vs. backward scan of those N characters is indistinguishable. That is exactly the subset the flattener admits; everything else falls through to the existing interpreter path unchanged.

Upstream: https://bugs.webkit.org/show_bug.cgi?id=258706
