### PR TITLE
js_parser: keep all macro-object properties when the destructuring pattern reorders keys

### DIFF
--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -480,21 +480,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
                         let mut end: usize = 0;
-                        // SAFETY: `end <= i < used.len() == object.properties.len()`;
-                        // G::Property has no Drop; src/dst never overlap when i != end.
-                        unsafe {
-                            let props_ptr = object.properties.slice_mut().as_mut_ptr();
-                            for (i, &keep) in used.iter().enumerate() {
-                                if keep {
-                                    if i != end {
-                                        core::ptr::copy_nonoverlapping(
-                                            props_ptr.add(i),
-                                            props_ptr.add(end),
-                                            1,
-                                        );
-                                    }
-                                    end += 1;
-                                }
+                        for (i, &keep) in used.iter().enumerate() {
+                            if keep {
+                                object.properties.slice_mut().swap(end, i);
+                                end += 1;
                             }
                         }
                         object.properties.truncate(end);

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -452,8 +452,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return;
                             }
                         }
-                        // Mark referenced indices first; compacting during lookup would
-                        // overwrite entries later `as_property` calls still need (#9613).
                         let mut used: smallvec::SmallVec<[bool; 8]> =
                             smallvec::smallvec![false; object.properties.len()];
                         for property in bound_object.properties() {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -452,7 +452,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return;
                             }
                         }
-                        let mut end: u32 = 0;
+                        // First pass: resolve every bound key against the unmodified
+                        // property list. Writing `properties[end] = properties[query.i]`
+                        // here would clobber entries that later bound keys still need
+                        // to look up (e.g. `const { c, a } = { a, b, c }` overwrites
+                        // `a` before it is found). Record which source indices are
+                        // referenced instead, then compact in a second pass.
+                        let mut used: smallvec::SmallVec<[bool; 8]> =
+                            smallvec::smallvec![false; object.properties.len()];
                         for property in bound_object.properties() {
                             if let Some(name) = property.key.as_string_literal(self.arena) {
                                 if let Some(query) = object.as_property(name) {
@@ -474,14 +481,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             }
                                         }
                                     }
-                                    // output_properties[end] = output_properties[query.i]
-                                    // SAFETY: both indices < object.properties.len; G::Property
-                                    // has no Drop; src/dst may alias when end == query.i.
-                                    unsafe {
-                                        let props_ptr = object.properties.slice_mut().as_mut_ptr();
-                                        core::ptr::copy(
-                                            props_ptr.add(query.i as usize),
-                                            props_ptr.add(end as usize),
+                                    used[query.i as usize] = true;
+                                }
+                            }
+                        }
+                        let mut end: usize = 0;
+                        // SAFETY: `end <= i < used.len() == object.properties.len()`;
+                        // G::Property has no Drop; src/dst never overlap when i != end.
+                        unsafe {
+                            let props_ptr = object.properties.slice_mut().as_mut_ptr();
+                            for (i, &keep) in used.iter().enumerate() {
+                                if keep {
+                                    if i != end {
+                                        core::ptr::copy_nonoverlapping(
+                                            props_ptr.add(i),
+                                            props_ptr.add(end),
                                             1,
                                         );
                                     }
@@ -489,7 +503,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 }
                             }
                         }
-                        object.properties.truncate(end as usize);
+                        object.properties.truncate(end);
                     }
                 }
             }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -452,12 +452,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return;
                             }
                         }
