### PR TITLE
install: accept -E/--exact for bun update

### DIFF
--- a/docs/snippets/cli/update.mdx
+++ b/docs/snippets/cli/update.mdx
@@ -14,6 +14,10 @@ bun update <name>@<version>
   Update packages to their latest versions
 </ParamField>
 
+<ParamField path="--exact" type="boolean">
+  Save the exact resolved version instead of the <code>^</code> range. Alias: <code>-E</code>
+</ParamField>
+
 ### Dependency Scope
 
 <ParamField path="--production" type="boolean">

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -155,6 +155,9 @@ pub static UPDATE_PARAMS: &[ParamType] = concat_params![
             "--latest                              Update packages to their latest versions"
         ),
         clap::param!(
+            "-E, --exact                           Save the exact resolved version instead of a ^range"
+        ),
+        clap::param!(
             "-i, --interactive                     Show an interactive list of outdated packages to select for update"
         ),
         clap::param!(
@@ -1352,6 +1355,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/pm#scan<r>.
 
         if subcommand == Subcommand::Update {
             cli.latest = args.flag(b"--latest");
+            cli.exact = args.flag(b"--exact");
             cli.interactive = args.flag(b"--interactive");
             cli.recursive = args.flag(b"--recursive");
         }

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -380,8 +380,11 @@ impl UpdateInteractiveCommand {
                 let original_version = e_str.data.slice();
 
                 // Preserve the version prefix from the original
-                let version_with_prefix =
-                    preserve_version_prefix(original_version, &update.target_version, exact_versions)?;
+                let version_with_prefix = preserve_version_prefix(
+                    original_version,
+                    &update.target_version,
+                    exact_versions,
+                )?;
 
                 // Update the version using hash map put
                 // `Expr::init` would put the `E.String` *node*

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -297,6 +297,7 @@ impl UpdateInteractiveCommand {
         manager: &mut PackageManager,
         updates: &[PackageUpdate],
     ) -> crate::Result<()> {
+        let exact_versions = manager.options.enable.exact_versions();
         // Group updates by workspace
         let mut workspace_groups: StringHashMap<Vec<usize>> = StringHashMap::default();
 
@@ -380,7 +381,7 @@ impl UpdateInteractiveCommand {
 
                 // Preserve the version prefix from the original
                 let version_with_prefix =
-                    preserve_version_prefix(original_version, &update.target_version)?;
+                    preserve_version_prefix(original_version, &update.target_version, exact_versions)?;
 
                 // Update the version using hash map put
                 // `Expr::init` would put the `E.String` *node*
@@ -413,6 +414,7 @@ impl UpdateInteractiveCommand {
         manager: &mut PackageManager,
         catalog_updates: &StringHashMap<CatalogUpdate>,
     ) -> crate::Result<()> {
+        let exact_versions = manager.options.enable.exact_versions();
         // Group catalog updates by workspace path
         let mut workspace_catalog_updates: StringHashMap<Vec<CatalogUpdateRequest>> =
             StringHashMap::default();
@@ -482,7 +484,11 @@ impl UpdateInteractiveCommand {
                 };
 
             // Use the PackageJSONEditor to update catalogs
-            edit_catalog_definitions(&mut updates_for_workspace[..], &mut package_json.root)?;
+            edit_catalog_definitions(
+                &mut updates_for_workspace[..],
+                &mut package_json.root,
+                exact_versions,
+            )?;
 
             // Save the updated package.json
             Self::save_package_json(package_json, package_json_path)?;
@@ -2246,6 +2252,7 @@ fn leak_dup(bytes: &[u8]) -> &'static [u8] {
 pub(crate) fn edit_catalog_definitions(
     updates: &mut [CatalogUpdateRequest],
     current_package_json: &mut Expr,
+    exact_versions: bool,
 ) -> crate::Result<()> {
     // using data store is going to result in undefined memory issues as
     // the store is cleared in some workspace situations. the solution
@@ -2264,6 +2271,7 @@ pub(crate) fn edit_catalog_definitions(
                 catalog_name,
                 &update.package_name,
                 &update.new_version,
+                exact_versions,
             )?;
         } else {
             update_default_catalog(
@@ -2271,6 +2279,7 @@ pub(crate) fn edit_catalog_definitions(
                 current_package_json,
                 &update.package_name,
                 &update.new_version,
+                exact_versions,
             )?;
         }
     }
@@ -2316,6 +2325,7 @@ fn update_default_catalog(
     package_json: &mut Expr,
     package_name: &[u8],
     new_version: &[u8],
+    exact_versions: bool,
 ) -> crate::Result<()> {
     // Get or create the catalog object
     // First check if catalog is under workspaces.catalog
@@ -2344,8 +2354,11 @@ fn update_default_catalog(
         if let Some(existing_prop) = catalog_obj.get(package_name) {
             if let Some(e_str) = existing_prop.data.e_string() {
                 let original_version = e_str.data.slice();
-                version_with_prefix =
-                    crate::cli::cli_dupe(&preserve_version_prefix(original_version, new_version)?);
+                version_with_prefix = crate::cli::cli_dupe(&preserve_version_prefix(
+                    original_version,
+                    new_version,
+                    exact_versions,
+                )?);
             }
         }
 
@@ -2404,6 +2417,7 @@ fn update_named_catalog(
     catalog_name: &[u8],
     package_name: &[u8],
     new_version: &[u8],
+    exact_versions: bool,
 ) -> crate::Result<()> {
     // Get or create the catalogs object
     // First check if catalogs is under workspaces.catalogs (newer structure)
@@ -2438,8 +2452,11 @@ fn update_named_catalog(
         if let Some(existing_prop) = catalog_obj.get(package_name) {
             if let Some(e_str) = existing_prop.data.e_string() {
                 let original_version = e_str.data.slice();
-                version_with_prefix =
-                    crate::cli::cli_dupe(&preserve_version_prefix(original_version, new_version)?);
+                version_with_prefix = crate::cli::cli_dupe(&preserve_version_prefix(
+                    original_version,
+                    new_version,
+                    exact_versions,
+                )?);
             }
         }
 
@@ -2501,6 +2518,7 @@ fn update_named_catalog(
 fn preserve_version_prefix(
     original_version: &[u8],
     new_version: &[u8],
+    exact_versions: bool,
 ) -> crate::Result<Box<[u8]>> {
     if original_version.len() > 1 {
         let mut orig_version: &[u8] = original_version;
@@ -2518,6 +2536,16 @@ fn preserve_version_prefix(
             } else {
                 alias = Some(after_npm);
             }
+        }
+
+        if exact_versions {
+            if let Some(a) = alias {
+                let mut v = Vec::new();
+                write!(&mut v, "npm:{}@{}", BStr::new(a), BStr::new(new_version))
+                    .expect("infallible: in-memory write");
+                return Ok(v.into_boxed_slice());
+            }
+            return Ok(Box::from(new_version));
         }
 
         // Preserve other version prefixes

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -317,7 +317,7 @@ for (const flag of ["-E", "--exact"]) {
       const { stderr, exited } = spawn({
         cmd: [bunExe(), "install", "--linker=hoisted"],
         cwd: package_dir,
-        stdout: "pipe",
+        stdout: "ignore",
         stdin: "pipe",
         stderr: "pipe",
         env,
@@ -350,6 +350,57 @@ for (const flag of ["-E", "--exact"]) {
     });
   });
 
+  it(`should accept ${flag} and write exact version on update --interactive`, async () => {
+    const urls: string[] = [];
+    const registry = {
+      "0.0.3": { bin: { "baz-run": "index.js" } },
+      "0.0.5": { bin: { "baz-exec": "index.js" } },
+      latest: "0.0.3",
+    };
+    setHandler(dummyRegistry(urls, registry));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        dependencies: { baz: "~0.0.3" },
+      }),
+    );
+    {
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--linker=hoisted"],
+        cwd: package_dir,
+        stdout: "ignore",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await new Response(stderr).text();
+      expect(err).not.toContain("error:");
+      expect(await exited).toBe(0);
+    }
+    registry.latest = "0.0.5";
+    setHandler(dummyRegistry(urls, registry));
+    const proc = spawn({
+      cmd: [bunExe(), "update", flag, "-i", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    proc.stdin.write(" ");
+    proc.stdin.write("\r");
+    proc.stdin.end();
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("Invalid Argument");
+    expect(err).not.toContain("error:");
+    expect(code).toBe(0);
+    expect(await file(join(package_dir, "package.json")).json()).toEqual({
+      name: "foo",
+      dependencies: { baz: "0.0.5" },
+    });
+  });
+
   it(`should accept ${flag} and write exact versions on update --latest`, async () => {
     const urls: string[] = [];
     const registry = {
@@ -369,7 +420,7 @@ for (const flag of ["-E", "--exact"]) {
       const { stderr, exited } = spawn({
         cmd: [bunExe(), "install", "--linker=hoisted"],
         cwd: package_dir,
-        stdout: "pipe",
+        stdout: "ignore",
         stdin: "pipe",
         stderr: "pipe",
         env,

--- a/test/cli/install/bun-update.test.ts
+++ b/test/cli/install/bun-update.test.ts
@@ -296,6 +296,112 @@ for (const { input } of [{ input: { baz: "~0.0.3", moo: "~0.1.0" } }]) {
   });
 }
 
+// https://github.com/oven-sh/bun/issues/7284
+for (const flag of ["-E", "--exact"]) {
+  it(`should accept ${flag} and write exact version on update <pkg>`, async () => {
+    const urls: string[] = [];
+    const registry = {
+      "0.0.3": { bin: { "baz-run": "index.js" } },
+      "0.0.5": { bin: { "baz-exec": "index.js" } },
+      latest: "0.0.3",
+    };
+    setHandler(dummyRegistry(urls, registry));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        dependencies: { baz: "~0.0.3" },
+      }),
+    );
+    {
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--linker=hoisted"],
+        cwd: package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await new Response(stderr).text();
+      expect(err).not.toContain("error:");
+      expect(await exited).toBe(0);
+    }
+    await rm(join(package_dir, "node_modules"), { force: true, recursive: true });
+    urls.length = 0;
+    registry.latest = "0.0.5";
+    setHandler(dummyRegistry(urls, registry));
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "update", flag, "baz", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await new Response(stderr).text();
+    const out = await new Response(stdout).text();
+    expect(err).not.toContain("Invalid Argument");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("baz@0.0.5");
+    expect(await exited).toBe(0);
+    expect(await file(join(package_dir, "package.json")).json()).toEqual({
+      name: "foo",
+      dependencies: { baz: "0.0.5" },
+    });
+  });
+
+  it(`should accept ${flag} and write exact versions on update --latest`, async () => {
+    const urls: string[] = [];
+    const registry = {
+      "0.0.3": { bin: { "baz-run": "index.js" } },
+      "0.0.5": { bin: { "baz-exec": "index.js" } },
+      latest: "0.0.3",
+    };
+    setHandler(dummyRegistry(urls, registry));
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "foo",
+        dependencies: { baz: "^0.0.3" },
+      }),
+    );
+    {
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--linker=hoisted"],
+        cwd: package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await new Response(stderr).text();
+      expect(err).not.toContain("error:");
+      expect(await exited).toBe(0);
+    }
+    urls.length = 0;
+    registry.latest = "0.0.5";
+    setHandler(dummyRegistry(urls, registry));
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "update", flag, "--latest", "--linker=hoisted"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await new Response(stderr).text();
+    const out = await new Response(stdout).text();
+    expect(err).not.toContain("Invalid Argument");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("0.0.5");
+    expect(await exited).toBe(0);
+    expect(await file(join(package_dir, "package.json")).json()).toEqual({
+      name: "foo",
+      dependencies: { baz: "0.0.5" },
+    });
+  });
+}
+
 it("lockfile should not be modified when there are no version changes, issue#5888", async () => {
   // Install packages
   const urls: string[] = [];


### PR DESCRIPTION
Fixes #7284.

## Problem

`bun update -E` fails with:
```
error: Invalid Argument '-E'
```
and `bun update --exact` exits 0 but the flag is silently ignored: package.json is still written with a `^`/`~` range rather than the exact resolved version.

## Cause

`UPDATE_PARAMS` in `src/install/PackageManager/CommandLineArguments.rs` did not declare `-E, --exact`, so the short form is rejected by the argument parser. Unknown long flags are intentionally tolerated, so `--exact` parsed but was never read: `cli.exact = args.flag(b"--exact")` was only evaluated for `Subcommand::Add | Subcommand::Install`.

The interactive updater (`bun update -i`) wrote versions via `preserve_version_prefix` in `src/runtime/cli/update_interactive_command.rs`, which unconditionally copied the leading `^`/`~` from the original spec and never consulted `exact_versions`.

## Fix

- Declare `-E, --exact` in `UPDATE_PARAMS` and read it in the existing `Subcommand::Update` branch. `PackageJSONEditor` already branches on `options.exact_versions` for `bun update <pkg>` and `bun update --latest`, so those paths now flow straight through.
- Thread `exact_versions` through `preserve_version_prefix` and its call sites so `bun update -i -E` (and bunfig `install.exact = true` on interactive) drop the range prefix; `npm:` alias prefixes are still preserved.
- Document `--exact` in `docs/snippets/cli/update.mdx` alongside `--latest`.

## Why this is the right behavior

`bun add` already supports `-E/--exact`, and bunfig's `install.exact = true` already sets the same `Enable::EXACT_VERSIONS` bit. This change makes the CLI flag match the bunfig option and brings parity with `bun add` and npm's `--save-exact` across all three `bun update` entry points.

## Verification

New tests in `test/cli/install/bun-update.test.ts` cover both spellings across all three update paths:
- `bun update -E baz` / `bun update --exact baz` write `"baz": "0.0.5"`
- `bun update -E -i` / `bun update --exact -i` write `"baz": "0.0.5"`
- `bun update -E --latest` / `bun update --exact --latest` write `"baz": "0.0.5"`

Before this change the `-E` cases fail on `Invalid Argument '-E'` and the `--exact` cases write `~0.0.5` / `^0.0.5`.
