### PR TITLE
build: make bun_shim_impl.exe reproducible (/Brepro, /DEBUG:NONE)

### DIFF
--- a/src/install/windows-shim/build.rs
+++ b/src/install/windows-shim/build.rs
@@ -10,8 +10,7 @@ fn main() {
     if std::env::var_os("CARGO_FEATURE_SHIM_STANDALONE").is_some()
         && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
     {
-        // oven-sh/bun#12738: hash in place of COFF TimeDateStamp, and no
-        // PDB-derived RSDS GUID, so the shim PE is byte-reproducible.
+        // oven-sh/bun#12738: byte-reproducible PE (no wall-clock TimeDateStamp / RSDS GUID).
         println!("cargo:rustc-link-arg=/Brepro");
         println!("cargo:rustc-link-arg=/DEBUG:NONE");
     }

--- a/src/install/windows-shim/build.rs
+++ b/src/install/windows-shim/build.rs
@@ -1,0 +1,19 @@
+//! Reproducible PE for the standalone `.bin/` launcher (oven-sh/bun#12738).
+//!
+//! lld-link (and MSVC link.exe) default to writing the wall-clock link time
+//! into the COFF `TimeDateStamp` field, and rustc passes `/DEBUG` regardless
+//! of `strip = "symbols"`, which embeds an `RSDS` CodeView record whose GUID
+//! is a hash of the `.pdb` (and so of absolute object paths). Both make the
+//! shim a fresh binary on every build. `/Brepro` turns the timestamps into a
+//! content hash; `/DEBUG:NONE` drops the PDB and its `RSDS` record. Both are
+//! appended after the driver's own `/DEBUG`, so the override wins.
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if std::env::var_os("CARGO_FEATURE_SHIM_STANDALONE").is_some()
+        && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+    {
+        println!("cargo:rustc-link-arg=/Brepro");
+        println!("cargo:rustc-link-arg=/DEBUG:NONE");
+    }
+}

--- a/src/install/windows-shim/build.rs
+++ b/src/install/windows-shim/build.rs
@@ -1,18 +1,17 @@
-//! Reproducible PE for the standalone `.bin/` launcher (oven-sh/bun#12738).
-//!
-//! lld-link (and MSVC link.exe) default to writing the wall-clock link time
-//! into the COFF `TimeDateStamp` field, and rustc passes `/DEBUG` regardless
-//! of `strip = "symbols"`, which embeds an `RSDS` CodeView record whose GUID
-//! is a hash of the `.pdb` (and so of absolute object paths). Both make the
-//! shim a fresh binary on every build. `/Brepro` turns the timestamps into a
-//! content hash; `/DEBUG:NONE` drops the PDB and its `RSDS` record. Both are
-//! appended after the driver's own `/DEBUG`, so the override wins.
+// Build scripts run on the host before bun_* crates are compiled; std is the only option.
+#![allow(
+    clippy::disallowed_methods,
+    clippy::disallowed_types,
+    clippy::disallowed_macros
+)]
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     if std::env::var_os("CARGO_FEATURE_SHIM_STANDALONE").is_some()
         && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
     {
+        // oven-sh/bun#12738: hash in place of COFF TimeDateStamp, and no
+        // PDB-derived RSDS GUID, so the shim PE is byte-reproducible.
         println!("cargo:rustc-link-arg=/Brepro");
         println!("cargo:rustc-link-arg=/DEBUG:NONE");
     }

