### PR TITLE
Bun.write(path, fetch()): opt into BufferAll so a streaming body completes

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5251,6 +5251,10 @@ pub fn write_file_internal(
                                 on_start_buffering(producer_task);
                             }
                         }
+                        locked.on_start_streaming = None;
+                        locked.on_readable_stream_available = None;
+                        locked.on_stream_cancelled = None;
+                        locked.on_stream_drained = None;
                         locked.task = Some(task.cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5244,15 +5244,9 @@ pub fn write_file_internal(
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
                             unreachable!()
                         };
-                        // Opt the producer into BufferAll before `task` is repurposed
-                        // so a paused fetch (#29831) resumes and eventually `resolve()`s.
-                        // Only valid while `on_start_streaming` hasn't been taken:
-                        // once the ByteStream is materialised the producer delivers
-                        // through it (never via `resolve()`), may already have dropped
-                        // its ref, and `check_body_stream_ref` can have moved the
-                        // readable out of `locked.readable`, so neither that slot nor
-                        // `locked.task` is a reliable witness here. The
-                        // materialised-stream case is the pre-existing #13237 hang.
+                        // Opt the producer into BufferAll before `task` is repurposed so a
+                        // paused fetch reaches `resolve()`. `on_start_streaming` still present
+                        // is the witness that `task` is the live producer and not stale.
                         if locked.on_start_streaming.is_some() {
                             if let (Some(on_start_buffering), Some(producer_task)) =
                                 (locked.on_start_buffering.take(), locked.task)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5251,6 +5251,7 @@ pub fn write_file_internal(
                                 on_start_buffering(producer_task);
                             }
                         }
+                        locked.on_start_buffering = None;
                         locked.on_start_streaming = None;
                         locked.on_readable_stream_available = None;
                         locked.on_stream_cancelled = None;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5244,12 +5244,21 @@ pub fn write_file_internal(
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
                             unreachable!()
                         };
-                        // Tell the producer to buffer the whole body before `task` is
-                        // repurposed; otherwise a paused fetch never reaches `resolve()`.
-                        if let (Some(on_start_buffering), Some(producer_task)) =
-                            (locked.on_start_buffering.take(), locked.task)
-                        {
-                            on_start_buffering(producer_task);
+                        // Opt the producer into BufferAll before `task` is repurposed
+                        // so a paused fetch (#29831) resumes and eventually `resolve()`s.
+                        // Only valid while `on_start_streaming` hasn't been taken:
+                        // once the ByteStream is materialised the producer delivers
+                        // through it (never via `resolve()`), may already have dropped
+                        // its ref, and `check_body_stream_ref` can have moved the
+                        // readable out of `locked.readable`, so neither that slot nor
+                        // `locked.task` is a reliable witness here. The
+                        // materialised-stream case is the pre-existing #13237 hang.
+                        if locked.on_start_streaming.is_some() {
+                            if let (Some(on_start_buffering), Some(producer_task)) =
+                                (locked.on_start_buffering.take(), locked.task)
+                            {
+                                on_start_buffering(producer_task);
+                            }
                         }
                         locked.task = Some(task.cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5244,18 +5244,7 @@ pub fn write_file_internal(
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
                             unreachable!()
                         };
-                        if locked.on_start_streaming.is_some() {
-                            if let (Some(on_start_buffering), Some(producer_task)) =
-                                (locked.on_start_buffering.take(), locked.task)
-                            {
-                                on_start_buffering(producer_task);
-                            }
-                        }
-                        locked.on_start_buffering = None;
-                        locked.on_start_streaming = None;
-                        locked.on_readable_stream_available = None;
-                        locked.on_stream_cancelled = None;
-                        locked.on_stream_drained = None;
+                        locked.take_over_as_buffering_consumer();
                         locked.task = Some(task.cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5244,9 +5244,6 @@ pub fn write_file_internal(
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
                             unreachable!()
                         };
-                        // Opt the producer into BufferAll before `task` is repurposed so a
-                        // paused fetch reaches `resolve()`. `on_start_streaming` still present
-                        // is the witness that `task` is the live producer and not stale.
                         if locked.on_start_streaming.is_some() {
                             if let (Some(on_start_buffering), Some(producer_task)) =
                                 (locked.on_start_buffering.take(), locked.task)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5244,6 +5244,13 @@ pub fn write_file_internal(
                         let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
                             unreachable!()
                         };
+                        // Tell the producer to buffer the whole body before `task` is
+                        // repurposed; otherwise a paused fetch never reaches `resolve()`.
+                        if let (Some(on_start_buffering), Some(producer_task)) =
+                            (locked.on_start_buffering.take(), locked.task)
+                        {
+                            on_start_buffering(producer_task);
+                        }
                         locked.task = Some(task.cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -295,6 +295,25 @@ impl PendingValue {
         bun_opaque::opaque_deref(self.global)
     }
 
+    /// A consumer that wants the complete body (not a stream) is about to
+    /// overwrite `task`/`on_receive_value`. Fire the producer's
+    /// `on_start_buffering` handshake with the producer's own `task` so it
+    /// switches to `BufferAll` (matching `set_promise` / `ValueBufferer`),
+    /// then clear the remaining producer hooks so they can't be invoked
+    /// against the consumer's `task` after it's been repurposed.
+    pub(crate) fn take_over_as_buffering_consumer(&mut self) {
+        if let (Some(on_start_buffering), Some(producer_task)) =
+            (self.on_start_buffering.take(), self.task)
+        {
+            on_start_buffering(producer_task);
+        }
+        self.on_start_buffering = None;
+        self.on_start_streaming = None;
+        self.on_readable_stream_available = None;
+        self.on_stream_cancelled = None;
+        self.on_stream_drained = None;
+    }
+
     /// For Http Client requests
     /// when Content-Length is provided this represents the whole size of the request
     /// If chunked encoded this will represent the total received size (ignoring the chunk headers)

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -295,12 +295,6 @@ impl PendingValue {
         bun_opaque::opaque_deref(self.global)
     }
 
-    /// A consumer that wants the complete body (not a stream) is about to
-    /// overwrite `task`/`on_receive_value`. Fire the producer's
-    /// `on_start_buffering` handshake with the producer's own `task` so it
-    /// switches to `BufferAll` (matching `set_promise` / `ValueBufferer`),
-    /// then clear the remaining producer hooks so they can't be invoked
-    /// against the consumer's `task` after it's been repurposed.
     pub(crate) fn take_over_as_buffering_consumer(&mut self) {
         if let (Some(on_start_buffering), Some(producer_task)) =
             (self.on_start_buffering.take(), self.task)

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -301,7 +301,6 @@ impl PendingValue {
         {
             on_start_buffering(producer_task);
         }
-        self.on_start_buffering = None;
         self.on_start_streaming = None;
         self.on_readable_stream_available = None;
         self.on_stream_cancelled = None;

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1420,6 +1420,7 @@ impl WriteFileWaitFromLockedValueTask {
                 // Re-registering for a future callback — `this` stays alive.
                 // Restore the moved-out blob so the next `then()` has its store.
                 this_ref.file_blob = file_blob;
+                locked.take_over_as_buffering_consumer();
                 locked.on_receive_value = Some(Self::then_wrap);
                 locked.task = Some(this.cast::<c_void>());
             }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2529,8 +2529,7 @@ impl FetchTasklet {
 
             if let BodyValue::Locked(locked) = body {
                 if locked.on_receive_value.is_some() {
-                    // Scenario 2b: a native consumer (Bun.write / ValueBufferer)
-                    // is awaiting resolve() via on_receive_value.
+                    // Scenario 2b.
                     return;
                 }
                 if let Some(promise) = locked.promise {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2528,9 +2528,14 @@ impl FetchTasklet {
             }
 
             if let BodyValue::Locked(locked) = body {
+                if locked.on_receive_value.is_some() {
+                    // Scenario 2b: a native consumer (Bun.write / ValueBufferer)
+                    // is awaiting resolve() via on_receive_value.
+                    return;
+                }
                 if let Some(promise) = locked.promise {
                     if promise.is_empty_or_undefined_or_null() {
-                        // Scenario 2b.
+                        // Scenario 2a.
                         this.ignore_remaining_response_body(true);
                     }
                 } else {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -377,20 +377,90 @@ const IS_UV_FS_COPYFILE_DISABLED =
     await gcTick();
   });
 
-  it("Bun.write(path, fetch()) with a streaming body", async () => {
-    using tmpbase = tempDir("bun-write-fetch-streaming", {});
-    const out = join(String(tmpbase), "dl.out");
-    const body = Buffer.alloc(300_000, "x").toString();
-    await using server = Bun.serve({
-      port: 0,
-      fetch: () => new Response(body),
+  describe("Bun.write(path, fetch()) with a streaming body", () => {
+    it("Content-Length body settles", async () => {
+      using dir = tempDir("bun-write-fetch-cl", {});
+      const out = join(String(dir), "dl.bin");
+      const body = Buffer.alloc(500_000, "x");
+      await using server = Bun.serve({ port: 0, fetch: () => new Response(body) });
+      const res = await fetch(server.url);
+      expect(res.headers.get("content-length")).toBe(String(body.length));
+      const written = await Bun.write(out, res);
+      expect(written).toBe(body.length);
+      expect(await Bun.file(out).bytes()).toEqual(new Uint8Array(body));
     });
-    const resp = await fetch(server.url);
-    expect(resp.status).toBe(200);
-    const written = await Bun.write(out, resp);
-    expect(written).toBe(body.length);
-    expect((await Bun.file(out).bytes()).length).toBe(body.length);
-    expect(await Bun.file(out).text()).toBe(body);
+
+    it("chunked body settles", async () => {
+      using dir = tempDir("bun-write-fetch-chunked", {});
+      const out = join(String(dir), "dl.bin");
+      const chunk = Buffer.alloc(80_000, "y");
+      const chunks = 4;
+      const { promise: fetched, resolve: markFetched } = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(async function* () {
+            yield chunk;
+            await fetched;
+            for (let i = 1; i < chunks; i++) yield chunk;
+          }),
+      });
+      const res = await fetch(server.url);
+      markFetched();
+      expect(res.headers.get("content-length")).toBeNull();
+      const written = await Bun.write(out, res);
+      expect(written).toBe(chunk.length * chunks);
+      expect((await Bun.file(out).bytes()).length).toBe(chunk.length * chunks);
+    });
+
+    it.each([
+      ["AbortError", undefined],
+      ["TimeoutError", new DOMException("The operation timed out.", "TimeoutError")],
+    ])("rejects with %s when the signal aborts mid-transfer", async (name, reason) => {
+      using dir = tempDir("bun-write-fetch-abort", {});
+      const { promise: gate, resolve: openGate } = Promise.withResolvers();
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(async function* () {
+            yield Buffer.alloc(200_000, "z");
+            await gate;
+          }),
+      });
+      try {
+        const ac = new AbortController();
+        // Scope the Response so it is collectible once Bun.write has
+        // registered on the body; on an unfixed build the finalizer then drops
+        // the body and the abort never reaches the write promise.
+        async function start() {
+          const res = await fetch(server.url, { signal: ac.signal });
+          return { write: Bun.write(join(String(dir), "dl.bin"), res) };
+        }
+        const { write } = await start();
+        await gcTick();
+        Bun.gc(true);
+        ac.abort(reason);
+        let caught;
+        await write.catch(e => (caught = e));
+        expect(caught).toBeInstanceOf(DOMException);
+        expect(caught.name).toBe(name);
+      } finally {
+        openGate();
+      }
+    });
+
+    it("settles when aborted after the body has been fully received", async () => {
+      using dir = tempDir("bun-write-fetch-late-abort", {});
+      const out = join(String(dir), "dl.bin");
+      const body = Buffer.alloc(500_000, "q");
+      await using server = Bun.serve({ port: 0, fetch: () => new Response(body) });
+      const ac = new AbortController();
+      const res = await fetch(server.url, { signal: ac.signal });
+      const written = await Bun.write(out, res);
+      ac.abort();
+      expect(written).toBe(body.length);
+      expect((await Bun.file(out).bytes()).length).toBe(body.length);
+    });
   });
 
   it.skipIf(!isASAN)("Bun.write(path, fetch()) then resp.body does not crash", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, test } from "bun:test";
 import fs, { mkdirSync } from "fs";
-import { bunEnv, bunExe, exampleHtml, exampleSite, gcTick, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, exampleHtml, exampleSite, gcTick, isASAN, isWindows, tempDir, withoutAggressiveGC } from "harness";
 import path, { join } from "path";
 
 let i = 0;
@@ -370,7 +370,7 @@ const IS_UV_FS_COPYFILE_DISABLED =
   it("Bun.write(path, fetch()) with a streaming body", async () => {
     using tmpbase = tempDir("bun-write-fetch-streaming", {});
     const out = join(String(tmpbase), "dl.out");
-    const body = Buffer.alloc(1_000_000, "x").toString();
+    const body = Buffer.alloc(300_000, "x").toString();
     await using server = Bun.serve({
       port: 0,
       fetch: () => new Response(body),
@@ -381,6 +381,20 @@ const IS_UV_FS_COPYFILE_DISABLED =
     expect(written).toBe(body.length);
     expect((await Bun.file(out).bytes()).length).toBe(body.length);
     expect(await Bun.file(out).text()).toBe(body);
+  });
+
+  it.skipIf(!isASAN)("Bun.write(path, fetch()) then resp.body does not crash", async () => {
+    using tmpbase = tempDir("bun-write-fetch-then-body", {});
+    const out = join(String(tmpbase), "dl.out");
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(Buffer.alloc(300_000, "y")),
+    });
+    const resp = await fetch(server.url);
+    const p = Bun.write(out, resp);
+    expect(resp.body).toBeInstanceOf(ReadableStream);
+    expect(() => resp.clone()).not.toThrow();
+    await Promise.race([p, Bun.sleep(1)]);
   });
 
   it("Response -> Bun.file -> Response -> text", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -394,17 +394,21 @@ const IS_UV_FS_COPYFILE_DISABLED =
   });
 
   it.skipIf(!isASAN)("Bun.write(path, fetch()) then resp.body does not crash", async () => {
-    using tmpbase = tempDir("bun-write-fetch-then-body", {});
-    const out = join(String(tmpbase), "dl.out");
-    await using server = Bun.serve({
-      port: 0,
-      fetch: () => new Response(Buffer.alloc(300_000, "y")),
-    });
-    const resp = await fetch(server.url);
-    const p = Bun.write(out, resp);
-    expect(resp.body).toBeInstanceOf(ReadableStream);
-    expect(() => resp.clone()).not.toThrow();
-    await Promise.race([p, Bun.sleep(1)]);
+    using dir = tempDir("bun-write-fetch-then-body", {});
+    const out = JSON.stringify(join(String(dir), "dl.out"));
+    const fixture = `
+      const server = Bun.serve({ port: 0, fetch: () => new Response(Buffer.alloc(300_000, "y")) });
+      const resp = await fetch(server.url);
+      const p = Bun.write(${out}, resp);
+      if (!(resp.body instanceof ReadableStream)) throw new Error("expected ReadableStream");
+      resp.clone();
+      await Promise.race([p, Bun.sleep(1)]);
+      console.log("OK");
+      process.exit(0);
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "OK", stderr: "", exitCode: 0 });
   });
 
   it("Response -> Bun.file -> Response -> text", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -367,6 +367,22 @@ const IS_UV_FS_COPYFILE_DISABLED =
     await gcTick();
   });
 
+  it("Bun.write(path, fetch()) with a streaming body", async () => {
+    using tmpbase = tempDir("bun-write-fetch-streaming", {});
+    const out = join(String(tmpbase), "dl.out");
+    const body = Buffer.alloc(1_000_000, "x").toString();
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(body),
+    });
+    const resp = await fetch(server.url);
+    expect(resp.status).toBe(200);
+    const written = await Bun.write(out, resp);
+    expect(written).toBe(body.length);
+    expect((await Bun.file(out).bytes()).length).toBe(body.length);
+    expect(await Bun.file(out).text()).toBe(body);
+  });
+
   it("Response -> Bun.file -> Response -> text", async () => {
     await gcTick();
     const file = path.join(import.meta.dir, "fetch.js.txt");

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1,6 +1,16 @@
 import { describe, expect, it, test } from "bun:test";
 import fs, { mkdirSync } from "fs";
-import { bunEnv, bunExe, exampleHtml, exampleSite, gcTick, isASAN, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  exampleHtml,
+  exampleSite,
+  gcTick,
+  isASAN,
+  isWindows,
+  tempDir,
+  withoutAggressiveGC,
+} from "harness";
 import path, { join } from "path";
 
 let i = 0;


### PR DESCRIPTION
Fixes #35854.

### Repro

```js
const srv = Bun.serve({ port: 0, fetch: () => new Response("x".repeat(500_000)) });
const res = await fetch(`http://127.0.0.1:${srv.port}/`);
await Bun.write("/tmp/out.bin", res);   // never settles on 1.4.0; 1.3.14 => 500000
```

On 1.4.0 (and main at `df6c7eed6`), `await Bun.write(path, await fetch(url))` never resolves once the response body is large enough to arrive as a stream (observed at roughly 128 KB and above; bodies that fit in one buffer still work). No file is created, no error. 1.3.14 returns the byte count.

The abort escape hatch is dead for the same reason: `fetch(url, { signal })` followed by `Bun.write(path, res)` hangs after the signal fires once the Response wrapper has been collected, because the finalizer drops the body before the abort can reach it.

### Cause

#29831 introduced `BodyReceiveMode::AutoPause`: after the first body chunk, `FetchTasklet::callback` CASes `AutoPause` to `Paused` and the transport stops reading until a consumer opts into `BufferAll` via `on_start_buffering` (used by `.text()/.arrayBuffer()/...` and `ValueBufferer`) or a ReadableStream drains it.

`write_file_internal`'s file-destination `BodyValue::Locked` arm only registers `on_receive_value` and then overwrites `locked.task` with the `WriteFileWaitFromLockedValueTask*`, never calling `on_start_buffering`. The transport parks after roughly one socket buffer, `has_more` stays true, `BodyValue::resolve` never runs, and the task's promise is never settled.

Separately, `on_response_finalize` only recognises `locked.promise` as a live consumer. `Bun.write` does not set `locked.promise`, so when the Response JS wrapper is collected while the body is still arriving the finalizer calls `ignore_remaining_response_body`, the tasklet is torn down, and a later `signal.abort()` has no listener to deliver to.

### Fix

Introduce `PendingValue::take_over_as_buffering_consumer()`, which performs the `on_start_buffering` handshake with the producer's own `task` pointer (the same handshake `set_promise` and `ValueBufferer` already do) and clears the remaining producer hooks so they cannot be invoked against the consumer's `task` after it has been repurposed. Call it from both the `write_file_internal` Locked arm and the `WriteFileWaitFromLockedValueTask::then()` Locked re-register arm before overwriting `locked.task`.

In `FetchTasklet::on_response_finalize`, treat `locked.on_receive_value` as a live consumer alongside `locked.promise`, so collecting the Response wrapper does not drop a body that `Bun.write` is still waiting on.

Covers every non-S3 file destination (path, `Bun.file`, fd blobs, `Bun.stdout`). The S3 destination pulls the stream itself and is unaffected. `Bun.write(path, new Response(res.body))` (a Locked value carrying a JS ReadableStream, #13237) is a separate arm and is not touched here.

### Verification

`test/js/bun/io/bun-write.test.js` gains a five-case acceptance suite under `Bun.write(path, fetch()) with a streaming body`:

- Content-Length body (500 KB) settles with the byte count
- chunked body settles
- abort mid-transfer rejects with `AbortError`
- abort mid-transfer with a `TimeoutError` reason rejects with `TimeoutError`
- abort after the body has been fully received still settles

The abort cases scope the Response to a helper and force GC before aborting so the `on_response_finalize` path is exercised deterministically. All five time out on main and pass here. An ASAN-gated test also checks that touching `resp.body` / `resp.clone()` after `Bun.write(path, resp)` does not crash.

Related: #31739 reworks this path to stream to disk instead of buffering; #32906 covers the JS-constructed ReadableStream body case. This PR is the minimal regression fix.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->
