### PR TITLE
FormData: anchor multipart boundary delimiters to a preceding CRLF

### DIFF
--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -280,7 +280,7 @@ pub fn for_each_multipart_entry<C>(
         buf[4 + boundary.len()..need].copy_from_slice(b"--");
         let final_boundary = &buf[..need];
 
-        if let Some(i) = strings::last_index_of(slice, final_boundary) {
+        if let Some(i) = strings::index_of(slice, final_boundary) {
             slice = &slice[..i];
         } else if slice.starts_with(&final_boundary[2..]) {
             // `--{boundary}--` at offset 0: an empty form with no preamble.

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -266,15 +266,10 @@ pub fn for_each_multipart_entry<C>(
     let mut slice = input;
     let subslicer = SlicedString::init(input, input);
 
-    // RFC 2046 §5.1.1: the CRLF preceding the encapsulation boundary is
-    // conceptually attached to the boundary, not to the preceding part's body.
-    // Matching `--boundary` without that leading CRLF lets a mid-line
-    // `--boundary` inside a field value terminate the part early and parses
-    // the value's remaining bytes as an attacker-authored extra part.
+    // RFC 2046 §5.1.1: the CRLF before `--boundary` is part of the delimiter.
     let mut buf = [0u8; 78];
     {
-        // Hand-rolled `\r\n--{boundary}--` formatting — boundary is raw
-        // bytes, not guaranteed UTF-8, so avoid `core::fmt`.
+        // `\r\n--{boundary}--` (boundary is raw bytes, so no `core::fmt`).
         let need = boundary.len() + 6;
         if need > buf.len() {
             return Err(crate::Error::BoundaryIsTooLong);
@@ -295,15 +290,12 @@ pub fn for_each_multipart_entry<C>(
         }
     }
 
-    // Hand-rolled `\r\n--{boundary}\r\n` formatting (same raw-bytes caveat).
-    // Length check already passed above (same `boundary.len() + 6`).
+    // `\r\n--{boundary}\r\n` (length bound already checked above).
     let sep_len = boundary.len() + 6;
     buf[4 + boundary.len()..sep_len].copy_from_slice(b"\r\n");
     let separator = &buf[..sep_len];
 
-    // The opening dash-boundary is the one delimiter permitted without a
-    // leading CRLF (no preamble). Consume it explicitly so every remaining
-    // delimiter is the full CRLF-anchored form.
+    // RFC 2046 permits the opening `--boundary` at offset 0 with no CRLF.
     if slice.starts_with(&separator[2..]) {
         slice = &slice[separator.len() - 2..];
     } else if let Some(i) = strings::index_of(slice, separator) {
@@ -316,10 +308,17 @@ pub fn for_each_multipart_entry<C>(
 
     while let Some(chunk) = splitter.next() {
         let mut remain = chunk;
-        let header_end =
-            strings::index_of(remain, b"\r\n\r\n").ok_or(crate::Error::IsMissingHeaderEnd)?;
-        let header = &remain[..header_end + 2];
-        remain = &remain[header_end + 4..];
+        let header;
+        if let Some(header_end) = strings::index_of(remain, b"\r\n\r\n") {
+            header = &remain[..header_end + 2];
+            remain = &remain[header_end + 4..];
+        } else if remain.ends_with(b"\r\n") {
+            // `body-part := MIME-part-headers [CRLF *OCTET]` permits no body.
+            header = remain;
+            remain = b"";
+        } else {
+            return Err(crate::Error::IsMissingHeaderEnd);
+        }
 
         let mut field = Field::default();
         let mut name = bun_semver::String::default();

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -266,35 +266,53 @@ pub fn for_each_multipart_entry<C>(
     let mut slice = input;
     let subslicer = SlicedString::init(input, input);
 
-    let mut buf = [0u8; 76];
+    // RFC 2046 §5.1.1: the CRLF preceding the encapsulation boundary is
+    // conceptually attached to the boundary, not to the preceding part's body.
+    // Matching `--boundary` without that leading CRLF lets a mid-line
+    // `--boundary` inside a field value terminate the part early and parses
+    // the value's remaining bytes as an attacker-authored extra part.
+    let mut buf = [0u8; 78];
     {
-        // Hand-rolled `--{boundary}--` formatting — boundary is raw bytes,
-        // not guaranteed UTF-8, so avoid `core::fmt`.
-        let need = boundary.len() + 4;
+        // Hand-rolled `\r\n--{boundary}--` formatting — boundary is raw
+        // bytes, not guaranteed UTF-8, so avoid `core::fmt`.
+        let need = boundary.len() + 6;
         if need > buf.len() {
             return Err(crate::Error::BoundaryIsTooLong);
         }
-        buf[..2].copy_from_slice(b"--");
-        buf[2..2 + boundary.len()].copy_from_slice(boundary);
-        buf[2 + boundary.len()..need].copy_from_slice(b"--");
+        buf[..2].copy_from_slice(b"\r\n");
+        buf[2..4].copy_from_slice(b"--");
+        buf[4..4 + boundary.len()].copy_from_slice(boundary);
+        buf[4 + boundary.len()..need].copy_from_slice(b"--");
         let final_boundary = &buf[..need];
 
-        let Some(final_boundary_index) = strings::last_index_of(input, final_boundary) else {
+        if let Some(i) = strings::last_index_of(slice, final_boundary) {
+            slice = &slice[..i];
+        } else if slice.starts_with(&final_boundary[2..]) {
+            // `--{boundary}--` at offset 0: an empty form with no preamble.
+            return Ok(());
+        } else {
             return Err(crate::Error::MissingFinalBoundary);
-        };
-        slice = &slice[..final_boundary_index];
+        }
     }
 
-    // Hand-rolled `--{boundary}\r\n` formatting (same raw-bytes caveat).
-    // Length check already passed above (same `boundary.len() + 4`).
-    let sep_len = boundary.len() + 4;
-    buf[..2].copy_from_slice(b"--");
-    buf[2..2 + boundary.len()].copy_from_slice(boundary);
-    buf[2 + boundary.len()..sep_len].copy_from_slice(b"\r\n");
+    // Hand-rolled `\r\n--{boundary}\r\n` formatting (same raw-bytes caveat).
+    // Length check already passed above (same `boundary.len() + 6`).
+    let sep_len = boundary.len() + 6;
+    buf[4 + boundary.len()..sep_len].copy_from_slice(b"\r\n");
     let separator = &buf[..sep_len];
 
+    // The opening dash-boundary is the one delimiter permitted without a
+    // leading CRLF (no preamble). Consume it explicitly so every remaining
+    // delimiter is the full CRLF-anchored form.
+    if slice.starts_with(&separator[2..]) {
+        slice = &slice[separator.len() - 2..];
+    } else if let Some(i) = strings::index_of(slice, separator) {
+        slice = &slice[i + separator.len()..];
+    } else {
+        return Ok(());
+    }
+
     let mut splitter = strings::split(slice, separator);
-    let _ = splitter.next(); // skip first boundary
 
     while let Some(chunk) = splitter.next() {
         let mut remain = chunk;
@@ -400,11 +418,7 @@ pub fn for_each_multipart_entry<C>(
             continue;
         }
 
-        let mut body = remain;
-        if body.ends_with(b"\r\n") {
-            body = &body[..body.len() - 2];
-        }
-        field.value = body;
+        field.value = remain;
         field.filename = filename.unwrap_or_default();
         field.is_file = is_file;
 

--- a/src/runtime/webcore/FormData.rs
+++ b/src/runtime/webcore/FormData.rs
@@ -280,11 +280,11 @@ pub fn for_each_multipart_entry<C>(
         buf[4 + boundary.len()..need].copy_from_slice(b"--");
         let final_boundary = &buf[..need];
 
-        if let Some(i) = strings::index_of(slice, final_boundary) {
-            slice = &slice[..i];
-        } else if slice.starts_with(&final_boundary[2..]) {
-            // `--{boundary}--` at offset 0: an empty form with no preamble.
+        if slice.starts_with(&final_boundary[2..]) {
+            // `--{boundary}--` at offset 0: everything after is epilogue.
             return Ok(());
+        } else if let Some(i) = strings::index_of(slice, final_boundary) {
+            slice = &slice[..i];
         } else {
             return Err(crate::Error::MissingFinalBoundary);
         }

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -305,6 +305,20 @@ describe("FormData", () => {
       expect([...fd]).toEqual([]);
     });
 
+    it("parses a headers-only part (no body octets) as an empty value", async () => {
+      const fd = await make(
+        `--${B}${CRLF}` + `Content-Disposition: form-data; name="a"${CRLF}` + `${CRLF}--${B}--${CRLF}`,
+      );
+      expect([...fd]).toEqual([["a", ""]]);
+    });
+
+    it("parses a zero-octet body as an empty value", async () => {
+      const fd = await make(
+        `--${B}${CRLF}` + `Content-Disposition: form-data; name="a"${CRLF}${CRLF}` + `${CRLF}--${B}--${CRLF}`,
+      );
+      expect([...fd]).toEqual([["a", ""]]);
+    });
+
     it("ignores a preamble before the first delimiter", async () => {
       const body =
         `this is a preamble${CRLF}` +

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -320,6 +320,18 @@ describe("FormData", () => {
       expect([...fd]).toEqual([]);
     });
 
+    it("treats the offset-0 close delimiter as final even when more parts follow", async () => {
+      const body =
+        `--${B}--${CRLF}` +
+        `--${B}${CRLF}` +
+        `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` +
+        `admin${CRLF}` +
+        `--${B}--${CRLF}`;
+      const fd = await make(body);
+      expect([...fd]).toEqual([]);
+      expect(fd.get("role")).toBeNull();
+    });
+
     it("parses a headers-only part (no body octets) as an empty value", async () => {
       const fd = await make(
         `--${B}${CRLF}` + `Content-Disposition: form-data; name="a"${CRLF}` + `${CRLF}--${B}--${CRLF}`,

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -289,6 +289,21 @@ describe("FormData", () => {
       expect([...fd]).toEqual([["comment", value]]);
     });
 
+    it("stops at the first close delimiter and discards the epilogue", async () => {
+      const body =
+        `--${B}${CRLF}` +
+        `Content-Disposition: form-data; name="comment"${CRLF}${CRLF}` +
+        `foo${CRLF}` +
+        `--${B}--${CRLF}` +
+        `--${B}${CRLF}` +
+        `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` +
+        `admin${CRLF}` +
+        `--${B}--${CRLF}`;
+      const fd = await make(body);
+      expect([...fd]).toEqual([["comment", "foo"]]);
+      expect(fd.get("role")).toBeNull();
+    });
+
     it("keeps a value that ends in CRLF", async () => {
       const value = `line1${CRLF}line2${CRLF}`;
       const body =

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -255,6 +255,92 @@ describe("FormData", () => {
     }
   });
 
+  // RFC 2046 §5.1.1: the CRLF preceding the boundary delimiter line is part of
+  // the delimiter. A `--boundary` sequence that is not at the start of a line
+  // is part of the enclosing field's value, not a delimiter.
+  describe("multipart boundary must follow CRLF", () => {
+    const B = "AaB03x";
+    const CRLF = "\r\n";
+    const make = (body: string) =>
+      new Response(body, { headers: { "Content-Type": `multipart/form-data; boundary=${B}` } }).formData();
+
+    for (const prefix of ["hello", "x", "zz", "-", "--"]) {
+      it(`keeps mid-line '${prefix}--${B}\\r\\n' in a value (not a delimiter)`, async () => {
+        const value =
+          `${prefix}--${B}${CRLF}` + `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` + `admin`;
+        const body =
+          `--${B}${CRLF}` +
+          `Content-Disposition: form-data; name="comment"${CRLF}${CRLF}` +
+          `${value}${CRLF}` +
+          `--${B}--${CRLF}`;
+        const fd = await make(body);
+        expect([...fd]).toEqual([["comment", value]]);
+        expect(fd.get("role")).toBeNull();
+      });
+    }
+
+    it("keeps mid-line '--boundary--' in a value (not the close delimiter)", async () => {
+      const value = `hello--${B}--world`;
+      const body =
+        `--${B}${CRLF}` +
+        `Content-Disposition: form-data; name="comment"${CRLF}${CRLF}` +
+        `${value}${CRLF}` +
+        `--${B}--${CRLF}`;
+      const fd = await make(body);
+      expect([...fd]).toEqual([["comment", value]]);
+    });
+
+    it("keeps a value that ends in CRLF", async () => {
+      const value = `line1${CRLF}line2${CRLF}`;
+      const body =
+        `--${B}${CRLF}` +
+        `Content-Disposition: form-data; name="a"${CRLF}${CRLF}` +
+        `${value}${CRLF}` +
+        `--${B}--${CRLF}`;
+      const fd = await make(body);
+      expect([...fd]).toEqual([["a", value]]);
+    });
+
+    it("accepts the close delimiter at offset 0 (empty form)", async () => {
+      const fd = await make(`--${B}--${CRLF}`);
+      expect([...fd]).toEqual([]);
+    });
+
+    it("ignores a preamble before the first delimiter", async () => {
+      const body =
+        `this is a preamble${CRLF}` +
+        `--${B}${CRLF}` +
+        `Content-Disposition: form-data; name="a"${CRLF}${CRLF}` +
+        `hello${CRLF}` +
+        `--${B}--${CRLF}`;
+      const fd = await make(body);
+      expect([...fd]).toEqual([["a", "hello"]]);
+    });
+
+    it("Bun.serve req.formData(): mid-line boundary in a value is not a delimiter", async () => {
+      const value =
+        `hello--${B}${CRLF}` + `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` + `admin`;
+      const body =
+        `--${B}${CRLF}` +
+        `Content-Disposition: form-data; name="comment"${CRLF}${CRLF}` +
+        `${value}${CRLF}` +
+        `--${B}--${CRLF}`;
+      await using server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const fd = await req.formData();
+          return Response.json([...fd]);
+        },
+      });
+      const res = await fetch(server.url, {
+        method: "POST",
+        headers: { "Content-Type": `multipart/form-data; boundary=${B}` },
+        body,
+      });
+      expect(await res.json()).toEqual([["comment", value]]);
+    });
+  });
+
   // RFC 2045 §5.1 / RFC 7231 §3.1.1.1: media type/subtype and parameter
   // attribute names are case-insensitive; the boundary VALUE is byte-exact.
   describe("Content-Type case-insensitivity", () => {

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -266,8 +266,7 @@ describe("FormData", () => {
 
     for (const prefix of ["hello", "x", "zz", "-", "--"]) {
       it(`keeps mid-line '${prefix}--${B}\\r\\n' in a value (not a delimiter)`, async () => {
-        const value =
-          `${prefix}--${B}${CRLF}` + `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` + `admin`;
+        const value = `${prefix}--${B}${CRLF}` + `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` + `admin`;
         const body =
           `--${B}${CRLF}` +
           `Content-Disposition: form-data; name="comment"${CRLF}${CRLF}` +
@@ -318,8 +317,7 @@ describe("FormData", () => {
     });
 
     it("Bun.serve req.formData(): mid-line boundary in a value is not a delimiter", async () => {
-      const value =
-        `hello--${B}${CRLF}` + `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` + `admin`;
+      const value = `hello--${B}${CRLF}` + `Content-Disposition: form-data; name="role"${CRLF}${CRLF}` + `admin`;
       const body =
         `--${B}${CRLF}` +
         `Content-Disposition: form-data; name="comment"${CRLF}${CRLF}` +


### PR DESCRIPTION
## Reproduction

```js
const CRLF = "\r\n", B = "AaB03x";
const value = `hello--${B}${CRLF}Content-Disposition: form-data; name="role"${CRLF}${CRLF}admin`;
const body  = `--${B}${CRLF}Content-Disposition: form-data; name="comment"${CRLF}${CRLF}${value}${CRLF}--${B}--${CRLF}`;
const fd = await new Response(body, {headers:{"content-type":`multipart/form-data; boundary=${B}`}}).formData();
console.log([...fd]);
// bun    : [["comment","hello"],["role","admin"]]   <-- injected field
// busboy : [["comment","hello--AaB03x\r\nContent-Disposition: ... admin"]]
// node   : TypeError (rejects: delimiter not at line start)
```

The body has one field `comment` whose value contains the bytes `hello--AaB03x\r\n...` mid-line (no preceding CRLF). Bun parses it as two fields, the second of which is entirely authored inside another field's value. `Bun.serve` `req.formData()` behaves the same. A busboy/multer-fronted validator and a Bun backend therefore disagree on the field set of the identical request.

## Cause

`for_each_multipart_entry` in `src/runtime/webcore/FormData.rs` splits the body on `--{boundary}\r\n`. RFC 2046 5.1.1 defines the delimiter as `CRLF "--" boundary`: the preceding CRLF is part of the delimiter, not the previous part's body. Without requiring it, any `--{boundary}\r\n` inside a value matches. `--{boundary}suffix` (no trailing CRLF) was already kept as content; only the leading CRLF was missing.

## Fix

Match on `\r\n--{boundary}\r\n` for inter-part delimiters and `\r\n--{boundary}--` for the close delimiter. The opening `--{boundary}\r\n`, which RFC 2046 permits at offset 0 with no leading CRLF, is consumed explicitly before splitting (and `--{boundary}--` at offset 0 is the empty-form case). The per-part trailing-`\r\n` strip is removed because the delimiter's leading CRLF is no longer attached to the body. Values that legitimately end in CRLF are preserved byte-exact, same as before.

## Verification

New tests in `test/js/web/html/FormData.test.ts` cover mid-line `--{boundary}\r\n` with several prefixes (including `-` and `--`), mid-line `--{boundary}--`, values ending in CRLF, the empty-form close delimiter at offset 0, a preamble before the first delimiter, and the same body through `Bun.serve` `req.formData()`. The mid-line cases fail on main (parse two fields) and pass with this change (parse one field whose value is the verbatim bytes).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (7c8feb891)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [11.16ms]
(pass) FormData > should be able to append a Blob [13.80ms]
(pass) FormData > should be able to set a Blob [11.43ms]
(pass) FormData > should be able to set a string [4.80ms]
(pass) FormData > should get filename from file [6.22ms]
(pass) FormData > should use the correct filenames [7.87ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [23.19ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [61.23ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [5.03ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [8.88ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [3.06ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [6.50ms]
(pass) FormData > should parse multipart/form-data 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (bac390e50)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [18.92ms]
(pass) FormData > should be able to append a Blob [2.17ms]
(pass) FormData > should be able to set a Blob [0.14ms]
(pass) FormData > should be able to set a string [0.06ms]
(pass) FormData > should get filename from file [1.01ms]
(pass) FormData > should use the correct filenames [0.17ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [6.99ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [13.26ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [2.01ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [0.11ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [0.03ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [0.05ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Request [0.02ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Request [0.05ms]
(pass)
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/html/FormData.test.ts
bun test v1.4.0 (7c8feb891)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [12.33ms]
(pass) FormData > should be able to append a Blob [14.41ms]
(pass) FormData > should be able to set a Blob [12.35ms]
(pass) FormData > should be able to set a string [4.63ms]
(pass) FormData > should get filename from file [7.47ms]
(pass) FormData > should use the correct filenames [8.66ms]
(pass) FormData > should parse multipart/form-data (simple) with Response [23.52ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Response [59.63ms]
(pass) FormData > should parse multipart/form-data (simple) with Request [4.18ms]
(pass) FormData > should roundtrip multipart/form-data (simple) with Request [9.22ms]
(pass) FormData > should parse multipart/form-data (simple with trailing CRLF) with Response [2.89ms]
(pass) FormData > should roundtrip multipart/form-data (simple with trailing CRLF) with Response [5.83ms]
(pass) FormData > should parse multipart/form-data 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1094ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 7m 03s
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+7c8feb891
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (7c8feb891)

test/js/web/html/FormData.test.ts:
(pass) FormData > should be able to append a string [0.48ms]
(pass) FormData > should be able to append a Blob [0.69ms]
(pass) FormData > should be able to set a Blob [0.12ms]
(pass) FormData > should be able to set a string [0.06ms]
(pass) FormData > should get filename from file [0.08ms]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/FormData.rs   |  65 ++++++++++++--------
 test/js/web/html/FormData.test.ts | 125 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 164 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/webcore/FormData.rs        7      8      0
test/js/web/html/FormData.test.ts      5      6      0
```

</details>

<!-- robobun:evidence:end -->