### PR TITLE
install: skip reinstalling file:/URL tarball deps on second install

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -15,10 +15,11 @@ use bun_threading::work_pool::Task as WorkPoolTask;
 #[cfg(windows)]
 use bun_threading::{ThreadPool, WaitGroup};
 
+use crate::lockfile::package::PackageColumns as _;
 use crate::package_installer::NodeModulesFolder;
 use crate::{
-    BuntagHashBuf, Lockfile, Npm, PackageID, PackageManager, Repository, Resolution,
-    TruncatedPackageNameHash, bun_fs, bun_json, buntaghashbuf_make, initialize_store, resolution,
+    BuntagHashBuf, Lockfile, Npm, PackageID, PackageManager, Resolution, TruncatedPackageNameHash,
+    bun_fs, bun_json, buntaghashbuf_make, initialize_store, resolution,
 };
 
 bun_output::declare_scope!(install, hidden);
@@ -36,6 +37,7 @@ pub struct PackageInstall<'a> {
 
     pub(crate) progress: Option<&'a mut Progress>,
 
+    pub(crate) package_id: PackageID,
     pub(crate) package_name: SemverString,
     pub(crate) package_version: &'a [u8],
     pub(crate) patch: Option<Patch>,
@@ -775,9 +777,7 @@ impl<'a> PackageInstall<'a> {
         true
     }
 
