### PR TITLE
js_parser: tighten when a macro result may enter const_values

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2349,8 +2349,6 @@ impl Data {
             | Data::EUndefined(_)
             | Data::EInlinedEnum(_) => true,
             Data::EString(str) => str.next.is_none(),
-            Data::EArray(array) => array.was_originally_macro,
-            Data::EObject(object) => object.was_originally_macro,
             _ => false,
         }
     }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -391,6 +391,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.visit_decl(
                     decl,
                     was_anonymous_named_expr,
+                    was_const,
                     was_const && !is_after,
                     if Self::ALLOW_MACROS {
                         prev_macro_call_count != self.macro_call_count
@@ -414,7 +415,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let replacer = _ptr.get();
                         if !self.replace_decl_and_possibly_remove(decl, replacer) {
                             let is_after = self.vis_scope().is_after_const_local_prefix;
-                            self.visit_decl(decl, false, was_const && !is_after, false);
+                            self.visit_decl(decl, false, was_const, was_const && !is_after, false);
                         } else {
                             continue 'outer;
                         }
@@ -439,7 +440,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         j
     }
 
-    pub(crate) fn visit_binding_and_expr_for_macro(&mut self, binding: Binding, expr: Expr) {
+    pub(crate) fn visit_binding_and_expr_for_macro(
+        &mut self,
+        binding: Binding,
+        expr: Expr,
+        was_const: bool,
+        has_default: bool,
+    ) {
         match binding.data {
             BData::BObject(bound_object) => {
                 let bound_object = bound_object.get();
@@ -459,16 +466,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             self.visit_binding_and_expr_for_macro(
                                                 property.value,
                                                 query.expr,
+                                                was_const,
+                                                property.default_value.is_some(),
                                             );
                                         }
                                         _ => {
-                                            if self.options.features.inlining {
-                                                if let BData::BIdentifier(id) = property.value.data
-                                                {
-                                                    self.const_values
-                                                        .put(id.r#ref, query.expr)
-                                                        .expect("oom");
-                                                }
+                                            if let BData::BIdentifier(id) = property.value.data {
+                                                self.maybe_record_macro_const_value(
+                                                    id.r#ref,
+                                                    query.expr,
+                                                    was_const,
+                                                    property.default_value.is_some(),
+                                                );
                                             }
                                         }
                                     }
@@ -507,24 +516,44 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 *child_expr = self.new_expr(E::Missing {}, expr.loc);
                                 continue;
                             }
-                            self.visit_binding_and_expr_for_macro(item.binding, *child_expr);
+                            self.visit_binding_and_expr_for_macro(
+                                item.binding,
+                                *child_expr,
+                                was_const,
+                                item.default_value.is_some(),
+                            );
                         }
                     }
                 }
             }
             BData::BIdentifier(id) => {
-                if self.options.features.inlining {
-                    self.const_values.put(id.r#ref, expr).expect("oom");
-                }
+                self.maybe_record_macro_const_value(id.r#ref, expr, was_const, has_default);
             }
             BData::BMissing(_) => {}
         }
+    }
+
+    fn maybe_record_macro_const_value(
+        &mut self,
+        ref_: Ref,
+        expr: Expr,
+        was_const: bool,
+        has_default: bool,
+    ) {
+        if !was_const || !self.options.features.inlining || !expr.can_be_const_value() {
+            return;
+        }
+        if has_default && matches!(expr.data, ExprData::EUndefined(_)) {
+            return;
+        }
+        self.const_values.put(ref_, expr).expect("oom");
     }
 
     pub(crate) fn visit_decl(
         &mut self,
         decl: &mut G::Decl,
         was_anonymous_named_expr: bool,
+        was_const: bool,
         could_be_const_value: bool,
         could_be_macro: bool,
     ) {
@@ -532,7 +561,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         match decl.binding.data {
             BData::BIdentifier(id) => {
                 let id_ref = id.r#ref;
-                if could_be_const_value || (Self::ALLOW_MACROS && could_be_macro) {
+                if could_be_const_value || (Self::ALLOW_MACROS && was_const && could_be_macro) {
                     if let Some(val) = decl.value {
                         if val.can_be_const_value() {
                             self.const_values.put(id_ref, val).expect("oom");
@@ -554,7 +583,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BData::BObject(_) | BData::BArray(_) => {
                 if Self::ALLOW_MACROS {
                     if could_be_macro && let Some(value) = decl.value {
-                        self.visit_binding_and_expr_for_macro(decl.binding, value);
+                        self.visit_binding_and_expr_for_macro(
+                            decl.binding,
+                            value,
+                            was_const,
+                            false,
+                        );
                     }
                 }
             }

--- a/test/bundler/transpiler/macro-identity.test.ts
+++ b/test/bundler/transpiler/macro-identity.test.ts
@@ -1,0 +1,201 @@
+// https://github.com/oven-sh/bun/issues/7196
+//
+// Object/array literals returned from a macro have fresh identity each time
+// the literal is evaluated. The const-inliner must not substitute the whole
+// literal at every use site: `const a = obj(); a === a` must stay `true`, not
+// become `({}) === ({})`. Primitive leaves reached through destructuring, and
+// direct `macro().prop` access, are still safe to inline.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const files = {
+  "m.ts": `
+    export const obj = () => ({});
+    export const arr = () => [1, 2, 3];
+    export const nested = () => ({ leaf: 7, inner: { z: 1 }, list: [9] });
+    export const holes = () => ({ a: undefined, b: 4 });
+    export const holesArr = () => [undefined, 6];
+  `,
+  "entry.ts": `
+    import { obj, arr, nested, holes, holesArr } from "./m.ts" with { type: "macro" };
+    const o = obj();
+    const a = arr();
+    const { leaf, inner, list } = nested();
+    const { a: da = 10, b: db = 20 } = holes();
+    const [dx = 30, dy = 40] = holesArr();
+    console.log(JSON.stringify({
+      o: o === o,
+      a: a === a,
+      inner: inner === inner,
+      list: list === list,
+      leaf,
+      aJson: JSON.stringify(a),
+      direct: nested().leaf,
+      da, db, dx, dy,
+    }));
+  `,
+};
+
+const expected = {
+  o: true,
+  a: true,
+  inner: true,
+  list: true,
+  leaf: 7,
+  aJson: "[1,2,3]",
+  direct: 7,
+  da: 10,
+  db: 4,
+  dx: 30,
+  dy: 6,
+};
+
+describe("macro object/array result preserves identity", () => {
+  test.concurrent("bun run", async () => {
+    using dir = tempDir("macro-identity-run", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
+      out: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  for (const minify of [false, true]) {
+    test.concurrent(`bun build${minify ? " --minify" : ""}`, async () => {
+      using dir = tempDir(`macro-identity-build-${minify}`, files);
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "entry.ts", "--target", "bun", ...(minify ? ["--minify"] : []), "--outfile", "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      expect({ buildErr, buildExit }).toEqual({ buildErr: "", buildExit: 0 });
+
+      await using run = Bun.spawn({
+        cmd: [bunExe(), "out.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+      expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+        out: expected,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  }
+});
+
+// https://github.com/oven-sh/bun/issues/12067
+// The macro path in visit_decl bypassed the `was_const` requirement, so a
+// `let`/`var` bound to a macro result was still substituted at every use,
+// turning `output += " "` into `"Hello" += " "`.
+describe("macro result bound to let/var is not substituted", () => {
+  const files = {
+    "m.ts": `
+      export const hello = () => "Hello";
+      export const pair = () => ({ x: 1, y: 2 });
+    `,
+    "entry.ts": `
+      import { hello, pair } from "./m.ts" with { type: "macro" };
+      let s = hello();
+      s += " ";
+      s += "World";
+      let { x, y } = pair();
+      x = 99;
+      console.log(JSON.stringify({ s, x, y }));
+    `,
+  };
+  const expected = { s: "Hello World", x: 99, y: 2 };
+
+  test.concurrent("bun run", async () => {
+    using dir = tempDir("macro-let-run", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
+      out: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("bun build --minify-syntax", async () => {
+    using dir = tempDir("macro-let-build", files);
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--target", "bun", "--minify-syntax", "--outfile", "out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect({ buildErr, buildExit }).toEqual({ buildErr: "", buildExit: 0 });
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+      out: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("let destructure still drops unused macro properties from the emitted literal", async () => {
+    using dir = tempDir("macro-let-trunc", {
+      "m.ts": `export const big = () => ({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 });`,
+      "entry.ts": `
+        import { big } from "./m.ts" with { type: "macro" };
+        let { a } = big();
+        a += 100;
+        console.log(a);
+      `,
+    });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--target", "bun", "--minify", "--outfile", "out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect({ buildErr, buildExit }).toEqual({ buildErr: "", buildExit: 0 });
+
+    const out = await Bun.file(`${dir}/out.js`).text();
+    expect(out).not.toContain("b:2");
+    expect(out).not.toContain("h:8");
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "101", stderr: "", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
Fixes #7196.
Fixes #12067.

## Repro

```ts
// macro.ts
export const obj = () => ({});
export const hello = () => "Hello";
```
```ts
import { obj, hello } from "./macro" with { type: "macro" };
const a = obj();
console.log(a === a);        // #7196
let s = hello();
s += " World";               // #12067
```
```
$ bun build entry.ts --target bun --minify
console.log({}==={});        // false
"Hello" += " World";         // SyntaxError
```

## Cause

`visit_decl` puts the macro result into `const_values` when `could_be_macro` is set, and `handle_identifier` then substitutes the stored expression at every use of the binding. Three checks that gate ordinary const-inlining were missing on that path:

- `can_be_const_value()` returned `true` for `EObject`/`EArray` whenever `was_originally_macro` was set. Object/array literals allocate a fresh value on each evaluation, so duplicating one at every use turns `a === a` into `({}) === ({})` (#7196). The `BIdentifier` leaf of `visit_binding_and_expr_for_macro` had the same hole for a nested object reached through destructuring.
- `could_be_macro` was computed from the macro-call count alone, without `was_const`, so a `let`/`var` bound to a macro result was still substituted, turning `s += x` into `"Hello" += x` (#12067).
- The destructuring leaves recorded the raw macro value without looking at the pattern's `default_value`, so `const [x = 5] = macroReturning([undefined])` inlined `x` as `undefined` instead of leaving the destructuring to apply the default at runtime.

## Fix

- Drop the `EArray`/`EObject` arms from `can_be_const_value()`.
- Require `was_const` when computing `could_be_macro` in `visit_decls`.
- Factor the leaf insert into `maybe_record_macro_const_value`, which also skips when the pattern has a default and the value is `EUndefined`. Thread `has_default` through the destructuring recursion.

Primitive leaves from `const { x } = macro()` and direct `macro().prop` still fold; only whole-object substitution, `let`/`var` bindings, and undefined-with-default leaves are kept as bindings.

## Verification

`test/bundler/transpiler/macro-identity.test.ts` covers `bun run`, `bun build`, and `bun build --minify` for:

- direct object/array bindings (`o === o`, `a === a`)
- nested object/array reached through destructuring (`inner`, `list`)
- destructured leaves with defaults over `undefined` and over a defined value
- a `let` string binding that is reassigned
- a `let` destructured binding that is reassigned

and asserts primitive-leaf / direct-property folding are kept. Five of the six cases fail on the released bun and all pass with this change. `macro-test.test.ts` and `bundler_minify.test.ts` remain green.

#9613 (destructuring with reordered property names) has a different root cause (the in-place property compaction overwrites entries before later lookups) and is not addressed here.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-identity.test.ts
bun test v1.4.0 (a3f66e1bd)

test/bundler/transpiler/macro-identity.test.ts:
59 |       cwd: String(dir),
60 |       stdout: "pipe",
61 |       stderr: "pipe",
62 |     });
63 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
64 |     expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
                                                                                         ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "out": {
-     "a": true,
+     "a": false,
      "aJson": "[1,2,3]",
-     "da": 10,
      "db": 4,
      "direct": 7,
-     "dx": 30,
      "dy": 6,
-     "inner": true,
+     "inner": false,
      "leaf": 7,
-     "list": true,
-     "o": true,
+     "list": false,
+     "o": false,
    },
    "stderr": "",
  }

- Expected  - 6
+ Received  + 4

      at <anonymous> (/workspace/bun/test/bundler/transpiler/macro-identity.test.ts:64:85)
(fail) macro
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/macro-identity.test.ts:
59 |       cwd: String(dir),
60 |       stdout: "pipe",
61 |       stderr: "pipe",
62 |     });
63 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
64 |     expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
                                                                                         ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "out": {
-     "a": true,
+     "a": false,
      "aJson": "[1,2,3]",
-     "da": 10,
      "db": 4,
      "direct": 7,
-     "dx": 30,
      "dy": 6,
-     "inner": true,
+     "inner": false,
      "leaf": 7,
-     "list": true,
-     "o": true,
+     "list": false,
+     "o": false,
    },
    "stderr": "",
  }

- Expected  - 6
+ Received  + 4

      at <anonymous> (/workspace/bun/test/bundler/transpiler/macro-identity.test.ts:64:85)
(fail) macro object/array result preserves identity > bun run [55.21ms]
128 |       cwd: String(dir),
129 |       stdout: "pipe",
130 |       stderr: "pipe",
131 |     });
132 |     c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-identity.test.ts
bun test v1.4.0 (a3f66e1bd)

test/bundler/transpiler/macro-identity.test.ts:
(pass) macro object/array result preserves identity > bun run [488.66ms]
(pass) macro result bound to let/var is not substituted > bun run [538.88ms]
(pass) macro result bound to let/var is not substituted > bun build --minify-syntax [847.84ms]
(pass) macro object/array result preserves identity > bun build --minify [923.79ms]
(pass) macro object/array result preserves identity > bun build [966.37ms]
(pass) macro result bound to let/var is not substituted > let destructure still drops unused macro properties from the emitted literal [877.03ms]

 6 pass
 0 fail
 12 expect() calls
Ran 6 tests across 1 file. [4.46s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a3f66e1bd8
  features     baseline

22 deps, 108 codegen, 1171 objects in 1682ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] gen ErrorCode+*.h
[3/1234] fetch tinycc
[tinycc] up to date
[4/1234] fetch picohttpparser
[picohttpparser] up to date
[5/1234] fetch zlib
[zlib] up to date
[6/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] fetch zstd
[zstd] up to date
[10/1234] fetch nodejs (prebuilt)
[nodejs] up to date
[11/1234] gen .bind.ts → GeneratedBindings.cpp
[12/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/js
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/expr.rs                                |   2 -
 src/js_parser/visit/mod.rs                     |  64 ++++++--
 test/bundler/transpiler/macro-identity.test.ts | 201 +++++++++++++++++++++++++
 3 files changed, 250 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/ast/expr.rs                                     2      3      0
src/js_parser/visit/mod.rs                          9     17      0
test/bundler/transpiler/macro-identity.test.ts      2      6      0
```

</details>

<!-- robobun:evidence:end -->