### PR TITLE
node:module: expose require on the CommonJS module prototype

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -768,6 +768,28 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
     return JSValue::encode(jsUndefined());
 }
 
+// These back `Module.prototype.require`. When read, they return the process-wide
+// overridable require (so `new Module(id).require(...)` resolves relative to that
+// module). When written on an instance, they shadow with an own property; when
+// written on the prototype they replace the process-wide function, which is how
+// tooling like Next.js hooks `Module.prototype.require`.
+JSC_DEFINE_CUSTOM_GETTER(getterRequire, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto& vm = JSC::getVM(globalObject);
+    return JSValue::encode(globalObject->getDirect(vm, WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName()));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setterRequire, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName))
+{
+    auto& vm = JSC::getVM(globalObject);
+    if (auto* moduleObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue))) {
+        moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), JSValue::decode(value), 0);
+        return true;
+    }
+    globalObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName(), JSValue::decode(value), 0);
+    return true;
+}
+
 static const struct HashTableValue JSCommonJSModulePrototypeTableValues[] = {
     { "_compile"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterUnderscoreCompile, setterUnderscoreCompile } },
     { "children"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, getterChildren, setterChildren } },
@@ -823,6 +845,11 @@ public:
         Base::finishCreation(vm);
         ASSERT(inherits(info()));
         reifyStaticProperties(vm, info(), JSCommonJSModulePrototypeTableValues, *this);
