### PR TITLE
test: enable 'bun pm trust' CPU usage test on Windows

### DIFF
--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -3839,8 +3839,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect(proc.resourceUsage()?.cpuTime.total).toBeLessThan(750_000);
       });
 
-      // https://github.com/oven-sh/bun/issues/11252
-      test.todoIf(isWindows)("bun pm trust", async () => {
+      test("bun pm trust", async () => {
         using ctx = await setupTest();
         const { packageDir, packageJson, env } = ctx;
         const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;


### PR DESCRIPTION
The `does not use 100% cpu > bun pm trust` test in `bun-install-lifecycle-scripts.test.ts` has been `test.todoIf(isWindows)` since #11253, because `bun pm trust --all` was exiting with code 3 on Windows (tracked as #11252).

That failure no longer reproduces. On current main, `bun pm trust --all` runs the blocked install script, writes the expected `what-bin.txt`, and exits 0 on Windows for both release and debug builds.

### Verification

Ran on Windows x64 (canary 1.4.0 and a debug build of main):

```
bun bd test test/cli/install/bun-install-lifecycle-scripts.test.ts -t "does not use 100% cpu" --rerun-each=3

(pass) lifecycle scripts > does not use 100% cpu > install [1568.57ms]
(pass) lifecycle scripts > does not use 100% cpu > bun pm trust [5719.15ms]
(pass) lifecycle scripts > does not use 100% cpu > install [1562.93ms]
(pass) lifecycle scripts > does not use 100% cpu > bun pm trust [5721.82ms]
(pass) lifecycle scripts > does not use 100% cpu > install [1531.94ms]
(pass) lifecycle scripts > does not use 100% cpu > bun pm trust [5694.03ms]

 6 pass
 0 fail
```

Release canary `resourceUsage().cpuTime.total` for the trust step was 15,625µs; debug build peaked at ~187,500µs across 5 runs. Both are well inside the `750_000 * 5` threshold.

Closes #11252

---

This PR is test-only (no `src/` change) because the underlying runtime behaviour is already correct; only the skip needed to go. There is no fail-before state for the automated proof to observe on Linux: the test was already enabled there and continues to pass, and on Windows it was skipped outright. The Windows CI lane is the only place that would have caught a regression, and this re-enables that coverage.
