### PR TITLE
bun test: union repeated --test-name-pattern/-t flags instead of last-wins

### DIFF
--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -410,12 +410,10 @@ pub struct TestOptions {
     pub path_ignore_patterns: Vec<Box<[u8]>>,
     pub path_ignore_patterns_from_cli: bool,
     pub test_filter_pattern: Vec<Box<[u8]>>,
-    /// `?*bun.jsc.RegularExpression` — typed as opaque to keep this file free
-    /// of `jsc/` references. Read via `test_filter_regex()`.
+    /// Erased `*mut bun_jsc::RegularExpression` handles — opaque to keep this
+    /// file free of `jsc/` references. Read via `test_filter_regex()`.
     // FORWARD_DECL(b0): erased bun_jsc::RegularExpression to break the T3→T6
-    // back-edge. High tier owns construction/destruction; this field only
-    // stores the pointer. LIFETIMES.tsv says OWNED, so the high-tier setter is
-    // responsible for freeing any previous value.
+    // back-edge. High tier owns construction/destruction.
     pub test_filter_regex: Vec<core::ptr::NonNull<()>>, // SAFETY: erased *mut bun_jsc::RegularExpression
     pub max_concurrency: u32,
     /// `bun test --isolate`: run each test file in a fresh global object on
@@ -459,8 +457,8 @@ pub struct Reporters {
 }
 
 impl TestOptions {
-    /// Returns the erased `*mut bun_jsc::RegularExpression`. Caller (high tier)
-    /// casts back: `unsafe { &*ptr.cast::<bun_jsc::RegularExpression>() }`.
+    /// Returns the erased `*mut bun_jsc::RegularExpression` handles. Caller
+    /// (high tier) casts each back with `p.cast::<bun_jsc::RegularExpression>()`.
     #[inline]
     pub fn test_filter_regex(&self) -> &[core::ptr::NonNull<()>] {
         // SAFETY: erased bun_jsc::RegularExpression — see field decl.

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -409,14 +409,14 @@ pub struct TestOptions {
     pub coverage: CodeCoverageOptions,
     pub path_ignore_patterns: Vec<Box<[u8]>>,
     pub path_ignore_patterns_from_cli: bool,
-    pub test_filter_pattern: Option<Box<[u8]>>,
+    pub test_filter_pattern: Vec<Box<[u8]>>,
     /// `?*bun.jsc.RegularExpression` — typed as opaque to keep this file free
     /// of `jsc/` references. Read via `test_filter_regex()`.
     // FORWARD_DECL(b0): erased bun_jsc::RegularExpression to break the T3→T6
     // back-edge. High tier owns construction/destruction; this field only
     // stores the pointer. LIFETIMES.tsv says OWNED, so the high-tier setter is
     // responsible for freeing any previous value.
-    pub test_filter_regex: Option<core::ptr::NonNull<()>>, // SAFETY: erased *mut bun_jsc::RegularExpression
+    pub test_filter_regex: Vec<core::ptr::NonNull<()>>, // SAFETY: erased *mut bun_jsc::RegularExpression
     pub max_concurrency: u32,
     /// `bun test --isolate`: run each test file in a fresh global object on
     /// the same VM, force-closing leaked handles between files.
@@ -462,9 +462,9 @@ impl TestOptions {
     /// Returns the erased `*mut bun_jsc::RegularExpression`. Caller (high tier)
     /// casts back: `unsafe { &*ptr.cast::<bun_jsc::RegularExpression>() }`.
     #[inline]
-    pub fn test_filter_regex(&self) -> Option<core::ptr::NonNull<()>> {
+    pub fn test_filter_regex(&self) -> &[core::ptr::NonNull<()>] {
         // SAFETY: erased bun_jsc::RegularExpression — see field decl.
-        self.test_filter_regex
+        &self.test_filter_regex
     }
 }
 
@@ -489,8 +489,8 @@ impl Default for TestOptions {
             coverage: CodeCoverageOptions::default(),
             path_ignore_patterns: Vec::new(),
             path_ignore_patterns_from_cli: false,
-            test_filter_pattern: None,
-            test_filter_regex: None,
+            test_filter_pattern: Vec::new(),
+            test_filter_regex: Vec::new(),
             // Under ASAN every spawned `bun` child is several-× heavier in
             // RSS and ~2× slower to start, so `describe.concurrent` test
             // files that spawn one child per test (e.g. process-stdio,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1732,7 +1732,9 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
             Err(_) => {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",
-                    bun_core::fmt::QuotedFormatter { text: &name_pattern },
+                    bun_core::fmt::QuotedFormatter {
+                        text: &name_pattern
+                    },
                 );
                 Global::exit(1);
             }

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -572,7 +572,7 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
         "--bail <NUMBER>?                 Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1."
     ),
     parse_param!(
-        "-t, --test-name-pattern/--grep <STR>    Run only tests with a name that matches the given regex."
+        "-t, --test-name-pattern/--grep <STR>...    Run only tests with a name that matches the given regex."
     ),
     parse_param!(
         "--reporter <STR>                 Test output reporter format. Available: 'junit' (requires --reporter-outfile), 'dots'. Default: console output."
@@ -1706,21 +1706,38 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         bun_core::pretty_errorln!("<r><red>error<r>: --retry cannot be used with --rerun-each");
         Global::exit(1);
     }
-    if let Some(name_pattern) = args.option(b"--test-name-pattern") {
-        ctx.test_options.test_filter_pattern = Some(name_pattern.into());
+    let name_patterns = args.options(b"--test-name-pattern");
+    if !name_patterns.is_empty() {
+        // Node.js allows `--test-name-pattern` to be repeated and runs the
+        // union of matches. `|` is lowest-precedence in ECMAScript regex, so
+        // joining the patterns with it is equivalent to testing each in turn.
+        let name_pattern: Box<[u8]> = if name_patterns.len() == 1 {
+            Box::from(name_patterns[0])
+        } else {
+            let mut joined =
+                Vec::with_capacity(name_patterns.iter().map(|p| p.len() + 1).sum::<usize>());
+            for (i, p) in name_patterns.iter().enumerate() {
+                if i > 0 {
+                    joined.push(b'|');
+                }
+                joined.extend_from_slice(p);
+            }
+            joined.into_boxed_slice()
+        };
         let regex = match RegularExpression::init(
-            bun_core::String::from_bytes(name_pattern),
+            bun_core::String::from_bytes(&name_pattern),
             RegexFlags::None,
         ) {
             Ok(r) => r,
             Err(_) => {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",
-                    bun_core::fmt::QuotedFormatter { text: name_pattern },
+                    bun_core::fmt::QuotedFormatter { text: &name_pattern },
                 );
                 Global::exit(1);
             }
         };
+        ctx.test_options.test_filter_pattern = Some(name_pattern);
         // The compiled regex lives in `bun_jsc::RegularExpression` (T6); the
         // T3 `TestOptions` field is type-erased to `NonNull<()>` to break the
         // back-edge. High tier owns construction/destruction.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1723,7 +1723,9 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
                 Global::exit(1);
             }
         };
-        ctx.test_options.test_filter_pattern.push(Box::from(*name_pattern));
+        ctx.test_options
+            .test_filter_pattern
+            .push(Box::from(*name_pattern));
         // The compiled regex lives in `bun_jsc::RegularExpression` (T6); the
         // T3 `TestOptions` field is type-erased to `NonNull<()>` to break the
         // back-edge. High tier owns construction/destruction.

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1706,44 +1706,30 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         bun_core::pretty_errorln!("<r><red>error<r>: --retry cannot be used with --rerun-each");
         Global::exit(1);
     }
-    let name_patterns = args.options(b"--test-name-pattern");
-    if !name_patterns.is_empty() {
-        // Node.js allows `--test-name-pattern` to be repeated and runs the
-        // union of matches. `|` is lowest-precedence in ECMAScript regex, so
-        // joining the patterns with it is equivalent to testing each in turn.
-        let name_pattern: Box<[u8]> = if name_patterns.len() == 1 {
-            Box::from(name_patterns[0])
-        } else {
-            let mut joined =
-                Vec::with_capacity(name_patterns.iter().map(|p| p.len() + 1).sum::<usize>());
-            for (i, p) in name_patterns.iter().enumerate() {
-                if i > 0 {
-                    joined.push(b'|');
-                }
-                joined.extend_from_slice(p);
-            }
-            joined.into_boxed_slice()
-        };
+    // Node.js allows `--test-name-pattern` to be repeated; a test matches if
+    // it matches any supplied pattern. Each is compiled to its own regex so
+    // capture-group numbering stays local to the pattern the user wrote.
+    for name_pattern in args.options(b"--test-name-pattern") {
         let regex = match RegularExpression::init(
-            bun_core::String::from_bytes(&name_pattern),
+            bun_core::String::from_bytes(name_pattern),
             RegexFlags::None,
         ) {
             Ok(r) => r,
             Err(_) => {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: --test-name-pattern expects a valid regular expression but received {}",
-                    bun_core::fmt::QuotedFormatter {
-                        text: &name_pattern
-                    },
+                    bun_core::fmt::QuotedFormatter { text: name_pattern },
                 );
                 Global::exit(1);
             }
         };
-        ctx.test_options.test_filter_pattern = Some(name_pattern);
+        ctx.test_options.test_filter_pattern.push(Box::from(*name_pattern));
         // The compiled regex lives in `bun_jsc::RegularExpression` (T6); the
         // T3 `TestOptions` field is type-erased to `NonNull<()>` to break the
         // back-edge. High tier owns construction/destruction.
-        ctx.test_options.test_filter_regex = core::ptr::NonNull::new(regex.cast::<()>());
+        if let Some(ptr) = core::ptr::NonNull::new(regex.cast::<()>()) {
+            ctx.test_options.test_filter_regex.push(ptr);
+        }
     }
     if let Some(since) = args.option(b"--changed") {
         ctx.test_options.changed = Some(since.into());

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -359,7 +359,7 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
         "--max-concurrency={}",
         opts.max_concurrency
     ))?);
