### PR TITLE
resolver: percent-decode relative ESM import specifiers

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2969,13 +2969,9 @@ fn esm_specifier_decode_buf() -> *mut bun_paths::PathBuffer {
     p
 }
 
-/// Node's ESM loader resolves relative specifiers as URLs and percent-decodes
-/// the pathname via `fileURLToPath()` before `stat`. Encoded path separators
-/// are rejected (ERR_INVALID_MODULE_SPECIFIER) prior to decoding. Absolute
-/// specifiers are not handled here because `file://` inputs are already
-/// decoded to an absolute filesystem path by the callers (moduleLoaderResolve,
-/// moduleLoaderImportModule, do_resolve_with_args) and we cannot distinguish
-/// that from a user-typed absolute path at this layer.
+/// Node's ESM loader percent-decodes relative specifiers via
+/// `fileURLToPath()` and rejects encoded separators before decoding.
+/// Absolute paths are left to the callers' existing `file://` handling.
 #[cold]
 fn decode_esm_specifier(path: &[u8]) -> Option<&'static [u8]> {
     for sep in [b"%2f".as_slice(), b"%2F", b"%5c", b"%5C"] {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4097,8 +4097,7 @@ impl VirtualMachine {
             normalize_specifier_for_resolution(specifier, &mut query_string);
         if is_esm
             && bun_core::strings::contains_char(normalized_specifier, b'%')
-            && (normalized_specifier.starts_with(b"./")
-                || normalized_specifier.starts_with(b"../"))
+            && (normalized_specifier.starts_with(b"./") || normalized_specifier.starts_with(b"../"))
         {
             normalized_specifier = decode_esm_specifier(normalized_specifier)
                 .ok_or(crate::CrateError::ModuleNotFound)?;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2974,7 +2974,9 @@ fn esm_specifier_decode_buf() -> *mut bun_paths::PathBuffer {
 /// Absolute paths are left to the callers' existing `file://` handling.
 #[cold]
 pub fn decode_esm_specifier(path: &[u8]) -> Option<&'static [u8]> {
-    for sep in [b"%2f".as_slice(), b"%2F", b"%5c", b"%5C"] {
+    // %2F,%5C: Node's ERR_INVALID_MODULE_SPECIFIER. %3F: Bun's module key
+    // re-splits on '?' at fetch time, so a decoded '?' cannot round-trip.
+    for sep in [b"%2f".as_slice(), b"%2F", b"%3f", b"%3F", b"%5c", b"%5C"] {
         if bun_core::strings::contains(path, sep) {
             return None;
         }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2969,10 +2969,13 @@ fn esm_specifier_decode_buf() -> *mut bun_paths::PathBuffer {
     p
 }
 
-/// Node's ESM loader resolves relative/absolute specifiers as URLs and
-/// percent-decodes the pathname via `fileURLToPath()` before `stat`. Encoded
-/// path separators are rejected (ERR_INVALID_MODULE_SPECIFIER) prior to
-/// decoding. `file://` specifiers are handled in C++ (moduleLoaderResolve).
+/// Node's ESM loader resolves relative specifiers as URLs and percent-decodes
+/// the pathname via `fileURLToPath()` before `stat`. Encoded path separators
+/// are rejected (ERR_INVALID_MODULE_SPECIFIER) prior to decoding. Absolute
+/// specifiers are not handled here because `file://` inputs are already
+/// decoded to an absolute filesystem path by the callers (moduleLoaderResolve,
+/// moduleLoaderImportModule, do_resolve_with_args) and we cannot distinguish
+/// that from a user-typed absolute path at this layer.
 #[cold]
 fn decode_esm_specifier(path: &[u8]) -> Option<&'static [u8]> {
     for sep in [b"%2f".as_slice(), b"%2F", b"%5c", b"%5C"] {
@@ -4094,7 +4097,8 @@ impl VirtualMachine {
             normalize_specifier_for_resolution(specifier, &mut query_string);
         if is_esm
             && bun_core::strings::contains_char(normalized_specifier, b'%')
-            && !bun_paths::is_package_path(normalized_specifier)
+            && (normalized_specifier.starts_with(b"./")
+                || normalized_specifier.starts_with(b"../"))
         {
             normalized_specifier = decode_esm_specifier(normalized_specifier)
                 .ok_or(crate::CrateError::ModuleNotFound)?;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2973,7 +2973,7 @@ fn esm_specifier_decode_buf() -> *mut bun_paths::PathBuffer {
 /// `fileURLToPath()` and rejects encoded separators before decoding.
 /// Absolute paths are left to the callers' existing `file://` handling.
 #[cold]
-fn decode_esm_specifier(path: &[u8]) -> Option<&'static [u8]> {
+pub fn decode_esm_specifier(path: &[u8]) -> Option<&'static [u8]> {
     for sep in [b"%2f".as_slice(), b"%2F", b"%5c", b"%5C"] {
         if bun_core::strings::contains(path, sep) {
             return None;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2954,6 +2954,46 @@ fn specifier_cache_resolver_buf() -> *mut bun_paths::PathBuffer {
     p
 }
 
+/// Heap-backed so only a pointer lives in TLS; see test/js/bun/binary/tls-segment-size.
+#[thread_local]
+static ESM_SPECIFIER_DECODE_BUF: core::cell::Cell<*mut bun_paths::PathBuffer> =
+    core::cell::Cell::new(core::ptr::null_mut());
+
+#[inline]
+fn esm_specifier_decode_buf() -> *mut bun_paths::PathBuffer {
+    let mut p = ESM_SPECIFIER_DECODE_BUF.get();
+    if p.is_null() {
+        p = bun_core::heap::into_raw(Box::new(bun_paths::PathBuffer::ZEROED));
+        ESM_SPECIFIER_DECODE_BUF.set(p);
+    }
+    p
+}
+
+/// Node's ESM loader resolves relative/absolute specifiers as URLs and
+/// percent-decodes the pathname via `fileURLToPath()` before `stat`. Encoded
+/// path separators are rejected (ERR_INVALID_MODULE_SPECIFIER) prior to
+/// decoding. `file://` specifiers are handled in C++ (moduleLoaderResolve).
+#[cold]
+fn decode_esm_specifier(path: &[u8]) -> Option<&'static [u8]> {
+    for sep in [b"%2f".as_slice(), b"%2F", b"%5c", b"%5C"] {
+        if bun_core::strings::contains(path, sep) {
+            return None;
+        }
+    }
+    // SAFETY: threadlocal heap allocation; `_resolve` does not recurse, so
+    // this is the unique live `&mut` on the JS thread for this call.
+    let buf = unsafe { &mut *esm_specifier_decode_buf() }.as_mut_slice();
+    if path.len() > buf.len() {
+        return None;
+    }
+    match bun_url::PercentEncoding::decode_into(buf, path) {
+        // SAFETY: `buf` is a threadlocal heap allocation that outlives the
+        // synchronous `resolve_and_auto_install` call below.
+        Ok(n) => Some(unsafe { bun_ptr::detach_lifetime(&buf[..n as usize]) }),
+        Err(_) => None,
+    }
+}
+
 fn ensure_source_code_printer() {
     if SOURCE_CODE_PRINTER.get().is_none() {
         let writer = bun_js_printer::BufferWriter::init();
@@ -4050,7 +4090,15 @@ impl VirtualMachine {
 
         let is_special_source = source == MAIN_FILE_NAME || Macro::is_macro_path(source);
         let mut query_string: &[u8] = b"";
-        let normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
+        let mut normalized_specifier =
+            normalize_specifier_for_resolution(specifier, &mut query_string);
+        if is_esm
+            && bun_core::strings::contains_char(normalized_specifier, b'%')
+            && !bun_paths::is_package_path(normalized_specifier)
+        {
+            normalized_specifier = decode_esm_specifier(normalized_specifier)
+                .ok_or(crate::CrateError::ModuleNotFound)?;
+        }
         let top_level_dir = self.top_level_dir();
         let source_to_use: &[u8] = if !is_special_source {
             if is_a_file_path {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4941,15 +4941,13 @@ unsafe fn _resolve<'a>(
     // ── Filesystem resolver ──────────────────────────────────────────────
     let is_special_source = source == MAIN_FILE_NAME || bun_js_parser::Macro::is_macro_path(source);
     let mut query_string: &[u8] = b"";
-    let mut normalized_specifier =
-        normalize_specifier_for_resolution(specifier, &mut query_string);
+    let mut normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
     if is_esm
         && bun_core::strings::contains_char(normalized_specifier, b'%')
         && (normalized_specifier.starts_with(b"./") || normalized_specifier.starts_with(b"../"))
     {
-        normalized_specifier =
-            bun_jsc::virtual_machine::decode_esm_specifier(normalized_specifier)
-                .ok_or(crate::Error::ModuleNotFound)?;
+        normalized_specifier = bun_jsc::virtual_machine::decode_esm_specifier(normalized_specifier)
+            .ok_or(crate::Error::ModuleNotFound)?;
     }
     // `Fs.PathName.init(source).dirWithTrailingSlash()` slices
     // `source` in place, so the `'a` lifetime is preserved.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4941,7 +4941,16 @@ unsafe fn _resolve<'a>(
     // ── Filesystem resolver ──────────────────────────────────────────────
     let is_special_source = source == MAIN_FILE_NAME || bun_js_parser::Macro::is_macro_path(source);
     let mut query_string: &[u8] = b"";
-    let normalized_specifier = normalize_specifier_for_resolution(specifier, &mut query_string);
+    let mut normalized_specifier =
+        normalize_specifier_for_resolution(specifier, &mut query_string);
+    if is_esm
+        && bun_core::strings::contains_char(normalized_specifier, b'%')
+        && (normalized_specifier.starts_with(b"./") || normalized_specifier.starts_with(b"../"))
+    {
+        normalized_specifier =
+            bun_jsc::virtual_machine::decode_esm_specifier(normalized_specifier)
+                .ok_or(crate::Error::ModuleNotFound)?;
+    }
     // `Fs.PathName.init(source).dirWithTrailingSlash()` slices
     // `source` in place, so the `'a` lifetime is preserved.
     let top_level_dir: &'a [u8] = Fs::FileSystem::get().top_level_dir;

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -703,13 +703,38 @@ describe("ESM import specifier percent-encoding", () => {
     expect(exitCode).toBe(0);
   });
 
+  it.concurrent("does not double-decode a file:// URL whose target path contains a literal '%'", async () => {
+    using dir = tempDir("esm-specifier-percent-file-url", {
+      "lit%25.js": "export default 'literal-percent-25';",
+      "index.mjs": [
+        `import { pathToFileURL } from 'node:url';`,
+        `const href = pathToFileURL(import.meta.dirname + '/lit%25.js').href;`,
+        `const m = await import(href);`,
+        `console.log(m.default);`,
+      ].join("\n"),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("literal-percent-25\n");
+    expect(exitCode).toBe(0);
+  });
+
   it.concurrent("rejects encoded path separators and malformed escapes", async () => {
     using dir = tempDir("esm-specifier-percent-sep", {
       "sub/file.js": "export default 1;",
       "a%ZZ.js": "export default 1;",
       "index.mjs": [
         `const out = {};`,
-        `for (const spec of ['./sub%2Ffile.js', './sub%2ffile.js', './sub%5Cfile.js', './a%ZZ.js']) {`,
+        `for (const spec of ['./sub%2Ffile.js', './sub%2ffile.js', './sub%5Cfile.js', './sub%5cfile.js', './a%ZZ.js']) {`,
         `  try { await import(spec); out[spec] = 'resolved'; }`,
         `  catch (e) { out[spec] = e.code ?? e.name; }`,
         `}`,
@@ -731,6 +756,7 @@ describe("ESM import specifier percent-encoding", () => {
       "./sub%2Ffile.js": "ERR_MODULE_NOT_FOUND",
       "./sub%2ffile.js": "ERR_MODULE_NOT_FOUND",
       "./sub%5Cfile.js": "ERR_MODULE_NOT_FOUND",
+      "./sub%5cfile.js": "ERR_MODULE_NOT_FOUND",
       "./a%ZZ.js": "ERR_MODULE_NOT_FOUND",
     });
     expect(exitCode).toBe(0);

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -728,13 +728,13 @@ describe("ESM import specifier percent-encoding", () => {
     expect(exitCode).toBe(0);
   });
 
-  it.concurrent("rejects encoded path separators and malformed escapes", async () => {
+  it.concurrent("rejects encoded separators, encoded '?' and malformed escapes", async () => {
     using dir = tempDir("esm-specifier-percent-sep", {
       "sub/file.js": "export default 1;",
       "a%ZZ.js": "export default 1;",
       "index.mjs": [
         `const out = {};`,
-        `for (const spec of ['./sub%2Ffile.js', './sub%2ffile.js', './sub%5Cfile.js', './sub%5cfile.js', './a%ZZ.js']) {`,
+        `for (const spec of ['./sub%2Ffile.js', './sub%2ffile.js', './sub%5Cfile.js', './sub%5cfile.js', './q%3Fmark.js', './q%3fmark.js', './a%ZZ.js']) {`,
         `  try { await import(spec); out[spec] = 'resolved'; }`,
         `  catch (e) { out[spec] = e.code ?? e.name; }`,
         `}`,
@@ -757,6 +757,8 @@ describe("ESM import specifier percent-encoding", () => {
       "./sub%2ffile.js": "ERR_MODULE_NOT_FOUND",
       "./sub%5Cfile.js": "ERR_MODULE_NOT_FOUND",
       "./sub%5cfile.js": "ERR_MODULE_NOT_FOUND",
+      "./q%3Fmark.js": "ERR_MODULE_NOT_FOUND",
+      "./q%3fmark.js": "ERR_MODULE_NOT_FOUND",
       "./a%ZZ.js": "ERR_MODULE_NOT_FOUND",
     });
     expect(exitCode).toBe(0);

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -646,6 +646,97 @@ describe("package.json exports target percent-encoding", () => {
   });
 });
 
+// https://github.com/oven-sh/bun/issues/8640
+describe("ESM import specifier percent-encoding", () => {
+  it.concurrent("decodes a relative ESM specifier before resolving", async () => {
+    using dir = tempDir("esm-specifier-percent", {
+      "foo bar.js": "export default 'decoded';",
+      "foo%20bar.js": "export default 'literal';",
+      "a#b.js": "export default 'hash';",
+      "lit%25.js": "export default 'percent';",
+      "index.mjs": [
+        `import space from './foo%20bar.js';`,
+        `import hash from './a%23b.js';`,
+        `import pct from './lit%2525.js';`,
+        `const dyn = (await import('./foo%20bar.js?v=1')).default;`,
+        `console.log(JSON.stringify({ space, hash, pct, dyn }));`,
+      ].join("\n"),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      space: "decoded",
+      hash: "hash",
+      pct: "percent",
+      dyn: "decoded",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("does not decode a CJS require() specifier", async () => {
+    using dir = tempDir("esm-specifier-percent-cjs", {
+      "req bar.js": "module.exports = 'decoded';",
+      "req%20bar.js": "module.exports = 'literal';",
+      "index.cjs": `console.log(require('./req%20bar.js'));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("literal\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("rejects encoded path separators and malformed escapes", async () => {
+    using dir = tempDir("esm-specifier-percent-sep", {
+      "sub/file.js": "export default 1;",
+      "a%ZZ.js": "export default 1;",
+      "index.mjs": [
+        `const out = {};`,
+        `for (const spec of ['./sub%2Ffile.js', './sub%2ffile.js', './sub%5Cfile.js', './a%ZZ.js']) {`,
+        `  try { await import(spec); out[spec] = 'resolved'; }`,
+        `  catch (e) { out[spec] = e.code ?? e.name; }`,
+        `}`,
+        `console.log(JSON.stringify(out));`,
+      ].join("\n"),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "./sub%2Ffile.js": "ERR_MODULE_NOT_FOUND",
+      "./sub%2ffile.js": "ERR_MODULE_NOT_FOUND",
+      "./sub%5Cfile.js": "ERR_MODULE_NOT_FOUND",
+      "./a%ZZ.js": "ERR_MODULE_NOT_FOUND",
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("package.json exports targets longer than the maximum path length", () => {
   it.concurrent("reports a resolution error for an oversized string exports target", async () => {
     using dir = tempDir("resolver-exports-long-target", {


### PR DESCRIPTION
## What

`import './foo%20bar.js'` should load the file `foo bar.js`. Node, Deno, and browsers all agree on this because ESM specifiers are URLs: a relative specifier is resolved against the parent module URL and the resulting pathname is percent-decoded (via `fileURLToPath`) before the filesystem is touched. Bun passed the specifier straight to the path resolver, so it looked for a file literally named `foo%20bar.js`:

```
error: Cannot find module './foo%20bar.js' from '/tmp/index.mjs'
```

Fixes #8640.
Fixes #17387.
Fixes #28745.

## Fix

In `VirtualMachine::_resolve` (and its `LoaderHooks` sibling in `jsc_hooks.rs`), after the query string is split off and before the resolver is entered, percent-decode the specifier when:

- the import is ESM (`is_esm`), because Node's CommonJS `require()` does **not** decode and we keep that behaviour;
- the specifier is relative (starts with `./` or `../`); and
- the specifier actually contains a `%`, so the common case is a single SIMD scan and nothing else.

Encoded path separators (`%2F`, `%2f`, `%5C`, `%5c`) are rejected before decoding, matching Node's `finalizeResolution` check. An encoded `?` (`%3F`, `%3f`) is also rejected because Bun's module key is re-split on `?` at fetch time, so a filesystem path containing a literal `?` cannot round-trip; `?` is also invalid in Windows filenames. An invalid escape such as `%ZZ` fails resolution instead of being treated as a literal, which is also what Node does (its `decodeURIComponent` call throws URIError). Rejections surface as `ERR_MODULE_NOT_FOUND` for consistency with the existing exports-target decode path; Node uses `ERR_INVALID_MODULE_SPECIFIER` for the separator case, which could be wired through both sites in a follow-up.

Absolute and `file://` specifiers are left alone here: `moduleLoaderResolve`, `moduleLoaderImportModule`, and `do_resolve_with_args` already convert `file://` URLs to a decoded absolute filesystem path before calling `_resolve`, and decoding that path a second time would break `import(pathToFileURL(p).href)` when `p` itself contains a literal `%`. A regression test covers that case.

The decode buffer is a lazily-allocated thread-local `PathBuffer`, the same pattern `SPECIFIER_CACHE_RESOLVER_BUF` already uses a few lines above, and the decoder is the existing `bun_url::PercentEncoding` that `ESModule::finalize` uses for package.json exports targets.

The change is scoped to the runtime loader; `Bun.build` resolution is untouched (esbuild does not decode either).

## Verification

New tests in `test/js/bun/resolve/resolve.test.ts`:

- static `import` and dynamic `import()` of `./foo%20bar.js` resolve to `foo bar.js` even when a literal `foo%20bar.js` file also exists; `%23` resolves to a file with `#` in its name; `%25` round-trips so a literal `%` filename can still be reached via double-encoding
- `require('./req%20bar.js')` still resolves the literal filename (CJS unchanged)
- `import(pathToFileURL(dir + '/lit%25.js').href)` still resolves to the literal `lit%25.js` file (no double decode)
- `%2F` / `%2f` / `%5C` / `%5c` / `%3F` / `%3f` and a malformed `%ZZ` escape all reject as module-not-found instead of decoding through

The first and last tests fail on `main` with `Cannot find module './a%23b.js'` and `./a%ZZ.js` resolving instead of rejecting; all four pass with this change. The rest of `resolve.test.ts`, `import-meta.test.js`, `import-meta-resolve.test.mjs`, and `import-query.test.ts` pass unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->