### PR TITLE
websocket: fail the client connection on any masked server frame

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2167,7 +2167,6 @@ fn parse_websocket_header(bytes: [u8; 2]) -> ParsedHeader {
     let header = WebsocketHeader::from_slice(bytes);
     let opcode = header.opcode();
     let payload_len = header.len() as usize;
-    let is_data_frame = matches!(opcode, Opcode::Text | Opcode::Binary);
     let mut parsed = ParsedHeader {
         opcode,
         payload_len,
@@ -2177,8 +2176,11 @@ fn parse_websocket_header(bytes: [u8; 2]) -> ParsedHeader {
         next: ReceiveState::Fail,
     };
 
-    // A server must not mask data frames it sends to a client.
-    if header.mask() && is_data_frame {
+    // RFC 6455 §5.1: a server MUST NOT mask any frame, and a client MUST fail
+    // the connection on any masked server frame. This is not limited to data
+    // frames; a masked control frame's 4-byte masking key would otherwise be
+    // parsed as payload (for Close, as the close code).
+    if header.mask() {
         parsed.next = ReceiveState::NeedMask;
         return parsed;
     }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2176,10 +2176,7 @@ fn parse_websocket_header(bytes: [u8; 2]) -> ParsedHeader {
         next: ReceiveState::Fail,
     };
 
-    // RFC 6455 §5.1: a server MUST NOT mask any frame, and a client MUST fail
-    // the connection on any masked server frame. This is not limited to data
-    // frames; a masked control frame's 4-byte masking key would otherwise be
-    // parsed as payload (for Close, as the close code).
+    // RFC 6455 §5.1: a server must not mask any frame it sends to a client.
     if header.mask() {
         parsed.next = ReceiveState::NeedMask;
         return parsed;

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -684,10 +684,23 @@ describe.concurrent("WebSocket client rejects masked server frames", () => {
   });
 
   it.each([
+    ["Text", 0x1],
+    ["Binary", 0x2],
     ["Ping", 0x9],
     ["Pong", 0xa],
   ])("fails a masked %s frame", async (_name, opcode) => {
     const frame = maskedFrame(opcode, Buffer.from("hi"), Buffer.from("aabbccdd", "hex"));
+    expect(await run(frame)).toEqual(EXPECTED_CLOSE);
+  });
+
+  it("fails a masked Continue frame mid-message", async () => {
+    // An unmasked FIN=0 Text frame first so receiving_is_final is false when the
+    // masked Continue header is parsed; otherwise the UnexpectedOpcode check
+    // fires before the NeedMask dispatch.
+    const frame = Buffer.concat([
+      Buffer.from([0x01, 0x02, 0x68, 0x69]),
+      maskedFrame(0x0, Buffer.from("there"), Buffer.from("aabbccdd", "hex")),
+    ]);
     expect(await run(frame)).toEqual(EXPECTED_CLOSE);
   });
 

--- a/test/js/web/websocket/websocket-client.test.ts
+++ b/test/js/web/websocket/websocket-client.test.ts
@@ -619,6 +619,91 @@ describe.concurrent("WebSocket ping()/pong() payload size limit", () => {
   });
 });
 
+// RFC 6455 §5.1: a server MUST NOT mask any frame it sends to the client, and a
+// client MUST fail the connection on any masked server frame. Bun enforced this
+// for Text/Binary but not for control frames, so a masked Close frame's 4-byte
+// masking key was parsed as the close payload: JS saw a clean close whose code
+// was the first two mask-key bytes, and that code was echoed back on the wire.
+describe.concurrent("WebSocket client rejects masked server frames", () => {
+  const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+  const EXPECTED_CLOSE = {
+    code: 1002,
+    wasClean: false,
+    reason: "Protocol error - unexpected mask from server",
+  };
+
+  function maskedFrame(opcode: number, payload: Buffer, maskKey: Buffer) {
+    const masked = Buffer.from(payload);
+    for (let i = 0; i < masked.length; i++) masked[i] ^= maskKey[i & 3];
+    return Buffer.concat([Buffer.from([0x80 | opcode, 0x80 | payload.length]), maskKey, masked]);
+  }
+
+  async function run(frame: Buffer) {
+    const sockets = new Set<import("node:net").Socket>();
+    const server = createServer(sock => {
+      sockets.add(sock);
+      let buf = Buffer.alloc(0);
+      sock.on("error", () => {});
+      sock.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        const i = buf.indexOf("\r\n\r\n");
+        if (i < 0) return;
+        const key = /sec-websocket-key: *([^\r\n]+)/i.exec(buf.toString("latin1"))![1];
+        const accept = createHash("sha1")
+          .update(key + GUID)
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+        );
+        sock.write(frame);
+        sock.removeAllListeners("data");
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const closed = await new Promise<CloseEvent>(resolve => {
+        ws.onerror = () => {};
+        ws.onclose = resolve;
+      });
+      return { code: closed.code, wasClean: closed.wasClean, reason: closed.reason };
+    } finally {
+      for (const s of sockets) s.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  // Before the fix each of these produced a CloseEvent whose code was the
+  // big-endian u16 of the first two mask-key bytes (0x1122 → 4386, 0x03ea →
+  // 1002, 0x03e8 → 1000) with wasClean = true.
+  it.each(["11223344", "03ea0000", "03e80000"])("fails a masked Close frame (mask key %s)", async maskKey => {
+    const frame = maskedFrame(0x8, Buffer.from([0x03, 0xe8]), Buffer.from(maskKey, "hex"));
+    expect(await run(frame)).toEqual(EXPECTED_CLOSE);
+  });
+
+  it.each([
+    ["Ping", 0x9],
+    ["Pong", 0xa],
+  ])("fails a masked %s frame", async (_name, opcode) => {
+    const frame = maskedFrame(opcode, Buffer.from("hi"), Buffer.from("aabbccdd", "hex"));
+    expect(await run(frame)).toEqual(EXPECTED_CLOSE);
+  });
+
+  it("fails a masked Close frame with a reason body", async () => {
+    // With a reason body the still-masked reason bytes previously tripped the
+    // UTF-8 check (1007) instead of the mask check; the failure was accidental
+    // and misdiagnosed.
+    const frame = maskedFrame(
+      0x8,
+      Buffer.concat([Buffer.from([0x03, 0xe8]), Buffer.from("bye")]),
+      Buffer.from("aabbccdd", "hex"),
+    );
+    expect(await run(frame)).toEqual(EXPECTED_CLOSE);
+  });
+});
+
 async function listen(): Promise<URL> {
   const pathname = path.join(import.meta.dir, "./websocket-server-echo.mjs");
   const { promise, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
RFC 6455 section 5.1 requires a client to fail the connection on **any** masked frame from the server. `parse_websocket_header` gated that check on `is_data_frame` (Text/Binary only), so control frames with the MASK bit set slipped through and the 4-byte masking key was consumed as payload.

## Symptom

A masked server Close frame (`88 82 <mask-key> <masked code>`) is not rejected. The first two mask-key bytes are read as the close code, so JS sees `wasClean: true` with a fabricated code, and that code is echoed back on the wire:

```
maskkey=11223344 -> code=4386 (0x1122) wasClean=true
maskkey=03e80000 -> code=1000          wasClean=true
```

Masked Ping/Pong frames fail only by accident (the trailing mask/payload bytes parse as an invalid next header, yielding `1002 "unsupported control frame"` instead of the mask error). With a Close reason body, the still-masked reason bytes usually trip the UTF-8 check and surface as 1007. Node/undici correctly fails every case with a protocol error.

## Fix

Drop the `&& is_data_frame` gate so the existing `UnexpectedMaskFromServer` path applies to every opcode.

## Verification

```
bun bd test test/js/web/websocket/websocket-client.test.ts -t "masked server frames"
```

6 new cases fail on the current release (wrong code / `wasClean: true` / wrong reason) and pass with this change. The full `websocket-client.test.ts`, `websocket-close-code.test.ts`, `websocket-close-fragmented.test.ts`, `websocket-client-short-read.test.ts` and `websocket-permessage-deflate-edge-cases.test.ts` suites stay green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (5ff2453bb)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:46227/
(pass) WebSocket > url [7.11ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [2.77ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [4.51ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:46227',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': '4JFktzhCQfe/5tq
... (truncated)

release without fix: 11 FAILED
bun test v1.3.14 (0d9b296a)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:34167/
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > url [4.67ms]
(pass) WebSocket > binaryType > (default) [0.09ms]
(pass) WebSocket > binaryType > (invalid) [0.12ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:34167',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'vZ+g/28fQgC1DFizsrfyFA=='
}
Received connection: 127.0.0.1
Received upgrade: {
  host: '127.0.0.1:34167',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-client.test.ts
bun test v1.4.0 (5ff2453bb)

test/js/web/websocket/websocket-client.test.ts:
Listening: ws://127.0.0.1:42587/
(pass) WebSocket > url [7.13ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (default) [2.95ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
(pass) WebSocket > binaryType > (invalid) [4.11ms]
Received client error: Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20) {
  errno: -104,
  code: 'ECONNRESET',
  syscall: 'read'
}
Received upgrade: {
  host: '127.0.0.1:42587',
  connection: 'Upgrade',
  upgrade: 'websocket',
  'sec-websocket-version': '13',
  'sec-websocket-extensions': 'permessage-deflate; client_max_window_bits',
  'sec-websocket-key': 'e8E5EcJdQ8mL6hj
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5ff2453bb6
  features     baseline

22 deps, 108 codegen, 1171 objects in 754ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] mkdir codegen
[2/1238] mkdir stamps
[3/1238] mkdir pch
[4/1238] mkdir obj
[5/1238] gen ErrorCode+*.h
[6/1238] gen bindgenv2
[7/1238] fetch tinycc
[tinycc] up to date
[8/1238] fetch zlib
[zlib] up to date
[9/1238] fetch picohttpparser
[picohttpparser] up to date
[10/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1238] install /workspace/bun
bun install v1.3.14 (0d9b296a)

Checked 124 installs across 170 packages (no changes) [91.00ms]
[12/1238] gen .bind.ts → GeneratedBindings.cpp
[13/1238] subst deps/zlib/zlib.h
[14/1238] subst deps/zlib/zconf.h
[15/1238] subst deps/libjpeg-turbo/jconfig.h
[16/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[17/1238] gen JSBuffer.lut.h
Generating /workspace/bun/bui
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/websocket_client.rs               |  5 +-
 test/js/web/websocket/websocket-client.test.ts | 98 ++++++++++++++++++++++++++
 2 files changed, 100 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 3 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/http_jsc/websocket_client.rs                    4      3      0
test/js/web/websocket/websocket-client.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->