### PR TITLE
bundler: stop emitting __require for external dynamic imports

### DIFF
--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -926,8 +926,7 @@ pub fn scan_imports_and_exports(
                             } else {
                                 // We should use "__require" instead of "require" if we're not
                                 // generating a CommonJS output file, since it won't exist otherwise.
-                                // External "import()" expressions are never lowered to "require()",
-                                // so they don't need "__require".
+                                // External "import()" is printed as-is, so it never needs "__require".
                                 if kind != ImportKind::Dynamic
                                     && should_call_runtime_require(output_format)
                                 {

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -926,7 +926,11 @@ pub fn scan_imports_and_exports(
                             } else {
                                 // We should use "__require" instead of "require" if we're not
                                 // generating a CommonJS output file, since it won't exist otherwise.
-                                if should_call_runtime_require(output_format) {
+                                // External "import()" expressions are never lowered to "require()",
+                                // so they don't need "__require".
+                                if kind != ImportKind::Dynamic
+                                    && should_call_runtime_require(output_format)
+                                {
                                     runtime_require_uses += 1;
                                 }
 

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -782,8 +782,22 @@ describe("bundler", () => {
     format: "esm",
     external: ["external-pkg"],
     onAfterBundle(api) {
-      api.expectFile("/out.js").toContain("__require");
+      api.expectFile("/out.js").toContain("var __require = ");
+      api.expectFile("/out.js").toContain('__require("external-pkg")');
       api.expectFile("/out.js").toContain('import("external-pkg")');
+    },
+  });
+  itBundled("edgecase/ExternalStaticImportIIFEStillEmitsRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        import "external-pkg";
+      `,
+    },
+    format: "iife",
+    external: ["external-pkg"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("var __require = ");
+      api.expectFile("/out.js").toContain('__require("external-pkg")');
     },
   });
   itBundled("edgecase/RuntimeExternalRequire", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -744,6 +744,48 @@ describe("bundler", () => {
     },
     target: "bun",
   });
+  itBundled("edgecase/ExternalDynamicImportDoesNotEmitRequire#12615", {
+    files: {
+      "/entry.js": /* js */ `
+        import("external-pkg", { with: { type: "text" } });
+      `,
+    },
+    format: "esm",
+    external: ["external-pkg"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__require");
+      api.expectFile("/out.js").not.toContain("Dynamic require");
+      api.expectFile("/out.js").toContain('import("external-pkg"');
+    },
+  });
+  itBundled("edgecase/ExternalDynamicImportDoesNotEmitRequireIIFE#12615", {
+    files: {
+      "/entry.js": /* js */ `
+        import("external-pkg");
+      `,
+    },
+    format: "iife",
+    external: ["external-pkg"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__require");
+      api.expectFile("/out.js").not.toContain("Dynamic require");
+      api.expectFile("/out.js").toContain('import("external-pkg")');
+    },
+  });
+  itBundled("edgecase/ExternalDynamicImportWithRequireStillEmitsRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log(require("external-pkg").x);
+        import("external-pkg");
+      `,
+    },
+    format: "esm",
+    external: ["external-pkg"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__require");
+      api.expectFile("/out.js").toContain('import("external-pkg")');
+    },
+  });
   itBundled("edgecase/RuntimeExternalRequire", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
+++ b/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
@@ -247,13 +247,6 @@ export {
 
 exports[`bundler react-compiler/DynamicImportInRender 1`] = `
 "var __MEMO_CACHE_SENTINEL = /* @__PURE__ */ Symbol.for("react.memo_cache_sentinel");
-var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
-  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
-}) : x)(function(x) {
-  if (typeof require !== "undefined")
-    return require.apply(this, arguments);
-  throw Error('Dynamic require of "' + x + '" is not supported');
-});
 
 // entry.jsx
 import { use } from "react";
@@ -284,13 +277,6 @@ export {
 
 exports[`bundler react-compiler/DynamicImportInEffectClosure 1`] = `
 "var __MEMO_CACHE_SENTINEL = /* @__PURE__ */ Symbol.for("react.memo_cache_sentinel");
-var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
-  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
-}) : x)(function(x) {
-  if (typeof require !== "undefined")
-    return require.apply(this, arguments);
-  throw Error('Dynamic require of "' + x + '" is not supported');
-});
 
 // entry.jsx
 import { useEffect } from "react";


### PR DESCRIPTION
Fixes #12615

## Problem

Bundling a file that only contains an external `import()` expression emits an unused `__require` polyfill:

```js
// input
import("something");
```

```js
// output (--external=something, --format=esm)
var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
  get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
}) : x)(function(x) {
  if (typeof require !== "undefined")
    return require.apply(this, arguments);
  throw Error('Dynamic require of "' + x + '" is not supported');
});

// entry.js
import("something");
```

The `__require` definition is never referenced.

## Cause

`scanImportsAndExports` counts a runtime `__require` use for every external import record that might become a `require()` call. The check was:

```rust
if kind == ImportKind::Require
    || !output_format.keep_es6_import_export_syntax()
    || kind == ImportKind::Dynamic
```

so any `import()` expression incremented `runtime_require_uses`. But the printer never lowers an external `import()` to `require()`/`__require()`; it always preserves the `import()` syntax regardless of output format. The equivalent esbuild code gates the dynamic-import arm on `UnsupportedJSFeatures.Has(compat.DynamicImport)`, which Bun has no analogue for (dynamic import is always assumed available), so the arm is never needed.

## Fix

Skip the `__require` use-count bump when the record kind is `Dynamic`. The rest of the block (synthetic default export, cross-chunk `__toESM` wrapping) is left intact since it still applies to cross-chunk dynamic imports.

## Tests

- `edgecase/ExternalDynamicImportDoesNotEmitRequire#12615` (esm)
- `edgecase/ExternalDynamicImportDoesNotEmitRequireIIFE#12615` (iife)
- `edgecase/ExternalDynamicImportWithRequireStillEmitsRequire` (guard: `require()` alongside `import()` still pulls in `__require`)
- Updated `react-compiler` snapshots where the dead polyfill was captured.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->