### PR TITLE
HTMLRewriter: validate EndTag.name like Element.tagName

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1790,11 +1790,37 @@ impl EndTag {
             return Ok(());
         }
         let name = setter_utf8_arg(global, value)?;
+        if let Err(e) = validate_tag_name(&name) {
+            return Err(global.throw_value(create_lolhtml_error(global, &e)));
+        }
         let Some(end_tag) = cell_get(&self.end_tag) else {
             return Ok(());
         };
         end_tag.set_name_str(name);
         Ok(())
+    }
+}
+
+/// lol-html's [`EndTag::set_name_str`] accepts the string verbatim, so a `>`
+/// in the assigned name becomes literal `</name>rest>` in the output. Apply
+/// the same check `Element::set_tag_name` runs (`tag_name_bytes_from_str`) so
+/// the two setters agree. The encoding-replacement check is omitted: the
+/// rewriter is built with `AsciiCompatibleEncoding::utf_8()`, under which
+/// every `str` encodes without replacement.
+fn validate_tag_name(name: &str) -> Result<(), lol_html::errors::TagNameError> {
+    use lol_html::errors::TagNameError;
+    match name.as_bytes().first() {
+        None => Err(TagNameError::Empty),
+        Some(ch) if !ch.is_ascii_alphabetic() => Err(TagNameError::InvalidFirstCharacter),
+        Some(_) => match name
+            .as_bytes()
+            .iter()
+            .copied()
+            .find(|&ch| matches!(ch, b' ' | b'\n' | b'\r' | b'\t' | b'\x0C' | b'/' | b'>'))
+        {
+            Some(ch) => Err(TagNameError::ForbiddenCharacter(ch as char)),
+            None => Ok(()),
+        },
     }
 }
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1208,6 +1208,61 @@ describe("tagName, endTag.name, and comment.text setters", () => {
     expect(out).toBe("<p>hi</div>");
   });
 
+  describe("endTag.name validates the same as element.tagName", () => {
+    const run = (name, setter) =>
+      new HTMLRewriter()
+        .on("div", {
+          element(el) {
+            if (setter === "tagName") el.tagName = name;
+            else el.onEndTag(end => void (end.name = name));
+          },
+        })
+        .transform("<div>x</div>");
+
+    it.each([
+      ["", /Tag name can't be empty/],
+      ["1div", /first character of the tag name/],
+      ["div>x", /`>` character is forbidden/],
+      ["div x", /` ` character is forbidden/],
+      ["div/x", /`\/` character is forbidden/],
+      ["div\nx", /`\n` character is forbidden/],
+      ["div\tx", /`\t` character is forbidden/],
+      ["div\rx", /`\r` character is forbidden/],
+      ["div\fx", /`\f` character is forbidden/],
+    ])("rejects %j", (name, message) => {
+      // element.tagName already validates via lol-html; endTag.name must match.
+      for (const setter of ["tagName", "endTag.name"]) {
+        expect(() => run(name, setter)).toThrow(
+          expect.objectContaining({ name: "HTMLRewriterError", message: expect.stringMatching(message) }),
+        );
+      }
+    });
+
+    it("rejecting the name leaves the end tag untouched", () => {
+      let threw;
+      const out = new HTMLRewriter()
+        .on("div", {
+          element(el) {
+            el.onEndTag(end => {
+              try {
+                end.name = "div><script>alert(1)</script";
+              } catch (e) {
+                threw = e;
+              }
+            });
+          },
+        })
+        .transform("<div>x</div>");
+      expect(threw?.name).toBe("HTMLRewriterError");
+      expect(out).toBe("<div>x</div>");
+      expect(out.includes("<script>")).toBe(false);
+    });
+
+    it("accepts a valid name", () => {
+      expect(run("section", "endTag.name")).toBe("<div>x</section>");
+    });
+  });
+
   it("the assigned value is coerced with ToString, which may re-enter the wrapper", () => {
     const out = new HTMLRewriter()
       .on("p", {


### PR DESCRIPTION
### Repro

```js
const out = new HTMLRewriter()
  .on("div", {
    element(el) {
      el.onEndTag(end => {
        end.name = "div><script>alert(1)</script";
      });
    },
  })
  .transform("<div>x</div>");
console.log(out);
// <div>x</div><script>alert(1)</script>
```

`endTag.name` accepts the assigned string verbatim and serializes it between `</` and `>`, so any `>` in the value closes the tag early and everything after becomes markup. `element.tagName` already rejects the same input:

```
HTMLRewriterError: `>` character is forbidden in the tag name
```

### Cause

`Element::set_tag_name` in lol-html runs `tag_name_bytes_from_str`, which rejects empty names, names whose first character is not an ASCII letter, and names containing any of ``' ' '\n' '\r' '\t' '\f' '/' '>'``. `EndTag::set_name_str` does none of that; Bun's `EndTag.name` setter calls it directly.

### Fix

Apply the same validation in the `EndTag.name` setter before calling `set_name_str`, throwing the same `HTMLRewriterError` (via lol-html's own `TagNameError`) as the `tagName` setter. The encoding-replacement check in `tag_name_bytes_from_str` is unnecessary here: the rewriter is always built with `AsciiCompatibleEncoding::utf_8()`, under which every Rust `str` encodes without replacement.

### Verification

```
USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter.test.js -t "endTag.name validates"
# 10 fail (endTag.name accepts every rejected value; injection test produces <script>), 1 pass

bun bd test test/js/workerd/html-rewriter.test.js -t "endTag.name validates"
# 11 pass
```

`cargo check -p bun_runtime` is clean; the local debug build could not link because the container host's shared overlay volume is at capacity (repeated `No space left on device` during the C++ build with ~40G of local files on a 1.9T volume). CI will be the authoritative build.
