### PR TITLE
bun:sqlite: close() finalizes outstanding prepared statements (drizzle close(true) "database is locked")

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -123,8 +123,8 @@ db.close();
 Passing `true` calls `sqlite3_close` instead of `sqlite3_close_v2`. Prepared statements are finalized either way, so for most code the two behave the same.
 
 <Note>
-  `close()` is called automatically when the database is garbage collected. It is safe to call multiple times but has no
-  effect after the first.
+  The underlying connection is released automatically once the `Database` and every `Statement` prepared from it have
+  been garbage collected. It is safe to call `.close()` multiple times; after the first it is a no-op.
 </Note>
 
 ### `using` statement

--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -112,25 +112,19 @@ const db = new Database("./mydb.sqlite");
 
 ### `.close(throwOnError: boolean = false)`
 
-To close a database connection but allow existing queries to finish, call `.close(false)`:
+To close a database connection, call `.close()`. Any statements prepared from it are finalized, so using one afterwards throws `Statement has finalized`:
 
 ```ts db.ts icon="/icons/typescript.svg" highlight={3}
 const db = new Database();
 // ... do stuff
-db.close(false);
+db.close();
 ```
 
-To close the database and throw an error if there are any pending queries, call `.close(true)`:
-
-```ts db.ts icon="/icons/typescript.svg" highlight={3}
-const db = new Database();
-// ... do stuff
-db.close(true);
-```
+Passing `true` calls `sqlite3_close` instead of `sqlite3_close_v2`. Prepared statements are finalized either way, so for most code the two behave the same.
 
 <Note>
