### PR TITLE
Bun.serve: close the connection after an async handler's Connection: close response

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -583,9 +583,8 @@ private:
         auto returnedData = result.returnedData;
         /* We need to uncork in all cases, except for nullptr (closed socket, or upgraded socket) */
         if (returnedData != nullptr) {
-            /* Mark that we are no longer parsing Http. httpResponseData is only
-             * live when the socket was neither closed nor upgraded in the
-             * handler (both destroy it). */
+            /* Mark that we are no longer parsing Http (inside the same liveness
+             * guard every other httpResponseData deref below already sits in). */
             httpResponseData->isParsingHttp = false;
             /* We don't want open sockets to keep the event loop alive between HTTP requests */
             us_socket_unref((us_socket_t *) returnedData);
@@ -646,6 +645,12 @@ private:
 
             /* Return the new upgraded websocket */
             return (us_socket_t *) asyncSocket;
+        }
+
+        /* returnedData was nullptr without close or upgrade (the lambdas'
+         * HTTP_NODE_PARSING_STOPPED / us_socket_is_shut_down early-returns). */
+        if (!us_socket_is_closed(s)) {
+            httpResponseData->isParsingHttp = false;
         }
 
         /* It is okay to uncork a closed socket and we need to */

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -310,7 +310,7 @@ private:
         ((AsyncSocket<SSL> *) s)->cork();
 
         /* Mark that we are inside the parser now */
-        httpContextData->flags.isParsingHttp = true;
+        httpResponseData->isParsingHttp = true;
         httpResponseData->isIdle = false;
 
         /* node:http compat: maintain the headers/request timeout window (see
@@ -548,8 +548,6 @@ private:
 
         auto httpErrorStatusCode = result.httpErrorStatusCode();
 
-        /* Mark that we are no longer parsing Http */
-        httpContextData->flags.isParsingHttp = false;
         /* If we got fullptr that means the parser wants us to close the socket from error (same as calling the errorHandler) */
         if (httpErrorStatusCode) {
             /* node:http compat: parse errors surface as the server's 'clientError'
@@ -583,6 +581,11 @@ private:
         auto returnedData = result.returnedData;
         /* We need to uncork in all cases, except for nullptr (closed socket, or upgraded socket) */
         if (returnedData != nullptr) {
+            /* Mark that we are no longer parsing Http. httpResponseData is only
+             * live when the socket was neither closed nor upgraded in the
+             * handler (both destroy it); every other branch below that still
+             * dereferences it is already gated on returnedData the same way. */
+            httpResponseData->isParsingHttp = false;
             /* We don't want open sockets to keep the event loop alive between HTTP requests */
             us_socket_unref((us_socket_t *) returnedData);
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -557,6 +557,8 @@ private:
              * parsing further requests on this connection. */
             if (IsNodeHttp && httpContextData->onClientError) {
                 httpResponseData->state |= HttpResponseData<SSL>::HTTP_NODE_PARSING_STOPPED;
+                /* Cleared before onClientError, which may close the socket. */
+                httpResponseData->isParsingHttp = false;
                 httpContextData->onClientError(SSL, s, result.parserError, data, length);
                 if (!us_socket_is_closed(s)) {
                     /* Balance the parsing ref taken at the top of onData (the
@@ -583,8 +585,7 @@ private:
         if (returnedData != nullptr) {
             /* Mark that we are no longer parsing Http. httpResponseData is only
              * live when the socket was neither closed nor upgraded in the
-             * handler (both destroy it); every other branch below that still
-             * dereferences it is already gated on returnedData the same way. */
+             * handler (both destroy it). */
             httpResponseData->isParsingHttp = false;
             /* We don't want open sockets to keep the event loop alive between HTTP requests */
             us_socket_unref((us_socket_t *) returnedData);

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -28,7 +28,6 @@ template<bool> struct HttpResponse;
 struct HttpRequest;
 
 struct HttpFlags {
-    bool isParsingHttp: 1 = false;
     bool rejectUnauthorized: 1 = false;
     bool usingCustomExpectHandler: 1 = false;
     bool requireHostHeader: 1 = true;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -157,9 +157,8 @@ public:
             /* We can only write the header once */
             if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_END_CALLED))) {
 
-                /* RFC 9112 9.6: a server that closes SHOULD send the close
-                 * connection option. Skipped once the body started or when the
-                 * application already wrote its own Connection header. */
+                /* RFC 9112 9.6: echo the close option unless the body started
+                 * or the application already wrote a Connection header. */
                 if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED | HttpResponseData<SSL>::HTTP_WROTE_CONNECTION_HEADER))) {
                     writeHeader("Connection", "close");
                 }
