### PR TITLE
bun:test fake timers: don't drain microtasks in the sync APIs

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1173,6 +1173,15 @@ impl VirtualMachine {
         let _ = self.event_loop_mut().drain_microtasks();
     }
 
+    /// Set [`Self::suppress_microtask_drain`] = `true`, restore the prior value
+    /// on drop. Makes `drain_microtasks_with_global()` a no-op for the guard's
+    /// lifetime.
+    #[inline]
+    pub fn suppress_microtask_drain_scope(&'static self) -> SuppressMicrotaskDrain {
+        let prev = self.suppress_microtask_drain.replace(true);
+        SuppressMicrotaskDrain { vm: self, prev }
+    }
+
     /// Acquires the JSC API lock for the duration of `f()`.
     ///
     /// Routes `f` through `JSC__VM__holdAPILock` via an `OpaqueWrap`-style C
@@ -1863,6 +1872,19 @@ bun_io::link_impl_EventLoopCtx! {
         pipe_read_buffer() => {
             core::ptr::from_mut::<[u8]>(vm_from_owner(this.cast()).rare_data().pipe_read_buffer())
         },
+    }
+}
+
+/// RAII guard returned by [`VirtualMachine::suppress_microtask_drain_scope`].
+pub struct SuppressMicrotaskDrain {
+    vm: &'static VirtualMachine,
+    prev: bool,
+}
+
+impl Drop for SuppressMicrotaskDrain {
+    #[inline]
+    fn drop(&mut self) {
+        self.vm.suppress_microtask_drain.set(self.prev);
     }
 }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1880,6 +1880,7 @@ bun_io::link_impl_EventLoopCtx! {
 }
 
 /// RAII guard returned by [`VirtualMachine::suppress_microtask_drain_scope`].
