### PR TITLE
worker_threads: buffer Worker messages while there is no 'message' listener

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -942,9 +942,17 @@ class Worker extends EventEmitter {
   #urlToRevoke = "";
   // threadId captured for cleaning up the messaging control port on close.
   #messagingThreadId: number | undefined = undefined;
+  // Node's Worker stops its public port while there are zero 'message' listeners, so
+  // messages queue natively and redeliver on the next listener add. Bun's native
+  // WebWorker has no stop(), so #onMessage buffers here and #scheduleFlush replays.
+  #bufferedMessages: unknown[] | null = null;
+  #flushScheduled = false;
 
   constructor(filename: string, options: NodeWorkerOptions = {}) {
     super();
+    this.on("newListener", name => {
+      if (name === "message") this.#scheduleFlush();
+    });
 
     // The `= {}` default only covers undefined; normalize null too so the
     // option accesses below don't throw on `new Worker(file, null)`.
@@ -1319,8 +1327,36 @@ class Worker extends EventEmitter {
   }
 
   #onMessage(event: MessageEvent) {
-    // TODO: is this right?
-    this.emit("message", event.data);
+    const data = event.data;
+    // With zero listeners (or earlier messages still buffered, to preserve FIFO),
+    // queue instead of emitting into the void.
+    if (this.#bufferedMessages !== null || this.listenerCount("message") === 0) {
+      (this.#bufferedMessages ??= []).push(data);
+      if (this.listenerCount("message") > 0) this.#scheduleFlush();
+      return;
+    }
+    this.emit("message", data);
+  }
+
+  #scheduleFlush() {
+    // Called from the 'newListener' hook (which fires BEFORE the listener is attached)
+    // and from #onMessage; the listenerCount check lives in the microtask for both.
+    if (this.#flushScheduled || this.#bufferedMessages === null) return;
+    this.#flushScheduled = true;
+    queueMicrotask(() => {
+      this.#flushScheduled = false;
+      const buf = this.#bufferedMessages;
+      this.#bufferedMessages = null;
+      if (buf === null) return;
+      for (let i = 0; i < buf.length; i++) {
+        // A once() listener may leave zero listeners mid-flush: re-queue the rest.
+        if (this.listenerCount("message") === 0) {
+          this.#bufferedMessages = buf.slice(i);
+          return;
+        }
+        this.emit("message", buf[i]);
+      }
+    });
   }
 
   #onMessageError(event: MessageEvent) {

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -1354,7 +1354,17 @@ class Worker extends EventEmitter {
           this.#bufferedMessages = buf.slice(i);
           return;
         }
-        this.emit("message", buf[i]);
+        try {
+          this.emit("message", buf[i]);
+        } catch (e) {
+          // Node delivers each queued message as its own task, so a throwing listener
+          // on buf[i] doesn't suppress buf[i+1..]. Re-queue the tail and rethrow.
+          if (i + 1 < buf.length) {
+            this.#bufferedMessages = buf.slice(i + 1);
+            this.#scheduleFlush();
+          }
+          throw e;
+        }
       }
     });
   }

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -942,9 +942,7 @@ class Worker extends EventEmitter {
   #urlToRevoke = "";
   // threadId captured for cleaning up the messaging control port on close.
   #messagingThreadId: number | undefined = undefined;
-  // Node's Worker stops its public port while there are zero 'message' listeners, so
-  // messages queue natively and redeliver on the next listener add. Bun's native
-  // WebWorker has no stop(), so #onMessage buffers here and #scheduleFlush replays.
+  // Node's Worker stops its public port while zero 'message' listeners exist; the native WebWorker has no stop(), so buffer here.
   #bufferedMessages: unknown[] | null = null;
   #flushScheduled = false;
 
@@ -1297,6 +1295,8 @@ class Worker extends EventEmitter {
       this.#stdin.destroy();
     }
     this.#stdinPort?.close();
+    // Node drains-and-drops the public port on exit; nothing buffered may surface after 'exit'.
+    this.#bufferedMessages = null;
     this.#onExitPromise = e.code;
     this.emit("exit", e.code);
   }
