### PR TITLE
compile: rename temp file by the path inject() opened, not /proc/self/fd

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1069,6 +1069,7 @@ pub(crate) fn inject(
     self_exe: &ZStr,
     inject_options: &InjectOptions,
     target: &CompileTarget,
+    out_temp_path: &mut bun_core::ZBox,
 ) -> Fd {
     let _ = inject_options;
     let mut buf = PathBuffer::uninit();
@@ -1279,6 +1280,13 @@ pub(crate) fn inject(
         }
     };
     let _ = (&mut zname_owned, &mut zname);
+
+    // Record the path we opened so the caller can rename it directly. On Linux
+    // `/proc/self/fd/N` readlink can return a path that does not exist in the
+    // caller's mount namespace (Docker Desktop virtiofs bind mounts are the
+    // common case: the dentry walk yields `/run/host_virtiofs/...`), so the
+    // caller must not attempt to re-derive this from the fd.
+    *out_temp_path = bun_core::ZBox::from_bytes(zname.as_bytes());
 
     match target.os {
         CompileTargetOs::Mac => {
@@ -1779,7 +1787,8 @@ pub fn to_executable(
         bun_core::ZBox::from_vec_with_nul(dest_z.as_bytes().to_vec())
     };
 
-    let fd = inject(&bytes, &self_exe, windows_options, target);
+    let mut temp_path = bun_core::ZBox::default();
+    let fd = inject(&bytes, &self_exe, windows_options, target, &mut temp_path);
     // Note: a scopeguard closure capturing `fd` by value would not observe
     // later reassignments; capturing by `&mut` conflicts with later uses. Explicit
     // `if fd != Fd::INVALID { fd.close(); }` calls are inserted at every return below
@@ -1916,24 +1925,19 @@ pub fn to_executable(
 
     #[cfg(not(windows))]
     {
-        let mut buf2 = PathBuffer::uninit();
-        // Note: borrowck — `get_fd_path` returns `&mut [u8]` borrowing `buf2`;
-        // copy it into an owned buffer so `temp_posix_buf` can also borrow `buf2`'s
-        // sibling without overlap.
-        let temp_location: Vec<u8> = match bun_sys::get_fd_path(fd, &mut buf2) {
-            Ok(p) => p.to_vec(),
-            Err(e) => {
-                if fd != Fd::INVALID {
-                    fd.close();
-                }
-                return Ok(CompileResult::fail_fmt(format_args!(
-                    "failed to get path for fd: {}",
-                    e
-                )));
-            }
-        };
-        let mut temp_posix_buf = PathBuffer::uninit();
-        let temp_posix = path::resolve_path::z(&temp_location, &mut temp_posix_buf);
+        if fd == Fd::INVALID {
+            // inject() already printed the specific failure via pretty_errorln!.
+            return Ok(CompileResult::fail_fmt(format_args!(
+                "failed to embed module graph in executable"
+            )));
+        }
+        // inject() created the temp file at `temp_path` (relative to cwd, or
+        // absolute when the tmpdir fallback fired). Rename from that exact
+        // path rather than re-deriving it via /proc/self/fd, which on
+        // virtiofs bind mounts (Docker Desktop dev containers) resolves to a
+        // host-side path that does not exist in this mount namespace and so
+        // would fail the rename with ENOENT (#12318).
+        let temp_posix: &ZStr = temp_path.as_zstr();
         let outfile_basename = bun_paths::basename(outfile);
         let mut outfile_posix_buf = PathBuffer::uninit();
         let outfile_posix = path::resolve_path::z(outfile_basename, &mut outfile_posix_buf);
@@ -1953,16 +1957,14 @@ pub fn to_executable(
             } else {
                 return Ok(CompileResult::fail_fmt(format_args!(
                     "failed to rename {} to {}: {}",
-                    bstr::BStr::new(&temp_location),
+                    bstr::BStr::new(temp_posix.as_bytes()),
                     bstr::BStr::new(outfile),
                     bstr::BStr::new(e.name())
                 )));
             }
         }
 
-        if fd != Fd::INVALID {
-            fd.close();
-        }
+        fd.close();
         Ok(CompileResult::Success)
     }
 }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1281,11 +1281,6 @@ pub(crate) fn inject(
     };
     let _ = (&mut zname_owned, &mut zname);
 
-    // Record the path we opened so the caller can rename it directly. On Linux
-    // `/proc/self/fd/N` readlink can return a path that does not exist in the
-    // caller's mount namespace (Docker Desktop virtiofs bind mounts are the
-    // common case: the dentry walk yields `/run/host_virtiofs/...`), so the
-    // caller must not attempt to re-derive this from the fd.
     *out_temp_path = bun_core::ZBox::from_bytes(zname.as_bytes());
 
     match target.os {
@@ -1931,12 +1926,7 @@ pub fn to_executable(
                 "failed to embed module graph in executable"
             )));
         }
