### PR TITLE
bundler: rename esm top-level vars that collide with host globals

### DIFF
--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -137,26 +137,14 @@ pub unsafe fn rename_symbols_in_chunk(
         );
     }
 
-    // Scope hoisting rewrites module-scope `const`/`let` to `var` so the
-    // declaration can be split from its initializer when a module is wrapped.
-    // For `--format=esm --target=browser` the chunk has no wrapper, so those
-    // `var`s sit at the true top level. Loaded as a module that is fine, but
-    // loaded as a classic `<script>` a top-level `var`/`function` becomes a
-    // property of `globalThis`. When the original name collides with a host
-    // global that the code reads back through `window`/`defaultView`, the
-    // bundle silently overwrites it (Chart.js's `const getComputedStyle = …`
-    // recurses into itself via `defaultView.getComputedStyle`; #14110).
-    // Reserve any declared top-level name that is in the pure-global table so
-    // the number renamer suffixes the binding while unbound references to the
-    // real global keep the name.
-    //
-    // Gated to `target=browser` because Bun/Node load ESM output in module
-    // scope, where `var` never reaches `globalThis`. `WrapKind::Cjs` modules
-    // keep their declarations inside the `__commonJS` closure, so skip those
-    // too. Only symbol kinds that print as a VarScoped declaration at the
-    // chunk top level (`var`/`function`/`async function`/`function*`) are
-    // considered; `class` and `import` stay lexical and cannot clobber
-    // `globalThis`.
+    // Scope hoisting rewrites module-scope `const`/`let` to `var`. In an
+    // unwrapped browser ESM chunk a top-level `var`/`function` becomes a
+    // `globalThis` property when the bundle is loaded as a classic `<script>`,
+    // so a name that collides with a host global overwrites it (#14110:
+    // Chart.js's `const getComputedStyle` recurses via
+    // `defaultView.getComputedStyle`). Reserve those names so the renamer
+    // suffixes the binding. CJS-wrapped modules keep their declarations in the
+    // closure; `class`/`import` are lexical and cannot clobber `globalThis`.
     if c.options.output_format == options::OutputFormat::Esm
         && c.options.target == options::Target::Browser
     {

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -139,23 +139,43 @@ pub unsafe fn rename_symbols_in_chunk(
 
     // Scope hoisting rewrites module-scope `const`/`let` to `var` so the
     // declaration can be split from its initializer when a module is wrapped.
-    // For `--format=esm` the chunk has no wrapper, so those `var`s sit at the
-    // true top level. Loaded as a module that is fine, but loaded as a classic
-    // `<script>` a top-level `var` becomes a property of `globalThis`. When the
-    // original name collides with a host global that the code reads back
-    // through `window`/`defaultView`, the bundle silently overwrites it
-    // (Chart.js's `const getComputedStyle = …` recurses into itself via
-    // `defaultView.getComputedStyle`; #14110). Reserve any declared top-level
-    // name that is in the pure-global table so the number renamer suffixes the
-    // binding while unbound references to the real global keep the name.
-    if c.options.output_format == options::OutputFormat::Esm {
+    // For `--format=esm --target=browser` the chunk has no wrapper, so those
+    // `var`s sit at the true top level. Loaded as a module that is fine, but
+    // loaded as a classic `<script>` a top-level `var`/`function` becomes a
+    // property of `globalThis`. When the original name collides with a host
+    // global that the code reads back through `window`/`defaultView`, the
+    // bundle silently overwrites it (Chart.js's `const getComputedStyle = …`
+    // recurses into itself via `defaultView.getComputedStyle`; #14110).
+    // Reserve any declared top-level name that is in the pure-global table so
+    // the number renamer suffixes the binding while unbound references to the
+    // real global keep the name.
+    //
+    // Gated to `target=browser` because Bun/Node load ESM output in module
+    // scope, where `var` never reaches `globalThis`. `WrapKind::Cjs` modules
+    // keep their declarations inside the `__commonJS` closure, so skip those
+    // too. Only symbol kinds that print as a VarScoped declaration at the
+    // chunk top level (`var`/`function`/`async function`/`function*`) are
+    // considered; `class` and `import` stay lexical and cannot clobber
+    // `globalThis`.
+    if c.options.output_format == options::OutputFormat::Esm
+        && c.options.target == options::Target::Browser
+    {
         for &source_index in files_in_order {
+            if all_flags[source_index as usize].wrap == WrapKind::Cjs {
+                continue;
+            }
             let scope = &all_module_scopes[source_index as usize];
             for member in scope.members.values() {
                 // SAFETY: `symbols` points to the live `c.graph.symbols`; read-only here.
                 let symbol = unsafe { &*symbols }.get_const(member.ref_).unwrap();
-                if symbol.kind != symbol::Kind::Unbound
-                    && !symbol.must_not_be_renamed()
+                if matches!(
+                    symbol.kind,
+                    symbol::Kind::Hoisted
+                        | symbol::Kind::HoistedFunction
+                        | symbol::Kind::GeneratorOrAsyncFunction
+                        | symbol::Kind::Constant
+                        | symbol::Kind::Other
+                ) && !symbol.must_not_be_renamed()
                     && defines_table::is_pure_global_identifier(symbol.original_name.slice())
                 {
                     reserved_names

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -137,14 +137,7 @@ pub unsafe fn rename_symbols_in_chunk(
         );
     }
 
-    // Scope hoisting rewrites module-scope `const`/`let` to `var`. In an
-    // unwrapped browser ESM chunk a top-level `var`/`function` becomes a
-    // `globalThis` property when the bundle is loaded as a classic `<script>`,
-    // so a name that collides with a host global overwrites it (#14110:
-    // Chart.js's `const getComputedStyle` recurses via
-    // `defaultView.getComputedStyle`). Reserve those names so the renamer
-    // suffixes the binding. CJS-wrapped modules keep their declarations in the
-    // closure; `class`/`import` are lexical and cannot clobber `globalThis`.
+    // A browser ESM chunk loaded as a classic `<script>` assigns its scope-hoisted top-level `var`/`function` onto `globalThis`, so reserve names that collide with known host globals so the renamer suffixes the binding.
     if c.options.output_format == options::OutputFormat::Esm
         && c.options.target == options::Target::Browser
     {
@@ -163,6 +156,8 @@ pub unsafe fn rename_symbols_in_chunk(
                         | symbol::Kind::GeneratorOrAsyncFunction
                         | symbol::Kind::Constant
                         | symbol::Kind::Other
+                        | symbol::Kind::TsEnum
+                        | symbol::Kind::TsNamespace
                 ) && !symbol.must_not_be_renamed()
                     && defines_table::is_pure_global_identifier(symbol.original_name.slice())
                 {

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -10,7 +10,9 @@ use bun_ast::{Part, SlotCounts};
 use crate::bun_renamer as renamer;
 use crate::bun_renamer::{ChunkRenamer, MinifyRenamer, NumberRenamer, StableSymbolCount};
 use crate::chunk::Content;
+use crate::defines_table;
 use crate::js_meta;
+use crate::options;
 use crate::{Chunk, LinkerContext, StableRef, WrapKind};
 
 /// TODO: investigate if we need to parallelize this function
@@ -133,6 +135,35 @@ pub unsafe fn rename_symbols_in_chunk(
             unsafe { &*symbols },
             &mut reserved_names,
         );
+    }
+
+    // Scope hoisting rewrites module-scope `const`/`let` to `var` so the
+    // declaration can be split from its initializer when a module is wrapped.
+    // For `--format=esm` the chunk has no wrapper, so those `var`s sit at the
+    // true top level. Loaded as a module that is fine, but loaded as a classic
+    // `<script>` a top-level `var` becomes a property of `globalThis`. When the
+    // original name collides with a host global that the code reads back
+    // through `window`/`defaultView`, the bundle silently overwrites it
+    // (Chart.js's `const getComputedStyle = …` recurses into itself via
+    // `defaultView.getComputedStyle`; #14110). Reserve any declared top-level
+    // name that is in the pure-global table so the number renamer suffixes the
+    // binding while unbound references to the real global keep the name.
+    if c.options.output_format == options::OutputFormat::Esm {
+        for &source_index in files_in_order {
+            let scope = &all_module_scopes[source_index as usize];
+            for member in scope.members.values() {
+                // SAFETY: `symbols` points to the live `c.graph.symbols`; read-only here.
+                let symbol = unsafe { &*symbols }.get_const(member.ref_).unwrap();
+                if symbol.kind != symbol::Kind::Unbound
+                    && !symbol.must_not_be_renamed()
+                    && defines_table::is_pure_global_identifier(symbol.original_name.slice())
+                {
+                    reserved_names
+                        .put(symbol.original_name.slice(), 1)
+                        .expect("unreachable");
+                }
+            }
+        }
     }
 
     let sorted_imports_from_other_chunks: Vec<StableRef> = {

--- a/src/js_parser/defines_table.rs
+++ b/src/js_parser/defines_table.rs
@@ -266,10 +266,7 @@ mod identifiers {
 }
 
 /// True when `name` is one of the pure global identifiers in
-/// `defines_table.string-map.ts` (the ~640 well-known host/browser globals).
-/// The bundler's renamer uses this to avoid emitting a chunk-top-level `var`
-/// that would overwrite the global when an ESM bundle is loaded as a classic
-/// script.
+/// `defines_table.string-map.ts`.
 pub fn is_pure_global_identifier(name: &[u8]) -> bool {
     lookup_pure_global_identifier(name).is_some()
 }

--- a/src/js_parser/defines_table.rs
+++ b/src/js_parser/defines_table.rs
@@ -265,6 +265,15 @@ mod identifiers {
     }
 }
 
+/// True when `name` is one of the pure global identifiers in
+/// `defines_table.string-map.ts` (the ~640 well-known host/browser globals).
+/// The bundler's renamer uses this to avoid emitting a chunk-top-level `var`
+/// that would overwrite the global when an ESM bundle is loaded as a classic
+/// script.
+pub fn is_pure_global_identifier(name: &[u8]) -> bool {
+    lookup_pure_global_identifier(name).is_some()
+}
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) enum PureGlobalIdentifierValue {
     NaN,

--- a/src/js_parser/defines_table.rs
+++ b/src/js_parser/defines_table.rs
@@ -265,8 +265,6 @@ mod identifiers {
     }
 }
 
-/// True when `name` is one of the pure global identifiers in
-/// `defines_table.string-map.ts`.
 pub fn is_pure_global_identifier(name: &[u8]) -> bool {
     lookup_pure_global_identifier(name).is_some()
 }

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2895,11 +2895,13 @@ describe("bundler", () => {
   });
   itBundled("edgecase/EsmTopLevelVarShadowsHostGlobalScoping", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.ts": /* ts */ `
         import { Response as ModResponse } from "external-pkg";
         import cjs from "./cjs.cjs";
         export class Response { body = "mine"; }
-        console.log(new Response().constructor.name, cjs.URL, typeof ModResponse);
+        export enum Event { Click }
+        export namespace Text { export const x = 1; }
+        console.log(new Response().constructor.name, cjs.URL, typeof ModResponse, Event.Click, Text.x);
       `,
       "/cjs.cjs": /* js */ `
         const URL = "cjs-url";
@@ -2920,8 +2922,10 @@ describe("bundler", () => {
       expect(out).toMatch(/\bimport { Response\b/);
       expect(out).toContain("{ URL, fetch }");
       expect(out).not.toMatch(/\bURL2\b/);
+      expect(out).not.toMatch(/\bvar Event\b/);
+      expect(out).not.toMatch(/\bvar Text\b/);
     },
-    run: { stdout: "Response cjs-url number" },
+    run: { stdout: "Response cjs-url number 0 1" },
   });
   for (const target of ["bun", "node"] as const) {
     itBundled(`edgecase/EsmTopLevelVarShadowsHostGlobalTarget_${target}`, {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2846,6 +2846,7 @@ describe("bundler", () => {
       `,
     },
     format: "esm",
+    target: "browser",
     runtimeFiles: {
       "/run.cjs": /* js */ `
         let calls = 0;
@@ -2884,6 +2885,7 @@ describe("bundler", () => {
       `,
     },
     format: "esm",
+    target: "browser",
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
       expect(out).not.toMatch(/\bvar fetch\b/);
@@ -2891,6 +2893,60 @@ describe("bundler", () => {
     },
     run: { stdout: "module fetch\nfunction" },
   });
+  itBundled("edgecase/EsmTopLevelVarShadowsHostGlobalScoping", {
+    files: {
+      "/entry.js": /* js */ `
+        import { Response as ModResponse } from "external-pkg";
+        import cjs from "./cjs.cjs";
+        export class Response { body = "mine"; }
+        console.log(new Response().constructor.name, cjs.URL, typeof ModResponse);
+      `,
+      "/cjs.cjs": /* js */ `
+        const URL = "cjs-url";
+        const fetch = () => "cjs-fetch";
+        module.exports = { URL, fetch };
+      `,
+    },
+    format: "esm",
+    target: "browser",
+    external: ["external-pkg"],
+    runtimeFiles: {
+      "/node_modules/external-pkg/index.js": `export const Response = 1;`,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toMatch(/\bclass Response\b/);
+      expect(out).not.toMatch(/\bclass Response2\b/);
+      expect(out).toMatch(/\bimport { Response\b/);
+      expect(out).toContain("{ URL, fetch }");
+      expect(out).not.toMatch(/\bURL2\b/);
+    },
+    run: { stdout: "Response cjs-url number" },
+  });
+  for (const target of ["bun", "node"] as const) {
+    itBundled(`edgecase/EsmTopLevelVarShadowsHostGlobalTarget_${target}`, {
+      files: {
+        "/entry.js": /* js */ `
+          import { getComputedStyle } from "./helpers.js";
+          const name = "app";
+          const status = "ok";
+          console.log(name, status, typeof getComputedStyle);
+        `,
+        "/helpers.js": /* js */ `
+          export const getComputedStyle = () => 0;
+        `,
+      },
+      format: "esm",
+      target,
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out).toMatch(/\bvar getComputedStyle\b/);
+        expect(out).toMatch(/\bvar name\b/);
+        expect(out).toMatch(/\bvar status\b/);
+      },
+      run: { stdout: "app ok function" },
+    });
+  }
   itBundled("edgecase/IifeTopLevelVarShadowsHostGlobal", {
     files: {
       "/entry.js": /* js */ `
@@ -2902,6 +2958,7 @@ describe("bundler", () => {
       `,
     },
     format: "iife",
+    target: "browser",
     runtimeFiles: {
       "/run.cjs": /* js */ `
         let calls = 0;

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2831,6 +2831,99 @@ describe("bundler", () => {
     },
     120_000,
   );
+  // https://github.com/oven-sh/bun/issues/14110
+  itBundled("edgecase/EsmTopLevelVarShadowsHostGlobal", {
+    files: {
+      "/entry.js": /* js */ `
+        import { getComputedStyle, requestAnimationFrame } from "./helpers.js";
+        const el = { ownerDocument: { defaultView: globalThis } };
+        console.log(getComputedStyle(el));
+        requestAnimationFrame(v => console.log(v));
+      `,
+      "/helpers.js": /* js */ `
+        export const getComputedStyle = el => el.ownerDocument.defaultView.getComputedStyle(el, null);
+        export const requestAnimationFrame = cb => cb("raf");
+      `,
+    },
+    format: "esm",
+    runtimeFiles: {
+      "/run.cjs": /* js */ `
+        let calls = 0;
+        globalThis.getComputedStyle = function native() {
+          if (++calls > 1000) throw new RangeError("Maximum call stack size exceeded");
+          return "native";
+        };
+        globalThis.requestAnimationFrame = cb => cb("native-raf");
+        const src = require("fs").readFileSync(__dirname + "/out.js", "utf8");
+        // Indirect eval runs in the global scope so top-level "var" becomes a
+        // globalThis property, matching a classic <script> tag.
+        (0, eval)(src);
+        console.log("calls=" + calls);
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toMatch(/\bvar getComputedStyle\b/);
+      expect(out).not.toMatch(/\bvar requestAnimationFrame\b/);
+      expect(out).toContain("defaultView.getComputedStyle(");
+    },
+    run: {
+      file: "/run.cjs",
+      stdout: "native\nraf\ncalls=1",
+    },
+  });
+  itBundled("edgecase/EsmTopLevelVarShadowsHostGlobalUnboundReference", {
+    files: {
+      "/entry.js": /* js */ `
+        import { fetch as moduleFetch } from "./helpers.js";
+        console.log(moduleFetch());
+        console.log(typeof fetch);
+      `,
+      "/helpers.js": /* js */ `
+        export const fetch = () => "module fetch";
+      `,
+    },
+    format: "esm",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).not.toMatch(/\bvar fetch\b/);
+      expect(out).toMatch(/typeof fetch\b/);
+    },
+    run: { stdout: "module fetch\nfunction" },
+  });
+  itBundled("edgecase/IifeTopLevelVarShadowsHostGlobal", {
+    files: {
+      "/entry.js": /* js */ `
+        import { getComputedStyle } from "./helpers.js";
+        globalThis.gcs = getComputedStyle;
+      `,
+      "/helpers.js": /* js */ `
+        export const getComputedStyle = el => el.ownerDocument.defaultView.getComputedStyle(el, null);
+      `,
+    },
+    format: "iife",
+    runtimeFiles: {
+      "/run.cjs": /* js */ `
+        let calls = 0;
+        globalThis.getComputedStyle = function native() {
+          if (++calls > 1000) throw new RangeError("Maximum call stack size exceeded");
+          return "native";
+        };
+        const src = require("fs").readFileSync(__dirname + "/out.js", "utf8");
+        (0, eval)(src);
+        console.log(globalThis.gcs({ ownerDocument: { defaultView: globalThis } }));
+        console.log("calls=" + calls);
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toMatch(/\bvar getComputedStyle\b/);
+    },
+    run: {
+      file: "/run.cjs",
+      stdout: "native\ncalls=1",
+    },
+  });
   itBundled("edgecase/NonAsciiPathDerivedWrapperName", {
     files: {
       "/entry.ts": /* js */ `


### PR DESCRIPTION
## Repro

```js
// helpers.js
export const getComputedStyle = el =>
  el.ownerDocument.defaultView.getComputedStyle(el, null);

// entry.js
import { getComputedStyle } from "./helpers.js";
getComputedStyle(document.body);
```

```
$ bun build entry.js --outfile=out.js
$ cat out.js | head -2
// helpers.js
var getComputedStyle = (el) => el.ownerDocument.defaultView.getComputedStyle(el, null);
```

Loaded via `<script src="out.js">` (classic script, no `type="module"`),
`var getComputedStyle` at the top level becomes a property of `window`,
so `defaultView.getComputedStyle` resolves back to the var and the
function recurses into itself:

```
Uncaught RangeError: Maximum call stack size exceeded
    at getComputedStyle (out.js:2:45)
    at getComputedStyle (out.js:2:71)
    ...
```

Chart.js ships exactly this helper; bundling it with Bun's default
`--format=esm` and loading the result in a classic script tag breaks at
runtime. The same output works when loaded as a module, and esbuild
`--format=esm` produces the same `var` and fails the same way (esbuild
only avoids it by defaulting to iife).

## Cause

`select_local_kind` in the parser rewrites module-scope `const`/`let` to
`var` during bundling so the declaration can be hoisted out of an
`__esm`/`__commonJS` wrapper. In ESM format the chunk has no wrapper, so
the `var` sits at the true top level.

The renamer only reserves names for unbound identifier references. Since
`.defaultView.getComputedStyle` is a property access and no bare
`getComputedStyle` reference appears anywhere in the bundle, the name is
never reserved and the declared symbol keeps it.

## Fix

While building the reserved-name set, walk each module scope once more
and reserve any declared top-level name that is in the pure-global
identifier table (`defines_table`). The number renamer then suffixes the
binding (`var getComputedStyle2`) and all references follow; the
`.defaultView.getComputedStyle` property access is untouched, so the
output works whether loaded as a module or a classic script.

Scope is kept tight so nothing changes for code that cannot hit the
hazard:

- only `--format=esm --target=browser` (Bun/Node load ESM in module
  scope, where `var` never reaches `globalThis`, so `--target=bun|node`
  and `--compile` are untouched);
- `WrapKind::Cjs` modules are skipped because their declarations stay
  inside the `__commonJS` closure;
- only symbol kinds that print as a VarScoped declaration
  (`var`/`function`/`async function`/`function*`) are considered;
  `class` and `import` bindings stay lexical at the chunk top level and
  cannot clobber `globalThis`, so `class Response {}` keeps its `.name`
  and `import { Response } from "pkg"` keeps its alias.

## Verification

`edgecase/EsmTopLevelVarShadowsHostGlobal` bundles the Chart.js-shaped
helper and evaluates the output via indirect `eval` (classic-script
scope). On `main` it overflows; with the fix it calls the host
`getComputedStyle` once.

`EsmTopLevelVarShadowsHostGlobalScoping` pins the gates: `class
Response {}` keeps `class Response`, an external `import { Response }`
keeps the bare alias, and a CJS-wrapped module keeps `{ URL, fetch }`
shorthand. `EsmTopLevelVarShadowsHostGlobalTarget_{bun,node}` confirm
that `--target=bun|node` leave `var getComputedStyle`/`var name`
unchanged, and `IifeTopLevelVarShadowsHostGlobal` confirms iife output
keeps the name (the IIFE already scopes it).

Fixes #14110

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->