### PR TITLE
parser: reject parameter decorators without experimentalDecorators

### DIFF
--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -232,9 +232,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
             let mut ts_decorators = bun_alloc::AstAlloc::vec();
             if opts.allow_ts_decorators {
+                let at_range = p.lexer.range();
                 ts_decorators = p.parse_type_script_decorators()?;
                 if ts_decorators.len_u32() > 0 {
                     arg_has_decorators = true;
+                    if p.options.features.standard_decorators {
+                        if Self::IS_TYPESCRIPT_ENABLED {
+                            p.log().add_range_error_with_notes(
+                                Some(p.source),
+                                at_range,
+                                b"Parameter decorators only work when experimental decorators are enabled"
+                                    .as_slice(),
+                                Box::new([bun_ast::Data {
+                                    text: std::borrow::Cow::Borrowed(
+                                        b"Add \"experimentalDecorators\": true to your tsconfig.json to enable them",
+                                    ),
+                                    ..Default::default()
+                                }]),
+                            );
+                        } else {
+                            p.log().add_range_error(
+                                Some(p.source),
+                                at_range,
+                                b"Parameter decorators are not allowed in JavaScript",
+                            );
+                        }
+                    }
                 }
             }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6408,6 +6408,8 @@ impl<'a> Resolver<'a> {
                         let mc = unsafe { &mut *merged_config };
                         mc.emit_decorator_metadata =
                             mc.emit_decorator_metadata || parent_config.emit_decorator_metadata;
+                        mc.experimental_decorators =
+                            mc.experimental_decorators || parent_config.experimental_decorators;
                         if !parent_config.base_url.is_empty() {
                             mc.base_url = core::mem::take(&mut parent_config.base_url);
                         }

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -727,6 +727,34 @@ describe("ES Decorators", () => {
       );
     });
 