-  `close(false)` is called automatically when the database is garbage collected. It is safe to call multiple times but
-  has no effect after the first.
+  `close()` is called automatically when the database is garbage collected. It is safe to call multiple times but has no
+  effect after the first.
 </Note>
 
 ### `using` statement

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -264,9 +264,11 @@ declare module "bun:sqlite" {
     /**
      * Close the database connection.
      *
+     * Outstanding prepared statements are finalized. Using one afterwards, or
+     * running a new query, throws an error.
+     *
      * It is safe to call this method multiple times. If the database is already
-     * closed, this is a no-op. Running queries after the database has been
-     * closed throws an error.
+     * closed, this is a no-op.
      *
      * @example
      * ```ts
@@ -274,18 +276,17 @@ declare module "bun:sqlite" {
      * ```
      * This is called automatically when the database instance is garbage collected.
      *
-     * Internally, this calls `sqlite3_close_v2`.
+     * Internally, this finalizes outstanding statements and calls `sqlite3_close_v2`.
      */
     close(
       /**
-       * If `true`, throw an error if the database is in use
+       * When `true`, this calls `sqlite3_close` instead of `sqlite3_close_v2`.
+       * Prepared statements are finalized either way, so for most code the two
+       * behave the same.
+       *
        * @default false
        *
-       * When `true`, this calls `sqlite3_close` instead of `sqlite3_close_v2`.
-       *
        * Learn more in the [sqlite3 documentation](https://www.sqlite.org/c3ref/close.html).
-       *
-       * In the future, Bun may default `throwOnError` to `true`, but for backwards compatibility it is `false` by default.
        */
       throwOnError?: boolean,
     ): void;

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -274,7 +274,8 @@ declare module "bun:sqlite" {
      * ```ts
      * db.close();
      * ```
-     * This is called automatically when the database instance is garbage collected.
+     * The underlying connection is released automatically once the `Database`
+     * and every `Statement` prepared from it have been garbage collected.
      *
      * Internally, this finalizes outstanding statements and calls `sqlite3_close_v2`.
      */

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -549,6 +549,18 @@ protected:
     void finishCreation(JSC::VM& vm);
 };
 
+static inline void untrackStatement(VersionSqlite3* versionDB, JSSQLStatement* statement)
+{
+    if (!versionDB)
+        return;
+    auto& statements = versionDB->statements;
+    size_t i = statements.find(statement);
+    if (i == WTF::notFound)
+        return;
+    statements[i] = statements.last();
+    statements.removeLast();
+}
+
 static JSValue toJSAsBuffer(JSC::VM& vm, JSC::JSGlobalObject* globalObject, sqlite3_stmt* stmt, int i)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -2849,8 +2861,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionFinalize, (JSC::JSGlobalObject * 
     if (castedThis->stmt) {
         sqlite3_finalize(castedThis->stmt);
         castedThis->stmt = nullptr;
-        if (castedThis->version_db)
-            castedThis->version_db->statements.removeFirst(castedThis);
+        untrackStatement(castedThis->version_db, castedThis);
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
@@ -2881,7 +2892,7 @@ JSSQLStatement::~JSSQLStatement()
     }
 
     if (this->version_db) {
-        this->version_db->statements.removeFirst(this);
+        untrackStatement(this->version_db, this);
         this->version_db->release();
     }
 }

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -202,6 +202,10 @@ static inline JSC::JSValue jsBigIntFromSQLite(JSC::JSGlobalObject* globalObject,
         return {};                                                                                                 \
     }
 
+namespace WebCore {
+class JSSQLStatement;
+}
+
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(VersionSqlite3);
 
 class VersionSqlite3 {
@@ -217,6 +221,13 @@ public:
     sqlite3* db;
     std::atomic<uint64_t> version;
     size_t reference_count;
+
+    // Every live JSSQLStatement prepared against this connection. Not owning:
+    // entries are added in JSSQLStatement::create, removed on finalize/destroy.
+    // close() walks this to finalize the underlying sqlite3_stmt so the handle
+    // can be released even when user code (or a library like drizzle) dropped a
+    // statement without finalizing it.
+    Vector<WebCore::JSSQLStatement*> statements;
 
     void release()
     {
@@ -475,6 +486,7 @@ public:
         JSSQLStatement* ptr = new (NotNull, JSC::allocateCell<JSSQLStatement>(globalObject->vm())) JSSQLStatement(structure, *globalObject, stmt, version_db, memorySizeChange);
         if (version_db) {
             ++version_db->reference_count;
+            version_db->statements.append(ptr);
         }
         ptr->finishCreation(globalObject->vm());
         return ptr;
@@ -1841,6 +1853,18 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
+    // A prepared statement keeps the sqlite3 connection alive until it is
+    // finalized, so release the ones handed out via db.prepare() whose JS
+    // wrappers are still around. Matches better-sqlite3's close().
+    Vector<JSSQLStatement*> statements;
+    statements.swap(versionDB->statements);
+    for (auto* statement : statements) {
+        if (statement->stmt) {
+            sqlite3_finalize(statement->stmt);
+            statement->stmt = nullptr;
+        }
+    }
+
     // sqlite3_close_v2 is used for automatic GC cleanup
     int statusCode = shouldThrowOnError ? sqlite3_close(db) : sqlite3_close_v2(db);
     if (statusCode != SQLITE_OK) {
@@ -2825,6 +2849,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFunctionFinalize, (JSC::JSGlobalObject * 
     if (castedThis->stmt) {
         sqlite3_finalize(castedThis->stmt);
         castedThis->stmt = nullptr;
+        if (castedThis->version_db)
+            castedThis->version_db->statements.removeFirst(castedThis);
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
@@ -2846,6 +2872,7 @@ JSSQLStatement::~JSSQLStatement()
 {
     if (this->stmt) {
         sqlite3_finalize(this->stmt);
+        this->stmt = nullptr;
     }
 
     if (auto* columnNames = this->columnNames.get()) {
@@ -2854,6 +2881,7 @@ JSSQLStatement::~JSSQLStatement()
     }
 
     if (this->version_db) {
+        this->version_db->statements.removeFirst(this);
         this->version_db->release();
     }
 }

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -222,11 +222,7 @@ public:
     std::atomic<uint64_t> version;
     size_t reference_count;
 
-    // Every live JSSQLStatement prepared against this connection. Not owning:
-    // entries are added in JSSQLStatement::create, removed on finalize/destroy.
-    // close() walks this to finalize the underlying sqlite3_stmt so the handle
-    // can be released even when user code (or a library like drizzle) dropped a
-    // statement without finalizing it.
+    // Not owning; close() walks this to finalize every outstanding sqlite3_stmt.
     Vector<WebCore::JSSQLStatement*> statements;
 
     void release()
@@ -1865,9 +1861,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return JSValue::encode(jsUndefined());
     }
 
-    // A prepared statement keeps the sqlite3 connection alive until it is
-    // finalized, so release the ones handed out via db.prepare() whose JS
-    // wrappers are still around. Matches better-sqlite3's close().
+    // Finalize outstanding prepared statements, matching better-sqlite3's close().
     Vector<JSSQLStatement*> statements;
     statements.swap(versionDB->statements);
     for (auto* statement : statements) {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1566,16 +1566,16 @@ it("close() should NOT throw an error if the database is in use", () => {
 it("close(true) works after db.prepare()'d statements were dropped without finalize (drizzle-orm pattern)", () => {
   const db = new Database(":memory:");
   db.exec("CREATE TABLE t (a INTEGER)");
-  // drizzle-orm/bun-sqlite's session prepareQuery() does this: prepare a
-  // statement, run it, let the reference fall out of scope. The wrapper is not
-  // finalized until GC, which previously made sqlite3_close() report "database
-  // is locked".
+  let weak;
   (() => {
-    db.prepare("INSERT INTO t VALUES (?)").run(1);
+    const stmt = db.prepare("INSERT INTO t VALUES (?)");
+    weak = new WeakRef(stmt);
+    stmt.run(1);
   })();
   (() => {
     expect(db.prepare("SELECT * FROM t").all()).toEqual([{ a: 1 }]);
   })();
+  expect(weak.deref()).toBeDefined();
   expect(() => db.close(true)).not.toThrow();
 });
 
@@ -1589,6 +1589,37 @@ it("should dispose without throwing when a prepared statement is still live", ()
       prepared = db.prepare("SELECT * FROM foo");
     }
   }).not.toThrow();
+  expect(() => prepared.all()).toThrow("Statement has finalized");
+});
+
+it("`using db` does not mask a thrown error with SuppressedError", () => {
+  let caught;
+  try {
+    using db = new Database(":memory:");
+    db.prepare("select 1");
+    throw new Error("REAL-BUG");
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).not.toBeInstanceOf(SuppressedError);
+  expect(caught.message).toBe("REAL-BUG");
+});
+
+it("close() with a live prepare()'d statement releases the database file", () => {
+  const dir = tempDirWithFiles("sqlite-close-live-statement", { "empty.txt": "" });
+  const file = path.join(dir, "my.db");
+  const db = new Database(file);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
+  db.exec("CREATE TABLE foo (name TEXT)");
+  db.exec("INSERT INTO foo (name) VALUES ('foo')");
+  const prepared = db.prepare("SELECT * FROM foo");
+  expect(prepared.all()).toEqual([{ name: "foo" }]);
+  db.exec("PRAGMA wal_checkpoint(truncate)");
+
+  db.close();
+
+  expect(readdirSync(dir).sort()).toEqual(["empty.txt", "my.db"]);
   expect(() => prepared.all()).toThrow("Statement has finalized");
 });
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1543,13 +1543,13 @@ it("should close with WAL enabled", () => {
   expect(readdirSync(dir).sort()).toEqual(["empty.txt", "my.db"]);
 });
 
-it("close(true) should throw an error if the database is in use", () => {
+it("close(true) finalizes outstanding prepared statements", () => {
   const db = new Database(":memory:");
   db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
   db.exec("INSERT INTO foo (name) VALUES ('foo')");
   const prepared = db.prepare("SELECT * FROM foo");
-  expect(() => db.close(true)).toThrow("database is locked");
-  prepared.finalize();
+  expect(() => db.close(true)).not.toThrow();
+  expect(() => prepared.all()).toThrow("Statement has finalized");
   expect(() => db.close(true)).not.toThrow();
 });
 
@@ -1558,19 +1558,38 @@ it("close() should NOT throw an error if the database is in use", () => {
   db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
   db.exec("INSERT INTO foo (name) VALUES ('foo')");
   const prepared = db.prepare("SELECT * FROM foo");
-  expect(() => db.close()).not.toThrow("database is locked");
+  expect(() => db.close()).not.toThrow();
+  expect(() => prepared.all()).toThrow("Statement has finalized");
 });
 
-it("should dispose AND throw an error if the database is in use", () => {
+// https://github.com/oven-sh/bun/issues/11418
+it("close(true) works after db.prepare()'d statements were dropped without finalize (drizzle-orm pattern)", () => {
+  const db = new Database(":memory:");
+  db.exec("CREATE TABLE t (a INTEGER)");
+  // drizzle-orm/bun-sqlite's session prepareQuery() does this: prepare a
+  // statement, run it, let the reference fall out of scope. The wrapper is not
+  // finalized until GC, which previously made sqlite3_close() report "database
+  // is locked".
+  (() => {
+    db.prepare("INSERT INTO t VALUES (?)").run(1);
+  })();
+  (() => {
+    expect(db.prepare("SELECT * FROM t").all()).toEqual([{ a: 1 }]);
+  })();
+  expect(() => db.close(true)).not.toThrow();
+});
+
+it("should dispose without throwing when a prepared statement is still live", () => {
+  let prepared;
   expect(() => {
-    let prepared;
     {
       using db = new Database(":memory:");
       db.exec("CREATE TABLE foo (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
       db.exec("INSERT INTO foo (name) VALUES ('foo')");
       prepared = db.prepare("SELECT * FROM foo");
     }
-  }).toThrow("database is locked");
+  }).not.toThrow();
+  expect(() => prepared.all()).toThrow("Statement has finalized");
 });
 
 it("should dispose", () => {
@@ -1664,11 +1683,13 @@ it("#13082", async () => {
       return stmt;
     })();
     Bun.gc(true);
-    await Bun.sleep(100);
+    await Bun.sleep(1);
     Bun.gc(true);
-    stmt.all();
-    stmt.get();
-    stmt.run();
+    // close() finalizes outstanding statements, so these throw rather than
+    // reading the closed database. The original bug was a segfault here.
+    expect(() => stmt.all()).toThrow("Statement has finalized");
+    expect(() => stmt.get()).toThrow("Statement has finalized");
+    expect(() => stmt.run()).toThrow("Statement has finalized");
   }
 
   const count = 100;
@@ -1677,7 +1698,8 @@ it("#13082", async () => {
     runs[i] = run();
   }
 
-  await Promise.allSettled(runs);
+  const results = await Promise.allSettled(runs);
+  for (const r of results) expect(r.status).toBe("fulfilled");
 });
 
 // The internal SQL.run / SQL.prepare / SQL.isInTransaction helpers used to


### PR DESCRIPTION
## Repro

```js
import { Database } from "bun:sqlite";

const db = new Database(":memory:");
db.exec("CREATE TABLE t (a INTEGER)");

// What drizzle-orm/bun-sqlite's session does for every query:
(() => { db.prepare("INSERT INTO t VALUES (?)").run(1); })();
(() => { db.prepare("SELECT * FROM t").all(); })();

db.close(true); // throws: database is locked
```

The statement wrappers fell out of scope but have not been garbage collected, so their `sqlite3_stmt*` is still live when `sqlite3_close()` runs and it reports `SQLITE_BUSY`. The original report (#11418) hit this via `drizzle-orm/bun-sqlite/migrator`, which prepares a statement per migration query.

## Cause

`Database#close` only finalized the query cache (`db.query()` results) and the `db.transaction()` controller statements (#27202). Statements returned from `db.prepare()` are not tracked anywhere on the JS side, so `close(true)` routed straight to `sqlite3_close()` with unfinalized statements outstanding.

## Fix

`VersionSqlite3` now records every `JSSQLStatement` prepared against it. `close()` (both the `sqlite3_close` and `sqlite3_close_v2` paths) walks that set and finalizes each statement before closing the connection, which is what better-sqlite3's `Database#close` does. Using a statement after its database was closed throws `Statement has finalized`, the same error `stmt.finalize()` already produced.

The garbage-collection path is unchanged: a database whose JS object is collected while statements are still reachable keeps the connection open through `VersionSqlite3`'s refcount until the last statement is finalized (`can continue to use existing statements after database has been GC'd` still covers this).

This supersedes the behavior asserted by the previous `close(true) should throw an error if the database is in use` and `should dispose AND throw an error if the database is in use` tests; those now assert the statement is finalized rather than that `close` throws.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/sqlite/sqlite.test.js -t "drizzle-orm pattern"
(fail) close(true) works after db.prepare()'d statements were dropped without finalize (drizzle-orm pattern)
  Error message: "database is locked"

$ bun bd test test/js/bun/sqlite/sqlite.test.js
 99 pass
 0 fail
```

Fixes #11418

## Related

#33307 adds the same statement tracking for `close(false)` but keeps `close(true)` throwing; this PR finalizes in both paths so the drizzle case works. #34122 routes `[Symbol.dispose]` to `close(false)`, which this PR also makes unnecessary since `close(true)` no longer throws for live prepared statements.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sqlite/sqlite.test.js

<!-- robobun:evidence:end -->