### PR TITLE
node-fetch: accept legacy Stream bodies in Response constructor

### DIFF
--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -40,9 +40,20 @@ class Response extends WebResponse {
   [kHeaders];
 
   constructor(body, init) {
-    const { Readable, Stream } = require("node:stream");
-    if (body && typeof body === "object" && (body instanceof Stream || body instanceof Readable)) {
-      body = Readable.toWeb(body);
+    if (body && typeof body === "object") {
+      const { Readable, Stream, PassThrough } = require("node:stream");
+      if (body instanceof Stream || body instanceof Readable) {
+        // Readable.toWeb requires a real Readable (with _readableState). Libraries such as
+        // minipass and combined-stream extend the legacy Stream base without that state, so
+        // route them through a PassThrough first (the same adaptation fetch() does below).
+        let readable = body;
+        if (typeof (readable as any)._readableState !== "object") {
+          const passthrough = new PassThrough();
+          readable.pipe(passthrough);
+          readable = passthrough;
+        }
+        body = Readable.toWeb(readable);
+      }
     }
 
     super(body, init);

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -3,7 +3,7 @@ import * as iso from "isomorphic-fetch";
 import fetch2, { fetch, Headers, Request, Response } from "node-fetch";
 import * as stream from "stream";
 
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 const originalResponse = globalThis.Response;
 const originalRequest = globalThis.Request;
@@ -157,4 +157,70 @@ test("node-fetch request body streams properly", async () => {
   const allData = Buffer.concat(receivedChunks).toString();
   expect(allData).toBe("first chunksecond chunkthird chunk");
   expect(requestBodyComplete).toBe(true);
+});
+
+// https://github.com/oven-sh/bun/issues/14481
+// https://github.com/oven-sh/bun/issues/13390
+describe("node-fetch Response accepts legacy Stream bodies", () => {
+  // Minimal stand-in for minipass / minipass-pipeline: extends the legacy Stream base
+  // class, implements pipe() and Symbol.asyncIterator, but has no _readableState.
+  class MinipassLike extends stream.Stream {
+    #chunks;
+    constructor(chunks) {
+      super();
+      this.#chunks = chunks;
+    }
+    pipe(dest) {
+      for (const chunk of this.#chunks) dest.write(chunk);
+      dest.end();
+      return dest;
+    }
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of this.#chunks) yield chunk;
+    }
+  }
+
+  // Minimal stand-in for combined-stream: extends the legacy Stream base class and
+  // implements pipe(), but provides neither _readableState nor Symbol.asyncIterator.
+  class LegacyStream extends stream.Stream {
+    #chunks;
+    constructor(chunks) {
+      super();
+      this.#chunks = chunks;
+    }
+    pipe(dest) {
+      for (const chunk of this.#chunks) dest.write(chunk);
+      dest.end();
+      return dest;
+    }
+  }
+
+  test("minipass-style stream (async iterable, no _readableState)", async () => {
+    const body = new MinipassLike([Buffer.from("hello "), Buffer.from("world")]);
+    expect(body instanceof stream.Stream).toBe(true);
+    expect(body instanceof stream.Readable).toBe(false);
+    expect(typeof body._readableState).toBe("undefined");
+    expect(typeof body[Symbol.asyncIterator]).toBe("function");
+
+    const res = new Response(body);
+    expect(await res.text()).toBe("hello world");
+  });
+
+  test("legacy stream (pipe only, no async iterator)", async () => {
+    const body = new LegacyStream([Buffer.from("abc"), Buffer.from("def")]);
+    expect(body instanceof stream.Stream).toBe(true);
+    expect(typeof body._readableState).toBe("undefined");
+    expect(body[Symbol.asyncIterator]).toBeUndefined();
+
+    const res = new Response(body);
+    expect(await res.text()).toBe("abcdef");
+  });
+
+  test("proper Readable body still works", async () => {
+    const body = stream.Readable.from([Buffer.from("proper "), Buffer.from("readable")]);
+    expect(typeof body._readableState).toBe("object");
+
+    const res = new Response(body);
+    expect(await res.text()).toBe("proper readable");
+  });
 });


### PR DESCRIPTION
## What does this PR do?

The Response constructor in Bun's `node-fetch` shim calls `Readable.toWeb()` on any body that is `instanceof Stream`, but `Readable.toWeb` requires a real `Readable` with `_readableState`. Libraries like `minipass` / `minipass-pipeline` (used by cacache, npm's fetch stack, older `@expo/cli`) and `combined-stream` extend the legacy `Stream` base without that state, so constructing a `Response` from them threw:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "streamReadable" argument must be of type stream.Readable. Received an instance of Pipeline
    at newReadableStreamFromStreamReadable (internal:webstreams_adapters)
    at new Response (node-fetch)
```

The fix routes such bodies through a `PassThrough` before calling `Readable.toWeb()`, which is the same adaptation the `fetch()` request-body path in this file already performs.

## Why is this correct?

Upstream `node-fetch` (v2 and v3) accepts any `instanceof Stream` as a body and consumes it via data/end events, so minipass pipelines work there. This change makes Bun's shim match that contract. Proper `Readable` bodies continue to go straight through `Readable.toWeb()` unchanged.

## How did you verify your code works?

Repro (works in Node, failed in Bun before this change, passes after):

```js
const Minipass = require("minipass");
const Pipeline = require("minipass-pipeline");
const { Response } = require("node-fetch");

const p = new Pipeline(new Minipass());
p.end("hello world");
new Response(p).text().then(t => console.log(t)); // "hello world"
```

Added three tests to `test/js/node/http/node-fetch.test.js` covering a minipass-like async-iterable `Stream`, a legacy pipe-only `Stream`, and the existing proper-`Readable` path. The first two fail on main and pass with the fix; the third passes on both.

Fixes #14481
Fixes #13390