### PR TITLE
Clear JSC CodeCache on --hot reload and balance ref_strings refcount

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -148,11 +148,7 @@ export const setSyntheticAllocationLimitForTesting: (limit: number) => number = 
   1,
 );
 
-export const refStringsCount: () => number = $newRustFunction(
-  "virtual_machine_exports.rs",
-  "Bun__refStringsCount",
-  0,
-);
+export const refStringsCount: () => number = $newRustFunction("virtual_machine_exports.rs", "Bun__refStringsCount", 0);
 
 // Shrink the markdown parser's block-metadata cap (in bytes) so its
 // `TooManyBlocks` error is reachable without 4 GiB of input. The cap can only

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -148,6 +148,12 @@ export const setSyntheticAllocationLimitForTesting: (limit: number) => number = 
   1,
 );
 
+export const refStringsCount: () => number = $newRustFunction(
+  "virtual_machine_exports.rs",
+  "Bun__refStringsCount",
+  0,
+);
+
 // Shrink the markdown parser's block-metadata cap (in bytes) so its
 // `TooManyBlocks` error is reachable without 4 GiB of input. The cap can only
 // be lowered, never raised past the real limit. Returns the previous value so

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3745,17 +3745,30 @@ impl VirtualMachine {
             };
         }
         // Const-generic bool can't be `!ADD_DOUBLE_REF`, so branch.
+        let mut was_new = false;
         let source = if ADD_DOUBLE_REF {
-            self.ref_counted_string::<false>(code, hash_)
+            self.ref_counted_string_with_was_new::<false>(&mut was_new, code, hash_)
         } else {
-            self.ref_counted_string::<true>(code, hash_)
+            self.ref_counted_string_with_was_new::<true>(&mut was_new, code, hash_)
         };
-        // SAFETY: `ref_counted_string` returns a live `*mut RefString` held in
-        // `self.ref_strings`; we own +1 (or +3 below) until JSC calls the
+        // SAFETY: `ref_counted_string_with_was_new` returns a live `*mut RefString`
+        // held in `self.ref_strings`; we own +1 (or +3 below) until JSC calls the
         // external-string finalizer.
         let source_ref = unsafe { &*source };
         if ADD_DOUBLE_REF {
             source_ref.ref_();
+            source_ref.ref_();
+        }
+
+        // `ref_strings` is a weak cache: entries self-remove via the external
+        // string finalizer (free_ref_string -> RefString::destroy ->
+        // clear_ref_string) when the impl refcount hits zero. Hand the caller
+        // exactly +1 that it will balance via `source_code_needs_deref = true`.
+        // A fresh entry already carries the +1 from `create_external`; a cache
+        // hit does not, so take one here. Without this the create_external +1
+        // was never released and every distinct transpiled source under --hot
+        // leaked its duped bytes and map slot forever.
+        if !was_new {
             source_ref.ref_();
         }
 
@@ -3764,7 +3777,7 @@ impl VirtualMachine {
             specifier,
             source_url: create_if_different(&specifier, source_url),
             allocator: source.cast::<c_void>(),
-            source_code_needs_deref: false,
+            source_code_needs_deref: true,
             ..Default::default()
         }
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3832,8 +3832,7 @@ impl VirtualMachine {
         }
     }
 
