### PR TITLE
assert: compare AggregateError.errors in deep equality

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1297,6 +1297,20 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 return false;
             }
 
+            // `.errors` (AggregateError) is non-enumerable, so it must be checked
+            // explicitly. Unlike `.cause`, Node treats a present-but-undefined
+            // `.errors` the same as a missing one, so there is no hasProperty gate.
+            const PropertyName errors(vm.propertyNames->errors);
+            auto leftErrors = left->get(globalObject, errors);
+            RETURN_IF_EXCEPTION(scope, {});
+            auto rightErrors = right->get(globalObject, errors);
+            RETURN_IF_EXCEPTION(scope, {});
+            bool errorsEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, skipPrototype>(globalObject, leftErrors, rightErrors, gcBuffer, stack, scope, true);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!errorsEqual) {
+                return false;
+            }
+
             // check arbitrary enumerable properties. `.stack` is not checked.
             left->materializeErrorInfoIfNeeded(vm);
             RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1297,9 +1297,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 return false;
             }
 
-            // `.errors` (AggregateError) is non-enumerable, so it must be checked
-            // explicitly. Unlike `.cause`, Node treats a present-but-undefined
-            // `.errors` the same as a missing one, so there is no hasProperty gate.
             const PropertyName errors(vm.propertyNames->errors);
             auto leftErrors = left->get(globalObject, errors);
             RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -395,6 +395,41 @@ const cases: Case[] = [
     strict: false,
     loose: false,
   },