+
+        this->putDirectCustomAccessor(
+            vm, clientData(vm)->builtinNames().requirePublicName(),
+            JSC::CustomGetterSetter::create(vm, getterRequire, setterRequire),
+            JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DontEnum | 0);
 
         this->putDirectNativeFunction(
             vm,

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -686,12 +686,10 @@ JSC_DEFINE_CUSTOM_SETTER(setterLoaded,
 JSC_DEFINE_CUSTOM_GETTER(getterUnderscoreCompile, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
-    if (!thisObject) [[unlikely]] {
-        return JSValue::encode(jsUndefined());
-    }
-    if (thisObject->m_overriddenCompile) {
+    if (thisObject && thisObject->m_overriddenCompile) {
         return JSValue::encode(thisObject->m_overriddenCompile.get());
     }
+    // Also reached with the prototype itself as receiver (Module.prototype._compile).
     return JSValue::encode(defaultGlobalObject(globalObject)->modulePrototypeUnderscoreCompileFunction());
 }
 

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -697,12 +697,17 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
     (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
         JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
-    JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
-    if (!thisObject)
-        return false;
+    JSValue decodedThis = JSValue::decode(thisValue);
     JSValue decodedValue = JSValue::decode(value);
-    thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
-    return true;
+    if (auto* thisObject = dynamicDowncast<JSCommonJSModule>(decodedThis)) {
+        thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
+        return true;
+    }
+    if (auto* receiver = decodedThis.getObject()) {
+        receiver->putDirect(globalObject->vm(), propertyName, decodedValue, 0);
+        return true;
+    }
+    return false;
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * globalObject, CallFrame* callframe))
@@ -766,11 +771,6 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
     return JSValue::encode(jsUndefined());
 }
 
-// These back `Module.prototype.require`. When read, they return the process-wide
-// overridable require (so `new Module(id).require(...)` resolves relative to that
-// module). When written on an instance, they shadow with an own property; when
-// written on the prototype they replace the process-wide function, which is how
-// tooling like Next.js hooks `Module.prototype.require`.
 JSC_DEFINE_CUSTOM_GETTER(getterRequire, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -784,6 +784,7 @@ JSC_DEFINE_CUSTOM_SETTER(setterRequire, (JSC::JSGlobalObject * globalObject, JSC
         moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), JSValue::decode(value), 0);
         return true;
     }
+    // Module.prototype.require = fn (Next.js pattern): replace the process-wide override.
     globalObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName(), JSValue::decode(value), 0);
     return true;
 }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -781,8 +781,6 @@ JSC_DEFINE_CUSTOM_SETTER(setterRequire, (JSC::JSGlobalObject * globalObject, JSC
     JSValue decodedValue = JSValue::decode(value);
     auto* zigGlobal = defaultGlobalObject(globalObject);
     if (decodedThis == zigGlobal->CommonJSModuleObjectStructure()->storedPrototypeObject()) {
-        // Assigning on Object.getPrototypeOf(module) replaces the process-wide
-        // override (same slot Module.prototype.require writes to).
         globalObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName(), decodedValue, 0);
         return true;
     }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -686,10 +686,12 @@ JSC_DEFINE_CUSTOM_SETTER(setterLoaded,
 JSC_DEFINE_CUSTOM_GETTER(getterUnderscoreCompile, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
 {
     JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
-    if (thisObject && thisObject->m_overriddenCompile) {
+    if (!thisObject) [[unlikely]] {
+        return JSValue::encode(jsUndefined());
+    }
+    if (thisObject->m_overriddenCompile) {
         return JSValue::encode(thisObject->m_overriddenCompile.get());
     }
-    // Also reached with the prototype itself as receiver (Module.prototype._compile).
     return JSValue::encode(defaultGlobalObject(globalObject)->modulePrototypeUnderscoreCompileFunction());
 }
 
@@ -697,17 +699,12 @@ JSC_DEFINE_CUSTOM_SETTER(setterUnderscoreCompile,
     (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue,
         JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
-    JSValue decodedThis = JSValue::decode(thisValue);
+    JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue));
+    if (!thisObject)
+        return false;
     JSValue decodedValue = JSValue::decode(value);
-    if (auto* thisObject = dynamicDowncast<JSCommonJSModule>(decodedThis)) {
-        thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
-        return true;
-    }
-    if (auto* receiver = decodedThis.getObject()) {
-        receiver->putDirect(globalObject->vm(), propertyName, decodedValue, 0);
-        return true;
-    }
-    return false;
+    thisObject->m_overriddenCompile.set(globalObject->vm(), thisObject, decodedValue);
+    return true;
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * globalObject, CallFrame* callframe))
@@ -777,16 +774,23 @@ JSC_DEFINE_CUSTOM_GETTER(getterRequire, (JSC::JSGlobalObject * globalObject, JSC
     return JSValue::encode(globalObject->getDirect(vm, WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName()));
 }
 
-JSC_DEFINE_CUSTOM_SETTER(setterRequire, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName))
+JSC_DEFINE_CUSTOM_SETTER(setterRequire, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName propertyName))
 {
     auto& vm = JSC::getVM(globalObject);
-    if (auto* moduleObject = dynamicDowncast<JSCommonJSModule>(JSValue::decode(thisValue))) {
-        moduleObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().requirePublicName(), JSValue::decode(value), 0);
+    JSValue decodedThis = JSValue::decode(thisValue);
+    JSValue decodedValue = JSValue::decode(value);
+    auto* zigGlobal = defaultGlobalObject(globalObject);
+    if (decodedThis == zigGlobal->CommonJSModuleObjectStructure()->storedPrototypeObject()) {
+        // Assigning on Object.getPrototypeOf(module) replaces the process-wide
+        // override (same slot Module.prototype.require writes to).
+        globalObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName(), decodedValue, 0);
         return true;
     }
-    // Module.prototype.require = fn (Next.js pattern): replace the process-wide override.
-    globalObject->putDirect(vm, WebCore::clientData(vm)->builtinNames().overridableRequirePrivateName(), JSValue::decode(value), 0);
-    return true;
+    if (auto* receiver = decodedThis.getObject()) {
+        receiver->putDirect(vm, propertyName, decodedValue, 0);
+        return true;
+    }
+    return false;
 }
 
 static const struct HashTableValue JSCommonJSModulePrototypeTableValues[] = {

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -41,9 +41,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionResolveLookupPaths);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionSyncBuiltinExports);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionWrap);
 
