### PR TITLE
install: preserve JSONC comments when rewriting package.json

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -75,6 +75,33 @@ impl Expr {
         self
     }
 
+    /// Zero every `Loc` in a JSON subtree parsed from another document, so splicing it into an AST never leaves offsets that index a different buffer.
+    pub fn clear_source_locs(&mut self) {
+        self.loc = Loc::EMPTY;
+        match &mut self.data {
+            Data::EObject(o) => {
+                let o = &mut **o;
+                o.close_brace_loc = Loc::EMPTY;
+                for prop in o.properties.slice_mut() {
+                    if let Some(key) = &mut prop.key {
+                        key.clear_source_locs();
+                    }
+                    if let Some(value) = &mut prop.value {
+                        value.clear_source_locs();
+                    }
+                }
+            }
+            Data::EArray(a) => {
+                let a = &mut **a;
+                a.close_bracket_loc = Loc::EMPTY;
+                for item in a.items.slice_mut() {
+                    item.clear_source_locs();
+                }
+            }
+            _ => {}
+        }
+    }
+
     #[inline]
     pub fn init_identifier(ref_: Ref, loc: Loc) -> Expr {
         Expr {

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -213,6 +213,7 @@ pub fn edit_trusted_dependencies(
             .data
             .e_object()
             .expect("infallible: variant checked");
+        let prev_close_brace_loc = obj.close_brace_loc;
         let old_props = obj.properties.slice();
         let mut root_properties: Vec<G::Property> = Vec::with_capacity(old_props.len() + 1);
         for p in old_props {
@@ -229,6 +230,7 @@ pub fn edit_trusted_dependencies(
         *package_json = Expr::init(
             E::Object {
                 properties: G::PropertyList::move_from_list(root_properties),
+                close_brace_loc: prev_close_brace_loc,
                 ..Default::default()
             },
             bun_ast::Loc::EMPTY,

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -992,6 +992,11 @@ pub(crate) fn edit(
                 bun_ast::Loc::EMPTY,
             );
         } else {
+            let prev_close_brace_loc = current_package_json
+                .data
+                .e_object()
+                .expect("infallible: variant checked")
+                .close_brace_loc;
             if needs_new_dependency_list && needs_new_trusted_dependencies_list {
                 let obj = current_package_json
                     .data
@@ -1024,6 +1029,7 @@ pub(crate) fn edit(
                     arena,
                     E::Object {
                         properties: G::PropertyList::move_from_list(root_properties),
+                        close_brace_loc: prev_close_brace_loc,
                         ..Default::default()
                     },
                     bun_ast::Loc::EMPTY,
@@ -1059,6 +1065,7 @@ pub(crate) fn edit(
                     arena,
                     E::Object {
                         properties: G::PropertyList::move_from_list(root_properties),
+                        close_brace_loc: prev_close_brace_loc,
                         ..Default::default()
                     },
                     bun_ast::Loc::EMPTY,

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -24,8 +24,7 @@ pub struct MapEntry {
     pub root: Expr,
     pub source: Source,
     pub indentation: Indentation,
-    /// Comment byte-ranges into `source.contents`, threaded into
-    /// `PrintJsonOptions.preserve_comments` so edits don't strip them.
+    /// Comment byte-ranges into `source.contents`, for `PrintJsonOptions.preserve_comments`.
     pub comments: Vec<bun_ast::Range>,
     /// Owns the path bytes that `source.path.{text,pretty,name.*}` borrow,
     /// so the source's path slices stay valid for the entry's lifetime.

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -24,6 +24,9 @@ pub struct MapEntry {
     pub root: Expr,
     pub source: Source,
     pub indentation: Indentation,
+    /// Comment byte-ranges into `source.contents`, threaded into
+    /// `PrintJsonOptions.preserve_comments` so edits don't strip them.
+    pub comments: Vec<bun_ast::Range>,
     /// Owns the path bytes that `source.path.{text,pretty,name.*}` borrow,
     /// so the source's path slices stay valid for the entry's lifetime.
     /// `StringHashMap` boxes its own key, so keep the duped copy alive here.
@@ -49,6 +52,7 @@ impl Default for MapEntry {
             root: Expr::default(),
             source: Source::default(),
             indentation: Indentation::default(),
+            comments: Vec::new(),
             _path_storage: bun_core::ZBox::default(),
             json_arena: bun_alloc::Arena::new(),
             stale_contents: Vec::new(),
@@ -66,6 +70,7 @@ impl MapEntry {
         let json_bump = bun_alloc::Arena::new();
         let parsed = parse_package_json(&self.source, log, &json_bump, false)?;
         self.root = bun_core::handle_oom(parsed.root.deep_clone(&json_bump));
+        self.comments = parsed.comments;
         self.json_arena = json_bump;
         Ok(())
     }
@@ -192,6 +197,7 @@ impl WorkspacePackageJSONCache {
             root: bun_core::handle_oom(parsed.root.deep_clone(&json_bump)),
             source,
             indentation: parsed.indentation,
+            comments: parsed.comments,
             // `source.path` borrows this allocation; the `Box<[u8]>` heap
             // address is stable across the move into the map.
             _path_storage: key,

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -379,6 +379,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         js_printer::PrintJsonOptions {
             indent: current_package_json_indent,
             mangled_props: None,
+            preserve_comments: &current_package_json.comments,
             ..Default::default()
         },
     ) {
@@ -494,6 +495,7 @@ fn update_package_json_and_install_with_manager_with_updates(
                 js_printer::PrintJsonOptions {
                     indent: root_package_json.indentation,
                     mangled_props: None,
+                    preserve_comments: &root_package_json.comments,
                     ..Default::default()
                 },
             ) {
@@ -544,9 +546,14 @@ fn update_package_json_and_install_with_manager_with_updates(
         // Now, we _re_ parse our in-memory edited package.json
         // so we can commit the version we changed from the lockfile
         let json_arena = bun_alloc::Arena::new();
-        let mut new_package_json: bun_ast::Expr =
-            match json::parse_package_json_utf8(&source, manager.log_mut(), &json_arena) {
-                Ok(v) => v,
+        let (mut new_package_json, new_package_json_comments): (bun_ast::Expr, _) =
+            match json::parse_package_json_utf8_with_opts(
+                json::PACKAGE_JSON_OPTS,
+                &source,
+                manager.log_mut(),
+                &json_arena,
+            ) {
+                Ok(v) => (v.root, v.comments),
                 Err(err) => {
                     bun_core::pretty_errorln!(
                         "package.json failed to parse due to error {}",
@@ -596,6 +603,7 @@ fn update_package_json_and_install_with_manager_with_updates(
             js_printer::PrintJsonOptions {
                 indent: current_package_json_indent,
                 mangled_props: None,
+                preserve_comments: &new_package_json_comments,
                 ..Default::default()
             },
         ) {

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -210,6 +210,31 @@ fn e_object_mut(expr: &mut Expr) -> &mut E::Object {
     }
 }
 
+/// Zero every `Loc` in a subtree spliced in from another document so comment-preserving `print_json` doesn't treat foreign offsets as package.json positions.
+fn clear_source_locs(expr: &mut Expr) {
+    expr.loc = bun_ast::Loc::EMPTY;
+    match &mut expr.data {
+        ExprData::EObject(o) => {
+            o.close_brace_loc = bun_ast::Loc::EMPTY;
+            for prop in o.properties.slice_mut() {
+                if let Some(key) = &mut prop.key {
+                    clear_source_locs(key);
+                }
+                if let Some(value) = &mut prop.value {
+                    clear_source_locs(value);
+                }
+            }
+        }
+        ExprData::EArray(a) => {
+            a.close_bracket_loc = bun_ast::Loc::EMPTY;
+            for item in a.items.slice_mut() {
+                clear_source_locs(item);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Shallow struct copy (`G::Property` lacks `Clone` because of its
 /// `Vec`/`NonNull` fields).
 fn shallow_clone_prop(p: &G::Property) -> G::Property {
@@ -1811,19 +1836,23 @@ fn update_package_json_after_migration(
                 }
             }
 
-            if let Some(catalog_expr) = ws_root.get_object(b"catalog") {
+            if let Some(mut catalog_expr) = ws_root.get_object(b"catalog") {
+                clear_source_locs(&mut catalog_expr);
                 catalog_obj = Some(catalog_expr);
             }
 
-            if let Some(catalogs_expr) = ws_root.get_object(b"catalogs") {
+            if let Some(mut catalogs_expr) = ws_root.get_object(b"catalogs") {
+                clear_source_locs(&mut catalogs_expr);
                 catalogs_obj = Some(catalogs_expr);
             }
 
-            if let Some(overrides_expr) = ws_root.get_object(b"overrides") {
+            if let Some(mut overrides_expr) = ws_root.get_object(b"overrides") {
+                clear_source_locs(&mut overrides_expr);
                 workspace_overrides_obj = Some(overrides_expr);
             }
 
-            if let Some(patched_deps_expr) = ws_root.get_object(b"patchedDependencies") {
+            if let Some(mut patched_deps_expr) = ws_root.get_object(b"patchedDependencies") {
+                clear_source_locs(&mut patched_deps_expr);
                 workspace_patched_deps_obj = Some(patched_deps_expr);
             }
         }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -210,31 +210,6 @@ fn e_object_mut(expr: &mut Expr) -> &mut E::Object {
     }
 }
 
-/// Zero every `Loc` in a subtree spliced in from another document so comment-preserving `print_json` doesn't treat foreign offsets as package.json positions.
-fn clear_source_locs(expr: &mut Expr) {
-    expr.loc = bun_ast::Loc::EMPTY;
-    match &mut expr.data {
-        ExprData::EObject(o) => {
-            o.close_brace_loc = bun_ast::Loc::EMPTY;
-            for prop in o.properties.slice_mut() {
-                if let Some(key) = &mut prop.key {
-                    clear_source_locs(key);
-                }
-                if let Some(value) = &mut prop.value {
-                    clear_source_locs(value);
-                }
-            }
-        }
-        ExprData::EArray(a) => {
-            a.close_bracket_loc = bun_ast::Loc::EMPTY;
-            for item in a.items.slice_mut() {
-                clear_source_locs(item);
-            }
-        }
-        _ => {}
-    }
-}
-
 /// Shallow struct copy (`G::Property` lacks `Clone` because of its
 /// `Vec`/`NonNull` fields).
 fn shallow_clone_prop(p: &G::Property) -> G::Property {
@@ -1837,22 +1812,22 @@ fn update_package_json_after_migration(
             }
 
             if let Some(mut catalog_expr) = ws_root.get_object(b"catalog") {
-                clear_source_locs(&mut catalog_expr);
+                catalog_expr.clear_source_locs();
                 catalog_obj = Some(catalog_expr);
             }
 
             if let Some(mut catalogs_expr) = ws_root.get_object(b"catalogs") {
-                clear_source_locs(&mut catalogs_expr);
+                catalogs_expr.clear_source_locs();
                 catalogs_obj = Some(catalogs_expr);
             }
 
             if let Some(mut overrides_expr) = ws_root.get_object(b"overrides") {
-                clear_source_locs(&mut overrides_expr);
+                overrides_expr.clear_source_locs();
                 workspace_overrides_obj = Some(overrides_expr);
             }
 
             if let Some(mut patched_deps_expr) = ws_root.get_object(b"patchedDependencies") {
-                clear_source_locs(&mut patched_deps_expr);
+                patched_deps_expr.clear_source_locs();
                 workspace_patched_deps_obj = Some(patched_deps_expr);
             }
         }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -2060,6 +2060,7 @@ fn update_package_json_after_migration(
             bun_js_printer::PrintJsonOptions {
                 indent: root_pkg_json.indentation,
                 mangled_props: None,
+                preserve_comments: &root_pkg_json.comments,
                 ..Default::default()
             },
         )
@@ -2078,6 +2079,8 @@ fn update_package_json_after_migration(
                 .written_without_trailing_zero()
                 .to_vec(),
         );
+        // The ranges are byte offsets into the replaced buffer.
+        root_pkg_json.comments.clear();
 
         // Write the updated package.json
         let _ = sys::File::write_file(

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1681,6 +1681,40 @@ pub mod __gated_printer {
             }
         }
 
+        /// Emit the next pending JSONC comment(s) inline if they share a source line with the value ending at `after` (no newline between).
+        #[inline]
+        pub fn flush_json_same_line_comment(&mut self, after: i32) {
+            if !IS_JSON || after < 0 {
+                return;
+            }
+            let comments = self.options.json_preserve_comments;
+            let source = self.options.json_comment_source;
+            while self.json_comment_cursor < comments.len() {
+                let range = comments[self.json_comment_cursor];
+                if range.loc.start <= after || range.len <= 0 {
+                    break;
+                }
+                let start = range.loc.start as usize;
+                let end = start + range.len as usize;
+                if end > source.len() || (after as usize) >= start {
+                    break;
+                }
+                if source[after as usize..start]
+                    .iter()
+                    .any(|&b| b == b'\n' || b == b'\r')
+                {
+                    break;
+                }
+                self.json_comment_cursor += 1;
+                self.json_comment_watermark = range.loc.start;
+                self.print(b" ");
+                self.print(&source[start..end]);
+                if source.get(start + 1) == Some(&b'/') {
+                    break;
+                }
+            }
+        }
+
         /// Emit each preserved JSONC comment starting before `before` exactly once; `leading_break` puts the newline/indent before it instead of after.
         #[inline]
         pub fn flush_json_comments_before(&mut self, before: i32, leading_break: bool) {
@@ -3641,12 +3675,6 @@ pub mod __gated_printer {
                         }
 
                         for (i, item) in items.iter().enumerate() {
-                            if i != 0 {
-                                self.print(b",");
-                                if e.is_single_line {
-                                    self.print_space();
-                                }
-                            }
                             if !e.is_single_line {
                                 self.print_newline();
                                 self.print_indent();
@@ -3656,9 +3684,19 @@ pub mod __gated_printer {
                             }
                             self.print_expr(*item, Level::Comma, ExprFlag::none());
 
-                            if i == items.len() - 1 && matches!(item.data, ExprData::EMissing(_)) {
+                            let last = i == items.len() - 1;
+                            if last && matches!(item.data, ExprData::EMissing(_)) {
                                 // Make sure there's a comma after trailing missing items
                                 self.print(b",");
+                            }
+                            if !last {
+                                self.print(b",");
+                                if e.is_single_line {
+                                    self.print_space();
+                                }
+                            }
+                            if IS_JSON && !e.is_single_line {
+                                self.flush_json_same_line_comment(json_value_end_loc(item));
                             }
                         }
 
@@ -3712,34 +3750,34 @@ pub mod __gated_printer {
                             self.indent();
                         }
 
-                        if e.is_single_line && !IS_JSON {
-                            self.print_space();
-                        } else {
-                            self.print_newline();
-                            self.print_indent();
-                        }
-                        if IS_JSON {
-                            if let Some(key) = &props[0].key {
-                                self.flush_json_comments_before(key.loc.start, false);
+                        for (i, property) in props.iter().enumerate() {
+                            if e.is_single_line && !IS_JSON {
+                                if i == 0 {
+                                    self.print_space();
+                                }
+                            } else {
+                                self.print_newline();
+                                self.print_indent();
                             }
-                        }
-                        self.print_property(&props[0]);
-
-                        if props.len() > 1 {
-                            for property in &props[1..] {
+                            let key_loc = property.key.as_ref().map_or(-1, |k| k.loc.start);
+                            if IS_JSON {
+                                self.flush_json_comments_before(key_loc, false);
+                            }
+                            self.print_property(property);
+                            if i + 1 < props.len() {
                                 self.print(b",");
                                 if e.is_single_line && !IS_JSON {
                                     self.print_space();
-                                } else {
-                                    self.print_newline();
-                                    self.print_indent();
                                 }
-                                if IS_JSON {
-                                    if let Some(key) = &property.key {
-                                        self.flush_json_comments_before(key.loc.start, false);
-                                    }
-                                }
-                                self.print_property(property);
+                            }
+                            if IS_JSON {
+                                let end_loc = property
+                                    .value
+                                    .as_ref()
+                                    .map(json_value_end_loc)
+                                    .filter(|&l| l >= 0)
+                                    .unwrap_or(key_loc);
+                                self.flush_json_same_line_comment(end_loc);
                             }
                         }
 
@@ -7866,6 +7904,15 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
     printer.writer.done()?;
 
     Ok(usize::try_from(printer.writer.written().max(0)).expect("int cast"))
+}
+
+/// Best-effort last source byte of a JSON value, for same-line-comment detection.
+fn json_value_end_loc(expr: &js_ast::Expr) -> i32 {
+    match &expr.data {
+        js_ast::expr::Data::EObject(o) if o.close_brace_loc.start > 0 => o.close_brace_loc.start,
+        js_ast::expr::Data::EArray(a) if a.close_bracket_loc.start > 0 => a.close_bracket_loc.start,
+        _ => expr.loc.start,
+    }
 }
 
 pub fn print_json<W: WriterTrait>(

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3658,9 +3658,9 @@ pub mod __gated_printer {
                             if !e.is_single_line {
                                 self.print_newline();
                                 self.print_indent();
-                            }
-                            if IS_JSON {
-                                self.flush_json_comments_before(item.loc.start, false);
+                                if IS_JSON {
+                                    self.flush_json_comments_before(item.loc.start, false);
+                                }
                             }
                             self.print_expr(*item, Level::Comma, ExprFlag::none());
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1083,8 +1083,7 @@ pub struct Options<'a> {
 
     pub mangled_props: Option<&'a crate::MangledProps>,
 
-    /// Comment byte-ranges (into `json_comment_source`) to interleave back into
-    /// the output when re-printing JSONC. See [`print_json`].
+    /// Comment byte-ranges into `json_comment_source`, re-emitted when printing JSONC.
     pub json_preserve_comments: &'a [bun_ast::Range],
     pub json_comment_source: &'a [u8],
 }
@@ -1157,9 +1156,7 @@ pub struct PrintJsonOptions<'a> {
     pub indent: Indentation,
     pub mangled_props: Option<&'a MangledProps>,
     pub minify_whitespace: bool,
-    /// Comment byte-ranges into `source.contents` to re-emit at their original
-    /// positions relative to surviving AST nodes. Preserves JSONC comments
-    /// across a parse → edit → print round-trip.
+    /// Comment byte-ranges into `source.contents`, re-emitted relative to surviving nodes.
     pub preserve_comments: &'a [bun_ast::Range],
 }
 
@@ -1418,8 +1415,7 @@ pub mod __gated_printer {
         // Always carried; gated at call sites with MAY_HAVE_MODULE_INFO.
         pub module_info: Option<&'a mut analyze_transpiled_module::ModuleInfo>,
 
-        /// Index into `options.json_preserve_comments` of the next comment to
-        /// emit; advanced by [`Self::flush_json_comments_before`].
+        /// Next `options.json_preserve_comments` entry to emit.
         pub json_comment_cursor: usize,
         pub json_comment_watermark: i32,
 
@@ -1685,11 +1681,8 @@ pub mod __gated_printer {
             }
         }
 
-        /// Emit every preserved JSONC comment whose source start precedes
-        /// `before`, maintaining a monotonic cursor so each comment is printed
-        /// once. `leading_break` selects whether the separator newline/indent
-        /// goes before or after the comment text (before-close-brace vs
-        /// before-property callers are positioned differently).
+        /// Emit each preserved JSONC comment starting before `before` exactly once;
+        /// `leading_break` puts the newline/indent before the comment instead of after.
         #[inline]
         pub fn flush_json_comments_before(&mut self, before: i32, leading_break: bool) {
             if !IS_JSON {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1082,6 +1082,11 @@ pub struct Options<'a> {
     pub line_offset_tables: Option<&'a SourceMap::line_offset_table::List<bun_alloc::AstAlloc>>,
 
     pub mangled_props: Option<&'a crate::MangledProps>,
+
+    /// Comment byte-ranges (into `json_comment_source`) to interleave back into
+    /// the output when re-printing JSONC. See [`print_json`].
+    pub json_preserve_comments: &'a [bun_ast::Range],
+    pub json_comment_source: &'a [u8],
 }
 
 impl<'a> Options<'a> {
@@ -1137,6 +1142,8 @@ impl<'a> Default for Options<'a> {
             ts_enums: None,
             line_offset_tables: None,
             mangled_props: None,
+            json_preserve_comments: &[],
+            json_comment_source: &[],
         }
     }
 }
@@ -1150,6 +1157,10 @@ pub struct PrintJsonOptions<'a> {
     pub indent: Indentation,
     pub mangled_props: Option<&'a MangledProps>,
     pub minify_whitespace: bool,
+    /// Comment byte-ranges into `source.contents` to re-emit at their original
+    /// positions relative to surviving AST nodes. Preserves JSONC comments
+    /// across a parse → edit → print round-trip.
+    pub preserve_comments: &'a [bun_ast::Range],
 }
 
 // `print_json` lives below the `Printer` impl (after `__gated_printer`) so it
@@ -1406,6 +1417,11 @@ pub mod __gated_printer {
         pub was_lazy_export: bool,
         // Always carried; gated at call sites with MAY_HAVE_MODULE_INFO.
         pub module_info: Option<&'a mut analyze_transpiled_module::ModuleInfo>,
+
+        /// Index into `options.json_preserve_comments` of the next comment to
+        /// emit; advanced by [`Self::flush_json_comments_before`].
+        pub json_comment_cursor: usize,
+        pub json_comment_watermark: i32,
 
         /// Arena for transient allocations during printing (rope flattening,
         /// UTF-16→UTF-8 transcoding).
@@ -1666,6 +1682,52 @@ pub mod __gated_printer {
                 let amt = i.min(indentation_buf.len());
                 self.print(&indentation_buf[..amt]);
                 i -= amt;
+            }
+        }
+
+        /// Emit every preserved JSONC comment whose source start precedes
+        /// `before`, maintaining a monotonic cursor so each comment is printed
+        /// once. `leading_break` selects whether the separator newline/indent
+        /// goes before or after the comment text (before-close-brace vs
+        /// before-property callers are positioned differently).
+        #[inline]
+        pub fn flush_json_comments_before(&mut self, before: i32, leading_break: bool) {
+            if !IS_JSON {
+                return;
+            }
+            let comments = self.options.json_preserve_comments;
+            if self.json_comment_cursor >= comments.len() {
+                return;
+            }
+            // `Loc::EMPTY` is -1; nodes spliced in by the editor carry it.
+            if before <= 0 || before < self.json_comment_watermark {
+                return;
+            }
+            self.json_comment_watermark = before;
+            let source = self.options.json_comment_source;
+            while self.json_comment_cursor < comments.len() {
+                let range = comments[self.json_comment_cursor];
+                if range.loc.start >= before {
+                    break;
+                }
+                self.json_comment_cursor += 1;
+                if range.loc.start < 0 || range.len <= 0 {
+                    continue;
+                }
+                let start = range.loc.start as usize;
+                let end = start + range.len as usize;
+                if end > source.len() {
+                    continue;
+                }
+                if leading_break {
+                    self.print_newline();
+                    self.print_indent();
+                }
+                self.print(&source[start..end]);
+                if !leading_break {
+                    self.print_newline();
+                    self.print_indent();
+                }
             }
         }
 
@@ -3572,6 +3634,15 @@ pub mod __gated_printer {
                     self.add_source_mapping(expr.loc);
                     self.print(b"[");
                     let items = e.items.slice();
+                    let close_loc = e.close_bracket_loc.start;
+                    let had_comments = IS_JSON
+                        && items.is_empty()
+                        && close_loc > 0
+                        && self
+                            .options
+                            .json_preserve_comments
+                            .get(self.json_comment_cursor)
+                            .is_some_and(|r| r.loc.start < close_loc);
                     if !items.is_empty() {
                         if !e.is_single_line {
                             self.indent();
@@ -3588,6 +3659,9 @@ pub mod __gated_printer {
                                 self.print_newline();
                                 self.print_indent();
                             }
+                            if IS_JSON {
+                                self.flush_json_comments_before(item.loc.start, false);
+                            }
                             self.print_expr(*item, Level::Comma, ExprFlag::none());
 
                             if i == items.len() - 1 && matches!(item.data, ExprData::EMissing(_)) {
@@ -3597,10 +3671,19 @@ pub mod __gated_printer {
                         }
 
                         if !e.is_single_line {
+                            if IS_JSON {
+                                self.flush_json_comments_before(close_loc, true);
+                            }
                             self.unindent();
                             self.print_newline();
                             self.print_indent();
                         }
+                    } else if had_comments {
+                        self.indent();
+                        self.flush_json_comments_before(close_loc, true);
+                        self.unindent();
+                        self.print_newline();
+                        self.print_indent();
                     }
 
                     if e.close_bracket_loc.start > expr.loc.start {
@@ -3623,6 +3706,15 @@ pub mod __gated_printer {
                     self.add_source_mapping(expr.loc);
                     self.print(b"{");
                     let props = e.properties.slice();
+                    let close_loc = e.close_brace_loc.start;
+                    let had_comments = IS_JSON
+                        && props.is_empty()
+                        && close_loc > 0
+                        && self
+                            .options
+                            .json_preserve_comments
+                            .get(self.json_comment_cursor)
+                            .is_some_and(|r| r.loc.start < close_loc);
                     if !props.is_empty() {
                         if !e.is_single_line {
                             self.indent();
@@ -3633,6 +3725,11 @@ pub mod __gated_printer {
                         } else {
                             self.print_newline();
                             self.print_indent();
+                        }
+                        if IS_JSON {
+                            if let Some(key) = &props[0].key {
+                                self.flush_json_comments_before(key.loc.start, false);
+                            }
                         }
                         self.print_property(&props[0]);
 
@@ -3645,6 +3742,11 @@ pub mod __gated_printer {
                                     self.print_newline();
                                     self.print_indent();
                                 }
+                                if IS_JSON {
+                                    if let Some(key) = &property.key {
+                                        self.flush_json_comments_before(key.loc.start, false);
+                                    }
+                                }
                                 self.print_property(property);
                             }
                         }
@@ -3652,10 +3754,19 @@ pub mod __gated_printer {
                         if e.is_single_line && !IS_JSON {
                             self.print_space();
                         } else {
+                            if IS_JSON {
+                                self.flush_json_comments_before(close_loc, true);
+                            }
                             self.unindent();
                             self.print_newline();
                             self.print_indent();
                         }
+                    } else if had_comments {
+                        self.indent();
+                        self.flush_json_comments_before(close_loc, true);
+                        self.unindent();
+                        self.print_newline();
+                        self.print_indent();
                     }
                     if e.close_brace_loc.start > expr.loc.start {
                         self.add_source_mapping(e.close_brace_loc);
@@ -6725,6 +6836,8 @@ pub mod __gated_printer {
                 stack_overflowed: false,
                 was_lazy_export: false,
                 module_info: None,
+                json_comment_cursor: 0,
+                json_comment_watermark: 0,
             };
             // The `Builder` field is `&'static [u32]` pending lifetime threading,
             // so instead of caching a self-borrow here,
@@ -7782,6 +7895,8 @@ pub fn print_json<W: WriterTrait>(
         indent: opts.indent,
         mangled_props: opts.mangled_props,
         minify_whitespace: opts.minify_whitespace,
+        json_preserve_comments: opts.preserve_comments,
+        json_comment_source: &source.contents,
         ..Default::default()
     };
     let mut printer = PrinterType::<W>::init(
@@ -7795,6 +7910,9 @@ pub fn print_json<W: WriterTrait>(
     printer.binary_expression_stack = Vec::new();
 
     printer.print_expr(expr, js_ast::op::Level::Lowest, ExprFlagSet::empty());
+    if !opts.preserve_comments.is_empty() {
+        printer.flush_json_comments_before(source.contents.len() as i32 + 1, true);
+    }
     printer.check_stack_overflow()?;
     printer.writer.get_error()?;
     printer.writer.done()?;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1681,8 +1681,7 @@ pub mod __gated_printer {
             }
         }
 
-        /// Emit each preserved JSONC comment starting before `before` exactly once;
-        /// `leading_break` puts the newline/indent before the comment instead of after.
+        /// Emit each preserved JSONC comment starting before `before` exactly once; `leading_break` puts the newline/indent before it instead of after.
         #[inline]
         pub fn flush_json_comments_before(&mut self, before: i32, leading_break: bool) {
             if !IS_JSON {

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -198,8 +198,13 @@ fn run_stage2<'s>(
 ) -> crate::Result<ParseOutput> {
     let mut parser = Parser::new(source, log, sidx, opts, tape_alloc);
     let root = parser.parse_value()?;
-    if check_len && !parser.at_trailing_end() {
-        return Err(parser.unexpected_here());
+    if check_len {
+        if !parser.at_trailing_end() {
+            return Err(parser.unexpected_here());
+        }
+    } else if opts.allow_comments {
+        // Scan past the root value so a comment after it still lands in `sidx.comments`.
+        let _ = parser.at_trailing_end();
     }
     let tape = parser.take_tape();
     drop(parser);

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -89,6 +89,7 @@ struct ParseOutput {
     root: Expr,
     tape: Option<Box<E::JsonTape>>,
     indentation: Indentation,
+    comments: Vec<bun_ast::Range>,
 }
 
 fn parse_impl(
@@ -210,6 +211,7 @@ fn run_stage2<'s>(
         } else {
             Indentation::default()
         },
+        comments: core::mem::take(&mut sidx.comments),
     })
 }
 
@@ -477,6 +479,7 @@ pub fn parse_package_json_utf8(
 pub struct JsonResult {
     pub root: Expr,
     pub indentation: Indentation,
+    pub comments: Vec<bun_ast::Range>,
 }
 
 /// package.json with runtime options, into the classic AST plus the document's guessed indentation.
@@ -496,6 +499,7 @@ pub fn parse_package_json_utf8_with_opts(
     Ok(JsonResult {
         root: out.root,
         indentation: out.indentation,
+        comments: out.comments,
     })
 }
 

--- a/src/parsers/json_index.rs
+++ b/src/parsers/json_index.rs
@@ -36,6 +36,9 @@ pub struct StructuralIndex<'c> {
     pub flags: u32,
     /// First comment seen (scalar indexer only).
     pub first_comment: Option<Range>,
+    /// Every comment range, in source order (scalar indexer only; the SIMD
+    /// kernel falls back to scalar on seeing a `/`).
+    pub comments: Vec<Range>,
     /// Set when the indexer hit an error.
     pub index_error: Option<IndexError>,
     done: bool,
@@ -78,6 +81,7 @@ impl<'c> StructuralIndex<'c> {
             dirty: Vec::new(),
             flags: 0,
             first_comment: None,
+            comments: Vec::new(),
             index_error: None,
             done: false,
             src_off: 0,
@@ -270,12 +274,14 @@ impl<'c> StructuralIndex<'c> {
                         }
                         _ => return self.fail(IndexError::UnexpectedSlash { pos: i }),
                     }
+                    let range = Range {
+                        loc: bun_ast::usize2loc(start),
+                        len: (i - start) as i32,
+                    };
                     if self.first_comment.is_none() {
-                        self.first_comment = Some(Range {
-                            loc: bun_ast::usize2loc(start),
-                            len: (i - start) as i32,
-                        });
+                        self.first_comment = Some(range);
                     }
+                    self.comments.push(range);
                 }
                 _ => {
                     let cls = JSON_BYTE_CLASS[c as usize];
@@ -461,6 +467,11 @@ mod tests {
         let first = x.first_comment.expect("comment recorded");
         assert_eq!(first.loc.start, 0);
         assert_eq!(first.len, 8);
+        assert_eq!(x.comments.len(), 2);
+        assert_eq!(x.comments[0].loc.start, 0);
+        assert_eq!(x.comments[0].len, 8);
+        assert_eq!(x.comments[1].loc.start, 14);
+        assert_eq!(x.comments[1].len, 7);
         let expected: Vec<u32> = vec![9, 10, 12, 22, 24, 25];
         assert_eq!(v, expected);
     }

--- a/src/parsers/json_index.rs
+++ b/src/parsers/json_index.rs
@@ -36,8 +36,7 @@ pub struct StructuralIndex<'c> {
     pub flags: u32,
     /// First comment seen (scalar indexer only).
     pub first_comment: Option<Range>,
-    /// Every comment range, in source order (scalar indexer only; the SIMD
-    /// kernel falls back to scalar on seeing a `/`).
+    /// Every comment range in source order (scalar indexer only).
     pub comments: Vec<Range>,
     /// Set when the indexer hit an error.
     pub index_error: Option<IndexError>,

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -687,27 +687,6 @@ impl PmPkgCommand {
         Self::set_nested(&mut nested, remaining_path, value, parse_json)
     }
 
-    /// Spliced-in nodes carry `Loc::EMPTY` so comment preservation never mistakes value-string offsets for package.json offsets.
-    fn clear_locs(expr: &mut Expr) {
-        expr.loc = Loc::EMPTY;
-        if let Some(obj) = expr.data.e_object_mut() {
-            obj.close_brace_loc = Loc::EMPTY;
-            for prop in obj.properties.slice_mut() {
-                if let Some(key) = &mut prop.key {
-                    Self::clear_locs(key);
-                }
-                if let Some(value) = &mut prop.value {
-                    Self::clear_locs(value);
-                }
-            }
-        } else if let Some(arr) = expr.data.e_array_mut() {
-            arr.close_bracket_loc = Loc::EMPTY;
-            for item in arr.items.slice_mut() {
-                Self::clear_locs(item);
-            }
-        }
-    }
-
     fn parse_value(value: &[u8], parse_json: bool) -> Result<Expr, Error> {
         if parse_json {
             if value == b"true" {
@@ -731,7 +710,7 @@ impl PmPkgCommand {
             if let Ok(mut json_expr) =
                 json::parse_package_json_utf8(&temp_source, &mut temp_log, dummy_bump())
             {
-                Self::clear_locs(&mut json_expr);
+                json_expr.clear_source_locs();
                 return Ok(json_expr);
             } else {
                 let data: &[u8] = dummy_bump().alloc_slice_copy(value);

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -687,8 +687,7 @@ impl PmPkgCommand {
         Self::set_nested(&mut nested, remaining_path, value, parse_json)
     }
 
-    /// Spliced-in nodes carry `Loc::EMPTY` so comment preservation never
-    /// mistakes value-string offsets for package.json offsets.
+    /// Spliced-in nodes carry `Loc::EMPTY` so comment preservation never mistakes value-string offsets for package.json offsets.
     fn clear_locs(expr: &mut Expr) {
         expr.loc = Loc::EMPTY;
         if let Some(obj) = expr.data.e_object_mut() {

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -687,6 +687,28 @@ impl PmPkgCommand {
         Self::set_nested(&mut nested, remaining_path, value, parse_json)
     }
 
+    /// Spliced-in nodes carry `Loc::EMPTY` so comment preservation never
+    /// mistakes value-string offsets for package.json offsets.
+    fn clear_locs(expr: &mut Expr) {
+        expr.loc = Loc::EMPTY;
+        if let Some(obj) = expr.data.e_object_mut() {
+            obj.close_brace_loc = Loc::EMPTY;
+            for prop in obj.properties.slice_mut() {
+                if let Some(key) = &mut prop.key {
+                    Self::clear_locs(key);
+                }
+                if let Some(value) = &mut prop.value {
+                    Self::clear_locs(value);
+                }
+            }
+        } else if let Some(arr) = expr.data.e_array_mut() {
+            arr.close_bracket_loc = Loc::EMPTY;
+            for item in arr.items.slice_mut() {
+                Self::clear_locs(item);
+            }
+        }
+    }
+
     fn parse_value(value: &[u8], parse_json: bool) -> Result<Expr, Error> {
         if parse_json {
             if value == b"true" {
@@ -707,9 +729,10 @@ impl PmPkgCommand {
 
             let temp_source = Source::init_path_string(b"package.json", value);
             let mut temp_log = Log::init();
-            if let Ok(json_expr) =
+            if let Ok(mut json_expr) =
                 json::parse_package_json_utf8(&temp_source, &mut temp_log, dummy_bump())
             {
+                Self::clear_locs(&mut json_expr);
                 return Ok(json_expr);
             } else {
                 let data: &[u8] = dummy_bump().alloc_slice_copy(value);

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -46,6 +46,7 @@ struct PackageJson {
     contents: Box<[u8]>,
     source: Source,
     indentation: bun_ast::Indentation,
+    comments: Vec<bun_ast::Range>,
 }
 
 impl PmPkgCommand {
@@ -184,6 +185,7 @@ impl PmPkgCommand {
             contents,
             source,
             indentation: result.indentation,
+            comments: result.comments,
         })
     }
 
@@ -845,6 +847,7 @@ impl PmPkgCommand {
             js_printer::PrintJsonOptions {
                 indent: pkg.indentation,
                 mangled_props: None,
+                preserve_comments: &pkg.comments,
                 ..Default::default()
             },
         ) {

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -552,12 +552,13 @@ impl TrustCommand {
 
         let bump = Bump::new();
         // SAFETY: `ctx.log` set by `Command::init`, non-null for the command.
-        // Layering: `parse_utf8` returns the T2
+        // Layering: the parser returns the T2
         // `bun_ast::Expr`; `PackageJSONEditor` and
         // `js_printer::print_json` consume the T4 `bun_ast::Expr`. Lift
         // once via `From<T2> for T4` (same as `updatePackageJSONAndInstall` /
         // `pack_command`).
-        let mut package_json: bun_ast::Expr = match bun_parsers::json::parse_utf8(
+        let parse_result = match bun_parsers::json::parse_package_json_utf8_with_opts(
+            bun_parsers::json::PACKAGE_JSON_OPTS,
             &package_json_source,
             unsafe { ctx.log_mut() },
             &bump,
@@ -572,6 +573,8 @@ impl TrustCommand {
                 Global::crash();
             }
         };
+        let mut package_json: bun_ast::Expr = parse_result.root;
+        let package_json_comments = parse_result.comments;
 
         // now add the package names to lockfile.trustedDependencies and package.json `trustedDependencies`
         debug_assert!(!package_names_to_add.keys().is_empty());
@@ -657,6 +660,7 @@ impl TrustCommand {
             &package_json_source,
             bun_js_printer::PrintJsonOptions {
                 mangled_props: None,
+                preserve_comments: &package_json_comments,
                 ..Default::default()
             },
         ) {

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -214,6 +214,7 @@ impl PmVersionCommand {
                 JSPrinter::PrintJsonOptions {
                     indent: printer_indent,
                     mangled_props: None,
+                    preserve_comments: &json_result.comments,
                     ..Default::default()
                 },
             ) {

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -204,6 +204,7 @@ impl UpdateInteractiveCommand {
             PrintJsonOptions {
                 indent: package_json.indentation,
                 mangled_props: None,
+                preserve_comments: &package_json.comments,
                 ..Default::default()
             },
         ) {

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -180,6 +180,7 @@ impl UpdateInteractiveCommand {
     fn save_package_json(
         package_json: &mut WorkspacePackageJsonCacheEntry,
         package_json_path: &[u8],
+        log: &mut bun_ast::Log,
     ) -> crate::Result<()> {
         let preserve_trailing_newline = !package_json.source.contents.is_empty()
             && *package_json.source.contents.last().unwrap() == b'\n';
@@ -241,6 +242,8 @@ impl UpdateInteractiveCommand {
             Cow::Owned(new_package_json_source.into_vec()),
         );
         package_json.stale_contents.push(old);
+        // Refresh `root`/`comments`, whose offsets still point into the old buffer.
+        package_json.reparse_root(log)?;
         Ok(())
     }
 
@@ -404,7 +407,7 @@ impl UpdateInteractiveCommand {
 
             // Write the updated package.json if modified
             if modified {
-                Self::save_package_json(package_json, package_json_path)?;
+                Self::save_package_json(package_json, package_json_path, log)?;
             }
         }
         Ok(())
@@ -486,7 +489,7 @@ impl UpdateInteractiveCommand {
             edit_catalog_definitions(&mut updates_for_workspace[..], &mut package_json.root)?;
 
             // Save the updated package.json
-            Self::save_package_json(package_json, package_json_path)?;
+            Self::save_package_json(package_json, package_json_path, log)?;
         }
         Ok(())
     }

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -114,7 +114,7 @@ it("should preserve comments in package.json on add", async () => {
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "add", "bar"],
     cwd: package_dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stdin: "pipe",
     stderr: "pipe",
     env,
@@ -155,7 +155,7 @@ it("should preserve comments in package.json on update", async () => {
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "update"],
     cwd: package_dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stdin: "pipe",
     stderr: "pipe",
     env,
@@ -197,7 +197,7 @@ it("should preserve comments in package.json on remove", async () => {
   const { stderr, exited } = spawn({
     cmd: [bunExe(), "remove", "pkg-a"],
     cwd: package_dir,
-    stdout: "pipe",
+    stdout: "ignore",
     stdin: "pipe",
     stderr: "pipe",
     env,

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -93,6 +93,127 @@ it("should add existing package", async () => {
   );
 });
 
+// https://github.com/oven-sh/bun/issues/11536
+it("should preserve comments in package.json on add", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    `{
+  // the name
+  "name": "foo",
+  /* scripts go here */
+  "scripts": {
+    // run the thing
+    "start": "node ."
+    // trailing note
+  }
+}
+`,
+  );
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "add", "bar"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  expect(await exited).toBe(0);
+  const out = await file(join(package_dir, "package.json")).text();
+  expect(out).toContain("// the name");
+  expect(out).toContain("/* scripts go here */");
+  expect(out).toContain("// run the thing");
+  expect(out).toContain("// trailing note");
+  expect(out).toContain('"bar": "^0.0.2"');
+  expect(JSON.parse(out.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, ""))).toEqual({
+    name: "foo",
+    scripts: { start: "node ." },
+    dependencies: { bar: "^0.0.2" },
+  });
+});
+
+it("should preserve comments in package.json on update", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    `{
+  "name": "foo",
+  "dependencies": {
+    // bar: primary dependency
+    "bar": "^0.0.2"
+    /* trailing after bar */
+  },
+  // end-of-file note
+  "private": true
+}
+`,
+  );
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "update"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  expect(await exited).toBe(0);
+  const out = await file(join(package_dir, "package.json")).text();
+  expect(out).toContain("// bar: primary dependency");
+  expect(out).toContain("/* trailing after bar */");
+  expect(out).toContain("// end-of-file note");
+  expect(out).toContain('"bar": "^0.0.2"');
+  // comment still precedes the property it documented
+  const barIdx = out.indexOf('"bar"');
+  const barCommentIdx = out.indexOf("// bar: primary");
+  expect(barCommentIdx).toBeGreaterThan(-1);
+  expect(barCommentIdx).toBeLessThan(barIdx);
+});
+
+it("should preserve comments in package.json on remove", async () => {
+  await writeFile(
+    join(add_dir, "package.json"),
+    JSON.stringify({ name: "pkg-a", version: "0.0.1" }),
+  );
+  const add_path = relative(package_dir, add_dir).replace(/\\/g, "/");
+  await writeFile(
+    join(package_dir, "package.json"),
+    `{
+  // project manifest
+  "name": "foo",
+  "dependencies": {
+    // local workspace dep
+    "pkg-a": "file:${add_path}"
+  },
+  // scripts below
+  "scripts": {
+    "test": "echo ok"
+  }
+}
+`,
+  );
+  const { stderr, exited } = spawn({
+    cmd: [bunExe(), "remove", "pkg-a"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const err = await stderr.text();
+  expect(err).not.toContain("error:");
+  expect(await exited).toBe(0);
+  const out = await file(join(package_dir, "package.json")).text();
+  expect(out).toContain("// project manifest");
+  expect(out).toContain("// scripts below");
+  expect(out).not.toContain('"pkg-a"');
+});
+
 it("should reject missing package", async () => {
   await writeFile(
     join(package_dir, "package.json"),

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -176,10 +176,7 @@ it("should preserve comments in package.json on update", async () => {
 });
 
 it("should preserve comments in package.json on remove", async () => {
-  await writeFile(
-    join(add_dir, "package.json"),
-    JSON.stringify({ name: "pkg-a", version: "0.0.1" }),
-  );
+  await writeFile(join(add_dir, "package.json"), JSON.stringify({ name: "pkg-a", version: "0.0.1" }));
   const add_path = relative(package_dir, add_dir).replace(/\\/g, "/");
   await writeFile(
     join(package_dir, "package.json"),

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -122,17 +122,20 @@ it("should preserve comments in package.json on add", async () => {
   const err = await stderr.text();
   expect(err).not.toContain("error:");
   expect(await exited).toBe(0);
-  const out = await file(join(package_dir, "package.json")).text();
-  expect(out).toContain("// the name");
-  expect(out).toContain("/* scripts go here */");
-  expect(out).toContain("// run the thing");
-  expect(out).toContain("// trailing note");
-  expect(out).toContain('"bar": "^0.0.2"');
-  expect(JSON.parse(out.replace(/\/\/.*$/gm, "").replace(/\/\*[\s\S]*?\*\//g, ""))).toEqual({
-    name: "foo",
-    scripts: { start: "node ." },
-    dependencies: { bar: "^0.0.2" },
-  });
+  expect(await file(join(package_dir, "package.json")).text()).toEqual(`{
+  // the name
+  "name": "foo",
+  /* scripts go here */
+  "scripts": {
+    // run the thing
+    "start": "node ."
+    // trailing note
+  },
+  "dependencies": {
+    "bar": "^0.0.2"
+  }
+}
+`);
 });
 
 it("should preserve comments in package.json on update", async () => {
@@ -144,9 +147,13 @@ it("should preserve comments in package.json on update", async () => {
   "name": "foo",
   "dependencies": {
     // bar: primary dependency
-    "bar": "^0.0.2"
+    "bar": "^0.0.2", // same-line trailer
     /* trailing after bar */
   },
+  "workspaces": [
+    // workspace packages
+    "packages/*" // glob
+  ],
   // end-of-file note
   "private": true
 }
@@ -163,16 +170,21 @@ it("should preserve comments in package.json on update", async () => {
   const err = await stderr.text();
   expect(err).not.toContain("error:");
   expect(await exited).toBe(0);
-  const out = await file(join(package_dir, "package.json")).text();
-  expect(out).toContain("// bar: primary dependency");
-  expect(out).toContain("/* trailing after bar */");
-  expect(out).toContain("// end-of-file note");
-  expect(out).toContain('"bar": "^0.0.2"');
-  // comment still precedes the property it documented
-  const barIdx = out.indexOf('"bar"');
-  const barCommentIdx = out.indexOf("// bar: primary");
-  expect(barCommentIdx).toBeGreaterThan(-1);
-  expect(barCommentIdx).toBeLessThan(barIdx);
+  expect(await file(join(package_dir, "package.json")).text()).toEqual(`{
+  "name": "foo",
+  "dependencies": {
+    // bar: primary dependency
+    "bar": "^0.0.2" // same-line trailer
+    /* trailing after bar */
+  },
+  "workspaces": [
+    // workspace packages
+    "packages/*" // glob
+  ],
+  // end-of-file note
+  "private": true
+}
+`);
 });
 
 it("should preserve comments in package.json on remove", async () => {
@@ -205,10 +217,18 @@ it("should preserve comments in package.json on remove", async () => {
   const err = await stderr.text();
   expect(err).not.toContain("error:");
   expect(await exited).toBe(0);
-  const out = await file(join(package_dir, "package.json")).text();
-  expect(out).toContain("// project manifest");
-  expect(out).toContain("// scripts below");
-  expect(out).not.toContain('"pkg-a"');
+  // `// local workspace dep` annotated the removed property; it is kept (never
+  // deleted) and flushed before the next surviving key.
+  expect(await file(join(package_dir, "package.json")).text()).toEqual(`{
+  // project manifest
+  "name": "foo",
+  // local workspace dep
+  // scripts below
+  "scripts": {
+    "test": "echo ok"
+  }
+}
+`);
 });
 
 it("should reject missing package", async () => {

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -952,6 +952,7 @@ test("bun pm trust preserves comments in a JSONC package.json", async () => {
   const out = await Bun.file(join(dirStr, "package.json")).text();
   expect(out).toContain("// my app");
   expect(out).toContain("// local dep");
+  expect(out).toContain("// before close brace");
   // stays inside the root object even though the editor rebuilds it
   expect(out.indexOf("// before close brace")).toBeLessThan(out.lastIndexOf("}"));
   expect(JSON.parse(out.replace(/\/\/.*$/gm, ""))).toEqual({

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -906,3 +906,55 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+test("bun pm trust preserves comments in a JSONC package.json", async () => {
+  using dir = tempDir("pm-trust-jsonc", {
+    "dep/package.json": JSON.stringify({
+      name: "dep-a",
+      version: "1.0.0",
+      scripts: { postinstall: "echo ran > postinstall.txt" },
+    }),
+    "package.json": `{
+  // my app
+  "name": "app",
+  "dependencies": {
+    // local dep
+    "dep-a": "file:./dep"
+  }
+}
+`,
+  });
+  const dirStr = String(dir);
+
+  await using install = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: dirStr,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const installErr = await install.stderr.text();
+  expect(installErr).not.toContain("error:");
+  expect(await install.exited).toBe(0);
+
+  await using trust = Bun.spawn({
+    cmd: [bunExe(), "pm", "trust", "dep-a"],
+    cwd: dirStr,
+    stdout: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const trustErr = await trust.stderr.text();
+  expect(trustErr).not.toContain("error:");
+  expect(await trust.exited).toBe(0);
+
+  const out = await Bun.file(join(dirStr, "package.json")).text();
+  expect(out).toContain("// my app");
+  expect(out).toContain("// local dep");
+  expect(JSON.parse(out.replace(/\/\/.*$/gm, ""))).toEqual({
+    name: "app",
+    dependencies: { "dep-a": "file:./dep" },
+    trustedDependencies: ["dep-a"],
+  });
+  expect(await exists(join(dirStr, "node_modules", "dep-a", "postinstall.txt"))).toBeTrue();
+});

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -921,6 +921,7 @@ test("bun pm trust preserves comments in a JSONC package.json", async () => {
     // local dep
     "dep-a": "file:./dep"
   }
+  // before close brace
 }
 `,
   });
@@ -951,6 +952,8 @@ test("bun pm trust preserves comments in a JSONC package.json", async () => {
   const out = await Bun.file(join(dirStr, "package.json")).text();
   expect(out).toContain("// my app");
   expect(out).toContain("// local dep");
+  // stays inside the root object even though the editor rebuilds it
+  expect(out.indexOf("// before close brace")).toBeLessThan(out.lastIndexOf("}"));
   expect(JSON.parse(out.replace(/\/\/.*$/gm, ""))).toEqual({
     name: "app",
     dependencies: { "dep-a": "file:./dep" },


### PR DESCRIPTION
Fixes #11536.

## What

Bun accepts comments and trailing commas in `package.json`, but any command that rewrites the file (`bun add`, `bun update`, `bun remove`, `bun update -i`, `bun pm pkg set/delete`, `bun pm version`, `bun pm trust`, and the pnpm-workspace migrator) would strip them, because the file is round-tripped through `parse → AST mutate → print_json` and the printer had no knowledge of comments.

## Repro

```jsonc
{
  "name": "test",
  // this is a test
  "dependencies": {
    "lodash": "^4.17.20", // pinned for CVE
    /* block comment */
    "is-odd": "^1.0.0"
  }
}
```

```sh
bun update
```

Before: every comment is gone.
After: comments are kept in place, including the same-line `// pinned for CVE` trailer.

## How

The structural indexer already scans comment bodies to skip them; it now also records each comment's byte range. The range list is threaded through `JsonResult` and the workspace package.json cache into a new `PrintJsonOptions.preserve_comments` field.

While printing an `E::Object`/`E::Array` the printer maintains a single monotonic cursor over the comment list and, for each property/item:

- flushes any own-line comments whose source position precedes the key,
- prints the value and separator,
- emits any comment that shared a line with that value inline (`"key": "val", // note` stays on its line),
- and before the closing `}` / `]` flushes remaining comments that lived inside the container.

Newly inserted properties carry `Loc::EMPTY` and therefore don't claim any comments; existing nodes keep their `Loc`s, so `bun update` (which overwrites values in place) leaves every comment exactly where it was. When a property is removed, a comment that used to precede it is kept and flushes before the next surviving key rather than being deleted.

`bun pm pkg set --json '<json>'` parses its value argument into a fresh subtree; those nodes' locs are cleared before splicing so they can't be mistaken for package.json offsets.

Callers that don't pass `preserve_comments` see no change (`&[]` default), so output for strict-JSON `package.json` files is byte-identical.

## Why this is the right shape

Threading comments through `E::Object`/`G::Property` would touch every AST consumer. Surgical byte-splice editing would mean rewriting `PackageJSONEditor`. Recording ranges at parse time and replaying them at print time by source position is additive on both sides, reuses the locs the parser already records, and keeps the existing edit logic untouched.

## Verification

New tests in `test/cli/install/bun-add.test.ts` cover `bun add`, `bun update`, and `bun remove` on a commented `package.json` with own-line, block, same-line-trailing, and array-element comments; each asserts the full output byte-for-byte. `test/cli/install/bun-pm.test.ts` covers `bun pm trust` on a JSONC manifest. All fail on `main` and pass with this patch. The existing `bun-add`, `bun-remove`, `bun-pm-pkg`, `bun-pm-version`, `bun-pm`, and transpiler suites are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->