### PR TITLE
cli: honor --bun / [run] bun for `bun <file>` and `bun -e`

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1048,6 +1048,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             crate::run_main::fail_with_build_error(vm);
         }
 
+        Self::ensure_node_shim_on_path(vm.transpiler.env_mut(), ctx.debug.run_in_bun);
+
         // Allow setting a custom timezone. Without `$TZ`, JSC/ICU lazily
         // auto-detects the host zone the first time a `Date` is constructed —
         // matching upstream Bun. `.env` files are loaded by
@@ -1878,6 +1880,66 @@ impl RunCommand {
     ) -> crate::Result<()> {
         bun_install::RunCommand::create_fake_temporary_node_executable(path, optional_bun_path)
             .map_err(Into::into)
+    }
+
+    /// Prepends the bun-node shim dir to the `PATH` stored in `env` when
+    /// `--bun` / `[run] bun` is set or `node` is not already resolvable.
+    ///
+    /// This is the shim half of [`Self::configure_path_for_run`], applied from
+    /// [`Self::boot`] so that code paths that boot the VM without going through
+    /// `configure_path_for_run` (the `bun <file>` / `bun run ./<file>` fast
+    /// path, `bun -e`, `bun -p`) still see a `node` on `$PATH`. It is a no-op
+    /// when `configure_path_for_run` has already run (it would have prepended
+    /// the same shim dir), and when running as the `node` shim
+    /// (`PRETEND_TO_BE_NODE` short-circuits inside the create call).
+    #[cold]
+    fn ensure_node_shim_on_path(env: &mut DotEnv::Loader, force_using_bun: bool) {
+        let Ok(bun_node_exe) = Self::bun_node_file_utf8() else {
+            return;
+        };
+        let Some(bun_node_dir) = bun_paths::dirname(bun_node_exe.as_bytes()) else {
+            return;
+        };
+
+        let path = env.get(b"PATH").unwrap_or(b"");
+        // `configure_path_for_run` always prepends the shim dir first; if it
+        // already did, do nothing.
+        if strings::has_prefix(path, bun_node_dir)
+            && path.get(bun_node_dir.len()).copied() == Some(DELIMITER)
+        {
+            return;
+        }
+
+        if !force_using_bun {
+            let mut buf = PathBuffer::uninit();
+            if which(&mut buf, path, b"", b"node").is_some() {
+                return;
+            }
+        }
+
+        let mut new_path: Vec<u8> = Vec::with_capacity(bun_node_dir.len() + 1 + path.len());
+        let mut optional_bun_self_path: &[u8] = b"";
+        if Self::create_fake_temporary_node_executable(&mut new_path, &mut optional_bun_self_path)
+            .is_err()
+        {
+            return;
+        }
+        if new_path.is_empty() {
+            return;
+        }
+        new_path.extend_from_slice(path);
+        env.map.put(b"PATH", &new_path).unwrap_or_oom();
+        env.map
+            .put(b"NODE", bun_node_exe.as_bytes())
+            .unwrap_or_oom();
+        env.map
+            .put(b"npm_node_execpath", bun_node_exe.as_bytes())
+            .unwrap_or_oom();
+        if !optional_bun_self_path.is_empty() {
+            env.map
+                .put_default(b"npm_execpath", optional_bun_self_path)
+                .unwrap_or_oom();
+        }
     }
 
     /// Prepends workspace

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1048,7 +1048,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             crate::run_main::fail_with_build_error(vm);
         }
 
-        Self::ensure_node_shim_on_path(vm.transpiler.env_mut(), ctx.debug.run_in_bun);
+        if ctx.debug.run_in_bun {
+            Self::prepend_node_shim(vm.transpiler.env_mut());
+        }
 
         // Allow setting a custom timezone. Without `$TZ`, JSC/ICU lazily
         // auto-detects the host zone the first time a `Date` is constructed —
@@ -1882,39 +1884,25 @@ impl RunCommand {
             .map_err(Into::into)
     }
 
-    /// Prepends the bun-node shim dir to the `PATH` stored in `env` when
-    /// `--bun` / `[run] bun` is set or `node` is not already resolvable.
-    ///
-    /// This is the shim half of [`Self::configure_path_for_run`], applied from
-    /// [`Self::boot`] so that code paths that boot the VM without going through
-    /// `configure_path_for_run` (the `bun <file>` / `bun run ./<file>` fast
-    /// path, `bun -e`, `bun -p`) still see a `node` on `$PATH`. It is a no-op
-    /// when `configure_path_for_run` has already run (it would have prepended
-    /// the same shim dir), and when running as the `node` shim
-    /// (`PRETEND_TO_BE_NODE` short-circuits inside the create call).
+    /// `--bun` shim half of [`Self::configure_path_for_run`] for boot paths that skip it (fast-path `bun <file>`, `bun -e`, `bun -p`).
     #[cold]
