### PR TITLE
bunx: parse --env-file

### DIFF
--- a/docs/snippets/cli/bunx.mdx
+++ b/docs/snippets/cli/bunx.mdx
@@ -21,6 +21,10 @@ Execute an npm package executable (CLI). If the package isn't installed in `node
   Skip installation if package is not already installed
 </ParamField>
 
+<ParamField path="--env-file" type="string">
+  Load environment variables from the specified file(s)
+</ParamField>
+
 <ParamField path="--verbose" type="boolean">
   Enable verbose output during installation
 </ParamField>

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -115,6 +115,19 @@ impl Options {
                     ctx.debug.run_in_bun = true;
                 } else if positional == b"--no-install" {
                     opts.no_install = true;
+                } else if positional == b"--env-file" {
+                    i += 1;
+                    if i >= argv.len() {
+                        Output::err_generic("--env-file requires a file path", format_args!(""));
+                        Global::exit(1);
+                    }
+                    ctx.args
+                        .env_files
+                        .push(Box::<[u8]>::from(argv[i].as_bytes()));
+                } else if positional.starts_with(b"--env-file=") {
+                    ctx.args
+                        .env_files
+                        .push(Box::<[u8]>::from(&positional[b"--env-file=".len()..]));
                 } else if positional == b"--package" || positional == b"-p" {
                     // Next argument should be the package name
                     i += 1;

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1992,6 +1992,7 @@ Flags:
   <cyan>--bun<r>                  Force the command to run with Bun instead of Node.js
   <cyan>-p, --package <blue>\\<package\\><r>    Specify package to install when binary name differs from package name
   <cyan>--no-install<r>           Skip installation if package is not already installed
+  <cyan>--env-file <blue>\\<file\\><r>      Load environment variables from the specified file(s)
   <cyan>--verbose<r>              Enable verbose output during installation
   <cyan>--silent<r>               Suppress output during installation
 

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1380,3 +1380,114 @@ it.concurrent.skipIf(isWindows)(
     }
   },
 );
