### PR TITLE
bun build: apply bunfig [serve.static].plugins to CLI bundles

### DIFF
--- a/docs/bundler/fullstack.mdx
+++ b/docs/bundler/fullstack.mdx
@@ -482,8 +482,8 @@ export default myPlugin;
 Bun lazily resolves and loads each plugin and uses them to bundle your routes.
 
 <Note>
-  Plugins live in `bunfig.toml` so that the `bun build` CLI, once it supports them, can know statically which plugins
-  are in use. These plugins work in `Bun.build()`'s JS API, but not yet in the CLI.
+  Plugins live in `bunfig.toml` so they can be discovered statically. The same `[serve.static].plugins` list is also
+  applied when you run `bun build` from the CLI, and plugins can always be passed directly to `Bun.build()`'s JS API.
 </Note>
 
 ## Inline Environment Variables

--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -96,6 +96,12 @@ plugins = ["./my-plugin.ts"]
 bun build ./app.ts --outdir ./out
 ```
 
+<Note>
+  Plugins loaded from `bunfig.toml` run their `onStart`, `onResolve`, `onLoad`, and `onBeforeParse` hooks during `bun
+  build` and `Bun.serve`. The `onEnd` hook is only invoked by `Bun.build()`'s JS API, which produces the `BuildOutput`
+  object that `onEnd` receives.
+</Note>
+
 ## Plugin lifecycle
 
 ### Namespaces

--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -85,6 +85,17 @@ await Bun.build({
 });
 ```
 
+To use a plugin with the `bun build` CLI, export it as the default export of a module and list that module in `bunfig.toml`:
+
+```toml title="bunfig.toml" icon="settings"
+[serve.static]
+plugins = ["./my-plugin.ts"]
+```
+
+```sh terminal icon="terminal"
+bun build ./app.ts --outdir ./out
+```
+
 ## Plugin lifecycle
 
 ### Namespaces

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3750,6 +3750,7 @@ pub mod bv2_impl {
             minify_duration: &mut u64,
             source_code_size: &mut u64,
             fetcher: Option<&DependenciesScanner>,
+            plugins: Option<NonNull<crate::bundle_v2::JSBundlerPlugin>>,
         ) -> Result<BuildResult, Error> {
             let mut this = BundleV2::init(
                 transpiler,
@@ -3760,6 +3761,7 @@ pub mod bv2_impl {
                 None,
                 alloc,
             )?;
+            this.plugins = plugins;
             this.unique_key = generate_unique_key();
 
             // Wrap so every exit path (incl. `?`) hits the cleanup below.

--- a/src/js/builtins/BundlerPlugin.ts
+++ b/src/js/builtins/BundlerPlugin.ts
@@ -47,19 +47,20 @@ interface PluginBuilderExt extends PluginBuilder {
 }
 
 /**
- * Used by Bun.serve() to resolve and load plugins.
+ * Used by Bun.serve() and the `bun build` CLI to resolve and load plugins.
  */
 export function loadAndResolvePluginsForServe(
   this: BundlerPlugin,
   plugins: string[],
   bunfig_folder: string,
   runSetupFn: typeof runSetupFunction,
+  target: BuildConfig["target"],
 ) {
   // Same config as created in HTMLBundle.init
   let config: BuildConfigExt = {
     experimentalCss: true,
     experimentalHtml: true,
-    target: "browser",
+    target: target || "browser",
     root: bunfig_folder,
   };
 

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -606,7 +606,7 @@ extern "C" Bun::JSBundlerPlugin* JSBundlerPlugin__create(Zig::GlobalObject* glob
         target);
 }
 
-extern "C" JSC::EncodedJSValue JSBundlerPlugin__loadAndResolvePluginsForServe(Bun::JSBundlerPlugin* plugin, JSC::EncodedJSValue encodedPlugins, JSC::EncodedJSValue encodedBunfigFolder)
+extern "C" JSC::EncodedJSValue JSBundlerPlugin__loadAndResolvePluginsForServe(Bun::JSBundlerPlugin* plugin, JSC::EncodedJSValue encodedPlugins, JSC::EncodedJSValue encodedBunfigFolder, JSC::EncodedJSValue encodedTarget)
 {
     auto& vm = plugin->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -623,6 +623,7 @@ extern "C" JSC::EncodedJSValue JSBundlerPlugin__loadAndResolvePluginsForServe(Bu
     arguments.append(JSValue::decode(encodedPlugins));
     arguments.append(JSValue::decode(encodedBunfigFolder));
     arguments.append(runSetupFn);
+    arguments.append(JSValue::decode(encodedTarget));
 
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::profiledCall(plugin->globalObject(), ProfilingReason::API, loadAndResolvePluginsForServeBuiltinFn, callData, plugin, arguments)));
 }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1635,6 +1635,7 @@ pub mod js_bundler {
             plugin: &Plugin,
             plugins: JSValue,
             bunfig_folder: JSValue,
+            target: JSValue,
         ) -> JSValue;
     }
 
