### PR TITLE
node:http: set res.shouldKeepAlive from the request's Connection header

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -823,13 +823,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             [kRejectNonStandardBodyWrites]: server.rejectNonStandardBodyWrites,
           });
         }
-        // Node.js's parserOnIncoming: `res.shouldKeepAlive = keepAlive`, where
-        // keepAlive is llhttp_should_keep_alive (HTTP/1.1: true unless
-        // Connection: close; HTTP/1.0: false unless Connection: keep-alive).
-        // Overwrites the constructor's HTTP/1.0 `shouldKeepAlive = false` so
-        // middleware that branches on res.shouldKeepAlive reads the same value
-        // Node.js exposes. kReqShouldKeepAlive (the transport decision) is
-        // separate and still forces close-on-finish for HTTP/1.0.
         http_res.shouldKeepAlive = isAncientHTTP
           ? (dispatchBits & DISPATCH_CONN_KEEPALIVE) !== 0
           : (dispatchBits & DISPATCH_CONN_CLOSE) === 0;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -823,6 +823,16 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             [kRejectNonStandardBodyWrites]: server.rejectNonStandardBodyWrites,
           });
         }
+        // Node.js's parserOnIncoming: `res.shouldKeepAlive = keepAlive`, where
+        // keepAlive is llhttp_should_keep_alive (HTTP/1.1: true unless
+        // Connection: close; HTTP/1.0: false unless Connection: keep-alive).
+        // Overwrites the constructor's HTTP/1.0 `shouldKeepAlive = false` so
+        // middleware that branches on res.shouldKeepAlive reads the same value
+        // Node.js exposes. kReqShouldKeepAlive (the transport decision) is
+        // separate and still forces close-on-finish for HTTP/1.0.
+        http_res.shouldKeepAlive = isAncientHTTP
+          ? (dispatchBits & DISPATCH_CONN_KEEPALIVE) !== 0
+          : (dispatchBits & DISPATCH_CONN_CLOSE) === 0;
         http_res._keepAliveTimeout = server.keepAliveTimeout;
         // Only stamp the symbol when the server actually set `uniqueHeaders`:
         // unconditionally adding it (even as undefined) forced a hidden-class
@@ -2766,6 +2776,7 @@ const DISPATCH_HAS_EXPECT = 1 << 4;
 const DISPATCH_EXPECT_CONTINUE = 1 << 5;
 const DISPATCH_HAS_CONTENT_LENGTH = 1 << 6;
 const DISPATCH_HAS_TRANSFER_ENCODING = 1 << 7;
+const DISPATCH_CONN_KEEPALIVE = 1 << 8;
 
 // Whether the response should advertise a persistent connection.
 // `connection` is the request's Connection header value (or undefined).

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6515,6 +6515,7 @@ function connectionListenerHTTP1(server, socket, options) {
     };
 
     const res = new ServerResponseClass(req);
