### PR TITLE
sql(postgres): send non-integer number params as text with OID 0 so NUMERIC stays exact

### DIFF
--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -66,6 +66,16 @@ fn has_binary_param_encoder(tag: types::Tag) -> bool {
     )
 }
 
+/// A non-integer JS number bound to a PG-inferred `int4` target must not be
+/// silently truncated by `coerce::<i32>`; send the decimal text so PG errors
+/// cleanly. `float8` / `timestamp` / `timestamptz` stay binary because their
+/// encoders accept arbitrary f64 (including ±Infinity, see `date::from_js`).
+fn number_needs_text(tag: types::Tag, value: JSValue) -> bool {
+    matches!(tag, types::Tag::int4 | types::Tag::int4_array)
+        && value.is_number()
+        && !value.is_any_int()
+}
+
 pub fn write_bind<Context: WriterContext>(
     name: &[u8],
     cursor_name: BunString,
@@ -113,12 +123,7 @@ pub fn write_bind<Context: WriterContext>(
             || 'brk: {
                 iter.to(i as u32);
                 if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-                    // Strings are passed through as-is. A JS number that is not
-                    // integer-valued (or is outside the int52 range) is also
-                    // sent as text when PG inferred a non-float8 target, so PG
-                    // parses the exact decimal instead of us lossily coercing.
-                    break 'brk value.is_string()
-                        || (tag != types::Tag::float8 && value.is_number() && !value.is_any_int());
+                    break 'brk value.is_string() || number_needs_text(tag, value);
                 }
                 if iter.any_failed() {
                     return Err(AnyPostgresError::InvalidQueryBinding);
@@ -181,8 +186,7 @@ pub fn write_bind<Context: WriterContext>(
         // for mistakes on our end, such as stripping the timezone
         // differently than what Postgres does when given a timestamp with
         // timezone.
-        let as_text = value.is_string()
-            || (tag != types::Tag::float8 && value.is_number() && !value.is_any_int());
+        let as_text = value.is_string() || number_needs_text(tag, value);
         let effective_tag = if tag.is_binary_format_supported() && as_text {
             types::Tag::text
         } else {

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -49,6 +49,23 @@ pub enum MessageType {
 /// The PostgreSQL wire protocol uses 16-bit integers for parameter and column counts.
 const MAX_PARAMETERS: usize = u16::MAX as usize;
 
+/// Parameter tags that the value-writing `match` below encodes in PG's binary
+/// format. `Tag::is_binary_format_supported` is wider (it also covers tags we
+/// only *decode* binary, e.g. `numeric`, `float4`); using it for the parameter
+/// format code would advertise binary but send text.
+fn has_binary_param_encoder(tag: types::Tag) -> bool {
+    matches!(
+        tag,
+        types::Tag::bool
+            | types::Tag::timestamp
+            | types::Tag::timestamptz
+            | types::Tag::bytea
+            | types::Tag::int4
+            | types::Tag::int4_array
+            | types::Tag::float8
+    )
+}
+
 pub fn write_bind<Context: WriterContext>(
     name: &[u8],
     cursor_name: BunString,
@@ -92,17 +109,24 @@ pub fn write_bind<Context: WriterContext>(
         };
 
         let force_text = is_custom_type
-            || (tag.is_binary_format_supported()
-                && 'brk: {
-                    iter.to(i as u32);
-                    if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
-                        break 'brk value.is_string();
-                    }
-                    if iter.any_failed() {
-                        return Err(AnyPostgresError::InvalidQueryBinding);
-                    }
-                    break 'brk false;
-                });
+            || !has_binary_param_encoder(tag)
+            || 'brk: {
+                iter.to(i as u32);
+                if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
+                    // Strings are passed through as-is. A JS number that is not
+                    // integer-valued (or is outside the int52 range) is also
+                    // sent as text when PG inferred a non-float8 target, so PG
+                    // parses the exact decimal instead of us lossily coercing.
+                    break 'brk value.is_string()
+                        || (tag != types::Tag::float8
+                            && value.is_number()
+                            && !value.is_any_int());
+                }
+                if iter.any_failed() {
+                    return Err(AnyPostgresError::InvalidQueryBinding);
+                }
+                break 'brk false;
+            };
 
         if force_text {
             // If they pass a value as a string, let's avoid attempting to
@@ -114,7 +138,7 @@ pub fn write_bind<Context: WriterContext>(
             continue;
         }
 
-        writer.short(tag.format_code())?;
+        writer.short(1)?;
     }
 
     // The number of parameter values that follow (possibly zero). This
@@ -159,7 +183,9 @@ pub fn write_bind<Context: WriterContext>(
         // for mistakes on our end, such as stripping the timezone
         // differently than what Postgres does when given a timestamp with
         // timezone.
-        let effective_tag = if tag.is_binary_format_supported() && value.is_string() {
+        let as_text = value.is_string()
+            || (tag != types::Tag::float8 && value.is_number() && !value.is_any_int());
+        let effective_tag = if tag.is_binary_format_supported() && as_text {
             types::Tag::text
         } else {
             tag

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -118,9 +118,7 @@ pub fn write_bind<Context: WriterContext>(
                     // sent as text when PG inferred a non-float8 target, so PG
                     // parses the exact decimal instead of us lossily coercing.
                     break 'brk value.is_string()
-                        || (tag != types::Tag::float8
-                            && value.is_number()
-                            && !value.is_any_int());
+                        || (tag != types::Tag::float8 && value.is_number() && !value.is_any_int());
                 }
                 if iter.any_failed() {
                     return Err(AnyPostgresError::InvalidQueryBinding);

--- a/src/sql_jsc/postgres/Signature.rs
+++ b/src/sql_jsc/postgres/Signature.rs
@@ -75,7 +75,6 @@ impl Signature {
                 Tag::bool
                 | Tag::int4
                 | Tag::int8
-                | Tag::float8
                 | Tag::int2
                 | Tag::numeric
                 | Tag::float4
@@ -83,6 +82,12 @@ impl Signature {
                     // We decide the type
                     fields.push(Int4::from(tag.0));
                 }
+                // A non-integer JS number: declaring float8 makes PG cast
+                // float8 -> numeric/text at DBL_DIG (15 digits), silently
+                // losing precision. Leave the OID unspecified and send the
+                // decimal string so PG parses it directly into the target
+                // type. This matches postgres.js (`number.to: 0`).
+                Tag::float8 => fields.push(0),
                 _ => {
                     // Allow postgres to decide the type
                     fields.push(0);

--- a/test/js/sql/postgres-number-param-precision.test.ts
+++ b/test/js/sql/postgres-number-param-precision.test.ts
@@ -38,7 +38,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     for (const [v, want] of cases) {
       await sql`insert into nprec values (${v}, ${v}, ${v})`;
     }
-    const rows = await sql`select n::text as n, f, t from nprec`;
+    const rows = await sql`select n::text as n, f, t from nprec order by ctid`;
 
     expect(
       rows.map((r: { n: string; f: number; t: string }) => ({

--- a/test/js/sql/postgres-number-param-precision.test.ts
+++ b/test/js/sql/postgres-number-param-precision.test.ts
@@ -1,0 +1,88 @@
+// A JS number bound as a tagged-template parameter must round-trip exactly into
+// a NUMERIC column. Bun previously declared the parameter as float8 (OID 701)
+// in Parse and sent the 8 binary IEEE-754 bytes; PostgreSQL then cast
+// float8 -> numeric using DBL_DIG (15 significant digits), so any value wider
+// than that was silently rounded. postgres.js / node-pg send numbers as text
+// with OID 0 and are exact for the same values.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+// Each value is an exact JS double whose decimal form is >= 16 significant
+// digits (or otherwise sensitive to the float8 -> numeric cast), so a lossy
+// float8 round-trip would change it.
+const cases: Array<[number, string]> = [
+  // 2^52: an exact JS integer, but outside JSC's int52 range so it was sent as
+  // float8 and rounded to 4503599627370500.
+  [4503599627370496, "4503599627370496"],
+  // 2^53.
+  [9007199254740992, "9007199254740992"],
+  // 0.1 + 0.2: the canonical 17-digit double; float8 -> numeric gave 0.3.
+  [0.1 + 0.2, "0.30000000000000004"],
+  // 16 significant digits spanning the decimal point.
+  [12345.678901234567, "12345.678901234567"],
+  // A large safe integer below 2^51 (goes via int8, must stay exact).
+  [2251799813685247, "2251799813685247"],
+];
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  test("JS number bound into NUMERIC round-trips exactly", async () => {
+    await container.ready;
+    await using sql = new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+    await sql`create temp table nprec (n numeric, f float8, t text)`;
+
+    for (const [v, want] of cases) {
+      await sql`insert into nprec values (${v}, ${v}, ${v})`;
+    }
+    const rows = await sql`select n::text as n, f, t from nprec`;
+
+    expect(
+      rows.map((r: { n: string; f: number; t: string }) => ({
+        n: r.n,
+        f: r.f,
+        t: r.t,
+      })),
+    ).toEqual(
+      cases.map(([v, want]) => ({
+        // NUMERIC stores the exact decimal the client sent.
+        n: want,
+        // float8 stores the same double bit-for-bit.
+        f: v,
+        // TEXT stores the JS decimal string, not PG's float8 rendering
+        // (which would be "4.503599627370496e+15" / "1e-07").
+        t: want,
+      })),
+    );
+  });
+
+  test("JS number bound into NUMERIC round-trips exactly (prepare: false)", async () => {
+    await container.ready;
+    await using sql = new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+      prepare: false,
+    });
+    await sql`create temp table nprec_u (n numeric)`;
+    const [v, want] = cases[0];
+    await sql`insert into nprec_u values (${v})`;
+    const [{ n }] = await sql`select n::text as n from nprec_u`;
+    expect(n).toBe(want);
+  });
+
+  test("untyped number parameter is sent as its JS decimal string", async () => {
+    // With OID 0 and no target-column context, PG resolves $1 to text, so the
+    // result is the string form. Cast to float8 to get a number back.
+    await container.ready;
+    await using sql = new SQL({
+      url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
+      max: 1,
+    });
+    const [{ x, y }] = await sql`select ${1.123456789} as x, ${1.123456789}::float8 as y`;
+    expect(x).toBe("1.123456789");
+    expect(y).toBe(1.123456789);
+  });
+});

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1003,7 +1003,11 @@ if (isDockerEnabled()) {
     });
 
     test("Double", async () => {
-      expect((await sql`select ${1.123456789} as x`)[0].x).toBe(1.123456789);
+      // Non-integer number parameters are sent with OID 0 so PG can parse the
+      // decimal directly into numeric/float8/text without a lossy float8 cast;
+      // with no target type PG resolves $1 to text (same as postgres.js).
+      expect((await sql`select ${1.123456789} as x`)[0].x).toBe("1.123456789");
+      expect((await sql`select ${1.123456789}::float8 as x`)[0].x).toBe(1.123456789);
     });
 
     test("String", async () => {


### PR DESCRIPTION
## Problem

A JS `number` bound via the tagged-template path into a `NUMERIC` column is silently rounded to ~15 significant digits.

```js
import { SQL } from "bun";
const sql = new SQL(process.env.PGURL);
await sql`create temp table nt (n numeric, f float8)`;
for (const v of [4503599627370496, 9007199254740992, 0.1 + 0.2, 12345.678901234567]) {
  await sql`insert into nt values (${v}, ${v})`;
  const [{ n, f }] = await sql`select n::text as n, f from nt order by ctid desc limit 1`;
  console.log(v, "-> numeric", n, Number(n) === v ? "exact" : "LOSSY", "| float8", f);
}
```
```
4503599627370496    -> numeric 4503599627370500      LOSSY   (2^52, an exact JS integer)
9007199254740992    -> numeric 9007199254740990      LOSSY
0.30000000000000004 -> numeric 0.3                   LOSSY
12345.678901234567  -> numeric 12345.6789012346      LOSSY
```

The same values written into a `float8` column, or bound via `${String(v)}`, are exact. `postgres.js` / `node-pg` are exact for the same query.

## Cause

`tag_jsc::from_js` maps a non-int52 JS number to `Tag::float8`; `Signature::generate` then declares OID 701 in Parse and `write_bind` sends the 8 binary IEEE-754 bytes. PostgreSQL's `float8 -> numeric` cast (`float8_numeric`) formats with `DBL_DIG` (15) significant digits, so any wider value is rounded on the server side before it reaches the column. A sibling effect: into a `text` column the value stores as PG's float8 rendering (`4.503599627370496e+15`, `1e-07`) rather than the JS decimal string.

## Fix

* In `Signature::generate`, leave the OID unspecified (0) for `Tag::float8` so PostgreSQL infers the target type from context, matching `postgres.js` (`number.to: 0`, `serialize: x => '' + x`).
* In `write_bind`, derive the parameter format code from the set of tags we actually have binary *encoders* for (previously it used `is_binary_format_supported`, which also covers decode-only tags like `numeric`/`float4`/`time` and so would advertise binary but then fall through to the text writer). A non-integer JS number bound to a non-float8 inferred target is sent as its decimal string so PG does the parse, avoiding a lossy JS coerce.

With this, the number is sent as `String(v)` (shortest-round-trip decimal) in text format. PostgreSQL parses it directly into the target type: `numeric` is exact; `float8` round-trips to the same double; `text` stores the JS decimal form.

### Behavior changes

* ``select ${1.5} as x`` now returns `"1.5"` (string) because PG resolves an untyped parameter in a bare `SELECT` to text. This matches `postgres.js`. Cast explicitly (``${1.5}::float8``) to get a number back. The existing `Double` test is updated accordingly.
* Binding a non-integer number into an integer column (``insert into int_col values (${0.7})``) now fails with PG's `invalid input syntax for type integer` instead of silently rounding via the float8 cast. This also matches `postgres.js`.

## Verification

`test/js/sql/postgres-number-param-precision.test.ts` inserts each of the values above into `numeric` / `float8` / `text` columns and asserts the exact round-trip, on both the named and `prepare: false` paths.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-number-param-precision.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (c24bcea75)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [3872.51ms]
(pass) rejects Postgres connection options containing null bytes [161.33ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [290.67ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [20.19ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [13.77ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [39.50ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor a
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (1f05e8279)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [117.15ms]
(pass) rejects Postgres connection options containing null bytes [4.42ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [4.29ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [0.33ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [0.22ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [9.34ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor an object [0.75ms]
(pass) shared createInstance validation (no server) > mysql: rejects tls that is neither a boolean nor an object [0.68ms]
(pass) shared createInstance validation (no server) > rejects simple
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-number-param-precision.test.ts test/js/sql/sql.test.ts
bun test v1.4.0 (c24bcea75)

test/js/sql/sql.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) text-format json[] with a malformed boolean literal returns an error instead of looping [3496.55ms]
(pass) rejects Postgres connection options containing null bytes [127.86ms]
(pass) shared createInstance validation (no server) > rejects username containing null bytes [222.18ms]
(pass) shared createInstance validation (no server) > rejects password containing null bytes [17.05ms]
(pass) shared createInstance validation (no server) > rejects database containing null bytes [11.62ms]
(pass) shared createInstance validation (no server) > SSL_CTX creation failure throws the structured BoringSSL error [27.13ms]
(pass) shared createInstance validation (no server) > postgres: rejects tls that is neither a boolean nor a
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1259ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bun_valkey v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql_jsc/postgres/PostgresRequest.rs            | 54 +++++++++----
 src/sql_jsc/postgres/Signature.rs                  |  7 +-
 .../js/sql/postgres-number-param-precision.test.ts | 88 ++++++++++++++++++++++
 test/js/sql/sql.test.ts                            |  6 +-
 4 files changed, 140 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/sql_jsc/postgres/PostgresRequest.rs                  4      6      0
src/sql_jsc/postgres/Signature.rs                        1      1      0
test/js/sql/postgres-number-param-precision.test.ts      0      2      0
test/js/sql/sql.test.ts                                  2      1      0
```

</details>

<!-- robobun:evidence:end -->