### PR TITLE
structuredClone: purify NaN in deserialized Date timestamp so getTime never returns a forged JSValue

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5152,11 +5152,7 @@ private:
             double d;
             if (!read(d))
                 return JSValue();
-            // timeClip() does not canonicalize an impure NaN (std::abs(NaN) > max
-            // is false, std::trunc preserves the payload), and Date.prototype.getTime
-            // boxes m_internalNumber with jsNumber() unpurified. A crafted payload
-            // reaching here via bun:jsc.deserialize / v8.deserialize would otherwise
-            // store a forged JSValue bit pattern that getTime()/valueOf() returns.
+            // timeClip() passes an impure NaN through; getTime() would box it unpurified.
             DateInstance* obj = DateInstance::create(m_lexicalGlobalObject->vm(), m_globalObject->dateStructure(), purifyNaN(d));
             addTerminalToObjectPool(obj);
             return obj;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -5152,7 +5152,12 @@ private:
             double d;
             if (!read(d))
                 return JSValue();
-            DateInstance* obj = DateInstance::create(m_lexicalGlobalObject->vm(), m_globalObject->dateStructure(), d);
+            // timeClip() does not canonicalize an impure NaN (std::abs(NaN) > max
+            // is false, std::trunc preserves the payload), and Date.prototype.getTime
+            // boxes m_internalNumber with jsNumber() unpurified. A crafted payload
+            // reaching here via bun:jsc.deserialize / v8.deserialize would otherwise
+            // store a forged JSValue bit pattern that getTime()/valueOf() returns.
+            DateInstance* obj = DateInstance::create(m_lexicalGlobalObject->vm(), m_globalObject->dateStructure(), purifyNaN(d));
             addTerminalToObjectPool(obj);
             return obj;
         }

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -234,6 +234,75 @@ describe("bun:jsc", () => {
   });
 });
 
+it("deserialize of a Date with a crafted NaN timestamp returns a Number from getTime, never a forged JSValue", async () => {
+  // DateTag carries an 8-byte raw double. DateInstance::create stores
+  // timeClip(d) in m_internalNumber, but timeClip() does not canonicalize an
+  // impure NaN (std::abs(NaN) > max is false, std::trunc preserves the
+  // payload), and Date.prototype.getTime()/valueOf() later box that field with
+  // jsNumber() unpurified. Without purifyNaN at the DateTag read, a crafted
+  // bun:jsc.deserialize / v8.deserialize buffer forges boolean/undefined/int32
+  // or a cell pointer that segfaults when touched. Run in a child: the
+  // unfixed debug build asserts !isImpureNaN(d) at boxing time, and the
+  // cell-pointer case segfaults on release.
+  const script = `
+    const { serialize, deserialize } = require("bun:jsc");
+    const v8 = require("node:v8");
+
+    // Derive the wire layout instead of hard-coding offsets: serialize an
+    // Invalid Date (timestamp is canonical NaN) and find those 8 LE bytes.
+    const nanLE = Buffer.alloc(8);
+    nanLE.writeDoubleLE(NaN, 0);
+    const base = Buffer.from(serialize(new Date(NaN)));
+    const at = base.indexOf(nanLE);
+    if (at < 0) throw new Error("NaN bytes not found in serialized Date");
+
+    const payloads = [
+      "fffe000000000007", // would forge boolean true
+      "fffe00000000000a", // would forge undefined
+      "fffc000012345678", // would forge int32 0x12345678
+      "fffe000000001008", // would forge an unmapped cell pointer -> SEGV
+    ];
+
+    for (const bits of payloads) {
+      const patched = Buffer.from(base);
+      Buffer.from(bits, "hex").reverse().copy(patched, at); // native-endian
+      for (const de of [deserialize, buf => v8.deserialize(Buffer.from(buf))]) {
+        const d = de(patched);
+        if (!(d instanceof Date)) throw new Error("not a Date: " + String(d));
+        const t = d.getTime();
+        // Touch it as an object: a forged cell derefs and crashes here.
+        Object.prototype.toString.call(t);
+        const v = d.valueOf();
+        process.stdout.write(JSON.stringify({ t: typeof t, tNaN: Number.isNaN(t), v: typeof v, vNaN: Number.isNaN(v) }) + "\\n");
+      }
+    }
+
+    // A legitimate Date still round-trips.
+    const ok = deserialize(serialize(new Date(1234567890123)));
+    process.stdout.write(JSON.stringify({ ok: ok instanceof Date, ms: ok.getTime() }) + "\\n");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const lines = stdout
+    .split("\n")
+    .filter(Boolean)
+    .map(l => JSON.parse(l));
+  // Two deserialize entry points x four payloads, each purified to number NaN,
+  // then the round-trip check.
+  expect(lines).toEqual([
+    ...Array.from({ length: 8 }, () => ({ t: "number", tNaN: true, v: "number", vNaN: true })),
+    { ok: true, ms: 1234567890123 },
+  ]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it("deserialize rejects an object reference index outside the deserialized object pool", async () => {
   // A payload whose first value is ObjectReferenceTag must have its pool index
   // validated against the number of objects deserialized so far (zero here),


### PR DESCRIPTION
## What

The `DateTag` deserialize path reads 8 raw bytes into a `double` and passes it to `DateInstance::create`, which stores `timeClip(d)` in `m_internalNumber`. `WTF::timeClip` does not canonicalize an impure NaN: `std::abs(NaN) > maxECMAScriptTime` is false, so it returns `std::trunc(NaN) + 0.0`, which preserves the NaN payload bit-for-bit. `Date.prototype.getTime` / `valueOf` later box `m_internalNumber` with `jsNumber()` unpurified (`DatePrototype.cpp:403`).

A crafted `bun:jsc.deserialize` / `v8.deserialize` buffer can plant any NaN bit pattern as the Date timestamp; `.getTime()` decodes it as a forged immediate (`boolean`/`undefined`/int32) or a forged cell pointer that segfaults when touched. Same bug class and primitive as #35435 (Blob `lastModified`) and #33824 (`bun:sql` `float8`), in a sink those fixes did not cover.

## Repro (pre-fix)

```js
const { deserialize } = require("bun:jsc");
const b = Buffer.alloc(13);
b.writeUInt32LE(14, 0);       // CurrentVersion
b[4] = 0x0b;                  // DateTag
b.writeBigUInt64LE(0xfffe000000000007n, 5);
typeof deserialize(b).getTime();   // "boolean"  (should be "number")

b.writeBigUInt64LE(0xfffe000000001008n, 5);
Object.prototype.toString.call(deserialize(b).getTime());
```

```
panic(main thread): Segmentation fault at address 0x100D
```

## Fix

Pass `purifyNaN(d)` at the `DateTag` read, matching the `DoubleTag` and `NumberObjectTag` paths immediately above it. An Invalid Date deserialized from any NaN bit pattern now has `m_internalNumber == PNaN`, so `.getTime()`/`.valueOf()` always return a `Number`.

## Verification

New test in `test/js/bun/jsc/bun-jsc.test.ts` forges `boolean`, `undefined`, `int32`, and cell-pointer payloads through both `bun:jsc.deserialize` and `v8.deserialize`, asserting each `.getTime()` / `.valueOf()` comes back as `number` NaN, and a legitimate Date still round-trips. Runs in a child process since the pre-fix debug build asserts `!isImpureNaN(d)` at boxing time and the cell-pointer case segfaults on release.

- `USE_SYSTEM_BUN=1 bun test ... -t "crafted NaN timestamp"`: fails (getTime returns `boolean`/`undefined`/int32; child crashes on the cell-pointer payload).
- `bun bd test ...`: 37 pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->