### PR TITLE
node:dns: IDNA-encode internationalized hostnames in resolve* and lookup

### DIFF
--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -176,10 +176,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, J
     return JSC::JSValue::encode(JSC::jsString(vm, host));
 }
 
-// IDNA-encode a hostname for node:dns resolve*/lookup. The caller has already
-// verified `input` contains non-ASCII bytes. Returns the number of ASCII bytes
-// written to `output`, or 0 if encoding failed or would not fit (Node.js passes
-// an empty name to c-ares in that case, which then rejects the query).
+// Returns ASCII bytes written, or 0 on IDNA failure or overflow.
 extern "C" int32_t Bun__hostnameToASCII(const char* input, size_t input_len, char* output, size_t output_cap)
 {
     auto domain = WTF::String::fromUTF8(std::span { input, input_len });

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -176,6 +176,37 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, J
     return JSC::JSValue::encode(JSC::jsString(vm, host));
 }
 
+// IDNA-encode a hostname for node:dns resolve*/lookup. The caller has already
+// verified `input` contains non-ASCII bytes. Returns the number of ASCII bytes
+// written to `output`, or 0 if encoding failed or would not fit (Node.js passes
+// an empty name to c-ares in that case, which then rejects the query).
+extern "C" int32_t Bun__hostnameToASCII(const char* input, size_t input_len, char* output, size_t output_cap)
+{
+    auto domain = WTF::String::fromUTF8(std::span { input, input_len });
+    if (domain.isNull())
+        return 0;
+    if (domain.is8Bit())
+        domain.convertTo16Bit();
+
+    constexpr static int allowedNameToASCIIErrors = UIDNA_ERROR_EMPTY_LABEL | UIDNA_ERROR_LABEL_TOO_LONG | UIDNA_ERROR_DOMAIN_NAME_TOO_LONG | UIDNA_ERROR_LEADING_HYPHEN | UIDNA_ERROR_TRAILING_HYPHEN | UIDNA_ERROR_HYPHEN_3_4;
+    constexpr static size_t hostnameBufferLength = 2048;
+
+    auto encoder = &WTF::URLParser::internationalDomainNameTranscoder();
+    char16_t hostnameBuffer[hostnameBufferLength];
+    UErrorCode error = U_ZERO_ERROR;
+    UIDNAInfo processingDetails = UIDNA_INFO_INITIALIZER;
+    const auto span = domain.span16();
+    int32_t numCharactersConverted = uidna_nameToASCII(encoder, span.data(), span.size(), hostnameBuffer, hostnameBufferLength, &processingDetails, &error);
+
+    if (!U_SUCCESS(error) || (processingDetails.errors & ~allowedNameToASCIIErrors) || numCharactersConverted <= 0)
+        return 0;
+    if (static_cast<size_t>(numCharactersConverted) > output_cap)
+        return 0;
+    for (int32_t i = 0; i < numCharactersConverted; i++)
+        output[i] = static_cast<char>(hostnameBuffer[i]);
+    return numCharactersConverted;
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -182,26 +182,19 @@ extern "C" int32_t Bun__hostnameToASCII(const char* input, size_t input_len, cha
     auto domain = WTF::String::fromUTF8(std::span { input, input_len });
     if (domain.isNull())
         return 0;
-    if (domain.is8Bit())
-        domain.convertTo16Bit();
 
-    constexpr static int allowedNameToASCIIErrors = UIDNA_ERROR_EMPTY_LABEL | UIDNA_ERROR_LABEL_TOO_LONG | UIDNA_ERROR_DOMAIN_NAME_TOO_LONG | UIDNA_ERROR_LEADING_HYPHEN | UIDNA_ERROR_TRAILING_HYPHEN | UIDNA_ERROR_HYPHEN_3_4;
-    constexpr static size_t hostnameBufferLength = 2048;
-
-    auto encoder = &WTF::URLParser::internationalDomainNameTranscoder();
-    char16_t hostnameBuffer[hostnameBufferLength];
-    UErrorCode error = U_ZERO_ERROR;
-    UIDNAInfo processingDetails = UIDNA_INFO_INITIALIZER;
-    const auto span = domain.span16();
-    int32_t numCharactersConverted = uidna_nameToASCII(encoder, span.data(), span.size(), hostnameBuffer, hostnameBufferLength, &processingDetails, &error);
-
-    if (!U_SUCCESS(error) || (processingDetails.errors & ~allowedNameToASCIIErrors) || numCharactersConverted <= 0)
+    auto ascii = icuToASCII(domain, IDNAMode::Default);
+    if (ascii.isEmpty() || ascii.length() > output_cap)
         return 0;
-    if (static_cast<size_t>(numCharactersConverted) > output_cap)
-        return 0;
-    for (int32_t i = 0; i < numCharactersConverted; i++)
-        output[i] = static_cast<char>(hostnameBuffer[i]);
-    return numCharactersConverted;
+
+    if (ascii.is8Bit()) {
+        memcpy(output, ascii.span8().data(), ascii.length());
+    } else {
+        const auto span = ascii.span16();
+        for (size_t i = 0; i < span.size(); i++)
+            output[i] = static_cast<char>(span[i]);
+    }
+    return static_cast<int32_t>(ascii.length());
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -312,6 +312,31 @@ pub(crate) mod lib_uv_backend {
 // normalizeDNSName
 // ──────────────────────────────────────────────────────────────────────────
 
+unsafe extern "C" {
+    fn Bun__hostnameToASCII(
+        input: *const u8,
+        input_len: usize,
+        output: *mut u8,
+        output_cap: usize,
+    ) -> i32;
+}
+
+/// IDNA-encode a hostname for node:dns, matching Node.js's `ada::idna::to_ascii`
+/// step in cares_wrap before `ares_query`/`uv_getaddrinfo`. ASCII-only names
+/// pass through unchanged (DNS is case-insensitive). Returns an empty slice on
+/// encoding failure, which c-ares then rejects the same way Node.js does.
+fn hostname_to_ascii<'a>(name: &'a [u8], buf: &'a mut [u8; 1024]) -> &'a [u8] {
+    if strings::first_non_ascii(name).is_none() {
+        return name;
+    }
+    // SAFETY: `buf` is a valid 1024-byte buffer; `name` is a valid slice.
+    let n = unsafe { Bun__hostnameToASCII(name.as_ptr(), name.len(), buf.as_mut_ptr(), buf.len()) };
+    if n <= 0 {
+        return &[];
+    }
+    &buf[..n as usize]
+}
+
 fn normalize_dns_name<'a>(name: &'a [u8], backend: &mut GetAddrInfoBackend) -> &'a [u8] {
     if *backend == GetAddrInfoBackend::CAres {
         // https://github.com/c-ares/c-ares/issues/477
@@ -5151,6 +5176,9 @@ impl Resolver {
         options: GetAddrInfoOptions,
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
+        let mut ascii_buf = [0u8; 1024];
+        let name = hostname_to_ascii(name, &mut ascii_buf);
+
         // The system backends copy the hostname into a fixed `bun.PathBuffer` on the
         // stack before null-terminating it. Reject anything that cannot fit so we never
         // index past that buffer. RFC 1035 caps hostnames at 253 octets and NI_MAXHOST
@@ -5355,6 +5383,9 @@ impl Resolver {
         name: &[u8],
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
+        let mut ascii_buf = [0u8; 1024];
+        let name = hostname_to_ascii(name, &mut ascii_buf);
+
         let channel: *mut c_ares::Channel = match self.get_channel() {
             ChannelResult::Result(res) => res,
             ChannelResult::Err(err) => {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -321,10 +321,8 @@ unsafe extern "C" {
     ) -> i32;
 }
 
-/// IDNA-encode a hostname for node:dns, matching Node.js's `ada::idna::to_ascii`
-/// step in cares_wrap before `ares_query`/`uv_getaddrinfo`. ASCII-only names
-/// pass through unchanged (DNS is case-insensitive). Returns an empty slice on
-/// encoding failure, which c-ares then rejects the same way Node.js does.
+/// Node.js's `ada::idna::to_ascii` step before `ares_query`/`uv_getaddrinfo`.
+/// ASCII names pass through; IDNA failure yields an empty slice c-ares rejects.
 fn hostname_to_ascii<'a>(name: &'a [u8], buf: &'a mut [u8; 1024]) -> &'a [u8] {
     if strings::first_non_ascii(name).is_none() {
         return name;
@@ -5422,9 +5420,7 @@ impl Resolver {
         // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
         let promise = unsafe { (*(*request).tail).promise.value() };
 
-        // Node.js sets `req.hostname` to the caller's argument before
-        // `ada::idna::to_ascii` runs in cares_wrap, so `err.hostname` always
-        // echoes the original spelling. Encode only the wire name here.
+        // Encode for the wire only so `err.hostname` still echoes the caller's spelling.
         let mut ascii_buf = [0u8; 1024];
         let ascii_name = hostname_to_ascii(name, &mut ascii_buf);
 

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -321,8 +321,6 @@ unsafe extern "C" {
     ) -> i32;
 }
 
-/// Node.js's `ada::idna::to_ascii` step before `ares_query`/`uv_getaddrinfo`.
-/// ASCII names pass through; IDNA failure yields an empty slice c-ares rejects.
 fn hostname_to_ascii<'a>(name: &'a [u8], buf: &'a mut [u8; 1024]) -> &'a [u8] {
     if strings::first_non_ascii(name).is_none() {
         return name;

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -321,16 +321,18 @@ unsafe extern "C" {
     ) -> i32;
 }
 
-fn hostname_to_ascii<'a>(name: &'a [u8], buf: &'a mut [u8; 1024]) -> &'a [u8] {
+/// `None` when the name is not valid IDNA. Callers must reject it themselves:
+/// an empty name is a legitimate root-zone query for NS/SOA in `Channel::resolve`.
+fn hostname_to_ascii<'a>(name: &'a [u8], buf: &'a mut [u8; 1024]) -> Option<&'a [u8]> {
     if strings::first_non_ascii(name).is_none() {
-        return name;
+        return Some(name);
     }
     // SAFETY: `buf` is a valid 1024-byte buffer; `name` is a valid slice.
     let n = unsafe { Bun__hostnameToASCII(name.as_ptr(), name.len(), buf.as_mut_ptr(), buf.len()) };
     if n <= 0 {
-        return &[];
+        return None;
     }
-    &buf[..n as usize]
+    Some(&buf[..n as usize])
 }
 
 fn normalize_dns_name<'a>(name: &'a [u8], backend: &mut GetAddrInfoBackend) -> &'a [u8] {
@@ -5173,28 +5175,31 @@ impl Resolver {
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
         let mut ascii_buf = [0u8; 1024];
-        let name = hostname_to_ascii(name, &mut ascii_buf);
-
         // The system backends copy the hostname into a fixed `bun.PathBuffer` on the
         // stack before null-terminating it. Reject anything that cannot fit so we never
         // index past that buffer. RFC 1035 caps hostnames at 253 octets and NI_MAXHOST
         // is 1025, so this never rejects a name that could have resolved.
-        if name.len() >= MAX_PATH_BYTES || strings::contains_char(name, 0) {
-            let mut promise = JSPromiseStrong::init(global_this);
-            let promise_value = promise.value();
-            error_to_deferred(
-                c_ares::Error::ENOTFOUND,
-                b"getaddrinfo",
-                Some(name),
-                &mut promise,
-            )
-            .reject_later(global_this);
-            return Ok(promise_value);
-        }
+        let ascii_name = match hostname_to_ascii(name, &mut ascii_buf) {
+            Some(ascii) if ascii.len() < MAX_PATH_BYTES && !strings::contains_char(ascii, 0) => {
+                ascii
+            }
+            _ => {
+                let mut promise = JSPromiseStrong::init(global_this);
+                let promise_value = promise.value();
+                error_to_deferred(
+                    c_ares::Error::ENOTFOUND,
+                    b"getaddrinfo",
+                    Some(name),
+                    &mut promise,
+                )
+                .reject_later(global_this);
+                return Ok(promise_value);
+            }
+        };
 
         let mut opts = options;
         let mut backend = opts.backend;
-        let normalized = normalize_dns_name(name, &mut backend);
+        let normalized = normalize_dns_name(ascii_name, &mut backend);
         opts.backend = backend;
         let query = GetAddrInfo {
             options: opts,
@@ -5393,6 +5398,22 @@ impl Resolver {
             }
         };
 
+        // Encode for the wire only. The cache key and the request keep the caller's
+        // spelling so `err.hostname` echoes it.
+        let mut ascii_buf = [0u8; 1024];
+        let Some(ascii_name) = hostname_to_ascii(name, &mut ascii_buf) else {
+            let mut promise = JSPromiseStrong::init(global_this);
+            let promise_value = promise.value();
+            error_to_deferred(
+                c_ares::Error::EBADNAME,
+                T::SYSCALL.as_bytes(),
+                Some(name),
+                &mut promise,
+            )
+            .reject_later(global_this);
+            return Ok(promise_value);
+        };
+
         let cache_field = T::CACHE_FIELD; // "pending_{TYPE_NAME}_cache_cares"
 
         let key = resolve_info_request::PendingCacheKey::<T>::init(name);
@@ -5417,10 +5438,6 @@ impl Resolver {
         );
         // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
         let promise = unsafe { (*(*request).tail).promise.value() };
-
-        // Encode for the wire only so `err.hostname` still echoes the caller's spelling.
-        let mut ascii_buf = [0u8; 1024];
-        let ascii_name = hostname_to_ascii(name, &mut ascii_buf);
 
         // SAFETY: `channel` is the live c-ares channel owned by `self`; `request`
         // is the freshly heap-allocated ResolveInfoRequest. c-ares stores the ctx

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -5383,9 +5383,6 @@ impl Resolver {
         name: &[u8],
         global_this: &JSGlobalObject,
     ) -> JsResult<JSValue> {
-        let mut ascii_buf = [0u8; 1024];
-        let name = hostname_to_ascii(name, &mut ascii_buf);
-
         let channel: *mut c_ares::Channel = match self.get_channel() {
             ChannelResult::Result(res) => res,
             ChannelResult::Err(err) => {
@@ -5425,11 +5422,17 @@ impl Resolver {
         // SAFETY: `request` just heap-allocated in `init()`; `tail` points at its inline `head`.
         let promise = unsafe { (*(*request).tail).promise.value() };
 
+        // Node.js sets `req.hostname` to the caller's argument before
+        // `ada::idna::to_ascii` runs in cares_wrap, so `err.hostname` always
+        // echoes the original spelling. Encode only the wire name here.
+        let mut ascii_buf = [0u8; 1024];
+        let ascii_name = hostname_to_ascii(name, &mut ascii_buf);
+
         // SAFETY: `channel` is the live c-ares channel owned by `self`; `request`
         // is the freshly heap-allocated ResolveInfoRequest. c-ares stores the ctx
         // pointer and calls `T::RAW_CALLBACK` (→ `on_cares_complete`) which
         // consumes the request, so the `&mut` borrow is not held past this call.
-        unsafe { (*channel).resolve(name, &mut *request) };
+        unsafe { (*channel).resolve(ascii_name, &mut *request) };
 
         // SAFETY: bun_vm() returns a live VM pointer for the duration of the call.
         self.request_sent(global_this.bun_vm());

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -321,8 +321,7 @@ unsafe extern "C" {
     ) -> i32;
 }
 
-/// `None` when the name is not valid IDNA. Callers must reject it themselves:
-/// an empty name is a legitimate root-zone query for NS/SOA in `Channel::resolve`.
+/// `None`: not valid IDNA. Do not map it to "", which NS/SOA treat as the root zone.
 fn hostname_to_ascii<'a>(name: &'a [u8], buf: &'a mut [u8; 1024]) -> Option<&'a [u8]> {
     if strings::first_non_ascii(name).is_none() {
         return Some(name);
@@ -5398,8 +5397,7 @@ impl Resolver {
             }
         };
 
-        // Encode for the wire only. The cache key and the request keep the caller's
-        // spelling so `err.hostname` echoes it.
+        // Wire name only; the cache key and request keep the caller's spelling for err.hostname.
         let mut ascii_buf = [0u8; 1024];
         let Some(ascii_name) = hostname_to_ascii(name, &mut ascii_buf) else {
             let mut promise = JSPromiseStrong::init(global_this);

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import * as dgram from "node:dgram";
 import * as dns from "node:dns";
@@ -990,5 +990,85 @@ describe("pending cache", () => {
   test.concurrent("concurrent lookup() of the same name all settle", async () => {
     const results = await Promise.all(Array.from({ length: 8 }, () => dns_promises.lookup("localhost", { family: 4 })));
     expect(results).toEqual(Array(8).fill({ address: "127.0.0.1", family: 4 }));
+  });
+});
+
+describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
+  // A tiny in-process DNS responder on 127.0.0.1 that answers A 10.7.7.7 for
+  // any query and records which qnames actually reached the wire. Node.js
+  // punycode-encodes IDN hostnames (ada::idna::to_ascii in cares_wrap) before
+  // ares_query; Bun must do the same so non-ASCII names are resolvable.
+  let server;
+  let resolver;
+  let callbackResolver;
+  const wire = [];
+
+  beforeAll(async () => {
+    server = dgram.createSocket("udp4");
+    server.on("message", (msg, rinfo) => {
+      let i = 12;
+      const labels = [];
+      while (msg[i]) {
+        labels.push(msg.slice(i + 1, i + 1 + msg[i]).toString("latin1"));
+        i += msg[i] + 1;
+      }
+      wire.push(labels.join("."));
+      const question = msg.slice(12, i + 5);
+      const header = Buffer.from([msg[0], msg[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
+      const answer = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 1, 44, 0, 4, 10, 7, 7, 7]);
+      server.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
+    });
+    const { promise, resolve } = Promise.withResolvers();
+    server.bind(0, "127.0.0.1", resolve);
+    await promise;
+
+    const servers = ["127.0.0.1:" + server.address().port];
+    resolver = new dns.promises.Resolver({ timeout: 2000, tries: 1 });
+    resolver.setServers(servers);
+    callbackResolver = new dns.Resolver({ timeout: 2000, tries: 1 });
+    callbackResolver.setServers(servers);
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  it.each([
+    ["bücher.example", "xn--bcher-kva.example"],
+    ["münchen.de", "xn--mnchen-3ya.de"],
+    ["例え.jp", "xn--r8jz45g.jp"],
+    ["straße.de", "xn--strae-oqa.de"],
+  ])("resolve4 of %p sends %p on the wire", async (input, ascii) => {
+    wire.length = 0;
+    const result = await resolver.resolve4(input);
+    expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: [ascii] });
+  });
+
+  it("already-punycoded names pass through unchanged", async () => {
+    wire.length = 0;
+    const result = await resolver.resolve4("xn--bcher-kva.example");
+    expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["xn--bcher-kva.example"] });
+  });
+
+  it("plain ASCII names pass through unchanged", async () => {
+    wire.length = 0;
+    const result = await resolver.resolve4("plain.example");
+    expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["plain.example"] });
+  });
+
+  it("callback Resolver resolve4 encodes IDN", async () => {
+    wire.length = 0;
+    const { promise, resolve, reject } = Promise.withResolvers();
+    callbackResolver.resolve4("bücher.example", (err, addrs) => (err ? reject(err) : resolve(addrs)));
+    const result = await promise;
+    expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["xn--bcher-kva.example"] });
+  });
+
+  it("callback Resolver resolve(hostname, 'A') encodes IDN", async () => {
+    wire.length = 0;
+    const { promise, resolve, reject } = Promise.withResolvers();
+    callbackResolver.resolve("例え.jp", "A", (err, addrs) => (err ? reject(err) : resolve(addrs)));
+    const result = await promise;
+    expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["xn--r8jz45g.jp"] });
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1018,7 +1018,8 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
       const answer = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 1, 44, 0, 4, 10, 7, 7, 7]);
       server.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
     });
-    const { promise, resolve } = Promise.withResolvers();
+    const { promise, resolve, reject } = Promise.withResolvers();
+    server.once("error", reject);
     server.bind(0, "127.0.0.1", resolve);
     await promise;
 
@@ -1070,5 +1071,15 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
     callbackResolver.resolve("例え.jp", "A", (err, addrs) => (err ? reject(err) : resolve(addrs)));
     const result = await promise;
     expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["xn--r8jz45g.jp"] });
+  });
+
+  it("err.hostname on failure preserves the caller's original spelling", async () => {
+    const r = new dns.promises.Resolver({ timeout: 100, tries: 1 });
+    r.setServers(["127.0.0.1:1"]);
+    const err = await r.resolve4("bücher.example").then(
+      () => ({}),
+      e => e,
+    );
+    expect(err.hostname).toBe("bücher.example");
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1093,18 +1093,40 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
     });
   });
 
