### PR TITLE
fs.promises.writeFile: stop appending NUL tail when writing a stream/async-iterable

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1587,10 +1587,14 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
 
       const prom = writer.write(chunk);
       if (prom && $isPromise(prom)) {
-        totalBytesWritten += await prom;
-      } else {
-        totalBytesWritten += prom;
+        await prom;
       }
+
+      // FileSink.write() may return the cumulative flushed byte count when a
+      // chunk triggers an auto-flush, so summing its return values double-counts
+      // buffered bytes. Count the chunk's own byte length instead; the ftruncate
+      // in the caller relies on this being exact.
+      totalBytesWritten += typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.byteLength;
     }
   } finally {
     await writer.end();

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1570,7 +1570,6 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
   const writer = Bun.file(fd).writer();
 
   const mustRencode = !(encoding === "utf8" || encoding === "utf-8" || encoding === "binary" || encoding === "buffer");
-  let totalBytesWritten = 0;
 
   try {
     for await (let chunk of iterable) {
@@ -1589,24 +1588,10 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
       if (prom && $isPromise(prom)) {
         await prom;
       }
-
-      // FileSink.write() may return the cumulative flushed byte count when a
-      // chunk triggers an auto-flush, so summing its return values double-counts
-      // buffered bytes. Count the chunk's own byte length instead; the ftruncate
-      // in the caller relies on this being exact.
-      totalBytesWritten += typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.byteLength;
     }
   } finally {
     await writer.end();
   }
-
-  return totalBytesWritten;
-}
-
-// The only flag spellings whose `open` truncates. `r+` & co. overwrite in place,
-// so resizing the file down to the bytes we wrote would destroy the rest of it.
-function flagTruncates(flag): boolean {
-  return flag === "w" || flag === "w+" || flag === "wx" || flag === "wx+" || flag === "xw" || flag === "xw+";
 }
 
 async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, flag, mode) {
@@ -1642,24 +1627,15 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
     throw $makeAbortError(undefined, { cause: signal.reason });
   }
 
-  let totalBytesWritten = 0;
-
   let error: Error | undefined;
 
   try {
-    totalBytesWritten = await writeFileAsyncIteratorInner(fdOrPath, iterable, encoding, signal);
+    await writeFileAsyncIteratorInner(fdOrPath, iterable, encoding, signal);
   } catch (err) {
     error = err as Error;
   }
 
-  // Handle cleanup outside of try-catch
   if (mustClose) {
-    if (flagTruncates(flag)) {
-      try {
-        await fs.ftruncate(fdOrPath, totalBytesWritten);
-      } catch {}
-    }
-
     await fs.close(fdOrPath);
   }
 

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,9 +1,9 @@
 import { expect, mock, test } from "bun:test";
-import { writeFile } from "fs/promises";
 import { readFileSync } from "fs";
-import { Readable } from "stream";
+import { writeFile } from "fs/promises";
 import { tempDirWithFiles } from "harness";
 import { join } from "path";
