### PR TITLE
Load workspace root .env from package subdirectories

### DIFF
--- a/docs/runtime/environment-variables.mdx
+++ b/docs/runtime/environment-variables.mdx
@@ -13,6 +13,8 @@ Bun reads the following files automatically (listed in order of increasing prece
 - `.env.production`, `.env.development`, `.env.test` (depending on the value of `NODE_ENV`)
 - `.env.local`
 
+In a monorepo using [workspaces](/install/workspaces), the same set of files is also loaded from the workspace root when running from a package subdirectory. Values from the package's own `.env` files take precedence over the root's.
+
 ```ini .env icon="settings"
 FOO=hello
 BAR=world

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -815,15 +815,12 @@ impl<'a> Transpiler<'a> {
                 // shared config. Skip when `--env-file` was passed or when
                 // default loading is disabled (same gating as cwd defaults).
                 if env_files.is_empty() && !skip_default_env {
-                    if let Some(root_dir) = Self::workspace_root_dir_entry(
-                        dir_info,
-                        dir.dir,
-                        self.resolver.generation,
-                    ) {
+                    if let Some(root_dir) =
+                        Self::workspace_root_dir_entry(dir_info, dir.dir, self.resolver.generation)
+                    {
                         // SAFETY: BSSMap singleton owns `*root_dir`;
                         // single-threaded path, sole `&mut` for the call.
-                        let root_dir: &mut bun_resolver::fs::DirEntry =
-                            unsafe { &mut *root_dir };
+                        let root_dir: &mut bun_resolver::fs::DirEntry = unsafe { &mut *root_dir };
                         env.load_workspace_root_defaults(suffix, root_dir)?;
                     }
                 }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -711,6 +711,36 @@ impl<'a> Transpiler<'a> {
         self.configure_linker_with_auto_jsx(true);
     }
 
+    /// Walk `start`'s parent chain to find the nearest ancestor whose
+    /// `package.json` declares `"workspaces"`, returning that directory's
+    /// entries. Returns `None` if no such ancestor exists, or if it is the
+    /// same directory we already loaded from (`skip_dir`).
+    fn workspace_root_dir_entry(
+        start: bun_resolver::DirInfoRef,
+        skip_dir: &[u8],
+        generation: bun_core::Generation,
+    ) -> Option<*mut bun_resolver::fs::DirEntry> {
+        let mut dir_info = Some(start);
+        while let Some(info) = dir_info {
+            if info.is_inside_node_modules() || info.is_node_modules() {
+                return None;
+            }
+            if let Some(pkg) = info.package_json() {
+                if pkg.has_workspaces {
+                    let entries = info.get_entries(generation)?;
+                    // SAFETY: BSSMap singleton owns `*entries`; read-only use
+                    // of `.dir` here, with no other live `&mut` to this slot.
+                    if unsafe { (*entries).dir } == skip_dir {
+                        return None;
+                    }
+                    return Some(entries);
+                }
+            }
+            dir_info = info.get_parent();
+        }
+        None
+    }
+
     /// Load `.env` files into the env loader according to
     /// `options.env.behavior`.
     pub fn run_env_loader(&mut self, skip_default_env: bool) -> crate::Result<()> {
@@ -779,6 +809,24 @@ impl<'a> Transpiler<'a> {
                     dot_env::DotEnvFileSuffix::Development
                 };
                 env.load(dir, &env_files, suffix, skip_default_env)?;
+
+                // When cwd is inside a workspace, also load the workspace
+                // root's `.env*` at lower priority so monorepo packages see
+                // shared config. Skip when `--env-file` was passed or when
+                // default loading is disabled (same gating as cwd defaults).
+                if env_files.is_empty() && !skip_default_env {
+                    if let Some(root_dir) = Self::workspace_root_dir_entry(
+                        dir_info,
+                        dir.dir,
+                        self.resolver.generation,
+                    ) {
+                        // SAFETY: BSSMap singleton owns `*root_dir`;
+                        // single-threaded path, sole `&mut` for the call.
+                        let root_dir: &mut bun_resolver::fs::DirEntry =
+                            unsafe { &mut *root_dir };
+                        env.load_workspace_root_defaults(suffix, root_dir)?;
+                    }
+                }
             }
             DotEnvBehavior::disable => {
                 env.load_process()?;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -711,15 +711,13 @@ impl<'a> Transpiler<'a> {
         self.configure_linker_with_auto_jsx(true);
     }
 
-    /// Walk `start`'s parent chain to find the nearest ancestor whose
-    /// `package.json` declares `"workspaces"`, returning that directory's
-    /// entries. Returns `None` if no such ancestor exists, or if it is the
-    /// same directory we already loaded from (`skip_dir`).
+    /// Nearest ancestor whose `package.json` declares `"workspaces"`, skipping
+    /// `skip_dir` and anything under `node_modules`.
     fn workspace_root_dir_entry(
         start: bun_resolver::DirInfoRef,
         skip_dir: &[u8],
         generation: bun_core::Generation,
-    ) -> Option<*mut bun_resolver::fs::DirEntry> {
+    ) -> Option<&'static bun_resolver::fs::DirEntry> {
         let mut dir_info = Some(start);
         while let Some(info) = dir_info {
             if info.is_inside_node_modules() || info.is_node_modules() {
@@ -727,10 +725,8 @@ impl<'a> Transpiler<'a> {
             }
             if let Some(pkg) = info.package_json() {
                 if pkg.has_workspaces {
-                    let entries = info.get_entries(generation)?;
-                    // SAFETY: BSSMap singleton owns `*entries`; read-only use
-                    // of `.dir` here, with no other live `&mut` to this slot.
-                    if unsafe { (*entries).dir } == skip_dir {
+                    let entries = info.get_entries_ref(generation)?;
+                    if entries.dir == skip_dir {
                         return None;
                     }
                     return Some(entries);
@@ -785,16 +781,9 @@ impl<'a> Transpiler<'a> {
                     merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
                 }
 
-                let Some(dir) = dir_info.get_entries(self.resolver.generation) else {
+                let Some(dir) = dir_info.get_entries_ref(self.resolver.generation) else {
                     return Ok(());
                 };
-                // `get_entries` returns `*mut bun_resolver::fs::DirEntry`
-                // (BSSMap-owned). `dot_env::Loader::load` takes
-                // `impl DirEntryProbe` (bun_dotenv sits below `bun_resolver`
-                // in the crate graph); `bun_resolver::fs::DirEntry` impls it.
-                // SAFETY: BSSMap singleton owns `*dir`; single-threaded path —
-                // sole `&mut` for the call.
-                let dir: &mut bun_resolver::fs::DirEntry = unsafe { &mut *dir };
 
                 // `Env.files: Box<[Box<[u8]>]>` but `Loader::load`
                 // wants `&[&[u8]]`. Re-borrow into a small Vec; the explicit
@@ -810,17 +799,12 @@ impl<'a> Transpiler<'a> {
                 };
                 env.load(dir, &env_files, suffix, skip_default_env)?;
 
-                // When cwd is inside a workspace, also load the workspace
-                // root's `.env*` at lower priority so monorepo packages see
-                // shared config. Skip when `--env-file` was passed or when
-                // default loading is disabled (same gating as cwd defaults).
+                // Default-load path only: fall back to the workspace root's
+                // `.env*` at lower priority (issue #11190).
                 if env_files.is_empty() && !skip_default_env {
                     if let Some(root_dir) =
                         Self::workspace_root_dir_entry(dir_info, dir.dir, self.resolver.generation)
                     {
-                        // SAFETY: BSSMap singleton owns `*root_dir`;
-                        // single-threaded path, sole `&mut` for the call.
-                        let root_dir: &mut bun_resolver::fs::DirEntry = unsafe { &mut *root_dir };
                         env.load_workspace_root_defaults(suffix, root_dir)?;
                     }
                 }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -21,6 +21,29 @@ pub enum DotEnvFileSuffix {
     Test,
 }
 
+impl DotEnvFileSuffix {
+    /// Auto-loaded `.env*` filenames, highest priority first. `.env.local` is
+    /// omitted under `bun test` so committed test env is not overridden by a
+    /// developer's local file.
+    pub const fn default_filenames(self) -> &'static [&'static [u8]] {
+        match self {
+            Self::Development => &[
+                b".env.development.local",
+                b".env.local",
+                b".env.development",
+                b".env",
+            ],
+            Self::Production => &[
+                b".env.production.local",
+                b".env.local",
+                b".env.production",
+                b".env",
+            ],
+            Self::Test => &[b".env.test.local", b".env.test", b".env"],
+        }
+    }
+}
+
 /// Directory-entry probe used by `Loader::load`. `bun_dotenv` sits below
 /// `bun_resolver` in the crate graph, so the concrete
 /// `bun_resolver::fs::DirEntry` is taken generically; the only operation
@@ -673,10 +696,6 @@ impl Loader {
         Ok(())
     }
 
-    // .env.local goes first
-    // Load .env.development if development
-    // Load .env.production if !development
-    // .env goes last
     fn load_default_files<D: DirEntryProbe + ?Sized>(
         &mut self,
         suffix: DotEnvFileSuffix,
@@ -684,47 +703,15 @@ impl Loader {
         value_buffer: &mut Vec<u8>,
     ) -> crate::Result<()> {
         let dir_handle = bun_sys::Fd::cwd();
-
-        // `bun_dotenv` sits below `bun_resolver` in the crate graph, so the
-        // directory entry is taken generically — `bun_resolver::fs::DirEntry`
-        // impls `DirEntryProbe`.
-        match suffix {
-            DotEnvFileSuffix::Development => {
-                self.try_load_default(dir, dir_handle, b".env.development.local", value_buffer)?
-            }
-            DotEnvFileSuffix::Production => {
-                self.try_load_default(dir, dir_handle, b".env.production.local", value_buffer)?
-            }
-            DotEnvFileSuffix::Test => {
-                self.try_load_default(dir, dir_handle, b".env.test.local", value_buffer)?
-            }
+        for name in suffix.default_filenames() {
+            self.try_load_default(dir, dir_handle, name, value_buffer)?;
         }
-
-        if suffix != DotEnvFileSuffix::Test {
-            self.try_load_default(dir, dir_handle, b".env.local", value_buffer)?;
-        }
-
-        match suffix {
-            DotEnvFileSuffix::Development => {
-                self.try_load_default(dir, dir_handle, b".env.development", value_buffer)?
-            }
-            DotEnvFileSuffix::Production => {
-                self.try_load_default(dir, dir_handle, b".env.production", value_buffer)?
-            }
-            DotEnvFileSuffix::Test => {
-                self.try_load_default(dir, dir_handle, b".env.test", value_buffer)?
-            }
-        }
-
-        self.try_load_default(dir, dir_handle, b".env", value_buffer)
+        Ok(())
     }
 
-    /// Load the default `.env*` set from the workspace root, after
-    /// `load_default_files` has already populated from cwd. Values already set
-    /// (process env, cwd `.env*`) win. Files are tracked by absolute path in
-    /// `custom_files_loaded` so cwd and root `.env` can both contribute.
-    ///
-    /// See https://github.com/oven-sh/bun/issues/11190.
+    /// Load [`DotEnvFileSuffix::default_filenames`] from the workspace root
+    /// after cwd has already been loaded. Existing values win; root files are
+    /// tracked by absolute path in `custom_files_loaded`. See issue #11190.
     pub fn load_workspace_root_defaults<D: DirEntryProbe + ?Sized>(
         &mut self,
         suffix: DotEnvFileSuffix,
@@ -733,91 +720,22 @@ impl Loader {
         let mut value_buffer: Vec<u8> = Vec::new();
         let mut path_buf = bun_paths::path_buffer_pool::get();
         let dir_path = dir.dir();
-
-        match suffix {
-            DotEnvFileSuffix::Development => self.try_load_workspace_root(
-                dir,
-                dir_path,
-                b".env.development.local",
-                &mut path_buf,
-                &mut value_buffer,
-            )?,
-            DotEnvFileSuffix::Production => self.try_load_workspace_root(
-                dir,
-                dir_path,
-                b".env.production.local",
-                &mut path_buf,
-                &mut value_buffer,
-            )?,
-            DotEnvFileSuffix::Test => self.try_load_workspace_root(
-                dir,
-                dir_path,
-                b".env.test.local",
-                &mut path_buf,
-                &mut value_buffer,
-            )?,
-        }
-
-        if suffix != DotEnvFileSuffix::Test {
-            self.try_load_workspace_root(
-                dir,
-                dir_path,
-                b".env.local",
-                &mut path_buf,
-                &mut value_buffer,
-            )?;
-        }
-
-        match suffix {
-            DotEnvFileSuffix::Development => self.try_load_workspace_root(
-                dir,
-                dir_path,
-                b".env.development",
-                &mut path_buf,
-                &mut value_buffer,
-            )?,
-            DotEnvFileSuffix::Production => self.try_load_workspace_root(
-                dir,
-                dir_path,
-                b".env.production",
-                &mut path_buf,
-                &mut value_buffer,
-            )?,
-            DotEnvFileSuffix::Test => self.try_load_workspace_root(
-                dir,
-                dir_path,
-                b".env.test",
-                &mut path_buf,
-                &mut value_buffer,
-            )?,
-        }
-
-        self.try_load_workspace_root(dir, dir_path, b".env", &mut path_buf, &mut value_buffer)
-    }
-
-    #[inline]
-    fn try_load_workspace_root<D: DirEntryProbe + ?Sized>(
-        &mut self,
-        dir: &D,
-        dir_path: &[u8],
-        name: &'static [u8],
-        path_buf: &mut PathBuffer,
-        value_buffer: &mut Vec<u8>,
-    ) -> crate::Result<()> {
-        if dir.has_comptime_query(name) {
+        for name in suffix.default_filenames() {
+            if !dir.has_comptime_query(name) {
+                continue;
+            }
             let joined = bun_paths::resolve_path::join_string_buf::<bun_paths::platform::Auto>(
                 &mut path_buf[..],
                 &[dir_path, name],
             );
-            self.load_env_file_dynamic::<false>(joined, value_buffer)?;
+            self.load_env_file_dynamic::<false>(joined, &mut value_buffer)?;
             analytics::Features::dotenv_inc();
         }
         Ok(())
     }
 
     /// Probe `dir` for a known `.env*` filename and, if present, load it into
-    /// its dedicated slot and bump the analytics counter. Shared body for the
-    /// eight call sites in `load_default_files`.
+    /// its dedicated slot and bump the analytics counter.
     #[inline]
     fn try_load_default<D: DirEntryProbe + ?Sized>(
         &mut self,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -30,6 +30,8 @@ pub enum DotEnvFileSuffix {
 pub trait DirEntryProbe {
     /// The argument MUST already be ASCII-lowercase.
     fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool;
+    /// Absolute path of this directory.
+    fn dir(&self) -> &[u8];
 }
 
 // LAYERING: the concrete `DirEntry` lives in `bun_resolver::fs` (higher tier,
@@ -715,6 +717,102 @@ impl Loader {
         }
 
         self.try_load_default(dir, dir_handle, b".env", value_buffer)
+    }
+
+    /// Load the default `.env*` set from the workspace root, after
+    /// `load_default_files` has already populated from cwd. Values already set
+    /// (process env, cwd `.env*`) win. Files are tracked by absolute path in
+    /// `custom_files_loaded` so cwd and root `.env` can both contribute.
+    ///
+    /// See https://github.com/oven-sh/bun/issues/11190.
+    pub fn load_workspace_root_defaults<D: DirEntryProbe + ?Sized>(
+        &mut self,
+        suffix: DotEnvFileSuffix,
+        dir: &D,
+    ) -> crate::Result<()> {
+        let mut value_buffer: Vec<u8> = Vec::new();
+        let mut path_buf = bun_paths::path_buffer_pool::get();
+        let dir_path = dir.dir();
+
+        match suffix {
+            DotEnvFileSuffix::Development => self.try_load_workspace_root(
+                dir,
+                dir_path,
+                b".env.development.local",
+                &mut path_buf,
+                &mut value_buffer,
+            )?,
+            DotEnvFileSuffix::Production => self.try_load_workspace_root(
+                dir,
+                dir_path,
+                b".env.production.local",
+                &mut path_buf,
+                &mut value_buffer,
+            )?,
+            DotEnvFileSuffix::Test => self.try_load_workspace_root(
+                dir,
+                dir_path,
+                b".env.test.local",
+                &mut path_buf,
+                &mut value_buffer,
+            )?,
+        }
+
+        if suffix != DotEnvFileSuffix::Test {
+            self.try_load_workspace_root(
+                dir,
+                dir_path,
+                b".env.local",
+                &mut path_buf,
+                &mut value_buffer,
+            )?;
+        }
+
+        match suffix {
+            DotEnvFileSuffix::Development => self.try_load_workspace_root(
+                dir,
+                dir_path,
+                b".env.development",
+                &mut path_buf,
+                &mut value_buffer,
+            )?,
+            DotEnvFileSuffix::Production => self.try_load_workspace_root(
+                dir,
+                dir_path,
+                b".env.production",
+                &mut path_buf,
+                &mut value_buffer,
+            )?,
+            DotEnvFileSuffix::Test => self.try_load_workspace_root(
+                dir,
+                dir_path,
+                b".env.test",
+                &mut path_buf,
+                &mut value_buffer,
+            )?,
+        }
+
+        self.try_load_workspace_root(dir, dir_path, b".env", &mut path_buf, &mut value_buffer)
+    }
+
+    #[inline]
+    fn try_load_workspace_root<D: DirEntryProbe + ?Sized>(
+        &mut self,
+        dir: &D,
+        dir_path: &[u8],
+        name: &'static [u8],
+        path_buf: &mut PathBuffer,
+        value_buffer: &mut Vec<u8>,
+    ) -> crate::Result<()> {
+        if dir.has_comptime_query(name) {
+            let joined = bun_paths::resolve_path::join_string_buf::<bun_paths::platform::Auto>(
+                &mut path_buf[..],
+                &[dir_path, name],
+            );
+            self.load_env_file_dynamic::<false>(joined, value_buffer)?;
+            analytics::Features::dotenv_inc();
+        }
+        Ok(())
     }
 
     /// Probe `dir` for a known `.env*` filename and, if present, load it into

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -763,6 +763,10 @@ impl bun_dotenv::DirEntryProbe for DirEntry {
     fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool {
         DirEntry::has_comptime_query(self, query_lower)
     }
+    #[inline]
+    fn dir(&self) -> &[u8] {
+        self.dir
+    }
 }
 
 // pub fn statBatch(fs: *FileSystemEntry, paths: []string) ![]?Stat {

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -86,6 +86,10 @@ pub struct PackageJSON {
     pub scripts: Option<Box<ScriptsMap>>,
     // Values borrow the source buffer (lifetime-erased; owned by `source_contents`).
     pub config: Option<Box<StringArrayHashMap<&'static [u8]>>>,
+    /// True when this package.json declares `"workspaces"` (array, or object
+    /// with a `"packages"` array). The resolver does not expand the globs;
+    /// this is only used to locate the monorepo root for `.env` loading.
+    pub has_workspaces: bool,
 
     pub arch: Architecture,
     pub os: OperatingSystem,
@@ -143,6 +147,7 @@ impl Default for PackageJSON {
             version: Box::default(),
             scripts: None,
             config: None,
+            has_workspaces: false,
             arch: Architecture::all(),
             os: OperatingSystem::all(),
             package_manager_package_id: INVALID_PACKAGE_ID,
@@ -520,6 +525,7 @@ impl PackageJSON {
             main_fields: MainFieldMap::default(),
             scripts: None,
             config: None,
+            has_workspaces: false,
             arch: Architecture::all(),
             os: OperatingSystem::all(),
             package_manager_package_id: INVALID_PACKAGE_ID,
@@ -585,6 +591,17 @@ impl PackageJSON {
                     b"The value for \"type\" must be a string",
                 );
             }
+        }
+
+        if let Some(workspaces_json) = json.as_property(b"workspaces") {
+            package_json.has_workspaces = match workspaces_json.expr.data {
+                js_ast::ExprData::EArrayJSON(_) => true,
+                js_ast::ExprData::EObjectJSON(obj) => matches!(
+                    (*obj).get(b"packages"),
+                    Some(js_ast::e::JsonValue::Array(_))
+                ),
+                _ => false,
+            };
         }
 
         // Read the "main" fields

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -86,9 +86,7 @@ pub struct PackageJSON {
     pub scripts: Option<Box<ScriptsMap>>,
     // Values borrow the source buffer (lifetime-erased; owned by `source_contents`).
     pub config: Option<Box<StringArrayHashMap<&'static [u8]>>>,
-    /// True when this package.json declares `"workspaces"` (array, or object
-    /// with a `"packages"` array). The resolver does not expand the globs;
-    /// this is only used to locate the monorepo root for `.env` loading.
+    /// Set when `"workspaces"` is an array or `{ "packages": [...] }`.
     pub has_workspaces: bool,
 
     pub arch: Architecture,

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1038,6 +1038,146 @@ test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permis
   }
 });
 
+// https://github.com/oven-sh/bun/issues/11190
+// https://github.com/oven-sh/bun/issues/10358
+describe.concurrent("workspace root .env is loaded from a subdirectory", () => {
+  const print = `console.log(JSON.stringify({
+    LOCAL: process.env.LOCAL ?? null,
+    ROOT_ONLY: process.env.ROOT_ONLY ?? null,
+    SHARED: process.env.SHARED ?? null,
+  }))`;
+
+  test("bun <file> from a workspace package loads root .env", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env": "ROOT_ONLY=root\nSHARED=root\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/.env": "LOCAL=local\nSHARED=local\n",
+      "packages/app/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/packages/app/index.ts`);
+    // local .env wins for SHARED; root .env fills in ROOT_ONLY
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: "local", ROOT_ONLY: "root", SHARED: "local" });
+  });
+
+  test("workspace package without its own .env sees root .env", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env": "ROOT_ONLY=root\nSHARED=root\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/packages/app/index.ts`);
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: "root", SHARED: "root" });
+  });
+
+  test('"workspaces": { "packages": [...] } object form', () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: { packages: ["packages/*"] } }),
+      ".env": "ROOT_ONLY=root\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/packages/app/index.ts`);
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: "root", SHARED: null });
+  });
+
+  test("root .env.development / .env.production follow NODE_ENV", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env.development": "ROOT_ONLY=dev\n",
+      ".env.production": "ROOT_ONLY=prod\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/index.ts": print,
+    });
+    expect(JSON.parse(bunRun(`${dir}/packages/app/index.ts`).stdout)).toEqual({
+      LOCAL: null,
+      ROOT_ONLY: "dev",
+      SHARED: null,
+    });
+    expect(JSON.parse(bunRun(`${dir}/packages/app/index.ts`, { NODE_ENV: "production" }).stdout)).toEqual({
+      LOCAL: null,
+      ROOT_ONLY: "prod",
+      SHARED: null,
+    });
+  });
+
+  test("bun test from a workspace package loads root .env.test", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env": "SHARED=plain\n",
+      ".env.test": "ROOT_ONLY=from_test\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/index.test.ts": "console.log(process.env.ROOT_ONLY, process.env.SHARED);",
+    });
+    const { stdout } = bunTest(`${dir}/packages/app/index.test.ts`, {});
+    expect(stdout).toBe(`bun test ${Bun.version_with_sha}\n` + "from_test plain");
+  });
+
+  test("root .env is loaded through 'bun run' script indirection", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env": "ROOT_ONLY=root\n",
+      "packages/app/package.json": JSON.stringify({
+        name: "app",
+        scripts: { go: `'${bunExe()}' index.ts` },
+      }),
+      "packages/app/index.ts": print,
+    });
+    const { stdout } = bunRunAsScript(`${dir}/packages/app`, "go");
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: "root", SHARED: null });
+  });
+
+  test("process env still wins over root .env", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env": "ROOT_ONLY=root\nSHARED=root\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/packages/app/index.ts`, { SHARED: "process" });
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: "root", SHARED: "process" });
+  });
+
+  test("--env-file disables workspace root lookup", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env": "ROOT_ONLY=root\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/.env.custom": "LOCAL=custom\n",
+      "packages/app/index.ts": print,
+    });
+    const result = Bun.spawnSync([bunExe(), "--env-file=.env.custom", "index.ts"], {
+      cwd: `${dir}/packages/app`,
+      env: { ...bunEnv, NODE_ENV: undefined },
+    });
+    expect(JSON.parse(result.stdout.toString())).toEqual({ LOCAL: "custom", ROOT_ONLY: null, SHARED: null });
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("no workspace root means no ancestor .env is loaded", () => {
+    const dir = tempDirWithFiles("dotenv-no-ws", {
+      "package.json": JSON.stringify({ name: "root" }),
+      ".env": "ROOT_ONLY=root\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/packages/app/index.ts`);
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: null, SHARED: null });
+  });
+
+  test("node_modules does not walk up to workspace root", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env": "ROOT_ONLY=root\n",
+      "node_modules/pkg/package.json": JSON.stringify({ name: "pkg" }),
+      "node_modules/pkg/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/node_modules/pkg/index.ts`);
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: null, SHARED: null });
+  });
+});
+
 // `st_size` is only a hint (sparse file, writer racing the loader): the env
 // loader's whole-file read used to `reserve_exact` it and abort the process in
 // `handle_alloc_error` before any user code ran. It must surface as a

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1040,7 +1040,7 @@ test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permis
 
 // https://github.com/oven-sh/bun/issues/11190
 // https://github.com/oven-sh/bun/issues/10358
