### PR TITLE
js_parser: swap instead of copy when compacting macro object properties

### DIFF
--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -474,18 +474,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             }
                                         }
                                     }
-                                    // output_properties[end] = output_properties[query.i]
-                                    // SAFETY: both indices < object.properties.len; G::Property
-                                    // has no Drop; src/dst may alias when end == query.i.
-                                    unsafe {
-                                        let props_ptr = object.properties.slice_mut().as_mut_ptr();
-                                        core::ptr::copy(
-                                            props_ptr.add(query.i as usize),
-                                            props_ptr.add(end as usize),
-                                            1,
-                                        );
+                                    // Swap (not copy) so the property currently at `end` stays
+                                    // reachable for later lookups when the binding order differs
+                                    // from the object order (#9613). `query.i < end` means the
+                                    // binding repeated a key already placed.
+                                    if query.i >= end {
+                                        object
+                                            .properties
+                                            .slice_mut()
+                                            .swap(end as usize, query.i as usize);
+                                        end += 1;
                                     }
-                                    end += 1;
                                 }
                             }
                         }

--- a/test/bundler/transpiler/macro-destructure.test.ts
+++ b/test/bundler/transpiler/macro-destructure.test.ts
@@ -1,0 +1,117 @@
+// https://github.com/oven-sh/bun/issues/9613
+//
+// Destructuring a macro result with the binding keys in a different order than
+// the returned object's properties used to drop bindings: the visitor compacted
+// the object's property array in place while still iterating the binding keys,
+// so a copy into `props[end]` could overwrite a property that a later key had
+// not yet looked up.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Debug builds print "[macro] call <name>" to stdout before the script's own
+// output; only the last line carries the JSON the test emits.
+const lastLine = (s: string) => s.trim().split("\n").pop() ?? "";
+
+const macroSrc = `
+  export function abc() { return { a: "a", b: "b", c: "c" }; }
+  export function nested() { return { outer: { x: 1, y: 2, z: 3 }, k: 7 }; }
+  export function wide() { return { a: 1, b: 2, c: 3, d: 4, e: 5 }; }
+`;
+
+describe("macro object destructure with reordered keys", () => {
+  test.concurrent("bun run: every permutation binds the right value", async () => {
+    using dir = tempDir("macro-destructure-run", {
+      "m.ts": macroSrc,
+      "entry.ts": `
+        import { abc } from "./m.ts" with { type: "macro" };
+        const rows: string[] = [];
+        { const { a, b, c } = abc(); rows.push([a, b, c].join(",")); }
+        { const { a, c, b } = abc(); rows.push([a, b, c].join(",")); }
+        { const { b, a, c } = abc(); rows.push([a, b, c].join(",")); }
+        { const { b, c, a } = abc(); rows.push([a, b, c].join(",")); }
+        { const { c, a, b } = abc(); rows.push([a, b, c].join(",")); }
+        { const { c, b, a } = abc(); rows.push([a, b, c].join(",")); }
+        console.log(JSON.stringify(rows));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: lastLine(stdout), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify(["a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c", "a,b,c"]),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("bun run: nested and aliased destructure", async () => {
+    using dir = tempDir("macro-destructure-nested", {
+      "m.ts": macroSrc,
+      "entry.ts": `
+        import { nested, abc } from "./m.ts" with { type: "macro" };
+        const { k, outer: { z, x, y } } = nested();
+        const { c: C, a: A, b: B } = abc();
+        console.log(JSON.stringify({ x, y, z, k, A, B, C }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: lastLine(stdout), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ x: 1, y: 2, z: 3, k: 7, A: "a", B: "b", C: "c" }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("bun build: subset destructure keeps only referenced keys", async () => {
+    using dir = tempDir("macro-destructure-build", {
+      "m.ts": macroSrc,
+      "entry.ts": `
+        import { wide } from "./m.ts" with { type: "macro" };
+        const { d, b } = wide();
+        console.log(JSON.stringify({ b, d }));
+      `,
+    });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.ts", "--target", "bun", "--outfile", "out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect({ buildErr, buildExit }).toEqual({ buildErr: "", buildExit: 0 });
+
+    const out = await Bun.file(`${dir}/out.js`).text();
+    // the emitted initializer must contain both kept keys and none of the dropped ones
+    expect(out).toMatch(/\{\s*d:\s*4,\s*b:\s*2\s*\}|\{\s*b:\s*2,\s*d:\s*4\s*\}/);
+    expect(out).not.toMatch(/[^a-zA-Z]a:\s*1/);
+    expect(out).not.toMatch(/[^a-zA-Z]c:\s*3/);
+    expect(out).not.toMatch(/[^a-zA-Z]e:\s*5/);
+
+    await using run = Bun.spawn({
+      cmd: [bunExe(), "out.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect({ runOut: lastLine(runOut), runErr, runExit }).toEqual({
+      runOut: JSON.stringify({ b: 2, d: 4 }),
+      runErr: "",
+      runExit: 0,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #9613.

## Repro

```ts
// m.ts
export function abc() { return { a: "a", b: "b", c: "c" }; }
// entry.ts
import { abc } from "./m.ts" with { type: "macro" };
const { b, a, c } = abc();
console.log(a, b, c);
```
```
$ bun build entry.ts --target bun
var { b, a, c } = {
  b: "b",
  c: "c"          // a is gone
};
$ bun run entry.ts
undefined b c
```

## Cause

`visit_binding_and_expr_for_macro` iterates the binding pattern's keys, looks each up in the macro-returned object with `as_property`, and compacts the object's property array to only the referenced entries. The compaction was an in-place `props[end] = props[query.i]` that ran inside the same loop, so when binding key order differed from the object's property order the copy into `props[end]` overwrote an entry a later binding key had not yet looked up. The subsequent `as_property` for that key then failed and the emitted initializer dropped the property.

## Fix

Swap `props[end]` and `props[query.i]` instead of copying, so the displaced entry stays in the array (in the not-yet-placed tail) and remains reachable for later lookups. Skip the swap when `query.i < end`, which only occurs when the binding repeats a key already placed; the property is already in the kept prefix.

This matches the existing compaction pattern elsewhere in the visitor (`scan_side_effects.rs`, `visit/mod.rs` decl compaction) and removes an `unsafe` block.

## Tests

`test/bundler/transpiler/macro-destructure.test.ts` covers every permutation of a three-key binding, a nested/aliased destructure where the old behaviour threw `TypeError: Cannot destructure ... from undefined`, and a `bun build` check that the subset dead-code-elimination still keeps only the referenced keys. The first two fail on the released bun and all three pass with this change.

The tests are in their own file rather than `macro-test.test.ts` because that file currently aborts the debug build (`!m_topGCOwnedDataScope` in `Heap::clearConcurrentRetainedDataIfPossible`, tracked separately).

Separate from #7196 / #12067 (see #35548), which are about whether a macro result may enter `const_values` at all; this is the property-matching bookkeeping once it does.