### PR TITLE
cli: inherit stdin in `bun --filter` when a single package matches

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -942,7 +942,16 @@ pub(crate) fn run_scripts_with_filter(
             buffer: Vec::new(),
             process: None,
             options: SpawnOptions {
-                stdin: spawn::Stdio::Inherit,
+                // Only inherit stdin when a single script matched. With >1
+                // concurrent children sharing fd 0 reads would interleave and a
+                // stdin-reading script would block on the TTY where it
+                // previously saw immediate EOF. #10647's use case is a single
+                // --filter '@scope/pkg' match.
+                stdin: if scripts.len() == 1 {
+                    spawn::Stdio::Inherit
+                } else {
+                    spawn::Stdio::Ignore
+                },
                 #[cfg(unix)]
                 stdout: spawn::Stdio::Buffer,
                 #[cfg(not(unix))]

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -743,6 +743,7 @@ pub(crate) fn run_scripts_with_filter(
 
     // Get list of packages that match the configuration
     let mut scripts: Vec<ScriptConfig> = Vec::new();
+    let mut matched_packages: usize = 0;
     // var scripts = std.ArrayHashMap([]const u8, ScriptConfig).init(ctx.allocator);
     while let Some(package_json_path) = package_json_iter.next()? {
         let dirpath =
@@ -785,6 +786,7 @@ pub(crate) fn run_scripts_with_filter(
             run_in_bun,
         )?;
 
+        let before = scripts.len();
         for (i, name) in [&pre_script_name[..], script_name, &post_script_name[..]]
             .iter()
             .enumerate()
@@ -846,6 +848,9 @@ pub(crate) fn run_scripts_with_filter(
                 PATH: Box::<[u8]>::from(&path_var[..]),
                 elide_count: ctx.bundler_options.elide_lines,
             });
+        }
+        if scripts.len() > before {
+            matched_packages += 1;
         }
     }
 
@@ -935,10 +940,7 @@ pub(crate) fn run_scripts_with_filter(
     let mut map: StringHashMap<Vec<*mut ProcessHandle>> = StringHashMap::default();
     // Inherit stdin only when one package matched (its pre/main/post run
     // sequentially); multiple packages run concurrently and would race on fd 0.
-    let single_package = scripts
-        .first()
-        .zip(scripts.last())
-        .is_some_and(|(a, b)| a.package_name == b.package_name);
+    let single_package = matched_packages == 1;
     for script in scripts.iter() {
         handles_vec.push(ProcessHandle {
             state: state_ptr,

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -942,7 +942,7 @@ pub(crate) fn run_scripts_with_filter(
             buffer: Vec::new(),
             process: None,
             options: SpawnOptions {
-                stdin: spawn::Stdio::Ignore,
+                stdin: spawn::Stdio::Inherit,
                 #[cfg(unix)]
                 stdout: spawn::Stdio::Buffer,
                 #[cfg(not(unix))]

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -933,6 +933,12 @@ pub(crate) fn run_scripts_with_filter(
     let state_ptr: bun_ptr::BackRef<State> =
         unsafe { bun_ptr::BackRef::from_raw(core::ptr::addr_of_mut!(state)) };
     let mut map: StringHashMap<Vec<*mut ProcessHandle>> = StringHashMap::default();
+    // Inherit stdin only when one package matched (its pre/main/post run
+    // sequentially); multiple packages run concurrently and would race on fd 0.
+    let single_package = scripts
+        .first()
+        .zip(scripts.last())
+        .is_some_and(|(a, b)| a.package_name == b.package_name);
     for script in scripts.iter() {
         handles_vec.push(ProcessHandle {
             state: state_ptr,
@@ -942,12 +948,7 @@ pub(crate) fn run_scripts_with_filter(
             buffer: Vec::new(),
             process: None,
             options: SpawnOptions {
-                // Only inherit stdin when a single script matched. With >1
-                // concurrent children sharing fd 0 reads would interleave and a
-                // stdin-reading script would block on the TTY where it
-                // previously saw immediate EOF. #10647's use case is a single
-                // --filter '@scope/pkg' match.
-                stdin: if scripts.len() == 1 {
+                stdin: if single_package {
                     spawn::Stdio::Inherit
                 } else {
                     spawn::Stdio::Ignore

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1139,7 +1139,14 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             group_dependents: Vec::new(),
             next_dependents: Vec::new(),
             options: SpawnOptions {
-                stdin: spawn::Stdio::Inherit,
+                // Inherit stdin only for a single script so reads don't race
+                // across concurrent children; matches plain `bun run` semantics
+                // for the one-script case.
+                stdin: if configs.len() == 1 {
+                    spawn::Stdio::Inherit
+                } else {
+                    spawn::Stdio::Ignore
+                },
                 #[cfg(unix)]
                 stdout: spawn::Stdio::Buffer,
                 #[cfg(not(unix))]

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1115,8 +1115,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     };
 
     // Initialize handles
-    // Inherit stdin only when one script group was requested (its pre/main/post
-    // run sequentially); multiple groups run concurrently and would race on fd 0.
+    // One requested script group inherits stdin like plain `bun run`.
     let single_group = group_infos.len() == 1;
     let mut handles: Vec<ProcessHandle> = Vec::with_capacity(configs.len());
     for (i, config) in configs.iter().enumerate() {

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1139,7 +1139,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             group_dependents: Vec::new(),
             next_dependents: Vec::new(),
             options: SpawnOptions {
-                stdin: spawn::Stdio::Ignore,
+                stdin: spawn::Stdio::Inherit,
                 #[cfg(unix)]
                 stdout: spawn::Stdio::Buffer,
                 #[cfg(not(unix))]

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1115,6 +1115,9 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
     };
 
     // Initialize handles
+    // Inherit stdin only when one script group was requested (its pre/main/post
+    // run sequentially); multiple groups run concurrently and would race on fd 0.
+    let single_group = group_infos.len() == 1;
     let mut handles: Vec<ProcessHandle> = Vec::with_capacity(configs.len());
     for (i, config) in configs.iter().enumerate() {
         // Find which group this belongs to, for color assignment
@@ -1139,10 +1142,7 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             group_dependents: Vec::new(),
             next_dependents: Vec::new(),
             options: SpawnOptions {
-                // Inherit stdin only for a single script so reads don't race
-                // across concurrent children; matches plain `bun run` semantics
-                // for the one-script case.
-                stdin: if configs.len() == 1 {
+                stdin: if single_group {
                     spawn::Stdio::Inherit
                 } else {
                     spawn::Stdio::Ignore

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -671,6 +671,38 @@ describe("bun", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("is inherited for a single package even with pre/post hooks", async () => {
+      const dir = tempDirWithFiles("filter-stdin-hooks", {
+        packages: {
+          pkga: {
+            "read.js": readJs,
+            "package.json": JSON.stringify({
+              name: "pkga",
+              scripts: {
+                prereadstdin: "echo pre",
+                readstdin: `${bunExe()} run read.js`,
+                postreadstdin: "echo post",
+              },
+            }),
+          },
+        },
+        "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--filter", "pkga", "readstdin"],
+        cwd: dir,
+        env: bunEnv,
+        stdin: new Blob(["hello-from-parent\n"]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("STDIN=[hello-from-parent]");
+      expect(exitCode).toBe(0);
+    });
+
     test("is ignored (EOF) when multiple scripts match the filter", async () => {
       const dir = tempDirWithFiles("filter-stdin-many", {
         packages: {

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -632,6 +632,42 @@ describe("bun", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/10647
+  test("stdin is inherited by the filtered script", async () => {
+    const dir = tempDirWithFiles("filter-stdin", {
+      packages: {
+        pkga: {
+          "read.js": `
+            let data = "";
+            process.stdin.setEncoding("utf8");
+            process.stdin.on("data", chunk => data += chunk);
+            process.stdin.on("end", () => console.log("STDIN=" + data.trim()));
+          `,
+          "package.json": JSON.stringify({
+            name: "pkga",
+            scripts: { readstdin: `${bunExe()} run read.js` },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "pkga", "readstdin"],
+      cwd: dir,
+      env: bunEnv,
+      stdin: new Blob(["hello-from-parent\n"]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.stringContaining("STDIN=hello-from-parent"),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("warning names which package.json failed to parse", async () => {
     const dir = tempDirWithFiles("filter-bad-pkgjson", {
       packages: {

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -633,39 +633,82 @@ describe("bun", () => {
   });
 
   // https://github.com/oven-sh/bun/issues/10647
-  test("stdin is inherited by the filtered script", async () => {
-    const dir = tempDirWithFiles("filter-stdin", {
-      packages: {
-        pkga: {
-          "read.js": `
-            let data = "";
-            process.stdin.setEncoding("utf8");
-            process.stdin.on("data", chunk => data += chunk);
-            process.stdin.on("end", () => console.log("STDIN=" + data.trim()));
-          `,
-          "package.json": JSON.stringify({
-            name: "pkga",
-            scripts: { readstdin: `${bunExe()} run read.js` },
-          }),
+  describe("stdin", () => {
+    const readJs = `
+      let data = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", chunk => data += chunk);
+      process.stdin.on("end", () => console.log("STDIN=[" + data.trim() + "]"));
+    `;
+
+    test("is inherited when a single script matches the filter", async () => {
+      const dir = tempDirWithFiles("filter-stdin-one", {
+        packages: {
+          pkga: {
+            "read.js": readJs,
+            "package.json": JSON.stringify({
+              name: "pkga",
+              scripts: { readstdin: `${bunExe()} run read.js` },
+            }),
+          },
         },
-      },
-      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+        "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--filter", "pkga", "readstdin"],
+        cwd: dir,
+        env: bunEnv,
+        stdin: new Blob(["hello-from-parent\n"]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr }).toEqual({
+        stdout: expect.stringContaining("STDIN=[hello-from-parent]"),
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
     });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "--filter", "pkga", "readstdin"],
-      cwd: dir,
-      env: bunEnv,
-      stdin: new Blob(["hello-from-parent\n"]),
-      stdout: "pipe",
-      stderr: "pipe",
+    test("is ignored (EOF) when multiple scripts match the filter", async () => {
+      const dir = tempDirWithFiles("filter-stdin-many", {
+        packages: {
+          pkga: {
+            "read.js": readJs,
+            "package.json": JSON.stringify({
+              name: "pkga",
+              scripts: { readstdin: `${bunExe()} run read.js` },
+            }),
+          },
+          pkgb: {
+            "read.js": readJs,
+            "package.json": JSON.stringify({
+              name: "pkgb",
+              scripts: { readstdin: `${bunExe()} run read.js` },
+            }),
+          },
+        },
+        "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--filter", "*", "readstdin"],
+        cwd: dir,
+        env: bunEnv,
+        stdin: new Blob(["hello-from-parent\n"]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // Both children run concurrently; neither should see the parent's stdin
+      // (it goes to /dev/null so each sees immediate EOF).
+      expect(stderr).toBe("");
+      expect(stdout).toContain("pkga readstdin: STDIN=[]");
+      expect(stdout).toContain("pkgb readstdin: STDIN=[]");
+      expect(stdout).not.toContain("hello-from-parent");
+      expect(exitCode).toBe(0);
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr }).toEqual({
-      stdout: expect.stringContaining("STDIN=hello-from-parent"),
-      stderr: "",
-    });
-    expect(exitCode).toBe(0);
   });
 
   test("warning names which package.json failed to parse", async () => {

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -73,68 +73,6 @@ describe.concurrent("parallel: basic", () => {
     expect(r.exitCode).toBe(0);
   });
 
-  describe("stdin", () => {
-    const readJs = `
-      let data = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", c => data += c);
-      process.stdin.on("end", () => console.log("STDIN=[" + data.trim() + "]"));
-    `;
-    async function spawnWithStdin(dir: string, args: string[]) {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", ...args],
-        env: { ...bunEnv, NO_COLOR: "1" },
-        cwd: dir,
-        stdin: new Blob(["hello-from-parent\n"]),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout, stderr, exitCode };
-    }
-
-    test("is inherited when a single script is requested", async () => {
-      using dir = tempDir("mr-par-stdin", {
-        "read.js": readJs,
-        "package.json": JSON.stringify({ scripts: { readstdin: `${bunExe()} run read.js` } }),
-      });
-      const r = await spawnWithStdin(String(dir), ["--parallel", "readstdin"]);
-      expect(r.stderr).toContain("Done");
-      expectPrefixed(r.stdout, "readstdin", "STDIN=[hello-from-parent]");
-      expect(r.exitCode).toBe(0);
-    });
-
-    test("is inherited for a single script even with pre/post hooks", async () => {
-      using dir = tempDir("mr-par-stdin-hooks", {
-        "read.js": readJs,
-        "package.json": JSON.stringify({
-          scripts: {
-            prereadstdin: "echo pre",
-            readstdin: `${bunExe()} run read.js`,
-            postreadstdin: "echo post",
-          },
-        }),
-      });
-      const r = await spawnWithStdin(String(dir), ["--parallel", "readstdin"]);
-      expectPrefixed(r.stdout, "readstdin", "STDIN=[hello-from-parent]");
-      expect(r.exitCode).toBe(0);
-    });
-
-    test("is ignored (EOF) when multiple scripts are requested", async () => {
-      using dir = tempDir("mr-par-stdin-multi", {
-        "read.js": readJs,
-        "package.json": JSON.stringify({
-          scripts: { a: `${bunExe()} run read.js`, b: `${bunExe()} run read.js` },
-        }),
-      });
-      const r = await spawnWithStdin(String(dir), ["--parallel", "a", "b"]);
-      expectPrefixed(r.stdout, "a", "STDIN=[]");
-      expectPrefixed(r.stdout, "b", "STDIN=[]");
-      expect(r.stdout).not.toContain("hello-from-parent");
-      expect(r.exitCode).toBe(0);
-    });
-  });
-
   test("runs many scripts (10+)", async () => {
     const scripts: Record<string, string> = {};
     for (let i = 0; i < 12; i++) {
@@ -165,6 +103,70 @@ describe.concurrent("parallel: basic", () => {
     expectDone(r.stderr, "a");
     expectDone(r.stderr, "b");
     expectDone(r.stderr, "c");
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+// ─── PARALLEL: STDIN ──────────────────────────────────────────────────────────
+
+describe.concurrent("parallel: stdin", () => {
+  const readJs = `
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", c => data += c);
+    process.stdin.on("end", () => console.log("STDIN=[" + data.trim() + "]"));
+  `;
+  async function spawnWithStdin(dir: string, args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", ...args],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      cwd: dir,
+      stdin: new Blob(["hello-from-parent\n"]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("is inherited when a single script is requested", async () => {
+    using dir = tempDir("mr-par-stdin", {
+      "read.js": readJs,
+      "package.json": JSON.stringify({ scripts: { readstdin: `${bunExe()} read.js` } }),
+    });
+    const r = await spawnWithStdin(String(dir), ["--parallel", "readstdin"]);
+    expect(r.stderr).toContain("Done");
+    expectPrefixed(r.stdout, "readstdin", "STDIN=[hello-from-parent]");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("is inherited for a single script even with pre/post hooks", async () => {
+    using dir = tempDir("mr-par-stdin-hooks", {
+      "read.js": readJs,
+      "package.json": JSON.stringify({
+        scripts: {
+          prereadstdin: "echo pre",
+          readstdin: `${bunExe()} read.js`,
+          postreadstdin: "echo post",
+        },
+      }),
+    });
+    const r = await spawnWithStdin(String(dir), ["--parallel", "readstdin"]);
+    expectPrefixed(r.stdout, "readstdin", "STDIN=[hello-from-parent]");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("is ignored (EOF) when multiple scripts are requested", async () => {
+    using dir = tempDir("mr-par-stdin-multi", {
+      "read.js": readJs,
+      "package.json": JSON.stringify({
+        scripts: { a: `${bunExe()} read.js`, b: `${bunExe()} read.js` },
+      }),
+    });
+    const r = await spawnWithStdin(String(dir), ["--parallel", "a", "b"]);
+    expectPrefixed(r.stdout, "a", "STDIN=[]");
+    expectPrefixed(r.stdout, "b", "STDIN=[]");
+    expect(r.stdout).not.toContain("hello-from-parent");
     expect(r.exitCode).toBe(0);
   });
 });

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -73,30 +73,66 @@ describe.concurrent("parallel: basic", () => {
     expect(r.exitCode).toBe(0);
   });
 
-  test("stdin is inherited by the spawned script", async () => {
-    using dir = tempDir("mr-par-stdin", {
-      "read.js": `
-        let data = "";
-        process.stdin.setEncoding("utf8");
-        process.stdin.on("data", c => data += c);
-        process.stdin.on("end", () => console.log("STDIN=" + data.trim()));
-      `,
-      "package.json": JSON.stringify({
-        scripts: { readstdin: `${bunExe()} run read.js` },
-      }),
+  describe("stdin", () => {
+    const readJs = `
+      let data = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", c => data += c);
+      process.stdin.on("end", () => console.log("STDIN=[" + data.trim() + "]"));
+    `;
+    async function spawnWithStdin(dir: string, args: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", ...args],
+        env: { ...bunEnv, NO_COLOR: "1" },
+        cwd: dir,
+        stdin: new Blob(["hello-from-parent\n"]),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test("is inherited when a single script is requested", async () => {
+      using dir = tempDir("mr-par-stdin", {
+        "read.js": readJs,
+        "package.json": JSON.stringify({ scripts: { readstdin: `${bunExe()} run read.js` } }),
+      });
+      const r = await spawnWithStdin(String(dir), ["--parallel", "readstdin"]);
+      expect(r.stderr).toContain("Done");
+      expectPrefixed(r.stdout, "readstdin", "STDIN=[hello-from-parent]");
+      expect(r.exitCode).toBe(0);
     });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "--parallel", "readstdin"],
-      env: { ...bunEnv, NO_COLOR: "1" },
-      cwd: String(dir),
-      stdin: new Blob(["hello-from-parent\n"]),
-      stdout: "pipe",
-      stderr: "pipe",
+
+    test("is inherited for a single script even with pre/post hooks", async () => {
+      using dir = tempDir("mr-par-stdin-hooks", {
+        "read.js": readJs,
+        "package.json": JSON.stringify({
+          scripts: {
+            prereadstdin: "echo pre",
+            readstdin: `${bunExe()} run read.js`,
+            postreadstdin: "echo post",
+          },
+        }),
+      });
+      const r = await spawnWithStdin(String(dir), ["--parallel", "readstdin"]);
+      expectPrefixed(r.stdout, "readstdin", "STDIN=[hello-from-parent]");
+      expect(r.exitCode).toBe(0);
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("Done");
-    expectPrefixed(stdout, "readstdin", "STDIN=hello-from-parent");
-    expect(exitCode).toBe(0);
+
+    test("is ignored (EOF) when multiple scripts are requested", async () => {
+      using dir = tempDir("mr-par-stdin-multi", {
+        "read.js": readJs,
+        "package.json": JSON.stringify({
+          scripts: { a: `${bunExe()} run read.js`, b: `${bunExe()} run read.js` },
+        }),
+      });
+      const r = await spawnWithStdin(String(dir), ["--parallel", "a", "b"]);
+      expectPrefixed(r.stdout, "a", "STDIN=[]");
+      expectPrefixed(r.stdout, "b", "STDIN=[]");
+      expect(r.stdout).not.toContain("hello-from-parent");
+      expect(r.exitCode).toBe(0);
+    });
   });
 
   test("runs many scripts (10+)", async () => {

--- a/test/cli/run/multi-run.test.ts
+++ b/test/cli/run/multi-run.test.ts
@@ -73,6 +73,32 @@ describe.concurrent("parallel: basic", () => {
     expect(r.exitCode).toBe(0);
   });
 
+  test("stdin is inherited by the spawned script", async () => {
+    using dir = tempDir("mr-par-stdin", {
+      "read.js": `
+        let data = "";
+        process.stdin.setEncoding("utf8");
+        process.stdin.on("data", c => data += c);
+        process.stdin.on("end", () => console.log("STDIN=" + data.trim()));
+      `,
+      "package.json": JSON.stringify({
+        scripts: { readstdin: `${bunExe()} run read.js` },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--parallel", "readstdin"],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      cwd: String(dir),
+      stdin: new Blob(["hello-from-parent\n"]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Done");
+    expectPrefixed(stdout, "readstdin", "STDIN=hello-from-parent");
+    expect(exitCode).toBe(0);
+  });
+
   test("runs many scripts (10+)", async () => {
     const scripts: Record<string, string> = {};
     for (let i = 0; i < 12; i++) {


### PR DESCRIPTION
## What does this PR do?

`bun run --filter` spawned each matched script with `stdin: Ignore` (wired to `/dev/null`), so interactive tools like `drizzle-kit push` or anything using `prompts`/`inquirer` could never receive keyboard input. Plain `bun run <script>` already inherits stdin.

Fixes #10647.

## Repro

```sh
# packages/pkga has: "readstdin": "bun -e 'process.stdin.pipe(process.stdout)'"
echo hello | bun run --filter pkga readstdin
```

Before: the script reads nothing (stdin is `/dev/null`, EOF immediately).
After: the script reads `hello`.

## Fix

Inherit stdin in `filter_run.rs` / `multi_run.rs` **only when a single package (filter_run) / script group (multi_run) matched**. Pre/post lifecycle hooks for that one match are chained sequentially, so they share stdin safely just like plain `bun run`.

When `--filter '*'` matches multiple packages they spawn concurrently in the parent's foreground process group; having N children share fd 0 would make reads interleave at the byte level, and a script that calls `process.stdin.resume()` would block on the parent's TTY where it previously saw immediate EOF. So the multi-match case keeps `/dev/null` semantics unchanged. The #10647 use case (`--filter '@workspace/db' db-push`) is a single match.

## How did you verify your code works?

Added tests in `test/cli/run/filter-workspace.test.ts` and `test/cli/run/multi-run.test.ts`:
- single match inherits stdin
- single match with pre/post hooks inherits stdin
- multi-match still sees EOF (`/dev/null`)

The inherit tests fail on main and pass with this change; the EOF tests pin existing behavior. `bun bd test test/cli/run/filter-workspace.test.ts test/cli/run/multi-run.test.ts`: 180 pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts test/cli/run/multi-run.test.ts

<!-- robobun:evidence:end -->