-    /// Interns `input_` in the VM's ref-string map and returns the entry with
-    /// exactly +1 owed to the caller on both fresh-insert and cache-hit paths.
+    /// Interns `input_` and returns the entry with exactly +1 owed to the caller.
     pub fn ref_counted_string<const DUPE: bool>(
         &mut self,
         input_: &[u8],
@@ -3843,8 +3842,7 @@ impl VirtualMachine {
         let mut was_new = false;
         let r = self.ref_counted_string_with_was_new::<DUPE>(&mut was_new, input_, hash_);
         if !was_new {
-            // SAFETY: `r` is live (held in `self.ref_strings`). A fresh entry
-            // already carries +1 from `create_external`; a cache hit does not.
+            // SAFETY: `r` is live in `self.ref_strings`; fresh entries already have +1 from `create_external`.
             unsafe { (*r).ref_() };
         }
         r

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3745,30 +3745,17 @@ impl VirtualMachine {
             };
         }
         // Const-generic bool can't be `!ADD_DOUBLE_REF`, so branch.
-        let mut was_new = false;
         let source = if ADD_DOUBLE_REF {
-            self.ref_counted_string_with_was_new::<false>(&mut was_new, code, hash_)
+            self.ref_counted_string::<false>(code, hash_)
         } else {
-            self.ref_counted_string_with_was_new::<true>(&mut was_new, code, hash_)
+            self.ref_counted_string::<true>(code, hash_)
         };
-        // SAFETY: `ref_counted_string_with_was_new` returns a live `*mut RefString`
-        // held in `self.ref_strings`; we own +1 (or +3 below) until JSC calls the
+        // SAFETY: `ref_counted_string` returns a live `*mut RefString` held in
+        // `self.ref_strings`; we own +1 (or +3 below) until JSC calls the
         // external-string finalizer.
         let source_ref = unsafe { &*source };
         if ADD_DOUBLE_REF {
             source_ref.ref_();
-            source_ref.ref_();
-        }
-
-        // `ref_strings` is a weak cache: entries self-remove via the external
-        // string finalizer (free_ref_string -> RefString::destroy ->
-        // clear_ref_string) when the impl refcount hits zero. Hand the caller
-        // exactly +1 that it will balance via `source_code_needs_deref = true`.
-        // A fresh entry already carries the +1 from `create_external`; a cache
-        // hit does not, so take one here. Without this the create_external +1
-        // was never released and every distinct transpiled source under --hot
-        // leaked its duped bytes and map slot forever.
-        if !was_new {
             source_ref.ref_();
         }
 
@@ -3845,7 +3832,8 @@ impl VirtualMachine {
         }
     }
 
-    /// Interns `input_` in the VM's ref-string map and returns the ref-counted entry.
+    /// Interns `input_` in the VM's ref-string map and returns the entry with
+    /// exactly +1 owed to the caller on both fresh-insert and cache-hit paths.
     pub fn ref_counted_string<const DUPE: bool>(
         &mut self,
         input_: &[u8],
@@ -3853,7 +3841,13 @@ impl VirtualMachine {
     ) -> *mut crate::ref_string::RefString {
         debug_assert!(!input_.is_empty());
         let mut was_new = false;
-        self.ref_counted_string_with_was_new::<DUPE>(&mut was_new, input_, hash_)
+        let r = self.ref_counted_string_with_was_new::<DUPE>(&mut was_new, input_, hash_);
+        if !was_new {
+            // SAFETY: `r` is live (held in `self.ref_strings`). A fresh entry
+            // already carries +1 from `create_external`; a cache hit does not.
+            unsafe { (*r).ref_() };
+        }
+        r
     }
 
     // Note: `flags` is a runtime arg —

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3537,8 +3537,7 @@ void GlobalObject::reload()
     this->requireMap()->clear(this);
     RETURN_IF_EXCEPTION(scope, );
 
-    // Stale entries (keyed by old source text) pin their SourceProvider; every
-    // module already re-transpiles after clearAll() so re-parsing is marginal.
+    // Stale entries (keyed by old source text) pin their old SourceProvider.
     vm.codeCache()->clear();
 
     // If we run the GC every time, we will never get the SourceProvider cache hit.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -180,6 +180,7 @@
 #include "EventLoopTask.h"
 #include "NodeModuleModule.h"
 #include <JavaScriptCore/JSCBytecodeCacheVersion.h>
+#include <JavaScriptCore/CodeCache.h>
 #include "JSPerformanceServerTiming.h"
 #include "JSPerformanceResourceTiming.h"
 #include "JSPerformanceTiming.h"
@@ -3535,6 +3536,15 @@ void GlobalObject::reload()
     }
     this->requireMap()->clear(this);
     RETURN_IF_EXCEPTION(scope, );