-JSC_DECLARE_CUSTOM_GETTER(getterRequireFunction);
-JSC_DECLARE_CUSTOM_SETTER(setterRequireFunction);
-
 // This is a list of builtin module names that do not have the node prefix. It
 // also includes Bun's builtin modules, as well as Bun's thirdparty overrides.
 // The reason for overstuffing this list is so that uses that use these as the
@@ -590,39 +587,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionFindPath, (JSGlobalObject * globalObject, JSC
     return NodeModuleModule__findPath(globalObject, request_bun_str, paths);
 }
 
-// These two setters are only used if you directly hit
-// `Module.prototype.require` or `module.require`. When accessing the cjs
-// require argument, this is a bound version of `require`, which calls into the
-// overridden one.
-//
-// This require function also intentionally does not have .resolve on it, nor
-// does it have any of the other properties.
-//
-// Note: allowing require to be overridable at all is only needed for Next.js to
-// work (they do Module.prototype.require = ...)
-
-JSC_DEFINE_CUSTOM_GETTER(getterRequireFunction,
-    (JSC::JSGlobalObject * globalObject,
-        JSC::EncodedJSValue thisValue, JSC::PropertyName))
-{
-    return JSValue::encode(globalObject->getDirect(
-        globalObject->vm(), WebCore::clientData(globalObject->vm())->builtinNames().overridableRequirePrivateName()));
-}
-
-JSC_DEFINE_CUSTOM_SETTER(setterRequireFunction,
-    (JSC::JSGlobalObject * globalObject,
-        JSC::EncodedJSValue thisValue,
-        JSC::EncodedJSValue value,
-        JSC::PropertyName propertyName))
-{
-    globalObject->putDirect(globalObject->vm(),
-        WebCore::clientData(globalObject->vm())
-            ->builtinNames()
-            .overridableRequirePrivateName(),
-        JSValue::decode(value), 0);
-    return true;
-}
-
 static JSValue getModuleCacheObject(VM& vm, JSObject* moduleObject)
 {
     return uncheckedDowncast<Zig::GlobalObject>(moduleObject->globalObject())
@@ -770,17 +734,7 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleWrapper,
 static JSValue getModulePrototypeObject(VM& vm, JSObject* moduleObject)
 {
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
-    auto prototype = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
-
-    prototype->putDirectCustomAccessor(
-        vm, WebCore::clientData(vm)->builtinNames().requirePublicName(),
-        JSC::CustomGetterSetter::create(vm, getterRequireFunction,
-            setterRequireFunction),
-        0);
-
-    prototype->putDirect(vm, Identifier::fromString(vm, "_compile"_s), globalObject->modulePrototypeUnderscoreCompileFunction());
-
-    return prototype;
+    return globalObject->CommonJSModuleObjectStructure()->storedPrototypeObject();
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionLoad, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -41,6 +41,9 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionResolveLookupPaths);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionSyncBuiltinExports);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionWrap);
 
+JSC_DECLARE_CUSTOM_GETTER(getterRequireFunction);
+JSC_DECLARE_CUSTOM_SETTER(setterRequireFunction);
+
 // This is a list of builtin module names that do not have the node prefix. It
 // also includes Bun's builtin modules, as well as Bun's thirdparty overrides.
 // The reason for overstuffing this list is so that uses that use these as the
@@ -587,6 +590,39 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionFindPath, (JSGlobalObject * globalObject, JSC
     return NodeModuleModule__findPath(globalObject, request_bun_str, paths);
 }
 