--- a/test/internal/shim-reproducible-build.test.ts
+++ b/test/internal/shim-reproducible-build.test.ts
@@ -1,0 +1,134 @@
+// Regression test for oven-sh/bun#12738: the Windows `.bin/` launcher PE
+// (`bun_shim_impl.exe`) is `include_bytes!`'d into bun.exe and copied next to
+// every package binary by `bun install`. Without `/Brepro` lld-link writes the
+// wall-clock link time into the PE COFF `TimeDateStamp` field, and its own
+// `/DEBUG` generates a `.pdb` whose content hash (which encodes absolute object
+// paths) lands in the image's RSDS GUID. Either makes the shim a fresh binary
+// on every build, so it can't be whitelisted by hash and trips AV heuristics.
+//
+// This test cross-compiles the shim twice into different target directories
+// (simulating different checkout paths) and asserts byte-identity. It runs on
+// any host that has the Windows cross-compile prerequisites (cargo + rust-src,
+// lld-link, an xwin-style winsysroot); it's a no-op elsewhere.
+
+import { describe, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { detectWindowsSysroot } from "../../scripts/build/config.ts";
+
+const repoRoot = resolve(import.meta.dir, "..", "..");
+const cargo = Bun.which("cargo");
+const lldLink = Bun.which("lld-link");
+const winsysroot = detectWindowsSysroot();
+const rustSrc = (() => {
+  if (cargo == null) return undefined;
+  const probe = Bun.spawnSync({
+    cmd: ["rustc", "--print=sysroot"],
+    cwd: repoRoot,
+    env: { ...process.env, RUSTUP_TOOLCHAIN: "" },
+  });
+  if (probe.exitCode !== 0) return undefined;
+  const sysroot = probe.stdout.toString().trim();
+  return existsSync(join(sysroot, "lib", "rustlib", "src", "rust")) ? sysroot : undefined;
+})();
+
+// Cross-compile from a non-Windows host only: native Windows test agents don't
+// reliably run inside a VS dev shell, so kernel32.lib isn't on %LIB%.
+const havePrereqs = !isWindows && cargo != null && lldLink != null && rustSrc != null && winsysroot != null;
+
+const triple = process.arch === "arm64" ? "aarch64-pc-windows-msvc" : "x86_64-pc-windows-msvc";
+
+async function buildShim(targetDir: string): Promise<Uint8Array> {
+  // Mirror the freestanding link flags from scripts/build/rust.ts so the
+  // standalone `#![no_std]` crate links at all; the flags under test
+  // (`/Brepro`, `/DEBUG:NONE`) come from the crate's own build.rs.
+  const rustflags = [
+    "-Zunstable-options",
+    "-Cpanic=immediate-abort",
+    "-Clink-arg=/ENTRY:shim_main",
+    "-Clink-arg=/SUBSYSTEM:CONSOLE",
+    "-Clink-arg=/NODEFAULTLIB",
+    "-Clink-arg=kernel32.lib",
+    "-Clink-arg=ntdll.lib",
+    `-Clink-arg=/winsysroot:${winsysroot}`,
+  ];
+  const env: Record<string, string> = {
+    ...process.env,
+    CARGO_ENCODED_RUSTFLAGS: rustflags.join("\x1f"),
+    CARGO_TERM_COLOR: "never",
+    RUSTUP_TOOLCHAIN: "",
+    [`CARGO_TARGET_${triple.toUpperCase().replace(/-/g, "_")}_LINKER`]: lldLink!,
+  };
+
+  await using proc = Bun.spawn({
+    cmd: [
+      cargo!,
+      "build",
+      "-p",
+      "bun_shim_impl",
+      "--bin",
+      "bun_shim_impl",
+      "--features",
+      "shim_standalone",
+      "--target-dir",
+      targetDir,
+      "--target",
+      triple,
+      "--profile",
+      "shim",
+      "-Zbuild-std=core,compiler_builtins",
+      "-Zbuild-std-features=compiler-builtins-mem",
+    ],
+    env,
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    throw new Error(`cargo build failed (exit ${exitCode}) in ${targetDir}:\n${stdout}\n${stderr}`);
+  }
+  return await Bun.file(join(targetDir, triple, "shim", "bun_shim_impl.exe")).bytes();
+}
+
+describe.skipIf(!havePrereqs)("bun_shim_impl.exe is reproducible", () => {
+  test(
+    "two clean builds in different target directories are byte-identical",
+    async () => {
+      using a = tempDir("shim-repro-a", {});
+      using b = tempDir("shim-repro-b", {});
+      const [pa, pb] = [join(String(a), "t"), join(String(b), "t")];
+
+      const exeA = await buildShim(pa);
+      // Wall-clock TimeDateStamp has 1-second resolution; without /Brepro two
+      // back-to-back links can still agree by accident.
+      await Bun.sleep(1100);
+      const exeB = await buildShim(pb);
+
+      const hashA = Bun.SHA256.hash(exeA, "hex");
+      const hashB = Bun.SHA256.hash(exeB, "hex");
+      expect({ size: exeB.length, sha256: hashB }).toEqual({ size: exeA.length, sha256: hashA });
+
+      // `/DEBUG:NONE`: no RSDS CodeView record (whose PDB-content-derived GUID
+      // encodes absolute object paths) and no `.pdb` reference in the image.
+      const bytes = Buffer.from(exeA);
+      expect(bytes.includes(Buffer.from("RSDS"))).toBe(false);
+      expect(bytes.includes(Buffer.from(".pdb"))).toBe(false);
+
+      // `/Brepro`: lld-link stamps the PE as reproducible by adding an
+      // IMAGE_DEBUG_TYPE_REPRO (16) debug-directory entry and replacing the
+      // COFF TimeDateStamp with a content hash. Scan for the entry's fixed
+      // tail (`MajorVersion=0, MinorVersion=0, Type=16, SizeOfData=0,
+      // AddressOfRawData=0, PointerToRawData=0`); `/DEBUG:NONE` leaves it as
+      // the only debug-directory entry.
+      // prettier-ignore
+      const reproEntryTail = Buffer.from([
+        0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      ]);
+      expect(bytes.includes(reproEntryTail)).toBe(true);
+    },
+    120_000,
+  );
+});

--- a/test/internal/shim-reproducible-build.test.ts
+++ b/test/internal/shim-reproducible-build.test.ts
@@ -48,7 +48,10 @@ const workspaceResolvable =
 const havePrereqs =
   !isWindows && cargo != null && lldLink != null && rustSrc != null && winsysroot != null && workspaceResolvable;
 
-const triple = process.arch === "arm64" ? "aarch64-pc-windows-msvc" : "x86_64-pc-windows-msvc";
+// `/Brepro` and `/DEBUG:NONE` are arch-independent lld-link behaviors, and
+// every provisioned winsysroot carries the x64 import libs (arm64 is optional),
+// so pin the target rather than match the host.
+const triple = "x86_64-pc-windows-msvc";
 
 async function buildShim(targetDir: string): Promise<Uint8Array> {
   // Mirror the freestanding link flags from scripts/build/rust.ts so the

--- a/test/internal/shim-reproducible-build.test.ts
+++ b/test/internal/shim-reproducible-build.test.ts
@@ -20,12 +20,13 @@ import { detectWindowsSysroot } from "../../scripts/build/config.ts";
 
 const repoRoot = resolve(import.meta.dir, "..", "..");
 const cargo = Bun.which("cargo");
+const rustc = Bun.which("rustc");
 const lldLink = Bun.which("lld-link");
 const winsysroot = detectWindowsSysroot();
 const rustSrc = (() => {
-  if (cargo == null) return undefined;
+  if (cargo == null || rustc == null) return undefined;
   const probe = Bun.spawnSync({
-    cmd: ["rustc", "--print=sysroot"],
+    cmd: [rustc, "--print=sysroot"],
     cwd: repoRoot,
     env: { ...process.env, RUSTUP_TOOLCHAIN: "" },
   });
@@ -34,9 +35,18 @@ const rustSrc = (() => {
   return existsSync(join(sysroot, "lib", "rustlib", "src", "rust")) ? sysroot : undefined;
 })();
 
+// Cargo parses the whole workspace manifest (including path deps) before
+// applying -p, so it needs vendor/lolhtml on disk even for a zero-dep crate.
+// Test-only CI lanes run a prebuilt binary and never fetch it; skip there.
+// Same prerequisite check as rust-windows-sys-link.test.ts / linear-fifo.test.ts.
+const workspaceResolvable =
+  existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+
 // Cross-compile from a non-Windows host only: native Windows test agents don't
 // reliably run inside a VS dev shell, so kernel32.lib isn't on %LIB%.
-const havePrereqs = !isWindows && cargo != null && lldLink != null && rustSrc != null && winsysroot != null;
+const havePrereqs =
+  !isWindows && cargo != null && lldLink != null && rustSrc != null && winsysroot != null && workspaceResolvable;
 
 const triple = process.arch === "arm64" ? "aarch64-pc-windows-msvc" : "x86_64-pc-windows-msvc";
 

--- a/test/internal/shim-reproducible-build.test.ts
+++ b/test/internal/shim-reproducible-build.test.ts
@@ -94,41 +94,37 @@ async function buildShim(targetDir: string): Promise<Uint8Array> {
 }
 
 describe.skipIf(!havePrereqs)("bun_shim_impl.exe is reproducible", () => {
-  test(
-    "two clean builds in different target directories are byte-identical",
-    async () => {
-      using a = tempDir("shim-repro-a", {});
-      using b = tempDir("shim-repro-b", {});
-      const [pa, pb] = [join(String(a), "t"), join(String(b), "t")];
+  test("two clean builds in different target directories are byte-identical", async () => {
+    using a = tempDir("shim-repro-a", {});
+    using b = tempDir("shim-repro-b", {});
+    const [pa, pb] = [join(String(a), "t"), join(String(b), "t")];
 
-      const exeA = await buildShim(pa);
-      // Wall-clock TimeDateStamp has 1-second resolution; without /Brepro two
-      // back-to-back links can still agree by accident.
-      await Bun.sleep(1100);
-      const exeB = await buildShim(pb);
+    const exeA = await buildShim(pa);
+    // Wall-clock TimeDateStamp has 1-second resolution; without /Brepro two
+    // back-to-back links can still agree by accident.
+    await Bun.sleep(1100);
+    const exeB = await buildShim(pb);
 
-      const hashA = Bun.SHA256.hash(exeA, "hex");
-      const hashB = Bun.SHA256.hash(exeB, "hex");
-      expect({ size: exeB.length, sha256: hashB }).toEqual({ size: exeA.length, sha256: hashA });
+    const hashA = Bun.SHA256.hash(exeA, "hex");
+    const hashB = Bun.SHA256.hash(exeB, "hex");
+    expect({ size: exeB.length, sha256: hashB }).toEqual({ size: exeA.length, sha256: hashA });
 
-      // `/DEBUG:NONE`: no RSDS CodeView record (whose PDB-content-derived GUID
-      // encodes absolute object paths) and no `.pdb` reference in the image.
-      const bytes = Buffer.from(exeA);
-      expect(bytes.includes(Buffer.from("RSDS"))).toBe(false);
-      expect(bytes.includes(Buffer.from(".pdb"))).toBe(false);
+    // `/DEBUG:NONE`: no RSDS CodeView record (whose PDB-content-derived GUID
+    // encodes absolute object paths) and no `.pdb` reference in the image.
+    const bytes = Buffer.from(exeA);
+    expect(bytes.includes(Buffer.from("RSDS"))).toBe(false);
+    expect(bytes.includes(Buffer.from(".pdb"))).toBe(false);
 
-      // `/Brepro`: lld-link stamps the PE as reproducible by adding an
-      // IMAGE_DEBUG_TYPE_REPRO (16) debug-directory entry and replacing the
-      // COFF TimeDateStamp with a content hash. Scan for the entry's fixed
-      // tail (`MajorVersion=0, MinorVersion=0, Type=16, SizeOfData=0,
-      // AddressOfRawData=0, PointerToRawData=0`); `/DEBUG:NONE` leaves it as
-      // the only debug-directory entry.
-      // prettier-ignore
-      const reproEntryTail = Buffer.from([
+    // `/Brepro`: lld-link stamps the PE as reproducible by adding an
+    // IMAGE_DEBUG_TYPE_REPRO (16) debug-directory entry and replacing the
+    // COFF TimeDateStamp with a content hash. Scan for the entry's fixed
+    // tail (`MajorVersion=0, MinorVersion=0, Type=16, SizeOfData=0,
+    // AddressOfRawData=0, PointerToRawData=0`); `/DEBUG:NONE` leaves it as
+    // the only debug-directory entry.
+    // prettier-ignore
+    const reproEntryTail = Buffer.from([
         0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       ]);
-      expect(bytes.includes(reproEntryTail)).toBe(true);
-    },
-    120_000,
-  );
+    expect(bytes.includes(reproEntryTail)).toBe(true);
+  }, 120_000);
 });

--- a/test/internal/shim-reproducible-build.test.ts
+++ b/test/internal/shim-reproducible-build.test.ts
@@ -76,6 +76,7 @@ async function buildShim(targetDir: string): Promise<Uint8Array> {
     cmd: [
       cargo!,
       "build",
+      "--locked",
       "-p",
       "bun_shim_impl",
       "--bin",


### PR DESCRIPTION
## Problem

`bun_shim_impl.exe` (the Windows `.bin/` launcher PE that `bun install` copies next to every package binary) is not reproducible: two builds of the same source produce different bytes.

```
$ dumpbin /headers bun_shim_impl.exe | grep "time date"
        6674BAC3 time date stamp Thu Jun 20 16:26:59 2024
```

This means every Bun release writes a never-before-seen binary to users' `node_modules/.bin/` directories, which trips Malwarebytes (and potentially other AV) heuristics and makes hash-based whitelisting impossible.

Fixes #12738.

## Cause

Two independent sources of non-determinism in the lld-link invocation that `cargo build -p bun_shim_impl --profile shim` drives:

1. **COFF `TimeDateStamp`**: without `/Brepro`, lld-link writes the wall-clock link time into the PE header at offset `e_lfanew + 8`. This is the byte-128 difference in the issue's `dumpbin` output.

2. **CodeView RSDS GUID**: rustc passes `/DEBUG` (regardless of `strip = "symbols"`), so lld-link writes a `.pdb` and embeds an `RSDS` record with a GUID derived from the PDB's content hash. The PDB encodes absolute object-file paths, so two builds from different checkout directories (different CI agents, for instance) produce different GUIDs even with `/Brepro`.

Reproduced on `main` by cross-compiling twice into separate target directories:

```
f1e82dd2f17c892372e70bbe0d1d5d48b549d1f0e3db81c20746335b3a638517  a/bun_shim_impl.exe
937c9c8819df8fd8bb11af7b899bb2efd6a9fb2f85b00c48b2c0764a15ce0480  b/bun_shim_impl.exe
  (first diff at byte 128: TimeDateStamp)
```

## Fix

`src/install/windows-shim/build.rs` emits two linker arguments for the standalone shim binary:

- `/Brepro`: replaces every `TimeDateStamp` field with a content hash of the image and adds an `IMAGE_DEBUG_TYPE_REPRO` debug-directory entry so tools know the field is not a date.
- `/DEBUG:NONE`: overrides rustc's `/DEBUG`, so no `.pdb` is generated and no `RSDS` record (with its path-dependent GUID) lands in the image.

`cargo:rustc-link-arg` from a build script is appended after both rustc's own `/DEBUG` and the `-Clink-arg` flags from `CARGO_ENCODED_RUSTFLAGS`, so `/DEBUG:NONE` reliably wins. Gated on `CARGO_FEATURE_SHIM_STANDALONE` + `CARGO_CFG_TARGET_OS=windows` so a bare `cargo check` on a non-Windows host is unaffected.

The shim was never debugged via its own PDB (the comment on `[profile.shim]` already states the intent is to discard it; the in-process launcher path in `bun_install` is what gets debugged), so dropping it costs nothing.

## Verification

Linux x64, cross-compiling to `x86_64-pc-windows-msvc` into two different target directories with a 2-second gap:

```
1fd383c7ca888798719cfbf9869026b736a3d0ce73650b96fea69cdf0c2e45a1  a/bun_shim_impl.exe
1fd383c7ca888798719cfbf9869026b736a3d0ce73650b96fea69cdf0c2e45a1  b/bun_shim_impl.exe
```

Native Windows x64 via `bun scripts/build.ts --target=bun-shim`, clean rebuild after a 2-second gap:

```
e898ddcfea3c8079613c86fc1ceb4074b03c98b14d72ada834ccd24647edae98  (both builds)
TimeDateStamp: 0x367e67a7   contains RSDS: False   .pdb present: False
```

(The cross-compile and native hashes differ because MSVC `link.exe` and `lld-link` use different DOS stub lengths; each toolchain is internally reproducible.)

`test/internal/shim-reproducible-build.test.ts` cross-compiles the shim twice into distinct temp directories and asserts byte-identity, no `RSDS`/`.pdb` in the image, and the presence of the `IMAGE_DEBUG_TYPE_REPRO` entry. Skips on hosts without `cargo`/`rust-src`/`lld-link`/a winsysroot. Fails on `main`, passes with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/internal/shim-reproducible-build.test.ts

<!-- robobun:evidence:end -->