+import { Readable } from "stream";
 test("fs.promises.writeFile async iterator", async () => {
   const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
     "file1.txt": "0 Hello, world!",

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,6 +1,9 @@
 import { expect, mock, test } from "bun:test";
 import { writeFile } from "fs/promises";
+import { readFileSync } from "fs";
+import { Readable } from "stream";
 import { tempDirWithFiles } from "harness";
+import { join } from "path";
 test("fs.promises.writeFile async iterator", async () => {
   const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
     "file1.txt": "0 Hello, world!",
@@ -25,6 +28,86 @@ test("fs.promises.writeFile async iterator", async () => {
   await writeFile(path, bufStream());
 
   expect(await Bun.file(path).text()).toBe("2 Hello, world!");
+});
+
+test("fs.promises.writeFile async iterator writes exact byte count for many small string chunks", async () => {
+  const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator-size", {
+    "placeholder": "",
+  });
+  const path = join(dir, "out.bin");
+  const chunk = "0123456789";
+  const count = 500;
+
+  async function* gen() {
+    for (let i = 0; i < count; i++) yield chunk;
+  }
+  await writeFile(path, gen());
+
+  const buf = readFileSync(path);
+  expect(buf.length).toBe(chunk.length * count);
+  expect(buf.toString()).toBe(Buffer.alloc(count * chunk.length, chunk).toString());
+});
+
+test("fs.promises.writeFile async iterator writes exact byte count for many small Buffer chunks", async () => {
+  const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator-size-buf", {
+    "placeholder": "",
+  });
+  const path = join(dir, "out.bin");
+  const chunk = Buffer.from("0123456789");
+  const count = 500;
+
+  async function* gen() {
+    for (let i = 0; i < count; i++) yield chunk;
+  }
+  await writeFile(path, gen());
+
+  const buf = readFileSync(path);
+  expect(buf.length).toBe(chunk.length * count);
+  expect(buf.equals(Buffer.alloc(chunk.length * count, chunk))).toBe(true);
+});
+
+test("fs.promises.writeFile with a node Readable stream writes exact byte count", async () => {
+  const dir = tempDirWithFiles("fs-promises-writeFile-readable-size", {
+    "placeholder": "",
+  });
+  const path = join(dir, "out.bin");
+  const count = 500;
+  let i = 0;
+  const rs = new Readable({
+    read() {
+      while (i < count) {
+        i++;
+        if (!this.push("0123456789")) return;
+      }
+      this.push(null);
+    },
+  });
+  await writeFile(path, rs);
+
+  const buf = readFileSync(path);
+  expect(buf.length).toBe(10 * count);
+  expect(buf.subarray(0, 10 * count).equals(Buffer.alloc(10 * count, "0123456789"))).toBe(true);
+});
+
+test("fs.promises.writeFile async iterator with multi-byte UTF-8 chunks writes exact byte count", async () => {
+  const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator-utf8", {
+    "placeholder": "",
+  });
+  const path = join(dir, "out.bin");
+  // "héllo" = 6 bytes in UTF-8 (é is 2 bytes)
+  const chunk = "héllo";
+  const chunkBytes = Buffer.byteLength(chunk);
+  expect(chunkBytes).toBe(6);
+  const count = 1000;
+
+  async function* gen() {
+    for (let i = 0; i < count; i++) yield chunk;
+  }
+  await writeFile(path, gen());
+
+  const buf = readFileSync(path);
+  expect(buf.length).toBe(chunkBytes * count);
+  expect(buf.toString("utf8")).toBe(Buffer.alloc(count * chunkBytes, chunk).toString("utf8"));
 });
 
 test("fs.promises.writeFile async iterator throws on invalid input", async () => {


### PR DESCRIPTION
## What

`fs.promises.writeFile(path, <stream | async-iterable>)` was silently writing files padded with trailing NUL bytes, up to roughly 2x the real data length. The data prefix is byte-perfect; the tail is all zeros.

## Repro

```js
import * as fsp from "node:fs/promises";
import * as fs from "node:fs";

async function* gen() { for (let i = 0; i < 500; i++) yield "0123456789"; }
await fsp.writeFile("out.bin", gen());
console.log(fs.statSync("out.bin").size); // node: 5000, bun before: 9090
```

Hits node `Readable`, web `ReadableStream`, and async generators with the default `"w"` flag. `FileHandle.writeFile(stream)` (no path, so no ftruncate) is unaffected.

## Cause

`writeFileAsyncIteratorInner` summed the return of `FileSink.write()` into `totalBytesWritten`, then the caller `ftruncate()`d the fd to that total. `FileSink.write()` returns the cumulative flushed byte count whenever a chunk triggers an auto-flush, so summing those values double-counts every buffered byte and the `ftruncate` extends the file past the real data with zeros.

## Fix

Remove the `ftruncate` (and the byte counter and `flagTruncates` helper it needed). It only ran for flags that already open with `O_TRUNC`, so the file always started empty and the final size after `writer.end()` is exactly the bytes written; the truncate was a no-op when the count was right and the source of the NUL tail when it was wrong. Node never ftruncates on this path either. The existing `r+` / `w` flag tests in `fs.test.ts` still pass.

## Verification

```
# before (system bun)
(fail) ... many small string chunks   Expected: 5000  Received: 9090
(fail) ... many small Buffer chunks   Expected: 5000  Received: 9090
(fail) ... node Readable stream       Expected: 5000  Received: 9090
(fail) ... multi-byte UTF-8 chunks    Expected: 6000  Received: 10092

# after (bun bd)
6 pass, 0 fail
```
