### PR TITLE
shell: buffer a fetch() Response body before redirecting it to stdin

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3249,7 +3249,11 @@ where
                     }
                 }
 
-                if lock.on_receive_value.is_some() || lock.task.is_some() {
+                if lock.on_receive_value.is_some() {
+                    this.render_missing();
+                    return;
+                }
+                if lock.task.is_some() {
                     // someone else is waiting for the stream or waiting for `onStartStreaming`
                     let Ok(readable) = value.to_readable_stream(global_this) else {
                         return;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1944,10 +1944,12 @@ where
 
     /// # Safety
     /// `this` must be a `*mut RequestContext` previously registered as `lock.task`.
-    pub(crate) fn do_render_with_body_locked(this: *mut c_void, value: &mut Body::Value) {
+    pub(crate) fn do_render_with_body_locked(this: *mut c_void, value: *mut Body::Value) {
         // SAFETY: caller upholds the fn-level contract — `this` is the
         // `*mut RequestContext` previously registered as `lock.task`.
-        Self::do_render_with_body(unsafe { bun_ptr::callback_ctx::<Self>(this) }, value, None);
+        let this = unsafe { bun_ptr::callback_ctx::<Self>(this) };
+        // SAFETY: live `&mut Value` reborrowed by `resolve`/`to_error_instance`.
+        Self::do_render_with_body(this, unsafe { &mut *value }, None);
     }
 
     fn render_with_blob_from_body_value(&mut self) {

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -732,6 +732,16 @@ impl Builtin {
                     // SAFETY: returned a live JSC-owned `*mut Value` borrowed
                     // from a Response/Request wrapper.
                     let body = unsafe { &mut *body };
+                    body.to_blob_if_possible();
+                    if crate::shell::states::cmd::Cmd::reject_unbufferable_body(
+                        body,
+                        global,
+                        redirect.stdin(),
+                    )
+                    .is_err()
+                    {
+                        return Some(Yield::failed());
+                    }
                     let is_file_blob = matches!(body, crate::webcore::body::Value::Blob(b)
                         if !b.needs_to_read_file());
                     if (redirect.stdout() || redirect.stderr()) && !is_file_blob {

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -446,7 +446,7 @@ pub fn handle_template_value(
             return Ok(());
         }
 
-        if let Some(_req) = template_value.as_::<crate::webcore::Response>() {
+        if crate::webcore::body::Value::from_request_or_response(template_value).is_some() {
             let idx = out_jsobjs.len();
             marked_argument_buffer.append(template_value);
             out_jsobjs.push(template_value);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -271,7 +271,6 @@ impl Cmd {
                         _ => {}
                     }
                     if Self::try_buffer_redirect_body(interp, this, n) {
-                        interp.as_cmd_mut(this).state = CmdState::BufferingRedirectBody;
                         return Yield::suspended();
                     }
                     interp.as_cmd_mut(this).state = CmdState::ExpandingArgs { idx: 0 };
@@ -337,37 +336,69 @@ impl Cmd {
         if idx >= interp.jsobjs.len() {
             return false;
         }
-        let Some(body) = crate::webcore::body::Value::from_request_or_response(interp.jsobjs[idx])
+        let Some(body_ptr) =
+            crate::webcore::body::Value::from_request_or_response(interp.jsobjs[idx])
         else {
             return false;
         };
-        // SAFETY: live JSC-owned `*mut Value` borrowed from the Request/Response
-        // wrapper while `jsobjs[idx]` is rooted.
-        let body = unsafe { &mut *body };
-        body.to_blob_if_possible();
-        let crate::webcore::body::Value::Locked(locked) = body else {
-            return false;
+        let start = {
+            // SAFETY: live JSC-owned `*mut Value` borrowed from the wrapper
+            // while `jsobjs[idx]` is rooted; the borrow ends before `start.fire()`.
+            let body = unsafe { &mut *body_ptr };
+            body.to_blob_if_possible();
+            let crate::webcore::body::Value::Locked(locked) = body else {
+                return false;
+            };
+            let ctx = bun_core::heap::alloc(RedirectBodyBufferCtx {
+                interp: interp.as_ctx_ptr(),
+                cmd: this,
+                keep_alive: bun_io::KeepAlive::default(),
+            });
+            // SAFETY: fresh heap allocation; freed by `on_redirect_body_received`
+            // or reclaimed below when the hook is not installed / was dropped.
+            unsafe {
+                (*ctx)
+                    .keep_alive
+                    .ref_(interp.event_loop.as_event_loop_ctx())
+            };
+            interp.as_cmd_mut(this).state = CmdState::BufferingRedirectBody;
+            match locked.hook_native_receiver(
+                ctx.cast::<core::ffi::c_void>(),
+                Self::on_redirect_body_received,
+            ) {
+                Some(start) => (start, ctx),
+                None => {
+                    interp.as_cmd_mut(this).state = CmdState::ExpandingRedirect { idx: 0 };
+                    // SAFETY: `ctx` was not published; reclaim and drop.
+                    unsafe {
+                        (*ctx)
+                            .keep_alive
+                            .unref(interp.event_loop.as_event_loop_ctx());
+                        bun_core::heap::destroy(ctx);
+                    };
+                    return false;
+                }
+            }
         };
-        let ctx = bun_core::heap::alloc(RedirectBodyBufferCtx {
-            interp: interp.as_ctx_ptr(),
-            cmd: this,
-            keep_alive: bun_io::KeepAlive::default(),
-        });
-        if !locked.hook_native_receiver(
-            ctx.cast::<core::ffi::c_void>(),
-            Self::on_redirect_body_received,
-        ) {
-            // SAFETY: `ctx` was just `heap::alloc`'d and never published.
-            unsafe { bun_core::heap::destroy(ctx) };
-            return false;
+        let (start, ctx) = start;
+        start.fire();
+        if matches!(interp.as_cmd(this).state, CmdState::BufferingRedirectBody) {
+            // SAFETY: same JSC-owned location as above, re-read after the
+            // producer callback — which may have resolved the body in place.
+            if !matches!(unsafe { &*body_ptr }, crate::webcore::body::Value::Locked(_)) {
+                // SAFETY: the producer resolved synchronously and dropped the
+                // hook without firing it (server empty-body path); `ctx` is
+                // still the live heap allocation we hold.
+                unsafe {
+                    (*ctx)
+                        .keep_alive
+                        .unref(interp.event_loop.as_event_loop_ctx());
+                    bun_core::heap::destroy(ctx);
+                };
+                interp.as_cmd_mut(this).state = CmdState::ExpandingRedirect { idx: 0 };
+                return false;
+            }
         }
-        // SAFETY: `ctx` is a fresh heap allocation published into the
-        // `PendingValue`; freed in `on_redirect_body_received`.
-        unsafe {
-            (*ctx)
-                .keep_alive
-                .ref_(interp.event_loop.as_event_loop_ctx())
-        };
         true
     }
 

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -461,7 +461,7 @@ impl Cmd {
                 interp,
                 this,
                 format_args!(
-                    "bun: failed to read Response body for stdin redirect: {}\n",
+                    "bun: failed to read body for stdin redirect: {}\n",
                     js_err.fmt_string(global),
                 ),
             )

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -385,8 +385,10 @@ impl Cmd {
         if matches!(interp.as_cmd(this).state, CmdState::BufferingRedirectBody) {
             // SAFETY: same JSC-owned location as above, re-read after the
             // producer callback — which may have resolved the body in place.
-            let still_locked =
-                matches!(unsafe { &*body_ptr }, crate::webcore::body::Value::Locked(_));
+            let still_locked = matches!(
+                unsafe { &*body_ptr },
+                crate::webcore::body::Value::Locked(_)
+            );
             if !still_locked {
                 // SAFETY: the producer resolved synchronously and dropped the
                 // hook without firing it (server empty-body path); `ctx` is

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -385,10 +385,9 @@ impl Cmd {
         if matches!(interp.as_cmd(this).state, CmdState::BufferingRedirectBody) {
             // SAFETY: same JSC-owned location as above, re-read after the
             // producer callback — which may have resolved the body in place.
-            if !matches!(
-                unsafe { &*body_ptr },
-                crate::webcore::body::Value::Locked(_)
-            ) {
+            let still_locked =
+                matches!(unsafe { &*body_ptr }, crate::webcore::body::Value::Locked(_));
+            if !still_locked {
                 // SAFETY: the producer resolved synchronously and dropped the
                 // hook without firing it (server empty-body path); `ctx` is
                 // still the live heap allocation we hold.

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -372,7 +372,11 @@ impl Cmd {
         }
         // SAFETY: `ctx` is a fresh heap allocation published into the
         // `PendingValue`; freed in `on_redirect_body_received`.
-        unsafe { (*ctx).keep_alive.ref_(interp.event_loop.as_event_loop_ctx()) };
+        unsafe {
+            (*ctx)
+                .keep_alive
+                .ref_(interp.event_loop.as_event_loop_ctx())
+        };
         true
     }
 
@@ -414,7 +418,10 @@ impl Cmd {
     /// `PendingValue::on_receive_value` hook. The producer has already written
     /// the final `InternalBlob` / `Error` into the Response body before
     /// invoking `resolve` / `to_error_instance`, so this only has to resume.
-    fn on_redirect_body_received(ctx: *mut core::ffi::c_void, _value: &mut crate::webcore::body::Value) {
+    fn on_redirect_body_received(
+        ctx: *mut core::ffi::c_void,
+        _value: &mut crate::webcore::body::Value,
+    ) {
         // SAFETY: `ctx` is the `heap::alloc`'d `RedirectBodyBufferCtx`
         // installed by `try_buffer_redirect_body`; consumed here.
         let mut ctx = unsafe { bun_core::heap::take(ctx.cast::<RedirectBodyBufferCtx>()) };

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -40,9 +40,18 @@ pub enum CmdState {
     ExpandingRedirect {
         idx: u32,
     },
+    BufferingRedirectBody,
     Exec,
     WaitingWriteErr,
     Done,
+}
+
+/// Heap-allocated resume context for `CmdState::BufferingRedirectBody`; stored
+/// in `PendingValue::task` and consumed by `Cmd::on_redirect_body_received`.
+struct RedirectBodyBufferCtx {
+    interp: *mut Interpreter,
+    cmd: NodeId,
+    keep_alive: bun_io::KeepAlive,
 }
 
 #[derive(Default)]
@@ -263,9 +272,14 @@ impl Cmd {
                         // "already expanded" re-entry (`idx > 0`).
                         _ => {}
                     }
+                    if Self::try_buffer_redirect_body(interp, this, n) {
+                        interp.as_cmd_mut(this).state = CmdState::BufferingRedirectBody;
+                        return Yield::suspended();
+                    }
                     interp.as_cmd_mut(this).state = CmdState::ExpandingArgs { idx: 0 };
                     continue;
                 }
+                CmdState::BufferingRedirectBody => return Yield::suspended(),
                 CmdState::ExpandingArgs { idx } => {
                     let args = n.name_and_args;
                     if (idx as usize) >= args.len() {
@@ -309,6 +323,112 @@ impl Cmd {
         ));
         let parent = interp.as_cmd(this).base.parent;
         interp.child_done(parent, this, 1)
+    }
+
+    /// If the stdin redirect is a `Request`/`Response` whose body is still a
+    /// `Locked` `PendingValue` (e.g. a `fetch()` body paused by backpressure),
+    /// hook its native completion and return `true`; the caller then parks in
+    /// `BufferingRedirectBody` until `on_redirect_body_received` resumes it.
+    /// Returns `false` when there is nothing to wait for; in that case the body
+    /// is either already a blob, or still `Locked` because a stream/consumer is
+    /// already attached (which `init_subproc_redirections` will throw on).
+    fn try_buffer_redirect_body(interp: &Interpreter, this: NodeId, node: &ast::Cmd) -> bool {
+        if !node.redirect.stdin() {
+            return false;
+        }
+        let Some(ast::Redirect::JsBuf(jsbuf)) = &node.redirect_file else {
+            return false;
+        };
+        if interp.global_this_ref().is_none() {
+            return false;
+        }
+        let idx = jsbuf.idx as usize;
+        if idx >= interp.jsobjs.len() {
+            return false;
+        }
+        let Some(body) = crate::webcore::body::Value::from_request_or_response(interp.jsobjs[idx])
+        else {
+            return false;
+        };
+        // SAFETY: live JSC-owned `*mut Value` borrowed from the Request/Response
+        // wrapper while `jsobjs[idx]` is rooted.
+        let body = unsafe { &mut *body };
+        body.to_blob_if_possible();
+        let crate::webcore::body::Value::Locked(locked) = body else {
+            return false;
+        };
+        let ctx = bun_core::heap::alloc(RedirectBodyBufferCtx {
+            interp: interp.as_ctx_ptr(),
+            cmd: this,
+            keep_alive: bun_io::KeepAlive::default(),
+        });
+        if !locked.hook_native_receiver(
+            ctx.cast::<core::ffi::c_void>(),
+            Self::on_redirect_body_received,
+        ) {
+            // SAFETY: `ctx` was just `heap::alloc`'d and never published.
+            unsafe { bun_core::heap::destroy(ctx) };
+            return false;
+        }
+        // SAFETY: `ctx` is a fresh heap allocation published into the
+        // `PendingValue`; freed in `on_redirect_body_received`.
+        unsafe { (*ctx).keep_alive.ref_(interp.event_loop.as_event_loop_ctx()) };
+        true
+    }
+
+    /// Reject a Request/Response body that `use_as_any_blob()` would silently
+    /// turn into an empty blob. `to_blob_if_possible()` and
+    /// `try_buffer_redirect_body` have already run, so a remaining `Locked`
+    /// means a ReadableStream or another consumer is attached and the body
+    /// cannot be drained synchronously.
+    pub(crate) fn reject_unbufferable_body(
+        body: &crate::webcore::body::Value,
+        global: &crate::jsc::JSGlobalObject,
+        stdin: bool,
+    ) -> crate::jsc::JsResult<()> {
+        match body {
+            crate::webcore::body::Value::Locked(_) => {
+                Err(global.throw_invalid_arguments(format_args!(
+                    "Request/Response body is a ReadableStream, which cannot be redirected in \
+                     Bun Shell yet{}",
+                    if stdin {
+                        ". Read it first: $`cmd < ${await response.bytes()}`"
+                    } else {
+                        ""
+                    },
+                )))
+            }
+            crate::webcore::body::Value::Used => Err(global
+                .err(
+                    crate::jsc::ErrorCode::BODY_ALREADY_USED,
+                    format_args!("Body already used"),
+                )
+                .throw()),
+            crate::webcore::body::Value::Error(err) => {
+                Err(global.throw_value(err.dupe(global).to_js(global)))
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// `PendingValue::on_receive_value` hook. The producer has already written
+    /// the final `InternalBlob` / `Error` into the Response body before
+    /// invoking `resolve` / `to_error_instance`, so this only has to resume.
+    fn on_redirect_body_received(ctx: *mut core::ffi::c_void, _value: &mut crate::webcore::body::Value) {
+        // SAFETY: `ctx` is the `heap::alloc`'d `RedirectBodyBufferCtx`
+        // installed by `try_buffer_redirect_body`; consumed here.
+        let mut ctx = unsafe { bun_core::heap::take(ctx.cast::<RedirectBodyBufferCtx>()) };
+        // SAFETY: the interpreter outlives the run (`has_pending_activity > 0`
+        // from `run()` to `finish()`), and we are on the JS thread.
+        let interp = unsafe { &*ctx.interp };
+        ctx.keep_alive.unref(interp.event_loop.as_event_loop_ctx());
+        let this = ctx.cmd;
+        debug_assert!(matches!(
+            interp.as_cmd(this).state,
+            CmdState::BufferingRedirectBody
+        ));
+        interp.as_cmd_mut(this).state = CmdState::ExpandingArgs { idx: 0 };
+        Yield::Next(this).run(interp);
     }
 
     pub fn child_done(
@@ -764,20 +884,24 @@ impl Cmd {
                     }
                 } else if crate::webcore::ReadableStream::from_js(jsval, global)?.is_some() {
                     panic!("TODO SHELL READABLE STREAM");
-                } else if let Some(req) = jsval.as_::<crate::webcore::Response>() {
-                    // SAFETY: `as_` returns a live JSC-owned `*mut Response`.
-                    let req = unsafe { &mut *req };
-                    req.get_body_value().to_blob_if_possible();
+                } else if let Some(body) =
+                    crate::webcore::body::Value::from_request_or_response(jsval)
+                {
+                    // SAFETY: live JSC-owned `*mut Value` borrowed from the
+                    // Request/Response wrapper while `jsval` is rooted.
+                    let body = unsafe { &mut *body };
+                    body.to_blob_if_possible();
+                    Self::reject_unbufferable_body(body, global, flags.stdin())?;
                     if flags.stdin() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = body.use_as_any_blob();
                         stdio[STDIN_NO].extract_blob(global, b, STDIN_NO as i32)?;
                     }
                     if flags.stdout() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = body.use_as_any_blob();
                         stdio[STDOUT_NO].extract_blob(global, b, STDOUT_NO as i32)?;
                     }
                     if flags.stderr() {
-                        let b = req.get_body_value().use_as_any_blob();
+                        let b = body.use_as_any_blob();
                         stdio[STDERR_NO].extract_blob(global, b, STDERR_NO as i32)?;
                     }
                 } else {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -46,8 +46,6 @@ pub enum CmdState {
     Done,
 }
 
-/// Heap-allocated resume context for `CmdState::BufferingRedirectBody`; stored
-/// in `PendingValue::task` and consumed by `Cmd::on_redirect_body_received`.
 struct RedirectBodyBufferCtx {
     interp: *mut Interpreter,
     cmd: NodeId,
@@ -325,13 +323,6 @@ impl Cmd {
         interp.child_done(parent, this, 1)
     }
 
-    /// If the stdin redirect is a `Request`/`Response` whose body is still a
-    /// `Locked` `PendingValue` (e.g. a `fetch()` body paused by backpressure),
-    /// hook its native completion and return `true`; the caller then parks in
-    /// `BufferingRedirectBody` until `on_redirect_body_received` resumes it.
-    /// Returns `false` when there is nothing to wait for; in that case the body
-    /// is either already a blob, or still `Locked` because a stream/consumer is
-    /// already attached (which `init_subproc_redirections` will throw on).
     fn try_buffer_redirect_body(interp: &Interpreter, this: NodeId, node: &ast::Cmd) -> bool {
         if !node.redirect.stdin() {
             return false;
@@ -380,11 +371,6 @@ impl Cmd {
         true
     }
 
-    /// Reject a Request/Response body that `use_as_any_blob()` would silently
-    /// turn into an empty blob. `to_blob_if_possible()` and
-    /// `try_buffer_redirect_body` have already run, so a remaining `Locked`
-    /// means a ReadableStream or another consumer is attached and the body
-    /// cannot be drained synchronously.
     pub(crate) fn reject_unbufferable_body(
         body: &crate::webcore::body::Value,
         global: &crate::jsc::JSGlobalObject,
@@ -415,9 +401,6 @@ impl Cmd {
         }
     }
 
-    /// `PendingValue::on_receive_value` hook. The producer has already written
-    /// the final `InternalBlob` / `Error` into the Response body before
-    /// invoking `resolve` / `to_error_instance`, so this only has to resume.
     fn on_redirect_body_received(
         ctx: *mut core::ffi::c_void,
         _value: &mut crate::webcore::body::Value,

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -385,7 +385,10 @@ impl Cmd {
         if matches!(interp.as_cmd(this).state, CmdState::BufferingRedirectBody) {
             // SAFETY: same JSC-owned location as above, re-read after the
             // producer callback — which may have resolved the body in place.
-            if !matches!(unsafe { &*body_ptr }, crate::webcore::body::Value::Locked(_)) {
+            if !matches!(
+                unsafe { &*body_ptr },
+                crate::webcore::body::Value::Locked(_)
+            ) {
                 // SAFETY: the producer resolved synchronously and dropped the
                 // hook without firing it (server empty-body path); `ctx` is
                 // still the live heap allocation we hold.

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -401,7 +401,10 @@ impl Cmd {
         }
     }
 
-    fn on_redirect_body_received(ctx: *mut core::ffi::c_void, value: *mut crate::webcore::body::Value) {
+    fn on_redirect_body_received(
+        ctx: *mut core::ffi::c_void,
+        value: *mut crate::webcore::body::Value,
+    ) {
         // SAFETY: `ctx` is the `heap::alloc`'d `RedirectBodyBufferCtx`
         // installed by `try_buffer_redirect_body`; consumed here.
         let mut ctx = unsafe { bun_core::heap::take(ctx.cast::<RedirectBodyBufferCtx>()) };

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -401,10 +401,7 @@ impl Cmd {
         }
     }
 
-    fn on_redirect_body_received(
-        ctx: *mut core::ffi::c_void,
-        _value: &mut crate::webcore::body::Value,
-    ) {
+    fn on_redirect_body_received(ctx: *mut core::ffi::c_void, value: *mut crate::webcore::body::Value) {
         // SAFETY: `ctx` is the `heap::alloc`'d `RedirectBodyBufferCtx`
         // installed by `try_buffer_redirect_body`; consumed here.
         let mut ctx = unsafe { bun_core::heap::take(ctx.cast::<RedirectBodyBufferCtx>()) };
@@ -417,6 +414,22 @@ impl Cmd {
             interp.as_cmd(this).state,
             CmdState::BufferingRedirectBody
         ));
+        // SAFETY: `value` aliases the owning body already written in place by
+        // the producer; no other borrow is live once we return.
+        if let crate::webcore::body::Value::Error(err) = unsafe { &*value } {
+            let global = interp.global_this_ref().expect("buffering only on Js loop");
+            let js_err = err.dupe(global).to_js(global);
+            Builtin::cmd_write_failing_error(
+                interp,
+                this,
+                format_args!(
+                    "bun: failed to read Response body for stdin redirect: {}\n",
+                    js_err.fmt_string(global),
+                ),
+            )
+            .run(interp);
+            return;
+        }
         interp.as_cmd_mut(this).state = CmdState::ExpandingArgs { idx: 0 };
         Yield::Next(this).run(interp);
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5227,6 +5227,19 @@ pub fn write_file_internal(
                                 "ReadableStream has already been used"
                             )));
                         }
+                        // SAFETY: re-borrow after the early-return paths.
+                        let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
+                            unreachable!()
+                        };
+                        if locked.is_disturbed2(global_this) {
+                            destination_blob.detach();
+                            return Err(global_this
+                                .err(
+                                    jsc::ErrorCode::BODY_ALREADY_USED,
+                                    format_args!("Body already used"),
+                                )
+                                .throw());
+                        }
                         let task =
                             bun_core::heap::into_raw(Box::new(WriteFileWaitFromLockedValueTask {
                                 global_this: bun_ptr::BackRef::new(global_this),
@@ -5238,10 +5251,6 @@ pub fn write_file_internal(
                                 promise: jsc::JSPromiseStrong::init(global_this),
                                 mkdirp_if_not_exists: options.mkdirp_if_not_exists.unwrap_or(true),
                             }));
-                        // SAFETY: re-borrow after the early-return paths.
-                        let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
-                            unreachable!()
-                        };
                         locked.task = Some(task.cast::<c_void>());
                         locked.on_receive_value = Some(WriteFileWaitFromLockedValueTask::then_wrap);
                         // SAFETY: `task` was just heap-allocated; consumed in `then_wrap`.

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1817,7 +1817,11 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         // so we can't hold a `match` borrow on `get_body_value()` across it.
         match self.get_body_value() {
             Value::Used => true,
-            Value::Locked(pending) if !pending.action.is_none() => true,
+            Value::Locked(pending)
+                if !pending.action.is_none() || pending.on_receive_value.is_some() =>
+            {
+                true
+            }
             Value::Locked(_) => 'brk: {
                 if let Some(readable) = self.get_body_readable_stream(global_object) {
                     break 'brk check(&readable, global_object);

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -323,9 +323,7 @@ impl PendingValue {
         on_receive: fn(ctx: *mut c_void, value: *mut Value),
     ) -> Option<DeferredStartBuffering> {
         // No producer `task` means nothing will ever call `resolve` on this body.
-        let Some(producer_task) = self.task else {
-            return None;
-        };
+        let producer_task = self.task?;
         if self.readable.has() || self.promise.is_some() || self.on_receive_value.is_some() {
             return None;
         }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -237,7 +237,7 @@ pub struct PendingValue {
     pub task: Option<*mut c_void>,
 
     /// runs after the data is available.
-    pub on_receive_value: Option<fn(ctx: *mut c_void, value: &mut Value)>,
+    pub on_receive_value: Option<fn(ctx: *mut c_void, value: *mut Value)>,
 
     /// conditionally runs when requesting data
     /// used in HTTP server to ignore request bodies unless asked for it
@@ -320,7 +320,7 @@ impl PendingValue {
     pub(crate) fn hook_native_receiver(
         &mut self,
         ctx: *mut c_void,
-        on_receive: fn(ctx: *mut c_void, value: &mut Value),
+        on_receive: fn(ctx: *mut c_void, value: *mut Value),
     ) -> bool {
         // No producer `task` means nothing will ever call `resolve` on this body.
         let Some(producer_task) = self.task else {
@@ -1047,7 +1047,7 @@ impl Value {
             }
 
             if let Some(callback) = locked.on_receive_value.take() {
-                callback(locked.task.unwrap(), new);
+                callback(locked.task.unwrap(), std::ptr::from_mut(new));
                 return Ok(());
             }
 
@@ -1356,7 +1356,7 @@ impl Value {
             if let Some(on_receive_value) = locked.on_receive_value.take() {
                 // `task` is the live request-ctx pointer registered alongside
                 // this callback.
-                on_receive_value(locked.task.unwrap(), self);
+                on_receive_value(locked.task.unwrap(), std::ptr::from_mut(self));
             }
 
             return Ok(());
@@ -2541,9 +2541,12 @@ impl<'a> ValueBufferer<'a> {
         Ok(())
     }
 
-    fn on_receive_value(ctx: *mut c_void, value: &mut Value) {
+    fn on_receive_value(ctx: *mut c_void, value: *mut Value) {
         // SAFETY: ctx was set from `self as *mut Self` in buffer_locked_body_value.
         let sink = unsafe { bun_ptr::callback_ctx::<Self>(ctx) };
+        // SAFETY: `value` is the live `&mut Value` the caller reborrowed into
+        // this callback; uniquely accessed for the duration.
+        let value = unsafe { &mut *value };
         match value {
             Value::Error(err) => {
                 bun_core::scoped_log!(BodyValueBufferer, "onReceiveValue Error");

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -317,6 +317,46 @@ impl PendingValue {
         self.to_any_blob_allow_promise()
     }
 
+    /// Install a native completion hook that fires once the producer (fetch /
+    /// server request) has delivered the full body, and tell that producer to
+    /// start buffering. Used by consumers that need the whole body as bytes
+    /// but are not themselves a JS Promise (`Bun.$` stdin redirect).
+    ///
+    /// Returns `false` when a ReadableStream or another consumer is already
+    /// attached; the caller must go through the stream or reject.
+    ///
+    /// The producer replaces the owning `Body::Value` with the final
+    /// `InternalBlob` / `Error` before invoking `resolve` / `to_error_instance`,
+    /// so when `on_receive` runs the body has already been updated in place and
+    /// the callback only needs to resume its state machine.
+    pub(crate) fn hook_native_receiver(
+        &mut self,
+        ctx: *mut c_void,
+        on_receive: fn(ctx: *mut c_void, value: &mut Value),
+    ) -> bool {
+        // A native producer (fetch tasklet / server request ctx) registers
+        // itself as `task`; without one there is nothing that will call
+        // `resolve` / `to_error_instance`, so the hook would never fire.
+        let Some(producer_task) = self.task else {
+            return false;
+        };
+        if self.readable.has() || self.promise.is_some() || self.on_receive_value.is_some() {
+            return false;
+        }
+        if let Some(on_start_buffering) = self.on_start_buffering.take() {
+            on_start_buffering(producer_task);
+        }
+        self.task = Some(ctx);
+        self.on_receive_value = Some(on_receive);
+        // `task` now names the consumer; the remaining producer-facing hooks
+        // would read it as their own ctx, so they must not fire anymore.
+        self.on_start_streaming = None;
+        self.on_readable_stream_available = None;
+        self.on_stream_cancelled = None;
+        self.on_stream_drained = None;
+        true
+    }
+
     pub(crate) fn is_disturbed<T: BodyOwnerJs>(
         &self,
         global_object: &JSGlobalObject,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -321,17 +321,15 @@ impl PendingValue {
         &mut self,
         ctx: *mut c_void,
         on_receive: fn(ctx: *mut c_void, value: *mut Value),
-    ) -> bool {
+    ) -> Option<DeferredStartBuffering> {
         // No producer `task` means nothing will ever call `resolve` on this body.
         let Some(producer_task) = self.task else {
-            return false;
+            return None;
         };
         if self.readable.has() || self.promise.is_some() || self.on_receive_value.is_some() {
-            return false;
+            return None;
         }
-        if let Some(on_start_buffering) = self.on_start_buffering.take() {
-            on_start_buffering(producer_task);
-        }
+        let on_start_buffering = self.on_start_buffering.take();
         self.task = Some(ctx);
         self.on_receive_value = Some(on_receive);
         // `task` now names the consumer, so the producer-ctx hooks must not fire.
@@ -339,7 +337,10 @@ impl PendingValue {
         self.on_readable_stream_available = None;
         self.on_stream_cancelled = None;
         self.on_stream_drained = None;
-        true
+        Some(DeferredStartBuffering {
+            on_start_buffering,
+            producer_task,
+        })
     }
 
     pub(crate) fn is_disturbed<T: BodyOwnerJs>(
@@ -347,7 +348,7 @@ impl PendingValue {
         global_object: &JSGlobalObject,
         this_value: JSValue,
     ) -> bool {
-        if self.promise.is_some() {
+        if self.promise.is_some() || self.on_receive_value.is_some() {
             return true;
         }
 
@@ -366,7 +367,7 @@ impl PendingValue {
     }
 
     pub(crate) fn is_disturbed2(&self, global_object: &JSGlobalObject) -> bool {
-        if self.promise.is_some() {
+        if self.promise.is_some() || self.on_receive_value.is_some() {
             return true;
         }
 
@@ -449,6 +450,19 @@ impl PendingValue {
                 on_start_buffering(self.task.unwrap());
             }
             Ok(promise_value)
+        }
+    }
+}
+
+pub struct DeferredStartBuffering {
+    on_start_buffering: Option<fn(ctx: *mut c_void)>,
+    producer_task: *mut c_void,
+}
+
+impl DeferredStartBuffering {
+    pub(crate) fn fire(self) {
+        if let Some(f) = self.on_start_buffering {
+            f(self.producer_task);
         }
     }
 }
@@ -802,7 +816,10 @@ impl Value {
                 if let Some(readable) = locked.readable.get(global_this) {
                     return Ok(readable.value);
                 }
-                if locked.promise.is_some() || !locked.action.is_none() {
+                if locked.promise.is_some()
+                    || !locked.action.is_none()
+                    || locked.on_receive_value.is_some()
+                {
                     return ReadableStream::used(global_this);
                 }
                 let mut drain_result = DrainResult::EstimatedSize(0);
@@ -1450,7 +1467,11 @@ impl Value {
             }));
         }
 
-        if locked.promise.is_some() || !locked.action.is_none() || locked.readable.has() {
+        if locked.promise.is_some()
+            || !locked.action.is_none()
+            || locked.readable.has()
+            || locked.on_receive_value.is_some()
+        {
             return Ok(Value::Used);
         }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2537,7 +2537,10 @@ impl<'a> ValueBufferer<'a> {
             unreachable!()
         };
 
-        if locked.on_receive_value.is_some() || locked.task.is_some() {
+        if locked.on_receive_value.is_some() {
+            return Err(crate::Error::StreamAlreadyUsed);
+        }
+        if locked.task.is_some() {
             // ValueBufferer wants the whole body; tell the producer to never
             // pause for JS backpressure before the stream is materialised.
             if let (Some(on_start_buffering), Some(task)) =

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -324,7 +324,11 @@ impl PendingValue {
     ) -> Option<DeferredStartBuffering> {
         // No producer `task` means nothing will ever call `resolve` on this body.
         let producer_task = self.task?;
-        if self.readable.has() || self.promise.is_some() || self.on_receive_value.is_some() {
+        if self.readable.has()
+            || self.promise.is_some()
+            || self.on_receive_value.is_some()
+            || !self.action.is_none()
+        {
             return None;
         }
         let on_start_buffering = self.on_start_buffering.take();

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -317,26 +317,12 @@ impl PendingValue {
         self.to_any_blob_allow_promise()
     }
 
-    /// Install a native completion hook that fires once the producer (fetch /
-    /// server request) has delivered the full body, and tell that producer to
-    /// start buffering. Used by consumers that need the whole body as bytes
-    /// but are not themselves a JS Promise (`Bun.$` stdin redirect).
-    ///
-    /// Returns `false` when a ReadableStream or another consumer is already
-    /// attached; the caller must go through the stream or reject.
-    ///
-    /// The producer replaces the owning `Body::Value` with the final
-    /// `InternalBlob` / `Error` before invoking `resolve` / `to_error_instance`,
-    /// so when `on_receive` runs the body has already been updated in place and
-    /// the callback only needs to resume its state machine.
     pub(crate) fn hook_native_receiver(
         &mut self,
         ctx: *mut c_void,
         on_receive: fn(ctx: *mut c_void, value: &mut Value),
     ) -> bool {
-        // A native producer (fetch tasklet / server request ctx) registers
-        // itself as `task`; without one there is nothing that will call
-        // `resolve` / `to_error_instance`, so the hook would never fire.
+        // No producer `task` means nothing will ever call `resolve` on this body.
         let Some(producer_task) = self.task else {
             return false;
         };
@@ -348,8 +334,7 @@ impl PendingValue {
         }
         self.task = Some(ctx);
         self.on_receive_value = Some(on_receive);
-        // `task` now names the consumer; the remaining producer-facing hooks
-        // would read it as their own ctx, so they must not fire anymore.
+        // `task` now names the consumer, so the producer-ctx hooks must not fire.
         self.on_start_streaming = None;
         self.on_readable_stream_available = None;
         self.on_stream_cancelled = None;

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1317,11 +1317,12 @@ pub struct WriteFileWaitFromLockedValueTask {
 }
 
 impl WriteFileWaitFromLockedValueTask {
-    pub fn then_wrap(this: *mut c_void, value: &mut body::Value) {
-        // SAFETY: `this` is the Box-allocated task registered as `locked.task` below.
+    pub fn then_wrap(this: *mut c_void, value: *mut body::Value) {
+        // SAFETY: `this` is the Box-allocated task registered as `locked.task`
+        // below; `value` is the live `&mut Value` reborrowed by the caller.
         let _ = Self::then(
             NonNull::new(this.cast::<WriteFileWaitFromLockedValueTask>()).unwrap(),
-            value,
+            unsafe { &mut *value },
         );
         // TODO: properly propagate exception upwards
     }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -1317,12 +1317,14 @@ pub struct WriteFileWaitFromLockedValueTask {
 }
 
 impl WriteFileWaitFromLockedValueTask {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn then_wrap(this: *mut c_void, value: *mut body::Value) {
         // SAFETY: `this` is the Box-allocated task registered as `locked.task`
         // below; `value` is the live `&mut Value` reborrowed by the caller.
+        let value = unsafe { &mut *value };
         let _ = Self::then(
             NonNull::new(this.cast::<WriteFileWaitFromLockedValueTask>()).unwrap(),
-            unsafe { &mut *value },
+            value,
         );
         // TODO: properly propagate exception upwards
     }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1785,6 +1785,7 @@ describe("deno_task", () => {
           using dir = tempDir("shell-body-write", {});
           const p = $`cat < ${res}`.quiet();
           p.run();
+          expect(res.bodyUsed).toBe(true);
           expect(() => Bun.write(join(String(dir), "out"), res)).toThrow(/already used/i);
           const { stdout } = await p;
           expect(stdout.length).toBe(500_000);

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1666,6 +1666,148 @@ describe("deno_task", () => {
     TestBuilder.command`BUN_DEBUG_QUIET_LOGS=1 ${BUN} -e ${code} > /dev/null`
       .quiet()
       .runAsTest("bunception redirect /dev/null");
+
+    // A fetch() Response body is delivered as a Locked PendingValue paused
+    // after the first socket read; the shell has to ask the producer to
+    // buffer and wait for it. Before this fix, `use_as_any_blob` substituted
+    // an empty blob, so the command ran on zero bytes and reported success.
+    // `cat` is an external command on POSIX and a builtin on Windows, so this
+    // covers both Cmd::init_subproc_redirections and Builtin::init_redirections.
+    describe("stdin from Request/Response", () => {
+      const countStdin = `process.stdout.write(String((await Bun.stdin.bytes()).length))`;
+
+      async function served(
+        size: number,
+        opts: { chunked?: boolean } = {},
+      ): Promise<[Response, () => void]> {
+        const srv = Bun.serve({
+          port: 0,
+          fetch: () =>
+            opts.chunked
+              ? new Response(
+                  (async function* () {
+                    let sent = 0;
+                    while (sent < size) {
+                      const n = Math.min(50_000, size - sent);
+                      yield Buffer.alloc(n, "x");
+                      sent += n;
+                      await Bun.sleep(1);
+                    }
+                  })(),
+                )
+              : new Response(Buffer.alloc(size, "x")),
+        });
+        const res = await fetch(`http://127.0.0.1:${srv.port}/`);
+        return [res, () => srv.stop(true)];
+      }
+
+      test.each([
+        ["a body that fits the first socket read", 100, {}],
+        ["a body larger than the backpressure window", 500_000, {}],
+        ["a chunked body from a slow origin", 500_000, { chunked: true }],
+      ] as const)("buffers %s", async (_name, size, opts) => {
+        const [res, stop] = await served(size, opts);
+        try {
+          const out = await $`${BUN} -e ${countStdin} < ${res}`.text();
+          expect(out).toBe(String(size));
+        } finally {
+          stop();
+        }
+      });
+
+      test("buffers a body larger than the backpressure window (builtin)", async () => {
+        const [res, stop] = await served(500_000);
+        try {
+          const { stdout } = await $`cat < ${res}`;
+          expect(stdout.length).toBe(500_000);
+        } finally {
+          stop();
+        }
+      });
+
+      test("pipes the buffered body through a pipeline", async () => {
+        const [res, stop] = await served(500_000);
+        try {
+          const out = await $`cat < ${res} | ${BUN} -e ${countStdin}`.text();
+          expect(out).toBe("500000");
+        } finally {
+          stop();
+        }
+      });
+
+      test("marks the body used after redirecting", async () => {
+        const [res, stop] = await served(500_000);
+        try {
+          await $`cat < ${res}`.quiet();
+          expect(res.bodyUsed).toBe(true);
+          await expect($`cat < ${res}`.text()).rejects.toThrow(/already used/i);
+        } finally {
+          stop();
+        }
+      });
+
+      test("accepts a Request body", async () => {
+        const req = new Request("http://x", { method: "POST", body: Buffer.alloc(200_000, "y") });
+        const { stdout } = await $`cat < ${req}`;
+        expect(stdout.length).toBe(200_000);
+      });
+
+      // Bodies that never had a native producer attached, or whose body has
+      // already been taken, have no bytes to buffer; they must throw instead of
+      // running the command on zero bytes.
+      test.each([
+        [
+          "a ReadableStream body",
+          () =>
+            new Response(
+              new ReadableStream({
+                start(c) {
+                  c.enqueue(new TextEncoder().encode("hi"));
+                  c.close();
+                },
+              }),
+            ),
+          /body is a ReadableStream/,
+        ],
+        [
+          "an async-generator body",
+          () =>
+            new Response(
+              (async function* () {
+                yield "hi";
+              })(),
+            ),
+          /body is a ReadableStream/,
+        ],
+        [
+          "an already-consumed body",
+          async () => {
+            const r = new Response("hi");
+            await r.text();
+            return r;
+          },
+          /already used/i,
+        ],
+      ])("rejects %s", async (_name, make, pattern) => {
+        const r = await make();
+        await expect($`cat < ${r}`.text()).rejects.toThrow(pattern);
+      });
+
+      test("stdout redirect to a stream-body Response rejects without the stdin hint", async () => {
+        const body = new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("x"));
+            c.close();
+          },
+        });
+        const err = await $`echo hi > ${new Response(body)}`.text().then(
+          () => null,
+          e => e,
+        );
+        expect(err?.message).toMatch(/body is a ReadableStream/);
+        expect(err?.message).not.toMatch(/Read it first/);
+      });
+    });
   });
 
   describe("pwd", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1694,8 +1694,13 @@ describe("deno_task", () => {
                 )
               : new Response(Buffer.alloc(size, "x")),
         });
-        const res = await fetch(`http://127.0.0.1:${srv.port}/`);
-        return [res, () => srv.stop(true)];
+        try {
+          const res = await fetch(`http://127.0.0.1:${srv.port}/`);
+          return [res, () => srv.stop(true)];
+        } catch (e) {
+          srv.stop(true);
+          throw e;
+        }
       }
 
       test.each([
@@ -1715,7 +1720,7 @@ describe("deno_task", () => {
       test("buffers a body larger than the backpressure window (builtin)", async () => {
         const [res, stop] = await served(500_000);
         try {
-          const { stdout } = await $`cat < ${res}`;
+          const { stdout } = await $`cat < ${res}`.quiet();
           expect(stdout.length).toBe(500_000);
         } finally {
           stop();
@@ -1745,8 +1750,33 @@ describe("deno_task", () => {
 
       test("accepts a Request body", async () => {
         const req = new Request("http://x", { method: "POST", body: Buffer.alloc(200_000, "y") });
-        const { stdout } = await $`cat < ${req}`;
+        const { stdout } = await $`cat < ${req}`.quiet();
         expect(stdout.length).toBe(200_000);
+      });
+
+      // The body can error after `fetch()` resolved (connection reset, short
+      // body). The shell is parked in BufferingRedirectBody at that point, so
+      // the resume path must fail the command rather than leaving the shell
+      // promise pending forever.
+      test("fails the command when the body errors mid-buffer", async () => {
+        await using srv = Bun.listen({
+          port: 0,
+          hostname: "127.0.0.1",
+          socket: {
+            data(socket) {
+              socket.write(
+                "HTTP/1.1 200 OK\r\nContent-Length: 500000\r\nConnection: close\r\n\r\n" +
+                  Buffer.alloc(1000, "x").toString(),
+              );
+              socket.flush();
+              socket.end();
+            },
+          },
+        });
+        const res = await fetch(`http://127.0.0.1:${srv.port}/`);
+        const { exitCode, stderr } = await $`cat < ${res}`.quiet().nothrow();
+        expect(stderr.toString()).toMatch(/failed to read Response body/);
+        expect(exitCode).toBe(1);
       });
 
       // Bodies that never had a native producer attached, or whose body has

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1775,8 +1775,22 @@ describe("deno_task", () => {
         });
         const res = await fetch(`http://127.0.0.1:${srv.port}/`);
         const { exitCode, stderr } = await $`cat < ${res}`.quiet().nothrow();
-        expect(stderr.toString()).toMatch(/failed to read Response body/);
+        expect(stderr.toString()).toMatch(/failed to read body for stdin redirect/);
         expect(exitCode).toBe(1);
+      });
+
+      test("Bun.write on the same body throws and the shell still settles", async () => {
+        const [res, stop] = await served(500_000);
+        try {
+          using dir = tempDir("shell-body-write", {});
+          const p = $`cat < ${res}`.quiet();
+          p.run();
+          expect(() => Bun.write(join(String(dir), "out"), res)).toThrow(/already used/i);
+          const { stdout } = await p;
+          expect(stdout.length).toBe(500_000);
+        } finally {
+          stop();
+        }
       });
 
       // Bodies that never had a native producer attached, or whose body has

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1676,10 +1676,7 @@ describe("deno_task", () => {
     describe("stdin from Request/Response", () => {
       const countStdin = `process.stdout.write(String((await Bun.stdin.bytes()).length))`;
 
-      async function served(
-        size: number,
-        opts: { chunked?: boolean } = {},
-      ): Promise<[Response, () => void]> {
+      async function served(size: number, opts: { chunked?: boolean } = {}): Promise<[Response, () => void]> {
         const srv = Bun.serve({
           port: 0,
           fetch: () =>


### PR DESCRIPTION
## What does this PR do?

``$`cmd < ${await fetch(url)}` `` delivered zero bytes whenever the response body had not finished arriving by the time the shell resolved the redirect: any body larger than the first ~128 KB socket read, or any chunked/slow origin. The command runs on nothing and reports exit 0, so e.g. ``$`gzip < ${resp} > out.gz` `` produces a valid empty archive.

```js
import { $ } from "bun";
const srv = Bun.serve({ port: 0, fetch: () => new Response(Buffer.alloc(500_000, "x")) });
const r = await fetch(`http://127.0.0.1:${srv.port}/`);
console.log((await $`wc -c < ${r}`.text()).trim());
// 1.3.14: 500000
// main:   0
srv.stop(true);
```

Regression since the fetch receive-backpressure coupling (81dfd5996700): the client socket is now paused after the first read until a consumer asks for more, so the body is still `Locked` when the shell reaches it. 1.3.14 buffered the whole body eagerly, so the same code delivered all 500000 bytes.

### Cause

`Cmd::init_subproc_redirections` and `Builtin::init_redirections` call `Body::use_as_any_blob()` on the Response body. For `Value::Locked` with no synchronously-readable source, that falls through to `.unwrap_or(AnyBlob::Blob(Blob::default()))` (src/runtime/webcore/Body.rs), and `Stdio::extract_blob` maps the empty blob to `Stdio::Ignore`. `Value::Used` and `Value::Error` take the same empty-blob fallback.

### Fix

A new `CmdState::BufferingRedirectBody` runs between redirect expansion and argv expansion. When the stdin redirect is a `Request`/`Response` whose body is still `Locked` with a native producer (the fetch tasklet or a server request context) attached:

- `PendingValue::hook_native_receiver` fires `on_start_buffering` with the producer's own task pointer (so the paused fetch socket switches to `BufferAll` and resumes), then installs `on_receive_value` with the shell's resume context. The remaining producer-facing hooks (`on_start_streaming`, `on_stream_cancelled`, ...) are cleared because `task` now names the consumer.
- The command parks in `BufferingRedirectBody` under its own `KeepAlive`.
- When the producer finishes it replaces the body with `InternalBlob` / `Error` and calls `resolve` / `to_error_instance`, which fires the hook; the command resumes and `use_as_any_blob()` now returns the buffered bytes.

Bodies that cannot be buffered natively (a JS-driven `ReadableStream`, an already-consumed body, a stored body error, or a body whose `.body` stream is already in use) now throw instead of being substituted with an empty blob, via `Cmd::reject_unbufferable_body` on both the subproc and builtin paths. `handle_template_value` and the subproc redirect path now use `Body::from_request_or_response`, so `Request` is accepted alongside `Response` (previously ``cat < ${request}`` threw `Invalid JS object used in shell: [object Request]`).

`Body::use_as_any_blob()` itself is unchanged.

### Related

- #35314 is the throw-only variant of the rejection half of this change; this PR keeps real `fetch()` bodies working as they did in 1.3.14 and only throws when there is no native producer to buffer from.
- #30550 implements true `ReadableStream` pumping into shell stdin; once it lands the `Locked` rejection here can route through `Stdio::ReadableStream` instead.

### How did you verify your code works?

`test/js/bun/shell/bunshell.test.ts` under `redirects > stdin from Request/Response`:

- a 100-byte body (fits the first read), a 500 000-byte body (paused by backpressure), and a chunked/slow 500 000-byte body each deliver their full byte count to a spawned `bun -e` counter
- the 500 000-byte body through the `cat` builtin
- the 500 000-byte body through a `cat | bun -e` pipeline
- the body is marked used after the redirect and a second redirect throws `Body already used`
- a `Request` body delivers its full byte count
- a `ReadableStream` body, an async-generator body, and an already-consumed body each reject instead of delivering zero bytes
- `echo hi > ${new Response(stream)}` rejects with the stream-body message and without the stdin hint

```
USE_SYSTEM_BUN=1 bun test bunshell.test.ts -t "stdin from Request/Response"   # 10 fail, 1 pass (small-body control)
bun bd test bunshell.test.ts -t "stdin from Request/Response"                 # 11 pass
bun bd test bunshell.test.ts                                                  # 425 pass, 0 fail
bun bd test test/js/web/fetch/body.test.ts                                    # 348 pass, 0 fail
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->