### PR TITLE
completions: recognise $HOME/~/${HOME} and CRLF-marked zsh snippets

### DIFF
--- a/src/runtime/cli/install_completions_command.rs
+++ b/src/runtime/cli/install_completions_command.rs
@@ -665,8 +665,14 @@ impl InstallCompletionsCommand {
                     let contents = &buf[..read];
 
                     // Do they possibly have it in the file already?
+                    // Besides the absolute path we're about to write and the marker
+                    // comment, also accept any reference to the `_bun` file under a
+                    // `.bun` directory so hand-edited `$HOME`/`${HOME}`/`~` variants
+                    // are recognised (#10897). The marker comment intentionally does
+                    // not require a trailing '\n' so CRLF files match too.
                     if strings::contains(contents, completions_path)
-                        || strings::contains(contents, b"# bun completions\n")
+                        || strings::contains(contents, b"# bun completions")
+                        || strings::contains(contents, b"/.bun/_bun")
                     {
                         break 'brk false;
                     }

--- a/src/runtime/cli/install_completions_command.rs
+++ b/src/runtime/cli/install_completions_command.rs
@@ -664,12 +664,7 @@ impl InstallCompletionsCommand {
 
                     let contents = &buf[..read];
 
-                    // Do they possibly have it in the file already?
-                    // Besides the absolute path we're about to write and the marker
-                    // comment, also accept any reference to the `_bun` file under a
-                    // `.bun` directory so hand-edited `$HOME`/`${HOME}`/`~` variants
-                    // are recognised (#10897). The marker comment intentionally does
-                    // not require a trailing '\n' so CRLF files match too.
+                    // Do they possibly have it in the file already? (#10897)
                     if strings::contains(contents, completions_path)
                         || strings::contains(contents, b"# bun completions")
                         || strings::contains(contents, b"/.bun/_bun")

--- a/test/regression/issue/10897.test.ts
+++ b/test/regression/issue/10897.test.ts
@@ -35,12 +35,14 @@ function countBunSourceLines(zshrc: string): number {
   return (zshrc.match(/source\s+"[^"]*_bun"/g) ?? []).length;
 }
 
-test.skipIf(!isPosix).each([
-  ['[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"'],
-  ['[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"'],
-  ['[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"'],
-  ['[ -s "$BUN_INSTALL/_bun" ] && source "$BUN_INSTALL/_bun"\n# bun completions\r'],
-])("bun completions leaves existing zsh snippet alone: %s", async snippet => {
+test
+  .skipIf(!isPosix)
+  .each([
+    ['[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"'],
+    ['[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"'],
+    ['[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"'],
+    ['[ -s "$BUN_INSTALL/_bun" ] && source "$BUN_INSTALL/_bun"\n# bun completions\r'],
+  ])("bun completions leaves existing zsh snippet alone: %s", async snippet => {
   const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
   using dir = tempDir("bun-completions-10897", {
     ".bun/.keep": "",

--- a/test/regression/issue/10897.test.ts
+++ b/test/regression/issue/10897.test.ts
@@ -1,10 +1,4 @@
 // https://github.com/oven-sh/bun/issues/10897
-//
-// `bun completions` (run by `bun upgrade` with IS_BUN_AUTO_UPDATE=true) only
-// recognised an already-installed zsh snippet by its absolute path or the
-// "# bun completions\n" marker. Users who reference the file via $HOME / ~ /
-// ${HOME}, or whose marker line ends in CRLF, got a fresh hardcoded copy
-// appended on every upgrade.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { readFileSync } from "node:fs";

--- a/test/regression/issue/10897.test.ts
+++ b/test/regression/issue/10897.test.ts
@@ -1,0 +1,79 @@
+// https://github.com/oven-sh/bun/issues/10897
+//
+// `bun completions` (run by `bun upgrade` with IS_BUN_AUTO_UPDATE=true) only
+// recognised an already-installed zsh snippet by its absolute path or the
+// "# bun completions\n" marker. Users who reference the file via $HOME / ~ /
+// ${HOME}, or whose marker line ends in CRLF, got a fresh hardcoded copy
+// appended on every upgrade.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+async function runCompletions(home: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "completions", join(home, ".bun")],
+    env: {
+      ...bunEnv,
+      HOME: home,
+      ZDOTDIR: home,
+      SHELL: "/bin/zsh",
+      IS_BUN_AUTO_UPDATE: "true",
+      BUN_INSTALL: undefined,
+      XDG_DATA_HOME: undefined,
+      XDG_CONFIG_HOME: undefined,
+      fpath: undefined,
+    } as Record<string, string | undefined>,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+function countBunSourceLines(zshrc: string): number {
+  return (zshrc.match(/source\s+"[^"]*_bun"/g) ?? []).length;
+}
+
+test.skipIf(!isPosix).each([
+  ['[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"'],
+  ['[ -s "${HOME}/.bun/_bun" ] && source "${HOME}/.bun/_bun"'],
+  ['[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"'],
+  ['[ -s "$BUN_INSTALL/_bun" ] && source "$BUN_INSTALL/_bun"\n# bun completions\r'],
+])("bun completions leaves existing zsh snippet alone: %s", async snippet => {
+  const zshrcBefore = `export PATH="/usr/local/bin:$PATH"\n\n${snippet}\n`;
+  using dir = tempDir("bun-completions-10897", {
+    ".bun/.keep": "",
+    ".zshrc": zshrcBefore,
+  });
+  const home = String(dir);
+
+  const { stderr, exitCode } = await runCompletions(home);
+
+  const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+  expect(countBunSourceLines(zshrcAfter)).toBe(1);
+  expect(zshrcAfter).toBe(zshrcBefore);
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(!isPosix)("bun completions still appends once on a fresh .zshrc", async () => {
+  const zshrcBefore = 'export PATH="/usr/local/bin:$PATH"\n';
+  using dir = tempDir("bun-completions-10897-fresh", {
+    ".bun/.keep": "",
+    ".zshrc": zshrcBefore,
+  });
+  const home = String(dir);
+
+  const first = await runCompletions(home);
+  const zshrcAfter = readFileSync(join(home, ".zshrc"), "utf8");
+  expect(zshrcAfter).toContain("# bun completions");
+  expect(countBunSourceLines(zshrcAfter)).toBe(1);
+  if (first.exitCode !== 0) expect(first.stderr).toBe("");
+  expect(first.exitCode).toBe(0);
+
+  const second = await runCompletions(home);
+  const zshrcAfter2 = readFileSync(join(home, ".zshrc"), "utf8");
+  expect(zshrcAfter2).toBe(zshrcAfter);
+  expect(second.exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #10897. Related: #30335, #7641, #7227, #18407.

## Reproduction

A `.zshrc` with a hand-edited `$HOME`-based source line and no marker comment:

```sh
export PATH="/usr/local/bin:$PATH"

[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
```

Running `bun completions` (as `bun upgrade` does, with `IS_BUN_AUTO_UPDATE=true`) appends a second hardcoded copy:

```sh
[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"

# bun completions
[ -s "/Users/alice/.bun/_bun" ] && source "/Users/alice/.bun/_bun"
```

The same happens for `${HOME}/.bun/_bun` and `~/.bun/_bun`, and for files where the `# bun completions` marker is followed by `\r\n` instead of `\n`.

## Cause

`src/runtime/cli/install_completions_command.rs` detects an already-installed snippet only by matching the literal absolute path it would write, or the exact `# bun completions\n` marker. `$HOME`/`${HOME}`/`~` variants are none of the above, and the marker check fails on CRLF.

## Fix

Also treat any existing reference to `/.bun/_bun` as evidence the snippet is already loaded, and drop the trailing-`\n` requirement on the marker check. One extra `strings::contains` clause.

This is a re-application of #30338 (closed when the Zig file it edited was removed in the Rust migration) plus the CRLF fix.

## Scope

This covers the cases reported in the #10897 thread: portable `$HOME`/`~`/`${HOME}` paths and CRLF marker lines. Setups that load `_bun` purely via `fpath` with no `/.bun/_bun` reference in the rc file are not detected by substring matching; for those, a `# bun completions` marker line (now matched regardless of line ending) suppresses the append. Spawning `zsh -ic` to probe live shell state was considered and rejected: it would execute arbitrary `.zshrc` side effects during auto-update and add interactive-shell startup latency to every `bun upgrade`. An explicit opt-out is tracked separately in #24968.

## Verification

`test/regression/issue/10897.test.ts` covers `$HOME`/`${HOME}`/`~` variants, a CRLF marker, and a fresh `.zshrc` (snippet still appended once, second run is a no-op). The four variant cases fail on `USE_SYSTEM_BUN=1` and pass on the patched build.