### PR TITLE
js_parser: don't fold wrappers that expose anonymous class/fn to NamedEvaluation

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -483,9 +483,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             name,
                                         )
                                         && name != b"__proto__"
-                                        // "({ f: class {} }).f" assigns name "f"; inlining
-                                        // would drop that and expose the class to the outer
-                                        // NamedEvaluation position instead.
+                                        // "({ f: class {} }).f" => keep; name is "f" per spec
                                         && !value.is_anonymous_named()
                                     {
                                         return Some(value);

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -483,6 +483,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             name,
                                         )
                                         && name != b"__proto__"
+                                        // "({ f: class {} }).f" assigns name "f"; inlining
+                                        // would drop that and expose the class to the outer
+                                        // NamedEvaluation position instead.
+                                        && !value.is_anonymous_named()
                                     {
                                         return Some(value);
                                     }

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -203,6 +203,7 @@ impl BinaryExpressionVisitor {
                 // "(sideEffects(), 2)" => "(sideEffects(), 2)"
                 // "(0, this.fn)" => "this.fn"
                 // "(0, this.fn)()" => "(0, this.fn)()"
+                // "(0, class {})" => "(0, class {})"
                 if p.options.features.minify_syntax {
                     // If e_.left is itself a comma, its .left was already simplified
                     // by the previous unwind step; only simplify its .right to avoid
@@ -221,14 +222,24 @@ impl BinaryExpressionVisitor {
                     };
                     if let Some(simplified_left) = simplified_left {
                         if simplified_left.is_empty() {
-                            return e_.right;
+                            if e_.right.is_anonymous_named() {
+                                e_.left = Expr {
+                                    data: prefill::data::ZERO,
+                                    loc: e_.left.loc,
+                                };
+                            } else {
+                                return e_.right;
+                            }
+                        } else {
+                            e_.left = simplified_left;
                         }
-                        e_.left = simplified_left;
                     } else {
                         // The left operand has no side effects, but we need to preserve
-                        // the comma operator semantics when used as a call target
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
-                            // Keep the comma expression to strip "this" binding
+                        // the comma operator semantics when used as a call target, and
+                        // avoid exposing an anonymous function/class to NamedEvaluation.
+                        if (is_call_target && e_.right.has_value_for_this_in_call())
+                            || e_.right.is_anonymous_named()
+                        {
                             e_.left = Expr {
                                 data: prefill::data::ZERO,
                                 loc: e_.left.loc,
@@ -371,7 +382,10 @@ impl BinaryExpressionVisitor {
                         // "(null ?? fn)()" => "fn()"
                         // "(null ?? this.fn)" => "this.fn"
                         // "(null ?? this.fn)()" => "(0, this.fn)()"
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        // "(null ?? class {})" => "(0, class {})"
+                        if (is_call_target && e_.right.has_value_for_this_in_call())
+                            || e_.right.is_anonymous_named()
+                        {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: ExprData::ENumber(E::Number::new(0.0)),
@@ -394,7 +408,10 @@ impl BinaryExpressionVisitor {
                     // "(0 || fn)()" => "fn()"
                     // "(0 || this.fn)" => "this.fn"
                     // "(0 || this.fn)()" => "(0, this.fn)()"
-                    if is_call_target && e_.right.has_value_for_this_in_call() {
+                    // "(0 || class {})" => "(0, class {})"
+                    if (is_call_target && e_.right.has_value_for_this_in_call())
+                        || e_.right.is_anonymous_named()
+                    {
                         return Expr::join_with_comma(
                             Expr {
                                 data: prefill::data::ZERO,
@@ -416,7 +433,10 @@ impl BinaryExpressionVisitor {
                         // "(1 && fn)()" => "fn()"
                         // "(1 && this.fn)" => "this.fn"
                         // "(1 && this.fn)()" => "(0, this.fn)()"
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        // "(1 && class {})" => "(0, class {})"
+                        if (is_call_target && e_.right.has_value_for_this_in_call())
+                            || e_.right.is_anonymous_named()
+                        {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: prefill::data::ZERO,
@@ -712,7 +732,7 @@ impl BinaryExpressionVisitor {
                 if let Some(dot) = e_.left.data.e_dot() {
                     if let Some(obj) = dot.target.data.e_object() {
                         if obj.properties.len_u32() == 0 {
-                            if dot.name != b"__proto__" {
+                            if dot.name != b"__proto__" && !e_.right.is_anonymous_named() {
                                 return e_.right;
                             }
                         }

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -377,6 +377,16 @@ impl BinaryExpressionVisitor {
                 let null_or_undefined = SideEffects::to_null_or_undefined(p, &e_.left.data);
                 if null_or_undefined.ok {
                     if !null_or_undefined.value {
+                        // "(class {} ?? 0)" => "(0, class {})"
+                        if e_.left.is_anonymous_named() {
+                            return Expr::join_with_comma(
+                                Expr {
+                                    data: prefill::data::ZERO,
+                                    loc: e_.left.loc,
+                                },
+                                e_.left,
+                            );
+                        }
                         return e_.left;
                     } else if null_or_undefined.side_effects == SideEffects::NoSideEffects {
                         // "(null ?? fn)()" => "fn()"
@@ -402,6 +412,16 @@ impl BinaryExpressionVisitor {
             Op::Code::BinLogicalOr => {
                 let side_effects = SideEffects::to_boolean(p, &e_.left.data);
                 if side_effects.ok && side_effects.value {
+                    // "(class {} || 0)" => "(0, class {})"
+                    if e_.left.is_anonymous_named() {
+                        return Expr::join_with_comma(
+                            Expr {
+                                data: prefill::data::ZERO,
+                                loc: e_.left.loc,
+                            },
+                            e_.left,
+                        );
+                    }
                     return e_.left;
                 } else if side_effects.ok && side_effects.side_effects == SideEffects::NoSideEffects
                 {

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -234,9 +234,6 @@ impl BinaryExpressionVisitor {
                             e_.left = simplified_left;
                         }
                     } else {
-                        // The left operand has no side effects, but we need to preserve
-                        // the comma operator semantics when used as a call target, and
-                        // avoid exposing an anonymous function/class to NamedEvaluation.
                         if (is_call_target && e_.right.has_value_for_this_in_call())
                             || e_.right.is_anonymous_named()
                         {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1091,7 +1091,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if array.items.len_u32() == 1 && number.value() == 0.0 {
                             let inlined = *array.items.at(0);
                             if inlined.can_be_inlined_from_property_access() {
-                                *e = inlined;
+                                // [class {}][0] -> (0, class {})
+                                *e = if inlined.is_anonymous_named() {
+                                    Expr {
+                                        data: prefill::data::ZERO,
+                                        loc: expr.loc,
+                                    }
+                                    .join_with_comma(inlined)
+                                } else {
+                                    inlined
+                                };
                                 return;
                             }
                         }
@@ -1108,7 +1117,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return;
                             }
                             debug_assert!(inlined.can_be_inlined_from_property_access());
-                            *e = inlined;
+                            *e = if inlined.is_anonymous_named() {
+                                Expr {
+                                    data: prefill::data::ZERO,
+                                    loc: expr.loc,
+                                }
+                                .join_with_comma(inlined)
+                            } else {
+                                inlined
+                            };
                             return;
                         }
                     }
@@ -1494,7 +1511,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "(1 ? fn : 2)()" => "fn()"
                 // "(1 ? this.fn : 2)" => "this.fn"
                 // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                if is_call_target && e_.yes.has_value_for_this_in_call() {
+                // "(1 ? class {} : 2)" => "(0, class {})"
+                if (is_call_target && e_.yes.has_value_for_this_in_call())
+                    || e_.yes.is_anonymous_named()
+                {
                     *e = p
                         .new_expr(E::Number::new(0.0), e_.test_.loc)
                         .join_with_comma(e_.yes);
@@ -1522,7 +1542,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // "(1 ? fn : 2)()" => "fn()"
                 // "(1 ? this.fn : 2)" => "this.fn"
                 // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                if is_call_target && e_.no.has_value_for_this_in_call() {
+                // "(0 ? 1 : class {})" => "(0, class {})"
+                if (is_call_target && e_.no.has_value_for_this_in_call())
+                    || e_.no.is_anonymous_named()
+                {
                     *e = p
                         .new_expr(E::Number::new(0.0), e_.test_.loc)
                         .join_with_comma(e_.no);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1501,20 +1501,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.visit_expr(&mut e_.no);
                 p.is_control_flow_dead = old;
 
+                // "(1 ? fn : 2)()" => "fn()"
+                // "(1 ? this.fn : 2)" => "this.fn"
+                // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
+                // "(1 ? class {} : 2)" => "(0, class {})"
+                let needs_comma_wrap = (is_call_target && e_.yes.has_value_for_this_in_call())
+                    || e_.yes.is_anonymous_named();
+
                 if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
                     *e = SideEffects::simplify_unused_expr(p, e_.test_)
+                        .or_else(|| {
+                            needs_comma_wrap.then(|| p.new_expr(E::Number::new(0.0), e_.test_.loc))
+                        })
                         .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test_.loc))
                         .join_with_comma(e_.yes);
                     return;
                 }
 
-                // "(1 ? fn : 2)()" => "fn()"
-                // "(1 ? this.fn : 2)" => "this.fn"
-                // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                // "(1 ? class {} : 2)" => "(0, class {})"
-                if (is_call_target && e_.yes.has_value_for_this_in_call())
-                    || e_.yes.is_anonymous_named()
-                {
+                if needs_comma_wrap {
                     *e = p
                         .new_expr(E::Number::new(0.0), e_.test_.loc)
                         .join_with_comma(e_.yes);
@@ -1531,21 +1535,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.is_control_flow_dead = old;
                 p.visit_expr(&mut e_.no);
 
+                // "(1 ? fn : 2)()" => "fn()"
+                // "(1 ? this.fn : 2)" => "this.fn"
+                // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
+                // "(0 ? 1 : class {})" => "(0, class {})"
+                let needs_comma_wrap = (is_call_target && e_.no.has_value_for_this_in_call())
+                    || e_.no.is_anonymous_named();
+
                 // "(a, false) ? b : c" => "a, c"
                 if side_effects.side_effects == SideEffects::CouldHaveSideEffects {
                     *e = SideEffects::simplify_unused_expr(p, e_.test_)
+                        .or_else(|| {
+                            needs_comma_wrap.then(|| p.new_expr(E::Number::new(0.0), e_.test_.loc))
+                        })
                         .unwrap_or_else(|| p.new_expr(E::Missing {}, e_.test_.loc))
                         .join_with_comma(e_.no);
                     return;
                 }
 
-                // "(1 ? fn : 2)()" => "fn()"
-                // "(1 ? this.fn : 2)" => "this.fn"
-                // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-                // "(0 ? 1 : class {})" => "(0, class {})"
-                if (is_call_target && e_.no.has_value_for_this_in_call())
-                    || e_.no.is_anonymous_named()
-                {
+                if needs_comma_wrap {
                     *e = p
                         .new_expr(E::Number::new(0.0), e_.test_.loc)
                         .join_with_comma(e_.no);

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -265,12 +265,17 @@ describe("constant folding preserves NamedEvaluation semantics", () => {
       const E = true ? class {} : 0;
       const F = false ? 0 : class {};
       const G = [class {}][0];
+      const H = [] ? class {} : 0;
+      const I = (function () {}) || 0;
+      const J = (() => {}) ?? 0;
+      const L = (class {}) ?? 0;
       const fn = (0, function () {});
       const ar = (0, () => {});
       function param(P = (0, class {})) { return P.name; }
       class Holder { field = (0, class {}); }
       console.log(JSON.stringify({
         A: A.name, B: B.name, C: C.name, D: D.name, E: E.name, F: F.name, G: G.name,
+        H: H.name, I: I.name, J: J.name, L: L.name,
         fn: fn.name, ar: ar.name, param: param(), field: new Holder().field.name,
       }));
     `;
@@ -285,6 +290,10 @@ describe("constant folding preserves NamedEvaluation semantics", () => {
       E: "",
       F: "",
       G: "",
+      H: "",
+      I: "",
+      J: "",
+      L: "",
       fn: "",
       ar: "",
       param: "",

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -252,3 +252,74 @@ describe("unterminated string literals in large files", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe("constant folding preserves NamedEvaluation semantics", () => {
+  // Folding a wrapper expression down to a bare anonymous class/function must
+  // not expose it to NamedEvaluation at the assignment/binding site.
+  test.concurrent("wrapped anonymous class/function .name stays empty", async () => {
+    const src = `
+      const A = (0, class {});
+      const B = true && class {};
+      const C = false || class {};
+      const D = null ?? class {};
+      const E = true ? class {} : 0;
+      const F = false ? 0 : class {};
+      const G = [class {}][0];
+      const fn = (0, function () {});
+      const ar = (0, () => {});
+      function param(P = (0, class {})) { return P.name; }
+      class Holder { field = (0, class {}); }
+      console.log(JSON.stringify({
+        A: A.name, B: B.name, C: C.name, D: D.name, E: E.name, F: F.name, G: G.name,
+        fn: fn.name, ar: ar.name, param: param(), field: new Holder().field.name,
+      }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      A: "",
+      B: "",
+      C: "",
+      D: "",
+      E: "",
+      F: "",
+      G: "",
+      fn: "",
+      ar: "",
+      param: "",
+      field: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("({ prop: class {} }).prop keeps the property key as .name", async () => {
+    const src = `
+      const K = ({ prop: class {} }).prop;
+      const M = ({ prop: function () {} }).prop;
+      const N = ({ prop: () => {} }).prop;
+      const X = ({}).x ??= class {};
+      console.log(JSON.stringify({ K: K.name, M: M.name, N: N.name, X: X.name }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ K: "prop", M: "prop", N: "prop", X: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("direct anonymous class/function still gets the binding name", async () => {
+    const src = `
+      const A = class {};
+      const B = function () {};
+      const C = () => {};
+      const D = (0, class Named {});
+      console.log(JSON.stringify({ A: A.name, B: B.name, C: C.name, D: D.name }));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ A: "A", B: "B", C: "C", D: "Named" });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`bun run` (no flags) gives anonymous classes/functions a `.name` the spec leaves empty:

```js
const A = (0, class {});
const B = true && class {};
const C = [class {}][0];
const K = ({ prop: class {} }).prop;
const fn = (0, function () {});
function param(P = (0, class {})) { return P.name; }
class Holder { field = (0, class {}); }
console.log(JSON.stringify({ A: A.name, B: B.name, C: C.name, K: K.name, fn: fn.name, param: param(), field: new Holder().field.name }));
// node:  {"A":"","B":"","C":"","K":"prop","fn":"","param":"","field":""}
// bun:   {"A":"A","B":"B","C":"C","K":"K","fn":"fn","param":"P","field":"field"}
```

## Why

The runtime transpiler forces `minify_syntax = true` for `target.is_bun()`, which enables constant folding at these sites:

- `BinComma`: `(0, expr)` -> `expr`
- `BinLogicalAnd` / `BinLogicalOr` / `BinNullishCoalescing`: `true && expr` -> `expr`
- `EIf`: `true ? expr : _` -> `expr`
- `EIndex` on `EArray`: `[expr][0]` -> `expr`
- `maybe_rewrite_property_access` on `EObject`: `({k: expr}).k` -> `expr`

When `expr` is an anonymous class/function/arrow, printing the folded result into a binding position (`const A = class {}`, default parameter, class field, object property) triggers NamedEvaluation and the binding name sticks. The `(0, expr)` idiom exists precisely to defeat this, so folding it away breaks real code (DI/registry keyed on `constructor.name`).

The object-literal case is worse: the spec assigns the property key (`"prop"`) as the name, so folding replaces a correct name with the wrong one.

## Fix

Guard each fold site with `is_anonymous_named()`, mirroring the existing `is_call_target && has_value_for_this_in_call()` pattern that already protects `this` binding. For comma/logical/ternary/array, emit `(0, expr)` instead of a bare anonymous class/function/arrow. For the object-literal property access, skip the fold (the property key name must be preserved).

Named classes/functions still fold normally since `is_anonymous_named()` returns false for them.

## Tests

Added to `test/bundler/transpiler/runtime-transpiler.test.ts`: all wrapper forms across `const`, default parameter, and class field positions, plus a guard test that direct `const A = class {}` still gets name `"A"` and `(0, class Named {})` still folds.