-describe.concurrent("workspace root .env is loaded from a subdirectory", () => {
+describe("workspace root .env is loaded from a subdirectory", () => {
   const print = `console.log(JSON.stringify({
     LOCAL: process.env.LOCAL ?? null,
     ROOT_ONLY: process.env.ROOT_ONLY ?? null,
@@ -1058,6 +1058,32 @@ describe.concurrent("workspace root .env is loaded from a subdirectory", () => {
     const { stdout } = bunRun(`${dir}/packages/app/index.ts`);
     // local .env wins for SHARED; root .env fills in ROOT_ONLY
     expect(JSON.parse(stdout)).toEqual({ LOCAL: "local", ROOT_ONLY: "root", SHARED: "local" });
+  });
+
+  test("package .env beats root .env.local and .env.development", () => {
+    const dir = tempDirWithFiles("dotenv-ws", {
+      "package.json": JSON.stringify({ name: "root", workspaces: ["packages/*"] }),
+      ".env.local": "SHARED=root-local\n",
+      ".env.development": "SHARED=root-dev\nROOT_ONLY=root-dev\n",
+      "packages/app/package.json": JSON.stringify({ name: "app" }),
+      "packages/app/.env": "SHARED=pkg\n",
+      "packages/app/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/packages/app/index.ts`);
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: "root-dev", SHARED: "pkg" });
+  });
+
+  test("stops at the nearest workspace root", () => {
+    const dir = tempDirWithFiles("dotenv-ws-nested", {
+      "package.json": JSON.stringify({ name: "outer", workspaces: ["packages/*"] }),
+      ".env": "ROOT_ONLY=outer\nSHARED=outer\n",
+      "packages/sub/package.json": JSON.stringify({ name: "inner", workspaces: ["apps/*"] }),
+      "packages/sub/.env": "SHARED=inner\n",
+      "packages/sub/apps/x/package.json": JSON.stringify({ name: "x" }),
+      "packages/sub/apps/x/index.ts": print,
+    });
+    const { stdout } = bunRun(`${dir}/packages/sub/apps/x/index.ts`);
+    expect(JSON.parse(stdout)).toEqual({ LOCAL: null, ROOT_ONLY: null, SHARED: "inner" });
   });
 
   test("workspace package without its own .env sees root .env", () => {


### PR DESCRIPTION
## What

When automatic `.env` loading runs from a workspace package directory, also load the same `.env*` set from the workspace root. The package's own files (and process env) still take precedence; the root only fills in whatever the package did not set.

## Repro

```sh
mkdir -p repo/packages/app && cd repo
cat > package.json <<'JSON'
{ "name": "root", "workspaces": ["packages/*"] }
JSON
echo 'DB_URL=postgres://root' > .env
cat > packages/app/package.json <<'JSON'
{ "name": "app" }
JSON
echo 'console.log(process.env.DB_URL)' > packages/app/index.ts

cd packages/app && bun index.ts
# before: undefined
# after:  postgres://root
```

Same applies to `bun --filter '*' <script>` and scripts that `cd packages/x && bun run ...`; the inner `bun` picks up the root `.env` from its own cwd.

## Cause

`run_env_loader` resolved the `DirInfo` for `top_level_dir` (the process cwd) and called `Loader::load` with that directory's entries only. There was no walk to the monorepo root. This was never implemented (not a regression in the loader itself), but it became visible once #9642 stopped `bun run <script>` from loading `.env` in the parent process, so scripts that `cd` into a package no longer inherited the root's values from the outer `bun run`.

## Fix

- `PackageJSON` now records `has_workspaces` (presence of `"workspaces"` as an array, or `{ "packages": [...] }`).
- After `env.load(...)` for cwd, walk the `DirInfo` parent chain to the nearest ancestor whose `package.json` has `has_workspaces`. If found and distinct from cwd (and not inside `node_modules`), call `Loader::load_workspace_root_defaults` on that directory.
- `load_workspace_root_defaults` probes the same `.env*` filenames via the existing `DirEntryProbe` and loads each by absolute path through `load_env_file_dynamic::<false>`, so cwd values win and both directories' `.env` can contribute.
- `--env-file` and `--no-env-file` keep bypassing default loading; `bun run <package.json-script>` keeps skipping default loading and leaves it to the child process. Plain projects without `"workspaces"` are unchanged.

## Why this is correct

`.env` auto-loading is a Bun convenience feature; there is no Node behavior to match here. This change scopes the extra lookup narrowly: it only triggers when an ancestor `package.json` declares `"workspaces"`, it keeps precedence as `process > package .env* > root .env*`, and it stays off the `bun run <script>` / `--env-file` / `node_modules` paths. Workspace detection matches what `bun --filter` already does (first ancestor with `"workspaces"`), so behavior is consistent with an existing CLI surface.

Fixes #11190
Fixes #10358

Fixes #5836

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/env.test.ts

<!-- robobun:evidence:end -->