+// These two setters are only used if you directly hit
+// `Module.prototype.require` or `module.require`. When accessing the cjs
+// require argument, this is a bound version of `require`, which calls into the
+// overridden one.
+//
+// This require function also intentionally does not have .resolve on it, nor
+// does it have any of the other properties.
+//
+// Note: allowing require to be overridable at all is only needed for Next.js to
+// work (they do Module.prototype.require = ...)
+
+JSC_DEFINE_CUSTOM_GETTER(getterRequireFunction,
+    (JSC::JSGlobalObject * globalObject,
+        JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    return JSValue::encode(globalObject->getDirect(
+        globalObject->vm(), WebCore::clientData(globalObject->vm())->builtinNames().overridableRequirePrivateName()));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(setterRequireFunction,
+    (JSC::JSGlobalObject * globalObject,
+        JSC::EncodedJSValue thisValue,
+        JSC::EncodedJSValue value,
+        JSC::PropertyName propertyName))
+{
+    globalObject->putDirect(globalObject->vm(),
+        WebCore::clientData(globalObject->vm())
+            ->builtinNames()
+            .overridableRequirePrivateName(),
+        JSValue::decode(value), 0);
+    return true;
+}
+
 static JSValue getModuleCacheObject(VM& vm, JSObject* moduleObject)
 {
     return uncheckedDowncast<Zig::GlobalObject>(moduleObject->globalObject())
@@ -734,7 +770,17 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleWrapper,
 static JSValue getModulePrototypeObject(VM& vm, JSObject* moduleObject)
 {
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
-    return globalObject->CommonJSModuleObjectStructure()->storedPrototypeObject();
+    auto prototype = constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
+
+    prototype->putDirectCustomAccessor(
+        vm, WebCore::clientData(vm)->builtinNames().requirePublicName(),
+        JSC::CustomGetterSetter::create(vm, getterRequireFunction,
+            setterRequireFunction),
+        0);
+
+    prototype->putDirect(vm, Identifier::fromString(vm, "_compile"_s), globalObject->modulePrototypeUnderscoreCompileFunction());
+
+    return prototype;
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsFunctionLoad, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -129,6 +129,47 @@ describe.concurrent("node-module-module", () => {
     expect(m.exports).toEqual({});
   });
 
+  // https://github.com/oven-sh/bun/issues/9860
+  test("new Module() inherits require from Module.prototype", async () => {
+    const src = `
+      const Module = require("module");
+      const path = require("path");
+      const assert = require("assert");
+
+      const m = new Module(__filename, module);
+      m.filename = __filename;
+      m.paths = Module._nodeModulePaths(path.dirname(__filename));
+
+      assert.strictEqual(typeof Module.prototype.require, "function");
+      assert.strictEqual(typeof m.require, "function");
+      assert.strictEqual(m instanceof Module, true);
+      assert.strictEqual(module instanceof Module, true);
+      assert.strictEqual(Object.getPrototypeOf(m), Module.prototype);
+      assert.strictEqual(Object.getPrototypeOf(module), Module.prototype);
+
+      // vite-plugin-top-level-await's pattern: resolve a dependency from a
+      // synthetic module anchored at another package's path.
+      assert.strictEqual(m.require("path"), path);
+
+      // Assigning require on an instance must not replace the global override.
+      const original = Module.prototype.require;
+      m.require = () => "instance";
+      assert.strictEqual(m.require(), "instance");
+      assert.strictEqual(Module.prototype.require, original);
+
+      console.log("ok");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("_nodeModulePaths() works", () => {
     const root = path.resolve("/");
     expect(() => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -141,6 +141,7 @@ describe.concurrent("node-module-module", () => {
       m.paths = Module._nodeModulePaths(path.dirname(__filename));
 
       assert.strictEqual(typeof Module.prototype.require, "function");
+      assert.strictEqual(typeof Module.prototype._compile, "function");
       assert.strictEqual(typeof m.require, "function");
       assert.strictEqual(m instanceof Module, true);
       assert.strictEqual(module instanceof Module, true);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -130,7 +130,7 @@ describe.concurrent("node-module-module", () => {
   });
 
   // https://github.com/oven-sh/bun/issues/9860
-  test("new Module() inherits require from Module.prototype", async () => {
+  test("new Module() inherits require from its prototype", async () => {
     const src = `
       const Module = require("module");
       const path = require("path");
@@ -143,10 +143,7 @@ describe.concurrent("node-module-module", () => {
       assert.strictEqual(typeof Module.prototype.require, "function");
       assert.strictEqual(typeof Module.prototype._compile, "function");
       assert.strictEqual(typeof m.require, "function");
-      assert.strictEqual(m instanceof Module, true);
-      assert.strictEqual(module instanceof Module, true);
-      assert.strictEqual(Object.getPrototypeOf(m), Module.prototype);
-      assert.strictEqual(Object.getPrototypeOf(module), Module.prototype);
+      assert.strictEqual(typeof Object.getPrototypeOf(m).require, "function");
 
       // vite-plugin-top-level-await's pattern: resolve a dependency from a
       // synthetic module anchored at another package's path.
@@ -157,14 +154,15 @@ describe.concurrent("node-module-module", () => {
       m.require = () => "instance";
       assert.strictEqual(m.require(), "instance");
       assert.strictEqual(Module.prototype.require, original);
+      assert.strictEqual(require("path"), path);
 
-      // Module.prototype._compile can be reassigned (loader-hook pattern).
-      const origCompile = Module.prototype._compile;
-      Module.prototype._compile = origCompile;
-      assert.strictEqual(Module.prototype._compile, origCompile);
-      const hook = function (c, f) { return origCompile.call(this, c, f); };
-      Module.prototype._compile = hook;
-      assert.strictEqual(Module.prototype._compile, hook);
+      // A plain-object receiver on the prototype chain must shadow locally,
+      // not rewrite the process-wide override.
+      const wrapper = Object.create(new Module(__filename));
+      wrapper.require = () => "wrapper";
+      assert.strictEqual(wrapper.require(), "wrapper");
+      assert.strictEqual(Module.prototype.require, original);
+      assert.strictEqual(require("path"), path);
 
       console.log("ok");
     `;

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -158,6 +158,14 @@ describe.concurrent("node-module-module", () => {
       assert.strictEqual(m.require(), "instance");
       assert.strictEqual(Module.prototype.require, original);
 
+      // Module.prototype._compile can be reassigned (loader-hook pattern).
+      const origCompile = Module.prototype._compile;
+      Module.prototype._compile = origCompile;
+      assert.strictEqual(Module.prototype._compile, origCompile);
+      const hook = function (c, f) { return origCompile.call(this, c, f); };
+      Module.prototype._compile = hook;
+      assert.strictEqual(Module.prototype._compile, hook);
+
       console.log("ok");
     `;
     await using proc = Bun.spawn({


### PR DESCRIPTION
Fixes #9860. Fixes #17072.

## What

`new Module(id).require` was `undefined`, breaking packages like [`vite-plugin-top-level-await`](https://github.com/Menci/vite-plugin-top-level-await) and Hexo that construct a `Module` and call `.require()` on it to resolve a dependency from another package's location:

```
TypeError: virtualModule.require is not a function. (In 'virtualModule.require(wantedModuleName)', 'virtualModule.require' is undefined)
    at requireFrom (node_modules/vite-plugin-top-level-await/dist/esbuild.js:14:26)
```

## Why

`JSCommonJSModulePrototype`, the actual `[[Prototype]]` of every CommonJS module object (including `new Module()`), exposed `_compile`, `filename`, `id`, `paths`, etc. but not `require`. In Node, `Module.prototype.require` is on the instance prototype, so `new Module(id).require(...)` resolves relative to that module. Loaded CJS modules in Bun were not affected because they get an own `require` installed when the module wrapper runs; only freshly constructed `new Module()` instances hit the prototype.

## Fix

Add a `require` custom accessor to `JSCommonJSModulePrototype`. The getter returns the process-wide overridable require (the same function the bound CJS `require` argument delegates to), so `m.require(id)` resolves relative to `m.filename`. The setter shadows with an own property when assigned on an instance or any other object on the chain, and writes the process-wide override slot only when the receiver is the prototype itself, so `someModule.require = fn` cannot accidentally hijack every `require()` in the process.

`require('node:module').prototype` is unchanged; this PR only touches the internal instance prototype. Unifying the two (and `module instanceof Module`) is covered by #33804.

## Verified

```sh
$ bun --bun vite build     # with vite-plugin-top-level-await
vite v5.4.21 building for production...
✓ built in 5.94s
```

The existing `Overwriting Module.prototype.require` test continues to pass.
