### PR TITLE
install: hoist workspace members in path order, not package-name order

### DIFF
--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -230,16 +230,16 @@ impl<'a> DepSorter<'a> {
             Ordering::Equal => {
                 // Match npm: order workspaces by relative path so the path-first
                 // workspace's deps win the root node_modules slot.
-                if l_dep.behavior.is_workspace()
-                    && l_dep.version.tag == dependency::Tag::Workspace
-                    && r_dep.version.tag == dependency::Tag::Workspace
-                {
-                    let l_path = l_dep.version.workspace().slice(string_buf);
-                    let r_path = r_dep.version.workspace().slice(string_buf);
-                    match strings::order(l_path, r_path) {
-                        Ordering::Less => return true,
-                        Ordering::Greater => return false,
-                        Ordering::Equal => {}
+                if l_dep.behavior.is_workspace() {
+                    if let (Some(l_path), Some(r_path)) = (
+                        self.lockfile.workspace_paths.get(&l_dep.name_hash),
+                        self.lockfile.workspace_paths.get(&r_dep.name_hash),
+                    ) {
+                        match strings::order(l_path.slice(string_buf), r_path.slice(string_buf)) {
+                            Ordering::Less => return true,
+                            Ordering::Greater => return false,
+                            Ordering::Equal => {}
+                        }
                     }
                 }
                 strings::order(l_dep.name.slice(string_buf), r_dep.name.slice(string_buf))

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -228,6 +228,24 @@ impl<'a> DepSorter<'a> {
             Ordering::Less => true,
             Ordering::Greater => false,
             Ordering::Equal => {
+                // npm's hoister visits workspaces in path order, so the
+                // path-alphabetically-first workspace's direct deps win the
+                // root node_modules slot. Sorting by package name here breaks
+                // peer-sharing packages like @nestjs/core when a scoped
+                // workspace name (`@libs/...`) sorts ahead of the app that
+                // actually provides the peer (#9838).
+                if l_dep.behavior.is_workspace()
+                    && l_dep.version.tag == dependency::Tag::Workspace
+                    && r_dep.version.tag == dependency::Tag::Workspace
+                {
+                    let l_path = l_dep.version.workspace().slice(string_buf);
+                    let r_path = r_dep.version.workspace().slice(string_buf);
+                    match strings::order(l_path, r_path) {
+                        Ordering::Less => return true,
+                        Ordering::Greater => return false,
+                        Ordering::Equal => {}
+                    }
+                }
                 strings::order(l_dep.name.slice(string_buf), r_dep.name.slice(string_buf))
                     == Ordering::Less
             }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -228,12 +228,8 @@ impl<'a> DepSorter<'a> {
             Ordering::Less => true,
             Ordering::Greater => false,
             Ordering::Equal => {
-                // npm's hoister visits workspaces in path order, so the
-                // path-alphabetically-first workspace's direct deps win the
-                // root node_modules slot. Sorting by package name here breaks
-                // peer-sharing packages like @nestjs/core when a scoped
-                // workspace name (`@libs/...`) sorts ahead of the app that
-                // actually provides the peer (#9838).
+                // Match npm: order workspaces by relative path so the path-first
+                // workspace's deps win the root node_modules slot.
                 if l_dep.behavior.is_workspace()
                     && l_dep.version.tag == dependency::Tag::Workspace
                     && r_dep.version.tag == dependency::Tag::Workspace

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3027,14 +3027,12 @@ pub(crate) fn parse_into_binary_lockfile(
 }
 
 /// True for peer edges the fresh resolver defers to its second phase
-/// (`install_peer`) and binds by version there. Two exemptions, matching
-/// `enqueue_dependency_with_main_and_success_fn`: optional peers return
-/// before the deferred phase (callers skip them entirely and leave the slot
-/// for `process_subtree`), and `*` peers express no version preference so
-/// the printed tree's path walk binds them.
+/// (`install_peer`) and binds by version there. Callers skip optional peers
+/// entirely; `*` peers express no version preference so the printed tree's
+/// path walk binds them.
 fn is_deferred_peer(dep: &Dependency) -> bool {
+    debug_assert!(!dep.behavior.is_optional_peer());
     dep.behavior.is_peer()
-        && !dep.behavior.is_optional_peer()
         && !(dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().version.is_star())
 }
 

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2865,6 +2865,13 @@ pub(crate) fn parse_into_binary_lockfile(
                     let dep = &mut dependencies[dep_id as usize];
                     let dep_name = dep.name.slice(string_buf);
 
+                    if dep.behavior.is_optional_peer() {
+                        // fresh resolve leaves optional peers unresolved until
+                        // process_subtree; binding them here via the path walk
+                        // shifts BFS enqueue order and breaks --frozen-lockfile.
+                        continue;
+                    }
+
                     let workspace_node_modules = {
                         let buf_slice = &mut path_buf[..];
                         let needed = workspace_name.len() + 1 + dep_name.len();
@@ -2955,6 +2962,9 @@ pub(crate) fn parse_into_binary_lockfile(
                 let dep_id: DependencyID = _dep_id;
                 let dep = &mut dependencies[dep_id as usize];
 
+                if dep.behavior.is_optional_peer() {
+                    continue 'deps;
+                }
                 let peer_res_id = if is_deferred_peer(dep) {
                     resolve_peer_dep_version_based(
                         dep,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -2801,6 +2801,9 @@ pub(crate) fn parse_into_binary_lockfile(
                 let dep_id: DependencyID = _dep_id;
                 let dep = &mut dependencies[dep_id as usize];
 
+                if dep.behavior.is_optional_peer() {
+                    continue;
+                }
                 let peer_res_id = if is_deferred_peer(dep) {
                     resolve_peer_dep_version_based(
                         dep,
@@ -2866,9 +2869,6 @@ pub(crate) fn parse_into_binary_lockfile(
                     let dep_name = dep.name.slice(string_buf);
 
                     if dep.behavior.is_optional_peer() {
-                        // fresh resolve leaves optional peers unresolved until
-                        // process_subtree; binding them here via the path walk
-                        // shifts BFS enqueue order and breaks --frozen-lockfile.
                         continue;
                     }
 
@@ -3029,10 +3029,9 @@ pub(crate) fn parse_into_binary_lockfile(
 /// True for peer edges the fresh resolver defers to its second phase
 /// (`install_peer`) and binds by version there. Two exemptions, matching
 /// `enqueue_dependency_with_main_and_success_fn`: optional peers return
-/// before the deferred phase and are bound to the hoisted-tree sibling by
-/// `process_subtree` instead, and `*` peers express no version preference
-/// and bind to whatever sibling pin existed first. Both of those are
-/// exactly what the printed tree's path walk reproduces, so they keep it.
+/// before the deferred phase (callers skip them entirely and leave the slot
+/// for `process_subtree`), and `*` peers express no version preference so
+/// the printed tree's path walk binds them.
 fn is_deferred_peer(dep: &Dependency) -> bool {
     dep.behavior.is_peer()
         && !dep.behavior.is_optional_peer()

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3972,9 +3972,9 @@ describe("hoisting", async () => {
       expect(await exists(join(packageDir, "node_modules", "strict-peer-dep", "node_modules"))).toBeFalse();
     }
 
-    async function install(cwd: string) {
+    async function install(cwd: string, ...args: string[]) {
       const { stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
+        cmd: [bunExe(), "install", ...args],
         cwd,
         stdout: "ignore",
         stderr: "pipe",
@@ -3982,6 +3982,7 @@ describe("hoisting", async () => {
       });
       const [err, exitCode] = await Promise.all([stderr.text(), exited]);
       expect(err).not.toContain("error:");
+      expect(err).not.toContain("lockfile had changes");
       expect(exitCode).toBe(0);
     }
 
@@ -3994,6 +3995,8 @@ describe("hoisting", async () => {
 
       await install(cwd);
       await checkLayout();
+
+      await install(cwd, "--frozen-lockfile");
 
       await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
       await rm(join(packageDir, "libs", "lib", "node_modules"), { recursive: true, force: true });

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3966,12 +3966,12 @@ describe("hoisting", async () => {
         name: "no-deps",
         version: "2.0.0",
       });
-      expect(await file(join(packageDir, "libs", "lib", "node_modules", "no-deps", "package.json")).json()).toMatchObject(
-        {
-          name: "no-deps",
-          version: "1.0.0",
-        },
-      );
+      expect(
+        await file(join(packageDir, "libs", "lib", "node_modules", "no-deps", "package.json")).json(),
+      ).toMatchObject({
+        name: "no-deps",
+        version: "1.0.0",
+      });
       expect(await exists(join(packageDir, "apps", "app", "node_modules"))).toBeFalse();
       expect(await exists(join(packageDir, "node_modules", "strict-peer-dep", "node_modules"))).toBeFalse();
     }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3925,10 +3925,6 @@ describe("hoisting", async () => {
 
   // https://github.com/oven-sh/bun/issues/9838
   test("conflicting workspace deps are hoisted in workspace-path order, not package-name order", async () => {
-    // `@libs/lib` sorts before `my-app` by name, but `apps/app` sorts before
-    // `libs/lib` by path. npm hoists by path, so the app's `no-deps@2.0.0`
-    // should win the root slot and `strict-peer-dep` (peer `no-deps@^2.0.0`)
-    // should dedupe onto it instead of nesting its own copy.
     await Promise.all([
       write(
         packageJson,
@@ -3976,6 +3972,19 @@ describe("hoisting", async () => {
       expect(await exists(join(packageDir, "node_modules", "strict-peer-dep", "node_modules"))).toBeFalse();
     }
 
+    async function install(cwd: string) {
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd,
+        stdout: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      const [err, exitCode] = await Promise.all([stderr.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
     for (const cwd of [packageDir, join(packageDir, "apps", "app")]) {
       await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
       await rm(join(packageDir, "apps", "app", "node_modules"), { recursive: true, force: true });
@@ -3983,41 +3992,18 @@ describe("hoisting", async () => {
       await rm(join(packageDir, "bun.lockb"), { force: true });
       await rm(join(packageDir, "bun.lock"), { force: true });
 
-      let { stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd,
-        stdout: "ignore",
-        stderr: "pipe",
-        env,
-      });
-
-      let err = await stderr.text();
-      expect(err).not.toContain("error:");
-      expect(await exited).toBe(0);
+      await install(cwd);
       await checkLayout();
 
-      // re-install with the saved lockfile + empty node_modules
       await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
       await rm(join(packageDir, "libs", "lib", "node_modules"), { recursive: true, force: true });
 
-      ({ stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd,
-        stdout: "ignore",
-        stderr: "pipe",
-        env,
-      }));
-
-      err = await stderr.text();
-      expect(err).not.toContain("error:");
-      expect(await exited).toBe(0);
+      await install(cwd);
       await checkLayout();
     }
   });
 
   test("conflicting workspace deps are hoisted in workspace-path order (reversed)", async () => {
-    // Reversed: path-first workspace now wants `no-deps@1.0.0`, so that is
-    // what should hoist to root regardless of which name sorts first.
     await Promise.all([
       write(
         packageJson,
@@ -4057,9 +4043,9 @@ describe("hoisting", async () => {
       env,
     });
 
-    const err = await stderr.text();
+    const [err, exitCode] = await Promise.all([stderr.text(), exited]);
     expect(err).not.toContain("error:");
-    expect(await exited).toBe(0);
+    expect(exitCode).toBe(0);
 
     expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
       name: "no-deps",

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3923,6 +3923,155 @@ describe("hoisting", async () => {
     assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
   });
 
+  // https://github.com/oven-sh/bun/issues/9838
+  test("conflicting workspace deps are hoisted in workspace-path order, not package-name order", async () => {
+    // `@libs/lib` sorts before `my-app` by name, but `apps/app` sorts before
+    // `libs/lib` by path. npm hoists by path, so the app's `no-deps@2.0.0`
+    // should win the root slot and `strict-peer-dep` (peer `no-deps@^2.0.0`)
+    // should dedupe onto it instead of nesting its own copy.
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "root",
+          private: true,
+          workspaces: ["libs/*", "apps/*"],
+        }),
+      ),
+      write(
+        join(packageDir, "apps", "app", "package.json"),
+        JSON.stringify({
+          name: "my-app",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": "2.0.0",
+            "strict-peer-dep": "1.0.0",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "libs", "lib", "package.json"),
+        JSON.stringify({
+          name: "@libs/lib",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+    ]);
+
+    async function checkLayout() {
+      expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+        name: "no-deps",
+        version: "2.0.0",
+      });
+      expect(await file(join(packageDir, "libs", "lib", "node_modules", "no-deps", "package.json")).json()).toMatchObject(
+        {
+          name: "no-deps",
+          version: "1.0.0",
+        },
+      );
+      expect(await exists(join(packageDir, "apps", "app", "node_modules"))).toBeFalse();
+      expect(await exists(join(packageDir, "node_modules", "strict-peer-dep", "node_modules"))).toBeFalse();
+    }
+
+    for (const cwd of [packageDir, join(packageDir, "apps", "app")]) {
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, "apps", "app", "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, "libs", "lib", "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, "bun.lockb"), { force: true });
+      await rm(join(packageDir, "bun.lock"), { force: true });
+
+      let { stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd,
+        stdout: "ignore",
+        stderr: "pipe",
+        env,
+      });
+
+      let err = await stderr.text();
+      expect(err).not.toContain("error:");
+      expect(await exited).toBe(0);
+      await checkLayout();
+
+      // re-install with the saved lockfile + empty node_modules
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await rm(join(packageDir, "libs", "lib", "node_modules"), { recursive: true, force: true });
+
+      ({ stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd,
+        stdout: "ignore",
+        stderr: "pipe",
+        env,
+      }));
+
+      err = await stderr.text();
+      expect(err).not.toContain("error:");
+      expect(await exited).toBe(0);
+      await checkLayout();
+    }
+  });
+
+  test("conflicting workspace deps are hoisted in workspace-path order (reversed)", async () => {
+    // Reversed: path-first workspace now wants `no-deps@1.0.0`, so that is
+    // what should hoist to root regardless of which name sorts first.
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "root",
+          private: true,
+          workspaces: ["zed/*", "aah/*"],
+        }),
+      ),
+      write(
+        join(packageDir, "aah", "a", "package.json"),
+        JSON.stringify({
+          name: "zzz-lib",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "zed", "z", "package.json"),
+        JSON.stringify({
+          name: "aaa-app",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": "2.0.0",
+          },
+        }),
+      ),
+    ]);
+
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await exited).toBe(0);
+
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+      version: "1.0.0",
+    });
+    expect(await file(join(packageDir, "zed", "z", "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+      version: "2.0.0",
+    });
+    expect(await exists(join(packageDir, "aah", "a", "node_modules"))).toBeFalse();
+  });
+
   test("hoisting/using incorrect peer dep on initial install", async () => {
     await writeFile(
       packageJson,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3942,6 +3942,7 @@ describe("hoisting", async () => {
           dependencies: {
             "no-deps": "2.0.0",
             "strict-peer-dep": "1.0.0",
+            "optional-peer-deps": "1.0.0",
           },
         }),
       ),
@@ -3970,6 +3971,7 @@ describe("hoisting", async () => {
       });
       expect(await exists(join(packageDir, "apps", "app", "node_modules"))).toBeFalse();
       expect(await exists(join(packageDir, "node_modules", "strict-peer-dep", "node_modules"))).toBeFalse();
+      expect(await exists(join(packageDir, "node_modules", "optional-peer-deps", "node_modules"))).toBeFalse();
     }
 
     async function install(cwd: string, ...args: string[]) {

--- a/test/integration/next-pages/test/__snapshots__/dev-server-ssr-100.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/dev-server-ssr-100.test.ts.snap
@@ -26725,7 +26725,7 @@ exports[`ssr works for 100-ish requests 1`] = `
           "package_id": 315,
         },
         "jiti": {
-          "id": 434,
+          "id": 937,
           "package_id": 316,
         },
         "js-tokens": {

--- a/test/integration/next-pages/test/__snapshots__/dev-server.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/dev-server.test.ts.snap
@@ -26725,7 +26725,7 @@ exports[`hot reloading works on the client (+ tailwind hmr) 1`] = `
           "package_id": 315,
         },
         "jiti": {
-          "id": 434,
+          "id": 937,
           "package_id": 316,
         },
         "js-tokens": {

--- a/test/integration/next-pages/test/__snapshots__/next-build.test.ts.snap
+++ b/test/integration/next-pages/test/__snapshots__/next-build.test.ts.snap
@@ -26725,7 +26725,7 @@ exports[`next build works: bun 1`] = `
           "package_id": 315,
         },
         "jiti": {
-          "id": 434,
+          "id": 937,
           "package_id": 316,
         },
         "js-tokens": {
@@ -54704,7 +54704,7 @@ exports[`next build works: node 1`] = `
           "package_id": 315,
         },
         "jiti": {
-          "id": 434,
+          "id": 937,
           "package_id": 316,
         },
         "js-tokens": {


### PR DESCRIPTION
## What

When two workspaces depend on conflicting versions of the same package, the hoisted linker's `DepSorter` visited workspace entries in **package-name** order, while npm visits them in **relative-path** order. Whichever workspace is visited first wins the root `node_modules` slot; the other gets a nested copy.

In the #9838 repro (a NestJS monorepo) that difference breaks DI:

| workspace path | package name | `@nestjs/core` dep |
| --- | --- | --- |
| `apps/nestjs-boilerplate` | `nestjs-boilerplate` | `^10.0.0` |
| `libs/nest-init-app-fastify-adapter` | `@libs/nest-init-app-fastify-adapter` | `^9.4.0` |

`@libs/...` sorts before `nestjs-boilerplate` by name, so bun hoisted `@nestjs/core@9.4.3` to root. Every root-level package that peers on `@nestjs/core>=10` (`nestjs-omacache`, `@nestjs/swagger`, `@nestjs/testing`) then got its **own nested** `@nestjs/core@10.4.22`, so the app's `Reflector` class and the guard's `Reflector` class had different identities:

```
Nest can't resolve dependencies of the ThrottlerGuard (THROTTLER:MODULE_OPTIONS, Symbol(ThrottlerStorage), ?).
Please make sure that the argument Reflector at index [2] is available in the AuthModule context.
```

npm sorts by path, so `apps/...` wins root (`@nestjs/core@10.4.22`), the `^9` copy nests only under the one lib that needs it, and the peer dependents all share the root copy.

## Fix

### `DepSorter` (`src/install/lockfile.rs`)

When both sides are workspace-behavior entries, compare by `lockfile.workspace_paths.get(&name_hash)` before falling back to name. That map is populated on every construction path (fresh parse, `bun.lock` load, migration) and is copied into the cloned lockfile before `resolve()` runs in `clean_with_logger`, so the sort key is stable across fresh install, re-install from a lockfile, and `--frozen-lockfile`. `Behavior::cmp` already puts workspaces first; this only changes the tie-break within that group.

### `parse_into_binary_lockfile` (`src/install/lockfile/bun.lock.rs`)

The sort-order change exposed a pre-existing `--frozen-lockfile` asymmetry: on load from `bun.lock`, the three resolution-binding loops (root, workspace, per-package) bound optional-peer edges via the `pkg_map` path walk, but fresh resolve leaves them at `invalid_package_id` until `process_subtree` binds them. With the new BFS order the two sides enqueue `@jridgewell/trace-mapping` at different points on the #9838 repro, so `--frozen-lockfile` reported "lockfile had changes". Skip `is_optional_peer()` in all three loops so load matches fresh resolve, and update the `is_deferred_peer` doc accordingly.

## Verification

With the issue's [empty_starter.zip](https://github.com/oven-sh/bun/files/14833716/empty_starter.zip), after `bun install --linker=hoisted`:

before:
```
node_modules/@nestjs/core: 9.4.3
node_modules/nestjs-omacache/node_modules/@nestjs/core: 10.4.22
node_modules/@nestjs/swagger/node_modules/@nestjs/core: 10.4.22
node_modules/@nestjs/testing/node_modules/@nestjs/core: 10.4.22
apps/nestjs-boilerplate/node_modules/@nestjs/core: 10.4.22
```

after (matches `npm install --legacy-peer-deps`):
```
node_modules/@nestjs/core: 10.4.22
libs/nest-init-app-fastify-adapter/node_modules/@nestjs/core: 9.4.3
```

and `bun install --frozen-lockfile` immediately after reports "no changes".

New tests in the `hoisting` suite cover both path orderings, re-install from the saved lockfile, `--frozen-lockfile` after install, and assert that a peer dependent (`strict-peer-dep` peering on `no-deps@^2.0.0`) gets no nested copy. The `next-pages` lockfile snapshots are regenerated (`jiti`'s root tree slot is now owned by its real dependency edge instead of `eslint`'s optional-peer edge; same `package_id`).

Fixes #9838.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->