+    test("experimentalDecorators in leaf tsconfig is honored through extends chain", async () => {
+      using dir = tempDir("es-dec-ts-param-extends", {
+        "base.json": JSON.stringify({ compilerOptions: {} }),
+        "tsconfig.json": JSON.stringify({
+          extends: "./base.json",
+          compilerOptions: { experimentalDecorators: true },
+        }),
+        "test.ts": `
+          const seen: string[] = [];
+          function d(...args: any[]) { seen.push("called:" + args.length); }
+          class C { constructor(@d y?: number) {} }
+          new C(1);
+          console.log(JSON.stringify(seen));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe('["called:3"]\n');
+      expect(exitCode).toBe(0);
+    });
+
     test("TS parameter decorators still work with experimentalDecorators", async () => {
       using dir = tempDir("es-dec-ts-param-exp", {
         "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -678,6 +678,81 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("class Foo\n");
       expect(exitCode).toBe(0);
     });
+
+    test("TS parameter decorators are rejected without experimentalDecorators", async () => {
+      using dir = tempDir("es-dec-ts-param", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+        "test.ts": `
+          function d(..._args: any[]) {}
+          class C {
+            constructor(@d y?: number) {}
+            m(@d x: number) { return x; }
+          }
+          new C(1);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const stderr = filterStderr(rawStderr);
+      expect(stderr).toContain("Parameter decorators only work when experimental decorators are enabled");
+      expect(stderr).toContain('"experimentalDecorators": true');
+      expect(stdout).toBe("");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("JS parameter decorators are rejected", async () => {
+      const { stderr, stdout, exitCode } = await runDecorator(`
+        function d() {}
+        class C { m(@d x) { return x; } }
+        new C().m(1);
+      `);
+      expect(stderr).toContain("Parameter decorators are not allowed in JavaScript");
+      expect(stdout).toBe("");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("Bun.Transpiler rejects parameter decorators without experimentalDecorators", () => {
+      const transpiler = new Bun.Transpiler({ loader: "ts" });
+      expect(() => transpiler.transformSync(`function d(){}\nclass C { constructor(@d y) {} }`)).toThrow(
+        /Parameter decorators only work when experimental decorators are enabled/,
+      );
+      expect(() => transpiler.transformSync(`function d(){}\nclass C { m(@d x) { return x; } }`)).toThrow(
+        /Parameter decorators only work when experimental decorators are enabled/,
+      );
+    });
+
+    test("TS parameter decorators still work with experimentalDecorators", async () => {
+      using dir = tempDir("es-dec-ts-param-exp", {
+        "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+        "test.ts": `
+          const seen: string[] = [];
+          function d(...args: any[]) { seen.push("called:" + args.length); }
+          class C {
+            constructor(@d y?: number) {}
+            m(@d x: number) { return x; }
+          }
+          new C(1); new C().m(2);
+          console.log(JSON.stringify(seen));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe('["called:3","called:3"]\n');
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("extends clause", () => {

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -233,11 +233,12 @@ describe("dropped TypeScript class members discard scopes", () => {
   // signature, abstract/declare method, or index signature), they are dropped too.
   // Scopes recorded while parsing them (e.g. arrow functions) used to be left behind,
   // so visiting a later scope of a different kind hit "Scope mismatch while visiting".
-  const cases: [name: string, source: string, expected: string[]][] = [
+  const cases: [name: string, source: string, expected: string[], experimentalDecorators?: boolean][] = [
     [
       "arrow decorator on a method overload signature plus an arrow parameter decorator",
       "class C {\r@((td) => { })oo(): oo;\n h(@(() => {})ny) {}}",
       ["class C"],
+      true,
     ],
     [
       "arrow decorator on a method overload signature followed by a nested block",
@@ -271,12 +272,13 @@ describe("dropped TypeScript class members discard scopes", () => {
     ],
   ];
 
-  test.concurrent.each(cases)("%s", async (_name, source, expected) => {
+  test.concurrent.each(cases)("%s", async (_name, source, expected, experimentalDecorators = false) => {
+    const tsconfig = experimentalDecorators ? { compilerOptions: { experimentalDecorators: true } } : undefined;
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
-        `process.stdout.write(new Bun.Transpiler({ loader: "tsx", tsconfig: { compilerOptions: { experimentalDecorators: true } } }).transformSync(${JSON.stringify(source)}))`,
+        `process.stdout.write(new Bun.Transpiler({ loader: "tsx", tsconfig: ${JSON.stringify(tsconfig)} }).transformSync(${JSON.stringify(source)}))`,
       ],
       env: bunEnv,
       stderr: "pipe",

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -276,7 +276,7 @@ describe("dropped TypeScript class members discard scopes", () => {
       cmd: [
         bunExe(),
         "-e",
-        `process.stdout.write(new Bun.Transpiler({ loader: "tsx" }).transformSync(${JSON.stringify(source)}))`,
+        `process.stdout.write(new Bun.Transpiler({ loader: "tsx", tsconfig: { compilerOptions: { experimentalDecorators: true } } }).transformSync(${JSON.stringify(source)}))`,
       ],
       env: bunEnv,
       stderr: "pipe",


### PR DESCRIPTION
## What

TC39 standard decorators do not include parameter decorators. When a TypeScript file used `@dec` on a constructor or method parameter without `experimentalDecorators` enabled, Bun parsed the decorator, stored it on `G::Arg.ts_decorators`, and then silently discarded it: the standard-decorator lowering pass and the printer both ignore that field. The decorator function was never called and no diagnostic was emitted.

## Repro

```ts
// no tsconfig (or experimentalDecorators: false)
const seen: string[] = [];
function d(...args: any[]) { seen.push("called:" + args.length); }
class C { constructor(@d y?: number) {} m(@d x: number) { return x; } }
new C(1); new C().m(2);
console.log(seen);
```

Before: prints `[]`, no error. A DI codebase (`constructor(@Inject(X) x)`) whose tsconfig lost the flag gets constructors with no injection and no indication anything is wrong.

## Fix

`parse_fn.rs` now emits a parse error when parameter decorators are found and `standard_decorators` is active, matching esbuild and tsc:

```
error: Parameter decorators only work when experimental decorators are enabled
    at pd.ts:3:23

note: Add "experimentalDecorators": true to your tsconfig.json to enable them
```

For `.js` files the message is `Parameter decorators are not allowed in JavaScript`.

Also fixes a pre-existing resolver bug surfaced by review: the tsconfig `extends`-chain merge in `resolver.rs` whitelisted `emitDecoratorMetadata` but not `experimentalDecorators`, so a leaf tsconfig that set the flag while extending a base that omitted it had the flag silently dropped. That config shape would otherwise hit the new error with a hint telling users to add a flag they already have.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/bundler/transpiler/es-decorators.test.ts -t "parameter decorators|extends chain"
  4 fail (decorators silently dropped / extends-chain flag lost)

bun bd test test/bundler/transpiler/es-decorators.test.ts -t "parameter decorators|extends chain"
  5 pass
```

Full decorator suites pass: `es-decorators.test.ts` (64), `decorators.test.ts` (24), `es-decorators-esbuild.test.ts` + `decorator-metadata.test.ts` + `bundler_decorator_metadata.test.ts` (154), `bundler_edgecase.test.ts` (130), `tsconfig-extends-leak.test.ts` + `tsconfig-override.test.ts` (8).
