### PR TITLE
Bun.serve: drop Content-Encoding when serving a fetch()-decoded Response

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -118,6 +118,9 @@ pub struct HTTPResponseMetadata {
     pub url: bun_ptr::RawSlice<u8>,
     pub owned_buf: Box<[u8]>,
     pub response: bun_picohttp::Response<'static>,
+    /// The client recognised `Content-Encoding` and will deliver decoded
+    /// bytes, so the header no longer describes the body it accompanies.
+    pub did_decompress: bool,
 }
 
 impl Default for HTTPResponseMetadata {
@@ -126,6 +129,7 @@ impl Default for HTTPResponseMetadata {
             url: bun_ptr::RawSlice::EMPTY,
             owned_buf: Box::default(),
             response: bun_picohttp::Response::default(),
+            did_decompress: false,
         }
     }
 }
@@ -3988,6 +3992,7 @@ impl<'a> HTTPClient<'a> {
             owned_buf,
             response: cloned_response,
             url: href,
+            did_decompress: self.state.encoding.is_compressed(),
         });
     }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -118,8 +118,6 @@ pub struct HTTPResponseMetadata {
     pub url: bun_ptr::RawSlice<u8>,
     pub owned_buf: Box<[u8]>,
     pub response: bun_picohttp::Response<'static>,
-    /// The client recognised `Content-Encoding` and will deliver decoded
-    /// bytes, so the header no longer describes the body it accompanies.
     pub did_decompress: bool,
 }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -715,6 +715,8 @@ impl BufferOutputSink {
         // SAFETY: result/original are live *Response (see SAFETY note above).
         // `url()` is +0 borrowed-bits; `set_url` takes +1 — `.clone()` to bump.
         unsafe { (*result).set_url((*original).url().clone()) };
+        // SAFETY: result/original are live *Response (see SAFETY note above).
+        unsafe { (*result).set_body_decoded((*original).body_decoded()) };
 
         // SAFETY: original is a live *Response kept alive by caller.
         let value = unsafe { (*original).get_body_value() };

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1862,8 +1862,9 @@ where
                     let mut crbuf = [0u8; RangeRequest::CONTENT_RANGE_BUF];
                     self.do_write_status(416);
                     if let Some(response) = self.response_weakref.get() {
+                        let body_decoded = response.body_decoded();
                         if let Some(mut headers_) = response.swap_init_headers() {
-                            self.do_write_headers(&mut headers_);
+                            self.do_write_headers(&mut headers_, body_decoded);
                             // `HeadersRef` releases the +1 ref in Drop; do NOT
                             // call `.deref()` explicitly (would double-free).
                             drop(headers_);
@@ -3632,6 +3633,7 @@ where
         });
         let mut has_content_disposition = false;
         let mut has_content_range = false;
+        let body_decoded = response.body_decoded();
         if let Some(mut headers_) = response.swap_init_headers() {
             has_content_disposition = headers_.fast_has(jsc::HTTPHeaderName::ContentDisposition);
             has_content_range = headers_.fast_has(jsc::HTTPHeaderName::ContentRange);
@@ -3645,7 +3647,7 @@ where
             }
 
             self.do_write_status(status);
-            self.do_write_headers(&mut headers_);
+            self.do_write_headers(&mut headers_, body_decoded);
             // `HeadersRef` is RAII — its Drop
             // already calls `WebCore__FetchHeaders__deref`, so an explicit
             // `.deref()` here would resolve (via DerefMut) to the inherent
@@ -3771,10 +3773,13 @@ where
         }
     }
 