+
+    // The VM's CodeCache is keyed by source text, so every reload of an edited
+    // file inserts a new UnlinkedModuleProgramCodeBlock entry that holds a
+    // Strong<> to the old SourceProvider (and its source string). Its prune
+    // policy only kicks in after ~10s elapsed or ~16 MB of accumulated source,
+    // which a tight edit-save loop never hits, so stale entries pile up
+    // unbounded. We already re-transpile every module after clearAll() above,
+    // so re-parsing cost here is marginal.
+    vm.codeCache()->clear();
 
     // If we run the GC every time, we will never get the SourceProvider cache hit.
     // So we run the GC every other time.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3537,13 +3537,8 @@ void GlobalObject::reload()
     this->requireMap()->clear(this);
     RETURN_IF_EXCEPTION(scope, );
 
-    // The VM's CodeCache is keyed by source text, so every reload of an edited
-    // file inserts a new UnlinkedModuleProgramCodeBlock entry that holds a
-    // Strong<> to the old SourceProvider (and its source string). Its prune
-    // policy only kicks in after ~10s elapsed or ~16 MB of accumulated source,
-    // which a tight edit-save loop never hits, so stale entries pile up
-    // unbounded. We already re-transpile every module after clearAll() above,
-    // so re-parsing cost here is marginal.
+    // Stale entries (keyed by old source text) pin their SourceProvider; every
+    // module already re-transpiles after clearAll() so re-parsing is marginal.
     vm.codeCache()->clear();
 
     // If we run the GC every time, we will never get the SourceProvider cache hit.

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -346,3 +346,13 @@ pub fn Bun__setSyntheticAllocationLimitForTesting(
         .store(limit, core::sync::atomic::Ordering::Relaxed);
     Ok(JSValue::js_number(prev as f64))
 }
+
+/// Number of live entries in the VM's ref-string source-code cache. Exposed via
+/// `bun:internal-for-testing` so --hot leak tests can observe the native-heap
+/// side of the leak (ref_strings entries are Box<[u8]> + ExternalStringImpl,
+/// not JS cells, so invisible to `heapStats()`).
+#[crate::host_fn(export = "Bun__refStringsCount")]
+pub fn Bun__refStringsCount(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    let count = VirtualMachine::get().ref_strings.count();
+    Ok(JSValue::js_number(f64::from(count)))
+}

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -347,10 +347,7 @@ pub fn Bun__setSyntheticAllocationLimitForTesting(
     Ok(JSValue::js_number(prev as f64))
 }
 
