### PR TITLE
node:dns: report locally-rejected malformed names as EBADNAME, not ENOTFOUND

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1924,7 +1924,7 @@ impl Error {
             Error::ENOTIMP => "DNS_ENOTIMP",
             Error::EREFUSED => "DNS_EREFUSED",
             Error::EBADQUERY => "DNS_EBADQUERY",
-            Error::EBADNAME => "DNS_ENOTFOUND",
+            Error::EBADNAME => "DNS_EBADNAME",
             Error::EBADFAMILY => "DNS_EBADFAMILY",
             Error::EBADRESP => "DNS_EBADRESP",
             Error::ECONNREFUSED => "DNS_ECONNREFUSED",

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1630,6 +1630,16 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
         timeouts: i32,
         results: *mut c_ares::AddrInfo,
     ) {
+        // Node.js `dns.lookup` is libc getaddrinfo and can only ever produce
+        // ENOTFOUND for a malformed hostname (via EAI_NONAME). When Bun uses
+        // c-ares for getaddrinfo it reports ARES_EBADNAME instead; remap it
+        // here so `dns.lookup` stays Node-compatible regardless of backend.
+        // The `dns.resolve*` path (ares_query) keeps EBADNAME; it does not
+        // flow through this handler.
+        let status = match status {
+            Some(c_ares::Error::EBADNAME) => Some(c_ares::Error::ENOTFOUND),
+            other => other,
+        };
         let result = if results.is_null() {
             None
         } else {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1630,9 +1630,7 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
         timeouts: i32,
         results: *mut c_ares::AddrInfo,
     ) {
-        // Node's dns.lookup (libc getaddrinfo) never yields EBADNAME; remap the
-        // c-ares status so lookup() is Node-compatible on every backend. The
-        // resolve* path (ares_query) does not flow through this handler.
+        // Node's dns.lookup never yields EBADNAME; remap for compat (resolve* doesn't use this handler).
         let status = match status {
             Some(c_ares::Error::EBADNAME) => Some(c_ares::Error::ENOTFOUND),
             other => other,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1630,12 +1630,9 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
         timeouts: i32,
         results: *mut c_ares::AddrInfo,
     ) {
-        // Node.js `dns.lookup` is libc getaddrinfo and can only ever produce
-        // ENOTFOUND for a malformed hostname (via EAI_NONAME). When Bun uses
-        // c-ares for getaddrinfo it reports ARES_EBADNAME instead; remap it
-        // here so `dns.lookup` stays Node-compatible regardless of backend.
-        // The `dns.resolve*` path (ares_query) keeps EBADNAME; it does not
-        // flow through this handler.
+        // Node's dns.lookup (libc getaddrinfo) never yields EBADNAME; remap the
+        // c-ares status so lookup() is Node-compatible on every backend. The
+        // resolve* path (ares_query) does not flow through this handler.
         let status = match status {
             Some(c_ares::Error::EBADNAME) => Some(c_ares::Error::ENOTFOUND),
             other => other,

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -113,7 +113,7 @@ describe("dns", () => {
       await expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
         // The c-ares backend rejects these client-side with DNS_EBADNAME; the
         // system/libc backends reach getaddrinfo which reports ENOTFOUND/ENOTIMP.
-        code: expect.stringMatching(/^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP|DNS_EBADNAME$/),
+        code: expect.stringMatching(/^(?:DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP|DNS_EBADNAME)$/),
         name: "DNSException",
       });
     });

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -111,7 +111,9 @@ describe("dns", () => {
     test.concurrent.each(malformedHostnames)("'%s'", async hostname => {
       // @ts-expect-error
       await expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
-        code: expect.stringMatching(/^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP$/),
+        // The c-ares backend rejects these client-side with DNS_EBADNAME; the
+        // system/libc backends reach getaddrinfo which reports ENOTFOUND/ENOTIMP.
+        code: expect.stringMatching(/^DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP|DNS_EBADNAME$/),
         name: "DNSException",
       });
     });

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -111,9 +111,7 @@ describe("dns", () => {
     test.concurrent.each(malformedHostnames)("'%s'", async hostname => {
       // @ts-expect-error
       await expect(dns.lookup(hostname, { backend })).rejects.toMatchObject({
-        // The c-ares backend rejects these client-side with DNS_EBADNAME; the
-        // system/libc backends reach getaddrinfo which reports ENOTFOUND/ENOTIMP.
-        code: expect.stringMatching(/^(?:DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP|DNS_EBADNAME)$/),
+        code: expect.stringMatching(/^(?:DNS_ENOTFOUND|DNS_ESERVFAIL|DNS_ENOTIMP)$/),
         name: "DNSException",
       });
     });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,7 +1,9 @@
-import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { isWindows } from "harness";
+import dgram from "node:dgram";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
+import { once } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as util from "node:util";
@@ -659,5 +661,92 @@ describe("dns.lookupService with a numeric-string port", () => {
     expect(() => dns_promises.lookupService("127.0.0.1", "nope")).toThrow(
       expect.objectContaining({ code: "ERR_SOCKET_BAD_PORT" }),
     );
+  });
+});
+
+describe("locally-rejected malformed hostnames report EBADNAME", () => {
+  // c-ares rejects these names client-side with ARES_EBADNAME before any packet
+  // leaves the process. Node.js reports that as EBADNAME; Bun used to relabel it
+  // to ENOTFOUND, making "bad input" indistinguishable from "domain not found".
+  //
+  // A local NXDOMAIN responder is used so that (a) the test is hermetic and
+  // (b) we can count wire queries: 0 proves the rejection was local.
+  let udp;
+  let wire = 0;
+  let resolver;
+  let promisesResolver;
+
+  beforeAll(async () => {
+    udp = dgram.createSocket("udp4");
+    udp.on("message", (msg, rinfo) => {
+      wire++;
+      // Copy the question section and reply NXDOMAIN (RCODE=3).
+      let i = 12;
+      while (msg[i]) i += msg[i] + 1;
+      const question = msg.slice(12, i + 5);
+      const header = Buffer.from([msg[0], msg[1], 0x81, 0x83, 0, 1, 0, 0, 0, 0, 0, 0]);
+      udp.send(Buffer.concat([header, question]), rinfo.port, rinfo.address);
+    });
+    udp.bind(0, "127.0.0.1");
+    await once(udp, "listening");
+
+    const servers = [`127.0.0.1:${udp.address().port}`];
+    resolver = new dns.Resolver({ timeout: 5000, tries: 1 });
+    resolver.setServers(servers);
+    promisesResolver = new dns_promises.Resolver({ timeout: 5000, tries: 1 });
+    promisesResolver.setServers(servers);
+  });
+
+  afterAll(() => {
+    udp?.close();
+  });
+
+  const longLabel = Buffer.alloc(64, "l").toString();
+  const longName =
+    Array.from({ length: 30 }, (_, i) => "seg" + String(i).padStart(6, "0")).join(".") + ".example";
+  const malformed = {
+    "label > 63 octets": longLabel + ".ex.example",
+    "name > 255 octets": longName,
+    "empty interior label": "a..example",
+    "leading dot": ".a.example",
+    "whitespace in label": "sp ace.example",
+  };
+
+  const callbackCode = (method, name) =>
+    new Promise((resolve, reject) => {
+      let sync = true;
+      resolver[method](name, err => {
+        if (sync) return reject(new Error("callback invoked synchronously"));
+        resolve(err?.code);
+      });
+      sync = false;
+    });
+
+  describe.each(Object.entries(malformed))("%s", (_label, name) => {
+    it("callback resolve4 reports EBADNAME asynchronously", async () => {
+      const before = wire;
+      expect(await callbackCode("resolve4", name)).toBe("EBADNAME");
+      expect(wire).toBe(before);
+    });
+
+    it("callback resolveTxt reports EBADNAME asynchronously", async () => {
+      const before = wire;
+      expect(await callbackCode("resolveTxt", name)).toBe("EBADNAME");
+      expect(wire).toBe(before);
+    });
+
+    it("promises resolve4 rejects with EBADNAME", async () => {
+      const before = wire;
+      await expect(promisesResolver.resolve4(name)).rejects.toThrow(
+        expect.objectContaining({ code: "EBADNAME" }),
+      );
+      expect(wire).toBe(before);
+    });
+  });
+
+  it("control: a well-formed name reaches the server and reports ENOTFOUND", async () => {
+    const before = wire;
+    expect(await callbackCode("resolve4", "good.example")).toBe("ENOTFOUND");
+    expect(wire).toBeGreaterThan(before);
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -699,6 +699,11 @@ describe("locally-rejected malformed hostnames report EBADNAME", () => {
 
   afterAll(() => {
     udp?.close();
+    // Drop the describe-scope references so the native Resolver allocations can
+    // be finalized before LeakSanitizer runs its end-of-process check.
+    resolver = undefined;
+    promisesResolver = undefined;
+    Bun.gc(true);
   });
 
   const longLabel = Buffer.alloc(64, "l").toString();

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -702,8 +702,7 @@ describe("locally-rejected malformed hostnames report EBADNAME", () => {
   });
 
   const longLabel = Buffer.alloc(64, "l").toString();
-  const longName =
-    Array.from({ length: 30 }, (_, i) => "seg" + String(i).padStart(6, "0")).join(".") + ".example";
+  const longName = Array.from({ length: 30 }, (_, i) => "seg" + String(i).padStart(6, "0")).join(".") + ".example";
   const malformed = {
     "label > 63 octets": longLabel + ".ex.example",
     "name > 255 octets": longName,
@@ -737,9 +736,7 @@ describe("locally-rejected malformed hostnames report EBADNAME", () => {
 
     it("promises resolve4 rejects with EBADNAME", async () => {
       const before = wire;
-      await expect(promisesResolver.resolve4(name)).rejects.toThrow(
-        expect.objectContaining({ code: "EBADNAME" }),
-      );
+      await expect(promisesResolver.resolve4(name)).rejects.toThrow(expect.objectContaining({ code: "EBADNAME" }));
       expect(wire).toBe(before);
     });
   });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -749,6 +749,9 @@ describe("locally-rejected malformed hostnames report EBADNAME", () => {
   it("control: a well-formed name reaches the server and reports ENOTFOUND", async () => {
     const before = wire;
     expect(await callbackCode("resolve4", "good.example")).toBe("ENOTFOUND");
+    await expect(promisesResolver.resolve4("good.example")).rejects.toThrow(
+      expect.objectContaining({ code: "ENOTFOUND" }),
+    );
     expect(wire).toBeGreaterThan(before);
   });
 });


### PR DESCRIPTION
## What

`dns.resolve4`, `dns.resolveTxt`, and the rest of the `resolve*` family report `ENOTFOUND` for hostnames that c-ares rejects client-side as malformed (label > 63 octets, name > 255 octets, empty interior label, leading dot, whitespace in a label). Node.js reports `EBADNAME`. No packet is sent by either runtime; c-ares refuses to encode the query. The relabel makes "your input is malformed" indistinguishable from "that domain does not exist".

```js
import dns from "node:dns";
const R = new dns.Resolver();
R.resolve4("l".repeat(64) + ".ex.example", e => console.log(e.code));
```

Before: `ENOTFOUND`
After (and Node.js v26.3.0): `EBADNAME`

## Cause and fix

`c_ares::Error::code()` mapped `Error::EBADNAME` to `"DNS_ENOTFOUND"`. The c-ares status was already being carried through correctly (the error's `errno` was `8 == ARES_EBADNAME`); only the string was wrong.

That table is also consulted by the c-ares `ares_getaddrinfo` path that backs `dns.lookup` on Linux. Node's `dns.lookup` is libc `getaddrinfo` and never produces `EBADNAME`, so `GetAddrInfoRequest::on_addr_info` now remaps `ARES_EBADNAME` back to `ENOTFOUND` for the lookup path only. `dns.resolve*` (which uses `ares_query`) does not flow through that handler and keeps the `EBADNAME` identity. Without the remap, `net.connect`/`http.get` to a malformed host surfaced `EBADNAME` on Linux and broke callers that branch on `err.code === "ENOTFOUND"` (for example the `proxy` npm package's 404 handler).

## Verification

`test/js/node/dns/node-dns.test.js` gains a `describe` block that binds a UDP socket on `127.0.0.1:0` answering every query with NXDOMAIN, points a `Resolver` at it, and for each of the five malformed shapes asserts:

- callback `resolve4` delivers `err.code === "EBADNAME"` asynchronously (not on the calling tick)
- callback `resolveTxt` likewise
- `dns.promises.Resolver#resolve4` rejects with `code: "EBADNAME"`
- the wire-query counter is unchanged (proving the rejection is local)

plus a control case (`good.example`) that does reach the mock server and reports `ENOTFOUND`. The `afterAll` drops the describe-scope `Resolver` references and runs a synchronous GC so LeakSanitizer sees the native channel finalized.

The existing `test-http-dns-error.js`, `test-net-dns-error.js`, `node-http.test.ts` "URL delimiter" case, and the `node-http-connect` proxy-package case cover the `dns.lookup` → `ENOTFOUND` guarantee on the c-ares backend.

## Related

The sibling issue where `resolve4("")` throws `ERR_INVALID_ARG_TYPE` synchronously (Node.js: async `ENOTFOUND` callback) is addressed separately by #32880, which removes the empty-string guards so the empty name reaches `ares_query`. The two changes are independent.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/dns/resolve-dns.test.ts test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->