### PR TITLE
bundler: seed reserved names with globalThis/Error/Infinity/NaN so locals can't capture printer literals

### DIFF
--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1115,9 +1115,7 @@ pub fn compute_initial_reserved_names(
 
     let mut names = StringHashMap::<u32>::default();
 
-    // Names the printer may emit as bare identifier literals without a Ref
-    // (e.g. `Promise.resolve(...)`, `globalThis.Bun`, `new Error(...)`) must be
-    // reserved so a user local is renamed away instead of capturing them.
+    // Identifiers the printer may emit as raw text without a Ref.
     const EXTRAS: [&[u8]; 4] = [b"Promise", b"Require", b"globalThis", b"Error"];
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1115,7 +1115,10 @@ pub fn compute_initial_reserved_names(
 
     let mut names = StringHashMap::<u32>::default();
 
-    const EXTRAS: [&[u8]; 2] = [b"Promise", b"Require"];
+    // Names the printer may emit as bare identifier literals without a Ref
+    // (e.g. `Promise.resolve(...)`, `globalThis.Bun`) must be reserved so a
+    // user local of the same name is renamed away instead of capturing them.
+    const EXTRAS: [&[u8]; 3] = [b"Promise", b"Require", b"globalThis"];
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1116,7 +1116,14 @@ pub fn compute_initial_reserved_names(
     let mut names = StringHashMap::<u32>::default();
 
     // Identifiers the printer may emit as raw text without a Ref.
-    const EXTRAS: [&[u8]; 4] = [b"Promise", b"Require", b"globalThis", b"Error"];
+    const EXTRAS: [&[u8]; 6] = [
+        b"Promise",
+        b"Require",
+        b"globalThis",
+        b"Error",
+        b"Infinity",
+        b"NaN",
+    ];
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1116,9 +1116,9 @@ pub fn compute_initial_reserved_names(
     let mut names = StringHashMap::<u32>::default();
 
     // Names the printer may emit as bare identifier literals without a Ref
-    // (e.g. `Promise.resolve(...)`, `globalThis.Bun`) must be reserved so a
-    // user local of the same name is renamed away instead of capturing them.
-    const EXTRAS: [&[u8]; 3] = [b"Promise", b"Require", b"globalThis"];
+    // (e.g. `Promise.resolve(...)`, `globalThis.Bun`, `new Error(...)`) must be
+    // reserved so a user local is renamed away instead of capturing them.
+    const EXTRAS: [&[u8]; 4] = [b"Promise", b"Require", b"globalThis", b"Error"];
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
 

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1116,13 +1116,14 @@ pub fn compute_initial_reserved_names(
     let mut names = StringHashMap::<u32>::default();
 
     // Identifiers the printer may emit as raw text without a Ref.
-    const EXTRAS: [&[u8]; 6] = [
+    const EXTRAS: [&[u8]; 7] = [
         b"Promise",
         b"Require",
         b"globalThis",
         b"Error",
         b"Infinity",
         b"NaN",
+        b"undefined",
     ];
 
     const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -138,9 +138,6 @@ error: Hello World`,
     run: { stdout: "" },
   });
   // https://github.com/oven-sh/bun/issues/8058
-  // The printer rewrites require("bun") / import("bun") to the literal text
-  // `globalThis.Bun`. A user local named `globalThis` must be renamed so it
-  // does not capture that reference.
   for (const minifyIdentifiers of [false, true]) {
     const suffix = minifyIdentifiers ? "Minified" : "";
     itBundled(`bun/RequireBunWithShadowedGlobalThis${suffix}`, {
@@ -193,8 +190,6 @@ error: Hello World`,
       run: { stdout: "intercepted\nPASS" },
     });
   }
-  // The printer emits `throw new Error(...)` as raw text for an unresolvable
-  // try/catch'd require. A user local named `Error` must be renamed.
   itBundled("bun/InlinedRequireErrorWithShadowedError", {
     target: "bun",
     files: {
@@ -211,6 +206,37 @@ error: Hello World`,
       `,
     },
     run: { stdout: "function\nPASS" },
+  });
+  itBundled("bun/InfinityLiteralWithShadowedInfinity", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+        {
+          let Infinity = 5;
+          if (1e400 === 5) throw new Error("Infinity literal captured local Infinity");
+          if (1e400 !== globalThis.Infinity) throw new Error("1e400 is not Infinity");
+          void Infinity;
+        }
+        console.log("PASS");
+      `,
+    },
+    run: { stdout: "PASS" },
+  });
+  itBundled("bun/NaNLiteralWithShadowedNaN", {
+    target: "bun",
+    minifySyntax: true,
+    files: {
+      "/entry.ts": /* js */ `
+        {
+          let NaN = 6;
+          if (0/0 === 6) throw new Error("folded NaN captured local NaN");
+          if (!globalThis.Number.isNaN(0/0)) throw new Error("0/0 is not NaN");
+          void NaN;
+        }
+        console.log("PASS");
+      `,
+    },
+    run: { stdout: "PASS" },
   });
   if (Bun.version.startsWith("1.4") || Bun.version.startsWith("1.3") || Bun.version.startsWith("1.2")) {
     for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -193,6 +193,25 @@ error: Hello World`,
       run: { stdout: "intercepted\nPASS" },
     });
   }
+  // The printer emits `throw new Error(...)` as raw text for an unresolvable
+  // try/catch'd require. A user local named `Error` must be renamed.
+  itBundled("bun/InlinedRequireErrorWithShadowedError", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+        {
+          let Error = function (this: any, msg: string) { this.intercepted = true; this.message = msg; };
+          let caught: any;
+          try { require("does-not-exist-pkg") } catch (e) { caught = e; }
+          console.log(typeof Error);
+          if (caught.intercepted) throw new globalThis.Error("require shim captured local Error");
+          if (!(caught instanceof globalThis.Error)) throw new globalThis.Error("not a real Error");
+        }
+        console.log("PASS");
+      `,
+    },
+    run: { stdout: "function\nPASS" },
+  });
   if (Bun.version.startsWith("1.4") || Bun.version.startsWith("1.3") || Bun.version.startsWith("1.2")) {
     for (const backend of ["api", "cli"] as const) {
       itBundled("bun/ExportsConditionsDevelopment" + backend.toUpperCase(), {

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -213,9 +213,9 @@ error: Hello World`,
       "/entry.ts": /* js */ `
         {
           let Infinity = 5;
-          if (1e400 === 5) throw new Error("Infinity literal captured local Infinity");
+          let trap = Infinity;
+          if (1e400 === trap) throw new Error("Infinity literal captured local Infinity");
           if (1e400 !== globalThis.Infinity) throw new Error("1e400 is not Infinity");
-          void Infinity;
         }
         console.log("PASS");
       `,
@@ -227,11 +227,25 @@ error: Hello World`,
     minifySyntax: true,
     files: {
       "/entry.ts": /* js */ `
+        function check(NaN: any) {
+          if (!globalThis.Number.isNaN(0/0)) throw new Error("folded NaN captured local NaN");
+          return NaN;
+        }
+        console.log(check(6) === 6 ? "PASS" : "FAIL");
+      `,
+    },
+    run: { stdout: "PASS" },
+  });
+  itBundled("bun/SynthesizedUndefinedWithShadowedUndefined", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
         {
-          let NaN = 6;
-          if (0/0 === 6) throw new Error("folded NaN captured local NaN");
-          if (!globalThis.Number.isNaN(0/0)) throw new Error("0/0 is not NaN");
-          void NaN;
+          let undefined = 5;
+          let trap = undefined;
+          const h = import.meta.hot;
+          if (h === trap) throw new Error("synthesized undefined captured local");
+          if (h !== globalThis.undefined) throw new Error("import.meta.hot is not undefined");
         }
         console.log("PASS");
       `,

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -137,6 +137,62 @@ error: Hello World`,
     },
     run: { stdout: "" },
   });
+  // https://github.com/oven-sh/bun/issues/8058
+  // The printer rewrites require("bun") / import("bun") to the literal text
+  // `globalThis.Bun`. A user local named `globalThis` must be renamed so it
+  // does not capture that reference.
+  for (const minifyIdentifiers of [false, true]) {
+    const suffix = minifyIdentifiers ? "Minified" : "";
+    itBundled(`bun/RequireBunWithShadowedGlobalThis${suffix}`, {
+      target: "bun",
+      minifyIdentifiers,
+      files: {
+        "/entry.ts": /* js */ `
+          {
+            let globalThis = { Bun: "intercepted" };
+            const b = require("bun");
+            if (b === "intercepted") throw new Error("require('bun') captured local globalThis");
+            if (typeof b.version !== "string") throw new Error("require('bun') did not return Bun");
+            void globalThis;
+          }
+          console.log("PASS");
+        `,
+      },
+      run: { stdout: "PASS" },
+    });
+    itBundled(`bun/DynamicImportBunWithShadowedGlobalThis${suffix}`, {
+      target: "bun",
+      minifyIdentifiers,
+      files: {
+        "/entry.ts": /* js */ `
+          (async () => {
+            let globalThis = { Bun: "intercepted" };
+            const b = await import("bun");
+            if (b === "intercepted") throw new Error("import('bun') captured local globalThis");
+            if (typeof b.version !== "string") throw new Error("import('bun') did not return Bun");
+            void globalThis;
+            console.log("PASS");
+          })();
+        `,
+      },
+      run: { stdout: "PASS" },
+    });
+    itBundled(`bun/ImportBunWithShadowedGlobalThis${suffix}`, {
+      target: "bun",
+      minifyIdentifiers,
+      files: {
+        "/entry.ts": /* js */ `
+          import * as b from "bun";
+          var globalThis = { Bun: "intercepted" };
+          console.log((globalThis as any).Bun);
+          if ((b as any) === "intercepted") throw new Error("import 'bun' captured local globalThis");
+          if (typeof b?.version !== "string") throw new Error("import 'bun' did not return Bun");
+          console.log("PASS");
+        `,
+      },
+      run: { stdout: "intercepted\nPASS" },
+    });
+  }
   if (Bun.version.startsWith("1.4") || Bun.version.startsWith("1.3") || Bun.version.startsWith("1.2")) {
     for (const backend of ["api", "cli"] as const) {
       itBundled("bun/ExportsConditionsDevelopment" + backend.toUpperCase(), {


### PR DESCRIPTION
Fixes #8058.

## Repro

```js
// test.js
{
  let globalThis = { Bun: "intercepted" };
  console.log(require("bun"));
}
```

```console
$ bun build test.js --target=bun
// ...
{
  let globalThis = { Bun: "intercepted" };
  console.log(globalThis.Bun);   // <-- wrong: captures the local
}
```

Running the bundle prints `intercepted` instead of the `Bun` object.

## Cause

With `--target=bun`, the printer rewrites `require("bun")` and `import("bun")` to the literal text `globalThis.Bun` in `print_require_or_import_expr`. That text is emitted via `self.print(b"...")` with no `Ref`, so the renamer never sees it. If the user declares a local binding named `globalThis` in the enclosing scope, the emitted identifier resolves to the local instead of the real global.

The bundler already guards against this for `Promise` (for `Promise.resolve(...)` in the dynamic-import rewrite) by seeding `compute_initial_reserved_names` with it. Grepping the printer for the same pattern turned up four more names it emits as bare identifiers on the bundler path:

- `Error` in `print_require_error` (`throw new Error(...)` shim for an unresolvable try/catch'd require). Under `--target=node`/`browser` this was incidentally reserved because the bundler runtime module references `Error`; under `--target=bun` it only references `TypeError`/`SuppressedError`, so a user local `Error` was captured.
- `Infinity` in `print_number`, emitted for `f64::INFINITY` precisely when `has_run_symbol_renamer` is true (the code documents that assumption). `1e400` parses directly to `f64::INFINITY` without any identifier reference, so there is no unbound symbol for the scope walk to reserve.
- `NaN` in `print_number`, emitted unconditionally; reachable via constant-folded `0/0` under `--minify-syntax`.
- `undefined` in `print_undefined`; synthesized `EUndefined` nodes (e.g. the `import.meta.hot` stub when HMR is off, or a JSX dev-mode `key` placeholder) reach the printer without any source-level `undefined` reference.

## Fix

Seed `compute_initial_reserved_names` with `globalThis`, `Error`, `Infinity`, `NaN`, and `undefined` alongside the existing `Promise`/`Require`. Any user binding with one of those names is renamed (e.g. `globalThis2`), so the printer's literal always resolves to the real global. This is a rename of a user local; all references to the user's binding move with it.

## Verification

After:

```js
{
  let globalThis2 = { Bun: "intercepted" };
  console.log(globalThis.Bun);   // real Bun object
}
```

New tests in `test/bundler/bundler_bun.test.ts` cover `require("bun")` / dynamic `import("bun")` / `import * as b from "bun"` with a shadowing `globalThis` (each with and without `--minify-identifiers`), a try/catch'd unresolvable require with a shadowing `Error`, `1e400` with a shadowing `Infinity`, constant-folded `0/0` with a shadowing `NaN` param, and `import.meta.hot` with a shadowing `undefined`. Seven of the ten fail against the unfixed build; all ten pass with the fix.
