### PR TITLE
install: warn when a link: dependency declares peerDependencies

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1539,6 +1539,74 @@ impl Diff {
     }
 }
 
+#[cold]
+#[inline(never)]
+fn warn_linked_peer_dependencies(
+    pm: &PackageManager,
+    source: &bun_ast::Source,
+    json: &Expr,
+    bump: &bun_alloc::Arena,
+) {
+    let Some(peer_deps) = json.as_property(b"peerDependencies") else {
+        return;
+    };
+    if peer_deps.expr.property_count() == 0 {
+        return;
+    }
+
+    let peer_meta = json.as_property(b"peerDependenciesMeta");
+    let linked_dir = source.path.name().dir;
+
+    let mut unresolved: Vec<(&[u8], &[u8], bool)> = Vec::new();
+    peer_deps.expr.for_each_property(|key, _loc, value| {
+        let installed = resolve_path::join_abs_string_z::<path::platform::Auto>(
+            linked_dir,
+            &[b"node_modules", key, b"package.json"],
+        );
+        if bun_sys::exists(installed.as_bytes()) {
+            return;
+        }
+        let ver = value.as_utf8(bump).unwrap_or(b"");
+        let is_optional = peer_meta
+            .as_ref()
+            .and_then(|m| m.expr.as_property(key))
+            .and_then(|m| m.expr.as_property(b"optional"))
+            .map(|o| matches!(&o.expr.data, ExprData::EBoolean(b) if b.value))
+            .unwrap_or(false);
+        unresolved.push((bump.alloc_slice_copy(key), ver, is_optional));
+    });
+    if unresolved.is_empty() {
+        return;
+    }
+
+    let name = json
+        .as_property(b"name")
+        .and_then(|q| q.expr.as_utf8(bump))
+        .unwrap_or(b"");
+    bun_core::warn!(
+        "Linked package <b>\"{}\"<r> declares peerDependencies that may not resolve from this project:",
+        bstr::BStr::new(name),
+    );
+    for (key, ver, is_optional) in &unresolved {
+        bun_core::pretty_errorln!(
+            "  <d>-<r> {}<d>@{}{}<r>",
+            bstr::BStr::new(key),
+            bstr::BStr::new(ver),
+            if *is_optional { " (optional)" } else { "" },
+        );
+    }
+    if pm.options.node_linker == crate::package_manager::Options::NodeLinker::Isolated {
+        bun_core::pretty_errorln!(
+            "  Linked packages resolve modules from their real location on disk. Install these peers in the linked package's own node_modules.",
+        );
+    } else {
+        bun_core::pretty_errorln!(
+            "  Linked packages resolve modules from their real location on disk.\n  Install these peers in the linked package's own node_modules, or run bun with <cyan>--preserve-symlinks<r>.",
+        );
+    }
+    Output::flush();
+}
+
 impl Package<u64> {
     pub fn hash(name: &[u8], version: SemverVersion) -> u64 {
         let mut hasher = bun_wyhash::Wyhash::init(0);
@@ -2169,38 +2237,7 @@ impl Package<u64> {
         if FEATURES == Features::LINK
             && pm.options.log_level != crate::package_manager::LogLevel::Silent
         {
-            if let Some(peer_deps) = json.as_property(b"peerDependencies") {
-                if peer_deps.expr.property_count() > 0 {
-                    let name = json
-                        .as_property(b"name")
-                        .and_then(|q| q.expr.as_utf8(&bump))
-                        .unwrap_or(b"");
-                    let peer_meta = json.as_property(b"peerDependenciesMeta");
-                    bun_core::warn!(
-                        "Linked package <b>\"{}\"<r> declares peerDependencies that will not resolve from this project:",
-                        bstr::BStr::new(name),
-                    );
-                    peer_deps.expr.for_each_property(|key, _loc, value| {
-                        let ver = value.as_utf8(&bump).unwrap_or(b"");
-                        let is_optional = peer_meta
-                            .as_ref()
-                            .and_then(|m| m.expr.as_property(key))
-                            .and_then(|m| m.expr.as_property(b"optional"))
-                            .map(|o| matches!(&o.expr.data, ExprData::EBoolean(b) if b.value))
-                            .unwrap_or(false);
-                        bun_core::pretty_errorln!(
-                            "  <d>-<r> {}<d>@{}{}<r>",
-                            bstr::BStr::new(key),
-                            bstr::BStr::new(ver),
-                            if is_optional { " (optional)" } else { "" },
-                        );
-                    });
-                    bun_core::pretty_errorln!(
-                        "  Linked packages resolve modules from their real location on disk.\n  Run bun with <cyan>--preserve-symlinks<r> to resolve peers from this project's node_modules.",
-                    );
-                    Output::flush();
-                }
-            }
+            warn_linked_peer_dependencies(pm, source, &json, &bump);
         }
 
         let mut workspace_names = workspace_map::WorkspaceMap::init();

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1541,12 +1541,7 @@ impl Diff {
 
 #[cold]
 #[inline(never)]
-fn warn_linked_peer_dependencies(
-    pm: &PackageManager,
-    source: &bun_ast::Source,
-    json: &Expr,
-    bump: &bun_alloc::Arena,
-) {
+fn warn_linked_peer_dependencies(source: &bun_ast::Source, json: &Expr, bump: &bun_alloc::Arena) {
     let Some(peer_deps) = json.as_property(b"peerDependencies") else {
         return;
     };
@@ -1563,7 +1558,7 @@ fn warn_linked_peer_dependencies(
             linked_dir,
             &[b"node_modules", key, b"package.json"],
         );
-        if bun_sys::exists(installed.as_bytes()) {
+        if bun_sys::exists_z(installed) {
             return;
         }
         let ver = value.as_utf8(bump).unwrap_or(b"");
@@ -1595,15 +1590,9 @@ fn warn_linked_peer_dependencies(
             if *is_optional { " (optional)" } else { "" },
         );
     }
-    if pm.options.node_linker == crate::package_manager::Options::NodeLinker::Isolated {
-        bun_core::pretty_errorln!(
-            "  Linked packages resolve modules from their real location on disk. Install these peers in the linked package's own node_modules.",
-        );
-    } else {
-        bun_core::pretty_errorln!(
-            "  Linked packages resolve modules from their real location on disk.\n  Install these peers in the linked package's own node_modules, or run bun with <cyan>--preserve-symlinks<r>.",
-        );
-    }
+    bun_core::pretty_errorln!(
+        "  Linked packages resolve modules from their real location on disk. Install these peers in the linked package's own node_modules.",
+    );
     Output::flush();
 }
 
@@ -2237,7 +2226,7 @@ impl Package<u64> {
         if FEATURES == Features::LINK
             && pm.options.log_level != crate::package_manager::LogLevel::Silent
         {
-            warn_linked_peer_dependencies(pm, source, &json, &bump);
+            warn_linked_peer_dependencies(source, &json, &bump);
         }
 
         let mut workspace_names = workspace_map::WorkspaceMap::init();

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2165,8 +2165,7 @@ impl Package<u64> {
             out
         };
 
-        // Linked packages are symlinks; node_modules lookup realpath's them
-        // first, so peers installed here are invisible. Match pnpm and warn.
+        // Symlinked packages realpath before node_modules lookup, so peers here are invisible; warn like pnpm.
         if FEATURES == Features::LINK
             && pm.options.log_level != crate::package_manager::LogLevel::Silent
         {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2165,13 +2165,8 @@ impl Package<u64> {
             out
         };
 
-        // `Features::LINK` skips dependencies and peerDependencies: the linked
-        // package is a symlink into its real source tree, so its own install
-        // owns that node_modules. Runtime resolution realpath's the symlink
-        // before walking node_modules, which means peers installed in *this*
-        // project are invisible to the linked package. pnpm prints a warning
-        // in this situation (https://github.com/pnpm/pnpm/pull/5876); do the
-        // same so `bun link` users aren't surprised.
+        // Linked packages are symlinks; node_modules lookup realpath's them
+        // first, so peers installed here are invisible. Match pnpm and warn.
         if FEATURES == Features::LINK
             && pm.options.log_level != crate::package_manager::LogLevel::Silent
         {

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2181,16 +2181,24 @@ impl Package<u64> {
                         .as_property(b"name")
                         .and_then(|q| q.expr.as_utf8(&bump))
                         .unwrap_or(b"");
+                    let peer_meta = json.as_property(b"peerDependenciesMeta");
                     bun_core::warn!(
                         "Linked package <b>\"{}\"<r> declares peerDependencies that will not resolve from this project:",
                         bstr::BStr::new(name),
                     );
                     peer_deps.expr.for_each_property(|key, _loc, value| {
                         let ver = value.as_utf8(&bump).unwrap_or(b"");
+                        let is_optional = peer_meta
+                            .as_ref()
+                            .and_then(|m| m.expr.as_property(key))
+                            .and_then(|m| m.expr.as_property(b"optional"))
+                            .map(|o| matches!(&o.expr.data, ExprData::EBoolean(b) if b.value))
+                            .unwrap_or(false);
                         bun_core::pretty_errorln!(
-                            "  <d>-<r> {}<d>@{}<r>",
+                            "  <d>-<r> {}<d>@{}{}<r>",
                             bstr::BStr::new(key),
                             bstr::BStr::new(ver),
+                            if is_optional { " (optional)" } else { "" },
                         );
                     });
                     bun_core::pretty_errorln!(

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -2165,6 +2165,42 @@ impl Package<u64> {
             out
         };
 
+        // `Features::LINK` skips dependencies and peerDependencies: the linked
+        // package is a symlink into its real source tree, so its own install
+        // owns that node_modules. Runtime resolution realpath's the symlink
+        // before walking node_modules, which means peers installed in *this*
+        // project are invisible to the linked package. pnpm prints a warning
+        // in this situation (https://github.com/pnpm/pnpm/pull/5876); do the
+        // same so `bun link` users aren't surprised.
+        if FEATURES == Features::LINK
+            && pm.options.log_level != crate::package_manager::LogLevel::Silent
+        {
+            if let Some(peer_deps) = json.as_property(b"peerDependencies") {
+                if peer_deps.expr.property_count() > 0 {
+                    let name = json
+                        .as_property(b"name")
+                        .and_then(|q| q.expr.as_utf8(&bump))
+                        .unwrap_or(b"");
+                    bun_core::warn!(
+                        "Linked package <b>\"{}\"<r> declares peerDependencies that will not resolve from this project:",
+                        bstr::BStr::new(name),
+                    );
+                    peer_deps.expr.for_each_property(|key, _loc, value| {
+                        let ver = value.as_utf8(&bump).unwrap_or(b"");
+                        bun_core::pretty_errorln!(
+                            "  <d>-<r> {}<d>@{}<r>",
+                            bstr::BStr::new(key),
+                            bstr::BStr::new(ver),
+                        );
+                    });
+                    bun_core::pretty_errorln!(
+                        "  Linked packages resolve modules from their real location on disk.\n  Run bun with <cyan>--preserve-symlinks<r> to resolve peers from this project's node_modules.",
+                    );
+                    Output::flush();
+                }
+            }
+        }
+
         let mut workspace_names = workspace_map::WorkspaceMap::init();
         // defer workspace_names.deinit(); — Drop handles it
 

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -532,21 +532,8 @@ it("should warn when linked package has peerDependencies", async () => {
     expect(err).toContain("peer-two@* (optional)");
     expect(err).not.toContain("peer-three");
     expect(err).toContain("resolve modules from their real location on disk");
-    expect(err).toContain("--preserve-symlinks");
+    expect(err).toContain("Install these peers in the linked package's own node_modules");
     expect(out).toContain(`installed ${link_name}@link:${link_name}`);
-    expect(exitCode).toBe(0);
-  }
-
-  // Under the isolated linker, --preserve-symlinks would break the store
-  // layout, so the warning should not recommend it.
-  {
-    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
-    await rm(join(package_dir, "bun.lock"), { force: true });
-    await rm(join(package_dir, "bun.lockb"), { force: true });
-    const { err, exitCode } = await run([bunExe(), "link", link_name, "--linker", "isolated"], package_dir);
-    expect(err.split(header).length - 1).toBe(1);
-    expect(err).not.toContain("--preserve-symlinks");
-    expect(err).toContain("own node_modules");
     expect(exitCode).toBe(0);
   }
 
@@ -557,7 +544,6 @@ it("should warn when linked package has peerDependencies", async () => {
     await rm(join(package_dir, "bun.lockb"), { force: true });
     const { err, exitCode } = await run([bunExe(), "link", link_name, "--silent"], package_dir);
     expect(err).not.toContain("peerDependencies");
-    expect(err).not.toContain("--preserve-symlinks");
     expect(exitCode).toBe(0);
   }
 
@@ -580,6 +566,23 @@ it("should warn when linked package has peerDependencies", async () => {
     expect(err.split(header).length - 1).toBe(1);
     expect(err).toContain("peer-one@^1.0.0");
     expect(err).not.toContain("peer-three");
-    expect(err).toContain("--preserve-symlinks");
+  }
+
+  // With every peer installed under the linked package, nothing is left to
+  // warn about.
+  {
+    for (const name of ["peer-one", "peer-two"]) {
+      await mkdir(join(link_dir, "node_modules", name), { recursive: true });
+      await writeFile(
+        join(link_dir, "node_modules", name, "package.json"),
+        JSON.stringify({ name, version: "1.0.0" }),
+      );
+    }
+    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+    await rm(join(package_dir, "bun.lock"), { force: true });
+    await rm(join(package_dir, "bun.lockb"), { force: true });
+    const { err, exitCode } = await run([bunExe(), "link", link_name], package_dir);
+    expect(err).not.toContain("peerDependencies");
+    expect(exitCode).toBe(0);
   }
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it } from "bun:test";
-import { access, mkdir, writeFile } from "fs/promises";
+import { access, mkdir, rm, writeFile } from "fs/promises";
 import {
   bunExe,
   bunEnv as env,
@@ -484,11 +484,19 @@ it("should warn when linked package has peerDependencies", async () => {
       peerDependencies: {
         "peer-one": "^1.0.0",
         "peer-two": "*",
+        "peer-three": "^2.0.0",
       },
       peerDependenciesMeta: {
         "peer-two": { optional: true },
       },
     }),
+  );
+  // peer-three is already installed in the linked package's own node_modules,
+  // so it resolves from there and should not be listed in the warning.
+  await mkdir(join(link_dir, "node_modules", "peer-three"), { recursive: true });
+  await writeFile(
+    join(link_dir, "node_modules", "peer-three", "package.json"),
+    JSON.stringify({ name: "peer-three", version: "2.0.0" }),
   );
   await writeFile(
     join(package_dir, "package.json"),
@@ -498,44 +506,66 @@ it("should warn when linked package has peerDependencies", async () => {
     }),
   );
 
-  // Registering the link (no args) should not warn: nothing is being resolved.
-  {
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "link"],
-      cwd: link_dir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env,
-    });
-    const err = stderrForInstall(await stderr.text());
-    expect(err).not.toContain("peerDependencies");
-    expect(await stdout.text()).toContain(`Success! Registered "${link_name}"`);
-    expect(await exited).toBe(0);
+  async function run(cmd: string[], cwd: string) {
+    const proc = spawn({ cmd, cwd, stdout: "pipe", stdin: "pipe", stderr: "pipe", env });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out, err: stderrForInstall(err), exitCode };
   }
 
-  // `bun link <name>` should warn, listing every peer and the workaround.
+  const header = `Linked package "${link_name}" declares peerDependencies that may not resolve from this project:`;
+
+  // Registering the link (no args) should not warn: nothing is being resolved.
   {
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "link", link_name],
-      cwd: package_dir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env,
-    });
-    const err = stderrForInstall(await stderr.text());
-    expect(err).toContain(`Linked package "${link_name}" declares peerDependencies`);
+    const { out, err, exitCode } = await run([bunExe(), "link"], link_dir);
+    expect(err).not.toContain("peerDependencies");
+    expect(out).toContain(`Success! Registered "${link_name}"`);
+    expect(exitCode).toBe(0);
+  }
+
+  // `bun link <name>` should warn once, listing peers not installed in the
+  // linked package and the remedy.
+  {
+    const { out, err, exitCode } = await run([bunExe(), "link", link_name], package_dir);
+    expect(err.split(header).length - 1).toBe(1);
     expect(err).toContain("peer-one@^1.0.0");
     expect(err).not.toContain("peer-one@^1.0.0 (optional)");
     expect(err).toContain("peer-two@* (optional)");
+    expect(err).not.toContain("peer-three");
+    expect(err).toContain("resolve modules from their real location on disk");
     expect(err).toContain("--preserve-symlinks");
-    expect(await stdout.text()).toContain(`installed ${link_name}@link:${link_name}`);
-    expect(await exited).toBe(0);
+    expect(out).toContain(`installed ${link_name}@link:${link_name}`);
+    expect(exitCode).toBe(0);
+  }
+
+  // Under the isolated linker, --preserve-symlinks would break the store
+  // layout, so the warning should not recommend it.
+  {
+    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+    await rm(join(package_dir, "bun.lock"), { force: true });
+    await rm(join(package_dir, "bun.lockb"), { force: true });
+    const { err, exitCode } = await run([bunExe(), "link", link_name, "--linker", "isolated"], package_dir);
+    expect(err.split(header).length - 1).toBe(1);
+    expect(err).not.toContain("--preserve-symlinks");
+    expect(err).toContain("own node_modules");
+    expect(exitCode).toBe(0);
+  }
+
+  // --silent suppresses the warning.
+  {
+    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+    await rm(join(package_dir, "bun.lock"), { force: true });
+    await rm(join(package_dir, "bun.lockb"), { force: true });
+    const { err, exitCode } = await run([bunExe(), "link", link_name, "--silent"], package_dir);
+    expect(err).not.toContain("peerDependencies");
+    expect(err).not.toContain("--preserve-symlinks");
+    expect(exitCode).toBe(0);
   }
 
   // `bun install` with a `link:` dependency in package.json should warn too.
   {
+    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+    await rm(join(package_dir, "bun.lock"), { force: true });
+    await rm(join(package_dir, "bun.lockb"), { force: true });
     await writeFile(
       join(package_dir, "package.json"),
       JSON.stringify({
@@ -547,25 +577,9 @@ it("should warn when linked package has peerDependencies", async () => {
       }),
     );
     const { err } = await runBunInstall(env, package_dir, { allowWarnings: true });
-    expect(err).toContain(`Linked package "${link_name}" declares peerDependencies`);
+    expect(err.split(header).length - 1).toBe(1);
     expect(err).toContain("peer-one@^1.0.0");
+    expect(err).not.toContain("peer-three");
     expect(err).toContain("--preserve-symlinks");
-  }
-
-  // --silent suppresses the warning.
-  {
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "link", link_name, "--silent"],
-      cwd: package_dir,
-      stdout: "pipe",
-      stdin: "pipe",
-      stderr: "pipe",
-      env,
-    });
-    const err = stderrForInstall(await stderr.text());
-    expect(err).not.toContain("peerDependencies");
-    expect(err).not.toContain("--preserve-symlinks");
-    await stdout.text();
-    expect(await exited).toBe(0);
   }
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -514,15 +514,15 @@ it("should warn when linked package has peerDependencies", async () => {
 
   const header = `Linked package "${link_name}" declares peerDependencies that may not resolve from this project:`;
 
-  // Registering the link (no args) should not warn: nothing is being resolved.
-  {
-    const { out, err, exitCode } = await run([bunExe(), "link"], link_dir);
-    expect(err).not.toContain("peerDependencies");
-    expect(out).toContain(`Success! Registered "${link_name}"`);
-    expect(exitCode).toBe(0);
-  }
-
   try {
+    // Registering the link (no args) should not warn: nothing is being resolved.
+    {
+      const { out, err, exitCode } = await run([bunExe(), "link"], link_dir);
+      expect(err).not.toContain("peerDependencies");
+      expect(out).toContain(`Success! Registered "${link_name}"`);
+      expect(exitCode).toBe(0);
+    }
+
     // `bun link <name>` should warn once, listing peers not installed in the
     // linked package and the remedy.
     {
@@ -535,16 +535,6 @@ it("should warn when linked package has peerDependencies", async () => {
       expect(err).toContain("resolve modules from their real location on disk");
       expect(err).toContain("Install these peers in the linked package's own node_modules");
       expect(out).toContain(`installed ${link_name}@link:${link_name}`);
-      expect(exitCode).toBe(0);
-    }
-
-    // --silent suppresses the warning.
-    {
-      await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
-      await rm(join(package_dir, "bun.lock"), { force: true });
-      await rm(join(package_dir, "bun.lockb"), { force: true });
-      const { err, exitCode } = await run([bunExe(), "link", link_name, "--silent"], package_dir);
-      expect(err).not.toContain("peerDependencies");
       expect(exitCode).toBe(0);
     }
 

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -522,64 +522,71 @@ it("should warn when linked package has peerDependencies", async () => {
     expect(exitCode).toBe(0);
   }
 
-  // `bun link <name>` should warn once, listing peers not installed in the
-  // linked package and the remedy.
-  {
-    const { out, err, exitCode } = await run([bunExe(), "link", link_name], package_dir);
-    expect(err.split(header).length - 1).toBe(1);
-    expect(err).toContain("peer-one@^1.0.0");
-    expect(err).not.toContain("peer-one@^1.0.0 (optional)");
-    expect(err).toContain("peer-two@* (optional)");
-    expect(err).not.toContain("peer-three");
-    expect(err).toContain("resolve modules from their real location on disk");
-    expect(err).toContain("Install these peers in the linked package's own node_modules");
-    expect(out).toContain(`installed ${link_name}@link:${link_name}`);
-    expect(exitCode).toBe(0);
-  }
-
-  // --silent suppresses the warning.
-  {
-    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
-    await rm(join(package_dir, "bun.lock"), { force: true });
-    await rm(join(package_dir, "bun.lockb"), { force: true });
-    const { err, exitCode } = await run([bunExe(), "link", link_name, "--silent"], package_dir);
-    expect(err).not.toContain("peerDependencies");
-    expect(exitCode).toBe(0);
-  }
-
-  // `bun install` with a `link:` dependency in package.json should warn too.
-  {
-    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
-    await rm(join(package_dir, "bun.lock"), { force: true });
-    await rm(join(package_dir, "bun.lockb"), { force: true });
-    await writeFile(
-      join(package_dir, "package.json"),
-      JSON.stringify({
-        name: "consumer",
-        version: "0.0.2",
-        dependencies: {
-          [link_name]: `link:${link_name}`,
-        },
-      }),
-    );
-    const { err } = await runBunInstall(env, package_dir, { allowWarnings: true });
-    expect(err.split(header).length - 1).toBe(1);
-    expect(err).toContain("peer-one@^1.0.0");
-    expect(err).not.toContain("peer-three");
-  }
-
-  // With every peer installed under the linked package, nothing is left to
-  // warn about.
-  {
-    for (const name of ["peer-one", "peer-two"]) {
-      await mkdir(join(link_dir, "node_modules", name), { recursive: true });
-      await writeFile(join(link_dir, "node_modules", name, "package.json"), JSON.stringify({ name, version: "1.0.0" }));
+  try {
+    // `bun link <name>` should warn once, listing peers not installed in the
+    // linked package and the remedy.
+    {
+      const { out, err, exitCode } = await run([bunExe(), "link", link_name], package_dir);
+      expect(err.split(header).length - 1).toBe(1);
+      expect(err).toContain("peer-one@^1.0.0");
+      expect(err).not.toContain("peer-one@^1.0.0 (optional)");
+      expect(err).toContain("peer-two@* (optional)");
+      expect(err).not.toContain("peer-three");
+      expect(err).toContain("resolve modules from their real location on disk");
+      expect(err).toContain("Install these peers in the linked package's own node_modules");
+      expect(out).toContain(`installed ${link_name}@link:${link_name}`);
+      expect(exitCode).toBe(0);
     }
-    await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
-    await rm(join(package_dir, "bun.lock"), { force: true });
-    await rm(join(package_dir, "bun.lockb"), { force: true });
-    const { err, exitCode } = await run([bunExe(), "link", link_name], package_dir);
-    expect(err).not.toContain("peerDependencies");
-    expect(exitCode).toBe(0);
+
+    // --silent suppresses the warning.
+    {
+      await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+      await rm(join(package_dir, "bun.lock"), { force: true });
+      await rm(join(package_dir, "bun.lockb"), { force: true });
+      const { err, exitCode } = await run([bunExe(), "link", link_name, "--silent"], package_dir);
+      expect(err).not.toContain("peerDependencies");
+      expect(exitCode).toBe(0);
+    }
+
+    // `bun install` with a `link:` dependency in package.json should warn too.
+    {
+      await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+      await rm(join(package_dir, "bun.lock"), { force: true });
+      await rm(join(package_dir, "bun.lockb"), { force: true });
+      await writeFile(
+        join(package_dir, "package.json"),
+        JSON.stringify({
+          name: "consumer",
+          version: "0.0.2",
+          dependencies: {
+            [link_name]: `link:${link_name}`,
+          },
+        }),
+      );
+      const { err } = await runBunInstall(env, package_dir, { allowWarnings: true });
+      expect(err.split(header).length - 1).toBe(1);
+      expect(err).toContain("peer-one@^1.0.0");
+      expect(err).not.toContain("peer-three");
+    }
+
+    // With every peer installed under the linked package, nothing is left to
+    // warn about.
+    {
+      for (const name of ["peer-one", "peer-two"]) {
+        await mkdir(join(link_dir, "node_modules", name), { recursive: true });
+        await writeFile(
+          join(link_dir, "node_modules", name, "package.json"),
+          JSON.stringify({ name, version: "1.0.0" }),
+        );
+      }
+      await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
+      await rm(join(package_dir, "bun.lock"), { force: true });
+      await rm(join(package_dir, "bun.lockb"), { force: true });
+      const { err, exitCode } = await run([bunExe(), "link", link_name], package_dir);
+      expect(err).not.toContain("peerDependencies");
+      expect(exitCode).toBe(0);
+    }
+  } finally {
+    await run([bunExe(), "unlink"], link_dir);
   }
 });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -573,10 +573,7 @@ it("should warn when linked package has peerDependencies", async () => {
   {
     for (const name of ["peer-one", "peer-two"]) {
       await mkdir(join(link_dir, "node_modules", name), { recursive: true });
-      await writeFile(
-        join(link_dir, "node_modules", name, "package.json"),
-        JSON.stringify({ name, version: "1.0.0" }),
-      );
+      await writeFile(join(link_dir, "node_modules", name, "package.json"), JSON.stringify({ name, version: "1.0.0" }));
     }
     await rm(join(package_dir, "node_modules"), { recursive: true, force: true });
     await rm(join(package_dir, "bun.lock"), { force: true });

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -472,3 +472,96 @@ it("should link dependency without crashing", async () => {
   // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
 });
+
+// https://github.com/oven-sh/bun/issues/13676
+it("should warn when linked package has peerDependencies", async () => {
+  const link_name = basename(link_dir).slice("bun-link.".length);
+  await writeFile(
+    join(link_dir, "package.json"),
+    JSON.stringify({
+      name: link_name,
+      version: "0.0.1",
+      peerDependencies: {
+        "peer-one": "^1.0.0",
+        "peer-two": "*",
+      },
+    }),
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "consumer",
+      version: "0.0.2",
+    }),
+  );
+
+  // Registering the link (no args) should not warn: nothing is being resolved.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "link"],
+      cwd: link_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = stderrForInstall(await stderr.text());
+    expect(err).not.toContain("peerDependencies");
+    expect(await stdout.text()).toContain(`Success! Registered "${link_name}"`);
+    expect(await exited).toBe(0);
+  }
+
+  // `bun link <name>` should warn, listing every peer and the workaround.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "link", link_name],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = stderrForInstall(await stderr.text());
+    expect(err).toContain(`Linked package "${link_name}" declares peerDependencies`);
+    expect(err).toContain("peer-one@^1.0.0");
+    expect(err).toContain("peer-two@*");
+    expect(err).toContain("--preserve-symlinks");
+    expect(await stdout.text()).toContain(`installed ${link_name}@link:${link_name}`);
+    expect(await exited).toBe(0);
+  }
+
+  // `bun install` with a `link:` dependency in package.json should warn too.
+  {
+    await writeFile(
+      join(package_dir, "package.json"),
+      JSON.stringify({
+        name: "consumer",
+        version: "0.0.2",
+        dependencies: {
+          [link_name]: `link:${link_name}`,
+        },
+      }),
+    );
+    const { err } = await runBunInstall(env, package_dir, { allowWarnings: true });
+    expect(err).toContain(`Linked package "${link_name}" declares peerDependencies`);
+    expect(err).toContain("peer-one@^1.0.0");
+    expect(err).toContain("--preserve-symlinks");
+  }
+
+  // --silent suppresses the warning.
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "link", link_name, "--silent"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = stderrForInstall(await stderr.text());
+    expect(err).not.toContain("peerDependencies");
+    expect(err).not.toContain("--preserve-symlinks");
+    await stdout.text();
+    expect(await exited).toBe(0);
+  }
+});

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -485,6 +485,9 @@ it("should warn when linked package has peerDependencies", async () => {
         "peer-one": "^1.0.0",
         "peer-two": "*",
       },
+      peerDependenciesMeta: {
+        "peer-two": { optional: true },
+      },
     }),
   );
   await writeFile(
@@ -524,7 +527,8 @@ it("should warn when linked package has peerDependencies", async () => {
     const err = stderrForInstall(await stderr.text());
     expect(err).toContain(`Linked package "${link_name}" declares peerDependencies`);
     expect(err).toContain("peer-one@^1.0.0");
-    expect(err).toContain("peer-two@*");
+    expect(err).not.toContain("peer-one@^1.0.0 (optional)");
+    expect(err).toContain("peer-two@* (optional)");
     expect(err).toContain("--preserve-symlinks");
     expect(await stdout.text()).toContain(`installed ${link_name}@link:${link_name}`);
     expect(await exited).toBe(0);


### PR DESCRIPTION
## What

`bun link <name>` (and `bun install` with a `link:` dependency) now prints a warning when the linked package declares `peerDependencies` that are not already present in the linked package's own `node_modules`:

```
$ bun link my-linked-lib
bun link v1.4.0
warn: Linked package "my-linked-lib" declares peerDependencies that may not resolve from this project:
  - react@^18.0.0
  - react-dom@^18.0.0
  Linked packages resolve modules from their real location on disk. Install these peers in the linked package's own node_modules.

installed my-linked-lib@link:my-linked-lib
```

Peers marked optional in `peerDependenciesMeta` are annotated `(optional)`. Peers already installed under the linked package are skipped, so running `bun install` inside the linked package silences the warning. `--silent` suppresses it entirely. Install behavior is unchanged.

## Why

A `link:` dependency is a symlink into the package's real source tree. Both bun and Node realpath that symlink before walking `node_modules`, so a peer installed in the consumer's tree is invisible to the linked package unless the linked package also has it in its own `node_modules`. That is inherent to symlink-based linking; npm and pnpm have the same limitation with their `link` commands, and pnpm prints an equivalent warning.

Before this change bun said nothing: `Features::LINK` has `peer_dependencies: false`, so the linked package's peers were never read. Users only discovered the problem at runtime as `Cannot find package 'react' from '/real/path/to/linked/index.js'` (or, worse, as two copies of the peer being loaded).

This does not make the linked package magically find the consumer's peers; doing that would require either a resolver change or a new install option. The warning surfaces the situation and the universally-safe remedy (install the peer under the linked package). `--preserve-symlinks` is another option for hoisted installs but is not mentioned in the warning because it breaks the isolated linker's store layout and the effective linker is not known at the point the warning is emitted.

Refs #13676.

## How

`parse_with_json_impl` already has the parsed `package.json` and the `Features` it was called with. When that is `Features::LINK` (only the `link:` resolver passes this), the new `warn_linked_peer_dependencies` helper walks `peerDependencies`, skips entries that already exist under the linked package's `node_modules`, annotates optional peers from `peerDependenciesMeta`, and prints the warning. The check runs once per linked package per install (the folder-resolver result is cached).

## Test

`test/cli/install/bun-link.test.ts` gains a case covering:
- `bun link <name>` prints the warning once with each unresolved peer listed and the real-location explanation
- a peer already present in the linked package's `node_modules` is not listed
- `peerDependenciesMeta` optional entries are annotated
- `bun install` with a `link:` dependency in `package.json` prints the same warning
- no warning when every peer is already installed under the linked package
