### PR TITLE
shell: set FORCE_COLOR for subprocesses whose output is relayed to a color terminal

### DIFF
--- a/src/runtime/shell/EnvMap.rs
+++ b/src/runtime/shell/EnvMap.rs
@@ -108,6 +108,10 @@ impl EnvMap {
         Some(val)
     }
 
+    pub fn contains(&self, key: EnvStr) -> bool {
+        self.map.contains(&key)
+    }
+
     pub fn clone(&self) -> EnvMap {
         let new = EnvMap {
             map: self.map.clone().expect("OOM"),

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -330,8 +330,8 @@ pub struct Interpreter {
     /// terminal. `Cmd` appends it to a child's env only when that child's
     /// resolved stdout is still the relayed `Stdio::Capture` pipe.
     pub force_color_env: Cell<Option<&'static [u8]>>,
-    /// Whether the root stderr is itself a tty; gates the `2>&1` relay arm of
-    /// the `force_color_env` check (the stderr capture may relay to a file).
+    /// Whether root stderr is itself a tty; gates the `1>&2` arm of the
+    /// `force_color_env` check, since that reroutes output onto root stderr.
     pub stderr_is_tty: Cell<bool>,
     pub exit_code: Cell<Option<ExitCode>>,
     pub this_jsvalue: Cell<crate::jsc::JSValue>,

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1264,7 +1264,11 @@ impl Interpreter {
                 .set(Some(match bun_core::output::Source::color_depth() {
                     ColorDepth::C16m => b"FORCE_COLOR=3\0",
                     ColorDepth::C256 => b"FORCE_COLOR=2\0",
-                    _ => b"FORCE_COLOR=1\0",
+                    ColorDepth::C16 => b"FORCE_COLOR=1\0",
+                    // Only reachable on Windows, where `is_color_terminal()` is
+                    // unconditional and `color_depth()` reads env vars stock
+                    // consoles do not set; Win10+ consoles are truecolor.
+                    ColorDepth::None => b"FORCE_COLOR=3\0",
                 }));
         }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -330,6 +330,9 @@ pub struct Interpreter {
     /// terminal. `Cmd` appends it to a child's env only when that child's
     /// resolved stdout is still the relayed `Stdio::Capture` pipe.
     pub force_color_env: Cell<Option<&'static [u8]>>,
+    /// Whether the root stderr is itself a tty; gates the `2>&1` relay arm of
+    /// the `force_color_env` check (the stderr capture may relay to a file).
+    pub stderr_is_tty: Cell<bool>,
     pub exit_code: Cell<Option<ExitCode>>,
     pub this_jsvalue: Cell<crate::jsc::JSValue>,
     pub cleanup_state: Cell<CleanupState>,
@@ -609,6 +612,7 @@ impl Interpreter {
             global_this: Cell::new(core::ptr::null_mut()),
             flags: Cell::new(InterpreterFlags::default()),
             force_color_env: Cell::new(None),
+            stderr_is_tty: Cell::new(false),
             // Starts at `None` so `async_cmd_done` only finishes once
             // `on_root_child_done` has recorded the real exit code.
             exit_code: Cell::new(None),
@@ -1244,6 +1248,8 @@ impl Interpreter {
                 captured: cap_err,
             });
         });
+
+        self.stderr_is_tty.set(bun_sys::isatty(stderr_fd));
 
         // JS path: children get a `Stdio::Capture` pipe, so isatty() is false.
         // When the relayed output is a color terminal, record a FORCE_COLOR

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -328,8 +328,7 @@ pub struct Interpreter {
     pub flags: Cell<InterpreterFlags>,
     /// `Some("FORCE_COLOR=N\0")` when the JS-captured root stdout is a color
     /// terminal. `Cmd` appends it to a child's env only when that child's
-    /// resolved stdout is still the relayed `Stdio::Capture` pipe (not
-    /// `> file` / `| next` / `$(..)`) and no FORCE_COLOR/NO_COLOR is in scope.
+    /// resolved stdout is still the relayed `Stdio::Capture` pipe.
     pub force_color_env: Cell<Option<&'static [u8]>>,
     pub exit_code: Cell<Option<ExitCode>>,
     pub this_jsvalue: Cell<crate::jsc::JSValue>,

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1251,14 +1251,15 @@ impl Interpreter {
         if cap_out.is_some()
             && bun_sys::isatty(stdout_fd)
             && bun_core::output::enable_ansi_colors_stdout()
+            && bun_core::output::Source::is_color_terminal()
         {
             use bun_core::output::ColorDepth;
-            let line: &'static [u8] = match bun_core::output::Source::color_depth() {
-                ColorDepth::C16m => b"FORCE_COLOR=3\0",
-                ColorDepth::C256 => b"FORCE_COLOR=2\0",
-                _ => b"FORCE_COLOR=1\0",
-            };
-            self.force_color_env.set(Some(line));
+            self.force_color_env
+                .set(Some(match bun_core::output::Source::color_depth() {
+                    ColorDepth::C16m => b"FORCE_COLOR=3\0",
+                    ColorDepth::C256 => b"FORCE_COLOR=2\0",
+                    _ => b"FORCE_COLOR=1\0",
+                }));
         }
 
         Ok(())

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -326,6 +326,11 @@ pub struct Interpreter {
     pub global_this: Cell<*mut crate::jsc::JSGlobalObject>,
 
     pub flags: Cell<InterpreterFlags>,
+    /// `Some("FORCE_COLOR=N\0")` when the JS-captured root stdout is a color
+    /// terminal. `Cmd` appends it to a child's env only when that child's
+    /// resolved stdout is still the relayed `Stdio::Capture` pipe (not
+    /// `> file` / `| next` / `$(..)`) and no FORCE_COLOR/NO_COLOR is in scope.
+    pub force_color_env: Cell<Option<&'static [u8]>>,
     pub exit_code: Cell<Option<ExitCode>>,
     pub this_jsvalue: Cell<crate::jsc::JSValue>,
     pub cleanup_state: Cell<CleanupState>,
@@ -604,6 +609,7 @@ impl Interpreter {
             async_commands_executing: Cell::new(0),
             global_this: Cell::new(core::ptr::null_mut()),
             flags: Cell::new(InterpreterFlags::default()),
+            force_color_env: Cell::new(None),
             // Starts at `None` so `async_cmd_done` only finishes once
             // `on_root_child_done` has recorded the real exit code.
             exit_code: Cell::new(None),
@@ -1239,6 +1245,22 @@ impl Interpreter {
                 captured: cap_err,
             });
         });
+
+        // JS path: children get a `Stdio::Capture` pipe, so isatty() is false.
+        // When the relayed output is a color terminal, record a FORCE_COLOR
+        // hint; `Cmd` only applies it when appropriate. See `force_color_env`.
+        if cap_out.is_some()
+            && bun_sys::isatty(stdout_fd)
+            && bun_core::output::enable_ansi_colors_stdout()
+        {
+            use bun_core::output::ColorDepth;
+            let line: &'static [u8] = match bun_core::output::Source::color_depth() {
+                ColorDepth::C16m => b"FORCE_COLOR=3\0",
+                ColorDepth::C256 => b"FORCE_COLOR=2\0",
+                _ => b"FORCE_COLOR=1\0",
+            };
+            self.force_color_env.set(Some(line));
+        }
 
         Ok(())
     }

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -539,6 +539,16 @@ impl Cmd {
         interp.as_cmd_mut(this).args[0] = resolved;
 
         // Fill env from export_env + cmd_local_env.
+        let force_color_env = interp.force_color_env.get().filter(|_| {
+            use crate::shell::env_str::EnvStr;
+            let env = interp.as_cmd(this).base.shell();
+            let fc = EnvStr::init_slice(b"FORCE_COLOR");
+            let nc = EnvStr::init_slice(b"NO_COLOR");
+            !(env.export_env.contains(fc)
+                || env.export_env.contains(nc)
+                || env.cmd_local_env.contains(fc)
+                || env.cmd_local_env.contains(nc))
+        });
         {
             let env = interp.as_cmd_mut(this).base.shell_mut();
             let mut iter = env.export_env.iterator();
@@ -568,6 +578,15 @@ impl Cmd {
                 drop(arena);
                 return Yield::failed();
             }
+        }
+
+        // When this command's stdout is the capture pipe that relays to the
+        // script's color terminal, hint FORCE_COLOR so color-aware programs
+        // do not suppress ANSI just because `isatty()` is false.
+        if let Some(line) = force_color_env
+            && matches!(spawn_args.stdio[1], Stdio::Capture(_))
+        {
+            spawn_args.env_array.push(line.as_ptr().cast());
         }
 
         // Stage the exec slot *before* spawning so PipeReader / process-exit

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -585,9 +585,13 @@ impl Cmd {
         // do not suppress ANSI just because `isatty()` is false.
         if let Some(line) = force_color_env {
             let stdout_is_relay = match &spawn_args.stdio[1] {
+                // Plain capture; also `2>&1`, whose combined output still
+                // relays through root stdout (slot 2 carries the dup there).
                 Stdio::Capture(_) => true,
+                // `1>&2`: output is rerouted onto root stderr, which only
+                // reaches the terminal when stderr is itself a tty.
                 Stdio::Dup2(d) if matches!(d.to, StdioKind::Stderr) => {
-                    matches!(spawn_args.stdio[2], Stdio::Capture(_))
+                    interp.stderr_is_tty.get() && matches!(spawn_args.stdio[2], Stdio::Capture(_))
                 }
                 _ => false,
             };

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -583,10 +583,17 @@ impl Cmd {
         // When this command's stdout is the capture pipe that relays to the
         // script's color terminal, hint FORCE_COLOR so color-aware programs
         // do not suppress ANSI just because `isatty()` is false.
-        if let Some(line) = force_color_env
-            && matches!(spawn_args.stdio[1], Stdio::Capture(_))
-        {
-            spawn_args.env_array.push(line.as_ptr().cast());
+        if let Some(line) = force_color_env {
+            let stdout_is_relay = match &spawn_args.stdio[1] {
+                Stdio::Capture(_) => true,
+                Stdio::Dup2(d) if matches!(d.to, StdioKind::Stderr) => {
+                    matches!(spawn_args.stdio[2], Stdio::Capture(_))
+                }
+                _ => false,
+            };
+            if stdout_is_relay {
+                spawn_args.env_array.push(line.as_ptr().cast());
+            }
         }
 
         // Stage the exec slot *before* spawning so PipeReader / process-exit

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2971,3 +2971,149 @@ test("cd treats interpolated arguments starting with tilde or dash as literal di
     expect(exitCode).toBe(1);
   }
 });
+
+// https://github.com/oven-sh/bun/issues/11046
+describe("FORCE_COLOR", () => {
+  // Bun shell relays subprocess stdout/stderr through a pipe so it can
+  // capture the output; the child therefore sees `isatty() === false` and
+  // suppresses ANSI colors. When the relayed output is going to a color
+  // terminal the shell now sets FORCE_COLOR so color-aware programs still
+  // emit escapes.
+  const colorEnv = {
+    ...bunEnv,
+    NO_COLOR: undefined,
+    FORCE_COLOR: undefined,
+    CI: undefined,
+    TERM: "xterm-256color",
+  };
+
+  async function runInTerminal(fixture: string) {
+    let output = "";
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    await using terminal = new Bun.Terminal({
+      cols: 200,
+      rows: 24,
+      data(_term, chunk: Uint8Array) {
+        output += new TextDecoder().decode(chunk);
+        if (output.includes("DONE")) resolve();
+      },
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: colorEnv,
+      terminal,
+    });
+    proc.exited.then(code => (code === 0 ? resolve() : reject(new Error(`exit ${code}: ${output}`))));
+    await promise;
+    await proc.exited;
+    return output;
+  }
+
+  function fixture(body: string) {
+    // The probe spawns a real external subprocess that prints its own
+    // FORCE_COLOR/NO_COLOR environ as `fc=<val> nc=<val>`. On POSIX `sh -c`
+    // keeps this fast; on Windows there is no stock equivalent so the child
+    // bun under test spawns another copy of itself.
+    const probe = isWindows
+      ? `\${process.argv[0]} -e \${'process.stdout.write("fc="+(process.env.FORCE_COLOR||"")+" nc="+(process.env.NO_COLOR||"")+"\\\\n")'}`
+      : `sh -c 'printf "fc=%s nc=%s\\n" "$FORCE_COLOR" "$NO_COLOR"'`;
+    return `import { $ } from "bun";\n${body.replaceAll("PROBE", probe)}\nprocess.stdout.write("DONE\\n");`;
+  }
+
+  test("is set for a subprocess whose output goes to a color terminal", async () => {
+    const output = await runInTerminal(fixture(`await $\`PROBE\`;`));
+    expect(output).toMatch(/^fc=[123] nc=\r?$/m);
+  });
+
+  test("is not set for a subprocess whose stdout is redirected to a file", async () => {
+    const output = await runInTerminal(
+      fixture(
+        `const f = require("path").join(require("os").tmpdir(), "fc-" + process.pid);
+         await $\`PROBE > \${f}\`;
+         process.stdout.write(require("fs").readFileSync(f, "utf8"));`,
+      ),
+    );
+    expect(output).toMatch(/^fc= nc=\r?$/m);
+  });
+
+  test("is not set for a non-final pipeline stage", async () => {
+    const output = await runInTerminal(fixture(`await $\`PROBE | cat\`;`));
+    expect(output).toMatch(/^fc= nc=\r?$/m);
+  });
+
+  test("is not set inside a command substitution", async () => {
+    const output = await runInTerminal(fixture(`await $\`echo result=$(PROBE)\`;`));
+    expect(output).toMatch(/^result=fc= nc=\r?$/m);
+  });
+
+  test("is not set when the caller's env specifies NO_COLOR", async () => {
+    const output = await runInTerminal(fixture(`await $\`PROBE\`.env({ ...process.env, NO_COLOR: "1" });`));
+    expect(output).toMatch(/^fc= nc=1\r?$/m);
+  });
+
+  test("is not set when an inline NO_COLOR=1 assignment is present", async () => {
+    const output = await runInTerminal(fixture(`await $\`NO_COLOR=1 PROBE\`;`));
+    expect(output).toMatch(/^fc= nc=1\r?$/m);
+  });
+
+  test("is not set after an in-script export NO_COLOR", async () => {
+    const output = await runInTerminal(fixture(`await $\`export NO_COLOR=1 && PROBE\`;`));
+    expect(output).toMatch(/^fc= nc=1\r?$/m);
+  });
+
+  test("does not override a FORCE_COLOR already in the caller's env", async () => {
+    const output = await runInTerminal(fixture(`await $\`PROBE\`.env({ ...process.env, FORCE_COLOR: "0" });`));
+    expect(output).toMatch(/^fc=0 nc=\r?$/m);
+  });
+
+  test("is not set for .quiet() / .text()", async () => {
+    const output = await runInTerminal(
+      fixture(`const out = await $\`PROBE\`.text(); process.stdout.write(out);`),
+    );
+    expect(output).toMatch(/^fc= nc=\r?$/m);
+  });
+
+  test("is not visible to shell expansion", async () => {
+    // The hint is appended to the child's spawn env only; it is not an
+    // exported shell variable.
+    const output = await runInTerminal(fixture(`await $\`echo fc=[$FORCE_COLOR]\`;`));
+    expect(output).toMatch(/^fc=\[\]\r?$/m);
+  });
+
+  test("is not set when the script's own stdout is not a terminal", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(`await $\`PROBE\`;`)],
+      env: colorEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "fc= nc=\nDONE\n", stderr: "", exitCode: 0 });
+  });
+
+  test.skipIf(isWindows)("is not set when stdout is redirected but stderr is a terminal", async () => {
+    // The script's stderr is the PTY (so bun's own color policy is "on"), but
+    // stdout (where the shell relays command output) is a file.
+    let output = "";
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    await using terminal = new Bun.Terminal({
+      cols: 200,
+      rows: 24,
+      data(_t, chunk: Uint8Array) {
+        output += new TextDecoder().decode(chunk);
+        if (output.includes("DONE")) resolve();
+      },
+    });
+    using dir = tempDir("shell-fc-stderr", {});
+    const out = join(String(dir), "out.txt");
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `exec "$0" -e "$1" > "$2"`, bunExe(), fixture(`await $\`PROBE\`; process.stderr.write("DONE\\n");`), out],
+      env: colorEnv,
+      terminal,
+    });
+    proc.exited.then(code => (code === 0 ? resolve() : reject(new Error(`exit ${code}: ${output}`))));
+    await promise;
+    await proc.exited;
+    expect(await Bun.file(out).text()).toBe("fc= nc=\nDONE\n");
+  });
+});

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3003,7 +3003,11 @@ describe("FORCE_COLOR", () => {
       env: colorEnv,
       terminal,
     });