+
+// https://github.com/oven-sh/bun/issues/12430
+describe("--env-file", () => {
+  async function makeLocalBin(dir: string, name: string, script: string) {
+    await mkdir(join(dir, "node_modules", name), { recursive: true });
+    await mkdir(join(dir, "node_modules", ".bin"), { recursive: true });
+    await writeFile(
+      join(dir, "node_modules", name, "package.json"),
+      JSON.stringify({ name, version: "1.0.0", bin: { [name]: "./cli.js" } }),
+    );
+    await writeFile(join(dir, "node_modules", name, "cli.js"), `#!/usr/bin/env node\n${script}\n`);
+    if (isWindows) {
+      await writeFile(
+        join(dir, "node_modules", ".bin", `${name}.cmd`),
+        `@echo off\r\nnode "%~dp0..\\${name}\\cli.js" %*\r\n`,
+      );
+    } else {
+      await writeFile(join(dir, "node_modules", ".bin", name), `#!/usr/bin/env node\nrequire("../${name}/cli.js");\n`);
+      chmodSync(join(dir, "node_modules", name, "cli.js"), 0o755);
+      chmodSync(join(dir, "node_modules", ".bin", name), 0o755);
+    }
+  }
+
+  async function run(dir: string, testEnv: Record<string, string>, ...args: string[]) {
+    const subprocess = spawn({
+      cmd: [bunExe(), "x", ...args],
+      cwd: dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: testEnv,
+    });
+    return await Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+  }
+
+  it.concurrent.each(["--env-file .env.custom", "--env-file=.env.custom"])(
+    "loads the file into the spawned process env (%s)",
+    async spelling => {
+      const { x_dir, env } = setup();
+      delete env.BUNX_TEST_VAR;
+      await makeLocalBin(x_dir, "print-env-var", `console.log("BUNX_TEST_VAR=" + (process.env.BUNX_TEST_VAR ?? ""));`);
+      await writeFile(join(x_dir, ".env.custom"), "BUNX_TEST_VAR=from-env-file\n");
+
+      const [err, out, exited] = await run(x_dir, env, ...spelling.split(" "), "print-env-var");
+
+      expect(err).not.toContain("error:");
+      expect(err).not.toContain("unrecognised dependency format");
+      expect(out.trim()).toBe("BUNX_TEST_VAR=from-env-file");
+      expect(exited).toBe(0);
+    },
+  );
+
+  it.concurrent("supports multiple --env-file flags (later wins)", async () => {
+    const { x_dir, env } = setup();
+    delete env.BUNX_TEST_A;
+    delete env.BUNX_TEST_B;
+    await makeLocalBin(
+      x_dir,
+      "print-env-ab",
+      `console.log("A=" + (process.env.BUNX_TEST_A ?? "") + " B=" + (process.env.BUNX_TEST_B ?? ""));`,
+    );
+    await writeFile(join(x_dir, ".env.a"), "BUNX_TEST_A=1\nBUNX_TEST_B=from-a\n");
+    await writeFile(join(x_dir, ".env.b"), "BUNX_TEST_B=from-b\n");
+
+    const [err, out, exited] = await run(x_dir, env, "--env-file", ".env.a", "--env-file=.env.b", "print-env-ab");
+
+    expect(err).not.toContain("error:");
+    expect(out.trim()).toBe("A=1 B=from-b");
+    expect(exited).toBe(0);
+  });
+
+  it.concurrent("does not treat the file path after --env-file as the package name", async () => {
+    const { x_dir, env } = setup();
+    await writeFile(join(x_dir, ".env.custom"), "X=1\n");
+
+    const [err, out, exited] = await run(x_dir, env, "--no-install", "--env-file", ".env.custom", "definitely-absent");
+
+    expect(err).not.toContain("unrecognised dependency format");
+    expect(err).not.toContain("@.env.custom");
+    expect(err).toContain("Could not find an existing 'definitely-absent' binary to run.");
+    expect(out).toHaveLength(0);
+    expect(exited).toBe(1);
+  });
+
+  it.concurrent("errors when --env-file is given without a path", async () => {
+    const { x_dir, env } = setup();
+
+    const [err, out, exited] = await run(x_dir, env, "--env-file");
+
+    expect(err).toContain("--env-file requires a file path");
+    expect(out).toHaveLength(0);
+    expect(exited).toBe(1);
+  });
+
+  it.concurrent("--env-file after the package name is passed through, not consumed by bunx", async () => {
+    const { x_dir, env } = setup();
+    delete env.BUNX_SHOULD_NOT_LOAD;
+    await writeFile(join(x_dir, ".env.passthrough"), "BUNX_SHOULD_NOT_LOAD=wrongly-consumed\n");
+    await makeLocalBin(
+      x_dir,
+      "print-passthrough",
+      `console.log(JSON.stringify([process.env.BUNX_SHOULD_NOT_LOAD ?? "unset", ...process.argv.slice(2)]));`,
+    );
+
+    const [err, out, exited] = await run(x_dir, env, "print-passthrough", "--env-file", ".env.passthrough");
+
+    expect(err).not.toContain("error:");
+    expect(JSON.parse(out)).toEqual(["unset", "--env-file", ".env.passthrough"]);
+    expect(exited).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #12430.
Fixes #17759.

### Problem

- `bunx --env-file .env serve` fails with `error: unrecognised dependency format: @.env` and never runs the package; the `.env` file is not loaded either way.
- `bunx` has its own argv loop (`Options::parse`, `src/runtime/cli/bunx_command.rs`) instead of the shared `Arguments.parse`. It only knows `--bun`, `--silent`, `--verbose`, `--no-install`, `--package`, `--version` and `--revision`; anything else starting with `-` is dropped, so the path after `--env-file` becomes the package name.

### Fix

- Parse `--env-file <path>` and `--env-file=<path>` in `Options::parse` and push the path onto `ctx.args.env_files`. A bare `--env-file` with no path is an error and exits 1, the same shape as bare `--package`.
- This is enough because the loading side already exists: `Run::configure_env_for_run` clones `ctx.args` into the transpiler options (`env_files` -> `options.env.files`, `src/bundler/options.rs`), and `run_env_loader` passes that list to `env.load`, whose result is the environment handed to the spawned binary. `bun run --env-file` uses the same path.
- Flags after the package name were already passthrough (the loop stops interpreting flags once it has a package name) and still are.
- Listed the flag in `bunx --help` (`src/runtime/cli/mod.rs`) and in `docs/snippets/cli/bunx.mdx`, which mirrors the help text.
- Verified with `test/cli/install/bunx.test.ts` (`describe("--env-file")`, offline, uses a local `node_modules/.bin` entry):
  - both spellings load the file into the child's environment
  - two `--env-file` flags compose, later one wins
  - the path after `--env-file` is not taken as the package name
  - bare `--env-file` prints `--env-file requires a file path` and exits 1
  - `--env-file` after the package name reaches the child's argv and is not loaded
- The first five fail on the released binary (`unrecognised dependency format`, empty variable, or usage text for the bare flag) and pass with this change. The last one passes on both and is there to pin the passthrough behavior.

### Background

- `bunx` resolves a package's bin (local `node_modules/.bin`, then a per-user cache under the temp dir, installing on a miss) and execs it. Before exec it builds the child's environment through the same env loader `bun run` uses, which is why a CLI flag that only appends to `ctx.args.env_files` is sufficient here.
- `bunx` never auto-loads a cwd `.env` (`configure_env_for_run` calls `run_env_loader(true)`, i.e. skip defaults), so `--no-env-file` has nothing to do there and is intentionally not special-cased.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->