### PR TITLE
bun test: carry node:test skip/todo reasons into the JUnit `<skipped>` element

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -2630,8 +2630,7 @@ function addTest(
     const register = effectiveMode === "todo" ? test.todo : test.skip;
     // Node runs todo bodies; bun:test only does so under --todo.
     const body = effectiveMode === "todo" ? createTopLevelTestRunner(node, fn, true) : kDefaultFunction;
-    const registerOptions =
-      node.message !== undefined ? { ...passOptions, note: node.message } : passOptions;
+    const registerOptions = node.message !== undefined ? { ...passOptions, note: node.message } : passOptions;
     if (registerOptions !== undefined) {
       register(name, body, registerOptions);
     } else {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -1626,7 +1626,8 @@ class TestNode {
 const fileGeneration = $newRustFunction("jest.rs", "jsFileGeneration", 0);
 // Overrides the running bun:test sequence result: `false` → skip, `true` → todo.
 // `done` binds the intended sequence so a late call after the bun:test watchdog
-// moved on cannot write onto the currently-running test.
+// moved on cannot write onto the currently-running test. The optional third
+// argument is the skip/todo reason string for reporters (JUnit `<skipped message>`).
 const markCurrentResult = $newRustFunction("jest.rs", "jsNodeTestMarkResult", 2);
 
 let rootNode: TestNode | undefined;
@@ -2540,9 +2541,9 @@ function createTopLevelTestRunner(node: TestNode, fn: TestFn, declaredTodo = fal
         // (Node counts these as skip/todo even when the body threw); a declared
         // todo body's failure must reach bun:test's own todo accounting instead.
         if (node.skipped) {
-          markCurrentResult(false, done);
+          markCurrentResult(false, done, node.message);
         } else if (node.todoFlag && !declaredTodo && (runChildReporterEnabled || !todoBefore)) {
-          markCurrentResult(true, done);
+          markCurrentResult(true, done, node.message);
         } else {
           done(failure);
           return;
@@ -2606,7 +2607,7 @@ function addTest(
     if (runChildReporterEnabled && effectiveMode === "skip") {
       const runner = function (done: (err?: unknown) => void) {
         reportDirectiveOnlyNode(node, "skip");
-        markCurrentResult(false, done);
+        markCurrentResult(false, done, node.message);
         done(undefined);
       };
       if (passOptions !== undefined) test(name, runner, passOptions);
@@ -2629,8 +2630,10 @@ function addTest(
     const register = effectiveMode === "todo" ? test.todo : test.skip;
     // Node runs todo bodies; bun:test only does so under --todo.
     const body = effectiveMode === "todo" ? createTopLevelTestRunner(node, fn, true) : kDefaultFunction;
-    if (passOptions !== undefined) {
-      register(name, body, passOptions);
+    const registerOptions =
+      node.message !== undefined ? { ...passOptions, note: node.message } : passOptions;
+    if (registerOptions !== undefined) {
+      register(name, body, registerOptions);
     } else {
       register(name, body);
     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -796,11 +796,12 @@ impl JunitReporter {
                 self.contents.extend_from_slice(b">\n");
                 self.contents.extend_from_slice(indent);
                 self.contents.extend_from_slice(b"  <skipped type=\"");
-                self.contents.extend_from_slice(if matches!(status, R::Todo) {
-                    b"todo"
-                } else {
-                    b"skipped"
-                });
+                self.contents
+                    .extend_from_slice(if matches!(status, R::Todo) {
+                        b"todo"
+                    } else {
+                        b"skipped"
+                    });
                 self.contents.extend_from_slice(b"\"");
                 if let Some(note) = note.filter(|n| !n.is_empty()) {
                     self.contents.extend_from_slice(b" message=\"");

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -793,19 +793,19 @@ impl JunitReporter {
                     let last = self.suite_stack.len() - 1;
                     self.suite_stack[last].metrics.skipped += 1;
                 }
-                let is_todo = matches!(status, R::Todo);
                 self.contents.extend_from_slice(b">\n");
                 self.contents.extend_from_slice(indent);
                 self.contents.extend_from_slice(b"  <skipped type=\"");
-                self.contents
-                    .extend_from_slice(if is_todo { b"todo" } else { b"skipped" });
+                self.contents.extend_from_slice(if matches!(status, R::Todo) {
+                    b"todo"
+                } else {
+                    b"skipped"
+                });
                 self.contents.extend_from_slice(b"\"");
                 if let Some(note) = note.filter(|n| !n.is_empty()) {
                     self.contents.extend_from_slice(b" message=\"");
                     escape_xml(note, &mut self.contents)?;
                     self.contents.extend_from_slice(b"\"");
-                } else if is_todo {
-                    self.contents.extend_from_slice(b" message=\"TODO\"");
                 }
                 self.contents.extend_from_slice(b" />\n");
                 self.contents.extend_from_slice(indent);

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -647,6 +647,7 @@ impl JunitReporter {
         assertions: u32,
         elapsed_ns: u64,
         line_number: u32,
+        note: Option<&[u8]>,
     ) -> crate::Result<()> {
         // Std::io::Write removed; bun_io::Write (top-level) provides write_fmt.
         let elapsed_ns_f64: f64 = elapsed_ns as f64;
@@ -787,26 +788,26 @@ impl JunitReporter {
                 self.contents.extend_from_slice(indent);
                 self.contents.extend_from_slice(b"</testcase>\n");
             }
-            R::SkippedBecauseLabel | R::Skip => {
+            R::SkippedBecauseLabel | R::Skip | R::Todo => {
                 if !self.suite_stack.is_empty() {
                     let last = self.suite_stack.len() - 1;
                     self.suite_stack[last].metrics.skipped += 1;
                 }
+                let is_todo = matches!(status, R::Todo);
                 self.contents.extend_from_slice(b">\n");
                 self.contents.extend_from_slice(indent);
-                self.contents.extend_from_slice(b"  <skipped />\n");
-                self.contents.extend_from_slice(indent);
-                self.contents.extend_from_slice(b"</testcase>\n");
-            }
-            R::Todo => {
-                if !self.suite_stack.is_empty() {
-                    let last = self.suite_stack.len() - 1;
-                    self.suite_stack[last].metrics.skipped += 1;
-                }
-                self.contents.extend_from_slice(b">\n");
-                self.contents.extend_from_slice(indent);
+                self.contents.extend_from_slice(b"  <skipped type=\"");
                 self.contents
-                    .extend_from_slice(b"  <skipped message=\"TODO\" />\n");
+                    .extend_from_slice(if is_todo { b"todo" } else { b"skipped" });
+                self.contents.extend_from_slice(b"\"");
+                if let Some(note) = note.filter(|n| !n.is_empty()) {
+                    self.contents.extend_from_slice(b" message=\"");
+                    escape_xml(note, &mut self.contents)?;
+                    self.contents.extend_from_slice(b"\"");
+                } else if is_todo {
+                    self.contents.extend_from_slice(b" message=\"TODO\"");
+                }
+                self.contents.extend_from_slice(b" />\n");
                 self.contents.extend_from_slice(indent);
                 self.contents.extend_from_slice(b"</testcase>\n");
             }
@@ -1338,6 +1339,9 @@ impl CommandLineReporter {
                 }
             }
 
+            let note: Option<&[u8]> =
+                sequence.note.as_deref().or(test_entry.note.as_deref());
+
             junit
                 .write_test_case(
                     status,
@@ -1347,6 +1351,7 @@ impl CommandLineReporter {
                     assertions,
                     elapsed_ns,
                     line_number,
+                    note,
                 )
                 .expect("oom");
         }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1339,8 +1339,7 @@ impl CommandLineReporter {
                 }
             }
 
-            let note: Option<&[u8]> =
-                sequence.note.as_deref().or(test_entry.note.as_deref());
+            let note: Option<&[u8]> = sequence.note.as_deref().or(test_entry.note.as_deref());
 
             junit
                 .write_test_case(

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -167,6 +167,9 @@ pub struct ExecutionSequence {
     /// Expectation set by expect.hasAssertions() or expect.assertions(n).
     pub expect_assertions: ExpectAssertions,
     pub maybe_skip: bool,
+    /// Skip/todo reason set at runtime (node:test `t.skip('reason')` /
+    /// `t.todo('reason')`); shadows `ExecutionEntry.note` when reporting.
+    pub note: Option<Box<[u8]>>,
 }
 
 impl ExecutionSequence {
@@ -189,6 +192,7 @@ impl ExecutionSequence {
             expect_call_count: 0,
             expect_assertions: ExpectAssertions::NotSet,
             maybe_skip: false,
+            note: None,
         }
     }
 

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use crate::test_runner::expect::JSValueTestExt;
 use core::sync::atomic::{AtomicI32, Ordering};
 
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult, StringJsc as _};
 use bun_core::String as BunString;
 
 use crate::test_runner::bun_test::{self, BaseScopeCfg, BunTest, DescribeScope};
@@ -246,6 +246,7 @@ pub(crate) fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> Js
                     bound,
                     formatted_label.as_deref(),
                     &args.options,
+                    args.note.as_deref(),
                     callback_length.saturating_sub(args_list.len()),
                     line_no,
                 )
@@ -261,6 +262,7 @@ pub(crate) fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> Js
             args.callback,
             args.description.as_deref(),
             &args.options,
+            args.note.as_deref(),
             callback_length,
             line_no,
         )?;
@@ -325,6 +327,7 @@ impl ScopeFunctions {
         callback: Option<JSValue>,
         description: Option<&[u8]>,
         options: &ParseArgumentsOptions,
+        note: Option<&[u8]>,
         callback_length: usize,
         line_no: u32,
     ) -> JsResult<()> {
@@ -446,7 +449,7 @@ impl ScopeFunctions {
                     bstr::BStr::new(bun_test.collection.active_scope().base.name.as_deref().unwrap_or(b"(unnamed)"))
                 ));
 
-                let _ = bun_test.collection.active_scope_mut().append_test(
+                let entry = bun_test.collection.active_scope_mut().append_test(
                     description,
                     if matches_filter { callback } else { None },
                     bun_test::ExecutionEntryCfg {
@@ -458,6 +461,9 @@ impl ScopeFunctions {
                     base,
                     bun_test::AddedInPhase::Collection,
                 )?;
+                if let Some(note) = note {
+                    entry.note = Some(note.to_vec().into_boxed_slice());
+                }
             }
         }
         Ok(())
@@ -522,6 +528,7 @@ pub struct ParseArgumentsResult {
     pub description: Option<Vec<u8>>,
     pub callback: Option<JSValue>,
     pub options: ParseArgumentsOptions,
+    pub note: Option<Vec<u8>>,
 }
 
 #[derive(Default, Clone, Copy)]
@@ -678,6 +685,7 @@ pub fn parse_arguments(
         description: None,
         callback: result_callback,
         options: ParseArgumentsOptions::default(),
+        note: None,
     };
     // `result` cleanup handled by Drop on early return.
 
@@ -712,6 +720,12 @@ pub fn parse_arguments(
                 return Err(global.throw(format_args!("{}(): Cannot set both retry and repeats", signature)));
             }
             result.options.repeats = repeats.as_number() as u32;
+        }
+        if let Some(note) = options.get(global, "note")? {
+            if note.is_string() {
+                let s = bun_core::String::from_js(note, global)?;
+                result.note = Some(s.to_utf8_bytes());
+            }
         }
     } else if options.is_undefined_or_null() {
         // no options

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1905,6 +1905,9 @@ pub struct ExecutionEntry {
     pub retry_count: u32,
     /// Number of times to repeat a test (0 = run once, 1 = run twice, etc.)
     pub repeat_count: u32,
+    /// Skip/todo reason supplied at declaration time (node:test `{skip:'reason'}`
+    /// / `{todo:'reason'}`); surfaced as `<skipped message="...">` in JUnit.
+    pub note: Option<Box<[u8]>>,
 
     pub next: Option<*mut ExecutionEntry>,
     /// if this entry fails, go to the entry 'failure_skip_past.next'
@@ -1928,6 +1931,7 @@ impl ExecutionEntry {
             added_in_phase: phase,
             retry_count: cfg.retry_count,
             repeat_count: cfg.repeat_count,
+            note: None,
             timespec: Timespec::EPOCH,
             next: None,
             failure_skip_past: None,

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -533,11 +533,11 @@ pub(crate) fn js_file_generation(
 /// `done`'s bound `DoneCallback.r#ref.phase` names the intended sequence so a
 /// late call after the watchdog moved on cannot mark the currently-running one.
 pub(crate) fn js_node_test_mark_result(
-    _global: &JSGlobalObject,
+    global: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     use super::execution::Result as ExecResult;
-    let [mode, done] = callframe.arguments_as_array::<2>();
+    let [mode, done, message] = callframe.arguments_as_array::<3>();
     let Some(buntest_strong) = bun_test::clone_active_strong() else {
         return Ok(JSValue::UNDEFINED);
     };
@@ -578,6 +578,10 @@ pub(crate) fn js_node_test_mark_result(
     let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
     if sequence.result == ExecResult::Pending {
         sequence.result = if mode.to_boolean() { ExecResult::Todo } else { ExecResult::Skip };
+        if message.is_string() {
+            let s = bun_core::String::from_js(message, global)?;
+            sequence.note = Some(s.to_utf8_bytes().into_boxed_slice());
+        }
     }
     Ok(JSValue::UNDEFINED)
 }

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -27,7 +27,7 @@ exports[`junit reporter more scenarios 1`] = `
         <skipped type="skipped" />
       </testcase>
       <testcase name="basic todo test" classname="comprehensive test suite" file="comprehensive.test.js" line="38" assertions="0">
-        <skipped type="todo" message="TODO" />
+        <skipped type="todo" />
       </testcase>
       <testcase name="addition 1 + 2 = 3" classname="comprehensive test suite" file="comprehensive.test.js" line="44" assertions="1" />
       <testcase name="addition 2 + 3 = 5" classname="comprehensive test suite" file="comprehensive.test.js" line="44" assertions="1" />
@@ -43,7 +43,7 @@ exports[`junit reporter more scenarios 1`] = `
       </testcase>
       <testcase name="skip if false" classname="comprehensive test suite" file="comprehensive.test.js" line="67" assertions="1" />
       <testcase name="todo if true" classname="comprehensive test suite" file="comprehensive.test.js" line="71" assertions="0">
-        <skipped type="todo" message="TODO" />
+        <skipped type="todo" />
       </testcase>
       <testcase name="todo if false" classname="comprehensive test suite" file="comprehensive.test.js" line="73" assertions="1" />
       <testcase name="test marked as failing" classname="comprehensive test suite" file="comprehensive.test.js" line="77" assertions="1" />

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -16,7 +16,7 @@ exports[`junit reporter more scenarios 1`] = `
       </testsuite>
       <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
         <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
-          <skipped />
+          <skipped type="skipped" />
         </testcase>
       </testsuite>
       <testcase name="basic passing test" classname="comprehensive test suite" file="comprehensive.test.js" line="26" assertions="1" />
@@ -24,10 +24,10 @@ exports[`junit reporter more scenarios 1`] = `
         <failure type="AssertionError" message="expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;">AssertionError: expect(received).toBe(expected)&#10;&#10;Expected: 3&#10;Received: 2&#10;&#10;      at comprehensive.test.js:31:27&#10;</failure>
       </testcase>
       <testcase name="basic skipped test" classname="comprehensive test suite" file="comprehensive.test.js" line="34" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="basic todo test" classname="comprehensive test suite" file="comprehensive.test.js" line="38" assertions="0">
-        <skipped message="TODO" />
+        <skipped type="todo" message="TODO" />
       </testcase>
       <testcase name="addition 1 + 2 = 3" classname="comprehensive test suite" file="comprehensive.test.js" line="44" assertions="1" />
       <testcase name="addition 2 + 3 = 5" classname="comprehensive test suite" file="comprehensive.test.js" line="44" assertions="1" />
@@ -36,14 +36,14 @@ exports[`junit reporter more scenarios 1`] = `
       <testcase name="string concat foo + bar = foobar" classname="comprehensive test suite" file="comprehensive.test.js" line="51" assertions="1" />
       <testcase name="conditional test that runs" classname="comprehensive test suite" file="comprehensive.test.js" line="55" assertions="1" />
       <testcase name="conditional test that skips" classname="comprehensive test suite" file="comprehensive.test.js" line="59" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="skip if true" classname="comprehensive test suite" file="comprehensive.test.js" line="63" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="skip if false" classname="comprehensive test suite" file="comprehensive.test.js" line="67" assertions="1" />
       <testcase name="todo if true" classname="comprehensive test suite" file="comprehensive.test.js" line="71" assertions="0">
-        <skipped message="TODO" />
+        <skipped type="todo" message="TODO" />
       </testcase>
       <testcase name="todo if false" classname="comprehensive test suite" file="comprehensive.test.js" line="73" assertions="1" />
       <testcase name="test marked as failing" classname="comprehensive test suite" file="comprehensive.test.js" line="77" assertions="1" />
@@ -62,75 +62,75 @@ exports[`junit reporter more scenarios 2`] = `
     <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="1" failures="0" skipped="21">
       <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
         <testcase name="should divide correctly" classname="division suite 10 / 5 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
-          <skipped />
+          <skipped type="skipped" />
         </testcase>
       </testsuite>
       <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
         <testcase name="should divide correctly" classname="division suite 20 / 10 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
-          <skipped />
+          <skipped type="skipped" />
         </testcase>
       </testsuite>
       <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="0" failures="0" skipped="1">
         <testcase name="nested test in conditional describe" classname="conditional describe that runs &gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="0">
-          <skipped />
+          <skipped type="skipped" />
         </testcase>
       </testsuite>
       <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
         <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
-          <skipped />
+          <skipped type="skipped" />
         </testcase>
       </testsuite>
       <testcase name="basic passing test" classname="comprehensive test suite" file="comprehensive.test.js" line="26" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="basic failing test" classname="comprehensive test suite" file="comprehensive.test.js" line="30" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="basic skipped test" classname="comprehensive test suite" file="comprehensive.test.js" line="34" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="basic todo test" classname="comprehensive test suite" file="comprehensive.test.js" line="38" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="addition 1 + 2 = 3" classname="comprehensive test suite" file="comprehensive.test.js" line="44" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="addition 2 + 3 = 5" classname="comprehensive test suite" file="comprehensive.test.js" line="44" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="addition 4 + 5 = 9" classname="comprehensive test suite" file="comprehensive.test.js" line="44" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="string concat hello + world = helloworld" classname="comprehensive test suite" file="comprehensive.test.js" line="51" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="string concat foo + bar = foobar" classname="comprehensive test suite" file="comprehensive.test.js" line="51" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="conditional test that runs" classname="comprehensive test suite" file="comprehensive.test.js" line="55" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="conditional test that skips" classname="comprehensive test suite" file="comprehensive.test.js" line="59" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="skip if true" classname="comprehensive test suite" file="comprehensive.test.js" line="63" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="skip if false" classname="comprehensive test suite" file="comprehensive.test.js" line="67" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="todo if true" classname="comprehensive test suite" file="comprehensive.test.js" line="71" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="todo if false" classname="comprehensive test suite" file="comprehensive.test.js" line="73" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="test marked as failing" classname="comprehensive test suite" file="comprehensive.test.js" line="77" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
       <testcase name="should match this test" classname="comprehensive test suite" file="comprehensive.test.js" line="81" assertions="1" />
       <testcase name="should not be matched by filter" classname="comprehensive test suite" file="comprehensive.test.js" line="85" assertions="0">
-        <skipped />
+        <skipped type="skipped" />
       </testcase>
     </testsuite>
   </testsuite>

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 describe("node:test", () => {
@@ -323,6 +323,47 @@ describe("node:test", () => {
       stderr: expect.stringContaining("0 fail"),
     });
   });
+});
+
+test("JUnit reporter carries node:test skip/todo reasons", async () => {
+  using dir = tempDir("node-test-junit-reasons", {
+    "reasons.test.mjs": `
+      import { test, describe } from "node:test";
+      describe("suite", () => {
+        test("skipped with reason", { skip: "not on tuesday" }, () => {});
+        test("runtime skip", (t) => { t.skip("runtime <reason>"); });
+        test("todo with reason", { todo: "implement later" }, () => {});
+        test("runtime todo", (t) => { t.todo("rewrite me"); });
+        test("plain skip", { skip: true }, () => {});
+        test("plain todo", { todo: true }, () => {});
+      });
+    `,
+  });
+  const outfile = join(String(dir), "out.xml");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--reporter=junit", `--reporter-outfile=${outfile}`, "reasons.test.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const xml = await Bun.file(outfile).text();
+  // declared {skip:'reason'} / {todo:'reason'}
+  expect(xml).toContain('<skipped type="skipped" message="not on tuesday" />');
+  expect(xml).toContain('<skipped type="todo" message="implement later" />');
+  // runtime t.skip('reason') / t.todo('reason'); message must be XML-escaped
+  expect(xml).toContain('<skipped type="skipped" message="runtime &lt;reason&gt;" />');
+  expect(xml).toContain('<skipped type="todo" message="rewrite me" />');
+  // skip/todo without a reason still carry the type attribute
+  expect(xml).toContain('<skipped type="skipped" />');
+  expect(xml).toContain('<skipped type="todo" message="TODO" />');
+  // no bare `<skipped />` survives
+  expect(xml).not.toMatch(/<skipped\s*\/>/);
+  // sanity: summary line saw the right counts
+  expect(stderr).toContain("3 skip");
+  expect(stderr).toContain("3 todo");
+  expect(exitCode).toBe(0);
 });
 
 async function runTests(filenames: string[], env: Record<string, string> = {}, args: string[] = []) {

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -347,7 +347,7 @@ test("JUnit reporter carries node:test skip/todo reasons", async () => {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const xml = await Bun.file(outfile).text();
   // declared {skip:'reason'} / {todo:'reason'}
   expect(xml).toContain('<skipped type="skipped" message="not on tuesday" />');
@@ -357,7 +357,7 @@ test("JUnit reporter carries node:test skip/todo reasons", async () => {
   expect(xml).toContain('<skipped type="todo" message="rewrite me" />');
   // skip/todo without a reason still carry the type attribute
   expect(xml).toContain('<skipped type="skipped" />');
-  expect(xml).toContain('<skipped type="todo" message="TODO" />');
+  expect(xml).toContain('<skipped type="todo" />');
   // no bare `<skipped />` survives
   expect(xml).not.toMatch(/<skipped\s*\/>/);
   // sanity: summary line saw the right counts


### PR DESCRIPTION
## Problem

`bun test --reporter=junit` drops the reason string for node:test skip/todo tests.

```js
// mix.test.mjs
import { test, describe } from 'node:test';
describe('suite', () => {
  test('skipped with reason', { skip: 'not on tuesday' }, () => {});
  test('runtime skip', (t) => { t.skip('runtime reason'); });
  test('todo with reason', { todo: 'implement later' }, () => {});
});
```

```sh
bun test --reporter=junit --reporter-outfile=b.xml ./mix.test.mjs
```

Before:
```xml
<skipped />
<skipped />
<skipped message="TODO" />
```

Node's `--test-reporter=junit`:
```xml
<skipped type="skipped" message="not on tuesday"/>
<skipped type="skipped" message="runtime reason"/>
<skipped type="todo" message="implement later"/>
```

A CI dashboard reading Bun's XML for a node:test suite lost every skip/todo reason.

## Cause

The reason string never crossed the JS/native boundary. `TestNode.message` in `src/js/node/test.ts` stores it, but `test.skip()`/`test.todo()` had no parameter to accept it and `jsNodeTestMarkResult` (the runtime `t.skip()`/`t.todo()` bridge) only took a boolean. The JUnit writer in `test_command.rs` had nothing to read and emitted hardcoded `<skipped />` / `<skipped message="TODO" />`.

## Fix

Thread the reason through to the reporter:

- `ExecutionEntry.note` holds the declaration-time reason. `parse_arguments` reads a new `note` option key, and `addTest` in `src/js/node/test.ts` passes `{ note: node.message }` when registering `test.skip`/`test.todo`.
- `ExecutionSequence.note` holds the runtime reason. `jsNodeTestMarkResult` accepts a third `message` argument that `createTopLevelTestRunner` now passes.
- `JunitReporter::write_test_case` takes a `note: Option<&[u8]>` and emits `<skipped type="skipped|todo" message="..." />`, XML-escaping the message. The runtime note shadows the declaration-time one. The `type` attribute is always present (matching Node), so bare `<skipped />` becomes `<skipped type="skipped" />` for plain bun:test skips too.

After:
```xml
<skipped type="skipped" message="not on tuesday" />
<skipped type="skipped" message="runtime reason" />
<skipped type="todo" message="implement later" />
```

Subtests from `t.test()` still don't appear as individual `<testcase>` elements since they run inline without registering with bun:test; that is a separate structural change.

## Verification

```sh
bun bd test test/js/node/test_runner/node-test.test.ts -t "JUnit reporter carries"
bun bd test test/js/junit-reporter/junit.test.js
```

The new test fails on main (first `toContain` assertion) and passes with this change. Updated the junit reporter snapshot for the new `type` attribute.