-                        // First pass: resolve every bound key against the unmodified
-                        // property list. Writing `properties[end] = properties[query.i]`
-                        // here would clobber entries that later bound keys still need
-                        // to look up (e.g. `const { c, a } = { a, b, c }` overwrites
-                        // `a` before it is found). Record which source indices are
-                        // referenced instead, then compact in a second pass.
+                        // Mark referenced indices first; compacting during lookup would
+                        // overwrite entries later `as_property` calls still need (#9613).
                         let mut used: smallvec::SmallVec<[bool; 8]> =
                             smallvec::smallvec![false; object.properties.len()];
                         for property in bound_object.properties() {

--- a/test/bundler/transpiler/macro-destructure.test.ts
+++ b/test/bundler/transpiler/macro-destructure.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/9613
+describe("destructuring a macro object", () => {
+  const files = {
+    "m.ts": `
+      export const obj = () => ({ a: "a", b: "b", c: "c" });
+      export const nested = () => ({ outer: { x: 1, y: 2, z: 3 }, other: 0 });
+    `,
+    "index.ts": `
+      import { obj, nested } from "./m.ts" with { type: "macro" };
+      const out: string[] = [];
+      { const { a, b, c } = obj(); out.push([a, b, c].join(",")); }
+      { const { a, c, b } = obj(); out.push([a, b, c].join(",")); }
+      { const { b, a, c } = obj(); out.push([a, b, c].join(",")); }
+      { const { b, c, a } = obj(); out.push([a, b, c].join(",")); }
+      { const { c, a, b } = obj(); out.push([a, b, c].join(",")); }
+      { const { c, b, a } = obj(); out.push([a, b, c].join(",")); }
+      { const { c, a } = obj(); out.push([a, c].join(",")); }
+      { const { b, a: a2 } = obj(); out.push([a2, b].join(",")); }
+      { const { a, a: a2 } = obj(); out.push([a, a2].join(",")); }
+      { const { c, missing } = obj(); out.push([c, String(missing)].join(",")); }
+      { const { outer: { z, x } } = nested(); out.push([x, z].join(",")); }
+      console.log(JSON.stringify(out));
+    `,
+  };
+  const expected = ["a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,c", "a,b", "a,a", "c,undefined", "1,3"];
+
+  async function run(cmd: string[], cwd: string) {
+    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
+    const [rawStdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug builds unconditionally print "[macro] call <name>" to stdout; drop those lines so the
+    // whole remaining output can be compared exactly.
+    const stdout = rawStdout
+      .split("\n")
+      .filter(l => !l.startsWith("[macro] "))
+      .join("\n");
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("bun run", async () => {
+    using dir = tempDir("macro-destructure-run", files);
+    expect(await run([bunExe(), "index.ts"], String(dir))).toEqual({
+      stdout: JSON.stringify(expected) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("bun build", async () => {
+    using dir = tempDir("macro-destructure-build", files);
+    const build = await run([bunExe(), "build", "./index.ts", "--target", "bun", "--outfile", "out.js"], String(dir));
+    expect(build).toMatchObject({ exitCode: 0 });
+    expect(await run([bunExe(), "out.js"], String(dir))).toEqual({
+      stdout: JSON.stringify(expected) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -133,65 +133,6 @@ test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
 });
 
-// https://github.com/oven-sh/bun/issues/9613
-describe("destructuring a macro object", () => {
-  const files = {
-    "m.ts": `
-      export const obj = () => ({ a: "a", b: "b", c: "c" });
-      export const nested = () => ({ outer: { x: 1, y: 2, z: 3 }, other: 0 });
-    `,
-    "index.ts": `
-      import { obj, nested } from "./m.ts" with { type: "macro" };
-      const out: string[] = [];
-      { const { a, b, c } = obj(); out.push([a, b, c].join(",")); }
-      { const { a, c, b } = obj(); out.push([a, b, c].join(",")); }
-      { const { b, a, c } = obj(); out.push([a, b, c].join(",")); }
-      { const { b, c, a } = obj(); out.push([a, b, c].join(",")); }
-      { const { c, a, b } = obj(); out.push([a, b, c].join(",")); }
-      { const { c, b, a } = obj(); out.push([a, b, c].join(",")); }
-      { const { c, a } = obj(); out.push([a, c].join(",")); }
-      { const { b, a: a2 } = obj(); out.push([a2, b].join(",")); }
-      { const { a, a: a2 } = obj(); out.push([a, a2].join(",")); }
-      { const { c, missing } = obj(); out.push([c, String(missing)].join(",")); }
-      { const { outer: { z, x } } = nested(); out.push([x, z].join(",")); }
-      console.log(JSON.stringify(out));
-    `,
-  };
-  const expected = ["a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,c", "a,b", "a,a", "c,undefined", "1,3"];
-
-  async function run(cmd: string[], cwd: string) {
-    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
-    const [rawStdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Debug builds unconditionally print "[macro] call <name>" to stdout; drop those lines so the
-    // whole remaining output can be compared exactly.
-    const stdout = rawStdout
-      .split("\n")
-      .filter(l => !l.startsWith("[macro] "))
-      .join("\n");
-    return { stdout, stderr, exitCode };
-  }
-
-  test.concurrent("bun run", async () => {
-    using dir = tempDir("macro-destructure-run", files);
-    expect(await run([bunExe(), "index.ts"], String(dir))).toEqual({
-      stdout: JSON.stringify(expected) + "\n",
-      stderr: "",
-      exitCode: 0,
-    });
-  });
-
-  test.concurrent("bun build", async () => {
-    using dir = tempDir("macro-destructure-build", files);
-    const build = await run([bunExe(), "build", "./index.ts", "--target", "bun", "--outfile", "out.js"], String(dir));
-    expect(build).toMatchObject({ exitCode: 0 });
-    expect(await run([bunExe(), "out.js"], String(dir))).toEqual({
-      stdout: JSON.stringify(expected) + "\n",
-      stderr: "",
-      exitCode: 0,
-    });
-  });
-});
-
 // A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside
 // JSC__JSValue__putToPropertyKey take a path that can throw, so the binding must check for
 // an exception. BUN_JSC_validateExceptionChecks=1 aborts the child if the check is missing.

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -133,10 +133,7 @@ test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
 });
 
-// #9613: a destructuring pattern whose key order differs from the macro's object literal must
-// keep every referenced property. The visitor previously compacted the object in place while
-// still looking keys up in it, so a write at `properties[end]` could overwrite an entry that a
-// later bound key needed.
+// https://github.com/oven-sh/bun/issues/9613
 describe("destructuring a macro object", () => {
   const files = {
     "m.ts": `
@@ -154,24 +151,30 @@ describe("destructuring a macro object", () => {
       { const { c, b, a } = obj(); out.push([a, b, c].join(",")); }
       { const { c, a } = obj(); out.push([a, c].join(",")); }
       { const { b, a: a2 } = obj(); out.push([a2, b].join(",")); }
+      { const { a, a: a2 } = obj(); out.push([a, a2].join(",")); }
       { const { c, missing } = obj(); out.push([c, String(missing)].join(",")); }
       { const { outer: { z, x } } = nested(); out.push([x, z].join(",")); }
       console.log(JSON.stringify(out));
     `,
   };
-  const expected = ["a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,c", "a,b", "c,undefined", "1,3"];
+  const expected = ["a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,c", "a,b", "a,a", "c,undefined", "1,3"];
 
   async function run(cmd: string[], cwd: string) {
     await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [rawStdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug builds unconditionally print "[macro] call <name>" to stdout; drop those lines so the
+    // whole remaining output can be compared exactly.
+    const stdout = rawStdout
+      .split("\n")
+      .filter(l => !l.startsWith("[macro] "))
+      .join("\n");
     return { stdout, stderr, exitCode };
   }
 
   test.concurrent("bun run", async () => {
     using dir = tempDir("macro-destructure-run", files);
-    const { stdout, stderr, exitCode } = await run([bunExe(), "index.ts"], String(dir));
-    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
-      out: expected,
+    expect(await run([bunExe(), "index.ts"], String(dir))).toEqual({
+      stdout: JSON.stringify(expected) + "\n",
       stderr: "",
       exitCode: 0,
     });
@@ -181,9 +184,8 @@ describe("destructuring a macro object", () => {
     using dir = tempDir("macro-destructure-build", files);
     const build = await run([bunExe(), "build", "./index.ts", "--target", "bun", "--outfile", "out.js"], String(dir));
     expect(build).toMatchObject({ exitCode: 0 });
-    const { stdout, stderr, exitCode } = await run([bunExe(), "out.js"], String(dir));
-    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
-      out: expected,
+    expect(await run([bunExe(), "out.js"], String(dir))).toEqual({
+      stdout: JSON.stringify(expected) + "\n",
       stderr: "",
       exitCode: 0,
     });

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -133,6 +133,74 @@ test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
 });
 
+// #9613: a destructuring pattern whose key order differs from the macro's object literal must
+// keep every referenced property. The visitor previously compacted the object in place while
+// still looking keys up in it, so a write at `properties[end]` could overwrite an entry that a
+// later bound key needed.
+describe("destructuring a macro object", () => {
+  const files = {
+    "m.ts": `
+      export const obj = () => ({ a: "a", b: "b", c: "c" });
+      export const nested = () => ({ outer: { x: 1, y: 2, z: 3 }, other: 0 });
+    `,
+    "index.ts": `
+      import { obj, nested } from "./m.ts" with { type: "macro" };
+      const out: string[] = [];
+      { const { a, b, c } = obj(); out.push([a, b, c].join(",")); }
+      { const { a, c, b } = obj(); out.push([a, b, c].join(",")); }
+      { const { b, a, c } = obj(); out.push([a, b, c].join(",")); }
+      { const { b, c, a } = obj(); out.push([a, b, c].join(",")); }
+      { const { c, a, b } = obj(); out.push([a, b, c].join(",")); }
+      { const { c, b, a } = obj(); out.push([a, b, c].join(",")); }
+      { const { c, a } = obj(); out.push([a, c].join(",")); }
+      { const { b, a: a2 } = obj(); out.push([a2, b].join(",")); }
+      { const { c, missing } = obj(); out.push([c, String(missing)].join(",")); }
+      { const { outer: { z, x } } = nested(); out.push([x, z].join(",")); }
+      console.log(JSON.stringify(out));
+    `,
+  };
+  const expected = [
+    "a,b,c",
+    "a,b,c",
+    "a,b,c",
+    "a,b,c",
+    "a,b,c",
+    "a,b,c",
+    "a,c",
+    "a,b",
+    "c,undefined",
+    "1,3",
+  ];
+
+  async function run(cmd: string[], cwd: string) {
+    await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("bun run", async () => {
+    using dir = tempDir("macro-destructure-run", files);
+    const { stdout, stderr, exitCode } = await run([bunExe(), "index.ts"], String(dir));
+    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
+      out: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("bun build", async () => {
+    using dir = tempDir("macro-destructure-build", files);
+    const build = await run([bunExe(), "build", "./index.ts", "--target", "bun", "--outfile", "out.js"], String(dir));
+    expect(build).toMatchObject({ exitCode: 0 });
+    const { stdout, stderr, exitCode } = await run([bunExe(), "out.js"], String(dir));
+    expect({ out: JSON.parse(stdout.trim().split("\n").pop()!), stderr, exitCode }).toEqual({
+      out: expected,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 // A numeric key >= 100000 (JSC's MIN_SPARSE_ARRAY_INDEX) makes the property put inside
 // JSC__JSValue__putToPropertyKey take a path that can throw, so the binding must check for
 // an exception. BUN_JSC_validateExceptionChecks=1 aborts the child if the check is missing.

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -159,18 +159,7 @@ describe("destructuring a macro object", () => {
       console.log(JSON.stringify(out));
     `,
   };
-  const expected = [
-    "a,b,c",
-    "a,b,c",
-    "a,b,c",
-    "a,b,c",
-    "a,b,c",
-    "a,b,c",
-    "a,c",
-    "a,b",
-    "c,undefined",
-    "1,3",
-  ];
+  const expected = ["a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,c", "a,b", "c,undefined", "1,3"];
 
   async function run(cmd: string[], cwd: string) {
     await using proc = Bun.spawn({ cmd, env: bunEnv, cwd, stdout: "pipe", stderr: "pipe" });


### PR DESCRIPTION
Fixes #9613.

## Repro

```ts
// macro.ts
export const obj = () => ({ a: "a", b: "b", c: "c" });
```
```ts
import { obj } from "./macro.ts" with { type: "macro" };
const { c, a, b } = obj();
console.log(a, b, c);   // undefined b c
```
```
$ bun build ./index.ts --target bun
const { c, a, b } = { c: "c", b: "b" };   // 'a' is gone
```

## Cause

`visit_binding_and_expr_for_macro` filters the inlined object literal down to the properties the binding pattern actually uses. It did this by iterating the pattern keys, looking each one up in the object with `as_property()`, and writing `properties[end] = properties[query.i]` into the same array it was searching. When the pattern's key order differed from the object's, an early write overwrote an entry that a later lookup still needed, so that key was dropped from the emitted literal and the binding became `undefined`.

For `{ c, a, b }` against `{ a, b, c }`:
- `c` matches index 2, write `props[0] = props[2]`; array is now `[c, b, c]`
- `a` searches `[c, b, c]` and is not found
- `b` matches index 1, write `props[1] = props[1]`
- truncate to 2: `{ c, b }`

## Fix

Split into two passes. The first pass resolves every bound key against the unmodified property list (recursing into nested objects and recording `const_values` exactly as before) and marks which source indices are referenced in a `SmallVec<[bool; 8]>`. The second pass compacts forward in source order with `slice::swap(end, i)`, matching the existing compaction pattern in `scan_side_effects.rs` and elsewhere in this file; no `unsafe` is needed.

## Verification

`test/bundler/transpiler/macro-destructure.test.ts` runs the repro under both `bun run` and `bun build`, covering all six permutations of `{a,b,c}`, a reordered subset, an aliased key, the same key bound twice (`{ a, a: a2 }`), a missing key, and a nested `{ outer: { z, x } }` pattern. Both tests fail on the released bun and pass with this change.

The tests live in their own file because `macro-test.test.ts` evaluates top-level macro imports at module load and can intermittently trip a pre-existing `!m_topGCOwnedDataScope` debug assertion before any test runs.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-destructure.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/1277] fetch zlib
[zlib] up to date
[2/1277] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[3/1277] gen bindgenv2
[4/1277] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1277] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[6/1277] subst deps/zlib/zlib.h
[7/1277] fetch picohttpparser
[picohttpparser] up to date
[8/1277] subst deps/zlib/zconf.h
[9/1277] subst deps/libjpeg-turbo/jconfig.h
[10/1277] fetch nodejs (prebuilt)
[nodejs] up to date
[11/1277] subst deps/libjpeg-turbo/jconfigint.h
[12/1277] subst deps/libjpeg-turbo/jversion.h
[13/1277] fetch zstd
[zstd] up to date
[14/1277] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/P
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/transpiler/macro-destructure.test.ts:
39 |     return { stdout, stderr, exitCode };
40 |   }
41 | 
42 |   test.concurrent("bun run", async () => {
43 |     using dir = tempDir("macro-destructure-run", files);
44 |     expect(await run([bunExe(), "index.ts"], String(dir))).toEqual({
                                                                ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
- "["a,b,c","a,b,c","a,b,c","a,b,c","a,b,c","a,b,c","a,c","a,b","a,a","c,undefined","1,3"]
+ "["a,b,c","a,,c",",b,c",",b,c",",b,c",",b,c",",c",",b","a,a","c,undefined",",3"]
  "
  ,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/transpiler/macro-destructure.test.ts:44:60)
(fail) destructuring a macro object > bun run [42.07ms]
50 | 
51 |   test.concurrent("bun build", async () => {
52 |     using dir = tempDir("macro-destructure-build", files);
53 |     const build = await run([bunExe(), "build", "./index.ts", "--target", "bun", "--outfile", "out.js"], String(dir));
54 |     expect(build).toMatchObject({ exitCode: 0 });
55 |     expect(
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/macro-destructure.test.ts
bun test v1.4.0 (4dbed4248)

test/bundler/transpiler/macro-destructure.test.ts:
(pass) destructuring a macro object > bun run [732.53ms]
(pass) destructuring a macro object > bun build [1231.15ms]

 2 pass
 0 fail
 3 expect() calls
Ran 2 tests across 1 file. [5.92s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4dbed4248e
  features     baseline

22 deps, 108 codegen, 1171 objects in 8637ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen ErrorCode+*.h
[2/1234] gen bindgenv2
[3/1234] fetch tinycc
[tinycc] up to date
[4/1234] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[5/1234] fetch zlib
[zlib] up to date
[6/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1234] fetch picohttpparser
[picohttpparser] up to date
[8/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingFs.cpp
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/buil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/mod.rs                        | 25 ++++------
 test/bundler/transpiler/macro-destructure.test.ts | 61 +++++++++++++++++++++++
 2 files changed, 72 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/js_parser/visit/mod.rs                             5      6      0
test/bundler/transpiler/macro-destructure.test.ts      0      1      0
```

</details>

<!-- robobun:evidence:end -->