### PR TITLE
resolver: fall through the "bun" exports condition when its target file is missing

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,10 +1278,6 @@ pub struct ESModule<'a> {
     pub conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub module_type: &'a mut ModuleType,
-    /// Treat the `"bun"` condition key as not matching. Used by the resolver to
-    /// retry when the `"bun"` target resolved to a file that is missing on
-    /// disk (e.g. node-targeted deployment bundles that pruned it) so the
-    /// remaining `"node"` / `"import"` / `"default"` conditions get a chance.
     pub skip_bun_condition: bool,
 }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1278,6 +1278,11 @@ pub struct ESModule<'a> {
     pub conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
     pub module_type: &'a mut ModuleType,
+    /// Treat the `"bun"` condition key as not matching. Used by the resolver to
+    /// retry when the `"bun"` target resolved to a file that is missing on
+    /// disk (e.g. node-targeted deployment bundles that pruned it) so the
+    /// remaining `"node"` / `"import"` / `"default"` conditions get a chance.
+    pub skip_bun_condition: bool,
 }
 
 #[derive(Clone)]
@@ -2107,6 +2112,14 @@ impl<'a> ESModule<'a> {
             EntryData::Map(object) => {
                 for entry in object.list.iter() {
                     let key: &[u8] = &entry.key;
+                    if self.skip_bun_condition && key == b"bun" {
+                        if let Some(log) = self.debug_logs.as_deref_mut() {
+                            log.add_note_fmt(format_args!(
+                                "The key \"bun\" was skipped (target missing on disk)"
+                            ));
+                        }
+                        continue;
+                    }
                     if self.conditions.contains_key(key) {
                         if let Some(log) = self.debug_logs.as_deref_mut() {
                             log.add_note_fmt(format_args!(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2666,7 +2666,8 @@ impl<'a> Resolver<'a> {
                                     // want problems due to Windows paths, which are very unlike URL
                                     // paths. We also want to avoid any "%" characters in the absolute
                                     // directory path accidentally being interpreted as URL escapes.
-                                    {
+                                    let mut skip_bun_condition = false;
+                                    loop {
                                         let esm_resolution = ESModule {
                                             conditions: match kind {
                                                 ast::ImportKind::Require
@@ -2681,9 +2682,12 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
+
+                                        let matched_status = esm_resolution.status;
 
                                         if self
                                             .handle_esm_resolution(
@@ -2704,6 +2708,29 @@ impl<'a> Resolver<'a> {
                                             }
                                             return MatchStatus::Success;
                                         }
+
+                                        // The exports map matched but the target file isn't on
+                                        // disk. If the `"bun"` condition is active, retry without
+                                        // it so node-targeted deployment bundles (Nitro/Nuxt) that
+                                        // only shipped the `"node"` target still resolve.
+                                        if !skip_bun_condition
+                                            && matches!(
+                                                matched_status,
+                                                crate::package_json::Status::Exact
+                                                    | crate::package_json::Status::ExactEndsWithStar
+                                                    | crate::package_json::Status::Inexact
+                                            )
+                                            && self
+                                                .opts
+                                                .conditions
+                                                .import
+                                                .contains_key(b"bun".as_slice())
+                                        {
+                                            skip_bun_condition = true;
+                                            module_type = package_json.module_type;
+                                            continue;
+                                        }
+                                        break;
                                     }
 
                                     // Some popular packages forget to include the extension in their
@@ -2738,6 +2765,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition: false,
                                         }
                                         .resolve(
                                             b"/",
@@ -3165,7 +3193,8 @@ impl<'a> Resolver<'a> {
                                     // want problems due to Windows paths, which are very unlike URL
                                     // paths. We also want to avoid any "%" characters in the absolute
                                     // directory path accidentally being interpreted as URL escapes.
-                                    {
+                                    let mut skip_bun_condition = false;
+                                    loop {
                                         let esm_resolution = ESModule {
                                             conditions: match kind {
                                                 ast::ImportKind::Require
@@ -3176,8 +3205,11 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
+
+                                        let matched_status = esm_resolution.status;
 
                                         if self
                                             .handle_esm_resolution(
@@ -3196,6 +3228,25 @@ impl<'a> Resolver<'a> {
                                             }
                                             return MatchStatus::Success;
                                         }
+
+                                        if !skip_bun_condition
+                                            && matches!(
+                                                matched_status,
+                                                crate::package_json::Status::Exact
+                                                    | crate::package_json::Status::ExactEndsWithStar
+                                                    | crate::package_json::Status::Inexact
+                                            )
+                                            && self
+                                                .opts
+                                                .conditions
+                                                .import
+                                                .contains_key(b"bun".as_slice())
+                                        {
+                                            skip_bun_condition = true;
+                                            module_type = options::ModuleType::Unknown;
+                                            continue;
+                                        }
+                                        break;
                                     }
 
                                     // Some popular packages forget to include the extension in their
@@ -3215,6 +3266,7 @@ impl<'a> Resolver<'a> {
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
                                             module_type: &mut module_type,
+                                            skip_bun_condition: false,
                                         }
                                         .resolve(
                                             b"/",
@@ -4850,6 +4902,7 @@ impl<'a> Resolver<'a> {
             },
             debug_logs: self.debug_logs.as_mut(),
             module_type: &mut module_type,
+            skip_bun_condition: false,
         }
         .resolve_imports(import_path, &imports_map.root);
         let _ = module_type;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2710,17 +2710,8 @@ impl<'a> Resolver<'a> {
                                         }
 
                                         if !skip_bun_condition
-                                            && matches!(
-                                                matched_status,
-                                                crate::package_json::Status::Exact
-                                                    | crate::package_json::Status::ExactEndsWithStar
-                                                    | crate::package_json::Status::Inexact
-                                            )
                                             && self
-                                                .opts
-                                                .conditions
-                                                .import
-                                                .contains_key(b"bun".as_slice())
+                                                .should_retry_without_bun_condition(matched_status)
                                         {
                                             skip_bun_condition = true;
                                             module_type = package_json.module_type;
@@ -3226,17 +3217,8 @@ impl<'a> Resolver<'a> {
                                         }
 
                                         if !skip_bun_condition
-                                            && matches!(
-                                                matched_status,
-                                                crate::package_json::Status::Exact
-                                                    | crate::package_json::Status::ExactEndsWithStar
-                                                    | crate::package_json::Status::Inexact
-                                            )
                                             && self
-                                                .opts
-                                                .conditions
-                                                .import
-                                                .contains_key(b"bun".as_slice())
+                                                .should_retry_without_bun_condition(matched_status)
                                         {
                                             skip_bun_condition = true;
                                             module_type = options::ModuleType::Unknown;
@@ -3668,6 +3650,14 @@ impl<'a> Resolver<'a> {
 
         // NOTE: the non-root path is genuinely unimplemented; this is not a stub.
         unreachable!("TODO: implement enqueueDependencyToResolve for non-root packages")
+    }
+
+    fn should_retry_without_bun_condition(&self, status: crate::package_json::Status) -> bool {
+        use crate::package_json::Status;
+        matches!(
+            status,
+            Status::Exact | Status::ExactEndsWithStar | Status::Inexact
+        ) && self.opts.conditions.import.contains_key(b"bun".as_slice())
     }
 
     fn handle_esm_resolution(
@@ -4928,13 +4918,7 @@ impl<'a> Resolver<'a> {
 
             if !result.is_success()
                 && !skip_bun_condition
-                && matches!(
-                    matched_status,
-                    crate::package_json::Status::Exact
-                        | crate::package_json::Status::ExactEndsWithStar
-                        | crate::package_json::Status::Inexact
-                )
-                && self.opts.conditions.import.contains_key(b"bun".as_slice())
+                && self.should_retry_without_bun_condition(matched_status)
             {
                 skip_bun_condition = true;
                 continue;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4916,7 +4916,7 @@ impl<'a> Resolver<'a> {
                 )
             };
 
-            if !result.is_success()
+            if matches!(result, MatchStatus::NotFound)
                 && !skip_bun_condition
                 && self.should_retry_without_bun_condition(matched_status)
             {

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2709,10 +2709,6 @@ impl<'a> Resolver<'a> {
                                             return MatchStatus::Success;
                                         }
 
-                                        // The exports map matched but the target file isn't on
-                                        // disk. If the `"bun"` condition is active, retry without
-                                        // it so node-targeted deployment bundles (Nitro/Nuxt) that
-                                        // only shipped the `"node"` target still resolve.
                                         if !skip_bun_condition
                                             && matches!(
                                                 matched_status,
@@ -4887,76 +4883,104 @@ impl<'a> Resolver<'a> {
             }
             return MatchStatus::NotFound;
         }
-        let mut module_type = options::ModuleType::Unknown;
+        let mut skip_bun_condition = false;
+        loop {
+            let mut module_type = options::ModuleType::Unknown;
 
-        // NOTE: keeping the `ESModule`'s borrow of `self.debug_logs` alive
-        // across the subsequent `&mut self` calls would be aliased-&mut UB, so
-        // the `ESModule` is constructed as a temporary whose
-        // borrow of `self.debug_logs` ends as soon as `resolve_imports` returns.
-        let esm_resolution = ESModule {
-            conditions: match kind {
-                ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
-                    &self.opts.conditions.require
-                }
-                _ => &self.opts.conditions.import,
-            },
-            debug_logs: self.debug_logs.as_mut(),
-            module_type: &mut module_type,
-            skip_bun_condition: false,
-        }
-        .resolve_imports(import_path, &imports_map.root);
-        let _ = module_type;
+            // NOTE: keeping the `ESModule`'s borrow of `self.debug_logs` alive
+            // across the subsequent `&mut self` calls would be aliased-&mut UB, so
+            // the `ESModule` is constructed as a temporary whose
+            // borrow of `self.debug_logs` ends as soon as `resolve_imports` returns.
+            let esm_resolution = ESModule {
+                conditions: match kind {
+                    ast::ImportKind::Require | ast::ImportKind::RequireResolve => {
+                        &self.opts.conditions.require
+                    }
+                    _ => &self.opts.conditions.import,
+                },
+                debug_logs: self.debug_logs.as_mut(),
+                module_type: &mut module_type,
+                skip_bun_condition,
+            }
+            .resolve_imports(import_path, &imports_map.root);
+            let _ = module_type;
 
-        if esm_resolution.status == crate::package_json::Status::PackageResolve {
-            // https://github.com/oven-sh/bun/issues/4972
-            // Resolve a subpath import to a Bun or Node.js builtin
-            //
-            // Code example:
-            //
-            //     import { readFileSync } from '#fs';
-            //
-            // package.json:
-            //
-            //     "imports": {
-            //       "#fs": "node:fs"
-            //     }
-            //
-            if self.opts.mark_builtins_as_external || self.opts.target.is_bun() {
-                if let Some(alias) = HardcodedAlias::get(
+            let matched_status = esm_resolution.status;
+
+            if matched_status == crate::package_json::Status::PackageResolve {
+                return self.handle_imports_package_resolve(
                     &esm_resolution.path,
-                    self.opts.target,
-                    HardcodedAliasCfg::default(),
-                ) {
-                    *out = MatchResult {
-                        path_pair: PathPair {
-                            primary: Fs::Path::init(alias.path.as_bytes()),
-                            secondary: None,
-                        },
-                        is_external: true,
-                        ..Default::default()
-                    };
-                    return MatchStatus::Success;
-                }
+                    kind,
+                    dir_info,
+                    global_cache,
+                    out,
+                );
             }
 
-            return self.load_node_modules(
-                &esm_resolution.path,
+            let result = self.handle_esm_resolution(
+                esm_resolution,
+                package_json.source.path.name().dir,
                 kind,
-                dir_info,
-                global_cache,
-                true,
+                package_json,
+                b"",
                 out,
             );
+
+            if !result.is_success()
+                && !skip_bun_condition
+                && matches!(
+                    matched_status,
+                    crate::package_json::Status::Exact
+                        | crate::package_json::Status::ExactEndsWithStar
+                        | crate::package_json::Status::Inexact
+                )
+                && self.opts.conditions.import.contains_key(b"bun".as_slice())
+            {
+                skip_bun_condition = true;
+                continue;
+            }
+            return result;
+        }
+    }
+
+    fn handle_imports_package_resolve(
+        &mut self,
+        path: &[u8],
+        kind: ast::ImportKind,
+        dir_info: DirInfoRef,
+        global_cache: GlobalCache,
+        out: &mut MatchResult,
+    ) -> MatchStatus {
+        // https://github.com/oven-sh/bun/issues/4972
+        // Resolve a subpath import to a Bun or Node.js builtin
+        //
+        // Code example:
+        //
+        //     import { readFileSync } from '#fs';
+        //
+        // package.json:
+        //
+        //     "imports": {
+        //       "#fs": "node:fs"
+        //     }
+        //
+        if self.opts.mark_builtins_as_external || self.opts.target.is_bun() {
+            if let Some(alias) =
+                HardcodedAlias::get(path, self.opts.target, HardcodedAliasCfg::default())
+            {
+                *out = MatchResult {
+                    path_pair: PathPair {
+                        primary: Fs::Path::init(alias.path.as_bytes()),
+                        secondary: None,
+                    },
+                    is_external: true,
+                    ..Default::default()
+                };
+                return MatchStatus::Success;
+            }
         }
 
-        self.handle_esm_resolution(
-            esm_resolution,
-            package_json.source.path.name().dir,
-            kind,
-            package_json,
-            b"",
-            out,
-        )
+        self.load_node_modules(path, kind, dir_info, global_cache, true, out)
     }
 
     pub fn check_browser_map<const KIND: BrowserMapPathKind>(

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3656,7 +3656,7 @@ impl<'a> Resolver<'a> {
         use crate::package_json::Status;
         matches!(
             status,
-            Status::Exact | Status::ExactEndsWithStar | Status::Inexact
+            Status::Exact | Status::ExactEndsWithStar | Status::Inexact | Status::PackageResolve
         ) && self.opts.conditions.import.contains_key(b"bun".as_slice())
     }
 
@@ -4897,24 +4897,24 @@ impl<'a> Resolver<'a> {
 
             let matched_status = esm_resolution.status;
 
-            if matched_status == crate::package_json::Status::PackageResolve {
-                return self.handle_imports_package_resolve(
+            let result = if matched_status == crate::package_json::Status::PackageResolve {
+                self.handle_imports_package_resolve(
                     &esm_resolution.path,
                     kind,
                     dir_info,
                     global_cache,
                     out,
-                );
-            }
-
-            let result = self.handle_esm_resolution(
-                esm_resolution,
-                package_json.source.path.name().dir,
-                kind,
-                package_json,
-                b"",
-                out,
-            );
+                )
+            } else {
+                self.handle_esm_resolution(
+                    esm_resolution,
+                    package_json.source.path.name().dir,
+                    kind,
+                    package_json,
+                    b"",
+                    out,
+                )
+            };
 
             if !result.is_success()
                 && !skip_bun_condition

--- a/test/regression/issue/07142.test.ts
+++ b/test/regression/issue/07142.test.ts
@@ -18,15 +18,11 @@ async function run(dir: string, entry: string) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
 }
 
-describe("exports \"bun\" condition target missing on disk", () => {
+describe('exports "bun" condition target missing on disk', () => {
   test("falls through to the node condition (import)", async () => {
     using dir = tempDir("issue-7142-import", {
       "node_modules/ofetch/package.json": JSON.stringify({

--- a/test/regression/issue/07142.test.ts
+++ b/test/regression/issue/07142.test.ts
@@ -1,0 +1,176 @@
+// https://github.com/oven-sh/bun/issues/7142
+//
+// Nitro/Nuxt produce a `.output/server/node_modules` that only contains the
+// files the "node" exports condition reaches. Packages like `ofetch` and
+// `node-fetch-native` also declare a `"bun"` condition pointing at a file the
+// bundler never copied, so Bun matched `"bun"`, found no file on disk, and
+// failed the whole resolution with "Cannot find package". When the `"bun"`
+// target is missing we now retry exports resolution without that condition so
+// the `"node"` / `"default"` target (which Node.js would pick) is used instead.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+async function run(dir: string, entry: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("exports \"bun\" condition target missing on disk", () => {
+  test("falls through to the node condition (import)", async () => {
+    using dir = tempDir("issue-7142-import", {
+      "node_modules/ofetch/package.json": JSON.stringify({
+        name: "ofetch",
+        type: "module",
+        exports: {
+          ".": {
+            bun: "./dist/index.mjs",
+            node: {
+              import: { default: "./dist/node.mjs" },
+              require: { default: "./dist/node.cjs" },
+            },
+            default: "./dist/index.mjs",
+          },
+        },
+      }),
+      // only the node target shipped
+      "node_modules/ofetch/dist/node.mjs": `export const picked = "node.mjs";\n`,
+      "node_modules/ipx/package.json": JSON.stringify({
+        name: "ipx",
+        type: "module",
+        exports: { ".": "./dist/index.mjs" },
+      }),
+      "node_modules/ipx/dist/index.mjs": `export { picked } from "ofetch";\n`,
+      "index.mjs": `import { picked } from "ipx";\nconsole.log(picked);\n`,
+      "package.json": JSON.stringify({ name: "app", type: "module" }),
+    });
+
+    const { stdout, stderr, exitCode } = await run(dir, "index.mjs");
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout.trim()).toBe("node.mjs");
+    expect(exitCode).toBe(0);
+  });
+
+  test("falls through to the node condition (require)", async () => {
+    using dir = tempDir("issue-7142-require", {
+      "node_modules/ofetch/package.json": JSON.stringify({
+        name: "ofetch",
+        exports: {
+          ".": {
+            bun: "./dist/bun.cjs",
+            node: "./dist/node.cjs",
+            default: "./dist/index.cjs",
+          },
+        },
+      }),
+      "node_modules/ofetch/dist/node.cjs": `module.exports = { picked: "node.cjs" };\n`,
+      "index.cjs": `const { picked } = require("ofetch");\nconsole.log(picked);\n`,
+      "package.json": JSON.stringify({ name: "app" }),
+    });
+
+    const { stdout, stderr, exitCode } = await run(dir, "index.cjs");
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout.trim()).toBe("node.cjs");
+    expect(exitCode).toBe(0);
+  });
+
+  test("falls through for wildcard subpath patterns", async () => {
+    using dir = tempDir("issue-7142-wildcard", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          "./*": {
+            bun: "./bun/*.mjs",
+            default: "./dist/*.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/thing.mjs": `export const picked = "dist/thing.mjs";\n`,
+      "index.mjs": `import { picked } from "pkg/thing";\nconsole.log(picked);\n`,
+      "package.json": JSON.stringify({ name: "app", type: "module" }),
+    });
+
+    const { stdout, stderr, exitCode } = await run(dir, "index.mjs");
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout.trim()).toBe("dist/thing.mjs");
+    expect(exitCode).toBe(0);
+  });
+
+  test("still prefers the bun condition when its target exists", async () => {
+    using dir = tempDir("issue-7142-prefers-bun", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          ".": {
+            bun: "./dist/bun.mjs",
+            node: "./dist/node.mjs",
+            default: "./dist/node.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/bun.mjs": `export const picked = "bun.mjs";\n`,
+      "node_modules/pkg/dist/node.mjs": `export const picked = "node.mjs";\n`,
+      "index.mjs": `import { picked } from "pkg";\nconsole.log(picked);\n`,
+      "package.json": JSON.stringify({ name: "app", type: "module" }),
+    });
+
+    const { stdout, exitCode } = await run(dir, "index.mjs");
+    expect(stdout.trim()).toBe("bun.mjs");
+    expect(exitCode).toBe(0);
+  });
+
+  test("still fails when the fallback target is also missing", async () => {
+    using dir = tempDir("issue-7142-all-missing", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          ".": {
+            bun: "./dist/bun.mjs",
+            default: "./dist/index.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/placeholder.mjs": "",
+      "index.mjs": `import "pkg";\n`,
+      "package.json": JSON.stringify({ name: "app", type: "module" }),
+    });
+
+    const { exitCode } = await run(dir, "index.mjs");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("bun: null is still respected as a hard block", async () => {
+    using dir = tempDir("issue-7142-null", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: {
+          ".": {
+            bun: null,
+            default: "./dist/index.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/dist/index.mjs": `export const picked = "index.mjs";\n`,
+      "index.mjs": `import { picked } from "pkg";\nconsole.log(picked);\n`,
+      "package.json": JSON.stringify({ name: "app", type: "module" }),
+    });
+
+    const { stdout, exitCode } = await run(dir, "index.mjs");
+    expect(stdout.trim()).not.toBe("index.mjs");
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/regression/issue/07142.test.ts
+++ b/test/regression/issue/07142.test.ts
@@ -1,12 +1,4 @@
 // https://github.com/oven-sh/bun/issues/7142
-//
-// Nitro/Nuxt produce a `.output/server/node_modules` that only contains the
-// files the "node" exports condition reaches. Packages like `ofetch` and
-// `node-fetch-native` also declare a `"bun"` condition pointing at a file the
-// bundler never copied, so Bun matched `"bun"`, found no file on disk, and
-// failed the whole resolution with "Cannot find package". When the `"bun"`
-// target is missing we now retry exports resolution without that condition so
-// the `"node"` / `"default"` target (which Node.js would pick) is used instead.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
@@ -22,7 +14,7 @@ async function run(dir: string, entry: string) {
   return { stdout, stderr, exitCode };
 }
 
-describe('exports "bun" condition target missing on disk', () => {
+describe.concurrent('exports "bun" condition target missing on disk', () => {
   test("falls through to the node condition (import)", async () => {
     using dir = tempDir("issue-7142-import", {
       "node_modules/ofetch/package.json": JSON.stringify({
@@ -39,7 +31,6 @@ describe('exports "bun" condition target missing on disk', () => {
           },
         },
       }),
-      // only the node target shipped
       "node_modules/ofetch/dist/node.mjs": `export const picked = "node.mjs";\n`,
       "node_modules/ipx/package.json": JSON.stringify({
         name: "ipx",
@@ -103,6 +94,31 @@ describe('exports "bun" condition target missing on disk', () => {
     expect(exitCode).toBe(0);
   });
 
+  test("falls through for the package.json imports map", async () => {
+    using dir = tempDir("issue-7142-imports", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: { ".": "./index.mjs" },
+        imports: {
+          "#internal": {
+            bun: "./bun.mjs",
+            default: "./node.mjs",
+          },
+        },
+      }),
+      "node_modules/pkg/node.mjs": `export const picked = "node.mjs";\n`,
+      "node_modules/pkg/index.mjs": `export { picked } from "#internal";\n`,
+      "index.mjs": `import { picked } from "pkg";\nconsole.log(picked);\n`,
+      "package.json": JSON.stringify({ name: "app", type: "module" }),
+    });
+
+    const { stdout, stderr, exitCode } = await run(dir, "index.mjs");
+    expect(stderr).not.toContain("Cannot find");
+    expect(stdout.trim()).toBe("node.mjs");
+    expect(exitCode).toBe(0);
+  });
+
   test("still prefers the bun condition when its target exists", async () => {
     using dir = tempDir("issue-7142-prefers-bun", {
       "node_modules/pkg/package.json": JSON.stringify({
@@ -144,7 +160,8 @@ describe('exports "bun" condition target missing on disk', () => {
       "package.json": JSON.stringify({ name: "app", type: "module" }),
     });
 
-    const { exitCode } = await run(dir, "index.mjs");
+    const { stderr, exitCode } = await run(dir, "index.mjs");
+    expect(stderr).toContain("pkg");
     expect(exitCode).not.toBe(0);
   });
 
@@ -165,7 +182,8 @@ describe('exports "bun" condition target missing on disk', () => {
       "package.json": JSON.stringify({ name: "app", type: "module" }),
     });
 
-    const { stdout, exitCode } = await run(dir, "index.mjs");
+    const { stdout, stderr, exitCode } = await run(dir, "index.mjs");
+    expect(stderr).toContain("pkg");
     expect(stdout.trim()).not.toBe("index.mjs");
     expect(exitCode).not.toBe(0);
   });

--- a/test/regression/issue/07142.test.ts
+++ b/test/regression/issue/07142.test.ts
@@ -119,6 +119,32 @@ describe.concurrent('exports "bun" condition target missing on disk', () => {
     expect(exitCode).toBe(0);
   });
 
+  test("falls through for an imports map bare-package target", async () => {
+    using dir = tempDir("issue-7142-imports-pkg", {
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        type: "module",
+        exports: { ".": "./index.mjs" },
+        imports: {
+          "#fetch": {
+            bun: "bun-only-pkg",
+            default: "dep",
+          },
+        },
+      }),
+      "node_modules/pkg/index.mjs": `export { picked } from "#fetch";\n`,
+      "node_modules/dep/package.json": JSON.stringify({ name: "dep", type: "module", main: "./index.mjs" }),
+      "node_modules/dep/index.mjs": `export const picked = "dep";\n`,
+      "index.mjs": `import { picked } from "pkg";\nconsole.log(picked);\n`,
+      "package.json": JSON.stringify({ name: "app", type: "module" }),
+    });
+
+    const { stdout, stderr, exitCode } = await run(dir, "index.mjs");
+    expect(stderr).not.toContain("Cannot find");
+    expect(stdout.trim()).toBe("dep");
+    expect(exitCode).toBe(0);
+  });
+
   test("still prefers the bun condition when its target exists", async () => {
     using dir = tempDir("issue-7142-prefers-bun", {
       "node_modules/pkg/package.json": JSON.stringify({

--- a/test/regression/issue/07142.test.ts
+++ b/test/regression/issue/07142.test.ts
@@ -161,7 +161,7 @@ describe.concurrent('exports "bun" condition target missing on disk', () => {
     });
 
     const { stderr, exitCode } = await run(dir, "index.mjs");
-    expect(stderr).toContain("pkg");
+    expect(stderr).toContain("Cannot find package 'pkg'");
     expect(exitCode).not.toBe(0);
   });
 
@@ -183,7 +183,7 @@ describe.concurrent('exports "bun" condition target missing on disk', () => {
     });
 
     const { stdout, stderr, exitCode } = await run(dir, "index.mjs");
-    expect(stderr).toContain("pkg");
+    expect(stderr).toContain("Cannot find package 'pkg'");
     expect(stdout.trim()).not.toBe("index.mjs");
     expect(exitCode).not.toBe(0);
   });


### PR DESCRIPTION
Fixes #7142.

## Repro

```sh
bunx nuxi@latest init app && cd app
bunx nuxi@latest module add image
bun run build
bun .output/server/index.mjs
```

```
error: Cannot find package 'ofetch' from '.../.output/server/node_modules/ipx/dist/index.mjs'
```

Node.js starts the same output without error.

## Cause

Nitro builds `.output/server/node_modules` for the `node-server` preset, so it only copies the files that Node's resolver reaches. `ofetch` (and `node-fetch-native`) declare a `"bun"` condition in their `exports` map:

```jsonc
"exports": {
  ".": {
    "bun": "./dist/index.mjs",         // not copied by Nitro
    "node": { "import": { "default": "./dist/node.mjs" } },  // copied
    ...
  }
}
```

Bun's default condition set includes `"bun"`, so `resolve_target` picks `./dist/index.mjs`, `handle_esm_resolution` finds no such file, and `load_node_modules` returns `NotFound` for the whole package. Node never sees the `"bun"` key, matches `"node"`, and succeeds.

## Fix

When the exports/imports map resolved to an exact path but that file is missing on disk, and the `"bun"` condition is in the active set, re-run the resolution once with `"bun"` treated as not matching. This lets the remaining `"node"` / `"import"` / `"default"` conditions select the file that the deployment bundler actually shipped.

The retry covers `load_node_modules` (package `exports`) and `load_package_imports` (`#`-prefixed `imports`). The Bun-only `.js` extension-strip fallback is left unchanged: Node rejects that specifier form, so a Node-targeted bundler cannot produce the precondition.

This only changes behaviour on the failure path: when the `"bun"` target exists it is still preferred, and `"bun": null` still hard-blocks (Status is `Null`, not `Exact`, so the retry guard does not fire). For targets other than `bun` the retry resolves to the same path and fails again, so the outcome is unchanged.

The `"bun"` condition is Bun's own extension: packages use it to opt into a Bun-specific entry, and tooling that has never heard of it (Nitro, serverless packagers) will reasonably prune that entry. Falling back to what Node would have loaded is the behaviour users expect when running such output under Bun.

## Verification

`test/regression/issue/07142.test.ts` covers import, require, wildcard subpaths, the `imports` map, the `"bun"` target still winning when present, the all-missing failure case, and `"bun": null` staying a hard block. 4 of 7 tests fail on the released Bun and all 7 pass with this change. Running the actual Nuxt `.output/server/index.mjs` now prints `Listening on http://[::]:3000`.
