### PR TITLE
Bun.serve: presign new Response(S3File) redirect for HEAD, not GET

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2467,9 +2467,6 @@ where
         // SAFETY: sole `&mut Response` for this cell in this frame.
         let response = unsafe { &mut *response_ptr };
 
-        // `new Response(s3file)` presigns Location for GET. A HEAD client
-        // following that 302 would send HEAD to a GET-signed URL and get
-        // 403 SignatureDoesNotMatch; re-sign for the actual method.
         if let Some(server) = this.server {
             // SAFETY: BACKREF
             let _ = response.resign_s3_location(this.method, server.global_this());

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2467,6 +2467,14 @@ where
         // SAFETY: sole `&mut Response` for this cell in this frame.
         let response = unsafe { &mut *response_ptr };
 
+        // `new Response(s3file)` presigns Location for GET. A HEAD client
+        // following that 302 would send HEAD to a GET-signed URL and get
+        // 403 SignatureDoesNotMatch; re-sign for the actual method.
+        if let Some(server) = this.server {
+            // SAFETY: BACKREF
+            let _ = response.resign_s3_location(this.method, server.global_this());
+        }
+
         // `render` drops the body for a null-body status on GET, so HEAD must
         // not derive framing from that body (or the user headers) either
         // (RFC 9110 §9.3.2): render the exact metadata+framing GET would.

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -179,6 +179,10 @@ pub struct Response {
     /// Response was GC'd (null) instead of dereferencing a freed pointer when
     /// backpressure lets GC run between `render()` and the async callback.
     pub weak_ptr_data: WeakPtrData,
+    /// `new Response(s3file)` presigns a GET URL into `Location`. Bun.serve
+    /// re-signs that URL with the request's actual method (HEAD) at render
+    /// time, so it needs the backing S3 store (credentials + path) here.
+    s3_presign_store: JsCell<Option<super::blob::store::StoreRef>>,
     js_ref: JsCell<JsRef>,
 
     // We must report a consistent value for this
@@ -194,6 +198,7 @@ impl Default for Response {
             redirected: Cell::new(false),
             ref_count: Cell::new(1),
             weak_ptr_data: WeakPtrData::EMPTY,
+            s3_presign_store: JsCell::new(None),
             js_ref: JsCell::new(JsRef::empty()),
             reported_estimated_size: Cell::new(0),
         }
@@ -629,6 +634,50 @@ impl Response {
         Ok(this.get_or_create_headers(global_this)?.to_js(global_this))
     }
 
+    /// If this Response was built by `new Response(s3file)`, re-sign the
+    /// `Location` header's presigned URL for `method`. The constructor signs
+    /// for GET; a client following the 302 with HEAD would otherwise present a
+    /// GET-signed URL to S3 and receive 403 SignatureDoesNotMatch.
+    ///
+    /// A sign failure leaves the existing (GET-signed) Location unchanged
+    /// rather than throwing: the constructor already signed these same
+    /// credentials+path for GET, so HEAD signing cannot fail differently.
+    pub(crate) fn resign_s3_location(
+        &self,
+        method: Method,
+        global_this: &JSGlobalObject,
+    ) -> JsResult<()> {
+        let Some(store) = self.s3_presign_store.get() else {
+            return Ok(());
+        };
+        let super::blob::store::Data::S3(s3) = &store.data else {
+            return Ok(());
+        };
+        let Ok(result) = s3.get_credentials().sign_request::<false>(
+            &bun_s3_signing::SignOptions {
+                path: s3.path(),
+                method,
+                content_hash: None,
+                content_md5: None,
+                search_params: None,
+                content_disposition: None,
+                content_type: None,
+                content_encoding: None,
+                acl: None,
+                storage_class: None,
+                request_payer: false,
+            },
+            Some(bun_s3_signing::SignQueryOptions { expires: 15 * 60 }),
+        ) else {
+            return Ok(());
+        };
+        self.get_or_create_headers(global_this)?.put(
+            HTTPHeaderName::Location,
+            &BunString::ascii(&result.url),
+            global_this,
+        )
+    }
+
     pub fn get_content_type(&self) -> JsResult<Option<ZigStringSlice>> {
         // R-2 escape hatch via `init_mut()` — `fast_get` (FFI out-param write)
         // does not re-enter JS.
@@ -821,6 +870,7 @@ impl Response {
             init: JsCell::new(init),
             url: JsCell::new(self.url.get().clone()),
             redirected: Cell::new(self.redirected.get()),
+            s3_presign_store: JsCell::new(self.s3_presign_store.get().clone()),
             ..Default::default()
         })
     }
@@ -849,6 +899,7 @@ impl Response {
             (*this).init.set(Init::default());
             (*this).body.get_mut().reset();
             (*this).url.set(OwnedString::new(BunString::empty()));
+            (*this).s3_presign_store.set(None);
             (*this).js_ref.set(JsRef::empty());
 
             // Contents are gone; the allocation itself stays until any outstanding
@@ -1194,6 +1245,9 @@ impl Response {
                     };
                     // `defer result.deinit()` — SignResult: Drop frees owned buffers at scope exit.
                     response.redirected.set(true);
+                    response
+                        .s3_presign_store
+                        .set(blob.store.get().as_ref().cloned());
                     let headers = response.get_or_create_headers(global_this)?;
                     headers.put(
                         HTTPHeaderName::Location,

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -179,9 +179,7 @@ pub struct Response {
     /// Response was GC'd (null) instead of dereferencing a freed pointer when
     /// backpressure lets GC run between `render()` and the async callback.
     pub weak_ptr_data: WeakPtrData,
-    /// `new Response(s3file)` presigns a GET URL into `Location`. Bun.serve
-    /// re-signs that URL with the request's actual method (HEAD) at render
-    /// time, so it needs the backing S3 store (credentials + path) here.
+    /// Backing S3 store for a `new Response(s3file)` 302; see [`Self::resign_s3_location`].
     s3_presign_store: JsCell<Option<super::blob::store::StoreRef>>,
     js_ref: JsCell<JsRef>,
 
@@ -634,14 +632,7 @@ impl Response {
         Ok(this.get_or_create_headers(global_this)?.to_js(global_this))
     }
 
-    /// If this Response was built by `new Response(s3file)`, re-sign the
-    /// `Location` header's presigned URL for `method`. The constructor signs
-    /// for GET; a client following the 302 with HEAD would otherwise present a
-    /// GET-signed URL to S3 and receive 403 SignatureDoesNotMatch.
-    ///
-    /// A sign failure leaves the existing (GET-signed) Location unchanged
-    /// rather than throwing: the constructor already signed these same
-    /// credentials+path for GET, so HEAD signing cannot fail differently.
+    /// Re-sign a `new Response(s3file)` 302 `Location` for `method` (the constructor presigns for GET only).
     pub(crate) fn resign_s3_location(
         &self,
         method: Method,

--- a/test/js/bun/s3/s3-serve-response-head.test.ts
+++ b/test/js/bun/s3/s3-serve-response-head.test.ts
@@ -93,7 +93,7 @@ test("Bun.serve new Response(S3File): HEAD redirects to a HEAD-signed URL (not G
   expect(seen).toEqual(["GET", "HEAD"]);
 });
 
-test("Bun.serve new Response(S3File): HEAD redirect (manual) carries a distinct signature", async () => {
+test("Bun.serve new Response(S3File): HEAD redirect Location is signed for HEAD", async () => {
   const s3 = new S3Client({
     endpoint: "http://127.0.0.1:1",
     accessKeyId: "testkey",
@@ -114,13 +114,15 @@ test("Bun.serve new Response(S3File): HEAD redirect (manual) carries a distinct 
   expect(getRes.status).toBe(302);
   expect(headRes.status).toBe(302);
 
-  const getLoc = new URL(getRes.headers.get("location")!);
-  const headLoc = new URL(headRes.headers.get("location")!);
-  // Same object, same credentials, same X-Amz-Date window; only the signed
-  // method differs, so the signatures must differ too.
-  if (getLoc.searchParams.get("X-Amz-Date") === headLoc.searchParams.get("X-Amz-Date")) {
-    expect(headLoc.searchParams.get("X-Amz-Signature")).not.toBe(getLoc.searchParams.get("X-Amz-Signature"));
-  }
+  const asReq = (loc: string, method: string) => new Request(loc, { method, headers: { host: new URL(loc).host } });
+
+  const getLoc = getRes.headers.get("location")!;
+  expect(verifySigV4(asReq(getLoc, "GET"), "testsecret")).toBe(true);
+  expect(verifySigV4(asReq(getLoc, "HEAD"), "testsecret")).toBe(false);
+
+  const headLoc = headRes.headers.get("location")!;
+  expect(verifySigV4(asReq(headLoc, "HEAD"), "testsecret")).toBe(true);
+  expect(verifySigV4(asReq(headLoc, "GET"), "testsecret")).toBe(false);
 });
 
 test("Bun.serve new Response(S3File): async handler HEAD redirects to a HEAD-signed URL", async () => {

--- a/test/js/bun/s3/s3-serve-response-head.test.ts
+++ b/test/js/bun/s3/s3-serve-response-head.test.ts
@@ -51,7 +51,7 @@ function makeMockS3(body: string) {
     fetch(req) {
       seen.push(req.method);
       if (!verifySigV4(req, "testsecret")) {
-        return new Response("<?xml version=\"1.0\"?><Error><Code>SignatureDoesNotMatch</Code></Error>", {
+        return new Response('<?xml version="1.0"?><Error><Code>SignatureDoesNotMatch</Code></Error>', {
           status: 403,
           headers: { "x-minio-error-code": "SignatureDoesNotMatch" },
         });

--- a/test/js/bun/s3/s3-serve-response-head.test.ts
+++ b/test/js/bun/s3/s3-serve-response-head.test.ts
@@ -1,0 +1,150 @@
+import { S3Client } from "bun";
+import { expect, test } from "bun:test";
+import { createHash, createHmac } from "node:crypto";
+
+// Minimal SigV4 query-auth verifier: recomputes X-Amz-Signature for the
+// received method + path + query and compares it to the one in the URL.
+// Real S3 endpoints (AWS, MinIO) reject any method that doesn't match the
+// signed canonical request with 403 SignatureDoesNotMatch.
+function verifySigV4(req: Request, secretKey: string): boolean {
+  const url = new URL(req.url);
+  const received = url.searchParams.get("X-Amz-Signature");
+  const credential = url.searchParams.get("X-Amz-Credential");
+  const amzDate = url.searchParams.get("X-Amz-Date");
+  const signedHeaders = url.searchParams.get("X-Amz-SignedHeaders");
+  if (!received || !credential || !amzDate || !signedHeaders) return false;
+
+  const [, date, region, service] = credential.split("/");
+  const scope = `${date}/${region}/${service}/aws4_request`;
+
+  const params = [...url.searchParams.entries()]
+    .filter(([k]) => k !== "X-Amz-Signature")
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .sort()
+    .join("&");
+
+  const canonicalHeaders = `host:${req.headers.get("host")}\n`;
+  const canonicalRequest = [req.method, url.pathname, params, canonicalHeaders, signedHeaders, "UNSIGNED-PAYLOAD"].join(
+    "\n",
+  );
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    createHash("sha256").update(canonicalRequest).digest("hex"),
+  ].join("\n");
+
+  const hmac = (key: Buffer | string, data: string) => createHmac("sha256", key).update(data).digest();
+  const kDate = hmac("AWS4" + secretKey, date);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, service);
+  const kSigning = hmac(kService, "aws4_request");
+  const expected = createHmac("sha256", kSigning).update(stringToSign).digest("hex");
+
+  return expected === received;
+}
+
+function makeMockS3(body: string) {
+  const seen: string[] = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      seen.push(req.method);
+      if (!verifySigV4(req, "testsecret")) {
+        return new Response("<?xml version=\"1.0\"?><Error><Code>SignatureDoesNotMatch</Code></Error>", {
+          status: 403,
+          headers: { "x-minio-error-code": "SignatureDoesNotMatch" },
+        });
+      }
+      return new Response(req.method === "HEAD" ? null : body, {
+        headers: { "content-length": String(body.length), "content-type": "text/plain" },
+      });
+    },
+  });
+  return { server, seen };
+}
+
+test("Bun.serve new Response(S3File): HEAD redirects to a HEAD-signed URL (not GET-signed)", async () => {
+  const body = "hello bun\n";
+  const { server: s3mock, seen } = makeMockS3(body);
+  await using _s3mock = s3mock;
+
+  const s3 = new S3Client({
+    endpoint: `http://${s3mock.hostname}:${s3mock.port}`,
+    accessKeyId: "testkey",
+    secretAccessKey: "testsecret",
+    bucket: "bkt",
+    region: "us-east-1",
+  });
+
+  await using app = Bun.serve({
+    port: 0,
+    fetch: () => new Response(s3.file("obj.txt")),
+  });
+
+  const getRes = await fetch(`http://${app.hostname}:${app.port}/`);
+  expect(getRes.status).toBe(200);
+  expect(await getRes.text()).toBe(body);
+
+  const headRes = await fetch(`http://${app.hostname}:${app.port}/`, { method: "HEAD" });
+  expect(headRes.status).toBe(200);
+  expect(headRes.headers.get("content-length")).toBe(String(body.length));
+
+  expect(seen).toEqual(["GET", "HEAD"]);
+});
+
+test("Bun.serve new Response(S3File): HEAD redirect (manual) carries a distinct signature", async () => {
+  const s3 = new S3Client({
+    endpoint: "http://127.0.0.1:1",
+    accessKeyId: "testkey",
+    secretAccessKey: "testsecret",
+    bucket: "bkt",
+    region: "us-east-1",
+  });
+
+  await using app = Bun.serve({
+    port: 0,
+    fetch: () => new Response(s3.file("obj.txt")),
+  });
+
+  const [getRes, headRes] = await Promise.all([
+    fetch(`http://${app.hostname}:${app.port}/`, { redirect: "manual" }),
+    fetch(`http://${app.hostname}:${app.port}/`, { method: "HEAD", redirect: "manual" }),
+  ]);
+  expect(getRes.status).toBe(302);
+  expect(headRes.status).toBe(302);
+
+  const getLoc = new URL(getRes.headers.get("location")!);
+  const headLoc = new URL(headRes.headers.get("location")!);
+  // Same object, same credentials, same X-Amz-Date window; only the signed
+  // method differs, so the signatures must differ too.
+  if (getLoc.searchParams.get("X-Amz-Date") === headLoc.searchParams.get("X-Amz-Date")) {
+    expect(headLoc.searchParams.get("X-Amz-Signature")).not.toBe(getLoc.searchParams.get("X-Amz-Signature"));
+  }
+});
+
+test("Bun.serve new Response(S3File): async handler HEAD redirects to a HEAD-signed URL", async () => {
+  const body = "hello bun\n";
+  const { server: s3mock, seen } = makeMockS3(body);
+  await using _s3mock = s3mock;
+
+  const s3 = new S3Client({
+    endpoint: `http://${s3mock.hostname}:${s3mock.port}`,
+    accessKeyId: "testkey",
+    secretAccessKey: "testsecret",
+    bucket: "bkt",
+    region: "us-east-1",
+  });
+
+  await using app = Bun.serve({
+    port: 0,
+    fetch: async () => {
+      await Bun.sleep(0);
+      return new Response(s3.file("obj.txt"));
+    },
+  });
+
+  const headRes = await fetch(`http://${app.hostname}:${app.port}/`, { method: "HEAD" });
+  expect(headRes.status).toBe(200);
+  expect(seen).toEqual(["HEAD"]);
+});


### PR DESCRIPTION
## What

`Bun.serve` returning `new Response(s3file)` now answers HEAD requests with a 302 whose `Location` is presigned for **HEAD**, so clients following the redirect (curl `-I`, uptime monitors, CDN health checks, `fetch(..., {method: "HEAD"})`) get 200 from S3 instead of `403 SignatureDoesNotMatch`.

## Repro

```ts
const s3 = new Bun.S3Client({ endpoint, accessKeyId, secretAccessKey, bucket, region: "us-east-1" });
const app = Bun.serve({ port: 0, fetch: () => new Response(s3.file("obj.txt")) });
await fetch(`http://127.0.0.1:${app.port}/`);                         // 200
await fetch(`http://127.0.0.1:${app.port}/`, { method: "HEAD" });     // before: 403  after: 200
```

Wire trace seen by the S3 origin before the fix (identical `X-Amz-Signature` for both verbs):

```
GET  /bkt/obj.txt?...X-Amz-Signature=0db70e6f...   -> 200
HEAD /bkt/obj.txt?...X-Amz-Signature=0db70e6f...   -> 403 SignatureDoesNotMatch
```

## Cause

`new Response(s3file)` converts to a 302 with `Location` set to a presigned URL hard-coded to `Method::GET` at construction time (`src/runtime/webcore/Response.rs`). `Bun.serve` writes that header verbatim for any method. A HEAD client following the 302 sends HEAD to a GET-signed URL; SigV4's canonical request includes the HTTP method, so every real S3 (AWS, MinIO) rejects it.

## Fix

The Response now retains a `StoreRef` to the backing S3 blob. `do_render_head_response` re-signs the `Location` URL with the request's actual method before writing headers. GET behaviour and the user-visible `response.headers.get("location")` value are unchanged.

## Verification

`test/js/bun/s3/s3-serve-response-head.test.ts` runs a SigV4-verifying mock S3 (HMAC-SHA256 query-auth): before the fix HEAD hits the verifier with a GET-signed URL and fails with 403; after the fix GET and HEAD both pass verification and get 200. A second test confirms GET and HEAD receive distinct `X-Amz-Signature` values, and a third covers the async handler path.