+#[must_use = "dropping immediately restores the prior suppress_microtask_drain value; bind to a named local"]
 pub struct SuppressMicrotaskDrain {
     vm: &'static VirtualMachine,
     prev: bool,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1179,7 +1179,7 @@ impl VirtualMachine {
     #[inline]
     pub fn suppress_microtask_drain_scope(&'static self) -> SuppressMicrotaskDrain {
         let prev = self.suppress_microtask_drain.replace(true);
-        SuppressMicrotaskDrain { vm: self, prev }
+        SuppressMicrotaskDrain { vm: self, prev, _not_send: core::marker::PhantomData }
     }
 
     /// Acquires the JSC API lock for the duration of `f()`.
@@ -1879,6 +1879,10 @@ bun_io::link_impl_EventLoopCtx! {
 pub struct SuppressMicrotaskDrain {
     vm: &'static VirtualMachine,
     prev: bool,
+    // `VirtualMachine` is `unsafe impl Sync`, so `&'static VirtualMachine` would
+    // make this guard auto-`Send`/`Sync`; the `Cell` write in `Drop` must stay
+    // on the JS thread.
+    _not_send: core::marker::PhantomData<*mut ()>,
 }
 
 impl Drop for SuppressMicrotaskDrain {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1179,7 +1179,11 @@ impl VirtualMachine {
     #[inline]
     pub fn suppress_microtask_drain_scope(&'static self) -> SuppressMicrotaskDrain {
         let prev = self.suppress_microtask_drain.replace(true);
-        SuppressMicrotaskDrain { vm: self, prev, _not_send: core::marker::PhantomData }
+        SuppressMicrotaskDrain {
+            vm: self,
+            prev,
+            _not_send: core::marker::PhantomData,
+        }
     }
 
     /// Acquires the JSC API lock for the duration of `f()`.

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -669,14 +669,11 @@ impl EventLoop {
         let vm = self.vm();
         // `Cell` swap through `&VirtualMachine` — no `&mut VM` formed (would
         // overlap `&mut self: EventLoop`, which is a value field of the VM).
-        let prev = self.vm_ref().suppress_microtask_drain.replace(true);
+        let _suppress = self.vm_ref().suppress_microtask_drain_scope();
 
         while self.tick_with_count(vm) > 0 {
             self.tick_concurrent();
         }
-
-        self.vm_ref().suppress_microtask_drain.set(prev);
-        // Note: reshaped for borrowck — `defer vm.suppress_microtask_drain = prev` moved to tail
     }
 
     pub fn enqueue_task(&mut self, task: Task) {

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -316,10 +316,41 @@ fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     Ok(frame.this())
 }
 
+/// RAII guard: set `vm.suppress_microtask_drain = true` for its lifetime,
+/// restore the prior value on drop.
+///
+/// Jest's sync fake-timer APIs (`advanceTimersByTime`, `runAllTimers`, ...)
+/// fire timer callbacks without flushing microtasks between or after them;
+/// microtasks queued inside a callback run at the test's next real `await`.
+/// The `*Async` variants are what opt into per-timer flushing. Without this
+/// guard each fired timer's `event_loop().exit()` sees depth 1 (the test body
+/// isn't itself inside an enter/exit pair) and drains eagerly.
+struct SuppressMicrotaskDrain {
+    vm: &'static bun_jsc::virtual_machine::VirtualMachine,
+    prev: bool,
+}
+
+impl SuppressMicrotaskDrain {
+    #[inline]
+    fn new(global: &JSGlobalObject) -> Self {
+        let vm = global.bun_vm();
+        let prev = vm.suppress_microtask_drain.replace(true);
+        Self { vm, prev }
+    }
+}
+
+impl Drop for SuppressMicrotaskDrain {
+    #[inline]
+    fn drop(&mut self) {
+        self.vm.suppress_microtask_drain.set(self.prev);
+    }
+}
+
 #[bun_jsc::host_fn]
 fn advance_timers_to_next_timer(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
+    let _suppress = SuppressMicrotaskDrain::new(global);
     let _ = FakeTimers::execute_next(global);
 
     Ok(frame.this())
@@ -354,6 +385,7 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     let effective_advance = if arg_number == 0.0 { 1.0 } else { arg_number };
     let target = current.add_ms_float(effective_advance);
 
+    let _suppress = SuppressMicrotaskDrain::new(global);
     FakeTimers::execute_until(global, target);
     CURRENT_TIME.set(global, &target, None);
 
@@ -364,6 +396,7 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
 fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
+    let _suppress = SuppressMicrotaskDrain::new(global);
     FakeTimers::execute_only_pending_timers(global);
 
     Ok(frame.this())
@@ -373,6 +406,7 @@ fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
+    let _suppress = SuppressMicrotaskDrain::new(global);
     FakeTimers::execute_all_timers(global);
 
     Ok(frame.this())

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -316,41 +316,24 @@ fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     Ok(frame.this())
 }
 
-/// RAII guard: set `vm.suppress_microtask_drain = true` for its lifetime,
-/// restore the prior value on drop.
-///
 /// Jest's sync fake-timer APIs (`advanceTimersByTime`, `runAllTimers`, ...)
 /// fire timer callbacks without flushing microtasks between or after them;
 /// microtasks queued inside a callback run at the test's next real `await`.
 /// The `*Async` variants are what opt into per-timer flushing. Without this
-/// guard each fired timer's `event_loop().exit()` sees depth 1 (the test body
-/// isn't itself inside an enter/exit pair) and drains eagerly.
-struct SuppressMicrotaskDrain {
-    vm: &'static bun_jsc::virtual_machine::VirtualMachine,
-    prev: bool,
-}
-
-impl SuppressMicrotaskDrain {
-    #[inline]
-    fn new(global: &JSGlobalObject) -> Self {
-        let vm = global.bun_vm();
-        let prev = vm.suppress_microtask_drain.replace(true);
-        Self { vm, prev }
-    }
-}
-
-impl Drop for SuppressMicrotaskDrain {
-    #[inline]
-    fn drop(&mut self) {
-        self.vm.suppress_microtask_drain.set(self.prev);
-    }
+/// suppression each fired timer's `event_loop().exit()` can see depth 1 (the
+/// test body isn't itself inside an enter/exit pair) and drain eagerly.
+#[inline]
+fn suppress_microtask_drain(
+    global: &JSGlobalObject,
+) -> bun_jsc::virtual_machine::SuppressMicrotaskDrain {
+    global.bun_vm().suppress_microtask_drain_scope()
 }
 
 #[bun_jsc::host_fn]
 fn advance_timers_to_next_timer(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
-    let _suppress = SuppressMicrotaskDrain::new(global);
+    let _suppress = suppress_microtask_drain(global);
     let _ = FakeTimers::execute_next(global);
 
     Ok(frame.this())
@@ -385,7 +368,7 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     let effective_advance = if arg_number == 0.0 { 1.0 } else { arg_number };
     let target = current.add_ms_float(effective_advance);
 
-    let _suppress = SuppressMicrotaskDrain::new(global);
+    let _suppress = suppress_microtask_drain(global);
     FakeTimers::execute_until(global, target);
     CURRENT_TIME.set(global, &target, None);
 
@@ -396,7 +379,7 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
 fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
-    let _suppress = SuppressMicrotaskDrain::new(global);
+    let _suppress = suppress_microtask_drain(global);
     FakeTimers::execute_only_pending_timers(global);
 
     Ok(frame.this())
@@ -406,7 +389,7 @@ fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
-    let _suppress = SuppressMicrotaskDrain::new(global);
+    let _suppress = suppress_microtask_drain(global);
     FakeTimers::execute_all_timers(global);
 
     Ok(frame.this())

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 afterEach(() => vi.useRealTimers());
 

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 afterEach(() => vi.useRealTimers());
 
@@ -111,83 +112,87 @@ describe("advanceTimersToNextTimer", () => {
     vi.useRealTimers();
   });
 });
-describe("sync APIs do not drain the microtask queue (jest parity)", () => {
+describe.concurrent("sync APIs do not drain the microtask queue (jest parity)", () => {
   // Jest's sync fake-timer APIs fire callbacks without flushing microtasks; a
   // microtask scheduled inside a callback runs at the test's next real `await`,
   // not before advanceTimersByTime() returns. The *Async variants opt into
   // per-timer flushing.
-  test("advanceTimersByTime", async () => {
-    vi.useFakeTimers();
-    const log: string[] = [];
-    setTimeout(() => {
-      log.push("T1");
-      Promise.resolve().then(() => log.push("P1"));
-    }, 10);
-    vi.advanceTimersByTime(10);
-    log.push("after-advance");
-    await Promise.resolve();
-    log.push("after-await");
-    expect(log).toEqual(["T1", "after-advance", "P1", "after-await"]);
-  });
+  //
+  // The ordering depends on event-loop enter/exit depth at the call site, which
+  // a prior test's real-time `await` can change, so assert in a subprocess.
+  const orderingFixture = (api: string) => `
+    import { jest, test } from "bun:test";
+    test("ordering", async () => {
+      jest.useFakeTimers();
+      const log = [];
+      setTimeout(() => { log.push("T1"); Promise.resolve().then(() => log.push("P1")); }, 5);
+      setTimeout(() => { log.push("T2"); Promise.resolve().then(() => log.push("P2")); }, 10);
+      jest.${api};
+      log.push("after-advance");
+      await Promise.resolve();
+      log.push("after-await");
+      console.log(JSON.stringify(log));
+      jest.useRealTimers();
+    });
+  `;
 
-  test("advanceTimersByTime: two timers, microtasks batch after", async () => {
-    vi.useFakeTimers();
-    const log: string[] = [];
-    setTimeout(() => {
-      log.push("T1");
-      Promise.resolve().then(() => log.push("P1"));
-    }, 5);
-    setTimeout(() => {
-      log.push("T2");
-      Promise.resolve().then(() => log.push("P2"));
-    }, 10);
-    vi.advanceTimersByTime(10);
-    log.push("after-advance");
-    await Promise.resolve();
-    expect(log).toEqual(["T1", "T2", "after-advance", "P1", "P2"]);
+  async function runOrderingFixture(api: string) {
+    using dir = tempDir("fake-timers-sync-microtask", {
+      "ordering.test.ts": orderingFixture(api),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "ordering.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("1 pass");
+    expect(stdout).toContain(JSON.stringify(["T1", "T2", "after-advance", "P1", "P2", "after-await"]) + "\n");
+    expect(exitCode).toBe(0);
+  }
+
+  test("advanceTimersByTime", async () => {
+    await runOrderingFixture("advanceTimersByTime(10)");
   });
 
   test("advanceTimersToNextTimer", async () => {
-    vi.useFakeTimers();
-    const log: string[] = [];
-    setTimeout(() => {
-      log.push("T1");
-      Promise.resolve().then(() => log.push("P1"));
-    }, 10);
-    vi.advanceTimersToNextTimer();
-    log.push("after-advance");
-    await Promise.resolve();
-    expect(log).toEqual(["T1", "after-advance", "P1"]);
+    using dir = tempDir("fake-timers-sync-microtask", {
+      "ordering.test.ts": `
+        import { jest, test } from "bun:test";
+        test("ordering", async () => {
+          jest.useFakeTimers();
+          const log = [];
+          setTimeout(() => { log.push("T1"); Promise.resolve().then(() => log.push("P1")); }, 10);
+          jest.advanceTimersToNextTimer();
+          log.push("after-advance");
+          await Promise.resolve();
+          log.push("after-await");
+          console.log(JSON.stringify(log));
+          jest.useRealTimers();
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "ordering.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("1 pass");
+    expect(stdout).toContain(JSON.stringify(["T1", "after-advance", "P1", "after-await"]) + "\n");
+    expect(exitCode).toBe(0);
   });
 
   test("runAllTimers", async () => {
-    vi.useFakeTimers();
-    const log: string[] = [];
-    setTimeout(() => {
-      log.push("T1");
-      Promise.resolve().then(() => log.push("P1"));
-    }, 5);
-    setTimeout(() => {
-      log.push("T2");
-      Promise.resolve().then(() => log.push("P2"));
-    }, 10);
-    vi.runAllTimers();
-    log.push("after");
-    await Promise.resolve();
-    expect(log).toEqual(["T1", "T2", "after", "P1", "P2"]);
+    await runOrderingFixture("runAllTimers()");
   });
 
   test("runOnlyPendingTimers", async () => {
-    vi.useFakeTimers();
-    const log: string[] = [];
-    setTimeout(() => {
-      log.push("T1");
-      Promise.resolve().then(() => log.push("P1"));
-    }, 5);
-    vi.runOnlyPendingTimers();
-    log.push("after");
-    await Promise.resolve();
-    expect(log).toEqual(["T1", "after", "P1"]);
+    await runOrderingFixture("runOnlyPendingTimers()");
   });
 
   test("microtask drain resumes after advanceTimersByTime returns", async () => {

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -111,6 +111,96 @@ describe("advanceTimersToNextTimer", () => {
     vi.useRealTimers();
   });
 });
+describe("sync APIs do not drain the microtask queue (jest parity)", () => {
+  // Jest's sync fake-timer APIs fire callbacks without flushing microtasks; a
+  // microtask scheduled inside a callback runs at the test's next real `await`,
+  // not before advanceTimersByTime() returns. The *Async variants opt into
+  // per-timer flushing.
+  test("advanceTimersByTime", async () => {
+    vi.useFakeTimers();
+    const log: string[] = [];
+    setTimeout(() => {
+      log.push("T1");
+      Promise.resolve().then(() => log.push("P1"));
+    }, 10);
+    vi.advanceTimersByTime(10);
+    log.push("after-advance");
+    await Promise.resolve();
+    log.push("after-await");
+    expect(log).toEqual(["T1", "after-advance", "P1", "after-await"]);
+  });
+
+  test("advanceTimersByTime: two timers, microtasks batch after", async () => {
+    vi.useFakeTimers();
+    const log: string[] = [];
+    setTimeout(() => {
+      log.push("T1");
+      Promise.resolve().then(() => log.push("P1"));
+    }, 5);
+    setTimeout(() => {
+      log.push("T2");
+      Promise.resolve().then(() => log.push("P2"));
+    }, 10);
+    vi.advanceTimersByTime(10);
+    log.push("after-advance");
+    await Promise.resolve();
+    expect(log).toEqual(["T1", "T2", "after-advance", "P1", "P2"]);
+  });
+
+  test("advanceTimersToNextTimer", async () => {
+    vi.useFakeTimers();
+    const log: string[] = [];
+    setTimeout(() => {
+      log.push("T1");
+      Promise.resolve().then(() => log.push("P1"));
+    }, 10);
+    vi.advanceTimersToNextTimer();
+    log.push("after-advance");
+    await Promise.resolve();
+    expect(log).toEqual(["T1", "after-advance", "P1"]);
+  });
+
+  test("runAllTimers", async () => {
+    vi.useFakeTimers();
+    const log: string[] = [];
+    setTimeout(() => {
+      log.push("T1");
+      Promise.resolve().then(() => log.push("P1"));
+    }, 5);
+    setTimeout(() => {
+      log.push("T2");
+      Promise.resolve().then(() => log.push("P2"));
+    }, 10);
+    vi.runAllTimers();
+    log.push("after");
+    await Promise.resolve();
+    expect(log).toEqual(["T1", "T2", "after", "P1", "P2"]);
+  });
+
+  test("runOnlyPendingTimers", async () => {
+    vi.useFakeTimers();
+    const log: string[] = [];
+    setTimeout(() => {
+      log.push("T1");
+      Promise.resolve().then(() => log.push("P1"));
+    }, 5);
+    vi.runOnlyPendingTimers();
+    log.push("after");
+    await Promise.resolve();
+    expect(log).toEqual(["T1", "after", "P1"]);
+  });
+
+  test("microtask drain resumes after advanceTimersByTime returns", async () => {
+    vi.useFakeTimers();
+    setTimeout(() => {}, 10);
+    vi.advanceTimersByTime(10);
+    let ran = false;
+    queueMicrotask(() => (ran = true));
+    await Promise.resolve();
+    expect(ran).toBe(true);
+  });
+});
+
 describe("advanceTimersByTime", () => {
   test("setInterval", () => {
     vi.useFakeTimers();

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -120,56 +120,32 @@ describe.concurrent("sync APIs do not drain the microtask queue (jest parity)", 
   //
   // The ordering depends on event-loop enter/exit depth at the call site, which
   // a prior test's real-time `await` can change, so assert in a subprocess.
-  const orderingFixture = (api: string) => `
-    import { jest, test } from "bun:test";
-    test("ordering", async () => {
-      jest.useFakeTimers();
-      const log = [];
-      setTimeout(() => { log.push("T1"); Promise.resolve().then(() => log.push("P1")); }, 5);
-      setTimeout(() => { log.push("T2"); Promise.resolve().then(() => log.push("P2")); }, 10);
-      jest.${api};
-      log.push("after-advance");
-      await Promise.resolve();
-      log.push("after-await");
-      console.log(JSON.stringify(log));
-      jest.useRealTimers();
-    });
-  `;
-
-  async function runOrderingFixture(api: string) {
-    using dir = tempDir("fake-timers-sync-microtask", {
-      "ordering.test.ts": orderingFixture(api),
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "ordering.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("1 pass");
-    expect(stdout).toContain(JSON.stringify(["T1", "T2", "after-advance", "P1", "P2", "after-await"]) + "\n");
-    expect(exitCode).toBe(0);
-  }
-
-  test("advanceTimersByTime", async () => {
-    await runOrderingFixture("advanceTimersByTime(10)");
-  });
-
-  test("advanceTimersToNextTimer", async () => {
+  async function runOrderingFixture({
+    timerCount,
+    api,
+    expected,
+  }: {
+    timerCount: 1 | 2;
+    api: string;
+    expected: string[];
+  }) {
+    const setups = Array.from(
+      { length: timerCount },
+      (_, i) =>
+        `setTimeout(() => { log.push("T${i + 1}"); Promise.resolve().then(() => log.push("P${i + 1}")); }, ${5 * (i + 1)});`,
+    ).join("\n      ");
     using dir = tempDir("fake-timers-sync-microtask", {
       "ordering.test.ts": `
         import { jest, test } from "bun:test";
         test("ordering", async () => {
           jest.useFakeTimers();
           const log = [];
-          setTimeout(() => { log.push("T1"); Promise.resolve().then(() => log.push("P1")); }, 10);
-          jest.advanceTimersToNextTimer();
+          ${setups}
+          jest.${api};
           log.push("after-advance");
           await Promise.resolve();
           log.push("after-await");
-          console.log(JSON.stringify(log));
+          console.log("ORDER=" + JSON.stringify(log));
           jest.useRealTimers();
         });
       `,
@@ -182,17 +158,44 @@ describe.concurrent("sync APIs do not drain the microtask queue (jest parity)", 
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("1 pass");
-    expect(stdout).toContain(JSON.stringify(["T1", "after-advance", "P1", "after-await"]) + "\n");
-    expect(exitCode).toBe(0);
+    const order = stdout.match(/^ORDER=(.*)$/m)?.[1];
+    expect({ order, exitCode, stderr: exitCode === 0 ? undefined : stderr }).toEqual({
+      order: JSON.stringify(expected),
+      exitCode: 0,
+      stderr: undefined,
+    });
+  }
+
+  test("advanceTimersByTime", async () => {
+    await runOrderingFixture({
+      timerCount: 2,
+      api: "advanceTimersByTime(10)",
+      expected: ["T1", "T2", "after-advance", "P1", "P2", "after-await"],
+    });
+  });
+
+  test("advanceTimersToNextTimer", async () => {
+    await runOrderingFixture({
+      timerCount: 1,
+      api: "advanceTimersToNextTimer()",
+      expected: ["T1", "after-advance", "P1", "after-await"],
+    });
   });
 
   test("runAllTimers", async () => {
-    await runOrderingFixture("runAllTimers()");
+    await runOrderingFixture({
+      timerCount: 2,
+      api: "runAllTimers()",
+      expected: ["T1", "T2", "after-advance", "P1", "P2", "after-await"],
+    });
   });
 
   test("runOnlyPendingTimers", async () => {
-    await runOrderingFixture("runOnlyPendingTimers()");
+    await runOrderingFixture({
+      timerCount: 2,
+      api: "runOnlyPendingTimers()",
+      expected: ["T1", "T2", "after-advance", "P1", "P2", "after-await"],
+    });
   });
 
   test("microtask drain resumes after advanceTimersByTime returns", async () => {


### PR DESCRIPTION
## What

`jest.advanceTimersByTime()` (and `advanceTimersToNextTimer`, `runAllTimers`, `runOnlyPendingTimers`) no longer drain the microtask queue while firing timer callbacks. This matches Jest 30 / `@sinonjs/fake-timers`, where only the `*Async` variants flush microtasks between timers.

## Repro

```ts
import { test, jest } from "bun:test";
test("advanceTimersByTime microtask ordering", async () => {
  jest.useFakeTimers();
  const log: string[] = [];
  setTimeout(() => { log.push("T1"); Promise.resolve().then(() => log.push("P1")); }, 10);
  jest.advanceTimersByTime(10);
  log.push("after-advance10");
  await Promise.resolve();
  log.push("after-await");
  console.log("ORDER " + JSON.stringify(log));
  jest.useRealTimers();
});
```

Before: `ORDER ["T1","P1","after-advance10","after-await"]`
Jest 30.4.1: `ORDER ["T1","after-advance10","P1","after-await"]`
After: `ORDER ["T1","after-advance10","P1","after-await"]`

## Cause

Each fake timer fires through `TimerObjectInternals::fire`, which wraps the callback in `event_loop().enter()` / `exit()`. The test body itself is not inside an enter/exit pair (`run_callback_with_result_and_forcefully_drain_microtasks` calls the test callback without one), so `exit()` sees `entered_event_loop_count == 1` and calls `drain_microtasks()` after every fired timer.

## Fix

Set `vm.suppress_microtask_drain = true` for the duration of the four sync fake-timer host functions, restored via RAII drop. `drain_microtasks_with_global()` already early-returns on that flag (it's the same mechanism `spawnSync` uses). The guard saves/restores the prior value so nesting is preserved.

## Verification

```
$ bun bd test test/js/bun/test/fake-timers/fake-timers.test.ts
 36 pass
 0 fail
```

All existing fake-timer users (`test-timers.test.ts`, `in-process-cron.test.ts`, `cron-local-time.test.ts`, regression 25869/26284) still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.0 (f2271f9ce)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [25.52ms]
(pass) advanceTimersToNextTimer > one setTimeout [7.73ms]
(pass) advanceTimersToNextTimer > setInterval [6.97ms]
(pass) advanceTimersToNextTimer > sorted timeouts [11.55ms]
(pass) advanceTimersToNextTimer > alternating intervals [8.52ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > microtask drain resumes after advanceTimersByTime returns [7.48ms]
157 |       stdout: "pipe",
158 |       stderr: "pipe",
159 |     });
160 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
161 |     const order = stdout.match(/^ORDER=(.*)$/m)?.[1];
162 |     expect({ order, exitCode, stderr: exitCode === 0 ? undefined : stderr }).toEqual({
                                                                                   ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
-   "order": "["T1","T2","afte
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (e2574e63f)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [13.57ms]
(pass) advanceTimersToNextTimer > one setTimeout [0.20ms]
(pass) advanceTimersToNextTimer > setInterval [0.10ms]
(pass) advanceTimersToNextTimer > sorted timeouts [0.14ms]
(pass) advanceTimersToNextTimer > alternating intervals [0.09ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > microtask drain resumes after advanceTimersByTime returns [0.22ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > advanceTimersByTime [49.52ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > runOnlyPendingTimers [13.02ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > runAllTimers [15.03ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > advanceTimersToNextTimer [22.03ms]
(pass) advanceTimersByTime > setInterval [0.25ms]
(pass) runOnlyPendingTimers > two setIntervals [0.21ms]
(pass) runAllTimers > two setIntervals [0.13ms]
(pass) getTimerCount > returns correct count of pending timers [0.13ms]
(pass) getTimerCount > throws error if fake timers not active [0.06ms]
(pass) clearAllTi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.0 (f2271f9ce)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [25.40ms]
(pass) advanceTimersToNextTimer > one setTimeout [7.34ms]
(pass) advanceTimersToNextTimer > setInterval [6.94ms]
(pass) advanceTimersToNextTimer > sorted timeouts [11.60ms]
(pass) advanceTimersToNextTimer > alternating intervals [8.76ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > microtask drain resumes after advanceTimersByTime returns [7.36ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > advanceTimersByTime [364.47ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > advanceTimersToNextTimer [308.91ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > runAllTimers [322.12ms]
(pass) sync APIs do not drain the microtask queue (jest parity) > runOnlyPendingTimers [339.27ms]
(pass) advanceTimersByTime > setInterval [6.88ms]
(pass) runOnlyPendingTimers > two setIntervals [7.32ms]
(pass) runAllTimers > two setI
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1202ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 237 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs                        | 31 ++++++++
 src/jsc/event_loop.rs                            |  5 +-
 src/runtime/test_runner/timers/FakeTimers.rs     | 17 ++++
 test/js/bun/test/fake-timers/fake-timers.test.ts | 98 ++++++++++++++++++++++++
 4 files changed, 147 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/VirtualMachine.rs                             8      8      0
src/jsc/event_loop.rs                                 5      2      0
src/runtime/test_runner/timers/FakeTimers.rs          3     13      0
test/js/bun/test/fake-timers/fake-timers.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->