### PR TITLE
install(windows): remove .bunx/.exe shims on `bun remove`

### DIFF
--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -721,6 +721,42 @@ fn update_package_json_and_install_with_manager_with_updates(
                                     }
                                 }
                             }
+                            #[cfg(windows)]
+                            bun_sys::EntryKind::File => {
+                                // On Windows, package bins are `<name>.exe` + `<name>.bunx`
+                                // shim pairs rather than symlinks. A `.bunx` whose encoded
+                                // target no longer exists is the dangling case; remove it
+                                // together with its `.exe` sibling.
+                                let name = entry.name.slice_u8();
+                                if !strings::has_suffix_comptime(name, b".bunx") {
+                                    continue 'iterator;
+                                }
+                                node_modules_buf[..name.len()].copy_from_slice(name);
+                                node_modules_buf[name.len()] = 0;
+                                let bunx_name: &ZStr =
+                                    ZStr::from_buf(&node_modules_buf, name.len());
+
+                                if !is_dangling_windows_shim(
+                                    node_modules_bin,
+                                    bunx_name,
+                                    manager.options.bin_path,
+                                ) {
+                                    continue 'iterator;
+                                }
+
+                                let _ = bun_sys::unlinkat(node_modules_bin, bunx_name);
+
+                                let stem_len = name.len() - b".bunx".len();
+                                node_modules_buf[stem_len..stem_len + b".exe".len()]
+                                    .copy_from_slice(b".exe");
+                                node_modules_buf[stem_len + b".exe".len()] = 0;
+                                let exe_name: &ZStr = ZStr::from_buf(
+                                    &node_modules_buf,
+                                    stem_len + b".exe".len(),
+                                );
+                                let _ = bun_sys::unlinkat(node_modules_bin, exe_name);
+                                continue 'iterator;
+                            }
                             _ => {}
                         }
                     }
@@ -741,6 +777,56 @@ fn update_package_json_and_install_with_manager_with_updates(
     }
 
     Ok(())
+}
+
+/// Decode the target path from a `.bunx` shim and report whether it no longer
+/// exists. The `.bunx` format (see `src/install/windows-shim/BinLinkingShim.rs`)
+/// begins with a UTF-16LE path relative to the parent of the bin directory,
+/// terminated by a `"` code unit. Anything we cannot decode is treated as live.
+#[cfg(windows)]
+fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) -> bool {
+    let Ok(file) = bun_sys::File::openat(bin_dir, bunx_name.as_bytes(), bun_sys::O::RDONLY, 0)
+    else {
+        return false;
+    };
+    let Ok(contents) = file.read_to_end_small() else {
+        return false;
+    };
+
+    let mut rel_target_byte_len = None;
+    let mut i = 0;
+    while i + 1 < contents.len() {
+        if contents[i] == b'"' && contents[i + 1] == 0 {
+            rel_target_byte_len = Some(i);
+            break;
+        }
+        i += 2;
+    }
+    let Some(rel_target_byte_len) = rel_target_byte_len else {
+        return false;
+    };
+    if rel_target_byte_len == 0 {
+        return false;
+    }
+
+    let base = bun_paths::dirname(bin_dir_path.as_bytes()).unwrap_or(b".");
+    let mut target_buf = bun_paths::w_path_buffer_pool::get();
+    let base_len =
+        strings::convert_utf8_to_utf16_in_buffer(target_buf.as_mut_slice(), base).len();
+
+    let rel_target_units = rel_target_byte_len / 2;
+    let total = base_len + 1 + rel_target_units;
+    if total >= target_buf.len() {
+        return false;
+    }
+
+    target_buf[base_len] = b'\\' as u16;
+    for j in 0..rel_target_units {
+        target_buf[base_len + 1 + j] =
+            u16::from_le_bytes([contents[j * 2], contents[j * 2 + 1]]);
+    }
+
+    bun_sys::exists_at_type_w(Fd::cwd(), &target_buf[..total]).is_err()
 }
 
 pub fn update_package_json_and_install_and_cli(

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -817,7 +817,10 @@ fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) 
         target_buf[base_len + 1 + j] = u16::from_le_bytes([contents[j * 2], contents[j * 2 + 1]]);
     }
 
