### PR TITLE
bun patch: accept absolute Windows paths from inside workspace packages

### DIFF
--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -104,8 +104,7 @@ pub fn do_patch_commit(
     let argument_owned: Option<Box<[u8]>>;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root
-        && (!Platform::Posix.is_absolute(argument)
-            || (cfg!(windows) && !Platform::Windows.is_absolute(argument)))
+        && !Platform::AUTO.is_absolute(argument)
     {
         if let Some(rel_path) = path_argument_relative_to_root_workspace_package(
             &lockfile,
@@ -738,8 +737,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     let argument_owned: Option<Box<[u8]>>;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root
-        && (!Platform::Posix.is_absolute(argument)
-            || (cfg!(windows) && !Platform::Windows.is_absolute(argument)))
+        && !Platform::AUTO.is_absolute(argument)
     {
         if let Some(rel_path) = path_argument_relative_to_root_workspace_package(
             &manager.lockfile,

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -300,19 +300,6 @@ describe("bun patch <pkg>", async () => {
     });
 
     // https://github.com/oven-sh/bun/issues/12882
-    //
-    // `bun patch <pkg>` run from a workspace package prints an absolute path in
-    // the suggested `bun patch --commit '<path>'` command. When the user ran
-    // that command verbatim from the same workspace package on Windows, the
-    // absolute drive-letter path was misclassified as relative and prefixed
-    // with the workspace-relative path, producing
-    //   ENOENT: packages\frontend\C:\project\node_modules\pkg\package.json
-    //
-    // This test drives the whole flow: parse the suggested path out of stdout
-    // and feed it straight back into `--commit` from inside the workspace
-    // package. It passes on POSIX before and after (the POSIX arm of the
-    // "is this path relative" check was already correct) and on Windows it
-    // exercises the fixed drive-letter-absolute case.
     test("inside workspace package with the absolute path from the patch suggestion", async () => {
       const tempdir = tempDirWithFiles("patch-ws-abs", {
         "package.json": JSON.stringify({
@@ -341,8 +328,6 @@ describe("bun patch <pkg>", async () => {
       const suggested = prep.stdout.toString().match(/bun patch --commit '([^']+)'/);
       expect(suggested).not.toBeNull();
       const absPath = suggested![1];
-      // The suggested path must be absolute and point at the root node_modules,
-      // not the workspace package's.
       expect(absPath).toContain("node_modules");
       expect(isAbsolute(absPath.replace(/\//g, sep))).toBe(true);
 

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -1,7 +1,7 @@
 import { $, ShellOutput } from "bun";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
-import { join } from "path";
+import { isAbsolute, join, sep } from "path";
 
 const expectNoError = (o: ShellOutput) => expect(o.stderr.toString()).not.toContain("error");
 // const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", sep) : path);
@@ -297,6 +297,70 @@ describe("bun patch <pkg>", async () => {
           ).toEqual("patches/@types%2Fws@8.5.4.patch");
         });
       }
+    });
+
+    // https://github.com/oven-sh/bun/issues/12882
+    //
+    // `bun patch <pkg>` run from a workspace package prints an absolute path in
+    // the suggested `bun patch --commit '<path>'` command. When the user ran
+    // that command verbatim from the same workspace package on Windows, the
+    // absolute drive-letter path was misclassified as relative and prefixed
+    // with the workspace-relative path, producing
+    //   ENOENT: packages\frontend\C:\project\node_modules\pkg\package.json
+    //
+    // This test drives the whole flow: parse the suggested path out of stdout
+    // and feed it straight back into `--commit` from inside the workspace
+    // package. It passes on POSIX before and after (the POSIX arm of the
+    // "is this path relative" check was already correct) and on Windows it
+    // exercises the fixed drive-letter-absolute case.
+    test("inside workspace package with the absolute path from the patch suggestion", async () => {
+      const tempdir = tempDirWithFiles("patch-ws-abs", {
+        "package.json": JSON.stringify({
+          name: "root",
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+        packages: {
+          frontend: {
+            "package.json": JSON.stringify({
+              name: "frontend",
+              version: "1.0.0",
+              dependencies: { "is-even": "1.0.0" },
+            }),
+          },
+        },
+      });
+
+      const subdir = join(tempdir, "packages", "frontend");
+
+      await $`${bunExe()} i`.env(bunEnv).cwd(subdir);
+
+      const prep = await $`${bunExe()} patch is-even`.env(bunEnv).cwd(subdir);
+      expect(prep.stderr.toString()).not.toContain("error");
+
+      const suggested = prep.stdout.toString().match(/bun patch --commit '([^']+)'/);
+      expect(suggested).not.toBeNull();
+      const absPath = suggested![1];
+      // The suggested path must be absolute and point at the root node_modules,
+      // not the workspace package's.
+      expect(absPath).toContain("node_modules");
+      expect(isAbsolute(absPath.replace(/\//g, sep))).toBe(true);
+
+      await Bun.write(
+        join(tempdir, "node_modules", "is-even", "index.js"),
+        "module.exports = function () { return 'patched'; };\n",
+      );
+
+      const commit = await $`${bunExe()} patch --commit ${absPath}`.env(bunEnv).cwd(subdir).throws(false);
+      expect(commit.stderr.toString()).not.toContain("ENOENT");
+      expect(commit.stderr.toString()).not.toContain("error");
+      expect(commit.exitCode).toBe(0);
+
+      expect(
+        (await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies["is-even@1.0.0"],
+      ).toEqual("patches/is-even@1.0.0.patch");
+      const patch = await Bun.file(join(tempdir, "patches", "is-even@1.0.0.patch")).text();
+      expect(patch).toContain("patched");
     });
 
     describe("inside ROOT workspace package", async () => {

--- a/test/cli/install/bun-patch.test.ts
+++ b/test/cli/install/bun-patch.test.ts
@@ -356,9 +356,9 @@ describe("bun patch <pkg>", async () => {
       expect(commit.stderr.toString()).not.toContain("error");
       expect(commit.exitCode).toBe(0);
 
-      expect(
-        (await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies["is-even@1.0.0"],
-      ).toEqual("patches/is-even@1.0.0.patch");
+      expect((await $`cat package.json`.cwd(tempdir).env(bunEnv).json()).patchedDependencies["is-even@1.0.0"]).toEqual(
+        "patches/is-even@1.0.0.patch",
+      );
       const patch = await Bun.file(join(tempdir, "patches", "is-even@1.0.0.patch")).text();
       expect(patch).toContain("patched");
     });


### PR DESCRIPTION
Fixes the "workspace path used when committing" half of #12882. The cross-drive `EPERM (copyfile)` half of that issue is #30556.

## Repro

From inside a workspace package on Windows, `bun patch <pkg>` prints an absolute path in its suggested follow-up command. Running that command verbatim from the same directory fails:

```
PS D:\git\ferry-traffic\packages\frontend> bun patch react-leaflet-heatmap-layer-v3
...
  bun patch --commit 'D:\git\ferry-traffic/node_modules/react-leaflet-heatmap-layer-v3'

PS D:\git\ferry-traffic\packages\frontend> bun patch --commit 'D:\git\ferry-traffic/node_modules/react-leaflet-heatmap-layer-v3'
bun patch v1.1.20
error: failed to read package.json: ENOENT: packages\frontend\D:\git\ferry-traffic\node_modules\react-leaflet-heatmap-layer-v3\package.json
```

Reproduced on current canary (1.4.0-canary.1 ae4b17de6) on Windows x64.

## Cause

`do_patch_commit` and `prepare_patch` rebase a relative path argument onto the workspace-package-relative prefix so that a path typed relative to the invoking cwd resolves from the workspace root (where the package manager actually runs). The "is this path relative" guard was:

```rust
!Platform::Posix.is_absolute(argument)
    || (cfg!(windows) && !Platform::Windows.is_absolute(argument))
```

On Windows, for `D:\...`:

- `Platform::Posix.is_absolute("D:\\...")` is `false` (does not start with `/`), so `!posix_abs` is `true`
- The whole disjunction is therefore `true` regardless of the Windows check

so a Windows drive-letter or UNC absolute path was treated as relative and joined onto `packages/<name>/`, producing `packages\frontend\D:\...\package.json`. The intent was `&&` (De Morgan of "absolute in either sense"), introduced in #12022.

## Fix

Replace the expression with `!Platform::AUTO.is_absolute(argument)`. On POSIX this is `Platform::Posix` (unchanged behaviour). On Windows it is `Platform::Windows`, whose `is_absolute` already returns `true` for `/`-rooted, `\\`-rooted, and drive-letter paths, which is exactly the set that must bypass the workspace prefix.

## Verification

New test "inside workspace package with the absolute path from the patch suggestion" in `test/cli/install/bun-patch.test.ts` runs `bun patch` from a workspace subdirectory, parses the suggested absolute path out of stdout, and feeds it straight back into `bun patch --commit` from the same subdirectory.

On Windows x64:
- `USE_SYSTEM_BUN=1 bun test` (canary ae4b17de6): **fails** with `ENOENT: packages\\frontend\\C:\\Users\\...\\node_modules\\is-even\\package.json`
- `bun bd test` (this branch): **passes**
- Full `bun-patch.test.ts`: 30/30 pass

On Linux x64:
- Full `bun-patch.test.ts`: 30/30 pass (the POSIX arm of the old expression was already correct, so the new test also passed before; the fix is behind `Platform::AUTO` which is `Posix` on Linux)

<details><summary>Windows fail-before output</summary>

```
bun patch v1.4.0-canary.1 (ae4b17de6)
ENOENT: No such file or directory: failed to read "packages\frontend\C:\Users\azureuser\AppData\Local\Temp\patch-ws-abs_p6lG1v\node_modules\is-even\package.json" (open)
error: expect(received).not.toContain(expected)
Expected to not contain: "ENOENT"
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-patch.test.ts

<!-- robobun:evidence:end -->