### PR TITLE
install: document that --production implies --frozen-lockfile

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -158,13 +158,15 @@ cowsay "Bun!"
 
 ## Production mode
 
-To install in production mode (without `devDependencies` or `optionalDependencies`):
+To install in production mode (without `devDependencies`):
 
 ```bash terminal icon="terminal"
 bun install --production
 ```
 
-For reproducible installs, use `--frozen-lockfile`. Bun installs the exact versions specified in the lockfile and does not update it. If your `package.json` disagrees with `bun.lock`, Bun exits with an error.
+Passing `--production` also implies `--frozen-lockfile`, so the install fails if `package.json` is out of sync with the lockfile. If you only want to skip `devDependencies` without freezing the lockfile, use `--omit=dev` instead.
+
+For reproducible installs without skipping `devDependencies`, use `--frozen-lockfile` on its own. Bun installs the exact versions specified in the lockfile and does not update it. If your `package.json` disagrees with `bun.lock`, Bun exits with an error.
 
 ```bash terminal icon="terminal"
 bun install --frozen-lockfile

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -164,7 +164,7 @@ To install in production mode (without `devDependencies`):
 bun install --production
 ```
 
-Passing `--production` also implies `--frozen-lockfile`, so the install fails if `package.json` is out of sync with the lockfile. If you only want to skip `devDependencies` without freezing the lockfile, use `--omit=dev` instead.
+Passing `--production` also implies `--frozen-lockfile`, so the install fails if `package.json` is out of sync with the lockfile. Production mode also aborts immediately on the first install error (for example, a bad lockfile or a failed bin link) instead of reporting it at the end. If you only want to skip `devDependencies` without these stricter checks, use `--omit=dev` instead.
 
 For reproducible installs without skipping `devDependencies`, use `--frozen-lockfile` on its own. Bun installs the exact versions specified in the lockfile and does not update it. If your `package.json` disagrees with `bun.lock`, Bun exits with an error.
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -430,7 +430,7 @@ peer = true
 
 Whether `bun install` runs in "production mode". Default `false`.
 