-    proc.exited.then(code => (code === 0 ? resolve() : reject(new Error(`exit ${code}: ${output}`))));
+    // Exit and PTY data delivery are independent; only the data callback
+    // resolves. A non-zero exit still rejects so failures surface promptly.
+    proc.exited.then(code => {
+      if (code !== 0) reject(new Error(`exit ${code}: ${output}`));
+    });
     await promise;
     await proc.exited;
     return output;
@@ -3029,8 +3033,10 @@ describe("FORCE_COLOR", () => {
     const output = await runInTerminal(
       fixture(
         `const f = require("path").join(require("os").tmpdir(), "fc-" + process.pid);
-         await $\`PROBE > \${f}\`;
-         process.stdout.write(require("fs").readFileSync(f, "utf8"));`,
+         try {
+           await $\`PROBE > \${f}\`;
+           process.stdout.write(require("fs").readFileSync(f, "utf8"));
+         } finally { require("fs").rmSync(f, { force: true }); }`,
       ),
     );
     expect(output).toMatch(/^fc= nc=\r?$/m);
@@ -3116,7 +3122,9 @@ describe("FORCE_COLOR", () => {
       env: colorEnv,
       terminal,
     });
-    proc.exited.then(code => (code === 0 ? resolve() : reject(new Error(`exit ${code}: ${output}`))));
+    proc.exited.then(code => {
+      if (code !== 0) reject(new Error(`exit ${code}: ${output}`));
+    });
     await promise;
     await proc.exited;
     expect(await Bun.file(out).text()).toBe("fc= nc=\nDONE\n");

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3010,7 +3010,9 @@ describe("FORCE_COLOR", () => {
     });
     await promise;
     await proc.exited;
-    return output;
+    // ConPTY wraps output in screen-control and window-title sequences; strip
+    // them so the line-anchored assertions see the visible text.
+    return output.replace(/\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "");
   }
 
   function fixture(body: string) {
@@ -3024,14 +3026,20 @@ describe("FORCE_COLOR", () => {
     return `import { $ } from "bun";\n${body.replaceAll("PROBE", probe)}\nprocess.stdout.write("DONE\\n");`;
   }
 
+  function probeResult(output: string) {
+    const m = output.match(/fc=([0-9]*) nc=([0-9]*)/);
+    if (!m) throw new Error(`no probe output in: ${JSON.stringify(output)}`);
+    return { fc: m[1], nc: m[2] };
+  }
+
   test("is set for a subprocess whose output goes to a color terminal", async () => {
     const output = await runInTerminal(fixture(`await $\`PROBE\`;`));
-    expect(output).toMatch(/^fc=[123] nc=\r?$/m);
+    expect(probeResult(output).fc).toMatch(/^[123]$/);
   });
 
   test("is set for `cmd 2>&1` when stderr is the relayed terminal", async () => {
     const output = await runInTerminal(fixture(`await $\`PROBE 2>&1\`;`));
-    expect(output).toMatch(/^fc=[123] nc=\r?$/m);
+    expect(probeResult(output).fc).toMatch(/^[123]$/);
   });
 
   test("is not set for a subprocess whose stdout is redirected to a file", async () => {
@@ -3044,54 +3052,54 @@ describe("FORCE_COLOR", () => {
          } finally { require("fs").rmSync(f, { force: true }); }`,
       ),
     );
-    expect(output).toMatch(/^fc= nc=\r?$/m);
+    expect(probeResult(output)).toEqual({ fc: "", nc: "" });
   });
 
   test("is not set for a non-final pipeline stage", async () => {
     const output = await runInTerminal(fixture(`await $\`PROBE | cat\`;`));
-    expect(output).toMatch(/^fc= nc=\r?$/m);
+    expect(probeResult(output)).toEqual({ fc: "", nc: "" });
   });
 
   test("is not set inside a command substitution", async () => {
     const output = await runInTerminal(fixture(`await $\`echo result=$(PROBE)\`;`));
-    expect(output).toMatch(/^result=fc= nc=\r?$/m);
+    expect(output).toContain("result=fc= nc=");
   });
 
   test("is not set when the caller's env specifies NO_COLOR", async () => {
     const output = await runInTerminal(fixture(`await $\`PROBE\`.env({ ...process.env, NO_COLOR: "1" });`));
-    expect(output).toMatch(/^fc= nc=1\r?$/m);
+    expect(probeResult(output)).toEqual({ fc: "", nc: "1" });
   });
 
   test("is not set when an inline NO_COLOR=1 assignment is present", async () => {
     const output = await runInTerminal(fixture(`await $\`NO_COLOR=1 PROBE\`;`));
-    expect(output).toMatch(/^fc= nc=1\r?$/m);
+    expect(probeResult(output)).toEqual({ fc: "", nc: "1" });
   });
 
   test("is not set after an in-script export NO_COLOR", async () => {
     const output = await runInTerminal(fixture(`await $\`export NO_COLOR=1 && PROBE\`;`));
-    expect(output).toMatch(/^fc= nc=1\r?$/m);
+    expect(probeResult(output)).toEqual({ fc: "", nc: "1" });
   });
 
   test("does not override a FORCE_COLOR already in the caller's env", async () => {
     const output = await runInTerminal(fixture(`await $\`PROBE\`.env({ ...process.env, FORCE_COLOR: "0" });`));
-    expect(output).toMatch(/^fc=0 nc=\r?$/m);
+    expect(probeResult(output).fc).toBe("0");
   });
 
   test("is not set for .quiet() / .text()", async () => {
     const output = await runInTerminal(fixture(`const out = await $\`PROBE\`.text(); process.stdout.write(out);`));
-    expect(output).toMatch(/^fc= nc=\r?$/m);
+    expect(probeResult(output)).toEqual({ fc: "", nc: "" });
   });
 
   test("is not visible to shell expansion", async () => {
     // The hint is appended to the child's spawn env only; it is not an
     // exported shell variable.
     const output = await runInTerminal(fixture(`await $\`echo fc=[$FORCE_COLOR]\`;`));
-    expect(output).toMatch(/^fc=\[\]\r?$/m);
+    expect(output).toContain("fc=[]");
   });
 
   test.skipIf(isWindows)("is not set when TERM=dumb", async () => {
     const output = await runInTerminal(fixture(`await $\`PROBE\`;`), { ...colorEnv, TERM: "dumb" });
-    expect(output).toMatch(/^fc= nc=\r?$/m);
+    expect(probeResult(output)).toEqual({ fc: "", nc: "" });
   });
 
   test("is not set when the script's own stdout is not a terminal", async () => {
@@ -3138,5 +3146,38 @@ describe("FORCE_COLOR", () => {
     await promise;
     await proc.exited;
     expect(await Bun.file(out).text()).toBe("fc= nc=\nDONE\n");
+  });
+
+  test("is set for `cmd 1>&2` when stderr is the relayed terminal", async () => {
+    const output = await runInTerminal(fixture(`await $\`PROBE 1>&2\`;`));
+    expect(probeResult(output).fc).toMatch(/^[123]$/);
+  });
+
+  test.skipIf(isWindows)("is not set for `cmd 1>&2` when the script's stderr is redirected", async () => {
+    // `1>&2` reroutes stdout onto stderr's destination; here root stderr is a
+    // file, so the output must stay plain even though stdout is the PTY.
+    let output = "";
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    await using terminal = new Bun.Terminal({
+      cols: 200,
+      rows: 24,
+      data(_t, chunk: Uint8Array) {
+        output += new TextDecoder().decode(chunk);
+        if (output.includes("DONE")) resolve();
+      },
+    });
+    using dir = tempDir("shell-fc-dup2", {});
+    const err = join(String(dir), "err.txt");
+    await using proc = Bun.spawn({
+      cmd: ["sh", "-c", `exec "$0" -e "$1" 2> "$2"`, bunExe(), fixture(`await $\`PROBE 1>&2\`;`), err],
+      env: colorEnv,
+      terminal,
+    });
+    proc.exited.then(code => {
+      if (code !== 0) reject(new Error(`exit ${code}: ${output}`));
+    });
+    await promise;
+    await proc.exited;
+    expect(await Bun.file(err).text()).toBe("fc= nc=\n");
   });
 });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3102,6 +3102,13 @@ describe("FORCE_COLOR", () => {
     expect(probeResult(output)).toEqual({ fc: "", nc: "" });
   });
 
+  test.skipIf(!isWindows)("defaults to truecolor when TERM is unset on Windows", async () => {
+    // Stock Windows consoles set none of the color env vars; supports-color
+    // treats a numeric FORCE_COLOR as an override, so 1 would downgrade them.
+    const output = await runInTerminal(fixture(`await $\`PROBE\`;`), { ...colorEnv, TERM: undefined });
+    expect(probeResult(output).fc).toBe("3");
+  });
+
   test("is not set when the script's own stdout is not a terminal", async () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture(`await $\`PROBE\`;`)],

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3067,9 +3067,7 @@ describe("FORCE_COLOR", () => {
   });
 
   test("is not set for .quiet() / .text()", async () => {
-    const output = await runInTerminal(
-      fixture(`const out = await $\`PROBE\`.text(); process.stdout.write(out);`),
-    );
+    const output = await runInTerminal(fixture(`const out = await $\`PROBE\`.text(); process.stdout.write(out);`));
     expect(output).toMatch(/^fc= nc=\r?$/m);
   });
 
@@ -3107,7 +3105,14 @@ describe("FORCE_COLOR", () => {
     using dir = tempDir("shell-fc-stderr", {});
     const out = join(String(dir), "out.txt");
     await using proc = Bun.spawn({
-      cmd: ["sh", "-c", `exec "$0" -e "$1" > "$2"`, bunExe(), fixture(`await $\`PROBE\`; process.stderr.write("DONE\\n");`), out],
+      cmd: [
+        "sh",
+        "-c",
+        `exec "$0" -e "$1" > "$2"`,
+        bunExe(),
+        fixture(`await $\`PROBE\`; process.stderr.write("DONE\\n");`),
+        out,
+      ],
       env: colorEnv,
       terminal,
     });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2987,7 +2987,7 @@ describe("FORCE_COLOR", () => {
     TERM: "xterm-256color",
   };
 
-  async function runInTerminal(fixture: string) {
+  async function runInTerminal(fixture: string, env: Record<string, string | undefined> = colorEnv) {
     let output = "";
     const { promise, resolve, reject } = Promise.withResolvers<void>();
     await using terminal = new Bun.Terminal({
@@ -3000,7 +3000,7 @@ describe("FORCE_COLOR", () => {
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: colorEnv,
+      env,
       terminal,
     });
     // Exit and PTY data delivery are independent; only the data callback
@@ -3026,6 +3026,11 @@ describe("FORCE_COLOR", () => {
 
   test("is set for a subprocess whose output goes to a color terminal", async () => {
     const output = await runInTerminal(fixture(`await $\`PROBE\`;`));
+    expect(output).toMatch(/^fc=[123] nc=\r?$/m);
+  });
+
+  test("is set for `cmd 2>&1` when stderr is the relayed terminal", async () => {
+    const output = await runInTerminal(fixture(`await $\`PROBE 2>&1\`;`));
     expect(output).toMatch(/^fc=[123] nc=\r?$/m);
   });
 
@@ -3082,6 +3087,11 @@ describe("FORCE_COLOR", () => {
     // exported shell variable.
     const output = await runInTerminal(fixture(`await $\`echo fc=[$FORCE_COLOR]\`;`));
     expect(output).toMatch(/^fc=\[\]\r?$/m);
+  });
+
+  test.skipIf(isWindows)("is not set when TERM=dumb", async () => {
+    const output = await runInTerminal(fixture(`await $\`PROBE\`;`), { ...colorEnv, TERM: "dumb" });
+    expect(output).toMatch(/^fc= nc=\r?$/m);
   });
 
   test("is not set when the script's own stdout is not a terminal", async () => {


### PR DESCRIPTION
Fixes #11046.

### What

Bun shell relays each command's stdout/stderr through a pipe so it can capture the bytes for `.stdout` / `.text()` while also writing them to the parent's stdout. The child therefore sees `isatty() === false` and most color-aware programs suppress their ANSI escapes:

```ts
// run from a real terminal
await $`python3 -c "import sys;print(sys.stdout.isatty())"`;
// False
```

The escapes themselves pass through fine; the programs just choose not to emit them.

### Fix

When the shell's root stdout is a color-capable terminal (specifically: the JS capture path, `isatty(stdout)`, `enable_ansi_colors_stdout()`, and `is_color_terminal()` all hold), record a `FORCE_COLOR=<depth>` hint on the interpreter. Each external command then appends it to its spawn env **only when** that command's resolved output lands on the relayed terminal: its stdout is still the capture pipe (including `cmd 2>&1`, whose combined output relays through root stdout), or it is `cmd 1>&2` and root stderr is itself a tty. The env in scope must not already carry a `FORCE_COLOR`/`NO_COLOR` preference. Subprocesses that honor `FORCE_COLOR` (Node/npm, chalk, supports-color, Python click/rich, Go fatih/color, bun itself, ...) then keep their colors even though their stdout is a pipe.

The level is taken from bun's detected terminal color depth (1/2/3 for 16/256/truecolor) so libraries that read the value do not get downgraded.

Not applied when:
- the command's stdout is redirected (`cmd > file`), piped to another stage (`cmd | grep`), or inside a command substitution (`$(cmd)`)
- the command is `cmd 1>&2` and the script's stderr is not a tty (e.g. `bun script.ts 2> err.log`)
- `FORCE_COLOR` or `NO_COLOR` is already in the caller's env, an inline `NO_COLOR=1 cmd` assignment, or a preceding `export`
- `.quiet()` / `.text()` / `.json()` are used (output is captured only; `setup_io_before_run` returns early)
- the script's own stdout is not a color terminal (e.g. `bun script.ts > out.txt`, `TERM=dumb`)
- the mini event loop (`bun run <script>`, `bun exec`): children there receive the dup'd tty fd directly

Known limitations, both inherent to `FORCE_COLOR` being a per-process env var (zx has the same):
- `cmd 2> errors.log` (stdout to terminal, stderr to file) still sets the hint because the gate follows stdout; programs that apply `FORCE_COLOR` process-wide may write escapes to the redirected stderr file. Also gating on stderr would break the more common `cmd 2> /dev/null`.
- a child that is itself a runner (`bun inner.ts`, `npm run`) passes the inherited `FORCE_COLOR` on to its own grandchildren, including ones that redirect to files. `NO_COLOR=1` in the inner script opts out.

This mirrors what [zx does](https://github.com/google/zx/blob/8.1.8/src/core.ts) and what bun's own parallel test runner already does for its piped workers (`src/runtime/cli/test/parallel/runner.rs`), but scoped per command rather than interpreter-wide so redirected output stays clean.

Programs that only check `isatty()` and ignore `FORCE_COLOR` still won't emit colors; for those, #33239's `.terminal()` (a real PTY) is the escape hatch.

### Verification

Sixteen tests in `test/js/bun/shell/bunshell.test.ts` under a `FORCE_COLOR` describe, exercised through a real PTY (`Bun.Terminal`). The three positive tests (plain relay, `cmd 2>&1`, `cmd 1>&2`) fail on main and pass here; the thirteen negative tests guard scope (redirect to file, pipeline stage, command substitution, `.env({NO_COLOR})`, inline `NO_COLOR=1`, `export NO_COLOR`, existing `FORCE_COLOR`, `.quiet()`, shell expansion unaffected, `TERM=dumb`, non-tty stdout, stdout redirected with stderr on the tty, `1>&2` with stderr redirected) and pass on both. Verified on Linux and on Windows (ConPTY); the PTY assertions strip ConPTY's screen-control sequences before matching.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->