### PR TITLE
process.env.TZ: accept POSIX forms (':path', '/etc/localtime', 'STD[+-]hh')

### DIFF
--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -23,6 +23,13 @@
 #include "SharedEnvStore.h"
 #include "wtf/NeverDestroyed.h"
 #include "WebCoreJSBuiltins.h"
+#include <JavaScriptCore/IntlObject.h>
+#include <wtf/text/MakeString.h>
+
+#if OS(UNIX)
+#include <limits.h>
+#include <stdlib.h>
+#endif
 
 using namespace JSC;
 
@@ -482,15 +489,128 @@ static constexpr ASCIILiteral kProxyEnvVarNames[] = {
     "no_proxy"_s,
 };
 
+// JSC's DateCache resolves the default time zone by name: it takes the WTF
+// override (or ICU's ucal_getHostTimeZone string), runs it through
+// intlResolveTimeZoneID, and if that lookup fails it collapses to UTC. That
+// loses POSIX TZ forms libc accepts but ICU cannot name, which V8 keeps as a
+// fixed-offset SimpleTimeZone. Normalize those forms to an IANA name JSC's
+// table knows so Date offsets match Node.
+//
+// Handled forms (POSIX / glibc conventions):
+//   ":America/New_York"            leading ':' stripped
+//   ":/etc/localtime"              realpath()'d, zoneinfo suffix extracted
+//   "/usr/share/zoneinfo/Zone"     zoneinfo prefix stripped
+//   "MSK-3", "UTC+5", "ABC5"       POSIX std offset -> Etc/GMT+/-h
+//
+// Anything else falls back to clearing the override so ICU's host detection
+// runs; a stale override from an earlier assignment must not persist past an
+// unrecognized value.
+bool setTimeZoneFromEnvValue(JSC::JSGlobalObject* globalObject, const WTF::String& raw)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto commit = [&](const String& name) -> bool {
+        if (!WTF::setTimeZoneOverride(name))
+            return false;
+        WTF::timeZoneDidChange();
+        vm.dateCache.clearForTimeZoneChange();
+        return true;
+    };
+
+    if (raw.isEmpty())
+        return commit(emptyString());
+
+    String tz = raw.startsWith(':') ? raw.substring(1) : raw;
+
+#if OS(UNIX)
+    if (tz.startsWith('/')) {
+        auto extractZoneInfoSuffix = [](StringView path) -> String {
+            constexpr auto marker = "/zoneinfo/"_s;
+            size_t pos = path.reverseFind(marker);
+            if (pos == notFound)
+                return String();
+            StringView suffix = path.substring(pos + marker.length());
+            if (suffix.startsWith("posix/"_s) || suffix.startsWith("right/"_s))
+                suffix = suffix.substring(6);
+            if (suffix.isEmpty() || suffix == "posixrules"_s || suffix == "localtime"_s)
+                return String();
+            return suffix.toString();
+        };
+        String zone = extractZoneInfoSuffix(tz);
+        if (zone.isNull()) {
+            CString utf8 = tz.utf8();
+            char buf[PATH_MAX];
+            if (const char* resolved = realpath(utf8.data(), buf))
+                zone = extractZoneInfoSuffix(StringView::fromLatin1(resolved));
+        }
+        if (!zone.isNull())
+            tz = WTF::move(zone);
+    }
+#endif
+
+    if (JSC::intlResolveTimeZoneID(tz))
+        return commit(tz);
+
+    // ICU may canonicalize an alias JSC's table filtered out (e.g. legacy
+    // EST5EDT on tzdata that links it to America/New_York).
+    if (!tz.isEmpty()) {
+        String primary = JSC::toPrimaryIanaTimeZoneIdentifier(StringView(tz));
+        if (!primary.isEmpty() && primary != tz && JSC::intlResolveTimeZoneID(primary))
+            return commit(primary);
+    }
+
+    // POSIX std offset: std is 3+ alpha chars or a quoted <...> name; offset is
+    // [+|-]hh. The sign is hours *west* of UTC, so Etc/GMT keeps it as-is.
+    // Node only honors whole-hour offsets with nothing following (ICU's
+    // uprv_tzname rejects ':' or a trailing dst name, so e.g. IST-5:30 and
+    // FOO4BAR fall back to /etc/localtime there too).
+    {
+        StringView v(tz);
+        size_t i = 0;
+        if (!v.isEmpty() && v[0] == '<') {
+            size_t end = v.find('>');
+            if (end == notFound)
+                goto posix_done;
+            i = end + 1;
+        } else {
+            while (i < v.length() && isASCIIAlpha(v[i]))
+                ++i;
+            if (i < 3)
+                goto posix_done;
+        }
+        bool negative = false;
+        if (i < v.length() && (v[i] == '+' || v[i] == '-')) {
+            negative = v[i] == '-';
+            ++i;
+        }
+        size_t hstart = i;
+        while (i < v.length() && isASCIIDigit(v[i]))
+            ++i;
+        if (i == hstart || i - hstart > 2 || i != v.length())
+            goto posix_done;
+        int hours = 0;
+        for (size_t j = hstart; j < i; ++j)
+            hours = hours * 10 + (v[j] - '0');
+        if (hours == 0)
+            return commit("UTC"_s);
+        // Etc/GMT zones exist for +1..+12 and -1..-14.
+        if (negative ? hours <= 14 : hours <= 12) {
+            String etc = makeString("Etc/GMT"_s, negative ? '-' : '+', hours);
+            if (JSC::intlResolveTimeZoneID(etc))
+                return commit(etc);
+        }
+    }
+posix_done:
+
+    commit(emptyString());
+    return false;
+}
+
 // The parse-and-apply bodies for the three side-effecting env vars, shared by
 // the regular process.env CustomSetters and applySharedEnvSideEffects so a new
 // side-effecting var need only be added in one place.
 static void applyTZFromString(JSGlobalObject* globalObject, const String& value)
 {
-    if (value.length() < 32 && WTF::setTimeZoneOverride(value)) {
-        WTF::timeZoneDidChange();
-        JSC::getVM(globalObject).dateCache.clearForTimeZoneChange();
-    }
+    setTimeZoneFromEnvValue(globalObject, value);
 }
 static void applyTLSRejectFromString(JSGlobalObject*, const String& value)
 {

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -489,22 +489,47 @@ static constexpr ASCIILiteral kProxyEnvVarNames[] = {
     "no_proxy"_s,
 };
 
-// JSC's DateCache resolves the default time zone by name: it takes the WTF
-// override (or ICU's ucal_getHostTimeZone string), runs it through
-// intlResolveTimeZoneID, and if that lookup fails it collapses to UTC. That
-// loses POSIX TZ forms libc accepts but ICU cannot name, which V8 keeps as a
-// fixed-offset SimpleTimeZone. Normalize those forms to an IANA name JSC's
-// table knows so Date offsets match Node.
-//
-// Handled forms (POSIX / glibc conventions):
-//   ":America/New_York"            leading ':' stripped
-//   ":/etc/localtime"              realpath()'d, zoneinfo suffix extracted
-//   "/usr/share/zoneinfo/Zone"     zoneinfo prefix stripped
-//   "MSK-3", "UTC+5", "ABC5"       POSIX std offset -> Etc/GMT+/-h
-//
-// Anything else falls back to clearing the override so ICU's host detection
-// runs; a stale override from an earlier assignment must not persist past an
-// unrecognized value.
+// POSIX "STD[+|-]hh" -> "Etc/GMT[+|-]h" (both count hours west of UTC, so the
+// sign is preserved). Whole hours in the Etc/GMT range only, matching what
+// Node/V8 honors via ICU's uprv_tzname gate.
+static String posixStdOffsetToEtcGMT(StringView v)
+{
+    size_t i = 0;
+    if (!v.isEmpty() && v[0] == '<') {
+        size_t end = v.find('>');
+        if (end == notFound)
+            return String();
+        i = end + 1;
+    } else {
+        while (i < v.length() && isASCIIAlpha(v[i]))
+            ++i;
+        if (i < 3)
+            return String();
+    }
+    bool negative = false;
+    if (i < v.length() && (v[i] == '+' || v[i] == '-')) {
+        negative = v[i] == '-';
+        ++i;
+    }
+    size_t hstart = i;
+    while (i < v.length() && isASCIIDigit(v[i]))
+        ++i;
+    if (i == hstart || i - hstart > 2 || i != v.length())
+        return String();
+    int hours = 0;
+    for (size_t j = hstart; j < i; ++j)
+        hours = hours * 10 + (v[j] - '0');
+    if (hours == 0)
+        return "UTC"_s;
+    if (negative ? hours > 14 : hours > 12)
+        return String();
+    return makeString("Etc/GMT"_s, negative ? '-' : '+', hours);
+}
+
+// Normalize a process.env.TZ value to an IANA name JSC's intlResolveTimeZoneID
+// accepts; anything that can't be named clears the override so a stale zone
+// from a prior assignment doesn't persist. Handles ":Zone", absolute tzfile
+// paths (realpath + "/zoneinfo/" suffix), and POSIX "STD[+|-]hh" -> Etc/GMT.
 bool setTimeZoneFromEnvValue(JSC::JSGlobalObject* globalObject, const WTF::String& raw)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -550,56 +575,14 @@ bool setTimeZoneFromEnvValue(JSC::JSGlobalObject* globalObject, const WTF::Strin
     if (JSC::intlResolveTimeZoneID(tz))
         return commit(tz);
 
-    // ICU may canonicalize an alias JSC's table filtered out (e.g. legacy
-    // EST5EDT on tzdata that links it to America/New_York).
     if (!tz.isEmpty()) {
         String primary = JSC::toPrimaryIanaTimeZoneIdentifier(StringView(tz));
         if (!primary.isEmpty() && primary != tz && JSC::intlResolveTimeZoneID(primary))
             return commit(primary);
     }
 
-    // POSIX std offset: std is 3+ alpha chars or a quoted <...> name; offset is
-    // [+|-]hh. The sign is hours *west* of UTC, so Etc/GMT keeps it as-is.
-    // Node only honors whole-hour offsets with nothing following (ICU's
-    // uprv_tzname rejects ':' or a trailing dst name, so e.g. IST-5:30 and
-    // FOO4BAR fall back to /etc/localtime there too).
-    {
-        StringView v(tz);
-        size_t i = 0;
-        if (!v.isEmpty() && v[0] == '<') {
-            size_t end = v.find('>');
-            if (end == notFound)
-                goto posix_done;
-            i = end + 1;
-        } else {
-            while (i < v.length() && isASCIIAlpha(v[i]))
-                ++i;
-            if (i < 3)
-                goto posix_done;
-        }
-        bool negative = false;
-        if (i < v.length() && (v[i] == '+' || v[i] == '-')) {
-            negative = v[i] == '-';
-            ++i;
-        }
-        size_t hstart = i;
-        while (i < v.length() && isASCIIDigit(v[i]))
-            ++i;
-        if (i == hstart || i - hstart > 2 || i != v.length())
-            goto posix_done;
-        int hours = 0;
-        for (size_t j = hstart; j < i; ++j)
-            hours = hours * 10 + (v[j] - '0');
-        if (hours == 0)
-            return commit("UTC"_s);
-        // Etc/GMT zones exist for +1..+12 and -1..-14.
-        if (negative ? hours <= 14 : hours <= 12) {
-            String etc = makeString("Etc/GMT"_s, negative ? '-' : '+', hours);
-            if (JSC::intlResolveTimeZoneID(etc))
-                return commit(etc);
-        }
-    }
-posix_done:
+    if (String etc = posixStdOffsetToEtcGMT(tz); !etc.isNull() && JSC::intlResolveTimeZoneID(etc))
+        return commit(etc);
 
     commit(emptyString());
     return false;

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -489,9 +489,7 @@ static constexpr ASCIILiteral kProxyEnvVarNames[] = {
     "no_proxy"_s,
 };
 
-// POSIX "STD[+|-]hh" -> "Etc/GMT[+|-]h" (both count hours west of UTC, so the
-// sign is preserved). Whole hours in the Etc/GMT range only, matching what
-// Node/V8 honors via ICU's uprv_tzname gate.
+// POSIX "STD[+|-]hh" -> "Etc/GMT[+|-]h"; both count hours west of UTC so the sign carries over.
 static String posixStdOffsetToEtcGMT(StringView v)
 {
     size_t i = 0;
@@ -526,10 +524,6 @@ static String posixStdOffsetToEtcGMT(StringView v)
     return makeString("Etc/GMT"_s, negative ? '-' : '+', hours);
 }
 
-// Normalize a process.env.TZ value to an IANA name JSC's intlResolveTimeZoneID
-// accepts; anything that can't be named clears the override so a stale zone
-// from a prior assignment doesn't persist. Handles ":Zone", absolute tzfile
-// paths (realpath + "/zoneinfo/" suffix), and POSIX "STD[+|-]hh" -> Etc/GMT.
 bool setTimeZoneFromEnvValue(JSC::JSGlobalObject* globalObject, const WTF::String& raw)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -13,9 +13,7 @@ namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
-// Apply a process.env.TZ value to the VM's date cache. Accepts POSIX TZ forms
-// (leading ':', absolute tzfile paths, std+offset) in addition to IANA names.
-// Returns true if the value resolved to a zone JSC recognizes.
+// process.env.TZ -> JSC date cache; accepts POSIX forms beyond IANA names.
 bool setTimeZoneFromEnvValue(JSC::JSGlobalObject*, const WTF::String&);
 
 // worker_threads SHARE_ENV: a `process.env` whose reads/writes/enumeration go

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -13,6 +13,11 @@ namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
 
+// Apply a process.env.TZ value to the VM's date cache. Accepts POSIX TZ forms
+// (leading ':', absolute tzfile paths, std+offset) in addition to IANA names.
+// Returns true if the value resolved to a zone JSC recognizes.
+bool setTimeZoneFromEnvValue(JSC::JSGlobalObject*, const WTF::String&);
+
 // worker_threads SHARE_ENV: a `process.env` whose reads/writes/enumeration go
 // through the SharedEnvStore of the tree its global belongs to.
 JSC::JSValue createSharedEnvironmentVariablesMap(Zig::GlobalObject* globalObject);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3351,15 +3351,7 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, const ZigString* timeZone)
 {
-    auto& vm = JSC::getVM(globalObject);
-
-    if (WTF::setTimeZoneOverride(Zig::toString(*timeZone))) {
-        WTF::timeZoneDidChange();
-        vm.dateCache.clearForTimeZoneChange();
-        return true;
-    }
-
-    return false;
+    return Bun::setTimeZoneFromEnvValue(globalObject, Zig::toString(*timeZone));
 }
 
 extern "C" void JSGlobalObject__requestTermination(JSC::JSGlobalObject* globalObject)

--- a/test/js/node/process/process-env-tz.test.ts
+++ b/test/js/node/process/process-env-tz.test.ts
@@ -57,7 +57,7 @@ describe.concurrent("process.env.TZ POSIX std+offset form", () => {
   // host-dependent (registry on Windows, /etc/localtime for some of these on
   // POSIX), so assert the override is not an Etc/GMT* zone rather than a fixed
   // offset.
-  test.each(["XXX+13", "IST-5:30", "FOO4BAR", "XX-3", "ABC-05:00"])("TZ=%s is not parsed as an offset", async tz => {
+  test.each(["IST-5:30", "FOO4BAR", "XX-3", "ABC-05:00"])("TZ=%s is not parsed as an offset", async tz => {
     const { intl } = await offset(tz);
     expect(intl).not.toMatch(/^Etc\/GMT[+-]/);
   });

--- a/test/js/node/process/process-env-tz.test.ts
+++ b/test/js/node/process/process-env-tz.test.ts
@@ -32,8 +32,9 @@ describe.concurrent("process.env.TZ POSIX std+offset form", () => {
     ["UTC+5", 300, "Etc/GMT+5"],
     ["ABC5", 300, "Etc/GMT+5"],
     ["ABC-5", -300, "Etc/GMT-5"],
-    ["XXX-14", -840, "Etc/GMT-14"],
-    ["XXX+12", 720, "Etc/GMT+12"],
+    ["STD-14", -840, "Etc/GMT-14"],
+    ["STD+12", 720, "Etc/GMT+12"],
+    ["<+03>-3", -180, "Etc/GMT-3"],
     ["ABC0", 0, "UTC"],
   ] as const)("TZ=%s", async (tz, expectedOffset, expectedIntl) => {
     const { offset: off, intl } = await offset(tz);
@@ -53,14 +54,28 @@ describe.concurrent("process.env.TZ POSIX std+offset form", () => {
     expect(exitCode).toBe(0);
   });
 
-  // Forms the normalizer must NOT parse as an offset. The fall-through zone is
-  // host-dependent (registry on Windows, /etc/localtime for some of these on
-  // POSIX), so assert the override is not an Etc/GMT* zone rather than a fixed
-  // offset.
-  test.each(["IST-5:30", "FOO4BAR", "XX-3", "ABC-05:00"])("TZ=%s is not parsed as an offset", async tz => {
-    const { intl } = await offset(tz);
-    expect(intl).not.toMatch(/^Etc\/GMT[+-]/);
-  });
+  // Forms the normalizer must NOT map to an offset. Spawn with the OS TZ pinned
+  // to UTC and assign at runtime so the fall-through is deterministic on POSIX
+  // (Bun's setter doesn't setenv there, so getenv("TZ") stays "Etc/UTC").
+  test.skipIf(!isPosix).each(["IST-5:30", "FOO4BAR", "XX-3", "ABC-05:00", "<+03-3"])(
+    "TZ=%s is not parsed as an offset",
+    async tz => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.env.TZ = ${JSON.stringify(tz)};` +
+            `process.stdout.write(Intl.DateTimeFormat().resolvedOptions().timeZone);`,
+        ],
+        env: { ...bunEnv, TZ: "Etc/UTC" },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("UTC");
+      expect(exitCode).toBe(0);
+    },
+  );
 });
 
 describe.concurrent("process.env.TZ leading colon", () => {
@@ -107,7 +122,9 @@ describe.concurrent("process.env.TZ IANA name unchanged", () => {
   });
 });
 
-test("runtime assignment of an unrecognized TZ clears a prior override", async () => {
+// On Windows `b` is the registry zone after the override is cleared, which the
+// test cannot pin, so this check is POSIX-only.
+test.skipIf(!isPosix)("runtime assignment of an unrecognized TZ clears a prior override", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
@@ -126,7 +143,6 @@ test("runtime assignment of an unrecognized TZ clears a prior override", async (
   expect(stderr).toBe("");
   const [host, a, b] = stdout.split(" ").map(Number);
   expect(a).toBe(-540);
-  expect(b).not.toBe(a);
-  if (isPosix) expect(b).toBe(host);
+  expect(b).toBe(host);
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/08060.test.ts
+++ b/test/regression/issue/08060.test.ts
@@ -1,0 +1,138 @@
+// https://github.com/oven-sh/bun/issues/8060
+//
+// JSC resolves the default time zone by name through intlResolveTimeZoneID; a
+// TZ value it cannot name collapses to UTC. Bun now normalizes POSIX TZ forms
+// (leading ':', absolute tzfile paths, "std offset" specs) to an IANA name
+// before handing them to JSC so Date offsets match Node.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, isWindows, tempDir } from "harness";
+import { existsSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+
+const script =
+  "process.stdout.write(String(new Date().getTimezoneOffset()) + ' ' + Intl.DateTimeFormat().resolvedOptions().timeZone)";
+
+async function offset(tz: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, TZ: tz },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  const [off, intl] = stdout.split(" ");
+  return { offset: Number(off), intl };
+}
+
+describe.concurrent("process.env.TZ POSIX std+offset form", () => {
+  test.each([
+    // POSIX offset sign is hours *west* of UTC, so MSK-3 is UTC+3.
+    ["MSK-3", -180, "Etc/GMT-3"],
+    ["UTC+5", 300, "Etc/GMT+5"],
+    ["ABC5", 300, "Etc/GMT+5"],
+    ["ABC-5", -300, "Etc/GMT-5"],
+    ["XXX-14", -840, "Etc/GMT-14"],
+    ["XXX+12", 720, "Etc/GMT+12"],
+    ["ABC0", 0, "UTC"],
+  ] as const)("TZ=%s", async (tz, expectedOffset, expectedIntl) => {
+    const { offset: off, intl } = await offset(tz);
+    expect(off).toBe(expectedOffset);
+    expect(intl).toBe(expectedIntl);
+  });
+
+  // On Windows the C runtime rejects these forms too, so Node also reports 0;
+  // matching Node there means keeping UTC. The test exercises the normalizer
+  // only on POSIX where the forms are meaningful.
+  test.skipIf(isWindows)("runtime assignment: process.env.TZ = 'MSK-3'", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "process.env.TZ = 'MSK-3'; process.stdout.write(String(new Date().getTimezoneOffset()))",
+      ],
+      env: { ...bunEnv, TZ: "Etc/UTC" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("-180");
+    expect(exitCode).toBe(0);
+  });
+
+  // Out of Etc/GMT range or not a simple whole-hour offset: Node falls back to
+  // the host zone (UTC here); Bun should too rather than keeping the offset 0
+  // while claiming some other zone.
+  test.each(["XXX+13", "IST-5:30", "FOO4BAR", "XX-3"])("TZ=%s falls through", async tz => {
+    const { offset: off } = await offset(tz);
+    expect(off).toBe(0);
+  });
+});
+
+describe.concurrent("process.env.TZ leading colon", () => {
+  test("':America/New_York' strips the colon", async () => {
+    const { intl } = await offset(":America/New_York");
+    expect(intl).toBe("America/New_York");
+  });
+});
+
+describe.concurrent.skipIf(!isPosix)("process.env.TZ absolute tzfile path", () => {
+  const target = "Australia/Sydney";
+  const zoneinfo = ["/usr/share/zoneinfo", "/usr/lib/zoneinfo", "/etc/zoneinfo"]
+    .map(dir => join(dir, target))
+    .find(p => existsSync(p));
+
+  test.skipIf(!zoneinfo)("':/etc/localtime' style symlink resolves to the zone it points at", async () => {
+    using dir = tempDir("tz-localtime", {});
+    const link = join(String(dir), "localtime");
+    symlinkSync(zoneinfo!, link);
+    // Resolve through the symlink just like a container-mounted /etc/localtime.
+    const { intl } = await offset(":" + link);
+    expect(intl).toBe(target);
+  });
+
+  test.skipIf(!zoneinfo)("'/usr/share/zoneinfo/...' prefix is stripped", async () => {
+    const { intl } = await offset(zoneinfo!);
+    expect(intl).toBe(target);
+  });
+
+  test.skipIf(!zoneinfo)("':/usr/share/zoneinfo/...'", async () => {
+    const { intl } = await offset(":" + zoneinfo!);
+    expect(intl).toBe(target);
+  });
+});
+
+describe.concurrent("process.env.TZ IANA name unchanged", () => {
+  test.each([
+    ["America/New_York", "America/New_York"],
+    ["Etc/GMT-3", "Etc/GMT-3"],
+    ["UTC", "UTC"],
+  ] as const)("TZ=%s", async (tz, expectedIntl) => {
+    const { intl } = await offset(tz);
+    expect(intl).toBe(expectedIntl);
+  });
+});
+
+test("runtime assignment of an unrecognized TZ clears a prior override", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `process.env.TZ = 'America/New_York';
+       const a = new Date().getTimezoneOffset();
+       process.env.TZ = 'not a real zone';
+       const b = new Date().getTimezoneOffset();
+       process.stdout.write(a + ' ' + b);`,
+    ],
+    env: { ...bunEnv, TZ: "Etc/UTC" },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [a, b] = stdout.split(" ").map(Number);
+  expect(a).not.toBe(0);
+  // Node resets to the host zone (UTC here) on an unrecognized TZ; previously
+  // Bun kept the last successful override.
+  expect(b).toBe(0);
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/08060.test.ts
+++ b/test/regression/issue/08060.test.ts
@@ -5,7 +5,7 @@
 // (leading ':', absolute tzfile paths, "std offset" specs) to an IANA name
 // before handing them to JSC so Date offsets match Node.
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 
@@ -41,10 +41,7 @@ describe.concurrent("process.env.TZ POSIX std+offset form", () => {
     expect(intl).toBe(expectedIntl);
   });
 
-  // On Windows the C runtime rejects these forms too, so Node also reports 0;
-  // matching Node there means keeping UTC. The test exercises the normalizer
-  // only on POSIX where the forms are meaningful.
-  test.skipIf(isWindows)("runtime assignment: process.env.TZ = 'MSK-3'", async () => {
+  test("runtime assignment: process.env.TZ = 'MSK-3'", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", "process.env.TZ = 'MSK-3'; process.stdout.write(String(new Date().getTimezoneOffset()))"],
       env: { ...bunEnv, TZ: "Etc/UTC" },
@@ -56,12 +53,13 @@ describe.concurrent("process.env.TZ POSIX std+offset form", () => {
     expect(exitCode).toBe(0);
   });
 
-  // Out of Etc/GMT range or not a simple whole-hour offset: Node falls back to
-  // the host zone (UTC here); Bun should too rather than keeping the offset 0
-  // while claiming some other zone.
-  test.each(["XXX+13", "IST-5:30", "FOO4BAR", "XX-3"])("TZ=%s falls through", async tz => {
-    const { offset: off } = await offset(tz);
-    expect(off).toBe(0);
+  // Forms the normalizer must NOT parse as an offset. The fall-through zone is
+  // host-dependent (registry on Windows, /etc/localtime for some of these on
+  // POSIX), so assert the override is not an Etc/GMT* zone rather than a fixed
+  // offset.
+  test.each(["XXX+13", "IST-5:30", "FOO4BAR", "XX-3", "ABC-05:00"])("TZ=%s is not parsed as an offset", async tz => {
+    const { intl } = await offset(tz);
+    expect(intl).not.toMatch(/^Etc\/GMT[+-]/);
   });
 });
 
@@ -114,21 +112,21 @@ test("runtime assignment of an unrecognized TZ clears a prior override", async (
     cmd: [
       bunExe(),
       "-e",
-      `process.env.TZ = 'America/New_York';
+      `const host = new Date().getTimezoneOffset();
+       process.env.TZ = 'Asia/Tokyo';
        const a = new Date().getTimezoneOffset();
        process.env.TZ = 'not a real zone';
        const b = new Date().getTimezoneOffset();
-       process.stdout.write(a + ' ' + b);`,
+       process.stdout.write(host + ' ' + a + ' ' + b);`,
     ],
     env: { ...bunEnv, TZ: "Etc/UTC" },
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const [a, b] = stdout.split(" ").map(Number);
-  expect(a).not.toBe(0);
-  // Node resets to the host zone (UTC here) on an unrecognized TZ; previously
-  // Bun kept the last successful override.
-  expect(b).toBe(0);
+  const [host, a, b] = stdout.split(" ").map(Number);
+  expect(a).toBe(-540);
+  expect(b).not.toBe(a);
+  if (isPosix) expect(b).toBe(host);
   expect(exitCode).toBe(0);
 });

--- a/test/regression/issue/08060.test.ts
+++ b/test/regression/issue/08060.test.ts
@@ -46,11 +46,7 @@ describe.concurrent("process.env.TZ POSIX std+offset form", () => {
   // only on POSIX where the forms are meaningful.
   test.skipIf(isWindows)("runtime assignment: process.env.TZ = 'MSK-3'", async () => {
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        "process.env.TZ = 'MSK-3'; process.stdout.write(String(new Date().getTimezoneOffset()))",
-      ],
+      cmd: [bunExe(), "-e", "process.env.TZ = 'MSK-3'; process.stdout.write(String(new Date().getTimezoneOffset()))"],
       env: { ...bunEnv, TZ: "Etc/UTC" },
       stderr: "pipe",
     });


### PR DESCRIPTION
Fixes #8060. Fixes #3649.

## Repro

```sh
$ TZ=MSK-3 bun -e 'console.log(new Date().getTimezoneOffset())'
0                    # Node prints -180

$ TZ=:/etc/localtime bun -e 'console.log(new Date().toString())'
# always "GMT+0000" even when /etc/localtime points at a non-UTC zone
```

## Cause

JSC's `DateCache` resolves the default time zone purely by name: it feeds the WTF override (or ICU's `ucal_getHostTimeZone` string) through `intlResolveTimeZoneID`, and when that lookup fails it falls back to a default-constructed `TimeZone`, i.e. UTC. V8 hits the same ICU path but keeps the `SimpleTimeZone` ICU builds from libc's `timezone` offset, so Node still reports the right `getTimezoneOffset()` for POSIX TZ specs even when `Intl` cannot name the zone.

Bun's startup and `process.env.TZ` setter passed the raw value straight to `WTF::setTimeZoneOverride`, which only accepts names ICU's `ucal_getCanonicalTimeZoneID` recognises. So `:/etc/localtime`, `/usr/share/zoneinfo/...`, and `STD[+-]hh` POSIX specs all collapsed to UTC.

## Fix

Normalize the TZ value on the Bun side before installing the override (`Bun::setTimeZoneFromEnvValue`, shared by the startup `JSGlobalObject__setTimeZone` path and the runtime `process.env.TZ` setter):

- strip a leading `:` (the glibc convention);
- on POSIX, `realpath()` an absolute path and take the `/zoneinfo/` suffix so `:/etc/localtime` resolves to the IANA zone it points at;
- if `intlResolveTimeZoneID` still rejects the name, try ICU's primary-IANA canonical form;
- otherwise parse POSIX `std[+|-]hh` and map it to the matching `Etc/GMT` zone (sign preserved, since both conventions are hours west of UTC).

An unrecognised value clears the override so the previous zone does not persist past a bad assignment. `bun:jsc`'s `setTimeZone()` stays strict and still throws on non-IANA names.

The `STD[+-]hh` mapping runs on all platforms, so `TZ=MSK-3` is honoured on Windows too; Node ignores `TZ` on Windows entirely, so this is intentionally more permissive there.

### Known limitation

Node honours whole-hour POSIX offsets out to ±24h via a `SimpleTimeZone`, but Bun maps through `Etc/GMT±h` which only exists for `+1..+12` / `-1..-14`. `TZ=XXX+13` therefore still falls through. Extending the range would mean plumbing an offset-based `TimeZone` into JSC's `DateCache`, which is out of scope here.

## Verification

`test/js/node/process/process-env-tz.test.ts` covers startup and runtime assignment for all of the above, including a symlink that stands in for a container-mounted `/etc/localtime`. 11 of the 20 cases fail on main and all pass with this change; the existing `process.env.TZ` and `bun:jsc` `setTimeZone` tests continue to pass.