-In production mode, `"devDependencies"` are not installed. The `--production` CLI flag overrides this setting.
+In production mode, `"devDependencies"` are not installed and the lockfile is frozen (as if `--frozen-lockfile` was passed), so installs fail if `package.json` disagrees with `bun.lock`. The `--production` CLI flag overrides this setting.
 
 ```toml title="bunfig.toml" icon="settings"
 [install]

--- a/docs/snippets/cli/add.mdx
+++ b/docs/snippets/cli/add.mdx
@@ -7,7 +7,7 @@ bun add <package> <@version>
 ### Dependency Management
 
 <ParamField path="--production" type="boolean">
-  Don't install devDependencies. Alias: <code>-p</code>
+  Don't install devDependencies. Implies --frozen-lockfile. Alias: <code>-p</code>
 </ParamField>
 
 <ParamField path="--omit" type="string">

--- a/docs/snippets/cli/install.mdx
+++ b/docs/snippets/cli/install.mdx
@@ -17,7 +17,7 @@ bun install <name>@<version>
 ### Dependency Scope & Management
 
 <ParamField path="--production" type="boolean">
-  Don't install devDependencies
+  Don't install devDependencies. Implies --frozen-lockfile
 </ParamField>
 
 <ParamField path="--no-save" type="boolean">

--- a/docs/snippets/cli/link.mdx
+++ b/docs/snippets/cli/link.mdx
@@ -13,7 +13,7 @@ bun link <packages>
 ### Dependency Management
 
 <ParamField path="--production" type="boolean">
-  Don't install devDependencies. Alias: <code>-p</code>
+  Don't install devDependencies. Implies --frozen-lockfile. Alias: <code>-p</code>
 </ParamField>
 
 <ParamField path="--omit" type="string">

--- a/docs/snippets/cli/outdated.mdx
+++ b/docs/snippets/cli/outdated.mdx
@@ -43,7 +43,7 @@ bun outdated <filter>
 ### Dependency Scope & Target
 
 <ParamField path="-p, --production" type="boolean">
-  Don't install devDependencies
+  Don't install devDependencies. Implies --frozen-lockfile
 </ParamField>
 
 <ParamField path="--omit" type="string">

--- a/docs/snippets/cli/patch.mdx
+++ b/docs/snippets/cli/patch.mdx
@@ -17,7 +17,7 @@ bun patch <package>@<version>
 ### Dependency Management
 
 <ParamField path="--production" type="boolean">
-  Don't install devDependencies. Alias: <code>-p</code>
+  Don't install devDependencies. Implies --frozen-lockfile. Alias: <code>-p</code>
 </ParamField>
 
 <ParamField path="--ignore-scripts" type="boolean">

--- a/docs/snippets/cli/publish.mdx
+++ b/docs/snippets/cli/publish.mdx
@@ -125,7 +125,7 @@ bun publish --cafile ./ca-cert.pem
 #### Dependency Management
 
 <ParamField path="-p, --production" type="boolean">
-  Don't install devDependencies
+  Don't install devDependencies. Implies --frozen-lockfile
 </ParamField>
 
 <ParamField path="--omit" type="string">

--- a/docs/snippets/cli/remove.mdx
+++ b/docs/snippets/cli/remove.mdx
@@ -51,7 +51,7 @@ bun remove <package>
 ### Dependency Filtering
 
 <ParamField path="--production" type="boolean">
-  Don't install devDependencies. Alias: <code>-p</code>
+  Don't install devDependencies. Implies --frozen-lockfile. Alias: <code>-p</code>
 </ParamField>
 
 <ParamField path="--omit" type="string">

--- a/docs/snippets/cli/update.mdx
+++ b/docs/snippets/cli/update.mdx
@@ -17,7 +17,7 @@ bun update <package> <version>
 ### Dependency Scope
 
 <ParamField path="--production" type="boolean">
-  Don't install devDependencies. Alias: <code>-p</code>
+  Don't install devDependencies. Implies --frozen-lockfile. Alias: <code>-p</code>
 </ParamField>
 
 <ParamField path="--global" type="boolean">

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -56,7 +56,9 @@ const BACKEND_PARAM: ParamType = clap::param!(
 const SHARED_PARAMS: &[ParamType] = &[
     clap::param!("-c, --config <STR>?                   Specify path to config file (bunfig.toml)"),
     clap::param!("-y, --yarn                            Write a yarn.lock file (yarn v1)"),
-    clap::param!("-p, --production                      Don't install devDependencies"),
+    clap::param!(
+        "-p, --production                      Don't install devDependencies. Implies --frozen-lockfile"
+    ),
     clap::param!("-P, --prod"),
     clap::param!(
         "--no-save                             Don't update package.json or save a lockfile"

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1521,6 +1521,9 @@ fn create_new_lockfile_and_enqueue(
             bun_core::pretty_errorln!(
                 "<r><red>error<r>: lockfile had changes, but lockfile is frozen"
             );
+            bun_core::note!(
+                "try re-running without <d>--frozen-lockfile<r> or <d>--production<r> and commit the updated lockfile"
+            );
         }
         Global::crash();
     }

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -736,7 +736,7 @@ pub fn install_with_manager(
                     "<r><red>error<r><d>:<r> lockfile had changes, but lockfile is frozen"
                 );
                 bun_core::note!(
-                    "try re-running without <d>--frozen-lockfile<r> and commit the updated lockfile"
+                    "try re-running without <d>--frozen-lockfile<r> or <d>--production<r> and commit the updated lockfile"
                 );
             }
             Global::crash();

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -731,15 +731,7 @@ pub fn install_with_manager(
                 }
             }
 
-            if log_level != Options::LogLevel::Silent {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r><d>:<r> lockfile had changes, but lockfile is frozen"
-                );
-                bun_core::note!(
-                    "try re-running without <d>--frozen-lockfile<r> or <d>--production<r> and commit the updated lockfile"
-                );
-            }
-            Global::crash();
+            crash_frozen_lockfile(log_level);
         }
     }
 
@@ -1378,6 +1370,20 @@ fn add_dependency_error(
 
 #[cold]
 #[inline(never)]
+fn crash_frozen_lockfile(log_level: Options::LogLevel) -> ! {
+    if log_level != Options::LogLevel::Silent {
+        bun_core::pretty_errorln!(
+            "<r><red>error<r><d>:<r> lockfile had changes, but lockfile is frozen"
+        );
+        bun_core::note!(
+            "try re-running without <d>--frozen-lockfile<r> or <d>--production<r> and commit the updated lockfile"
+        );
+    }
+    Global::crash();
+}
+
+#[cold]
+#[inline(never)]
 fn report_lockfile_load_error(
     manager: &mut PackageManager,
     cause: &lockfile::LoadResultErr,
@@ -1517,15 +1523,7 @@ fn create_new_lockfile_and_enqueue(
     if manager.options.enable.frozen_lockfile()
         && !matches!(load_result, lockfile::LoadResult::NotFound)
     {
-        if log_level != Options::LogLevel::Silent {
-            bun_core::pretty_errorln!(
-                "<r><red>error<r>: lockfile had changes, but lockfile is frozen"
-            );
-            bun_core::note!(
-                "try re-running without <d>--frozen-lockfile<r> or <d>--production<r> and commit the updated lockfile"
-            );
-        }
-        Global::crash();
+        crash_frozen_lockfile(log_level);
     }
 
     // SAFETY: `manager.log` is a non-null backref to the CLI log set at init().

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6821,9 +6821,7 @@ describe.concurrent("bun-install", () => {
       // the note should mention --production, not just --frozen-lockfile
       const err = await stderr.text();
       expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
-      expect(err).toContain(
-        "try re-running without --frozen-lockfile or --production and commit the updated lockfile",
-      );
+      expect(err).toContain("try re-running without --frozen-lockfile or --production and commit the updated lockfile");
       expect(await exited).toBe(1);
     });
   });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6812,8 +6812,8 @@ describe.concurrent("bun-install", () => {
       const { stderr, exited } = spawn({
         cmd: [bunExe(), "install", "--production"],
         cwd: ctx.package_dir,
-        stdout: "pipe",
-        stdin: "pipe",
+        stdout: "ignore",
+        stdin: "ignore",
         stderr: "pipe",
         env,
       });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6764,6 +6764,68 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/10949
+  it("documents that --production implies --frozen-lockfile", async () => {
+    await withContext(defaultOpts, async ctx => {
+      let urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, { "0.0.3": { as: "0.0.3" }, "0.0.5": { as: "0.0.5" } }),
+      );
+
+      // --help should say that --production implies --frozen-lockfile
+      const help = spawn({
+        cmd: [bunExe(), "install", "--help"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [helpOut, helpErr] = await Promise.all([help.stdout.text(), help.stderr.text()]);
+      const helpText = helpOut + helpErr;
+      const productionLine = helpText.split("\n").find(line => line.includes("--production"));
+      expect(productionLine).toMatch(/--production.*Implies --frozen-lockfile/);
+      expect(await help.exited).toBe(0);
+
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.3" } }),
+      );
+
+      expect(
+        await spawn({
+          cmd: [bunExe(), "install"],
+          cwd: ctx.package_dir,
+          stdout: "ignore",
+          stdin: "ignore",
+          stderr: "ignore",
+          env,
+        }).exited,
+      ).toBe(0);
+
+      // change version of baz in package.json so it disagrees with the lockfile
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: "0.0.5" } }),
+      );
+
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--production"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+
+      // the note should mention --production, not just --frozen-lockfile
+      const err = await stderr.text();
+      expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
+      expect(err).toContain("--production");
+      expect(await exited).toBe(1);
+    });
+  });
+
   it("should perform bin-linking across multiple dependencies", async () => {
     await withContext(defaultOpts, async ctx => {
       const foo_package = JSON.stringify({

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -6821,7 +6821,9 @@ describe.concurrent("bun-install", () => {
       // the note should mention --production, not just --frozen-lockfile
       const err = await stderr.text();
       expect(err).toContain("error: lockfile had changes, but lockfile is frozen");
-      expect(err).toContain("--production");
+      expect(err).toContain(
+        "try re-running without --frozen-lockfile or --production and commit the updated lockfile",
+      );
       expect(await exited).toBe(1);
     });
   });


### PR DESCRIPTION
## What

`bun install --production` has always enabled `--frozen-lockfile` internally (see [`PackageManagerOptions.rs`](https://github.com/oven-sh/bun/blob/main/src/install/PackageManager/PackageManagerOptions.rs#L817-L821)), but neither `--help` nor the docs said so. Users who only expected `devDependencies` to be skipped would hit:

```
error: lockfile had changes, but lockfile is frozen
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