-        // inject() created the temp file at `temp_path` (relative to cwd, or
-        // absolute when the tmpdir fallback fired). Rename from that exact
-        // path rather than re-deriving it via /proc/self/fd, which on
-        // virtiofs bind mounts (Docker Desktop dev containers) resolves to a
-        // host-side path that does not exist in this mount namespace and so
-        // would fail the rename with ENOENT (#12318).
+        // Rename by the path inject() opened; /proc/self/fd readlink is wrong under virtiofs bind mounts (#12318).
         let temp_posix: &ZStr = temp_path.as_zstr();
         let outfile_basename = bun_paths::basename(outfile);
         let mut outfile_posix_buf = PathBuffer::uninit();

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
-import { rmSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { readdirSync, rmSync } from "fs";
+import { bunEnv, bunExe, isLinux, isMusl, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
@@ -1230,3 +1230,106 @@ test("compile --compile-executable-path rejects a Mach-O template whose __BUN se
     expect(exitCode).toBe(0);
   }
 }, 60_000);
+
+// On Docker Desktop (macOS/Windows) the working directory is a virtiofs bind
+// mount, and Linux's /proc/self/fd/N readlink resolves to the host-side
+// mount source (e.g. /run/host_virtiofs/Users/...) which does not exist in
+// the container's mount namespace. The compile step used to re-derive the
+// temp file path via that readlink and fail the final rename with ENOENT
+// (issue #12318). The shim below reproduces that exact readlink behavior so
+// the test fails without the fix.
+const cc = Bun.which("cc") ?? Bun.which("gcc") ?? Bun.which("clang");
+// LD_PRELOAD cannot intercept the statically-linked musl build.
+describe.skipIf(!isLinux || isMusl || !cc)("compile when /proc/self/fd resolves outside the mount namespace", () => {
+  const PROCFD_SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+static ssize_t (*real_readlink)(const char *, char *, size_t);
+static ssize_t (*real_readlinkat)(int, const char *, char *, size_t);
+
+static ssize_t rewrite(const char *path, char *buf, size_t bufsiz, ssize_t r) {
+    if (r <= 0) return r;
+    if (strncmp(path, "/proc/self/fd/", 14) != 0) return r;
+    /* Only touch the compile temp file; leave /proc/self/exe etc. alone. */
+    if (r < 10 || memcmp(buf + r - 10, ".bun-build", 10) != 0) return r;
+    char tmp[8192];
+    size_t len = (size_t)r < sizeof(tmp) - 1 ? (size_t)r : sizeof(tmp) - 1;
+    memcpy(tmp, buf, len);
+    tmp[len] = 0;
+    int n = snprintf(buf, bufsiz, "/run/host_virtiofs%s", tmp);
+    if (n < 0) return r;
+    return (size_t)n < bufsiz ? (ssize_t)n : (ssize_t)bufsiz;
+}
+
+ssize_t readlink(const char *path, char *buf, size_t bufsiz) {
+    if (!real_readlink) real_readlink = dlsym(RTLD_NEXT, "readlink");
+    return rewrite(path, buf, bufsiz, real_readlink(path, buf, bufsiz));
+}
+
+ssize_t readlinkat(int dirfd, const char *path, char *buf, size_t bufsiz) {
+    if (!real_readlinkat) real_readlinkat = dlsym(RTLD_NEXT, "readlinkat");
+    return rewrite(path, buf, bufsiz, real_readlinkat(dirfd, path, buf, bufsiz));
+}
+`;
+
+  let shimPath: string;
+  let shimDir: ReturnType<typeof tempDir> | undefined;
+
+  beforeAll(async () => {
+    shimDir = tempDir("compile-procfd-shim", { "shim.c": PROCFD_SHIM_C });
+    shimPath = join(String(shimDir), "shim.so");
+    await using proc = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(shimDir), "shim.c"), "-ldl"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (code !== 0) throw new Error(`shim compile failed: ${err || out}`);
+  });
+
+  afterAll(() => {
+    shimDir?.[Symbol.dispose]();
+  });
+
+  test("--outfile mycli", async () => {
+    using dir = tempDir("compile-procfd", {
+      "cli.ts": `console.log("Hello world!");`,
+    });
+    const cwd = String(dir);
+    const existing = bunEnv.LD_PRELOAD;
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "./cli.ts", "--compile", "--outfile", "mycli"],
+      env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    expect({ stdout, stderr }).toEqual({
+      stdout: expect.not.stringContaining("/run/host_virtiofs"),
+      stderr: expect.not.stringContaining("failed to rename"),
+    });
+    expect(stderr).not.toContain("/run/host_virtiofs");
+    const outPath = join(cwd, "mycli");
+    expect(await Bun.file(outPath).exists()).toBe(true);
+    // No .bun-build temp file left behind in cwd.
+    expect(readdirSync(cwd).filter(n => n.endsWith(".bun-build"))).toEqual([]);
+    expect(exitCode).toBe(0);
+
+    // The produced binary must actually run.
+    await using run = Bun.spawn({ cmd: [outPath], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [runOut, runErr, runCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+    expect(runErr).toBe("");
+    expect(runOut).toBe("Hello world!\n");
+    expect(runCode).toBe(0);
+  }, 60_000);
+});

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1309,11 +1309,7 @@ ssize_t readlinkat(int dirfd, const char *path, char *buf, size_t bufsiz) {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      build.stdout.text(),
-      build.stderr.text(),
-      build.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
     expect({ stdout, stderr }).toEqual({
       stdout: expect.not.stringContaining("/run/host_virtiofs"),
       stderr: expect.not.stringContaining("failed to rename"),


### PR DESCRIPTION
Fixes #12318, fixes #10046.

## Repro

In a Docker Desktop dev container on macOS (virtiofs file sharing), `bun build --compile` from a bind-mounted working directory:

```
root@...:/workspaces/bun# bun build ./cli.ts --compile --outfile mycli
  [10ms]  bundle  1 modules
error: failed to rename /run/host_virtiofs/Users/.../bun/.17debdb779bfefff-00000000.bun-build to mycli: ENOENT
```

The temp file is actually at `./.17debdb779bfefff-00000000.bun-build` in the cwd and a manual `mv` succeeds.

## Cause

`inject()` creates the temp file by name in the cwd (`.{hex}-{ctr}.bun-build`) and returns only the fd. `to_executable()` then calls `bun_sys::get_fd_path(fd)` (Linux: `readlink("/proc/self/fd/N")`) to recover the path for the final rename.

When the cwd is a virtiofs bind mount (Docker Desktop on macOS/Windows), the kernel's `d_path()` walk for `/proc/self/fd/N` yields the VM-side mount source path (`/run/host_virtiofs/Users/...`), which is not a valid path in the container's mount namespace. `renameat()` on that path fails with ENOENT, and `move_file_z_with_handle`'s EXDEV fallback never runs because the error is not EXDEV.

## Fix

`inject()` already knows the exact path it created the temp file at. Thread that out via a `&mut ZBox` and have the POSIX arm of `to_executable()` rename from it directly (`renameat(Fd::cwd(), zname, root_dir, basename)`), dropping the `get_fd_path` round-trip entirely. This is strictly more correct: we rename from the same path we opened, so any filesystem-level path-canonicalisation quirk (virtiofs, overlayfs, FUSE) no longer matters, and EXDEV still falls through to the existing copy-via-fd path. Also bail out early when `inject()` returns `Fd::INVALID` so we do not try to rename an empty path.

Windows keeps `GetFinalPathNameByHandle`, which does not have this class of problem.

## Test

`bundler_compile.test.ts` gains a Linux-glibc case that LD_PRELOADs a shim rewriting `readlink("/proc/self/fd/*")` to prepend `/run/host_virtiofs` when the target ends in `.bun-build`, reproducing the exact procfs behaviour seen on Docker Desktop. Before this change the build fails with `failed to rename /run/host_virtiofs/.../.<hex>.bun-build to mycli: ENOENT`; after, the build succeeds, the compiled binary runs and prints `Hello world!`, and no `.bun-build` temp file is left behind.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->