-    bun_sys::exists_at_type_w(Fd::cwd(), &target_buf[..total]).is_err()
+    match bun_sys::exists_at_type_w(Fd::cwd(), &target_buf[..total]) {
+        Ok(_) => false,
+        Err(e) => e.get_errno() == bun_sys::E::ENOENT,
+    }
 }
 
 pub fn update_package_json_and_install_and_cli(

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -817,8 +817,7 @@ fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) 
         joined[base_len + 1 + j] = u16::from_le_bytes([contents[j * 2], contents[j * 2 + 1]]);
     }
 
-    // The encoded target may contain `..` (bin.rs only strips one leading `..\`); resolve it
-    // because the existence check goes through an NT path.
+    // encoded target may contain `..`; resolve before the NT-path existence check.
     let mut target_buf = bun_paths::w_path_buffer_pool::get();
     let target = bun_paths::resolve_path::normalize_buf_t::<u16, bun_paths::platform::Windows>(
         &joined[..total],

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -803,21 +803,29 @@ fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) 
     }
 
     let base = bun_paths::dirname(bin_dir_path.as_bytes()).unwrap_or(b".");
-    let mut target_buf = bun_paths::w_path_buffer_pool::get();
-    let base_len = strings::convert_utf8_to_utf16_in_buffer(target_buf.as_mut_slice(), base).len();
+    let mut joined = bun_paths::w_path_buffer_pool::get();
+    let base_len = strings::convert_utf8_to_utf16_in_buffer(joined.as_mut_slice(), base).len();
 
     let rel_target_units = rel_target_byte_len / 2;
     let total = base_len + 1 + rel_target_units;