-    // 1. verify that .bun-tag exists (was it installed from bun?)
-    // 2. check .bun-tag against the resolved version
-    fn verify_git_resolution(&mut self, repo: &Repository, root_node_modules_dir: &Dir) -> bool {
+    fn verify_bun_tag(&mut self, expected: &[u8], root_node_modules_dir: &Dir) -> bool {
         let dest_len = self.destination_dir_subpath.len();
         let suffix: &[u8] = &[SEP, b'.', b'b', b'u', b'n', b'-', b't', b'a', b'g'];
         // Reshaped for borrowck — write into buf via raw indices.
@@ -803,20 +803,47 @@ impl<'a> PackageInstall<'a> {
         else {
             return false;
         };
-        strings::eql_long(
-            repo.resolved.slice(&self.lockfile.buffers.string_bytes),
-            &bun_tag_file.bytes,
-            true,
-        )
+        strings::eql_long(expected, &bun_tag_file.bytes, true)
+    }
+
+    fn read_cached_bun_tag(&self, buf: &mut [u8]) -> Option<usize> {
+        let tag_path = path::resolve_path::join_z::<path::platform::Auto>(&[
+            self.cache_dir_subpath.as_bytes(),
+            b".bun-tag",
+        ]);
+        let len = sys::File::openat(self.cache_dir, tag_path.as_bytes(), sys::O::RDONLY, 0)
+            .ok()?
+            .read_all(buf)
+            .ok()?;
+        (len < buf.len()).then_some(len)
     }
 
     pub(crate) fn verify(&mut self, resolution: &Resolution, root_node_modules_dir: &Dir) -> bool {
         let verified = match resolution.tag {
-            resolution::Tag::Git => {
-                self.verify_git_resolution(resolution.git(), root_node_modules_dir)
+            resolution::Tag::Git | resolution::Tag::Github => {
+                let lockfile = self.lockfile;
+                self.verify_bun_tag(
+                    resolution
+                        .repository()
+                        .resolved
+                        .slice(&lockfile.buffers.string_bytes),
+                    root_node_modules_dir,
+                )
             }
-            resolution::Tag::Github => {
-                self.verify_git_resolution(resolution.github(), root_node_modules_dir)
+            resolution::Tag::LocalTarball | resolution::Tag::RemoteTarball => 'tarball: {
+                let integrity =
+                    self.lockfile.packages.items_meta()[self.package_id as usize].integrity;
+                let mut buf = [0u8; 128];
+                let expected: &[u8] = if integrity.tag.is_supported() {
+                    bun_core::fmt::buf_print_infallible(&mut buf, format_args!("{}", integrity))
+                } else {
+                    // Lockfile predates tarball integrity: installing would copy the cache entry.
+                    let Some(len) = self.read_cached_bun_tag(&mut buf) else {
+                        break 'tarball false;
+                    };
+                    &buf[..len]
+                };
+                self.verify_bun_tag(expected, root_node_modules_dir)
             }
             resolution::Tag::Root => self.verify_transitive_symlinked_folder(root_node_modules_dir),
             resolution::Tag::Folder => {

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1388,6 +1388,7 @@ impl<'a> PackageInstaller<'a> {
             // field outlives `installer`. `destination_dir_subpath` above derives from the
             // same raw pointer, so this `&mut` does not invalidate it under stacked-borrows.
             destination_dir_subpath_buf: unsafe { (*subpath_buf_ptr).as_mut_slice() },
+            package_id,
             package_name: pkg_name,
             patch: patch_contents_hash
                 .map(|contents_hash| package_install::Patch { contents_hash }),

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -733,7 +733,7 @@ pub fn cached_tarball_folder_name_print<'a>(
     let mut w = ByteCursor::new(buf);
     w.put(b"@T@");
     w.put_u64_hex16::<true>(Semver::semver_string::Builder::string_hash(url));
-    w.put_cache_version(Some(CacheVersion::CURRENT));
+    w.put_cache_version(Some(CacheVersion::TARBALL));
     w.put_patch_hash(patch_hash);
     w.finish_z()
 }
@@ -1289,6 +1289,8 @@ pub fn write_yarn_lock(this: &mut PackageManager) -> Result<(), Error> {
 pub(crate) struct CacheVersion;
 impl CacheVersion {
     pub(crate) const CURRENT: usize = 1;
+    /// 2: tarball entries carry `.bun-tag`.
+    pub(crate) const TARBALL: usize = 2;
 }
 
 // ────────────────────────────── helpers ───────────────────────────────────────

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -36,6 +36,7 @@ use bun_threading::{Mutex, thread_pool};
 
 use crate::NetworkTask;
 use crate::bun_fs::FileSystem;
+use crate::extract_tarball;
 use crate::integrity::{self, Integrity};
 use crate::package_manager_real::PackageManager;
 
@@ -1125,25 +1126,26 @@ impl TarballStream {
                 }
             }
 
-            if tarball.resolution.tag == ResolutionTag::Github {
-                'insert_tag: {
-                    if self.resolved_github_dirname.is_empty() {
-                        break 'insert_tag;
+            let integrity = match tarball.resolution.tag {
+                ResolutionTag::Github
+                | ResolutionTag::RemoteTarball
+                | ResolutionTag::LocalTarball => {
+                    if tarball.integrity.tag.is_supported() {
+                        tarball.integrity
+                    } else {
+                        self.hasher.final_()
                     }
-                    if bun_sys::File::openat(
-                        self.dest.unwrap(),
-                        bun_core::zstr!(".bun-tag"),
-                        O::WRONLY
-                            | O::CREAT
-                            | O::TRUNC
-                            | if cfg!(windows) { 0 } else { O::NOFOLLOW },
-                        0o664,
-                    )
-                    .and_then(|f| f.write_all(self.resolved_github_dirname))
-                    .is_err()
-                    {
-                        let _ = bun_sys::unlinkat(self.dest.unwrap(), bun_core::zstr!(".bun-tag"));
+                }
+                _ => Integrity::default(),
+            };
+
+            if let Some(dest) = self.dest {
+                if tarball.resolution.tag == ResolutionTag::Github {
+                    if !self.resolved_github_dirname.is_empty() {
+                        extract_tarball::write_bun_tag(dest, self.resolved_github_dirname);
                     }
+                } else {
+                    tarball.write_tarball_bun_tag(dest, &integrity);
                 }
             }
 
@@ -1154,12 +1156,13 @@ impl TarballStream {
 
             let (name, basename) = tarball.name_and_basename();
 
-            let mut result = match tarball.move_to_cache_directory(
+            let result = match tarball.move_to_cache_directory(
                 &mut (*task).log,
                 self.tmpname.as_zstr(),
                 name,
                 basename,
                 self.resolved_github_dirname,
+                &integrity,
             ) {
                 Ok(r) => r,
                 Err(err) => {
@@ -1168,19 +1171,6 @@ impl TarballStream {
                     return;
                 }
             };
-
-            match tarball.resolution.tag {
-                ResolutionTag::Github
-                | ResolutionTag::RemoteTarball
-                | ResolutionTag::LocalTarball => {
-                    if tarball.integrity.tag.is_supported() {
-                        result.integrity = tarball.integrity;
-                    } else {
-                        result.integrity = self.hasher.final_();
-                    }
-                }
-                _ => {}
-            }
 
             if PackageManager::verbose_install() {
                 bun_core::pretty_errorln!(

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -57,28 +57,59 @@ impl ExtractTarball {
                 return Err(crate::Error::IntegrityCheckFailed);
             }
         }
-        let mut result = self.extract(log, bytes)?;
-
         // Compute and store SHA-512 integrity hash for GitHub / URL / local tarballs
         // so the lockfile can pin the exact tarball content. On subsequent installs
         // the hash stored in the lockfile is forwarded via this.integrity and verified
         // above, preventing a compromised server from silently swapping the tarball.
-        match self.resolution.tag {
+        let integrity = match self.resolution.tag {
             ResolutionTag::Github | ResolutionTag::RemoteTarball | ResolutionTag::LocalTarball => {
                 if self.integrity.tag.is_supported() {
                     // Re-installing with an existing lockfile: integrity was already
                     // verified above, propagate the known value to ExtractData so that
                     // the lockfile keeps it on re-serialisation.
-                    result.integrity = self.integrity;
+                    self.integrity
                 } else {
                     // First install (no integrity in the lockfile yet): compute it.
-                    result.integrity = Integrity::for_bytes(bytes);
+                    Integrity::for_bytes(bytes)
                 }
             }
-            _ => {}
-        }
+            _ => Integrity::default(),
+        };
 
-        Ok(result)
+        self.extract(log, bytes, &integrity)
+    }
+
+    /// Like the GitHub commit tag, but holding the integrity; read back by `PackageInstall::verify`.
+    pub(crate) fn write_tarball_bun_tag(&self, dir: Fd, integrity: &Integrity) {
+        if !matches!(
+            self.resolution.tag,
+            ResolutionTag::LocalTarball | ResolutionTag::RemoteTarball
+        ) || !integrity.tag.is_supported()
+        {
+            return;
+        }
+        let mut buf = [0u8; 128];
+        write_bun_tag(
+            dir,
+            bun_fmt::buf_print_infallible(&mut buf, format_args!("{}", integrity)),
+        );
+    }
+}
+
+pub(crate) fn write_bun_tag(dir: Fd, contents: &[u8]) {
+    if sys::File::openat(
+        dir,
+        ZStr::from_static(b".bun-tag\0"),
+        sys::O::WRONLY
+            | sys::O::CREAT
+            | sys::O::TRUNC
+            | if cfg!(windows) { 0 } else { sys::O::NOFOLLOW },
+        0o664,
+    )
+    .and_then(|f| f.write_all(contents))
+    .is_err()
+    {
+        let _ = sys::unlinkat(dir, ZStr::from_static(b".bun-tag\0"));
     }
 }
 
@@ -225,7 +256,12 @@ impl ExtractTarball {
         (name, basename)
     }
 
-    fn extract(&self, log: &mut bun_ast::Log, tgz_bytes: &[u8]) -> Result<ExtractData, Error> {
+    fn extract(
+        &self,
+        log: &mut bun_ast::Log,
+        tgz_bytes: &[u8],
+        integrity: &Integrity,
+    ) -> Result<ExtractData, Error> {
         let _tracer = bun_core::perf::trace("ExtractTarball.extract");
 
         let tmpdir = Dir::borrow(&self.temp_dir);
@@ -382,24 +418,7 @@ impl ExtractTarball {
                     // installed from GitHub. package.json version becomes sort of
                     // meaningless in cases like this.
                     if !resolved.is_empty() {
-                        // Create/truncate `.bun-tag`, then write the resolved tag.
-                        if sys::File::openat(
-                            extract_destination.fd(),
-                            ZStr::from_static(b".bun-tag\0"),
-                            sys::O::WRONLY
-                                | sys::O::CREAT
-                                | sys::O::TRUNC
-                                | if cfg!(windows) { 0 } else { sys::O::NOFOLLOW },
-                            0o664,
-                        )
-                        .and_then(|f| f.write_all(resolved))
-                        .is_err()
-                        {
-                            let _ = sys::unlinkat(
-                                extract_destination.fd(),
-                                ZStr::from_static(b".bun-tag\0"),
-                            );
-                        }
+                        write_bun_tag(extract_destination.fd(), resolved);
                     }
                 }
                 _ => {
@@ -417,6 +436,8 @@ impl ExtractTarball {
                             ..Default::default()
                         },
                     )?;
+
+                    self.write_tarball_bun_tag(extract_destination.fd(), integrity);
                 }
             }
 
@@ -439,7 +460,7 @@ impl ExtractTarball {
             }
         }
 
-        self.move_to_cache_directory(log, tmpname, name, basename, resolved)
+        self.move_to_cache_directory(log, tmpname, name, basename, resolved, integrity)
     }
 
     /// Rename the freshly-extracted temp directory into the cache, read
@@ -452,6 +473,7 @@ impl ExtractTarball {
         name: &[u8],
         basename: &[u8],
         resolved: &[u8],
+        integrity: &Integrity,
     ) -> Result<ExtractData, Error> {
         let package_manager = self.package_manager.get();
 
@@ -756,6 +778,7 @@ impl ExtractTarball {
                             return Ok(ExtractData {
                                 url: url.into(),
                                 resolved: resolved.into(),
+                                integrity: *integrity,
                                 ..Default::default()
                             });
                         }
@@ -867,7 +890,7 @@ impl ExtractTarball {
                     path: ret_json_path.into(),
                     buf: json_buf,
                 }),
-                ..Default::default()
+                integrity: *integrity,
             })
         })
     }

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -483,6 +483,7 @@ impl PatchTask {
             destination_dir_subpath_buf: &mut dest_subpath_buf[..],
             patch: None,
             progress: None,
+            package_id: patch.pkg_id,
             package_name: pkg_name,
             package_version: &resolution_label,
             // dummy value

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2510,7 +2510,11 @@ it("should add local tarball dependency", async () => {
   expect(await exited).toBe(0);
   expect(urls.sort()).toBeEmpty();
   expect(requested).toBe(0);
-  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toEqual([
+    ".bun-tag",
+    "index.js",
+    "package.json",
+  ]);
   const package_json = await file(join(package_dir, "node_modules", "baz", "package.json")).json();
   expect(package_json.name).toBe("baz");
   expect(package_json.version).toBe("0.0.3");
@@ -2875,7 +2879,11 @@ it("should add an uncompressed .tar local tarball", async () => {
   expect(await exited).toBe(0);
   expect(urls).toBeEmpty();
   expect(requested).toBe(0);
-  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toStrictEqual(["index.js", "package.json"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", "baz"))).toStrictEqual([
+    ".bun-tag",
+    "index.js",
+    "package.json",
+  ]);
   const package_json = await file(join(package_dir, "node_modules", "baz", "package.json")).json();
   expect(package_json.name).toBe("baz");
   expect(package_json.version).toBe("0.0.3");

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -1,6 +1,7 @@
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { rmSync } from "fs";
+import { cp, readdir } from "fs/promises";
 import {
   bunEnv,
   bunExe,
@@ -122,6 +123,66 @@ index c8950c17b265104bcf27f8c345df1a1b13a78950..7ce57ab96400ab0ff4fac7e06f6e02c2
       : (x: string) => x;
 
   const versions: [version: string, patchVersion?: string][] = [["1.0.0"]];
+
+  test("should patch a file: tarball dependency with bun patch --commit and skip it on the next install", async () => {
+    await using filedir = tempDir("patch-tarball", {
+      "package.json": JSON.stringify({ name: "bun-patch-test", dependencies: { baz: "file:baz.tgz" } }),
+      "bunfig.toml": '[install]\nlinker = "hoisted"\ncache = false\n',
+    });
+    await cp(join(import.meta.dir, "baz-0.0.3.tgz"), join(String(filedir), "baz.tgz"));
+    const installed = join(String(filedir), "node_modules", "baz");
+    const unpatchedIndex = '#! /usr/bin/env node\n\nconsole.log("run baz");\n';
+
+    const first = await $`${bunExe()} i`.env(bunEnv).cwd(filedir).quiet();
+    expect(first.stdout.toString()).toContain("1 package installed");
+    expect(await Bun.file(join(installed, "index.js")).text()).toBe(unpatchedIndex);
+    expect(await readdir(installed).then(f => f.sort())).toEqual([".bun-tag", "index.js", "package.json"]);
+
+    const prepare = await $`${bunExe()} patch baz`.env(bunEnv).cwd(filedir).quiet().nothrow();
+    expect(prepare.stderr.toString()).not.toContain("error");
+    expect(prepare.exitCode).toBe(0);
+    await Bun.write(join(installed, "index.js"), unpatchedIndex.replace("run baz", "run patched baz"));
+
+    // The cache entry and the edited copy both contain `.bun-tag`, so the diff is the edit alone.
+    const commit = await $`${bunExe()} patch --commit node_modules/baz`.env(bunEnv).cwd(filedir).quiet().nothrow();
+    expect(commit.stderr.toString()).not.toContain("error");
+    expect(commit.exitCode).toBe(0);
+    expect((await Bun.file(join(String(filedir), "package.json")).json()).patchedDependencies).toEqual({
+      "baz@baz.tgz": "patches/baz@baz.tgz.patch",
+    });
+    const patch = await Bun.file(join(String(filedir), "patches", "baz@baz.tgz.patch")).text();
+    expect(patch.match(/^diff --git .*$/gm)).toEqual(["diff --git a/index.js b/index.js"]);
+    expect(patch).toContain('-console.log("run baz");');
+    expect(patch).toContain('+console.log("run patched baz");');
+
+    // `--commit` reinstalls the package from the patched cache entry.
+    expect(await Bun.file(join(installed, "index.js")).text()).toContain("run patched baz");
+    const patchedFiles = await readdir(installed).then(f => f.sort());
+    expect(patchedFiles).toEqual([
+      ".bun-tag",
+      expect.stringMatching(/^\.bun-tag-[0-9a-f]+$/),
+      "index.js",
+      "package.json",
+    ]);
+
+    const second = await $`${bunExe()} i`.env(bunEnv).cwd(filedir).quiet();
+    expect(second.stdout.toString()).toContain("(no changes)");
+    expect(await Bun.file(join(installed, "index.js")).text()).toContain("run patched baz");
+    expect(await readdir(installed).then(f => f.sort())).toEqual(patchedFiles);
+
+    // Dropping the patch must reinstall the unpatched tarball.
+    await Bun.write(
+      join(String(filedir), "package.json"),
+      JSON.stringify({ name: "bun-patch-test", dependencies: { baz: "file:baz.tgz" } }),
+    );
+    const third = await $`${bunExe()} i`.env(bunEnv).cwd(filedir).quiet();
+    expect(third.stdout.toString()).toContain("1 package installed");
+    expect(await Bun.file(join(installed, "index.js")).text()).toBe(unpatchedIndex);
+    expect(await readdir(installed).then(f => f.sort())).toEqual([".bun-tag", "index.js", "package.json"]);
+
+    const fourth = await $`${bunExe()} i`.env(bunEnv).cwd(filedir).quiet();
+    expect(fourth.stdout.toString()).toContain("(no changes)");
+  });
 
   describe("should patch a dependency when its dependencies are not hoisted", async () => {
     // is-even depends on is-odd ^0.1.2 and we add is-odd 3.0.1, which should be hoisted

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -269,6 +269,39 @@ describe("streaming tarball extraction", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.each([
+    ["streaming", {}],
+    ["buffered", { BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1" }],
+  ] as const)("a URL tarball dependency is tagged with its integrity and not reinstalled (%s)", async (label, env) => {
+    await using reg = await makeRegistry(tgz, shasum, integrity, chunkBytes);
+
+    using dir = tempDir("streaming-url-dep", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": `${reg.url}stream-pkg/-/stream-pkg-1.0.0.tgz` },
+      }),
+    });
+
+    const first = await runInstall(String(dir), env);
+    expect(first.stderr).not.toContain("error:");
+    if (label === "streaming") {
+      expect(first.stderr).toContain("Streamed ");
+    } else {
+      expect(first.stderr).not.toContain("Streamed ");
+    }
+    expect(first.stdout).toContain("1 package installed");
+    expect(readFileSync(join(String(dir), "node_modules", "stream-pkg", ".bun-tag"), "utf8")).toBe(integrity);
+    expect(readFileSync(join(String(dir), "bun.lock"), "utf8")).toContain(`"${integrity}"`);
+    expect(first.exitCode).toBe(0);
+
+    const second = await runInstall(String(dir), env);
+    expect(second.stderr).not.toContain("Saved lockfile");
+    expect(second.stdout).toContain("(no changes)");
+    expect(reg.tarballHits).toBe(1);
+    expect(second.exitCode).toBe(0);
+  });
+
   // Regression: archive_read_set_options() clobbered the a->format set by
   // archive_read_set_format(), so archive_read_open1() fell back to format
   // bidding. The tar bidder needs 512 decompressed bytes up front; when the

--- a/test/cli/install/bun-install-tarball-integrity.test.ts
+++ b/test/cli/install/bun-install-tarball-integrity.test.ts
@@ -278,7 +278,11 @@ describe.concurrent("tarball integrity", () => {
       expect(err).not.toContain("error:");
       expect(await proc.exited).toBe(0);
       // Package should be installed
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual([
+        ".bun-tag",
+        "index.js",
+        "package.json",
+      ]);
     });
   });
 
@@ -488,7 +492,11 @@ describe.concurrent("tarball integrity", () => {
       expect(err).not.toContain("Integrity check failed");
       expect(err).not.toContain("error:");
       expect(await proc.exited).toBe(0);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual([
+        ".bun-tag",
+        "index.js",
+        "package.json",
+      ]);
     });
   });
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,7 +1,7 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
 import { readFileSync, readlinkSync, realpathSync, statSync } from "fs";
-import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
+import { access, cp, exists, lstat, mkdir, readlink, rename, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
   bunExe,
@@ -4613,6 +4613,7 @@ describe.concurrent("bun-install", () => {
       expect(ctx.requested).toBe(0);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "when"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "when"))).toEqual([
+        ".bun-tag",
         ".gitignore",
         ".gitmodules",
         "LICENSE.txt",
@@ -4674,6 +4675,7 @@ describe.concurrent("bun-install", () => {
       expect(ctx.requested).toBe(0);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "when"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "when"))).toEqual([
+        ".bun-tag",
         ".gitignore",
         ".gitmodules",
         "LICENSE.txt",
@@ -4743,6 +4745,7 @@ describe.concurrent("bun-install", () => {
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@vercel"))).toEqual(["turbopack-node"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@vercel", "turbopack-node"))).toEqual([
+        ".bun-tag",
         "package.json",
         "src",
         "tsconfig.json",
@@ -6351,7 +6354,11 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual([
+        ".bun-tag",
+        "index.js",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
         name: "baz",
         version: "0.0.3",
@@ -6401,6 +6408,7 @@ describe.concurrent("bun-install", () => {
         expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toStrictEqual([".bin", ".cache", "baz"]);
         expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
         expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toStrictEqual([
+          ".bun-tag",
           "index.js",
           "package.json",
         ]);
@@ -6453,7 +6461,11 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "baz"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual(["index.js", "package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual([
+        ".bun-tag",
+        "index.js",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json()).toEqual({
         name: "baz",
         version: "0.0.3",
@@ -6503,7 +6515,11 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "bar", "index.js"));
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "bar"))).toEqual(["index.js", "package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "bar"))).toEqual([
+        ".bun-tag",
+        "index.js",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
         name: "baz",
         version: "0.0.3",
@@ -6552,7 +6568,11 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "bar"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "bar", "index.js"));
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "bar"))).toEqual(["index.js", "package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "bar"))).toEqual([
+        ".bun-tag",
+        "index.js",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "bar", "package.json")).json()).toEqual({
         name: "baz",
         version: "0.0.3",
@@ -6561,6 +6581,231 @@ describe.concurrent("bun-install", () => {
         },
       });
       await access(join(ctx.package_dir, "bun.lockb"));
+    });
+  });
+
+  // https://github.com/oven-sh/bun/issues/8260
+  describe.each(["tarball path", "tarball URL"] as const)("%s dependency is not reinstalled", kind => {
+    // The dependency always points at the same path/URL; `useFixture` swaps the
+    // bytes behind it, simulating a vendored tarball being rebuilt in place.
+    function setup(ctx: TestContext) {
+      const state = { served: "", requests: 0 };
+      setContextHandler(ctx, () => {
+        state.requests++;
+        return new Response(file(state.served));
+      });
+      return {
+        state,
+        async useFixture(name: string) {
+          state.served = join(import.meta.dir, name);
+          await cp(state.served, join(ctx.package_dir, "baz.tgz"));
+        },
+        async writePackageJson() {
+          const dep = kind === "tarball URL" ? `${ctx.registry_url}baz.tgz` : "file:./baz.tgz";
+          await writeFile(
+            join(ctx.package_dir, "package.json"),
+            JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { baz: dep } }),
+          );
+        },
+        lockfile: join(ctx.package_dir, "bun.lock"),
+        // The context's bunfig disables the global cache, so the cache lives here.
+        cache: join(ctx.package_dir, "node_modules", ".cache"),
+        async installedVersion() {
+          const pkg = await file(join(ctx.package_dir, "node_modules", "baz", "package.json")).json();
+          return pkg.version;
+        },
+      };
+    }
+
+    async function install(ctx: TestContext, ...args: string[]) {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--save-text-lockfile", ...args],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+      expect(err).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      return { out, err };
+    }
+
+    it("when nothing changed", async () => {
+      await withContext(defaultOpts, async ctx => {
+        const t = setup(ctx);
+        await t.useFixture("baz-0.0.3.tgz");
+        await t.writePackageJson();
+
+        expect((await install(ctx)).out).toContain("1 package installed");
+        expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual([
+          ".bun-tag",
+          "index.js",
+          "package.json",
+        ]);
+        const requestsAfterFirstInstall = t.state.requests;
+
+        const second = await install(ctx);
+        expect(second.err).not.toContain("Saved lockfile");
+        expect(second.out.replace(/\s*\[[0-9.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+          expect.stringContaining("bun install v1."),
+          "",
+          "Checked 1 install across 2 packages (no changes)",
+        ]);
+        expect(t.state.requests).toBe(requestsAfterFirstInstall);
+
+        expect((await install(ctx, "--force")).out).toContain("1 package installed");
+      });
+    });
+
+    it("unless the tarball was rebuilt at the same path", async () => {
+      await withContext(defaultOpts, async ctx => {
+        const t = setup(ctx);
+        await t.useFixture("baz-0.0.3.tgz");
+        await t.writePackageJson();
+        await install(ctx);
+        expect(await t.installedVersion()).toBe("0.0.3");
+        const lockfileBefore = await file(t.lockfile).text();
+
+        await t.useFixture("baz-0.0.5.tgz");
+        await rm(t.lockfile);
+        expect((await install(ctx)).out).toContain("1 package installed");
+        expect(await t.installedVersion()).toBe("0.0.5");
+        expect(await file(t.lockfile).text()).not.toBe(lockfileBefore);
+
+        expect((await install(ctx)).out).toContain("(no changes)");
+      });
+    });
+
+    it("unless the lockfile pins a different integrity", async () => {
+      await withContext(defaultOpts, async ctx => {
+        const t = setup(ctx);
+        await t.writePackageJson();
+
+        await t.useFixture("baz-0.0.5.tgz");
+        await install(ctx);
+        const rebuiltLockfile = await file(t.lockfile).text();
+        await rm(join(ctx.package_dir, "node_modules"), { recursive: true });
+        await rm(t.lockfile);
+
+        await t.useFixture("baz-0.0.3.tgz");
+        await install(ctx);
+        expect(await t.installedVersion()).toBe("0.0.3");
+
+        // A collaborator rebuilt the tarball and committed the new lockfile; pull
+        // both onto a machine whose node_modules (and cache) still hold the old build.
+        await t.useFixture("baz-0.0.5.tgz");
+        await writeFile(t.lockfile, rebuiltLockfile);
+        const stale = await install(ctx);
+        expect(stale.err).not.toContain("Saved lockfile");
+        expect(stale.out).not.toContain("(no changes)");
+
+        // With the old extraction out of the cache the pinned build gets installed.
+        await rm(t.cache, { recursive: true });
+        const { out, err } = await install(ctx);
+        expect(err).not.toContain("Saved lockfile");
+        expect(out).toContain("1 package installed");
+        expect(await t.installedVersion()).toBe("0.0.5");
+
+        expect((await install(ctx)).out).toContain("(no changes)");
+      });
+    });
+
+    it("and cache entries extracted before tags existed are not reused", async () => {
+      await withContext(defaultOpts, async ctx => {
+        const t = setup(ctx);
+        await t.useFixture("baz-0.0.3.tgz");
+        await t.writePackageJson();
+        await install(ctx);
+        const tarballEntries = async () => (await readdirSorted(t.cache)).filter(name => name.startsWith("@T@"));
+        const [entry] = await tarballEntries();
+        expect(entry).toEndWith("@@@2");
+
+        // What an older bun leaves behind: the extraction under the previous
+        // cache folder name and an installed copy, neither of them tagged.
+        const oldEntry = entry.replace(/@@@2$/, "@@@1");
+        await rename(join(t.cache, entry), join(t.cache, oldEntry));
+        await rm(join(t.cache, oldEntry, ".bun-tag"));
+        await rm(join(ctx.package_dir, "node_modules", "baz", ".bun-tag"));
+
+        expect((await install(ctx)).out).toContain("1 package installed");
+        expect(await tarballEntries()).toEqual([oldEntry, entry]);
+        expect(await readdirSorted(join(ctx.package_dir, "node_modules", "baz"))).toEqual([
+          ".bun-tag",
+          "index.js",
+          "package.json",
+        ]);
+        expect((await install(ctx)).out).toContain("(no changes)");
+      });
+    });
+
+    // Symlinks into the cache need extra privileges on Windows.
+    it.skipIf(isWindows)("with --backend=symlink, until the cache it points into is removed", async () => {
+      await withContext(defaultOpts, async ctx => {
+        const t = setup(ctx);
+        await t.useFixture("baz-0.0.3.tgz");
+        await t.writePackageJson();
+        const tag = join(ctx.package_dir, "node_modules", "baz", ".bun-tag");
+
+        expect((await install(ctx, "--backend=symlink")).out).toContain("1 package installed");
+        expect((await lstat(tag)).isSymbolicLink()).toBe(true);
+        expect((await install(ctx, "--backend=symlink")).out).toContain("(no changes)");
+
+        await rm(t.cache, { recursive: true });
+        expect((await install(ctx, "--backend=symlink")).out).toContain("1 package installed");
+        expect(await file(tag).text()).toStartWith("sha512-");
+        expect((await install(ctx, "--backend=symlink")).out).toContain("(no changes)");
+      });
+    });
+
+    describe("when the lockfile predates tarball integrity", () => {
+      async function installThenStripIntegrity(ctx: TestContext, t: ReturnType<typeof setup>) {
+        await t.useFixture("baz-0.0.3.tgz");
+        await t.writePackageJson();
+        await install(ctx);
+        const withIntegrity = await file(t.lockfile).text();
+        const withoutIntegrity = withIntegrity.replace(/, "sha512-[^"]+"\]/, "]");
+        expect(withoutIntegrity).not.toBe(withIntegrity);
+        await writeFile(t.lockfile, withoutIntegrity);
+        return { withIntegrity, withoutIntegrity };
+      }
+
+      it("is upgraded by the first install that extracts the tarball", async () => {
+        await withContext(defaultOpts, async ctx => {
+          const t = setup(ctx);
+          const { withIntegrity } = await installThenStripIntegrity(ctx, t);
+          // Entries extracted by older versions live under another cache folder
+          // name, so after upgrading bun the cache is effectively empty.
+          await rm(t.cache, { recursive: true });
+
+          const upgrade = await install(ctx);
+          expect(upgrade.out).toContain("1 package installed");
+          expect(upgrade.err).toContain("Saved lockfile");
+          expect(await file(t.lockfile).text()).toBe(withIntegrity);
+
+          expect((await install(ctx)).out).toContain("(no changes)");
+        });
+      });
+
+      it("is compared against the cache entry when the tarball is already cached", async () => {
+        await withContext(defaultOpts, async ctx => {
+          const t = setup(ctx);
+          const { withoutIntegrity } = await installThenStripIntegrity(ctx, t);
+
+          // e.g. --frozen-lockfile, which cannot add the integrity to the lockfile.
+          for (let i = 0; i < 2; i++) {
+            const { out, err } = await install(ctx, "--frozen-lockfile");
+            expect(err).not.toContain("Saved lockfile");
+            expect(out).toContain("(no changes)");
+          }
+          expect(await file(t.lockfile).text()).toBe(withoutIntegrity);
+
+          await rm(join(ctx.package_dir, "node_modules", "baz", ".bun-tag"));
+          expect((await install(ctx, "--frozen-lockfile")).out).toContain("1 package installed");
+          expect((await install(ctx, "--frozen-lockfile")).out).toContain("(no changes)");
+        });
+      });
     });
   });
 
@@ -6627,7 +6872,10 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual([
+        ".bun-tag",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6718,7 +6966,10 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual([
+        ".bun-tag",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6783,7 +7034,10 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual([
+        ".bun-tag",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6873,7 +7127,10 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual([
+        ".bun-tag",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",
@@ -6934,7 +7191,10 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["baz-run"]);
       expect(join(ctx.package_dir, "node_modules", ".bin", "baz-run")).toBeValidBin(join("..", "baz", "index.js"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn"))).toEqual(["moo"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual(["package.json"]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "@barn", "moo"))).toEqual([
+        ".bun-tag",
+        "package.json",
+      ]);
       expect(await file(join(ctx.package_dir, "node_modules", "@barn", "moo", "package.json")).json()).toEqual({
         name: "@barn/moo",
         version: "0.1.0",

--- a/test/cli/install/install-fd-leak.test.ts
+++ b/test/cli/install/install-fd-leak.test.ts
@@ -1,4 +1,4 @@
-import { Archive, spawn, write } from "bun";
+import { Archive, spawn } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
 import { rm } from "fs/promises";
 import { bunEnv, bunExe, isMacOS, isWindows, readdirSorted, tempDir } from "harness";
@@ -84,7 +84,7 @@ describe.skipIf(isWindows)("install does not leak file descriptors", () => {
           expect(exitCode).toBe(0);
           // Confirm the copy actually happened — every file must land.
           const files = await readdirSorted(await installed());
-          expect(files.length).toBe(NUM_FILES + 1); // + package.json
+          expect(files.length).toBe(NUM_FILES + 2); // + package.json + .bun-tag
         };
 
         // Cold install: extract tarball → cache → node_modules.
@@ -96,10 +96,7 @@ describe.skipIf(isWindows)("install does not leak file descriptors", () => {
         if (linker === "isolated") {
           await rm(join(String(projDir), "node_modules", ".bun"), { recursive: true, force: true });
         } else {
-          await write(
-            join(await installed(), "package.json"),
-            JSON.stringify({ name: "many-files-pkg", version: "0.0.0-stale" }),
-          );
+          await rm(join(await installed(), ".bun-tag"));
         }
 
         // Warm reinstall: cache → uninstall → node_modules.


### PR DESCRIPTION
Fixes #8260

### Problem
- Every `bun install` re-copies `file:` and URL tarball dependencies into `node_modules`, even when nothing changed; with a few vendored tarballs this costs seconds per install. npm reports `up to date` for the same setup.
- `PackageInstall::verify` has no arm for `LocalTarball`/`RemoteTarball`, so they fall through to `verify_package_json_name_and_version` (`src/install/PackageInstall.rs`), which compares the installed `package.json` `"version"` against `package_version`.
- For tarballs `package_version` is the formatted resolution, i.e. the path or URL (`src/install/PackageInstaller.rs`, `resolution.fmt(...)`), so the comparison never matches and `needs_install` is always true.
- Only the hoisted linker is affected; the isolated linker keys its store path on the resolution and checks for the directory.

### Fix
- Extraction writes the tarball's integrity (`sha512-...`, the same string bun.lock stores) to `.bun-tag` inside the cache entry, in both the buffered (`extract_tarball.rs`) and streaming (`TarballStream.rs`) paths. The existing github `.bun-tag` write in those two files moves to the shared `write_bun_tag` helper.
- `verify()` compares that file against the integrity in the package's lockfile meta. Git/github keep comparing against the resolved commit; all three go through one `verify_bun_tag(expected)`. `PackageInstall` gains a `package_id` field to look the integrity up.
- The tarball cache folder name gets its own cache version (`@T@<hash>@@@2`), so entries extracted by older versions are extracted once more and pick up the tag.
- Why the tag lives in the cache entry rather than being written after the copy:
  - the tag is content: a tarball rebuilt at the same path (or a pulled lockfile with a new sha512) changes the integrity, so `verify()` fails and the package is reinstalled;
  - the patched and unpatched cache entries carry the same tag, so `bun patch --commit` diffs it against itself and the patch file never contains it;
  - with `--backend=symlink` the tag is a symlink into the cache like every other file, so `bun pm cache rm` invalidates the install instead of leaving a dangling package that still verifies.
- A lockfile written before tarball integrity was recorded has no pin to compare against. `verify()` then compares the node_modules tag with the cache entry's tag, i.e. with what installing would copy, so such lockfiles stop reinstalling too (including under `--frozen-lockfile`, which cannot add the pin); the first install that does extract the tarball fills the integrity in and re-saves the lockfile, as before.
- Git checkouts are not touched: #38269 (now on main) made their `.bun-tag` the cache-hit marker with its own write in `repository.rs`, and `verify()` reads it exactly as before. Tarball cache hits stay a directory probe, since the entry is renamed into the cache only after the tag is written.
- `.bun-tag` is now present in tarball packages in `node_modules` and in the isolated store; directory-listing assertions in existing tests are updated accordingly (after the rebase this includes the `x.tar`/`X.TGZ` install tests and the uncompressed `.tar` add test that #38333 added).
- Verified with `bun bd test` on:
  - `test/cli/install/bun-install.test.ts`, `"<kind> dependency is not reinstalled"` for both `file:` and URL: no-op second install with no registry request, `--force` still reinstalls, rebuild at the same path with the lockfile removed reinstalls the new content, a lockfile pinning a different sha512 is never reported as `(no changes)` and installs the pinned build once the stale extraction is out of the cache, an untagged `@@@1` entry planted in the cache is left alone and re-extracted as `@@@2`, lockfile without integrity is upgraded on a cold cache and compared against the cache entry on a warm one (`--frozen-lockfile`), and under `--backend=symlink` the package is skipped until the cache it links into is removed. All fourteen fail on main.
  - `test/cli/install/bun-install-streaming-extract.test.ts`: a URL tarball large enough to take the streaming extractor (asserted via `Streamed` in verbose output), and the same tarball with streaming disabled, end up with `.bun-tag` equal to the sha512 in bun.lock and skip the second install. Both fail on main.
  - `test/cli/install/bun-install-patch.test.ts`, `file:` tarball: install, `bun patch baz`, edit `index.js`, `bun patch --commit node_modules/baz`. The written patch has `index.js` as its only `diff --git` entry (no `.bun-tag`), the package ends up with `.bun-tag` plus `.bun-tag-<hash>`, the next install prints `(no changes)`, and removing the patch reinstalls the unpatched tarball. Fails on main at the first `.bun-tag` assertion; the `(no changes)` step fails there too.
  - Mutation check (before the rebase): reverting the cache version bump, ignoring the lockfile integrity in `verify()`, or dropping the streaming tag write each fails exactly the tests written for it and nothing else.
  - After the rebase: the whole of `bun-install.test.ts` (the only failures are the tests that clone from bitbucket/gitlab or fetch from the public internet, which this sandbox blocks), `bun-install-patch.test.ts`, `bun-install-streaming-extract.test.ts`, `bun-install-tarball-integrity.test.ts`, `bun-install-git-deps.test.ts`, `lockfile-version-2.test.ts`, `bun-update-lockfile-sync.test.ts`, `bun-lock.test.ts`, `install-fd-leak.test.ts`, the tarball tests in `bun-add`, `bun-prune`, `bun-dedupe`, `bun-add-catalog`, `bun-workspaces`, `bun-pm-licenses` and `isolated-install`, the patch tests in `isolated-install`, and the non-registry `patch --commit` tests in `bun-patch.test.ts`.
  - `bun run rust:check-all` passes on all ten targets.

### Background
- `.bun-tag`: a file bun already writes into git and github cache entries holding the resolved commit; on later installs `verify()` reads `node_modules/<pkg>/.bun-tag` and skips the package if it matches the lockfile. This PR gives tarballs the same file, holding their integrity.
- Tarball integrity: for `file:`/URL tarballs bun hashes the tarball bytes on first extraction and stores the result in the package's lockfile meta (the `"sha512-..."` element of the bun.lock entry); later extractions verify against it.
- Cache folder name: tarball extractions are cached under `@T@<hash of path or URL>@@@<cache version>`; the version suffix exists so the layout of an entry can change without reusing entries written by older versions.
- `bun patch --commit`: diffs `node_modules/<pkg>` against the unpatched cache entry with `git diff --no-index`, writes the result to `patches/`, and reinstalls; the reinstall builds a second cache entry by copying the unpatched one, applying the patch, and adding an empty `.bun-tag-<patch hash>` marker that `verify()` also checks.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts test/cli/install/bun-install-patch.test.ts test/cli/install/bun-install.test.ts test/cli/install/install-fd-leak.test.ts

<!-- robobun:evidence:end -->
