### PR TITLE
WebSocket client: set MessageEvent.origin to the URL's origin, not the full URL

### DIFF
--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -450,6 +450,7 @@ size_t WebSocket::memoryCost() const
 {
     size_t cost = sizeof(WebSocket);
     cost += m_url.string().sizeInBytes();
+    cost += m_origin.sizeInBytes();
     cost += m_subprotocol.sizeInBytes();
     cost += m_extensions.sizeInBytes();
 
@@ -501,6 +502,8 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
         updateHasPendingActivity();
         return Exception { SyntaxError, makeString("URL has fragment component "_s, m_url.stringCenterEllipsizedToLength()) };
     }
+
+    m_origin = m_url.protocolHostAndPort();
 
     // ASSERT(context.contentSecurityPolicy());
     // auto& contentSecurityPolicy = *context.contentSecurityPolicy();
@@ -1432,7 +1435,7 @@ void WebSocket::didReceiveMessage(String&& message)
     if (this->hasEventListeners("message"_s)) {
         // the main reason for dispatching on a separate tick is to handle when you haven't yet attached an event listener
         this->incPendingActivityCount();
-        dispatchEvent(MessageEvent::create(WTF::move(message), m_url.string()));
+        dispatchEvent(MessageEvent::create(WTF::move(message), m_origin));
         this->decPendingActivityCount();
         return;
     }
@@ -1441,7 +1444,7 @@ void WebSocket::didReceiveMessage(String&& message)
         this->incPendingActivityCount();
         context->postTask([this, message_ = WTF::move(message), protectedThis = Ref { *this }](ScriptExecutionContext& context) {
             ASSERT(scriptExecutionContext());
-            protectedThis->dispatchEvent(MessageEvent::create(message_, protectedThis->m_url.string()));
+            protectedThis->dispatchEvent(MessageEvent::create(message_, protectedThis->m_origin));
             protectedThis->decPendingActivityCount();
         });
     }
@@ -1466,7 +1469,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
             // the main reason for dispatching on a separate tick is to handle when you haven't yet attached an event listener
             this->incPendingActivityCount();
             RefPtr<Blob> blob = Blob::create(binaryData, scriptExecutionContext()->jsGlobalObject());
-            dispatchEvent(MessageEvent::create(eventName, blob.releaseNonNull(), m_url.string()));
+            dispatchEvent(MessageEvent::create(eventName, blob.releaseNonNull(), m_origin));
             this->decPendingActivityCount();
             return;
         }
@@ -1476,7 +1479,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
             this->incPendingActivityCount();
             context->postTask([this, name = eventName, blob = blob.releaseNonNull(), protectedThis = Ref { *this }](ScriptExecutionContext& context) {
                 ASSERT(scriptExecutionContext());
-                protectedThis->dispatchEvent(MessageEvent::create(name, blob, protectedThis->m_url.string()));
+                protectedThis->dispatchEvent(MessageEvent::create(name, blob, protectedThis->m_origin));
                 protectedThis->decPendingActivityCount();
             });
         }
@@ -1486,7 +1489,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
         if (this->hasEventListeners(eventName)) {
             // the main reason for dispatching on a separate tick is to handle when you haven't yet attached an event listener
             this->incPendingActivityCount();
-            dispatchEvent(MessageEvent::create(eventName, ArrayBuffer::create(binaryData), m_url.string()));
+            dispatchEvent(MessageEvent::create(eventName, ArrayBuffer::create(binaryData), m_origin));
             this->decPendingActivityCount();
             return;
         }
@@ -1496,7 +1499,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
             this->incPendingActivityCount();
             context->postTask([this, name = eventName, buffer = WTF::move(arrayBuffer), protectedThis = Ref { *this }](ScriptExecutionContext& context) {
                 ASSERT(scriptExecutionContext());
-                protectedThis->dispatchEvent(MessageEvent::create(name, buffer, m_url.string()));
+                protectedThis->dispatchEvent(MessageEvent::create(name, buffer, protectedThis->m_origin));
                 protectedThis->decPendingActivityCount();
             });
         }
@@ -1524,7 +1527,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
             JSC::EnsureStillAliveScope ensureStillAlive(buffer);
             MessageEvent::Init init;
             init.data = buffer;
-            init.origin = this->m_url.string();
+            init.origin = this->m_origin;
 
             dispatchEvent(MessageEvent::create(eventName, WTF::move(init), EventIsTrusted::Yes));
             this->decPendingActivityCount();
@@ -1544,7 +1547,7 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
                 JSC::EnsureStillAliveScope ensureStillAlive(uint8array);
                 MessageEvent::Init init;
                 init.data = uint8array;
-                init.origin = protectedThis->m_url.string();
+                init.origin = protectedThis->m_origin;
                 protectedThis->dispatchEvent(MessageEvent::create(name, WTF::move(init), EventIsTrusted::Yes));
                 protectedThis->decPendingActivityCount();
             });

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -324,6 +324,7 @@ private:
 
     State m_state { CONNECTING };
     URL m_url;