-    fn do_write_headers(&mut self, headers: &mut FetchHeaders) {
+    fn do_write_headers(&mut self, headers: &mut FetchHeaders, body_decoded: bool) {
         ctx_log!("writeHeaders");
         headers.fast_remove(jsc::HTTPHeaderName::ContentLength);
         headers.fast_remove(jsc::HTTPHeaderName::TransferEncoding);
+        if body_decoded {
+            headers.fast_remove(jsc::HTTPHeaderName::ContentEncoding);
+        }
         if HTTP3 {
             // RFC 9114 §4.2: connection-specific fields are malformed.
             headers.fast_remove(jsc::HTTPHeaderName::Connection);

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -214,9 +214,13 @@ impl StaticRoute {
                 }
             };
 
+            let body_decoded = response.body_decoded();
             if let Some(h) = response.get_init_headers_mut() {
                 h.fast_remove(HTTPHeaderName::TransferEncoding);
                 h.fast_remove(HTTPHeaderName::ContentLength);
+                if body_decoded {
+                    h.fast_remove(HTTPHeaderName::ContentEncoding);
+                }
             }
 
             // Consuming the body left a plain `Blob` behind, which no longer implies

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -171,6 +171,10 @@ pub struct Response {
     // `Copy` and has no `Drop`.
     url: JsCell<OwnedString>,
     redirected: Cell<bool>,
+    /// `fetch()` transparently decoded `Content-Encoding`; the header is kept
+    /// for user inspection (#5668) but `Bun.serve` must not re-emit it against
+    /// the now-decoded body.
+    body_decoded: Cell<bool>,
     /// We increment this count in fetch so if JS Response is discarted we can resolve the Body
     /// In the server we use a flag response_protected to protect/unprotect the response
     pub ref_count: Cell<u32>,
@@ -192,6 +196,7 @@ impl Default for Response {
             init: JsCell::new(Init::default()),
             url: JsCell::new(OwnedString::new(BunString::empty())),
             redirected: Cell::new(false),
+            body_decoded: Cell::new(false),
             ref_count: Cell::new(1),
             weak_ptr_data: WeakPtrData::EMPTY,
             js_ref: JsCell::new(JsRef::empty()),
@@ -358,6 +363,16 @@ impl Response {
     #[inline]
     pub fn swap_init_headers(&self) -> Option<HeadersRef> {
         self.init.with_mut(|init| init.headers.take())
+    }
+
+    #[inline]
+    pub fn body_decoded(&self) -> bool {
+        self.body_decoded.get()
+    }
+
+    #[inline]
+    pub fn set_body_decoded(&self, value: bool) {
+        self.body_decoded.set(value);
     }
 
     #[inline]
@@ -821,6 +836,7 @@ impl Response {
             init: JsCell::new(init),
             url: JsCell::new(self.url.get().clone()),
             redirected: Cell::new(self.redirected.get()),
+            body_decoded: Cell::new(self.body_decoded.get()),
             ..Default::default()
         })
     }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -171,9 +171,6 @@ pub struct Response {
     // `Copy` and has no `Drop`.
     url: JsCell<OwnedString>,
     redirected: Cell<bool>,
-    /// `fetch()` transparently decoded `Content-Encoding`; the header is kept
-    /// for user inspection (#5668) but `Bun.serve` must not re-emit it against
-    /// the now-decoded body.
     body_decoded: Cell<bool>,
     /// We increment this count in fetch so if JS Response is discarted we can resolve the Body
     /// In the server we use a flag response_protected to protect/unprotect the response

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1768,7 +1768,8 @@ impl FetchTasklet {
         };
         let url = BunString::clone_utf8(metadata.url.slice());
         let redirected = self.result.redirected;
-        Response::init(
+        let did_decompress = metadata.did_decompress;
+        let response = Response::init(
             crate::webcore::response::Init {
                 // SAFETY: create_from_pico_headers returns a fresh refcount=1 FetchHeaders*.
                 headers: Some(unsafe { HeadersRef::adopt(headers) }),
@@ -1779,7 +1780,9 @@ impl FetchTasklet {
             Body::new(self.to_body_value()),
             url,
             redirected,
-        )
+        );
+        response.set_body_decoded(did_decompress);
+        response
     }
 
     fn ignore_remaining_response_body(&mut self, from_finalizer: bool) {

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "node:events";
 import * as net from "node:net";
+import { brotliCompressSync, deflateSync, gzipSync, zstdCompressSync } from "node:zlib";
 
 // https://github.com/oven-sh/bun/issues/9180
 test("weird headers", async () => {
@@ -158,5 +159,119 @@ describe("response Connection: close closes the socket", () => {
     } finally {
       socket.destroy();
     }
+  });
+});
+
+// `return fetch(upstream)` reverse-proxy: fetch decodes Content-Encoding, so
+// Bun.serve must not forward that header against the now-plaintext body.
+describe("proxied fetch() response drops decoded Content-Encoding", () => {
+  const payload = Buffer.alloc(2700, "The quick brown fox jumps over the lazy dog. ").toString();
+  const codings: [string, Buffer][] = [
+    ["gzip", gzipSync(payload)],
+    ["deflate", deflateSync(payload)],
+    ["br", brotliCompressSync(payload)],
+    ["zstd", zstdCompressSync(payload)],
+  ];
+
+  async function rawGet(port: number, bodyLen: number): Promise<{ head: string; body: Buffer }> {
+    let buf = Buffer.alloc(0);
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        open(s) {
+          s.write("GET / HTTP/1.1\r\nHost: x\r\nAccept-Encoding: gzip, deflate, br, zstd\r\n\r\n");
+        },
+        data(s, d) {
+          buf = Buffer.concat([buf, Buffer.from(d)]);
+          const sep = buf.indexOf("\r\n\r\n");
+          if (sep !== -1 && buf.length - sep - 4 >= bodyLen) {
+            s.end();
+            resolve();
+          }
+        },
+        error(s, e) {
+          reject(e);
+        },
+        close() {
+          resolve();
+        },
+      },
+    });
+    await promise;
+    const sep = buf.indexOf("\r\n\r\n");
+    return { head: buf.subarray(0, sep).toString(), body: buf.subarray(sep + 4, sep + 4 + bodyLen) };
+  }
+
+  for (const [name, compressed] of codings) {
+    test(name, async () => {
+      using upstream = Bun.serve({
+        port: 0,
+        development: false,
+        fetch() {
+          return new Response(compressed, { headers: { "content-encoding": name } });
+        },
+      });
+
+      let sawUpstreamEncoding: string | null | undefined;
+      using proxy = Bun.serve({
+        port: 0,
+        development: false,
+        async fetch(req) {
+          const res = await fetch(new URL(new URL(req.url).pathname, upstream.url));
+          sawUpstreamEncoding = res.headers.get("content-encoding");
+          return res;
+        },
+      });
+
+      const { head, body } = await rawGet(proxy.port, payload.length);
+      expect(head.toLowerCase()).not.toContain("content-encoding");
+      expect(head).toMatch(/content-length: 2700\b/i);
+      expect(body.toString()).toBe(payload);
+      // fetch() itself still exposes the upstream header (issue #5668).
+      expect(sawUpstreamEncoding).toBe(name);
+
+      const res = await fetch(proxy.url);
+      expect(res.headers.get("content-encoding")).toBeNull();
+      expect(await res.text()).toBe(payload);
+    });
+  }
+
+  test("explicit Content-Encoding on a handler-built Response is preserved", async () => {
+    const gz = gzipSync(payload);
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch() {
+        return new Response(gz, { headers: { "content-encoding": "gzip" } });
+      },
+    });
+    const { head } = await rawGet(server.port, gz.length);
+    expect(head.toLowerCase()).toContain("content-encoding: gzip");
+    const res = await fetch(server.url);
+    expect(await res.text()).toBe(payload);
+  });
+
+  test("decompress: false keeps the body compressed and forwards the header", async () => {
+    const gz = gzipSync(payload);
+    using upstream = Bun.serve({
+      port: 0,
+      development: false,
+      fetch() {
+        return new Response(gz, { headers: { "content-encoding": "gzip" } });
+      },
+    });
+    using proxy = Bun.serve({
+      port: 0,
+      development: false,
+      fetch: req => fetch(new URL(new URL(req.url).pathname, upstream.url), { decompress: false }),
+    });
+
+    const { head, body } = await rawGet(proxy.port, gz.length);
+    expect(head.toLowerCase()).toContain("content-encoding: gzip");
+    expect(body.equals(gz)).toBe(true);
+    const res = await fetch(proxy.url);
+    expect(await res.text()).toBe(payload);
   });
 });

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -238,6 +238,22 @@ describe("proxied fetch() response drops decoded Content-Encoding", () => {
     });
   }
 
