### PR TITLE
redis: propagate the real failure reason to the connect() promise

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -810,6 +810,7 @@ impl JSValkeyClient {
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
                 auto_flusher: Default::default(),
+                close_reason: None,
             }),
             global_object,
             this_value: JsCell::new(JsRef::empty()),
@@ -930,6 +931,7 @@ impl JSValkeyClient {
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
                 auto_flusher: Default::default(),
+                close_reason: None,
             }),
             global_object,
             this_value: JsCell::new(JsRef::empty()),
@@ -1045,6 +1047,7 @@ impl JSValkeyClient {
         // Without this, every subsequent command rejects with "Connection has
         // failed" forever — see https://github.com/oven-sh/bun/issues/29925.
         self.client_mut().flags.failed = false;
+        self.client_mut().close_reason = None;
         let self_br = BackRef::new(self);
         let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
 
@@ -1374,12 +1377,14 @@ impl JSValkeyClient {
         };
         this_jsvalue.ensure_still_alive();
 
-        // Create an error value
-        let error_value = protocol_jsc::valkey_error_to_js(
-            &global_object,
-            b"Connection closed",
-            protocol::RedisError::ConnectionClosed,
-        );
+        let error_value = match self.client_mut().close_reason.take() {
+            Some((message, err)) => protocol_jsc::valkey_error_to_js(&global_object, &*message, err),
+            None => protocol_jsc::valkey_error_to_js(
+                &global_object,
+                b"Connection closed",
+                protocol::RedisError::ConnectionClosed,
+            ),
+        };
 
         let _exit = self.vm().enter_event_loop_scope();
 
@@ -1977,6 +1982,13 @@ impl<const SSL: bool> SocketHandler<SSL> {
             p.client_mut().status = valkey::Status::Disconnected;
             p.update_poll_ref();
         });
