### PR TITLE
redis: reject (not throw) ERR_REDIS_INVALID_STATE from subscriber-mode guard

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -28,10 +28,6 @@ const fn bname(b: &'static [u8]) -> &'static str {
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Returns a rejected `Promise` (never throws) when the client is in
-/// subscriber mode. The prototype methods that call this are declared as
-/// promise-returning, so a state error must reject rather than throw so that
-/// `.catch()` / `await ... catch` observes it.
 fn require_not_subscriber(this: &JSValkeyClient, function_name: &[u8]) -> Option<JSValue> {
     if this.is_subscriber() {
         // `global_object: GlobalRef` derefs safely (BACKREF — VM-owned global outlives client).

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -28,38 +28,46 @@ const fn bname(b: &'static [u8]) -> &'static str {
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-fn require_not_subscriber(this: &JSValkeyClient, function_name: &[u8]) -> JsResult<()> {
+/// Returns a rejected `Promise` (never throws) when the client is in
+/// subscriber mode. The prototype methods that call this are declared as
+/// promise-returning, so a state error must reject rather than throw so that
+/// `.catch()` / `await ... catch` observes it.
+fn require_not_subscriber(this: &JSValkeyClient, function_name: &[u8]) -> Option<JSValue> {
     if this.is_subscriber() {
         // `global_object: GlobalRef` derefs safely (BACKREF — VM-owned global outlives client).
         let global: &JSGlobalObject = &this.global_object;
-        return Err(global
-            .err(
-                ErrorCode::REDIS_INVALID_STATE,
-                format_args!(
-                    "RedisClient.prototype.{} cannot be called while in subscriber mode.",
-                    bstr::BStr::new(function_name)
-                ),
-            )
-            .throw());
+        return Some(
+            global
+                .err(
+                    ErrorCode::REDIS_INVALID_STATE,
+                    format_args!(
+                        "RedisClient.prototype.{} cannot be called while in subscriber mode.",
+                        bstr::BStr::new(function_name)
+                    ),
+                )
+                .reject(),
+        );
     }
-    Ok(())
+    None
 }
 
-fn require_subscriber(this: &JSValkeyClient, function_name: &[u8]) -> JsResult<()> {
+fn require_subscriber(this: &JSValkeyClient, function_name: &[u8]) -> Option<JSValue> {
     if !this.is_subscriber() {
         // `global_object: GlobalRef` derefs safely (BACKREF — VM-owned global outlives client).
         let global: &JSGlobalObject = &this.global_object;
-        return Err(global
-            .err(
-                ErrorCode::REDIS_INVALID_STATE,
-                format_args!(
-                    "RedisClient.prototype.{} can only be called while in subscriber mode.",
-                    bstr::BStr::new(function_name)
-                ),
-            )
-            .throw());
+        return Some(
+            global
+                .err(
+                    ErrorCode::REDIS_INVALID_STATE,
+                    format_args!(
+                        "RedisClient.prototype.{} can only be called while in subscriber mode.",
+                        bstr::BStr::new(function_name)
+                    ),
+                )
+                .reject(),
+        );
     }
-    Ok(())
+    None
 }
 
 fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgument>> {
@@ -149,12 +157,12 @@ pub(crate) mod compile {
     pub(crate) fn test_correct_state<const REQ: ClientStateRequirement>(
         this: &JSValkeyClient,
         js_client_prototype_function_name: &[u8],
-    ) -> JsResult<()> {
+    ) -> Option<JSValue> {
         match REQ {
             ClientStateRequirement::NotSubscriber => {
                 require_not_subscriber(this, js_client_prototype_function_name)
             }
-            ClientStateRequirement::DontCare => Ok(()),
+            ClientStateRequirement::DontCare => None,
         }
     }
 }
@@ -176,9 +184,12 @@ macro_rules! cmd_noargs {
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
+            if let Some(rejected) = compile::test_correct_state::<
+                { compile::ClientStateRequirement::$state },
+            >(this, $name)
+            {
+                return Ok(rejected);
+            }
             send_cmd(
                 this,
                 global,
@@ -200,9 +211,12 @@ macro_rules! cmd_key {
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
+            if let Some(rejected) = compile::test_correct_state::<
+                { compile::ClientStateRequirement::$state },
+            >(this, $name)
+            {
+                return Ok(rejected);
+            }
 
             let Some(key) = from_js(global, frame.argument(0))? else {
                 return Err(global.throw_invalid_argument_type(
@@ -232,9 +246,12 @@ macro_rules! cmd_key_varargs {
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
+            if let Some(rejected) = compile::test_correct_state::<
+                { compile::ClientStateRequirement::$state },
+            >(this, $name)
+            {
+                return Ok(rejected);
+            }
 
             if frame.argument(0).is_undefined_or_null() {
                 return Err(global.throw_missing_arguments_value(&[$arg0_name]));
@@ -278,9 +295,12 @@ macro_rules! cmd_key_value {
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
+            if let Some(rejected) = compile::test_correct_state::<
+                { compile::ClientStateRequirement::$state },
+            >(this, $name)
+            {
+                return Ok(rejected);
+            }
 
             let Some(key) = from_js(global, frame.argument(0))? else {
                 return Err(global.throw_invalid_argument_type(
@@ -317,9 +337,12 @@ macro_rules! cmd_key_value_value2 {
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
+            if let Some(rejected) = compile::test_correct_state::<
+                { compile::ClientStateRequirement::$state },
+            >(this, $name)
+            {
+                return Ok(rejected);
+            }
 
             let Some(key) = from_js(global, frame.argument(0))? else {
                 return Err(global.throw_invalid_argument_type(
@@ -363,9 +386,12 @@ macro_rules! cmd_strings_varargs {
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
+            if let Some(rejected) = compile::test_correct_state::<
+                { compile::ClientStateRequirement::$state },
+            >(this, $name)
+            {
+                return Ok(rejected);
+            }
 
             let mut args: Vec<JSArgument> = Vec::with_capacity(frame.arguments().len());
 
@@ -400,9 +426,12 @@ macro_rules! cmd_key_value_varargs {
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
+            if let Some(rejected) = compile::test_correct_state::<
+                { compile::ClientStateRequirement::$state },
+            >(this, $name)
+            {
+                return Ok(rejected);
+            }
 
             let mut args: Vec<JSArgument> = Vec::with_capacity(frame.arguments().len());
 
@@ -481,7 +510,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn get(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"get")?;
+        if let Some(rejected) = require_not_subscriber(this, b"get") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("get", "key", "string or buffer"));
@@ -503,7 +534,9 @@ impl JSValkeyClient {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"getBuffer")?;
+        if let Some(rejected) = require_not_subscriber(this, b"getBuffer") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("getBuffer", "key", "string or buffer"));
@@ -521,7 +554,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn set(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"set")?;
+        if let Some(rejected) = require_not_subscriber(this, b"set") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
         let mut args: Vec<JSArgument> = Vec::with_capacity(args_view.len());
@@ -569,7 +604,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn incr(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"incr")?;
+        if let Some(rejected) = require_not_subscriber(this, b"incr") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("incr", "key", "string or buffer"));
@@ -587,7 +624,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn decr(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"decr")?;
+        if let Some(rejected) = require_not_subscriber(this, b"decr") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("decr", "key", "string or buffer"));
@@ -605,7 +644,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn exists(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"exists")?;
+        if let Some(rejected) = require_not_subscriber(this, b"exists") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("exists", "key", "string or buffer"));
@@ -624,7 +665,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn expire(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"expire")?;
+        if let Some(rejected) = require_not_subscriber(this, b"expire") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("expire", "key", "string or buffer"));
@@ -657,7 +700,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn ttl(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"ttl")?;
+        if let Some(rejected) = require_not_subscriber(this, b"ttl") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("ttl", "key", "string or buffer"));
@@ -676,7 +721,9 @@ impl JSValkeyClient {
     // Implement srem (remove value from a set)
     #[bun_jsc::host_fn(method)]
     pub fn srem(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"srem")?;
+        if let Some(rejected) = require_not_subscriber(this, b"srem") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
         if args_view.len() < 2 {
@@ -721,7 +768,9 @@ impl JSValkeyClient {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"srandmember")?;
+        if let Some(rejected) = require_not_subscriber(this, b"srandmember") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
         let mut args: Vec<JSArgument> = Vec::with_capacity(args_view.len());
@@ -760,7 +809,9 @@ impl JSValkeyClient {
     // Implement smembers (get all members of a set)
     #[bun_jsc::host_fn(method)]
     pub fn smembers(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"smembers")?;
+        if let Some(rejected) = require_not_subscriber(this, b"smembers") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("smembers", "key", "string or buffer"));
@@ -779,7 +830,9 @@ impl JSValkeyClient {
     // Implement spop (pop a random member from a set)
     #[bun_jsc::host_fn(method)]
     pub fn spop(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"spop")?;
+        if let Some(rejected) = require_not_subscriber(this, b"spop") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
         let mut args: Vec<JSArgument> = Vec::with_capacity(args_view.len());
@@ -814,7 +867,9 @@ impl JSValkeyClient {
     // Implement sadd (add member to a set)
     #[bun_jsc::host_fn(method)]
     pub fn sadd(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"sadd")?;
+        if let Some(rejected) = require_not_subscriber(this, b"sadd") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
         if args_view.len() < 2 {
@@ -855,7 +910,9 @@ impl JSValkeyClient {
     // Implement sismember (check if value is member of a set)
     #[bun_jsc::host_fn(method)]
     pub fn sismember(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"sismember")?;
+        if let Some(rejected) = require_not_subscriber(this, b"sismember") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("sismember", "key", "string or buffer"));
@@ -881,7 +938,9 @@ impl JSValkeyClient {
     // Implement hmget (get multiple values from hash)
     #[bun_jsc::host_fn(method)]
     pub fn hmget(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"hmget")?;
+        if let Some(rejected) = require_not_subscriber(this, b"hmget") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
         if args_view.len() < 2 {
@@ -943,7 +1002,9 @@ impl JSValkeyClient {
     // Implement hincrby (increment hash field by integer value)
     #[bun_jsc::host_fn(method)]
     pub fn hincrby(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"hincrby")?;
+        if let Some(rejected) = require_not_subscriber(this, b"hincrby") {
+            return Ok(rejected);
+        }
 
         let key = OwnedString::new(frame.argument(0).to_bun_string(global)?);
         let field = OwnedString::new(frame.argument(1).to_bun_string(global)?);
@@ -971,7 +1032,9 @@ impl JSValkeyClient {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"hincrbyfloat")?;
+        if let Some(rejected) = require_not_subscriber(this, b"hincrbyfloat") {
+            return Ok(rejected);
+        }
 
         let key = OwnedString::new(frame.argument(0).to_bun_string(global)?);
         let field = OwnedString::new(frame.argument(1).to_bun_string(global)?);
@@ -998,7 +1061,9 @@ impl JSValkeyClient {
         frame: &CallFrame,
         command: &'static [u8],
     ) -> JsResult<JSValue> {
-        require_not_subscriber(this, command)?;
+        if let Some(rejected) = require_not_subscriber(this, command) {
+            return Ok(rejected);
+        }
 
         let key = OwnedString::new(frame.argument(0).to_bun_string(global)?);
 
@@ -1141,7 +1206,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn hsetnx(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"hsetnx")?;
+        if let Some(rejected) = require_not_subscriber(this, b"hsetnx") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("hsetnx", "key", "string or buffer"));
@@ -1165,7 +1232,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn hexists(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"hexists")?;
+        if let Some(rejected) = require_not_subscriber(this, b"hexists") {
+            return Ok(rejected);
+        }
 
         let Some(key) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("hexists", "key", "string or buffer"));
@@ -1520,7 +1589,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn smove(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"smove")?;
+        if let Some(rejected) = require_not_subscriber(this, b"smove") {
+            return Ok(rejected);
+        }
 
         let Some(source) = from_js(global, frame.argument(0))? else {
             return Err(global.throw_invalid_argument_type("smove", "source", "string or buffer"));
@@ -1612,7 +1683,9 @@ impl JSValkeyClient {
 
     #[bun_jsc::host_fn(method)]
     pub fn publish(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"publish")?;
+        if let Some(rejected) = require_not_subscriber(this, b"publish") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
         let mut args: Vec<JSArgument> = Vec::with_capacity(args_view.len());
@@ -1758,7 +1831,9 @@ impl JSValkeyClient {
         let _guard = this.ref_scope();
 
         // Check if we're in subscription mode
-        require_subscriber(this, b"unsubscribe")?;
+        if let Some(rejected) = require_subscriber(this, b"unsubscribe") {
+            return Ok(rejected);
+        }
 
         let args_view = frame.arguments();
 

--- a/test/js/valkey/valkey-subscriber-guard.test.ts
+++ b/test/js/valkey/valkey-subscriber-guard.test.ts
@@ -1,0 +1,101 @@
+import { RedisClient } from "bun";
+import { describe, expect, test } from "bun:test";
+
+// Minimal RESP3 server stub: answers HELLO, SUBSCRIBE, GET, PING and +OK for
+// everything else. Enough to drive a client into subscriber mode without
+// Docker.
+const CRLF = "\r\n";
+const blk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
+const HELLO = `%3${CRLF}${blk("server")}${blk("redis")}${blk("proto")}:3${CRLF}${blk("version")}${blk("7.4.0")}`;
+
+function makeStubServer() {
+  return Bun.listen<{ buf: string }>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(s) {
+        s.data = { buf: "" };
+      },
+      data(s, raw) {
+        const t = raw.toString();
+        if (t.includes("HELLO")) s.write(HELLO);
+        else if (t.includes("\r\nSUBSCRIBE\r\n"))
+          s.write(`>3${CRLF}${blk("subscribe")}${blk("news")}:1${CRLF}`);
+        else if (t.includes("\r\nUNSUBSCRIBE\r\n"))
+          s.write(`>3${CRLF}${blk("unsubscribe")}${blk("news")}:0${CRLF}`);
+        else if (t.includes("\r\nGET\r\n")) s.write(`+from-server${CRLF}`);
+        else if (t.includes("\r\nPING\r\n")) s.write(`+PONG${CRLF}`);
+        else s.write(`+OK${CRLF}`);
+      },
+    },
+  });
+}
+
+describe("RedisClient subscriber-mode guard", () => {
+  test("command methods return a rejected promise (not a sync throw) in subscriber mode", async () => {
+    using srv = makeStubServer();
+    const c = new RedisClient(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false });
+    try {
+      await c.connect();
+      await c.subscribe("news", () => {});
+
+      // The method must return a Promise synchronously so that
+      // `.catch()` / `.then(_, onReject)` can observe the state error.
+      let syncThrow: unknown = null;
+      let returned: unknown;
+      try {
+        returned = c.get("k");
+      } catch (e) {
+        syncThrow = e;
+      }
+      expect(syncThrow).toBeNull();
+      expect(returned).toBeInstanceOf(Promise);
+
+      // Swallow the rejection from the captured promise (we re-assert via
+      // `expect().rejects` below) so it isn't reported as unhandled.
+      await (returned as Promise<unknown>).catch(() => {});
+
+      // The rejection carries the ERR_REDIS_INVALID_STATE error.
+      const getErr = await c.get("k").then(
+        v => ({ status: "fulfilled", value: v }),
+        e => ({ status: "rejected", code: e?.code, message: String(e?.message) }),
+      );
+      expect(getErr).toEqual({
+        status: "rejected",
+        code: "ERR_REDIS_INVALID_STATE",
+        message: expect.stringContaining("cannot be called while in subscriber mode"),
+      });
+
+      // Same contract for a macro-generated method and one of the other
+      // hand-written ones.
+      await expect(c.keys("*")).rejects.toThrow("cannot be called while in subscriber mode");
+      await expect(c.set("k", "v")).rejects.toThrow("cannot be called while in subscriber mode");
+    } finally {
+      c.close();
+    }
+  });
+
+  test("unsubscribe() on a non-subscriber returns a rejected promise", async () => {
+    using srv = makeStubServer();
+    const c = new RedisClient(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false });
+    try {
+      await c.connect();
+
+      let syncThrow: unknown = null;
+      let returned: unknown;
+      try {
+        returned = c.unsubscribe("news");
+      } catch (e) {
+        syncThrow = e;
+      }
+      expect(syncThrow).toBeNull();
+      expect(returned).toBeInstanceOf(Promise);
+      await expect(returned).rejects.toMatchObject({
+        code: "ERR_REDIS_INVALID_STATE",
+        message: expect.stringContaining("can only be called while in subscriber mode"),
+      });
+    } finally {
+      c.close();
+    }
+  });
+});

--- a/test/js/valkey/valkey-subscriber-guard.test.ts
+++ b/test/js/valkey/valkey-subscriber-guard.test.ts
@@ -19,10 +19,8 @@ function makeStubServer() {
       data(s, raw) {
         const t = raw.toString();
         if (t.includes("HELLO")) s.write(HELLO);
-        else if (t.includes("\r\nSUBSCRIBE\r\n"))
-          s.write(`>3${CRLF}${blk("subscribe")}${blk("news")}:1${CRLF}`);
-        else if (t.includes("\r\nUNSUBSCRIBE\r\n"))
-          s.write(`>3${CRLF}${blk("unsubscribe")}${blk("news")}:0${CRLF}`);
+        else if (t.includes("\r\nSUBSCRIBE\r\n")) s.write(`>3${CRLF}${blk("subscribe")}${blk("news")}:1${CRLF}`);
+        else if (t.includes("\r\nUNSUBSCRIBE\r\n")) s.write(`>3${CRLF}${blk("unsubscribe")}${blk("news")}:0${CRLF}`);
         else if (t.includes("\r\nGET\r\n")) s.write(`+from-server${CRLF}`);
         else if (t.includes("\r\nPING\r\n")) s.write(`+PONG${CRLF}`);
         else s.write(`+OK${CRLF}`);

--- a/test/js/valkey/valkey-subscriber-guard.test.ts
+++ b/test/js/valkey/valkey-subscriber-guard.test.ts
@@ -9,13 +9,10 @@ const blk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
 const HELLO = `%3${CRLF}${blk("server")}${blk("redis")}${blk("proto")}:3${CRLF}${blk("version")}${blk("7.4.0")}`;
 
 function makeStubServer() {
-  return Bun.listen<{ buf: string }>({
+  return Bun.listen({
     hostname: "127.0.0.1",
     port: 0,
     socket: {
-      open(s) {
-        s.data = { buf: "" };
-      },
       data(s, raw) {
         const t = raw.toString();
         if (t.includes("HELLO")) s.write(HELLO);

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -6291,7 +6291,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
 
         await subscriber.subscribe(testChannel(), () => {});
 
-        expect(() => subscriber.set(testKey(), testValue())).toThrow(
+        await expect(subscriber.set(testKey(), testValue())).rejects.toThrow(
           "RedisClient.prototype.set cannot be called while in subscriber mode",
         );
 

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -6535,7 +6535,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const subscriber = await ctx.newSubscriberClient(connectionType);
         await subscriber.subscribe(channel, () => {});
 
-        expect(async () => subscriber.publish(channel, "self-published")).toThrow(
+        await expect(subscriber.publish(channel, "self-published")).rejects.toThrow(
           "RedisClient.prototype.publish cannot be called while in subscriber mode.",
         );
       });
@@ -6547,7 +6547,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         const subscriber = await ctx.newSubscriberClient(connectionType);
         await subscriber.subscribe(channel, () => {});
 
-        expect(() => subscriber.set(testKey, testValue())).toThrow(
+        await expect(subscriber.set(testKey, testValue())).rejects.toThrow(
           "RedisClient.prototype.set cannot be called while in subscriber mode.",
         );
 
@@ -6569,7 +6569,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
       test("unsubscribing from non-subscribed channels", async () => {
         const channel = "never-subscribed-channel";
 
-        expect(() => ctx.redis.unsubscribe(channel)).toThrow(
+        await expect(ctx.redis.unsubscribe(channel)).rejects.toThrow(
           "RedisClient.prototype.unsubscribe can only be called while in subscriber mode.",
         );
       });
@@ -6831,7 +6831,7 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
 
         const duplicate = await subscriber.duplicate();
 
-        expect(() => duplicate.set("test-key", "test-value")).not.toThrow();
+        await expect(duplicate.set("test-key", "test-value")).resolves.toBe("OK");
 
         await subscriber.unsubscribe(testChannel);
       });


### PR DESCRIPTION
## Repro

```ts
const c = new Bun.RedisClient(url, { autoReconnect: false });
await c.connect();
await c.subscribe("news", () => {});

let syncThrow = false, p: any = null;
try { p = c.get("k"); } catch (e) { syncThrow = true; }
console.log("returned a Promise?", p instanceof Promise);  // false
console.log("threw synchronously?", syncThrow);            // true
```

```
RedisError: RedisClient.prototype.get cannot be called while in subscriber mode.
 code: "ERR_REDIS_INVALID_STATE"
returned a Promise? false
threw synchronously? true
```

`redis.get(k).catch(handle)` (or `.then(_, onReject)`) is the normal error path for a promise API; a synchronous throw bypasses it entirely and surfaces as an uncaught exception one frame up. The guard is also inconsistent: `send("GET", [...])` and `ping()` go through on the same subscribed connection (RESP3 permits regular commands while subscribed), so the typed-method block doesn't actually protect anything the server would refuse.

## Cause

`require_not_subscriber` / `require_subscriber` in `src/runtime/valkey_jsc/js_valkey_functions.rs` built an `ErrorBuilder` and called `.throw()`, returning `Err(JsError)` through the `?` in every command prototype:

```rust
fn require_not_subscriber(this: &JSValkeyClient, function_name: &[u8]) -> JsResult<()> {
    if this.is_subscriber() {
        return Err(global.err(ErrorCode::REDIS_INVALID_STATE, ...).throw());
    }
    Ok(())
}
// caller:
require_not_subscriber(this, b"get")?;
```

That propagates as a synchronous JS exception, not a rejected promise.

## Fix

Return a rejected `Promise` from the guard instead of throwing. `require_not_subscriber` / `require_subscriber` now return `Option<JSValue>` where `Some` is the already-rejected promise; callers early-return it as `Ok(rejected)`. The error code (`ERR_REDIS_INVALID_STATE`) and message are unchanged, so `try { await c.get(k) } catch (e) { ... }` continues to work and `.catch()` now works too.

The guard itself is kept (typed methods still reject in subscriber mode; `send()` remains the raw escape hatch). Dropping it is a separable behavioural decision.

## Verification

New hermetic test `test/js/valkey/valkey-subscriber-guard.test.ts` drives an in-process RESP3 stub (no Docker). It asserts that `get()` / `set()` / `keys()` return a `Promise` synchronously and that the promise rejects with `ERR_REDIS_INVALID_STATE`, and that `unsubscribe()` on a non-subscriber does the same.

```
$ USE_SYSTEM_BUN=1 bun test test/js/valkey/valkey-subscriber-guard.test.ts
 0 pass  2 fail   # get()/unsubscribe() threw synchronously

$ bun bd test test/js/valkey/valkey-subscriber-guard.test.ts
 2 pass  0 fail

$ bun bd test test/js/valkey/
 52 pass  1065 skip  0 fail
```

The existing docker-gated assertion in `valkey.test.ts` (`setting in subscriber mode gracefully fails`) is updated from `toThrow` to `rejects.toThrow`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 910 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-subscriber-guard.test.ts test/js/valkey/valkey.test.ts
bun test v1.4.0 (fda8f23f1)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specif
... (truncated)

release without fix: 8 failed, 910 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME overwr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 910 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-subscriber-guard.test.ts test/js/valkey/valkey.test.ts
bun test v1.4.0 (fda8f23f1)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specif
... (truncated)

release with fix: 910 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fda8f23f14
  features     baseline

22 deps, 108 codegen, 1171 objects in 1131ms

ninja: Entering directory `/workspace/bun/build/release'
[1/214] gen ErrorCode+*.h
[2/214] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/214] fetch lsquic
[lsquic] up to date
[4/214] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey_functions.rs  | 207 +++++++++++++++++--------
 test/js/valkey/valkey-subscriber-guard.test.ts |  96 ++++++++++++
 test/js/valkey/valkey.test.ts                  |  10 +-
 3 files changed, 240 insertions(+), 73 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/runtime/valkey_jsc/js_valkey_functions.rs       7      6      0
test/js/valkey/valkey-subscriber-guard.test.ts      1      2      0
test/js/valkey/valkey.test.ts                       3      3      0
```

</details>

<!-- robobun:evidence:end -->