### PR TITLE
js_parser: stop cascading errors after "await" in a non-async function

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -200,6 +200,7 @@ pub struct LexerSnapshot<'a> {
     pub(crate) rescan_close_brace_as_template_token: bool,
     pub(crate) prev_error_loc: Loc,
     pub(crate) prev_token_was_await_keyword: bool,
+    pub(crate) await_keyword_loc: Loc,
     pub(crate) fn_or_arrow_start_loc: Loc,
     pub(crate) regex_flags_start: Option<u16>,
     pub(crate) string_literal_raw_content: &'a [u8],
@@ -283,6 +284,7 @@ pub struct LexerType<
     pub(crate) rescan_close_brace_as_template_token: bool,
     pub(crate) prev_error_loc: Loc,
     pub(crate) prev_token_was_await_keyword: bool,
+    pub(crate) await_keyword_loc: Loc,
     pub(crate) fn_or_arrow_start_loc: Loc,
     pub(crate) regex_flags_start: Option<u16>,
     pub(crate) arena: &'a Arena,
@@ -452,6 +454,7 @@ lexer_impl_header! {
             rescan_close_brace_as_template_token: self.rescan_close_brace_as_template_token,
             prev_error_loc: self.prev_error_loc,
             prev_token_was_await_keyword: self.prev_token_was_await_keyword,
+            await_keyword_loc: self.await_keyword_loc,
             fn_or_arrow_start_loc: self.fn_or_arrow_start_loc,
             regex_flags_start: self.regex_flags_start,
             string_literal_raw_content: self.string_literal_raw_content,
@@ -492,6 +495,7 @@ lexer_impl_header! {
             original.rescan_close_brace_as_template_token;
         self.prev_error_loc = original.prev_error_loc;
         self.prev_token_was_await_keyword = original.prev_token_was_await_keyword;
+        self.await_keyword_loc = original.await_keyword_loc;
         self.fn_or_arrow_start_loc = original.fn_or_arrow_start_loc;
         self.regex_flags_start = original.regex_flags_start;
         self.string_literal_raw_content = original.string_literal_raw_content;
@@ -2165,13 +2169,13 @@ lexer_impl_header! {
                 &notes[0..(!self.fn_or_arrow_start_loc.is_empty()) as usize];
 
             self.add_range_error_with_notes(
-                self.range(),
+                range_of_identifier(self.source, self.await_keyword_loc),
                 format_args!(
                     "\"await\" can only be used inside an \"async\" function"
                 ),
                 notes_ptr,
             )?;
-            return Ok(());
+            return Err(Error::SyntaxError);
         }
         if self.contents.len() != self.start {
             self.add_range_error(
@@ -2581,6 +2585,7 @@ lexer_impl_header! {
             rescan_close_brace_as_template_token: false,
             prev_error_loc: Loc::EMPTY,
             prev_token_was_await_keyword: false,
+            await_keyword_loc: Loc::EMPTY,
             fn_or_arrow_start_loc: Loc::EMPTY,
             regex_flags_start: None,
             arena,

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -183,6 +183,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 AwaitOrYield::AllowIdent => {
                     p.lexer.prev_token_was_await_keyword = true;
+                    p.lexer.await_keyword_loc = loc;
                     p.lexer.fn_or_arrow_start_loc = p.fn_or_arrow_data_parse.needs_async_loc;
                 }
             },

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4519,23 +4519,27 @@ describe("await can only be used inside an async function message", () => {
       transpiler.transformSync(code);
       expect.unreachable();
     } catch (e) {
-      function handle(error) {
-        expect(error.message).toBe('"await" can only be used inside an "async" function');
+      // https://github.com/oven-sh/bun/issues/13097: the friendly await diagnostic must
+      // not be followed by a cascading error, and its range must cover "await" itself.
+      const errors = e instanceof AggregateError ? e.errors : [e];
+      expect(errors).toHaveLength(1);
+      const error = errors[0];
+      expect(error.message).toBe('"await" can only be used inside an "async" function');
+      expect(error.position.offset).toBe(code.indexOf("await"));
+      expect(error.position.length).toBe("await".length);
 
-        if (hasNote) {
-          expect(error.notes).toHaveLength(1);
-          expect(error.notes[0].message).toBe('Consider adding the "async" keyword here');
-          expect(error.notes[0].position.lineText).toContain("foo");
-        } else {
-          expect(error.notes).toHaveLength(0);
-        }
-      }
-      if (e instanceof AggregateError) {
-        handle(e.errors[0]);
+      if (hasNote) {
+        expect(error.notes).toHaveLength(1);
+        expect(error.notes[0].message).toBe('Consider adding the "async" keyword here');
+        expect(error.notes[0].position.lineText).toContain("foo");
       } else {
-        expect.unreachable();
+        expect(error.notes).toHaveLength(0);
       }
     }
+  }
+
+  function assertNoError(code) {
+    expect(() => transpiler.transformSync(code)).not.toThrow();
   }
   it("in object method", () => {
     assertError(
@@ -4597,6 +4601,24 @@ describe("await can only be used inside an async function message", () => {
 
   it("in arrow function with expression body", () => {
     assertError(`const foo = () => await bar();`, false);
+  });
+
+  // https://github.com/oven-sh/bun/issues/13097
+  it.each([
+    "setInterval(() => { await console.log(); }, 500);",
+    "() => { await a.b.c.d(); }",
+    "() => { await new Foo(); }",
+    "() => { await 1 + 2; }",
+    "() => { await using x = y; }",
+  ])("does not cascade into a second error for %p", code => {
+    assertError(code, false);
+  });
+
+  it("'await' followed by a call/index/template suffix is a valid identifier reference", () => {
+    assertNoError("() => { await (1 + 2); }");
+    assertNoError("() => { await(foo); }");
+    assertNoError("() => { await[0]; }");
+    assertNoError("() => { await`tpl`; }");
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Fixes #13097.

When `await` is used inside a non-async function, Bun currently emits the correct diagnostic followed by an unrelated secondary error:

```ts
setInterval(() => {
    await console.log();
}, 500);
```
```
2 |     await console.log();
              ^
error: "await" can only be used inside an "async" function
    at file.ts:2:11

2 |     await console.log();
                     ^
error: Unexpected .
    at file.ts:2:18
```

The secondary error changes depending on what follows the awaited expression (`Expected "=>" but found ";"` for `await foo()`, etc).

#### Root cause

When `await` is seen as a prefix identifier inside a non-async scope, the parser sets `lexer.prev_token_was_await_keyword` and falls through treating `await` as a plain identifier. The very next `expected_string()` (usually from the statement's `expect_or_insert_semicolon`) notices the flag and emits the friendly diagnostic, but then `return Ok(())`, so `expect()` falls through to `self.next()` and the parser continues scanning from the middle of the awaited expression.

esbuild's `ExpectedString` does `panic(LexerPanic{})` on that path, which aborts the parse. This PR matches that by returning `Err(Error::SyntaxError)`.

The diagnostic range was also `self.range()` (the token *after* `await`). esbuild stores `AwaitKeywordLoc` and reports the range of the `await` identifier itself; this PR adds `await_keyword_loc` and does the same.

#### After

```
2 |     await console.log();
        ^
error: "await" can only be used inside an "async" function
    at file.ts:2:5

1 | function foo() {
    ^
note: Consider adding the "async" keyword here
   at file.ts:1:1
```

Single error, caret on `await`.

### How did you verify your code works?

Extended the existing `describe("await can only be used inside an async function message")` block in `test/bundler/transpiler/transpiler.test.js`:

- `assertError` now asserts exactly one diagnostic with `offset`/`length` covering the `await` token (the old helper relied on the two-error `AggregateError`).
- Added `it.each` cases for property access, chained property access, `new`, a numeric literal, and `await using`.
- Added a case confirming `await(expr)`, `await[i]`, ``await`tpl` `` still parse without error since `await` is a valid identifier there.
- `bun bd test test/bundler/transpiler`: 3844 pass, 0 fail.
