### PR TITLE
fetch: honour Connection: close on non-2xx responses and HTTP/1.0 defaults in the keep-alive pool

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4770,9 +4770,14 @@ impl<'a> HTTPClient<'a> {
 
         // RFC 9112 §9.3: HTTP/1.0 connections are non-persistent unless the
         // response carries an explicit `Connection: keep-alive`. The header loop
-        // below can flip this back on. h2/h3 reach here with a synthetic
-        // minor_version of 0 but overwrite allow_keepalive afterwards.
-        if response.minor_version == 0 {
+        // below can flip this back on. Skip the CONNECT reply itself: that
+        // status line is about the client↔proxy hop, and allow_keepalive is not
+        // reset between here and the origin response inside the tunnel. h2/h3
+        // reach here with a synthetic minor_version of 0 but overwrite
+        // allow_keepalive afterwards.
+        if response.minor_version == 0
+            && !(self.flags.proxy_tunneling && self.proxy_tunnel.is_none())
+        {
             self.state.flags.allow_keepalive = false;
         }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4767,6 +4767,15 @@ impl<'a> HTTPClient<'a> {
         let mut location: &[u8] = b"";
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
+
+        // RFC 9112 §9.3: HTTP/1.0 connections are non-persistent unless the
+        // response carries an explicit `Connection: keep-alive`. The header loop
+        // below can flip this back on. h2/h3 reach here with a synthetic
+        // minor_version of 0 but overwrite allow_keepalive afterwards.
+        if response.minor_version == 0 {
+            self.state.flags.allow_keepalive = false;
+        }
+
         for (header_i, header) in response.headers.list.iter().enumerate() {
             match hash_header_name(header.name()) {
                 h if h == hash_header_const(b"Content-Length") => {
@@ -4876,19 +4885,19 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
-                    if response.status_code >= 200 && response.status_code <= 299 {
-                        // HTTP headers are case-insensitive (RFC 7230)
-                        if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            header.value(),
-                            b"close",
-                        ) {
-                            self.state.flags.allow_keepalive = false;
-                        } else if bun_core::strings::eql_case_insensitive_ascii_check_length(
-                            header.value(),
-                            b"keep-alive",
-                        ) {
-                            self.state.flags.allow_keepalive = true;
-                        }
+                    // RFC 9112 §9.6: `close` on a response means the server will
+                    // close after this message regardless of status code; the
+                    // connection MUST NOT be reused.
+                    if bun_core::strings::eql_case_insensitive_ascii_check_length(
+                        header.value(),
+                        b"close",
+                    ) {
+                        self.state.flags.allow_keepalive = false;
+                    } else if bun_core::strings::eql_case_insensitive_ascii_check_length(
+                        header.value(),
+                        b"keep-alive",
+                    ) {
+                        self.state.flags.allow_keepalive = true;
                     }
                 }
                 h if h == hash_header_const(b"Last-Modified") => {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4768,13 +4768,6 @@ impl<'a> HTTPClient<'a> {
         let mut pretend_304 = false;
         let mut is_server_sent_events = false;
 
-        // RFC 9112 §9.3: HTTP/1.0 connections are non-persistent unless the
-        // response carries an explicit `Connection: keep-alive`. The header loop
-        // below can flip this back on. Skip the CONNECT reply itself: that
-        // status line is about the client↔proxy hop, and allow_keepalive is not
-        // reset between here and the origin response inside the tunnel. h2/h3
-        // reach here with a synthetic minor_version of 0 but overwrite
-        // allow_keepalive afterwards.
         if response.minor_version == 0
             && !(self.flags.proxy_tunneling && self.proxy_tunnel.is_none())
         {
@@ -4890,9 +4883,6 @@ impl<'a> HTTPClient<'a> {
                     location = header.value();
                 }
                 h if h == hash_header_const(b"Connection") => {
-                    // RFC 9112 §9.6: `close` on a response means the server will
-                    // close after this message regardless of status code; the
-                    // connection MUST NOT be reused.
                     if bun_core::strings::eql_case_insensitive_ascii_check_length(
                         header.value(),
                         b"close",

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -251,6 +251,62 @@ test("an early response to a streaming POST closes the socket instead of pooling
   });
 });
 
+// Negative contract for the gate above: a streamed POST whose chunked body
+// completed (terminator written) before the response arrived must still hand
+// its connection back to the keep-alive pool.
+test("a completed streaming POST keeps its connection in the keep-alive pool", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      let connections = 0;
+      const server = net.createServer(sock => {
+        connections++;
+        sock.on("error", () => {});
+        let buf = "";
+        sock.on("data", d => {
+          buf += d.toString("latin1");
+          // One response per fully-received chunked message (terminator seen).
+          while (buf.includes("0\\r\\n\\r\\n")) {
+            buf = buf.slice(buf.indexOf("0\\r\\n\\r\\n") + 5);
+            sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\n\\r\\nok");
+          }
+        });
+      });
+      server.listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+      const url = "http://127.0.0.1:" + server.address().port + "/";
+
+      const results = [];
+      for (let i = 0; i < 8; i++) {
+        const body = new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("hello"));
+            c.close();
+          },
+        });
+        const res = await fetch(url, { method: "POST", duplex: "half", body });
+        results.push(res.status, await res.text());
+      }
+      console.log(JSON.stringify({ results, connections }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    result: { results: Array(8).fill([200, "ok"]).flat(), connections: 1 },
+    exitCode: 0,
+  });
+});
+
 // RFC 9112 §9.3/§9.6: a response carrying `Connection: close` must not be
 // pooled whatever its status code, and an HTTP/1.0 response is non-persistent
 // unless it carries an explicit `Connection: keep-alive`. The server below says
@@ -399,62 +455,6 @@ test("a proxy that answers CONNECT with HTTP/1.0 200 still allows the tunnel to 
   const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
   expect({ result, exitCode }).toEqual({
     result: { connects: 1, bodies: ["ok", "ok", "ok"] },
-    exitCode: 0,
-  });
-});
-
-// Negative contract for the gate above: a streamed POST whose chunked body
-// completed (terminator written) before the response arrived must still hand
-// its connection back to the keep-alive pool.
-test("a completed streaming POST keeps its connection in the keep-alive pool", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-      import net from "node:net";
-      let connections = 0;
-      const server = net.createServer(sock => {
-        connections++;
-        sock.on("error", () => {});
-        let buf = "";
-        sock.on("data", d => {
-          buf += d.toString("latin1");
-          // One response per fully-received chunked message (terminator seen).
-          while (buf.includes("0\\r\\n\\r\\n")) {
-            buf = buf.slice(buf.indexOf("0\\r\\n\\r\\n") + 5);
-            sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\n\\r\\nok");
-          }
-        });
-      });
-      server.listen(0, "127.0.0.1");
-      await new Promise(r => server.on("listening", r));
-      const url = "http://127.0.0.1:" + server.address().port + "/";
-
-      const results = [];
-      for (let i = 0; i < 8; i++) {
-        const body = new ReadableStream({
-          start(c) {
-            c.enqueue(new TextEncoder().encode("hello"));
-            c.close();
-          },
-        });
-        const res = await fetch(url, { method: "POST", duplex: "half", body });
-        results.push(res.status, await res.text());
-      }
-      console.log(JSON.stringify({ results, connections }));
-      process.exit(0);
-      `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
-  expect({ result, exitCode }).toEqual({
-    result: { results: Array(8).fill([200, "ok"]).flat(), connections: 1 },
     exitCode: 0,
   });
 });

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -307,6 +307,109 @@ test("a completed streaming POST keeps its connection in the keep-alive pool", a
   });
 });
 
+// The do_redirect pooling gate only fires when request_stage == Done, which a
+// ReadableStream body reaches after the terminating chunk is written (a bytes
+// body parks at .body so the socket was already closed on redirect regardless
+// of Connection). With Connection: close ignored on 3xx, the closing socket was
+// pooled and immediately reused for the follow-up GET: if the origin lingers
+// (RFC 9112 §9.6: it stops reading further requests) fetch hangs forever, and
+// if it closes the GET hits FIN and is silently retried, so the origin sees it
+// twice. Subprocess so the pool is empty and a hang doesn't wedge the runner.
+test("a 303 with Connection: close after a streaming POST sends the follow-up GET on a new connection", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      const conns = [];
+      const server = net.createServer(sock => {
+        const rec = { id: conns.length, data: "", requests: [] };
+        conns.push(rec);
+        sock.on("error", () => {});
+        sock.on("data", chunk => {
+          rec.data += chunk.toString("latin1");
+          for (const m of rec.data.matchAll(/(GET|POST) (\\S+) HTTP\\/1\\.1\\r\\n/g)) {
+            const line = m[1] + " " + m[2];
+            if (!rec.requests.includes(line)) rec.requests.push(line);
+          }
+          if (rec.id === 0) {
+            // Origin: reply 303+close once the chunked body terminator arrives,
+            // then linger (keep the socket open, ignore anything further). Any
+            // pipelined follow-up written here never gets a response.
+            if (!rec.responded && rec.data.includes("0\\r\\n\\r\\n")) {
+              rec.responded = true;
+              sock.write(
+                "HTTP/1.1 303 See Other\\r\\n" +
+                  "Location: /second\\r\\n" +
+                  "Connection: close\\r\\n" +
+                  "Content-Length: 0\\r\\n\\r\\n",
+              );
+            }
+          } else {
+            // Fresh connection: answer the redirected GET.
+            sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: 2\\r\\nConnection: close\\r\\n\\r\\nok");
+            sock.end();
+          }
+        });
+      });
+      await new Promise(r => server.listen(0, "127.0.0.1", r));
+      const url = "http://127.0.0.1:" + server.address().port + "/first";
+
+      const body = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("streamed-upload"));
+          c.close();
+        },
+      });
+      let outcome;
+      try {
+        const res = await fetch(url, {
+          method: "POST",
+          body,
+          duplex: "half",
+          signal: AbortSignal.timeout(2000),
+        });
+        outcome = { status: res.status, path: new URL(res.url).pathname, redirected: res.redirected, text: await res.text() };
+      } catch (e) {
+        outcome = { error: String(e) };
+      }
+      // outcome being populated means the follow-up GET already completed on
+      // its connection; nothing else writes to the recorded sockets after this.
+      console.log(
+        JSON.stringify({
+          outcome,
+          connections: conns.length,
+          conn0Requests: conns[0]?.requests,
+          conn0SawGET: (conns[0]?.data ?? "").includes("GET /second"),
+          conn1Requests: conns[1]?.requests,
+        }),
+      );
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    // Without the fix the GET is pipelined onto conn0 (conn0SawGET: true,
+    // conn0Requests includes "GET /second") and the lingering origin never
+    // answers it, so outcome is {error: TimeoutError ...} and connections: 1.
+    result: {
+      outcome: { status: 200, path: "/second", redirected: true, text: "ok" },
+      connections: 2,
+      conn0Requests: ["POST /first"],
+      conn0SawGET: false,
+      conn1Requests: ["GET /second"],
+    },
+    exitCode: 0,
+  });
+});
+
 // RFC 9112 §9.3/§9.6: a response carrying `Connection: close` must not be
 // pooled whatever its status code, and an HTTP/1.0 response is non-persistent
 // unless it carries an explicit `Connection: keep-alive`. The server below says

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -326,6 +326,83 @@ test("Connection: close on a non-2xx response and HTTP/1.0 defaults are not pool
   });
 });
 
+// Guard for the CONNECT exemption on the HTTP/1.0 default above: older
+// proxies (Squid, tinyproxy, Apache mod_proxy_connect) answer CONNECT with
+// `HTTP/1.0 200 Connection Established`. That status line is about the
+// client↔proxy hop; once the tunnel is up the origin's HTTP/1.1 response
+// governs persistence, so the tunnel must still be pooled.
+test("a proxy that answers CONNECT with HTTP/1.0 200 still allows the tunnel to be pooled", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      const tlsCert = ${JSON.stringify({ cert: tls.cert, key: tls.key })};
+      await using origin = Bun.serve({
+        port: 0,
+        tls: tlsCert,
+        fetch: () => new Response("ok"),
+      });
+
+      let connects = 0;
+      const proxy = net.createServer(client => {
+        let head = Buffer.alloc(0);
+        let upstream;
+        client.on("error", () => {});
+        client.on("close", () => upstream?.destroy());
+        client.on("data", chunk => {
+          if (upstream) return upstream.write(chunk);
+          head = Buffer.concat([head, chunk]);
+          const end = head.indexOf("\\r\\n\\r\\n");
+          if (end === -1) return;
+          connects++;
+          const leftover = head.subarray(end + 4);
+          upstream = net.connect(origin.port, "127.0.0.1", () => {
+            client.write("HTTP/1.0 200 Connection Established\\r\\n\\r\\n");
+            if (leftover.length) upstream.write(leftover);
+          });
+          upstream.on("error", () => {});
+          upstream.on("data", d => client.write(d));
+          upstream.on("close", () => client.destroy());
+        });
+      });
+      await new Promise(r => proxy.listen(0, "127.0.0.1", r));
+
+      const bodies = [];
+      for (let i = 0; i < 3; i++) {
+        const res = await fetch("https://localhost:" + origin.port + "/", {
+          proxy: "http://127.0.0.1:" + proxy.address().port,
+          tls: { rejectUnauthorized: false },
+        });
+        bodies.push(await res.text());
+      }
+      proxy.close();
+      console.log(JSON.stringify({ connects, bodies }));
+      process.exit(0);
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      NO_PROXY: undefined,
+      no_proxy: undefined,
+      HTTP_PROXY: undefined,
+      http_proxy: undefined,
+      HTTPS_PROXY: undefined,
+      https_proxy: undefined,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    result: { connects: 1, bodies: ["ok", "ok", "ok"] },
+    exitCode: 0,
+  });
+});
+
 // Negative contract for the gate above: a streamed POST whose chunked body
 // completed (terminator written) before the response arrived must still hand
 // its connection back to the keep-alive pool.

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -251,6 +251,81 @@ test("an early response to a streaming POST closes the socket instead of pooling
   });
 });
 
+// RFC 9112 §9.3/§9.6: a response carrying `Connection: close` must not be
+// pooled whatever its status code, and an HTTP/1.0 response is non-persistent
+// unless it carries an explicit `Connection: keep-alive`. The server below says
+// `close` but keeps the socket open so reuse is directly observable as the
+// same connection serving more than one request. Subprocess so the pool is
+// empty at the start and doesn't leak between rows.
+test("Connection: close on a non-2xx response and HTTP/1.0 defaults are not pooled", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      const rows = [
+        ["1.1 200 close", "HTTP/1.1 200 OK", "Connection: close\\r\\n", 3],
+        ["1.1 404 close", "HTTP/1.1 404 Not Found", "Connection: close\\r\\n", 3],
+        ["1.1 503 close", "HTTP/1.1 503 Unavailable", "Connection: close\\r\\n", 3],
+        ["1.1 302 close", "HTTP/1.1 302 Found", "Connection: close\\r\\nLocation: /x\\r\\n", 3],
+        ["1.0 200 (no keep-alive)", "HTTP/1.0 200 OK", "", 3],
+        ["1.0 404 (no keep-alive)", "HTTP/1.0 404 Not Found", "", 3],
+        ["1.0 200 keep-alive", "HTTP/1.0 200 OK", "Connection: keep-alive\\r\\n", 1],
+        ["1.1 404 (implicit keep-alive)", "HTTP/1.1 404 Not Found", "", 1],
+      ];
+      const result = [];
+      for (const [name, line, hdr, expected] of rows) {
+        let conns = 0;
+        const per = [];
+        const server = net.createServer(s => {
+          const id = ++conns;
+          let buf = "";
+          s.on("error", () => {});
+          s.on("data", d => {
+            buf += d;
+            while (buf.includes("\\r\\n\\r\\n")) {
+              buf = buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4);
+              per.push(id);
+              s.write(line + "\\r\\n" + hdr + "content-length: 2\\r\\n\\r\\nhi");
+            }
+          });
+        });
+        await new Promise(r => server.listen(0, "127.0.0.1", r));
+        const url = "http://127.0.0.1:" + server.address().port + "/";
+        for (let i = 0; i < 3; i++) {
+          const res = await fetch(url, { redirect: "manual" });
+          await res.arrayBuffer();
+        }
+        server.close();
+        result.push({ row: name, connections: conns, per: per.join(","), expected });
+      }
+      console.log(JSON.stringify(result));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("[") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    result: [
+      { row: "1.1 200 close", connections: 3, per: "1,2,3", expected: 3 },
+      { row: "1.1 404 close", connections: 3, per: "1,2,3", expected: 3 },
+      { row: "1.1 503 close", connections: 3, per: "1,2,3", expected: 3 },
+      { row: "1.1 302 close", connections: 3, per: "1,2,3", expected: 3 },
+      { row: "1.0 200 (no keep-alive)", connections: 3, per: "1,2,3", expected: 3 },
+      { row: "1.0 404 (no keep-alive)", connections: 3, per: "1,2,3", expected: 3 },
+      { row: "1.0 200 keep-alive", connections: 1, per: "1,1,1", expected: 1 },
+      { row: "1.1 404 (implicit keep-alive)", connections: 1, per: "1,1,1", expected: 1 },
+    ],
+    exitCode: 0,
+  });
+});
+
 // Negative contract for the gate above: a streamed POST whose chunked body
 // completed (terminator written) before the response arrived must still hand
 // its connection back to the keep-alive pool.


### PR DESCRIPTION
## What

`fetch()` was returning a connection to the keep-alive pool after a response that said `Connection: close`, as long as the status code was not 2xx. It was also pooling HTTP/1.0 responses that carried no `Connection: keep-alive`.

RFC 9112 §9.6: once a `close` connection option is received the client MUST NOT send further requests on that connection. RFC 9112 §9.3: an HTTP/1.0 response is non-persistent by default. Node/undici open a fresh connection in every one of these cases.

## Repro

```js
import net from "node:net";
for (const [name, line, hdr] of [
  ["1.1 200 close", "HTTP/1.1 200 OK", "Connection: close\r\n"],
  ["1.1 404 close", "HTTP/1.1 404 Not Found", "Connection: close\r\n"],
  ["1.1 503 close", "HTTP/1.1 503 Unavailable", "Connection: close\r\n"],
  ["1.0 200", "HTTP/1.0 200 OK", ""],
]) {
  let conns = 0;
  const srv = net.createServer(s => { ++conns; let b = ""; s.on("data", d => { b += d;
    while (b.includes("\r\n\r\n")) { b = b.slice(b.indexOf("\r\n\r\n") + 4);
      s.write(line + "\r\n" + hdr + "content-length: 2\r\n\r\nhi"); } }); });
  await new Promise(r => srv.listen(0, "127.0.0.1", r));
  for (let i = 0; i < 3; i++) await (await fetch("http://127.0.0.1:" + srv.address().port + "/")).arrayBuffer();
  srv.close(); console.log(name, "connections:", conns);
}
```

Before (bun 1.4.0-canary): `200 close` opens 3 connections, the other three rows all print `connections: 1` (the closed/non-persistent socket was reused). Node prints 3 for every row. Origins that actually close after an error response (nginx 4xx/5xx, LB drains, S3) turn the reuse into sporadic ECONNRESET on the follow-up request.

## Cause

`handle_response_metadata` guarded the `Connection` header with `response.status_code >= 200 && response.status_code <= 299`, so `close` on a 3xx/4xx/5xx was ignored and `allow_keepalive` stayed at its default of `true`. There was no `minor_version` check at all, so HTTP/1.0 responses also fell through to the HTTP/1.1 persistent default.

## Fix

- Drop the 2xx guard on the `Connection` header branch; `close` / `keep-alive` now apply regardless of status code.
- Before the header loop, set `allow_keepalive = false` when `response.minor_version == 0`; an explicit `Connection: keep-alive` in the loop can turn it back on. h2/h3 pass through this function with a synthetic `minor_version: 0` but already overwrite `allow_keepalive = true` afterwards, so multiplexed pooling is unaffected.

## Verification

`bun bd test test/js/web/fetch/fetch-keepalive.test.ts` passes (6/6). The new test fails on an unpatched build with `connections: 1` for the 404/503/302+close and HTTP/1.0 rows and passes with the fix. `fetch-redirect.test.ts`, `fetch-connection-header.test.ts` and `fetch-http2-client.test.ts` are unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-keepalive.test.ts
bun test v1.4.0 (ff67ffe6f)

test/js/web/fetch/fetch-keepalive.test.ts:
(pass) keepalive [71.01ms]
(pass) fetch does not reuse a pooled TLS connection for a request with a different Host header [210.52ms]
(pass) PUT with a ReadableStream body is not retried on keep-alive disconnect [594.71ms]
(pass) an early response to a streaming POST closes the socket instead of pooling it mid-chunked-body [1975.45ms]
309 |     stderr: "pipe",
310 |   });
311 | 
312 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
313 |   const result = stdout.startsWith("[") ? JSON.parse(stdout.trim()) : { stdout, stderr };
314 |   expect({ result, exitCode }).toEqual({
                                     ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "result": [
      {
        "connections": 3,
        "expected": 3,
        "per": "1,2,3",
        "row": "1.1 200 close",
      },
      {
-       "connections": 3,
+       "connection
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (824db453e)

test/js/web/fetch/fetch-keepalive.test.ts:
(pass) keepalive [58.70ms]
(pass) fetch does not reuse a pooled TLS connection for a request with a different Host header [13.79ms]
(pass) PUT with a ReadableStream body is not retried on keep-alive disconnect [114.77ms]
(pass) an early response to a streaming POST closes the socket instead of pooling it mid-chunked-body [31.56ms]
(pass) Connection: close on a non-2xx response and HTTP/1.0 defaults are not pooled [46.86ms]
(pass) a proxy that answers CONNECT with HTTP/1.0 200 still allows the tunnel to be pooled [44.17ms]
(pass) a completed streaming POST keeps its connection in the keep-alive pool [28.57ms]

 7 pass
 0 fail
 10 expect() calls
Ran 7 tests across 1 file. [1.54s]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-keepalive.test.ts
bun test v1.4.0 (ff67ffe6f)

test/js/web/fetch/fetch-keepalive.test.ts:
(pass) keepalive [54.04ms]
(pass) fetch does not reuse a pooled TLS connection for a request with a different Host header [154.06ms]
(pass) PUT with a ReadableStream body is not retried on keep-alive disconnect [412.57ms]
(pass) an early response to a streaming POST closes the socket instead of pooling it mid-chunked-body [1282.89ms]
(pass) Connection: close on a non-2xx response and HTTP/1.0 defaults are not pooled [1799.51ms]
(pass) a proxy that answers CONNECT with HTTP/1.0 200 still allows the tunnel to be pooled [1599.57ms]
(pass) a completed streaming POST keeps its connection in the keep-alive pool [1326.50ms]

 7 pass
 0 fail
 10 expect() calls
Ran 7 tests across 1 file. [9.00s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1105ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen bindgenv2
[2/138] gen ErrorCode+*.h
[3/138] gen cpp.rs (cppbind)
[4/138] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/138] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[6/138] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fiel
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lib.rs                           |  30 +++---
 test/js/web/fetch/fetch-keepalive.test.ts | 152 ++++++++++++++++++++++++++++++
 2 files changed, 169 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/http/lib.rs                                8      6      0
test/js/web/fetch/fetch-keepalive.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->