### PR TITLE
bun:test: don't report beforeAll/afterAll as phantom '(unnamed)' tests in describe.skip/describe.todo

### DIFF
--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -42,6 +42,13 @@ impl Order {
     pub fn generate_all_order(&mut self, entries: &[Box<ExecutionEntry>]) -> JsResult<AllOrderResult> {
         let start = self.groups.len();
         for entry_box in entries.iter() {
+            if entry_box.callback.is_none() {
+                // The hook's callback was dropped because its describe is .skip/.todo
+                // (`ExecutionEntry::create`). Scheduling it would mint a standalone sequence
+                // with `test_entry = None` that the reporter then prints as a phantom
+                // "(unnamed)" skipped/todo test.
+                continue;
+            }
             // Callers (e.g. BunTestRoot.hook_scope) only hold `&` access to the Vec, so we accept
             // `&[Box<_>]` and recover each Box's heap pointer as *mut to mutate through the
             // pointer, not the slice. SAFETY: each Box<ExecutionEntry> is live and

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -225,6 +225,36 @@ describe("bun test", () => {
       expect(stderr).toContain("should run");
     });
   });
+  describe("describe.skip / describe.todo", () => {
+    const fixture = (kind: "skip" | "todo") => `
+      import { describe, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+      describe.${kind}("disabled suite", () => {
+        beforeAll(() => { console.error("beforeAll ran"); });
+        afterAll(() => { console.error("afterAll ran"); });
+        beforeEach(() => {});
+        afterEach(() => {});
+        test("the only real test", () => {});
+      });
+    `;
+    for (const kind of ["skip", "todo"] as const) {
+      test(`should not count beforeAll/afterAll as ${kind} tests`, () => {
+        const stderr = runTest({ input: fixture(kind) });
+        expect(stderr).not.toContain("(unnamed)");
+        expect(stderr).not.toContain("beforeAll ran");
+        expect(stderr).not.toContain("afterAll ran");
+        expect(stderr).toContain("the only real test");
+        expect(stderr).toMatch(new RegExp(`\\b1 ${kind}\\b`));
+        expect(stderr).toContain("Ran 1 test across 1 file");
+      });
+    }
+    test("should still run beforeAll/afterAll in describe.todo with --todo", () => {
+      const stderr = runTest({ args: ["--todo"], input: fixture("todo") });
+      expect(stderr).not.toContain("(unnamed)");
+      expect(stderr).toContain("beforeAll ran");
+      expect(stderr).toContain("afterAll ran");
+      expect(stderr).toContain("Ran 1 test across 1 file");
+    });
+  });
   describe("only", () => {
     test("should run nested describe.only", () => {
       const stderr = runTest({


### PR DESCRIPTION
## What

`beforeAll`/`afterAll` hooks inside a `describe.skip` or `describe.todo` block are reported as `(unnamed)` skipped/todo tests, inflating the summary and JUnit counts. `beforeEach`/`afterEach` are not affected.

```ts
import { describe, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
describe.skip("disabled suite", () => {
  beforeAll(() => {});
  afterAll(() => {});
  beforeEach(() => {});
  afterEach(() => {});
  test("the only real test", () => {});
});
```

Before:
```
(skip) disabled suite > (unnamed)
(skip) disabled suite > the only real test
(skip) disabled suite > (unnamed)

 3 skip
Ran 3 tests across 1 file.
```
JUnit: `tests="3" skipped="3"` with two `<testcase name="(unnamed)"><skipped/></testcase>` entries.
Jest 30: `Tests: 1 skipped, 1 total`.

## Cause

`describe.skip`/`describe.todo` inherit their mode to every child, and `ExecutionEntry::create` drops the callback for Skip/Todo entries. `Order::generate_all_order` still scheduled each `beforeAll`/`afterAll` entry as its own `ExecutionSequence` with `test_entry = None`. At execution time the callback-less entry sets `sequence.result` to `Skip`/`Todo`, and `on_sequence_completed` reports any non-Pass sequence, falling back to `first_entry` (the hook, `name = None`) as the test to print.

`beforeEach`/`afterEach` are folded into each test's own sequence and only gathered when the test has a callback, so they never get a standalone sequence.

## Fix

Skip hook entries whose callback is `None` in `generate_all_order`. A hook with no callback has nothing to run and is not a test to report. `describe.todo` with `--todo` is unaffected: `run_todo` keeps the callback, so the hook is still scheduled and runs.

After:
```
(skip) disabled suite > the only real test

 1 skip
Ran 1 test across 1 file.
```
JUnit: `tests="1" skipped="1"`.

## Related

#35497 removes `always_use_hooks` so an all-`test.skip` describe no longer runs its hooks, which also stops scheduling the `describe.skip` phantoms. It does not cover `describe.todo` (a todo test still marks its ancestors `has_callback`, so the nulled hooks are still scheduled). The two changes touch different code paths and compose.

## Tests

Added three cases to `test/cli/test/bun-test.test.ts` asserting one reported test (no `(unnamed)`, no hook output) for `describe.skip` and `describe.todo`, and that `describe.todo` with `--todo` still runs its `beforeAll`/`afterAll`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->