### PR TITLE
bundler: declare require inside a CommonJS wrapper whose body contains direct eval

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2959,6 +2959,19 @@ impl<'a> LinkerContext<'a> {
         self.top_level_symbols_to_parts(Index::RUNTIME.get(), r#ref)
     }
 
+    /// The unbound `require` a CommonJS wrapper must declare for a direct `eval` in its body (ESM output only, see `auto_polyfill_require`).
+    pub(crate) fn direct_eval_require_ref(&self, source_index: crate::IndexInt) -> Option<Ref> {
+        if self.options.output_format != Format::Esm {
+            return None;
+        }
+        let scope = &self.graph.ast.items_module_scope()[source_index as usize];
+        if !scope.contains_direct_eval {
+            return None;
+        }
+        let ref_ = scope.members.get(&b"require"[..])?.ref_;
+        (self.graph.symbols.get_const(ref_)?.kind == bun_ast::symbol::Kind::Unbound).then_some(ref_)
+    }
+
     /// Note: returns `'static` so callers can hold the source across a
     /// `&mut self.log` borrow; the underlying `parse_graph.input_files` slab
     /// is append-only and outlives the link step (LIFETIMES.tsv: GRAPHBACKED).
@@ -3148,6 +3161,17 @@ impl<'a> LinkerContext<'a> {
                             crate::Index::RUNTIME,
                         )
                         .expect("unreachable");
+
+                    if self.direct_eval_require_ref(source_index).is_some() {
+                        self.graph
+                            .generate_runtime_symbol_import_and_use(
+                                source_index,
+                                crate::Index::part(part_index),
+                                b"__require",
+                                1,
+                            )
+                            .expect("unreachable");
+                    }
                 }
             }
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -274,6 +274,39 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
             .expect("unreachable");
     }
 
+    // "var require = __require;" so a direct eval in the body can reach it.
+    if flags.wrap == WrapKind::Cjs {
+        if let (Some(require_ref), Some(runtime_require_ref)) = (
+            c.direct_eval_require_ref(source_index as crate::IndexInt),
+            runtime_require_ref,
+        ) {
+            let decls = G::DeclList::from_slice(&[G::Decl {
+                binding: Binding::alloc(
+                    temp_arena,
+                    B::Identifier { r#ref: require_ref },
+                    bun_ast::Loc::EMPTY,
+                ),
+                value: Some(Expr::init(
+                    E::Identifier {
+                        ref_: runtime_require_ref,
+                        ..Default::default()
+                    },
+                    bun_ast::Loc::EMPTY,
+                )),
+            }]);
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(Stmt::alloc(
+                    S::Local {
+                        decls,
+                        ..Default::default()
+                    },
+                    bun_ast::Loc::EMPTY,
+                ))
+                .expect("unreachable");
+        }
+    }
+
     // `convert_stmts_for_chunk` takes `&mut c` inside the loop body, so capture
     // the per-file bitset as a BackRef once. The `parts_live` Vec doesn't
     // reallocate after `tree_shaking_and_code_splitting` initializes it.

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -597,4 +597,184 @@ describe("bundler", () => {
       stdout: "loaded ok",
     },
   });