-    if total >= target_buf.len() {
+    if total >= joined.len() {
         return false;
     }
 
-    target_buf[base_len] = b'\\' as u16;
+    joined[base_len] = b'\\' as u16;
     for j in 0..rel_target_units {
-        target_buf[base_len + 1 + j] = u16::from_le_bytes([contents[j * 2], contents[j * 2 + 1]]);
+        joined[base_len + 1 + j] = u16::from_le_bytes([contents[j * 2], contents[j * 2 + 1]]);
     }
 
-    match bun_sys::exists_at_type_w(Fd::cwd(), &target_buf[..total]) {
+    // The encoded target may contain `..` (bin.rs only strips one leading `..\`); resolve it
+    // because the existence check goes through an NT path.
+    let mut target_buf = bun_paths::w_path_buffer_pool::get();
+    let target = bun_paths::resolve_path::normalize_buf_t::<u16, bun_paths::platform::Windows>(
+        &joined[..total],
+        target_buf.as_mut_slice(),
+    );
+
+    match bun_sys::exists_at_type_w(Fd::cwd(), target) {
         Ok(_) => false,
         Err(e) => e.get_errno() == bun_sys::E::ENOENT,
     }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -723,10 +723,7 @@ fn update_package_json_and_install_with_manager_with_updates(
                             }
                             #[cfg(windows)]
                             bun_sys::EntryKind::File => {
-                                // On Windows, package bins are `<name>.exe` + `<name>.bunx`
-                                // shim pairs rather than symlinks. A `.bunx` whose encoded
-                                // target no longer exists is the dangling case; remove it
-                                // together with its `.exe` sibling.
+                                // Windows counterpart of the SymLink arm: `<name>.bunx` + `<name>.exe` shim pairs.
                                 let name = entry.name.slice_u8();
                                 if !strings::has_suffix_comptime(name, b".bunx") {
                                     continue 'iterator;
@@ -777,10 +774,7 @@ fn update_package_json_and_install_with_manager_with_updates(
     Ok(())
 }
 
-/// Decode the target path from a `.bunx` shim and report whether it no longer
-/// exists. The `.bunx` format (see `src/install/windows-shim/BinLinkingShim.rs`)
-/// begins with a UTF-16LE path relative to the parent of the bin directory,
-/// terminated by a `"` code unit. Anything we cannot decode is treated as live.
+/// Does `bunx_name`'s encoded target (see `windows-shim/BinLinkingShim.rs`) no longer exist?
 #[cfg(windows)]
 fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) -> bool {
     let Ok(file) = bun_sys::File::openat(bin_dir, bunx_name.as_bytes(), bun_sys::O::RDONLY, 0)
@@ -791,6 +785,7 @@ fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) 
         return false;
     };
 
+    // encoding: [WSTR:bin_path][u16:'"']...; bin_path is relative to `dirname(bin_dir)`.
     let mut rel_target_byte_len = None;
     let mut i = 0;
     while i + 1 < contents.len() {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -750,10 +750,8 @@ fn update_package_json_and_install_with_manager_with_updates(
                                 node_modules_buf[stem_len..stem_len + b".exe".len()]
                                     .copy_from_slice(b".exe");
                                 node_modules_buf[stem_len + b".exe".len()] = 0;
-                                let exe_name: &ZStr = ZStr::from_buf(
-                                    &node_modules_buf,
-                                    stem_len + b".exe".len(),
-                                );
+                                let exe_name: &ZStr =
+                                    ZStr::from_buf(&node_modules_buf, stem_len + b".exe".len());
                                 let _ = bun_sys::unlinkat(node_modules_bin, exe_name);
                                 continue 'iterator;
                             }
@@ -811,8 +809,7 @@ fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) 
 
     let base = bun_paths::dirname(bin_dir_path.as_bytes()).unwrap_or(b".");
     let mut target_buf = bun_paths::w_path_buffer_pool::get();
-    let base_len =
-        strings::convert_utf8_to_utf16_in_buffer(target_buf.as_mut_slice(), base).len();
+    let base_len = strings::convert_utf8_to_utf16_in_buffer(target_buf.as_mut_slice(), base).len();
 
     let rel_target_units = rel_target_byte_len / 2;
     let total = base_len + 1 + rel_target_units;
@@ -822,8 +819,7 @@ fn is_dangling_windows_shim(bin_dir: Fd, bunx_name: &ZStr, bin_dir_path: &ZStr) 
 
     target_buf[base_len] = b'\\' as u16;
     for j in 0..rel_target_units {
-        target_buf[base_len + 1 + j] =
-            u16::from_le_bytes([contents[j * 2], contents[j * 2 + 1]]);
+        target_buf[base_len + 1 + j] = u16::from_le_bytes([contents[j * 2], contents[j * 2 + 1]]);
     }
 
     bun_sys::exists_at_type_w(Fd::cwd(), &target_buf[..total]).is_err()

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -1,9 +1,12 @@
-import { file, spawn } from "bun";
+import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
 import { mkdir, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, tmpdirSync } from "harness";
+import { existsSync } from "fs";
+import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toHaveBins } from "harness";
 import { join, relative } from "path";
 import { createTestContext, destroyTestContext, dummyAfterAll, dummyBeforeAll } from "./dummy.registry";
+
+expect.extend({ toHaveBins });
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
@@ -340,3 +343,62 @@ it.concurrent("should remove peerDependencies", async () => {
     destroyTestContext(ctx);
   }
 });