@@ -268,7 +267,9 @@ public:
             /* Remove onAborted function if we reach the end */
             if (httpResponseData->offset == totalSize) {
                 httpResponseData->markDone(this);
-                uncorkAndCloseIfNeeded(httpResponseData, keepCorked);
+                if (uncorkAndCloseIfNeeded(httpResponseData, keepCorked)) {
+                    return true;
+                }
             }
 
             return success;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -96,6 +96,37 @@ public:
         getHttpResponseData()->state |= HttpResponseData<SSL>::HTTP_WROTE_DATE_HEADER;
     }
 
+    /* Uncorks a corked end, then closes if the response is done and flagged
+     * close; returns true when the socket was closed. While the parser is
+     * running on THIS socket, the close defers to onData's tail so the body
+     * is still consumed and validated. */
+    bool uncorkAndCloseIfNeeded(HttpResponseData<SSL> *httpResponseData, bool keepCorked) {
+        if (Super::isCorked()) {
+            if (keepCorked) {
+                return false;
+            }
+            this->uncork();
+        }
+
+        if (httpResponseData->isParsingHttp) {
+            return false;
+        }
+
+        if (httpResponseData->shouldCloseConnection()) {
+            if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
+                if (((AsyncSocket<SSL> *) this)->hasFullyDrained()) {
+                    ((AsyncSocket<SSL> *) this)->shutdown();
+                    /* We need to force close after sending FIN since we want to hinder
+                     * clients from keeping to send their huge data */
+                    ((AsyncSocket<SSL> *) this)->close();
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     /* Returns true on success, indicating that it might be feasible to write more data.
      * Will start timeout if stream reaches totalSize or write failure.
      * keepCorked: if true, skip the trailing uncork so the caller can batch
@@ -126,12 +157,10 @@ public:
             /* We can only write the header once */
             if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_END_CALLED))) {
 
-                /* HTTP 1.1 must send this back unless the client already sent it to us.
-                * It is a connection close when either of the two parties say so but the
-                * one party must tell the other one so.
-                *
-                * This check also serves to limit writing the header only once. */
-                if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE) == 0 && !(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED))) {
+                /* RFC 9112 9.6: a server that closes SHOULD send the close
+                 * connection option. Skipped once the body started or when the
+                 * application already wrote its own Connection header. */
+                if (!(httpResponseData->state & (HttpResponseData<SSL>::HTTP_WRITE_CALLED | HttpResponseData<SSL>::HTTP_WROTE_CONNECTION_HEADER))) {
                     writeHeader("Connection", "close");
                 }
 
@@ -187,21 +216,8 @@ public:
             }
             httpResponseData->markDone(this);
 
-            /* We need to check if we should close this socket here now */
-            if (!Super::isCorked()) {
-                if (httpResponseData->shouldCloseConnection()) {
-                    if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                        if (((AsyncSocket<SSL> *) this)->hasFullyDrained()) {
-                            ((AsyncSocket<SSL> *) this)->shutdown();
-                            /* We need to force close after sending FIN since we want to hinder
-                                * clients from keeping to send their huge data */
-                            ((AsyncSocket<SSL> *) this)->close();
-                            return true;
-                        }
-                    }
-                }
-            } else if (!keepCorked) {
-                this->uncork();
+            if (uncorkAndCloseIfNeeded(httpResponseData, keepCorked)) {
+                return true;
             }
 
             /* tryEnd can never fail when in chunked mode, since we do not have tryWrite (yet), only write */
@@ -252,22 +268,7 @@ public:
             /* Remove onAborted function if we reach the end */
             if (httpResponseData->offset == totalSize) {
                 httpResponseData->markDone(this);
-
-                /* We need to check if we should close this socket here now */
-                if (!Super::isCorked()) {
-                    if (httpResponseData->shouldCloseConnection()) {
-                        if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_RESPONSE_PENDING) == 0) {
-                            if (((AsyncSocket<SSL> *) this)->hasFullyDrained()) {
-                                ((AsyncSocket<SSL> *) this)->shutdown();
-                                /* We need to force close after sending FIN since we want to hinder
-                                * clients from keeping to send their huge data */
-                                ((AsyncSocket<SSL> *) this)->close();
-                            }
-                        }
-                    }
-                }  else if (!keepCorked) {
-                    this->uncork();
-                }
+                uncorkAndCloseIfNeeded(httpResponseData, keepCorked);
             }
 
             return success;