+
+  // ============================================================================
+  // Direct eval inside a wrapped CommonJS module must see `require`.
+  // protobufjs (used by @grpc/proto-loader and every @google-cloud/* gRPC
+  // client) hides its Buffer probe from bundlers via
+  // `eval("require")("buffer")`, and falls back to Uint8Array when that throws,
+  // which breaks grpc-js. https://github.com/oven-sh/bun/issues/9367
+  // ============================================================================
+
+  // This is @protobufjs/inquire verbatim.
+  const inquireCjs = /* js */ `
+    function inquire(moduleName) {
+      try {
+        var mod = eval("quire".replace(/^/, "re"))(moduleName);
+        if (mod && (mod.length || Object.keys(mod).length))
+          return mod;
+      } catch (e) {}
+      return null;
+    }
+    module.exports = inquire;
+  `;
+  const printInquiredBuffer = /* js */ `
+    const buffer = inquire("buffer");
+    if (!buffer) throw new Error("buffer module not found");
+    const b = buffer.Buffer.from([1, 2, 3]);
+    console.log(b.constructor.name);
+    console.log(Buffer.isBuffer(b));
+  `;
+  const inquireFiles = {
+    "/entry.js": `const inquire = require("./inquire.cjs");\n${printInquiredBuffer}`,
+    "/inquire.cjs": inquireCjs,
+  };
+  // IIFE output never calls a CommonJS entry point, so this variant imports the dep instead.
+  const inquireFilesEsmEntry = {
+    "/entry.js": `import inquire from "./inquire.cjs";\n${printInquiredBuffer}`,
+    "/inquire.cjs": inquireCjs,
+  };
+  const requireDecl = /\bvar require = __require;/;
+
+  itBundled("cjs/DirectEvalSeesRequireBun", {
+    files: inquireFiles,
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toMatch(requireDecl);
+      api.expectFile("/out.js").toContain("var __require = import.meta.require;");
+    },
+    run: { stdout: "Buffer\ntrue" },
+  });
+
+  itBundled("cjs/DirectEvalSeesRequireBunMinified", {
+    files: inquireFiles,
+    target: "bun",
+    minifyIdentifiers: true,
+    minifySyntax: true,
+    minifyWhitespace: true,
+    run: { stdout: "Buffer\ntrue" },
+  });
+
+  itBundled("cjs/DirectEvalSeesRequireNodeESM", {
+    files: inquireFiles,
+    target: "node",
+    format: "esm",
+    outfile: "/out.mjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.mjs").toMatch(requireDecl);
+      api.expectFile("/out.mjs").toContain("createRequire(import.meta.url)");
+    },
+    run: { runtime: "node", stdout: "Buffer\ntrue" },
+  });
+
+  // There is no usable __require in IIFE output (the node flavor imports
+  // node:module), so nothing is injected and the eval keeps resolving the
+  // `require` of the CommonJS file Node loads the bundle as.
+  itBundled("cjs/DirectEvalSeesRequireNodeIIFE", {
+    files: inquireFilesEsmEntry,
+    target: "node",
+    format: "iife",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toMatch(requireDecl);
+      api.expectFile("/out.js").not.toContain("__require");
+    },
+    run: { runtime: "node", stdout: "Buffer\ntrue" },
+  });
+
+  // The file declares its own `require`, so there is nothing to inject.
+  itBundled("cjs/DirectEvalWithShadowedRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        import value from "./shadow.cjs";
+        console.log(value);
+      `,
+      "/shadow.cjs": /* js */ `
+        var require = () => "shadowed";
+        eval("0");
+        module.exports = require("anything");
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toMatch(requireDecl);
+      api.expectFile("/out.js").not.toContain("__require");
+    },
+    run: { stdout: "shadowed" },
+  });
+
+  // Same file mixes a dynamic require() (which rewrites to the chunk-level
+  // __require) with direct eval; the injected declaration must still be
+  // named `require`.
+  const dynamicRequireFiles = {
+    "/entry.js": /* js */ `
+      console.log(require("./mod.cjs"));
+    `,
+    "/mod.cjs": /* js */ `
+      var name = "buffer";
+      var Buf = require(name).Buffer;
+      module.exports = eval("req" + "uire")("buffer").Buffer === Buf;
+    `,
+  };
+
+  itBundled("cjs/DirectEvalWithDynamicRequireBun", {
+    files: dynamicRequireFiles,
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toMatch(requireDecl);
+    },
+    run: { stdout: "true" },
+  });
+
+  itBundled("cjs/DirectEvalWithDynamicRequireNodeESM", {
+    files: dynamicRequireFiles,
+    target: "node",
+    format: "esm",
+    outfile: "/out.mjs",
+    run: { runtime: "node", stdout: "true" },
+  });
+
+  itBundled("cjs/DirectEvalSeesRequireCompile", {
+    files: inquireFiles,
+    target: "bun",
+    compile: true,
+    run: { stdout: "Buffer\ntrue" },
+  });
+
+  itBundled("cjs/DirectEvalRequireShapeBun", {
+    files: {
+      "/entry.js": /* js */ `
+        const probe = require("./probe.cjs");
+        console.log(JSON.stringify(probe));
+      `,
+      "/probe.cjs": /* js */ `
+        const req = eval("req" + "uire");
+        module.exports = {
+          type: typeof req,
+          resolve: typeof req.resolve,
+          assert: req("assert").strictEqual === require("assert").strictEqual,
+        };
+      `,
+    },
+    target: "bun",
+    run: { stdout: '{"type":"function","resolve":"function","assert":true}' },
+  });
+
+  // No direct eval: nothing is injected and __require stays tree-shaken.
+  itBundled("cjs/NoRequireDeclWithoutDirectEval", {
+    files: {
+      "/entry.js": /* js */ `
+        const x = require("./mod.cjs");
+        console.log(x);
+      `,
+      "/mod.cjs": /* js */ `
+        module.exports = typeof require;
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toMatch(requireDecl);
+      api.expectFile("/out.js").not.toContain("__require");
+    },
+    run: { stdout: "function" },
+  });
 });


### PR DESCRIPTION
Fixes #9367
Fixes #14891
Fixes #22058
Fixes #19601

### Problem

- `@protobufjs/inquire` (pulled in by `protobufjs`, `@grpc/proto-loader`, `google-gax`, every `@google-cloud/*` gRPC client, `firebase-admin`) probes for Buffer with `eval("quire".replace(/^/, "re"))(moduleName)` so bundlers cannot see the `require`.
- In ESM output the `__commonJS` closure body has no `require` binding, so the eval throws `ReferenceError: require is not defined`, protobufjs falls back from `BufferWriter` to `Writer`, serializers return `Uint8Array`, and grpc-js fails with `Error: undefined undefined: undefined`.
- `src/bundler/linker_context/generateCodeForFileInChunkJS.rs` builds the wrapper from `exports`/`module` only; nothing in the wrapped scope is named `require`.

### Fix

- `LinkerContext::direct_eval_require_ref` (one predicate used by both sites): the file is CommonJS-wrapped, its module scope `contains_direct_eval`, its `require` scope member is still the parser's `Unbound` symbol (the file does not declare its own), and the output format is `esm`.
- `create_wrapper_for_file` marks the runtime `__require` part live for such files, the same way the static dynamic-require path does.
- `generate_code_for_file_in_chunk_js` prepends `var require = __require;` to the wrapper body through `stmts.inside_wrapper_prefix`, after the `"use strict"` directive:

  ```js
  var __require = import.meta.require;                 // target=bun
  // var __require = createRequire(import.meta.url);   // target=node
  var require_inquire = __commonJS(function (exports, module) {
    var require = __require;
    ...eval("require")(...)...
  });
  ```

- Why this is correct: direct eval resolves names lexically, and the closure body is the innermost scope the user's code shares with us, so a `var` there is visible to every eval in the file. The binding is looked up from `module_scope.members` rather than `ast.require_ref`, because the parser repoints the latter at the per-file `__require` polyfill as soon as the file also contains a dynamic `require(expr)`, which would print the wrong name. `require` is `Unbound`, so the renamer keeps the literal name under `--minify`. `__require` is the runtime's own per-target implementation, so `require.resolve` and identity with the static path hold.
- Why `esm` only: `auto_polyfill_require` (`ParseTask.rs`) only enables the `__require` part for `esm`; in `iife` it is not emitted for any target (node's flavor imports `node:module`). Today node loads an `iife` bundle as a CommonJS file, so the eval already finds Node's `require`; the new test pins that this stays untouched. `--format=cjs` already has `require` in scope. The `iife` gap in the existing dynamic-require path is a pre-existing bug and is filed separately.
- `src/runtime.js` is unchanged, so bundles without an eval-containing CommonJS file are byte for byte identical to main.
- Verified: `test/bundler/bundler_cjs.test.ts` (`DirectEval*`, `NoRequireDeclWithoutDirectEval`); 8 of the 10 new cases fail on the released binary and all pass with this build, the 2 that pass both ways pin unchanged behavior (node `iife`, user-declared `require`). `bundler_cjs2esm`, `bundler_bun`, `bundler_edgecase` sourcemap cases, `bundler_npm/ReactSSR`, `transpiler/react-compiler` and `esbuild/default` pass unmodified. Real `protobufjs@7.2.5` + `@protobufjs/inquire@1.1.0` bundled with `--target=bun` goes from `Uint8Array`/`isBuffer: false` to `Buffer`/`isBuffer: true`.

### Background

- **CommonJS wrapping**: when a CommonJS file is bundled, its body is moved into a closure passed to the `__commonJS` runtime helper and executed lazily on first `require`. `stmts.inside_wrapper_prefix` is the linker's list of statements synthesized at the top of that closure body.
- **`__require`**: an export of the bundler's runtime module, defined per target (`import.meta.require` for bun, `createRequire(import.meta.url)` for node). The printer rewrites any `require` the parser could not resolve statically to it; `generate_runtime_symbol_import_and_use` is what keeps a runtime export from being tree-shaken.
- **Direct eval**: `eval(...)` called by name. The engine evaluates the string in the caller's scope, so the parser marks that scope `contains_direct_eval` and the renamer refuses to rename anything visible to it; names must exist literally.
- **`Unbound` symbol**: the parser declares `require`/`module`/`exports` for every file; when the file does not declare the name itself, the symbol has kind `Unbound` and prints as its original name in every renaming mode.

<details>
<summary>Earlier revision</summary>

The first version of this PR added a third `require` parameter to the closure and a `req` argument to `__commonJS` itself. That changed the runtime helper in every bundle with a wrapped CommonJS file (shifting `react-compiler` snapshot bytes and the `bundler_edgecase`/`bundler_npm` sourcemap offsets) and made the `__require` part live in `iife` output, where it does not exist. Reworked per review into the prefix declaration above, which only touches files that need it.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.0 (2c1ba3ed6)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1558.67ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [806.55ms]
(pass) bundler > cjs/__toESM_import_syntax_function [793.09ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [909.99ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [893.34ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [613.59ms]
(pass) bundler > cjs/__toESM_target_node [1208.07ms]
(pass) bundler > cjs/__toESM_target_browser [710.53ms]
(pass) bundler > cjs/__toESM_target_bun [712.28ms]
(pass) bundler > cjs/__toESM_format_esm [793.92ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [685.80ms]
(pass) bundler > cjs/__toESM_mjs_reexport [739.84ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [739.41ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [641.10ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [1251.80ms]
(pass) bundler > cjs/__toESM_default_
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [64.32ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [39.22ms]
(pass) bundler > cjs/__toESM_import_syntax_function [32.33ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [25.94ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [254.82ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [39.42ms]
(pass) bundler > cjs/__toESM_target_node [54.13ms]
(pass) bundler > cjs/__toESM_target_browser [85.96ms]
(pass) bundler > cjs/__toESM_target_bun [28.53ms]
(pass) bundler > cjs/__toESM_format_esm [69.92ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [35.49ms]
(pass) bundler > cjs/__toESM_mjs_reexport [72.69ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [103.76ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [147.88ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [46.79ms]
(pass) bundler > cjs/__toESM_default_prop_no_esModule [45.84ms]
(pass) bundler > cjs/__toESM_mixed_import_styles [63.72ms]
(pass) bundler > cjs/__toESM_esModule_non_true [51.80ms]
(pass) bundler > cjs/__toESM_
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts
bun test v1.4.0 (2c1ba3ed6)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [1398.19ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [606.41ms]
(pass) bundler > cjs/__toESM_import_syntax_function [676.27ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [620.86ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [973.72ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [692.47ms]
(pass) bundler > cjs/__toESM_target_node [880.07ms]
(pass) bundler > cjs/__toESM_target_browser [1438.48ms]
(pass) bundler > cjs/__toESM_target_bun [666.12ms]
(pass) bundler > cjs/__toESM_format_esm [723.07ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [654.75ms]
(pass) bundler > cjs/__toESM_mjs_reexport [737.03ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [753.99ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [710.08ms]
(pass) bundler > cjs/__toESM_reexport_with_rename [1407.45ms]
(pass) bundler > cjs/__toESM_default_
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2c1ba3ed63
  features     baseline

22 deps, 107 codegen, 1176 objects in 4585ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen bindgenv2
[2/1238] gen ErrorCode+*.h
[3/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/1238] fetch zlib
[zlib] up to date
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1237] subst deps/zlib/zconf.h
[9/1237] subst deps/zlib/zlib.h
[10/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[11/1237] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       |  24 +++
 .../linker_context/generateCodeForFileInChunkJS.rs |  33 ++++
 test/bundler/bundler_cjs.test.ts                   | 180 +++++++++++++++++++++
 3 files changed, 237 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/LinkerContext.rs                                 11     11      0
…/bundler/linker_context/generateCodeForFileInChunkJS.rs      8      7      0
test/bundler/bundler_cjs.test.ts                              5      9      0
```

</details>

<!-- robobun:evidence:end -->