-/// Number of live entries in the VM's ref-string source-code cache. Exposed via
-/// `bun:internal-for-testing` so --hot leak tests can observe the native-heap
-/// side of the leak (ref_strings entries are Box<[u8]> + ExternalStringImpl,
-/// not JS cells, so invisible to `heapStats()`).
+/// Live entries in the VM's ref-string cache (native-heap; invisible to heapStats).
 #[crate::host_fn(export = "Bun__refStringsCount")]
 pub fn Bun__refStringsCount(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
     let count = VirtualMachine::get().ref_strings.count();

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -313,18 +313,9 @@ impl FileSystemRouter {
             root_dir_info.abs_path
         };
 
-        // Note: `vm.refCountedString` is an interning cache — on a cache HIT it
-        // returns the existing `*mut RefString` WITHOUT bumping the refcount.
-        // `getScriptSrc`/`getOrigin` use `.leak()` (no ref), so without an
-        // explicit hold N routers sharing one interned RefString → N finalizers
-        // deref a single +1 → UAF on the second deref. Claim an explicit +1 here
-        // so each `FileSystemRouter` owns its hold; `finalize` releases it.
+        // `ref_counted_string` hands back +1; `finalize` releases it.
         let claim = |p: *mut RefString| -> BackRef<RefString> {
-            // `ref_counted_string` returns a live interned `*mut RefString`; wrap as
-            // `BackRef` (owner-outlives-holder: VM intern cache + our +1).
-            let r = BackRef::from(core::ptr::NonNull::new(p).expect("ref_counted_string"));
-            r.ref_();
-            r
+            BackRef::from(core::ptr::NonNull::new(p).expect("ref_counted_string"))
         };
         let fs_router = Box::new(FileSystemRouter {
             origin: if !origin_str.slice().is_empty() {

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -39,8 +39,8 @@ pub use bun_install_jsc::ini_jsc::ini_testing_parse as ini_ini_ini_testing_ap_is
 pub use bun_jsc::bindgen_test::get_bindgen_test_functions as jsc_bindgen_test_get_bindgen_test_functions;
 pub use bun_jsc::counters::create_counters_object as jsc_counters_create_counters_object;
 pub use bun_jsc::event_loop::get_active_tasks as jsc_event_loop_get_active_tasks;
-pub use bun_jsc::virtual_machine_exports::Bun__setSyntheticAllocationLimitForTesting as jsc_virtual_machine_exports_bun__set_synthetic_allocation_limit_for_testing;
 pub use bun_jsc::virtual_machine_exports::Bun__refStringsCount as jsc_virtual_machine_exports_bun__ref_strings_count;
+pub use bun_jsc::virtual_machine_exports::Bun__setSyntheticAllocationLimitForTesting as jsc_virtual_machine_exports_bun__set_synthetic_allocation_limit_for_testing;
 // `emit_handle_ipc_message` is implemented in this crate (`ipc_host.rs`)
 // because it dereferences `Subprocess`, a runtime type.
 pub use crate::ipc_host::emit_handle_ipc_message as jsc_ipc_emit_handle_ipc_message;

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -40,6 +40,7 @@ pub use bun_jsc::bindgen_test::get_bindgen_test_functions as jsc_bindgen_test_ge
 pub use bun_jsc::counters::create_counters_object as jsc_counters_create_counters_object;
 pub use bun_jsc::event_loop::get_active_tasks as jsc_event_loop_get_active_tasks;
 pub use bun_jsc::virtual_machine_exports::Bun__setSyntheticAllocationLimitForTesting as jsc_virtual_machine_exports_bun__set_synthetic_allocation_limit_for_testing;
+pub use bun_jsc::virtual_machine_exports::Bun__refStringsCount as jsc_virtual_machine_exports_bun__ref_strings_count;
 // `emit_handle_ipc_message` is implemented in this crate (`ipc_host.rs`)
 // because it dereferences `Subprocess`, a runtime type.
 pub use crate::ipc_host::emit_handle_ipc_message as jsc_ipc_emit_handle_ipc_message;

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -772,7 +772,6 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     expect(reloadCounter).toBe(50);
     bundler.kill();
     await runner.exited;
-    // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
 );

--- a/test/regression/issue/11083.test.ts
+++ b/test/regression/issue/11083.test.ts
@@ -1,11 +1,4 @@
 // https://github.com/oven-sh/bun/issues/11083
-//
-// Each --hot reload of an edited file inserted a new UnlinkedModuleProgramCodeBlock
-// into JSC's CodeCache (keyed by source text) that holds a Strong<> to the
-// SourceProvider and its source string. On top of that, ref_counted_resolved_source()
-// leaked the +1 from create_external() so the duped source bytes and ref_strings
-// map slot survived forever even after the owning SourceProvider was collected.
-// reload() now clears the CodeCache and the ref is balanced.
 
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
@@ -19,9 +12,8 @@ test(
     using dir = tempDir("hot-11083", {});
     const root = join(String(dir), "leak-runner.mjs");
 
-    // Keep the file small so even a debug build cycles fast enough to outrun
-    // JSC's ~10s CodeCache prune timer. Content is unique every iteration so
-    // the cache key (source hash) never repeats.
+    // Small file so debug builds cycle faster than JSC's ~10s CodeCache prune
+    // timer; unique content each iteration so the cache key never repeats.
     const writeSource = (iter: number) => {
       writeFileSync(
         root,
@@ -33,7 +25,7 @@ const { refStringsCount } = require("bun:internal-for-testing");
 console.error(JSON.stringify({
   i: globalThis.__i,
   umpcb: s.objectTypeCounts.UnlinkedModuleProgramCodeBlock || 0,
-  refs: typeof refStringsCount === "function" ? refStringsCount() : 0,
+  refs: refStringsCount(),
 }));
 `,
       );
@@ -64,7 +56,7 @@ console.error(JSON.stringify({
         const line = buf.slice(0, nl);
         buf = buf.slice(nl + 1);
         if (!line.startsWith("{")) {
-          if (/Watcher crashed|panic:|oh no:/.test(line)) {
+          if (/Watcher crashed|panic:|oh no:|TypeError:|is not a function/.test(line)) {
             throw new Error("child --hot died: " + line);
           }
           continue;
@@ -83,18 +75,8 @@ console.error(JSON.stringify({
     }
 
     expect(reached).toBe(target);
-
-    // With the CodeCache cleared on every reload only the current module
-    // graph's blocks survive a sync GC (bun:main + this file = 2). Without it,
-    // one entry is added per reload and none are evicted inside the first
-    // ~10s, so this climbs to ~target.
     expect(maxCodeBlocks).toBeLessThan(10);
-
-    // ref_strings is native-heap (Box<[u8]> + ExternalStringImpl) and invisible
-    // to heapStats(); without the refcount balance fix each distinct transpiled
-    // source leaks a map slot forever (climbs to ~target). With the fix, entries
-    // self-remove when their SourceProvider is collected so only the current
-    // file's entry (plus a small number from builtin modules) survives.
+    expect(maxRefStrings).toBeGreaterThan(0);
     expect(maxRefStrings).toBeLessThan(10);
   },
   isDebug ? 60_000 : 20_000,

--- a/test/regression/issue/11083.test.ts
+++ b/test/regression/issue/11083.test.ts
@@ -2,10 +2,9 @@
 //
 // Each --hot reload of an edited file inserted a new UnlinkedModuleProgramCodeBlock
 // into JSC's CodeCache (keyed by source text) that holds a Strong<> to the
-// SourceProvider and its source string. The cache's prune only fires after ~10s
-// elapsed or ~16 MB accumulated, so a tight edit loop piled up stale entries
-// unbounded. On top of that, the ref_strings source cache leaked its initial +1
-// ref so the duped source bytes survived even after the provider was collected.
+// SourceProvider and its source string. On top of that, ref_counted_resolved_source()
+// leaked the +1 from create_external() so the duped source bytes and ref_strings
+// map slot survived forever even after the owning SourceProvider was collected.
 // reload() now clears the CodeCache and the ref is balanced.
 
 import { spawn } from "bun";
@@ -15,7 +14,7 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 test(
-  "bun --hot should not accumulate stale code blocks when file content changes on every reload",
+  "bun --hot should not accumulate stale code blocks or ref-string entries when file content changes on every reload",
   async () => {
     using dir = tempDir("hot-11083", {});
     const root = join(String(dir), "leak-runner.mjs");
@@ -30,9 +29,11 @@ test(
 Bun.gc(true);
 globalThis.__i = (globalThis.__i ?? 0) + 1;
 const s = require("bun:jsc").heapStats();
+const { refStringsCount } = require("bun:internal-for-testing");
 console.error(JSON.stringify({
   i: globalThis.__i,
   umpcb: s.objectTypeCounts.UnlinkedModuleProgramCodeBlock || 0,
+  refs: typeof refStringsCount === "function" ? refStringsCount() : 0,
 }));
 `,
       );
@@ -52,6 +53,7 @@ console.error(JSON.stringify({
 
     const target = 50;
     let maxCodeBlocks = 0;
+    let maxRefStrings = 0;
     let reached = 0;
     let buf = "";
     outer: for await (const chunk of runner.stderr!) {
@@ -61,10 +63,16 @@ console.error(JSON.stringify({
       while ((nl = buf.indexOf("\n")) >= 0) {
         const line = buf.slice(0, nl);
         buf = buf.slice(nl + 1);
-        if (!line.startsWith("{")) continue;
-        const { i, umpcb } = JSON.parse(line);
+        if (!line.startsWith("{")) {
+          if (/Watcher crashed|panic:|oh no:/.test(line)) {
+            throw new Error("child --hot died: " + line);
+          }
+          continue;
+        }
+        const { i, umpcb, refs } = JSON.parse(line);
         reached = i;
         maxCodeBlocks = Math.max(maxCodeBlocks, umpcb);
+        maxRefStrings = Math.max(maxRefStrings, refs);
         progressed = true;
         if (i >= target) {
           runner.kill();
@@ -79,11 +87,15 @@ console.error(JSON.stringify({
     // With the CodeCache cleared on every reload only the current module
     // graph's blocks survive a sync GC (bun:main + this file = 2). Without it,
     // one entry is added per reload and none are evicted inside the first
-    // ~10s, so this climbs to ~target. The leaked code block pins its
-    // SourceProvider and source string, so this single count covers the whole
-    // chain; a heap-wide JSString delta would be noisier under conservative
-    // GC / JIT tier-up without adding coverage.
+    // ~10s, so this climbs to ~target.
     expect(maxCodeBlocks).toBeLessThan(10);
+
+    // ref_strings is native-heap (Box<[u8]> + ExternalStringImpl) and invisible
+    // to heapStats(); without the refcount balance fix each distinct transpiled
+    // source leaks a map slot forever (climbs to ~target). With the fix, entries
+    // self-remove when their SourceProvider is collected so only the current
+    // file's entry (plus a small number from builtin modules) survives.
+    expect(maxRefStrings).toBeLessThan(10);
   },
   isDebug ? 60_000 : 20_000,
 );

--- a/test/regression/issue/11083.test.ts
+++ b/test/regression/issue/11083.test.ts
@@ -1,0 +1,89 @@
+// https://github.com/oven-sh/bun/issues/11083
+//
+// Each --hot reload of an edited file inserted a new UnlinkedModuleProgramCodeBlock
+// into JSC's CodeCache (keyed by source text) that holds a Strong<> to the
+// SourceProvider and its source string. The cache's prune only fires after ~10s
+// elapsed or ~16 MB accumulated, so a tight edit loop piled up stale entries
+// unbounded. On top of that, the ref_strings source cache leaked its initial +1
+// ref so the duped source bytes survived even after the provider was collected.
+// reload() now clears the CodeCache and the ref is balanced.
+
+import { spawn } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+test(
+  "bun --hot should not accumulate stale code blocks when file content changes on every reload",
+  async () => {
+    using dir = tempDir("hot-11083", {});
+    const root = join(String(dir), "leak-runner.mjs");
+
+    // Keep the file small so even a debug build cycles fast enough to outrun
+    // JSC's ~10s CodeCache prune timer. Content is unique every iteration so
+    // the cache key (source hash) never repeats.
+    const writeSource = (iter: number) => {
+      writeFileSync(
+        root,
+        `var unused_${iter} = ${iter};
+Bun.gc(true);
+globalThis.__i = (globalThis.__i ?? 0) + 1;
+const s = require("bun:jsc").heapStats();
+console.error(JSON.stringify({
+  i: globalThis.__i,
+  umpcb: s.objectTypeCounts.UnlinkedModuleProgramCodeBlock || 0,
+}));
+`,
+      );
+    };
+
+    let iter = 0;
+    writeSource(++iter);
+
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", root],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const target = 50;
+    let maxCodeBlocks = 0;
+    let reached = 0;
+    let buf = "";
+    outer: for await (const chunk of runner.stderr!) {
+      buf += new TextDecoder().decode(chunk);
+      let nl: number;
+      let progressed = false;
+      while ((nl = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.startsWith("{")) continue;
+        const { i, umpcb } = JSON.parse(line);
+        reached = i;
+        maxCodeBlocks = Math.max(maxCodeBlocks, umpcb);
+        progressed = true;
+        if (i >= target) {
+          runner.kill();
+          break outer;
+        }
+      }
+      if (progressed) writeSource(++iter);
+    }
+
+    expect(reached).toBe(target);
+
+    // With the CodeCache cleared on every reload only the current module
+    // graph's blocks survive a sync GC (bun:main + this file = 2). Without it,
+    // one entry is added per reload and none are evicted inside the first
+    // ~10s, so this climbs to ~target. The leaked code block pins its
+    // SourceProvider and source string, so this single count covers the whole
+    // chain; a heap-wide JSString delta would be noisier under conservative
+    // GC / JIT tier-up without adding coverage.
+    expect(maxCodeBlocks).toBeLessThan(10);
+  },
+  isDebug ? 60_000 : 20_000,
+);


### PR DESCRIPTION
Fixes #11083
Fixes #14734

Re-applies #30553 (closed unmerged when the Rust rewrite moved the files) against the current tree, with the refcount invariant pushed into the shared helper so it also covers `FileSystemRouter`.

## Reproduction

```ts
import { spawn } from "bun";
import { writeFileSync } from "node:fs";

let i = 0;
function next() {
  i++;
  writeFileSync("hello.mjs", `var x = ${i};
Bun.gc(true);
const s = require("bun:jsc").heapStats();
console.error(JSON.stringify({ i: ${i}, umpcb: s.objectTypeCounts.UnlinkedModuleProgramCodeBlock || 0 }));
`);
}
next();
await using runner = spawn({
  cmd: [process.execPath, "--hot", "run", "hello.mjs"],
  stdio: ["ignore", "ignore", "pipe"],
});
for await (const chunk of runner.stderr) {
  if (new TextDecoder().decode(chunk).includes("}")) next();
}
```

`heapStats().objectTypeCounts.UnlinkedModuleProgramCodeBlock` climbs exactly +1 per reload with no upper bound; RSS grows linearly.

## Cause

Two leaks on the `--hot` reload path whenever the edited file's content changes. They are not independent: the refcount fix only drains once the SourceProvider is released, which needs the CodeCache entry gone.

### `ref_strings` leaks its initial ref

`ref_counted_string()` returned +1 on a fresh insert (from `String::create_external()`) but +0 on a cache hit. `ref_counted_resolved_source()` set `source_code_needs_deref = false`, so the fresh-insert +1 was never balanced. The `ref_strings` map is weak (entries self-remove via `free_ref_string -> RefString::destroy -> clear_ref_string` when the impl refcount hits zero), but with that leaked +1 the `ExternalStringImpl` refcount could never reach zero, so the duped source bytes and the map slot survived forever even after the owning `SourceProvider` was collected.

`FileSystemRouter` had the same bug: `claim()` took an unconditional +1 on whatever `ref_counted_string` returned, so a fresh origin/base_dir/asset_prefix leaked +1 after `finalize()` released its single hold.

### JSC CodeCache accumulates stale entries

`JSC::CodeCache` is keyed by source text (`SourceCodeKey` = hash + length + flags). Every reload of an edited file produces a different transpiled string, so `getUnlinkedModuleProgramCodeBlock` misses and inserts a fresh entry holding a `Strong<UnlinkedModuleProgramCodeBlock>`, whose key keeps the old `Zig::SourceProvider` (and its source `StringImpl`) alive via `RefPtr`.

The cache's `prune()` only runs `pruneSlowCase()` when ~10s have elapsed, or the working set grew by ~16 MB of source text, or it hit 2000 entries. A tight edit-save loop hits none of these, so one entry is added per reload and none are evicted. The cap is in source bytes, not code-block overhead, so 16 MB of pinned source can hold substantially more in `UnlinkedModuleProgramCodeBlock` + `SourceProvider` objects.

## Fix

- `ref_counted_string()` now always returns exactly +1 (takes an extra ref on cache hit). Callers consume it uniformly: `ref_counted_resolved_source` sets `source_code_needs_deref = true`, and `FileSystemRouter::claim` drops its extra ref.
- `GlobalObject::reload()` calls `vm.codeCache()->clear()` alongside `moduleLoader()->clearAll()` / `requireMap()->clear()`. Every module already goes through fetch + transpile after `clearAll()`, so the added JSC re-parse is a fraction of the existing per-reload work; it trades that for not pinning up to ~2000 stale code blocks between prunes.

## Verification

`refStringsCount()` is exposed via `bun:internal-for-testing` so the test can observe the native-heap side (ref_strings entries are `Box<[u8]>` + `ExternalStringImpl`, invisible to `heapStats()`).

`test/regression/issue/11083.test.ts` does 50 reloads with unique content each time and asserts both the max live `UnlinkedModuleProgramCodeBlock` count and the `ref_strings` count stay under 10. With the fix both sit at 1-2; reverting either half drives its counter to ~50.

| build | maxCodeBlocks | maxRefStrings | result |
|---|---|---|---|
| both fixes | 2 | 1 | pass |
| CodeCache clear only | 2 | 45 | fail (refs) |
| neither (system bun) | 51 | n/a | fail (throws) |

`test/cli/hot/hot.test.ts` (12 tests) and `test/js/bun/util/filesystem_router.test.ts` (29 tests, including the UAF guard) remain green.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/hot.test.ts

<!-- robobun:evidence:end -->