@@ -372,6 +373,8 @@ public:
         BackPressure backpressure(std::move(((AsyncSocketData<SSL> *) responseData)->buffer));
 
         auto* socketData = responseData->socketData;
+        /* Captured before ~HttpResponseData and adopt (both invalidate it). */
+        bool isParsingHttp = responseData->isParsingHttp;
         HttpContextData<SSL> *httpContextData = httpContext->getSocketContextData();
 
         /* Destroy HttpResponseData (the IsNodeHttp=true type on node:http
@@ -412,7 +415,7 @@ public:
         }
 
         /* We should only mark this if inside the parser; if upgrading "async" we cannot set this */
-        if (httpContextData->flags.isParsingHttp) {
+        if (isParsingHttp) {
             /* We need to tell the Http parser that we changed socket */
             httpContextData->upgradedWebSocket = webSocket;
         }

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -143,6 +143,10 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * into the shared word so the shared response-end path (internalEnd) never
          * has to touch the node-only field. */
         HTTP_NODE_HAS_RESPONSE_TRAILERS = 1 << 16,
+        /* The application already wrote a Connection header (Bun.serve's
+         * Response headers, or node:http's _storeHeader which always writes
+         * one); suppresses the automatic one in internalEnd. */
+        HTTP_WROTE_CONNECTION_HEADER = 1 << 17,
 
         /* Bits that describe the connection rather than the response in flight.
          * There is one HttpResponseData per socket, reused by every request on a
@@ -197,6 +201,10 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     /* The parser writes this through a bool& (getHeaders / consumePostPadded),
      * so it cannot live in `state`. */
     bool isConnectRequest = false;
+    /* Brackets one onData call on THIS socket (can span several pipelined
+     * requests). Not a `state` bit: resetResponseState would clear it
+     * mid-parse. */
+    bool isParsingHttp = false;
 
     /* Chunk-extension bytes consumed on the current chunk-size line, reset per
      * chunk (llhttp's on_chunk_header); capped at MAX_CHUNK_EXTENSION_SIZE for

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -830,11 +830,9 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
         }
 
+        // Prevent automatic Connection: close insertion when user provides one
         if (header.key == WebCore::HTTPHeaderName::Connection) {
-            // Prevent automatic Connection: close insertion when user provides one
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONNECTION_HEADER;
-            // RFC 9112 §9.6: a server that sends the "close" connection option
-            // MUST close after the response.
             if (connectionValueHasClose(value)) {
                 data->state |= uWS::HttpResponseData<isSSL>::HTTP_CONNECTION_CLOSE;
             }
@@ -941,10 +939,9 @@ static bool NodeHTTPServer__writeHead(
     }
     response->writeStatus(std::string_view(statusMessage, statusMessageLength));
 
-    // node:http's ServerResponse owns the Date header entirely (it honors
-    // res.sendDate / removeHeader("date") in JS), so never let uWS write its
-    // own Date header for these responses. It owns the Connection header the
-    // same way (_storeHeader always decides and writes one).
+    // node:http's ServerResponse owns the Date and Connection headers entirely
+    // (it honors res.sendDate / removeHeader in JS, and _storeHeader always
+    // writes a Connection line), so never let uWS write its own.
     response->getHttpResponseData()->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER
         | uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONNECTION_HEADER;
 

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -830,12 +830,14 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
             data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_TRANSFER_ENCODING_HEADER;
         }
 
-        // RFC 9112 §9.6: a server that sends the "close" connection option MUST
-        // close the connection after the response. Mark the uWS state so
-        // end()/tryEnd() shut the socket down instead of returning it to the
-        // keep-alive pool.
-        if (header.key == WebCore::HTTPHeaderName::Connection && connectionValueHasClose(value)) {
-            data->state |= uWS::HttpResponseData<isSSL>::HTTP_CONNECTION_CLOSE;
+        if (header.key == WebCore::HTTPHeaderName::Connection) {
+            // Prevent automatic Connection: close insertion when user provides one
+            data->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONNECTION_HEADER;
+            // RFC 9112 §9.6: a server that sends the "close" connection option
+            // MUST close after the response.
+            if (connectionValueHasClose(value)) {
+                data->state |= uWS::HttpResponseData<isSSL>::HTTP_CONNECTION_CLOSE;
+            }
         }
         writeResponseHeader<isSSL>(res, name, value);
     }
@@ -941,8 +943,10 @@ static bool NodeHTTPServer__writeHead(
 
     // node:http's ServerResponse owns the Date header entirely (it honors
     // res.sendDate / removeHeader("date") in JS), so never let uWS write its
-    // own Date header for these responses.
-    response->getHttpResponseData()->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER;
+    // own Date header for these responses. It owns the Connection header the
+    // same way (_storeHeader always decides and writes one).
+    response->getHttpResponseData()->state |= uWS::HttpResponseData<isSSL>::HTTP_WROTE_DATE_HEADER
+        | uWS::HttpResponseData<isSSL>::HTTP_WROTE_CONNECTION_HEADER;
 
     // 204/304 responses must not carry any body framing, even when the user
     // explicitly set a Transfer-Encoding header (Node.js suppresses the

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1365,7 +1365,7 @@ extern "C"
       auto *data = uwsRes->getHttpResponseData();
       if (close_connection)
       {
-        if (!(data->state & uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE))
+        if (!(data->state & (uWS::HttpResponseData<true>::HTTP_WRITE_CALLED | uWS::HttpResponseData<true>::HTTP_WROTE_CONNECTION_HEADER)))
         {
           uwsRes->writeHeader("Connection", "close");
         }
@@ -1377,7 +1377,12 @@ extern "C"
       }
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone(uwsRes);
-      uwsRes->resetTimeout();
+      // keepCorked: a corked caller (onData, cork()) owns the uncork and close.
+      // node:http's destroy path relies on its cork being discarded, not flushed.
+      if (!uwsRes->uncorkAndCloseIfNeeded(data, true))
+      {
+        uwsRes->resetTimeout();
+      }
     }
     else
     {
@@ -1385,7 +1390,7 @@ extern "C"
       auto *data = uwsRes->getHttpResponseData();
       if (close_connection)
       {
-        if (!(data->state & uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE))
+        if (!(data->state & (uWS::HttpResponseData<false>::HTTP_WRITE_CALLED | uWS::HttpResponseData<false>::HTTP_WROTE_CONNECTION_HEADER)))
         {
           uwsRes->writeHeader("Connection", "close");
         }
@@ -1399,7 +1404,10 @@ extern "C"
       }
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone(uwsRes);
-      uwsRes->resetTimeout();
+      if (!uwsRes->uncorkAndCloseIfNeeded(data, true))
+      {
+        uwsRes->resetTimeout();
+      }
     }
   }
 

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1326,7 +1326,10 @@ extern "C"
       data->offset = offset;
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone(uwsRes);
-      uwsRes->resetTimeout();
+      if (!uwsRes->uncorkAndCloseIfNeeded(data, /* keepCorked: caller owns uncork */ true))
+      {
+        uwsRes->resetTimeout();
+      }
     }
     else
     {
@@ -1335,7 +1338,10 @@ extern "C"
       data->offset = offset;
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone(uwsRes);
-      uwsRes->resetTimeout();
+      if (!uwsRes->uncorkAndCloseIfNeeded(data, /* keepCorked: caller owns uncork */ true))
+      {
+        uwsRes->resetTimeout();
+      }
     }
   }
   void uws_res_reset_timeout(int ssl, uws_res_r res) {
@@ -1377,9 +1383,7 @@ extern "C"
       }
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
       data->markDone(uwsRes);
