### PR TITLE
Bun.plugin: don't run onLoad/onResolve hooks while loading preload files

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -718,6 +718,12 @@ impl JSGlobalObject {
         target: BunPluginTarget,
     ) -> JsResult<Option<JSValue>> {
         crate::mark_binding();
+        // Suppress runtime onResolve while loading `preload` entries so a plugin
+        // registered in an earlier preload cannot redirect a later preload (or
+        // its static imports, which reach here via the linker).
+        if self.bun_vm().is_in_preload {
+            return Ok(None);
+        }
         let ns = (namespace_.length() > 0).then_some(&namespace_);
         let result = crate::from_js_host_call(self, || {
             Bun__runOnResolvePlugins(self, ns, &path, &source, target)

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -718,9 +718,7 @@ impl JSGlobalObject {
         target: BunPluginTarget,
     ) -> JsResult<Option<JSValue>> {
         crate::mark_binding();
-        // Suppress runtime onResolve while loading `preload` entries so a plugin
-        // registered in an earlier preload cannot redirect a later preload (or
-        // its static imports, which reach here via the linker).
+        // Preload files resolve with the default resolver, not earlier preloads' onResolve.
         if self.bun_vm().is_in_preload {
             return Ok(None);
         }

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -718,8 +718,11 @@ impl JSGlobalObject {
         target: BunPluginTarget,
     ) -> JsResult<Option<JSValue>> {
         crate::mark_binding();
-        // Preload files resolve with the default resolver, not earlier preloads' onResolve.
-        if self.bun_vm().is_in_preload {
+        let vm = self.bun_vm();
+        if !vm.currently_loading_preload.is_empty()
+            && namespace_.length() == 0
+            && path.eql_utf8(&vm.currently_loading_preload)
+        {
             return Ok(None);
         }
         let ns = (namespace_.length() > 0).then_some(&namespace_);

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -592,7 +592,10 @@ unsafe extern "C" fn Bun__runVirtualModule(
     specifier_ptr: *const bun_core::String,
 ) -> JSValue {
     jsc::mark_binding();
-    if global.bun_vm().plugin_runner.is_none() {
+    let vm = global.bun_vm();
+    // Skip onLoad while loading `preload` entries so a plugin registered in an
+    // earlier preload cannot intercept a later preload file.
+    if vm.plugin_runner.is_none() || vm.is_in_preload {
         return JSValue::ZERO;
     }
 

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -593,8 +593,7 @@ unsafe extern "C" fn Bun__runVirtualModule(
 ) -> JSValue {
     jsc::mark_binding();
     let vm = global.bun_vm();
-    // Preload files load with the default loader, not earlier preloads' onLoad.
-    if vm.plugin_runner.is_none() || vm.is_in_preload {
+    if vm.plugin_runner.is_none() {
         return JSValue::ZERO;
     }
 
@@ -603,6 +602,9 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier = specifier_slice.slice();
 
     if !PluginRunner::could_be_plugin(specifier) {
+        return JSValue::ZERO;
+    }
+    if vm.is_loading_preload_entry(specifier) {
         return JSValue::ZERO;
     }
 

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -593,8 +593,7 @@ unsafe extern "C" fn Bun__runVirtualModule(
 ) -> JSValue {
     jsc::mark_binding();
     let vm = global.bun_vm();
-    // Skip onLoad while loading `preload` entries so a plugin registered in an
-    // earlier preload cannot intercept a later preload file.
+    // Preload files load with the default loader, not earlier preloads' onLoad.
     if vm.plugin_runner.is_none() || vm.is_in_preload {
         return JSValue::ZERO;
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -183,9 +183,7 @@ pub struct VirtualMachine {
     /// threads.
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
     pub preload: Vec<Box<[u8]>>,
-    /// Resolved path of the preload entry currently being imported by
-    /// `load_preloads`, so the runtime plugin dispatch can skip onLoad/onResolve
-    /// for that exact file while still serving its own imports.
+    /// Resolved path of the preload entry `load_preloads` is currently importing.
     pub currently_loading_preload: Vec<u8>,
     pub unhandled_pending_rejection_to_capture: Option<*mut JSValue>,
     // Note: layering — the concrete `bun_standalone_graph::Graph` lives
@@ -617,8 +615,7 @@ unsafe impl Sync for VirtualMachine {}
 unsafe impl Send for VirtualMachine {}
 
 impl VirtualMachine {
-    /// True while `load_preloads` is importing `specifier` as a preload entry,
-    /// so runtime plugin hooks skip that file but still serve its own imports.
+    /// True while `load_preloads` is importing `specifier` as a preload entry.
     #[inline]
     pub fn is_loading_preload_entry(&self, specifier: &[u8]) -> bool {
         !self.currently_loading_preload.is_empty()

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -183,6 +183,10 @@ pub struct VirtualMachine {
     /// threads.
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
     pub preload: Vec<Box<[u8]>>,
+    /// Resolved path of the preload entry currently being imported by
+    /// `load_preloads`, so the runtime plugin dispatch can skip onLoad/onResolve
+    /// for that exact file while still serving its own imports.
+    pub currently_loading_preload: Vec<u8>,
     pub unhandled_pending_rejection_to_capture: Option<*mut JSValue>,
     // Note: layering — the concrete `bun_standalone_graph::Graph` lives
     // in a higher-tier crate. The resolver already broke that cycle with the
@@ -613,6 +617,14 @@ unsafe impl Sync for VirtualMachine {}
 unsafe impl Send for VirtualMachine {}
 
 impl VirtualMachine {
+    /// True while `load_preloads` is importing `specifier` as a preload entry,
+    /// so runtime plugin hooks skip that file but still serve its own imports.
+    #[inline]
+    pub fn is_loading_preload_entry(&self, specifier: &[u8]) -> bool {
+        !self.currently_loading_preload.is_empty()
+            && self.currently_loading_preload.as_slice() == specifier
+    }
+
     /// Safe `&'static` accessor for the current thread's VM. The VM is a
     /// per-thread singleton allocated once in [`init`] and never freed until
     /// thread teardown, so the `'static` lifetime is sound. Mutation goes
@@ -2104,6 +2116,7 @@ impl VirtualMachine {
             // their validity invariants even when len/cap are 0. Write the
             // canonical empty value via `ptr::write` (no Drop of zeroed bytes).
             addr_of_mut!((*vm).preload).write(Vec::new());
+            addr_of_mut!((*vm).currently_loading_preload).write(Vec::new());
             addr_of_mut!((*vm).argv).write(Vec::new());
             addr_of_mut!((*vm).resolved_path_dups).write(Vec::new());
             addr_of_mut!((*vm).macros).write(Default::default());

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4240,7 +4240,7 @@ impl VirtualMachine {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
 
-        if jsc_vm.plugin_runner.is_some() && !jsc_vm.is_in_preload {
+        if jsc_vm.plugin_runner.is_some() {
             use bun_bundler::transpiler::PluginRunner;
             let spec = specifier_utf8.slice();
             if PluginRunner::could_be_plugin(spec) {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4457,6 +4457,7 @@ impl VirtualMachine {
         // time and `load_preloads` clears the boxes but keeps the Vec buffer,
         // so reclaim it here or every Worker leaks it.
         drop(core::mem::take(&mut self.preload));
+        drop(core::mem::take(&mut self.currently_loading_preload));
 
         // SAFETY: this VM is raw-`dealloc`'d (no field `Drop` runs), so
         // `transpiler` is never auto-dropped after `deinit` clears its fields.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4240,7 +4240,7 @@ impl VirtualMachine {
         let specifier_utf8 = specifier.to_utf8();
         let source_utf8 = source.to_utf8();
 
-        if jsc_vm.plugin_runner.is_some() {
+        if jsc_vm.plugin_runner.is_some() && !jsc_vm.is_in_preload {
             use bun_bundler::transpiler::PluginRunner;
             let spec = specifier_utf8.slice();
             if PluginRunner::could_be_plugin(spec) {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5134,7 +5134,7 @@ unsafe fn resolve_hook(
 
     // `PluginRunner.onResolveJSC`.
     // SAFETY: `vm` is the live per-thread VM.
-    if unsafe { &*vm }.plugin_runner.is_some() && !unsafe { &*vm }.is_in_preload {
+    if unsafe { &*vm }.plugin_runner.is_some() {
         use bun_bundler_jsc::PluginRunner as plugin_runner;
         if plugin_runner::could_be_plugin(specifier_utf8.slice()) {
             let namespace = plugin_runner::extract_namespace(specifier_utf8.slice());

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -680,6 +680,8 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
     scopeguard::defer! {
         // SAFETY: per fn contract.
         unsafe { (*vm_for_guard).is_in_preload = false };
+        // SAFETY: per fn contract.
+        unsafe { (*vm_for_guard).currently_loading_preload.clear() };
     }
 
     // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
@@ -772,6 +774,14 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
                 .text;
             bun_core::String::from_bytes(path_text)
         };
+        // Runtime plugin hooks skip exactly this preload entry, not its imports.
+        {
+            let name_utf8 = module_name.to_utf8();
+            // SAFETY: per fn contract.
+            let slot = unsafe { &mut (*vm).currently_loading_preload };
+            slot.clear();
+            slot.extend_from_slice(name_utf8.slice());
+        }
         // Note: use `import_ptr` (not `import`) so the `*mut` we store in
         // `pending_internal_promise` keeps the FFI's mutable provenance instead
         // of being laundered through `&JSInternalPromise -> *const -> *mut`

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -5134,7 +5134,7 @@ unsafe fn resolve_hook(
 
     // `PluginRunner.onResolveJSC`.
     // SAFETY: `vm` is the live per-thread VM.
-    if unsafe { &*vm }.plugin_runner.is_some() {
+    if unsafe { &*vm }.plugin_runner.is_some() && !unsafe { &*vm }.is_in_preload {
         use bun_bundler_jsc::PluginRunner as plugin_runner;
         if plugin_runner::could_be_plugin(specifier_utf8.slice()) {
             let namespace = plugin_runner::extract_namespace(specifier_utf8.slice());

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -722,3 +722,120 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+// https://github.com/oven-sh/bun/issues/9373
+describe("preloaded plugins do not intercept other preload files", () => {
+  function makePlugin(tag: string) {
+    return `
+      import { plugin } from "bun";
+      plugin({
+        name: ${JSON.stringify(tag)},
+        setup(build) {
+          console.log("setup " + ${JSON.stringify(tag)});
+          build.onLoad({ filter: /\\.ts$/ }, async (args) => {
+            console.log("onLoad " + ${JSON.stringify(tag)} + " " + require("path").basename(args.path));
+            return { contents: await Bun.file(args.path).text() };
+          });
+          build.onResolve({ filter: /\\.ts$/ }, (args) => {
+            console.log("onResolve " + ${JSON.stringify(tag)} + " " + require("path").basename(args.path));
+            return undefined;
+          });
+        },
+      });
+    `;
+  }
+
+  function summarize(stdout: string, stderr: string) {
+    const lines = stdout.trim() ? stdout.trim().split("\n") : ["(no stdout)", stderr];
+    return {
+      // onLoad/onResolve lines whose target is one of the preload files themselves.
+      hooksOnPreloadFiles: lines.filter(l => /^on(Load|Resolve) .* plugin-\d\.ts$/.test(l)),
+      setups: lines.filter(l => l.startsWith("setup ")),
+      loadsForUserFiles: lines.filter(l => l.startsWith("onLoad ") && !/plugin-\d\.ts$/.test(l)),
+      output: lines.filter(l => !/^(setup|onLoad|onResolve) /.test(l)),
+    };
+  }
+
+  it.concurrent("with bunfig preload", async () => {
+    using dir = tempDir("plugin-preload-no-intercept-bunfig", {
+      "plugin-1.ts": makePlugin("p1"),
+      "plugin-2.ts": makePlugin("p2"),
+      "plugin-3.ts": makePlugin("p3"),
+      "bunfig.toml": `preload = ["./plugin-1.ts", "./plugin-2.ts", "./plugin-3.ts"]`,
+      "dep.ts": `export const foo = () => console.log("Foo!");`,
+      "entry.ts": `import { foo } from "./dep.ts"; console.log("Hello, world!"); foo();`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(summarize(stdout, stderr)).toEqual({
+      hooksOnPreloadFiles: [],
+      setups: ["setup p1", "setup p2", "setup p3"],
+      loadsForUserFiles: ["onLoad p1 entry.ts", "onLoad p1 dep.ts"],
+      output: ["Hello, world!", "Foo!"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("with --preload flags", async () => {
+    using dir = tempDir("plugin-preload-no-intercept-flag", {
+      "plugin-1.ts": makePlugin("p1"),
+      "plugin-2.ts": makePlugin("p2"),
+      "entry.ts": `console.log("done");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./plugin-1.ts", "--preload", "./plugin-2.ts", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(summarize(stdout, stderr)).toEqual({
+      hooksOnPreloadFiles: [],
+      setups: ["setup p1", "setup p2"],
+      loadsForUserFiles: ["onLoad p1 entry.ts"],
+      output: ["done"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("build.module virtual modules still work across preloads", async () => {
+    using dir = tempDir("plugin-preload-virtual-module", {
+      "plugin-1.ts": `
+        Bun.plugin({
+          name: "virtual",
+          setup(build) {
+            build.module("shared-config", () => ({
+              exports: { value: 42 },
+              loader: "object",
+            }));
+          },
+        });
+      `,
+      "plugin-2.ts": `
+        const { value } = require("shared-config");
+        console.log("plugin-2 read config:", value);
+      `,
+      "entry.ts": `console.log("done");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./plugin-1.ts", "--preload", "./plugin-2.ts", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim() || stderr).toBe("plugin-2 read config: 42\ndone");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -748,10 +748,11 @@ describe("preloaded plugins do not intercept other preload files", () => {
   function summarize(stdout: string, stderr: string) {
     const lines = stdout.trim() ? stdout.trim().split("\n") : ["(no stdout)", stderr];
     return {
-      // onLoad/onResolve lines whose target is one of the preload files themselves.
-      hooksOnPreloadFiles: lines.filter(l => /^on(Load|Resolve) .* plugin-\d\.ts$/.test(l)),
+      // onLoad/onResolve lines whose target is one of the preload files (or a
+      // file they statically import).
+      hooksOnPreloadFiles: lines.filter(l => /^on(Load|Resolve) .* (plugin-\d|helper)\.ts$/.test(l)),
       setups: lines.filter(l => l.startsWith("setup ")),
-      loadsForUserFiles: lines.filter(l => l.startsWith("onLoad ") && !/plugin-\d\.ts$/.test(l)),
+      loadsForUserFiles: lines.filter(l => l.startsWith("onLoad ") && !/(plugin-\d|helper)\.ts$/.test(l)),
       output: lines.filter(l => !/^(setup|onLoad|onResolve) /.test(l)),
     };
   }
@@ -759,8 +760,11 @@ describe("preloaded plugins do not intercept other preload files", () => {
   it.concurrent("with bunfig preload", async () => {
     using dir = tempDir("plugin-preload-no-intercept-bunfig", {
       "plugin-1.ts": makePlugin("p1"),
-      "plugin-2.ts": makePlugin("p2"),
+      // plugin-2 has a relative static import so its import records go through
+      // the runtime linker's onResolve dispatch while still in preload.
+      "plugin-2.ts": `import "./helper.ts";\n` + makePlugin("p2"),
       "plugin-3.ts": makePlugin("p3"),
+      "helper.ts": `export {};`,
       "bunfig.toml": `preload = ["./plugin-1.ts", "./plugin-2.ts", "./plugin-3.ts"]`,
       "dep.ts": `export const foo = () => console.log("Foo!");`,
       "entry.ts": `import { foo } from "./dep.ts"; console.log("Hello, world!"); foo();`,
@@ -813,6 +817,9 @@ describe("preloaded plugins do not intercept other preload files", () => {
         Bun.plugin({
           name: "virtual",
           setup(build) {
+            // Registering an onLoad sets vm.plugin_runner, so the is_in_preload
+            // gate in the onLoad/onResolve dispatch is actually reached.
+            build.onLoad({ filter: /\\0never/ }, () => undefined);
             build.module("shared-config", () => ({
               exports: { value: 42 },
               loader: "object",

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -748,8 +748,7 @@ describe("preloaded plugins do not intercept other preload files", () => {
   function summarize(stdout: string, stderr: string) {
     const lines = stdout.trim() ? stdout.trim().split("\n") : ["(no stdout)", stderr];
     return {
-      // onLoad/onResolve lines whose target is one of the preload files (or a
-      // file they statically import).
+      // Hook calls whose target is a preload file or one of its static imports.
       hooksOnPreloadFiles: lines.filter(l => /^on(Load|Resolve) .* (plugin-\d|helper)\.ts$/.test(l)),
       setups: lines.filter(l => l.startsWith("setup ")),
       loadsForUserFiles: lines.filter(l => l.startsWith("onLoad ") && !/(plugin-\d|helper)\.ts$/.test(l)),
@@ -760,8 +759,7 @@ describe("preloaded plugins do not intercept other preload files", () => {
   it.concurrent("with bunfig preload", async () => {
     using dir = tempDir("plugin-preload-no-intercept-bunfig", {
       "plugin-1.ts": makePlugin("p1"),
-      // plugin-2 has a relative static import so its import records go through
-      // the runtime linker's onResolve dispatch while still in preload.
+      // A relative static import routes plugin-2's link step through onResolve.
       "plugin-2.ts": `import "./helper.ts";\n` + makePlugin("p2"),
       "plugin-3.ts": makePlugin("p3"),
       "helper.ts": `export {};`,
@@ -817,8 +815,7 @@ describe("preloaded plugins do not intercept other preload files", () => {
         Bun.plugin({
           name: "virtual",
           setup(build) {
-            // Registering an onLoad sets vm.plugin_runner, so the is_in_preload
-            // gate in the onLoad/onResolve dispatch is actually reached.
+            // Populates vm.plugin_runner so the is_in_preload gate is reached.
             build.onLoad({ filter: /\\0never/ }, () => undefined);
             build.module("shared-config", () => ({
               exports: { value: 42 },

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -724,7 +724,7 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
 });
 
 // https://github.com/oven-sh/bun/issues/9373
-describe("preloaded plugins do not intercept other preload files", () => {
+describe("preloaded plugins do not intercept other preload entry files", () => {
   function makePlugin(tag: string) {
     return `
       import { plugin } from "bun";
@@ -748,10 +748,9 @@ describe("preloaded plugins do not intercept other preload files", () => {
   function summarize(stdout: string, stderr: string) {
     const lines = stdout.trim() ? stdout.trim().split("\n") : ["(no stdout)", stderr];
     return {
-      // Hook calls whose target is a preload file or one of its static imports.
-      hooksOnPreloadFiles: lines.filter(l => /^on(Load|Resolve) .* (plugin-\d|helper)\.ts$/.test(l)),
+      hooksOnPreloadEntries: lines.filter(l => /^on(Load|Resolve) .* plugin-\d\.ts$/.test(l)),
       setups: lines.filter(l => l.startsWith("setup ")),
-      loadsForUserFiles: lines.filter(l => l.startsWith("onLoad ") && !/(plugin-\d|helper)\.ts$/.test(l)),
+      loads: lines.filter(l => l.startsWith("onLoad ") && !/plugin-\d\.ts$/.test(l)),
       output: lines.filter(l => !/^(setup|onLoad|onResolve) /.test(l)),
     };
   }
@@ -759,10 +758,8 @@ describe("preloaded plugins do not intercept other preload files", () => {
   it.concurrent("with bunfig preload", async () => {
     using dir = tempDir("plugin-preload-no-intercept-bunfig", {
       "plugin-1.ts": makePlugin("p1"),
-      // A relative static import routes plugin-2's link step through onResolve.
-      "plugin-2.ts": `import "./helper.ts";\n` + makePlugin("p2"),
+      "plugin-2.ts": makePlugin("p2"),
       "plugin-3.ts": makePlugin("p3"),
-      "helper.ts": `export {};`,
       "bunfig.toml": `preload = ["./plugin-1.ts", "./plugin-2.ts", "./plugin-3.ts"]`,
       "dep.ts": `export const foo = () => console.log("Foo!");`,
       "entry.ts": `import { foo } from "./dep.ts"; console.log("Hello, world!"); foo();`,
@@ -777,9 +774,9 @@ describe("preloaded plugins do not intercept other preload files", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(summarize(stdout, stderr)).toEqual({
-      hooksOnPreloadFiles: [],
+      hooksOnPreloadEntries: [],
       setups: ["setup p1", "setup p2", "setup p3"],
-      loadsForUserFiles: ["onLoad p1 entry.ts", "onLoad p1 dep.ts"],
+      loads: ["onLoad p1 entry.ts", "onLoad p1 dep.ts"],
       output: ["Hello, world!", "Foo!"],
     });
     expect(exitCode).toBe(0);
@@ -801,11 +798,47 @@ describe("preloaded plugins do not intercept other preload files", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(summarize(stdout, stderr)).toEqual({
-      hooksOnPreloadFiles: [],
+      hooksOnPreloadEntries: [],
       setups: ["setup p1", "setup p2"],
-      loadsForUserFiles: ["onLoad p1 entry.ts"],
+      loads: ["onLoad p1 entry.ts"],
       output: ["done"],
     });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("a later preload can still import through an earlier preload's onLoad", async () => {
+    using dir = tempDir("plugin-preload-cross-onload", {
+      "plugin-1.ts": `
+        Bun.plugin({
+          name: "virt",
+          setup(build) {
+            build.onResolve({ filter: /.*/, namespace: "virt" }, (args) => ({
+              path: args.path,
+              namespace: "virt",
+            }));
+            build.onLoad({ filter: /.*/, namespace: "virt" }, (args) => ({
+              contents: "export default " + JSON.stringify("virt-loaded:" + args.path),
+              loader: "js",
+            }));
+          },
+        });
+      `,
+      "plugin-2.ts": `
+        import v from "virt:shared-thing";
+        console.log(v);
+      `,
+      "entry.ts": `console.log("entry done");`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./plugin-1.ts", "--preload", "./plugin-2.ts", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim() || stderr).toBe("virt-loaded:shared-thing\nentry done");
     expect(exitCode).toBe(0);
   });
 
@@ -815,7 +848,6 @@ describe("preloaded plugins do not intercept other preload files", () => {
         Bun.plugin({
           name: "virtual",
           setup(build) {
-            // Populates vm.plugin_runner so the is_in_preload gate is reached.
             build.onLoad({ filter: /\\0never/ }, () => undefined);
             build.module("shared-config", () => ({
               exports: { value: 42 },


### PR DESCRIPTION
When multiple preload files each register runtime plugin hooks, the first preload's onLoad/onResolve intercepts the loading of subsequent preload files themselves.

## Repro

```toml
# bunfig.toml
preload = ["./plugin-1.ts", "./plugin-2.ts", "./plugin-3.ts"]
```

```ts
// plugin-1.ts
Bun.plugin({
  name: "plugin-1",
  setup(build) {
    console.log("plugin-1 setup");
    build.onLoad({ filter: /\.ts$/ }, async (args) => {
      console.log("plugin-1 onLoad", args.path);
      return { contents: await Bun.file(args.path).text() };
    });
  },
});
```

(plugin-2.ts and plugin-3.ts are identical with the name changed.)

```
$ bun entry.ts
plugin-1 setup
plugin-1 onLoad /tmp/plugin-2.ts    <-- plugin-1 intercepts plugin-2.ts
plugin-2 setup
plugin-1 onLoad /tmp/plugin-3.ts    <-- and plugin-3.ts
plugin-3 setup
plugin-1 onLoad /tmp/entry.ts
...
```

## Cause

`load_preloads` imports each preload entry sequentially through the normal module loader and waits on it before moving to the next. Once plugin-1's setup registers an onLoad (flipping `vm.plugin_runner` to `Some`), the next `JSModuleLoader::import` for plugin-2.ts reaches `Bun__runVirtualModule` and `run_on_resolve_plugins`, which match plugin-2.ts against plugin-1's filter and hand it to plugin-1's callback.

## Fix

Track the resolved path of the preload entry currently being imported on `vm.currently_loading_preload`, set for each iteration of the preload loop and cleared on exit. `Bun__runVirtualModule` (onLoad) and `run_on_resolve_plugins` (onResolve) bail out when the specifier equals that path, so the preload entry file itself loads with the default loader while anything it imports continues to use whatever hooks are already registered.

That second property matters: a setup where preload-1 provides a `virt:` loader and preload-2 does `import v from "virt:shared-thing"` keeps working, and `build.module()` virtual modules remain available across preloads. Both are covered by tests alongside the interception fix.

After:
```
$ bun entry.ts
plugin-1 setup
plugin-2 setup
plugin-3 setup
plugin-1 onLoad /tmp/entry.ts
...
```

Fixes #9373

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (d020b7ad1)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1971.09ms]
(pass) require > beep:boop returns 42 [17.21ms]
(pass) require > object module works [17.02ms]
(pass) module > throws with require() [24.55ms]
(pass) module > async module works with async import [37.55ms]
(pass) module > sync module module works with require() [8.14ms]
(pass) module > sync module module works with require.resolve() [6.00ms]
(pass) module > sync module module works with import [11.11ms]
(pass) module > modules are overridable [111.38ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [10.89ms]
(pass) dynamic import > beep:boop returns 42 [7.05ms]
(pass) dynamic import > async:onLoad re
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (015e4437f)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [56.99ms]
(pass) require > beep:boop returns 42 [0.26ms]
(pass) require > object module works [0.15ms]
(pass) module > throws with require() [0.30ms]
(pass) module > async module works with async import [3.46ms]
(pass) module > sync module module works with require() [0.12ms]
(pass) module > sync module module works with require.resolve() [0.07ms]
(pass) module > sync module module works with import [0.15ms]
(pass) module > modules are overridable [0.30ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.15ms]
(pass) dynamic import > beep:boop returns 42 [0.11ms]
(pass) dynamic import > async:onLoad returns 42 [1.56ms]
(pass) dynamic import > async object loader returns 42 [1.37ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [3.43ms]
(pass) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (d020b7ad1)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1642.65ms]
(pass) require > beep:boop returns 42 [14.80ms]
(pass) require > object module works [13.12ms]
(pass) module > throws with require() [21.98ms]
(pass) module > async module works with async import [34.07ms]
(pass) module > sync module module works with require() [9.53ms]
(pass) module > sync module module works with require.resolve() [3.88ms]
(pass) module > sync module module works with import [6.19ms]
(pass) module > modules are overridable [19.16ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [7.03ms]
(pass) dynamic import > beep:boop returns 42 [5.35ms]
(pass) dynamic import > async:onLoad retur
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d020b7ad15
  features     baseline

22 deps, 108 codegen, 1171 objects in 2739ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1233] gen bindgenv2
[2/1233] fetch tinycc
[tinycc] up to date
[3/1232] gen ErrorCode+*.h
[4/1232] gen .bind.ts → GeneratedBindings.cpp
[5/1232] fetch zlib
[zlib] up to date
[6/1232] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1232] fetch picohttpparser
[picohttpparser] up to date
[8/1232] subst deps/zlib/zlib.h
[9/1232] subst deps/zlib/zconf.h
[10/1183] fetch zstd
[zstd] up to date
[11/1152] fetch nodejs (prebuilt)
[nodejs] up to date
[12/1152] subst deps/libjpeg-turbo/jconfig.h
[13/1152] fetch libarchive
[libarchive] up to date
[14/1029] fetch libdeflate
[libdeflate] up to date
[15/1018] subst deps/libjpeg-turbo/jconfigint.h
[16/1018] subst deps/libjpeg-turbo/jversion.h
[17/955] fetch brotli
[brotli] up to date
[18/924] fetch cares
[cares] up to date
[19/833] fetch libspng
[libspng] up to date
[20/832] fetch libwebp
[libwebp] up to date
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs          |   7 ++
 src/jsc/ModuleLoader.rs            |   6 +-
 src/jsc/VirtualMachine.rs          |  11 +++
 src/runtime/jsc_hooks.rs           |  10 +++
 test/js/bun/plugin/plugins.test.ts | 153 +++++++++++++++++++++++++++++++++++++
 5 files changed, 186 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/JSGlobalObject.rs               2      4      0
src/jsc/ModuleLoader.rs                 2      3      0
src/jsc/VirtualMachine.rs              10     10      0
src/runtime/jsc_hooks.rs                5      7      0
test/js/bun/plugin/plugins.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->