### PR TITLE
util: coerce isDeepStrictEqual skipPrototype to boolean

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -34,7 +34,7 @@ function isFunction(value) {
 
 const deepEquals = Bun.deepEquals;
 function isDeepStrictEqual(a, b, skipPrototype) {
-  return deepEquals(a, b, true, skipPrototype);
+  return deepEquals(a, b, true, !!skipPrototype);
 }
 
 const parseArgs = $newRustFunction("parse_args.rs", "parseArgs", 1);

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -729,6 +729,25 @@ describe("util.isDeepStrictEqual", () => {
       expect(util.isDeepStrictEqual(new String("a"), new S("a"), true)).toBe(true);
     });
 
+    test("ignores a foreign prototype on a plain object", () => {
+      const fake = Object.assign(Object.create(Array.prototype), { a: 1 });
+      expect(util.isDeepStrictEqual(fake, { a: 1 })).toBe(false);
+      expect(util.isDeepStrictEqual(fake, { a: 1 }, true)).toBe(true);
+    });
+
+    test("accepts any truthy value", () => {
+      for (const truthy of [1, "yes", {}, []]) {
+        expect(util.isDeepStrictEqual(new Foo(42), new Bar(42), truthy)).toBe(true);
+      }
+      for (const falsy of [0, "", null, undefined, false]) {
+        expect(util.isDeepStrictEqual(new Foo(42), new Bar(42), falsy)).toBe(false);
+      }
+    });
+
+    test("has length 3", () => {
+      expect(util.isDeepStrictEqual.length).toBe(3);
+    });
+
     test("does not leak into assert.deepStrictEqual", () => {
       expect(() => assert.deepStrictEqual(new Foo(42), new Bar(42))).toThrow();
     });


### PR DESCRIPTION
## Problem

The bulk of Node 26's `util.isDeepStrictEqual(a, b, skipPrototype)` support landed in #34434, which threads the third argument through to `Bun__deepEquals<true, false, true>`. One edge remained: `Bun.deepEquals` only enters the skip-prototype instantiation when its fourth argument is a literal boolean (`skipPrototype.isBoolean() && skipPrototype.asBoolean()`), while Node coerces the argument, so any truthy value enables the mode.

```js
import util from "node:util";
class A { constructor(){ this.x = 1; } }
class B { constructor(){ this.x = 1; } }
util.isDeepStrictEqual(new A(), new B(), 1);  // node: true, bun: false
```

## Fix

Coerce with `!!skipPrototype` in the `node:util` wrapper before forwarding to `Bun.deepEquals`. The `Bun.deepEquals` API itself is left strict.

## Tests

Added to the existing `skipPrototype` describe block in `test/js/node/assert/deep-equal.test.ts`:
- truthy non-boolean values (`1`, `"yes"`, `{}`, `[]`) enable skipPrototype; falsy values do not
- `Object.assign(Object.create(Array.prototype), {a:1})` vs `{a:1}` with `skipPrototype=true` (the other repro from the report, already passing on main, now locked in)
- `util.isDeepStrictEqual.length === 3`

All verified against Node v26.3.0.

## Related

The exact repro in the original report (using `true` rather than a truthy non-boolean) was already fixed on main by #34434; the reporter's canary predated that merge. #33080 covered the same ground and is superseded.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.0 (a4c16450a)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [67.74ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [5.50ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [73.49ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [12.00ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [8.85ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [6.21ms]
(pass) assert.deepStrictEqual > rejects '' and false [4.87ms]
(pass) assert.deepStrictEqual > rejects null and undefined [5.08ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [13.05ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [6.49ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [10.59ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [5.95ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [5.83ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [11.42ms]
(pass) assert.
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8a8aa8b26)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [1.20ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [0.08ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [1.35ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [0.20ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [0.10ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [0.05ms]
(pass) assert.deepStrictEqual > rejects '' and false [0.04ms]
(pass) assert.deepStrictEqual > rejects null and undefined [0.04ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [0.25ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [0.08ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [0.15ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [0.08ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [0.05ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [0.08ms]
(pass) assert.deepStrictEqual > accepts two boxed booleans [0.10ms]
(pass) assert.deepStrictEqual > accepts two boxed symbols [0.10ms]
(pass) assert.deepStrictEqual > accepts two boxe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.0 (a4c16450a)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [73.58ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [5.80ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [78.00ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [14.06ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [11.54ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [5.70ms]
(pass) assert.deepStrictEqual > rejects '' and false [5.06ms]
(pass) assert.deepStrictEqual > rejects null and undefined [5.15ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [13.92ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [6.67ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [12.48ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [6.88ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [7.90ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [11.60ms]
(pass) assert
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1150ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (10708ms)
Bundle modules (87ms)
Postprocesss modules (149ms)
Bundle Functions (838ms)
Generate Code (40ms)

[11.84s] Bundled "src/js" for production
  2112 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 50s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+a4c16450a
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (a4c16450a)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [1.14ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [0.07ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [1.38ms]
(pass) assert.deepStri
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/util.ts                    |  2 +-
 test/js/node/assert/deep-equal.test.ts | 19 +++++++++++++++++++
 2 files changed, 20 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/node/util.ts                         1      1      0
test/js/node/assert/deep-equal.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->