+
+        if this.client.get().close_reason.is_none() {
+            this.client_mut().close_reason = Some((
+                Box::<[u8]>::from(&b"Failed to connect"[..]),
+                protocol::RedisError::ConnectionClosed,
+            ));
+        }
 
         narrow_terminated(this.client_mut().on_close())
     }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1511,6 +1511,7 @@ impl JSValkeyClient {
 
     fn connect(&self) -> Result<(), crate::Error> {
         self.client_mut().flags.needs_to_open_socket = false;
+        self.client_mut().close_reason = None;
 
         let _guard = self.ref_scope();
 

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1378,7 +1378,9 @@ impl JSValkeyClient {
         this_jsvalue.ensure_still_alive();
 
         let error_value = match self.client_mut().close_reason.take() {
-            Some((message, err)) => protocol_jsc::valkey_error_to_js(&global_object, &*message, err),
+            Some((message, err)) => {
+                protocol_jsc::valkey_error_to_js(&global_object, &*message, err)
+            }
             None => protocol_jsc::valkey_error_to_js(
                 &global_object,
                 b"Connection closed",

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -275,6 +275,11 @@ pub struct ValkeyClient {
 
     pub flags: ConnectionFlags,
 
+    /// First failure recorded via `fail()`. `on_valkey_close()` uses this so
+    /// the `connect()` promise rejects with the real cause (HELLO auth error
+    /// text, connection timeout, …) instead of a generic "Connection closed".
+    pub close_reason: Option<(Box<[u8]>, RedisError)>,
+
     // Auto-pipelining
     pub auto_flusher: AutoFlusher,
 
@@ -571,6 +576,10 @@ impl ValkeyClient {
         debug!("failed: {}: {:?}", bstr::BStr::new(message), err);
         if self.flags.failed {
             return Ok(());
+        }
+
+        if self.close_reason.is_none() {
+            self.close_reason = Some((Box::<[u8]>::from(message), err));
         }
 
         if self.flags.finalized {
@@ -1270,6 +1279,7 @@ impl ValkeyClient {
         self.flags.failed = false;
         self.flags.is_authenticated = false;
         self.flags.is_selecting_db_internal = false;
+        self.close_reason = None;
         if matches!(self.socket, AnySocket::SocketTcp(_)) {
             // if is tcp, we need to start the connection process
             // if is tls, we need to wait for the handshake to complete

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -341,12 +341,18 @@ describe("Valkey: connect() error identity", () => {
   // Previously all connect-time failures surfaced as ERR_REDIS_CONNECTION_CLOSED / "Connection closed".
   const CRLF = "\r\n";
 
-  async function stubServer(reply: (text: string) => string | null) {
+  async function stubServer(helloReply: string | null) {
     const server = net.createServer(sock => {
+      let received = "";
+      let replied = false;
       sock.on("error", () => {});
       sock.on("data", d => {
-        const r = reply(d.toString().toUpperCase());
-        if (r !== null) sock.write(r);
+        if (replied || helloReply === null) return;
+        received += d.toString().toUpperCase();
+        if (received.includes("HELLO") && received.endsWith(CRLF)) {
+          replied = true;
+          sock.write(helloReply);
+        }
       });
     });
     await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
@@ -369,9 +375,7 @@ describe("Valkey: connect() error identity", () => {
   }
 
   test("-WRONGPASS reply to HELLO rejects connect() with the server's error text", async () => {
-    const srv = await stubServer(t =>
-      t.includes("HELLO") ? `-WRONGPASS invalid username-password pair or user is disabled.${CRLF}` : `+OK${CRLF}`,
-    );
+    const srv = await stubServer(`-WRONGPASS invalid username-password pair or user is disabled.${CRLF}`);
     try {
       expect(await connectError(`redis://:bad@127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
         code: "ERR_REDIS_AUTHENTICATION_FAILED",
@@ -383,11 +387,7 @@ describe("Valkey: connect() error identity", () => {
   });
 
   test("-NOAUTH reply to HELLO rejects connect() with the server's error text", async () => {
-    const srv = await stubServer(t =>
-      t.includes("HELLO")
-        ? `-NOAUTH HELLO must be called with the client already authenticated${CRLF}`
-        : `-NOAUTH Authentication required.${CRLF}`,
-    );
+    const srv = await stubServer(`-NOAUTH HELLO must be called with the client already authenticated${CRLF}`);
     try {
       expect(await connectError(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
         code: "ERR_REDIS_AUTHENTICATION_FAILED",
@@ -399,7 +399,7 @@ describe("Valkey: connect() error identity", () => {
   });
 
   test("connectionTimeout expiry rejects connect() with ERR_REDIS_CONNECTION_TIMEOUT", async () => {
-    const srv = await stubServer(() => null);
+    const srv = await stubServer(null);
     try {
       expect(
         await connectError(`redis://127.0.0.1:${srv.port}`, {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -401,12 +401,15 @@ describe("Valkey: connect() error identity", () => {
   test("connectionTimeout expiry rejects connect() with ERR_REDIS_CONNECTION_TIMEOUT", async () => {
     const srv = await stubServer(() => null);
     try {
-      const err = await connectError(`redis://127.0.0.1:${srv.port}`, {
-        autoReconnect: false,
-        connectionTimeout: 200,
+      expect(
+        await connectError(`redis://127.0.0.1:${srv.port}`, {
+          autoReconnect: false,
+          connectionTimeout: 200,
+        }),
+      ).toEqual({
+        code: "ERR_REDIS_CONNECTION_TIMEOUT",
+        message: "Connection timeout reached after 200ms",
       });
-      expect(err.code).toBe("ERR_REDIS_CONNECTION_TIMEOUT");
-      expect(err.message).toContain("Connection timeout reached after");
     } finally {
       srv.close();
     }

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -337,6 +337,99 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
   });
 });
 
+describe("Valkey: connect() error identity", () => {
+  // https://github.com/oven-sh/bun/issues/3064
+  // Previously all connect-time failures surfaced as ERR_REDIS_CONNECTION_CLOSED / "Connection closed".
+  const CRLF = "\r\n";
+
+  async function stubServer(reply: (text: string) => string | null) {
+    const server = net.createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", d => {
+        const r = reply(d.toString().toUpperCase());
+        if (r !== null) sock.write(r);
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    return { port, close: () => server.close() };
+  }
+
+  async function connectError(url: string, options: any) {
+    const client = new RedisClient(url, options);
+    try {
+      await client.connect();
+      return { code: undefined, message: "<connected>" };
+    } catch (e: any) {
+      return { code: e?.code, message: e?.message };
+    } finally {
+      try {
+        client.close();
+      } catch {}
+    }
+  }
+
+  test("-WRONGPASS reply to HELLO rejects connect() with the server's error text", async () => {
+    const srv = await stubServer(t =>
+      t.includes("HELLO") ? `-WRONGPASS invalid username-password pair or user is disabled.${CRLF}` : `+OK${CRLF}`,
+    );
+    try {
+      expect(await connectError(`redis://:bad@127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "WRONGPASS invalid username-password pair or user is disabled.",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("-NOAUTH reply to HELLO rejects connect() with the server's error text", async () => {
+    const srv = await stubServer(t =>
+      t.includes("HELLO")
+        ? `-NOAUTH HELLO must be called with the client already authenticated${CRLF}`
+        : `-NOAUTH Authentication required.${CRLF}`,
+    );
+    try {
+      expect(await connectError(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "NOAUTH HELLO must be called with the client already authenticated",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("connectionTimeout expiry rejects connect() with ERR_REDIS_CONNECTION_TIMEOUT", async () => {
+    const srv = await stubServer(() => null);
+    try {
+      const err = await connectError(`redis://127.0.0.1:${srv.port}`, {
+        autoReconnect: false,
+        connectionTimeout: 200,
+      });
+      expect(err.code).toBe("ERR_REDIS_CONNECTION_TIMEOUT");
+      expect(err.message).toContain("Connection timeout reached after");
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("TCP connect error rejects connect() with a distinguishable message", async () => {
+    const listener = net.createServer();
+    await new Promise<void>(resolve => listener.listen(0, "127.0.0.1", resolve));
+    const { port } = listener.address() as net.AddressInfo;
+    await new Promise<void>(resolve => listener.close(() => resolve()));
+
+    const err = await connectError(`redis://127.0.0.1:${port}`, {
+      autoReconnect: false,
+      connectionTimeout: 2000,
+    });
+    expect(err).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: "Failed to connect",
+    });
+  });
+});
+
 describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
   function readCommands(state: { buffer: Buffer }): string[][] {
     const commands: string[][] = [];

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -338,7 +338,6 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
 });
 
 describe("Valkey: connect() error identity", () => {
-  // https://github.com/oven-sh/bun/issues/3064
   // Previously all connect-time failures surfaced as ERR_REDIS_CONNECTION_CLOSED / "Connection closed".
   const CRLF = "\r\n";
 


### PR DESCRIPTION
## Problem

Four distinct connect-time failures all surfaced as the same `ERR_REDIS_CONNECTION_CLOSED` / `"Connection closed"` when awaited via `client.connect()`:

```
wrong password (-WRONGPASS)                -> ERR_REDIS_CONNECTION_CLOSED | Connection closed
no auth to auth server (-NOAUTH)           -> ERR_REDIS_CONNECTION_CLOSED | Connection closed
connectionTimeout 400ms (silent server)    -> ERR_REDIS_CONNECTION_CLOSED | Connection closed
ECONNREFUSED (nothing listening)           -> ERR_REDIS_CONNECTION_CLOSED | Connection closed
```

A misconfigured password read exactly like a network blip, which leads to retry storms against a permanent auth failure and makes it impossible to tell "wrong password" from "server down" from "timeout".

## Cause

`handle_hello_response()` and `on_connection_timeout()` already call `fail()` with the right message and `RedisError` (queued commands were rejected with the correct error). But `fail()` only rejects in-flight and queued commands; the `connect()` promise is held in `connection_promise` and is rejected later by `on_valkey_close()`, which always built a fresh generic `"Connection closed"` error regardless of what caused the close.

## Fix

Store the first failure passed to `fail()` in a new `close_reason` field on `ValkeyClient`, and have `on_valkey_close()` use it (falling back to the generic error when none was recorded). `on_connect_error()` now records `"Failed to connect"` to distinguish a TCP-level connect failure. The field is reset alongside `flags.failed` in `do_connect()` and `on_open()`.

After:

```
wrong password (-WRONGPASS)                -> ERR_REDIS_AUTHENTICATION_FAILED | WRONGPASS invalid username-password pair or user is disabled.
no auth to auth server (-NOAUTH)           -> ERR_REDIS_AUTHENTICATION_FAILED | NOAUTH HELLO must be called with the client already authenticated
connectionTimeout 400ms (silent server)    -> ERR_REDIS_CONNECTION_TIMEOUT | Connection timeout reached after 400ms
ECONNREFUSED (nothing listening)           -> ERR_REDIS_CONNECTION_CLOSED | Failed to connect
```

The `onclose` callback now also receives the specific error instead of the generic one.

## Verification

New tests in `test/js/valkey/reliability/connection-failures.test.ts` use local `net.createServer` stubs for each case (no Docker needed). All four fail on the released binary and pass with this change.

Related: #23467 (this change will surface the real reason that connection fails instead of the generic `ERR_REDIS_CONNECTION_CLOSED`).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 13 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/reliability/connection-failures.test.ts
bun test v1.4.0 (fb01fcce5)

test/js/valkey/reliability/connection-failures.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey: Connection Failures > Connection Failure Handling > should handle initial connection failure gracefully
(skip) Valkey: Connection Failures > Connection Failure Handling > should reject commands with appropriate errors when disconnected
(skip) Valkey: Connection Failures > Connection Failure Handling > should handle connection timeout
(skip) Valkey: Connection Failures > Connection Failure Handling > should report correct connected status
(skip) Valkey: Connection Failures > Reconnection Behavior > should reject commands when offline queue is enabled
(skip) Valkey: Connection Failures > Reconnection Behavior > should reject commands when offline queue is dis
... (truncated)

release without fix: 4 failed, 13 skipped
bun test v1.4.0-canary.1 (643a531e0)

test/js/valkey/reliability/connection-failures.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey: Connection Failures > Connection Failure Handling > should handle initial connection failure gracefully
(skip) Valkey: Connection Failures > Connection Failure Handling > should reject commands with appropriate errors when disconnected
(skip) Valkey: Connection Failures > Connection Failure Handling > should handle connection timeout
(skip) Valkey: Connection Failures > Connection Failure Handling > should report correct connected status
(skip) Valkey: Connection Failures > Reconnection Behavior > should reject commands when offline queue is enabled
(skip) Valkey: Connection Failures > Reconnection Behavior > should reject commands when offline queue is disabled
(skip) Valkey: Connection Failures > Reconnection Behavior > should stop reconnection attempts after max retries
(skip) Valkey: Connection Failures > Connection Event Callba
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 13 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/reliability/connection-failures.test.ts
bun test v1.4.0 (fb01fcce5)

test/js/valkey/reliability/connection-failures.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey: Connection Failures > Connection Failure Handling > should handle initial connection failure gracefully
(skip) Valkey: Connection Failures > Connection Failure Handling > should reject commands with appropriate errors when disconnected
(skip) Valkey: Connection Failures > Connection Failure Handling > should handle connection timeout
(skip) Valkey: Connection Failures > Connection Failure Handling > should report correct connected status
(skip) Valkey: Connection Failures > Reconnection Behavior > should reject commands when offline queue is enabled
(skip) Valkey: Connection Failures > Reconnection Behavior > should reject commands when offline queue is dis
... (truncated)

release with fix: 13 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fb01fcce55
  features     baseline

22 deps, 108 codegen, 1171 objects in 903ms

ninja: Entering directory `/workspace/bun/build/release'
[1/214] gen ErrorCode+*.h
[2/214] fetch lsquic
[lsquic] up to date
[3/214] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[4/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_arr.c.o
[5/214] cc obj/vendor/lsquic/src/liblsquic/ls-sfparser.c.o
[6/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_di_error.c.o
[7/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_crand.c.o
[8/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_cfcw.c.o
[9/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_enc_sess_common.c.o
[10/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_alarmset.c.o
[11/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_attq.c.o
[12/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_adaptive_cc.c.o
[13/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_eng_hist.c.o
[14/214] cc obj/vendor/lsquic/src/liblsquic/lsquic_frab_list.c.o
[15/214] cc obj/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey.rs                | 27 ++++--
 src/runtime/valkey_jsc/valkey.rs                   | 10 +++
 .../valkey/reliability/connection-failures.test.ts | 95 ++++++++++++++++++++++
 3 files changed, 126 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/runtime/valkey_jsc/js_valkey.rs                         7      6      0
src/runtime/valkey_jsc/valkey.rs                            5      3      0
test/js/valkey/reliability/connection-failures.test.ts      1      7      0
```

</details>

<!-- robobun:evidence:end -->