### PR TITLE
watcher(windows): watch workspace packages outside the project root

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -368,8 +368,8 @@ pub struct DevServer {
     // in `thread_main` once `running` flips false). Auto-dropping a
     // `Box<Watcher>` here would free the heap block while the watcher thread
     // is still blocked in `GetQueuedCompletionStatus`/`read()` holding a
-    // `*mut Watcher` into it (and on Windows the kernel still has a pending
-    // `ReadDirectoryChangesW` against the inline `DirWatcher.buf`/`overlapped`).
+    // `*mut Watcher` into it (and on Windows the kernel still has pending
+    // `ReadDirectoryChangesW` I/O against the per-root `DirWatcher` buffers).
     // `ManuallyDrop` so `Drop for DevServer` can hand the raw pointer to
     // `Watcher::shutdown` instead.
     pub(crate) bun_watcher: ::core::mem::ManuallyDrop<Box<Watcher>>,
@@ -1095,10 +1095,9 @@ impl Drop for DevServer {
         // Hand ownership of the heap allocation to the watcher thread (which frees it in
         // `thread_main` once `running` flips false). Auto-dropping the `Box`
         // here would free the allocation out from under the still-running
-        // thread; on Windows the kernel additionally retains a pending
-        // `ReadDirectoryChangesW` against the inline 64 KiB `DirWatcher.buf` +
-        // `overlapped`, so the freed block being recycled by mimalloc for a
-        // later allocation is a kernel write into live unrelated heap data.
+        // thread; on Windows the kernel additionally retains pending
+        // `ReadDirectoryChangesW` I/O against the per-root `DirWatcher`
+        // buffers until `stop()` cancels and drains it.
         // SAFETY: `bun_watcher` was written exactly once in `init()` and is
         // never taken elsewhere; this is `Drop`, so the field is not read again.
         let watcher = unsafe { ::core::mem::ManuallyDrop::take(&mut self.bun_watcher) };

--- a/src/runtime/node/path_watcher.rs
+++ b/src/runtime/node/path_watcher.rs
@@ -2,8 +2,8 @@
 //!
 //! This is deliberately independent of `bun.Watcher` (the bundler/--watch/--hot
 //! watcher). `bun.Watcher` is shaped around a module graph — its WatchItem carries
-//! `options.Loader`, `*PackageJSON`, a filesystem handle, and on Windows is pinned
-//! to `top_level_dir`. None of that applies to `fs.watch()`, and routing `fs.watch()`
+//! `options.Loader`, `*PackageJSON`, a filesystem handle, and on Windows watches
+//! per-module-graph roots. None of that applies to `fs.watch()`, and routing `fs.watch()`
 //! through it required a 1k-line shim (the old version of this file) full of
 //! lock-ordering workarounds, a WorkPool directory crawler, and a bolted-on FSEvents
 //! side-channel.

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -56,6 +56,13 @@ pub mod kernel32 {
             lpOverlapped: *mut *mut OVERLAPPED,
             dwMilliseconds: DWORD,
         ) -> BOOL;
+        pub fn CancelIoEx(hFile: HANDLE, lpOverlapped: LPOVERLAPPED) -> BOOL;
+        pub fn GetOverlappedResult(
+            hFile: HANDLE,
+            lpOverlapped: LPOVERLAPPED,
+            lpNumberOfBytesTransferred: *mut DWORD,
+            bWait: BOOL,
+        ) -> BOOL;
         pub fn ReadDirectoryChangesW(
             hDirectory: HANDLE,
             lpBuffer: *mut c_void,

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -760,8 +760,8 @@ impl Watcher {
             Err(err) => {
                 return Err(err.with_path(file_path));
             }
-            // Not appended (e.g. outside the project root on Windows); the
-            // caller keeps the descriptor.
+            // Not appended (on Windows: its watch root could not be opened);
+            // the caller keeps the descriptor.
             Ok(FdOwnership::Caller) => return Ok(FdOwnership::Caller),
             Ok(FdOwnership::Watcher) => {}
         }
@@ -1117,9 +1117,9 @@ pub enum FdOwnership {
     /// close it. The caller must not use or close it afterwards.
     Watcher,
     /// The watchlist did not take the descriptor: the file was already
-    /// watched with a valid stored one, or the path is not watchable (e.g.
-    /// outside the project root on Windows). The caller still owns `fd` and
-    /// must close it (or keep using it).
+    /// watched with a valid stored one, or (on Windows) its watch root could
+    /// not be opened. The caller still owns `fd` and must close it (or keep
+    /// using it).
     Caller,
 }
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -129,6 +129,16 @@ pub struct Watcher {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(crate) eventlist_index_scratch: Vec<platform::EventListIndex>,
 
+    /// Scratch snapshot of `watchlist.file_path` taken under `mutex` in
+    /// `watch_loop_cycle`; owned by the watcher thread.
+    #[cfg(windows)]
+    pub(crate) platform_scratch: Vec<bun_ptr::RawSlice<u8>>,
+
+    /// Watch roots whose `add_root` failed, so the warning prints once per
+    /// root rather than once per file per reload.
+    #[cfg(windows)]
+    pub(crate) unwatchable_roots: Vec<Box<[u8]>>,
+
     pub(crate) ctx: *mut (),
     pub(crate) on_file_update: fn(*mut (), &mut [WatchEvent], &[ChangedFilePath], &WatchList),
     pub(crate) on_error: fn(*mut (), sys::Error),
@@ -205,6 +215,10 @@ impl Watcher {
             evict_list_i: 0,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index_scratch: Vec::new(),
+            #[cfg(windows)]
+            platform_scratch: Vec::new(),
+            #[cfg(windows)]
+            unwatchable_roots: Vec::new(),
             thread_lock: ThreadLock::init_unlocked(),
         });
 
@@ -353,10 +367,18 @@ impl Watcher {
 
         log!("Watcher started");
 
-        let owner_still_alive = match self.watch_loop() {
+        let loop_result = self.watch_loop();
+        // Both exits must stop the platform before the Box can drop: on
+        // Windows every root still has a pending ReadDirectoryChangesW aimed
+        // at its buffer. Locked to serialise against `add_root` on other
+        // threads.
+        {
+            let _guard = self.mutex.lock_guard();
+            self.platform.stop();
+        }
+        let owner_still_alive = match loop_result {
             Err(err) => {
                 self.watchloop_handle.store(false);
-                self.platform.stop();
                 let running = self.running.load();
                 if running {
                     (self.on_error)(self.ctx, err);
@@ -522,13 +544,8 @@ impl Watcher {
     ) -> sys::Result<FdOwnership> {
         #[cfg(windows)]
         {
-            // on windows we can only watch items that are in the directory tree of the top level dir
-            let rel = bun_paths::resolve_path::is_parent_or_equal(self.top_level_dir(), file_path);
-            if rel == bun_paths::resolve_path::ParentEqual::Unrelated {
-                bun_core::warn!(
-                    "File {} is not in the project directory and will not be watched\n",
-                    bstr::BStr::new(file_path)
-                );
+            let pathname = bun_paths::fs::PathName::init(file_path);
+            if !self.ensure_watch_root_covers(pathname.dir_with_trailing_slash()) {
                 return Ok(FdOwnership::Caller);
             }
         }
@@ -593,12 +610,7 @@ impl Watcher {
     ) -> sys::Result<WatchItemIndex> {
         #[cfg(windows)]
         {
-            let rel = bun_paths::resolve_path::is_parent_or_equal(self.top_level_dir(), file_path);
-            if rel == bun_paths::resolve_path::ParentEqual::Unrelated {
-                bun_core::warn!(
-                    "Directory {} is not in the project directory and will not be watched\n",
-                    bstr::BStr::new(file_path)
-                );
+            if !self.ensure_watch_root_covers(file_path) {
                 return Ok(NO_WATCH_ITEM);
             }
         }
@@ -783,6 +795,33 @@ impl Watcher {
     #[inline]
     fn top_level_dir(&self) -> &[u8] {
         self.cwd
+    }
+
+    /// Ensure `dir` (absolute, trailing separator) is inside a Windows watch
+    /// root, registering a new recursive `ReadDirectoryChangesW` root if not.
+    /// Returns false only when opening the root failed (the file is then
+    /// skipped, as before). Caller holds `self.mutex`.
+    #[cfg(windows)]
+    fn ensure_watch_root_covers(&mut self, dir: &[u8]) -> bool {
+        if self.platform.covers(dir) {
+            return true;
+        }
+        let root = platform::pick_watch_root(dir);
+        if self.unwatchable_roots.iter().any(|r| r.as_ref() == root) {
+            return false;
+        }
+        match self.platform.add_root(root) {
+            Ok(()) => true,
+            Err(err) => {
+                bun_core::warn!(
+                    "Directory {} could not be opened for watching ({}); changes under it will not be watched\n",
+                    bstr::BStr::new(root),
+                    err.name()
+                );
+                self.unwatchable_roots.push(root.to_vec().into_boxed_slice());
+                false
+            }
+        }
     }
 
     pub fn add_directory<const CLONE_FILE_PATH: bool>(

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -818,7 +818,8 @@ impl Watcher {
                     bstr::BStr::new(root),
                     err.name()
                 );
-                self.unwatchable_roots.push(root.to_vec().into_boxed_slice());
+                self.unwatchable_roots
+                    .push(root.to_vec().into_boxed_slice());
                 false
             }
         }

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -172,21 +172,21 @@ impl DirWatcher {
         if self.is_dead() {
             return;
         }
-        // Copy the handle before publishing `dead`: once the store lands, a
-        // transpiler thread may reuse this slot and overwrite `dir_handle`.
+        // Every field read happens before publishing `dead`: once the store
+        // lands, a transpiler thread may reuse this slot and rewrite the box.
         let handle = self.dir_handle;
-        self.state.dead.store(true);
-        // SAFETY: `handle` is the handle `add_root` opened; `stop()` skips
-        // dead roots, so this is the only close.
-        unsafe {
-            let _ = w::CloseHandle(handle);
-        }
         bun_core::scoped_log!(
             watcher,
             "stopped watching {} ({})",
             bstr::BStr::new(&self.state.path),
             bstr::BStr::new(cause.name())
         );
+        self.state.dead.store(true);
+        // SAFETY: `handle` is the handle `add_root` opened; `stop()` skips
+        // dead roots, so this is the only close.
+        unsafe {
+            let _ = w::CloseHandle(handle);
+        }
     }
 }
 
@@ -587,17 +587,18 @@ pub(crate) fn pick_watch_root(dir: &[u8]) -> &[u8] {
     }
 
     // Nearest enclosing package.json.
+    const PKG: &[u8] = b"package.json";
     let mut probe = bun_paths::path_buffer_pool::get();
     let mut end = dir.len(); // index one past a separator
     for _ in 0..64 {
-        if end <= 3 || end + NM.len() + 1 >= probe.len() {
+        if end <= 3 || end + PKG.len() + 1 >= probe.len() {
             break;
         }
         probe[..end].copy_from_slice(&dir[..end]);
-        probe[end..end + 12].copy_from_slice(b"package.json");
-        probe[end + 12] = 0;
-        // SAFETY: the NUL at [end + 12] was written above.
-        let candidate = unsafe { bun_core::ZStr::from_raw(probe.as_ptr(), end + 12) };
+        probe[end..end + PKG.len()].copy_from_slice(PKG);
+        probe[end + PKG.len()] = 0;
+        // SAFETY: the NUL at [end + PKG.len()] was written above.
+        let candidate = unsafe { bun_core::ZStr::from_raw(probe.as_ptr(), end + PKG.len()) };
         if bun_sys::exists_z(candidate) {
             return &dir[..end];
         }

--- a/src/watcher/WindowsWatcher.rs
+++ b/src/watcher/WindowsWatcher.rs
@@ -1,13 +1,23 @@
 //! Bun's filesystem watcher implementation for windows using kernel32
+//!
+//! Each watch root is a recursive `ReadDirectoryChangesW` on one directory,
+//! so files resolved outside the initial root (workspace packages reached
+//! through a `node_modules` symlink, `bun link`ed packages, `file:` deps)
+//! need an additional root. All `DirWatcher`s share one IOCP; a completion's
+//! `lpOverlapped` is the address of the `DirWatcher` that fired (it is the
+//! first field), so `next()` identifies the source without touching the
+//! `watchers` Vec and therefore without the mutex.
 
 use core::mem::size_of;
 use core::ptr;
+use std::sync::Arc;
 
-use crate::watcher_impl::{Op, WatchEvent, WatchItemColumns, WatchItemIndex, Watcher};
+use crate::watcher_impl::{Op, WatchEvent, WatchItemColumns, WatchItemIndex, WatchList, Watcher};
 use bun_core::strings;
 use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
 use bun_paths::{PathBuffer, WPathBuffer};
 use bun_ptr::{BackRef, RawSlice};
+use bun_threading::Mutex;
 
 use bun_sys::windows as w;
 use bun_sys::windows::HANDLE;
@@ -17,33 +27,47 @@ bun_core::declare_scope!(watcher, visible);
 pub(crate) type Platform = WindowsWatcher;
 
 pub struct WindowsWatcher {
+    /// `INVALID_HANDLE_VALUE` once `stop()` has run; `add_root` returns early
+    /// then (same shape as the inotify/kqueue `fd = INVALID` convention).
     pub(crate) iocp: HANDLE,
-    pub(crate) watcher: DirWatcher,
+    /// One entry per watch root. `Box` keeps each `DirWatcher` at a stable
+    /// address across Vec growth while its async `ReadDirectoryChangesW` is
+    /// pending. Grown/reused under `Watcher.mutex`; the watch thread touches
+    /// the boxes only through completion pointers, never through this Vec.
+    pub(crate) watchers: Vec<Box<DirWatcher>>,
+    /// Parallel to `watchers`. `covers()` on transpiler threads reads this
+    /// (under `Watcher.mutex`) instead of the `DirWatcher` boxes, which the
+    /// watch thread mutates without the lock.
+    pub(crate) roots: Vec<Arc<RootState>>,
+    /// Scratch for `root + event filename` during `watch_loop_cycle`. Owned
+    /// by the watch thread.
     pub(crate) buf: PathBuffer,
-    pub(crate) base_idx: usize,
+    /// The `DirWatcher` whose buffer was just returned by `next()` and must be
+    /// re-armed on the next `next()` call. Watch-thread-only. Also seeded by
+    /// `new()` so the first root is armed by the watch thread, not before it.
+    needs_rearm: Option<ptr::NonNull<DirWatcher>>,
+}
+
+/// Root metadata shared between a `DirWatcher` (watch thread) and
+/// `WindowsWatcher.roots` (transpiler threads, under `Watcher.mutex`).
+pub(crate) struct RootState {
+    /// Absolute path of the watched root with a trailing separator.
+    pub path: Box<[u8]>,
+    /// Set by `mark_dead` once the root is retired and its handle closed.
+    /// `add_root` reuses dead slots.
+    pub dead: bun_core::AtomicCell<bool>,
 }
 
 impl Default for WindowsWatcher {
     fn default() -> Self {
         Self {
             iocp: w::INVALID_HANDLE_VALUE,
-            watcher: DirWatcher {
-                overlapped: bun_core::ffi::zeroed(),
-                buf: [0u8; 64 * 1024],
-                dir_handle: w::INVALID_HANDLE_VALUE,
-            },
+            watchers: Vec::new(),
+            roots: Vec::new(),
             buf: PathBuffer::uninit(),
-            base_idx: 0,
+            needs_rearm: None,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::IntoStaticStr, thiserror::Error)]
-pub enum Error {
-    #[error("IocpFailed")]
-    IocpFailed,
-    #[error("CreateFileFailed")]
-    CreateFileFailed,
 }
 
 #[repr(u32)]
@@ -76,14 +100,19 @@ pub struct DirWatcher {
     /// `EventIterator::next`).
     pub(crate) buf: [u8; 64 * 1024],
     pub(crate) dir_handle: HANDLE,
+    /// Shared with `WindowsWatcher.roots`: `state.path` prefixes each event's
+    /// relative filename; `state.dead` retires the root.
+    pub(crate) state: Arc<RootState>,
 }
 
 // `OVERLAPPED` = 32 bytes / align 8 on Win64; `buf` must be ≥ 4-aligned for
 // the `*FILE_NOTIFY_INFORMATION` cast. Asserting the offset (not just the
-// total size) is what proves that alignment requirement.
+// total size) is what proves that alignment requirement. `overlapped` at
+// offset 0 is load-bearing: `next()` recovers `*mut DirWatcher` from the
+// `lpOverlapped` out-param.
 bun_core::assert_ffi_layout!(
     DirWatcher,
-    32 + 64 * 1024 + ::core::mem::size_of::<HANDLE>(),
+    32 + 64 * 1024 + ::core::mem::size_of::<HANDLE>() + ::core::mem::size_of::<Arc<RootState>>(),
     ::core::mem::align_of::<w::OVERLAPPED>();
     overlapped @ 0, buf @ 32, dir_handle @ 32 + 64 * 1024,
 );
@@ -129,6 +158,35 @@ impl DirWatcher {
         }
         bun_core::scoped_log!(watcher, "read directory changes!");
         Ok(())
+    }
+
+    fn is_dead(&self) -> bool {
+        self.state.dead.load()
+    }
+
+    /// Close the handle and retire this root; `covers()` skips it afterwards,
+    /// `stop()` won't close it again, and `add_root` may reuse the slot.
+    /// Watch-thread-only; called only at points where this root has no
+    /// pending I/O (its completion was just dequeued, or its re-arm failed).
+    fn mark_dead(&self, cause: &bun_sys::Error) {
+        if self.is_dead() {
+            return;
+        }
+        // Copy the handle before publishing `dead`: once the store lands, a
+        // transpiler thread may reuse this slot and overwrite `dir_handle`.
+        let handle = self.dir_handle;
+        self.state.dead.store(true);
+        // SAFETY: `handle` is the handle `add_root` opened; `stop()` skips
+        // dead roots, so this is the only close.
+        unsafe {
+            let _ = w::CloseHandle(handle);
+        }
+        bun_core::scoped_log!(
+            watcher,
+            "stopped watching {} ({})",
+            bstr::BStr::new(&self.state.path),
+            bstr::BStr::new(cause.name())
+        );
     }
 }
 
@@ -211,17 +269,38 @@ impl EventIterator {
 }
 
 impl WindowsWatcher {
-    // `Self` carries the 64 KiB `DirWatcher` buffer inline; it is moved once
-    // into `Box::new(Watcher { .. })` in `Watcher::init`.
-    #[allow(clippy::large_stack_frames)]
     pub(crate) fn new(root: &[u8]) -> crate::Result<Self> {
         let mut this = Self::default();
-        this.init(root)?;
+        this.iocp = w::CreateIoCompletionPort(w::INVALID_HANDLE_VALUE, ptr::null_mut(), 0, 1)
+            .map_err(crate::Error::from)?;
+        if let Err(e) = this.add_root_inner::<false>(root) {
+            // SAFETY: iocp was just created above.
+            unsafe {
+                let _ = w::CloseHandle(this.iocp);
+            }
+            return Err(e);
+        }
         Ok(this)
     }
 
-    fn init(&mut self, root: &[u8]) -> Result<(), crate::Error> {
+    /// Open `root` for recursive change notification, associate it with the
+    /// shared IOCP, arm it, and append to (or reuse a dead slot of)
+    /// `self.watchers`. Caller holds `Watcher.mutex`; the watch thread is
+    /// running, so arming here is safe (`shutdown` hands cleanup to it).
+    pub(crate) fn add_root(&mut self, root: &[u8]) -> Result<(), crate::Error> {
+        self.add_root_inner::<true>(root)
+    }
+
+    /// `ARM = false` defers the first `ReadDirectoryChangesW` to the watch
+    /// thread (via `needs_rearm`): `new()` runs before `Watcher::start`, and a
+    /// shutdown-before-start drops the `DirWatcher` without `stop()`, which
+    /// must not leave kernel I/O pending against the freed buffer.
+    fn add_root_inner<const ARM: bool>(&mut self, root: &[u8]) -> Result<(), crate::Error> {
         use bun_paths::string_paths as paths;
+        if self.iocp == w::INVALID_HANDLE_VALUE {
+            // stop() already ran; the watch thread is gone.
+            return Err(crate::Error::Sys(bun_sys::SystemErrno::ESHUTDOWN));
+        }
         let mut pathbuf = WPathBuffer::uninit();
         let wpath = paths::to_nt_path(&mut pathbuf, root);
         let path_len_bytes: u16 = (wpath.len() * 2) as u16;
@@ -244,7 +323,9 @@ impl WindowsWatcher {
         let rc = unsafe {
             w::ntdll::NtCreateFile(
                 &mut handle,
-                w::FILE_LIST_DIRECTORY,
+                // SYNCHRONIZE lets stop()'s GetOverlappedResult(bWait) wait on
+                // this handle; NtCreateFile grants exactly what is asked.
+                w::FILE_LIST_DIRECTORY | w::SYNCHRONIZE,
                 &mut attr,
                 &mut io,
                 ptr::null_mut(),
@@ -260,55 +341,115 @@ impl WindowsWatcher {
         if rc != w::NTSTATUS::SUCCESS {
             let err = w::Win32Error::from_nt_status(rc);
             bun_core::scoped_log!(watcher, "failed to open directory for watching: {}", err.0);
-            return Err(Error::CreateFileFailed.into());
+            return Err(crate::Error::Sys(
+                bun_sys::SystemErrno::init(err.0 as u32).unwrap_or(bun_sys::SystemErrno::EINVAL),
+            ));
         }
         let handle_guard = scopeguard::guard(handle, |h| unsafe {
             // SAFETY: handle was successfully opened by NtCreateFile above.
             let _ = w::CloseHandle(h);
         });
 
-        self.iocp = w::CreateIoCompletionPort(*handle_guard, ptr::null_mut(), 0, 1)
-            .map_err(|_| crate::Error::from(Error::IocpFailed))?;
-        let iocp_guard = scopeguard::guard(self.iocp, |h| unsafe {
-            // SAFETY: iocp handle was successfully created above.
-            let _ = w::CloseHandle(h);
+        // Reuse a dead slot if one exists so repeated kill/re-add cycles
+        // (package rebuilds deleting their own root) don't grow the Vec.
+        let slot = self.roots.iter().position(|r| r.dead.load());
+        let key = slot.unwrap_or(self.watchers.len()) as w::ULONG_PTR;
+        w::CreateIoCompletionPort(*handle_guard, self.iocp, key, 0).map_err(crate::Error::from)?;
+
+        let needs_slash = root.is_empty() || !paths::char_is_any_slash(root[root.len() - 1]);
+        let mut root_buf = Vec::with_capacity(root.len() + usize::from(needs_slash));
+        root_buf.extend_from_slice(root);
+        if needs_slash {
+            root_buf.push(b'\\');
+        }
+        let state = Arc::new(RootState {
+            path: root_buf.into_boxed_slice(),
+            dead: bun_core::AtomicCell::new(false),
         });
 
-        // Materializing an uninit `[u8; N]` by value is immediate UB, and constructing a 64KiB
-        // `DirWatcher` temporary on the stack defeats the in-place-init intent. Assign fields in
-        // place instead — `buf` was already zero-initialised by `Default` and is an output buffer
-        // filled by ReadDirectoryChangesW before any read.
-        self.watcher.overlapped = bun_core::ffi::zeroed::<w::OVERLAPPED>();
-        self.watcher.dir_handle = *handle_guard;
-
-        self.buf[..root.len()].copy_from_slice(root);
-        let needs_slash = root.is_empty() || !paths::char_is_any_slash(root[root.len() - 1]);
-        if needs_slash {
-            self.buf[root.len()] = b'\\';
-        }
-        self.base_idx = if needs_slash {
-            root.len() + 1
-        } else {
-            root.len()
+        let dw_ptr = match slot {
+            Some(idx) => {
+                // The slot is dead: its handle is closed, it has no pending
+                // I/O, and the watch thread holds no pointer to it, so the box
+                // can be rewritten in place.
+                let dw = &mut self.watchers[idx];
+                dw.overlapped = bun_core::ffi::zeroed();
+                dw.dir_handle = *handle_guard;
+                dw.state = Arc::clone(&state);
+                if ARM {
+                    // On failure `handle_guard` closes the handle and
+                    // `roots[idx]` keeps its dead entry, so the slot stays
+                    // reusable.
+                    dw.prepare().map_err(crate::Error::from)?;
+                }
+                let dw_ptr = ptr::NonNull::from(&mut **dw);
+                self.roots[idx] = state;
+                dw_ptr
+            }
+            None => {
+                // Initialize on the heap: `Box::new(DirWatcher { .. })`
+                // materialises the 64KB `buf` on the stack first in debug
+                // builds.
+                let mut dw = Box::<DirWatcher>::new_zeroed();
+                // SAFETY: all-zero bytes are valid for `overlapped` (must be
+                // zeroed for ReadDirectoryChangesW) and `buf`; the remaining
+                // fields are written below, so `assume_init` sees a
+                // fully-initialised value.
+                let mut dw = unsafe {
+                    let p = dw.as_mut_ptr();
+                    (&raw mut (*p).dir_handle).write(*handle_guard);
+                    (&raw mut (*p).state).write(Arc::clone(&state));
+                    dw.assume_init()
+                };
+                if ARM {
+                    dw.prepare().map_err(crate::Error::from)?;
+                }
+                let dw_ptr = ptr::NonNull::from(&mut *dw);
+                self.watchers.push(dw);
+                self.roots.push(state);
+                dw_ptr
+            }
         };
+        if !ARM {
+            self.needs_rearm = Some(dw_ptr);
+        }
 
-        // disarm the cleanup scopeguards on success
-        scopeguard::ScopeGuard::into_inner(iocp_guard);
+        bun_core::scoped_log!(watcher, "watching root[{}]: {}", key, bstr::BStr::new(root));
+
         scopeguard::ScopeGuard::into_inner(handle_guard);
         Ok(())
     }
 
+    /// True if `dir` (absolute, with trailing separator) is already inside one
+    /// of the live watched roots. Caller holds `Watcher.mutex`.
+    pub(crate) fn covers(&self, dir: &[u8]) -> bool {
+        self.roots.iter().any(|root| {
+            !root.dead.load() && is_parent_or_equal(&root.path, dir) != ParentEqual::Unrelated
+        })
+    }
+
     /// wait until new events are available
     fn next(&mut self, timeout: Timeout) -> bun_sys::Result<Option<EventIterator>> {
-        if let Err(err) = self.watcher.prepare() {
-            bun_core::scoped_log!(watcher, "prepare() returned error");
-            return Err(err);
+        if let Some(dw) = self.needs_rearm.take() {
+            // SAFETY: `dw` was the `lpOverlapped` of the previous completion
+            // (or seeded by `new()`), pointing at offset 0 of a
+            // `Box<DirWatcher>` in `self.watchers`. Live roots are never
+            // rewritten, so it is valid.
+            let dw = unsafe { dw.as_ptr().as_mut().unwrap_unchecked() };
+            if !dw.is_dead() {
+                if let Err(err) = dw.prepare() {
+                    dw.mark_dead(&err);
+                }
+            }
         }
 
         let mut nbytes: w::DWORD = 0;
         let mut key: w::ULONG_PTR = 0;
         let mut overlapped: *mut w::OVERLAPPED = ptr::null_mut();
         loop {
+            // With every root dead this parks until `add_root` arms a new
+            // root on the same IOCP — same idle shape as inotify at
+            // watch_count 0.
             // SAFETY: iocp is a valid IOCP handle; out-params are valid stack locals.
             let rc = unsafe {
                 w::kernel32::GetQueuedCompletionStatus(
@@ -319,12 +460,13 @@ impl WindowsWatcher {
                     timeout as w::DWORD,
                 )
             };
-            if rc == 0 {
-                let err = w::Win32Error::get();
-                // `WAIT_TIMEOUT` (258) — not yet a named const on `bun_sys::windows::Win32Error`.
-                if err == w::Win32Error::TIMEOUT || err == w::Win32Error(258) {
-                    return Ok(None);
-                } else {
+            let Some(overlapped) = ptr::NonNull::new(overlapped) else {
+                if rc == 0 {
+                    let err = w::Win32Error::get();
+                    // `WAIT_TIMEOUT` (258) — not yet a named const on `bun_sys::windows::Win32Error`.
+                    if err == w::Win32Error::TIMEOUT || err == w::Win32Error(258) {
+                        return Ok(None);
+                    }
                     bun_core::scoped_log!(watcher, "GetQueuedCompletionStatus failed: {}", err.0);
                     return Err(bun_sys::Error {
                         errno: bun_sys::SystemErrno::init(err.0 as u32)
@@ -334,38 +476,6 @@ impl WindowsWatcher {
                         ..Default::default()
                     });
                 }
-            }
-
-            if !overlapped.is_null() {
-                // ignore possible spurious events
-                if overlapped != &mut self.watcher.overlapped as *mut w::OVERLAPPED {
-                    continue;
-                }
-                if nbytes == 0 {
-                    // ReadDirectoryChangesW internal change-buffer overflow — too many
-                    // events arrived between drain and re-arm. This is NOT a shutdown
-                    // signal: stop() closes the dir handle, which surfaces as rc==0 /
-                    // ERROR_OPERATION_ABORTED above, never as rc!=0 && nbytes==0. Per
-                    // MSDN, the function returns zero bytes when its internal buffer
-                    // overflows. Drop the lost events, re-arm, and keep watching so
-                    // --hot picks up the next change. Returning ESHUTDOWN here kills
-                    // the watcher thread and the --hot child silently exits
-                    // (hot.test.ts "should work with sourcemap generation" flake).
-                    bun_core::scoped_log!(
-                        watcher,
-                        "ReadDirectoryChangesW buffer overflow (nbytes==0); re-arming"
-                    );
-                    if let Err(err) = self.watcher.prepare() {
-                        return Err(err);
-                    }
-                    continue;
-                }
-                return Ok(Some(EventIterator {
-                    watcher: BackRef::new(&self.watcher),
-                    offset: 0,
-                    has_next: true,
-                }));
-            } else {
                 bun_core::scoped_log!(
                     watcher,
                     "GetQueuedCompletionStatus returned no overlapped event"
@@ -375,17 +485,135 @@ impl WindowsWatcher {
                     syscall: bun_sys::Tag::watch,
                     ..Default::default()
                 });
+            };
+            // `overlapped` is the address we passed to `ReadDirectoryChangesW`:
+            // offset 0 of a boxed `DirWatcher` in `self.watchers`.
+            let dw: ptr::NonNull<DirWatcher> = overlapped.cast();
+
+            if rc == 0 {
+                // A dequeued failed-I/O packet: the root directory is gone
+                // (handle closed, or the directory was deleted). Retire this
+                // root; other roots keep running.
+                let err = bun_sys::Error {
+                    errno: bun_sys::SystemErrno::init(w::Win32Error::get().0 as u32)
+                        .unwrap_or(bun_sys::SystemErrno::EINVAL) as _,
+                    syscall: bun_sys::Tag::watch,
+                    ..Default::default()
+                };
+                // SAFETY: see the cast note above — `dw` is a live boxed DirWatcher.
+                unsafe { dw.as_ptr().as_ref().unwrap_unchecked() }.mark_dead(&err);
+                continue;
             }
+
+            if nbytes == 0 {
+                // ReadDirectoryChangesW's internal buffer overflowed (MSDN:
+                // zero bytes on success), not a shutdown — a closed handle
+                // surfaces as rc == 0 above. Drop the lost events and re-arm
+                // so --hot keeps watching.
+                bun_core::scoped_log!(
+                    watcher,
+                    "ReadDirectoryChangesW buffer overflow (nbytes==0); re-arming"
+                );
+                // SAFETY: see the cast note above — `dw` is a live boxed DirWatcher.
+                let dw = unsafe { dw.as_ptr().as_mut().unwrap_unchecked() };
+                if let Err(err) = dw.prepare() {
+                    dw.mark_dead(&err);
+                }
+                continue;
+            }
+            self.needs_rearm = Some(dw);
+            return Ok(Some(EventIterator {
+                // SAFETY: `dw` is a live boxed DirWatcher (see above); its
+                // buffer stays valid until the matching `prepare()` on the
+                // next `next()` call.
+                watcher: unsafe { BackRef::from_raw(dw.as_ptr()) },
+                offset: 0,
+                has_next: true,
+            }));
         }
     }
 
     pub(crate) fn stop(&mut self) {
-        // SAFETY: handles were opened in init() and are valid until stop() is called once.
+        // Runs on the watch thread after the loop exits, under `Watcher.mutex`.
+        // SAFETY: live handles were opened in add_root(); dead roots already
+        // closed theirs in mark_dead() with no I/O pending.
         unsafe {
-            w::CloseHandle(self.watcher.dir_handle);
-            w::CloseHandle(self.iocp);
+            for (dw, root) in self.watchers.iter_mut().zip(&self.roots) {
+                if !root.dead.load() {
+                    root.dead.store(true);
+                    // Cancel the pending ReadDirectoryChangesW and wait for
+                    // the cancellation to finish writing `overlapped`: the
+                    // caller frees this DirWatcher right after stop() returns,
+                    // and CloseHandle alone only initiates cancellation.
+                    let _ = w::kernel32::CancelIoEx(dw.dir_handle, &mut dw.overlapped);
+                    let mut nbytes: w::DWORD = 0;
+                    let _ = w::kernel32::GetOverlappedResult(
+                        dw.dir_handle,
+                        &mut dw.overlapped,
+                        &mut nbytes,
+                        1,
+                    );
+                    let _ = w::CloseHandle(dw.dir_handle);
+                }
+            }
+            let _ = w::CloseHandle(self.iocp);
         }
+        self.iocp = w::INVALID_HANDLE_VALUE;
     }
+}
+
+/// The directory to open a watch root at for a file resolved to `dir`
+/// (absolute, trailing separator): the subtree up to the first `node_modules`
+/// component, else the nearest enclosing directory with a `package.json`, else
+/// `dir` itself. Rooting at the package keeps a `dist/` rebuild from deleting
+/// its own root, and keeps `bun build --watch` from opening one root per
+/// `node_modules` package.
+pub(crate) fn pick_watch_root(dir: &[u8]) -> &[u8] {
+    use bun_paths::string_paths::char_is_any_slash;
+    const NM: &[u8] = b"node_modules";
+
+    // First `node_modules` component, if any.
+    let mut search = 0;
+    while let Some(rel) = strings::index_of(&dir[search..], NM) {
+        let start = search + rel;
+        let end = start + NM.len();
+        let bounded = (start == 0 || char_is_any_slash(dir[start - 1]))
+            && (end == dir.len() || char_is_any_slash(dir[end]));
+        if bounded {
+            let root_end = if end < dir.len() { end + 1 } else { end };
+            return &dir[..root_end];
+        }
+        search = end;
+    }
+
+    // Nearest enclosing package.json.
+    let mut probe = bun_paths::path_buffer_pool::get();
+    let mut end = dir.len(); // index one past a separator
+    for _ in 0..64 {
+        if end <= 3 || end + NM.len() + 1 >= probe.len() {
+            break;
+        }
+        probe[..end].copy_from_slice(&dir[..end]);
+        probe[end..end + 12].copy_from_slice(b"package.json");
+        probe[end + 12] = 0;
+        // SAFETY: the NUL at [end + 12] was written above.
+        let candidate = unsafe { bun_core::ZStr::from_raw(probe.as_ptr(), end + 12) };
+        if bun_sys::exists_z(candidate) {
+            return &dir[..end];
+        }
+        // Step to the parent: strip the trailing separator and the last
+        // component.
+        let mut i = end - 1; // at the separator
+        while i > 0 && !char_is_any_slash(dir[i - 1]) {
+            i -= 1;
+        }
+        if i == 0 || i >= end - 1 {
+            break;
+        }
+        end = i;
+    }
+
+    dir
 }
 
 #[repr(u32)]
@@ -395,11 +623,31 @@ pub(crate) enum Timeout {
     None = 0,
 }
 
-pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
-    // We re-borrow buf inside the inner loop instead of holding `&this.platform.buf`
-    // across calls to `this.platform.next()`.
-    let base_idx = this.platform.base_idx;
+/// Snapshot the watchlist's path column under `mutex`: `add_file` on other
+/// threads may realloc it mid-scan, and a mid-batch dispatch can evict and
+/// reorder it (same pattern as `INotifyWatcher`'s `eventlist_index_scratch`).
+/// Raw slices, not owned copies: the path bytes are freed only by
+/// `flush_evictions` inside a dispatch on this thread, and the snapshot is
+/// retaken after every dispatch; a watchlist realloc moves the `Cow` structs,
+/// not the bytes they point to. Takes field borrows, not `&mut Watcher`, so
+/// the caller's `EventIterator` pointer into `platform` keeps its provenance.
+fn snapshot_watchlist_paths(
+    mutex: &Mutex,
+    scratch: &mut Vec<RawSlice<u8>>,
+    watchlist: &WatchList,
+) -> usize {
+    let _guard = mutex.lock_guard();
+    scratch.clear();
+    scratch.extend(
+        watchlist
+            .items_file_path()
+            .iter()
+            .map(|p| RawSlice::new(p.as_ref())),
+    );
+    scratch.len()
+}
 
+pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
     let mut event_id: usize = 0;
 
     // first wait has infinite timeout - we're waiting for the next event and don't want to spin
@@ -413,15 +661,21 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
         // NOTE: using a 1ms timeout would be ideal, but that actually makes the thread wait for at least 10ms more than it should
         // Instead we use a 0ms timeout, which may not do as much coalescing but is more responsive.
         timeout = Timeout::None;
-        bun_core::scoped_log!(
-            watcher,
-            "number of watched items: {}",
-            this.watchlist.items_file_path().len()
-        );
+
+        let base_idx = {
+            let root = &iter.watcher.state.path;
+            this.platform.buf[..root.len()].copy_from_slice(root);
+            root.len()
+        };
+
+        let mut n_items =
+            snapshot_watchlist_paths(&this.mutex, &mut this.platform_scratch, &this.watchlist);
+
+        bun_core::scoped_log!(watcher, "number of watched items: {}", n_items);
         while let Some(event) = iter.next() {
-            // `event.filename` is a `RawSlice<u16>` into `this.platform.watcher.buf`,
-            // live for the duration of this iteration (no `prepare()` until the
-            // outer loop reiterates) — encapsulated by the `RawSlice` invariant.
+            // `event.filename` is a `RawSlice<u16>` into the firing
+            // `DirWatcher`'s buf, live for the duration of this iteration (no
+            // `prepare()` until the next `next()` call).
             let filename: &[u16] = event.filename.slice();
             let convert_res =
                 strings::copy_utf16_into_utf8(&mut this.platform.buf[base_idx..], filename);
@@ -442,20 +696,23 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
             //   to implement and maintain.
             // - others that i'm not thinking of
 
-            let n_items = this.watchlist.items_file_path().len();
-            for item_idx in 0..n_items {
+            let mut item_idx = 0;
+            while item_idx < n_items {
                 // reshaped for borrowck — `rel` is computed in a scoped
-                // block so the borrows of `this.watchlist` / `this.platform.buf`
-                // are released before we touch `this.watch_events` or hand the
-                // whole `&mut Watcher` to `process_watch_event_batch`.
+                // block so the borrows of `this.platform_scratch` /
+                // `this.platform.buf` are released before we touch
+                // `this.watch_events` or hand the whole `&mut Watcher` to
+                // `process_watch_event_batch`.
                 let rel = {
                     let eventpath = &this.platform.buf[..eventpath_len];
-                    let path = &this.watchlist.items_file_path()[item_idx];
-                    let rel = is_parent_or_equal(path.as_ref(), eventpath);
+                    // `slice()` is valid per the snapshot invariant on
+                    // `snapshot_watchlist_paths`.
+                    let path: &[u8] = this.platform_scratch[item_idx].slice();
+                    let rel = is_parent_or_equal(path, eventpath);
                     bun_core::scoped_log!(
                         watcher,
                         "checking path: {} = .{}",
-                        bstr::BStr::new(path.as_ref()),
+                        bstr::BStr::new(path),
                         match rel {
                             ParentEqual::Parent => "parent",
                             ParentEqual::Equal => "equal",
@@ -466,6 +723,7 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                 };
                 // skip unrelated items
                 if rel == ParentEqual::Unrelated {
+                    item_idx += 1;
                     continue;
                 }
                 // if the event is for a parent dir of the item, only emit it if it's a delete or rename
@@ -477,18 +735,32 @@ pub(crate) fn watch_loop_cycle(this: &mut Watcher) -> bun_sys::Result<()> {
                     // passing `this: &mut Watcher` above materialises a fresh Unique
                     // borrow over the whole `Watcher`, which under Stacked Borrows pops the
                     // SharedReadOnly tag that `iter.watcher` (a `*const DirWatcher` derived from
-                    // an earlier `&this.platform.watcher`) carries. The next `iter.next()` would
+                    // an earlier shared borrow) carries. The next `iter.next()` would
                     // then dereference a pointer with invalidated provenance — UB that MIRI flags.
-                    // The callee never touches `platform.watcher`, so re-deriving the pointer
-                    // here from the now-current `&mut Watcher` restores valid provenance.
-                    iter.watcher = BackRef::new(&this.platform.watcher);
+                    // The callee never touches the `DirWatcher` buffer, so re-deriving the
+                    // pointer here from the now-current `&mut Watcher` restores valid provenance.
+                    if let Some(dw) = this.platform.needs_rearm {
+                        // SAFETY: `dw` is the live boxed DirWatcher that produced `iter`.
+                        iter.watcher = unsafe { BackRef::from_raw(dw.as_ptr()) };
+                    }
                     // Reset event_id to start a new batch
                     event_id = 0;
+                    // The dispatch may have evicted watchlist entries
+                    // (`swap_remove` reorders the live list and frees their
+                    // path bytes); refresh the snapshot so emitted indices
+                    // stay in sync, and re-check this slot against it.
+                    n_items = snapshot_watchlist_paths(
+                        &this.mutex,
+                        &mut this.platform_scratch,
+                        &this.watchlist,
+                    );
+                    continue;
                 }
 
                 this.watch_events[event_id] =
                     create_watch_event(&event, item_idx as WatchItemIndex);
                 event_id += 1;
+                item_idx += 1;
             }
         }
     }

--- a/src/watcher/error.rs
+++ b/src/watcher/error.rs
@@ -4,9 +4,6 @@ pub enum Error {
     KQueueError,
     #[error(transparent)]
     Sys(#[from] bun_errno::SystemErrno),
-    #[cfg(windows)]
-    #[error(transparent)]
-    Windows(#[from] crate::windows_watcher::Error),
 }
 
 impl Error {
@@ -15,8 +12,6 @@ impl Error {
         match self {
             Self::KQueueError => "KQueueError",
             Self::Sys(e) => <&'static str>::from(e),
-            #[cfg(windows)]
-            Self::Windows(e) => <&'static str>::from(e),
         }
     }
 }

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1669,8 +1669,6 @@ class OutputLineStream extends EventEmitter {
               this.panicked = true;
               this.emit("panic");
             }
-            // These can be noisy due to symlinks.
-            if (isWindows && line.includes("is not in the project directory and will not be watched")) continue;
             console.log("\x1b[0;30m" + name + "|\x1b[0m", line);
             this.emit("line", line);
           }

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -145,6 +145,7 @@ test.concurrent.skipIf(!isWindows)("--hot survives a linked package being delete
   //    [app] 3 2  edit the app again (cwd root must still fire); the
   //               recreated package is re-imported on this reload
   // 5. [app] 3 4  edit only the recreated package (fresh root must fire)
+  // 6.            done
   let phase = 1;
   for await (const line of iter) {
     if (phase === 1 && line === "[app] 1 1") {
@@ -164,6 +165,7 @@ test.concurrent.skipIf(!isWindows)("--hot survives a linked package being delete
     } else if (phase === 4 && line === "[app] 3 2") {
       phase = 5;
     } else if (phase === 5 && line === "[app] 3 4") {
+      phase = 6;
       break;
     }
 
@@ -182,6 +184,6 @@ test.concurrent.skipIf(!isWindows)("--hot survives a linked package being delete
         break;
     }
   }
-  expect(phase).toBe(5);
+  expect(phase).toBe(6);
   expect(stderr).not.toContain("is not in the project directory");
 });

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -1,7 +1,8 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir } from "harness";
-import { writeFile } from "node:fs/promises";
+import { bunEnv, bunExe, forEachLine, isBroken, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { mkdirSync, symlinkSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe.todoIf(isBroken && isWindows)("--watch works", async () => {
@@ -47,4 +48,140 @@ describe.todoIf(isBroken && isWindows)("--watch works", async () => {
       await process.exited;
     });
   }
+});
+
+function workspaceFixture(prefix: string) {
+  const appSource = (app: number) => `import { value } from "@test/db";\nconsole.log("[app]", ${app}, value);\n`;
+  const root = tempDirWithFiles(prefix, {
+    "packages/db/package.json": JSON.stringify({ name: "@test/db", main: "index.js" }),
+    "packages/db/index.js": `export const value = 1;\n`,
+    "apps/myapp/package.json": JSON.stringify({ name: "myapp" }),
+    "apps/myapp/index.js": appSource(1),
+  });
+  mkdirSync(join(root, "apps/myapp/node_modules/@test"), { recursive: true });
+  symlinkSync(join(root, "packages/db"), join(root, "apps/myapp/node_modules/@test/db"), "junction");
+  return { root, appSource };
+}
+
+// https://github.com/oven-sh/bun/issues/9547
+//
+// The Windows watcher is a recursive ReadDirectoryChangesW rooted at the cwd.
+// A workspace package reached through a node_modules symlink resolves to its
+// real path in a sibling tree, so before this fix the import was appended to
+// the watch list but the change never fired and the process printed "is not
+// in the project directory and will not be watched" once per imported file
+// per reload. On POSIX the per-file inotify/kqueue watch follows the inode
+// and already fires, so the reload assertion only exercises the fix on
+// Windows; the stderr assertion (no warning, no crash) is meaningful
+// everywhere. Every --watch reload on Windows is a fresh process, so this
+// covers root registration; the multi-root lifecycle inside one process is
+// covered by the --hot test below.
+test.concurrent("--watch picks up changes in a linked workspace package outside the cwd", async () => {
+  const { root, appSource } = workspaceFixture("watch-workspace");
+  const dbIndex = join(root, "packages/db/index.js");
+  const appIndex = join(root, "apps/myapp/index.js");
+
+  await using watcher = spawn({
+    cmd: [bunExe(), "--watch", "index.js"],
+    cwd: join(root, "apps/myapp"),
+    env: bunEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  (async () => {
+    for await (const chunk of watcher.stderr) stderr += new TextDecoder().decode(chunk);
+  })();
+
+  // Alternate edits between the out-of-cwd package and the in-cwd app. Re-save
+  // the target generation on every line until it appears; without the fix no
+  // event ever fires for packages/db on Windows and the loop never advances
+  // past (1, 1).
+  const iter = forEachLine(watcher.stdout);
+  let db = 1;
+  let app = 1;
+  for await (const line of iter) {
+    expect(stderr).not.toContain("is not in the project directory");
+    if (line === `[app] ${app} ${db}`) {
+      if (db === 4 && app === 4) break;
+      if (db <= app) db += 1;
+      else app += 1;
+    }
+    if (db > app) await writeFile(dbIndex, `export const value = ${db};\n`);
+    else await writeFile(appIndex, appSource(app));
+  }
+  expect({ db, app }).toEqual({ db: 4, app: 4 });
+  expect(stderr).not.toContain("is not in the project directory");
+});
+
+// The multi-root lifecycle only runs inside one long-lived process, which on
+// Windows means --hot (a --watch reload is a fresh process per generation):
+// per-root re-arm rotation across completions, a deleted secondary root dying
+// without taking the cwd root down, and covers() skipping the dead root and
+// opening a fresh one when the recreated package is re-imported.
+test.concurrent.skipIf(!isWindows)("--hot survives a linked package being deleted and recreated", async () => {
+  const { root, appSource } = workspaceFixture("hot-workspace-rm");
+  const dbIndex = join(root, "packages/db/index.js");
+  const appIndex = join(root, "apps/myapp/index.js");
+
+  await using runner = spawn({
+    cmd: [bunExe(), "--hot", "index.js"],
+    cwd: join(root, "apps/myapp"),
+    env: bunEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stderr = "";
+  (async () => {
+    for await (const chunk of runner.stderr) stderr += new TextDecoder().decode(chunk);
+  })();
+
+  const iter = forEachLine(runner.stdout);
+  // Phases, advanced when the expected line appears; each phase's edit is
+  // re-saved on every other line so a write that lands before the watcher
+  // armed its root cannot stall the test.
+  // 1. [app] 1 1  startup
+  // 2. [app] 2 1  edit the app (cwd root)
+  // 3. [app] 2 2  edit the package (secondary root)
+  // 4.            delete the package and its junction (kills that root)
+  //    [app] 3 2  edit the app again (cwd root must still fire); the
+  //               recreated package is re-imported on this reload
+  // 5. [app] 3 4  edit only the recreated package (fresh root must fire)
+  let phase = 1;
+  for await (const line of iter) {
+    if (phase === 1 && line === "[app] 1 1") {
+      phase = 2;
+    } else if (phase === 2 && line === "[app] 2 1") {
+      phase = 3;
+    } else if (phase === 3 && line === "[app] 2 2") {
+      // Remove the junction first so packages/db has no second opener and
+      // actually leaves delete-pending.
+      await rm(join(root, "apps/myapp/node_modules/@test/db"), { recursive: true, force: true });
+      await rm(join(root, "packages/db"), { recursive: true, force: true });
+      await mkdir(join(root, "packages/db"), { recursive: true });
+      await writeFile(join(root, "packages/db/package.json"), JSON.stringify({ name: "@test/db", main: "index.js" }));
+      await writeFile(dbIndex, `export const value = 2;\n`);
+      symlinkSync(join(root, "packages/db"), join(root, "apps/myapp/node_modules/@test/db"), "junction");
+      phase = 4;
+    } else if (phase === 4 && line === "[app] 3 2") {
+      phase = 5;
+    } else if (phase === 5 && line === "[app] 3 4") {
+      break;
+    }
+
+    switch (phase) {
+      case 2:
+        await writeFile(appIndex, appSource(2));
+        break;
+      case 3:
+        await writeFile(dbIndex, `export const value = 2;\n`);
+        break;
+      case 4:
+        await writeFile(appIndex, appSource(3));
+        break;
+      case 5:
+        await writeFile(dbIndex, `export const value = 4;\n`);
+        break;
+    }
+  }
+  expect(phase).toBe(5);
+  expect(stderr).not.toContain("is not in the project directory");
 });


### PR DESCRIPTION
### Problem

- On Windows the watcher is one recursive `ReadDirectoryChangesW` rooted at the cwd, so a file that resolves outside it (a workspace package reached through a `node_modules` junction, `bun link`, a `file:` dependency) is appended to the watch list but its events never fire, and every reload prints `File ... is not in the project directory and will not be watched` once per file. Fixes #9547.

### Fix

- Each watch root is a `Box<DirWatcher>` (its own `ReadDirectoryChangesW`) sharing one IOCP. A completion's `lpOverlapped` is the address of the `DirWatcher` that fired, so the watch thread identifies the source without touching the roots Vec and without the mutex.
- Roots open at the package directory, not the imported file's own directory: the prefix up to the first `node_modules` component if there is one, else the nearest enclosing directory with a `package.json`, else the file's directory. A `dist/` rebuild no longer deletes its own root, and `bun build --watch` with an out-of-cwd hoisted `node_modules` opens one root total for it.
- A root whose directory disappears is retired in place (flag flip plus handle close, logged to the debug scope); other roots keep running, and `add_root` reuses dead slots so kill/re-add cycles don't grow the Vec. With every root dead the thread parks on the IOCP until the next out-of-root import arms a new root, like inotify at watch_count zero.
- `stop()` runs on both watch-thread exits under the mutex; it marks roots dead, cancels pending I/O and waits for the cancellation (`CancelIoEx` + `GetOverlappedResult(bWait)`, which needs `SYNCHRONIZE` in the `NtCreateFile` mask) before the buffers are freed, then invalidates the IOCP so a later `add_root` from a still-running `--hot` process returns early instead of using a closed handle.
- The initial root is armed by the watch thread (seeded through `needs_rearm`), not in `Watcher::init`, so a shutdown before `start()` has no pending kernel I/O against a freed buffer.
- The per-cycle path scan snapshots raw slices of the watchlist path column under the mutex (the column is `Cow::Owned` on Windows, so owned copies would malloc per path per completion) and re-snapshots after a mid-batch dispatch, whose evictions `swap_remove`-reorder the live list.
- `add_root` failures map the NTSTATUS / Win32 code to an errno, so the once-per-root warning names the cause (for example `ENOENT`) instead of an internal enum variant.
- Verified: `bun bd test test/cli/hot/watch.test.ts` (4/4), `hot.test.ts` (12/12), `watch-many-dirs.test.ts` on Windows and Linux debug builds; the two new tests fail on main on Windows (warning printed, reload stalls) and pass with this build.

### Background

- `ReadDirectoryChangesW` watches one directory tree per call and reports paths relative to it; completions are delivered through an I/O completion port (IOCP) the handle is associated with. The `OVERLAPPED` passed when arming comes back as `lpOverlapped`, which is why it sits at offset 0 of `DirWatcher` and doubles as the root's identity.
- `--watch` reloads on Windows replace the process, so each generation re-registers roots from scratch; only `--hot` and the dev server exercise the in-process lifecycle (re-arm rotation, root death and reuse). The new `--hot` test deletes and recreates a linked package mid-session to cover that path.
- Closing a directory handle only initiates cancellation of its pending I/O; the kernel finishes writing the `OVERLAPPED` asynchronously, which is why `stop()` must wait before the `Box<Watcher>` is dropped.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/watch.test.ts

<!-- robobun:evidence:end -->