### PR TITLE
node-fetch: accept legacy Stream instances as Response body

### DIFF
--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -40,9 +40,18 @@ class Response extends WebResponse {
   [kHeaders];
 
   constructor(body, init) {
-    const { Readable, Stream } = require("node:stream");
+    const { Readable, Stream, PassThrough } = require("node:stream");
     if (body && typeof body === "object" && (body instanceof Stream || body instanceof Readable)) {
-      body = Readable.toWeb(body);
+      // Readable.toWeb requires a Node.js Readable (with _readableState). Packages like minipass
+      // extend the legacy Stream base class without that state, so route them through a
+      // PassThrough first — the same approach used in fetch() below for legacy streams.
+      let readable = body;
+      if (typeof readable._readableState !== "object") {
+        const passthrough = new PassThrough();
+        readable.pipe(passthrough);
+        readable = passthrough;
+      }
+      body = Readable.toWeb(readable);
     }
 
     super(body, init);

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -42,9 +42,7 @@ class Response extends WebResponse {
   constructor(body, init) {
     const { Readable, Stream, PassThrough } = require("node:stream");
     if (body && typeof body === "object" && (body instanceof Stream || body instanceof Readable)) {
-      // Readable.toWeb requires a Node.js Readable (with _readableState). Packages like minipass
-      // extend the legacy Stream base class without that state, so route them through a
-      // PassThrough first — the same approach used in fetch() below for legacy streams.
+      // Readable.toWeb requires _readableState; minipass etc. extend Stream without it.
       let readable = body;
       if (typeof readable._readableState !== "object") {
         const passthrough = new PassThrough();

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -46,6 +46,7 @@ class Response extends WebResponse {
       let readable = body;
       if (typeof readable._readableState !== "object") {
         const passthrough = new PassThrough();
+        readable.on("error", err => passthrough.destroy(err));
         readable.pipe(passthrough);
         readable = passthrough;
       }
@@ -171,6 +172,7 @@ async function fetch(
       let readable = initBody;
       if (!(readable instanceof Readable)) {
         const passthrough = new PassThrough();
+        readable.on("error", err => passthrough.destroy(err));
         readable.pipe(passthrough);
         readable = passthrough;
       }

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -76,6 +76,18 @@ test("node-fetch Response accepts a legacy Stream body that is not a stream.Read
   expect(await res.text()).toBe("hello world");
 });
 
+test("node-fetch Response rejects body consumers when a legacy Stream body errors", async () => {
+  class MinipassLike extends stream.Stream {}
+
+  const body = new MinipassLike();
+  body.on("error", () => {});
+
+  const res = new Response(body, { status: 200 });
+  queueMicrotask(() => body.emit("error", new Error("integrity check failed")));
+
+  await expect(res.text()).rejects.toThrow("integrity check failed");
+});
+
 test("node-fetch Response accepts a stream.Readable body", async () => {
   const body = stream.Readable.from([Buffer.from("from "), Buffer.from("readable")]);
   const res = new Response(body, { status: 200 });

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -56,9 +56,6 @@ for (const [impl, name] of [
 }
 
 // https://github.com/oven-sh/bun/issues/13390
-// Packages like minipass (used by cacache, @expo/cli) implement streams by extending the legacy
-// Stream base class directly, without Node's Readable machinery. node-fetch accepts these as
-// Response bodies; previously Bun's override threw ERR_INVALID_ARG_TYPE from Readable.toWeb.
 test("node-fetch Response accepts a legacy Stream body that is not a stream.Readable", async () => {
   class MinipassLike extends stream.Stream {
     end(chunk) {

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -88,6 +88,22 @@ test("node-fetch Response rejects body consumers when a legacy Stream body error
   await expect(res.text()).rejects.toThrow("integrity check failed");
 });
 
+test("node-fetch fetch() rejects when a legacy Stream request body errors", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response("ok"),
+  });
+
+  class Legacy extends stream.Stream {}
+  const body = new Legacy();
+  body.on("error", () => {});
+
+  const p = fetch2(server.url.href, { method: "POST", body });
+  queueMicrotask(() => body.emit("error", new Error("upload failed")));
+
+  await expect(p).rejects.toThrow("upload failed");
+});
+
 test("node-fetch Response accepts a stream.Readable body", async () => {
   const body = stream.Readable.from([Buffer.from("from "), Buffer.from("readable")]);
   const res = new Response(body, { status: 200 });

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -55,6 +55,37 @@ for (const [impl, name] of [
   });
 }
 
+// https://github.com/oven-sh/bun/issues/13390
+// Packages like minipass (used by cacache, @expo/cli) implement streams by extending the legacy
+// Stream base class directly, without Node's Readable machinery. node-fetch accepts these as
+// Response bodies; previously Bun's override threw ERR_INVALID_ARG_TYPE from Readable.toWeb.
+test("node-fetch Response accepts a legacy Stream body that is not a stream.Readable", async () => {
+  class MinipassLike extends stream.Stream {
+    end(chunk) {
+      if (chunk) this.emit("data", chunk);
+      this.emit("end");
+    }
+  }
+
+  const body = new MinipassLike();
+  expect(body instanceof stream.Stream).toBe(true);
+  expect(body instanceof stream.Readable).toBe(false);
+  expect(body._readableState).toBeUndefined();
+
+  const res = new Response(body, { status: 200 });
+  queueMicrotask(() => body.end(Buffer.from("hello world")));
+
+  expect(res.body).toBeInstanceOf(stream.Readable);
+  expect(await res.text()).toBe("hello world");
+});
+
+test("node-fetch Response accepts a stream.Readable body", async () => {
+  const body = stream.Readable.from([Buffer.from("from "), Buffer.from("readable")]);
+  const res = new Response(body, { status: 200 });
+  expect(res.body).toBeInstanceOf(stream.Readable);
+  expect(await res.text()).toBe("from readable");
+});
+
 test("node-fetch uses node streams instead of web streams", async () => {
   using server = Bun.serve({
     port: 0,


### PR DESCRIPTION
Fixes #13390.
Fixes #8487.
Fixes #14481.

## Problem

`@expo/cli` (and `node-fetch-cache`) use `cacache` to cache HTTP responses. `cacache.get.stream()` returns a `Pipeline` instance from `minipass-pipeline`, which extends `minipass`, which extends the legacy `stream.Stream` base class directly (not `stream.Readable`). It has `.pipe()` and emits `data`/`end`, but it has no `_readableState`.

Those packages pass that stream to `new Response(bodyStream, meta)` from `node-fetch`. Upstream `node-fetch` stores any `body instanceof Stream` as-is and later consumes it via `data`/`end`, so this works under Node. Bun's `node-fetch` override instead calls `Readable.toWeb(body)` so the body can be handed to the native `Response` constructor, and `Readable.toWeb` throws `ERR_INVALID_ARG_TYPE` for anything without `_readableState`:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "streamReadable" argument must be an stream.Readable. Received an instance of Pipeline
    at newReadableStreamFromStreamReadable (node:stream:2527:41)
    at new Response (node-fetch:48:13)
    at new NFCResponse (.../node_modules/@expo/cli/build/src/api/rest/cache/response.js:21:8)
```

## Fix

When the body is `instanceof Stream` but does not have `_readableState`, pipe it through a `PassThrough` before calling `Readable.toWeb`. This is the same approach the module already uses in `fetch()` for legacy request body streams that lack `Symbol.asyncIterator`.

## Verification

With the real packages from the issue:

```js
const { Response } = require("node-fetch");
const Minipass = require("minipass");
const Pipeline = require("minipass-pipeline");

const mp = new Minipass();
const res = new Response(new Pipeline(mp), { status: 200 });
mp.end("hello world");
console.log(await res.text()); // "hello world"
```

Before: throws `ERR_INVALID_ARG_TYPE`. After: prints `hello world`, matching Node.

Added a test in `test/js/node/http/node-fetch.test.js` that constructs a `Response` from a `stream.Stream` subclass without `_readableState` and reads the body back. The test fails on main with the reported error and passes with this change. Also added a test confirming the existing `stream.Readable` body path is unchanged.