-    if let Some(pattern) = &opts.test_filter_pattern {
+    for pattern in &opts.test_filter_pattern {
         argv.push(lit(b"-t\0"));
         argv.push(dupe_z(pattern));
     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2214,7 +2214,9 @@ impl TestCommand {
                 filter_regex: ctx
                     .test_options
                     .test_filter_regex()
-                    .map(|p| p.cast::<jsc::RegularExpression>()),
+                    .iter()
+                    .map(|p| p.cast::<jsc::RegularExpression>())
+                    .collect(),
                 snapshots: Snapshots {
                     update_snapshots: ctx.test_options.update_snapshots,
                     total: 0,
@@ -3011,9 +3013,16 @@ impl TestCommand {
 
                 reporter.print_summary();
             } else {
+                let patterns = &ctx.test_options.test_filter_pattern;
+                pretty_error!("<red>error<r><d>:<r> regex ");
+                for (i, p) in patterns.iter().enumerate() {
+                    if i > 0 {
+                        pretty_error!("<d>,<r> ");
+                    }
+                    pretty_error!("<b>{}<r>", bun_fmt::quote(p));
+                }
                 pretty_error!(
-                    "<red>error<r><d>:<r> regex <b>{}<r> matched 0 tests. Searched {} file{} (skipping {} test{}) ",
-                    bun_fmt::quote(ctx.test_options.test_filter_pattern.as_ref().unwrap()),
+                    " matched 0 tests. Searched {} file{} (skipping {} test{}) ",
                     summary.files,
                     if summary.files == 1 { "" } else { "s" },
                     summary.skipped_because_label,

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -402,7 +402,7 @@ impl ScopeFunctions {
                 if let Some(reporter) = bun_test.reporter {
                     // SAFETY: reporter outlives every BunTest (owned by test_command::exec).
                     let reporter = unsafe { reporter.as_ref() };
-                    if let Some(filter_regex) = reporter.jest.filter_regex {
+                    if !reporter.jest.filter_regex.is_empty() {
                         group_log::log(format_args!("matches_filter begin"));
                         debug_assert!(bun_test.collection.filter_buffer.is_empty());
                         // reshaped for borrowck — clear at end via explicit call below.
@@ -426,10 +426,14 @@ impl ScopeFunctions {
                             "matches_filter \"{}\"",
                             bstr::BStr::new(bun_test.collection.filter_buffer.as_slice())
                         ));
-                        // SAFETY: `filter_regex` is the FFI-allocated Yarr handle stored in
-                        // `TestRunner` for the process lifetime; single-threaded here so the
-                        // exclusive borrow is unaliased.
-                        matches_filter = unsafe { &mut *filter_regex.as_ptr() }.matches(str);
+                        // SAFETY: each `filter_regex` is the FFI-allocated Yarr handle stored
+                        // in `TestRunner` for the process lifetime; single-threaded here so
+                        // the exclusive borrow is unaliased.
+                        matches_filter = reporter
+                            .jest
+                            .filter_regex
+                            .iter()
+                            .any(|r| unsafe { &mut *r.as_ptr() }.matches(str));
 
                         bun_test.collection.filter_buffer.clear();
                     }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1035,7 +1035,7 @@ impl BunTest {
 
                 let has_filter = if let Some(reporter) = self.reporter {
                     // SAFETY: reporter outlives every BunTest (see field doc).
-                    unsafe { reporter.as_ref() }.jest.filter_regex.is_some()
+                    !unsafe { reporter.as_ref() }.jest.filter_regex.is_empty()
                 } else {
                     false
                 };

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -141,7 +141,7 @@ pub struct TestRunner<'a> {
     /// Raw `*mut` because `RegularExpression::matches` mutates its internal
     /// cursor through C++ — storing `&'a RegularExpression` and casting back to
     /// `*mut` at the use site would launder shared provenance into a write (UB).
-    pub filter_regex: Option<core::ptr::NonNull<RegularExpression>>,
+    pub filter_regex: Box<[core::ptr::NonNull<RegularExpression>]>,
 
     pub unhandled_errors_between_tests: u32,
     pub summary: Summary,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1324,6 +1324,27 @@ describe("bun test", () => {
     `);
   });
 
+  test.each([
+    ["-t", "alpha", "-t", "beta"],
+    ["--test-name-pattern", "alpha", "--test-name-pattern", "beta"],
+    ["--grep", "alpha", "-t", "beta"],
+  ])("repeated -t/--test-name-pattern runs the union of matches", (...args) => {
+    const stderr = runTest({
+      args,
+      input: `
+        import { test } from "bun:test";
+        test("alpha one", () => {});
+        test("beta two", () => {});
+        test("gamma three", () => {});
+      `,
+    });
+    expect(stderr).toContain("(pass) alpha one");
+    expect(stderr).toContain("(pass) beta two");
+    expect(stderr).not.toContain("(pass) gamma three");
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("1 filtered out");
+  });
+
   test("--tsconfig-override works", () => {
     const dir = tempDirWithFiles("test-tsconfig-override", {
       "math.test.ts": `

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1351,14 +1351,14 @@ describe("bun test", () => {
       input: `
         import { test } from "bun:test";
         test("foofoo", () => {});
-        test("bar", () => {});
+        test("just bar", () => {});
         test("barbar", () => {});
         test("quux", () => {});
       `,
     });
     expect(stderr).toContain("(pass) foofoo");
     expect(stderr).toContain("(pass) barbar");
-    expect(stderr).not.toContain("(pass) bar ");
+    expect(stderr).not.toContain("(pass) just bar");
     expect(stderr).not.toContain("(pass) quux");
     expect(stderr).toContain("2 pass");
     expect(stderr).toContain("2 filtered out");

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1345,6 +1345,25 @@ describe("bun test", () => {
     expect(stderr).toContain("1 filtered out");
   });
 
+  test("repeated -t compiles each pattern independently (backreferences stay local)", () => {
+    const stderr = runTest({
+      args: ["-t", "(foo)\\1", "-t", "(bar)\\1"],
+      input: `
+        import { test } from "bun:test";
+        test("foofoo", () => {});
+        test("bar", () => {});
+        test("barbar", () => {});
+        test("quux", () => {});
+      `,
+    });
+    expect(stderr).toContain("(pass) foofoo");
+    expect(stderr).toContain("(pass) barbar");
+    expect(stderr).not.toContain("(pass) bar ");
+    expect(stderr).not.toContain("(pass) quux");
+    expect(stderr).toContain("2 pass");
+    expect(stderr).toContain("2 filtered out");
+  });
+
   test("--tsconfig-override works", () => {
     const dir = tempDirWithFiles("test-tsconfig-override", {
       "math.test.ts": `

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1337,6 +1337,7 @@ describe("bun test", () => {
         test("beta two", () => {});
         test("gamma three", () => {});
       `,
+      expectExitCode: 0,
     });
     expect(stderr).toContain("(pass) alpha one");
     expect(stderr).toContain("(pass) beta two");
@@ -1355,6 +1356,7 @@ describe("bun test", () => {
         test("barbar", () => {});
         test("quux", () => {});
       `,
+      expectExitCode: 0,
     });
     expect(stderr).toContain("(pass) foofoo");
     expect(stderr).toContain("(pass) barbar");


### PR DESCRIPTION
## Problem

Node.js documents `--test-name-pattern` as repeatable: "a test is run if it matches any of the supplied patterns". Bun declared it as a single-value option, so repeating the flag silently overwrote the previous value and only the last pattern was honored. A Node CI invocation listing several patterns would silently drop every test matched only by the earlier flags.

```js
// tnp.test.mjs
import { test } from 'node:test';
test('alpha one', () => console.log('RAN alpha'));
test('beta two', () => console.log('RAN beta'));
test('gamma three', () => console.log('RAN gamma'));
```

```
$ node --test --test-name-pattern=alpha --test-name-pattern=beta tnp.test.mjs
RAN alpha
RAN beta

$ bun test --test-name-pattern alpha --test-name-pattern beta ./tnp.test.mjs
RAN beta
Ran 1 test across 1 file.
```

## Cause

`-t, --test-name-pattern` was declared with `<STR>` (single `Values::One`), so `ComptimeClap` stored each occurrence into the same single-option slot, last one winning, and `args.option()` returned only that survivor.

## Fix

Declare the flag with `<STR>...` (`Values::Many`) and read it via `args.options()`. Each pattern is compiled to its own `RegularExpression`; the filter site in `ScopeFunctions.rs` matches if `.any()` of them match the test name. This mirrors Node, which compiles each `--test-name-pattern` into its own `RegExp`, so capture-group numbering stays local to the pattern the user wrote (e.g. `-t '(foo)\1' -t '(bar)\1'` behaves the same as in Node rather than renumbering across a joined alternation).

`TestOptions` now carries `Vec<Box<[u8]>>` / `Vec<NonNull<()>>` for the pattern sources and compiled handles. `--parallel` forwards each `-t` verbatim to workers. The `regex "..." matched 0 tests` diagnostic lists every supplied pattern, and an invalid-regex error names the specific flag value that failed to compile.

## Verification

```
$ bun-debug test --test-name-pattern alpha --test-name-pattern beta ./tnp.test.mjs
RAN alpha
RAN beta
Ran 2 tests across 1 file.
```

`test/cli/test/bun-test.test.ts` gains a `test.each` covering `-t`, `--test-name-pattern`, and the `--grep` alias repeated and mixed, plus a backreference case (`-t '(foo)\1' -t '(bar)\1'`). Both fail on the released binary and pass with this change; the full file is green (81 pass, 6 todo).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->