### PR TITLE
run --filter: forward FORCE_COLOR to scripts when attached to a color TTY

### DIFF
--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -867,24 +867,8 @@ pub(crate) fn run_scripts_with_filter(
 
     // SAFETY: Transpiler::init always sets `env` to the process-lifetime singleton.
     let env_ptr: *mut bun_dotenv::Loader = this_transpiler.env;
-    // Child stdout/stderr are pipes, so isatty()-based color detection in the
-    // child reports false. When we are rendering with color, forward that
-    // decision via FORCE_COLOR so tools like Vite/Next/chalk keep their colors.
-    // Skip if the user already set FORCE_COLOR or NO_COLOR so explicit choices
-    // are preserved verbatim.
-    if Output::enable_ansi_colors_stdout() {
-        // SAFETY: env_ptr is the process-lifetime DotEnv loader.
-        let env = unsafe { &mut *env_ptr };
-        if env.map.get(b"FORCE_COLOR").is_none() && env.map.get(b"NO_COLOR").is_none() {
-            use bun_core::output::{ColorDepth, Source};
-            let depth: &[u8] = match Source::color_depth() {
-                ColorDepth::C16m => b"3",
-                ColorDepth::C256 => b"2",
-                _ => b"1",
-            };
-            let _ = env.map.put(b"FORCE_COLOR", depth);
-        }
-    }
+    // SAFETY: env_ptr is the process-lifetime DotEnv loader.
+    RunCommand::forward_color_to_piped_scripts(unsafe { &mut *env_ptr });
     let event_loop = MiniEventLoopMod::init_global(
         // SAFETY: see above; `&'static mut` reborrow of the singleton for first-init only.
         Some(unsafe { &mut *env_ptr }),

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -909,6 +909,9 @@ pub(crate) fn run_scripts_with_filter(
         remaining_scripts: 0,
         draw_buf: Vec::new(),
         last_lines_written: 0,
+        // Redraw renderer emits cursor-up/erase-line sequences; those only make
+        // sense on a real terminal. `FORCE_COLOR` (which we now inject for
+        // child scripts) must not enable it on a pipe.
         pretty_output: {
             #[cfg(windows)]
             {
@@ -916,7 +919,7 @@ pub(crate) fn run_scripts_with_filter(
             }
             #[cfg(not(windows))]
             {
-                Output::enable_ansi_colors_stdout()
+                Output::is_stdout_tty() && Output::enable_ansi_colors_stdout()
             }
         },
         shell_bin,

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -867,6 +867,24 @@ pub(crate) fn run_scripts_with_filter(
 
     // SAFETY: Transpiler::init always sets `env` to the process-lifetime singleton.
     let env_ptr: *mut bun_dotenv::Loader = this_transpiler.env;
+    // Child stdout/stderr are pipes, so isatty()-based color detection in the
+    // child reports false. When we are rendering with color, forward that
+    // decision via FORCE_COLOR so tools like Vite/Next/chalk keep their colors.
+    // Skip if the user already set FORCE_COLOR or NO_COLOR so explicit choices
+    // are preserved verbatim.
+    if Output::enable_ansi_colors_stdout() {
+        // SAFETY: env_ptr is the process-lifetime DotEnv loader.
+        let env = unsafe { &mut *env_ptr };
+        if env.map.get(b"FORCE_COLOR").is_none() && env.map.get(b"NO_COLOR").is_none() {
+            use bun_core::output::{ColorDepth, Source};
+            let depth: &[u8] = match Source::color_depth() {
+                ColorDepth::C16m => b"3",
+                ColorDepth::C256 => b"2",
+                _ => b"1",
+            };
+            let _ = env.map.put(b"FORCE_COLOR", depth);
+        }
+    }
     let event_loop = MiniEventLoopMod::init_global(
         // SAFETY: see above; `&'static mut` reborrow of the singleton for first-init only.
         Some(unsafe { &mut *env_ptr }),

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -802,6 +802,24 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
 
     // SAFETY: transpiler.env is a process-lifetime *mut Loader set in init.
     let env_ptr: *mut DotEnvLoader = this_transpiler.env;
+    // Child stdout/stderr are pipes, so isatty()-based color detection in the
+    // child reports false. When we are rendering with color, forward that
+    // decision via FORCE_COLOR so downstream tools keep their colors. Skip if
+    // the user already set FORCE_COLOR or NO_COLOR so explicit choices are
+    // preserved verbatim.
+    if Output::enable_ansi_colors_stdout() {
+        // SAFETY: env_ptr is the process-lifetime DotEnv loader; no other borrow is live yet.
+        let env = unsafe { &mut *env_ptr };
+        if env.map.get(b"FORCE_COLOR").is_none() && env.map.get(b"NO_COLOR").is_none() {
+            use bun_core::output::{ColorDepth, Source};
+            let depth: &[u8] = match Source::color_depth() {
+                ColorDepth::C16m => b"3",
+                ColorDepth::C256 => b"2",
+                _ => b"1",
+            };
+            let _ = env.map.put(b"FORCE_COLOR", depth);
+        }
+    }
     let event_loop = bun_event_loop::MiniEventLoop::init_global(
         // SAFETY: env_ptr is the process-lifetime DotEnv loader; no other borrow of it is live yet.
         Some(unsafe { &mut *env_ptr }),

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -802,24 +802,8 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
 
     // SAFETY: transpiler.env is a process-lifetime *mut Loader set in init.
     let env_ptr: *mut DotEnvLoader = this_transpiler.env;
-    // Child stdout/stderr are pipes, so isatty()-based color detection in the
-    // child reports false. When we are rendering with color, forward that
-    // decision via FORCE_COLOR so downstream tools keep their colors. Skip if
-    // the user already set FORCE_COLOR or NO_COLOR so explicit choices are
-    // preserved verbatim.
-    if Output::enable_ansi_colors_stdout() {
-        // SAFETY: env_ptr is the process-lifetime DotEnv loader; no other borrow is live yet.
-        let env = unsafe { &mut *env_ptr };
-        if env.map.get(b"FORCE_COLOR").is_none() && env.map.get(b"NO_COLOR").is_none() {
-            use bun_core::output::{ColorDepth, Source};
-            let depth: &[u8] = match Source::color_depth() {
-                ColorDepth::C16m => b"3",
-                ColorDepth::C256 => b"2",
-                _ => b"1",
-            };
-            let _ = env.map.put(b"FORCE_COLOR", depth);
-        }
-    }
+    // SAFETY: env_ptr is the process-lifetime DotEnv loader; no other borrow is live yet.
+    RunCommand::forward_color_to_piped_scripts(unsafe { &mut *env_ptr });
     let event_loop = bun_event_loop::MiniEventLoop::init_global(
         // SAFETY: env_ptr is the process-lifetime DotEnv loader; no other borrow of it is live yet.
         Some(unsafe { &mut *env_ptr }),

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1917,24 +1917,19 @@ impl RunCommand {
         Ok(())
     }
 
-    /// `--filter` / `--parallel` pipe script stdout/stderr so isatty()-based
-    /// color detection in the script is false. When the parent is rendering
-    /// with color, forward that decision via `FORCE_COLOR` at the depth the
-    /// parent detected so tools like chalk/supports-color keep their colors.
-    /// Leaves the env untouched if the user already set `FORCE_COLOR`,
-    /// `NO_COLOR`, or `NODE_DISABLE_COLORS`, or if the parent itself is not
-    /// rendering in color.
+    /// `--filter` / `--parallel` pipe script stdio, so isatty() in the script
+    /// is false. Forward the parent's color decision via `FORCE_COLOR` unless
+    /// the user set `FORCE_COLOR`/`NO_COLOR`/`NODE_DISABLE_COLORS` themselves.
     pub fn forward_color_to_piped_scripts(env: &mut DotEnv::Loader) {
-        if !Output::enable_ansi_colors_stdout() {
+        if !(Output::is_stdout_tty() && Output::enable_ansi_colors_stdout()) {
             return;
         }
-        if env.map.get(b"FORCE_COLOR").is_some() || env.map.get(b"NO_COLOR").is_some() {
-            return;
-        }
-        if env
-            .map
-            .get(b"NODE_DISABLE_COLORS")
-            .is_some_and(|v| !v.is_empty())
+        if env.map.get(b"FORCE_COLOR").is_some()
+            || env.map.get(b"NO_COLOR").is_some_and(|v| !v.is_empty())
+            || env
+                .map
+                .get(b"NODE_DISABLE_COLORS")
+                .is_some_and(|v| !v.is_empty())
         {
             return;
         }
@@ -1942,7 +1937,11 @@ impl RunCommand {
         let depth: &[u8] = match Source::color_depth() {
             ColorDepth::C16m => b"3",
             ColorDepth::C256 => b"2",
-            _ => b"1",
+            ColorDepth::C16 => b"1",
+            // Windows terminals typically don't set TERM/COLORTERM; every
+            // supported Windows build has truecolor (see is_color_terminal).
+            ColorDepth::None if cfg!(windows) => b"3",
+            ColorDepth::None => b"1",
         };
         let _ = env.map.put(b"FORCE_COLOR", depth);
     }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1917,6 +1917,36 @@ impl RunCommand {
         Ok(())
     }
 
+    /// `--filter` / `--parallel` pipe script stdout/stderr so isatty()-based
+    /// color detection in the script is false. When the parent is rendering
+    /// with color, forward that decision via `FORCE_COLOR` at the depth the
+    /// parent detected so tools like chalk/supports-color keep their colors.
+    /// Leaves the env untouched if the user already set `FORCE_COLOR`,
+    /// `NO_COLOR`, or `NODE_DISABLE_COLORS`, or if the parent itself is not
+    /// rendering in color.
+    pub fn forward_color_to_piped_scripts(env: &mut DotEnv::Loader) {
+        if !Output::enable_ansi_colors_stdout() {
+            return;
+        }
+        if env.map.get(b"FORCE_COLOR").is_some() || env.map.get(b"NO_COLOR").is_some() {
+            return;
+        }
+        if env
+            .map
+            .get(b"NODE_DISABLE_COLORS")
+            .is_some_and(|v| !v.is_empty())
+        {
+            return;
+        }
+        use bun_core::output::{ColorDepth, Source};
+        let depth: &[u8] = match Source::color_depth() {
+            ColorDepth::C16m => b"3",
+            ColorDepth::C256 => b"2",
+            _ => b"1",
+        };
+        let _ = env.map.put(b"FORCE_COLOR", depth);
+    }
+
     /// Builds a new PATH with `node_modules/.bin` for each ancestor of `cwd`
     /// (plus `package_json_dir` and the bun-node shim dir) prepended, returns
     /// it as an owned buffer, and writes the original PATH out via

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -471,7 +471,7 @@ describe("bun", () => {
     expect(exitCode).toBe(23);
   });
 
-  function runElideLinesTest({
+  async function runElideLinesTest({
     elideLines,
     target_pattern,
     antipattern,
@@ -498,63 +498,58 @@ describe("bun", () => {
       }),
     });
 
-    if (process.platform === "win32") {
-      // Windows spawnSync pipes stdout, so `windowsIsTerminal()` returns false,
-      // `state.pretty_output` is false, and `redraw()` short-circuits before
-      // ever emitting elision output. `target_pattern` is intentionally NOT
-      // iterated here: every caller bundles TTY-only regexes such as
-      // `/\[N lines elided\]/` that would never appear in piped Windows output
-      // and would fail the test for the wrong reason. The hardcoded log_line
-      // match covers the non-TTY subset of every caller's target_pattern.
-      // `antipattern` is iterated because absence-checks remain valid on either
-      // code path.
-      const { exitCode, stderr, stdout } = spawnSync({
-        cwd: dir,
-        cmd: [bunExe(), "run", "--filter", "./packages/dep0", "--elide-lines", String(elideLines), "script"],
-        env: { ...bunEnv, FORCE_COLOR: "1", NO_COLOR: "0" },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const stdoutval = stdout.toString();
-      expect(stderr.toString()).not.toContain("--elide-lines is only supported in terminal environments");
-      expect(stdoutval).toMatch(/(?:log_line[\s\S]*?){20}/);
-      if (antipattern) {
-        for (const r of antipattern) {
-          expect(stdoutval).not.toMatch(r);
-        }
-      }
-      expect(exitCode).toBe(0);
-      return;
-    }
-
-    runInCwdSuccess({
+    // Elision lives in the redraw renderer which only runs when stdout is a
+    // real terminal, so spawn on a pty. The final frame is written in full at
+    // exit so `[N lines elided]` is observable in the collected output.
+    const decoder = new TextDecoder();
+    let output = "";
+    const done = Promise.withResolvers<void>();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--elide-lines", String(elideLines), "--filter", "./packages/dep0", "script"],
       cwd: dir,
-      pattern: "./packages/dep0",
-      env: { FORCE_COLOR: "1", NO_COLOR: "0" },
-      target_pattern,
-      antipattern,
-      command: ["script"],
-      elideCount: elideLines,
+      env: { ...bunEnv, FORCE_COLOR: undefined, NO_COLOR: undefined, TERM: "xterm-256color" },
+      terminal: {
+        cols: 200,
+        rows: 40,
+        data(_t, chunk: Uint8Array) {
+          output += decoder.decode(chunk, { stream: true });
+        },
+        exit() {
+          done.resolve();
+        },
+      },
     });
+    await done.promise;
+    const exitCode = await proc.exited;
+    output += decoder.decode();
+    const stdoutval = Bun.stripANSI(output);
+    for (const r of target_pattern) {
+      expect(stdoutval).toMatch(r);
+    }
+    if (antipattern) {
+      for (const r of antipattern) {
+        expect(stdoutval).not.toMatch(r);
+      }
+    }
+    expect(exitCode).toBe(0);
   }
 
-  test("elides output by default when using --filter", () => {
-    runElideLinesTest({
+  test("elides output by default when using --filter", async () => {
+    await runElideLinesTest({
       elideLines: 10,
-      target_pattern: [/\[10 lines elided\]/, /(?:log_line[\s\S]*?){20}/],
+      target_pattern: [/\[10 lines elided\]/, /(?:log_line[\s\S]*?){10}/],
     });
   });
 
-  test("respects --elide-lines argument", () => {
-    runElideLinesTest({
+  test("respects --elide-lines argument", async () => {
+    await runElideLinesTest({
       elideLines: 15,
-      target_pattern: [/\[5 lines elided\]/, /(?:log_line[\s\S]*?){20}/],
+      target_pattern: [/\[5 lines elided\]/, /(?:log_line[\s\S]*?){15}/],
     });
   });
 
-  test("--elide-lines=0 shows all output", () => {
-    runElideLinesTest({
+  test("--elide-lines=0 shows all output", async () => {
+    await runElideLinesTest({
       elideLines: 0,
       target_pattern: [/(?:log_line[\s\S]*?){20}/],
       antipattern: [/lines elided/],
@@ -702,6 +697,7 @@ describe("--filter forwards color to scripts", () => {
         ...bunEnv,
         NO_COLOR: undefined,
         FORCE_COLOR: undefined,
+        NODE_DISABLE_COLORS: undefined,
         CI: undefined,
         TERM: "xterm-256color",
         COLORTERM: undefined,
@@ -722,12 +718,14 @@ describe("--filter forwards color to scripts", () => {
       },
     });
     await done.promise;
-    await proc.exited;
+    const exitCode = await proc.exited;
     output += decoder.decode();
     const stripped = Bun.stripANSI(output).replace(/\r/g, "");
     const m = stripped.match(/RESULT (\{[^}]*\})/);
     if (!m) throw new Error("missing RESULT in terminal output: " + JSON.stringify(output));
-    return JSON.parse(m[1]);
+    const result = JSON.parse(m[1]);
+    expect(exitCode).toBe(0);
+    return result;
   }
 
   test("sets FORCE_COLOR when parent stdout is a color TTY", async () => {
@@ -791,6 +789,7 @@ describe("--filter forwards color to scripts", () => {
         ...bunEnv,
         NO_COLOR: undefined,
         FORCE_COLOR: undefined,
+        NODE_DISABLE_COLORS: undefined,
         CI: undefined,
         TERM: "xterm-256color",
         COLORTERM: undefined,
@@ -808,6 +807,25 @@ describe("--filter forwards color to scripts", () => {
       FORCE_COLOR: null,
       NO_COLOR: null,
     });
+    expect(exitCode).toBe(0);
+  });
+
+  // A nested `bun --filter` inherits the outer runner's injected FORCE_COLOR
+  // but its own stdout is a pipe. The redraw renderer must stay off so its
+  // cursor-up/erase sequences don't corrupt the outer tree.
+  test("FORCE_COLOR on piped stdout uses the line-prefixed writer, not redraw", async () => {
+    const dir = colorFixture();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "*", "probe"],
+      cwd: dir,
+      env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "2" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("pkga probe: RESULT ");
+    expect(stdout).not.toContain("\x1b[?2026h");
+    expect(stdout).not.toContain("\x1b[1A");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -662,3 +662,126 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/10346
+// `bun --filter` pipes child stdout/stderr, so the child's isatty() is false and
+// tools that gate color on it go monochrome. When the parent is attached to a
+// color terminal the filter runner now forwards that decision via FORCE_COLOR.
+describe("--filter forwards color to scripts", () => {
+  function colorFixture() {
+    return tempDirWithFiles("filter-color", {
+      packages: {
+        pkga: {
+          "probe.js": `process.stdout.write("RESULT " + JSON.stringify({
+            FORCE_COLOR: process.env.FORCE_COLOR ?? null,
+            NO_COLOR: process.env.NO_COLOR ?? null,
+            enableANSI: Bun.enableANSIColors,
+          }) + "\\n");`,
+          "package.json": JSON.stringify({
+            name: "pkga",
+            scripts: { probe: `${bunExe()} probe.js` },
+          }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    });
+  }
+
+  async function runOnPTY(dir: string, extraEnv: Record<string, string | undefined>) {
+    const decoder = new TextDecoder();
+    let output = "";
+    const done = Promise.withResolvers<void>();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "*", "probe"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        NO_COLOR: undefined,
+        FORCE_COLOR: undefined,
+        CI: undefined,
+        TERM: "xterm-256color",
+        COLORTERM: undefined,
+        ...extraEnv,
+      },
+      terminal: {
+        cols: 200,
+        rows: 24,
+        data(_t, chunk: Uint8Array) {
+          output += decoder.decode(chunk, { stream: true });
+          if (output.includes("RESULT ") && output.includes("}")) done.resolve();
+        },
+        exit() {
+          done.resolve();
+        },
+      },
+    });
+    await done.promise;
+    await proc.exited;
+    output += decoder.decode();
+    const stripped = Bun.stripANSI(output).replace(/\r/g, "");
+    const m = stripped.match(/RESULT (\{[^}]*\})/);
+    if (!m) throw new Error("missing RESULT in terminal output: " + JSON.stringify(output));
+    return JSON.parse(m[1]);
+  }
+
+  test("sets FORCE_COLOR when parent stdout is a color TTY", async () => {
+    const dir = colorFixture();
+    const result = await runOnPTY(dir, {});
+    expect(result).toEqual({
+      FORCE_COLOR: "2",
+      NO_COLOR: null,
+      enableANSI: true,
+    });
+  });
+
+  test("sets FORCE_COLOR=3 for a truecolor terminal", async () => {
+    const dir = colorFixture();
+    const result = await runOnPTY(dir, { COLORTERM: "truecolor" });
+    expect(result).toEqual({
+      FORCE_COLOR: "3",
+      NO_COLOR: null,
+      enableANSI: true,
+    });
+  });
+
+  test("respects an explicit NO_COLOR", async () => {
+    const dir = colorFixture();
+    const result = await runOnPTY(dir, { NO_COLOR: "1" });
+    expect(result).toEqual({
+      FORCE_COLOR: null,
+      NO_COLOR: "1",
+      enableANSI: false,
+    });
+  });
+
+  test("respects an explicit FORCE_COLOR value", async () => {
+    const dir = colorFixture();
+    const result = await runOnPTY(dir, { FORCE_COLOR: "0" });
+    expect(result.FORCE_COLOR).toBe("0");
+  });
+
+  test("does not set FORCE_COLOR when parent stdout is not a TTY", async () => {
+    const dir = colorFixture();
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "*", "probe"],
+      cwd: dir,
+      env: {
+        ...bunEnv,
+        NO_COLOR: undefined,
+        FORCE_COLOR: undefined,
+        CI: undefined,
+        TERM: "xterm-256color",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const m = stdout.match(/RESULT (\{[^}]*\})/);
+    if (!m) throw new Error("missing RESULT in: " + JSON.stringify(stdout));
+    const result = JSON.parse(m[1]);
+    expect({ FORCE_COLOR: result.FORCE_COLOR, NO_COLOR: result.NO_COLOR }).toEqual({
+      FORCE_COLOR: null,
+      NO_COLOR: null,
+    });
+  });
+});

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -687,7 +687,11 @@ describe("--filter forwards color to scripts", () => {
     });
   }
 
-  async function runOnPTY(dir: string, extraEnv: Record<string, string | undefined>, args = ["--filter", "*", "probe"]) {
+  async function runOnPTY(
+    dir: string,
+    extraEnv: Record<string, string | undefined>,
+    args = ["--filter", "*", "probe"],
+  ) {
     const decoder = new TextDecoder();
     let output = "";
     const done = Promise.withResolvers<void>();

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -687,12 +687,12 @@ describe("--filter forwards color to scripts", () => {
     });
   }
 
-  async function runOnPTY(dir: string, extraEnv: Record<string, string | undefined>) {
+  async function runOnPTY(dir: string, extraEnv: Record<string, string | undefined>, args = ["--filter", "*", "probe"]) {
     const decoder = new TextDecoder();
     let output = "";
     const done = Promise.withResolvers<void>();
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "--filter", "*", "probe"],
+      cmd: [bunExe(), "run", ...args],
       cwd: dir,
       env: {
         ...bunEnv,
@@ -701,6 +701,8 @@ describe("--filter forwards color to scripts", () => {
         CI: undefined,
         TERM: "xterm-256color",
         COLORTERM: undefined,
+        TMUX: undefined,
+        TERM_PROGRAM: undefined,
         ...extraEnv,
       },
       terminal: {
@@ -760,6 +762,22 @@ describe("--filter forwards color to scripts", () => {
     expect(result.FORCE_COLOR).toBe("0");
   });
 
+  test("respects NODE_DISABLE_COLORS", async () => {
+    const dir = colorFixture();
+    const result = await runOnPTY(dir, { NODE_DISABLE_COLORS: "1" });
+    expect(result.FORCE_COLOR).toBe(null);
+  });
+
+  test("--parallel forwards FORCE_COLOR the same way", async () => {
+    const dir = colorFixture();
+    const result = await runOnPTY(dir, {}, ["--filter", "*", "--parallel", "probe"]);
+    expect(result).toEqual({
+      FORCE_COLOR: "2",
+      NO_COLOR: null,
+      enableANSI: true,
+    });
+  });
+
   test("does not set FORCE_COLOR when parent stdout is not a TTY", async () => {
     const dir = colorFixture();
     await using proc = Bun.spawn({
@@ -771,17 +789,21 @@ describe("--filter forwards color to scripts", () => {
         FORCE_COLOR: undefined,
         CI: undefined,
         TERM: "xterm-256color",
+        COLORTERM: undefined,
+        TMUX: undefined,
+        TERM_PROGRAM: undefined,
       },
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     const m = stdout.match(/RESULT (\{[^}]*\})/);
-    if (!m) throw new Error("missing RESULT in: " + JSON.stringify(stdout));
+    if (!m) throw new Error("missing RESULT in: " + JSON.stringify({ stdout, stderr }));
     const result = JSON.parse(m[1]);
     expect({ FORCE_COLOR: result.FORCE_COLOR, NO_COLOR: result.NO_COLOR }).toEqual({
       FORCE_COLOR: null,
       NO_COLOR: null,
     });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -87,8 +87,6 @@ function runInCwdSuccess({
   antipattern,
   command = ["present"],
   auto = false,
-  env = {},
-  elideCount,
 }: {
   cwd: string;
   pattern: string | string[];
@@ -96,15 +94,8 @@ function runInCwdSuccess({
   antipattern?: RegExp | RegExp[];
   command?: string[];
   auto?: boolean;
-  env?: Record<string, string | undefined>;
-  elideCount?: number;
 }) {
   const cmd = auto ? [bunExe()] : [bunExe(), "run"];
-
-  // Add elide-lines first if specified
-  if (elideCount !== undefined) {
-    cmd.push("--elide-lines", elideCount.toString());
-  }
 
   if (Array.isArray(pattern)) {
     for (const p of pattern) {
@@ -121,7 +112,7 @@ function runInCwdSuccess({
   const { exitCode, stdout, stderr } = spawnSync({
     cwd,
     cmd,
-    env: { ...bunEnv, ...env },
+    env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
Fixes #10346.

## What

`bun --filter` (and `bun run --parallel`/`--sequential`) wires script stdout/stderr to pipes so it can prefix and redraw the output. That hides the terminal from the script: `isatty()` is false, so chalk/supports-color and anything that gates on it drops to monochrome even though the parent is rendering its own cyan frame in color.

Before, on a color terminal:

```
pkga dev $ vite
│ VITE v5.x  ready in 123 ms      <- grey
│ ➜  Local:   http://localhost:5173/   <- grey
└─ Running...
```

## Fix

When the parent bun's own stdout is a color TTY and the user has not set `FORCE_COLOR`, `NO_COLOR`, or `NODE_DISABLE_COLORS` themselves, inject `FORCE_COLOR` into the script environment at the depth the parent detected (`1`/`2`/`3` for 16/256/truecolor; `3` on Windows where no `TERM`/`COLORTERM` is typically set but every supported build has truecolor). This matches what turbo/nx/lerna do for their task runners. The logic lives in a single `RunCommand::forward_color_to_piped_scripts` helper called from both the `--filter` and `--parallel` runners.

Explicit `FORCE_COLOR` (including `FORCE_COLOR=0`), `NO_COLOR`, and `NODE_DISABLE_COLORS` are passed through untouched, and nothing is injected when stdout is not itself a TTY, so piped/redirected output stays clean.

The `bun test --parallel` worker launcher also sets `FORCE_COLOR` for its workers but is intentionally left as-is here: it gates on stderr (where test output goes), it controls its own worker processes rather than arbitrary user scripts, and tightening it could change test-output snapshots. It can adopt the helper separately if wanted.

### Related: redraw renderer now requires a real TTY

The filter runner's `pretty_output` (the cursor-driven redraw renderer) was previously enabled whenever `enable_ansi_colors_stdout()` was true, so a nested `bun --filter` that inherited the injected `FORCE_COLOR` would emit cursor-up/erase sequences into the outer runner's pipe and corrupt its tree. `pretty_output` is now also gated on `is_stdout_tty()` on POSIX, matching the existing Windows check. `FORCE_COLOR` forces color, not redraw.

The `--elide-lines` tests have been moved onto a pty accordingly (elision only exists in the redraw path), which also lets them exercise the real output on Windows instead of falling back to the line-prefixed subset.

## Verification

New tests in `test/cli/run/filter-workspace.test.ts` spawn `bun --filter` and `bun --parallel` on a pty via `Bun.Terminal` and assert the child sees `FORCE_COLOR` and `Bun.enableANSIColors === true`, plus negative cases for `NO_COLOR`, `NODE_DISABLE_COLORS`, explicit `FORCE_COLOR=0`, piped stdout, and `FORCE_COLOR` on a pipe not enabling the redraw renderer.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts

<!-- robobun:evidence:end -->