### PR TITLE
node:tls: forward ecdhCurve to the SSL context via SSL_CTX_set1_groups_list

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1178,6 +1178,15 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
     }
   }
 
+  if (options.ecdh_curve) {
+    if (!SSL_CTX_set1_groups_list(ssl_context, options.ecdh_curve)) {
+      ERR_clear_error();
+      *err = CREATE_BUN_SOCKET_ERROR_INVALID_ECDH_CURVE;
+      ssl_ctx_build_fail(ssl_context);
+      return NULL;
+    }
+  }
+
   /* Surface resumable sessions through the new-session callback the way Node
    * does: for TLS 1.3 the resumable session only exists once the peer's
    * NewSessionTicket arrives, and BoringSSL only exposes it here. NO_INTERNAL

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -500,6 +500,9 @@ struct us_bun_socket_context_options_t {
     /* Colon-separated signature algorithm list applied via
      * SSL_CTX_set1_sigalgs_list. */
     const char *sigalgs;
+    /* Colon-separated key-exchange group (curve) list applied via
+     * SSL_CTX_set1_groups_list. */
+    const char *ecdh_curve;
 };
 
 enum create_bun_socket_error_t {
@@ -509,6 +512,7 @@ enum create_bun_socket_error_t {
     CREATE_BUN_SOCKET_ERROR_INVALID_CA,
     CREATE_BUN_SOCKET_ERROR_INVALID_CIPHERS,
     CREATE_BUN_SOCKET_ERROR_INVALID_CRL,
+    CREATE_BUN_SOCKET_ERROR_INVALID_ECDH_CURVE,
 };
 
 /* Build an SSL_CTX from options. Returns the BoringSSL SSL_CTX*; caller owns

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -85,6 +85,7 @@ namespace uWS {
         unsigned int crl_count = 0;
         int allow_partial_trust_chain = 0;
         const char *sigalgs = nullptr;
+        const char *ecdh_curve = nullptr;
 
         /* Conversion operator used internally */
         operator struct us_bun_socket_context_options_t() const {

--- a/src/http/ssl_config.rs
+++ b/src/http/ssl_config.rs
@@ -38,6 +38,7 @@ pub struct SSLConfig {
     pub session_timeout: i32,
     pub allow_partial_trust_chain: bool,
     pub sigalgs: CStrPtr,
+    pub ecdh_curve: CStrPtr,
     /// Minimum/maximum TLS protocol version (TLS1_VERSION..TLS1_3_VERSION); 0 = unset/default.
     pub ssl_min_version: i32,
     pub ssl_max_version: i32,
@@ -114,6 +115,7 @@ impl SSLConfig {
         session_timeout: 0,
         allow_partial_trust_chain: false,
         sigalgs: core::ptr::null(),
+        ecdh_curve: core::ptr::null(),
         ssl_min_version: 0,
         ssl_max_version: 0,
         request_cert: 0,
@@ -223,6 +225,9 @@ impl SSLConfig {
         if !self.sigalgs.is_null() {
             ctx_opts.sigalgs = self.sigalgs;
         }
+        if !self.ecdh_curve.is_null() {
+            ctx_opts.ecdh_curve = self.ecdh_curve;
+        }
         if let Some(crl) = &self.crl {
             ctx_opts.crl = crl.as_ptr();
             ctx_opts.crl_count = crl.len() as u32;
@@ -299,6 +304,7 @@ impl SSLConfig {
             return false;
         }
         eq_cstr!(sigalgs);
+        eq_cstr!(ecdh_curve);
         if self.ssl_min_version != other.ssl_min_version {
             return false;
         }
@@ -373,6 +379,7 @@ impl SSLConfig {
         hasher.update(&self.session_timeout.to_ne_bytes());
         hasher.update(&[self.allow_partial_trust_chain as u8]);
         hash_cstr!(sigalgs);
+        hash_cstr!(ecdh_curve);
         hasher.update(&self.ssl_min_version.to_ne_bytes());
         hasher.update(&self.ssl_max_version.to_ne_bytes());
         hasher.update(&self.request_cert.to_ne_bytes());
@@ -413,6 +420,7 @@ impl SSLConfig {
         free_strings(&mut self.ca);
         free_strings(&mut self.crl);
         free_string(&mut self.sigalgs);
+        free_string(&mut self.ecdh_curve);
         free_string(&mut self.ssl_ciphers);
         free_string(&mut self.protos);
     }
@@ -470,6 +478,7 @@ impl Clone for SSLConfig {
             session_timeout: self.session_timeout,
             allow_partial_trust_chain: self.allow_partial_trust_chain,
             sigalgs: clone_string(self.sigalgs),
+            ecdh_curve: clone_string(self.ecdh_curve),
             ssl_min_version: self.ssl_min_version,
             ssl_max_version: self.ssl_max_version,
             request_cert: self.request_cert,

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1111,6 +1111,7 @@ function buildSharedCreds(server) {
       allowPartialTrustChain: server.allowPartialTrustChain,
       sessionTimeout: server.sessionTimeout,
       sigalgs: server.sigalgs,
+      ecdhCurve: server.ecdhCurve,
       passphrase: server.passphrase,
       secureProtocol: server.secureProtocol,
       minVersion: server.minVersion,
@@ -1158,6 +1159,7 @@ function Server(options, secureConnectionListener): void {
   this.allowPartialTrustChain = undefined;
   this.sessionTimeout = undefined;
   this.sigalgs = undefined;
+  this.ecdhCurve = undefined;
   this.passphrase = undefined;
   this.secureOptions = undefined;
   // The Server constructor is the only writer of these: node assigns them
@@ -1301,6 +1303,10 @@ function Server(options, secureConnectionListener): void {
       }
       next.sigalgs = sigalgs;
 
+      const ecdhCurve = options.ecdhCurve;
+      if (ecdhCurve !== undefined) validateString(ecdhCurve, "options.ecdhCurve");
+      next.ecdhCurve = ecdhCurve;
+
       let passphrase = options.passphrase;
       if (passphrase && typeof passphrase !== "string") {
         throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
@@ -1349,6 +1355,7 @@ function Server(options, secureConnectionListener): void {
       this.allowPartialTrustChain = next.allowPartialTrustChain;
       this.sessionTimeout = next.sessionTimeout;
       this.sigalgs = next.sigalgs;
+      this.ecdhCurve = next.ecdhCurve;
       this.passphrase = next.passphrase;
       this.servername = next.servername;
       this.secureOptions = next.secureOptions;
@@ -1394,6 +1401,7 @@ function Server(options, secureConnectionListener): void {
         allowPartialTrustChain: this.allowPartialTrustChain,
         sessionTimeout: this.sessionTimeout ?? 0,
         sigalgs: this.sigalgs,
+        ecdhCurve: this.ecdhCurve,
         passphrase: this.passphrase,
         secureOptions: this.secureOptions,
         rejectUnauthorized: this._rejectUnauthorized,

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -319,6 +319,7 @@ pub struct SSLConfig {
     pub allow_partial_trust_chain: bool,
     pub session_timeout: i32,
     pub sigalgs: GenOpt<GenString>,
+    pub ecdh_curve: GenOpt<GenString>,
 }
 
 // ── refcount release on drop ──────────────────────────────────────────────
@@ -416,6 +417,7 @@ impl Drop for SSLConfig {
         // `alpn_protocols`: `SSLConfigAlpnProtocols` — released by its own `Drop`.
         release_gen_opt_string(&self.ciphers);
         release_gen_opt_string(&self.sigalgs);
+        release_gen_opt_string(&self.ecdh_curve);
     }
 }
 
@@ -569,6 +571,7 @@ struct ExternSSLConfig {
     allow_partial_trust_chain: bool,
     session_timeout: i32,
     sigalgs: RawWTFStringImpl,
+    ecdh_curve: RawWTFStringImpl,
 }
 
 // safe: same handle/out-param contract as
@@ -607,6 +610,7 @@ impl SSLConfig {
             allow_partial_trust_chain: ext.allow_partial_trust_chain,
             session_timeout: ext.session_timeout,
             sigalgs: adopt_opt_string(ext.sigalgs),
+            ecdh_curve: adopt_opt_string(ext.ecdh_curve),
         }
     }
 

--- a/src/runtime/socket/SSLConfig.bindv2.ts
+++ b/src/runtime/socket/SSLConfig.bindv2.ts
@@ -108,5 +108,9 @@ export const SSLConfig = b.dictionary(
       internalName: "session_timeout",
     },
     sigalgs: b.String.nullable,
+    ecdhCurve: {
+      type: b.String.nullable,
+      internalName: "ecdh_curve",
+    },
   },
 );

--- a/src/runtime/socket/SSLConfig.rs
+++ b/src/runtime/socket/SSLConfig.rs
@@ -182,6 +182,14 @@ impl SSLConfigFromJs for SSLConfig {
             result.sigalgs = zbox_into_raw(&sigalgs.to_owned_slice_z());
             any = true;
         }
+        if let Some(ecdh_curve) = generated.ecdh_curve.get() {
+            let z = ecdh_curve.to_owned_slice_z();
+            // Node's setECDHCurve: "auto" and "" keep the library defaults.
+            if !z.is_empty() && z.as_bytes() != b"auto" {
+                result.ecdh_curve = zbox_into_raw(&z);
+                any = true;
+            }
+        }
         any = any
             || result.low_memory_mode
             || generated.reject_unauthorized.is_some()
@@ -205,6 +213,7 @@ impl SSLConfigFromJs for SSLConfig {
             || result.ssl_min_version != 0
             || result.ssl_max_version != 0
             || !result.sigalgs.is_null()
+            || !result.ecdh_curve.is_null()
             || result.session_timeout != 0
             || result.allow_partial_trust_chain;
 

--- a/src/runtime/socket/uws_jsc.rs
+++ b/src/runtime/socket/uws_jsc.rs
@@ -77,6 +77,12 @@ pub fn create_bun_socket_error_to_js(
                 format_args!("Failed to parse CRL"),
             )
             .to_js(),
+        create_bun_socket_error_t::invalid_ecdh_curve => global_object
+            .err(
+                bun_jsc::ErrorCode::ERR_CRYPTO_OPERATION_FAILED,
+                format_args!("Failed to set ECDH curve"),
+            )
+            .to_js(),
     }
 }
 

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -148,6 +148,12 @@ pub(crate) fn create_bun_socket_error_to_js(
                 format_args!("Failed to parse CRL"),
             )
             .to_js(),
+        E::invalid_ecdh_curve => global
+            .err(
+                ErrorCode::ERR_CRYPTO_OPERATION_FAILED,
+                format_args!("Failed to set ECDH curve"),
+            )
+            .to_js(),
     }
 }
 

--- a/src/uws_sys/SocketContext.rs
+++ b/src/uws_sys/SocketContext.rs
@@ -123,6 +123,7 @@ pub struct BunSocketContextOptions {
     pub crl_count: u32,
     pub allow_partial_trust_chain: i32,
     pub sigalgs: *const c_char,
+    pub ecdh_curve: *const c_char,
 }
 
 impl Default for BunSocketContextOptions {
@@ -153,6 +154,7 @@ impl Default for BunSocketContextOptions {
             crl_count: 0,
             allow_partial_trust_chain: 0,
             sigalgs: ptr::null(),
+            ecdh_curve: ptr::null(),
         }
     }
 }
@@ -257,6 +259,7 @@ impl BunSocketContextOptions {
         feed_arr(&mut h, self.crl, self.crl_count);
         h.update(bun_core::bytes_of(&self.allow_partial_trust_chain));
         feed_z(&mut h, self.sigalgs);
+        feed_z(&mut h, self.ecdh_curve);
         let mut out = [0u8; 32];
         h.final_(&mut out);
         out

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -109,6 +109,7 @@ pub enum create_bun_socket_error_t {
     invalid_ca,
     invalid_ciphers,
     invalid_crl,
+    invalid_ecdh_curve,
 }
 
 impl create_bun_socket_error_t {
@@ -120,6 +121,7 @@ impl create_bun_socket_error_t {
             Self::invalid_ca => Some(b"Invalid CA"),
             Self::invalid_ciphers => Some(b"Invalid ciphers"),
             Self::invalid_crl => Some(b"Invalid CRL"),
+            Self::invalid_ecdh_curve => Some(b"Failed to set ECDH curve"),
         }
     }
 }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1151,3 +1151,77 @@ it("an inherited checkServerIdentity cannot become the hostname verifier", async
     failureDetail: "",
   });
 });
+
+describe("ecdhCurve", () => {
+  // Node: SecureContext::SetECDHCurve calls SSL_CTX_set1_groups_list and throws
+  // ERR_CRYPTO_OPERATION_FAILED("Failed to set ECDH curve") on failure; "auto"
+  // and "" keep the library defaults.
+  // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_context.cc
+  it("createSecureContext rejects an unparsable curve list like Node", () => {
+    for (const accepted of ["auto", "", "X25519", "P-384", "X25519:P-384"]) {
+      expect(() => tls.createSecureContext({ ecdhCurve: accepted })).not.toThrow();
+    }
+    let err: any;
+    try {
+      tls.createSecureContext({ ecdhCurve: "not-a-curve" });
+    } catch (e) {
+      err = e;
+    }
+    expect({ code: err?.code, message: err?.message }).toEqual({
+      code: "ERR_CRYPTO_OPERATION_FAILED",
+      message: "Failed to set ECDH curve",
+    });
+  });
+
+  it("tls.connect rejects an unparsable curve list synchronously", () => {
+    let err: any;
+    let socket: tls.TLSSocket | undefined;
+    try {
+      socket = tls.connect({ host: "127.0.0.1", port: 1, ecdhCurve: "not-a-curve" });
+    } catch (e) {
+      err = e;
+    }
+    socket?.on("error", () => {});
+    socket?.destroy();
+    expect(err?.code).toBe("ERR_CRYPTO_OPERATION_FAILED");
+  });
+
+  // Narrow the client's and server's key-exchange groups to disjoint sets and
+  // assert the handshake fails: only if ecdhCurve reaches both SSL contexts can
+  // there be no overlap. BoringSSL's default list contains X25519, P-256 and
+  // P-384, so ignoring the option on either side would let them agree.
+  it("tls.connect/tls.createServer apply ecdhCurve to the SSL context", async () => {
+    const server = tls.createServer({ ...COMMON_CERT_, ecdhCurve: "P-384" }, socket => socket.end());
+    server.on("tlsClientError", () => {});
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as AddressInfo).port;
+
+    const probe = (ecdhCurve: string) =>
+      new Promise<string>(resolve => {
+        const s = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false, ecdhCurve }, () => {
+          s.destroy();
+          resolve("connected");
+        });
+        s.on("error", e => resolve((e as NodeJS.ErrnoException).code || e.message));
+      });
+
+    try {
+      expect({
+        matching: await probe("P-384"),
+        noOverlapP256: await probe("P-256"),
+        noOverlapX25519: await probe("X25519"),
+        listWithOverlap: await probe("P-256:P-384"),
+        auto: await probe("auto"),
+      }).toEqual({
+        matching: "connected",
+        noOverlapP256: expect.stringContaining("HANDSHAKE_FAILURE"),
+        noOverlapX25519: expect.stringContaining("HANDSHAKE_FAILURE"),
+        listWithOverlap: "connected",
+        auto: "connected",
+      });
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`ecdhCurve` on `tls.connect` / `tls.createServer` / `tls.createSecureContext` was validated as a string in `tls.ts` and then silently dropped. No corresponding field existed in the bindgen option struct, `SSLConfig`, `BunSocketContextOptions`, or usockets, so the ClientHello always offered BoringSSL's fixed default groups (`x25519:secp256r1:secp384r1`) regardless of what the caller configured, and an unparsable curve list was accepted without error.

Node applies the list via `SSL_CTX_set1_groups_list` and throws `ERR_CRYPTO_OPERATION_FAILED("Failed to set ECDH curve")` when BoringSSL rejects it.

The `sigalgs` half of the same report already works on current `main` (landed in #32630); the canary in the report predates that change.

## Repro

```js
import tls from "node:tls";
tls.createSecureContext({ ecdhCurve: "not-a-curve" }); // node: throws ERR_CRYPTO_OPERATION_FAILED; bun: no throw
```

Wire-level (against `openssl s_server -www`): `tls.connect({ecdhCurve: "X25519"})` offers only `x25519` in Node but Bun still offers `x25519:secp256r1:secp384r1`.

## Fix

Plumb the option through every layer and apply it when the `SSL_CTX` is built:

- `SSLConfig.bindv2.ts` / `generated.rs`: read `ecdhCurve` from the options object
- `runtime/socket/SSLConfig.rs`: copy into `SSLConfig`, skipping `"auto"` / `""` the way Node's `setECDHCurve` does
- `http/ssl_config.rs`, `uws_sys/SocketContext.rs`, `libusockets.h`, `App.h`: carry the field to usockets
- `openssl.c`: `SSL_CTX_set1_groups_list(ctx, options.ecdh_curve)`, returning a new `CREATE_BUN_SOCKET_ERROR_INVALID_ECDH_CURVE` on failure
- `uws_jsc.rs` / `sql_jsc/jsc.rs`: map that error to `ERR_CRYPTO_OPERATION_FAILED` / `"Failed to set ECDH curve"` (Node's shape)
- `tls.ts`: track `ecdhCurve` on `tls.Server` and forward it through `setSecureContext` / the server `[buntls]` path

## Verification

New tests in `test/js/node/tls/node-tls-connect.test.ts`:

- `createSecureContext` / `tls.connect` throw `ERR_CRYPTO_OPERATION_FAILED` for an unparsable curve and accept `"auto"` / `""` / valid names / colon-separated lists
- Handshake between a server pinned to `P-384` and clients pinned to `P-256` / `X25519` fails with `HANDSHAKE_FAILURE` (no group overlap), while `P-384` / `P-256:P-384` / `"auto"` connect. On current `main` both sides ignore the option and every probe connects.

Related: #29602 is an earlier, broader PR (adds a `groups` alias, flips the default to PQ hybrids, adds `getSharedGroup()`) against the pre-Rust layout; this PR is just the `ecdhCurve` plumbing on the current codebase.
