### PR TITLE
ci: add comment-cop action to flag multi-line comments in claude PRs

### DIFF
--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -1,0 +1,167 @@
+name: Comment Cop
+
+# Flags multi-line code comments added in src/ by claude-labeled PRs that
+# don't carry a SAFETY: marker, and asks for them to be deleted. Runs
+# entirely against the GitHub API (no checkout of PR code).
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "src/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment-cop:
+    if: >
+      github.repository == 'oven-sh/bun' &&
+      contains(github.event.pull_request.labels.*.name, 'claude') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'claude')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: comment-cop-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Scan diff for added multi-line comments
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const crypto = require('crypto');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+
+            const SRC_EXT = /\.(rs|c|cc|cpp|h|hpp|m|mm|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
+            const MIN_LINES = 2;
+            const MAX_COMMENTS = 25;
+
+            function isCommentLine(line) {
+              const t = line.trimStart();
+              // Rust doc comments are API documentation, not the target here.
+              if (t.startsWith('///') || t.startsWith('//!')) return false;
+              if (t.startsWith('//')) return true;
+              if (t.startsWith('/*')) return true;
+              if (t === '*' || t === '*/' || t.startsWith('* ')) return true;
+              return false;
+            }
+
+            function groupsFromPatch(path, patch) {
+              const out = [];
+              let newLine = 0;
+              let cur = null;
+              const flush = () => {
+                if (cur && cur.lines.length >= MIN_LINES) {
+                  const text = cur.lines.join('\n');
+                  if (!/SAFETY:/.test(text)) out.push({ path, start: cur.start, end: cur.end, text });
+                }
+                cur = null;
+              };
+              for (const raw of patch.split('\n')) {
+                if (raw.startsWith('@@')) {
+                  flush();
+                  const m = /\+(\d+)/.exec(raw);
+                  newLine = m ? parseInt(m[1], 10) : 1;
+                  continue;
+                }
+                if (raw.startsWith('+') && !raw.startsWith('+++')) {
+                  const content = raw.slice(1);
+                  if (isCommentLine(content)) {
+                    if (cur) {
+                      cur.end = newLine;
+                      cur.lines.push(content);
+                    } else {
+                      cur = { start: newLine, end: newLine, lines: [content] };
+                    }
+                  } else {
+                    flush();
+                  }
+                  newLine++;
+                } else if (raw.startsWith('-') && !raw.startsWith('---')) {
+                  flush();
+                } else if (raw.startsWith('\\')) {
+                  // "\ No newline at end of file"
+                } else {
+                  // context line (leading space, or blank)
+                  flush();
+                  newLine++;
+                }
+              }
+              flush();
+              return out;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number, per_page: 100,
+            });
+
+            const groups = [];
+            for (const f of files) {
+              if (f.status === 'removed') continue;
+              if (!f.filename.startsWith('src/')) continue;
+              if (!SRC_EXT.test(f.filename)) continue;
+              if (!f.patch) continue; // too large to include a patch
+              for (const g of groupsFromPatch(f.filename, f.patch)) groups.push(g);
+            }
+
+            if (groups.length === 0) {
+              core.info('No multi-line comment groups found.');
+              return;
+            }
+
+            const existing = await github.paginate(github.rest.pulls.listReviewComments, {
+              owner, repo, pull_number, per_page: 100,
+            });
+            const seen = new Set();
+            for (const c of existing) {
+              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(c.body || '');
+              if (m) seen.add(m[1]);
+            }
+
+            const keyFor = g => `${g.path}:${crypto.createHash('sha256').update(g.text).digest('hex').slice(0, 12)}`;
+
+            const fresh = groups.filter(g => !seen.has(keyFor(g)));
+            if (fresh.length === 0) {
+              core.info(`All ${groups.length} group(s) already have a comment-cop marker.`);
+              return;
+            }
+
+            const capped = fresh.slice(0, MAX_COMMENTS);
+            const bodyFor = g => {
+              const key = keyFor(g);
+              return (
+                `<!-- comment-cop:${key} -->\n` +
+                `Delete this added comment block (no \`SAFETY:\` marker).\n\n` +
+                `Once removed, resolve this review thread.`
+              );
+            };
+
+            const comments = capped.map(g => {
+              const c = { path: g.path, line: g.end, side: 'RIGHT', body: bodyFor(g) };
+              if (g.start < g.end) {
+                c.start_line = g.start;
+                c.start_side = 'RIGHT';
+              }
+              return c;
+            });
+
+            const overflow = fresh.length > capped.length
+              ? ` (${fresh.length - capped.length} more not shown; will surface on the next push once these are addressed)`
+              : '';
+
+            await github.rest.pulls.createReview({
+              owner, repo, pull_number,
+              commit_id: headSha,
+              event: 'COMMENT',
+              body:
+                `**comment-cop**: ${capped.length} multi-line comment block(s) were added in \`src/\` ` +
+                `without a \`SAFETY:\` marker${overflow}. See inline.`,
+              comments,
+            });
+
+            core.info(`Posted ${comments.length} review comment(s).`);