+  // U+200D (ZWJ) outside a CONTEXTJ position fails UTS #46, so there is no
+  // ASCII form to send. Before IDNA encoding these names were rejected with
+  // no wire traffic. An encoding failure must not turn into an empty name:
+  // Channel::resolve lets an empty name through for NS and SOA as a root-zone
+  // query, so these would otherwise return the root servers.
+  const unencodable = "a\u200Db.example";
+
+  it.each(["resolveNs", "resolveSoa", "resolve4", "resolveTxt"])(
+    "%s of an unencodable name rejects without a query",
+    async method => {
+      wire.length = 0;
+      const err = await resolver[method](unencodable).then(
+        () => ({}),
+        e => e,
+      );
+      expect({ code: err.code, hostname: err.hostname, wire: [...wire] }).toEqual({
+        code: "ENOTFOUND",
+        hostname: unencodable,
+        wire: [],
+      });
+    },
+  );
+
   // dns.lookup() goes through the default resolver, so point that resolver at
   // the fake server in a child process. The trailing dot keeps c-ares from also
-  // trying the host's search domains. The hostname is spelled with a \\u escape
-  // so argv stays ASCII on every platform.
-  it("c-ares lookup() sends the punycode form on the wire", async () => {
-    wire.length = 0;
+  // trying the host's search domains. The hostname is passed as a JS string
+  // literal with \\u escapes so argv stays ASCII on every platform.
+  async function caresLookupInChild(hostnameLiteral) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `require("node:dns").setServers(["127.0.0.1:" + process.argv[1]]);
-         Bun.dns.lookup("b\\u00fccher.example.", { backend: "c-ares", family: 4 }).then(
+         Bun.dns.lookup(${hostnameLiteral}, { backend: "c-ares", family: 4 }).then(
            r => console.log(JSON.stringify(r.map(({ address, family }) => ({ address, family })))),
            e => console.log(JSON.stringify({ code: e.code })),
          );`,
@@ -1115,10 +1137,22 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect({ result: JSON.parse(stdout), wire: [...wire] }).toEqual({
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  it("c-ares lookup() sends the punycode form on the wire", async () => {
+    wire.length = 0;
+    const result = await caresLookupInChild('"b\\u00fccher.example."');
+    expect({ result, wire: [...wire] }).toEqual({
       result: [{ address: "10.7.7.7", family: 4 }],
       wire: ["xn--bcher-kva.example"],
     });
-    expect(exitCode).toBe(0);
+  });
+
+  it("c-ares lookup() of an unencodable name rejects without a query", async () => {
+    wire.length = 0;
+    const result = await caresLookupInChild('"a\\u200Db.example."');
+    expect({ result, wire: [...wire] }).toEqual({ result: { code: "DNS_ENOTFOUND" }, wire: [] });
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1015,7 +1015,8 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
       wire.push(labels.join("."));
       const question = msg.slice(12, i + 5);
       const header = Buffer.from([msg[0], msg[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
-      const answer = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 1, 44, 0, 4, 10, 7, 7, 7]);
+      // TTL=0 so c-ares does not cache across tests that share an ASCII qname.
+      const answer = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 10, 7, 7, 7]);
       server.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
     });
     const { promise, resolve, reject } = Promise.withResolvers();
@@ -1047,8 +1048,8 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
 
   it("already-punycoded names pass through unchanged", async () => {
     wire.length = 0;
-    const result = await resolver.resolve4("xn--bcher-kva.example");
-    expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["xn--bcher-kva.example"] });
+    const result = await resolver.resolve4("xn--nxasmq6b.example");
+    expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["xn--nxasmq6b.example"] });
   });
 
   it("plain ASCII names pass through unchanged", async () => {

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1012,8 +1012,14 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
         labels.push(msg.slice(i + 1, i + 1 + msg[i]).toString("latin1"));
         i += msg[i] + 1;
       }
-      wire.push(labels.join("."));
+      const qname = labels.join(".");
+      wire.push(qname);
       const question = msg.slice(12, i + 5);
+      if (qname.endsWith(".nxdomain.test")) {
+        const nxdomain = Buffer.from([msg[0], msg[1], 0x81, 0x83, 0, 1, 0, 0, 0, 0, 0, 0]);
+        server.send(Buffer.concat([nxdomain, question]), rinfo.port, rinfo.address);
+        return;
+      }
       const header = Buffer.from([msg[0], msg[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
       // TTL=0 so c-ares does not cache across tests that share an ASCII qname.
       const answer = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 0, 0, 4, 10, 7, 7, 7]);
@@ -1074,13 +1080,45 @@ describe("dns.resolve IDNA-encodes internationalized hostnames", () => {
     expect({ result, wire: [...wire] }).toEqual({ result: ["10.7.7.7"], wire: ["xn--r8jz45g.jp"] });
   });
 
-  it("err.hostname on failure preserves the caller's original spelling", async () => {
-    const r = new dns.promises.Resolver({ timeout: 100, tries: 1 });
-    r.setServers(["127.0.0.1:1"]);
-    const err = await r.resolve4("bücher.example").then(
+  it("err.hostname on NXDOMAIN preserves the caller's original spelling", async () => {
+    wire.length = 0;
+    const err = await resolver.resolve4("bücher.nxdomain.test").then(
       () => ({}),
       e => e,
     );
-    expect(err.hostname).toBe("bücher.example");
+    expect({ code: err.code, hostname: err.hostname, wire: [...wire] }).toEqual({
+      code: "ENOTFOUND",
+      hostname: "bücher.nxdomain.test",
+      wire: ["xn--bcher-kva.nxdomain.test"],
+    });
+  });
+
+  // dns.lookup() goes through the default resolver, so point that resolver at
+  // the fake server in a child process. The trailing dot keeps c-ares from also
+  // trying the host's search domains. The hostname is spelled with a \\u escape
+  // so argv stays ASCII on every platform.
+  it("c-ares lookup() sends the punycode form on the wire", async () => {
+    wire.length = 0;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("node:dns").setServers(["127.0.0.1:" + process.argv[1]]);
+         Bun.dns.lookup("b\\u00fccher.example.", { backend: "c-ares", family: 4 }).then(
+           r => console.log(JSON.stringify(r.map(({ address, family }) => ({ address, family })))),
+           e => console.log(JSON.stringify({ code: e.code })),
+         );`,
+        String(server.address().port),
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect({ result: JSON.parse(stdout), wire: [...wire] }).toEqual({
+      result: [{ address: "10.7.7.7", family: 4 }],
+      wire: ["xn--bcher-kva.example"],
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## What

`dns.resolve*` (and `dns.promises.Resolver.resolve*`) fail immediately with `ENOTFOUND` for any hostname that contains a non-ASCII character, without sending a query. Node.js resolves the same names by punycode-encoding them first.

## Repro

A loopback UDP responder that answers `A 10.7.7.7` for any qname and records what reached the wire:

```js
import dgram from "node:dgram"; import dns from "node:dns";
const seen = [];
const s = dgram.createSocket("udp4");
s.on("message", (m, ri) => {
  let i = 12, labels = [];
  while (m[i]) { labels.push(m.slice(i+1, i+1+m[i]).toString("latin1")); i += m[i]+1; }
  seen.push(labels.join("."));
  const q = m.slice(12, i+5);
  const ans = Buffer.from([0xc0,0x0c,0,1,0,1,0,0,1,44,0,4,10,7,7,7]);
  const hdr = Buffer.from([m[0],m[1],0x81,0x80,0,1,0,1,0,0,0,0]);
  s.send(Buffer.concat([hdr,q,ans]), ri.port, ri.address);
});
s.bind(0, "127.0.0.1", async () => {
  const R = new dns.promises.Resolver({ timeout: 800, tries: 1 });
  R.setServers(["127.0.0.1:" + s.address().port]);
  for (const name of ["bücher.example","münchen.de","例え.jp","xn--bcher-kva.example","plain.example"]) {
    try { console.log(JSON.stringify(name),"->",JSON.stringify(await R.resolve4(name))); }
    catch (e) { console.log(JSON.stringify(name),"-> ERR",e.code); }
  }
  console.log("wire:", JSON.stringify(seen));
  s.close();
});
```

**node v26.3.0**: all five names resolve to `["10.7.7.7"]`; wire shows `["xn--bcher-kva.example","xn--mnchen-3ya.de","xn--r8jz45g.jp","xn--bcher-kva.example","plain.example"]`.

**bun (before)**: the three Unicode names fail `ERR ENOTFOUND` with zero wire traffic; only the two ASCII names are queried.

## Cause

Node.js applies `ada::idna::to_ascii` in [cares_wrap.cc `Query()`](https://github.com/nodejs/node/blob/v26.3.0/src/cares_wrap.cc#L1783) and [`GetAddrInfo()`](https://github.com/nodejs/node/blob/v26.3.0/src/cares_wrap.cc#L1966) before handing the name to c-ares / libuv. Bun's `Resolver::do_resolve_cares` and `Resolver::do_lookup` pass the raw UTF-8 bytes straight to `ares_query`, which rejects non-ASCII labels.

## Fix

Add an `extern "C"` helper `Bun__hostnameToASCII` in `NodeURL.cpp` that wraps the file's existing `icuToASCII` (the port of Node's ICU ToASCII that `url.domainToASCII` and the `idna` binding already use), and call it from the two native chokepoints (`do_resolve_cares`, `do_lookup`) that every `node:dns` resolve/lookup passes through. ASCII-only names short-circuit in Rust via `strings::first_non_ascii` so the common path is unchanged.

In `do_resolve_cares` the encoded name is passed only to `ares_query`. The request itself keeps the caller's spelling, so `err.hostname` on failure matches Node.

A name that fails IDNA encoding (for example a ZWJ outside a CONTEXTJ position) is rejected before any query is sent. `hostname_to_ascii` returns `None` and both callers reject the promise with `ENOTFOUND` and the original `hostname`, which is what these names produced before this change. The name is not mapped to `""`: `Channel::resolve` accepts `""` for NS and SOA as a root-zone query, and `ares_getaddrinfo("")` queries the root as well, so an empty name would have returned root-zone data for invalid input. (Node.js does pass the empty `to_ascii` result to c-ares and has that behavior. It is not worth matching.)

<details>
<summary>Rebase note</summary>

Rebased onto main after #39468 landed. That PR refactored `NodeURL.cpp` and added a shared `icuToASCII` helper, so `Bun__hostnameToASCII` now calls it instead of carrying its own `uidna_nameToASCII` call and error mask. The same error classes are filtered. In `node-dns.test.js`, main added a `pending cache` block at the end of the file. The new IDNA block follows it. Both blocks pass together.

</details>

## Tests

Added to `test/js/node/dns/node-dns.test.js`. An in-process UDP responder on `127.0.0.1:0` records each qname it receives. The tests check:

- `promises.Resolver.resolve4`, callback `Resolver.resolve4`, and `Resolver.resolve(host, "A")` send the punycode form (`xn--bcher-kva.example`, `xn--mnchen-3ya.de`, `xn--r8jz45g.jp`, `xn--strae-oqa.de`) and resolve.
- Already-punycoded and plain ASCII names reach the wire unchanged.
- For a name the responder answers with NXDOMAIN, the wire gets the punycode form and `err.hostname` keeps the caller's spelling.
- `dns.lookup` with the c-ares backend (a child process with the default resolver pointed at the responder) sends the punycode form.
- A name that fails IDNA encoding is rejected by `resolveNs`, `resolveSoa`, `resolve4`, `resolveTxt`, and the c-ares `lookup` with `ENOTFOUND`, the original `hostname`, and nothing on the wire. Without the `None` guard the NS, SOA, and lookup cases send a root-zone query.

`bun bd test test/js/node/dns/node-dns.test.js -t IDNA-encodes`: 15 pass. The same filter on the released bun: 8 fail. The resolve cases fail with `queryA ENOTFOUND` and the lookup case with `DNS_ENOTFOUND`, each with an empty wire log. The 5 unencodable-name cases pass there too, since that is the behavior this change preserves.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->