+    String m_origin;
     unsigned m_bufferedAmount { 0 };
     unsigned m_bufferedAmountAfterClose { 0 };
     // In browsers, the default is Blob, however most applications

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -619,6 +619,46 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   });
 });
 
+describe.concurrent.each(["arraybuffer", "nodebuffer", "blob"] as const)(
+  "WebSocket MessageEvent.origin (binaryType=%s)",
+  binaryType => {
+    it("is the URL's origin, not the full URL", async () => {
+      await using server = Bun.serve({
+        port: 0,
+        fetch(req, server) {
+          if (server.upgrade(req)) return;
+          return new Response("no", { status: 400 });
+        },
+        websocket: {
+          open(ws) {
+            ws.send("hello");
+            ws.send(new Uint8Array([1, 2, 3]));
+          },
+          message() {},
+        },
+      });
+
+      const expectedOrigin = `ws://127.0.0.1:${server.port}`;
+      const ws = new WebSocket(`${expectedOrigin}/some/path?token=secret`);
+      ws.binaryType = binaryType;
+      try {
+        const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+        const origins: string[] = [];
+        ws.addEventListener("message", ev => {
+          origins.push(ev.origin);
+          if (origins.length === 2) resolve(origins);
+        });
+        ws.addEventListener("error", e => reject((e as ErrorEvent).error ?? new Error("error")));
+        ws.addEventListener("close", e => reject(new Error(`closed ${e.code} before messages`)));
+
+        expect(await promise).toEqual([expectedOrigin, expectedOrigin]);
+      } finally {
+        ws.terminate();
+      }
+    });
+  },
+);
+
 async function listen(): Promise<URL> {
   const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");
   const { promise, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
The [WHATWG WebSocket spec](https://websockets.spec.whatwg.org/#feedback-from-the-protocol) says `message` events are fired with `origin` set to "the serialization of the WebSocket object's url's origin" (`scheme://host[:port]`). Bun was passing `m_url.string()` (the full href) at every `MessageEvent::create` call site in `didReceiveMessage` / `didReceiveBinaryData`, so `event.origin === expectedOrigin` checks failed and any request path/query (e.g. `?token=...`) leaked into a field documented as an origin.

```js
const ws = new WebSocket(`ws://127.0.0.1:${port}/some/path?token=secret`);
ws.onmessage = ev => console.log(ev.origin);
// before: ws://127.0.0.1:PORT/some/path?token=secret
// after:  ws://127.0.0.1:PORT   (matches Node/undici and browsers)
```

### Fix

Store `m_origin = m_url.protocolHostAndPort()` once in `connect()` (the same helper `URLDecomposition::origin()` uses for ws/wss URLs, and what upstream WebKit does via `SecurityOrigin::create(m_url)`) and pass it at all eight dispatch sites across the text, Blob, ArrayBuffer and NodeBuffer paths.

### Verification

New `describe.concurrent.each` block in `test/js/web/websocket/websocket-client.test.ts` connects to a `Bun.serve` WebSocket with a path+query URL under each `binaryType` and asserts both the text and binary `MessageEvent.origin` equal `ws://127.0.0.1:${port}`. With `src/` reverted the three cases fail with the full URL in the diff; with the fix, 37/37 tests in the file pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (6dd21ecec)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:33461/
(pass) WebSocket > url [7.93ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [3.20ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [4.60ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:33461',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'S7w/XTxJTHeAkQa
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6dd21ecec)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:38931/
(pass) WebSocket > url [0.57ms]
(pass) WebSocket > binaryType > (default) [0.11ms]
(pass) WebSocket > binaryType > (invalid) [0.16ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:38931',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'WeMVR73oR96pzVyXxGSPpw=='
}
(pass) WebSocket > readyState [7.25ms]
Received connection: 127.0.0.1
Received bytes: <Buffer 88 82 e6 3c 79 55 e5 d4>
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received close: 1000 <Buffer >
Received
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (6dd21ecec)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:39363/
(pass) WebSocket > url [13.59ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [6.39ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [6.72ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:39363',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'NSzHqaEXTfKkCo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1056ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/12] gen cpp.rs (cppbind)
[2/11] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[3/11] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[4/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[5/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[6/11] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[7/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[8/11] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-0.cpp.o
[8/11] link bun-profile
[9/11] bun-profile --revision
1.4.0-canary.1+6dd21ecec
[11/11] strip bun
[build] done
bun test v1.4.0-canary.1 (6dd21ecec)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:36941/
(pass) WebSocket > url [0.55ms]
(pass) WebSocket > binaryType > (default) [0.11ms]
(pass) WebSocket > binaryType > (invalid) [0.16ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Rece
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/WebSocket.cpp         | 19 ++++++------
 src/jsc/bindings/webcore/WebSocket.h           |  1 +
 test/js/web/websocket/websocket-client.test.ts | 40 ++++++++++++++++++++++++++
 3 files changed, 52 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/jsc/bindings/webcore/WebSocket.cpp              5      2      0
src/jsc/bindings/webcore/WebSocket.h                1      1      0
test/js/web/websocket/websocket-client.test.ts      4      2      0
```

</details>

<!-- robobun:evidence:end -->