### PR TITLE
Promise.any: give the rejected AggregateError a stack, message, and no spurious cause

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "549170099226f816a4b204ea1d8fa102fb79eefa";
+export const WEBKIT_VERSION = "autobuild-preview-pr-340-6e83cef9";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/promise/promise-any-aggregate-error.test.ts
+++ b/test/js/node/promise/promise-any-aggregate-error.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Promise.any AggregateError", () => {
+  async function getRejection(iterable: Iterable<unknown>, ctor = Promise): Promise<AggregateError> {
+    try {
+      await ctor.any(iterable);
+    } catch (e) {
+      return e as AggregateError;
+    }
+    throw new Error("expected rejection");
+  }
+
+  test.concurrent("rejected promises (fast path, settled in microtask)", async () => {
+    const err = await getRejection([Promise.reject(new Error("r1")), Promise.reject("r2")]);
+
+    expect(err).toBeInstanceOf(AggregateError);
+    expect(err.message).toBe("All promises were rejected");
+    expect(Object.prototype.hasOwnProperty.call(err, "cause")).toBe(false);
+    expect("cause" in err).toBe(false);
+    expect(typeof err.stack).toBe("string");
+    expect(err.stack).toStartWith("AggregateError: All promises were rejected");
+    expect(err.errors).toHaveLength(2);
+    expect((err.errors[0] as Error).message).toBe("r1");
+    expect(err.errors[1]).toBe("r2");
+
+    const own = Object.getOwnPropertyNames(err);
+    expect(own).toContain("message");
+    expect(own).toContain("errors");
+    expect(own).toContain("stack");
+    expect(own).not.toContain("cause");
+  });
+
+  test.concurrent("empty iterable (synchronous rejection)", async () => {
+    const err = await getRejection([]);
+
+    expect(err).toBeInstanceOf(AggregateError);
+    expect(err.message).toBe("All promises were rejected");
+    expect(Object.prototype.hasOwnProperty.call(err, "cause")).toBe(false);
+    expect(typeof err.stack).toBe("string");
+    expect(err.stack).toStartWith("AggregateError: All promises were rejected");
+    expect(err.errors).toEqual([]);
+  });
+
+  test.concurrent("already-rejected non-promise values", async () => {
+    const err = await getRejection([Promise.reject(1), Promise.reject(2), Promise.reject(3)]);
+
+    expect(err.message).toBe("All promises were rejected");
+    expect(Object.prototype.hasOwnProperty.call(err, "cause")).toBe(false);
+    expect(typeof err.stack).toBe("string");
+    expect(err.errors).toEqual([1, 2, 3]);
+  });
+
+  test.concurrent("Promise subclass (slow path)", async () => {
+    class P<T> extends Promise<T> {}
+    const err = await getRejection([P.reject(1), P.reject(2)], P);
+
+    expect(err).toBeInstanceOf(AggregateError);
+    expect(err.message).toBe("All promises were rejected");
+    expect(Object.prototype.hasOwnProperty.call(err, "cause")).toBe(false);
+    expect(typeof err.stack).toBe("string");
+    expect(err.errors).toEqual([1, 2]);
+  });
+
+  test.concurrent("Promise subclass with empty iterable (slow path, synchronous)", async () => {
+    class P<T> extends Promise<T> {}
+    const err = await getRejection([], P);
+
+    expect(err.message).toBe("All promises were rejected");
+    expect(Object.prototype.hasOwnProperty.call(err, "cause")).toBe(false);
+    expect(typeof err.stack).toBe("string");
+  });
+
+  test.concurrent("thenable rejection (onRejected function path)", async () => {
+    const thenable = {
+      then(_onFulfilled: unknown, onRejected: (reason: unknown) => void) {
+        onRejected("from-thenable");
+      },
+    };
+    const err = await getRejection([thenable]);
+
+    expect(err.message).toBe("All promises were rejected");
+    expect(Object.prototype.hasOwnProperty.call(err, "cause")).toBe(false);
+    expect(typeof err.stack).toBe("string");
+    expect(err.errors).toEqual(["from-thenable"]);
+  });
+
+  test.concurrent("user-constructed AggregateError is unaffected", () => {
+    const withCause = new AggregateError([1], "msg", { cause: "c" });
+    expect(withCause.message).toBe("msg");
+    expect(withCause.cause).toBe("c");
+    expect(Object.prototype.hasOwnProperty.call(withCause, "cause")).toBe(true);
+    expect(typeof withCause.stack).toBe("string");
+
+    const noCause = new AggregateError([1], "msg");
+    expect(Object.prototype.hasOwnProperty.call(noCause, "cause")).toBe(false);
+
+    const undefCause = new AggregateError([1], "msg", { cause: undefined });
+    expect(Object.prototype.hasOwnProperty.call(undefCause, "cause")).toBe(true);
+    expect(undefCause.cause).toBe(undefined);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Bumps `WEBKIT_VERSION` to pick up [oven-sh/WebKit#340](https://github.com/oven-sh/WebKit/pull/340) and adds test coverage for the `AggregateError` that `Promise.any` rejects with.

### Problem

The `AggregateError` rejected by `Promise.any` has no `.stack` (it is `undefined`, not even an own property), an empty `.message`, and a spurious own `cause: undefined`:

```js
try { await Promise.any([Promise.reject(new Error("r1")), Promise.reject("r2")]); }
catch (e) {
  console.log("stack:", typeof e.stack, "msg:", JSON.stringify(e.message),
              "own:", Object.getOwnPropertyNames(e));
  console.log("hasOwnCause:", Object.prototype.hasOwnProperty.call(e, "cause"));
}
// node: stack: string  msg: "All promises were rejected"  own: [stack,message,errors]  hasOwnCause: false
// bun:  stack: undefined  msg: ""  own: [cause,errors]  hasOwnCause: true
```

A user-constructed `new AggregateError(...)` in the same process has a stack and no own `cause`, so this is specific to the `Promise.any` construction path. The result is that the most common real-world `AggregateError` (a `Promise.any` fan-in where every branch rejected) is an undebuggable rejection.

### Cause

The five `Promise.any` rejection sites in `JSPromiseConstructor.cpp` / `JSMicrotask.cpp` call `createAggregateError(vm, structure, errors, String(), jsUndefined())`. `ErrorInstance::finishCreation` installs `cause` whenever the passed `JSValue` is non-empty, so `jsUndefined()` becomes an own `cause: undefined`; the null `String()` leaves no own `message`.

The async paths (`promiseAnyResolveJob`, the reject element functions) run from a native internal microtask with no JS frames on the stack, so `m_stackTrace` is an empty vector and `materializeErrorInfoIfNeeded`'s Bun branch (gated on `!m_stackTrace->isEmpty()`) never runs, leaving `.stack` unmaterialized.

### Fix (in oven-sh/WebKit#340)

- Add `createAggregateErrorForPromiseAnyRejection`, which passes an empty `JSValue()` for `cause` and, under `USE(BUN_JSC_ADDITIONS)`, V8's `"All promises were rejected"` message. Route all five call sites through it.
- In `materializeErrorInfoIfNeeded`, drop the `isEmpty()` gate on the Bun branch so the embedder hook still runs for zero-frame errors and produces the `"Name: message"` header; `line`/`column`/`sourceURL` are only set when there are frames.

### Verification

With this bump:

```
stack: string msg: "All promises were rejected" own: [ "message", "errors", "stack" ]
hasOwnCause: false
```

which matches Node. The new test covers every `Promise.any` rejection path: the fast-path internal microtask, the empty-iterable synchronous rejection, the subclass slow path (both async and empty), and a custom thenable. It also asserts that user-constructed `AggregateError` with and without an explicit `cause` is unchanged.

This is the error-object half of #29157; #35174 covers the `console.dir` / `Bun.inspect` print path that currently skips the aggregate header. With both in, the #29157 repro prints `AggregateError: All promises were rejected` followed by the member errors.

### Also in this range (oven-sh/WebKit 549170099226..6e83cef951dc)

- [#328](https://github.com/oven-sh/WebKit/pull/328) inspector: release throw scope before tail-calling impl in injected-script prototype host functions
- [#317](https://github.com/oven-sh/WebKit/pull/317) LiteralParser: throw RangeError on OOM when copying a JSON string value
- [#331](https://github.com/oven-sh/WebKit/pull/331) SignalsWin: fix VEH return value and register behind AddressSanitizer's handler
- [#332](https://github.com/oven-sh/WebKit/pull/332) Heap: make minEdenToOldGenerationRatio a JSC option

> **Draft**: `WEBKIT_VERSION` currently points at the preview build of oven-sh/WebKit#340. Once that PR is merged this will be retargeted at the resulting `autobuild-<sha>` on main.