with a note telling them to remove a flag they never passed.

## Changes

- `--production` help text now says `Don't install devDependencies. Implies --frozen-lockfile`
- The frozen-lockfile error note now mentions `--production` alongside `--frozen-lockfile`
- `docs/pm/cli/install.mdx` documents the implied flag and points to `--omit=dev` as the alternative for skipping devDeps without freezing the lockfile. Also drops the incorrect `or optionalDependencies` (production mode does not skip optionals)
- `docs/runtime/bunfig.mdx` and `docs/snippets/cli/install.mdx` updated to match

## Why document rather than change behavior

The behavior has been in place since `--frozen-lockfile` was added in v0.6.10 and is relied on by CI pipelines that expect production installs to be reproducible. Changing it would be a silent behavior change; documenting it plus providing a clear alternative (`--omit=dev`) is the lower-risk fix.

## Verification

```
$ bun-debug install --help | grep production
  -p, --production                   Don't install devDependencies. Implies --frozen-lockfile
```

New test in `test/cli/install/bun-install.test.ts` asserts both the help text and that the error note mentions `--production` when a stale lockfile is hit via `--production`.

The `docs/pm/cli/install.mdx` hunk overlaps with one line of #33709 (which is a broader docs-only sweep); this PR additionally fixes help text, the error note, bunfig docs, and the flag snippet.

Fixes #10949

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->