### PR TITLE
node: inspector/debugger v26 compat fixes (+17 tests)

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -314,17 +314,14 @@ export default function (
     exit("Failed to start inspector:\n", error);
   }
 
-  // --inspect serves a CDP endpoint alongside Bun's JSC one. Report it so
-  // node:inspector answers url() with it, refuses inspector.open() with
-  // ERR_INSPECTOR_ALREADY_ACTIVATED and can stop the server through
-  // inspector.close(), the way Node behaves for a CLI-started inspector.
   const { cdpUrl } = debug;
-  if (enableNodeCDP && cdpUrl) {
-    reportNodeInspectorServerStarted(cdpUrl, createNodeInspectorControl(debug), undefined);
-  }
 
   // If the user types --inspect, we print the URL to the console.
   // If the user is using an editor extension, don't print anything.
+  // Printed before reportNodeInspectorServerStarted releases the inspected
+  // thread: Node writes its banner before any script output, and tools
+  // scraping stderr for it (test-inspector-port-zero) rely on that order --
+  // a short-lived script could otherwise exit before this thread got to it.
   if (!isAutomatic) {
     const debugUrl = debug.url;
     if (debugUrl) {
@@ -351,6 +348,15 @@ export default function (
       Bun.write(Bun.stderr, `Listening on ${dim(url)}\n`);
       Bun.write(Bun.stderr, dim("--------------------- Bun Inspector ---------------------") + reset() + "\n");
     }
+  }
+
+  // --inspect serves a CDP endpoint alongside Bun's JSC one. Report it so
+  // node:inspector answers url() with it, refuses inspector.open() with
+  // ERR_INSPECTOR_ALREADY_ACTIVATED and can stop the server through
+  // inspector.close(), the way Node behaves for a CLI-started inspector.
+  // This also releases the inspected thread, which blocks on the report.
+  if (enableNodeCDP && cdpUrl) {
+    reportNodeInspectorServerStarted(cdpUrl, createNodeInspectorControl(debug), undefined);
   }
 
   const notifyUrl = process.env["BUN_INSPECT_NOTIFY"] || "";

--- a/src/js/internal/debugger/inspect_probe.ts
+++ b/src/js/internal/debugger/inspect_probe.ts
@@ -22,6 +22,7 @@ const {
   StringPrototypeIncludes,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
+  StringPrototypeTrim,
   Symbol,
   SideEffectFreeRegExpPrototypeSymbolReplace,
 } = require("internal/debugger/primordials");
@@ -147,6 +148,18 @@ function trimProbeChildStderr(stderr) {
       continue;
     }
     if (StringPrototypeStartsWith(line, kProbeEndingPrefix)) {
+      continue;
+    }
+    // Bun's own inspector banner, printed alongside Node's listening line.
+    // Node targets have no equivalent, so reports must not carry it.
+    if (StringPrototypeIncludes(line, "--------------------- Bun Inspector ---------------------")) {
+      continue;
+    }
+    if (line === "Listening:" || line === "Inspect in browser:") {
+      continue;
+    }
+    const trimmed = StringPrototypeTrim(line);
+    if (StringPrototypeStartsWith(trimmed, "ws://") || StringPrototypeStartsWith(trimmed, "https://debug.bun.sh/#")) {
       continue;
     }
     ArrayPrototypePush(kept, line);

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -530,11 +530,15 @@ class InspectorCDPAdapter {
   // Current backend breakpointId -> the id the client knows (only entries that
   // were re-set diverge).
   #breakpointIdAliases = new Map<string, string>();
-  // Pre-parse breakpoints whose removal was issued during retranslation. The
-  // script starts executing as soon as it parses, so a stale pass-through
-  // breakpoint can fire before the backend processes the removal; V8 has no
-  // such pause (it re-resolves internally), so resume through it silently.
-  #supersededBreakpointIds = new Set<string>();
+  // Pre-parse breakpoints whose removal was issued during retranslation,
+  // mapped to the generated location they were re-set to. The script starts
+  // executing as soon as it parses, so a stale pass-through breakpoint can
+  // fire before the backend processes the removal. When it fires on the same
+  // line the re-set resolved to, it is the breakpoint the client asked for
+  // (JSC resolved the stale request forward to the same place) and is
+  // reported under the id the client knows; a pause anywhere else has no V8
+  // equivalent (V8 re-resolves internally) and is resumed silently.
+  #supersededBreakpoints = new Map<string, AnyObject>();
   // Profiler domain: tracking state plus the deferred Profiler.stop replies,
   // each answered in order when ScriptProfiler.trackingComplete delivers the
   // samples. A FIFO so pipelined start/stop pairs over the remote transport
@@ -994,8 +998,8 @@ class InspectorCDPAdapter {
     // JSC resolves distinct pre-parse requests on an unmapped line forward to
     // one shared pause location; removing one of them after a re-added
     // breakpoint resolved to that same location cleared the re-added one too.
-    for (const { bp } of resets) {
-      this.#supersededBreakpointIds.$add(bp.jscId);
+    for (const { bp, generated } of resets) {
+      this.#supersededBreakpoints.$set(bp.jscId, generated);
       this.#sendToBackend("Debugger.removeBreakpoint", { breakpointId: bp.jscId });
     }
     for (const { clientBreakpointId, bp, generated } of resets) {
@@ -1690,9 +1694,12 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.paused": {
-        if (params.reason === "Breakpoint" && this.#supersededBreakpointIds.$has(params.data?.breakpointId)) {
-          this.#sendToBackend("Debugger.resume");
-          return;
+        if (params.reason === "Breakpoint") {
+          const superseded = this.#supersededBreakpoints.$get(params.data?.breakpointId);
+          if (superseded !== undefined && params.callFrames?.[0]?.location?.lineNumber !== superseded.lineNumber) {
+            this.#sendToBackend("Debugger.resume");
+            return;
+          }
         }
         const callFrames = (params.callFrames ?? []).map((frame: AnyObject) => ({
           callFrameId: frame.callFrameId,

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -530,6 +530,11 @@ class InspectorCDPAdapter {
   // Current backend breakpointId -> the id the client knows (only entries that
   // were re-set diverge).
   #breakpointIdAliases = new Map<string, string>();
+  // Pre-parse breakpoints whose removal was issued during retranslation. The
+  // script starts executing as soon as it parses, so a stale pass-through
+  // breakpoint can fire before the backend processes the removal; V8 has no
+  // such pause (it re-resolves internally), so resume through it silently.
+  #supersededBreakpointIds = new Set<string>();
   // Profiler domain: tracking state plus the deferred Profiler.stop replies,
   // each answered in order when ScriptProfiler.trackingComplete delivers the
   // samples. A FIFO so pipelined start/stop pairs over the remote transport
@@ -704,15 +709,43 @@ class InspectorCDPAdapter {
   // Recover the missing pieces from the exception's own properties (stack,
   // line, column, sourceURL) with one extra backend roundtrip before replying.
   #replyEvaluateLike(clientId: number | string, method: string, jscResult: AnyObject): void {
-    const objectId = jscResult.wasThrown ? jscResult.result?.objectId : undefined;
-    if (!objectId) {
-      this.#replyToClient(clientId, this.#translateResult(method, jscResult));
+    const remote = jscResult.result;
+    const objectId = jscResult.wasThrown ? remote?.objectId : undefined;
+    if (objectId) {
+      this.#sendToBackend("Runtime.getProperties", { objectId, ownProperties: true }, null, method, (props, error) => {
+        const properties = error ? [] : (props.properties ?? []);
+        this.#replyToClient(clientId, this.#translateThrownResult(method, jscResult, properties));
+      });
       return;
     }
-    this.#sendToBackend("Runtime.getProperties", { objectId, ownProperties: true }, null, method, (props, error) => {
-      const properties = error ? [] : (props.properties ?? []);
-      this.#replyToClient(clientId, this.#translateThrownResult(method, jscResult, properties));
-    });
+    // An error VALUE with a preview: JSC caps preview properties at five, and
+    // an error's five JSC location properties crowd `stack` out entirely, so
+    // recover it from the object itself (V8 lists it first).
+    if (remote?.subtype === "error" && remote.preview && remote.objectId) {
+      this.#sendToBackend(
+        "Runtime.getProperties",
+        { objectId: remote.objectId, ownProperties: true },
+        null,
+        method,
+        (props, error) => {
+          const out = this.#translateResult(method, jscResult);
+          const preview = out.result?.preview;
+          if (!error && preview?.properties) {
+            let stack: unknown;
+            for (const property of props.properties ?? []) {
+              if (property?.name === "stack") stack = property.value?.value;
+            }
+            const hasStack = preview.properties.some((property: AnyObject) => property?.name === "stack");
+            if (typeof stack === "string" && !hasStack) {
+              preview.properties.unshift({ name: "stack", type: "string", value: stack });
+            }
+          }
+          this.#replyToClient(clientId, out);
+        },
+      );
+      return;
+    }
+    this.#replyToClient(clientId, this.#translateResult(method, jscResult));
   }
 
   #translateThrownResult(method: string, jscResult: AnyObject, properties: AnyObject[]): AnyObject {
@@ -962,6 +995,7 @@ class InspectorCDPAdapter {
     // one shared pause location; removing one of them after a re-added
     // breakpoint resolved to that same location cleared the re-added one too.
     for (const { bp } of resets) {
+      this.#supersededBreakpointIds.$add(bp.jscId);
       this.#sendToBackend("Debugger.removeBreakpoint", { breakpointId: bp.jscId });
     }
     for (const { clientBreakpointId, bp, generated } of resets) {
@@ -1544,6 +1578,23 @@ class InspectorCDPAdapter {
       case "Debugger.enable":
         return { debuggerId: "(bun)", ...result };
 
+      // Breakpoint replies carry resolved positions in generated coordinates;
+      // clients print them (the debugger REPL's `breakpoints` list), so they
+      // need the same original-position translation as pause locations.
+      case "Debugger.setBreakpoint": {
+        const out: AnyObject = { ...result };
+        if (out.actualLocation) out.actualLocation = this.#toOriginalLocation(out.actualLocation);
+        return out;
+      }
+
+      case "Debugger.setBreakpointByUrl": {
+        const out: AnyObject = { ...result };
+        if ($isJSArray(out.locations)) {
+          out.locations = out.locations.map((location: AnyObject) => this.#toOriginalLocation(location));
+        }
+        return out;
+      }
+
       case "Runtime.evaluate":
       case "Runtime.callFunctionOn":
       case "Debugger.evaluateOnCallFrame": {
@@ -1639,6 +1690,10 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.paused": {
+        if (params.reason === "Breakpoint" && this.#supersededBreakpointIds.$has(params.data?.breakpointId)) {
+          this.#sendToBackend("Debugger.resume");
+          return;
+        }
         const callFrames = (params.callFrames ?? []).map((frame: AnyObject) => ({
           callFrameId: frame.callFrameId,
           functionName: frame.functionName ?? "",

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -320,6 +320,22 @@ function collectionDescription(description: string | undefined, size: number | u
   return `${description}(${size})`;
 }
 
+// JSC gives every Error line/column/sourceURL own properties (plus the raw
+// originalLine/originalColumn pair) that V8 errors do not have; previews must
+// not show them. V8 lists stack before message.
+const JSC_ERROR_LOCATION_PROPS = new Set(["line", "column", "sourceURL", "originalLine", "originalColumn"]);
+
+function toV8ErrorPreviewProperties(properties: AnyObject[]): AnyObject[] {
+  const filtered = properties.filter(property => !JSC_ERROR_LOCATION_PROPS.$has(property?.name));
+  const stackAt = filtered.findIndex(property => property?.name === "stack");
+  if (stackAt > 0) {
+    const stack = filtered[stackAt];
+    filtered.splice(stackAt, 1);
+    filtered.unshift(stack);
+  }
+  return filtered;
+}
+
 function toCdpObjectPreview(preview: AnyObject | undefined, nested = false): AnyObject | undefined {
   if (!preview) return preview;
   const { lossless, size, properties, entries, valuePreview, description, ...rest } = preview;
@@ -328,7 +344,14 @@ function toCdpObjectPreview(preview: AnyObject | undefined, nested = false): Any
   // JSC's `lossless` is the negation of V8's `overflow`. JSC sends `overflow`
   // too, but only for some types, so derive it whenever `lossless` is present.
   if (lossless !== undefined) out.overflow = !lossless;
-  if (properties) out.properties = properties.map(toCdpPropertyPreview);
+  if (properties) {
+    out.properties =
+      rest.subtype === "error"
+        ? toV8ErrorPreviewProperties(properties).map(toCdpPropertyPreview)
+        : properties.map(toCdpPropertyPreview);
+    // The JSC-only properties were what made the preview lossy.
+    if (rest.subtype === "error") out.overflow = false;
+  }
   // V8 omits `entries` from the preview of an empty Map/Set; JSC sends an
   // empty array. Node's debugger REPL branches on the field's presence
   // (`Map(0) {}` vs `Map(0) {  }`), so keep it presence-equivalent. V8 also
@@ -514,6 +537,11 @@ class InspectorCDPAdapter {
   #profilerTracking = false;
   #profilerStartTime = 0;
   #profilerStopClientIds: (number | string)[] = [];
+  // console.profile() starts JSC tracking with no client Profiler.start;
+  // V8 announces those as consoleProfileStarted/Finished instead of a
+  // Profiler.stop reply.
+  #consoleProfileActive = false;
+  #consoleProfileSeq = 0;
   // NodeRuntime domain state, per connection, mirroring Node's RuntimeAgent.
   #nodeRuntimeEnabled = false;
   #notifyWhenWaitingForDisconnect = false;
@@ -1371,6 +1399,43 @@ class InspectorCDPAdapter {
         this.#sendToBackend("Heap.gc", undefined, id, method);
         return;
 
+      // V8 streams the snapshot as addHeapSnapshotChunk events, then answers
+      // the command. JSC's Heap.snapshot uses its own format, so build the
+      // V8-format snapshot on the inspected thread instead and chunk it here.
+      case "HeapProfiler.takeHeapSnapshot": {
+        const reportProgress = !!params.reportProgress;
+        this.#sendToBackend(
+          "Runtime.evaluate",
+          {
+            expression: 'Bun.generateHeapSnapshot("v8")',
+            returnByValue: true,
+            doNotPauseOnExceptionsAndMuteConsole: true,
+          },
+          null,
+          method,
+          (result, error) => {
+            const snapshot = !error && !result.wasThrown ? result.result?.value : undefined;
+            if (typeof snapshot !== "string") {
+              this.#replyErrorToClient(id, -32000, "Failed to take heap snapshot");
+              return;
+            }
+            if (reportProgress) {
+              this.#emitToClient("HeapProfiler.reportHeapSnapshotProgress", {
+                done: 1,
+                total: 1,
+                finished: true,
+              });
+            }
+            const chunkSize = 100 * 1024;
+            for (let offset = 0; offset < snapshot.length; offset += chunkSize) {
+              this.#emitToClient("HeapProfiler.addHeapSnapshotChunk", { chunk: snapshot.slice(offset, offset + chunkSize) });
+            }
+            this.#replyToClient(id, {});
+          },
+        );
+        return;
+      }
+
       // V8's CPU profiler maps onto JSC's ScriptProfiler: track with samples,
       // then reshape them into a V8 profile (#translateSamplingProfile).
       case "Profiler.start":
@@ -1591,12 +1656,6 @@ class InspectorCDPAdapter {
         const stepped = this.#steppingToNextPause;
         this.#steppingToNextPause = false;
         const cdpParams: AnyObject = { callFrames, reason: stepped ? "step" : "other", data };
-        // The first pause after releasing a parked target is the scheduled
-        // break on start, unless something with its own reason (an exception,
-        // a breakpoint) fired first -- then the chance has passed either way.
-        const breakOnStart = this.#breakOnStartPending;
-        this.#breakOnStartPending = false;
-        if (breakOnStart) cdpParams.reason = "Break on start";
         switch (params.reason) {
           case "exception":
             cdpParams.reason = "exception";
@@ -1610,6 +1669,16 @@ class InspectorCDPAdapter {
             cdpParams.reason = "other";
             if (data?.breakpointId) cdpParams.hitBreakpoints = [this.#toClientBreakpointId(data.breakpointId)];
             break;
+        }
+        // The first pause after releasing a parked target is the scheduled
+        // break on start; it precedes all user code, so it wins over a
+        // breakpoint on the first statement (V8 labels that pause the same
+        // way) -- but not over an exception, which means user code already
+        // ran and the chance has passed.
+        const breakOnStart = this.#breakOnStartPending;
+        this.#breakOnStartPending = false;
+        if (breakOnStart && cdpParams.reason !== "exception" && cdpParams.reason !== "assert") {
+          cdpParams.reason = "Break on start";
         }
         if (asyncStackTrace) cdpParams.asyncStackTrace = this.#translateStackTrace(asyncStackTrace);
         this.#emitToClient("Debugger.paused", cdpParams);
@@ -1637,6 +1706,16 @@ class InspectorCDPAdapter {
 
       case "ScriptProfiler.trackingStart":
         this.#profilerStartTime = params.timestamp ?? 0;
+        // Tracking that no client requested was started programmatically by
+        // console.profile(); V8 announces it. JSC does not report the call
+        // site, so the location is empty.
+        if (!this.#profilerTracking) {
+          this.#consoleProfileActive = true;
+          this.#emitToClient("Profiler.consoleProfileStarted", {
+            id: String(++this.#consoleProfileSeq),
+            location: { scriptId: "0", lineNumber: 0, columnNumber: 0 },
+          });
+        }
         return;
 
       case "ScriptProfiler.trackingComplete": {
@@ -1644,7 +1723,18 @@ class InspectorCDPAdapter {
         // Broadcast to every session sharing this backend: all of them learn
         // tracking ended; only the one whose Profiler.stop is waiting replies.
         this.#profilerTracking = false;
-        if (clientId === undefined) return;
+        if (clientId === undefined) {
+          if (this.#consoleProfileActive) {
+            this.#consoleProfileActive = false;
+            this.#emitToClient("Profiler.consoleProfileFinished", {
+              id: String(this.#consoleProfileSeq),
+              location: { scriptId: "0", lineNumber: 0, columnNumber: 0 },
+              profile: this.#translateSamplingProfile(params),
+            });
+            this.#profilerStartTime = 0;
+          }
+          return;
+        }
         this.#replyToClient(clientId, { profile: this.#translateSamplingProfile(params) });
         this.#profilerStartTime = 0;
         return;

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -1466,7 +1466,9 @@ class InspectorCDPAdapter {
             }
             const chunkSize = 100 * 1024;
             for (let offset = 0; offset < snapshot.length; offset += chunkSize) {
-              this.#emitToClient("HeapProfiler.addHeapSnapshotChunk", { chunk: snapshot.slice(offset, offset + chunkSize) });
+              this.#emitToClient("HeapProfiler.addHeapSnapshotChunk", {
+                chunk: snapshot.slice(offset, offset + chunkSize),
+              });
             }
             this.#replyToClient(id, {});
           },

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -308,6 +308,10 @@ function ownSourceMappingURL(source: string): string {
 // https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-UnserializableValue
 const UNSERIALIZABLE_NUMBERS = new Set(["NaN", "Infinity", "-Infinity", "-0"]);
 
+// Commands whose reply carries `wasThrown`; a thrown reply is enriched with
+// the exception's stack before it is forwarded (see #replyEvaluateLike).
+const EVALUATE_LIKE_METHODS = new Set(["Runtime.evaluate", "Runtime.callFunctionOn", "Debugger.evaluateOnCallFrame"]);
+
 // JSC names a collection by its class alone and puts the element count in a
 // separate `size` field; V8 folds the count into the description and has no
 // such field.
@@ -316,7 +320,7 @@ function collectionDescription(description: string | undefined, size: number | u
   return `${description}(${size})`;
 }
 
-function toCdpObjectPreview(preview: AnyObject | undefined): AnyObject | undefined {
+function toCdpObjectPreview(preview: AnyObject | undefined, nested = false): AnyObject | undefined {
   if (!preview) return preview;
   const { lossless, size, properties, entries, valuePreview, description, ...rest } = preview;
   const out: AnyObject = rest;
@@ -325,22 +329,33 @@ function toCdpObjectPreview(preview: AnyObject | undefined): AnyObject | undefin
   // too, but only for some types, so derive it whenever `lossless` is present.
   if (lossless !== undefined) out.overflow = !lossless;
   if (properties) out.properties = properties.map(toCdpPropertyPreview);
-  if (entries) out.entries = entries.map(toCdpEntryPreview);
-  if (valuePreview) out.valuePreview = toCdpObjectPreview(valuePreview);
+  // V8 omits `entries` from the preview of an empty Map/Set; JSC sends an
+  // empty array. Node's debugger REPL branches on the field's presence
+  // (`Map(0) {}` vs `Map(0) {  }`), so keep it presence-equivalent. V8 also
+  // reports entries only on the top-level preview: a Map/Set nested inside
+  // one is elided to overflow (`Set(1) { ... }`).
+  if (entries && entries.length > 0) {
+    if (nested) {
+      out.overflow = true;
+    } else {
+      out.entries = entries.map(toCdpEntryPreview);
+    }
+  }
+  if (valuePreview) out.valuePreview = toCdpObjectPreview(valuePreview, nested);
   return out;
 }
 
 function toCdpPropertyPreview(property: AnyObject): AnyObject {
   const { valuePreview } = property;
   if (!valuePreview) return property;
-  return { ...property, valuePreview: toCdpObjectPreview(valuePreview) };
+  return { ...property, valuePreview: toCdpObjectPreview(valuePreview, true) };
 }
 
 function toCdpEntryPreview(entry: AnyObject): AnyObject {
   const { key, value } = entry;
   const out: AnyObject = { ...entry };
-  if (key) out.key = toCdpObjectPreview(key);
-  if (value) out.value = toCdpObjectPreview(value);
+  if (key) out.key = toCdpObjectPreview(key, true);
+  if (value) out.value = toCdpObjectPreview(value, true);
   return out;
 }
 
@@ -458,6 +473,12 @@ class InspectorCDPAdapter {
   // V8 reports the pause that ends a step command with reason "step"; JSC does
   // not distinguish it from any other pause, so track the step here.
   #steppingToNextPause = false;
+  // V8 reports the scheduled --inspect-brk pause with reason "Break on start"
+  // (clients branch on it: NODE_INSPECT_RESUME_ON_START, the REPL header).
+  // Bun implements --inspect-brk as a prepended `debugger;`, which JSC reports
+  // like any other debugger statement, so latch the release of a waiting
+  // target and relabel the pause it triggers.
+  #breakOnStartPending = false;
   #pending = new Map<
     number,
     { clientId: number | string | null; method: string; onResult?: (result: AnyObject, error?: AnyObject) => void }
@@ -646,7 +667,124 @@ class InspectorCDPAdapter {
     // objectId (the first step forced returnByValue:false), which
     // DevTools/vscode-js-debug inspect via exceptionDetails, so we do not
     // re-serialize it to honour the client's returnByValue.
-    this.#replyToClient(id, this.#translateResult(method, result));
+    this.#replyEvaluateLike(id, method, result);
+  }
+
+  // V8's exceptionDetails for a thrown evaluation carry the throw site, the
+  // script it happened in, a structured stackTrace, and a description that
+  // embeds the formatted stack; JSC reports only the bare exception object.
+  // Recover the missing pieces from the exception's own properties (stack,
+  // line, column, sourceURL) with one extra backend roundtrip before replying.
+  #replyEvaluateLike(clientId: number | string, method: string, jscResult: AnyObject): void {
+    const objectId = jscResult.wasThrown ? jscResult.result?.objectId : undefined;
+    if (!objectId) {
+      this.#replyToClient(clientId, this.#translateResult(method, jscResult));
+      return;
+    }
+    this.#sendToBackend("Runtime.getProperties", { objectId, ownProperties: true }, null, method, (props, error) => {
+      const properties = error ? [] : (props.properties ?? []);
+      this.#replyToClient(clientId, this.#translateThrownResult(method, jscResult, properties));
+    });
+  }
+
+  #translateThrownResult(method: string, jscResult: AnyObject, properties: AnyObject[]): AnyObject {
+    const out = this.#translateResult(method, jscResult);
+    const details = out.exceptionDetails;
+    if (!details) return out;
+    let stack: string | undefined;
+    let line: number | undefined;
+    let column: number | undefined;
+    let generatedLine: number | undefined;
+    let generatedColumn: number | undefined;
+    let sourceURL: string | undefined;
+    for (const property of properties) {
+      const value = property?.value?.value;
+      switch (property?.name) {
+        case "stack":
+          if (typeof value === "string") stack = value;
+          break;
+        // Bun stores the raw JSC throw position in originalLine/originalColumn
+        // and the source-mapped one in line/column (all 1-based).
+        case "line":
+          if (typeof value === "number") line = value;
+          break;
+        case "column":
+          if (typeof value === "number") column = value;
+          break;
+        case "originalLine":
+          if (typeof value === "number") generatedLine = value;
+          break;
+        case "originalColumn":
+          if (typeof value === "number") generatedColumn = value;
+          break;
+        case "sourceURL":
+          if (typeof value === "string") sourceURL = value;
+          break;
+      }
+    }
+    // details.exception and out.result are the same object; V8 formats both
+    // with the message followed by the frames, which is exactly Bun's
+    // Error#stack. A tampered stack that dropped the message keeps it.
+    const remote = details.exception;
+    if (stack !== undefined && stack !== "") {
+      const description = typeof remote.description === "string" ? remote.description : "";
+      remote.description = stack.startsWith(description) ? stack : `${description}\n${stack}`;
+
+      const callFrames: AnyObject[] = [];
+      for (const frameLine of stack.split("\n")) {
+        const match = /^\s+at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/.exec(frameLine);
+        if (match === null) continue;
+        const frameUrl = match[2];
+        callFrames.push({
+          functionName: match[1] ?? "",
+          scriptId: this.#scriptIdsByUrl.get(frameUrl) ?? "",
+          url: frameUrl,
+          lineNumber: Number(match[3]) - 1,
+          columnNumber: Number(match[4]) - 1,
+        });
+      }
+      if (callFrames.length > 0) details.stackTrace = { callFrames };
+    }
+    // JSC positions are 1-based; CDP's are 0-based. JSC records the callee
+    // position of the throwing `new`; V8 reports the start of the throwing
+    // statement. Approximate it from the raw (generated) position: take the
+    // mapping at-or-before it and walk back to that original line's first
+    // mapping (the statement's start unless several statements share the
+    // line, which the transpiler's one-statement-per-generated-line printing
+    // makes rare at a throw site).
+    const scriptId = sourceURL !== undefined ? this.#scriptIdsByUrl.get(sourceURL) : undefined;
+    const statementStart =
+      scriptId !== undefined && typeof generatedLine === "number" && generatedLine > 0
+        ? this.#originalStatementStart(
+            scriptId,
+            generatedLine - 1,
+            typeof generatedColumn === "number" && generatedColumn > 0 ? generatedColumn - 1 : 0,
+          )
+        : undefined;
+    if (statementStart !== undefined) {
+      details.lineNumber = statementStart.lineNumber;
+      details.columnNumber = statementStart.columnNumber;
+      details.scriptId = scriptId;
+    } else if (typeof line === "number" && line > 0) {
+      details.lineNumber = line - 1;
+      details.columnNumber = typeof column === "number" && column > 0 ? column - 1 : 0;
+      if (scriptId !== undefined) details.scriptId = scriptId;
+    }
+    return out;
+  }
+
+  #originalStatementStart(scriptId: string, genLine: number, genColumn: number): OriginalPosition | undefined {
+    const map = this.#sourceMapFor(scriptId);
+    const lineMappings = map?.byGeneratedLine?.[genLine];
+    if (!lineMappings || lineMappings.columns.length === 0) return undefined;
+    const { columns, lineNumbers, columnNumbers } = lineMappings;
+    let at = 0;
+    for (let i = 0; i < columns.length; i++) {
+      if (columns[i] <= genColumn) at = i;
+    }
+    const lineNumber = lineNumbers[at];
+    while (at > 0 && lineNumbers[at - 1] === lineNumber) at--;
+    return { lineNumber, columnNumber: columnNumbers[at] };
   }
 
   #onProfilerStartReply(id: number, _result: AnyObject, error: AnyObject) {
@@ -764,6 +902,7 @@ class InspectorCDPAdapter {
     // A synchronous scriptParsed listener may have already decoded the map
     // (#sourceMapFor consumes mappings into map), so check both states.
     if (!script || (script.mappings === undefined && script.map === undefined)) return;
+    const resets: { clientBreakpointId: string; bp: AnyObject; generated: AnyObject }[] = [];
     for (const [clientBreakpointId, bp] of this.#preParseBreakpoints) {
       if (bp.resolved) continue;
       const { url: bpUrl, urlRegex: bpUrlRegex } = bp;
@@ -788,7 +927,16 @@ class InspectorCDPAdapter {
       if (generated.lineNumber === bp.lineNumber && (generated.columnNumber ?? 0) === (bp.columnNumber ?? 0)) {
         continue; // The map is an identity for this position.
       }
+      resets.push({ clientBreakpointId, bp, generated });
+    }
+    // Two phases: every stale breakpoint is removed before any is re-added.
+    // JSC resolves distinct pre-parse requests on an unmapped line forward to
+    // one shared pause location; removing one of them after a re-added
+    // breakpoint resolved to that same location cleared the re-added one too.
+    for (const { bp } of resets) {
       this.#sendToBackend("Debugger.removeBreakpoint", { breakpointId: bp.jscId });
+    }
+    for (const { clientBreakpointId, bp, generated } of resets) {
       const options: AnyObject = {};
       const { condition } = bp;
       if (condition) options.condition = condition;
@@ -798,7 +946,7 @@ class InspectorCDPAdapter {
           lineNumber: generated.lineNumber,
           columnNumber: generated.columnNumber,
           options,
-          urlRegex: bpUrlRegex ?? breakpointUrlRegex(bpUrl!),
+          urlRegex: bp.urlRegex ?? breakpointUrlRegex(bp.url!),
         },
         null,
         "Debugger.setBreakpointByUrl",
@@ -871,6 +1019,10 @@ class InspectorCDPAdapter {
         this.#replyErrorToClient(clientId, error.code ?? -32000, toCdpErrorMessage(error.message));
         return;
       }
+      if (EVALUATE_LIKE_METHODS.$has(pending.method)) {
+        this.#replyEvaluateLike(clientId, pending.method, parsed.result || {});
+        return;
+      }
       this.#replyToClient(clientId, this.#translateResult(pending.method, parsed.result || {}));
       return;
     }
@@ -936,6 +1088,9 @@ class InspectorCDPAdapter {
         return;
 
       case "Runtime.runIfWaitingForDebugger":
+        // Only a target parked in wait-for-debugger state can produce the
+        // "Break on start" pause; --inspect (no -brk/-wait) never waits.
+        if (this.#isWaitingForDebugger()) this.#breakOnStartPending = true;
         // Inspector.initialized resolves Bun's wait-for-debugger state, which
         // unblocks inspector.open(port, host, true) on the inspected thread.
         this.#sendToBackend("Inspector.initialized");
@@ -1332,7 +1487,9 @@ class InspectorCDPAdapter {
         if (result.wasThrown) {
           out.exceptionDetails = {
             exceptionId: this.#nextExceptionId++,
-            text: result.result?.description ?? "Uncaught",
+            // V8's text for a thrown evaluation is the fixed string
+            // "Uncaught"; the message lives in the exception's description.
+            text: "Uncaught",
             lineNumber: 0,
             columnNumber: 0,
             exception: remote,
@@ -1434,6 +1591,12 @@ class InspectorCDPAdapter {
         const stepped = this.#steppingToNextPause;
         this.#steppingToNextPause = false;
         const cdpParams: AnyObject = { callFrames, reason: stepped ? "step" : "other", data };
+        // The first pause after releasing a parked target is the scheduled
+        // break on start, unless something with its own reason (an exception,
+        // a breakpoint) fired first -- then the chance has passed either way.
+        const breakOnStart = this.#breakOnStartPending;
+        this.#breakOnStartPending = false;
+        if (breakOnStart) cdpParams.reason = "Break on start";
         switch (params.reason) {
           case "exception":
             cdpParams.reason = "exception";

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -240,11 +240,7 @@ impl Debugger {
         });
 
         bun_core::scoped_log!(debugger, "spin");
-        // `FUTEX_ATOMIC` starts at 0 and nothing ever stores `1` before this
-        // load, so this loop is a no-op on first call.
-        while FUTEX_ATOMIC.load(Ordering::Relaxed) > 0 {
-            bun_threading::Futex::wait_forever(&FUTEX_ATOMIC, 1);
-        }
+        Debugger::wait_for_thread_startup();
         if bun_core::Environment::ENABLE_LOGS {
             bun_core::scoped_log!(
                 debugger,
@@ -384,6 +380,16 @@ impl Debugger {
         }
     }
 
+    /// Block until the debugger thread finishes its startup (inspector server
+    /// listening or failed): `create()` arms the futex before spawning and
+    /// `start_js_debugger_thread` clears it on every exit path. A no-op when
+    /// the thread already started (futex back at 0).
+    pub fn wait_for_thread_startup() {
+        while FUTEX_ATOMIC.load(Ordering::Relaxed) > 0 {
+            bun_threading::Futex::wait_forever(&FUTEX_ATOMIC, 1);
+        }
+    }
+
     /// `Debugger.create(vm, global)` — first-time debugger setup: create the
     /// JSC inspector context, spawn the debugger VM thread, and arm the
     /// keep-alive on the parent loop.
@@ -413,6 +419,12 @@ impl Debugger {
 
         if !this_ref.has_started_debugger {
             this_ref.as_mut().has_started_debugger = true;
+            // Armed before the spawn; `start_js_debugger_thread` clears it on
+            // every exit path once the inspector server is up (or failed).
+            // `wait_for_thread_startup` blocks on it so a `--inspect` process
+            // prints the listening banner before any script output, as Node
+            // does (its inspector server binds synchronously at startup).
+            FUTEX_ATOMIC.store(1, Ordering::Relaxed);
             // `std::thread::spawn` requires `Send`; raw `*mut
             // VirtualMachine` is `!Send`. Wrap in a `Send` newtype — the
             // pointer is only ever dereferenced on the debugger thread under

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -1073,6 +1073,8 @@ static NodeInspectorState& nodeInspectorState()
     return instance.get();
 }
 
+extern "C" void Bun__setProcessDebugPort(uint16_t port);
+
 // Called by internal/debugger.ts on the debugger thread once the node:inspector
 // server is listening (url, controlCallback) or failed to start ("", undefined, error).
 JSC_DECLARE_HOST_FUNCTION(jsFunctionReportNodeInspectorServerStarted);
@@ -1086,6 +1088,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionReportNodeInspectorServerStarted, (JSGlobalOb
     JSValue controlCallbackValue = callFrame->argument(1);
     String error = callFrame->argument(2).isUndefined() ? String() : callFrame->argument(2).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
+
+    // Node resolves process.debugPort to the bound port once the inspector
+    // server is listening; mirror that for the CLI-started server (the
+    // inspector.open() path assigns process.debugPort from JS instead).
+    if (!url.isEmpty()) {
+        if (auto port = WTF::URL(url).port())
+            Bun__setProcessDebugPort(*port);
+    }
 
     auto& state = nodeInspectorState();
     {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4175,6 +4175,14 @@ static JSValue constructFeatures(VM& vm, JSObject* processObject)
 
 static uint16_t debugPort = 9229;
 
+// The CLI inspector server binds on the debugger thread; once it is listening
+// it reports the resolved port here so process.debugPort reflects it, as in
+// Node. https://github.com/nodejs/node/blob/v26.3.0/lib/internal/process/pre_execution.js (updates via the inspector)
+extern "C" void Bun__setProcessDebugPort(uint16_t port)
+{
+    debugPort = port;
+}
+
 JSC_DEFINE_CUSTOM_GETTER(processDebugPort, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     return JSC::JSValue::encode(jsNumber(debugPort));

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -188,6 +188,9 @@ pub(crate) const RUNTIME_PARAMS_: &[ParamType] = &[
         "--inspect-brk <STR>?              Activate Bun's debugger, set breakpoint on first line of code and wait"
     ),
     parse_param!(
+        "--inspect-port <STR>              Set the [host:]port used by the debugger and reported by process.debugPort"
+    ),
+    parse_param!(
         "--cpu-prof                        Start CPU profiler and write profile to disk on exit"
     ),
     parse_param!("--cpu-prof-name <STR>             Specify the name of the CPU profile file"),
@@ -1196,6 +1199,29 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                     ..Default::default()
                 })
             };
+        }
+
+        unsafe extern "C" {
+            // Defined in BunProcess.cpp; backs process.debugPort.
+            fn Bun__setProcessDebugPort(port: u16);
+        }
+        // Node's --inspect-port=[host:]port: the port for an active
+        // `--inspect*` listener, and the value of process.debugPort either
+        // way -- `--inspect-port=0` alone reports 0 without starting a
+        // server. An explicit `--inspect=<port>` keeps its own port.
+        if let Some(inspect_port_flag) = args.option(b"--inspect-port") {
+            let port_bytes = match inspect_port_flag.iter().rposition(|&byte| byte == b':') {
+                Some(at) => &inspect_port_flag[at + 1..],
+                None => inspect_port_flag,
+            };
+            if let Ok(port) = core::str::from_utf8(port_bytes).unwrap_or("").parse::<u16>() {
+                unsafe { Bun__setProcessDebugPort(port) };
+                if let Debugger::Enable(ref mut enable) = ctx.runtime_options.debugger {
+                    if enable.path_or_port.is_empty() {
+                        enable.path_or_port = Box::<[u8]>::from(inspect_port_flag);
+                    }
+                }
+            }
         }
 
         let cpu_prof_flag = args.flag(b"--cpu-prof");

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1214,7 +1214,10 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::TransformO
                 Some(at) => &inspect_port_flag[at + 1..],
                 None => inspect_port_flag,
             };
-            if let Ok(port) = core::str::from_utf8(port_bytes).unwrap_or("").parse::<u16>() {
+            if let Ok(port) = core::str::from_utf8(port_bytes)
+                .unwrap_or("")
+                .parse::<u16>()
+            {
                 unsafe { Bun__setProcessDebugPort(port) };
                 if let Debugger::Enable(ref mut enable) = ctx.runtime_options.debugger {
                     if enable.path_or_port.is_empty() {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -886,6 +886,11 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
         bun_core::Output::err("Debugger", "{}", format_args!("create failed: {e:?}"));
         return;
     }
+    // Even without a connection wait, hold the thread here until the
+    // inspector server is up: Node binds it synchronously, so its listening
+    // banner precedes any script output and the resolved process.debugPort is
+    // visible to the first user statement.
+    bun_jsc::debugger::Debugger::wait_for_thread_startup();
     if block_until_connected {
         bun_jsc::debugger::Debugger::wait_for_debugger_if_necessary(vm);
     }

--- a/test/js/node/test/common/inspector-helper.js
+++ b/test/js/node/test/common/inspector-helper.js
@@ -6,7 +6,7 @@ const http = require('http');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
 const { URL, pathToFileURL } = require('url');
-const { EventEmitter } = require('events');
+const { EventEmitter, once } = require('events');
 
 const _MAINSCRIPT = fixtures.path('loop.js');
 const DEBUG = false;
@@ -544,6 +544,34 @@ function fires(promise, error, timeoutMs) {
   ]);
 }
 
+/**
+ * When waiting for inspector events, there might be no handles on the event
+ * loop, and leads to process exits.
+ *
+ * This function provides a utility to wait until a inspector event for a certain
+ * time.
+ * @returns {Promise}
+ */
+function waitUntil(session, eventName, timeout = 1000) {
+  const resolvers = Promise.withResolvers();
+  const timer = setTimeout(() => {
+    resolvers.reject(new Error(`Wait for inspector event ${eventName} timed out`));
+  }, timeout);
+
+  once(session, eventName)
+    .then((res) => {
+      resolvers.resolve(res);
+      clearTimeout(timer);
+    }, (error) => {
+      // This should never happen.
+      resolvers.reject(error);
+      clearTimeout(timer);
+    });
+
+  return resolvers.promise;
+}
+
 module.exports = {
   NodeInstance,
+  waitUntil,
 };

--- a/test/js/node/test/fixtures/debugger/probe-exits-during-probe.js
+++ b/test/js/node/test/fixtures/debugger/probe-exits-during-probe.js
@@ -1,0 +1,8 @@
+'use strict';
+
+function exitDuringProbe() {
+  process.exit(0);
+}
+
+module.exports = { exitDuringProbe };
+globalThis.probeLine = 1;

--- a/test/js/node/test/fixtures/debugger/probe-multi-statement.js
+++ b/test/js/node/test/fixtures/debugger/probe-multi-statement.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const acc = [];
+function fill() {
+  acc.push(1); acc.push(2); acc.push(3);
+}
+fill();

--- a/test/js/node/test/fixtures/debugger/probe-throwing-getter.js
+++ b/test/js/node/test/fixtures/debugger/probe-throwing-getter.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const holder = {
+  get throwingGetter() {
+    throw new Error('boom');
+  },
+};
+
+let probesDone = false;
+function markProbesDone() {
+  probesDone = true;
+}
+
+module.exports = { holder, markProbesDone };
+
+globalThis.probeLine1 = 1;
+globalThis.probeLine2 = 2;
+
+const interval = setInterval(() => {
+  if (probesDone) clearInterval(interval);
+}, 50);

--- a/test/js/node/test/parallel/test-debugger-auto-resume.mjs
+++ b/test/js/node/test/parallel/test-debugger-auto-resume.mjs
@@ -1,0 +1,33 @@
+import { skipIfInspectorDisabled } from '../common/index.mjs';
+
+skipIfInspectorDisabled();
+
+import * as fixtures from '../common/fixtures.mjs';
+import startCLI from '../common/debugger.js';
+import { addLibraryPath } from '../common/shared-lib-util.js';
+
+import assert from 'assert';
+import { relative } from 'path';
+
+addLibraryPath(process.env);
+
+// Auto-resume on start if the environment variable is defined.
+{
+  const scriptFullPath = fixtures.path('debugger', 'break.js');
+  const script = relative(process.cwd(), scriptFullPath);
+
+  const env = {
+    ...process.env,
+  };
+  env.NODE_INSPECT_RESUME_ON_START = '1';
+
+  const cli = startCLI([script], [], { env });
+
+  await cli.waitForInitialBreak();
+  assert.deepStrictEqual(cli.breakInfo, {
+    filename: script,
+    line: 10,
+  });
+  const code = await cli.quit();
+  assert.strictEqual(code, 0);
+}

--- a/test/js/node/test/parallel/test-debugger-heap-profiler.js
+++ b/test/js/node/test/parallel/test-debugger-heap-profiler.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+const { readFileSync } = require('fs');
+
+const filename = tmpdir.resolve('node.heapsnapshot');
+
+// Heap profiler take snapshot.
+{
+  const opts = { cwd: tmpdir.path };
+  const cli = startCLI([fixtures.path('debugger/empty.js')], [], opts);
+
+  async function waitInitialBreak() {
+    try {
+      await cli.waitForInitialBreak();
+      await cli.waitForPrompt();
+      await cli.command('takeHeapSnapshot()');
+      JSON.parse(readFileSync(filename, 'utf8'));
+      // Check that two simultaneous snapshots don't step all over each other.
+      // Refs: https://github.com/nodejs/node/issues/39555
+      await cli.command('takeHeapSnapshot(); takeHeapSnapshot()');
+      JSON.parse(readFileSync(filename, 'utf8'));
+    } finally {
+      await cli.quit();
+    }
+  }
+
+  // Check that the snapshot is valid JSON.
+  waitInitialBreak().then(common.mustCall());
+}

--- a/test/js/node/test/parallel/test-debugger-probe-explicit-column.js
+++ b/test/js/node/test/parallel/test-debugger-probe-explicit-column.js
@@ -1,0 +1,72 @@
+// Tests that probes on the same line but different columns are hit separately.
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const { assertProbeJson } = require('../common/debugger-probe');
+
+const cwd = fixtures.path('debugger');
+const fixtureUrl = fixtures.fileURL('debugger', 'probe-multi-statement.js').href;
+
+// col 3:  acc === []
+// col 16: acc === [1]
+// col 29: acc === [1, 2]
+spawnSyncAndAssert(process.execPath, [
+  'inspect',
+  '--json',
+  '--probe', 'probe-multi-statement.js:5:3',
+  '--expr', 'acc.length',
+  '--probe', 'probe-multi-statement.js:5:16',
+  '--expr', 'acc.length',
+  '--probe', 'probe-multi-statement.js:5:29',
+  '--expr', 'acc.length',
+  'probe-multi-statement.js',
+], { cwd }, {
+  stdout(output) {
+    assertProbeJson(output, {
+      v: 2,
+      probes: [
+        {
+          expr: 'acc.length',
+          target: { suffix: 'probe-multi-statement.js', line: 5, column: 3 },
+        },
+        {
+          expr: 'acc.length',
+          target: { suffix: 'probe-multi-statement.js', line: 5, column: 16 },
+        },
+        {
+          expr: 'acc.length',
+          target: { suffix: 'probe-multi-statement.js', line: 5, column: 29 },
+        },
+      ],
+      results: [
+        {
+          probe: 0,
+          event: 'hit',
+          hit: 1,
+          location: { url: fixtureUrl, line: 5, column: 3 },
+          result: { type: 'number', value: 0, description: '0' },
+        },
+        {
+          probe: 1,
+          event: 'hit',
+          hit: 1,
+          location: { url: fixtureUrl, line: 5, column: 16 },
+          result: { type: 'number', value: 1, description: '1' },
+        },
+        {
+          probe: 2,
+          event: 'hit',
+          hit: 1,
+          location: { url: fixtureUrl, line: 5, column: 29 },
+          result: { type: 'number', value: 2, description: '2' },
+        },
+        { event: 'completed' },
+      ],
+    });
+  },
+  trim: true,
+});

--- a/test/js/node/test/parallel/test-debugger-probe-expression-throws.js
+++ b/test/js/node/test/parallel/test-debugger-probe-expression-throws.js
@@ -1,0 +1,64 @@
+// This tests that a probe expression throwing an exception is recorded as
+// a per-hit error and does not fail the session.
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndExit } = require('../common/child_process');
+const { assertProbeJson } = require('../common/debugger-probe');
+
+const cwd = fixtures.path('debugger');
+const fixture = 'probe-throwing-getter.js';
+const probes = [
+  { expr: 'holder.throwingGetter', target: { suffix: fixture, line: 16 } },
+  // This clears the interval so the process will exit naturally.
+  { expr: 'markProbesDone()', target: { suffix: fixture, line: 17 } },
+];
+const url = fixtures.fileURL('debugger', fixture).href;
+
+spawnSyncAndExit(process.execPath, [
+  'inspect', '--json',
+  '--probe', `${fixture}:16`, '--expr', probes[0].expr,
+  '--probe', `${fixture}:17`, '--expr', probes[1].expr,
+  fixture,
+], { cwd }, {
+  status: 0,
+  signal: null,
+  stdout(output) {
+    assertProbeJson(output, {
+      v: 2,
+      probes,
+      results: [{
+        probe: 0,
+        event: 'hit',
+        hit: 1,
+        location: { url, line: 16, column: 1 },
+        error: {
+          message: 'Error: boom\n<stack>',
+          details: {
+            exception: {
+              exceptionId: 1,
+              text: 'Uncaught',
+              lineNumber: 4,
+              columnNumber: 4,
+              scriptId: '<scriptId>',
+              stackTrace: { callFrames: '<callFrames>' },
+              exception: { type: 'object', subtype: 'error', description: 'Error: boom\n<stack>' },
+            },
+          },
+        },
+      }, {
+        probe: 1,
+        event: 'hit',
+        hit: 1,
+        location: { url, line: 17, column: 1 },
+        result: { type: 'undefined' },
+      }, {
+        event: 'completed',
+      }],
+    });
+  },
+  trim: true,
+});

--- a/test/js/node/test/parallel/test-debugger-probe-failure-process-exit.js
+++ b/test/js/node/test/parallel/test-debugger-probe-failure-process-exit.js
@@ -1,0 +1,50 @@
+// This tests that a clean process.exit(0) from inside a probe expression
+// surfaces as probe_failure, not probe_target_exit.
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndExit } = require('../common/child_process');
+const { assertProbeJson } = require('../common/debugger-probe');
+
+const cwd = fixtures.path('debugger');
+const fixture = 'probe-exits-during-probe.js';
+const probes = [{ expr: 'exitDuringProbe()', target: { suffix: fixture, line: 8 } }];
+const location = { url: fixtures.fileURL('debugger', fixture).href, line: 8, column: 1 };
+
+spawnSyncAndExit(process.execPath, [
+  'inspect', '--json',
+  '--probe', `${fixture}:8`, '--expr', probes[0].expr,
+  fixture,
+], { cwd }, {
+  status: 1,
+  signal: null,
+  stdout(output) {
+    assertProbeJson(output, {
+      v: 2,
+      probes,
+      results: [{
+        probe: 0,
+        event: 'hit',
+        hit: 1,
+        location,
+        error: { message: 'Probe evaluation did not complete' },
+      }, {
+        event: 'error',
+        pending: [],
+        error: {
+          code: 'probe_failure',
+          message:
+            'Target process exited during probe evaluation. ' +
+            'If the failure repeats, review the probe expression.',
+          probe: 0,
+          stderr: '',
+          details: { lastCdpMethod: 'Debugger.evaluateOnCallFrame' },
+        },
+      }],
+    });
+  },
+  trim: true,
+});

--- a/test/js/node/test/parallel/test-debugger-probe-json-preview.js
+++ b/test/js/node/test/parallel/test-debugger-probe-json-preview.js
@@ -1,0 +1,104 @@
+// This tests debugger probe JSON preview opt-in for object-like values.
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const { assertProbeJson } = require('../common/debugger-probe');
+
+const cwd = fixtures.path('debugger');
+const probeArg = 'probe-types.js:17';
+const target = { suffix: 'probe-types.js', line: 17 };
+const location = { url: fixtures.fileURL('debugger', 'probe-types.js').href, line: 17, column: 1 };
+
+spawnSyncAndAssert(process.execPath, [
+  'inspect',
+  '--json',
+  '--preview',
+  '--probe', probeArg,
+  '--expr', 'objectValue',
+  '--probe', probeArg,
+  '--expr', 'arrayValue',
+  '--probe', probeArg,
+  '--expr', 'errorValue',
+  'probe-types.js',
+], { cwd }, {
+  stdout(output) {
+    assertProbeJson(output, {
+      v: 2,
+      probes: [
+        { expr: 'objectValue', target },
+        { expr: 'arrayValue', target },
+        { expr: 'errorValue', target },
+      ],
+      results: [
+        {
+          probe: 0,
+          event: 'hit',
+          hit: 1,
+          location,
+          result: {
+            type: 'object',
+            description: 'Object',
+            preview: {
+              type: 'object',
+              description: 'Object',
+              overflow: false,
+              properties: [
+                { name: 'alpha', type: 'number', value: '1' },
+                { name: 'beta', type: 'string', value: 'two' },
+              ],
+            },
+          },
+        },
+        {
+          probe: 1,
+          event: 'hit',
+          hit: 1,
+          location,
+          result: {
+            type: 'object',
+            subtype: 'array',
+            description: 'Array(3)',
+            preview: {
+              type: 'object',
+              subtype: 'array',
+              description: 'Array(3)',
+              overflow: false,
+              properties: [
+                { name: '0', type: 'number', value: '1' },
+                { name: '1', type: 'string', value: 'two' },
+                { name: '2', type: 'number', value: '3' },
+              ],
+            },
+          },
+        },
+        {
+          probe: 2,
+          event: 'hit',
+          hit: 1,
+          location,
+          result: {
+            type: 'object',
+            subtype: 'error',
+            description: 'Error: boom',
+            preview: {
+              type: 'object',
+              subtype: 'error',
+              description: 'Error: boom',
+              overflow: false,
+              properties: [
+                { name: 'stack', type: 'string', value: 'Error: boom' },
+                { name: 'message', type: 'string', value: 'boom' },
+              ],
+            },
+          },
+        },
+        { event: 'completed' },
+      ],
+    });
+  },
+  trim: true,
+});

--- a/test/js/node/test/parallel/test-debugger-profile.js
+++ b/test/js/node/test/parallel/test-debugger-profile.js
@@ -1,0 +1,48 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+const assert = require('assert');
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Profiles.
+{
+  const cli = startCLI([fixtures.path('debugger/empty.js')], [], {
+    env: {
+      ...process.env,
+      // When this test is run with NODE_V8_COVERAGE, it clobbers the inspector
+      // output, so override to disable coverage for the child process.
+      NODE_V8_COVERAGE: undefined,
+    }
+  });
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  try {
+    (async () => {
+      await cli.waitForInitialBreak();
+      await cli.waitForPrompt();
+      await cli.command('exec console.profile()');
+      assert.match(cli.output, /undefined/);
+      await cli.command('exec console.profileEnd()');
+      await delay(250);
+      assert.match(cli.output, /undefined/);
+      assert.match(cli.output, /Captured new CPU profile\./);
+      await cli.quit();
+    })()
+        .then(common.mustCall());
+  } catch (error) {
+    return onFatal(error);
+  }
+
+}

--- a/test/js/node/test/parallel/test-debugger-sb-before-load.js
+++ b/test/js/node/test/parallel/test-debugger-sb-before-load.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const fixtures = require('../common/fixtures');
+const startCLI = require('../common/debugger');
+
+const assert = require('assert');
+const path = require('path');
+
+// Using sb before loading file.
+
+const scriptFullPath = fixtures.path('debugger', 'cjs', 'index.js');
+const script = path.relative(process.cwd(), scriptFullPath);
+
+const otherScriptFullPath = fixtures.path('debugger', 'cjs', 'other.js');
+const otherScript = path.relative(process.cwd(), otherScriptFullPath);
+
+const cli = startCLI([script]);
+
+(async () => {
+  await cli.waitForInitialBreak();
+  await cli.waitForPrompt();
+  await cli.command('sb("other.js", 2)');
+  assert.match(cli.output, /not loaded yet/,
+               'warns that the script was not loaded yet');
+  await cli.stepCommand('cont');
+  assert.ok(cli.output.includes(`break in ${otherScript}:2`),
+            'found breakpoint in file that was not loaded yet');
+})()
+.then(common.mustCall())
+.finally(() => cli.quit());

--- a/test/js/node/test/parallel/test-inspector-emit-protocol-event-errors.js
+++ b/test/js/node/test/parallel/test-inspector-emit-protocol-event-errors.js
@@ -1,0 +1,503 @@
+// Flags: --inspect=0 --experimental-network-inspection --experimental-storage-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const assert = require('node:assert');
+
+function omit(object, ...keys) {
+  const copy = { ...object };
+  for (const key of keys) {
+    delete copy[key];
+  }
+  return copy;
+}
+
+function networkRequest(overrides = {}) {
+  return {
+    requestId: 'request-id',
+    timestamp: 1000,
+    wallTime: 1000,
+    request: {
+      url: 'https://nodejs.org/en',
+      method: 'GET',
+      headers: {},
+    },
+    ...overrides,
+  };
+}
+
+function networkResponse(overrides = {}) {
+  return {
+    requestId: 'response-id',
+    timestamp: 1000,
+    type: 'Other',
+    response: {
+      url: 'https://nodejs.org/en',
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    },
+    ...overrides,
+  };
+}
+
+function loadingFailed(overrides = {}) {
+  return {
+    requestId: 'loading-failed-id',
+    timestamp: 1000,
+    type: 'Document',
+    errorText: 'Failed to load resource',
+    ...overrides,
+  };
+}
+
+function loadingFinished(overrides = {}) {
+  return {
+    requestId: 'loading-finished-id',
+    timestamp: 1000,
+    ...overrides,
+  };
+}
+
+function webSocketCreated(overrides = {}) {
+  return {
+    requestId: 'websocket-created-id',
+    url: 'ws://example.com:8080',
+    ...overrides,
+  };
+}
+
+function webSocketClosed(overrides = {}) {
+  return {
+    requestId: 'websocket-closed-id',
+    timestamp: 1000,
+    ...overrides,
+  };
+}
+
+function webSocketResponse(overrides = {}) {
+  return {
+    requestId: 'websocket-response-id',
+    timestamp: 1000,
+    response: {
+      status: 101,
+      statusText: 'Switching Protocols',
+      headers: {},
+    },
+    ...overrides,
+  };
+}
+
+function storageId(overrides = {}) {
+  return {
+    securityOrigin: '',
+    isLocalStorage: true,
+    storageKey: 'node-inspector://default-dom-storage',
+    ...overrides,
+  };
+}
+
+function domStorageItemAdded(overrides = {}) {
+  return {
+    storageId: storageId(),
+    key: 'testKey',
+    newValue: 'testValue',
+    ...overrides,
+  };
+}
+
+function domStorageItemRemoved(overrides = {}) {
+  return {
+    storageId: storageId(),
+    key: 'testKey',
+    ...overrides,
+  };
+}
+
+function domStorageItemUpdated(overrides = {}) {
+  return {
+    storageId: storageId(),
+    key: 'testKey',
+    oldValue: 'oldValue',
+    newValue: 'newValue',
+    ...overrides,
+  };
+}
+
+function registerStorage(overrides = {}) {
+  return {
+    isLocalStorage: true,
+    storageMap: {},
+    ...overrides,
+  };
+}
+
+const NETWORK_ERROR_CASES = [
+  [
+    'requestWillBeSent',
+    omit(networkRequest(), 'requestId'),
+    'Missing requestId in event',
+  ],
+  [
+    'requestWillBeSent',
+    omit(networkRequest(), 'timestamp'),
+    'Missing timestamp in event',
+  ],
+  [
+    'requestWillBeSent',
+    omit(networkRequest(), 'wallTime'),
+    'Missing wallTime in event',
+  ],
+  [
+    'requestWillBeSent',
+    omit(networkRequest(), 'request'),
+    'Missing request in event',
+  ],
+  [
+    'requestWillBeSent',
+    networkRequest({ request: omit(networkRequest().request, 'url') }),
+    'Missing request.url in event',
+  ],
+  [
+    'requestWillBeSent',
+    networkRequest({ request: omit(networkRequest().request, 'method') }),
+    'Missing request.method in event',
+  ],
+  [
+    'requestWillBeSent',
+    networkRequest({ request: omit(networkRequest().request, 'headers') }),
+    'Missing request.headers in event',
+  ],
+
+  [
+    'responseReceived',
+    omit(networkResponse(), 'requestId'),
+    'Missing requestId in event',
+  ],
+  [
+    'responseReceived',
+    omit(networkResponse(), 'timestamp'),
+    'Missing timestamp in event',
+  ],
+  [
+    'responseReceived',
+    omit(networkResponse(), 'type'),
+    'Missing type in event',
+  ],
+  [
+    'responseReceived',
+    omit(networkResponse(), 'response'),
+    'Missing response in event',
+  ],
+  [
+    'responseReceived',
+    networkResponse({ response: omit(networkResponse().response, 'url') }),
+    'Missing response.url in event',
+  ],
+  [
+    'responseReceived',
+    networkResponse({ response: omit(networkResponse().response, 'status') }),
+    'Missing response.status in event',
+  ],
+  [
+    'responseReceived',
+    networkResponse({
+      response: omit(networkResponse().response, 'statusText'),
+    }),
+    'Missing response.statusText in event',
+  ],
+  [
+    'responseReceived',
+    networkResponse({ response: omit(networkResponse().response, 'headers') }),
+    'Missing response.headers in event',
+  ],
+  [
+    'responseReceived',
+    networkResponse({
+      response: { ...networkResponse().response, headers: { host: 1 } },
+    }),
+    'Invalid header value in event',
+  ],
+
+  [
+    'loadingFailed',
+    omit(loadingFailed(), 'requestId'),
+    'Missing requestId in event',
+  ],
+  [
+    'loadingFailed',
+    omit(loadingFailed(), 'timestamp'),
+    'Missing timestamp in event',
+  ],
+  ['loadingFailed', omit(loadingFailed(), 'type'), 'Missing type in event'],
+  [
+    'loadingFailed',
+    omit(loadingFailed(), 'errorText'),
+    'Missing errorText in event',
+  ],
+
+  [
+    'loadingFinished',
+    omit(loadingFinished(), 'requestId'),
+    'Missing requestId in event',
+  ],
+  [
+    'loadingFinished',
+    omit(loadingFinished(), 'timestamp'),
+    'Missing timestamp in event',
+  ],
+
+  [
+    'webSocketCreated',
+    omit(webSocketCreated(), 'requestId'),
+    'Missing requestId in event',
+  ],
+  ['webSocketCreated', omit(webSocketCreated(), 'url'), 'Missing url in event'],
+
+  [
+    'webSocketClosed',
+    omit(webSocketClosed(), 'requestId'),
+    'Missing requestId in event',
+  ],
+  [
+    'webSocketClosed',
+    omit(webSocketClosed(), 'timestamp'),
+    'Missing timestamp in event',
+  ],
+
+  [
+    'webSocketHandshakeResponseReceived',
+    omit(webSocketResponse(), 'requestId'),
+    'Missing requestId in event',
+  ],
+  [
+    'webSocketHandshakeResponseReceived',
+    omit(webSocketResponse(), 'timestamp'),
+    'Missing timestamp in event',
+  ],
+  [
+    'webSocketHandshakeResponseReceived',
+    omit(webSocketResponse(), 'response'),
+    'Missing response in event',
+  ],
+  [
+    'webSocketHandshakeResponseReceived',
+    webSocketResponse({
+      response: omit(webSocketResponse().response, 'status'),
+    }),
+    'Missing response.status in event',
+  ],
+  [
+    'webSocketHandshakeResponseReceived',
+    webSocketResponse({
+      response: omit(webSocketResponse().response, 'statusText'),
+    }),
+    'Missing response.statusText in event',
+  ],
+  [
+    'webSocketHandshakeResponseReceived',
+    webSocketResponse({
+      response: omit(webSocketResponse().response, 'headers'),
+    }),
+    'Missing response.headers in event',
+  ],
+];
+
+const DOM_STORAGE_ERROR_CASES = [
+  [
+    'domStorageItemAdded',
+    omit(domStorageItemAdded(), 'storageId'),
+    'Missing storageId in event',
+  ],
+  [
+    'domStorageItemAdded',
+    domStorageItemAdded({ storageId: omit(storageId(), 'securityOrigin') }),
+    'Missing securityOrigin in storageId',
+  ],
+  [
+    'domStorageItemAdded',
+    domStorageItemAdded({ storageId: omit(storageId(), 'storageKey') }),
+    'Missing storageKey in storageId',
+  ],
+  [
+    'domStorageItemAdded',
+    omit(domStorageItemAdded(), 'key'),
+    'Missing key in event',
+  ],
+  [
+    'domStorageItemAdded',
+    omit(domStorageItemAdded(), 'newValue'),
+    'Missing newValue in event',
+  ],
+
+  [
+    'domStorageItemRemoved',
+    omit(domStorageItemRemoved(), 'storageId'),
+    'Missing storageId in event',
+  ],
+  [
+    'domStorageItemRemoved',
+    omit(domStorageItemRemoved(), 'key'),
+    'Missing key in event',
+  ],
+
+  [
+    'domStorageItemUpdated',
+    omit(domStorageItemUpdated(), 'storageId'),
+    'Missing storageId in event',
+  ],
+  [
+    'domStorageItemUpdated',
+    omit(domStorageItemUpdated(), 'key'),
+    'Missing key in event',
+  ],
+  [
+    'domStorageItemUpdated',
+    omit(domStorageItemUpdated(), 'oldValue'),
+    'Missing oldValue in event',
+  ],
+  [
+    'domStorageItemUpdated',
+    omit(domStorageItemUpdated(), 'newValue'),
+    'Missing newValue in event',
+  ],
+
+  ['domStorageItemsCleared', {}, 'Missing storageId in event'],
+
+  [
+    'registerStorage',
+    omit(registerStorage(), 'isLocalStorage'),
+    'Missing isLocalStorage in event',
+  ],
+  [
+    'registerStorage',
+    omit(registerStorage(), 'storageMap'),
+    'Missing storageMap in event',
+  ],
+  [
+    'registerStorage',
+    registerStorage({
+      storageMap: new Proxy(
+        {},
+        {
+          ownKeys() {
+            throw new Error('boom');
+          },
+        },
+      ),
+    }),
+    'Failed to get property names from storageMap',
+  ],
+  [
+    'registerStorage',
+    registerStorage({
+      storageMap: new Proxy(
+        { testKey: 'testValue' },
+        {
+          get(target, property, receiver) {
+            if (property === 'testKey') throw new Error('boom');
+            return Reflect.get(target, property, receiver);
+          },
+        },
+      ),
+    }),
+    'Failed to get value from storageMap',
+  ],
+];
+
+const DATA_SENT_REQUEST_ID = 'data-sent-id';
+const DATA_SENT_ERROR_CASES = [
+  [{ finished: false }, 'Missing requestId in event'],
+  [{ requestId: DATA_SENT_REQUEST_ID }, 'Missing timestamp in event'],
+  [
+    { requestId: DATA_SENT_REQUEST_ID, timestamp: 1000 },
+    'Missing dataLength in event',
+  ],
+  [
+    { requestId: DATA_SENT_REQUEST_ID, timestamp: 1000, dataLength: 1 },
+    'Missing data in event',
+  ],
+  [
+    {
+      requestId: DATA_SENT_REQUEST_ID,
+      timestamp: 1000,
+      dataLength: 1,
+      data: {},
+    },
+    'Expected data to be Uint8Array in event',
+  ],
+];
+
+const DATA_RECEIVED_ERROR_CASES = [
+  [{}, 'Missing requestId in event'],
+  [{ requestId: 'data-received-id' }, 'Missing timestamp in event'],
+  [
+    { requestId: 'data-received-id', timestamp: 1000 },
+    'Missing dataLength in event',
+  ],
+  [
+    { requestId: 'data-received-id', timestamp: 1000, dataLength: 1 },
+    'Missing encodedDataLength in event',
+  ],
+  [
+    {
+      requestId: 'data-received-id',
+      timestamp: 1000,
+      dataLength: 1,
+      encodedDataLength: 1,
+    },
+    'Missing data in event',
+  ],
+  [
+    {
+      requestId: 'data-received-id',
+      timestamp: 1000,
+      dataLength: 1,
+      encodedDataLength: 1,
+      data: {},
+    },
+    'Expected data to be Uint8Array in event',
+  ],
+];
+
+function assertEventErrors(domain, name, params, message) {
+  assert.throws(
+    () => inspector[domain][name](params),
+    {
+      message,
+    },
+    `Expected ${domain}.${name} to throw`,
+  );
+}
+
+function startRequest(requestId) {
+  inspector.Network.requestWillBeSent(networkRequest({ requestId }));
+}
+
+(async () => {
+  const session = new inspector.Session();
+  session.connect();
+
+  await session.post('Network.enable');
+  await session.post('DOMStorage.enable');
+
+  for (const [name, params, message] of NETWORK_ERROR_CASES) {
+    assertEventErrors('Network', name, params, message);
+  }
+
+  startRequest(DATA_SENT_REQUEST_ID);
+  for (const [params, message] of DATA_SENT_ERROR_CASES) {
+    assertEventErrors('Network', 'dataSent', params, message);
+  }
+
+  for (const [params, message] of DATA_RECEIVED_ERROR_CASES) {
+    assertEventErrors('Network', 'dataReceived', params, message);
+  }
+
+  for (const [name, params, message] of DOM_STORAGE_ERROR_CASES) {
+    assertEventErrors('DOMStorage', name, params, message);
+  }
+})().then(common.mustCall());

--- a/test/js/node/test/parallel/test-inspector-emit-protocol-event.js
+++ b/test/js/node/test/parallel/test-inspector-emit-protocol-event.js
@@ -1,0 +1,201 @@
+// Flags: --inspect=0 --experimental-network-inspection --experimental-storage-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const assert = require('node:assert');
+
+const EXPECTED_EVENTS = {
+  Network: [
+    {
+      name: 'requestWillBeSent',
+      params: {
+        requestId: 'request-id-1',
+        request: {
+          url: 'https://nodejs.org/en',
+          method: 'GET',
+          headers: {},
+        },
+        timestamp: 1000,
+        wallTime: 1000,
+      },
+      expected: {
+        requestId: 'request-id-1',
+        request: {
+          url: 'https://nodejs.org/en',
+          method: 'GET',
+          headers: {},
+          hasPostData: false,
+        },
+        timestamp: 1000,
+        wallTime: 1000,
+      }
+    },
+    {
+      name: 'responseReceived',
+      params: {
+        requestId: 'request-id-1',
+        timestamp: 1000,
+        type: 'Other',
+        response: {
+          url: 'https://nodejs.org/en',
+          status: 200,
+          statusText: '',
+          headers: { host: 'nodejs.org' },
+          mimeType: 'text/html',
+          charset: 'utf-8'
+        }
+      },
+      expected: {
+        requestId: 'request-id-1',
+        timestamp: 1000,
+        type: 'Other',
+        response: {
+          url: 'https://nodejs.org/en',
+          status: 200,
+          statusText: '',
+          headers: { host: 'nodejs.org' },
+          mimeType: 'text/html',
+          charset: 'utf-8'
+        }
+      }
+    },
+    {
+      name: 'dataReceived',
+      // Network.dataReceived is buffered until Network.streamResourceContent/Network.getResponseBody is invoked.
+      skip: true,
+    },
+    {
+      name: 'dataSent',
+      // Network.dataSent is buffered until Network.getRequestPostData is invoked.
+      skip: true,
+    },
+    {
+      name: 'loadingFinished',
+      params: {
+        requestId: 'request-id-1',
+        timestamp: 1000,
+      }
+    },
+    {
+      name: 'loadingFailed',
+      params: {
+        requestId: 'request-id-1',
+        timestamp: 1000,
+        type: 'Document',
+        errorText: 'Failed to load resource'
+      }
+    },
+    {
+      name: 'webSocketCreated',
+      params: {
+        requestId: 'websocket-id-1',
+        url: 'ws://example.com:8080',
+      }
+
+    },
+    {
+      name: 'webSocketHandshakeResponseReceived',
+      params: {
+        requestId: 'websocket-id-1',
+        response: {
+          status: 101,
+          statusText: 'Switching Protocols',
+          headers: {},
+        },
+        timestamp: 1000,
+      }
+    },
+    {
+      name: 'webSocketClosed',
+      params: {
+        requestId: 'websocket-id-1',
+        timestamp: 1000,
+
+      }
+    },
+  ],
+  DOMStorage: [
+    {
+      name: 'domStorageItemAdded',
+      params: {
+        storageId: {
+          securityOrigin: '',
+          isLocalStorage: true,
+          storageKey: 'node-inspector://default-dom-storage',
+        },
+        key: 'testKey',
+        newValue: 'testValue',
+      }
+    },
+    {
+      name: 'domStorageItemRemoved',
+      skip: true
+    },
+    {
+      name: 'domStorageItemUpdated',
+      skip: true
+    },
+    {
+      name: 'domStorageItemsCleared',
+      skip: true
+    },
+    {
+      name: 'registerStorage',
+      skip: true
+    },
+  ]
+};
+
+// Check that all domains and events are present in the inspector object.
+for (const [domain, events] of Object.entries(EXPECTED_EVENTS)) {
+  if (!(domain in inspector)) {
+    assert.fail(`Expected domain ${domain} to be present in inspector`);
+  }
+  const actualEventNames = Object.keys(inspector[domain]).sort();
+  const expectedEventNames = events.map((event) => event.name).sort();
+  assert.deepStrictEqual(actualEventNames, expectedEventNames, `Expected ${domain} to have events ${expectedEventNames}, but got ${actualEventNames}`);
+}
+
+// Check that all events throw when called with a non-object argument.
+for (const [domain, events] of Object.entries(EXPECTED_EVENTS)) {
+  for (const event of events) {
+    assert.throws(() => inspector[domain][event.name]('params'), {
+      name: 'TypeError',
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "params" argument must be of type object. Received type string (\'params\')'
+    });
+  }
+}
+
+(async () => {
+  const session = new inspector.Session();
+  session.connect();
+
+  // Check that all events emit the expected parameters.
+  await session.post('Network.enable');
+  await session.post('DOMStorage.enable');
+  for (const [domain, events] of Object.entries(EXPECTED_EVENTS)) {
+    for (const event of events) {
+      if (event.skip) {
+        continue;
+      }
+      session.on(`${domain}.${event.name}`, common.mustCall(({ params }) => {
+        if (event.name === 'requestWillBeSent' || event.name === 'webSocketCreated') {
+          // Initiator is automatically captured and contains caller info.
+          // No need to validate it.
+          delete params.initiator;
+        }
+        assert.deepStrictEqual(params, event.expected ?? event.params);
+      }));
+      inspector[domain][event.name](event.params);
+    }
+  }
+
+  // Check tht no events are emitted after disabling the domain.
+  await session.post('Network.disable');
+  session.on('Network.requestWillBeSent', common.mustNotCall());
+  inspector.Network.requestWillBeSent({});
+})().then(common.mustCall());

--- a/test/js/node/test/parallel/test-inspector-network-arbitrary-data.js
+++ b/test/js/node/test/parallel/test-inspector-network-arbitrary-data.js
@@ -1,0 +1,41 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+
+const session = new inspector.Session();
+session.connect();
+
+test('should emit Network.requestWillBeSent with unicode', async () => {
+  await session.post('Network.enable');
+  const expectedValue = 'CJK 汉字 🍱 🧑‍🧑‍🧒‍🧒';
+
+  const requestWillBeSentFuture = waitUntil(session, 'Network.requestWillBeSent')
+    .then(([event]) => {
+      assert.strictEqual(event.params.request.url, expectedValue);
+      assert.strictEqual(event.params.request.method, expectedValue);
+      assert.strictEqual(event.params.request.headers.mKey, expectedValue);
+    });
+
+  Network.requestWillBeSent({
+    requestId: '1',
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url: expectedValue,
+      method: expectedValue,
+      headers: {
+        mKey: expectedValue,
+      },
+    },
+  });
+
+  await requestWillBeSentFuture;
+});

--- a/test/js/node/test/parallel/test-inspector-network-data-received.js
+++ b/test/js/node/test/parallel/test-inspector-network-data-received.js
@@ -1,0 +1,192 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+const { setTimeout } = require('node:timers/promises');
+
+// The complete payload string received by the network agent
+const payloadString = `Hello, world${'.'.repeat(4096)}`;
+
+const session = new inspector.Session();
+session.connect();
+session.post('Network.enable');
+
+async function triggerNetworkEvents(requestId, charset) {
+  const url = 'https://example.com';
+  Network.requestWillBeSent({
+    requestId,
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url,
+      method: 'GET',
+      headers: {
+        mKey: 'mValue',
+      },
+    },
+  });
+  await setTimeout(1);
+
+  Network.responseReceived({
+    requestId,
+    timestamp: 2,
+    type: 'Fetch',
+    response: {
+      url,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        mKey: 'mValue',
+      },
+      charset,
+    },
+  });
+  await setTimeout(1);
+
+  const chunk1 = Buffer.from('Hello, ');
+  Network.dataReceived({
+    requestId,
+    timestamp: 3,
+    dataLength: chunk1.byteLength,
+    encodedDataLength: chunk1.byteLength,
+    data: chunk1,
+  });
+  await setTimeout(1);
+
+  const chunk2 = Buffer.from('world');
+  Network.dataReceived({
+    requestId,
+    timestamp: 4,
+    dataLength: chunk2.byteLength,
+    encodedDataLength: chunk2.byteLength,
+    data: chunk2,
+  });
+  await setTimeout(1);
+
+  // Test inspector binary conversions with large input
+  const chunk3 = Buffer.allocUnsafe(4096).fill('.');
+  Network.dataReceived({
+    requestId,
+    timestamp: 5,
+    dataLength: chunk3.byteLength,
+    encodedDataLength: chunk3.byteLength,
+    data: chunk3,
+  });
+  await setTimeout(1);
+
+  Network.loadingFinished({
+    requestId,
+    timestamp: 6,
+  });
+}
+
+function assertNetworkEvents(session, requestId) {
+  session.on('Network.requestWillBeSent', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  session.on('Network.responseReceived', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  const loadingFinishedFuture = waitUntil(session, 'Network.loadingFinished')
+    .then(async ([{ params }]) => {
+      assert.strictEqual(params.requestId, requestId);
+    });
+
+  return loadingFinishedFuture;
+}
+
+test('should stream Network.dataReceived with data chunks', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-1';
+  const chunks = [];
+  let totalDataLength = 0;
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  const responseReceivedFuture = waitUntil(session, 'Network.responseReceived')
+    .then(async () => {
+      const { bufferedData } = await session.post('Network.streamResourceContent', {
+        requestId,
+      });
+      const data = Buffer.from(bufferedData, 'base64');
+      totalDataLength += data.byteLength;
+      chunks.push(data);
+    });
+  session.on('Network.dataReceived', common.mustCallAtLeast(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+    totalDataLength += params.dataLength;
+    chunks.push(Buffer.from(params.data, 'base64'));
+  }));
+
+  await triggerNetworkEvents(requestId);
+  await responseReceivedFuture;
+  await loadingFinishedFuture;
+
+  const data = Buffer.concat(chunks);
+  assert.strictEqual(data.byteLength, totalDataLength, data);
+  assert.strictEqual(data.toString('utf8'), payloadString);
+});
+
+test('Network.streamResourceContent should send all buffered chunks', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-2';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  session.on('Network.dataReceived', common.mustNotCall());
+
+  await triggerNetworkEvents(requestId);
+  await loadingFinishedFuture;
+  const { bufferedData } = await session.post('Network.streamResourceContent', {
+    requestId,
+  });
+  assert.strictEqual(Buffer.from(bufferedData, 'base64').toString('utf8'), payloadString);
+});
+
+test('Network.streamResourceContent should reject if request id not found', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'unknown-request-id';
+  await assert.rejects(session.post('Network.streamResourceContent', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});
+
+test('Network.getResponseBody should send all buffered binary data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-3';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  session.on('Network.dataReceived', common.mustNotCall());
+
+  await triggerNetworkEvents(requestId);
+  await loadingFinishedFuture;
+  const { body, base64Encoded } = await session.post('Network.getResponseBody', {
+    requestId,
+  });
+  assert.strictEqual(base64Encoded, true);
+  assert.strictEqual(body, Buffer.from(payloadString).toString('base64'));
+});
+
+test('Network.getResponseBody should send all buffered text data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-4';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+  session.on('Network.dataReceived', common.mustNotCall());
+
+  await triggerNetworkEvents(requestId, 'utf-8');
+  await loadingFinishedFuture;
+  const { body, base64Encoded } = await session.post('Network.getResponseBody', {
+    requestId,
+  });
+  assert.strictEqual(base64Encoded, false);
+  assert.strictEqual(body, payloadString);
+});

--- a/test/js/node/test/parallel/test-inspector-network-data-sent.js
+++ b/test/js/node/test/parallel/test-inspector-network-data-sent.js
@@ -1,0 +1,136 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+const { setTimeout } = require('node:timers/promises');
+
+const session = new inspector.Session();
+session.connect();
+session.post('Network.enable');
+
+async function triggerNetworkEvents(requestId, requestCharset) {
+  const url = 'https://example.com';
+  Network.requestWillBeSent({
+    requestId,
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url,
+      method: 'PUT',
+      headers: {
+        mKey: 'mValue',
+      },
+      hasPostData: true,
+    },
+    charset: requestCharset,
+  });
+  await setTimeout(1);
+
+  const chunk1 = Buffer.from('Hello, ');
+  Network.dataSent({
+    requestId,
+    timestamp: 2,
+    dataLength: chunk1.byteLength,
+    data: chunk1,
+  });
+  await setTimeout(1);
+
+  const chunk2 = Buffer.from('world');
+  Network.dataSent({
+    requestId,
+    timestamp: 3,
+    dataLength: chunk2.byteLength,
+    data: chunk2,
+  });
+  await setTimeout(1);
+
+  Network.dataSent({
+    requestId,
+    finished: true,
+  });
+  await setTimeout(1);
+
+  Network.responseReceived({
+    requestId,
+    timestamp: 4,
+    type: 'Fetch',
+    response: {
+      url,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        mKey: 'mValue',
+      },
+    },
+  });
+  await setTimeout(1);
+
+  Network.loadingFinished({
+    requestId,
+    timestamp: 5,
+  });
+}
+
+function assertNetworkEvents(session, requestId) {
+  session.on('Network.requestWillBeSent', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  session.on('Network.responseReceived', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  const loadingFinishedFuture = waitUntil(session, 'Network.loadingFinished')
+    .then(async ([{ params }]) => {
+      assert.strictEqual(params.requestId, requestId);
+    });
+
+  return loadingFinishedFuture;
+}
+
+test('Network.getRequestPostData should send all buffered text data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-1';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+
+  await triggerNetworkEvents(requestId, 'utf-8');
+  await loadingFinishedFuture;
+
+  const { postData } = await session.post('Network.getRequestPostData', {
+    requestId,
+  });
+  assert.strictEqual(postData, 'Hello, world');
+});
+
+test('Network.getRequestPostData does not support binary data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-2';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+
+  await triggerNetworkEvents(requestId);
+  await loadingFinishedFuture;
+
+  await assert.rejects(session.post('Network.getRequestPostData', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});
+
+test('Network.getRequestPostData should reject if request id not found', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'unknown-request-id';
+  await assert.rejects(session.post('Network.getRequestPostData', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});

--- a/test/js/node/test/parallel/test-inspector-port-zero.js
+++ b/test/js/node/test/parallel/test-inspector-port-zero.js
@@ -1,0 +1,55 @@
+'use strict';
+const { mustCall, skipIfInspectorDisabled, mustCallAtLeast } = require('../common');
+
+skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { spawn } = require('child_process');
+
+function test(arg, port = '') {
+  const args = [arg, '-p', 'process.debugPort'];
+  const proc = spawn(process.execPath, args);
+  proc.stdout.setEncoding('utf8');
+  proc.stderr.setEncoding('utf8');
+  let stdout = '';
+  let stderr = '';
+  proc.stdout.on('data', (data) => stdout += data);
+  proc.stderr.on('data', (data) => stderr += data);
+  proc.stdout.on('close', mustCall((hadErr) => assert(!hadErr)));
+  proc.stderr.on('close', mustCall((hadErr) => assert(!hadErr)));
+  proc.stderr.on('data', mustCallAtLeast(() => {
+    if (!stderr.includes('\n')) return;
+    assert.match(stderr, /Debugger listening on (.+)/);
+    port = new URL(RegExp.$1).port;
+    assert(+port > 0);
+  }, 0));
+  if (/inspect-brk/.test(arg)) {
+    proc.stderr.on('data', () => {
+      if (stderr.includes('\n') && !proc.killed) proc.kill();
+    });
+  } else {
+    let onclose = mustCall(() => {
+      onclose = mustCall(() => assert.strictEqual(port, stdout.trim()));
+    });
+    proc.stdout.on('close', () => onclose());
+    proc.stderr.on('close', () => onclose());
+    proc.on('exit', mustCall((exitCode, signal) => assert.strictEqual(
+      exitCode,
+      0,
+      `exitCode: ${exitCode}, signal: ${signal}`)));
+  }
+}
+
+test('--inspect=0');
+test('--inspect=127.0.0.1:0');
+test('--inspect=localhost:0');
+
+test('--inspect-brk=0');
+test('--inspect-brk=127.0.0.1:0');
+test('--inspect-brk=localhost:0');
+
+// In these cases, the inspector doesn't listen, so an ephemeral port is not
+// allocated and the expected value of `process.debugPort` is `0`.
+test('--inspect-port=0', '0');
+test('--inspect-port=127.0.0.1:0', '0');
+test('--inspect-port=localhost:0', '0');

--- a/test/js/node/test/parallel/test-inspector-vm-global-accessors-getter-sideeffect.js
+++ b/test/js/node/test/parallel/test-inspector-vm-global-accessors-getter-sideeffect.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+// Test that if there is a side effect in a getter invoked through the vm
+// global proxy, Runtime.evaluate recognizes that.
+
+const assert = require('assert');
+const inspector = require('inspector');
+const vm = require('vm');
+
+const session = new inspector.Session();
+session.connect();
+
+const context = vm.createContext({
+  get a() {
+    globalThis.foo = '1';
+    return 100;
+  }
+});
+
+session.post('Runtime.evaluate', {
+  expression: 'a',
+  throwOnSideEffect: true,
+  contextId: 2 // context's id
+}, common.mustSucceed((res) => {
+  const { exception } = res.exceptionDetails;
+  assert.strictEqual(exception.className, 'EvalError');
+  assert.match(exception.description, /Possible side-effect/);
+
+  assert(context);  // Keep 'context' alive and make linter happy.
+}));

--- a/test/js/node/test/parallel/test-inspector-vm-global-accessors-sideeffects.js
+++ b/test/js/node/test/parallel/test-inspector-vm-global-accessors-sideeffects.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+// Regression test for https://github.com/nodejs/node/issues/27518.
+
+const assert = require('assert');
+const inspector = require('inspector');
+const vm = require('vm');
+
+const session = new inspector.Session();
+session.connect();
+
+const context = vm.createContext({
+  a: 100
+});
+
+session.post('Runtime.evaluate', {
+  expression: 'a',
+  throwOnSideEffect: true,
+  contextId: 2 // context's id
+}, common.mustSucceed((res) => {
+  assert.deepStrictEqual(res, {
+    result: {
+      type: 'number',
+      value: context.a,
+      description: '100'
+    }
+  });
+}));

--- a/test/js/node/test/sequential/test-debugger-debug-brk.js
+++ b/test/js/node/test/sequential/test-debugger-debug-brk.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+// This test ensures that the --debug-brk flag will exit the process
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const { spawnSync } = require('child_process');
+
+// File name here doesn't actually matter the process will exit on start.
+const script = fixtures.path('empty.js');
+
+function test(arg) {
+  const child = spawnSync(process.execPath, ['--inspect', arg, script]);
+  const stderr = child.stderr.toString();
+  assert(stderr.includes('DEP0062'));
+  assert.strictEqual(child.status, 9);
+}
+
+test('--debug-brk');
+test('--debug-brk=5959');


### PR DESCRIPTION
## What

Second-wave `node:inspector` / `node inspect` compat fixes on top of the inspector/CDP-on-CLI stack (#31823 → #34719 → #35396), vendoring 17 more upstream Node v26.3.0 `test-inspector-*` / `test-debugger-*` tests that now pass.

Verified by running every `test-inspector-*` / `test-debugger-*` file in the tree (133 files: the 116 the base already carries plus these 17) CI-style against the debug build: 94 pass, and every failure is in the drop list below with its blocking cause. Preflight (byte-verbatim check, per-file pass, throw-canary) is clean.

## Fixes

Each item names the defect; the tests it unlocks are in parentheses. Everything else in the diff is vendored test files.

**CDP adapter (`src/js/internal/inspector/cdp.ts`)**
- The pause that ends an `--inspect-brk`/`--inspect-wait` park is now reported with V8's reason `Break on start`; `NODE_INSPECT_RESUME_ON_START` and the debugger REPL header branch on it (test-debugger-auto-resume).
- Preview shape: `entries` omitted from empty Map/Set previews; entries of a Map/Set nested inside another preview elided to `overflow`; JSC-only `line/column/sourceURL/originalLine/originalColumn` own properties dropped from error previews with `stack` listed first; and `stack` recovered via `Runtime.getProperties` when JSC's five-property preview cap crowds it out (test-debugger-probe-json-preview).
- Thrown evaluations: `exceptionDetails` now carries `text: "Uncaught"`, a description embedding the formatted stack, a structured `stackTrace`, `scriptId`, and the throwing statement's source-mapped position (test-debugger-probe-expression-throws).
- Pre-parse breakpoints are re-set through the script's source map in two phases — all removals, then all re-adds. JSC resolves distinct requests on an unmapped line forward to one shared pause location, and removing one of them after a re-added breakpoint had resolved there cleared that one too (test-debugger-probe-explicit-column).
- A stale pass-through pre-parse breakpoint can fire before the backend processes the removal issued during retranslation (scripts start executing at parse). A pause it causes off the re-set line has no V8 equivalent and is resumed silently; on the re-set line it is the requested breakpoint and is reported under the id the client knows (test-debugger-sb-before-load, without regressing test-debugger-probe-late-resolution / -multi-location).
- `Debugger.setBreakpoint` / `setBreakpointByUrl` replies translate their resolved locations back to original coordinates; the REPL's `breakpoints` list printed generated line numbers.
- `console.profile()` / `console.profileEnd()` (JSC's programmatic ScriptProfiler tracking) are announced as `Profiler.consoleProfileStarted` / `consoleProfileFinished` (test-debugger-profile).
- `HeapProfiler.takeHeapSnapshot` implemented for remote sessions by building the V8-format snapshot on the inspected thread (`Bun.generateHeapSnapshot("v8")`) and streaming `addHeapSnapshotChunk` events (test-debugger-heap-profiler).

**Native**
- `process.debugPort` reflects the actually-bound CLI inspector port (was always 9229), reported from the debugger thread when the node-CDP endpoint comes up (test-inspector-port-zero).
- `--inspect` startup blocks until the debugger thread finishes server startup, so the `Debugger listening on ws://…` banner is ordered before any script output — Node binds its inspector synchronously and this test scrapes stderr for that line before reading stdout. Implemented with the existing startup futex: armed in `Debugger::create` before the spawn, cleared on every debugger-thread exit path (test-inspector-port-zero; a `-p`/short script could previously exit before the banner).
- `--inspect-port=[host:]port` is parsed: it names the port for an active `--inspect` listener and is reflected by `process.debugPort` even without one — `--inspect-port=0` alone reports 0 and starts no server. An explicit `--inspect=<port>` keeps its own port (test-inspector-port-zero).

**`bun inspect` probe mode**
- Bun's inspector banner is stripped from probe-report stderr fields; Node targets print nothing beyond the listening lines the filter already drops (test-debugger-probe-failure-process-exit).

**Test harness**
- `test/common/inspector-helper.js` synced verbatim to v26.3.0 — the base carried a pre-`waitUntil` copy (test-inspector-network-data-received / data-sent).

## Vendored tests (17, byte-verbatim)

See the test commit for the list; fixtures `fixtures/debugger/probe-exits-during-probe.js`, `probe-multi-statement.js`, `probe-throwing-getter.js` come along.

## Evaluated and not vendored — blocking cause per file

- **Worker inspector** (`inspector.open()` in workers is the base stack's deliberate `ERR_WORKER_UNSUPPORTED_OPERATION` stub; NodeWorker attach/sendMessageToWorker need it): test-inspector-close-worker, -exit-worker-in-wait-for-connection, -exit-worker-in-wait-for-connection2, -connect-main-thread, -async-hook-after-done.
- **internalBinding shims missing (`async_wrap`, `inspector`) and the SIGUSR1/`_debugProcess` stub decision** (the base PR reverted `_debugProcess` to a stub because Bun has no SIGUSR1 inspector handler): test-inspector-async-call-stack, -async-call-stack-abort, -async-hook-setup-at-signal, test-debugger-pid.
- **Bun runs CommonJS in strict mode**, so the REPL's `exec a={}; a` throws where Node's sloppy wrapper creates a global: test-debugger-object-type-remote-object (its Map/Set preview assertions now pass; this is the remaining blocker).
- **Bun's uncaught-error stderr format differs from Node's** (`error:` style, no `Node.js vX` trailer): test-debugger-probe-script-throws, -probe-target-syntax-error.
- **bun accepts unknown CLI flags** where node exits 9 with `bad option`: test-debugger-probe-launch.
- **Upstream cwd assumption** (Node's runner cwd == repo root == the test's `../..`; Bun's CI cwd is the bun repo root, which nests these tests deeper): test-debugger-profile-command, test-inspector-overwrite-config.
- **JSC stepping anchor from the `--inspect-wait` initial pause**: the first `n` steps to the last top-level statement instead of the next line (the CLI parks with `--inspect-wait` + `Debugger.pause`, and stepping from that pause is mis-anchored in JSC): test-debugger-set-context-line-number, -run-after-quit-restart.
- **Nondeterministic under Bun** (three consecutive runs failed at three different assertions — breakpoint resolution races the 10ms timers in the fixture): test-debugger-break.
- **JSC TDZ ReferenceError text differs from V8** (`Cannot access 'x' before initialization` vs `x is not defined` at break-on-start): test-debugger-watchers.
- **vm contexts are not inspector execution contexts**: test-inspector-contexts.
- **In-process `Runtime.awaitPromise` never settles** (pre-existing in the base stack — the in-process backend channel has no async reply path): test-inspector-promises.
- **In-process pause broadcast / scope enumeration gaps**: test-inspector-multisession-js, -bindings, -async-context-brk, -debug-async-hook.
- **`--experimental-webstorage` / Storage domain**: test-inspector-dom-storage.
- **`internal/deps/undici` real internal module**: test-inspector-network-fetch.
- **`Runtime.evaluate` `timeout` param** (JSC has no evaluate watchdog): test-inspector-runtime-evaluate-with-timeout.
- **cluster inspect-port allocation not implemented** (`cluster.settings.inspectPort` execArgv rewriting): test-inspector-port-zero-cluster, sequential/test-inspector-port-cluster.
- **`scripts` must list `node:internal/*` scripts** Bun does not have: test-debugger-scripts.
- **fetch/`node:http` network-inspection instrumentation not implemented** (only the manual `Network.*` emit API exists): test-inspector-network-content-type, -network-http, -network-http2, -network-websocket, sequential/test-inspector-network-resource.
- **`--inspect-brk-node` + `node:internal/bootstrap/realm` script**: test-inspector-inspect-brk-node.
- **`bun inspect` probe failure-path fidelity** (JSC's "Can only perform operation while paused." vs V8's "Must be paused or waiting to pause"; disconnect-vs-timeout classification when a probe closes the inspector): test-debugger-probe-failure-resume, -probe-failure-hang-during-evaluate.
