### PR TITLE
resolver: read every default main-field name when parsing package.json

### DIFF
--- a/src/ast/target.rs
+++ b/src/ast/target.rs
@@ -80,7 +80,7 @@ impl Target {
     // `bake_graph()` stays in bun_bake (would back-edge into tier-6).
     // `out_extensions()` stays in bun_bundler (allocator-heavy, only used there).
 
-    const MAIN_FIELD_NAMES: [&'static str; 4] = [
+    pub const MAIN_FIELD_NAMES: [&'static str; 4] = [
         "browser",
         "module",
         "main",

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -206,14 +206,8 @@ pub(crate) use bun_ast::Target;
 // module-level name for callers that pre-date it.
 pub use bun_ast::target::TARGET_MAP;
 
-pub(crate) const TARGET_MAIN_FIELD_NAMES: [&[u8]; 4] = [
-    b"browser",
-    b"module",
-    b"main",
-    // https://github.com/jsforum/jsforum/issues/5
-    // Older packages might use jsnext:main in place of module
-    b"jsnext:main",
-];
+// Re-export of the byte view in `bun_resolver::options`, kept under its pre-existing name.
+pub(crate) use bun_resolver::options::ALL_DEFAULT_MAIN_FIELD_NAMES as TARGET_MAIN_FIELD_NAMES;
 
 // Note that this means if a package specifies "module" and "main", the ES6
 // module will not be selected. This means tree shaking will not work when

--- a/src/resolver/options.rs
+++ b/src/resolver/options.rs
@@ -12,6 +12,14 @@ pub use crate::tsconfig_json::options::jsx;
 pub(crate) use bun_ast::Target;
 pub use bun_options_types::bundle_enums::ModuleType;
 
+// Byte view of the canonical `Target::MAIN_FIELD_NAMES`; `PackageJSON::parse` reads the whole union.
+pub const ALL_DEFAULT_MAIN_FIELD_NAMES: [&[u8]; 4] = [
+    Target::MAIN_FIELD_NAMES[0].as_bytes(),
+    Target::MAIN_FIELD_NAMES[1].as_bytes(),
+    Target::MAIN_FIELD_NAMES[2].as_bytes(),
+    Target::MAIN_FIELD_NAMES[3].as_bytes(),
+];
+
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum Packages {
     #[default]

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -562,20 +562,25 @@ impl PackageJSON {
             }
         }
 
-        // Read the "main" fields
-        for main in r.opts.main_fields.iter() {
-            if let Some(main_json) = json.as_property(main) {
+        // Cached across targets, so store every default main-field name, not just this target's (#14253).
+        let mut read_main_field = |name: &[u8]| {
+            if let Some(main_json) = json.as_property(name) {
                 let expr: &js_ast::Expr = &main_json.expr;
-
                 if let Some(str) = expr.as_utf8_string_literal() {
                     if !str.is_empty() {
                         package_json
                             .main_fields
-                            .put(main, Box::from(str))
+                            .put(name, Box::from(str))
                             .expect("unreachable");
                     }
                 }
             }
+        };
+        for name in crate::options::ALL_DEFAULT_MAIN_FIELD_NAMES {
+            read_main_field(name);
+        }
+        for name in r.opts.main_fields.iter() {
+            read_main_field(name);
         }
 
         // Read the "browser" property

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -900,6 +900,85 @@ describe("Bun.build", () => {
       expect(await html?.text()).toContain("<meta name='injected-by-plugin' content='true'>");
     },
   );
+
+  // https://github.com/oven-sh/bun/issues/14253
+  // Parsed package.json is cached process-globally. The cache must store every
+  // default main-field name so a later build with a different target finds the
+  // field it needs.
+  describe("target main-field resolution is independent of prior resolutions in the same process", () => {
+    const pkgFiles = {
+      "node_modules/dual-pkg/package.json": JSON.stringify({
+        name: "dual-pkg",
+        version: "1.0.0",
+        main: "./node.js",
+        browser: "./browser.js",
+      }),
+      "node_modules/dual-pkg/node.js": `module.exports = "RESOLVED_NODE";`,
+      "node_modules/dual-pkg/browser.js": `module.exports = "RESOLVED_BROWSER";`,
+      "entry.ts": `import v from "dual-pkg"; console.log(v);`,
+    };
+
+    test.concurrent("runtime import then Bun.build({ target: 'browser' })", async () => {
+      using dir = tempDir("bun-build-main-fields-runtime-first", {
+        ...pkgFiles,
+        "build.ts": `
+          import v from "dual-pkg";
+          if (v !== "RESOLVED_NODE") throw new Error("runtime import resolved to " + v);
+          const result = await Bun.build({ entrypoints: ["./entry.ts"], target: "browser" });
+          if (!result.success) throw new AggregateError(result.logs, "build failed");
+          const text = await result.outputs[0].text();
+          console.log(text.includes("RESOLVED_BROWSER") ? "browser" : text.includes("RESOLVED_NODE") ? "node" : "neither");
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("browser");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("Bun.build for each target in the same process", async () => {
+      using dir = tempDir("bun-build-main-fields-sequential", {
+        ...pkgFiles,
+        "build.ts": `
+          async function buildFor(target) {
+            const result = await Bun.build({ entrypoints: ["./entry.ts"], target });
+            if (!result.success) throw new AggregateError(result.logs, "build failed for " + target);
+            const text = await result.outputs[0].text();
+            return text.includes("RESOLVED_BROWSER") ? "browser" : text.includes("RESOLVED_NODE") ? "node" : "neither";
+          }
+          console.log(JSON.stringify({
+            bun: await buildFor("bun"),
+            browser: await buildFor("browser"),
+            node: await buildFor("node"),
+            browser2: await buildFor("browser"),
+          }));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        bun: "node",
+        browser: "browser",
+        node: "node",
+        browser2: "browser",
+      });
+      expect(exitCode).toBe(0);
+    });
+  });
 });
 
 test.concurrent("macro with nested object", async () => {


### PR DESCRIPTION
Fixes #14253.

## Repro

```ts
// node_modules/dual-pkg/package.json
{ "name": "dual-pkg", "main": "./node.js", "browser": "./browser.js" }

// build.ts
import v from "dual-pkg";              // runtime import (target=bun)
const r = await Bun.build({ entrypoints: ["./entry.ts"], target: "browser" });
// r.outputs[0] bundles ./node.js instead of ./browser.js
```

Same symptom for two sequential `Bun.build` calls with different targets in the same process: a `target: "bun"` build followed by a `target: "browser"` build bundles the `main` entry for both.

## Cause

`PackageJSON::parse` populated `main_fields` by iterating only the invoking resolver's `opts.main_fields`:

```rust
for main in r.opts.main_fields.iter() {
    if let Some(main_json) = json.as_property(main) { ... main_fields.put(main, ...) }
}
```

The parsed `PackageJSON` is then interned into the process-global `DirInfo` cache (keyed only by directory path). The runtime's resolver (target `bun`, `main_fields = ["module", "main", "jsnext:main"]`) parses first and never stores `"browser"`. A later `Bun.build({ target: "browser" })` reuses that cached `PackageJSON`, iterates its own `opts.main_fields = ["browser", "module", ...]`, fails to find `"browser"` in the map, and falls through to `"main"`.

The object-form `"browser"` map right below this block is already parsed unconditionally for exactly this reason (see the existing comment in `package_json.rs`); the string-form main field was not.

## Fix

Always read the fixed union of every per-target default (`browser`, `module`, `main`, `jsnext:main`) into `main_fields`, in addition to `r.opts.main_fields` for custom user-configured names. This matches esbuild, which reads a hardcoded `["main", "module", "browser"]` at parse time independent of `options.MainFields`.

The consuming loop in `load_as_file_or_directory` iterates the *current* resolver's `opts.main_fields` and looks each key up in the stored map, so storing extra entries is harmless: a target that does not list `"browser"` never reads it.

There is one literal table for the default names. `bun_ast::Target::MAIN_FIELD_NAMES` is the canonical list (it already backs `Target::default_main_fields`). `bun_resolver::options::ALL_DEFAULT_MAIN_FIELD_NAMES` is its byte view, which `PackageJSON::parse` reads. `bun_bundler` re-exports that byte view as `TARGET_MAIN_FIELD_NAMES` instead of keeping its own copy.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/bun-build-api.test.ts -t "target main-field"
(fail) runtime import then Bun.build({ target: 'browser' })   Expected: "browser"  Received: "node"
(fail) Bun.build for each target in the same process          browser: "node", browser2: "node"

$ bun bd test test/bundler/bun-build-api.test.ts -t "target main-field"
(pass) runtime import then Bun.build({ target: 'browser' })
(pass) Bun.build for each target in the same process
```

Also green after the rebase: full `bun-build-api.test.ts` (55 pass, 0 fail) with the debug build.

<details><summary>Rebase notes</summary>

Main deleted the resolver crate's per-target `DEFAULT_MAIN_FIELDS_*` block as dead code and moved the canonical per-target lists into `bun_ast::Target` (same union-index structure this PR had introduced). The branch was rebuilt on top of that: the union constant now derives from `Target::MAIN_FIELD_NAMES` (made `pub`, str to bytes via `as_bytes()`), and the bundler's byte table became a re-export. The parse-side fix and the tests are unchanged.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
