### PR TITLE
s3: make the bucket in an s3:// URL override any configured bucket

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -798,11 +798,8 @@ pub mod store {
     // S3
     // ────────────────────────────────────────────────────────────────────
 
-    /// For an `s3://bucket/key` URL, returns the `bucket` segment. Returns
-    /// `None` for non-`s3://` inputs, or when the URL has no key separator
-    /// (so `s3://name` falls through and `name` is treated as a plain key,
-    /// using the configured bucket).
-    pub fn s3_url_bucket(path: &[u8]) -> Option<&[u8]> {
+    /// `s3://bucket/key` → `Some((bucket, key))`; anything else (including `s3://name` / `s3://name/`) → `None`.
+    pub fn s3_url_bucket_and_key(path: &[u8]) -> Option<(&[u8], &[u8])> {
         let url = bun_url::URL::parse(path);
         if !url.is_s3() {
             return None;
@@ -812,12 +809,11 @@ pub mod store {
             after = rest;
         }
         let end = bun_core::strings::index_of_any(after, b"/\\")?;
-        let bucket = &after[..end];
-        if bucket.is_empty() {
-            None
-        } else {
-            Some(bucket)
+        let (bucket, key) = (&after[..end], &after[end + 1..]);
+        if bucket.is_empty() || key.is_empty() {
+            return None;
         }
+        Some((bucket, key))
     }
 
     /// An S3 blob store. Data-only at this tier;
@@ -849,8 +845,11 @@ pub mod store {
         }
 
         pub fn path(&self) -> &[u8] {
-            let url = bun_url::URL::parse(self.pathlike.slice());
-            let mut path_name = url.s3_path();
+            let raw = self.pathlike.slice();
+            if let Some((_, key)) = s3_url_bucket_and_key(raw) {
+                return key;
+            }
+            let mut path_name = bun_url::URL::parse(raw).s3_path();
             // normalize start and ending
             if bun_core::strings::ends_with(path_name, b"/") {
                 path_name = &path_name[0..path_name.len()];
@@ -862,13 +861,6 @@ pub mod store {
             {
                 path_name = &path_name[1..];
             }
-            // For an `s3://bucket/key` URL the bucket has already been moved
-            // into `credentials.bucket` by `S3::init`; return only the key.
-            if url.is_s3() {
-                if let Some(end) = bun_core::strings::index_of_any(path_name, b"/\\") {
-                    path_name = &path_name[end + 1..];
-                }
-            }
             path_name
         }
 
@@ -877,10 +869,7 @@ pub mod store {
             mime_type: Option<MimeType>,
             mut credentials: bun_s3_signing::S3Credentials,
         ) -> S3 {
-            // `s3://bucket/key` addresses `bucket` explicitly: make it override
-            // any bucket inherited from the client / env / per-file options so
-            // the URL is never re-rooted under that ambient bucket.
-            if let Some(bucket) = s3_url_bucket(pathlike.slice()) {
+            if let Some((bucket, _)) = s3_url_bucket_and_key(pathlike.slice()) {
                 credentials.bucket = Box::<[u8]>::from(bucket);
             }
             S3 {

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -813,7 +813,11 @@ pub mod store {
         }
         let end = bun_core::strings::index_of_any(after, b"/\\")?;
         let bucket = &after[..end];
-        if bucket.is_empty() { None } else { Some(bucket) }
+        if bucket.is_empty() {
+            None
+        } else {
+            Some(bucket)
+        }
     }
 
     /// An S3 blob store. Data-only at this tier;

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -798,6 +798,24 @@ pub mod store {
     // S3
     // ────────────────────────────────────────────────────────────────────
 
+    /// For an `s3://bucket/key` URL, returns the `bucket` segment. Returns
+    /// `None` for non-`s3://` inputs, or when the URL has no key separator
+    /// (so `s3://name` falls through and `name` is treated as a plain key,
+    /// using the configured bucket).
+    pub fn s3_url_bucket(path: &[u8]) -> Option<&[u8]> {
+        let url = bun_url::URL::parse(path);
+        if !url.is_s3() {
+            return None;
+        }
+        let mut after = url.s3_path();
+        if let [b'/' | b'\\', rest @ ..] = after {
+            after = rest;
+        }
+        let end = bun_core::strings::index_of_any(after, b"/\\")?;
+        let bucket = &after[..end];
+        if bucket.is_empty() { None } else { Some(bucket) }
+    }
+
     /// An S3 blob store. Data-only at this tier;
     /// I/O methods (`unlink`/`stat`/`listObjects`/`getCredentialsWithOptions`)
     /// live in `bun_runtime` because they reach the HTTP client / event loop.
@@ -827,7 +845,8 @@ pub mod store {
         }
 
         pub fn path(&self) -> &[u8] {
-            let mut path_name = bun_url::URL::parse(self.pathlike.slice()).s3_path();
+            let url = bun_url::URL::parse(self.pathlike.slice());
+            let mut path_name = url.s3_path();
             // normalize start and ending
             if bun_core::strings::ends_with(path_name, b"/") {
                 path_name = &path_name[0..path_name.len()];
@@ -839,14 +858,27 @@ pub mod store {
             {
                 path_name = &path_name[1..];
             }
+            // For an `s3://bucket/key` URL the bucket has already been moved
+            // into `credentials.bucket` by `S3::init`; return only the key.
+            if url.is_s3() {
+                if let Some(end) = bun_core::strings::index_of_any(path_name, b"/\\") {
+                    path_name = &path_name[end + 1..];
+                }
+            }
             path_name
         }
 
         pub fn init(
             pathlike: PathLike,
             mime_type: Option<MimeType>,
-            credentials: bun_s3_signing::S3Credentials,
+            mut credentials: bun_s3_signing::S3Credentials,
         ) -> S3 {
+            // `s3://bucket/key` addresses `bucket` explicitly: make it override
+            // any bucket inherited from the client / env / per-file options so
+            // the URL is never re-rooted under that ambient bucket.
+            if let Some(bucket) = s3_url_bucket(pathlike.slice()) {
+                credentials.bucket = Box::<[u8]>::from(bucket);
+            }
             S3 {
                 // Heap-allocate a fresh refcounted copy.
                 credentials: Some(Rc::new(credentials)),

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -268,7 +268,7 @@ impl S3Ext for S3 {
         // private intrusive ref-count and cannot be struct-copied; the impl deep-copies
         // internally.
         use crate::webcore::s3_client::S3CredentialsExt as _;
-        S3Credentials::get_credentials_with_options(
+        let mut result = S3Credentials::get_credentials_with_options(
             self.get_credentials(),
             self.options,
             options,
@@ -276,7 +276,15 @@ impl S3Ext for S3 {
             self.storage_class,
             self.request_payer,
             global_object,
-        )
+        )?;
+        // An `s3://bucket/key` URL's bucket overrides any `bucket` from `options`.
+        if let Some(bucket) = bun_jsc::webcore_types::store::s3_url_bucket(self.pathlike.slice()) {
+            if result.credentials.bucket.as_ref() != bucket {
+                result.credentials.bucket = Box::<[u8]>::from(bucket);
+                result.changed_credentials = true;
+            }
+        }
+        Ok(result)
     }
 
     fn unlink(

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -277,8 +277,9 @@ impl S3Ext for S3 {
             self.request_payer,
             global_object,
         )?;
-        // An `s3://bucket/key` URL's bucket overrides any `bucket` from `options`.
-        if let Some(bucket) = bun_jsc::webcore_types::store::s3_url_bucket(self.pathlike.slice()) {
+        if let Some((bucket, _)) =
+            bun_jsc::webcore_types::store::s3_url_bucket_and_key(self.pathlike.slice())
+        {
             if result.credentials.bucket.as_ref() != bucket {
                 result.credentials.bucket = Box::<[u8]>::from(bucket);
                 result.changed_credentials = true;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1894,6 +1894,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             }
         }
 
+        if let Some((bucket, _)) = bun_jsc::webcore_types::store::s3_url_bucket_and_key(url.href) {
+            credentials_with_options.credentials.bucket = Box::<[u8]>::from(bucket);
+        }
+
         if let HTTPRequestBody::ReadableStream(ref readable_stream) = body {
             // we cannot direct stream to s3 we need to use multi part upload
             // `defer body.ReadableStream.deinit()` → Drop on `body` scope exit.
@@ -1920,7 +1924,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // re-parsed URL; the slices stay valid for the buffer's lifetime.
             let url_static =
                 ZigURL::parse(unsafe { bun_ptr::detach_lifetime(&owned_buffer[..url_len]) });
-            let s3_path = url_static.s3_path();
+            let s3_path = bun_jsc::webcore_types::store::s3_url_bucket_and_key(url_static.href)
+                .map_or_else(|| url_static.s3_path(), |(_, key)| key);
 
             // Proxy href (if any) lives in the same buffer, immediately after `url`.
             let proxy_url: Option<&[u8]> = if proxy.is_some() {
@@ -1972,7 +1977,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
         let mut result = match credentials_with_options.credentials.sign_request::<false>(
             &SignOptions {
-                path: url.s3_path(),
+                path: bun_jsc::webcore_types::store::s3_url_bucket_and_key(url.href)
+                    .map_or_else(|| url.s3_path(), |(_, key)| key),
                 method,
                 ..Default::default()
             },

--- a/test/js/bun/s3/s3-url-bucket.test.ts
+++ b/test/js/bun/s3/s3-url-bucket.test.ts
@@ -42,6 +42,11 @@ describe("s3:// URL bucket overrides configured bucket", () => {
     expect(presignPath({ ...creds, bucket: "cfgbkt" }, "s3://onlyname")).toBe("/cfgbkt/onlyname");
   });
 
+  it("s3://name/ and s3://name\\ (trailing separator, no key) are treated as plain keys", () => {
+    expect(presignPath({ ...creds, bucket: "cfgbkt" }, "s3://onlyname/")).toBe("/cfgbkt/onlyname");
+    expect(presignPath({ ...creds, bucket: "cfgbkt" }, "s3://onlyname\\")).toBe("/cfgbkt/onlyname");
+  });
+
   it("uppercase S3:// scheme is recognized", () => {
     expect(presignPath({ ...creds, bucket: "cfgbkt" }, "S3://urlbkt/dir/f.txt")).toBe("/urlbkt/dir/f.txt");
   });
@@ -61,42 +66,79 @@ describe("s3:// URL bucket overrides configured bucket", () => {
     expect(client.file("dir/f.txt").bucket).toBe("cfgbkt");
   });
 
-  describe.each(["S3_BUCKET", "AWS_BUCKET"])("env var %s", varName => {
-    it("Bun.file with s3:// URL: URL bucket wins over env bucket", async () => {
-      using server = Bun.serve({
-        port: 0,
-        fetch(req) {
-          return new Response(new URL(req.url).pathname, {
-            headers: { etag: '"abc"' },
-            status: 200,
-          });
-        },
-      });
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `const f = Bun.file("s3://urlbkt/dir/f.txt", {
+  it.each(["S3_BUCKET", "AWS_BUCKET"])("Bun.file with s3:// URL: URL bucket wins over %s", async varName => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response(new URL(req.url).pathname, {
+          headers: { etag: '"abc"' },
+          status: 200,
+        });
+      },
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const f = Bun.file("s3://urlbkt/dir/f.txt", {
+           accessKeyId: "a", secretAccessKey: "b", region: "us-east-1",
+           endpoint: ${JSON.stringify(server.url.href)},
+         });
+         console.log(await f.text());
+         console.log(f.bucket);`,
+      ],
+      env: {
+        ...bunEnv,
+        [varName]: "envbkt",
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("/urlbkt/dir/f.txt\nurlbkt\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("fetch with s3:// URL: URL bucket wins over s3.bucket option and env bucket", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new Response(new URL(req.url).pathname, {
+          headers: { etag: '"abc"' },
+          status: 200,
+        });
+      },
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const res = await fetch("s3://urlbkt/dir/f.txt", {
+           s3: {
              accessKeyId: "a", secretAccessKey: "b", region: "us-east-1",
              endpoint: ${JSON.stringify(server.url.href)},
-           });
-           console.log(await f.text());
-           console.log(f.bucket);`,
-        ],
-        env: {
-          ...bunEnv,
-          [varName]: "envbkt",
-          HTTP_PROXY: undefined,
-          HTTPS_PROXY: undefined,
-          http_proxy: undefined,
-          https_proxy: undefined,
-        },
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout).toBe("/urlbkt/dir/f.txt\nurlbkt\n");
-      expect(exitCode).toBe(0);
+             bucket: "optbkt",
+           },
+         });
+         console.log(await res.text());`,
+      ],
+      env: {
+        ...bunEnv,
+        S3_BUCKET: "envbkt",
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+      },
+      stderr: "pipe",
     });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("/urlbkt/dir/f.txt\n");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/s3/s3-url-bucket.test.ts
+++ b/test/js/bun/s3/s3-url-bucket.test.ts
@@ -1,0 +1,102 @@
+import { S3Client, type S3Options } from "bun";
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// An explicit `s3://bucket/key` URL must address `bucket`, regardless of any
+// bucket configured on the client, in per-file options, or via env vars.
+// Previously the configured bucket silently won and the URL's bucket was
+// demoted to a key prefix, so `s3://urlbkt/dir/f.txt` with `bucket: "cfgbkt"`
+// requested `/cfgbkt/urlbkt/dir/f.txt`.
+
+describe("s3:// URL bucket overrides configured bucket", () => {
+  const creds: S3Options = {
+    accessKeyId: "a",
+    secretAccessKey: "b",
+    region: "us-east-1",
+  };
+
+  function presignPath(opts: S3Options, key: string, fileOpts?: S3Options) {
+    const client = new S3Client(opts);
+    return new URL(client.presign(key, fileOpts)).pathname;
+  }
+
+  it("no configured bucket: s3:// URL bucket is honored", () => {
+    expect(presignPath({ ...creds }, "s3://urlbkt/dir/f.txt")).toBe("/urlbkt/dir/f.txt");
+  });
+
+  it("configured bucket: s3:// URL bucket wins", () => {
+    expect(presignPath({ ...creds, bucket: "cfgbkt" }, "s3://urlbkt/dir/f.txt")).toBe("/urlbkt/dir/f.txt");
+  });
+
+  it("per-file bucket option: s3:// URL bucket wins", () => {
+    expect(presignPath({ ...creds, bucket: "cfgbkt" }, "s3://urlbkt/dir/f.txt", { bucket: "per" })).toBe(
+      "/urlbkt/dir/f.txt",
+    );
+  });
+
+  it("plain key with configured bucket: configured bucket is used", () => {
+    expect(presignPath({ ...creds, bucket: "cfgbkt" }, "dir/f.txt")).toBe("/cfgbkt/dir/f.txt");
+  });
+
+  it("s3://name with no key separator is treated as a plain key", () => {
+    expect(presignPath({ ...creds, bucket: "cfgbkt" }, "s3://onlyname")).toBe("/cfgbkt/onlyname");
+  });
+
+  it("uppercase S3:// scheme is recognized", () => {
+    expect(presignPath({ ...creds, bucket: "cfgbkt" }, "S3://urlbkt/dir/f.txt")).toBe("/urlbkt/dir/f.txt");
+  });
+
+  it("configured bucket + virtualHostedStyle: s3:// URL bucket wins", () => {
+    const client = new S3Client({ ...creds, bucket: "cfgbkt", virtualHostedStyle: true });
+    const url = new URL(client.presign("s3://urlbkt/dir/f.txt"));
+    expect({ host: url.host, path: url.pathname }).toEqual({
+      host: "urlbkt.s3.us-east-1.amazonaws.com",
+      path: "/dir/f.txt",
+    });
+  });
+
+  it(".bucket property reflects the s3:// URL bucket", () => {
+    const client = new S3Client({ ...creds, bucket: "cfgbkt" });
+    expect(client.file("s3://urlbkt/dir/f.txt").bucket).toBe("urlbkt");
+    expect(client.file("dir/f.txt").bucket).toBe("cfgbkt");
+  });
+
+  describe.each(["S3_BUCKET", "AWS_BUCKET"])("env var %s", varName => {
+    it("Bun.file with s3:// URL: URL bucket wins over env bucket", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          return new Response(new URL(req.url).pathname, {
+            headers: { etag: '"abc"' },
+            status: 200,
+          });
+        },
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const f = Bun.file("s3://urlbkt/dir/f.txt", {
+             accessKeyId: "a", secretAccessKey: "b", region: "us-east-1",
+             endpoint: ${JSON.stringify(server.url.href)},
+           });
+           console.log(await f.text());
+           console.log(f.bucket);`,
+        ],
+        env: {
+          ...bunEnv,
+          [varName]: "envbkt",
+          HTTP_PROXY: undefined,
+          HTTPS_PROXY: undefined,
+          http_proxy: undefined,
+          https_proxy: undefined,
+        },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("/urlbkt/dir/f.txt\nurlbkt\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+});

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1407,8 +1407,8 @@ for (let credentials of allCredentials) {
             expect(url.includes("X-Amz-SignedHeaders")).toBe(true);
           });
 
-          it("s3().presign() endpoint should work", async () => {
-            const url = s3("s3://folder/credentials-test", s3Options).presign({
+          it("s3().presign() bucket option should work", async () => {
+            const url = s3("s3://credentials-test", s3Options).presign({
               expiresIn: 10,
               bucket: "my-bucket",
             });


### PR DESCRIPTION
## Problem

An explicit `s3://bucket/key` URL was silently re-rooted under whatever bucket was already configured on the `S3Client`, in per-file options, or via `S3_BUCKET` / `AWS_BUCKET`. The URL's bucket was demoted to a key prefix, so a program that ran correctly without an ambient bucket would address the wrong object the moment one appeared.

```js
const origin = Bun.serve({ port: 0, fetch: req => new Response(new URL(req.url).pathname) });
const base = { endpoint: origin.url.href, accessKeyId: "a", secretAccessKey: "b", region: "us-east-1" };

await new S3Client({ ...base }).file("s3://urlbkt/dir/f.txt").text();
// -> /urlbkt/dir/f.txt   (ok)

await new S3Client({ ...base, bucket: "cfgbkt" }).file("s3://urlbkt/dir/f.txt").text();
// -> /cfgbkt/urlbkt/dir/f.txt   (wrong bucket AND wrong key)
```

## Cause

`S3.path()` strips the `s3://` prefix but returns `bucket/key` as a single path, and `sign_request` only splits the bucket out of that path when `credentials.bucket` is empty. When a bucket is already configured it is used as-is and the whole `bucket/key` string becomes the object key.

## Fix

Add `s3_url_bucket_and_key(path)` which returns `Some((bucket, key))` for an `s3://bucket/key` URL and `None` otherwise (including `s3://name` / `s3://name/` with no key, which fall through to the configured bucket as before). Callers apply the URL bucket as the authoritative one:

- `S3::init` writes it into `credentials.bucket`, overriding any inherited bucket.
- `S3::path()` returns the `key` part directly, so the two cannot disagree.
- `S3Ext::get_credentials_with_options` re-applies it after merging per-call options so a `bucket` option passed to `presign`/`write`/`unlink` cannot shadow it.
- `fetch("s3://...")` applies the same override before signing and before the multipart upload stream path.

## Verification

`test/js/bun/s3/s3-url-bucket.test.ts` covers `S3Client` with and without a configured bucket, per-file `bucket` options, `virtualHostedStyle`, the `.bucket` getter, uppercase `S3://`, `Bun.file` under `S3_BUCKET` / `AWS_BUCKET`, `fetch("s3://...")` with both an env bucket and an `s3.bucket` option, and the `s3://name` / `s3://name/` / `s3://name\` no-key forms. All bug cases fail on current main (producing `/cfgbkt/urlbkt/...`, `/envbkt/urlbkt/...`, `/optbkt/urlbkt/...`) and pass with the fix.