### PR TITLE
run: scope the --bun node shim directory by uid

### DIFF
--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -590,8 +590,9 @@ impl RunCommand {
                 let _ = bun_sys::delete_tree_absolute(dir);
             }
 
-            // `<tmp>/bun-node-<uid>-<sha>` + `/node` + NUL. The prefix is
-            // bounded (<= 12 + 10 + 10 + 1 + 9 = 42 bytes), so 64 is plenty.
+            // `<tmp>/bun-node-<uid>-<sha>` + `/node` + NUL. The longest prefix
+            // is android's `/data/local/tmp` (15); with a 10-digit uid and
+            // 9-char sha the whole thing is 51 bytes, so 64 is plenty.
             debug_assert!(dir.len() + b"/node\0".len() <= 64);
             let mut dir_buf = [0u8; 64];
             dir_buf[..dir.len()].copy_from_slice(dir);

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -406,12 +406,9 @@ pub static PRETEND_TO_BE_NODE: core::sync::atomic::AtomicBool =
 
 use bun_core::ZStr;
 
-/// `bun-node-<uid>-<sha>` / `bun-node-<uid>-debug` / `bun-node-<uid>`.
-/// Shared by the POSIX `bun_node_dir()` accessor and the Windows branch of
-/// `create_fake_temporary_node_executable`; `uid` is `getuid()` on POSIX and
-/// `user_unique_id()` (a username hash) on Windows — same scheme `bunx` uses
-/// for its `bunx-<uid>-*` cache so users on a multi-user host don't share a
-/// shim directory (#7504).
+/// `bun-node-<uid>[-<sha>|-debug]` — same per-user scheme as the
+/// `bunx-<uid>-*` cache (#7504). `uid` = `getuid()` on POSIX,
+/// `user_unique_id()` on Windows.
 pub fn bun_node_dir_name(uid: u32) -> String {
     if bun_core::env::IS_DEBUG {
         format!("bun-node-{uid}-debug")
@@ -435,20 +432,10 @@ impl RunCommand {
         "/tmp"
     };
 
-    /// `/tmp/bun-node-<uid>-<sha>` (or debug variant). Windows builds compute
-    /// the temp prefix at runtime via GetTempPathW and use
-    /// `bun_sys::windows::user_unique_id()` in place of the uid, so this
-    /// accessor is POSIX-only.
-    ///
-    /// The uid keeps each user on a multi-user host in their own directory
-    /// (#7504) — the same scheme `bunx` uses for its cache. Without it the
-    /// first user to run `--bun` owns the shared `/tmp/bun-node-<sha>` (mode
-    /// 0700) and every other user's `--bun` silently falls through to the real
-    /// `node`.
-    ///
-    /// NOTE: the SHA alone does not uniquely identify a binary — two local
-    /// builds at the same commit share this dir. `create_fake_temporary_node_executable`
-    /// therefore re-points a stale link on EEXIST instead of trusting it.
+    /// `/tmp/bun-node-<uid>-<sha>` (or debug variant). POSIX-only; Windows
+    /// computes the temp prefix at runtime via GetTempPathW. The SHA alone
+    /// does not uniquely identify a binary, so the EEXIST branch below
+    /// re-points a stale link instead of trusting it.
     #[cfg(not(windows))]
     pub fn bun_node_dir() -> &'static str {
         static ONCE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
@@ -599,9 +586,7 @@ impl RunCommand {
                 }
             };
 
-            // `<tmp>/bun-node-<uid>-<sha>` + `/node` + NUL fits in 64 bytes.
-            // Every component but the uid is const-evaluable; uid is u32, so
-            // at most 10 digits.
+            // `<tmp>/bun-node-<uid>-<sha>` + `/node\0` fits in 64 bytes.
             const _: () = assert!(
                 RunCommand::BUN_NODE_TMP.len()
                     + "/bun-node-".len()
@@ -708,12 +693,8 @@ impl RunCommand {
 
             target_path_buffer[..prefix.len()].copy_from_slice(prefix);
 
-            // Keyed by user (same scheme as `bunx-<uid>-*`, using
-            // `user_unique_id()` as the Windows uid stand-in) so accounts that
-            // share a temp dir — SYSTEM / services without a loaded profile
-            // fall back to `C:\Windows\Temp` — don't reuse each other's
-            // hardlinks (#7504). ASCII-only, so widen byte-by-byte into a
-            // small stack buffer.
+            // Keyed by `user_unique_id()` (see `bun_node_dir_name`);
+            // ASCII-only, so widen byte-by-byte into a small stack buffer.
             let dir_name_str = bun_node_dir_name(win::user_unique_id());
             let mut dir_name_buf = [0u16; 64];
             for (i, b) in dir_name_str.bytes().enumerate() {

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -410,33 +410,41 @@ impl RunCommand {
     #[cfg(not(windows))]
     const SHELLS_TO_SEARCH: &'static [&'static [u8]] = &[b"bash", b"sh", b"zsh"];
 
-    /// `/tmp/bun-node-<sha>` (or debug variant). Windows builds compute the path
-    /// at runtime via GetTempPathW, so this constant is POSIX-only.
+    /// `/tmp/bun-node-<uid>-<sha>` (or debug variant). Windows builds compute
+    /// the path at runtime via GetTempPathW (already per-user), so this is
+    /// POSIX-only.
+    ///
+    /// The uid keeps each user on a multi-user host in their own directory
+    /// (#7504) — the same scheme `bunx` uses for its cache. Without it the
+    /// first user to run `--bun` owns the shared `/tmp/bun-node-<sha>` (mode
+    /// 0700) and every other user's `--bun` silently falls through to the real
+    /// `node`.
     ///
     /// NOTE: the SHA alone does not uniquely identify a binary — two local
     /// builds at the same commit share this dir. `create_fake_temporary_node_executable`
     /// therefore re-points a stale link on EEXIST instead of trusting it.
     #[cfg(not(windows))]
-    pub const BUN_NODE_DIR: &'static str = {
-        // `const_format::concatcp!` cannot host
-        // `if` expressions inline, so split into helper consts.
-        use const_format::concatcp;
-        const TMP: &str = if cfg!(target_os = "macos") {
-            "/private/tmp"
-        } else if cfg!(target_os = "android") {
-            "/data/local/tmp"
-        } else {
-            "/tmp"
-        };
-        const SUFFIX: &str = if bun_core::env::IS_DEBUG {
-            "/bun-node-debug"
-        } else if bun_core::env::GIT_SHA_SHORT.is_empty() {
-            "/bun-node"
-        } else {
-            concatcp!("/bun-node-", bun_core::env::GIT_SHA_SHORT)
-        };
-        concatcp!(TMP, SUFFIX)
-    };
+    pub fn bun_node_dir() -> &'static str {
+        static ONCE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+        ONCE.get_or_init(|| {
+            let tmp = if cfg!(target_os = "macos") {
+                "/private/tmp"
+            } else if cfg!(target_os = "android") {
+                "/data/local/tmp"
+            } else {
+                "/tmp"
+            };
+            let uid = bun_sys::c::getuid();
+            if bun_core::env::IS_DEBUG {
+                format!("{tmp}/bun-node-{uid}-debug")
+            } else if bun_core::env::GIT_SHA_SHORT.is_empty() {
+                format!("{tmp}/bun-node-{uid}")
+            } else {
+                format!("{tmp}/bun-node-{uid}-{}", bun_core::env::GIT_SHA_SHORT)
+            }
+        })
+        .as_str()
+    }
 
     fn find_shell_impl<'a>(
         buf: &'a mut bun_paths::PathBuffer,
@@ -520,9 +528,8 @@ impl RunCommand {
 
         #[cfg(not(windows))]
         {
-            use const_format::concatcp;
-
             let argv0: &ZStr = bun_core::argv().get(0).unwrap_or(bun_core::zstr!("bun"));
+            let dir = Self::bun_node_dir().as_bytes();
 
             // PREFER `self_exe_path()` OVER `argv[0]`: on a nested `--bun`, the
             // OUTER bun prepends `BUN_NODE_DIR` to `PATH` and the INNER bun is
@@ -553,7 +560,7 @@ impl RunCommand {
                     }
                     result => {
                         let argv0_bytes = argv0.as_bytes();
-                        if argv0_bytes.starts_with(Self::BUN_NODE_DIR.as_bytes()) {
+                        if argv0_bytes.starts_with(dir) {
                             // `self_exe_path()` failed and `argv[0]` is the shim
                             // under `BUN_NODE_DIR` (nested `--bun`). Using it as
                             // the target would recreate the #30711 self-loop; the
@@ -580,32 +587,33 @@ impl RunCommand {
             {
                 // Debug-only cleanup; failures are ignored. The EEXIST branch
                 // below already handles a stale dir.
-                let _ = bun_sys::delete_tree_absolute(Self::BUN_NODE_DIR.as_bytes());
+                let _ = bun_sys::delete_tree_absolute(dir);
             }
 
-            const NODE_LINK: &ZStr = {
-                const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "/node\0").as_bytes();
-                // SAFETY: literal ends in NUL; len excludes it.
-                ZStr::from_static(B)
-            };
-            const BUN_LINK: &ZStr = {
-                const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "/bun\0").as_bytes();
-                // SAFETY: literal ends in NUL; len excludes it.
-                ZStr::from_static(B)
-            };
-            const DIR_Z: &ZStr = {
-                const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "\0").as_bytes();
-                // SAFETY: literal ends in NUL; len excludes it.
-                ZStr::from_static(B)
-            };
+            // `<tmp>/bun-node-<uid>-<sha>` + `/node` + NUL. The prefix is
+            // bounded (<= 12 + 10 + 10 + 1 + 9 = 42 bytes), so 64 is plenty.
+            debug_assert!(dir.len() + b"/node\0".len() <= 64);
+            let mut dir_buf = [0u8; 64];
+            dir_buf[..dir.len()].copy_from_slice(dir);
+            let dir_z = ZStr::from_buf(&dir_buf, dir.len());
+
+            let mut node_buf = [0u8; 64];
+            node_buf[..dir.len()].copy_from_slice(dir);
+            node_buf[dir.len()..][..5].copy_from_slice(b"/node");
+            let node_link = ZStr::from_buf(&node_buf, dir.len() + 5);
+
+            let mut bun_buf = [0u8; 64];
+            bun_buf[..dir.len()].copy_from_slice(dir);
+            bun_buf[dir.len()..][..4].copy_from_slice(b"/bun");
+            let bun_link = ZStr::from_buf(&bun_buf, dir.len() + 4);
 
             // Don't trust attacker-created entries in a shared temp dir
             // (`BUN_NODE_DIR` lives under e.g. `/tmp`). Create it `0700`; if it
             // already exists, refuse to use it unless it's a directory we own
             // with no group/other write bits.
-            match bun_sys::mkdir(DIR_Z, 0o700) {
+            match bun_sys::mkdir(dir_z, 0o700) {
                 Ok(()) => {}
-                Err(e) if e.get_errno() == bun_sys::E::EEXIST => match bun_sys::lstat(DIR_Z) {
+                Err(e) if e.get_errno() == bun_sys::E::EEXIST => match bun_sys::lstat(dir_z) {
                     Ok(st)
                         if bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode)
                             == bun_sys::FileKind::Directory
@@ -616,7 +624,7 @@ impl RunCommand {
                 Err(_) => return Ok(()),
             }
 
-            for dest in [NODE_LINK, BUN_LINK] {
+            for dest in [node_link, bun_link] {
                 let mut replaced = false;
                 loop {
                     match bun_sys::symlink(argv0_z, dest) {
@@ -651,7 +659,7 @@ impl RunCommand {
             // The reason for the extra delim is because we are going to append the system PATH
             // later on. this is done by the caller, and explains why we are adding bun_node_dir
             // to the end of the path slice rather than the start.
-            path.extend_from_slice(Self::BUN_NODE_DIR.as_bytes());
+            path.extend_from_slice(dir);
             path.push(bun_paths::DELIMITER);
             Ok(())
         }

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -406,13 +406,39 @@ pub static PRETEND_TO_BE_NODE: core::sync::atomic::AtomicBool =
 
 use bun_core::ZStr;
 
+/// `bun-node-<uid>-<sha>` / `bun-node-<uid>-debug` / `bun-node-<uid>`.
+/// Shared by the POSIX `bun_node_dir()` accessor and the Windows branch of
+/// `create_fake_temporary_node_executable`; `uid` is `getuid()` on POSIX and
+/// `user_unique_id()` (a username hash) on Windows — same scheme `bunx` uses
+/// for its `bunx-<uid>-*` cache so users on a multi-user host don't share a
+/// shim directory (#7504).
+pub fn bun_node_dir_name(uid: u32) -> String {
+    if bun_core::env::IS_DEBUG {
+        format!("bun-node-{uid}-debug")
+    } else if bun_core::env::GIT_SHA_SHORT.is_empty() {
+        format!("bun-node-{uid}")
+    } else {
+        format!("bun-node-{uid}-{}", bun_core::env::GIT_SHA_SHORT)
+    }
+}
+
 impl RunCommand {
     #[cfg(not(windows))]
     const SHELLS_TO_SEARCH: &'static [&'static [u8]] = &[b"bash", b"sh", b"zsh"];
 
+    #[cfg(not(windows))]
+    const BUN_NODE_TMP: &'static str = if cfg!(target_os = "macos") {
+        "/private/tmp"
+    } else if cfg!(target_os = "android") {
+        "/data/local/tmp"
+    } else {
+        "/tmp"
+    };
+
     /// `/tmp/bun-node-<uid>-<sha>` (or debug variant). Windows builds compute
-    /// the path at runtime via GetTempPathW (already per-user), so this is
-    /// POSIX-only.
+    /// the temp prefix at runtime via GetTempPathW and use
+    /// `bun_sys::windows::user_unique_id()` in place of the uid, so this
+    /// accessor is POSIX-only.
     ///
     /// The uid keeps each user on a multi-user host in their own directory
     /// (#7504) — the same scheme `bunx` uses for its cache. Without it the
@@ -427,21 +453,11 @@ impl RunCommand {
     pub fn bun_node_dir() -> &'static str {
         static ONCE: std::sync::OnceLock<String> = std::sync::OnceLock::new();
         ONCE.get_or_init(|| {
-            let tmp = if cfg!(target_os = "macos") {
-                "/private/tmp"
-            } else if cfg!(target_os = "android") {
-                "/data/local/tmp"
-            } else {
-                "/tmp"
-            };
-            let uid = bun_sys::c::getuid();
-            if bun_core::env::IS_DEBUG {
-                format!("{tmp}/bun-node-{uid}-debug")
-            } else if bun_core::env::GIT_SHA_SHORT.is_empty() {
-                format!("{tmp}/bun-node-{uid}")
-            } else {
-                format!("{tmp}/bun-node-{uid}-{}", bun_core::env::GIT_SHA_SHORT)
-            }
+            format!(
+                "{}/{}",
+                Self::BUN_NODE_TMP,
+                bun_node_dir_name(bun_sys::c::getuid() as u32),
+            )
         })
         .as_str()
     }
@@ -583,16 +599,18 @@ impl RunCommand {
                 }
             };
 
-            #[cfg(bun_debug)]
-            {
-                // Debug-only cleanup; failures are ignored. The EEXIST branch
-                // below already handles a stale dir.
-                let _ = bun_sys::delete_tree_absolute(dir);
-            }
-
-            // `<tmp>/bun-node-<uid>-<sha>` + `/node` + NUL. The longest prefix
-            // is android's `/data/local/tmp` (15); with a 10-digit uid and
-            // 9-char sha the whole thing is 51 bytes, so 64 is plenty.
+            // `<tmp>/bun-node-<uid>-<sha>` + `/node` + NUL fits in 64 bytes.
+            // Every component but the uid is const-evaluable; uid is u32, so
+            // at most 10 digits.
+            const _: () = assert!(
+                RunCommand::BUN_NODE_TMP.len()
+                    + "/bun-node-".len()
+                    + 10 // u32::MAX digits
+                    + "-".len()
+                    + bun_core::env::GIT_SHA_SHORT.len()
+                    + "/node\0".len()
+                    <= 64
+            );
             debug_assert!(dir.len() + b"/node\0".len() <= 64);
             let mut dir_buf = [0u8; 64];
             dir_buf[..dir.len()].copy_from_slice(dir);
@@ -631,7 +649,7 @@ impl RunCommand {
                     match bun_sys::symlink(argv0_z, dest) {
                         Ok(()) => break,
                         Err(e) if e.get_errno() == bun_sys::E::EEXIST => {
-                            // The dir is keyed only on GIT_SHA_SHORT, so two
+                            // The dir is keyed on (uid, GIT_SHA_SHORT), so two
                             // different binaries built at the same commit (e.g.
                             // side-by-side local builds being benchmarked)
                             // collide here. Blindly reusing the existing link
@@ -690,16 +708,13 @@ impl RunCommand {
 
             target_path_buffer[..prefix.len()].copy_from_slice(prefix);
 
-            // The dir name is ASCII-only, so widen the const `&str` byte-by-
-            // byte into a small stack buffer at runtime (Rust macros require a
-            // single string *literal* token, which `concatcp!` doesn't yield).
-            let dir_name_str: &str = if bun_core::env::IS_DEBUG {
-                "bun-node-debug"
-            } else if bun_core::env::GIT_SHA_SHORT.is_empty() {
-                "bun-node"
-            } else {
-                const_format::concatcp!("bun-node-", bun_core::env::GIT_SHA_SHORT)
-            };
+            // Keyed by user (same scheme as `bunx-<uid>-*`, using
+            // `user_unique_id()` as the Windows uid stand-in) so accounts that
+            // share a temp dir — SYSTEM / services without a loaded profile
+            // fall back to `C:\Windows\Temp` — don't reuse each other's
+            // hardlinks (#7504). ASCII-only, so widen byte-by-byte into a
+            // small stack buffer.
+            let dir_name_str = bun_node_dir_name(win::user_unique_id());
             let mut dir_name_buf = [0u16; 64];
             for (i, b) in dir_name_str.bytes().enumerate() {
                 debug_assert!(b < 0x80, "dir_name is ASCII-only");

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1798,23 +1798,28 @@ impl RunCommand {
         Global::exit(1);
     }
 
-    // This path is almost always a path to a user directory. So it cannot be
-    // inlined like our uses of /tmp. On Windows use `GetTempPathW` /
-    // `RealFS.platformTempDir` instead — this const is POSIX-only and
-    // referencing it on Windows is a compile error.
-    //
     // Canonical definition lives in `bun_install::RunCommand` (lower tier so
     // the package manager can use it without depending on `bun_runtime`).
     #[cfg(not(windows))]
-    pub const BUN_NODE_DIR: &'static str = bun_install::RunCommand::BUN_NODE_DIR;
+    #[inline]
+    pub fn bun_node_dir() -> &'static str {
+        bun_install::RunCommand::bun_node_dir()
+    }
 
     /// Returns the path to the
     /// fake `node` shim that points back at the running `bun` binary.
     pub fn bun_node_file_utf8() -> crate::Result<&'static ZStr> {
         #[cfg(not(windows))]
         {
-            const BUN_NODE_DIR_Z: &str = const_format::concatcp!(RunCommand::BUN_NODE_DIR, "\0");
-            Ok(ZStr::from_static(BUN_NODE_DIR_Z.as_bytes()))
+            static ONCE: std::sync::OnceLock<Vec<u8>> = std::sync::OnceLock::new();
+            let bytes = ONCE.get_or_init(|| {
+                let dir = Self::bun_node_dir().as_bytes();
+                let mut v = Vec::with_capacity(dir.len() + 1);
+                v.extend_from_slice(dir);
+                v.push(0);
+                v
+            });
+            Ok(ZStr::from_slice_with_nul(bytes))
         }
         #[cfg(windows)]
         {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1843,18 +1843,11 @@ impl RunCommand {
                 &temp_path_buffer[..len as usize],
             );
 
-            const FILE_NAME: &str = const_format::concatcp!(
-                "bun-node",
-                if Environment::GIT_SHA_SHORT.len() > 0 {
-                    const_format::concatcp!("-", Environment::GIT_SHA_SHORT)
-                } else {
-                    ""
-                },
-                "\\node.exe"
-            );
+            let dir_name = bun_install::bun_node_dir_name(sys::windows::user_unique_id());
             let conv_len = converted.len();
-            let total = conv_len + FILE_NAME.len();
-            target_path_buffer[conv_len..total].copy_from_slice(FILE_NAME.as_bytes());
+            let total = conv_len + dir_name.len() + b"\\node.exe".len();
+            target_path_buffer[conv_len..][..dir_name.len()].copy_from_slice(dir_name.as_bytes());
+            target_path_buffer[conv_len + dir_name.len()..total].copy_from_slice(b"\\node.exe");
             target_path_buffer[total] = 0;
 
             // Park the

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1119,4 +1119,41 @@ describe.concurrent("bun run", () => {
       exitCode: 0,
     });
   });
+
+  // https://github.com/oven-sh/bun/issues/7504 — the `bun-node` shim dir used to
+  // be a fixed `/tmp/bun-node-<sha>`, shared across all users. The first user to
+  // run `--bun` owned it (mode 0700), and every other user's `--bun` silently
+  // fell through to the real `node`. The dir name must carry the uid so each
+  // user gets their own, same as the `bunx-<uid>-*` cache.
+  it.skipIf(isWindows)("--bun creates a per-user node shim directory (#7504)", async () => {
+    using dir = tempDir("bun-run-node-shim-uid", {
+      "package.json": JSON.stringify({
+        name: "shim-uid",
+        scripts: {
+          // Print the PATH entry that holds the node shim, and confirm `node`
+          // resolved through it is actually bun.
+          go: `node -e 'const p = process.env.PATH.split(":").find(e => /bun-node/.test(e)); console.log(p); console.log(typeof Bun);'`,
+        },
+      }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--bun", "run", "go"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [shimDir, bunType] = stdout.trim().split("\n");
+    const uid = process.getuid!();
+
+    expect(stderr).not.toContain("error");
+    expect({ shimDir, bunType, exitCode }).toEqual({
+      shimDir: expect.stringMatching(new RegExp(`/bun-node-${uid}(-|$)`)),
+      bunType: "object",
+      exitCode: 0,
+    });
+  });
 });


### PR DESCRIPTION
Fixes #7504

## Repro

On a multi-user host:

```console
# user A
$ bun --bun run go          # creates /tmp/bun-node-<sha>, mode 0700, owned by A
RUNNING-IN-BUN

# user B, same bun build
$ bun --bun run go
RUNNING-IN-NODE             # silently fell through to the real node
```

where `go` is `node -e 'console.log(typeof Bun !== "undefined" ? "RUNNING-IN-BUN" : "RUNNING-IN-NODE")'`.

## Cause

`create_fake_temporary_node_executable` (src/install/lib.rs) writes its `node`/`bun` symlinks under `/tmp/bun-node-<sha>`, a path shared by every user on the host. The first user creates it mode 0700; every other user's `mkdir` sees `EEXIST`, the owner check (`st_uid == getuid()`) fails, and the function returns `Ok(())` without prepending anything to `PATH`. Their `--bun` scripts that spawn `node` get the real node.

## Fix

Include the uid in the directory name (`/tmp/bun-node-<uid>-<sha>`), the same scheme `bunx` already uses for its cache (`/tmp/bunx-<uid>-*`, see `src/runtime/cli/bunx_command.rs`), so each user gets their own directory. The 0700 + owner/mode check is kept as the tamper guard.

`BUN_NODE_DIR` is no longer a compile-time constant (the uid is a runtime value), so it is now a `OnceLock<String>`-backed `fn bun_node_dir() -> &'static str`, with the directory-name portion factored into `bun_node_dir_name(uid)` shared by both platforms. The link paths inside `create_fake_temporary_node_executable` are built into small stack buffers (const-asserted at 64 bytes); the function is already `#[cold]`.

Windows: the directory name now also carries `bun_sys::windows::user_unique_id()` (a hash of the username), matching `bunx`. `GetTempPathW` is per-user for interactive sessions but falls back to `C:\Windows\Temp` for SYSTEM / services without a loaded profile, so accounts in that situation no longer share a shim directory. Routing both the Windows create path and `bun_node_file_utf8` through `bun_node_dir_name` also fixes a pre-existing debug-build mismatch between the two (create used `bun-node-debug`, `bun_node_file_utf8` used `bun-node-<sha>`).

The debug-only `delete_tree_absolute(dir)` wipe in the POSIX branch is dropped. It raced concurrent `--bun` spawners in `bun-run.test.ts` (the file is `describe.concurrent`), and the `readlink`-based re-point on `EEXIST` already handles a stale link.

## Verification

```console
$ rm -rf /tmp/bun-node*

# as root (uid 0)
$ bun-debug --bun run go
RUNNING-IN-BUN

# as testuser (uid 1000)
$ su testuser -c 'bun-debug --bun run go'
RUNNING-IN-BUN

$ ls -ld /tmp/bun-node*
drwx------ root     /tmp/bun-node-0-debug
drwx------ testuser /tmp/bun-node-1000-debug
```

On Windows (manually verified on windows-x64):

```
$ bun-debug --bun run go
C:\Users\...\AppData\Local\Temp\bun-node-1233398628-debug
object
```

Added `--bun creates a per-user node shim directory (#7504)` to `test/cli/install/bun-run.test.ts`, which asserts the shim directory that lands on the child's `PATH` carries the current uid and that `node` resolved through it is bun. Fails on main (`shimDir: "/tmp/bun-node-1498d7b77"`), passes with the change; full file stays green on both Linux (293/293) and Windows (402/402). Ran 20x with the concurrent `--bun` priority suite to verify the race is gone.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-run.test.ts

<!-- robobun:evidence:end -->