### PR TITLE
node-fetch: forward TLS options from the agent to fetch

### DIFF
--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,4 +1,4 @@
-const { isTypedArray, isArrayBuffer } = require("node:util/types");
+const { isTypedArray, isArrayBuffer, isArrayBufferView } = require("node:util/types");
 
 function isPemObject(obj: unknown): obj is { pem: unknown } {
   return $isObject(obj) && "pem" in obj;
@@ -178,7 +178,32 @@ function processPfxOptions(options) {
   return out;
 }
 
+function isPemKeyEntry(k) {
+  return k && typeof k === "object" && !isArrayBufferView(k) && "pem" in k;
+}
+
+function hasPemObject(key) {
+  if (!key) return false;
+  if ($isArray(key)) return key.some(isPemKeyEntry);
+  return isPemKeyEntry(key);
+}
+
+// Unwraps Node's key: [{ pem, passphrase }] form into the string/Buffer entries the native SSLConfig accepts
+function normalizePemKeyOption(key, ctxPassphrase) {
+  if (!key || !hasPemObject(key)) return key;
+  const entries = $isArray(key) ? key : [key];
+  return entries.map(k => {
+    if (!isPemKeyEntry(k)) return k;
+    // Node: an explicit per-key null passphrase means "no passphrase" and does not fall back to the context-level one
+    const passphrase = k.passphrase !== undefined ? k.passphrase : ctxPassphrase;
+    if (passphrase == null) return k.pem;
+    const { createPrivateKey } = require("node:crypto");
+    return createPrivateKey({ key: k.pem, passphrase }).export({ type: "pkcs8", format: "pem" });
+  });
+}
+
 export {
+  normalizePemKeyOption,
   processPfxOptions,
   secureProtocolToVersionRange,
   throwOnInvalidTLSArray,

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -178,13 +178,16 @@ function processPfxOptions(options) {
   return out;
 }
 
+const ArrayPrototypeSome = Array.prototype.some;
+const ArrayPrototypeMap = Array.prototype.map;
+
 function isPemKeyEntry(k) {
   return k && typeof k === "object" && !isArrayBufferView(k) && "pem" in k;
 }
 
 function hasPemObject(key) {
   if (!key) return false;
-  if ($isArray(key)) return key.some(isPemKeyEntry);
+  if ($isArray(key)) return ArrayPrototypeSome.$call(key, isPemKeyEntry);
   return isPemKeyEntry(key);
 }
 
@@ -192,7 +195,7 @@ function hasPemObject(key) {
 function normalizePemKeyOption(key, ctxPassphrase) {
   if (!key || !hasPemObject(key)) return key;
   const entries = $isArray(key) ? key : [key];
-  return entries.map(k => {
+  return ArrayPrototypeMap.$call(entries, k => {
     if (!isPemKeyEntry(k)) return k;
     // Node: an explicit per-key null passphrase means "no passphrase" and does not fall back to the context-level one
     const passphrase = k.passphrase !== undefined ? k.passphrase : ctxPassphrase;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -9,6 +9,7 @@ const {
   throwOnInvalidTLSArray,
   tlsStringToProtocolVersion,
   secureProtocolToVersionRange,
+  normalizePemKeyOption,
   processPfxOptions,
   validateSecureProtocol,
 } = require("internal/tls");
@@ -306,7 +307,6 @@ const ArrayPrototypePush = Array.prototype.push;
 const ArrayPrototypeSome = Array.prototype.some;
 const ArrayPrototypeReduce = Array.prototype.reduce;
 const ArrayPrototypeFilter = Array.prototype.filter;
-const ArrayPrototypeMap = Array.prototype.map;
 
 const ObjectFreeze = Object.freeze;
 
@@ -510,31 +510,6 @@ const NativeSecureContext = $rust("SecureContext.rs", "js.getConstructor");
 // accepts null|string|ArrayBuffer|Blob|array, so coerce falsy → null before
 // crossing into native so `{ key: false }` etc. doesn't throw
 // ERR_INVALID_ARG_TYPE from the bindgen layer.
-
-function hasPemObject(key) {
-  if (!key) return false;
-  if ($isArray(key)) return ArrayPrototypeSome.$call(key, isPemKeyEntry);
-  return isPemKeyEntry(key);
-}
-
-function isPemKeyEntry(k) {
-  return k && typeof k === "object" && !isArrayBufferView(k) && "pem" in k;
-}
-
-function normalizePemKeyOption(key, ctxPassphrase) {
-  if (!key || !hasPemObject(key)) return key;
-  const entries = $isArray(key) ? key : [key];
-  return ArrayPrototypeMap.$call(entries, k => {
-    if (!isPemKeyEntry(k)) return k;
-    // Node: val?.passphrase !== undefined ? val.passphrase : passphrase - an
-    // explicit per-key null means "no passphrase for this key" and does NOT
-    // fall back to the context-level one.
-    const passphrase = k.passphrase !== undefined ? k.passphrase : ctxPassphrase;
-    if (passphrase == null) return k.pem;
-    const { createPrivateKey } = require("node:crypto");
-    return createPrivateKey({ key: k.pem, passphrase }).export({ type: "pkcs8", format: "pem" });
-  });
-}
 
 const SSL_OP_CIPHER_SERVER_PREFERENCE = 0x00400000;
 

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -170,6 +170,8 @@ function tlsFromAgent(agent, url) {
     if (typeof value === "string" && (key === "minVersion" || key === "maxVersion")) {
       value = require("internal/tls").tlsStringToProtocolVersion(value);
       if (!value) continue;
+    } else if (key === "key") {
+      value = require("internal/tls").normalizePemKeyOption(value, opts.passphrase);
     }
     (tls ??= { __proto__: null })[key] = value;
   }
@@ -229,7 +231,7 @@ async function fetch(
       init = { ...init, body: Readable.toWeb(readable) };
     }
   }
-  const initAgent = init && (init as any).agent;
+  const initAgent = init && Object.hasOwn(init, "agent") ? (init as any).agent : undefined;
   if (initAgent && (init as any).tls === undefined) {
     const tls = tlsFromAgent(initAgent, url);
     if (tls !== undefined) init = { ...init, tls } as any;

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -156,13 +156,10 @@ function tlsFromAgent(agent, url) {
     agent = agent.$call(undefined, parsedUrl);
   }
   if (!$isObject(agent)) return undefined;
-  // https.Agent keeps its options on `options`; the proxy-agent family uses `connectOpts`
-  let options = Object.hasOwn(agent, "options") ? agent.options : undefined;
-  if (!$isObject(options)) options = undefined;
-  let connectOpts = Object.hasOwn(agent, "connectOpts") ? agent.connectOpts : undefined;
-  if (!$isObject(connectOpts)) connectOpts = undefined;
-  if (options === undefined && connectOpts === undefined) return undefined;
-  const opts = { __proto__: null, ...connectOpts, ...options };
+  // Node's https.Agent applies `agent.options` to every tls.connect it makes
+  const options = Object.hasOwn(agent, "options") ? agent.options : undefined;
+  if (!$isObject(options)) return undefined;
+  const opts = { __proto__: null, ...options };
   let tls;
   for (const key of kAgentTlsKeys) {
     let value = opts[key];

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -135,7 +135,6 @@ const kAgentTlsKeys = [
   "cert",
   "key",
   "passphrase",
-  "pfx",
   "ciphers",
   "secureOptions",
   "minVersion",
@@ -157,16 +156,22 @@ function tlsFromAgent(agent, url) {
     agent = agent.$call(undefined, parsedUrl);
   }
   if (!$isObject(agent)) return undefined;
-  // https.Agent stores the constructor options on `options`. Agents from the
-  // `proxy-agent` family keep their TLS settings on `connectOpts` instead.
-  let opts = agent.options;
-  if (!$isObject(opts)) opts = agent.connectOpts;
-  else if ($isObject(agent.connectOpts)) opts = { __proto__: null, ...agent.connectOpts, ...opts };
-  if (!$isObject(opts)) return undefined;
+  // https.Agent keeps its options on `options`; the proxy-agent family uses `connectOpts`
+  let options = Object.hasOwn(agent, "options") ? agent.options : undefined;
+  if (!$isObject(options)) options = undefined;
+  let connectOpts = Object.hasOwn(agent, "connectOpts") ? agent.connectOpts : undefined;
+  if (!$isObject(connectOpts)) connectOpts = undefined;
+  if (options === undefined && connectOpts === undefined) return undefined;
+  const opts = { __proto__: null, ...connectOpts, ...options };
   let tls;
   for (const key of kAgentTlsKeys) {
-    const value = opts[key];
-    if (value !== undefined) (tls ??= { __proto__: null })[key] = value;
+    let value = opts[key];
+    if (value === undefined) continue;
+    if (typeof value === "string" && (key === "minVersion" || key === "maxVersion")) {
+      value = require("internal/tls").tlsStringToProtocolVersion(value);
+      if (!value) continue;
+    }
+    (tls ??= { __proto__: null })[key] = value;
   }
   return tls;
 }

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -129,6 +129,7 @@ class Response extends WebResponse {
 var ResponsePrototype = Response.prototype;
 
 const kUrl = Symbol("kUrl");
+const ObjectHasOwn = Object.hasOwn;
 
 const kAgentTlsKeys = [
   "ca",
@@ -157,7 +158,7 @@ function tlsFromAgent(agent, url) {
   }
   if (!$isObject(agent)) return undefined;
   // Node's https.Agent applies `agent.options` to every tls.connect it makes
-  const options = Object.hasOwn(agent, "options") ? agent.options : undefined;
+  const options = ObjectHasOwn(agent, "options") ? agent.options : undefined;
   if (!$isObject(options)) return undefined;
   const opts = { __proto__: null, ...options };
   let tls;
@@ -228,7 +229,7 @@ async function fetch(
       init = { ...init, body: Readable.toWeb(readable) };
     }
   }
-  const initAgent = init && Object.hasOwn(init, "agent") ? (init as any).agent : undefined;
+  const initAgent = init && ObjectHasOwn(init, "agent") ? (init as any).agent : undefined;
   if (initAgent && (init as any).tls === undefined) {
     const tls = tlsFromAgent(initAgent, url);
     if (tls !== undefined) init = { ...init, tls } as any;

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -130,6 +130,47 @@ var ResponsePrototype = Response.prototype;
 
 const kUrl = Symbol("kUrl");
 
+const kAgentTlsKeys = [
+  "ca",
+  "cert",
+  "key",
+  "passphrase",
+  "pfx",
+  "ciphers",
+  "secureOptions",
+  "minVersion",
+  "maxVersion",
+  "servername",
+  "rejectUnauthorized",
+  "checkServerIdentity",
+];
+
+function tlsFromAgent(agent, url) {
+  if ($isCallable(agent)) {
+    let parsedUrl;
+    if (url instanceof URL) parsedUrl = url;
+    else {
+      const href = typeof url === "string" ? url : $isObject(url) ? url.url : undefined;
+      if (typeof href !== "string" || !URL.canParse(href)) return undefined;
+      parsedUrl = new URL(href);
+    }
+    agent = agent.$call(undefined, parsedUrl);
+  }
+  if (!$isObject(agent)) return undefined;
+  // https.Agent stores the constructor options on `options`. Agents from the
+  // `proxy-agent` family keep their TLS settings on `connectOpts` instead.
+  let opts = agent.options;
+  if (!$isObject(opts)) opts = agent.connectOpts;
+  else if ($isObject(agent.connectOpts)) opts = { __proto__: null, ...agent.connectOpts, ...opts };
+  if (!$isObject(opts)) return undefined;
+  let tls;
+  for (const key of kAgentTlsKeys) {
+    const value = opts[key];
+    if (value !== undefined) (tls ??= { __proto__: null })[key] = value;
+  }
+  return tls;
+}
+
 class Request extends WebRequest {
   [kUrl]?: string;
 
@@ -182,6 +223,11 @@ async function fetch(
       }
       init = { ...init, body: Readable.toWeb(readable) };
     }
+  }
+  const initAgent = init && (init as any).agent;
+  if (initAgent && (init as any).tls === undefined) {
+    const tls = tlsFromAgent(initAgent, url);
+    if (tls !== undefined) init = { ...init, tls } as any;
   }
   const response = await nativeFetch.$call(undefined, url, init);
   Object.setPrototypeOf(response, ResponsePrototype);

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -4,12 +4,12 @@
 // Bun's node-fetch shim must forward those TLS options to the underlying fetch.
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import https from "node:https";
+import { tls as harnessTls } from "harness";
+import nodeFetch from "node-fetch";
 import { once } from "node:events";
+import https from "node:https";
 import type { AddressInfo } from "node:net";
 import { join } from "path";
-import nodeFetch from "node-fetch";
-import { tls as harnessTls } from "harness";
 
 const fixturesDir = join(import.meta.dir, "..", "tls", "fixtures");
 const ca1 = readFileSync(join(fixturesDir, "ca1-cert.pem"), "utf8");

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -1,0 +1,169 @@
+// https://github.com/oven-sh/bun/issues/7332
+// https://github.com/oven-sh/bun/issues/19754
+// @kubernetes/client-node passes an https.Agent (with ca/cert/key) to node-fetch.
+// Bun's node-fetch shim must forward those TLS options to the underlying fetch.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import https from "node:https";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { join } from "path";
+import nodeFetch from "node-fetch";
+import { tls as harnessTls } from "harness";
+
+const fixturesDir = join(import.meta.dir, "..", "tls", "fixtures");
+const ca1 = readFileSync(join(fixturesDir, "ca1-cert.pem"), "utf8");
+const serverKey = readFileSync(join(fixturesDir, "agent1-key.pem"), "utf8");
+const serverCert = readFileSync(join(fixturesDir, "agent1-cert.pem"), "utf8");
+
+describe("node-fetch honors TLS options from agent", () => {
+  test("rejects self-signed server cert when agent has no ca (baseline)", async () => {
+    using server = Bun.serve({
+      tls: harnessTls,
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    await expect(nodeFetch(`https://localhost:${server.port}/`)).rejects.toThrow();
+  });
+
+  test("verifies server via agent.options.ca", async () => {
+    using server = Bun.serve({
+      tls: harnessTls,
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    const agent = new https.Agent({ ca: harnessTls.cert });
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+      expect(await res.text()).toBe("OK");
+      expect(res.status).toBe(200);
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("sends client cert/key for mTLS via agent", async () => {
+    const server = https.createServer(
+      {
+        key: serverKey,
+        cert: serverCert,
+        ca: ca1,
+        requestCert: true,
+        rejectUnauthorized: false,
+      },
+      (req, res) => {
+        const socket = req.socket as import("node:tls").TLSSocket;
+        res.writeHead(200, { "content-type": "application/json", connection: "close" });
+        res.end(JSON.stringify({ authorized: socket.authorized }));
+      },
+    );
+    server.on("clientError", () => {});
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const agent = new https.Agent({
+      ca: ca1,
+      cert: serverCert,
+      key: serverKey,
+      servername: "agent1",
+    });
+    try {
+      // Without cert/key on the agent the server sees an unauthenticated client.
+      const anon = await nodeFetch(`https://localhost:${port}/`, {
+        agent: new https.Agent({ ca: ca1, servername: "agent1" }),
+      });
+      expect(await anon.json()).toEqual({ authorized: false });
+
+      const res = await nodeFetch(`https://localhost:${port}/`, { agent });
+      expect(await res.json()).toEqual({ authorized: true });
+    } finally {
+      agent.destroy();
+      server.close();
+      await once(server, "close");
+    }
+  });
+
+  test("forwards rejectUnauthorized: false from agent", async () => {
+    using server = Bun.serve({
+      tls: harnessTls,
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    const agent = new https.Agent({ rejectUnauthorized: false });
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+      expect(await res.text()).toBe("OK");
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("accepts agent as a function", async () => {
+    using server = Bun.serve({
+      tls: harnessTls,
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    const agent = new https.Agent({ ca: harnessTls.cert });
+    let calledWith: URL | undefined;
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, {
+        agent: (url: URL) => {
+          calledWith = url;
+          return agent;
+        },
+      });
+      expect(await res.text()).toBe("OK");
+      expect(calledWith).toBeInstanceOf(URL);
+      expect(calledWith!.protocol).toBe("https:");
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("reads ca from agent.connectOpts (proxy-agent shape)", async () => {
+    using server = Bun.serve({
+      tls: harnessTls,
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    const agent = { connectOpts: { ca: harnessTls.cert } };
+    const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+    expect(await res.text()).toBe("OK");
+  });
+
+  test("explicit tls in init is not overridden by agent options", async () => {
+    using server = Bun.serve({
+      tls: harnessTls,
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    // agent with a wrong CA; explicit tls with the right one should win
+    const agent = new https.Agent({ ca: ca1 });
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, {
+        agent,
+        // @ts-expect-error Bun extension
+        tls: { ca: harnessTls.cert },
+      });
+      expect(await res.text()).toBe("OK");
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("a plain http request with an agent still works", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    const agent = new https.Agent({ ca: harnessTls.cert });
+    try {
+      const res = await nodeFetch(`http://localhost:${server.port}/`, { agent });
+      expect(await res.text()).toBe("OK");
+    } finally {
+      agent.destroy();
+    }
+  });
+});

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -23,7 +23,9 @@ describe("node-fetch honors TLS options from agent", () => {
       port: 0,
       fetch: () => new Response("OK"),
     });
-    await expect(nodeFetch(`https://localhost:${server.port}/`)).rejects.toThrow();
+    await expect(nodeFetch(`https://localhost:${server.port}/`)).rejects.toThrow(
+      expect.objectContaining({ code: expect.stringMatching(/SELF_SIGNED|UNABLE_TO_VERIFY/) }),
+    );
   });
 
   test("verifies server via agent.options.ca", async () => {
@@ -91,6 +93,21 @@ describe("node-fetch honors TLS options from agent", () => {
       fetch: () => new Response("OK"),
     });
     const agent = new https.Agent({ rejectUnauthorized: false });
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+      expect(await res.text()).toBe("OK");
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("converts string minVersion/maxVersion from agent options", async () => {
+    using server = Bun.serve({
+      tls: harnessTls,
+      port: 0,
+      fetch: () => new Response("OK"),
+    });
+    const agent = new https.Agent({ ca: harnessTls.cert, minVersion: "TLSv1.2", maxVersion: "TLSv1.3" });
     try {
       const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
       expect(await res.text()).toBe("OK");

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -79,6 +79,20 @@ describe("node-fetch honors TLS options from agent", () => {
 
       const res = await nodeFetch(`https://localhost:${port}/`, { agent });
       expect(await res.json()).toEqual({ authorized: true });
+
+      // Node also accepts the key as [{ pem }] objects.
+      const pemAgent = new https.Agent({
+        ca: ca1,
+        cert: serverCert,
+        key: [{ pem: serverKey }],
+        servername: "agent1",
+      });
+      try {
+        const pemRes = await nodeFetch(`https://localhost:${port}/`, { agent: pemAgent });
+        expect(await pemRes.json()).toEqual({ authorized: true });
+      } finally {
+        pemAgent.destroy();
+      }
     } finally {
       agent.destroy();
       server.close();

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -64,6 +64,7 @@ describe("node-fetch honors TLS options from agent", () => {
     await once(server, "listening");
     const { port } = server.address() as AddressInfo;
 
+    const anonAgent = new https.Agent({ ca: ca1, servername: "agent1" });
     const agent = new https.Agent({
       ca: ca1,
       cert: serverCert,
@@ -72,9 +73,7 @@ describe("node-fetch honors TLS options from agent", () => {
     });
     try {
       // Without cert/key on the agent the server sees an unauthenticated client.
-      const anon = await nodeFetch(`https://localhost:${port}/`, {
-        agent: new https.Agent({ ca: ca1, servername: "agent1" }),
-      });
+      const anon = await nodeFetch(`https://localhost:${port}/`, { agent: anonAgent });
       expect(await anon.json()).toEqual({ authorized: false });
 
       const res = await nodeFetch(`https://localhost:${port}/`, { agent });
@@ -94,6 +93,7 @@ describe("node-fetch honors TLS options from agent", () => {
         pemAgent.destroy();
       }
     } finally {
+      anonAgent.destroy();
       agent.destroy();
       server.close();
       await once(server, "close");

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -107,13 +107,21 @@ describe("node-fetch applies TLS options from the agent", () => {
     }
   });
 
-  test("accepts string minVersion and maxVersion on the agent", async () => {
-    await using server = await serveSelfSigned();
+  test("applies string minVersion and maxVersion from the agent", async () => {
+    await using server = await serve({ key: serverKey, cert: serverCert, minVersion: "TLSv1.3" });
     const agent = new https.Agent({ ca: ca1, servername, minVersion: "TLSv1.2", maxVersion: "TLSv1.3" });
+    // A client capped at TLS 1.2 cannot talk to a server that requires TLS 1.3.
+    const cappedAgent = new https.Agent({ ca: ca1, servername, minVersion: "TLSv1.2", maxVersion: "TLSv1.2" });
     try {
       assert.deepStrictEqual(await fetchWith(server.port, agent), { authorized: false });
+      await assert.rejects(fetchWith(server.port, cappedAgent), (err: Error & { code?: string }) => {
+        // Node reports the handshake alert as EPROTO, Bun's fetch as a verification error.
+        assert.match(String(err.code), /EPROTO|PROTOCOL_VERSION|UNKNOWN_CERTIFICATE_VERIFICATION_ERROR/);
+        return true;
+      });
     } finally {
       agent.destroy();
+      cappedAgent.destroy();
     }
   });
 

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -1,198 +1,153 @@
 // https://github.com/oven-sh/bun/issues/7332
 // https://github.com/oven-sh/bun/issues/19754
 // @kubernetes/client-node passes an https.Agent (with ca/cert/key) to node-fetch.
-// Bun's node-fetch shim must forward those TLS options to the underlying fetch.
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "fs";
-import { tls as harnessTls } from "harness";
-import nodeFetch from "node-fetch";
+// Bun's node-fetch shim must apply those TLS options like node-fetch does on Node.
+// This file uses node:test so it runs unchanged on Node: `node --test <file>`.
+import assert from "node:assert";
 import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import http from "node:http";
 import https from "node:https";
 import type { AddressInfo } from "node:net";
-import { join } from "path";
+import path from "node:path";
+import { describe, test } from "node:test";
+import type { TLSSocket } from "node:tls";
+import nodeFetch from "node-fetch";
 
-const fixturesDir = join(import.meta.dir, "..", "tls", "fixtures");
-const ca1 = readFileSync(join(fixturesDir, "ca1-cert.pem"), "utf8");
-const serverKey = readFileSync(join(fixturesDir, "agent1-key.pem"), "utf8");
-const serverCert = readFileSync(join(fixturesDir, "agent1-cert.pem"), "utf8");
+const fixturesDir = path.join(import.meta.dirname, "..", "tls", "fixtures");
+const ca1 = readFileSync(path.join(fixturesDir, "ca1-cert.pem"), "utf8");
+const serverKey = readFileSync(path.join(fixturesDir, "agent1-key.pem"), "utf8");
+const serverCert = readFileSync(path.join(fixturesDir, "agent1-cert.pem"), "utf8");
+// agent1-cert has CN=agent1 and no SAN, so clients verify it under that servername.
+const servername = "agent1";
 
-describe("node-fetch honors TLS options from agent", () => {
-  test("rejects self-signed server cert when agent has no ca (baseline)", async () => {
-    using server = Bun.serve({
-      tls: harnessTls,
-      port: 0,
-      fetch: () => new Response("OK"),
+async function listen(server: http.Server | https.Server) {
+  server.on("tlsClientError", () => {});
+  server.listen(0);
+  await once(server, "listening");
+  return {
+    port: (server.address() as AddressInfo).port,
+    async [Symbol.asyncDispose]() {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+function serve(options: https.ServerOptions) {
+  return listen(
+    https.createServer(options, (req, res) => {
+      const socket = req.socket as TLSSocket;
+      res.writeHead(200, { "content-type": "application/json", connection: "close" });
+      res.end(JSON.stringify({ authorized: socket.authorized }));
+    }),
+  );
+}
+
+function serveSelfSigned() {
+  return serve({ key: serverKey, cert: serverCert });
+}
+
+async function fetchWith(port: number, agent: https.Agent | ((url: URL) => https.Agent)) {
+  const res = await nodeFetch(`https://localhost:${port}/`, { agent });
+  assert.strictEqual(res.status, 200);
+  return (await res.json()) as { authorized: boolean };
+}
+
+describe("node-fetch applies TLS options from the agent", () => {
+  test("rejects a server signed by an unknown CA when no agent is given (baseline)", async () => {
+    await using server = await serveSelfSigned();
+    await assert.rejects(nodeFetch(`https://localhost:${server.port}/`), (err: Error & { code?: string }) => {
+      assert.match(String(err.code), /UNABLE_TO_VERIFY|UNABLE_TO_GET_ISSUER|SELF_SIGNED/);
+      return true;
     });
-    await expect(nodeFetch(`https://localhost:${server.port}/`)).rejects.toThrow(
-      expect.objectContaining({ code: expect.stringMatching(/SELF_SIGNED|UNABLE_TO_VERIFY/) }),
-    );
   });
 
-  test("verifies server via agent.options.ca", async () => {
-    using server = Bun.serve({
-      tls: harnessTls,
-      port: 0,
-      fetch: () => new Response("OK"),
-    });
-    const agent = new https.Agent({ ca: harnessTls.cert });
+  test("verifies the server via agent.options.ca and servername", async () => {
+    await using server = await serveSelfSigned();
+    const agent = new https.Agent({ ca: ca1, servername });
     try {
-      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
-      expect(await res.text()).toBe("OK");
-      expect(res.status).toBe(200);
+      assert.deepStrictEqual(await fetchWith(server.port, agent), { authorized: false });
     } finally {
       agent.destroy();
     }
   });
 
-  test("sends client cert/key for mTLS via agent", async () => {
-    const server = https.createServer(
-      {
-        key: serverKey,
-        cert: serverCert,
-        ca: ca1,
-        requestCert: true,
-        rejectUnauthorized: false,
-      },
-      (req, res) => {
-        const socket = req.socket as import("node:tls").TLSSocket;
-        res.writeHead(200, { "content-type": "application/json", connection: "close" });
-        res.end(JSON.stringify({ authorized: socket.authorized }));
-      },
-    );
-    server.on("clientError", () => {});
-    server.listen(0);
-    await once(server, "listening");
-    const { port } = server.address() as AddressInfo;
-
-    const anonAgent = new https.Agent({ ca: ca1, servername: "agent1" });
-    const agent = new https.Agent({
-      ca: ca1,
-      cert: serverCert,
+  test("sends the client cert and key for mTLS via the agent", async () => {
+    await using server = await serve({
       key: serverKey,
-      servername: "agent1",
+      cert: serverCert,
+      ca: ca1,
+      requestCert: true,
+      rejectUnauthorized: false,
     });
+    const anonAgent = new https.Agent({ ca: ca1, servername });
+    const agent = new https.Agent({ ca: ca1, cert: serverCert, key: serverKey, servername });
+    // Node also accepts the key as [{ pem }] objects.
+    const pemAgent = new https.Agent({ ca: ca1, cert: serverCert, key: [{ pem: serverKey }], servername });
     try {
       // Without cert/key on the agent the server sees an unauthenticated client.
-      const anon = await nodeFetch(`https://localhost:${port}/`, { agent: anonAgent });
-      expect(await anon.json()).toEqual({ authorized: false });
-
-      const res = await nodeFetch(`https://localhost:${port}/`, { agent });
-      expect(await res.json()).toEqual({ authorized: true });
-
-      // Node also accepts the key as [{ pem }] objects.
-      const pemAgent = new https.Agent({
-        ca: ca1,
-        cert: serverCert,
-        key: [{ pem: serverKey }],
-        servername: "agent1",
-      });
-      try {
-        const pemRes = await nodeFetch(`https://localhost:${port}/`, { agent: pemAgent });
-        expect(await pemRes.json()).toEqual({ authorized: true });
-      } finally {
-        pemAgent.destroy();
-      }
+      assert.deepStrictEqual(await fetchWith(server.port, anonAgent), { authorized: false });
+      assert.deepStrictEqual(await fetchWith(server.port, agent), { authorized: true });
+      assert.deepStrictEqual(await fetchWith(server.port, pemAgent), { authorized: true });
     } finally {
       anonAgent.destroy();
       agent.destroy();
-      server.close();
-      await once(server, "close");
+      pemAgent.destroy();
     }
   });
 
-  test("forwards rejectUnauthorized: false from agent", async () => {
-    using server = Bun.serve({
-      tls: harnessTls,
-      port: 0,
-      fetch: () => new Response("OK"),
-    });
+  test("applies rejectUnauthorized: false from the agent", async () => {
+    await using server = await serveSelfSigned();
     const agent = new https.Agent({ rejectUnauthorized: false });
     try {
-      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
-      expect(await res.text()).toBe("OK");
+      assert.deepStrictEqual(await fetchWith(server.port, agent), { authorized: false });
     } finally {
       agent.destroy();
     }
   });
 
-  test("converts string minVersion/maxVersion from agent options", async () => {
-    using server = Bun.serve({
-      tls: harnessTls,
-      port: 0,
-      fetch: () => new Response("OK"),
-    });
-    const agent = new https.Agent({ ca: harnessTls.cert, minVersion: "TLSv1.2", maxVersion: "TLSv1.3" });
+  test("accepts string minVersion and maxVersion on the agent", async () => {
+    await using server = await serveSelfSigned();
+    const agent = new https.Agent({ ca: ca1, servername, minVersion: "TLSv1.2", maxVersion: "TLSv1.3" });
     try {
-      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
-      expect(await res.text()).toBe("OK");
+      assert.deepStrictEqual(await fetchWith(server.port, agent), { authorized: false });
     } finally {
       agent.destroy();
     }
   });
 
-  test("accepts agent as a function", async () => {
-    using server = Bun.serve({
-      tls: harnessTls,
-      port: 0,
-      fetch: () => new Response("OK"),
-    });
-    const agent = new https.Agent({ ca: harnessTls.cert });
-    let calledWith: URL | undefined;
+  test("accepts agent as a function of the request URL", async () => {
+    await using server = await serveSelfSigned();
+    const agent = new https.Agent({ ca: ca1, servername });
+    // node-fetch v2 passes a legacy url.parse() object and v3 a WHATWG URL. Both have these fields.
+    let calledWith: { protocol: string; hostname: string; port: string } | undefined;
     try {
-      const res = await nodeFetch(`https://localhost:${server.port}/`, {
-        agent: (url: URL) => {
-          calledWith = url;
-          return agent;
-        },
+      const body = await fetchWith(server.port, url => {
+        calledWith = url;
+        return agent;
       });
-      expect(await res.text()).toBe("OK");
-      expect(calledWith).toBeInstanceOf(URL);
-      expect(calledWith!.protocol).toBe("https:");
+      assert.deepStrictEqual(body, { authorized: false });
+      assert.deepStrictEqual(
+        { protocol: calledWith?.protocol, hostname: calledWith?.hostname, port: String(calledWith?.port) },
+        { protocol: "https:", hostname: "localhost", port: String(server.port) },
+      );
     } finally {
       agent.destroy();
     }
   });
 
-  test("reads ca from agent.connectOpts (proxy-agent shape)", async () => {
-    using server = Bun.serve({
-      tls: harnessTls,
-      port: 0,
-      fetch: () => new Response("OK"),
-    });
-    const agent = { connectOpts: { ca: harnessTls.cert } };
-    const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
-    expect(await res.text()).toBe("OK");
-  });
-
-  test("explicit tls in init is not overridden by agent options", async () => {
-    using server = Bun.serve({
-      tls: harnessTls,
-      port: 0,
-      fetch: () => new Response("OK"),
-    });
-    // agent with a wrong CA; explicit tls with the right one should win
-    const agent = new https.Agent({ ca: ca1 });
-    try {
-      const res = await nodeFetch(`https://localhost:${server.port}/`, {
-        agent,
-        // @ts-expect-error Bun extension
-        tls: { ca: harnessTls.cert },
-      });
-      expect(await res.text()).toBe("OK");
-    } finally {
-      agent.destroy();
-    }
-  });
-
-  test("a plain http request with an agent still works", async () => {
-    using server = Bun.serve({
-      port: 0,
-      fetch: () => new Response("OK"),
-    });
-    const agent = new https.Agent({ ca: harnessTls.cert });
+  test("a plain http request with an http.Agent still works", async () => {
+    await using server = await listen(
+      http.createServer((req, res) => {
+        res.writeHead(200, { connection: "close" });
+        res.end("OK");
+      }),
+    );
+    const agent = new http.Agent();
     try {
       const res = await nodeFetch(`http://localhost:${server.port}/`, { agent });
-      expect(await res.text()).toBe("OK");
+      assert.strictEqual(await res.text(), "OK");
     } finally {
       agent.destroy();
     }

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -3,6 +3,7 @@
 // @kubernetes/client-node passes an https.Agent (with ca/cert/key) to node-fetch.
 // Bun's node-fetch shim must apply those TLS options like node-fetch does on Node.
 // This file uses node:test so it runs unchanged on Node: `node --test <file>`.
+import nodeFetch from "node-fetch";
 import assert from "node:assert";
 import { once } from "node:events";
 import { readFileSync } from "node:fs";
@@ -12,7 +13,6 @@ import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { describe, test } from "node:test";
 import type { TLSSocket } from "node:tls";
-import nodeFetch from "node-fetch";
 
 const fixturesDir = path.join(import.meta.dirname, "..", "tls", "fixtures");
 const ca1 = readFileSync(path.join(fixturesDir, "ca1-cert.pem"), "utf8");


### PR DESCRIPTION
Fixes #7332
Fixes #19754

### Problem

`@kubernetes/client-node` (and any other `node-fetch` user that configures mTLS via an `https.Agent`) fails under Bun with `SELF_SIGNED_CERT_IN_CHAIN` / `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, or with 401s once `NODE_TLS_REJECT_UNAUTHORIZED=0` is set.

```js
import fetch from 'node-fetch';
import https from 'node:https';

await fetch('https://kubernetes.local/api', {
  agent: new https.Agent({ ca, cert, key }),
});
// error: self signed certificate in certificate chain
//   code: 'DEPTH_ZERO_SELF_SIGNED_CERT'
```

The same code works in Node.js because the real `node-fetch` hands the agent to `https.request`, which applies `ca`/`cert`/`key`/`rejectUnauthorized` from `agent.options`.

### Cause

Bun's `node-fetch` shim forwards the call to the native `fetch` but drops the `agent` option. Native `fetch` has no concept of an Agent, so the CA bundle and client certificate never reach the TLS layer.

### Fix

Read the TLS-relevant options off `agent.options` and hand them to the native fetch via its `tls` init option. This is what `https.Agent` does on Node: `agent.options` is applied to every `tls.connect` it makes. The function form of `agent` is supported, and an explicit `tls` on the init still wins.

- `agent.options` is read via an own-property check and copied into a null-prototype object, so the extraction is prototype-pollution safe.
- Forwarded keys: `ca`, `cert`, `key`, `passphrase`, `ciphers`, `secureOptions`, `minVersion`, `maxVersion`, `servername`, `rejectUnauthorized`, `checkServerIdentity`.
- Node-style string `minVersion`/`maxVersion` (`"TLSv1.2"`) are converted to the numeric protocol constants the native tls config expects.
- Node's `key: [{ pem, passphrase }]` form is unwrapped through `normalizePemKeyOption`, now hoisted from `node:tls` into `internal/tls` and shared by both callers.
- `pfx` is not forwarded since fetch's SSLConfig has no field for it.
- `agent.connectOpts` is not read. Node rejects a non-Agent object with `ERR_INVALID_ARG_TYPE`, and on the proxy-agent family `connectOpts` describes the TLS hop to the proxy, not the origin.

This picks up where #26964 (closed by its author) left off.

### Verification

`test/js/node/http/node-fetch-agent-tls.test.ts` uses `node:test`, so the same file runs on Node and Bun. Every case passes on Node v26.3.0 with node-fetch 2.6.7 and on Bun with this change:

- rejects a server signed by an unknown CA when no agent is given, with the error code asserted (baseline)
- verifies the server via `agent.options.ca` and `servername`
- presents the client cert/key for mTLS (server reports `authorized: true` only when cert/key are on the agent), including the `key: [{ pem }]` form
- applies `rejectUnauthorized: false` from the agent
- accepts string `minVersion`/`maxVersion` on the agent
- accepts `agent` as a function of the request URL
- a plain http request with an `http.Agent` still works

```
# node --test --experimental-strip-types test/js/node/http/node-fetch-agent-tls.test.ts
 pass 7, fail 0

# bun bd test test/js/node/http/node-fetch-agent-tls.test.ts
 7 pass, 0 fail

# USE_SYSTEM_BUN=1 bun test test/js/node/http/node-fetch-agent-tls.test.ts
 2 pass, 5 fail   # UNABLE_TO_VERIFY_LEAF_SIGNATURE / SELF_SIGNED_CERT_IN_CHAIN
```

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-fetch-agent-tls.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/http/node-fetch-agent-tls.test.ts:
(pass) node-fetch applies TLS options from the agent > rejects a server signed by an unknown CA when no agent is given (baseline) [566.28ms]
125 |         readable.pipe(passthrough);
126 |         readable = passthrough;
127 |       }
128 |       init = { ...init, body: Readable.toWeb(readable) };
129 |     }
130 |   const response = await nativeFetch.@call(@undefined, url, init);
                                                ^
TypeError: unable to verify the first certificate
  path: "https://localhost:43719/",
 errno: 0,
  code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE"

      at async fetch (node-fetch:130:43)
      at async fetchWith (/workspace/bun/test/js/node/http/node-fetch-agent-tls.test.ts:52:21)
      at async <anonymous> (/workspace/bun/test/js/node/http/node-fetch-agent-tls.test.ts:70:36)
      at async <anonymous> (node:test:1781:26)
      at async executeTestNode (node:test:1785:63)
(fail) node-fetch appli
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/http/node-fetch-agent-tls.test.ts:
(pass) node-fetch applies TLS options from the agent > rejects a server signed by an unknown CA when no agent is given (baseline) [16.22ms]
102 |         let passthrough = new PassThrough;
103 |         readable.pipe(passthrough), readable = passthrough;
104 |       }
105 |       init = { ...init, body: Readable.toWeb(readable) };
106 |     }
107 |   let response = await nativeFetch.@call(@undefined, url, init);
                                              ^
TypeError: unable to verify the first certificate
  path: "https://localhost:36643/",
 errno: 0,
  code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE"

      at async fetch (node-fetch:107:41)
      at async fetchWith (/workspace/bun/test/js/node/http/node-fetch-agent-tls.test.ts:52:21)
      at async <anonymous> (/workspace/bun/test/js/node/http/node-fetch-agent-tls.test.ts:70:36)
      at async <anonymous> (node:test:1445:26)
      at async executeTestNode (node:test:1448:63)
(fail) node-fetch applies TLS options from the agent > verifies the server via agent.options.ca and servername [3.16ms]
102 |         let passthrough = new PassThr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-fetch-agent-tls.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/http/node-fetch-agent-tls.test.ts:
(pass) node-fetch applies TLS options from the agent > rejects a server signed by an unknown CA when no agent is given (baseline) [651.00ms]
(pass) node-fetch applies TLS options from the agent > verifies the server via agent.options.ca and servername [394.93ms]
(pass) node-fetch applies TLS options from the agent > sends the client cert and key for mTLS via the agent [160.81ms]
(pass) node-fetch applies TLS options from the agent > applies rejectUnauthorized: false from the agent [77.23ms]
(pass) node-fetch applies TLS options from the agent > applies string minVersion and maxVersion from the agent [97.19ms]
(pass) node-fetch applies TLS options from the agent > accepts agent as a function of the request URL [77.24ms]
(pass) node-fetch applies TLS options from the agent > a plain http request with an http.Agent still works [99.67ms]

 7 pass
 0 fail
Ran 7 tests across 1 file. [4.44s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 669ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen cpp.rs (cppbind)
[2/24] gen JS modules (bundle-modules)
Preprocess modules (8244ms)
Bundle modules (57ms)
Postprocesss modules (236ms)
Bundle Functions (483ms)
Generate Code (49ms)

[9.08s] Bundled "src/js" for production
  2596 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 44s
[4/8] cxx obj/src/jsc/bindings/sqlite/JSSQLStatement.cpp.o
[5/8] link bun-profile
[7/8] strip bun
[7/8] bun-profile --revision
1.4.3-canary.1+6f4796f3c
[build] done
bun test v1.4.3-canary.1 (6f4796f3c)

test/js/node/http/node-fetch-agent-tls.test.ts:
(pass) node-fetch applies TLS options from the agent > rejects a server signed by an unknown CA when no agent is given (baseline) [16.03ms]
(pass) node-fetch applies TLS options from the agent > verifies the server via agent.options.ca a
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/tls.ts                         |  30 ++++-
 src/js/node/tls.ts                             |  27 +---
 src/js/thirdparty/node-fetch.ts                |  51 ++++++++
 test/js/node/http/node-fetch-agent-tls.test.ts | 163 +++++++++++++++++++++++++
 4 files changed, 244 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/js/internal/tls.ts                              3      4     19
src/js/node/tls.ts                                  1      2     19
src/js/thirdparty/node-fetch.ts                     4      4     19
test/js/node/http/node-fetch-agent-tls.test.ts      4      7     19
```

</details>

**root cause** · written by the author bot

Bun's node-fetch shim ignored the https.Agent passed in fetch options, so TLS settings such as ca, cert, key, rejectUnauthorized, and minVersion that Node's https.Agent applies to every tls.connect were dropped and requests to servers signed by a private CA failed. The fix adds a tlsFromAgent helper that resolves a function agent against the request URL, reads TLS options from agent.options only (never the proxy-hop connectOpts), normalizes string TLS versions and { pem } keys through a helper shared with node:tls, and forwards the result to the native fetch call. Lookups use a module-local…

<!-- robobun:evidence:end -->