+    res.shouldKeepAlive = shouldKeepAlive;
     const handle = createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout);
     handle.onfinished = function () {
       socket[kHttp1ActiveRequests] = Math.max(0, (socket[kHttp1ActiveRequests] || 1) - 1);

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -177,6 +177,7 @@ static constexpr uint32_t kDispatchHasExpect = 1 << 4;
 static constexpr uint32_t kDispatchExpectContinue = 1 << 5;
 static constexpr uint32_t kDispatchHasContentLength = 1 << 6;
 static constexpr uint32_t kDispatchHasTransferEncoding = 1 << 7;
+static constexpr uint32_t kDispatchConnKeepAlive = 1 << 8;
 
 static bool svEqualsIgnoreCase(std::string_view a, std::string_view lower)
 {
@@ -284,6 +285,8 @@ static void assignHeadersFromUWebSocketsForCall(uWS::HttpRequest* request, JSVal
                     bits |= kDispatchConnClose;
                 if (svValueHasToken(value, "upgrade"))
                     bits |= kDispatchConnUpgrade;
+                if (svValueHasToken(value, "keep-alive"))
+                    bits |= kDispatchConnKeepAlive;
             }
             break;
         case 14:

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,12 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: address.address,
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3689,6 +3689,61 @@ it("statusCode = 204 with an empty first write still discards the body", async (
   }
 });
 
+it("res.shouldKeepAlive reflects the request's Connection header like Node's parserOnIncoming", async () => {
+  // Node.js sets res.shouldKeepAlive = llhttp_should_keep_alive(parser) in
+  // parserOnIncoming: HTTP/1.1 defaults to keep-alive unless Connection: close,
+  // HTTP/1.0 defaults to close unless Connection: keep-alive. Middleware
+  // (compression, on-headers) branches on this before writing headers.
+  const seen: Record<string, boolean> = {};
+  const wire: Record<string, string> = {};
+  const server = createServer((req, res) => {
+    seen[req.url!] = res.shouldKeepAlive;
+    res.end("x");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const send = (path: string, raw: string) =>
+      new Promise<void>((resolve, reject) => {
+        const socket = connect(port, "127.0.0.1");
+        let data = "";
+        socket.on("data", chunk => (data += chunk));
+        socket.on("error", reject);
+        socket.on("close", () => {
+          wire[path] = data.match(/^Connection:.*$/im)?.[0] ?? "(none)";
+          resolve();
+        });
+        socket.write(raw);
+        // Only /11none keeps the connection open; close the writable side so
+        // the server answers and we observe its FIN instead of waiting.
+        socket.end();
+      });
+
+    await send("/11close", "GET /11close HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    await send("/10keepalive", "GET /10keepalive HTTP/1.0\r\nHost: x\r\nConnection: Keep-Alive\r\n\r\n");
+    await send("/11none", "GET /11none HTTP/1.1\r\nHost: x\r\n\r\n");
+    await send("/10none", "GET /10none HTTP/1.0\r\nHost: x\r\n\r\n");
+
+    expect(seen).toEqual({
+      "/11close": false,
+      "/10keepalive": true,
+      "/11none": true,
+      "/10none": false,
+    });
+    // The property fix must not change what goes on the wire.
+    expect(wire).toEqual({
+      "/11close": "Connection: close",
+      "/10keepalive": "Connection: close",
+      "/11none": "Connection: keep-alive",
+      "/10none": "Connection: close",
+    });
+  } finally {
+    server.close();
+  }
+});
+
 it("res.shouldKeepAlive = false renders Connection: close and ends the socket", async () => {
   // Graceful-shutdown helpers (stoppable, http-terminator) clear
   // shouldKeepAlive on in-flight responses; the rendered header and the

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3309,6 +3309,44 @@ it("http2 allowHTTP1 fallback frames a HEAD response like plain HTTP/1 (no Conte
   }
 });
 
+it("http2 allowHTTP1 fallback sets res.shouldKeepAlive from the request's Connection header", async () => {
+  // Node.js's parserOnIncoming: `res.shouldKeepAlive = keepAlive` (the parser's
+  // llhttp_should_keep_alive value). The fallback path receives that value as
+  // the kOnHeadersComplete callback parameter and must apply it to the response
+  // so middleware reading res.shouldKeepAlive sees the same value as on node:http.
+  const seen = {};
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    seen[req.url] = res.shouldKeepAlive;
+    res.setHeader("content-length", "1");
+    res.end("x");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const port = server.address().port;
+    const send = raw =>
+      new Promise((resolve, reject) => {
+        const socket = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] }, () =>
+          socket.end(raw),
+        );
+        socket.on("error", reject);
+        socket.on("data", () => {});
+        socket.on("close", resolve);
+      });
+    await send("GET /11close HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    await send("GET /10keepalive HTTP/1.0\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n");
+    await send("GET /11none HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    await send("GET /10none HTTP/1.0\r\nHost: localhost\r\n\r\n");
+    expect(seen).toEqual({
+      "/11close": false,
+      "/10keepalive": true,
+      "/11none": true,
+      "/10none": false,
+    });
+  } finally {
+    server.close();
+  }
+});
+
 it("http2 allowHTTP1 fallback writes a close-delimited body raw and ends the connection", async () => {
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
     res.removeHeader("content-length");


### PR DESCRIPTION
### Problem

`res.shouldKeepAlive` on a `node:http` ServerResponse does not reflect the request's `Connection` header; it only carries the HTTP-version default. The value is inverted relative to Node.js for the two explicit-header cases:

```js
import http from 'node:http'; import net from 'node:net';
const seen = {};
const s = http.createServer((q, r) => { seen[q.url] = r.shouldKeepAlive; r.end('x'); });
await new Promise(r => s.listen(0, '127.0.0.1', r));
const port = s.address().port;
const send = raw => new Promise(r => { const c = net.connect(port, '127.0.0.1', () => c.write(raw)); c.on('close', r); setTimeout(() => { c.destroy(); r(); }, 1000); });
await send('GET /11close HTTP/1.1\\r\\nHost: h\\r\\nConnection: close\\r\\n\\r\\n');
await send('GET /10keepalive HTTP/1.0\\r\\nHost: h\\r\\nConnection: keep-alive\\r\\n\\r\\n');
console.log(seen); s.close();
// node: { '/11close': false, '/10keepalive': true }
// bun : { '/11close': true,  '/10keepalive': false }
```

The `Connection:` header written on the wire is already correct; this is a property-only mismatch, but middleware that branches on `res.shouldKeepAlive` before writing headers (`compression`, `on-headers`-style helpers) reads the wrong value.

### Cause

Node.js's `parserOnIncoming` assigns `res.shouldKeepAlive = keepAlive` immediately after constructing the ServerResponse, where `keepAlive` is `llhttp_should_keep_alive` (HTTP/1.1: true unless `Connection: close`; HTTP/1.0: false unless `Connection: keep-alive`). Bun's `onNodeHTTPRequest` never makes that assignment, so the property keeps the ServerResponse constructor's version-only default (`true`, or `false` for HTTP/1.0). The native dispatch bitfield also had no `keep-alive` token bit, so HTTP/1.0 could not detect an explicit keep-alive without materializing `req.headers`.

### Fix

- `NodeHTTP.cpp`: add `kDispatchConnKeepAlive` to the Connection-token scan alongside `close`/`upgrade`.
- `_http_server.ts` `onNodeHTTPRequest`: after constructing the response, assign `http_res.shouldKeepAlive` from the llhttp-style decision (HTTP/1.0 → keep-alive bit, HTTP/1.1 → not-close bit), matching Node's `parserOnIncoming`.

`http_req[kReqShouldKeepAlive]` (the transport decision that drives `kMustCloseConnection` and the rendered `Connection` header) is unchanged, so the wire behaviour is identical before and after; the test asserts both the property and the wire header for all four version/header combinations.

Related: #32945 additionally makes the transport honour HTTP/1.0 keep-alive when the response has a Content-Length. This PR is the property-only fix and does not change what goes on the wire.

### Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http.test.ts -t "reflects the request's Connection header"
(fail) res.shouldKeepAlive reflects the request's Connection header like Node's parserOnIncoming
  - "/10keepalive": true,  + "/10keepalive": false,
  - "/11close": false,     + "/11close": true,

$ bun bd test test/js/node/http/node-http.test.ts -t shouldKeepAlive
(pass) res.shouldKeepAlive reflects the request's Connection header like Node's parserOnIncoming
(pass) res.shouldKeepAlive = false renders Connection: close and ends the socket
(pass) removeHeader('connection') with shouldKeepAlive = false still closes the socket on finish
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (82ca9df58)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [524.65ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [78.50ms]
(pass) node:http > createServer > request & response body streaming (large) [139.48ms]
(pass) node:http > createServer > request & response body streaming (small) [83.80ms]
(pass) node:http > createServer > listen should return server [21.71ms]
(pass) node:http > createServer > listen callback should be bound to server [27.41ms]
(pass) node:http > createServer > should use the provided port [58.15ms]
(pass) node:http > createServer > should assign a random port when undefined [27.68ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [68.20ms]
(pass) node:http > response > set-cookie works with getHeader [5.26ms]
(pass) node:http > response > set-cookie works with getHeaders [6.49ms]
(pass) node:http > request > should not insert extraneou
... (truncated)

release without fix: 7 skipped
bun test v1.4.0-canary.1 (82ca9df58)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [10.00ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [4.49ms]
(pass) node:http > createServer > request & response body streaming (large) [5.68ms]
(pass) node:http > createServer > request & response body streaming (small) [2.41ms]
(pass) node:http > createServer > listen should return server [0.81ms]
(pass) node:http > createServer > listen callback should be bound to server [1.77ms]
(pass) node:http > createServer > should use the provided port [1.49ms]
(pass) node:http > createServer > should assign a random port when undefined [0.93ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [2.64ms]
(pass) node:http > response > set-cookie works with getHeader [0.08ms]
(pass) node:http > response > set-cookie works with getHeaders [0.10ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [3.16ms]
(pass) node:http > request > multiple Set-Cookie headers works #6810 [10.69ms]
(pass) node:http > request > should make a standard GET request when passed string as first arg [
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (82ca9df58)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [430.15ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [77.40ms]
(pass) node:http > createServer > request & response body streaming (large) [133.53ms]
(pass) node:http > createServer > request & response body streaming (small) [80.53ms]
(pass) node:http > createServer > listen should return server [20.43ms]
(pass) node:http > createServer > listen callback should be bound to server [25.11ms]
(pass) node:http > createServer > should use the provided port [49.28ms]
(pass) node:http > createServer > should assign a random port when undefined [27.50ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [64.89ms]
(pass) node:http > response > set-cookie works with getHeader [5.21ms]
(pass) node:http > response > set-cookie works with getHeaders [6.28ms]
(pass) node:http > request > should not insert extraneou
... (truncated)

release with fix: 7 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1018ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen cpp.rs (cppbind)
[2/26] gen JS modules (bundle-modules)
Preprocess modules (16127ms)
Bundle modules (69ms)
Postprocesss modules (1619ms)
Bundle Functions (2125ms)
Generate Code (32ms)

[20.00s] Bundled "src/js" for production
  2532 kb
  192 internal modules
  13 native modules
  90 internal functions across 19 files
[3/11] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[4/11] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[5/11] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[6/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_http-0.cpp.o
[7/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[8/11] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[8/11] link bun-profile
[9/11] bun-profile --revision
1.4.0-canary.1+82ca9df58
[11/11] strip bun
[build] done
bun test v1.4.0-canary.1 (82ca9df58)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [9.76ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [3.11ms]
(pass) node:htt
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts           |  4 +++
 src/js/node/http2.ts                  |  1 +
 src/jsc/bindings/NodeHTTP.cpp         |  3 ++
 test/js/node/http/node-http-proxy.js  |  4 +--
 test/js/node/http/node-http.test.ts   | 55 +++++++++++++++++++++++++++++++++++
 test/js/node/http2/node-http2.test.js | 38 ++++++++++++++++++++++++
 6 files changed, 103 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 3 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/_http_server.ts                4      3      0
src/js/node/http2.ts                       1      1      0
src/jsc/bindings/NodeHTTP.cpp              2      2      0
test/js/node/http/node-http-proxy.js       1      1      0
test/js/node/http/node-http.test.ts        2      1      0
test/js/node/http2/node-http2.test.js      3      1      0
```

</details>

<!-- robobun:evidence:end -->