### PR TITLE
fetch: honor tls.ciphers instead of resetting the cipher list to "ALL"

### DIFF
--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -82,12 +82,7 @@ pub fn load() {
 // Remove once the bindgen pipeline lands these in the sys crate.
 // ──────────────────────────────────────────────────────────────────────────
 
-/// `#define SSL_DEFAULT_CIPHER_LIST "ALL"`
-pub const SSL_DEFAULT_CIPHER_LIST: &core::ffi::CStr = c"ALL";
-
-use boring::{
-    CRYPTO_BUFFER_POOL, CRYPTO_BUFFER_POOL_new, SSL_CTX_set_cipher_list, SSL_CTX_set0_buffer_pool,
-};
+use boring::{CRYPTO_BUFFER_POOL, CRYPTO_BUFFER_POOL_new, SSL_CTX_set0_buffer_pool};
 
 std::thread_local! {
     // One pool per thread, lazily allocated on the first `ssl_ctx_setup()`
@@ -96,8 +91,13 @@ std::thread_local! {
         const { Cell::new(ptr::null_mut()) };
 }
 
-/// Install the per-thread `CRYPTO_BUFFER_POOL` and set the cipher list to
-/// BoringSSL's `SSL_DEFAULT_CIPHER_LIST` (`"ALL"`).
+/// Install the per-thread `CRYPTO_BUFFER_POOL` on `ctx`.
+///
+/// The cipher list is left as configured by the caller: `SSL_CTX_new`
+/// already initializes it to `SSL_DEFAULT_CIPHER_LIST` (`"ALL"`), and
+/// `create_ssl_context` in openssl.c applies any user-supplied
+/// `ssl_ciphers` on top of that. Reapplying `"ALL"` here would discard
+/// a user's `tls.ciphers` pin.
 ///
 /// # Safety
 /// `ctx` must be a live `SSL_CTX*`.
@@ -105,13 +105,12 @@ pub unsafe fn ssl_ctx_setup(ctx: *mut boring::SSL_CTX) {
     AUTO_CRYPTO_BUFFER_POOL.with(|pool| {
         // SAFETY: caller guarantees `ctx` is a live `SSL_CTX*`; the pool pointer
         // is either freshly returned by `CRYPTO_BUFFER_POOL_new` or a previously
-        // stored thread-local pool, and `SSL_DEFAULT_CIPHER_LIST` is a valid C string.
+        // stored thread-local pool.
         unsafe {
             if pool.get().is_null() {
                 pool.set(CRYPTO_BUFFER_POOL_new());
             }
             SSL_CTX_set0_buffer_pool(ctx, pool.get());
-            let _ = SSL_CTX_set_cipher_list(ctx, SSL_DEFAULT_CIPHER_LIST.as_ptr());
         }
     });
 }

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -113,6 +113,30 @@ describe.concurrent("fetch-tls", () => {
     });
   });
 
+  it("fetch honors tls.ciphers when building the client SSL context", async () => {
+    // A TLSv1.2-capped server that reports the cipher it actually negotiated.
+    const server = tls.createServer({ ...CERT_LOCALHOST_IP, maxVersion: "TLSv1.2" }, socket => {
+      const body = JSON.stringify({ negotiated: socket.getCipher().name });
+      socket.on("error", () => {});
+      socket.end(`HTTP/1.1 200 OK\r\nContent-Length: ${body.length}\r\nConnection: close\r\n\r\n${body}`);
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    try {
+      // CHACHA20-POLY1305 is not first in either BoringSSL's "ALL" order or
+      // bun's DEFAULT_CIPHER_LIST, so it will only be negotiated if the client
+      // offers exactly this one suite.
+      const pin = "ECDHE-RSA-CHACHA20-POLY1305";
+      const res = await fetch(`https://localhost:${port}/`, {
+        keepalive: false,
+        tls: { ca: validTls.cert, ciphers: pin },
+      });
+      expect(await res.json()).toEqual({ negotiated: pin });
+    } finally {
+      server.close();
+    }
+  });
+
   it("fetch with valid tls should not throw", async () => {
     await createServer(CERT_LOCALHOST_IP, async port => {
       const urls = [`https://localhost:${port}`, `https://127.0.0.1:${port}`];


### PR DESCRIPTION
## Problem

`fetch(url, { tls: { ciphers } })` accepts the documented `ciphers` option but always offers bun's default cipher list anyway. Pinning `ECDHE-ECDSA-CHACHA20-POLY1305` against a TLSv1.2 server still negotiates `ECDHE-ECDSA-AES128-GCM-SHA256`, a suite the client should never have offered. The same option through `Bun.connect({ tls: { ciphers } })` is honored, and node's `https.request({ ciphers })` honors it too.

## Cause

`HTTPContext::init_with_opts` builds the custom SSL context via `create_ssl_context` in `packages/bun-usockets/src/crypto/openssl.c`, which correctly applies the user's `ssl_ciphers` with `SSL_CTX_set_cipher_list`. It then calls `ssl_ctx_setup()` in `src/boringssl/lib.rs`, which unconditionally ran `SSL_CTX_set_cipher_list(ctx, "ALL")`, clobbering what was just set. `Bun.connect` builds its SSL context through `SSLContextCache` and never calls `ssl_ctx_setup()`, which is why it was unaffected.

## Fix

Drop the `SSL_CTX_set_cipher_list(ctx, "ALL")` call from `ssl_ctx_setup()`. `SSL_CTX_new` already initializes a fresh context's cipher list to `SSL_DEFAULT_CIPHER_LIST` (`"ALL"`), so the default fetch context is unchanged and custom contexts now keep the ciphers `create_ssl_context` applied.

## Verification

```
# before
fetch tls.ciphers  -> {"negotiated":"ECDHE-ECDSA-AES128-GCM-SHA256"}
Bun.connect ciphers-> {"negotiated":"ECDHE-ECDSA-CHACHA20-POLY1305"}
# after
fetch tls.ciphers  -> {"negotiated":"ECDHE-ECDSA-CHACHA20-POLY1305"}
Bun.connect ciphers-> {"negotiated":"ECDHE-ECDSA-CHACHA20-POLY1305"}
```

New test in `test/js/web/fetch/fetch.tls.test.ts` pins `ECDHE-RSA-CHACHA20-POLY1305` against a TLSv1.2 `tls.createServer` and asserts the server reports that exact cipher.