+  {
+    name: "AggregateError with deep-equal errors",
+    a: () => new AggregateError([new TypeError("x")], "agg"),
+    b: () => new AggregateError([new TypeError("x")], "agg"),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "AggregateError with different inner errors",
+    a: () => new AggregateError([new Error("x")], "agg"),
+    b: () => new AggregateError([new Error("y")], "agg"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "AggregateError with different error counts",
+    a: () => new AggregateError([new Error("x")], "agg"),
+    b: () => new AggregateError([new Error("x"), new Error("x")], "agg"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "AggregateError vs plain Error with same message",
+    a: () => new AggregateError([], "x"),
+    b: () => new Error("x"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "Error with non-enumerable own errors vs Error without",
+    a: () => Object.defineProperty(new Error("x"), "errors", { value: [1], enumerable: false, configurable: true }),
+    b: () => new Error("x"),
+    strict: false,
+    loose: false,
+  },
 
   // Map and Set.
   {


### PR DESCRIPTION
## What

`util.isDeepStrictEqual` / `assert.deepStrictEqual` / `assert.deepEqual` now compare the non-enumerable `.errors` array on `Error` instances, matching Node.js.

## Repro

```js
import util from 'node:util';
const mk = msgs => new AggregateError(msgs.map(m => new Error(m)), 'agg');
util.isDeepStrictEqual(mk(['x']), mk(['y']));      // node: false, bun (before): true
util.isDeepStrictEqual(mk(['x']), mk(['x', 'x'])); // node: false, bun (before): true
```

Any test asserting which errors a `Promise.any` rejection carries was a false green on Bun regardless of the inner error content.

## Cause

`AggregateError` defines `.errors` with `PropertyAttribute::DontEnum` (JSC `AggregateError.cpp`), so the enumerable-property walk in `Bun__deepEquals`'s `ErrorInstanceType` handler never visited it. The handler already special-cased the non-enumerable `.cause` but not `.errors`.

Node handles both via `isEnumerableOrIdentical` in [`lib/internal/util/comparisons.js`](https://github.com/nodejs/node/blob/main/lib/internal/util/comparisons.js):

```js
!isEnumerableOrIdentical(val1, val2, 'cause', mode, memos) ||
!isEnumerableOrIdentical(val1, val2, 'errors', mode, memos)
```

## Fix

Add an explicit get-and-recurse for `.errors` in `bindings.cpp` right after the `.cause` block. Unlike `.cause`, Node does not gate `.errors` on `hasOwn` presence (a present-but-undefined `.errors` is equal to a missing one), so there is no `hasProperty` check.

## Verification

New cases in `test/js/node/assert/deep-equal.test.ts` (runs through `assert.deepStrictEqual`, `assert.deepEqual`, and `util.isDeepStrictEqual`):

- AggregateError with deep-equal errors: equal
- AggregateError with different inner errors: not equal
- AggregateError with different error counts: not equal
- AggregateError vs plain Error with same message: not equal
- Error with non-enumerable own `errors` vs Error without: not equal

All expectations cross-checked against Node v26.3.0. Fails on canary (9 failures), passes with this change.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.0 (cda0d070e)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [71.70ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [5.11ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [74.55ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [12.00ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [8.57ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [5.59ms]
(pass) assert.deepStrictEqual > rejects '' and false [5.03ms]
(pass) assert.deepStrictEqual > rejects null and undefined [5.36ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [13.14ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [6.63ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [11.02ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [6.27ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [5.76ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [11.49ms]
(pass) assert.
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cda0d070e)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [1.85ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [0.10ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [2.31ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [0.36ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [0.18ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [0.08ms]
(pass) assert.deepStrictEqual > rejects '' and false [0.08ms]
(pass) assert.deepStrictEqual > rejects null and undefined [0.07ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [0.40ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [0.13ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [0.27ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [0.12ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [0.09ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [0.15ms]
(pass) assert.deepStrictEqual > accepts two boxed booleans [0.19ms]
(pass) assert.deepStrictEqual > accepts two boxed symbols [0.20ms]
(pass) assert.deepStrictEqual > accepts two boxe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/assert/deep-equal.test.ts
bun test v1.4.0 (cda0d070e)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [108.02ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [9.54ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [120.18ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [18.77ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [13.64ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [8.26ms]
(pass) assert.deepStrictEqual > rejects '' and false [7.34ms]
(pass) assert.deepStrictEqual > rejects null and undefined [7.96ms]
(pass) assert.deepStrictEqual > rejects { a: -0 } and { a: 0 } [21.82ms]
(pass) assert.deepStrictEqual > rejects 1n and 1 [10.25ms]
(pass) assert.deepStrictEqual > rejects new String('a') and 'a' [16.02ms]
(pass) assert.deepStrictEqual > accepts two boxed equal strings [9.26ms]
(pass) assert.deepStrictEqual > accepts two boxed equal numbers [10.18ms]
(pass) assert.deepStrictEqual > rejects boxed -0 and boxed 0 [16.68ms]
(pass) as
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1315ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/12] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[2/12] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[3/12] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[4/12] gen cpp.rs (cppbind)
[5/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_http-0.cpp.o
[6/11] cxx obj/src/jsc/bindings/bindings.cpp.o
[7/11] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[8/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[8/11] link bun-profile
[9/11] bun-profile --revision
1.4.0-canary.1+cda0d070e
[11/11] strip bun
[build] done
bun test v1.4.0-canary.1 (cda0d070e)

test/js/node/assert/deep-equal.test.ts:
(pass) assert.deepStrictEqual > rejects 0 and -0 [2.07ms]
(pass) assert.deepStrictEqual > accepts NaN and NaN [0.13ms]
(pass) assert.deepStrictEqual > rejects [0] and [-0] [2.42ms]
(pass) assert.deepStrictEqual > rejects '1' and 1 [0.38ms]
(pass) assert.deepStrictEqual > rejects ['1'] and [1] [0.18ms]
(pass) assert.deepStrictEqual > rejects '+00000000' and false [0.09ms]
(pass) assert.deepStric
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp          | 11 +++++++++++
 test/js/node/assert/deep-equal.test.ts | 35 ++++++++++++++++++++++++++++++++++
 2 files changed, 46 insertions(+)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/bindings/bindings.cpp               2      2      0
test/js/node/assert/deep-equal.test.ts      3      1      0
```

</details>

<!-- robobun:evidence:end -->