### PR TITLE
test(coverage): print every entry in the text reporter's "Uncovered Line #s" column

### DIFF
--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -230,9 +230,6 @@ pub mod text {
         executable_lines_that_havent_been_executed.set_intersection(&report.executable_lines);
 
         let mut iter = executable_lines_that_havent_been_executed.iterator::<true, true>();
-        let mut start_of_line_range: usize = 0;
-        let mut prev_line: usize = 0;
-        let mut is_first = true;
 
         // `concat!(pretty_fmt!(..), "{}")` requires a literal; split into a
         // prefix `write_all` + plain `write!` so the const-generic `ENABLE_COLORS` can
@@ -240,49 +237,44 @@ pub mod text {
         let red = pretty_fmt::<ENABLE_COLORS>("<red>");
         let comma = pretty_fmt::<ENABLE_COLORS>("<r><d>,<r>");
 
-        while let Some(next_line) = iter.next() {
-            if next_line == (prev_line + 1) {
-                prev_line = next_line;
-                continue;
-            } else if is_first && start_of_line_range == 0 && prev_line == 0 {
-                start_of_line_range = next_line;
-                prev_line = next_line;
-                continue;
+        // Inclusive [start, end] of the current run of consecutive uncovered lines.
+        let mut pending: Option<(usize, usize)> = None;
+        let mut is_first = true;
+        while let Some(line) = iter.next() {
+            match pending {
+                Some((start, end)) if line == end + 1 => pending = Some((start, line)),
+                Some((start, end)) => {
+                    write_line_range(writer, &mut is_first, &red, &comma, start, end)?;
+                    pending = Some((line, line));
+                }
+                None => pending = Some((line, line)),
             }
-
-            if is_first {
-                is_first = false;
-            } else {
-                writer.write_all(&comma)?;
-            }
-
-            if start_of_line_range == prev_line {
-                writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
-            } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
-            }
-
-            prev_line = next_line;
-            start_of_line_range = next_line;
         }
-
-        if prev_line != start_of_line_range {
-            if is_first {
-            } else {
-                writer.write_all(&comma)?;
-            }
-
-            if start_of_line_range == prev_line {
-                writer.write_all(&red)?;
-                write!(writer, "{}", start_of_line_range + 1)?;
-            } else {
-                writer.write_all(&red)?;
-                write!(writer, "{}-{}", start_of_line_range + 1, prev_line + 1)?;
-            }
+        if let Some((start, end)) = pending {
+            write_line_range(writer, &mut is_first, &red, &comma, start, end)?;
         }
         Ok(())
+    }
+
+    fn write_line_range(
+        writer: &mut impl bun_io::Write,
+        is_first: &mut bool,
+        red: &[u8],
+        comma: &[u8],
+        start: usize,
+        end: usize,
+    ) -> bun_io::Result<()> {
+        if *is_first {
+            *is_first = false;
+        } else {
+            writer.write_all(comma)?;
+        }
+        writer.write_all(red)?;
+        if start == end {
+            write!(writer, "{}", start + 1)
+        } else {
+            write!(writer, "{}-{}", start + 1, end + 1)
+        }
     }
 }
 

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -99,14 +99,25 @@ test("coverage text reporter prints every uncovered line", () => {
   return "ok";
 }
 `,
+    // the old sentinel couldn't tell bit index 0 apart from "no run yet"; line 1 (and 4) were lost.
+    "line1.ts": `export function miss(): never {
+  throw new Error("a");
+}
+export function also(): never {
+  throw new Error("b");
+}
+export function ok2() { return "ok"; }
+`,
     "demo.test.ts": `import { test, expect } from "bun:test";
 import { check } from "./many";
 import { only } from "./one";
 import { mix } from "./mix";
+import { ok2 } from "./line1";
 test("paths", () => {
   expect(check(0)).toBe("ok");
   expect(only(1)).toBe("ok");
   expect(mix(2)).toBe("ok");
+  expect(ok2()).toBe("ok");
 });
 `,
   });
@@ -121,7 +132,8 @@ test("paths", () => {
   const table = stderr.split("\n").filter(l => l.includes(" | "));
   expect(normalizeBunSnapshot(table.join("\n"), dir)).toMatchInlineSnapshot(`
 "File       | % Funcs | % Lines | Uncovered Line #s
-All files  |  100.00 |   74.24 |
+All files  |   83.33 |   70.68 |
+ line1.ts  |   33.33 |   60.00 | 1,4
  many.ts   |  100.00 |   72.73 | 3,6,9
  mix.ts    |  100.00 |   70.00 | 3-4,8
  one.ts    |  100.00 |   80.00 | 3"

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -57,6 +57,78 @@ export class Y {
   );
 });
 
+// https://github.com/oven-sh/bun/issues/9008
+// The text reporter would show "% Lines" < 100% but leave "Uncovered Line #s" empty (or
+// truncated) because its run-tracker used 0 as a sentinel and only flushed the trailing
+// pending run when it was a multi-line range.
+test("coverage text reporter prints every uncovered line", () => {
+  const dir = tempDirWithFiles("cov", {
+    "bunfig.toml": `[test]\ncoverageSkipTestFiles = true\n`,
+    // three non-adjacent uncovered lines (3, 6, 9): previously the trailing one was dropped.
+    "many.ts": `export function check(n: number): string {
+  if (n === 1) {
+    throw new Error("one");
+  }
+  if (n === 2) {
+    throw new Error("two");
+  }
+  if (n === 3) {
+    throw new Error("three");
+  }
+  return "ok";
+}
+`,
+    // exactly one uncovered line (3): previously the column was blank.
+    "one.ts": `export function only(n: number): string {
+  if (n < 0) {
+    throw new Error("negative");
+  }
+  return "ok";
+}
+`,
+    // a run followed by an isolated line (3-4, then 8).
+    "mix.ts": `export function mix(n: number): string {
+  if (n === 1) {
+    n += 1;
+    throw new Error("a");
+  }
+  const x = n * 2;
+  if (x === -1) {
+    throw new Error("b");
+  }
+  return "ok";
+}
+`,
+    "demo.test.ts": `import { test, expect } from "bun:test";
+import { check } from "./many";
+import { only } from "./one";
+import { mix } from "./mix";
+test("paths", () => {
+  expect(check(0)).toBe("ok");
+  expect(only(1)).toBe("ok");
+  expect(mix(2)).toBe("ok");
+});
+`,
+  });
+
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage"], {
+    cwd: dir,
+    env: bunEnv,
+    stdio: [null, null, "pipe"],
+  });
+
+  let stderr = result.stderr.toString("utf-8");
+  const table = stderr.split("\n").filter(l => l.includes(" | "));
+  expect(normalizeBunSnapshot(table.join("\n"), dir)).toMatchInlineSnapshot(`
+"File       | % Funcs | % Lines | Uncovered Line #s
+All files  |  100.00 |   74.24 |
+ many.ts   |  100.00 |   72.73 | 3,6,9
+ mix.ts    |  100.00 |   70.00 | 3-4,8
+ one.ts    |  100.00 |   80.00 | 3"
+`);
+  expect(result.exitCode).toBe(0);
+});
+
 test("coverage excludes node_modules directory", () => {
   const dir = tempDirWithFiles("cov", {
     "node_modules/pi/index.js": `
@@ -193,7 +265,7 @@ test("should call only some functions", () => {
 File           | % Funcs | % Lines | Uncovered Line #s
 ---------------|---------|---------|-------------------
 All files      |   75.00 |   83.33 |
- include-me.ts |   50.00 |   66.67 | 
+ include-me.ts |   50.00 |   66.67 | 6
  test.test.ts  |  100.00 |  100.00 | 
 ---------------|---------|---------|-------------------
 


### PR DESCRIPTION
Fixes #9008.

### Repro

```ts
// target.ts
export function only(n: number): string {
  if (n < 0) {
    throw new Error("negative");   // never hit
  }
  return "ok";
}
```

```console
$ bun test --coverage
File       | % Funcs | % Lines | Uncovered Line #s
 target.ts |  100.00 |   80.00 |
```

80% lines, but the column is blank. With several non-adjacent uncovered lines the last one is silently dropped (e.g. lines 3, 6, 9 uncovered prints `3,6`; a `3-4` range followed by a lone 8 prints `3-4`). This is exactly what the reporter in #9008 saw: `parse-fen.ts | 100.00 | 98.95 |` with nothing after the bar. The lcov reporter already gets it right (`DA:112,0`), so this is purely a formatting bug in the text table.

### Cause

`text::write_format` in `src/sourcemap_jsc/CodeCoverage.rs` collapses consecutive uncovered line indices into `start-end` runs. It tracked the pending run with sentinel zeros (`start_of_line_range == 0 && prev_line == 0` meaning "no run yet") and its post-loop flush was gated on `prev_line != start_of_line_range`:

- A trailing single-line run has `start == prev`, so the flush skips it. Since the loop only emits a run when the *next* non-adjacent line arrives, the last run is always left to the post-loop flush; when it's a single line, it disappears.
- The sentinel also can't tell "no run" apart from "line index 0 pending", so the first source line can be lost too.

### Fix

Track the pending run as `Option<(usize, usize)>` and always flush it after the loop (single line or range). The `--parallel` reporter already worked this way; this aligns the serial path with it.

### Verification

New test in `test/cli/test/coverage.test.ts` covers a lone uncovered line, three isolated lines, and a range followed by a single line:

| | before | after |
|---|---|---|
| many.ts (3,6,9 uncovered) | `3,6` | `3,6,9` |
| mix.ts (3-4,8 uncovered) | `3-4` | `3-4,8` |
| one.ts (3 uncovered) | *(blank)* | `3` |

One existing inline snapshot (`coveragePathIgnorePatterns - partial coverage without nan`) is updated: it had captured the buggy empty column for an uncalled single-line function and now correctly shows `| 6`. On the original #9008 repro, `parse-fen.ts` now shows `| 112` and `object.ts` shows `| 19,23,27` (was `19,23`).

Overlaps with the text-reporter portion of #32849 / #31485, which bundle this alongside larger coverage changes; this PR is the minimal fix for just the column formatting so #9008 can close independently.