@@ -1328,8 +1328,7 @@ class Worker extends EventEmitter {
 
   #onMessage(event: MessageEvent) {
     const data = event.data;
-    // With zero listeners (or earlier messages still buffered, to preserve FIFO),
-    // queue instead of emitting into the void.
+    // Zero listeners (or an earlier buffer still pending, for FIFO): queue instead of emitting into the void.
     if (this.#bufferedMessages !== null || this.listenerCount("message") === 0) {
       (this.#bufferedMessages ??= []).push(data);
       if (this.listenerCount("message") > 0) this.#scheduleFlush();
@@ -1339,8 +1338,7 @@ class Worker extends EventEmitter {
   }
 
   #scheduleFlush() {
-    // Called from the 'newListener' hook (which fires BEFORE the listener is attached)
-    // and from #onMessage; the listenerCount check lives in the microtask for both.
+    // 'newListener' fires BEFORE the listener is attached, so the listenerCount check lives in the microtask.
     if (this.#flushScheduled || this.#bufferedMessages === null) return;
     this.#flushScheduled = true;
     queueMicrotask(() => {
@@ -1357,8 +1355,7 @@ class Worker extends EventEmitter {
         try {
           this.emit("message", buf[i]);
         } catch (e) {
-          // Node delivers each queued message as its own task, so a throwing listener
-          // on buf[i] doesn't suppress buf[i+1..]. Re-queue the tail and rethrow.
+          // A throwing listener must not suppress later buffered messages: re-queue the tail and rethrow.
           if (i + 1 < buf.length) {
             this.#bufferedMessages = buf.slice(i + 1);
             this.#scheduleFlush();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1756,3 +1756,74 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
 });
+
+// Node stops the Worker's public port while there are zero 'message' listeners, so
+// messages the worker sends during that gap buffer and redeliver on the next listener add.
+describe("Worker buffers messages while there is no 'message' listener", () => {
+  test("once() leaves a gap during which the next reply is buffered, not dropped", async () => {
+    // The worker posts a reply ("a") and then Atomics-notifies. In Bun, the reply
+    // reaches the parent's native message dispatch before the waitAsync promise
+    // resolves, so the parent has zero 'message' listeners at delivery time.
+    const sab = new SharedArrayBuffer(4);
+    const flag = new Int32Array(sab);
+    const w = new Worker(
+      `const { parentPort, workerData } = require("node:worker_threads");
+       const flag = new Int32Array(workerData.sab);
+       setInterval(() => {}, 1e6);
+       parentPort.on("message", () => {
+         parentPort.postMessage("a");
+         parentPort.postMessage("b");
+         Atomics.store(flag, 0, 1);
+         Atomics.notify(flag, 0);
+       });
+       parentPort.postMessage("ready");`,
+      { eval: true, workerData: { sab } },
+    );
+    try {
+      expect(await new Promise(r => w.once("message", r))).toBe("ready");
+      const done = Atomics.waitAsync(flag, 0, 0).value;
+      w.postMessage("go");
+      await done;
+      const got: unknown[] = [];
+      w.on("message", m => got.push(m));
+      // The flush of buffered messages is a microtask; one setImmediate round
+      // is enough to observe it (and any still-in-flight native dispatch).
+      await new Promise(r => setImmediate(r));
+      expect(got).toEqual(["a", "b"]);
+    } finally {
+      await w.terminate();
+    }
+  });
+
+  test("postMessageToThread main->worker: reply via parentPort survives the listener gap", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const wt = require("node:worker_threads");
+         const src =
+           'const wt = require("node:worker_threads");' +
+           'setInterval(() => {}, 1e6);' +
+           'process.on("workerMessage", (v, s) => wt.parentPort.postMessage({ workerGot: v, source: s }));' +
+           'wt.parentPort.postMessage({ tid: wt.threadId });';
+         const w = new wt.Worker(src, { eval: true });
+         (async () => {
+           const { tid } = await new Promise(r => w.once("message", r));
+           await wt.postMessageToThread(tid, "m2w", 5000);
+           const reply = await new Promise((r, rej) => {
+             w.once("message", r);
+             setTimeout(() => rej(new Error("DROPPED")), 2000);
+           });
+           console.log(JSON.stringify(reply));
+           await w.terminate();
+         })().catch(e => { console.error(e.code || String(e)); process.exit(1); });`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim()).toBe(`{"workerGot":"m2w","source":0}`);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1795,6 +1795,60 @@ describe("Worker buffers messages while there is no 'message' listener", () => {
     }
   });
 
+  test("a throwing listener does not drop later buffered messages", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("node:worker_threads");
+         const sab = new SharedArrayBuffer(4);
+         const flag = new Int32Array(sab);
+         const w = new Worker(
+           \`const { parentPort, workerData } = require("node:worker_threads");
+            const flag = new Int32Array(workerData.sab);
+            setInterval(() => {}, 1e6);
+            parentPort.on("message", () => {
+              parentPort.postMessage("a");
+              parentPort.postMessage("b");
+              Atomics.store(flag, 0, 1);
+              Atomics.notify(flag, 0);
+            });
+            parentPort.postMessage("ready");\`,
+           { eval: true, workerData: { sab } },
+         );
+         process.on("uncaughtException", e => console.log("thrown:" + e.message));
+         (async () => {
+           await new Promise(r => w.once("message", r));
+           const done = Atomics.waitAsync(flag, 0, 0).value;
+           w.postMessage("go");
+           await done;
+           w.on("message", m => {
+             if (m === "a") throw new Error("boom");
+             console.log("got:" + m);
+           });
+           await new Promise(r => setImmediate(r));
+           await new Promise(r => setImmediate(r));
+           await w.terminate();
+         })();`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.trim()).toBe("");
+    expect(stdout.trim().split("\n")).toEqual(["thrown:boom", "got:b"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("messages buffered before exit are dropped, not delivered after 'exit'", async () => {
+    const w = new Worker(`require("node:worker_threads").parentPort.postMessage("x")`, { eval: true });
+    await once(w, "exit");
+    const got: unknown[] = [];
+    w.on("message", m => got.push(m));
+    await new Promise(r => setImmediate(r));
+    expect(got).toEqual([]);
+  });
+
   test("postMessageToThread main->worker: reply via parentPort survives the listener gap", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1812,7 +1812,7 @@ describe("Worker buffers messages while there is no 'message' listener", () => {
            await wt.postMessageToThread(tid, "m2w", 5000);
            const reply = await new Promise((r, rej) => {
              w.once("message", r);
-             setTimeout(() => rej(new Error("DROPPED")), 2000);
+             setTimeout(() => rej(new Error("DROPPED")), 2000).unref();
            });
            console.log(JSON.stringify(reply));
            await w.terminate();


### PR DESCRIPTION
## Repro

```js
import { Worker } from "node:worker_threads";
const w = new Worker(`
  const { parentPort } = require("node:worker_threads");
  parentPort.on("message", () => { parentPort.postMessage("a"); parentPort.postMessage("b"); });
  parentPort.postMessage("ready");
`, { eval: true });
await new Promise(r => w.once("message", r));   // consume 'ready'; listener removed
w.postMessage("go");
await new Promise(r => setTimeout(r, 300));      // 'a' and 'b' arrive during this gap
const got = [];
w.on("message", m => got.push(m));
await new Promise(r => setTimeout(r, 300));
console.log(got);
// node : [ 'a', 'b' ]
// bun  : []
```

This was reported as `postMessageToThread` main->worker "silently dropping" the message. The `workerMessage` listener does fire; the repro's verification path sends a reply via `parentPort.postMessage` from inside that listener, and that reply reaches the parent's native message dispatch before the parent's `await postMessageToThread(...)` resolves. The parent has zero `'message'` listeners at that moment (the first `once` already fired), so the reply was emitted into the void, and the follow-up `w.once('message', ...)` never saw it.

## Cause

Node's `Worker` routes user messages through a separate public `MessagePort` and wires it up with `setupPortReferencing`: the port is `stop()`ped while the Worker EventEmitter has zero `'message'` listeners, so messages queue natively, and `start()`ed again on the first listener add so the queue redelivers.

Bun's `Worker` wraps a native `WebWorker` whose `addEventListener('message', #onMessage)` is always attached and has no `stop()`. `#onMessage` unconditionally did `this.emit('message', data)`, which drops the event when there are no listeners.

## Fix

`#onMessage` buffers the data while `listenerCount('message') === 0` (and while an earlier buffer is still pending, to preserve FIFO). A `'newListener'` hook schedules a microtask flush; the flush re-queues the tail if a `once()` listener leaves zero listeners mid-flush.

## Verification

Two new tests in `worker_threads.test.ts`: a direct buffer-during-gap check (fails with `[]` on main, passes with `['a','b']`) and the `postMessageToThread` main->worker scenario from the report (fails with `Error: DROPPED` on main). The full `worker_threads.test.ts` suite (93 tests) and the ported Node `test-worker-messaging*` / `test-worker-onmessage*` / `test-worker*ref*` tests pass.

The reported worker->worker hang did not reproduce across 10 runs of a 4-worker round-robin on a debug+ASAN build at HEAD; `test-worker-messaging.js` (Node's own cross-thread `postMessageToThread` test) passes.