### PR TITLE
fs.promises.writeFile: apply backpressure when draining an (async) iterable

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1566,34 +1566,41 @@ function throwEBADFIfNecessary(fn: string, fd) {
   }
 }
 
-async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: AbortSignal | null) {
-  const writer = Bun.file(fd).writer();
+// Node splits each chunk into writes of at most this many bytes so a single
+// huge chunk never pins the threadpool for the whole transfer.
+const kWriteFileMaxChunkSize = 512 * 1024;
 
-  const mustRencode = !(encoding === "utf8" || encoding === "utf-8" || encoding === "binary" || encoding === "buffer");
+async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: AbortSignal | null) {
+  // Write each chunk via the async fs.write binding (threadpool I/O) rather
+  // than Bun.file().writer(): FileSink writes to regular files synchronously
+  // and buffers pollable fds without bound, so a fast Readable drives a
+  // microtask-only loop that starves timers and (for an unbounded producer)
+  // grows memory until OOM. Awaiting fs.write per chunk is what Node's
+  // writeFileHandle does and naturally yields to the event loop.
   let totalBytesWritten = 0;
 
-  try {
-    for await (let chunk of iterable) {
+  for await (let chunk of iterable) {
+    if (signal?.aborted) {
+      throw $makeAbortError(undefined, { cause: signal.reason });
+    }
+
+    if (!types.isArrayBufferView(chunk)) {
+      if ($isUndefinedOrNull(chunk)) {
+        throw $ERR_INVALID_ARG_TYPE("chunk", ["string", "ArrayBufferView", "ArrayBuffer"], chunk);
+      }
+      chunk = Buffer.from(chunk, encoding);
+    }
+
+    let remaining = chunk.byteLength;
+    while (remaining > 0) {
+      const writeSize = remaining < kWriteFileMaxChunkSize ? remaining : kWriteFileMaxChunkSize;
+      const bytesWritten = await fs.write(fd, chunk, chunk.byteLength - remaining, writeSize, null);
+      totalBytesWritten += bytesWritten;
+      remaining -= bytesWritten;
       if (signal?.aborted) {
         throw $makeAbortError(undefined, { cause: signal.reason });
       }
-
-      if (mustRencode && typeof chunk === "string") {
-        $debug("Re-encoding chunk to", encoding);
-        chunk = Buffer.from(chunk, encoding);
-      } else if ($isUndefinedOrNull(chunk)) {
-        throw $ERR_INVALID_ARG_TYPE("chunk", ["string", "ArrayBufferView", "ArrayBuffer"], chunk);
-      }
-
-      const prom = writer.write(chunk);
-      if (prom && $isPromise(prom)) {
-        totalBytesWritten += await prom;
-      } else {
-        totalBytesWritten += prom;
-      }
     }
-  } finally {
-    await writer.end();
   }
 
   return totalBytesWritten;

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,6 +1,8 @@
 import { expect, mock, test } from "bun:test";
 import { writeFile } from "fs/promises";
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
+import { devNull } from "os";
+import { Readable } from "stream";
 test("fs.promises.writeFile async iterator", async () => {
   const dir = tempDirWithFiles("fs-promises-writeFile-async-iterator", {
     "file1.txt": "0 Hello, world!",
@@ -51,3 +53,81 @@ test("fs.promises.writeFile async iterator throws on invalid input", async () =>
   expect(() => writeFile(dir, fn)).toThrow();
   expect(fn[Symbol.asyncIterator]).not.toBeCalled();
 });
+
+// Draining a fast Readable into writeFile must not turn into a microtask-only
+// spin: the consumer has to yield to the event loop so timers keep firing, and
+// an unbounded producer must stay memory-bounded via backpressure (node
+// behaviour).
+test.concurrent("fs.promises.writeFile(Readable) yields to the event loop", async () => {
+  let timerFired = false;
+  const timer = setTimeout(() => (timerFired = true), 1);
+  try {
+    let pushed = 0;
+    // 4 KB chunks keep the Readable's 16 KB default highWaterMark to a handful
+    // of buffered chunks, so only a few fs.write round-trips run before read()
+    // observes the fired timer.
+    const chunk = Buffer.alloc(4096, "0");
+    const limit = 200_000;
+    const readable = new Readable({
+      read() {
+        // End the stream as soon as a macrotask has been observed, otherwise
+        // keep pushing up to `limit` chunks. A well-behaved producer that
+        // honours push()'s backpressure return; the old FileSink path still
+        // drained this without a single macrotask, so `timerFired` stayed
+        // false for the whole transfer.
+        if (timerFired) return void this.push(null);
+        while (pushed < limit) {
+          pushed++;
+          if (!this.push(chunk)) return;
+        }
+        this.push(null);
+      },
+    });
+    await writeFile(devNull, readable);
+    expect(timerFired).toBe(true);
+    expect(pushed).toBeLessThan(limit);
+  } finally {
+    clearTimeout(timer);
+  }
+});
+
+test.concurrent(
+  "fs.promises.writeFile applies backpressure to an unbounded Readable",
+  async () => {
+    // A Readable that never ends: it pushes a 1 KB chunk on every read(). With
+    // backpressure the drain is paced by fs.write's threadpool round-trip, so a
+    // timeout timer can fire and memory stays flat. Without it the consumer
+    // spins in microtasks, the timer never runs, and the subprocess grows
+    // unbounded until it is killed.
+    const fixture = `
+      const { writeFile } = require("node:fs/promises");
+      const { Readable } = require("node:stream");
+      const { devNull } = require("node:os");
+      const KB = Buffer.alloc(1024, 65);
+      const rss0 = process.memoryUsage().rss;
+      setTimeout(() => {
+        console.log(JSON.stringify({ rssDeltaMB: Math.round((process.memoryUsage().rss - rss0) / 1048576) }));
+        process.exit(0);
+      }, 1000);
+      writeFile(devNull, new Readable({ read() { this.push(KB); } })).catch(() => {});
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 10_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // The unfixed build never reaches the timer at all, so stdout is empty and
+    // the spawn timeout kills the process.
+    expect(stdout.trim()).not.toBe("");
+    const report = JSON.parse(stdout.trim());
+    // Growth over baseline: node/bounded is ~0, the old unbounded-buffering
+    // path climbed 50-200+ MB/s. ASAN inflates jitter but not by this much.
+    expect(report.rssDeltaMB).toBeLessThan(isASAN ? 128 : 64);
+    expect(exitCode).toBe(0);
+  },
+  15_000,
+);


### PR DESCRIPTION
## Repro

```js
import * as fsp from "node:fs/promises";
import { Readable } from "node:stream";

let ticks = 0;
setInterval(() => ticks++, 100).unref();
setTimeout(() => { console.log({ heartbeatsIn4s: ticks }); process.exit(0); }, 4000).unref();

// unbounded producer
await fsp.writeFile("/dev/null", new Readable({ read() { this.push("0123456789".repeat(100)); } }));
```

Node: ~39 heartbeats in 4s, RSS flat (~60 MB).
Bun before: 0 heartbeats, RSS climbs 50-230 MB/s, never reaches the timer.

## Cause

`writeFileAsyncIteratorInner` drained chunks through `Bun.file(fd).writer()`. For regular files FileSink's `write()` is synchronous (returns a number, never a Promise), and a `Readable`'s async iterator hands over the next buffered chunk in a microtask, so the `for await` body spun microtask-only for the entire transfer: timers and I/O were starved, and an unbounded producer grew the FileSink buffer until OOM.

## Fix

Write each chunk via the async `fs.write` binding instead, matching Node's `writeFileHandle`. Each write is a threadpool round-trip, which paces the Readable via `push()`'s return value and lets the event loop tick between chunks. Chunks are capped at 512 KB per write like Node.

As a side effect this also fixes the existing `writeFile with a non-truncating flag > promises.writeFile of an async/sync iterable with flag "r+"/"rs+"` cases in `test/js/node/fs/fs.test.ts`, which were failing because the FileSink path did not honour an `r+` fd's open mode.

## Verification

```
# before
$ USE_SYSTEM_BUN=1 bun test test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
 2 pass
 2 fail   # 'yields to the event loop' + 'applies backpressure to an unbounded Readable'

# after
$ bun bd test test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
 4 pass
 0 fail
```

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
bun test v1.4.0 (cc72c4c09)

test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts:
(pass) fs.promises.writeFile async iterator [497.47ms]
(pass) fs.promises.writeFile async iterator throws on invalid input [189.83ms]
82 |         }
83 |         this.push(null);
84 |       },
85 |     });
86 |     await writeFile(devNull, readable);
87 |     expect(timerFired).toBe(true);
                            ^
error: expect(received).toBe(expected)

Expected: true
Received: false

      at <anonymous> (/workspace/bun/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts:87:24)
(fail) fs.promises.writeFile(Readable) yields to the event loop [16888.63ms]
(fail) fs.promises.writeFile applies backpressure to an unbounded Readable [16851.43ms]
  ^ this test timed out after 15000ms.

 2 pass
 2 fail
 7 expect() calls
Ran 4 tests across 1 file. [25.00s]
error: script "bd" exited with code 1
__F:2:S:0

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts:
(pass) fs.promises.writeFile async iterator [29.69ms]
(pass) fs.promises.writeFile async iterator throws on invalid input [6.55ms]
83 |         this.push(null);
84 |       },
85 |     });
86 |     await writeFile(devNull, readable);
87 |     expect(timerFired).toBe(true);
88 |     expect(pushed).toBeLessThan(limit);
                        ^
error: expect(received).toBeLessThan(expected)

Expected: < 200000
Received: 200000

      at <anonymous> (/workspace/bun/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts:88:20)
(fail) fs.promises.writeFile(Readable) yields to the event loop [189.21ms]
120 |     });
121 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
122 |     expect(stderr).toBe("");
123 |     // The unfixed build never reaches the timer at all, so stdout is empty and
124 |     // the spawn timeout kills the process.
125 |     expect(stdout.trim()).not.toBe("");
                                    ^
error: expect(received).not.toBe(expected)

Expected: not ""

      at <anonymous> (/wo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
bun test v1.4.0 (cc72c4c09)

test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts:
(pass) fs.promises.writeFile async iterator [296.24ms]
(pass) fs.promises.writeFile async iterator throws on invalid input [433.54ms]
(pass) fs.promises.writeFile(Readable) yields to the event loop [482.22ms]
(pass) fs.promises.writeFile applies backpressure to an unbounded Readable [3020.04ms]

 4 pass
 0 fail
 12 expect() calls
Ran 4 tests across 1 file. [8.34s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2055ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (16419ms)
Bundle modules (345ms)
Postprocesss modules (282ms)
Bundle Functions (1627ms)
Generate Code (41ms)

[18.73s] Bundled "src/js" for production
  2112 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Blocking[0m waiting for file lock on build directory
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 1m 03s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+cc72c4c09
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (cc72c4c09)

test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts:
(pass) fs.promises.writeFile async iterator [3.33ms]
(pass) fs.promises.writeFile async iterator throws on inval
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/fs.promises.ts                         | 45 +++++++-----
 .../fs-promises-writeFile-async-iterator.test.ts   | 82 +++++++++++++++++++++-
 2 files changed, 107 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/fs.promises.ts                                    1      1      0
…js/node/fs/fs-promises-writeFile-async-iterator.test.ts      1      5      0
```

</details>

<!-- robobun:evidence:end -->