### PR TITLE
node:http: throw ERR_SERVER_ALREADY_LISTEN on second listen()

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -558,6 +558,9 @@ Server.prototype.address = function () {
 };
 
 Server.prototype.listen = function () {
+  if (this[serverSymbol]) {
+    throw $ERR_SERVER_ALREADY_LISTEN();
+  }
   const server = this;
   let port, host, onListen;
   let socketPath;

--- a/test/js/node/http/node-http-server-already-listen.test.ts
+++ b/test/js/node/http/node-http-server-already-listen.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+test("http.Server: listen() on an already-listening server throws ERR_SERVER_ALREADY_LISTEN", async () => {
+  const server = createServer((req, res) => res.end("ok"));
+  try {
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const firstPort = (server.address() as AddressInfo).port;
+
+    let err: any;
+    try {
+      server.listen(0, "127.0.0.1");
+    } catch (e) {
+      err = e;
+    }
+    expect(err?.code).toBe("ERR_SERVER_ALREADY_LISTEN");
+    expect((server.address() as AddressInfo).port).toBe(firstPort);
+
+    // close() then listen() again must still work
+    await new Promise<void>(r => server.close(() => r()));
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    expect(server.address()).not.toBeNull();
+  } finally {
+    server.close();
+  }
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -181,30 +181,6 @@ describe("node:http", () => {
       }
     });
 
-    it("listen on an already-listening server throws ERR_SERVER_ALREADY_LISTEN", async () => {
-      const server = createServer((req, res) => res.end("ok"));
-      try {
-        await once(server.listen(0, "127.0.0.1"), "listening");
-        const firstPort = (server.address() as AddressInfo).port;
-
-        let err: any;
-        try {
-          server.listen(0, "127.0.0.1");
-        } catch (e) {
-          err = e;
-        }
-        expect(err?.code).toBe("ERR_SERVER_ALREADY_LISTEN");
-        expect((server.address() as AddressInfo).port).toBe(firstPort);
-
-        // close() then listen() again must still work
-        await new Promise<void>(r => server.close(() => r()));
-        await once(server.listen(0, "127.0.0.1"), "listening");
-        expect(server.address()).not.toBeNull();
-      } finally {
-        server.close();
-      }
-    });
-
     it("should assign a random port when undefined", async () => {
       const server1 = http.createServer(() => {});
       const server2 = http.createServer(() => {});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -181,6 +181,30 @@ describe("node:http", () => {
       }
     });
 
+    it("listen on an already-listening server throws ERR_SERVER_ALREADY_LISTEN", async () => {
+      const server = createServer((req, res) => res.end("ok"));
+      try {
+        await once(server.listen(0, "127.0.0.1"), "listening");
+        const firstPort = (server.address() as AddressInfo).port;
+
+        let err: any;
+        try {
+          server.listen(0, "127.0.0.1");
+        } catch (e) {
+          err = e;
+        }
+        expect(err?.code).toBe("ERR_SERVER_ALREADY_LISTEN");
+        expect((server.address() as AddressInfo).port).toBe(firstPort);
+
+        // close() then listen() again must still work
+        await new Promise<void>(r => server.close(() => r()));
+        await once(server.listen(0, "127.0.0.1"), "listening");
+        expect(server.address()).not.toBeNull();
+      } finally {
+        server.close();
+      }
+    });
+
     it("should assign a random port when undefined", async () => {
       const server1 = http.createServer(() => {});
       const server2 = http.createServer(() => {});

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -165,22 +165,21 @@ describe.each(["FormData", "Blob", "Buffer", "String", "URLSearchParams", "strea
 test("do not leak", async () => {
   await using server = createServer((req, res) => {
     res.end();
-  }).listen(0);
+  }).listen(0, "127.0.0.1");
   await once(server, "listening");
 
-  let url;
+  const url = new URL(`http://127.0.0.1:${server.address().port}`);
   let isDone = false;
-  server.listen(0, "127.0.0.1", function attack() {
+  (function attack() {
     if (isDone) {
       return;
     }
-    url ??= new URL(`http://127.0.0.1:${server.address().port}`);
     const controller = new AbortController();
     fetch(url, { signal: controller.signal })
       .then(res => res.arrayBuffer())
       .catch(() => {})
       .then(attack);
-  });
+  })();
 
   let prev = Infinity;
   let count = 0;


### PR DESCRIPTION
### What does this PR do?

Calling `server.listen()` on an already-listening `http.Server` was silently binding a second port and leaking the original listener. Node.js throws `ERR_SERVER_ALREADY_LISTEN` synchronously.

#### Repro

```js
import http from 'node:http'; import net from 'node:net';
const probe = p => new Promise(r => { const c = net.connect(p, '127.0.0.1'); c.once('connect', () => { c.destroy(); r('open'); }); c.once('error', e => r('err:' + e.code)); });
const s = http.createServer((q, r) => r.end('ok'));
await new Promise(r => s.listen(0, '127.0.0.1', r));
const p1 = s.address().port;
let threw = null; try { s.listen(0, '127.0.0.1'); } catch (e) { threw = e.code; }
await new Promise(r => setTimeout(r, 300));
const p2 = s.address().port;
console.log({ threw, portChanged: p2 !== p1, origPort: await probe(p1), secondPort: p2 !== p1 ? await probe(p2) : 'same' });
// node:   { threw: 'ERR_SERVER_ALREADY_LISTEN', portChanged: false, origPort: 'open', secondPort: 'same' }
// before: { threw: null, portChanged: true, origPort: 'open', secondPort: 'open' }
// after:  { threw: 'ERR_SERVER_ALREADY_LISTEN', portChanged: false, origPort: 'open', secondPort: 'same' }
```

#### Cause

`Server.prototype.listen` in `src/js/node/_http_server.ts` overrides the `net.Server` version with its own `Bun.serve`-backed implementation and was missing the already-listening guard that `net.Server.listen` has (net.ts checks `this._handle`). `http2.createServer()` uses `net.Server` under the hood and already threw correctly; only `http.Server` (and `https.Server`, which aliases it) was affected.

#### Fix

Check `this[serverSymbol]` at the top of `Server.prototype.listen` and throw `ERR_SERVER_ALREADY_LISTEN` before any side effects, matching Node's placement (before the `listening` callback is registered). `close()` clears `this[serverSymbol]`, so close-then-relisten continues to work.

#### Verification

`bun bd test test/js/node/http/node-http.test.ts -t ERR_SERVER_ALREADY_LISTEN` passes; fails on main with `Received: undefined`. Full `node-http.test.ts` suite passes (one pre-existing unrelated local proxy failure also fails on main).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-leak.test.ts

<!-- robobun:evidence:end -->