-    fn ensure_node_shim_on_path(env: &mut DotEnv::Loader, force_using_bun: bool) {
+    #[inline(never)]
+    fn prepend_node_shim(env: &mut DotEnv::Loader) {
         let Ok(bun_node_exe) = Self::bun_node_file_utf8() else {
             return;
         };
+        #[cfg(not(windows))]
+        let bun_node_dir = bun_node_exe.as_bytes();
+        #[cfg(windows)]
         let Some(bun_node_dir) = bun_paths::dirname(bun_node_exe.as_bytes()) else {
             return;
         };
 
         let path = env.get(b"PATH").unwrap_or(b"");
-        // `configure_path_for_run` always prepends the shim dir first; if it
-        // already did, do nothing.
         if strings::has_prefix(path, bun_node_dir)
             && path.get(bun_node_dir.len()).copied() == Some(DELIMITER)
         {
             return;
-        }
-
-        if !force_using_bun {
-            let mut buf = PathBuffer::uninit();
-            if which(&mut buf, path, b"", b"node").is_some() {
-                return;
-            }
         }
 
         let mut new_path: Vec<u8> = Vec::with_capacity(bun_node_dir.len() + 1 + path.len());

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -249,10 +249,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
   });
 });
 
-// Issue #7703: `bun <file>` / `bun -e` boots the VM through a fast path that
-// used to skip the bun-node shim dir, so a child with a `#!/usr/bin/env node`
-// shebang could not find `node` even though `bun run <script>` could.
-describe("node shim for file entry points", () => {
+describe("--bun node shim for file entry points (#7703)", () => {
   const execPath = process.execPath;
   const whereNode = `
     const node = Bun.which("node");
@@ -265,7 +262,7 @@ describe("node shim for file entry points", () => {
     ["bun run ./<file>", ["run", "./where-node.js"]],
     ["bun -e", ["-e", whereNode]],
   ] as const) {
-    test.concurrent(`--bun adds the node shim for \`${label}\``, async () => {
+    test(`--bun adds the node shim for \`${label}\``, async () => {
       const cwd = tempDirWithFiles("run.bun.file", { "where-node.js": whereNode });
       await using proc = Bun.spawn({
         cmd: [bunExe(), "--bun", ...argv],
@@ -285,7 +282,7 @@ describe("node shim for file entry points", () => {
     });
   }
 
-  test.concurrent("bunfig [run] bun=true adds the node shim for `bun <file>`", async () => {
+  test("bunfig [run] bun=true adds the node shim for `bun <file>`", async () => {
     const cwd = tempDirWithFiles("run.bun.file", {
       "bunfig.toml": toTOMLString({ run: { bun: true } }),
       "where-node.js": whereNode,
@@ -307,7 +304,7 @@ describe("node shim for file entry points", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent.skipIf(isWindows)("spawning a bin with a node shebang works without node on PATH", async () => {
+  test.skipIf(isWindows)("spawning a bin with a node shebang works under --bun without node on PATH", async () => {
     const cwd = tempDirWithFiles("run.bun.shebang", {
       "bin/my-cli": `#!/usr/bin/env node\nprocess.stdout.write("ran under " + process.argv0);\n`,
       "index.js": `
@@ -319,7 +316,7 @@ describe("node shim for file entry points", () => {
     });
     chmodSync(pathJoin(cwd, "bin", "my-cli"), 0o755);
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "index.js"],
+      cmd: [bunExe(), "--bun", "index.js"],
       env: { ...bunEnv, PATH: pathJoin(cwd, "bin") },
       stdout: "pipe",
       stderr: "pipe",

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { realpathSync } from "fs";
+import { chmodSync, realpathSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDirWithFiles, toTOMLString } from "harness";
 import { join as pathJoin } from "node:path";
 
@@ -247,4 +247,90 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
     expect(realpathSync(nodeBin)).toBe(realpathSync(node));
     expect(result.success).toBeTrue();
   });
+});
+
+// Issue #7703: `bun <file>` / `bun -e` boots the VM through a fast path that
+// used to skip the bun-node shim dir, so a child with a `#!/usr/bin/env node`
+// shebang could not find `node` even though `bun run <script>` could.
+describe("node shim for file entry points", () => {
+  const execPath = process.execPath;
+  const whereNode = `
+    const node = Bun.which("node");
+    if (!node) throw new Error("node not on PATH");
+    console.log(require("fs").realpathSync(node));
+  `;
+
+  for (const [label, argv] of [
+    ["bun <file>", ["./where-node.js"]],
+    ["bun run ./<file>", ["run", "./where-node.js"]],
+    ["bun -e", ["-e", whereNode]],
+  ] as const) {
+    test.concurrent(`--bun adds the node shim for \`${label}\``, async () => {
+      const cwd = tempDirWithFiles("run.bun.file", { "where-node.js": whereNode });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--bun", ...argv],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr.trim()).toBe("");
+      if (isWindows) {
+        expect(stdout.trim()).toContain("\\bun-node-");
+      } else {
+        expect(stdout.trim()).toBe(realpathSync(execPath));
+      }
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test.concurrent("bunfig [run] bun=true adds the node shim for `bun <file>`", async () => {
+    const cwd = tempDirWithFiles("run.bun.file", {
+      "bunfig.toml": toTOMLString({ run: { bun: true } }),
+      "where-node.js": whereNode,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-c=bunfig.toml", "./where-node.js"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.trim()).toBe("");
+    if (isWindows) {
+      expect(stdout.trim()).toContain("\\bun-node-");
+    } else {
+      expect(stdout.trim()).toBe(realpathSync(execPath));
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent.skipIf(isWindows)(
+    "spawning a bin with a node shebang works without node on PATH",
+    async () => {
+      const cwd = tempDirWithFiles("run.bun.shebang", {
+        "bin/my-cli": `#!/usr/bin/env node\nprocess.stdout.write("ran under " + process.argv0);\n`,
+        "index.js": `
+        const result = Bun.spawnSync({ cmd: ["my-cli"], stdout: "pipe", stderr: "pipe" });
+        process.stdout.write(result.stdout.toString());
+        process.stderr.write(result.stderr.toString());
+        process.exit(result.exitCode);
+      `,
+      });
+      chmodSync(pathJoin(cwd, "bin", "my-cli"), 0o755);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.js"],
+        env: { ...bunEnv, PATH: pathJoin(cwd, "bin") },
+        stdout: "pipe",
+        stderr: "pipe",
+        cwd,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("ran under node");
+      expect(exitCode).toBe(0);
+    },
+  );
 });

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -307,30 +307,27 @@ describe("node shim for file entry points", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent.skipIf(isWindows)(
-    "spawning a bin with a node shebang works without node on PATH",
-    async () => {
-      const cwd = tempDirWithFiles("run.bun.shebang", {
-        "bin/my-cli": `#!/usr/bin/env node\nprocess.stdout.write("ran under " + process.argv0);\n`,
-        "index.js": `
+  test.concurrent.skipIf(isWindows)("spawning a bin with a node shebang works without node on PATH", async () => {
+    const cwd = tempDirWithFiles("run.bun.shebang", {
+      "bin/my-cli": `#!/usr/bin/env node\nprocess.stdout.write("ran under " + process.argv0);\n`,
+      "index.js": `
         const result = Bun.spawnSync({ cmd: ["my-cli"], stdout: "pipe", stderr: "pipe" });
         process.stdout.write(result.stdout.toString());
         process.stderr.write(result.stderr.toString());
         process.exit(result.exitCode);
       `,
-      });
-      chmodSync(pathJoin(cwd, "bin", "my-cli"), 0o755);
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "index.js"],
-        env: { ...bunEnv, PATH: pathJoin(cwd, "bin") },
-        stdout: "pipe",
-        stderr: "pipe",
-        cwd,
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("ran under node");
-      expect(exitCode).toBe(0);
-    },
-  );
+    });
+    chmodSync(pathJoin(cwd, "bin", "my-cli"), 0o755);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: { ...bunEnv, PATH: pathJoin(cwd, "bin") },
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ran under node");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
Related to #7703.

## Repro

```sh
bun --bun -e 'console.log(Bun.which("node"))'
```

With Node installed this prints the real `node` on `$PATH` instead of the bun shim; with Node absent it prints `null`. Compare with `bun run --bun <script>`, which resolves `node` to bun in both cases.

## Cause

`--bun` and `[run] bun = true` are implemented inside `configure_path_for_run`, which prepends `<tmp>/bun-node-*/` to `$PATH` and sets `NODE`/`npm_node_execpath`. The fast path in `RunCommand::exec` (taken when the target is a file) returns from `maybe_open_with_bun_js` before `configure_path_for_run` is ever reached, and `bun -e` / `bun -p` route through `exec_eval`, which never calls it either. So the flag was a no-op on those entry points even though the docs describe it as applying to both `bun run` and `bun`.

## Fix

Add `RunCommand::prepend_node_shim`, called from `RunCommand::boot` when `ctx.debug.run_in_bun` is set (and only then, so plain `bun foo.js` startup is byte-for-byte unchanged). It creates the `node` symlink via the existing `create_fake_temporary_node_executable` helper and prepends the shim dir to the env loader's `PATH`, skipping when the slow path already prepended it. `.bin`-dir stitching is deliberately not applied here.

#7703 as reported (no `--bun`, no system Node) is not auto-fixed: extending the `bun run` "when `node` is absent from `$PATH`" fallback to the file fast path injects `PATH`/`NODE`/`npm_node_execpath` into `process.env` for every process spawned with a minimal env (breaks `child_process.test.ts` "should allow us to set env") and adds a `which("node")` probe to every `bun <file>` cold start. Users without a system Node can pass `--bun` or set `[run] bun = true` in `bunfig.toml`, both of which now work for file entry points.

## Tests

New tests in `test/cli/install/bun-run-bunfig.test.ts`:

- `bun --bun ./file.js`, `bun --bun run ./file.js`, `bun --bun -e '...'` each resolve `node` to the running bun binary
- `bunfig.toml` `[run] bun=true` does the same for `bun ./file.js`
- (POSIX) spawning a `#!/usr/bin/env node` bin from `bun --bun file.js` with no `node` on `$PATH` succeeds

All five fail on main with `env: 'node': No such file or directory` (test 5) or by resolving the system `node` (tests 1-4).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-run-bunfig.test.ts

<!-- robobun:evidence:end -->