+
+// https://github.com/oven-sh/bun/issues/11970
+for (const global of [false, true]) {
+  it.concurrent(`should delete bins of the removed package${global ? " (global)" : ""}`, async () => {
+    const dir = tmpdirSync();
+    await Promise.all([
+      write(join(dir, "package.json"), JSON.stringify({ name: "foo" })),
+      write(
+        join(dir, "has-two-bins", "package.json"),
+        JSON.stringify({
+          name: "has-two-bins",
+          version: "1.0.0",
+          bin: { "bin-a": "./bin-a.js", "bin-b": "./bin-b.js" },
+        }),
+      ),
+      write(join(dir, "has-two-bins", "bin-a.js"), `#!/usr/bin/env node\nconsole.log("a")`),
+      write(join(dir, "has-two-bins", "bin-b.js"), `#!/usr/bin/env node\nconsole.log("b")`),
+      write(
+        join(dir, "has-one-bin", "package.json"),
+        JSON.stringify({ name: "has-one-bin", version: "1.0.0", bin: { "bin-c": "./bin-c.js" } }),
+      ),
+      write(join(dir, "has-one-bin", "bin-c.js"), `#!/usr/bin/env node\nconsole.log("c")`),
+    ]);
+
+    const binDir = global ? join(dir, "bun-home", "bin") : join(dir, "node_modules", ".bin");
+    const installEnv = {
+      ...env,
+      ...(global && {
+        BUN_INSTALL: join(dir, "bun-home"),
+        BUN_INSTALL_BIN: binDir,
+      }),
+    };
+    const globalArgs = global ? ["-g"] : [];
+
+    async function run(args: string[]) {
+      await using proc = spawn({
+        cmd: [bunExe(), ...args],
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: installEnv,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      return stdout;
+    }
+
+    await run(["add", "--linker=hoisted", ...globalArgs, "./has-two-bins", "./has-one-bin"]);
+    expect(await readdirSorted(binDir)).toHaveBins(["bin-a", "bin-b", "bin-c"]);
+
+    await run(["remove", ...globalArgs, "has-two-bins"]);
+    // bin-a and bin-b are removed; bin-c (from a still-installed package) is not.
+    expect(await readdirSorted(binDir)).toHaveBins(["bin-c"]);
+
+    await run(["remove", ...globalArgs, "has-one-bin"]);
+    expect(existsSync(binDir) ? await readdirSorted(binDir) : []).toEqual([]);
+  });
+}

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -2,11 +2,12 @@ import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
 import { existsSync } from "fs";
 import { mkdir, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toHaveBins } from "harness";
+import { bunExe, bunEnv as env, isWindows, readdirSorted, tmpdirSync } from "harness";
 import { join, relative } from "path";
 import { createTestContext, destroyTestContext, dummyAfterAll, dummyBeforeAll } from "./dummy.registry";
 
-expect.extend({ toHaveBins });
+const binEntries = (names: string[]) =>
+  isWindows ? names.flatMap(n => [`${n}.bunx`, `${n}.exe`]) : names;
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);
@@ -392,11 +393,11 @@ for (const global of [false, true]) {
     }
 
     await run(["add", "--linker=hoisted", ...globalArgs, "./has-two-bins", "./has-one-bin"]);
-    expect(await readdirSorted(binDir)).toHaveBins(["bin-a", "bin-b", "bin-c"]);
+    expect(await readdirSorted(binDir)).toEqual(binEntries(["bin-a", "bin-b", "bin-c"]));
 
     await run(["remove", ...globalArgs, "has-two-bins"]);
     // bin-a and bin-b are removed; bin-c (from a still-installed package) is not.
-    expect(await readdirSorted(binDir)).toHaveBins(["bin-c"]);
+    expect(await readdirSorted(binDir)).toEqual(binEntries(["bin-c"]));
 
     await run(["remove", ...globalArgs, "has-one-bin"]);
     expect(existsSync(binDir) ? await readdirSorted(binDir) : []).toEqual([]);

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -6,8 +6,7 @@ import { bunExe, bunEnv as env, isWindows, readdirSorted, tmpdirSync } from "har
 import { join, relative } from "path";
 import { createTestContext, destroyTestContext, dummyAfterAll, dummyBeforeAll } from "./dummy.registry";
 
-const binEntries = (names: string[]) =>
-  isWindows ? names.flatMap(n => [`${n}.bunx`, `${n}.exe`]) : names;
+const binEntries = (names: string[]) => (isWindows ? names.flatMap(n => [`${n}.bunx`, `${n}.exe`]) : names);
 
 beforeAll(dummyBeforeAll);
 afterAll(dummyAfterAll);

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
-import { mkdir, writeFile } from "fs/promises";
 import { existsSync } from "fs";
+import { mkdir, writeFile } from "fs/promises";
 import { bunExe, bunEnv as env, readdirSorted, tmpdirSync, toHaveBins } from "harness";
 import { join, relative } from "path";
 import { createTestContext, destroyTestContext, dummyAfterAll, dummyBeforeAll } from "./dummy.registry";

--- a/test/cli/install/bun-remove.test.ts
+++ b/test/cli/install/bun-remove.test.ts
@@ -345,8 +345,14 @@ it.concurrent("should remove peerDependencies", async () => {
 });
 
 // https://github.com/oven-sh/bun/issues/11970
-for (const global of [false, true]) {
-  it.concurrent(`should delete bins of the removed package${global ? " (global)" : ""}`, async () => {
+// The "global, disjoint bin dir" variant places the bin dir two levels deep
+// outside $BUN_INSTALL so the encoded .bunx target carries a residual `..`.
+for (const [global, binDirParts, label] of [
+  [false, ["node_modules", ".bin"], ""],
+  [true, ["bun-home", "bin"], " (global)"],
+  [true, ["nested", "separate-bin"], " (global, disjoint bin dir)"],
+] as const) {
+  it.concurrent(`should delete bins of the removed package${label}`, async () => {
     const dir = tmpdirSync();
     await Promise.all([
       write(join(dir, "package.json"), JSON.stringify({ name: "foo" })),
@@ -367,7 +373,7 @@ for (const global of [false, true]) {
       write(join(dir, "has-one-bin", "bin-c.js"), `#!/usr/bin/env node\nconsole.log("c")`),
     ]);
 
-    const binDir = global ? join(dir, "bun-home", "bin") : join(dir, "node_modules", ".bin");
+    const binDir = join(dir, ...binDirParts);
     const installEnv = {
       ...env,
       ...(global && {


### PR DESCRIPTION
Fixes #11970.

## Problem

On Windows, `bun remove` (both global and local) removes the package's `node_modules` entry but leaves its `<name>.exe` and `<name>.bunx` shim files behind in the bin directory. The shim then launches a binary whose target no longer exists:

```pwsh
PS> bun add -g cowsay
PS> bun remove -g cowsay
PS> cowsay hello
Error: Cannot find module 'C:\Users\User\.bun\install\global\node_modules\cowsay\cli.js'
```

POSIX is unaffected because package bins there are symlinks and the dangling-symlink sweep already removes them.

## Cause

`update_package_json_and_install_with_manager_with_updates` finishes a `remove` by walking the bin directory and unlinking any entry it cannot open, but it matches only on `EntryKind::SymLink`. Windows bins are regular `.exe` / `.bunx` files, so the `_ => {}` arm skips them and they accumulate forever.

## Fix

Add a Windows arm to the same sweep that recognises `.bunx` entries. A `.bunx` begins with the UTF-16LE target path (relative to the parent of the bin directory) terminated by a `"` code unit; the arm reads that path, joins it against `dirname(bin_path)`, normalises (the encoded path can carry a residual `..` when the global bin directory lives outside `$BUN_INSTALL`, and the existence check goes through an NT path), and if `NtQueryAttributesFile` reports `ENOENT` unlinks the `.bunx` together with its sibling `.exe`. Any other outcome, including a file the sweep cannot decode or a non-`ENOENT` error, leaves the pair in place. This covers both `bun remove -g` (`$BUN_INSTALL/bin`) and local `bun remove` (`node_modules/.bin`), and matches what npm does with its `.cmd`/`.ps1` wrappers on uninstall.

## Verification

Three new tests in `test/cli/install/bun-remove.test.ts` (`should delete bins of the removed package` plus a `(global)` and a `(global, disjoint bin dir)` variant) install two packages with three bins between them, remove one, assert the exact surviving directory listing, then remove the other and assert the bin directory is empty. The disjoint variant places `BUN_INSTALL_BIN` two levels deep outside `$BUN_INSTALL` so the encoded shim path contains `..`, guarding the normalisation step.

On Windows all three fail on `main` and pass with this change:

```
(fail) should delete bins of the removed package
(fail) should delete bins of the removed package (global)
(fail) should delete bins of the removed package (global, disjoint bin dir)
  error: expect(received).toEqual(expected)
    [
  +   "bin-a.bunx",
  +   "bin-a.exe",
  +   "bin-b.bunx",
  +   "bin-b.exe",
      "bin-c.bunx",
      "bin-c.exe",
    ]
```

On POSIX they pass on both `main` and this branch (the symlink sweep already handled this case), so the Linux gate cannot observe fail-before; the Rust change is entirely `#[cfg(windows)]`-gated and is a no-op there. The Windows CI lane is the check of record.

Also confirmed the original report end to end with a Windows debug build: `bun add -g cowsay && bun remove -g cowsay` now leaves `$BUN_INSTALL\bin` empty.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-remove.test.ts

<!-- robobun:evidence:end -->