### PR TITLE
node:test: honor only markers under --only and accept --test-only as an alias

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -2608,18 +2608,24 @@ function addTest(
   // Node merges .todo()/.skip() into the options and checks skip first, so
   // test.todo(name, { skip: true }, fn) is a skip.
   const effectiveMode = mode === "skip" || options.skip ? "skip" : mode === "todo" || options.todo ? "todo" : undefined;
+  // Node's `only` (the option and test.only()/describe.only() spellings) is a
+  // no-op unless --test-only is passed; under the flag it is independent of
+  // skip/todo (an only-marked skip/todo is still included in the filter) and
+  // maps to bun:test's chained .only, whose filter matches Node's.
+  const isOnly = (mode === "only" || options.only) && testOnlyEnabled();
 
   if (effectiveMode === "todo" || effectiveMode === "skip") {
     // Under a run() child, register skip as an ordinary test so its directive
     // event fires in execution order (not at collection time).
     if (runChildReporterEnabled && effectiveMode === "skip") {
+      const register = isOnly ? test.only : test;
       const runner = function (done: (err?: unknown) => void) {
         reportDirectiveOnlyNode(node, "skip");
         markCurrentResult(false, done);
         done(undefined);
       };
-      if (passOptions !== undefined) test(name, runner, passOptions);
-      else test(name, runner);
+      if (passOptions !== undefined) register(name, runner, passOptions);
+      else register(name, runner);
       return Promise.resolve(undefined);
     }
     // Node runs a todo body, so `t.skip()` inside one still changes the
@@ -2630,12 +2636,14 @@ function addTest(
       // The test.todo() spelling carries the directive in `mode`, not in the
       // options, so the node has to be marked for the runner to report it.
       node.todoFlag = true;
+      const register = isOnly ? test.only : test;
       const runner = createTopLevelTestRunner(node, fn);
-      if (passOptions !== undefined) test(name, runner, passOptions);
-      else test(name, runner);
+      if (passOptions !== undefined) register(name, runner, passOptions);
+      else register(name, runner);
       return Promise.resolve(undefined);
     }
-    const register = effectiveMode === "todo" ? test.todo : test.skip;
+    const base = effectiveMode === "todo" ? test.todo : test.skip;
+    const register = isOnly ? base.only : base;
     // Node runs todo bodies; bun:test only does so under --todo.
     const body = effectiveMode === "todo" ? createTopLevelTestRunner(node, fn, true) : kDefaultFunction;
     if (passOptions !== undefined) {
@@ -2646,10 +2654,7 @@ function addTest(
     return Promise.resolve(undefined);
   }
 
-  // Node's `only` (the option and test.only()/describe.only() spellings) is a
-  // no-op unless --test-only is passed; under the flag it maps to bun:test's
-  // test.only() whose filter matches Node's.
-  const register = (mode === "only" || options.only) && testOnlyEnabled() ? test.only : test;
+  const register = isOnly ? test.only : test;
   const runner = createTopLevelTestRunner(node, fn);
   if (passOptions !== undefined) {
     register(name, runner, passOptions);
@@ -2727,6 +2732,7 @@ function addSuite(
   // Node merges .todo()/.skip() into the options and checks skip first, so
   // describe.todo(name, { skip: true }, fn) is a skip.
   const effectiveMode = mode === "skip" || options.skip ? "skip" : mode === "todo" || options.todo ? "todo" : undefined;
+  const isOnly = (mode === "only" || options.only) && testOnlyEnabled();
 
   // Node never invokes a skipped suite's callback (it does run a todo one), so
   // the children are never declared and side effects in the body never happen.
@@ -2744,9 +2750,8 @@ function addSuite(
   else if (effectiveMode === "todo") {
     suiteNode.todoFlag = true;
     register = runChildReporterEnabled ? describe : describe.todo;
-  } else if ((mode === "only" || options.only) && testOnlyEnabled()) {
-    register = describe.only;
   }
+  if (isOnly) register = register.only;
   if (effectiveMode !== undefined) reportDirectiveOnlyNode(suiteNode, effectiveMode);
 
   if (passOptions !== undefined) {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1628,6 +1628,15 @@ const fileGeneration = $newRustFunction("jest.rs", "jsFileGeneration", 0);
 // `done` binds the intended sequence so a late call after the bun:test watchdog
 // moved on cannot write onto the currently-running test.
 const markCurrentResult = $newRustFunction("jest.rs", "jsNodeTestMarkResult", 2);
+// Whether `bun test` was started with `--only` (Node's `--test-only`). Node
+// only applies the `only` filter when that flag is set; without it the marker
+// is a no-op (every test runs). Read lazily once: the CLI flag is fixed for
+// the process, but this module may be loaded before the runner is in place.
+const readTestOnly = $newRustFunction("jest.rs", "jsNodeTestOnly", 0);
+let testOnlyFlag: boolean | undefined;
+function testOnlyEnabled(): boolean {
+  return (testOnlyFlag ??= readTestOnly());
+}
 
 let rootNode: TestNode | undefined;
 let rootGeneration = -1;
@@ -2559,7 +2568,7 @@ function addTest(
   arg1: unknown,
   arg2: unknown,
   executionParent: TestNode | undefined,
-  mode?: "skip" | "todo",
+  mode?: "skip" | "todo" | "only",
 ): Promise<undefined> {
   const { name, options, fn } = parseTestArgs(arg0, arg1, arg2);
   const { ownTags } = validateTestOptions(options);
@@ -2637,14 +2646,15 @@ function addTest(
     return Promise.resolve(undefined);
   }
 
-  // Node's `only` (the option and the test.only()/describe.only() spellings)
-  // is a no-op unless --test-only is passed, so it registers an ordinary
-  // test/suite; bun:test's only() would skip siblings and is rejected in CI.
+  // Node's `only` (the option and test.only()/describe.only() spellings) is a
+  // no-op unless --test-only is passed; under the flag it maps to bun:test's
+  // test.only() whose filter matches Node's.
+  const register = (mode === "only" || options.only) && testOnlyEnabled() ? test.only : test;
   const runner = createTopLevelTestRunner(node, fn);
   if (passOptions !== undefined) {
-    test(name, runner, passOptions);
+    register(name, runner, passOptions);
   } else {
-    test(name, runner);
+    register(name, runner);
   }
 
   // Resolved eagerly rather than when the runner settles: bun:test never invokes
@@ -2659,7 +2669,7 @@ function addSuite(
   arg1: unknown,
   arg2: unknown,
   executionParent?: TestNode,
-  mode?: "skip" | "todo",
+  mode?: "skip" | "todo" | "only",
 ): Promise<undefined> {
   const { name, options, fn } = parseTestArgs(arg0, arg1, arg2);
   const { ownTags } = validateTestOptions(options);
@@ -2734,6 +2744,8 @@ function addSuite(
   else if (effectiveMode === "todo") {
     suiteNode.todoFlag = true;
     register = runChildReporterEnabled ? describe : describe.todo;
+  } else if ((mode === "only" || options.only) && testOnlyEnabled()) {
+    register = describe.only;
   }
   if (effectiveMode !== undefined) reportDirectiveOnlyNode(suiteNode, effectiveMode);
 
@@ -2762,7 +2774,7 @@ test.todo = function (arg0: unknown, arg1: unknown, arg2: unknown) {
 };
 
 test.only = function (arg0: unknown, arg1: unknown, arg2: unknown) {
-  return addTest(arg0, arg1, arg2, undefined);
+  return addTest(arg0, arg1, arg2, undefined, "only");
 };
 
 function describe(arg0: unknown, arg1: unknown, arg2: unknown) {
@@ -2778,7 +2790,7 @@ describe.todo = function (arg0: unknown, arg1: unknown, arg2: unknown) {
 };
 
 describe.only = function (arg0: unknown, arg1: unknown, arg2: unknown) {
-  return addSuite(arg0, arg1, arg2, undefined);
+  return addSuite(arg0, arg1, arg2, undefined, "only");
 };
 
 function hookOwner(): TestNode {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1628,10 +1628,7 @@ const fileGeneration = $newRustFunction("jest.rs", "jsFileGeneration", 0);
 // `done` binds the intended sequence so a late call after the bun:test watchdog
 // moved on cannot write onto the currently-running test.
 const markCurrentResult = $newRustFunction("jest.rs", "jsNodeTestMarkResult", 2);
-// Whether `bun test` was started with `--only` (Node's `--test-only`). Node
-// only applies the `only` filter when that flag is set; without it the marker
-// is a no-op (every test runs). Read lazily once: the CLI flag is fixed for
-// the process, but this module may be loaded before the runner is in place.
+// Lazily cached: this module can be loaded before the TestRunner exists.
 const readTestOnly = $newRustFunction("jest.rs", "jsNodeTestOnly", 0);
 let testOnlyFlag: boolean | undefined;
 function testOnlyEnabled(): boolean {
@@ -2608,10 +2605,8 @@ function addTest(
   // Node merges .todo()/.skip() into the options and checks skip first, so
   // test.todo(name, { skip: true }, fn) is a skip.
   const effectiveMode = mode === "skip" || options.skip ? "skip" : mode === "todo" || options.todo ? "todo" : undefined;
-  // Node's `only` (the option and test.only()/describe.only() spellings) is a
-  // no-op unless --test-only is passed; under the flag it is independent of
-  // skip/todo (an only-marked skip/todo is still included in the filter) and
-  // maps to bun:test's chained .only, whose filter matches Node's.
+  // Under --test-only, `only` is independent of skip/todo: an only-marked
+  // skip/todo stays in the filter, so bun:test's chained .only carries both.
   const isOnly = (mode === "only" || options.only) && testOnlyEnabled();
 
   if (effectiveMode === "todo" || effectiveMode === "skip") {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -555,7 +555,7 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
         "--todo                           Include tests that are marked with \"test.todo()\""
     ),
     parse_param!(
-        "--only                           Run only tests that are marked with \"test.only()\" or \"describe.only()\""
+        "--only/--test-only               Run only tests that are marked with \"test.only()\" or \"describe.only()\""
     ),
     parse_param!("--pass-with-no-tests             Exit with code 0 when no tests are found"),
     parse_param!("--concurrent                     Treat all tests as `test.concurrent()` tests"),

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -528,6 +528,17 @@ pub(crate) fn js_file_generation(
     Ok(JSValue::from(generation))
 }
 
+/// Reached only from `node:test`: whether `bun test` was started with `--only`
+/// (Node's `--test-only`). Node filters on `only` only when that flag is set.
+pub(crate) fn js_node_test_only(
+    _global: &JSGlobalObject,
+    _callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    // SAFETY: same invariant as `runner()` — RUNNER is only read on the JS thread.
+    let only = Jest::runner_ptr().is_some_and(|p| unsafe { (*p.as_ptr()).test_options.only });
+    Ok(JSValue::from(only))
+}
+
 /// Reached only from `node:test` (`t.skip()` / `t.todo()` at runtime): overrides
 /// the running sequence's result so bun:test reports skip/todo instead of pass.
 /// `done`'s bound `DoneCallback.r#ref.phase` names the intended sequence so a

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -528,8 +528,7 @@ pub(crate) fn js_file_generation(
     Ok(JSValue::from(generation))
 }
 
-/// Reached only from `node:test`: whether `bun test` was started with `--only`
-/// (Node's `--test-only`). Node filters on `only` only when that flag is set.
+/// Reached only from `node:test`: whether `bun test` was started with `--only`.
 pub(crate) fn js_node_test_only(
     _global: &JSGlobalObject,
     _callframe: &CallFrame,

--- a/test/js/node/test_runner/fixtures/30-only-filter.js
+++ b/test/js/node/test_runner/fixtures/30-only-filter.js
@@ -1,0 +1,21 @@
+// Under `--only` / `--test-only` (Node's --test-only), exactly the four
+// only-marked tests run; without the flag, `only` is a no-op and all eight run.
+const { test, describe } = require("node:test");
+
+test.only("top-level only modifier", () => console.log("RAN top-only-modifier"));
+test("top-level only option", { only: true }, () => console.log("RAN top-only-option"));
+test("top-level plain", () => console.log("RAN top-plain"));
+
+describe.only("only-modifier suite", () => {
+  test("child of only-modifier suite", () => console.log("RAN suite-modifier-child"));
+});
+describe("only-option suite", { only: true }, () => {
+  test("child of only-option suite", () => console.log("RAN suite-option-child"));
+});
+describe("plain suite", () => {
+  test.only("only test inside plain suite", () => console.log("RAN plain-suite-only-child"));
+  test("plain test inside plain suite", () => console.log("RAN plain-suite-plain-child"));
+});
+describe("unmarked suite", () => {
+  test("unmarked child", () => console.log("RAN unmarked-child"));
+});

--- a/test/js/node/test_runner/fixtures/30-only-filter.js
+++ b/test/js/node/test_runner/fixtures/30-only-filter.js
@@ -1,4 +1,4 @@
-// Under `--only` / `--test-only` (Node's --test-only), exactly the four
+// Under `--only` / `--test-only` (Node's --test-only), exactly the five
 // only-marked tests run; without the flag, `only` is a no-op and all eight run.
 const { test, describe } = require("node:test");
 

--- a/test/js/node/test_runner/fixtures/30-only-filter.js
+++ b/test/js/node/test_runner/fixtures/30-only-filter.js
@@ -1,5 +1,6 @@
-// Under `--only` / `--test-only` (Node's --test-only), exactly the five
-// only-marked tests run; without the flag, `only` is a no-op and all eight run.
+// Under `--only` / `--test-only` (Node's --test-only) the seven only-marked
+// entries are selected (five run, one todo, one skip); without the flag `only`
+// is a no-op and all ten entries are selected.
 const { test, describe } = require("node:test");
 
 test.only("top-level only modifier", () => console.log("RAN top-only-modifier"));
@@ -19,3 +20,7 @@ describe("plain suite", () => {
 describe("unmarked suite", () => {
   test("unmarked child", () => console.log("RAN unmarked-child"));
 });
+// `only` is independent of skip/todo: under --test-only these are included in
+// the filter and reported as their directive, not filtered out.
+test.only("only+todo", { todo: true }, () => console.log("RAN only-todo"));
+test.only("only+skip", { skip: true }, () => console.log("RAN only-skip"));

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -169,8 +169,7 @@ describe("node:test", () => {
         const { exitCode, stdout, stderr } = await runTests(["30-only-filter.js"], { CI: "false" }, [flag]);
         // The five only-marked tests (test.only, {only:true}, describe.only,
         // describe {only:true}, and a test.only nested in a plain describe) run,
-        // and nothing else does. Previously `--test-only` was an unknown flag
-        // (ran 8) and `--only` ran zero tests with exit 0.
+        // and nothing else does.
         expect(stdout.match(/^RAN .*/gm)?.sort()).toEqual([
           "RAN plain-suite-only-child",
           "RAN suite-modifier-child",
@@ -194,7 +193,16 @@ describe("node:test", () => {
       // Without the flag, `only` is a no-op like in Node — every marker form in
       // the fixture runs alongside its unmarked siblings.
       const { exitCode, stdout, stderr } = await runTests(["30-only-filter.js"], { CI: "false" });
-      expect(stdout.match(/^RAN .*/gm)).toHaveLength(8);
+      expect(stdout.match(/^RAN .*/gm)?.sort()).toEqual([
+        "RAN plain-suite-only-child",
+        "RAN plain-suite-plain-child",
+        "RAN suite-modifier-child",
+        "RAN suite-option-child",
+        "RAN top-only-modifier",
+        "RAN top-only-option",
+        "RAN top-plain",
+        "RAN unmarked-child",
+      ]);
       expect(stderr).toContain("8 pass");
       expect({ exitCode, stderr }).toMatchObject({
         exitCode: 0,

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -160,6 +160,50 @@ describe("node:test", () => {
     });
   });
 
+  for (const flag of ["--only", "--test-only"]) {
+    test.concurrent(
+      `should run exactly the only-marked node:test tests under ${flag}`,
+      async () => {
+        // CI=false: the shim maps Node's `only` onto bun:test's test.only, which
+        // bun:test guards against in CI independently of node:test.
+        const { exitCode, stdout, stderr } = await runTests(["30-only-filter.js"], { CI: "false" }, [flag]);
+        // The five only-marked tests (test.only, {only:true}, describe.only,
+        // describe {only:true}, and a test.only nested in a plain describe) run,
+        // and nothing else does. Previously `--test-only` was an unknown flag
+        // (ran 8) and `--only` ran zero tests with exit 0.
+        expect(stdout.match(/^RAN .*/gm)?.sort()).toEqual([
+          "RAN plain-suite-only-child",
+          "RAN suite-modifier-child",
+          "RAN suite-option-child",
+          "RAN top-only-modifier",
+          "RAN top-only-option",
+        ]);
+        expect(stderr).toContain("5 pass");
+        expect({ exitCode, stderr }).toMatchObject({
+          exitCode: 0,
+          stderr: expect.stringContaining("0 fail"),
+        });
+      },
+      30_000,
+    );
+  }
+
+  test.concurrent(
+    "should run every node:test test when no --only/--test-only flag is passed",
+    async () => {
+      // Without the flag, `only` is a no-op like in Node — every marker form in
+      // the fixture runs alongside its unmarked siblings.
+      const { exitCode, stdout, stderr } = await runTests(["30-only-filter.js"], { CI: "false" });
+      expect(stdout.match(/^RAN .*/gm)).toHaveLength(8);
+      expect(stderr).toContain("8 pass");
+      expect({ exitCode, stderr }).toMatchObject({
+        exitCode: 0,
+        stderr: expect.stringContaining("0 fail"),
+      });
+    },
+    30_000,
+  );
+
   test("should serialize inline suites and await async describe callbacks like node", async () => {
     const { exitCode, stderr } = await runTests(["09-inline-suites.js"]);
     expect(stderr).toContain("3 pass");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -177,7 +177,11 @@ describe("node:test", () => {
           "RAN top-only-modifier",
           "RAN top-only-option",
         ]);
+        // only+skip and only+todo are included in the filter (reported as their
+        // directive), not dropped: Node under --test-only reports 5/1/1 here.
         expect(stderr).toContain("5 pass");
+        expect(stderr).toContain("1 skip");
+        expect(stderr).toContain("1 todo");
         expect({ exitCode, stderr }).toMatchObject({
           exitCode: 0,
           stderr: expect.stringContaining("0 fail"),
@@ -204,6 +208,8 @@ describe("node:test", () => {
         "RAN unmarked-child",
       ]);
       expect(stderr).toContain("8 pass");
+      expect(stderr).toContain("1 skip");
+      expect(stderr).toContain("1 todo");
       expect({ exitCode, stderr }).toMatchObject({
         exitCode: 0,
         stderr: expect.stringContaining("0 fail"),


### PR DESCRIPTION
### What does this PR do?

There was no way to run a focused subset of `node:test` tests under `bun test`.

```js
// only.test.mjs
import { test, describe } from 'node:test';
test.only('focused', () => {});
test('unfocused', () => {});
describe('d', { only: true }, () => { test('in-only-suite', () => {}); });
describe('e', () => { test('plain-in-suite', () => {}); });
```

| Command | node v26.3.0 | bun (before) | bun (after) |
| --- | --- | --- | --- |
| no flag | 4 tests | 4 tests | 4 tests |
| `--test-only` | 2 tests | 4 tests (unknown flag, dropped) | 2 tests |
| `--only` | n/a | **Ran 0 tests, exit 0** | 2 tests |

Cause: the `node:test` shim intentionally registered `test.only`/`describe.only`/`{only:true}` as ordinary tests, because bun:test's `test.only()` filters siblings unconditionally while Node's is a no-op unless `--test-only` is passed. So `--only` had nothing to select, and `--test-only` was not a known flag.

Fix:

- `src/runtime/cli/Arguments.rs`: accept `--test-only` as an alias of `--only`.
- `src/runtime/test_runner/jest.rs`: add `js_node_test_only`, a private binding that reports whether the runner was started with `--only`.
- `src/js/node/test.ts`: when that flag is set, route Node's `only` markers (the `.only()` modifiers and the `{only:true}` option, for `test` and `describe`) through bun:test's `test.only`/`describe.only`, whose propagation filter matches Node's `--test-only` semantics. Without the flag the markers stay a no-op and every test runs, matching `node --test`.

Supersedes #33087, which targeted the pre-#32631/#34444 shim and did not add the `--test-only` alias.

### How did you verify your code works?

New fixture `test/js/node/test_runner/fixtures/30-only-filter.js` covers `test.only`, `test({only:true})`, `describe.only`, `describe({only:true})`, and a `test.only` nested inside a plain `describe`, alongside unmarked siblings. `node --test --test-only` runs 5 of the 8; `node --test` runs all 8.

New cases in `test/js/node/test_runner/node-test.test.ts`:

```
bun bd test test/js/node/test_runner/node-test.test.ts -t "only-marked|no --only"
```

Without the `src/` change (`git stash push -- src/ && bun bd test ...`): the `--only` case receives `undefined` (zero tests ran) and the `--test-only` case receives all 8 lines. With the change: both run exactly the 5 focused tests and the no-flag case still runs all 8.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (b713596ce)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [3109.57ms]
(pass) node:test > should run hooks in the right order [3287.15ms]
(pass) node:test > should run tests with different variations [2562.14ms]
(pass) node:test > should run async tests [2681.23ms]
(pass) node:test > should run all tests from multiple files [4092.51ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [2657.73ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [2612.19ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [2816.32ms]
(pass) node:test > should support done callbacks in tests and hooks [2737.51ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [2993.01ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (12261c969)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run basic tests [49.68ms]
(pass) node:test > should run hooks in the right order [68.43ms]
(pass) node:test > should run tests with different variations [48.79ms]
(pass) node:test > should run async tests [49.23ms]
(pass) node:test > should run all tests from multiple files [73.02ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [51.31ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [52.01ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [55.33ms]
(pass) node:test > should support done callbacks in tests and hooks [49.07ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [50.38ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurrent too [52.63ms]
(pass) node:test > should run todo bodies under --todo instead of registering an empty function [45.88ms]
(pass) node:test > should forward Infinity and finite timeouts s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/test_runner/node-test.test.ts
bun test v1.4.0 (b713596ce)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run hooks in the right order [3748.17ms]
(pass) node:test > should run basic tests [3781.08ms]
(pass) node:test > should run tests with different variations [3018.88ms]
(pass) node:test > should run async tests [3013.95ms]
(pass) node:test > should run all tests from multiple files [4474.09ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [3230.12ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [3010.73ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [3020.53ms]
(pass) node:test > should support done callbacks in tests and hooks [4079.63ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [4239.11ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurre
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b713596cea
  features     baseline

22 deps, 108 codegen, 1171 objects in 824ms

ninja: Entering directory `/workspace/bun/build/release'
[1/213] gen ErrorCode+*.h
[2/213] fetch lsquic
[lsquic] up to date
[3/213] cc obj/vendor/lsquic/src/liblsquic/ls-sfparser.c.o
[4/213] cc obj/vendor/lsquic/src/liblsquic/lsquic_arr.c.o
[5/213] cc obj/vendor/lsquic/src/liblsquic/lsquic_attq.c.o
[6/213] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[7/213] cc obj/vendor/lsquic/src/liblsquic/lsquic_adaptive_cc.c.o
[8/213] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 240 extern-C blocks audited
[9/213] cc obj/vendor/lsquic/src/liblsquic/lsquic_alarmset.c.o
[10/213] cc obj/vendor/lsquic/src/liblsquic/lsquic_bw_sampler.c.o
[11/213] gen cpp.rs (cppbind)
[12/213] cc obj/vendor/lsquic/src/liblsquic/lsquic_cfcw.c.o
[13/213] cc obj/vendor/lsquic/src/liblsquic/ls
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/test.ts                                | 45 +++++++++++------
 src/runtime/cli/Arguments.rs                       |  2 +-
 src/runtime/test_runner/jest.rs                    | 11 ++++
 .../js/node/test_runner/fixtures/30-only-filter.js | 26 ++++++++++
 test/js/node/test_runner/node-test.test.ts         | 58 ++++++++++++++++++++++
 5 files changed, 127 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/js/node/test.ts                                      6      6      0
src/runtime/cli/Arguments.rs                             2      1      0
src/runtime/test_runner/jest.rs                          2      1      0
test/js/node/test_runner/fixtures/30-only-filter.js      1      3      0
test/js/node/test_runner/node-test.test.ts               4      5      0
```

</details>

<!-- robobun:evidence:end -->