@@ -1670,6 +1671,7 @@ pub mod js_bundler {
             &self,
             plugins: JSValue,
             bunfig_folder: JSValue,
+            target: JSValue,
         ) -> JSValue;
     }
 
@@ -1761,9 +1763,10 @@ pub mod js_bundler {
             &self,
             plugins: JSValue,
             bunfig_folder: JSValue,
+            target: JSValue,
         ) -> JSValue {
             jsc::mark_binding();
-            JSBundlerPlugin__loadAndResolvePluginsForServe(self, plugins, bunfig_folder)
+            JSBundlerPlugin__loadAndResolvePluginsForServe(self, plugins, bunfig_folder, target)
         }
     }
 

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -569,6 +569,9 @@ impl BuildCommand {
         // `this_transpiler` for the rest of its life. Snapshot every options
         // field read after that point so the borrow checker is satisfied.
         let opt_output_dir: Box<[u8]> = this_transpiler.options.output_dir.clone();
+        let opt_serve_plugins = this_transpiler.options.serve_plugins.clone();
+        let opt_bunfig_path: Box<[u8]> = this_transpiler.options.bunfig_path.clone();
+        let opt_target = this_transpiler.options.target;
         let opt_minify_identifiers = this_transpiler.options.minify_identifiers;
         let opt_minify_whitespace = this_transpiler.options.minify_whitespace;
         let opt_minify_syntax = this_transpiler.options.minify_syntax;
@@ -620,10 +623,30 @@ impl BuildCommand {
                 // resolver subset; bundler-side `entry_naming` is sufficient.
             }
 
-            // Stack-owned Mini event loop so its tasks/concurrent_tasks queues
-            // drop at scope exit; the arena bulk-free skips Drop. Outlives the
-            // BACKREF passed to `generate_from_cli`.
-            let mut event_loop = bun_event_loop::AnyEventLoop::init();
+            // Bundler plugins from bunfig `[serve.static].plugins` need a JS VM +
+            // JS event loop so onLoad/onResolve callbacks can run. Without
+            // plugins the Mini loop is used and no VM is created.
+            let (mut event_loop, plugins) = if let Some(specifiers) =
+                opt_serve_plugins.as_deref().filter(|s| !s.is_empty())
+            {
+                let (vm_ptr, plugin) = load_bundler_plugins(
+                    ctx.args.clone(),
+                    ctx.log,
+                    ctx.runtime_options.smol,
+                    opt_target,
+                    specifiers,
+                    &opt_bunfig_path,
+                );
+                // SAFETY: `vm_ptr` is the unique live VM on this thread;
+                // process-lifetime (exec() never returns).
+                let vm = unsafe { &mut *vm_ptr };
+                (
+                    bun_event_loop::AnyEventLoop::js(vm.event_loop().cast()),
+                    Some(plugin),
+                )
+            } else {
+                (bun_event_loop::AnyEventLoop::init(), None)
+            };
 
             let build_result = match BundleV2::generate_from_cli(
                 this_transpiler,
@@ -634,6 +657,7 @@ impl BuildCommand {
                 &mut minify_duration,
                 &mut input_code_length,
                 fetcher,
+                plugins,
             ) {
                 Ok(r) => r,
                 Err(err) => {
@@ -1137,6 +1161,126 @@ impl BuildCommand {
             ctx.debug.hot_reload == HotReload::Watch,
         );
     }
+}
+
+/// When `[serve.static].plugins` is configured in bunfig, `bun build` spins up a
+/// JS VM so those plugins can participate in bundling. Returns the created VM
+/// (caller keeps it alive for the bundle) and the loaded `JSBundlerPlugin`, or
+/// prints the error and exits.
+///
+/// `#[cold]` so the VM-init body is kept out of the no-plugin fast path's icache
+/// footprint.
+#[cold]
+fn load_bundler_plugins(
+    args: api::TransformOptions,
+    log: *mut bun_ast::Log,
+    smol: bool,
+    target: bun_ast::Target,
+    plugin_specifiers: &[Box<[u8]>],
+    bunfig_path: &[u8],
+) -> (
+    *mut bun_jsc::virtual_machine::VirtualMachine,
+    core::ptr::NonNull<bun_bundler::bundle_v2::JSBundlerPlugin>,
+) {
+    use bun_jsc::virtual_machine::{InitOptions as VmInitOptions, VirtualMachine};
+    use crate::api::js_bundler::{Plugin, PluginJscExt as _};
+    use bun_core::String as BunString;
+
+    bun_jsc::initialize(false);
+    bun_ast::initialize_store();
+
+    let vm_ptr = match VirtualMachine::init(VmInitOptions {
+        transform_options: args,
+        log: core::ptr::NonNull::new(log),
+        smol,
+        mini_mode: smol,
+        is_main_thread: true,
+        ..Default::default()
+    }) {
+        Ok(p) => p,
+        Err(err) => {
+            bun_core::pretty_errorln!(
+                "<r><red>error<r><d>:<r> failed to initialize JavaScript runtime for bundler plugins: {}",
+                err.name()
+            );
+            Global::exit(1);
+        }
+    };
+    // SAFETY: `init` returns the unique freshly-boxed VM on this thread.
+    let vm = unsafe { &mut *vm_ptr };
+    vm.load_extra_env_and_source_code_printer();
+    vm.event_loop_ref().ensure_waker();
+    let global = vm.global();
+
+    // The API lock must be held for every JSC heap access, both during plugin
+    // setup here and while the bundler drives plugin callbacks through the JS
+    // event loop. `exec()` never returns (it diverges via `exit_or_watch`), so
+    // the guard is intentionally never dropped.
+    // SAFETY: `vm.jsc_vm` is the live `JSC::VM*` set in `VirtualMachine::init`.
+    #[allow(clippy::mem_forget)]
+    core::mem::forget(unsafe { (*vm.jsc_vm).get_api_lock() });
+
+    let plugin_target = match target {
+        bun_ast::Target::Bun | bun_ast::Target::BunMacro => bun_jsc::BunPluginTarget::Bun,
+        bun_ast::Target::Node => bun_jsc::BunPluginTarget::Node,
+        _ => bun_jsc::BunPluginTarget::Browser,
+    };
+    let plugin = Plugin::create(global, plugin_target);
+    let plugin_ref = Plugin::opaque_ref(plugin);
+
+    let mut bunstring_array: Vec<BunString> = Vec::with_capacity(plugin_specifiers.len());
+    for spec in plugin_specifiers {
+        bunstring_array.push(BunString::init(&**spec));
+    }
+    let bunfig_folder = bun_paths::resolve_path::dirname::<
+        bun_paths::resolve_path::platform::Auto,
+    >(bunfig_path);
+
+    let fail = |err: bun_jsc::JSValue| -> ! {
+        // SAFETY: `vm_ptr` is the unique live VM on this thread.
+        unsafe { (*vm_ptr).print_error_like_object_to_console(err) };
+        Output::flush();
+        Global::exit(1);
+    };
+
+    let setup = || -> bun_jsc::JsResult<bun_jsc::JSValue> {
+        let plugin_js_array = bun_jsc::bun_string_jsc::to_js_array(global, &bunstring_array)?;
+        let bunfig_folder_js = bun_jsc::bun_string_jsc::create_utf8_for_js(global, bunfig_folder)?;
+        vm.event_loop_mut().enter();
+        let result = bun_jsc::host_fn::from_js_host_call(global, || {
+            plugin_ref.load_and_resolve_plugins_for_serve(plugin_js_array, bunfig_folder_js)
+        });
+        vm.event_loop_mut().exit();
+        result
+    };
+
+    match setup() {
+        Ok(result) => {
+            if let Some(e) = global.try_take_exception() {
+                fail(e);
+            }
+            if !result.is_empty_or_undefined_or_null() {
+                if let Some(promise) = result.as_any_promise() {
+                    promise.set_handled(global.vm());
+                    vm.wait_for_promise(promise);
+                    match promise.unwrap(global.vm(), bun_jsc::PromiseUnwrapMode::MarkHandled) {
+                        bun_jsc::PromiseResult::Pending => unreachable!(),
+                        bun_jsc::PromiseResult::Fulfilled(_) => {}
+                        bun_jsc::PromiseResult::Rejected(err) => fail(err),
+                    }
+                }
+            }
+        }
+        Err(_) => {
+            let e = global.try_take_exception().unwrap_or(bun_jsc::JSValue::UNDEFINED);
+            fail(e);
+        }
+    }
+
+    (
+        vm_ptr,
+        core::ptr::NonNull::new(plugin).expect("Plugin::create returns non-null"),
+    )
 }
 
 fn exit_or_watch(code: u8, watch: bool) -> ! {

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1279,8 +1279,7 @@ fn load_bundler_plugins(
     )
 }
 
-/// Set by [`load_bundler_plugins`] so [`exit_or_watch`] can route the process
-/// exit through the VM's `on_exit`/`global_exit` path when plugins were loaded.
+/// Set by [`load_bundler_plugins`]; [`exit_or_watch`] routes through it.
 static BUILD_PLUGIN_VM: core::sync::atomic::AtomicPtr<bun_jsc::virtual_machine::VirtualMachine> =
     core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
 
@@ -1294,8 +1293,7 @@ fn exit_or_watch(code: u8, watch: bool) -> ! {
     }
     let vm_ptr = BUILD_PLUGIN_VM.swap(core::ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);
     if !vm_ptr.is_null() {
-        // SAFETY: set once from `load_bundler_plugins` on this thread; the VM
-        // is process-lifetime and never otherwise torn down.
+        // SAFETY: set by `load_bundler_plugins` on this thread; process-lifetime.
         let vm = unsafe { &mut *vm_ptr };
         vm.exit_handler.exit_code = code;
         vm.on_exit();

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -623,29 +623,28 @@ impl BuildCommand {
                 // resolver subset; bundler-side `entry_naming` is sufficient.
             }
 
-            // Bundler plugins from bunfig `[serve.static].plugins` need a JS VM +
-            // JS event loop so onLoad/onResolve callbacks can run. Without
-            // plugins the Mini loop is used and no VM is created.
-            let (mut event_loop, plugins) =
-                if let Some(specifiers) = opt_serve_plugins.as_deref().filter(|s| !s.is_empty()) {
-                    let (vm_ptr, plugin) = load_bundler_plugins(
-                        ctx.args.clone(),
-                        ctx.log,
-                        ctx.runtime_options.smol,
-                        opt_target,
-                        specifiers,
-                        &opt_bunfig_path,
-                    );
-                    // SAFETY: `vm_ptr` is the unique live VM on this thread;
-                    // process-lifetime (exec() never returns).
-                    let vm = unsafe { &mut *vm_ptr };
-                    (
-                        bun_event_loop::AnyEventLoop::js(vm.event_loop().cast()),
-                        Some(plugin),
-                    )
-                } else {
-                    (bun_event_loop::AnyEventLoop::init(), None)
-                };
+            // bunfig `[serve.static].plugins` need a JS VM + Js event loop.
+            let (mut event_loop, plugins) = if let Some(specifiers) = opt_serve_plugins
+                .as_deref()
+                .filter(|s| fetcher.is_none() && !s.is_empty())
+            {
+                let (vm_ptr, plugin) = load_bundler_plugins(
+                    ctx.args.clone(),
+                    ctx.log,
+                    ctx.runtime_options.smol,
+                    opt_target,
+                    specifiers,
+                    &opt_bunfig_path,
+                );
+                // SAFETY: unique live VM on this thread; process-lifetime.
+                let vm = unsafe { &mut *vm_ptr };
+                (
+                    bun_event_loop::AnyEventLoop::js(vm.event_loop().cast()),
+                    Some(plugin),
+                )
+            } else {
+                (bun_event_loop::AnyEventLoop::init(), None)
+            };
 
             let build_result = match BundleV2::generate_from_cli(
                 this_transpiler,
@@ -1162,13 +1161,7 @@ impl BuildCommand {
     }
 }
 
-/// When `[serve.static].plugins` is configured in bunfig, `bun build` spins up a
-/// JS VM so those plugins can participate in bundling. Returns the created VM
-/// (caller keeps it alive for the bundle) and the loaded `JSBundlerPlugin`, or
-/// prints the error and exits.
-///
-/// `#[cold]` so the VM-init body is kept out of the no-plugin fast path's icache
-/// footprint.
+/// Start a JS VM, load each bunfig plugin, and return the `JSBundlerPlugin`.
 #[cold]
 fn load_bundler_plugins(
     args: api::TransformOptions,
@@ -1210,19 +1203,17 @@ fn load_bundler_plugins(
     vm.load_extra_env_and_source_code_printer();
     vm.event_loop_ref().ensure_waker();
     let global = vm.global();
+    BUILD_PLUGIN_VM.store(vm_ptr, core::sync::atomic::Ordering::Relaxed);
 
-    // The API lock must be held for every JSC heap access, both during plugin
-    // setup here and while the bundler drives plugin callbacks through the JS
-    // event loop. `exec()` never returns (it diverges via `exit_or_watch`), so
-    // the guard is intentionally never dropped.
+    // Held for the rest of the process (`exec()` diverges via `exit_or_watch`).
     // SAFETY: `vm.jsc_vm` is the live `JSC::VM*` set in `VirtualMachine::init`.
     #[allow(clippy::mem_forget)]
     core::mem::forget(unsafe { (*vm.jsc_vm).get_api_lock() });
 
-    let plugin_target = match target {
-        bun_ast::Target::Bun | bun_ast::Target::BunMacro => bun_jsc::BunPluginTarget::Bun,
-        bun_ast::Target::Node => bun_jsc::BunPluginTarget::Node,
-        _ => bun_jsc::BunPluginTarget::Browser,
+    let (plugin_target, target_name): (bun_jsc::BunPluginTarget, &[u8]) = match target {
+        bun_ast::Target::Bun | bun_ast::Target::BunMacro => (bun_jsc::BunPluginTarget::Bun, b"bun"),
+        bun_ast::Target::Node => (bun_jsc::BunPluginTarget::Node, b"node"),
+        _ => (bun_jsc::BunPluginTarget::Browser, b"browser"),
     };
     let plugin = Plugin::create(global, plugin_target);
     let plugin_ref = Plugin::opaque_ref(plugin);
@@ -1238,15 +1229,20 @@ fn load_bundler_plugins(
         // SAFETY: `vm_ptr` is the unique live VM on this thread.
         unsafe { (*vm_ptr).print_error_like_object_to_console(err) };
         Output::flush();
-        Global::exit(1);
+        exit_or_watch(1, false);
     };
 
     let setup = || -> bun_jsc::JsResult<bun_jsc::JSValue> {
         let plugin_js_array = bun_jsc::bun_string_jsc::to_js_array(global, &bunstring_array)?;
         let bunfig_folder_js = bun_jsc::bun_string_jsc::create_utf8_for_js(global, bunfig_folder)?;
+        let target_js = bun_jsc::bun_string_jsc::create_utf8_for_js(global, target_name)?;
         vm.event_loop_mut().enter();
         let result = bun_jsc::host_fn::from_js_host_call(global, || {
-            plugin_ref.load_and_resolve_plugins_for_serve(plugin_js_array, bunfig_folder_js)
+            plugin_ref.load_and_resolve_plugins_for_serve(
+                plugin_js_array,
+                bunfig_folder_js,
+                target_js,
+            )
         });
         vm.event_loop_mut().exit();
         result
@@ -1283,6 +1279,11 @@ fn load_bundler_plugins(
     )
 }
 
+/// Set by [`load_bundler_plugins`] so [`exit_or_watch`] can route the process
+/// exit through the VM's `on_exit`/`global_exit` path when plugins were loaded.
+static BUILD_PLUGIN_VM: core::sync::atomic::AtomicPtr<bun_jsc::virtual_machine::VirtualMachine> =
+    core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
+
 fn exit_or_watch(code: u8, watch: bool) -> ! {
     if watch {
         // the watcher thread will exit the process. `std::thread::sleep`
@@ -1290,6 +1291,15 @@ fn exit_or_watch(code: u8, watch: bool) -> ! {
         // (the stdlib loops internally where the OS primitive is narrower),
         // so this parks the thread for ~584 years — effectively forever.
         std::thread::sleep(std::time::Duration::from_secs(u64::MAX / 1_000_000_000));
+    }
+    let vm_ptr = BUILD_PLUGIN_VM.swap(core::ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);
+    if !vm_ptr.is_null() {
+        // SAFETY: set once from `load_bundler_plugins` on this thread; the VM
+        // is process-lifetime and never otherwise torn down.
+        let vm = unsafe { &mut *vm_ptr };
+        vm.exit_handler.exit_code = code;
+        vm.on_exit();
+        vm.global_exit();
     }
     Global::exit(u32::from(code));
 }

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -626,27 +626,26 @@ impl BuildCommand {
             // Bundler plugins from bunfig `[serve.static].plugins` need a JS VM +
             // JS event loop so onLoad/onResolve callbacks can run. Without
             // plugins the Mini loop is used and no VM is created.
-            let (mut event_loop, plugins) = if let Some(specifiers) =
-                opt_serve_plugins.as_deref().filter(|s| !s.is_empty())
-            {
-                let (vm_ptr, plugin) = load_bundler_plugins(
-                    ctx.args.clone(),
-                    ctx.log,
-                    ctx.runtime_options.smol,
-                    opt_target,
-                    specifiers,
-                    &opt_bunfig_path,
-                );
-                // SAFETY: `vm_ptr` is the unique live VM on this thread;
-                // process-lifetime (exec() never returns).
-                let vm = unsafe { &mut *vm_ptr };
-                (
-                    bun_event_loop::AnyEventLoop::js(vm.event_loop().cast()),
-                    Some(plugin),
-                )
-            } else {
-                (bun_event_loop::AnyEventLoop::init(), None)
-            };
+            let (mut event_loop, plugins) =
+                if let Some(specifiers) = opt_serve_plugins.as_deref().filter(|s| !s.is_empty()) {
+                    let (vm_ptr, plugin) = load_bundler_plugins(
+                        ctx.args.clone(),
+                        ctx.log,
+                        ctx.runtime_options.smol,
+                        opt_target,
+                        specifiers,
+                        &opt_bunfig_path,
+                    );
+                    // SAFETY: `vm_ptr` is the unique live VM on this thread;
+                    // process-lifetime (exec() never returns).
+                    let vm = unsafe { &mut *vm_ptr };
+                    (
+                        bun_event_loop::AnyEventLoop::js(vm.event_loop().cast()),
+                        Some(plugin),
+                    )
+                } else {
+                    (bun_event_loop::AnyEventLoop::init(), None)
+                };
 
             let build_result = match BundleV2::generate_from_cli(
                 this_transpiler,
@@ -1182,9 +1181,9 @@ fn load_bundler_plugins(
     *mut bun_jsc::virtual_machine::VirtualMachine,
     core::ptr::NonNull<bun_bundler::bundle_v2::JSBundlerPlugin>,
 ) {
-    use bun_jsc::virtual_machine::{InitOptions as VmInitOptions, VirtualMachine};
     use crate::api::js_bundler::{Plugin, PluginJscExt as _};
     use bun_core::String as BunString;
+    use bun_jsc::virtual_machine::{InitOptions as VmInitOptions, VirtualMachine};
 
     bun_jsc::initialize(false);
     bun_ast::initialize_store();
@@ -1232,9 +1231,8 @@ fn load_bundler_plugins(
     for spec in plugin_specifiers {
         bunstring_array.push(BunString::init(&**spec));
     }
-    let bunfig_folder = bun_paths::resolve_path::dirname::<
-        bun_paths::resolve_path::platform::Auto,
-    >(bunfig_path);
+    let bunfig_folder =
+        bun_paths::resolve_path::dirname::<bun_paths::resolve_path::platform::Auto>(bunfig_path);
 
     let fail = |err: bun_jsc::JSValue| -> ! {
         // SAFETY: `vm_ptr` is the unique live VM on this thread.
@@ -1272,7 +1270,9 @@ fn load_bundler_plugins(
             }
         }
         Err(_) => {
-            let e = global.try_take_exception().unwrap_or(bun_jsc::JSValue::UNDEFINED);
+            let e = global
+                .try_take_exception()
+                .unwrap_or(bun_jsc::JSValue::UNDEFINED);
             fail(e);
         }
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1038,7 +1038,11 @@ impl ServePlugins {
                 ServePluginsState::Pending { plugin, .. } => plugin.as_ref(),
                 _ => unreachable!(),
             }
-            .load_and_resolve_plugins_for_serve(plugin_js_array, bunfig_folder_bunstr)
+            .load_and_resolve_plugins_for_serve(
+                plugin_js_array,
+                bunfig_folder_bunstr,
+                jsc::JSValue::UNDEFINED,
+            )
         })?;
         global.bun_vm().event_loop_mut().exit();
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -466,6 +466,133 @@ test("multi-entry build writes each entry point into the output directory", asyn
   expect(b).toContain('"B"');
 });
 
+// https://github.com/oven-sh/bun/issues/7138
+describe("bunfig [serve.static].plugins", () => {
+  const pluginSource = `
+    import type { BunPlugin } from "bun";
+    const p: BunPlugin = {
+      name: "myext",
+      setup(build) {
+        build.onResolve({ filter: /^virtual:hello$/ }, () => {
+          return { path: "hello", namespace: "virtual" };
+        });
+        build.onLoad({ filter: /.*/, namespace: "virtual" }, () => {
+          return { contents: 'export default "RESOLVED";', loader: "js" };
+        });
+        build.onLoad({ filter: /\\.myext$/ }, async (args) => {
+          const text = await Bun.file(args.path).text();
+          return {
+            contents: "export default " + JSON.stringify(text.trim()) + ";",
+            loader: "js",
+          };
+        });
+      },
+    };
+    export default p;
+  `;
+
+  test("onLoad plugin runs for bun build", async () => {
+    using dir = tempDir("build-cli-plugin-onload", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": pluginSource,
+      "data.myext": "hello from loader",
+      "entry.ts": `import msg from "./data.myext";\nconsole.log(msg);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--outdir", "out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const out = await Bun.file(path.join(String(dir), "out", "entry.js")).text();
+    expect(out).toContain('"hello from loader"');
+    // Without the plugin the bundler would emit data.myext as an asset file and
+    // list it in the build summary.
+    expect(stdout).not.toContain("asset");
+  });
+
+  test("onResolve plugin runs for bun build", async () => {
+    using dir = tempDir("build-cli-plugin-onresolve", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": pluginSource,
+      "entry.ts": `import msg from "virtual:hello";\nconsole.log(msg);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--outdir", "out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const out = await Bun.file(path.join(String(dir), "out", "entry.js")).text();
+    expect(out).toContain('"RESOLVED"');
+  });
+
+  test(
+    "onLoad plugin runs for bun build --compile",
+    async () => {
+      using dir = tempDir("build-cli-plugin-compile", {
+        "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+        "plugin.ts": pluginSource,
+        "data.myext": "compiled via plugin",
+        "entry.ts": `import msg from "./data.myext";\nconsole.log(msg);`,
+      });
+      const outfile = path.join(String(dir), isWindows ? "compiled.exe" : "compiled");
+      {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "build", "entry.ts", "--compile", "--outfile", outfile],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+          stdout: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+      }
+      {
+        await using proc = Bun.spawn({
+          cmd: [outfile],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+          stdout: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("compiled via plugin\n");
+        expect(exitCode).toBe(0);
+      }
+    },
+    60_000,
+  );
+
+  test("failed plugin load exits non-zero", async () => {
+    using dir = tempDir("build-cli-plugin-error", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": `throw new Error("plugin load failed");`,
+      "entry.ts": `console.log("unreachable");`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--outdir", "out"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("plugin load failed");
+    expect(exitCode).toBe(1);
+  });
+});
+
 describe("CLI argument error messages", () => {
   test("--format with an unrecognized value echoes the value back", async () => {
     using dir = tempDir("build-format-err", { "in.js": "console.log(1)" });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -535,44 +535,40 @@ describe("bunfig [serve.static].plugins", () => {
     expect(out).toContain('"RESOLVED"');
   });
 
-  test(
-    "onLoad plugin runs for bun build --compile",
-    async () => {
-      using dir = tempDir("build-cli-plugin-compile", {
-        "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
-        "plugin.ts": pluginSource,
-        "data.myext": "compiled via plugin",
-        "entry.ts": `import msg from "./data.myext";\nconsole.log(msg);`,
+  test("onLoad plugin runs for bun build --compile", async () => {
+    using dir = tempDir("build-cli-plugin-compile", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": pluginSource,
+      "data.myext": "compiled via plugin",
+      "entry.ts": `import msg from "./data.myext";\nconsole.log(msg);`,
+    });
+    const outfile = path.join(String(dir), isWindows ? "compiled.exe" : "compiled");
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "entry.ts", "--compile", "--outfile", outfile],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
       });
-      const outfile = path.join(String(dir), isWindows ? "compiled.exe" : "compiled");
-      {
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "build", "entry.ts", "--compile", "--outfile", outfile],
-          env: bunEnv,
-          cwd: String(dir),
-          stderr: "pipe",
-          stdout: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(exitCode).toBe(0);
-      }
-      {
-        await using proc = Bun.spawn({
-          cmd: [outfile],
-          env: bunEnv,
-          cwd: String(dir),
-          stderr: "pipe",
-          stdout: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(stdout).toBe("compiled via plugin\n");
-        expect(exitCode).toBe(0);
-      }
-    },
-    60_000,
-  );
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+    {
+      await using proc = Bun.spawn({
+        cmd: [outfile],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("compiled via plugin\n");
+      expect(exitCode).toBe(0);
+    }
+  }, 60_000);
 
   test("failed plugin load exits non-zero", async () => {
     using dir = tempDir("build-cli-plugin-error", {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -515,6 +515,26 @@ describe("bunfig [serve.static].plugins", () => {
     expect(stdout).not.toContain("asset");
   });
 
+  test("onLoad plugin runs when bundling to stdout", async () => {
+    using dir = tempDir("build-cli-plugin-stdout", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": pluginSource,
+      "data.myext": "from stdout loader",
+      "entry.ts": `import msg from "./data.myext";\nconsole.log(msg);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain('"from stdout loader"');
+    expect(exitCode).toBe(0);
+  });
+
   test("onResolve plugin runs for bun build", async () => {
     using dir = tempDir("build-cli-plugin-onresolve", {
       "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
@@ -533,6 +553,42 @@ describe("bunfig [serve.static].plugins", () => {
     expect(exitCode).toBe(0);
     const out = await Bun.file(path.join(String(dir), "out", "entry.js")).text();
     expect(out).toContain('"RESOLVED"');
+  });
+
+  test.each([
+    ["bun", "bun"],
+    ["node", "node"],
+    ["browser", "browser"],
+    [undefined, "browser"],
+  ] as const)("build.config.target reflects --target=%s", async (flag, expected) => {
+    using dir = tempDir("build-cli-plugin-target", {
+      "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+      "plugin.ts": `
+        export default {
+          name: "check-target",
+          setup(build) {
+            build.onLoad({ filter: /\\.tgt$/ }, () => ({
+              contents: "export default " + JSON.stringify(build.config.target),
+              loader: "js",
+            }));
+          },
+        };
+      `,
+      "x.tgt": "",
+      "entry.ts": `import t from "./x.tgt";\nconsole.log(t);`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--outdir", "out", ...(flag ? ["--target", flag] : [])],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const out = await Bun.file(path.join(String(dir), "out", "entry.js")).text();
+    expect(out).toContain(JSON.stringify(expected));
   });
 
   test("onLoad plugin runs for bun build --compile", async () => {


### PR DESCRIPTION
Fixes #7138.

## Repro

```toml
# bunfig.toml
[serve.static]
plugins = ["./plugin.ts"]
```
```ts
// plugin.ts
export default {
  name: "myext",
  setup(build) {
    build.onLoad({ filter: /\.myext$/ }, async (args) => ({
      contents: "export default " + JSON.stringify((await Bun.file(args.path).text()).trim()),
      loader: "js",
    }));
  },
};
```
```ts
// entry.ts
import msg from "./data.myext";
console.log(msg);
```

Before, `bun build entry.ts --outdir out` ignores the plugin and emits `data.myext` as an asset:

```js
var data_default = "./data-qzxxsyds.myext";
console.log(data_default);
```

After, the plugin's `onLoad` runs and the file is inlined:

```js
var data_default = "hello from loader";
console.log(data_default);
```

## Cause

The `bun build` CLI (`src/runtime/cli/build_command.rs`) ran with no JavaScript VM and a Mini event loop, so it could never execute bundler plugin callbacks. `[serve.static].plugins` was already parsed into `options.serve_plugins` for every command, but the CLI bundle path never looked at it. `BundleV2::generate_from_cli` hardcoded `plugins: None`.

The docs for `[serve.static].plugins` already said "so that the `bun build` CLI, once it supports them, can know statically which plugins are in use"; this closes that gap.

## Fix

When `[serve.static].plugins` is non-empty, `bun build` now:

1. starts a `VirtualMachine` on the main thread (same init sequence as `bun run`) and acquires the JSC API lock for the rest of the process;
2. creates a `JSBundlerPlugin` targeted at the bundle's `--target`, resolves/imports each listed module, and runs `setup()` via the existing `loadAndResolvePluginsForServe` builtin (the same loader `Bun.serve` uses), blocking on the returned promise with `vm.wait_for_promise`;
3. passes the loaded plugin plus an `AnyEventLoop::Js` wrapper of `vm.event_loop()` into `generate_from_cli`, so `wait_for_parse()` ticks the JS loop and drains onLoad/onResolve callbacks enqueued from worker threads.

`generate_from_cli` gains a `plugins` parameter and sets it on the `BundleV2` after `init()`, mirroring what the `Bun.build()` completion task and bake production already do. With no plugins configured, no VM is created and the existing Mini-loop path is unchanged.

A plugin module that fails to resolve, import, or validate prints the error and exits with code 1.

Works with `--compile` and `--outdir`. `--watch` re-execs on file change as before, so plugins are reloaded on each rebuild.

## Verification

New tests in `test/bundler/cli.test.ts` under `bunfig [serve.static].plugins`:

- `onLoad` plugin runs for `bun build` (the `.myext` file is inlined, not emitted as an asset)
- `onResolve` + namespaced `onLoad` plugin resolves a `virtual:` import
- plugin runs for `bun build --compile`; the compiled executable prints the plugin-loaded content
- a plugin that throws during import fails the build with exit code 1

All four fail on the released build and pass with this change. `bundler_plugin.test.ts` and `serve-plugins-dev-server.test.ts` are unchanged.

Docs in `bundler/plugins.mdx` now mention the bunfig key for CLI builds, and the "not yet in the CLI" note in `bundler/fullstack.mdx` is updated.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->