+  test("static route built from a fetch() Response", async () => {
+    using upstream = Bun.serve({
+      port: 0,
+      development: false,
+      fetch() {
+        return new Response(gzipSync(payload), { headers: { "content-encoding": "gzip" } });
+      },
+    });
+    const snapshot = await fetch(upstream.url);
+    using proxy = Bun.serve({ port: 0, development: false, routes: { "/": snapshot } });
+
+    const { head, body } = await rawGet(proxy.port, payload.length);
+    expect(head.toLowerCase()).not.toContain("content-encoding");
+    expect(body.toString()).toBe(payload);
+  });
+
   test("explicit Content-Encoding on a handler-built Response is preserved", async () => {
     const gz = gzipSync(payload);
     using server = Bun.serve({

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -254,6 +254,33 @@ describe("proxied fetch() response drops decoded Content-Encoding", () => {
     expect(body.toString()).toBe(payload);
   });
 
+  test("HTMLRewriter.transform() on a fetch() Response", async () => {
+    const html = "<a href=/x>hi</a>";
+    const rewritten = '<a href="/y">hi</a>';
+    using upstream = Bun.serve({
+      port: 0,
+      development: false,
+      fetch() {
+        return new Response(gzipSync(html), {
+          headers: { "content-encoding": "gzip", "content-type": "text/html" },
+        });
+      },
+    });
+    using proxy = Bun.serve({
+      port: 0,
+      development: false,
+      async fetch() {
+        return new HTMLRewriter()
+          .on("a", { element: el => void el.setAttribute("href", "/y") })
+          .transform(await fetch(upstream.url));
+      },
+    });
+
+    const { head, body } = await rawGet(proxy.port, rewritten.length);
+    expect(head.toLowerCase()).not.toContain("content-encoding");
+    expect(body.toString()).toBe(rewritten);
+  });
+
   test("explicit Content-Encoding on a handler-built Response is preserved", async () => {
     const gz = gzipSync(payload);
     using server = Bun.serve({


### PR DESCRIPTION
## What

The `return fetch(upstream)` reverse-proxy one-liner served undecodable responses for any upstream that compresses:

```js
Bun.serve({ fetch: req => fetch(upstream + new URL(req.url).pathname) });
```

`fetch()` decodes the gzip/deflate/br/zstd body but keeps `Content-Encoding` in the Response headers (intentionally, per #5668). `Bun.serve` then recomputes `Content-Length` from the decoded bytes while forwarding `Content-Encoding` verbatim, so clients receive e.g. `Content-Encoding: gzip` + `Content-Length: 2700` + 2700 bytes of plaintext, and every client that honours the header fails to decompress (`ZlibError` in Bun's own fetch, `ERR_CONTENT_DECODING_FAILED` in browsers, `curl --compressed` errors).

Since Bun's fetch always sends `Accept-Encoding: gzip, deflate, br, zstd`, any compressing upstream (i.e. most of them) was unreadable through the naive proxy.

## Fix

The HTTP client records on the cloned response metadata whether it will decode the body (`HTTPResponseMetadata::did_decompress`, derived from `state.encoding.is_compressed()`). `FetchTasklet::to_response` copies that onto the new `Response::body_decoded` flag. When `Bun.serve` writes such a Response, `do_write_headers` now strips `Content-Encoding` alongside the `Content-Length`/`Transfer-Encoding` it already drops.

Unaffected:
- `response.headers.get("content-encoding")` on a fetch Response still returns the upstream value (#5668).
- A handler-built `new Response(gzippedBytes, { headers: { "content-encoding": "gzip" } })` is served as-is.
- `fetch(url, { decompress: false })` forwards the compressed bytes with the header intact.

## Verification

`test/js/bun/http/bun-serve-headers.test.ts` gains a `proxied fetch() response drops decoded Content-Encoding` suite: a raw-socket client asserts the wire head carries no `Content-Encoding` and the body is the decoded payload, for each of gzip/deflate/br/zstd, plus the two negative cases above. Fails on main with the stale header on the wire; passes with this change. The existing `presence of content-encoding header(issue #5668)` test in `fetch.test.ts` continues to pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.0 (dc1ce9469)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [572.50ms]
(pass) response Connection: close closes the socket > string body [399.96ms]
(pass) response Connection: close closes the socket > case-insensitive value [61.28ms]
(pass) response Connection: close closes the socket > token list [54.42ms]
(pass) response Connection: close closes the socket > streaming body [62.06ms]
(pass) response Connection: close closes the socket > keep-alive still the default [76.18ms]
224 |           return res;
225 |         },
226 |       });
227 | 
228 |       const { head, body } = await rawGet(proxy.port, payload.length);
229 |       expect(head.toLowerCase()).not.toContain("content-encoding");
                                           ^
error: expect(received).not.toContain(expected)

Expected to not contain: "content-encoding"
Received: "http/1.1 200 ok\r\ncontent-encoding: gzip\r\ncontent-type: application/octet-stream\r\ndate: sat, 25 jul 2026 04:12:54 gmt\r
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [10.18ms]
84 |       });
85 | 
86 |       const responses = (result.raw.match(/HTTP\/1\.1 200/g) ?? []).length;
87 |       const head = result.raw.split("\r\n\r\n")[0];
88 |       expect(head).toMatch(/\r\nconnection:[^\r\n]*\bclose\b/i);
89 |       expect({ responses, handled, closedByServer: result.closedByServer }).toEqual({
                                                                                 ^
error: expect(received).toEqual(expected)

  {
-   "closedByServer": true,
-   "handled": 1,
-   "responses": 1,
+   "closedByServer": false,
+   "handled": 2,
+   "responses": 2,
  }

- Expected  - 3
+ Received  + 3

      at check (/workspace/bun/test/js/bun/http/bun-serve-headers.test.ts:89:77)
      at async <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-headers.test.ts:100:11)
(fail) response Connection: close closes the socket > string body [7.64ms]
84 |       });
85 | 
86 |       const responses = (result.raw.match(/HTTP\/1\.1 200/g) ?? []).length;
87 |       const head = result.raw.split("\r\n\r\n")[0];
88 |       expect(head).toMatch(/\r\nconn
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.0 (dc1ce9469)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [541.44ms]
(pass) response Connection: close closes the socket > string body [401.68ms]
(pass) response Connection: close closes the socket > case-insensitive value [68.63ms]
(pass) response Connection: close closes the socket > token list [61.07ms]
(pass) response Connection: close closes the socket > streaming body [78.86ms]
(pass) response Connection: close closes the socket > keep-alive still the default [74.74ms]
(pass) proxied fetch() response drops decoded Content-Encoding > gzip [99.69ms]
(pass) proxied fetch() response drops decoded Content-Encoding > deflate [41.09ms]
(pass) proxied fetch() response drops decoded Content-Encoding > br [37.11ms]
(pass) proxied fetch() response drops decoded Content-Encoding > zstd [40.76ms]
(pass) proxied fetch() response drops decoded Content-Encoding > explicit Content-Encoding on a handler-built Response is preserved [40.73ms]
(pass) proxied fetch() respon
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     dc1ce94699
  features     baseline

22 deps, 108 codegen, 1171 objects in 2931ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] gen bindgenv2
[3/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1234] fetch zlib
[zlib] up to date
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] fetch tinycc
[tinycc] up to date
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] subst deps/zlib/zconf.h
[11/1234] subst deps/zlib/zlib.h
[12/1234] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[13/1234] fetch brotli
[brotl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lib.rs                            |   5 ++
 src/runtime/server/RequestContext.rs       |  11 ++-
 src/runtime/webcore/Response.rs            |  16 ++++
 src/runtime/webcore/fetch/FetchTasklet.rs  |   7 +-
 test/js/bun/http/bun-serve-headers.test.ts | 115 +++++++++++++++++++++++++++++
 5 files changed, 149 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/http/lib.rs                                 4      3      0
src/runtime/server/RequestContext.rs            3      4      0
src/runtime/webcore/Response.rs                 3      4      0
src/runtime/webcore/fetch/FetchTasklet.rs       2      2      0
test/js/bun/http/bun-serve-headers.test.ts      2      8      0
```

</details>

<!-- robobun:evidence:end -->