--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -1,14 +1,12 @@
 name: Comment Cop
 
-# Flags multi-line code comments added in src/ by claude-labeled PRs that
-# don't carry a SAFETY: marker, and asks for them to be deleted. Runs
-# entirely against the GitHub API (no checkout of PR code).
+# Flags multi-line code comments added in src/ by claude-labeled PRs and
+# asks for them to be deleted. Groups containing a SAFETY: marker are
+# skipped. Runs entirely against the GitHub API (no checkout of PR code).
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      - "src/**"
 
 permissions:
   contents: read
@@ -39,12 +37,9 @@ jobs:
 
             const SRC_EXT = /\.(rs|c|cc|cpp|h|hpp|m|mm|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
             const MIN_LINES = 2;
-            const MAX_COMMENTS = 25;
 
             function isCommentLine(line) {
               const t = line.trimStart();
-              // Rust doc comments are API documentation, not the target here.
-              if (t.startsWith('///') || t.startsWith('//!')) return false;
               if (t.startsWith('//')) return true;
               if (t.startsWith('/*')) return true;
               if (t === '*' || t === '*/' || t.startsWith('* ')) return true;
@@ -67,9 +62,7 @@ jobs:
                   flush();
                   const m = /\+(\d+)/.exec(raw);
                   newLine = m ? parseInt(m[1], 10) : 1;
-                  continue;
-                }
-                if (raw.startsWith('+') && !raw.startsWith('+++')) {
+                } else if (raw.startsWith('+')) {
                   const content = raw.slice(1);
                   if (isCommentLine(content)) {
                     if (cur) {
@@ -82,7 +75,7 @@ jobs:
                     flush();
                   }
                   newLine++;
-                } else if (raw.startsWith('-') && !raw.startsWith('---')) {
+                } else if (raw.startsWith('-')) {
                   flush();
                 } else if (raw.startsWith('\\')) {
                   // "\ No newline at end of file"
@@ -105,63 +98,95 @@ jobs:
               if (f.status === 'removed') continue;
               if (!f.filename.startsWith('src/')) continue;
               if (!SRC_EXT.test(f.filename)) continue;
-              if (!f.patch) continue; // too large to include a patch
+              if (!f.patch) continue;
               for (const g of groupsFromPatch(f.filename, f.patch)) groups.push(g);
             }
 
-            if (groups.length === 0) {
-              core.info('No multi-line comment groups found.');
-              return;
-            }
-
-            const existing = await github.paginate(github.rest.pulls.listReviewComments, {
-              owner, repo, pull_number, per_page: 100,
-            });
-            const seen = new Set();
-            for (const c of existing) {
-              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(c.body || '');
-              if (m) seen.add(m[1]);
-            }
-
             const keyFor = g => `${g.path}:${crypto.createHash('sha256').update(g.text).digest('hex').slice(0, 12)}`;
+            const presentKeys = new Set(groups.map(keyFor));
 
-            const fresh = groups.filter(g => !seen.has(keyFor(g)));
+            // Fetch existing comment-cop review threads (for dedup + auto-resolve).
+            const threads = [];
+            {
+              const q = `
+                query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      reviewThreads(first: 100, after: $after) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes { id isResolved comments(first: 1) { nodes { body } } }
+                      }
+                    }
+                  }
+                }`;
+              let after = null;
+              for (;;) {
+                const res = await github.graphql(q, { owner, repo, pr: pull_number, after });
+                const page = res.repository.pullRequest.reviewThreads;
+                for (const t of page.nodes) threads.push(t);
+                if (!page.pageInfo.hasNextPage) break;
+                after = page.pageInfo.endCursor;
+              }
+            }
+
+            const seenKeys = new Set();
+            const toResolve = [];
+            for (const t of threads) {
+              const body = t.comments.nodes[0]?.body || '';
+              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(body);
+              if (!m) continue;
+              const key = m[1];
+              seenKeys.add(key);
+              if (!t.isResolved && !presentKeys.has(key)) toResolve.push(t.id);
+            }
+
+            // Auto-resolve threads whose flagged block is gone from the current diff.
+            if (toResolve.length > 0) {
+              const mut = `
+                mutation($id: ID!) {
+                  resolveReviewThread(input: { threadId: $id }) { thread { id } }
+                }`;
+              for (const id of toResolve) {
+                try {
+                  await github.graphql(mut, { id });
+                } catch (e) {
+                  core.warning(`resolveReviewThread failed for ${id}: ${e.message}`);
+                }
+              }
+              core.info(`Resolved ${toResolve.length} stale comment-cop thread(s).`);
+            }
+
+            // Post new line comments for groups not already flagged.
+            const fresh = groups.filter(g => !seenKeys.has(keyFor(g)));
             if (fresh.length === 0) {
-              core.info(`All ${groups.length} group(s) already have a comment-cop marker.`);
+              core.info(`No new comment groups to flag (${groups.length} present, all already flagged).`);
               return;
             }
 
-            const capped = fresh.slice(0, MAX_COMMENTS);
-            const bodyFor = g => {
-              const key = keyFor(g);
-              return (
-                `<!-- comment-cop:${key} -->\n` +
-                `Delete this added comment block (no \`SAFETY:\` marker).\n\n` +
-                `Once removed, resolve this review thread.`
-              );
-            };
+            const bodyFor = g =>
+              `<!-- comment-cop:${keyFor(g)} -->\n` +
+              `Delete this added comment block.\n\n` +
+              `Once removed, resolve this review thread.`;
 
-            const comments = capped.map(g => {
-              const c = { path: g.path, line: g.end, side: 'RIGHT', body: bodyFor(g) };
+            let posted = 0;
+            for (const g of fresh) {
+              const params = {
+                owner, repo, pull_number,
+                commit_id: headSha,
+                path: g.path,
+                line: g.end,
+                side: 'RIGHT',
+                body: bodyFor(g),
+              };
               if (g.start < g.end) {
-                c.start_line = g.start;
-                c.start_side = 'RIGHT';
+                params.start_line = g.start;
+                params.start_side = 'RIGHT';
               }
-              return c;
-            });
-
-            const overflow = fresh.length > capped.length
-              ? ` (${fresh.length - capped.length} more not shown; will surface on the next push once these are addressed)`
-              : '';
-
-            await github.rest.pulls.createReview({
-              owner, repo, pull_number,
-              commit_id: headSha,
-              event: 'COMMENT',
-              body:
-                `**comment-cop**: ${capped.length} multi-line comment block(s) were added in \`src/\` ` +
-                `without a \`SAFETY:\` marker${overflow}. See inline.`,
-              comments,
-            });
-
-            core.info(`Posted ${comments.length} review comment(s).`);
+              try {
+                await github.rest.pulls.createReviewComment(params);
+                posted++;
+              } catch (e) {
+                core.warning(`createReviewComment failed for ${g.path}:${g.start}-${g.end}: ${e.message}`);
+              }
+            }
+            core.info(`Posted ${posted} review comment(s).`);


### PR DESCRIPTION
Adds a self-contained GitHub Action that scans `claude`-labeled PRs for multi-line comment blocks added under `src/` and leaves a review line comment on each one asking for it to be deleted (and the thread resolved once done).

### Behavior

- Triggers on `pull_request_target` (`opened` / `synchronize` / `reopened` / `labeled`), gated on `github.repository == 'oven-sh/bun'` and the `claude` label being present. The `labeled` trigger covers the normal case where `auto-label-claude-prs.yml` applies the label after open.
- Fetches PR files via `pulls.listFiles` and parses the unified diff in `actions/github-script`. No repo checkout.
- A group is **2+ consecutive added lines** that are pure comment lines (`//`, `///`, `//!`, `/* ... */`, `* ` continuation) in `.rs` / `.c` / `.cpp` / `.h` / `.ts` / `.js` and friends. Groups containing `SAFETY:` are skipped.
- Posts one standalone review line comment per consecutive group via `pulls.createReviewComment` (no review summary).
- Each comment carries `<!-- comment-cop:<path>:<sha12> -->` keyed on the group's content hash, so reruns (new pushes, relabels) skip groups that already have a marker.
- On each run, any existing comment-cop thread whose flagged block is no longer present in the diff is auto-resolved via `resolveReviewThread`.

### Verification

Dry-ran the parser against the five most recent open `claude` PRs via `gh api repos/oven-sh/bun/pulls/<n>/files`:

```
#35531  src/runtime/webcore/Blob.rs:5245-5246
#35529  src/http_jsc/websocket_client.rs:907-910
#35528  src/runtime/webcore/FileSink.rs:917-920
#35526  src/http_jsc/websocket_client.rs:2179-2182
#35532  (clean)
```

Cross-checked `#35531` line numbers against the fetched head ref; `Blob.rs:5245` is the first line of the flagged block. `actionlint` and prettier both pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->