### PR TITLE
FormData: send only basename, not full path, as Bun.file() multipart filename

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4157,8 +4157,17 @@ pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
 
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
-    this.get_name_string()
-        .map_or(BunString::EMPTY, Clone::clone)
+    let Some(name) = this.get_name_string() else {
+        return BunString::EMPTY;
+    };
+    if this.needs_to_read_file() || this.is_s3() {
+        let utf8 = name.to_utf8();
+        let base = bun_paths::basename(&utf8);
+        if base.len() != utf8.len() {
+            return BunString::clone_utf8(base);
+        }
+    }
+    name.clone()
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -248,7 +248,7 @@ pub trait BlobExt {
     fn get_slice(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_mime_type_or_content_type(&self) -> Option<MimeType>;
     fn get_type(&self, global_this: &JSGlobalObject) -> JSValue;
-    fn get_name_string(&self) -> Option<&BunString>;
+    fn get_name_string(&self) -> Option<BunString>;
     fn get_name(&self, _: JSValue, global_this: &JSGlobalObject) -> JsResult<JSValue>;
     fn set_name(
         &self,
@@ -1114,7 +1114,7 @@ impl BlobExt for Blob {
                         writer,
                         ENABLE_ANSI_COLORS,
                         "name<d>:<r> <green>\"{f}\"<r>",
-                        self.get_name_string().unwrap_or(&BunString::EMPTY),
+                        self.get_name_string().unwrap_or(BunString::EMPTY),
                     )?;
                     if !self.content_type_slice().is_empty()
                         || self.offset.get() > 0
@@ -2059,21 +2059,20 @@ impl BlobExt for Blob {
         JSValue::js_empty_string(global_this)
     }
 
-    fn get_name_string(&self) -> Option<&BunString> {
-        if self.name.get().tag() != bun_core::Tag::Dead {
-            return Some(self.name.get());
+    /// `name` holds only an assigned name; it stays `Dead` for a plain
+    /// `Bun.file()`, whose name is derived from the store path on each call.
+    fn get_name_string(&self) -> Option<BunString> {
+        let name = self.name.get();
+        if name.tag() != bun_core::Tag::Dead {
+            return Some(name.clone());
         }
-        if let Some(path) = self.store_path() {
-            self.name.set(BunString::clone_utf8(path));
-            return Some(self.name.get());
-        }
-        None
+        self.store_path().map(BunString::clone_utf8)
     }
 
     // TODO: Move this to a separate `File` object or BunFile
     fn get_name(&self, _: JSValue, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(match self.get_name_string() {
-            Some(name) => name.to_js(global_this)?,
+            Some(name) => name.into_js(global_this)?,
             None => JSValue::UNDEFINED,
         })
     }
@@ -4157,19 +4156,14 @@ pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
 
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
-    let Some(name) = this.get_name_string() else {
-        return BunString::EMPTY;
-    };
-    // A name equal to the store path was derived from it; a user-assigned name differs and is sent as given.
-    if let Some(path) = this.store_path() {
-        if *name.to_utf8() == *path {
-            let base = bun_paths::basename(path);
-            if base.len() != path.len() {
-                return BunString::clone_utf8(base);
-            }
-        }
+    let name = this.name.get();
+    if name.tag() != bun_core::Tag::Dead {
+        return name.clone();
     }
-    name.clone()
+    match this.store_path() {
+        Some(path) => BunString::clone_utf8(bun_paths::basename(path)),
+        None => BunString::EMPTY,
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4160,11 +4160,17 @@ pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
     let Some(name) = this.get_name_string() else {
         return BunString::EMPTY;
     };
-    if this.needs_to_read_file() || this.is_s3() {
-        let utf8 = name.to_utf8();
-        let base = bun_paths::basename(&utf8);
-        if base.len() != utf8.len() {
-            return BunString::clone_utf8(base);
+    // A name that `get_name_string` derived from the store path (a `Bun.file()`
+    // path or S3 key) is reduced to its basename so the multipart part never
+    // carries the host directory layout. A name the user assigned (`new
+    // File(bits, name)`, `blob.name = ...`) differs from the store path and is
+    // used as given.
+    if let Some(path) = this.store_path() {
+        if *name.to_utf8() == *path {
+            let base = bun_paths::basename(path);
+            if base.len() != path.len() {
+                return BunString::clone_utf8(base);
+            }
         }
     }
     name.clone()

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2059,8 +2059,6 @@ impl BlobExt for Blob {
         JSValue::js_empty_string(global_this)
     }
 
-    /// `name` holds only an assigned name; it stays `Dead` for a plain
-    /// `Bun.file()`, whose name is derived from the store path on each call.
     fn get_name_string(&self) -> Option<BunString> {
         let name = self.name.get();
         if name.tag() != bun_core::Tag::Dead {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4160,11 +4160,7 @@ pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
     let Some(name) = this.get_name_string() else {
         return BunString::EMPTY;
     };
-    // A name that `get_name_string` derived from the store path (a `Bun.file()`
-    // path or S3 key) is reduced to its basename so the multipart part never
-    // carries the host directory layout. A name the user assigned (`new
-    // File(bits, name)`, `blob.name = ...`) differs from the store path and is
-    // used as given.
+    // A name equal to the store path was derived from it; a user-assigned name differs and is sent as given.
     if let Some(path) = this.store_path() {
         if *name.to_utf8() == *path {
             let base = bun_paths::basename(path);

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { join } from "path";
 
 describe("FormData", () => {
@@ -599,6 +599,36 @@ describe("FormData", () => {
       const formData = new FormData();
       formData.append("foo", Bun.file("missing"));
       expect(() => new Response(formData)).toThrow();
+    });
+
+    it("serializes only the basename, not the full path, as the multipart filename", async () => {
+      using dir = tempDir("formdata-bunfile-path", {
+        "nested/secret-dir/report.pdf": "%PDF",
+      });
+      const fullPath = join(String(dir), "nested", "secret-dir", "report.pdf");
+      const file = Bun.file(fullPath);
+      expect(file.name).toBe(fullPath);
+
+      for (const method of ["append", "set"] as const) {
+        const fd = new FormData();
+        fd[method]("upload", file);
+
+        const wire = await new Request("http://x/", { method: "POST", body: fd }).text();
+        const cd = wire.split("\r\n").find(l => l.startsWith("Content-Disposition"))!;
+        expect(cd).toBe(`Content-Disposition: form-data; name="upload"; filename="report.pdf"`);
+        expect(wire).not.toContain("secret-dir");
+        expect(wire).not.toContain(String(dir));
+      }
+
+      // Bun.file's own .name stays the full path.
+      expect(file.name).toBe(fullPath);
+
+      // An explicit filename argument is used verbatim.
+      const fd2 = new FormData();
+      fd2.append("upload", file, "override.bin");
+      const wire2 = await new Request("http://x/", { method: "POST", body: fd2 }).text();
+      const cd2 = wire2.split("\r\n").find(l => l.startsWith("Content-Disposition"))!;
+      expect(cd2).toBe(`Content-Disposition: form-data; name="upload"; filename="override.bin"`);
     });
   });
 

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -609,26 +609,54 @@ describe("FormData", () => {
       const file = Bun.file(fullPath);
       expect(file.name).toBe(fullPath);
 
+      const contentDisposition = async (fd: FormData) => {
+        const wire = await new Request("http://x/", { method: "POST", body: fd }).text();
+        expect(wire).not.toContain("secret-dir");
+        expect(wire).not.toContain(String(dir));
+        return wire.split("\r\n").find(l => l.startsWith("Content-Disposition"))!;
+      };
+
       for (const method of ["append", "set"] as const) {
         const fd = new FormData();
         fd[method]("upload", file);
-
-        const wire = await new Request("http://x/", { method: "POST", body: fd }).text();
-        const cd = wire.split("\r\n").find(l => l.startsWith("Content-Disposition"))!;
-        expect(cd).toBe(`Content-Disposition: form-data; name="upload"; filename="report.pdf"`);
-        expect(wire).not.toContain("secret-dir");
-        expect(wire).not.toContain(String(dir));
+        expect(await contentDisposition(fd)).toBe(
+          `Content-Disposition: form-data; name="upload"; filename="report.pdf"`,
+        );
       }
 
       // Bun.file's own .name stays the full path.
       expect(file.name).toBe(fullPath);
 
+      // A File read back out of a FormData is still sent as the basename.
+      const roundTrip = new FormData();
+      roundTrip.append("upload", file);
+      const reappended = new FormData();
+      reappended.append("upload", roundTrip.get("upload") as File);
+      expect(await contentDisposition(reappended)).toBe(
+        `Content-Disposition: form-data; name="upload"; filename="report.pdf"`,
+      );
+
       // An explicit filename argument is used verbatim.
-      const fd2 = new FormData();
-      fd2.append("upload", file, "override.bin");
-      const wire2 = await new Request("http://x/", { method: "POST", body: fd2 }).text();
-      const cd2 = wire2.split("\r\n").find(l => l.startsWith("Content-Disposition"))!;
-      expect(cd2).toBe(`Content-Disposition: form-data; name="upload"; filename="override.bin"`);
+      const explicitArg = new FormData();
+      explicitArg.append("upload", file, "override.bin");
+      expect(await contentDisposition(explicitArg)).toBe(
+        `Content-Disposition: form-data; name="upload"; filename="override.bin"`,
+      );
+
+      // A user-assigned name is used verbatim, even over a Bun.file-backed store.
+      const wrapped = new FormData();
+      wrapped.append("upload", new File([file], "reports/q3.pdf"));
+      expect(await contentDisposition(wrapped)).toBe(
+        `Content-Disposition: form-data; name="upload"; filename="reports/q3.pdf"`,
+      );
+
+      const renamed = Bun.file(fullPath);
+      renamed.name = "renamed.pdf";
+      const renamedFd = new FormData();
+      renamedFd.append("upload", renamed);
+      expect(await contentDisposition(renamedFd)).toBe(
+        `Content-Disposition: form-data; name="upload"; filename="renamed.pdf"`,
+      );
     });
   });
 


### PR DESCRIPTION
## Repro

```js
import { mkdirSync, writeFileSync } from "node:fs";
mkdirSync("/tmp/secret-dir", { recursive: true });
writeFileSync("/tmp/secret-dir/report.pdf", "%PDF");
const fd = new FormData();
fd.append("upload", Bun.file("/tmp/secret-dir/report.pdf"));
console.log((await new Request("http://x/", { method: "POST", body: fd }).text())
  .split("\r\n").find(l => l.startsWith("Content-Disposition")));
```

Before:
```
Content-Disposition: form-data; name="upload"; filename="/tmp/secret-dir/report.pdf"
```

After (and in browsers):
```
Content-Disposition: form-data; name="upload"; filename="report.pdf"
```

## Cause

`FormData.append`/`set` default the entry filename from `Blob__getFileNameString` when no explicit filename is given (`JSDOMFormData.cpp:311`/`474`). For a `Bun.file(path)` blob that returned the full host path, which was emitted verbatim in the multipart `Content-Disposition` header. The documented upload shape (`fd.append("f", Bun.file(p)); fetch(url, { method: "POST", body: fd })`) therefore disclosed the client's directory layout, usernames, and temp paths to the server.

A browser `File` reports only the basename (File API: "the name of the file without path information"), and Node's `fs.openAsBlob` part serializes `filename="blob"`; neither leaks a path.

## Fix

`Blob__getFileNameString` returns an assigned `name` as given, and otherwise `basename(store_path)` (a `Bun.file()` path or S3 key), computed on the raw path bytes. Its only callers are the `FormData.append`/`set` default-filename paths.

For that to be a clean rule, `get_name_string()` no longer caches the derived path into `blob.name`. Before, the first `.name` read wrote the full path into `name`, which made an assigned name and a derived one indistinguishable. The JS `name` getter is already cached by JSC on the wrapper (`cache: true`), so nothing is recomputed on repeated reads from JS.

Unchanged:
- `Bun.file(path).name` still returns the full path.
- An explicit `fd.append(name, blob, filename)` argument is still used verbatim.
- An assigned name is used verbatim: `new File([..], "reports/q3.pdf")`, `new File([Bun.file(p)], "reports/q3.pdf")`, `bunFile.name = "renamed.pdf"`.
- A `File` read back out of a FormData (`fd.get()`) and appended again still serializes the basename.

## Verification

```sh
bun bd test test/js/web/html/FormData.test.ts
```

150 pass / 0 fail. The new test fails on the current release (emits the full path) and passes with this change. Also green: `FormData-multipart-serialization`, `form-data-set-append`, `fetch-file-upload`, `FormData-file-error-leak`, `structured-clone-blob-file`, `structured-clone-fastpath`, `fetch/blob`, `fetch/body`, `util/inspect`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.22ms]
(pass) FormData > should be able to append a Blob [8.24ms]
(pass) FormData > should be able to set a Blob [5.72ms]
(pass) FormData > should be able to set a string [2.64ms]
(pass) FormData > should get filename from file [3.83ms]
(pass) FormData > should use the correct filenames [4.82ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [12.99ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [28.39ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.32ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.00ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.55ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.71ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (aacd9512f)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.06ms]
(pass) FormData > should be able to append a Blob [0.12ms]
(pass) FormData > should be able to set a Blob [0.06ms]
(pass) FormData > should be able to set a string [0.03ms]
(pass) FormData > should get filename from file [0.04ms]
(pass) FormData > should use the correct filenames [0.05ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [0.27ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [0.55ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [0.03ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.03ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.02ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.01ms]
(pass) F
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [3.30ms]
(pass) FormData > should be able to append a Blob [7.96ms]
(pass) FormData > should be able to set a Blob [5.63ms]
(pass) FormData > should be able to set a string [2.63ms]
(pass) FormData > should get filename from file [3.31ms]
(pass) FormData > should use the correct filenames [4.75ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [13.37ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [28.73ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.33ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [5.53ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [1.61ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [3.46ms]
(pass) FormData > should parse multipart/form-data (si
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 582ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 242 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_pic
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/Blob.rs       | 29 ++++++++++---------
 test/js/web/html/FormData.test.ts | 60 ++++++++++++++++++++++++++++++++++++++-
 2 files changed, 75 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 5 passed · 2 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/Blob.rs           14     11      0
test/js/web/html/FormData.test.ts      2      9      0
```

</details>

<!-- robobun:evidence:end -->