### PR TITLE
websocket client: echo the received close code verbatim on the wire

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -874,14 +874,18 @@ impl<const SSL: bool> WebSocket<SSL> {
     /// Assemble the (optional) close payload, echo a close frame back, and
     /// stop reading: a received Close always terminates the parse loop.
     fn recv_close(&self, cursor: &mut RecvCursor<'_>) -> Step {
-        if cursor.body_remain == 1 || cursor.body_remain > MAX_CONTROL_PAYLOAD {
-            return self.recv_failed(ErrorCode::InvalidControlFrame);
-        }
-
-        if cursor.body_remain == 0 {
-            self.close_received.set(true);
-            self.send_close();
-            return Step::Terminated;
+        // Once `buffer_control_payload` has started buffering, `body_remain`
+        // counts bytes buffered so far (see its doc comment), so these length
+        // guards only apply on first entry.
+        if !self.control_frame_started.get() {
+            if cursor.body_remain == 1 || cursor.body_remain > MAX_CONTROL_PAYLOAD {
+                return self.recv_failed(ErrorCode::InvalidControlFrame);
+            }
+            if cursor.body_remain == 0 {
+                self.close_received.set(true);
+                self.send_close();
+                return Step::Terminated;
+            }
         }
 
         let Some((payload, payload_len)) = self.buffer_control_payload(cursor) else {
@@ -891,12 +895,8 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.close_received.set(true);
         if payload_len >= 2 {
             let received_code = u16::from_be_bytes([payload[0], payload[1]]);
-            let (echo_code, dispatch_code) = received_close_codes(received_code);
-            self.send_close_with_body(
-                Some(echo_code),
-                Some(dispatch_code),
-                &payload[2..payload_len],
-            );
+            let code = received_close_code(received_code);
+            self.send_close_with_body(Some(code), None, &payload[2..payload_len]);
         } else {
             self.send_close();
         }
@@ -2124,18 +2124,17 @@ enum Step {
     Terminated,
 }
 
-/// Map a status code received in a Close frame to the `(wire echo, JS dispatch)`
-/// pair. RFC 6455 §7.4.1-§7.4.2: codes outside the legal on-wire set (`<1000`,
-/// the reserved `1004`–`1006` and `1015`–`2999`, and the undefined `>4999`) are
-/// a protocol error, so JS sees 1002. §7.1.5: the JS-visible code is otherwise
-/// the received one. §5.5.1: the wire echo repeats the received code verbatim.
-fn received_close_codes(received: u16) -> (u16, u16) {
+/// Map a status code received in a Close frame to the code echoed on the wire
+/// and reported to JS. RFC 6455 §7.4.1-§7.4.2: codes outside the legal on-wire
+/// set (`<1000`, the reserved `1004`–`1006` and `1015`–`2999`, and the
+/// undefined `>4999`) are a protocol error, so both see 1002. Otherwise the
+/// received code passes through verbatim (§5.5.1, §7.1.5).
+fn received_close_code(received: u16) -> u16 {
     let is_invalid = received < 1000
         || (1004..1007).contains(&received)
         || (1015..=2999).contains(&received)
         || received > 4999;
-    let dispatch = if is_invalid { 1002 } else { received };
-    (dispatch, dispatch)
+    if is_invalid { 1002 } else { received }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -874,9 +874,6 @@ impl<const SSL: bool> WebSocket<SSL> {
     /// Assemble the (optional) close payload, echo a close frame back, and
     /// stop reading: a received Close always terminates the parse loop.
     fn recv_close(&self, cursor: &mut RecvCursor<'_>) -> Step {
-        // Once `buffer_control_payload` has started buffering, `body_remain`
-        // counts bytes buffered so far (see its doc comment), so these length
-        // guards only apply on first entry.
         if !self.control_frame_started.get() {
             if cursor.body_remain == 1 || cursor.body_remain > MAX_CONTROL_PAYLOAD {
                 return self.recv_failed(ErrorCode::InvalidControlFrame);
@@ -904,10 +901,8 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     pub fn send_close(&self) {
-        // Received a bodyless Close: echo a bodyless Close frame on the wire
-        // (RFC 6455 §5.5.1 — the peer distinguishes "no status" from an
-        // explicit 1000), and report 1005 ("no status received") to JS per
-        // §7.1.5.
+        // Received a bodyless Close: echo bodyless (RFC 6455 §5.5.1) and
+        // report 1005 to JS (§7.1.5).
         self.send_close_with_body(None, Some(1005), &[]);
     }
 
@@ -1151,10 +1146,8 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     /// `code` is the status code written to the wire frame; `None` writes a
-    /// bodyless Close frame (payload length 0). `dispatch_code` overrides the
-    /// code reported to JS (`CloseEvent.code`) when it differs from the wire
-    /// code — e.g. a received bodyless Close echoes bodyless but reports 1005;
-    /// when `None`, JS sees `code` (or 1005 if `code` is also `None`).
+    /// bodyless Close. `dispatch_code` overrides the JS-visible
+    /// `CloseEvent.code`; `None` reports `code` (or 1005 when both are `None`).
     fn send_close_with_body(&self, code: Option<u16>, dispatch_code: Option<u16>, body: &[u8]) {
         let body_len = body.len().min(MAX_CLOSE_REASON);
         log!("Sending close with code {:?}", code);
@@ -1174,7 +1167,6 @@ impl<const SSL: bool> WebSocket<SSL> {
         // → terminate → cancel(Failure) would RST and discard the buffered
         // frame.
         let mut frame = [0u8; CONTROL_HEADER_SIZE + 2 + MAX_CLOSE_REASON];
-        // A bodyless echo (`code` is None) carries no code and no reason.
         let payload_len = code.map_or(0, |_| 2 + body_len);
         let header = WebsocketHeader::new((payload_len & 0x7F) as u8, true, Opcode::Close);
         frame[..2].copy_from_slice(&header.slice());
@@ -2124,11 +2116,9 @@ enum Step {
     Terminated,
 }
 
-/// Map a status code received in a Close frame to the code echoed on the wire
-/// and reported to JS. RFC 6455 §7.4.1-§7.4.2: codes outside the legal on-wire
-/// set (`<1000`, the reserved `1004`–`1006` and `1015`–`2999`, and the
-/// undefined `>4999`) are a protocol error, so both see 1002. Otherwise the
-/// received code passes through verbatim (§5.5.1, §7.1.5).
+/// Map a received Close status code to the code echoed and reported to JS:
+/// codes outside the RFC 6455 §7.4 on-wire set become 1002, the rest pass
+/// through verbatim.
 fn received_close_code(received: u16) -> u16 {
     let is_invalid = received < 1000
         || (1004..1007).contains(&received)

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -892,7 +892,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         if payload_len >= 2 {
             let received_code = u16::from_be_bytes([payload[0], payload[1]]);
             let (echo_code, dispatch_code) = received_close_codes(received_code);
-            self.send_close_with_body(echo_code, Some(dispatch_code), &payload[2..payload_len]);
+            self.send_close_with_body(Some(echo_code), Some(dispatch_code), &payload[2..payload_len]);
         } else {
             self.send_close();
         }
@@ -900,9 +900,11 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     pub fn send_close(&self) {
-        // Received a bodyless Close: echo a normal-closure frame on the wire,
-        // but report 1005 ("no status received") to JS per RFC 6455 §7.1.5.
-        self.send_close_with_body(1000, Some(1005), &[]);
+        // Received a bodyless Close: echo a bodyless Close frame on the wire
+        // (RFC 6455 §5.5.1 — the peer distinguishes "no status" from an
+        // explicit 1000), and report 1005 ("no status received") to JS per
+        // §7.1.5.
+        self.send_close_with_body(None, Some(1005), &[]);
     }
 
     fn enqueue_encoded_bytes(&self, bytes: &[u8]) -> bool {
@@ -1144,13 +1146,14 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.enqueue_encoded_bytes(&ping_frame_bytes[..CONTROL_HEADER_SIZE + ping_len])
     }
 
-    /// `code` is the status code written to the wire frame. `dispatch_code`
-    /// overrides the code reported to JS (`CloseEvent.code`) when it differs
-    /// from the wire code — e.g. a received bodyless Close echoes 1000 but
-    /// reports 1005; when `None`, JS sees `code`.
-    fn send_close_with_body(&self, code: u16, dispatch_code: Option<u16>, body: &[u8]) {
+    /// `code` is the status code written to the wire frame; `None` writes a
+    /// bodyless Close frame (payload length 0). `dispatch_code` overrides the
+    /// code reported to JS (`CloseEvent.code`) when it differs from the wire
+    /// code — e.g. a received bodyless Close echoes bodyless but reports 1005;
+    /// when `None`, JS sees `code` (or 1005 if `code` is also `None`).
+    fn send_close_with_body(&self, code: Option<u16>, dispatch_code: Option<u16>, body: &[u8]) {
         let body_len = body.len().min(MAX_CLOSE_REASON);
-        log!("Sending close with code {}", code);
+        log!("Sending close with code {:?}", code);
         if self.has_pending_close_dispatch() {
             // A close is already mid-flush (user-initiated ws.close() under
             // backpressure); don't enqueue a second close frame on top of it.
@@ -1167,35 +1170,39 @@ impl<const SSL: bool> WebSocket<SSL> {
         // → terminate → cancel(Failure) would RST and discard the buffered
         // frame.
         let mut frame = [0u8; CONTROL_HEADER_SIZE + 2 + MAX_CLOSE_REASON];
-        let header = WebsocketHeader::new(((body_len + 2) & 0x7F) as u8, true, Opcode::Close);
+        // A bodyless echo (`code` is None) carries no code and no reason.
+        let payload_len = code.map_or(0, |_| 2 + body_len);
+        let header = WebsocketHeader::new((payload_len & 0x7F) as u8, true, Opcode::Close);
         frame[..2].copy_from_slice(&header.slice());
         // the 4-byte masking key lives at frame[2..6]
-        frame[CONTROL_HEADER_SIZE..][..2].copy_from_slice(&code.to_be_bytes());
 
         let mut reason = bun_core::String::empty();
-        if body_len > 0 {
-            let body = &body[..body_len];
-            // close is always utf8
-            if !strings::is_valid_utf8(body) {
-                self.terminate(ErrorCode::InvalidUtf8);
-                return;
+        if let Some(code) = code {
+            frame[CONTROL_HEADER_SIZE..][..2].copy_from_slice(&code.to_be_bytes());
+            if body_len > 0 {
+                let body = &body[..body_len];
+                // close is always utf8
+                if !strings::is_valid_utf8(body) {
+                    self.terminate(ErrorCode::InvalidUtf8);
+                    return;
+                }
+                reason = bun_core::String::clone_utf8(body);
+                frame[CONTROL_HEADER_SIZE + 2..][..body_len].copy_from_slice(body);
             }
-            reason = bun_core::String::clone_utf8(body);
-            frame[CONTROL_HEADER_SIZE + 2..][..body_len].copy_from_slice(body);
         }
 
         // we must mask the code (and the reason, if any)
-        let frame_len = CONTROL_HEADER_SIZE + 2 + body_len;
+        let frame_len = CONTROL_HEADER_SIZE + payload_len;
         {
             let (head, payload) = frame.split_at_mut(CONTROL_HEADER_SIZE);
             let mask_buf: &mut [u8; 4] = (&mut head[2..CONTROL_HEADER_SIZE])
                 .try_into()
                 .expect("infallible: size matches");
-            Mask::fill_in_place(&self.global_this, mask_buf, &mut payload[..2 + body_len]);
+            Mask::fill_in_place(&self.global_this, mask_buf, &mut payload[..payload_len]);
         }
 
         if self.enqueue_encoded_bytes(&frame[..frame_len]) {
-            let dispatch_code = dispatch_code.unwrap_or(code);
+            let dispatch_code = dispatch_code.or(code).unwrap_or(1005);
             if self.send_buffer.borrow().readable_length() == 0 {
                 self.shutdown_after_close_frame();
                 self.clear_data();
@@ -1487,7 +1494,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             .and_then(|str| encode_close_reason(str, &mut reason_buf))
             .unwrap_or(0);
 
-        this.send_close_with_body(code, None, &reason_buf[..reason_len]);
+        this.send_close_with_body(Some(code), None, &reason_buf[..reason_len]);
     }
 
     /// Allocate a client with `ref_count == 1` (the I/O-layer ref, released by
@@ -2117,16 +2124,14 @@ enum Step {
 /// pair. RFC 6455 §7.4.1-§7.4.2: codes outside the legal on-wire set (`<1000`,
 /// the reserved `1004`–`1006` and `1015`–`2999`, and the undefined `>4999`) are
 /// a protocol error, so JS sees 1002. §7.1.5: the JS-visible code is otherwise
-/// the received one. The wire echo acknowledges a 1001 ("going away") with a
-/// normal-closure frame.
+/// the received one. §5.5.1: the wire echo repeats the received code verbatim.
 fn received_close_codes(received: u16) -> (u16, u16) {
     let is_invalid = received < 1000
         || (1004..1007).contains(&received)
         || (1015..=2999).contains(&received)
         || received > 4999;
     let dispatch = if is_invalid { 1002 } else { received };
-    let echo = if dispatch == 1001 { 1000 } else { dispatch };
-    (echo, dispatch)
+    (dispatch, dispatch)
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -892,7 +892,11 @@ impl<const SSL: bool> WebSocket<SSL> {
         if payload_len >= 2 {
             let received_code = u16::from_be_bytes([payload[0], payload[1]]);
             let (echo_code, dispatch_code) = received_close_codes(received_code);
-            self.send_close_with_body(Some(echo_code), Some(dispatch_code), &payload[2..payload_len]);
+            self.send_close_with_body(
+                Some(echo_code),
+                Some(dispatch_code),
+                &payload[2..payload_len],
+            );
         } else {
             self.send_close();
         }

--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -228,3 +228,89 @@ describe.concurrent("WebSocket client and server-sent close frames", () => {
     });
   });
 });
+
+// RFC 6455 §5.5.1: when a client receives a Close frame it echoes one back,
+// "typically" with the received status code. The WIRE echo is what the peer
+// sees; it's distinct from the JS-visible CloseEvent.code (which §7.1.5
+// governs). Node/undici echo the received code verbatim and answer a bodyless
+// Close with a bodyless Close.
+describe.concurrent("WebSocket client echoes the received close code on the wire", () => {
+  type Echo = { wireCode: number | "EMPTY"; jsCode: number };
+
+  async function serverSendsCloseAndReadsEcho(sent: number | "EMPTY"): Promise<Echo> {
+    const sentFrame =
+      sent === "EMPTY" ? Buffer.from([0x88, 0]) : Buffer.from([0x88, 2, (sent >> 8) & 0xff, sent & 0xff]);
+    const gotEcho = Promise.withResolvers<number | "EMPTY">();
+    const listening = Promise.withResolvers<void>();
+
+    const server = createServer(sock => {
+      let buf = Buffer.alloc(0);
+      let upgraded = false;
+      sock.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        if (!upgraded) {
+          const head = buf.toString("latin1");
+          if (!head.includes("\r\n\r\n")) return;
+          const key = /Sec-WebSocket-Key:\s*(.*)\r\n/i.exec(head)![1].trim();
+          const accept = crypto
+            .createHash("sha1")
+            .update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+            .digest("base64");
+          sock.write(
+            "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+              `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+          );
+          upgraded = true;
+          buf = Buffer.alloc(0);
+          sock.write(sentFrame);
+          return;
+        }
+        // Client frames are masked: 2-byte header + 4-byte mask key, then the
+        // payload XOR'd with the key. A close frame's opcode is 8.
+        if (buf.length < 2 || (buf[0] & 0x0f) !== 8) return;
+        const len = buf[1] & 0x7f;
+        if (buf.length < 6 + len) return;
+        const key = buf.subarray(2, 6);
+        const wireCode = len >= 2 ? ((buf[6] ^ key[0]) << 8) | (buf[7] ^ key[1]) : "EMPTY";
+        gotEcho.resolve(wireCode);
+        sock.end();
+      });
+      sock.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1", () => listening.resolve());
+    await listening.promise;
+
+    try {
+      const address = server.address() as import("node:net").AddressInfo;
+      const ws = new WebSocket(`ws://127.0.0.1:${address.port}`);
+      const jsClose = Promise.withResolvers<number>();
+      ws.addEventListener("close", e => jsClose.resolve(e.code));
+      ws.addEventListener("error", () => {});
+      const [wireCode, jsCode] = await Promise.all([gotEcho.promise, jsClose.promise]);
+      return { wireCode, jsCode };
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  }
+
+  // `sent` is what the server puts on the wire; `wireCode` is what the client
+  // must echo back; `jsCode` is CloseEvent.code. Every legal code echoes
+  // verbatim, including 1001 (going away). A bodyless Close echoes bodyless
+  // (so the peer can still distinguish "no status" from an explicit 1000) and
+  // JS sees the reserved 1005.
+  const cases: { sent: number | "EMPTY"; wireCode: number | "EMPTY"; jsCode: number }[] = [
+    { sent: "EMPTY", wireCode: "EMPTY", jsCode: 1005 },
+    { sent: 1000, wireCode: 1000, jsCode: 1000 },
+    { sent: 1001, wireCode: 1001, jsCode: 1001 },
+    { sent: 1002, wireCode: 1002, jsCode: 1002 },
+    { sent: 1003, wireCode: 1003, jsCode: 1003 },
+    { sent: 3000, wireCode: 3000, jsCode: 3000 },
+    { sent: 4999, wireCode: 4999, jsCode: 4999 },
+  ];
+
+  describe.each(cases)("server sends $sent", ({ sent, wireCode, jsCode }) => {
+    it(`client echoes ${wireCode} on the wire and JS sees ${jsCode}`, async () => {
+      expect(await serverSendsCloseAndReadsEcho(sent)).toEqual({ wireCode, jsCode });
+    });
+  });
+});

--- a/test/js/web/websocket/websocket-close-code.test.ts
+++ b/test/js/web/websocket/websocket-close-code.test.ts
@@ -237,15 +237,17 @@ describe.concurrent("WebSocket client and server-sent close frames", () => {
 describe.concurrent("WebSocket client echoes the received close code on the wire", () => {
   type Echo = { wireCode: number | "EMPTY"; jsCode: number };
 
-  async function serverSendsCloseAndReadsEcho(sent: number | "EMPTY"): Promise<Echo> {
-    const sentFrame =
-      sent === "EMPTY" ? Buffer.from([0x88, 0]) : Buffer.from([0x88, 2, (sent >> 8) & 0xff, sent & 0xff]);
+  // `segments` is written one entry at a time with a short gap, so a multi-
+  // entry array reaches the client as separate TCP reads (same split-delivery
+  // pattern as websocket-close-fragmented / websocket-client-short-read).
+  async function serverSendsCloseAndReadsEcho(segments: Buffer[]): Promise<Echo> {
     const gotEcho = Promise.withResolvers<number | "EMPTY">();
     const listening = Promise.withResolvers<void>();
 
     const server = createServer(sock => {
       let buf = Buffer.alloc(0);
       let upgraded = false;
+      sock.setNoDelay(true);
       sock.on("data", chunk => {
         buf = Buffer.concat([buf, chunk]);
         if (!upgraded) {
@@ -262,7 +264,13 @@ describe.concurrent("WebSocket client echoes the received close code on the wire
           );
           upgraded = true;
           buf = Buffer.alloc(0);
-          sock.write(sentFrame);
+          void (async () => {
+            for (const [i, seg] of segments.entries()) {
+              if (i > 0) await new Promise(r => setTimeout(r, 10));
+              if (sock.destroyed) return;
+              sock.write(seg);
+            }
+          })();
           return;
         }
         // Client frames are masked: 2-byte header + 4-byte mask key, then the
@@ -275,7 +283,10 @@ describe.concurrent("WebSocket client echoes the received close code on the wire
         gotEcho.resolve(wireCode);
         sock.end();
       });
-      sock.on("error", () => {});
+      // A regression that RSTs or FINs without echoing a Close frame must fail
+      // the assertion, not the harness timeout.
+      sock.on("error", e => gotEcho.reject(e));
+      sock.on("close", () => gotEcho.reject(new Error("socket closed without close-frame echo")));
     });
     server.listen(0, "127.0.0.1", () => listening.resolve());
     await listening.promise;
@@ -291,6 +302,10 @@ describe.concurrent("WebSocket client echoes the received close code on the wire
     } finally {
       await new Promise(r => server.close(r));
     }
+  }
+
+  function closeFrame(sent: number | "EMPTY") {
+    return sent === "EMPTY" ? Buffer.from([0x88, 0]) : Buffer.from([0x88, 2, (sent >> 8) & 0xff, sent & 0xff]);
   }
 
   // `sent` is what the server puts on the wire; `wireCode` is what the client
@@ -310,7 +325,25 @@ describe.concurrent("WebSocket client echoes the received close code on the wire
 
   describe.each(cases)("server sends $sent", ({ sent, wireCode, jsCode }) => {
     it(`client echoes ${wireCode} on the wire and JS sees ${jsCode}`, async () => {
-      expect(await serverSendsCloseAndReadsEcho(sent)).toEqual({ wireCode, jsCode });
+      expect(await serverSendsCloseAndReadsEcho([closeFrame(sent)])).toEqual({ wireCode, jsCode });
+    });
+  });
+
+  // recv_close's length guards must only run on first entry: once
+  // buffer_control_payload has started, body_remain is "bytes buffered so
+  // far", so a Close frame whose 2-byte header arrives alone (or with 1
+  // payload byte) must still deliver the server's code on re-entry.
+  it("Close header and code split across reads still echoes the received code", async () => {
+    expect(await serverSendsCloseAndReadsEcho([Buffer.from([0x88, 0x02]), Buffer.from([0x03, 0xe8])])).toEqual({
+      wireCode: 1000,
+      jsCode: 1000,
+    });
+  });
+
+  it("Close header and 1 payload byte split across reads still echoes the received code", async () => {
+    expect(await serverSendsCloseAndReadsEcho([Buffer.from([0x88, 0x02, 0x0b]), Buffer.from([0xb8])])).toEqual({
+      wireCode: 3000,
+      jsCode: 3000,
     });
   });
 });


### PR DESCRIPTION
### Problem

When the client `WebSocket` receives a server-initiated Close frame, RFC 6455 section 5.5.1 says the echo it sends back "typically echoes the status code it received". Bun rewrote the echo in three cases:

- a server Close frame with **no status code** (empty payload) was answered with an explicit `1000`, so the peer could no longer tell "no status" from a deliberate normal closure. This is exactly what the reserved off-wire code `1005` exists to represent; putting `1000` on the wire hides it.
- a received `1001` ("going away") was answered with `1000`.
- a Close frame whose 2-byte header and status-code bytes arrived in **separate TCP reads** was treated as bodyless (echoed bodyless, JS reported `1005`) or, if exactly one code byte arrived with the header, failed as `InvalidControlFrame`.

Every other legal code already echoed verbatim. Node/undici echo bodyless → bodyless and `1001` → `1001`.

The JS-visible `CloseEvent.code` was already correct for the first two cases (`1005` for bodyless, `1001` for `1001`); only the wire echo was wrong. The split-read case was wrong on both the wire and in JS.

### Repro

```js
// server sends a close frame, records what the client echoes back on the wire
import net from "node:net"; import crypto from "node:crypto";
const acc = k => crypto.createHash("sha1").update(k + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest("base64");
const cases = ["EMPTY", 1000, 1001, 1002, 3000]; let ci = -1;
const frame = c => c === "EMPTY" ? Buffer.from([0x88, 0]) : Buffer.from([0x88, 2, c >> 8, c & 0xff]);
const srv = net.createServer(sock => { let head = "", up = false, c = -1; sock.on("data", ch => {
  if (!up) { head += ch.toString("latin1"); if (!head.includes("\r\n\r\n")) return; up = true; c = ++ci;
    const key = /Sec-WebSocket-Key: (.+)\r\n/i.exec(head)[1].trim();
    sock.write(`HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${acc(key)}\r\n\r\n`);
    setTimeout(() => sock.write(frame(cases[c])), 60); return; }
  if ((ch[0] & 15) === 8) { const len = ch[1] & 127, k = ch.subarray(2, 6);
    const code = len >= 2 ? ((ch[6] ^ k[0]) << 8 | (ch[7] ^ k[1])) : "EMPTY";
    console.log(`server sent ${cases[c]} -> client echoed ${code}`); if (c === cases.length - 1) process.exit(0); }
}); }).listen(0, "127.0.0.1", () => { let i = 0;
  const next = () => { if (i >= cases.length) return; const ws = new WebSocket(`ws://127.0.0.1:${srv.address().port}`); i++; ws.onerror = () => {}; ws.onclose = () => setTimeout(next, 50); };
  next(); });
```

```
bun (before):  EMPTY -> 1000 | 1000 -> 1000 | 1001 -> 1000 | 1002 -> 1002 | 3000 -> 3000
node:          EMPTY -> EMPTY | 1000 -> 1000 | 1001 -> 1001 | 1002 -> 1002 | 3000 -> 3000
bun (after):   EMPTY -> EMPTY | 1000 -> 1000 | 1001 -> 1001 | 1002 -> 1002 | 3000 -> 3000
```

### Cause

`src/http_jsc/websocket_client.rs`:

- `send_close()` (the bodyless-Close echo path) called `send_close_with_body(1000, Some(1005), &[])`, and `send_close_with_body` had no way to emit a bodyless frame: it always wrote the 2-byte code.
- `received_close_codes()` special-cased `1001`: `let echo = if dispatch == 1001 { 1000 } else { dispatch }`.
- `recv_close()` checked `body_remain == 0` / `== 1` on every entry. Once `buffer_control_payload` has started buffering a partial payload it repurposes `body_remain` to "bytes buffered so far", so on re-entry a Close whose header arrived alone (buffered = 0) hit the bodyless branch and one whose header arrived with a single code byte (buffered = 1) hit the `InvalidControlFrame` branch. `recv_ping_or_pong` already gated its size check on `!control_frame_started`; `recv_close` did not.

### Fix

- `send_close_with_body` now takes `code: Option<u16>`. `None` emits a bodyless Close frame (payload length 0, mask key still present). The JS dispatch code falls back to `1005` when both `code` and `dispatch_code` are `None`.
- `send_close()` passes `None` for the wire code.
- `received_close_codes()` is replaced by `received_close_code() -> u16`: with the `1001 -> 1000` rewrite gone, the wire echo and JS dispatch are always the same value.
- `recv_close()` gates its length checks on `!control_frame_started`, matching `recv_ping_or_pong`.

The JS `ws.close(code, reason)` entrypoint passes `Some(code)` and is unchanged in behaviour.

### Verification

New describe block in `test/js/web/websocket/websocket-close-code.test.ts` runs a raw TCP server that sends a Close frame (optionally split across writes) and unmasks the client's echo, asserting both the wire code and `CloseEvent.code` for `EMPTY`, `1000`, `1001`, `1002`, `1003`, `3000`, `4999`, and two split-read variants.

```
# USE_SYSTEM_BUN=1 (before)
(fail) server sends EMPTY > client echoes EMPTY ...                    # got wireCode 1000
(fail) server sends 1001  > client echoes 1001 ...                     # got wireCode 1000
(fail) Close header and code split across reads ...                    # got jsCode 1005
(fail) Close header and 1 payload byte split across reads ...          # ECONNRESET
5 pass, 4 fail

# bun bd (after)
33 pass, 0 fail   (whole file)
```

`websocket.test.js -t close` (22 tests), `websocket-client.test.ts` (34 tests), `websocket-close-fragmented.test.ts`, `websocket-pong-fragmented.test.ts`, and `websocket-client-short-read.test.ts` pass unchanged.

Not a duplicate of #33457: that PR fixes the user-initiated `ws.close()` (no arguments) path to send a bodyless frame; this one fixes the server-initiated echo path. They share the `Option<u16>` refactor of `send_close_with_body` so whichever lands second will need a small rebase there.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-close-code.test.ts
bun test v1.4.0 (a3aa9c5fd)

test/js/web/websocket/websocket-close-code.test.ts:
(pass) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [172.61ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [163.26ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [134.63ms]
(pass) WebSocket close() argument validation > validates arguments while the socket is still connecting [125.82ms]
(pass) WebSocket close() argument validation > accepts a reason of exactly 123 UTF-8 bytes [177.23ms]
(pass) WebSocket close() argument validation > close(1000) is allowed > and the code and reason reach the server [95.95ms]
(pass) WebSocket close() argument validation > close(1001) is allowed > and the code and reason reach the server [84.86ms]
(pass) WebSocket close() argument validation > close(1002) is allowed > and the code and 
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (a3aa9c5fd)

test/js/web/websocket/websocket-close-code.test.ts:
(pass) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [36.48ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [23.70ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [21.24ms]
(pass) WebSocket close() argument validation > validates arguments while the socket is still connecting [20.77ms]
(pass) WebSocket close() argument validation > accepts a reason of exactly 123 UTF-8 bytes [25.76ms]
(pass) WebSocket close() argument validation > close(1000) is allowed > and the code and reason reach the server [22.72ms]
(pass) WebSocket close() argument validation > close(1001) is allowed > and the code and reason reach the server [21.70ms]
(pass) WebSocket close() argument validation > close(1002) is allowed > and the code and reason reach the server [21.90ms]
(pass) WebSocket close() argument validation > close(1003) is allowed > and the code and reason reach the server [21.53ms]
(pass) WebSocket close(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-close-code.test.ts
bun test v1.4.0 (a3aa9c5fd)

test/js/web/websocket/websocket-close-code.test.ts:
(pass) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [196.31ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [180.21ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [146.27ms]
(pass) WebSocket close() argument validation > validates arguments while the socket is still connecting [137.80ms]
(pass) WebSocket close() argument validation > accepts a reason of exactly 123 UTF-8 bytes [197.70ms]
(pass) WebSocket close() argument validation > close(1000) is allowed > and the code and reason reach the server [115.57ms]
(pass) WebSocket close() argument validation > close(1001) is allowed > and the code and reason reach the server [104.47ms]
(pass) WebSocket close() argument validation > close(1002) is allowed > and the code an
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 845ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] cc obj/src/jsc/bindings/node/http/llhttp/http.c.o
[2/9] cc obj/src/jsc/bindings/node/http/llhttp/api.c.o
[3/9] cc obj/src/jsc/bindings/node/http/llhttp/llhttp.c.o
[4/9] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_http-0.cpp.o
[5/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[6/9] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[6/9] link bun-profile
[7/9] bun-profile --revision
1.4.0-canary.1+a3aa9c5fd
[9/9] strip bun
[build] done
bun test v1.4.0-canary.1 (a3aa9c5fd)

test/js/web/websocket/websocket-close-code.test.ts:
(pass) WebSocket close() argument validation > throws InvalidAccessError for close codes an endpoint must not send [12.83ms]
(pass) WebSocket close() argument validation > throws SyntaxError when the reason is longer than 123 UTF-8 bytes [11.54ms]
(pass) WebSocket close() argument validation > validates arguments even when the socket is already closed [9.96ms]
(pass) WebSocket close() argument validation > validates arguments while the socket is still connecting [9.2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/websocket_client.rs                   |  94 ++++++++--------
 test/js/web/websocket/websocket-close-code.test.ts | 119 +++++++++++++++++++++
 2 files changed, 170 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/http_jsc/websocket_client.rs                        9      6      0
test/js/web/websocket/websocket-close-code.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->