### PR TITLE
bun:test: skip beforeAll/afterAll for describe blocks with no non-skipped tests

### DIFF
--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -82,7 +82,7 @@ impl Order {
         if current.failed {
             return Ok(()); // do not schedule any tests in a failed describe scope
         }
-        let use_hooks = self.cfg.always_use_hooks || current.base.has_callback;
+        let use_hooks = current.base.has_callback;
 
         // gather beforeAll
         let beforeall_order: AllOrderResult = if use_hooks {
@@ -262,7 +262,6 @@ impl AllOrderResult {
 }
 
 pub struct Config {
-    pub always_use_hooks: bool,
     // The only call site seeds a concrete `DefaultPrng` (xoshiro256++), so
     // no type-erased Random vtable is needed.
     pub randomize: Option<bun_core::rand::DefaultPrng>,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1829,7 +1829,11 @@ impl DescribeScope {
         let has_cb = entry.callback.is_some();
         // jest-circus runs a describe's beforeAll/afterAll iff it contains at least one
         // test that isn't skipped. `test.todo` counts; `test.skip` and filtered-out don't.
-        let triggers_all_hooks = !matches!(entry.base.mode, ScopeMode::Skip | ScopeMode::FilteredOut);
+        // `entry.base.mode` is post-inheritance (a non-Normal parent overrides `self_mode`),
+        // so also check `base.self_mode` to keep a `-t`-filtered or `.skip` test inside a
+        // `describe.todo` from triggering hooks.
+        let triggers_all_hooks = !matches!(base.self_mode, ScopeMode::Skip | ScopeMode::FilteredOut)
+            && !matches!(entry.base.mode, ScopeMode::Skip | ScopeMode::FilteredOut);
         entry.base.propagate(has_cb, triggers_all_hooks);
         self.entries.push(TestScheduleEntry::TestCallback(entry));
         match self.entries.last_mut().unwrap() {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1033,12 +1033,6 @@ impl BunTest {
                 self.phase = Phase::Execution;
                 debug::dump_describe(&self.collection.root_scope)?;
 
-                let has_filter = if let Some(reporter) = self.reporter {
-                    // SAFETY: reporter outlives every BunTest (see field doc).
-                    unsafe { reporter.as_ref() }.jest.filter_regex.is_some()
-                } else {
-                    false
-                };
                 // Derive a per-file shuffle PRNG from (seed, file_path) so a
                 // file's test order depends only on the path and the printed
                 // seed — not on which worker ran it or what files preceded it
@@ -1064,7 +1058,6 @@ impl BunTest {
                 let should_randomize = per_file_prng.take();
 
                 let mut order = Order::Order::init(Order::Config {
-                    always_use_hooks: self.collection.root_scope.base.only == Only::No && !has_filter,
                     randomize: should_randomize,
                 });
 
@@ -1693,6 +1686,9 @@ pub struct BaseScope {
     pub concurrent: bool,
     pub mode: ScopeMode,
     pub only: Only,
+    /// On a test entry: `callback.is_some()` (drives beforeEach/afterEach).
+    /// On a describe: at least one descendant test has `mode` other than Skip/FilteredOut
+    /// (drives beforeAll/afterAll; jest runs those iff the block has a non-skipped test).
     pub has_callback: bool,
     /// this value is 0 unless the debugger is active and the scope has a debugger id
     pub test_id_for_debugger: i32,
@@ -1729,7 +1725,7 @@ impl BaseScope {
         }
     }
 
-    pub fn propagate(&mut self, has_callback: bool) {
+    pub fn propagate(&mut self, has_callback: bool, triggers_all_hooks: bool) {
         self.has_callback = has_callback;
         if let Some(parent) = self.parent {
             // SAFETY: parent backref valid; tree is single-threaded and parent
@@ -1738,7 +1734,7 @@ impl BaseScope {
             if self.only != Only::No {
                 parent.mark_contains_only();
             }
-            if self.has_callback {
+            if triggers_all_hooks {
                 parent.mark_has_callback();
             }
         }
@@ -1813,7 +1809,7 @@ impl DescribeScope {
         base: BaseScopeCfg,
     ) -> &mut DescribeScope {
         let mut child = Self::create(BaseScope::init(base, name_not_owned, Some(std::ptr::from_mut(self)), false));
-        child.base.propagate(false);
+        child.base.propagate(false, false);
         self.entries.push(TestScheduleEntry::Describe(child));
         match self.entries.last_mut().unwrap() {
             TestScheduleEntry::Describe(d) => &mut **d,
@@ -1831,7 +1827,10 @@ impl DescribeScope {
     ) -> JsResult<&mut ExecutionEntry> {
         let mut entry = ExecutionEntry::create(name_not_owned, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
         let has_cb = entry.callback.is_some();
-        entry.base.propagate(has_cb);
+        // jest-circus runs a describe's beforeAll/afterAll iff it contains at least one
+        // test that isn't skipped. `test.todo` counts; `test.skip` and filtered-out don't.
+        let triggers_all_hooks = !matches!(entry.base.mode, ScopeMode::Skip | ScopeMode::FilteredOut);
+        entry.base.propagate(has_cb, triggers_all_hooks);
         self.entries.push(TestScheduleEntry::TestCallback(entry));
         match self.entries.last_mut().unwrap() {
             TestScheduleEntry::TestCallback(e) => Ok(&mut **e),

--- a/test/js/bun/test/describe.test.ts
+++ b/test/js/bun/test/describe.test.ts
@@ -223,3 +223,129 @@ describe("passing arrow function as args", () => {
     expect(fullOutput).toInclude("1 fail");
   });
 });
+
+describe("beforeAll/afterAll are pruned when a describe has no non-skipped tests", () => {
+  // jest-circus only runs a describe's beforeAll/afterAll when the block contains at least
+  // one test whose mode is not "skip". test.todo counts (hooks run); test.skip does not.
+  test("all-skipped, nested-all-skipped, and empty describes don't run hooks", () => {
+    const test_dir = tempDirWithFiles("describe-skip-hooks", {
+      "hooks.test.js": `
+        import { describe, test, beforeAll, afterAll } from "bun:test";
+        const L = [];
+        afterAll(() => console.log("HOOKLOG " + JSON.stringify(L)));
+
+        describe("all-skipped", () => {
+          beforeAll(() => void L.push("bA-allskip"));
+          afterAll(() => void L.push("aA-allskip"));
+          test.skip("a1", () => {});
+          test.skip("a2", () => {});
+        });
+
+        describe("outer", () => {
+          beforeAll(() => void L.push("bA-outer"));
+          afterAll(() => void L.push("aA-outer"));
+          describe("inner-allskip", () => {
+            beforeAll(() => void L.push("bA-inner"));
+            afterAll(() => void L.push("aA-inner"));
+            test.skip("i1", () => {});
+          });
+        });
+
+        describe("empty", () => {
+          beforeAll(() => void L.push("bA-empty"));
+          afterAll(() => void L.push("aA-empty"));
+        });
+
+        describe("all-todo", () => {
+          beforeAll(() => void L.push("bA-alltodo"));
+          afterAll(() => void L.push("aA-alltodo"));
+          test.todo("t1");
+        });
+
+        describe("mixed", () => {
+          beforeAll(() => void L.push("bA-mixed"));
+          afterAll(() => void L.push("aA-mixed"));
+          test.skip("s", () => {});
+          test("n", () => void L.push("BODY-mixed"));
+        });
+
+        test("keep", () => void L.push("BODY-keep"));
+      `,
+    });
+
+    const { stdout, stderr, exitCode } = spawnSync({
+      cmd: [bunExe(), "test", "hooks.test.js"],
+      cwd: test_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const out = stdout.toString();
+    const err = stderr.toString();
+    const hookLine = out.split("\n").find(l => l.startsWith("HOOKLOG "));
+    expect(hookLine).toBeDefined();
+    const log = JSON.parse(hookLine!.slice("HOOKLOG ".length));
+
+    // jest 30 output for the same fixture:
+    expect(log).toEqual(["bA-alltodo", "aA-alltodo", "bA-mixed", "BODY-mixed", "aA-mixed", "BODY-keep"]);
+
+    // skipped tests are still reported
+    expect(err).toInclude("all-skipped > a1");
+    expect(err).toInclude("outer > inner-allskip > i1");
+    expect(exitCode).toBe(0);
+  });
+
+  test("describe.skip, test.failing-only, and skip+todo mix keep jest parity", () => {
+    const test_dir = tempDirWithFiles("describe-skip-hooks-parity", {
+      "parity.test.js": `
+        import { describe, test, beforeAll, afterAll } from "bun:test";
+        const L = [];
+        afterAll(() => console.log("HOOKLOG " + JSON.stringify(L)));
+
+        describe.skip("dskip", () => {
+          beforeAll(() => void L.push("bA-dskip"));
+          afterAll(() => void L.push("aA-dskip"));
+          test("t", () => {});
+        });
+
+        describe("all-failing", () => {
+          beforeAll(() => void L.push("bA-allfailing"));
+          afterAll(() => void L.push("aA-allfailing"));
+          test.failing("f", () => { throw new Error("expected") });
+        });
+
+        describe("skip-plus-todo", () => {
+          beforeAll(() => void L.push("bA-skipPlusTodo"));
+          afterAll(() => void L.push("aA-skipPlusTodo"));
+          test.skip("s", () => {});
+          test.todo("t");
+        });
+
+        test("keep", () => void L.push("BODY-keep"));
+      `,
+    });
+
+    const { stdout, exitCode } = spawnSync({
+      cmd: [bunExe(), "test", "parity.test.js"],
+      cwd: test_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const out = stdout.toString();
+    const hookLine = out.split("\n").find(l => l.startsWith("HOOKLOG "));
+    expect(hookLine).toBeDefined();
+    const log = JSON.parse(hookLine!.slice("HOOKLOG ".length));
+
+    expect(log).toEqual([
+      "bA-allfailing",
+      "aA-allfailing",
+      "bA-skipPlusTodo",
+      "aA-skipPlusTodo",
+      "BODY-keep",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/test/describe.test.ts
+++ b/test/js/bun/test/describe.test.ts
@@ -339,13 +339,7 @@ describe("beforeAll/afterAll are pruned when a describe has no non-skipped tests
     expect(hookLine).toBeDefined();
     const log = JSON.parse(hookLine!.slice("HOOKLOG ".length));
 
-    expect(log).toEqual([
-      "bA-allfailing",
-      "aA-allfailing",
-      "bA-skipPlusTodo",
-      "aA-skipPlusTodo",
-      "BODY-keep",
-    ]);
+    expect(log).toEqual(["bA-allfailing", "aA-allfailing", "bA-skipPlusTodo", "aA-skipPlusTodo", "BODY-keep"]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/test/describe.test.ts
+++ b/test/js/bun/test/describe.test.ts
@@ -342,4 +342,39 @@ describe("beforeAll/afterAll are pruned when a describe has no non-skipped tests
     expect(log).toEqual(["bA-allfailing", "aA-allfailing", "bA-skipPlusTodo", "aA-skipPlusTodo", "BODY-keep"]);
     expect(exitCode).toBe(0);
   });
+
+  test("a -t-filtered test inside describe.todo does not trigger hooks", () => {
+    const test_dir = tempDirWithFiles("describe-skip-hooks-filter-todo", {
+      "filter.test.js": `
+        import { describe, test, beforeAll, afterAll } from "bun:test";
+        const L = [];
+        afterAll(() => console.log("HOOKLOG " + JSON.stringify(L)));
+
+        describe.todo("dtodo", () => {
+          beforeAll(() => void L.push("bA-dtodo"));
+          afterAll(() => void L.push("aA-dtodo"));
+          test("unmatched", () => {});
+          test.skip("also-unmatched", () => {});
+        });
+
+        test("keep", () => void L.push("BODY-keep"));
+      `,
+    });
+
+    const { stdout, exitCode } = spawnSync({
+      cmd: [bunExe(), "test", "--todo", "-t", "keep", "filter.test.js"],
+      cwd: test_dir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+
+    const out = stdout.toString();
+    const hookLine = out.split("\n").find(l => l.startsWith("HOOKLOG "));
+    expect(hookLine).toBeDefined();
+    const log = JSON.parse(hookLine!.slice("HOOKLOG ".length));
+
+    expect(log).toEqual(["BODY-keep"]);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -647,7 +647,8 @@ it("skip() and skipIf()", () => {
   expect(result.match(/reachable/g)).toHaveLength(6);
 });
 
-it("should run beforeAll() & afterAll() even without tests", async () => {
+// https://github.com/oven-sh/bun/issues/3494
+it("should run beforeAll() & afterAll() for a describe whose only tests are nested, and skip them for an empty describe", async () => {
   const test_dir = tmpdirSync();
   try {
     await writeFile(
@@ -657,6 +658,14 @@ beforeAll(() => console.log("before all"));
 beforeEach(() => console.log("before each"));
 afterEach(() => console.log("after each"));
 afterAll(() => console.log("after all"));
+
+describe("nested-only", () => {
+  beforeAll(() => console.log("before all nested-only"));
+  afterAll(() => console.log("after all nested-only"));
+  describe("inner", () => {
+    test("t", () => {});
+  });
+});
 
 describe("empty", () => {
   beforeAll(() => console.log("before all scoped"));
@@ -676,15 +685,19 @@ describe("empty", () => {
     });
     expect(stderr).toBeDefined();
     const err = await stderr.text();
-    expect(err).toContain("0 pass");
+    expect(err).toContain("1 pass");
     expect(err).toContain("0 fail");
     expect(stdout).toBeDefined();
     const out = await stdout.text();
+    // jest-circus skips a describe's beforeAll/afterAll when it has no non-skipped descendant
+    // test, so the "empty" block's hooks never run.
     expect(out.split(/\r?\n/)).toEqual([
       `bun test ${Bun.version_with_sha}`,
       "before all",
-      "before all scoped",
-      "after all scoped",
+      "before all nested-only",
+      "before each",
+      "after each",
+      "after all nested-only",
       "after all",
       "",
     ]);


### PR DESCRIPTION
## What

A `describe` block whose children are all `test.skip` (including a nested inner all-skip block, and the outer block whose only descendants are skipped) still runs its `beforeAll`/`afterAll`. jest-circus prunes those hooks when the block has no runnable test, so the standard "disable a suite with `.skip`" idiom doesn't boot its DB/server fixture in jest; in bun it does.

```ts
import { describe, test, beforeAll, afterAll } from "bun:test";
const L = [];
afterAll(() => console.log("HOOKLOG " + JSON.stringify(L)));
describe("all-skipped", () => {
  beforeAll(() => void L.push("bA-allskip"));
  afterAll(() => void L.push("aA-allskip"));
  test.skip("a1", () => {}); test.skip("a2", () => {});
});
describe("outer", () => {
  beforeAll(() => void L.push("bA-outer")); afterAll(() => void L.push("aA-outer"));
  describe("inner-allskip", () => {
    beforeAll(() => void L.push("bA-inner")); afterAll(() => void L.push("aA-inner"));
    test.skip("i1", () => {});
  });
});
test("keep", () => void L.push("BODY-keep"));
// bun (before):  HOOKLOG ["bA-allskip","aA-allskip","bA-outer","bA-inner","aA-inner","aA-outer","BODY-keep"]
// jest 30 / bun (after):  HOOKLOG ["BODY-keep"]
```

## Cause

`Order::generate_order_describe` gated `beforeAll`/`afterAll` on `always_use_hooks || describe.has_callback`. `always_use_hooks` was `true` whenever there was no `-t` filter and no `.only` anywhere in the file, so it masked `has_callback` on plain runs. `has_callback` on a describe was already correctly `false` for an all-skip block (skipped tests get `callback = None`), which is why `-t` and `.only` already pruned these hooks correctly.

## Fix

Drop `always_use_hooks` and rely on `has_callback` alone. To keep the todo boundary at parity (jest **does** run hooks for a block whose only tests are `test.todo`), `append_test` now propagates `mark_has_callback` to ancestor describes when `entry.mode` is not `Skip`/`FilteredOut`, rather than when the callback is non-null. A test entry's own `has_callback` stays `callback.is_some()`, so `beforeEach`/`afterEach` gating is unchanged.

Two adjacent cases also move to jest parity:

- An empty `describe` (no tests at all) no longer runs its hooks. Jest doesn't either.
- `describe.skip`'s hooks are no longer scheduled at all. Previously they were scheduled with a null callback and surfaced as `(skip) <name> > (unnamed)` lines; the test inside is still reported as skipped.

Unchanged boundaries, verified against jest 30: `describe.skip`, `-t` filter exclusion, `.only` elsewhere all still prune hooks; a `test.todo`-only block and a `test.failing`-only block still run hooks; a mixed skip+normal or skip+todo block still runs hooks.

## Tests

`test/js/bun/test/describe.test.ts` gains two tests: one that asserts the exact hook log for the all-skip / nested-all-skip / empty / all-todo / mixed cases (fails on the released binary with the extra `allskip`/`outer`/`inner`/`empty` entries), and one that guards the `describe.skip` / `test.failing` / skip+todo parity boundaries.

`test/js/bun/test/test-test.test.ts`'s `should run beforeAll() & afterAll() even without tests` (added for #3494) asserted hooks ran for a truly empty describe, which is broader than the issue it was fixing. It now tests the actual #3494 scenario (a describe whose only tests are in a nested describe still runs its hooks) alongside the new empty-describe pruning. Also fails on the released binary.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts

<!-- robobun:evidence:end -->