-      // keepCorked: a corked caller (onData, cork()) owns the uncork and close.
-      // node:http's destroy path relies on its cork being discarded, not flushed.
-      if (!uwsRes->uncorkAndCloseIfNeeded(data, true))
+      if (!uwsRes->uncorkAndCloseIfNeeded(data, /* keepCorked: caller owns uncork */ true))
       {
         uwsRes->resetTimeout();
       }
@@ -1404,7 +1408,7 @@ extern "C"
       }
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
       data->markDone(uwsRes);
-      if (!uwsRes->uncorkAndCloseIfNeeded(data, true))
+      if (!uwsRes->uncorkAndCloseIfNeeded(data, /* keepCorked: caller owns uncork */ true))
       {
         uwsRes->resetTimeout();
       }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3684,12 +3684,15 @@ it.each([
 // check there was skipped because internalEnd's own uncork had already
 // released the cork slot.
 describe("Connection: close on an async handler", () => {
-  // Resolves either when the server FINs (correct) or when a second response
+  // Resolves either when the server closes (correct) or when a second response
   // arrives on the same connection (the bug), so a broken server never hangs.
+  // `serverClosed` is true iff the socket closed without us destroying it: on
+  // Windows the second write can draw an RST that pre-empts 'end', so 'close
+  // without client destroy' is the portable signal.
   function exchange(port: number, payload: string) {
     const { promise, resolve } = Promise.withResolvers<{ raw: string; serverClosed: boolean; responses: number }>();
     const chunks: Buffer[] = [];
-    let serverClosed = false;
+    let weDestroyed = false;
     let sentSecond = false;
     const sock = net.connect(port, "127.0.0.1", () => sock.write(payload));
     const raw = () => Buffer.concat(chunks).toString("latin1");
@@ -3701,13 +3704,12 @@ describe("Connection: close on an async handler", () => {
         sock.write("GET /two HTTP/1.1\r\nHost: x\r\n\r\n", err => void err);
       }
       if (responses() > 1) {
+        weDestroyed = true;
         sock.destroy();
-        resolve({ raw: raw(), serverClosed: false, responses: responses() });
       }
     });
-    sock.on("end", () => (serverClosed = true));
     sock.on("error", () => {});
-    sock.on("close", () => resolve({ raw: raw(), serverClosed, responses: responses() }));
+    sock.on("close", () => resolve({ raw: raw(), serverClosed: !weDestroyed, responses: responses() }));
     return promise;
   }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3756,6 +3756,7 @@ describe("Connection: close on an async handler", () => {
   // (its microtask drain) must still close; the close gate is per socket, not
   // per server.
   it("async: closes when the response resolves inside another socket's onData", async () => {
+    const armedReady = Promise.withResolvers<void>();
     let armed: (() => void) | null = null;
     using server = serve({
       port: 0,
@@ -3765,6 +3766,7 @@ describe("Connection: close on an async handler", () => {
         if (path === "/a") {
           return new Promise<Response>(resolve => {
             armed = () => resolve(new Response("hi", { headers: { connection: "close" } }));
+            armedReady.resolve();
           });
         }
         if (path === "/b") armed?.();
@@ -3772,7 +3774,7 @@ describe("Connection: close on an async handler", () => {
       },
     });
     const a = exchange(server.port, "GET /a HTTP/1.1\r\nHost: x\r\n\r\n");
-    while (!armed) await Bun.sleep(1);
+    await armedReady.promise;
     await fetch(`http://127.0.0.1:${server.port}/b`);
     const { serverClosed, responses } = await a;
     expect({ responses, serverClosed }).toEqual({ responses: 1, serverClosed: true });

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -3676,3 +3676,103 @@ it.each([
 
   expect(statusLine).toBe("HTTP/1.1 400 Bad Request");
 });
+
+// RFC 9112 9.6: a server that receives a "close" connection option MUST close
+// the connection after its response; a server that sends one MUST do the same.
+// The sync request-header case worked on main (onData's tail closes it); an
+// async handler's end() runs outside onData, inside cork(), and the close
+// check there was skipped because internalEnd's own uncork had already
+// released the cork slot.
+describe("Connection: close on an async handler", () => {
+  // Resolves either when the server FINs (correct) or when a second response
+  // arrives on the same connection (the bug), so a broken server never hangs.
+  function exchange(port: number, payload: string) {
+    const { promise, resolve } = Promise.withResolvers<{ raw: string; serverClosed: boolean; responses: number }>();
+    const chunks: Buffer[] = [];
+    let serverClosed = false;
+    let sentSecond = false;
+    const sock = net.connect(port, "127.0.0.1", () => sock.write(payload));
+    const raw = () => Buffer.concat(chunks).toString("latin1");
+    const responses = () => (raw().match(/HTTP\/1\.1 200 OK/g) || []).length;
+    sock.on("data", d => {
+      chunks.push(d);
+      if (!sentSecond && raw().includes("\r\n\r\nhi")) {
+        sentSecond = true;
+        sock.write("GET /two HTTP/1.1\r\nHost: x\r\n\r\n", err => void err);
+      }
+      if (responses() > 1) {
+        sock.destroy();
+        resolve({ raw: raw(), serverClosed: false, responses: responses() });
+      }
+    });
+    sock.on("end", () => (serverClosed = true));
+    sock.on("error", () => {});
+    sock.on("close", () => resolve({ raw: raw(), serverClosed, responses: responses() }));
+    return promise;
+  }
+
+  const closeHeaders = (raw: string) => (raw.match(/\r\nconnection: close\r\n/gi) || []).length;
+
+  for (const kind of ["sync", "async"] as const) {
+    const wrap =
+      kind === "sync"
+        ? (f: () => Response) => f
+        : (f: () => Response) => async () => {
+            await Bun.sleep(1);
+            return f();
+          };
+
+    it(`${kind}: a request with Connection: close gets one response, a close header, and a server FIN`, async () => {
+      using server = serve({ port: 0, hostname: "127.0.0.1", fetch: wrap(() => new Response("hi")) });
+      const { raw, serverClosed, responses } = await exchange(
+        server.port,
+        "GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n",
+      );
+      expect({ responses, closeHeaders: closeHeaders(raw), serverClosed }).toEqual({
+        responses: 1,
+        closeHeaders: 1,
+        serverClosed: true,
+      });
+    });
+
+    it(`${kind}: a Response with connection: close gets one close header and a server FIN`, async () => {
+      using server = serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: wrap(() => new Response("hi", { headers: { connection: "close" } })),
+      });
+      const { raw, serverClosed, responses } = await exchange(server.port, "GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+      expect({ responses, closeHeaders: closeHeaders(raw), serverClosed }).toEqual({
+        responses: 1,
+        closeHeaders: 1,
+        serverClosed: true,
+      });
+    });
+  }
+
+  // An async response that resolves inside ANOTHER socket's request handler
+  // (its microtask drain) must still close; the close gate is per socket, not
+  // per server.
+  it("async: closes when the response resolves inside another socket's onData", async () => {
+    let armed: (() => void) | null = null;
+    using server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: req => {
+        const path = new URL(req.url).pathname;
+        if (path === "/a") {
+          return new Promise<Response>(resolve => {
+            armed = () => resolve(new Response("hi", { headers: { connection: "close" } }));
+          });
+        }
+        if (path === "/b") armed?.();
+        return new Response("hi");
+      },
+    });
+    const a = exchange(server.port, "GET /a HTTP/1.1\r\nHost: x\r\n\r\n");
+    while (!armed) await Bun.sleep(1);
+    await fetch(`http://127.0.0.1:${server.port}/b`);
+    const { serverClosed, responses } = await a;
+    expect({ responses, serverClosed }).toEqual({ responses: 1, serverClosed: true });
+  });
+});


### PR DESCRIPTION
## What

An async handler (any `await` before returning the `Response`) dropped both connection-lifetime signals:

- a request's `Connection: close` was not echoed and did not close the socket; a second request on the same connection was answered
- a `Response` carrying `connection: close` put the header on the wire but kept the socket open

RFC 9112 section 9.6 makes both a MUST. The sync request-header path already closed via `onData`'s tail; every other path kept the socket alive until `idleTimeout`.

```js
// bun repro.mjs
import net from "node:net";
for (const mode of ["sync", "await", "await+resp-close-hdr"]) {
  const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
    fetch: mode === "sync" ? () => new Response("hi")
      : mode === "await" ? async () => { await Bun.sleep(1); return new Response("hi"); }
      : async () => { await Bun.sleep(1); return new Response("hi", { headers: { connection: "close" } }); } });
  const r = await new Promise(res => { let buf = "", sent2 = false;
    const c = net.connect(s.port, "127.0.0.1", () => c.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"));
    c.on("data", d => { buf += d; if (!sent2 && buf.includes("hi")) { sent2 = true; setTimeout(() => c.write("GET /two HTTP/1.1\r\nHost: x\r\n\r\n"), 300); } });
    c.on("close", () => res({ mode, closedByServer: true, responses: (buf.match(/200 OK/g) || []).length }));
    setTimeout(() => { c.destroy(); res({ mode, closedByServer: false, responses: (buf.match(/200 OK/g) || []).length }); }, 3000);
  });
  s.stop(true); console.log(JSON.stringify(r));
}
// main:
// {"mode":"sync","closedByServer":true,"responses":1}
// {"mode":"await","closedByServer":false,"responses":2}
// {"mode":"await+resp-close-hdr","closedByServer":false,"responses":2}
```

## Why

The async response ends inside `HttpResponse::cork()`. `internalEnd` is therefore corked, takes its `else if (!keepCorked) this->uncork()` branch, and returns without a close check. `cork()`'s own close check at the tail would have caught it, but it sits behind the `findCorkSlot(this) == INVALID_CORK_SLOT` early return that `internalEnd`'s uncork just triggered. So nothing ever reaches `shutdown()/close()`.

The `Connection: close` response header was also gated on `(state & HTTP_CONNECTION_CLOSE) == 0`, which skips it whenever the close came from the request (the bit is already set), so the SHOULD-echo was only written when neither side had asked for the close.

## Fix

`internalEnd` now routes both end paths through a new `uncorkAndCloseIfNeeded()`, which uncorks and then closes when flagged unless the parser is running on THIS socket (so a sync end inside `onData` still defers to `onData`'s tail and `request-smuggling.test.ts`'s body-validation cases keep 400ing). The flag is per socket rather than per server so a close-flagged response that resolves inside another socket's request handler (its microtask drain) still closes; `upgrade()` now reads the same per-socket flag, captured before the `HttpResponseData` destructor.

The response header check now tests `HTTP_WROTE_CONNECTION_HEADER` (set by `writeFetchHeadersToUWSResponse` and by node:http's `writeHead`, which always writes its own) instead of `HTTP_CONNECTION_CLOSE`, so the header is echoed whenever the server is closing and the application did not write a Connection header itself.

`uws_res_end_without_body` gets the same close-after-end, with `keepCorked=true` so node:http's destroy path (which corks, calls it, then force-closes) keeps discarding the buffered bytes rather than flushing them.

This is the minimal async-face of #33005, rebased onto `main`'s `uint32_t state` word and the `resetResponseState`/`shouldCloseConnection` helpers that landed since; #33005 additionally replaces the `length() == 5` request-side detection with a token-list scan and discards pipelined bytes behind a close-flagged request.

## Verification

New `Connection: close on an async handler` describe block in `test/js/bun/http/serve.test.ts` (5 tests, raw `net` socket):

- sync and async, request with `Connection: close`: one response, one `Connection: close` header, server FIN, second request refused
- sync and async, `Response` with `connection: close`: same
- async response that resolves inside another socket's `onData`: still closes

On `main` 4 of the 5 fail (sync+response-header already works); with this change all 5 pass.

No regressions in `bun-serve-headers.test.ts`, `request-smuggling.test.ts` (81 pass), `serve.test.ts`, `websocket-server.test.ts`, or `test/js/node/http/*` (failure sets identical to a `main` debug build).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->