### PR TITLE
node:dns: report CNAME records in resolveAny instead of null entries

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -428,6 +428,14 @@ impl struct_hostent {
         // SAFETY: caller guarantees `this` was allocated by c-ares (or is null).
         unsafe { ares_free_hostent(this) };
     }
+
+    /// True when `h_aliases` has at least one entry. After
+    /// `ares_parse_a_reply`/`ares_parse_aaaa_reply` this indicates the answer
+    /// section contained at least one CNAME record.
+    pub fn has_aliases(&self) -> bool {
+        // SAFETY: h_aliases is either null or a NULL-terminated array of C strings.
+        !self.h_aliases.is_null() && unsafe { !(*self.h_aliases).is_null() }
+    }
 }
 
 pub struct hostent_with_ttls {
@@ -510,6 +518,17 @@ impl hostent_with_ttls {
             with_ttls.ttls[i] = ttl.ttl;
         }
         Ok(with_ttls)
+    }
+
+    /// True when the inner hostent has at least one address in `h_addr_list`.
+    pub fn has_addresses(&self) -> bool {
+        if self.hostent.is_null() {
+            return false;
+        }
+        // SAFETY: hostent is non-null (checked); h_addr_list is null or a
+        // NULL-terminated array.
+        let h = unsafe { &*self.hostent };
+        !h.h_addr_list.is_null() && unsafe { !(*h.h_addr_list).is_null() }
     }
 
     pub fn parse_aaaa(buffer: &[u8]) -> Result<Box<hostent_with_ttls>, Error> {
@@ -1420,6 +1439,7 @@ pub struct struct_ares_uri_reply {
 }
 
 pub struct struct_any_reply {
+    pub cname_reply: Option<Box<hostent_with_ttls>>,
     pub a_reply: Option<Box<hostent_with_ttls>>,
     pub aaaa_reply: Option<Box<hostent_with_ttls>>,
     pub mx_reply: *mut struct_ares_mx_reply,
@@ -1435,6 +1455,7 @@ pub struct struct_any_reply {
 impl Default for struct_any_reply {
     fn default() -> Self {
         Self {
+            cname_reply: None,
             a_reply: None,
             aaaa_reply: None,
             mx_reply: ptr::null_mut(),
@@ -1494,18 +1515,33 @@ impl struct_any_reply {
         let abuf = buffer.as_ptr();
         let alen = c_int::try_from(buffer.len()).unwrap_or(c_int::MAX);
 
+        // Node's `ns_t_cname_or_a`: when the answer section carries a CNAME,
+        // report it as a CNAME record and do not emit A records.
+        // `ares_parse_a_reply` surfaces CNAMEs via `h_aliases`.
         match hostent_with_ttls::parse_a(buffer) {
             Ok(result) => {
-                reply.a_reply = Some(result);
-                any_success = true;
+                // SAFETY: parse_a succeeded → hostent is non-null.
+                let has_cname = unsafe { (*result.hostent).has_aliases() };
+                if has_cname {
+                    reply.cname_reply = Some(result);
+                    any_success = true;
+                } else if result.has_addresses() {
+                    reply.a_reply = Some(result);
+                    any_success = true;
+                }
             }
             Err(err) => last_error = Some(err as c_int),
         }
 
         match hostent_with_ttls::parse_aaaa(buffer) {
             Ok(result) => {
-                reply.aaaa_reply = Some(result);
-                any_success = true;
+                // `ares_parse_aaaa_reply` also succeeds on a CNAME-only answer
+                // with zero AAAA addresses; skip that case so it does not
+                // contribute an empty slot.
+                if result.has_addresses() {
+                    reply.aaaa_reply = Some(result);
+                    any_success = true;
+                }
             }
             Err(err) => last_error = Some(err as c_int),
         }
@@ -1593,8 +1629,8 @@ impl struct_any_reply {
 
 impl Drop for struct_any_reply {
     fn drop(&mut self) {
-        // a_reply / aaaa_reply are Box<hostent_with_ttls>; their Drop frees the
-        // inner hostent via ares_free_hostent.
+        // cname_reply / a_reply / aaaa_reply are Box<hostent_with_ttls>; their
+        // Drop frees the inner hostent via ares_free_hostent.
         // SAFETY: each field is either null or a c-ares allocation matching its free fn.
         unsafe {
             if !self.mx_reply.is_null() {

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -429,9 +429,7 @@ impl struct_hostent {
         unsafe { ares_free_hostent(this) };
     }
 
-    /// True when `h_aliases` has at least one entry. After
-    /// `ares_parse_a_reply`/`ares_parse_aaaa_reply` this indicates the answer
-    /// section contained at least one CNAME record.
+    /// True when `h_aliases` has at least one entry (a CNAME was present).
     pub fn has_aliases(&self) -> bool {
         // SAFETY: h_aliases is either null or a NULL-terminated array of C strings.
         !self.h_aliases.is_null() && unsafe { !(*self.h_aliases).is_null() }
@@ -525,8 +523,7 @@ impl hostent_with_ttls {
         if self.hostent.is_null() {
             return false;
         }
-        // SAFETY: hostent is non-null (checked); h_addr_list is null or a
-        // NULL-terminated array.
+        // SAFETY: hostent non-null; h_addr_list is null or NULL-terminated.
         let h = unsafe { &*self.hostent };
         !h.h_addr_list.is_null() && unsafe { !(*h.h_addr_list).is_null() }
     }
@@ -1515,9 +1512,7 @@ impl struct_any_reply {
         let abuf = buffer.as_ptr();
         let alen = c_int::try_from(buffer.len()).unwrap_or(c_int::MAX);
 
-        // Node's `ns_t_cname_or_a`: when the answer section carries a CNAME,
-        // report it as a CNAME record and do not emit A records.
-        // `ares_parse_a_reply` surfaces CNAMEs via `h_aliases`.
+        // Node's `ns_t_cname_or_a`: a CNAME in the answer is reported as CNAME, not A.
         match hostent_with_ttls::parse_a(buffer) {
             Ok(result) => {
                 // SAFETY: parse_a succeeded → hostent is non-null.
@@ -1535,9 +1530,6 @@ impl struct_any_reply {
 
         match hostent_with_ttls::parse_aaaa(buffer) {
             Ok(result) => {
-                // `ares_parse_aaaa_reply` also succeeds on a CNAME-only answer
-                // with zero AAAA addresses; skip that case so it does not
-                // contribute an empty slot.
                 if result.has_addresses() {
                     reply.aaaa_reply = Some(result);
                     any_success = true;

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -562,22 +562,22 @@ pub(crate) fn any_reply_to_js(
     this: &mut c_ares::struct_any_reply,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
-    // The field set is expanded manually here. Keep in lockstep with
-    // `c_ares::struct_any_reply`'s fields.
-    let len: usize = this.a_reply.is_some() as usize
-        + this.aaaa_reply.is_some() as usize
-        + (!this.mx_reply.is_null()) as usize
-        + (!this.ns_reply.is_null()) as usize
-        + (!this.txt_reply.is_null()) as usize
-        + (!this.srv_reply.is_null()) as usize
-        + (!this.ptr_reply.is_null()) as usize
-        + (!this.naptr_reply.is_null()) as usize
-        + (!this.soa_reply.is_null()) as usize
-        + (!this.caa_reply.is_null()) as usize;
-
-    let array = JSValue::create_empty_array(global_this, len)?;
+    // Each field may contribute zero or many records, so start empty and let
+    // `put_index` grow the array instead of precomputing a length that can
+    // overshoot and leave trailing holes.
+    let array = JSValue::create_empty_array(global_this, 0)?;
     let mut i: u32 = 0;
 
+    if let Some(reply) = this.cname_reply.as_deref_mut() {
+        // SAFETY: parse_a succeeded → hostent is non-null.
+        let hostent = unsafe { &*reply.hostent };
+        if !hostent.h_name.is_null() {
+            // SAFETY: h_name is a non-null NUL-terminated C string from c-ares.
+            let name = unsafe { bun_core::ffi::cstr(hostent.h_name) }.to_bytes();
+            let response = utf8_to_js(global_this, name)?;
+            any_reply_append_all(global_this, array, &mut i, response, b"cname")?;
+        }
+    }
     if let Some(reply) = this.a_reply.as_deref_mut() {
         let response = hostent_with_ttls_to_js_response(reply, global_this, b"a")?;
         any_reply_append_all(global_this, array, &mut i, response, b"a")?;

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -562,9 +562,6 @@ pub(crate) fn any_reply_to_js(
     this: &mut c_ares::struct_any_reply,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
-    // Each field may contribute zero or many records, so start empty and let
-    // `put_index` grow the array instead of precomputing a length that can
-    // overshoot and leave trailing holes.
     let array = JSValue::create_empty_array(global_this, 0)?;
     let mut i: u32 = 0;
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -708,7 +708,8 @@ describe("dns.resolveAny with CNAME records", () => {
       const hdr = Buffer.from([m[0], m[1], 0x81, 0x80, 0, 1, 0, ans.length, 0, 0, 0, 0]);
       server.send(Buffer.concat([hdr, q, ...ans]), ri.port, ri.address);
     });
-    const { promise, resolve } = Promise.withResolvers();
+    const { promise, resolve, reject } = Promise.withResolvers();
+    server.once("error", reject);
     server.bind(0, "127.0.0.1", resolve);
     await promise;
     resolver = new dns.promises.Resolver({ timeout: 2000, tries: 1 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,5 +1,6 @@
-import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { isWindows } from "harness";
+import * as dgram from "node:dgram";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
 import * as fs from "node:fs";
@@ -659,5 +660,90 @@ describe("dns.lookupService with a numeric-string port", () => {
     expect(() => dns_promises.lookupService("127.0.0.1", "nope")).toThrow(
       expect.objectContaining({ code: "ERR_SOCKET_BAD_PORT" }),
     );
+  });
+});
+
+describe("dns.resolveAny with CNAME records", () => {
+  // Loopback UDP responder so no network is touched.
+  const enc = n =>
+    Buffer.concat([
+      ...n.split(".").map(p => Buffer.concat([Buffer.from([p.length]), Buffer.from(p)])),
+      Buffer.from([0]),
+    ]);
+  const rr = (name, type, ttl, rd) =>
+    Buffer.concat([enc(name), Buffer.from([0, type, 0, 1, 0, 0, ttl >> 8, ttl & 255, 0, rd.length]), rd]);
+
+  let server;
+  let resolver;
+
+  beforeAll(async () => {
+    server = dgram.createSocket("udp4");
+    server.on("message", (m, ri) => {
+      let i = 12;
+      const labels = [];
+      while (m[i]) {
+        labels.push(m.slice(i + 1, i + 1 + m[i]).toString());
+        i += m[i] + 1;
+      }
+      const q = m.slice(12, i + 5);
+      const name = labels.join(".");
+      const rest = labels.slice(1).join(".");
+      let ans;
+      if (labels[0] === "loop") {
+        ans = [rr(name, 5, 60, enc("b." + rest)), rr("b." + rest, 5, 60, enc(name))];
+      } else if (labels[0] === "one") {
+        ans = [rr(name, 5, 60, enc("target.example"))];
+      } else if (labels[0] === "aaaa") {
+        ans = [
+          rr(name, 5, 60, enc("target.example")),
+          rr(name, 28, 60, Buffer.from([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42])),
+        ];
+      } else {
+        ans = [
+          rr(name, 1, 60, Buffer.from([10, 0, 0, 1])),
+          rr(name, 5, 60, enc("mixtarget.example")),
+          rr(name, 16, 60, Buffer.from([2, 104, 105])),
+        ];
+      }
+      const hdr = Buffer.from([m[0], m[1], 0x81, 0x80, 0, 1, 0, ans.length, 0, 0, 0, 0]);
+      server.send(Buffer.concat([hdr, q, ...ans]), ri.port, ri.address);
+    });
+    const { promise, resolve } = Promise.withResolvers();
+    server.bind(0, "127.0.0.1", resolve);
+    await promise;
+    resolver = new dns.promises.Resolver({ timeout: 2000, tries: 1 });
+    resolver.setServers(["127.0.0.1:" + server.address().port]);
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  it("returns {type:'CNAME', value} for a CNAME-only ANY answer", async () => {
+    const res = await resolver.resolveAny("one.z.example");
+    expect(res).toEqual([{ value: "target.example", type: "CNAME" }]);
+  });
+
+  it("returns a single CNAME for a CNAME chain", async () => {
+    const res = await resolver.resolveAny("loop.z.example");
+    expect(res).toEqual([{ value: "b.z.example", type: "CNAME" }]);
+  });
+
+  it("reports CNAME (not A) plus other records in a mixed answer and never emits null", async () => {
+    const res = await resolver.resolveAny("mix.z.example");
+    expect(res).toEqual([{ value: "mixtarget.example", type: "CNAME" }, { entries: ["hi"], type: "TXT" }]);
+  });
+
+  it("still returns AAAA records alongside CNAME", async () => {
+    const res = await resolver.resolveAny("aaaa.z.example");
+    expect(res).toEqual([{ value: "target.example", type: "CNAME" }, { address: "::2a", ttl: 60, type: "AAAA" }]);
+  });
+
+  it("callback form returns the same shape", async () => {
+    const r = new dns.Resolver({ timeout: 2000, tries: 1 });
+    r.setServers(["127.0.0.1:" + server.address().port]);
+    const { promise, resolve, reject } = Promise.withResolvers();
+    r.resolveAny("one.z.example", (err, res) => (err ? reject(err) : resolve(res)));
+    expect(await promise).toEqual([{ value: "target.example", type: "CNAME" }]);
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -731,12 +731,18 @@ describe("dns.resolveAny with CNAME records", () => {
 
   it("reports CNAME (not A) plus other records in a mixed answer and never emits null", async () => {
     const res = await resolver.resolveAny("mix.z.example");
-    expect(res).toEqual([{ value: "mixtarget.example", type: "CNAME" }, { entries: ["hi"], type: "TXT" }]);
+    expect(res).toEqual([
+      { value: "mixtarget.example", type: "CNAME" },
+      { entries: ["hi"], type: "TXT" },
+    ]);
   });
 
   it("still returns AAAA records alongside CNAME", async () => {
     const res = await resolver.resolveAny("aaaa.z.example");
-    expect(res).toEqual([{ value: "target.example", type: "CNAME" }, { address: "::2a", ttl: 60, type: "AAAA" }]);
+    expect(res).toEqual([
+      { value: "target.example", type: "CNAME" },
+      { address: "::2a", ttl: 60, type: "AAAA" },
+    ]);
   });
 
   it("callback form returns the same shape", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes `dns.resolveAny()` returning literal `null` array entries whenever the ANY answer contains a CNAME record.

## Reproduction

With a loopback responder that answers ANY with a single CNAME:

```
bun:  one.z.example   [null,null]
bun:  mix.z.example   [{"address":"10.0.0.1","ttl":60,"type":"A"},{"entries":["hi"],"type":"TXT"},null]

node: one.z.example   [{"value":"target.example","type":"CNAME"}]
node: mix.z.example   [{"value":"mixtarget.example","type":"CNAME"},{"entries":["hi"],"type":"TXT"}]
```

Any consumer doing `r.type` on the documented record array would throw.

## Cause

`struct_any_reply::parse` feeds the raw reply buffer to `ares_parse_a_reply` / `ares_parse_aaaa_reply`. Both of those **succeed** when the answer section carries only CNAME records (the returned hostent has aliases but an empty `h_addr_list`), so `a_reply` / `aaaa_reply` end up `Some(...)` and are counted toward the pre-sized result array, but `hostent_with_ttls_to_js_response` then appends zero records for them, leaving holes that serialize as `null`. There was also no CNAME branch at all in `struct_any_reply`.

## Fix

Match Node's `ns_t_cname_or_a` semantics in `AnyTraits::Parse`:

- After the A parse, if the hostent has aliases (`h_aliases[0] != NULL`, meaning the answer carried a CNAME), store it in a new `cname_reply` field instead of `a_reply`. `any_reply_to_js` emits `{ value: h_name, type: "CNAME" }` for it (no `ttl`, same as Node).
- After the AAAA parse, drop results with zero addresses so a CNAME-only answer no longer contributes a phantom AAAA slot.
- Build the result array from length 0 and let `put_index` grow it, so a field that appends nothing can never leave a trailing hole regardless of record type.

## Verification

Output is now byte-identical to Node v26.3.0 for CNAME-only, CNAME-chain, A+CNAME+TXT, and CNAME+AAAA answers. New tests in `test/js/node/dns/node-dns.test.js` cover all four plus the callback form; `test-dns-resolveany.js` and `test-dns-resolveany-bad-ancount.js` still pass.