### PR TITLE
Bun.Transpiler: default autoImportJSX to true for the automatic JSX runtime

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2462,6 +2462,15 @@ declare module "bun" {
      */
     macro?: MacroMap;
 
+    /**
+     * When the automatic JSX runtime is active, prepend the
+     * `import { jsx, ... } from "<jsxImportSource>/jsx-runtime"` statement that
+     * binds the generated `jsx`/`jsxs`/`jsxDEV`/`Fragment` calls.
+     *
+     * Has no effect when the classic runtime (`jsx: "react"`) is in use.
+     *
+     * @default true
+     */
     autoImportJSX?: boolean;
     allowBunRuntime?: boolean;
     exports?: {

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -97,6 +97,7 @@ impl Default for Config {
             log: bun_ast::Log::default(), // overwritten at construction
             runtime: Runtime::Features {
                 top_level_await: true,
+                auto_import_jsx: true,
                 ..Default::default()
             },
             tree_shaking: false,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2086,6 +2086,7 @@ export default <>hi</>
         "process.env.NODE_ENV": JSON.stringify("development"),
       },
       logLevel: "error",
+      autoImportJSX: false,
     });
 
     expect(bun.transformSync("console.log(<div key={() => {}} points={() => {}}></div>);")).toBe(
@@ -2154,6 +2155,40 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  // https://github.com/oven-sh/bun/issues/7499
+  // The automatic JSX runtime emits calls to generated symbols (jsxDEV_7x81h0kn
+  // etc.). Bun.Transpiler previously defaulted autoImportJSX to false, so those
+  // calls were left undefined in the output.
+  it("JSX automatic runtime import is emitted by default", () => {
+    for (const loader of ["jsx", "tsx"]) {
+      const out = new Bun.Transpiler({ loader }).transformSync("export default <><div /></>");
+      expect(out).toStartWith("import {");
+      expect(out).toContain('from "react/jsx-dev-runtime"');
+      // Every generated JSX symbol that is called/used must be bound by the import.
+      for (const [name] of out.matchAll(/\b(jsxDEV|jsx|jsxs|Fragment|createElement)_\w+\b/g)) {
+        expect(out).toContain(` as ${name}`);
+      }
+    }
+
+    // tsconfig jsxImportSource is honored by the default-on auto-import.
+    const preact = new Bun.Transpiler({
+      loader: "tsx",
+      tsconfig: { compilerOptions: { jsx: "react-jsx", jsxImportSource: "preact" } },
+    }).transformSync("export default <div />");
+    expect(preact).toContain('from "preact/jsx-runtime"');
+
+    // The classic runtime has no auto-import and must stay import-free.
+    const classic = new Bun.Transpiler({
+      loader: "tsx",
+      tsconfig: { compilerOptions: { jsx: "react" } },
+    }).transformSync("export default <div />");
+    expect(classic).not.toContain("import ");
+
+    // autoImportJSX: false opts out of the import.
+    const optOut = new Bun.Transpiler({ loader: "tsx", autoImportJSX: false }).transformSync("export default <div />");
+    expect(optOut).not.toContain("import ");
+  });
+
   // Non-bundle transpile without `minify.identifiers` uses NoOpRenamer
   // (prints symbol.original_name verbatim), so the `generatedSymbolName`
   // hash suffix on the automatic JSX runtime import is the sole collision
@@ -2203,6 +2238,7 @@ console.log(<div {...obj} key="after" />);`),
             loader: "jsx",
             define: { "process.env.NODE_ENV": JSON.stringify("development") },
             logLevel: "error",
+            autoImportJSX: false,
           });
           process.stdout.write(t.transformSync('console.log(<div key key="duplicate"></div>);'));
           process.stdout.write(t.transformSync('console.log(<div key className="x" key="duplicate"></div>);'));
@@ -2344,6 +2380,7 @@ console.log(<div {...obj} key="after" />);`),
       define: {
         "process.env.NODE_ENV": JSON.stringify("development"),
       },
+      autoImportJSX: false,
     });
     expect(bun.transformSync("export var foo = <div>{...a}b</div>")).toBe(
       `export var foo = jsxDEV_7x81h0kn("div", {


### PR DESCRIPTION
Fixes #7499.

## Problem

`Bun.Transpiler` with the automatic JSX runtime (the default) rewrites `<div />` into a call against a generated symbol like `jsxDEV_7x81h0kn("div", ...)` whose hash suffix guards against shadowing by user locals. The `import { jsxDEV as jsxDEV_7x81h0kn } from "react/jsx-dev-runtime"` statement that defines that symbol is only emitted when `autoImportJSX` is true, and the option defaulted to false.

```js
new Bun.Transpiler({ loader: "tsx" }).transformSync("export default <div />");
// before: export default jsxDEV_7x81h0kn("div", {}, undefined, false, undefined, this);
```

That output references an identifier that nothing defines. Running it fails with `ReferenceError: Can't find variable: jsxDEV_7x81h0kn`, and feeding it back into `Bun.build` from a plugin (the #7499 repro) fails the same way.

## Fix

Default `autoImportJSX` to true in `Bun.Transpiler`, matching the bundler, the module loader, and what the automatic runtime is defined to do. The classic runtime (`jsx: "react"`) has no auto-import and is unaffected. `autoImportJSX: false` still opts out.

```js
new Bun.Transpiler({ loader: "tsx" }).transformSync("export default <div />");
// after:
// import { jsxDEV as jsxDEV_7x81h0kn } from "react/jsx-dev-runtime";
// export default jsxDEV_7x81h0kn("div", {}, undefined, false, undefined, this);
```

## Verification

New test in `test/bundler/transpiler/transpiler.test.js` fails on main (`Expected to start with: "import {"`) and passes with this change. The three existing JSX-mechanics tests that assert on exact output now pass `autoImportJSX: false` to keep their expectations focused on the transform body.