### PR TITLE
node: worker_threads/util/url/URLPattern v26 compat fixes (+6 tests)

### DIFF
--- a/src/js/internal/test/binding.ts
+++ b/src/js/internal/test/binding.ts
@@ -92,6 +92,20 @@ function internalBinding(name: string) {
       return { TCP: TestTCPWrap, constants: { SOCKET: 0, SERVER: 1 } };
     case "util":
       return { isInsideNodeModules };
+    case "worker":
+      // node's env message port is the thread's control channel to its parent;
+      // bun's equivalent is the port to the main-thread messaging hub.
+      return { getEnvMessagePort: require("internal/worker/messaging").getMainThreadPort };
+    case "js_stream":
+      // Just enough of JSStream for tests that probe how a native handle
+      // behaves (the structured-clone serializer rejects it as a host object).
+      return {
+        JSStream: class JSStream {
+          constructor() {
+            return new TextEncoder();
+          }
+        },
+      };
     // The icu-era binding node exposed until nodejs/node#55156; vendored
     // tests like test-icu-punycode still consume it.
     case "icu": {

--- a/src/js/internal/worker/io.ts
+++ b/src/js/internal/worker/io.ts
@@ -1,0 +1,14 @@
+// The control-channel message-type table from node's lib/internal/worker/io.js.
+// Exposed as `internal/worker/io` (gated like `internal/test/binding`) for the
+// vendored node test suite; values must match node's exactly — they travel over
+// the wire to the hub in internal/worker/messaging.ts.
+const messageTypes = {
+  UP_AND_RUNNING: "upAndRunning",
+  COULD_NOT_SERIALIZE_ERROR: "couldNotSerializeError",
+  ERROR_MESSAGE: "errorMessage",
+  STDIO_PAYLOAD: "stdioPayload",
+  STDIO_WANTS_MORE_DATA: "stdioWantsMoreData",
+  LOAD_SCRIPT: "loadScript",
+};
+
+export default { messageTypes };

--- a/src/js/internal/worker/messaging.ts
+++ b/src/js/internal/worker/messaging.ts
@@ -11,6 +11,8 @@
 
 const { validateNumber } = require("internal/validators");
 const { SafeMap } = require("internal/primordials");
+const { messageTypes: envMessageTypes } = require("internal/worker/io");
+const { kInternalAssertionSuffix } = require("internal/shared");
 
 const messageTypes = {
   REGISTER_MAIN_THREAD_PORT: "registerMainThreadPort",
@@ -27,6 +29,10 @@ let isMainThread = true;
 // SafeMap: its prototype is a frozen null-proto snapshot taken at bootstrap, so the
 // cross-thread routing table can't be broken by user code replacing Map.prototype.
 const threadsPorts = new SafeMap<number, any>();
+
+// Main-thread hub only: threadId -> callback invoked when that thread reports
+// `couldNotSerializeError` on its control port (node: Worker[kOnCouldNotSerializeErr]).
+const couldNotSerializeErrHandlers = new SafeMap<number, () => void>();
 
 // Only populated on child threads; always undefined on the main thread.
 let mainThreadPort: any;
@@ -48,7 +54,9 @@ function initThreadInfo(threadId: number, mainThread: boolean) {
 }
 
 // This event handler is always executed on the main thread only.
-function handleMessageFromThread(message) {
+// `sourceThreadId` is 0 for the hub's own synchronous calls; port-delivered
+// messages carry the registering thread's id (see makeThreadMessageHandler).
+function handleMessageFromThread(message, sourceThreadId = 0) {
   switch (message.type) {
     case messageTypes.REGISTER_MAIN_THREAD_PORT: {
       const { threadId, port } = message;
@@ -58,13 +66,16 @@ function handleMessageFromThread(message) {
 
       // Handle messages on this port. When another thread wants to register a
       // child, this takes care of relaying it, so any thread links to the main one.
-      port.on("message", handleMessageFromThread);
+      port.on("message", makeThreadMessageHandler(threadId));
 
       // Self-clean when the peer dies without an UNREGISTER (e.g. a grandchild
       // whose intermediate parent was terminated, so that parent's Worker#onClose
       // never ran); otherwise the stale entry lingers in the hub forever.
       port.on("close", () => {
-        if (threadsPorts.get(threadId) === port) threadsPorts.delete(threadId);
+        if (threadsPorts.get(threadId) === port) {
+          threadsPorts.delete(threadId);
+          couldNotSerializeErrHandlers.delete(threadId);
+        }
       });
 
       // Never block the thread on this port.
@@ -77,6 +88,7 @@ function handleMessageFromThread(message) {
         port.close();
         threadsPorts.delete(message.threadId);
       }
+      couldNotSerializeErrHandlers.delete(message.threadId);
       break;
     }
     case messageTypes.SEND_MESSAGE_TO_WORKER: {
@@ -84,7 +96,24 @@ function handleMessageFromThread(message) {
       sendMessageToWorker(source, destination, value, transferList, memory);
       break;
     }
+    case envMessageTypes.COULD_NOT_SERIALIZE_ERROR: {
+      // node: the parent's Worker[kOnCouldNotSerializeErr] emits
+      // ERR_WORKER_UNSERIALIZABLE_ERROR (lib/internal/worker.js).
+      const onCouldNotSerializeErr = couldNotSerializeErrHandlers.get(sourceThreadId);
+      if (onCouldNotSerializeErr) onCouldNotSerializeErr();
+      break;
+    }
+    default:
+      // node's Worker[kOnMessage] crashes the receiving thread on unknown
+      // control-message types (assert.fail in lib/internal/worker.js).
+      throw $ERR_INTERNAL_ASSERTION(`Unknown worker message type ${message.type}` + kInternalAssertionSuffix);
   }
+}
+
+function makeThreadMessageHandler(sourceThreadId: number) {
+  return function handleThreadMessage(message) {
+    handleMessageFromThread(message, sourceThreadId);
+  };
 }
 
 function handleMessageFromMainThread(message) {
@@ -167,7 +196,7 @@ function createMessagingChannel() {
 
 // Bun half of Node's createMainThreadPort: register the hub-side port now that the
 // child's threadId is known. Called after `new Worker`.
-function registerMainThreadPort(threadId: number, portToMain: any) {
+function registerMainThreadPort(threadId: number, portToMain: any, onCouldNotSerializeErr?: () => void) {
   const registrationMessage = {
     type: messageTypes.REGISTER_MAIN_THREAD_PORT,
     threadId,
@@ -175,6 +204,9 @@ function registerMainThreadPort(threadId: number, portToMain: any) {
   };
 
   if (isMainThread) {
+    // The callback can only be delivered on the thread that owns the Worker
+    // object, so it is tracked only when that owner is the hub itself.
+    if (onCouldNotSerializeErr) couldNotSerializeErrHandlers.set(threadId, onCouldNotSerializeErr);
     handleMessageFromThread(registrationMessage);
   } else if (mainThreadPort) {
     mainThreadPort.postMessage(registrationMessage, [portToMain]);
@@ -287,8 +319,15 @@ async function postMessageToThread(threadId, value, transferList, timeout) {
   }
 }
 
+// internalBinding('worker').getEnvMessagePort for the vendored test suite: the
+// calling thread's port to the main-thread hub (undefined on the main thread).
+function getMainThreadPort() {
+  return mainThreadPort;
+}
+
 export default {
   initThreadInfo,
+  getMainThreadPort,
   createMessagingChannel,
   registerMainThreadPort,
   destroyMainThreadPort,

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -47,7 +47,7 @@ const formatWithOptions = utl.formatWithOptions;
 const format = utl.format;
 const stripVTControlCharacters = utl.stripVTControlCharacters;
 
-var debugs = {};
+var debugs = { __proto__: null };
 var debugEnvRegex = /^$/;
 const NODE_DEBUG = process.env.NODE_DEBUG;
 if (NODE_DEBUG) {
@@ -75,21 +75,87 @@ function emitWarningIfNeeded(set) {
   }
 }
 
-function debuglog(set) {
-  set = set.toUpperCase();
-  if (!debugs[set]) {
-    if (debugEnvRegex.test(set)) {
-      var pid = process.pid;
+const debuglogNoop = () => {};
+
+// Port of node's debuglogImpl + debuglog (lib/internal/util/debuglog.js):
+// lazy init, an `enabled` accessor on the returned logger, and the optional
+// callback receiving the optimized debug function.
+function debuglogImpl(enabled, set) {
+  if (debugs[set] === undefined) {
+    if (enabled) {
+      const pid = process.pid;
       emitWarningIfNeeded(set);
-      debugs[set] = function () {
-        var msg = format.$apply(cjs_exports, arguments);
-        console.error("%s %d: %s", set, pid, msg);
+      debugs[set] = function debug(...args) {
+        lazyUtilColors ??= require("internal/util/colors");
+        const colors = lazyUtilColors.shouldColorize(process.stderr);
+        const msg = formatWithOptions({ colors }, ...args);
+        const coloredPID = inspect(pid, { colors });
+        process.stderr.write(format("%s %s: %s\n", set, coloredPID, msg));
       };
     } else {
-      debugs[set] = function () {};
+      debugs[set] = debuglogNoop;
     }
   }
   return debugs[set];
+}
+
+function debuglog(set, cb) {
+  function init() {
+    set = set.toUpperCase();
+    enabled = debugEnvRegex.test(set);
+  }
+  let debug = (...args) => {
+    init();
+    // Only invokes debuglogImpl() when the debug function is
+    // called for the first time.
+    debug = debuglogImpl(enabled, set);
+    if (typeof cb === "function") {
+      Object.defineProperty(debug, "enabled", {
+        __proto__: null,
+        get() {
+          return enabled;
+        },
+        configurable: true,
+        enumerable: true,
+      });
+      cb(debug);
+    }
+    switch (args.length) {
+      case 1:
+        return debug(args[0]);
+      case 2:
+        return debug(args[0], args[1]);
+      default:
+        return debug(...args);
+    }
+  };
+  let enabled;
+  let test = () => {
+    init();
+    test = () => enabled;
+    return enabled;
+  };
+  const logger = (...args) => {
+    // Improve performance when debug is disabled.
+    if (enabled === false) return;
+    switch (args.length) {
+      case 1:
+        return debug(args[0]);
+      case 2:
+        return debug(args[0], args[1]);
+      default:
+        return debug(...args);
+    }
+  };
+  Object.defineProperty(logger, "enabled", {
+    __proto__: null,
+    get() {
+      return test();
+    },
+    configurable: true,
+    enumerable: true,
+  });
+  return logger;
 }
 
 function isBoolean(arg) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -1068,7 +1068,7 @@ class Worker extends EventEmitter {
     // threadId is only assigned once the WebWorker exists; register the hub-side
     // control port with the messaging hub now.
     this.#messagingThreadId = this.#worker.threadId;
-    messaging.registerMainThreadPort(this.#messagingThreadId, portToMain);
+    messaging.registerMainThreadPort(this.#messagingThreadId, portToMain, this.#onCouldNotSerializeError.bind(this));
     // The transfer is committed - release fds that were transferred but are
     // not referenced from workerData (nothing will deserialize them).
     options[kFinalizeJSTransferables]?.();
@@ -1291,6 +1291,12 @@ class Worker extends EventEmitter {
     this.#stdinPort?.close();
     this.#onExitPromise = e.code;
     this.emit("exit", e.code);
+  }
+
+  // node's Worker[kOnCouldNotSerializeErr]: the worker reported that
+  // serializing its uncaught exception failed.
+  #onCouldNotSerializeError() {
+    this.emit("error", $ERR_WORKER_UNSERIALIZABLE_ERROR("Serializing an uncaught exception failed"));
   }
 
   #onError(event: ErrorEvent) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -58,7 +58,7 @@ function validateWorkerFilename(filename) {
 
 const {
   MessageChannel,
-  BroadcastChannel,
+  BroadcastChannel: WebBroadcastChannel,
   Worker: WebWorker,
 } = globalThis as typeof globalThis & {
   // The Worker constructor secretly takes an extra parameter to provide the node:worker_threads
@@ -67,6 +67,57 @@ const {
   Worker: new (...args: [...ConstructorParameters<typeof globalThis.Worker>, nodeWorker: Worker]) => WebWorker;
 };
 const SHARE_ENV = Symbol.for("nodejs.worker_threads.SHARE_ENV");
+
+// node implements BroadcastChannel itself (lib/internal/worker/io.js) with
+// argument handling the WHATWG constructor does not have: a missing name is
+// ERR_MISSING_ARGS, any non-symbol name is stringified, postMessage() demands
+// an argument, and a closed channel reports an InvalidStateError DOMException.
+class BroadcastChannel extends WebBroadcastChannel {
+  #closed = false;
+
+  constructor(name?: unknown) {
+    if (arguments.length === 0) throw $ERR_MISSING_ARGS("name");
+    // node's `${name}` under V8; JSC words the symbol failure differently.
+    if (typeof name === "symbol") throw new TypeError("Cannot convert a Symbol value to a string");
+    super(`${name}`);
+  }
+
+  // node brand-checks `this` on every member before anything else
+  // (ERR_INVALID_THIS, checked ahead of argument validation).
+  static #check(channel: BroadcastChannel) {
+    if (!(#closed in channel)) throw $ERR_INVALID_THIS("BroadcastChannel");
+  }
+
+  get name() {
+    BroadcastChannel.#check(this);
+    return super.name;
+  }
+
+  close() {
+    BroadcastChannel.#check(this);
+    this.#closed = true;
+    super.close();
+  }
+
+  postMessage(message: unknown) {
+    BroadcastChannel.#check(this);
+    if (arguments.length === 0) throw $ERR_MISSING_ARGS("message");
+    if (this.#closed) throw new DOMException("BroadcastChannel is closed.", "InvalidStateError");
+    super.postMessage(message);
+  }
+
+  ref() {
+    BroadcastChannel.#check(this);
+    super.ref();
+    return this;
+  }
+
+  unref() {
+    BroadcastChannel.#check(this);
+    super.unref();
+    return this;
+  }
+}
 
 const isMainThread = Bun.isMainThread;
 const {

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -361,5 +361,6 @@ const errors: ErrorCodeMapping = [
   // distinct from a malformed chunk-size line (HPE_INVALID_CHUNK_SIZE).
   ["HPE_STRICT", Error],
   ["ERR_NOT_BUILDING_SNAPSHOT", Error],
+  ["ERR_WORKER_UNSERIALIZABLE_ERROR", Error],
 ];
 export default errors;

--- a/src/jsc/bindings/webcore/BroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/BroadcastChannel.cpp
@@ -92,6 +92,24 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
     dispatchEvent(event.event);
 }
 
+void BroadcastChannel::dispatchPendingMessage()
+{
+    auto message = BunBroadcastChannelRegistry::singleton().takePending(m_name, *this);
+    if (!message)
+        return;
+    dispatchMessage(message.releaseNonNull());
+}
+
+JSC::JSValue BroadcastChannel::tryTakeMessage(JSC::JSGlobalObject* lexicalGlobalObject)
+{
+    if (isClosed())
+        return JSC::jsUndefined();
+    auto message = BunBroadcastChannelRegistry::singleton().takePending(m_name, *this);
+    if (!message)
+        return JSC::jsUndefined();
+    return message->deserialize(*lexicalGlobalObject, lexicalGlobalObject, SerializationErrorMode::NonThrowing);
+}
+
 void BroadcastChannel::close()
 {
     uint64_t prev = m_state.fetch_or(Closed, std::memory_order_acq_rel);
@@ -129,6 +147,10 @@ bool BroadcastChannel::hasPendingActivity() const
 
 void BroadcastChannel::jsRef(JSGlobalObject* lexicalGlobalObject)
 {
+    // node: ref() on a closed channel is a no-op (its handle is gone), and
+    // nothing would ever release the ref again.
+    if (isClosed())
+        return;
     if (!m_hasRef) {
         m_hasRef = true;
         Bun__eventLoop__incrementRefConcurrently(WebCore::clientData(lexicalGlobalObject->vm())->bunVM, 1);

--- a/src/jsc/bindings/webcore/BroadcastChannel.h
+++ b/src/jsc/bindings/webcore/BroadcastChannel.h
@@ -73,6 +73,10 @@ public:
 
     // Called on this channel's context thread with one message.
     void dispatchMessage(Ref<SerializedScriptValue>&&);
+    // Pops one registry-queued message and dispatches it as a 'message' event.
+    void dispatchPendingMessage();
+    // node:worker_threads receiveMessageOnPort — synchronous single pop.
+    JSC::JSValue tryTakeMessage(JSC::JSGlobalObject*);
 
     bool hasPendingActivity() const;
 

--- a/src/jsc/bindings/webcore/BunBroadcastChannelRegistry.cpp
+++ b/src/jsc/bindings/webcore/BunBroadcastChannelRegistry.cpp
@@ -60,6 +60,10 @@ void BunBroadcastChannelRegistry::post(const String& name, BroadcastChannel& sou
         for (auto& sub : it->value) {
             if (sub.identity == &source)
                 continue;
+            // Queued in the registry (not captured in the task) so
+            // receiveMessageOnPort can consume it synchronously and close()
+            // drops what was never delivered.
+            sub.pending.append(message.copyRef());
             targets.append({ sub.ctxId, sub.channel });
         }
     }
@@ -68,12 +72,28 @@ void BunBroadcastChannelRegistry::post(const String& name, BroadcastChannel& sou
     // Same-context subscribers share a task queue, so this preserves the
     // spec-mandated (message-major, creation-minor) delivery order.
     for (auto& [ctxId, weakChannel] : targets) {
-        ScriptExecutionContext::postTaskTo(ctxId, [weakChannel, message = message.copyRef()](ScriptExecutionContext&) mutable {
+        ScriptExecutionContext::postTaskTo(ctxId, [weakChannel](ScriptExecutionContext&) mutable {
             // Resolve on the target thread so any last deref happens here.
             if (RefPtr channel = weakChannel.get())
-                channel->dispatchMessage(WTF::move(message));
+                channel->dispatchPendingMessage();
         });
     }
+}
+
+RefPtr<SerializedScriptValue> BunBroadcastChannelRegistry::takePending(const String& name, BroadcastChannel& channel)
+{
+    Locker locker { m_lock };
+    auto it = m_subscribers.find(name);
+    if (it == m_subscribers.end())
+        return nullptr;
+    for (auto& sub : it->value) {
+        if (sub.identity != &channel)
+            continue;
+        if (sub.pending.isEmpty())
+            return nullptr;
+        return sub.pending.takeFirst();
+    }
+    return nullptr;
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/BunBroadcastChannelRegistry.h
+++ b/src/jsc/bindings/webcore/BunBroadcastChannelRegistry.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ScriptExecutionContext.h"
+#include <wtf/Deque.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
@@ -29,6 +30,9 @@ public:
     void subscribe(const String& name, ScriptExecutionContextIdentifier, BroadcastChannel&);
     void unsubscribe(const String& name, BroadcastChannel&);
     void post(const String& name, BroadcastChannel& source, Ref<SerializedScriptValue>&&);
+    // Synchronous single pop of a delivered-but-not-yet-dispatched message,
+    // for node:worker_threads receiveMessageOnPort(broadcastChannel).
+    RefPtr<SerializedScriptValue> takePending(const String& name, BroadcastChannel&);
 
 private:
     friend class WTF::NeverDestroyed<BunBroadcastChannelRegistry>;
@@ -40,6 +44,10 @@ private:
         // Raw pointer used only for identity comparison under the lock;
         // never dereferenced.
         BroadcastChannel* identity;
+        // Messages posted but not yet dispatched (or synchronously consumed
+        // via takePending). Kept in the registry rather than the channel so
+        // the posting thread never needs a strong channel ref.
+        Deque<Ref<SerializedScriptValue>> pending;
     };
 
     WTF::Lock m_lock;

--- a/src/jsc/bindings/webcore/JSURLPattern.cpp
+++ b/src/jsc/bindings/webcore/JSURLPattern.cpp
@@ -233,15 +233,15 @@ template<> void JSURLPatternDOMConstructor::initializeProperties(VM& vm, JSDOMGl
 
 static const std::array<HashTableValue, 12> JSURLPatternPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPatternConstructor, 0 } },
-    HashTableValue { "protocol"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_protocol, 0 } },
-    HashTableValue { "username"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_username, 0 } },
-    HashTableValue { "password"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_password, 0 } },
-    HashTableValue { "hostname"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_hostname, 0 } },
-    HashTableValue { "port"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_port, 0 } },
-    HashTableValue { "pathname"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_pathname, 0 } },
-    HashTableValue { "search"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_search, 0 } },
-    HashTableValue { "hash"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_hash, 0 } },
-    HashTableValue { "hasRegExpGroups"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_hasRegExpGroups, 0 } },
+    HashTableValue { "protocol"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_protocol, 0 } },
+    HashTableValue { "username"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_username, 0 } },
+    HashTableValue { "password"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_password, 0 } },
+    HashTableValue { "hostname"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_hostname, 0 } },
+    HashTableValue { "port"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_port, 0 } },
+    HashTableValue { "pathname"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_pathname, 0 } },
+    HashTableValue { "search"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_search, 0 } },
+    HashTableValue { "hash"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_hash, 0 } },
+    HashTableValue { "hasRegExpGroups"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor, NoIntrinsic, { HashTableValue::GetterSetterType, jsURLPattern_hasRegExpGroups, 0 } },
     HashTableValue { "test"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsURLPatternPrototypeFunction_test, 0 } },
     HashTableValue { "exec"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsURLPatternPrototypeFunction_exec, 0 } },
 };
@@ -305,7 +305,15 @@ static inline JSValue jsURLPattern_protocolGetter(JSGlobalObject& lexicalGlobalO
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_protocol, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_protocolGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_protocolGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_usernameGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -318,7 +326,15 @@ static inline JSValue jsURLPattern_usernameGetter(JSGlobalObject& lexicalGlobalO
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_username, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_usernameGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_usernameGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_passwordGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -331,7 +347,15 @@ static inline JSValue jsURLPattern_passwordGetter(JSGlobalObject& lexicalGlobalO
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_password, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_passwordGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_passwordGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_hostnameGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -344,7 +368,15 @@ static inline JSValue jsURLPattern_hostnameGetter(JSGlobalObject& lexicalGlobalO
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_hostname, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_hostnameGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_hostnameGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_portGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -357,7 +389,15 @@ static inline JSValue jsURLPattern_portGetter(JSGlobalObject& lexicalGlobalObjec
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_port, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_portGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_portGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_pathnameGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -370,7 +410,15 @@ static inline JSValue jsURLPattern_pathnameGetter(JSGlobalObject& lexicalGlobalO
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_pathname, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_pathnameGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_pathnameGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_searchGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -383,7 +431,15 @@ static inline JSValue jsURLPattern_searchGetter(JSGlobalObject& lexicalGlobalObj
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_search, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_searchGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_searchGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_hashGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -396,7 +452,15 @@ static inline JSValue jsURLPattern_hashGetter(JSGlobalObject& lexicalGlobalObjec
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_hash, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_hashGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_hashGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSValue jsURLPattern_hasRegExpGroupsGetter(JSGlobalObject& lexicalGlobalObject, JSURLPattern& thisObject)
@@ -409,7 +473,15 @@ static inline JSValue jsURLPattern_hasRegExpGroupsGetter(JSGlobalObject& lexical
 
 JSC_DEFINE_CUSTOM_GETTER(jsURLPattern_hasRegExpGroups, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue thisValue, PropertyName attributeName))
 {
-    return IDLAttribute<JSURLPattern>::get<jsURLPattern_hasRegExpGroupsGetter, CastedThisErrorBehavior::Assert>(*lexicalGlobalObject, thisValue, attributeName);
+    UNUSED_PARAM(attributeName);
+    // node throws a plain TypeError("Illegal invocation") for a foreign `this`.
+    auto* thisObject = dynamicDowncast<JSURLPattern>(JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return JSValue::encode(jsURLPattern_hasRegExpGroupsGetter(*lexicalGlobalObject, *thisObject));
 }
 
 static inline JSC::EncodedJSValue jsURLPatternPrototypeFunction_testBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSURLPattern>::ClassParameter castedThis)
@@ -433,7 +505,13 @@ static inline JSC::EncodedJSValue jsURLPatternPrototypeFunction_testBody(JSC::JS
 
 JSC_DEFINE_HOST_FUNCTION(jsURLPatternPrototypeFunction_test, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return IDLOperation<JSURLPattern>::call<jsURLPatternPrototypeFunction_testBody>(*lexicalGlobalObject, *callFrame, "test");
+    auto* castedThis = dynamicDowncast<JSURLPattern>(callFrame->thisValue());
+    if (!castedThis) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return jsURLPatternPrototypeFunction_testBody(lexicalGlobalObject, callFrame, castedThis);
 }
 
 static inline JSC::EncodedJSValue jsURLPatternPrototypeFunction_execBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSURLPattern>::ClassParameter castedThis)
@@ -457,7 +535,13 @@ static inline JSC::EncodedJSValue jsURLPatternPrototypeFunction_execBody(JSC::JS
 
 JSC_DEFINE_HOST_FUNCTION(jsURLPatternPrototypeFunction_exec, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return IDLOperation<JSURLPattern>::call<jsURLPatternPrototypeFunction_execBody>(*lexicalGlobalObject, *callFrame, "exec");
+    auto* castedThis = dynamicDowncast<JSURLPattern>(callFrame->thisValue());
+    if (!castedThis) [[unlikely]] {
+        auto& vm = JSC::getVM(lexicalGlobalObject);
+        auto throwScope = DECLARE_THROW_SCOPE(vm);
+        return throwVMTypeError(lexicalGlobalObject, throwScope, "Illegal invocation"_s);
+    }
+    return jsURLPatternPrototypeFunction_execBody(lexicalGlobalObject, callFrame, castedThis);
 }
 
 JSC::GCClient::IsoSubspace* JSURLPattern::subspaceForImpl(JSC::VM& vm)

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -56,6 +56,7 @@
 // #include "JSIDBSerializationGlobalObject.h"
 // #include "JSImageBitmap.h"
 // #include "JSImageData.h"
+#include "JSMessageChannel.h"
 #include "JSMessagePort.h"
 // #include "JSNavigator.h"
 // #include "JSRTCCertificate.h"
@@ -1627,7 +1628,14 @@ private:
         }
 
         if (value.isSymbol()) {
-            code = SerializationReturnCode::DataCloneError;
+            VM& vm = m_lexicalGlobalObject->vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            // node (V8) names the failing value: `Symbol(foo) could not be cloned.`
+            auto descriptionExpected = asSymbol(value)->tryGetDescriptiveString();
+            String description = descriptionExpected ? descriptionExpected.value() : String("Symbol()"_s);
+            WebCore::propagateException(*m_lexicalGlobalObject, scope,
+                Exception { DataCloneError, makeString(description, " could not be cloned."_s) });
+            code = SerializationReturnCode::ExistingExceptionError;
             return true;
         }
 
@@ -2812,8 +2820,35 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
             // like a plain object from JS's perspective (matches Node.js).
             // ObjectPrototype is allowed because %Object.prototype% is an immutable
             // prototype exotic object that the spec carves out of this rejection.
-            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info())
-                return SerializationReturnCode::DataCloneError;
+            if (inObject->classInfo() != JSFinalObject::info() && inObject->classInfo() != Zig::NapiPrototype::info() && inObject->classInfo() != JSC::ObjectPrototype::info()) {
+                // A MessageChannel's ports would need transferring, and that is
+                // the error node reports for one found in a message (its
+                // MessageChannel is a plain object whose ports are discovered
+                // during the clone walk).
+                if (inObject->inherits<JSMessageChannel>()) {
+                    WebCore::propagateException(*m_lexicalGlobalObject, scope,
+                        Exception { DataCloneError, "Object that needs transfer was found in message but not listed in transferList"_s });
+                    return SerializationReturnCode::ExistingExceptionError;
+                }
+                // node (V8) renders a rejected callable with its source text
+                // (`function foo() {} could not be cloned.`); any other
+                // unsupported object is reported as a host object.
+                if (auto* function = dynamicDowncast<JSC::JSFunction>(inObject)) {
+                    JSString* sourceString = function->toString(m_lexicalGlobalObject);
+                    RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
+                    String source = sourceString->value(m_lexicalGlobalObject);
+                    RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
+                    WebCore::propagateException(*m_lexicalGlobalObject, scope,
+                        Exception { DataCloneError, makeString(source, " could not be cloned."_s) });
+                } else if (inObject->isCallable()) {
+                    WebCore::propagateException(*m_lexicalGlobalObject, scope,
+                        Exception { DataCloneError, makeString("function "_s, inObject->classInfo()->className, "() { [native code] } could not be cloned."_s) });
+                } else {
+                    WebCore::propagateException(*m_lexicalGlobalObject, scope,
+                        Exception { DataCloneError, "Cannot clone object of unsupported type."_s });
+                }
+                return SerializationReturnCode::ExistingExceptionError;
+            }
             inputObjectStack.append(inObject);
             indexStack.append(0);
             propertyStack.append(PropertyNameArrayBuilder(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude));

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -767,9 +767,8 @@ JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobal
 
     if (auto* messagePort = dynamicDowncast<JSMessagePort>(port)) {
         RELEASE_AND_RETURN(scope, JSC::JSValue::encode(messagePort->wrapped().tryTakeMessage(lexicalGlobalObject)));
-    } else if (dynamicDowncast<JSBroadcastChannel>(port)) {
-        // TODO: support broadcast channels
-        return JSC::JSValue::encode(jsUndefined());
+    } else if (auto* broadcastChannel = dynamicDowncast<JSBroadcastChannel>(port)) {
+        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(broadcastChannel->wrapped().tryTakeMessage(lexicalGlobalObject)));
     }
 
     return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_ARG_TYPE, "The \"port\" argument must be a MessagePort instance"_s);

--- a/src/resolve_builtins/HardcodedModule.rs
+++ b/src/resolve_builtins/HardcodedModule.rs
@@ -184,6 +184,10 @@ pub enum HardcodedModule {
     /// gated behind '--expose-internals' like `bun:internal-for-testing`.
     #[strum(serialize = "internal/test/binding")]
     InternalTestBinding,
+    /// Node's `internal/worker/io` (message-type table), gated behind
+    /// '--expose-internals' like `internal/test/binding`.
+    #[strum(serialize = "internal/worker/io")]
+    InternalWorkerIo,
 }
 
 bun_core::comptime_string_map! {
@@ -202,6 +206,7 @@ bun_core::comptime_string_map! {
         b"bun:wrap" => HardcodedModule::BunWrap,
         b"bun:internal-for-testing" => HardcodedModule::BunInternalForTesting,
         b"internal/test/binding" => HardcodedModule::InternalTestBinding,
+        b"internal/worker/io" => HardcodedModule::InternalWorkerIo,
         // Node.js
         b"node:assert" => HardcodedModule::NodeAssert,
         b"node:assert/strict" => HardcodedModule::NodeAssertStrict,
@@ -708,6 +713,7 @@ const BUN_EXTRA_ALIAS_KVS: &[AliasKv] = &[
     entry!("bun:wrap"),
     entry!("bun:internal-for-testing"),
     entry!("internal/test/binding"),
+    entry!("internal/worker/io"),
     (
         b"ffi",
         Alias {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3672,6 +3672,17 @@ fn get_hardcoded_module(
             }
             Some(js_synthetic_module(b"internal:test/binding", specifier))
         }
+        HardcodedModule::InternalWorkerIo => {
+            // Same `--expose-internals` gate as `internal/test/binding`.
+            if !bun_core::env::IS_DEBUG {
+                let allowed = bun_jsc::module_loader::IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS
+                    .load(core::sync::atomic::Ordering::Relaxed);
+                if !allowed {
+                    return None;
+                }
+            }
+            Some(js_synthetic_module(b"internal:worker/io", specifier))
+        }
         HardcodedModule::BunWrap => {
             // `Runtime.Runtime.sourceCode()` — the bundler's CJS-interop
             // shim, embedded as a static string in `bun_ast::runtime`.

--- a/test/js/node/test/fixtures/node_modules/url-deprecations.js
+++ b/test/js/node/test/fixtures/node_modules/url-deprecations.js
@@ -1,0 +1,5 @@
+const url = require('url');
+
+url.parse('foo');
+url.format('foo');
+url.resolve('foo', 'bar');

--- a/test/js/node/test/parallel/test-url-parse-deprecation.js
+++ b/test/js/node/test/parallel/test-url-parse-deprecation.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+const assert = require('assert');
+const url = require('url');
+
+const fixturePath = fixtures.path('node_modules', 'url-deprecations.js');
+
+// Application deprecation for url.parse()
+url.parse('foo');
+common.expectWarning('DeprecationWarning',
+                     [/`url\.parse\(\)` behavior is not standardized/, 'DEP0169']);
+
+// No warnings from inside node_modules
+common.spawnPromisified(process.execPath, [fixturePath]).then(
+  common.mustCall(({ code, signal, stderr }) => {
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+    assert.doesNotMatch(stderr, /\[DEP0169\]/);
+  })
+);

--- a/test/js/node/test/parallel/test-urlpattern-invalidthis.js
+++ b/test/js/node/test/parallel/test-urlpattern-invalidthis.js
@@ -1,0 +1,40 @@
+'use strict';
+
+require('../common');
+
+const { URLPattern } = require('url');
+const assert = require('assert');
+
+const pattern = new URLPattern();
+const proto = Object.getPrototypeOf(pattern);
+
+// Verifies that attempts to call the property getters on a URLPattern
+// with the incorrect `this` will not crash the process.
+[
+  'protocol',
+  'username',
+  'password',
+  'hostname',
+  'port',
+  'pathname',
+  'search',
+  'hash',
+  'hasRegExpGroups',
+].forEach((i) => {
+  const prop = Object.getOwnPropertyDescriptor(proto, i).get;
+  assert.throws(() => prop({}), {
+    message: 'Illegal invocation',
+  }, i);
+});
+
+// Verifies that attempts to call the exec and test functions
+// with the wrong this also throw
+
+const { test, exec } = pattern;
+
+assert.throws(() => test({}), {
+  message: 'Illegal invocation',
+});
+assert.throws(() => exec({}), {
+  message: 'Illegal invocation',
+});

--- a/test/js/node/test/parallel/test-worker-broadcastchannel.js
+++ b/test/js/node/test/parallel/test-worker-broadcastchannel.js
@@ -1,0 +1,185 @@
+'use strict';
+
+const common = require('../common');
+const {
+  BroadcastChannel,
+  Worker,
+  receiveMessageOnPort
+} = require('worker_threads');
+const assert = require('assert');
+const { inspect } = require('util');
+
+assert.throws(() => new BroadcastChannel(Symbol('test')), {
+  message: /Cannot convert a Symbol value to a string/
+});
+
+assert.throws(() => new BroadcastChannel(), {
+  message: /The "name" argument must be specified/
+});
+
+// These should all just work
+[undefined, 1, null, 'test', 1n, false, Infinity].forEach((i) => {
+  const bc = new BroadcastChannel(i);
+  assert.strictEqual(bc.name, `${i}`);
+  bc.close();
+});
+
+{
+  // Empty postMessage throws
+  const bc = new BroadcastChannel('whatever');
+  assert.throws(() => bc.postMessage(), {
+    message: /The "message" argument must be specified/
+  });
+  bc.close();
+  // Calling close multiple times should not throw
+  bc.close();
+
+  // Calling postMessage after close should throw
+  assert.throws(() => bc.postMessage(null), {
+    message: /BroadcastChannel is closed/
+  });
+}
+
+{
+  const bc1 = new BroadcastChannel('channel1');
+  const bc2 = new BroadcastChannel('channel1');
+  const bc3 = new BroadcastChannel('channel1');
+  const bc4 = new BroadcastChannel('channel2');
+  assert.strictEqual(bc1.name, 'channel1');
+  assert.strictEqual(bc2.name, 'channel1');
+  assert.strictEqual(bc3.name, 'channel1');
+  assert.strictEqual(bc4.name, 'channel2');
+  bc1.addEventListener('message', common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc1.close();
+    bc2.close();
+    bc4.close();
+  }));
+  bc3.addEventListener('message', common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc3.close();
+  }));
+  bc2.addEventListener('message', common.mustNotCall());
+  bc4.addEventListener('message', common.mustNotCall());
+  bc2.postMessage('hello');
+}
+
+{
+  const bc1 = new BroadcastChannel('onmessage-channel1');
+  const bc2 = new BroadcastChannel('onmessage-channel1');
+  const bc3 = new BroadcastChannel('onmessage-channel1');
+  const bc4 = new BroadcastChannel('onmessage-channel2');
+  assert.strictEqual(bc1.name, 'onmessage-channel1');
+  assert.strictEqual(bc2.name, 'onmessage-channel1');
+  assert.strictEqual(bc3.name, 'onmessage-channel1');
+  assert.strictEqual(bc4.name, 'onmessage-channel2');
+  bc1.onmessage = common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc1.close();
+    bc2.close();
+    bc4.close();
+  });
+  bc3.onmessage = common.mustCall((event) => {
+    assert.strictEqual(event.data, 'hello');
+    bc3.close();
+  });
+  bc2.onmessage = common.mustNotCall();
+  bc4.onmessage = common.mustNotCall();
+  bc2.postMessage('hello');
+}
+
+{
+  const bc = new BroadcastChannel('worker1');
+  new Worker(`
+    const assert = require('assert');
+    const { BroadcastChannel } = require('worker_threads');
+    const bc = new BroadcastChannel('worker1');
+    bc.addEventListener('message', (event) => {
+      assert.strictEqual(event.data, 123);
+      // If this close() is not executed, the test should hang and timeout.
+      // If the test does hang and timeout in CI, then the first step should
+      // be to check that the two bc.close() calls are being made.
+      bc.close();
+    });
+    bc.postMessage(321);
+  `, { eval: true });
+  bc.addEventListener('message', common.mustCall(({ data }) => {
+    assert.strictEqual(data, 321);
+    bc.postMessage(123);
+    bc.close();
+  }));
+}
+
+{
+  const bc1 = new BroadcastChannel('channel3');
+  const bc2 = new BroadcastChannel('channel3');
+  const bc3 = new BroadcastChannel('channel3');
+  bc3.postMessage(new SharedArrayBuffer(10));
+  let received = 0;
+  for (const bc of [bc1, bc2]) {
+    bc.addEventListener('message', common.mustCall(({ data }) => {
+      assert(data instanceof SharedArrayBuffer);
+      if (++received === 2) {
+        bc1.close();
+        bc2.close();
+        bc3.close();
+      }
+    }));
+  }
+}
+
+{
+  const bc1 = new BroadcastChannel('channel3');
+  const mc = new MessageChannel();
+  assert.throws(() => bc1.postMessage(mc), {
+    message: /Object that needs transfer was found/
+  });
+  assert.throws(() => bc1.postMessage(Symbol()), {
+    message: /Symbol\(\) could not be cloned/
+  });
+  bc1.close();
+  assert.throws(() => bc1.postMessage(Symbol()), {
+    message: /BroadcastChannel is closed/
+  });
+}
+
+{
+  const bc1 = new BroadcastChannel('channel4');
+  const bc2 = new BroadcastChannel('channel4');
+  bc1.postMessage('some data');
+  assert.strictEqual(receiveMessageOnPort(bc2).message, 'some data');
+  assert.strictEqual(receiveMessageOnPort(bc2), undefined);
+  bc1.close();
+  bc2.close();
+}
+
+{
+  assert.throws(() => Reflect.get(BroadcastChannel.prototype, 'name', {}), {
+    code: 'ERR_INVALID_THIS',
+  });
+
+  [
+    'close',
+    'postMessage',
+    'ref',
+    'unref',
+  ].forEach((i) => {
+    assert.throws(() => Reflect.apply(BroadcastChannel.prototype[i], [], {}), {
+      code: 'ERR_INVALID_THIS',
+    });
+  });
+}
+
+{
+  const bc = new BroadcastChannel('channel5');
+  assert.strictEqual(
+    inspect(bc.ref()),
+    "BroadcastChannel { name: 'channel5', active: true }"
+  );
+
+  bc.close();
+  assert.strictEqual(
+    inspect(bc.ref()),
+    "BroadcastChannel { name: 'channel5', active: false }"
+  );
+}

--- a/test/js/node/test/parallel/test-worker-message-not-serializable.js
+++ b/test/js/node/test/parallel/test-worker-message-not-serializable.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Flags: --expose-internals
+
+// Check that main thread handles unserializable errors in a worker thread as
+// expected.
+
+const common = require('../common');
+
+const assert = require('assert');
+
+const { Worker } = require('worker_threads');
+
+const worker = new Worker(`
+  const { internalBinding } = require('internal/test/binding');
+  const { getEnvMessagePort } = internalBinding('worker');
+  const { messageTypes } = require('internal/worker/io');
+  const messagePort = getEnvMessagePort();
+  messagePort.postMessage({ type: messageTypes.COULD_NOT_SERIALIZE_ERROR });
+`, { eval: true });
+
+worker.on('error', common.mustCall((e) => {
+  assert.strictEqual(e.code, 'ERR_WORKER_UNSERIALIZABLE_ERROR');
+}));

--- a/test/js/node/test/parallel/test-worker-message-port-transfer-native.js
+++ b/test/js/node/test/parallel/test-worker-message-port-transfer-native.js
@@ -1,0 +1,37 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { MessageChannel } = require('worker_threads');
+const { internalBinding } = require('internal/test/binding');
+
+// Test that passing native objects and functions to .postMessage() throws
+// DataCloneError exceptions.
+
+{
+  const { port1, port2 } = new MessageChannel();
+  port2.once('message', common.mustNotCall());
+
+  assert.throws(() => {
+    port1.postMessage(function foo() {});
+  }, {
+    name: 'DataCloneError',
+    message: /function foo\(\) \{\} could not be cloned\.$/
+  });
+  port1.close();
+}
+
+{
+  const { port1, port2 } = new MessageChannel();
+  port2.once('message', common.mustNotCall());
+
+  const nativeObject = new (internalBinding('js_stream').JSStream)();
+
+  assert.throws(() => {
+    port1.postMessage(nativeObject);
+  }, {
+    name: 'DataCloneError',
+    message: /Cannot clone object of unsupported type\.$/
+  });
+  port1.close();
+}

--- a/test/js/node/test/parallel/test-worker-message-type-unknown.js
+++ b/test/js/node/test/parallel/test-worker-message-type-unknown.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Check that main thread handles an unknown message type from a worker thread
+// as expected.
+
+require('../common');
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+const { Worker } = require('worker_threads');
+if (process.argv[2] !== 'spawned') {
+  const result = spawnSync(process.execPath,
+                           [ '--expose-internals', __filename, 'spawned'],
+                           { encoding: 'utf8' });
+  assert.ok(result.stderr.includes('Unknown worker message type FHQWHGADS'),
+            `Expected error not found in: ${result.stderr}`);
+} else {
+  new Worker(`
+    const { internalBinding } = require('internal/test/binding');
+    const { getEnvMessagePort } = internalBinding('worker');
+    const messagePort = getEnvMessagePort();
+    messagePort.postMessage({ type: 'FHQWHGADS' });
+    `, { eval: true });
+}

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -519,3 +519,52 @@ describe("util.parseEnv", () => {
     expect(util.parseEnv(new String("FOO=bar"))).toEqual({ FOO: "bar" });
   });
 });
+
+describe("util.debuglog", () => {
+  it("exposes an `enabled` accessor and passes the optimized logger to the callback", async () => {
+    const code = `
+      const util = require("util");
+      const assert = require("assert");
+      let inner = null;
+      const debug = util.debuglog("tud", (fn) => {
+        assert.strictEqual(typeof fn, "function");
+        inner = fn;
+      });
+      assert.strictEqual(typeof Object.getOwnPropertyDescriptor(debug, "enabled").get, "function");
+      debug("this", { is: "a" }, /debugging/);
+      debug("num=%d str=%s obj=%j", 1, "a", { foo: "bar" });
+      assert.strictEqual(typeof Object.getOwnPropertyDescriptor(inner, "enabled").get, "function");
+      console.log(debug.enabled ? "outer enabled" : "outer disabled");
+      console.log(inner.enabled ? "inner enabled" : "inner disabled");
+    `;
+    const run = async env => {
+      const proc = Bun.spawn({
+        cmd: [process.execPath, "-e", code],
+        env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1", NO_COLOR: undefined, FORCE_COLOR: undefined, NODE_DEBUG: env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      return { stdout, stderr, exitCode };
+    };
+
+    {
+      // Wildcard-enabled section: node's "SET PID: message" format on stderr.
+      const { stdout, stderr, exitCode } = await run("foo,tu*,bar");
+      expect(stdout).toBe("outer enabled\ninner enabled\n");
+      expect(stderr).toMatch(/^TUD \d+: this \{ is: 'a' \} \/debugging\/\nTUD \d+: num=1 str=a obj=\{"foo":"bar"\}\n$/);
+      expect(exitCode).toBe(0);
+    }
+    {
+      // Non-matching sections: nothing on stderr, enabled getters report false.
+      const { stdout, stderr, exitCode } = await run("foo,bar,test-*");
+      expect(stdout).toBe("outer disabled\ninner disabled\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+  }, 20_000);
+});

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -540,15 +540,17 @@ describe("util.debuglog", () => {
     const run = async env => {
       const proc = Bun.spawn({
         cmd: [process.execPath, "-e", code],
-        env: { ...process.env, BUN_DEBUG_QUIET_LOGS: "1", NO_COLOR: undefined, FORCE_COLOR: undefined, NODE_DEBUG: env },
+        env: {
+          ...process.env,
+          BUN_DEBUG_QUIET_LOGS: "1",
+          NO_COLOR: undefined,
+          FORCE_COLOR: undefined,
+          NODE_DEBUG: env,
+        },
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       return { stdout, stderr, exitCode };
     };
 


### PR DESCRIPTION
Fixes eight distinct node-v26 compat gaps found by running the remaining worker_threads/util/url upstream failures, and vendors the six upstream tests those fixes make pass byte-verbatim:
`test-worker-message-type-unknown`, `test-worker-message-not-serializable`, `test-worker-broadcastchannel`, `test-worker-message-port-transfer-native`, `test-urlpattern-invalidthis`, `test-url-parse-deprecation` (plus a new `util.debuglog` block in `util.test.js`).

### Worker control-channel protocol (`internal/worker/io`, hub message handling)
Node's worker/parent control channel speaks a `{type}` protocol (lib/internal/worker/io.js). Bun's hub (internal/worker/messaging.ts) silently ignored unknown types and had no handling for worker-reported serialization failures.
- New gated module `internal/worker/io` exporting node's `messageTypes` table (gated exactly like `internal/test/binding`: `--expose-internals` on release, always-on in debug).
- `internalBinding('worker').getEnvMessagePort` returns the calling thread's control port.
- The hub now emits `ERR_WORKER_UNSERIALIZABLE_ERROR` ("Serializing an uncaught exception failed") on the owning `Worker` when a thread reports `couldNotSerializeError`, and crashes on unknown control-message types with node's `Unknown worker message type <type>` internal assertion (lib/internal/worker.js `[kOnMessage]`).
- Tests: `test-worker-message-type-unknown.js`, `test-worker-message-not-serializable.js`.

### Per-value structured-clone error messages (SerializedScriptValue.cpp)
Every clone failure produced the generic "The object can not be cloned." Node (V8) names the value. Now:
- symbols: `Symbol(foo) could not be cloned.`
- functions: `function foo() {} could not be cloned.` (source text, like `Function.prototype.toString`)
- other unsupported objects: `Cannot clone object of unsupported type.`
- a `MessageChannel` in a message: `Object that needs transfer was found in message but not listed in transferList` (its ports are what node discovers during the clone walk)
The failure sites use the same propagate-custom-exception pattern the MessagePort-not-in-transferList case already used.
- `internalBinding('js_stream').JSStream` test shim added (a native handle the serializer rejects as a host object).
- Test: `test-worker-message-port-transfer-native.js`.

### node's BroadcastChannel argument semantics (worker_threads.ts)
node implements BroadcastChannel itself (lib/internal/worker/io.js) with argument handling the WHATWG constructor does not have. The `worker_threads` export is now a subclass with node's contract: missing name → `ERR_MISSING_ARGS`, symbol name → `TypeError: Cannot convert a Symbol value to a string`, `postMessage()` with no argument → `ERR_MISSING_ARGS`, closed channel → `InvalidStateError` DOMException "BroadcastChannel is closed.". The web global is untouched.

### receiveMessageOnPort(broadcastChannel) + ref-after-close hang (BroadcastChannel/registry)
`receiveMessageOnPort(bc)` was a TODO returning `undefined`. Posted messages now sit in a per-subscriber queue in the broadcast registry (instead of being captured in the dispatch task), so `receiveMessageOnPort` can pop one synchronously; the dispatch task pops the same queue, preserving delivery order and making close() drop undelivered messages like node.
Separately, `bc.ref()` after `bc.close()` re-incremented the event-loop ref with nothing left to release it, pinning the process forever (the vendored test's inspect block does exactly this). node's ref() on a closed channel is a no-op; `jsRef` now checks `isClosed()`.
- Test: `test-worker-broadcastchannel.js` (with the two items above).

Not shipped: node's receiver-major BroadcastChannel delivery order (asserted by `test-worker-broadcastchannel-wpt.js`). Implementing it made that test pass but broke Bun's own `broadcast-channel.test.ts` "messages are delivered in port creation order", which pins the browser message-major order on the same shared dispatcher — reverted rather than change web-observable behavior for node compat.

### URLPattern brand checks threw nothing (JSURLPattern.cpp)
The nine attribute getters used `CastedThisErrorBehavior::Assert`, so calling an extracted getter on a foreign `this` returned garbage instead of throwing (debug builds assert-crashed). They and `exec`/`test` now throw node's `TypeError: Illegal invocation`. The `DOMAttribute` property flag is dropped on these entries so JSC's own brand check (with WebKit's message wording) doesn't fire first.
- Test: `test-urlpattern-invalidthis.js`.

### util.debuglog was missing half its API (util.ts)
Ported node's `debuglog` (lib/internal/util/debuglog.js): the optional `callback` argument receiving the optimized logger, the lazy `enabled` accessor on both, colorized `SET PID: message` output via `formatWithOptions`/`shouldColorize` on stderr (was plain `console.error`).
- Test: `util.test.js` (`util.debuglog` block). The upstream `sequential/test-util-debug.js` passes locally but cannot be vendored: CI exports `NO_COLOR=1`, and with `NO_COLOR` set the test fails identically under real node v26.3.0 (the NO_COLOR-ignored warning lands in its byte-exact stderr expectation).

### url.parse deprecation test was missing its fixture
`test-url-parse-deprecation.js` only failed because `fixtures/node_modules/url-deprecations.js` was never vendored (the suppress-inside-node_modules logic already exists). Fixture added (force-added past the `node_modules` gitignore rule, like its siblings).

All vendored tests are byte-identical to `nodejs/node` v26.3.0 and fail on the unfixed build (verified before each fix).
