### PR TITLE
Bun.serve({ unix }) in a cluster worker adopts a shared listen fd from the primary

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -399,6 +399,32 @@ struct us_listen_socket_t *us_socket_group_listen(struct us_socket_group_t *grou
     return ls;
 }
 
+struct us_listen_socket_t *us_socket_group_listen_fd(struct us_socket_group_t *group,
+        unsigned char kind, struct ssl_ctx_st *ssl_ctx,
+        LIBUS_SOCKET_DESCRIPTOR fd, int backlog, int options, int socket_ext_size, int *error) {
+    apple_no_sigpipe(fd);
+    bsd_set_nonblocking(fd);
+    if (listen(fd, backlog > 0 ? backlog : 512)) {
+        *error = LIBUS_ERR;
+        return 0;
+    }
+
+    struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
+    us_poll_init(p, fd, POLL_TYPE_SEMI_SOCKET);
+    if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_READABLE) != 0) {
+        int saved_errno = errno;
+        us_poll_free(p, group->loop);
+        *error = saved_errno;
+        errno = saved_errno;
+        return 0;
+    }
+
+    struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
+    us_internal_init_listen_socket(ls, group, kind, ssl_ctx, options, socket_ext_size);
+
+    return ls;
+}
+
 struct us_listen_socket_t *us_socket_group_listen_unix(struct us_socket_group_t *group,
         unsigned char kind, struct ssl_ctx_st *ssl_ctx,
         const char *path, size_t pathlen, int options, int socket_ext_size, int *error) {

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -399,6 +399,8 @@ struct us_listen_socket_t *us_socket_group_listen(struct us_socket_group_t *grou
     return ls;
 }
 
+/* Adopt an already-bound fd as a listen socket. The fd is consumed: closed
+ * here on failure, owned by the listen socket on success. */
 struct us_listen_socket_t *us_socket_group_listen_fd(struct us_socket_group_t *group,
         unsigned char kind, struct ssl_ctx_st *ssl_ctx,
         LIBUS_SOCKET_DESCRIPTOR fd, int backlog, int options, int socket_ext_size, int *error) {
@@ -406,6 +408,7 @@ struct us_listen_socket_t *us_socket_group_listen_fd(struct us_socket_group_t *g
     bsd_set_nonblocking(fd);
     if (listen(fd, backlog > 0 ? backlog : 512)) {
         *error = LIBUS_ERR;
+        bsd_close_socket(fd);
         return 0;
     }
 
@@ -413,6 +416,7 @@ struct us_listen_socket_t *us_socket_group_listen_fd(struct us_socket_group_t *g
     us_poll_init(p, fd, POLL_TYPE_SEMI_SOCKET);
     if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_READABLE) != 0) {
         int saved_errno = errno;
+        bsd_close_socket(fd);
         us_poll_free(p, group->loop);
         *error = saved_errno;
         errno = saved_errno;

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -407,8 +407,10 @@ struct us_listen_socket_t *us_socket_group_listen_fd(struct us_socket_group_t *g
     apple_no_sigpipe(fd);
     bsd_set_nonblocking(fd);
     if (listen(fd, backlog > 0 ? backlog : 512)) {
-        *error = LIBUS_ERR;
+        int saved_errno = errno;
         bsd_close_socket(fd);
+        *error = saved_errno;
+        errno = saved_errno;
         return 0;
     }
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -395,6 +395,10 @@ struct us_listen_socket_t *us_socket_group_listen_unix(us_socket_group_r group,
     unsigned char kind, struct ssl_ctx_st *ssl_ctx,
     const char *path, size_t pathlen, int options, int socket_ext_size, int *error)
     __attribute__((nonnull(1, 4, 8)));  /* ssl_ctx nullable */
+struct us_listen_socket_t *us_socket_group_listen_fd(us_socket_group_r group,
+    unsigned char kind, struct ssl_ctx_st *ssl_ctx,
+    LIBUS_SOCKET_DESCRIPTOR fd, int backlog, int options, int socket_ext_size, int *error)
+    __attribute__((nonnull(1, 8)));  /* ssl_ctx nullable */
 void us_listen_socket_close(struct us_listen_socket_t *ls) nonnull_fn_decl;
 
 /* SNI: tree hangs off the listen socket. ssl_ctx is up_ref'd; user is opaque

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -741,6 +741,11 @@ public:
         return std::move(*this);
     }
 
+    TemplatedApp &&listen_fd(LIBUS_SOCKET_DESCRIPTOR fd, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
+        handler(httpContext ? trackListenSocket(httpContext->listen_fd(sslCtxOrNull(), fd, options)) : nullptr);
+        return std::move(*this);
+    }
+
     void setOnSocketClosed(HttpContextData<SSL>::OnSocketClosedCallback onClose) {
         httpContext->getSocketContextData()->onSocketClosed = onClose;
     }

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -1027,6 +1027,15 @@ public:
 
         return socket;
     }
+
+    us_listen_socket_t *listen_fd(struct ssl_ctx_st *sslCtx, LIBUS_SOCKET_DESCRIPTOR fd, int options) {
+        int error = 0;
+        auto* socket = us_socket_group_listen_fd(&group, socketKind(), sslCtx, fd, 512, options, socketExtSize(), &error);
+        if (socket) {
+            us_socket_unref(&socket->s);
+        }
+        return socket;
+    }
 };
 
 }

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -226,6 +226,10 @@ export function parseHandle(target, serialized, fd) {
     case "net.Socket": {
       throw new Error("TODO case net.Socket");
     }
+    case "bun.ServeUnixFd": {
+      emit(target, serialized.message, { fd });
+      return;
+    }
     case "dgram.Native": {
       // A non-reading UDP handle (cluster-shared dgram socket): wrap the
       // received descriptor so the cluster child can adopt it.

--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -60,12 +60,28 @@ cluster._setupWorker = function () {
 cluster._bunServeUnix = function (path) {
   return new Promise(resolve => {
     if (!process.connected) return resolve(-1);
-    send({ act: "bunServeUnix", path }, (reply, handle) => {
-      if (handle && typeof handle.fd === "number" && handle.fd >= 0) {
-        resolve(handle.fd);
-      } else {
-        resolve(typeof reply?.errno === "number" && reply.errno < 0 ? reply.errno : -1);
+    let settled = false;
+    const settle = v => {
+      if (settled) {
+        // The primary replied after the deadline; its dup of the listen fd
+        // would otherwise sit in this process's table forever.
+        if (typeof v === "number" && v >= 0) require("node:fs").closeSync(v);
+        return;
       }
+      settled = true;
+      clearTimeout(timer);
+      process.removeListener("disconnect", onDisconnect);
+      resolve(v);
+    };
+    const onDisconnect = () => settle(-1);
+    process.once("disconnect", onDisconnect);
+    // A non-cluster primary (Node.js, older Bun, or plain child_process.fork
+    // with NODE_UNIQUE_ID in env) silently drops the unknown act; bound the
+    // wait so Bun.serve falls through to a direct bind instead of hanging.
+    const timer = setTimeout(() => settle(-1), 5000);
+    send({ act: "bunServeUnix", path }, (reply, handle) => {
+      if (handle && typeof handle.fd === "number" && handle.fd >= 0) settle(handle.fd);
+      else settle(typeof reply?.errno === "number" && reply.errno < 0 ? reply.errno : -1);
     });
   });
 };

--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -79,7 +79,8 @@ cluster._bunServeUnix = function (unixPath) {
     // A primary that does not know this act silently drops it; bound the wait so Bun.serve falls back to a direct bind.
     const timer = setTimeout(() => settle(-1), 5000);
     const sent = send({ act: "bunServeUnix", path: unixPath }, (reply, handle) => {
-      if (handle && typeof handle.fd === "number" && handle.fd >= 0) settle(handle.fd);
+      const fd = handle?.fd;
+      if (typeof fd === "number" && fd >= 0) settle(fd);
       else settle(typeof reply?.errno === "number" && reply.errno < 0 ? reply.errno : -1);
     });
     if (sent === false) settle(-1);

--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -57,14 +57,15 @@ cluster._setupWorker = function () {
   }
 };
 
-cluster._bunServeUnix = function (path) {
+cluster._bunServeUnix = function (unixPath) {
   return new Promise(resolve => {
     if (!process.connected) return resolve(-1);
+    // Resolve against the worker's cwd; the bind happens in the primary, whose cwd may differ.
+    if (unixPath.charCodeAt(0) !== 0 && process.platform !== "win32") unixPath = path.resolve(unixPath);
     let settled = false;
     const settle = v => {
       if (settled) {
-        // The primary replied after the deadline; its dup of the listen fd
-        // would otherwise sit in this process's table forever.
+        // A reply that lost the race against the deadline carries a dup'd fd; close it.
         if (typeof v === "number" && v >= 0) require("node:fs").closeSync(v);
         return;
       }
@@ -75,14 +76,13 @@ cluster._bunServeUnix = function (path) {
     };
     const onDisconnect = () => settle(-1);
     process.once("disconnect", onDisconnect);
-    // A non-cluster primary (Node.js, older Bun, or plain child_process.fork
-    // with NODE_UNIQUE_ID in env) silently drops the unknown act; bound the
-    // wait so Bun.serve falls through to a direct bind instead of hanging.
+    // A primary that does not know this act silently drops it; bound the wait so Bun.serve falls back to a direct bind.
     const timer = setTimeout(() => settle(-1), 5000);
-    send({ act: "bunServeUnix", path }, (reply, handle) => {
+    const sent = send({ act: "bunServeUnix", path: unixPath }, (reply, handle) => {
       if (handle && typeof handle.fd === "number" && handle.fd >= 0) settle(handle.fd);
       else settle(typeof reply?.errno === "number" && reply.errno < 0 ? reply.errno : -1);
     });
+    if (sent === false) settle(-1);
   });
 };
 

--- a/src/js/internal/cluster/child.ts
+++ b/src/js/internal/cluster/child.ts
@@ -57,6 +57,19 @@ cluster._setupWorker = function () {
   }
 };
 
+cluster._bunServeUnix = function (path) {
+  return new Promise(resolve => {
+    if (!process.connected) return resolve(-1);
+    send({ act: "bunServeUnix", path }, (reply, handle) => {
+      if (handle && typeof handle.fd === "number" && handle.fd >= 0) {
+        resolve(handle.fd);
+      } else {
+        resolve(typeof reply?.errno === "number" && reply.errno < 0 ? reply.errno : -1);
+      }
+    });
+  });
+};
+
 // `obj` is a net#Server or a dgram#Socket object.
 cluster._getServer = function (obj, options, cb) {
   let address = options.address;

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -329,7 +329,11 @@ function bunServeUnix(worker, message) {
     });
   }
   entry.workers.add(worker.id);
-  const reply = { cmd: "NODE_HANDLE", type: "bun.ServeUnixFd", message: { errno: 0, key, ack: message.seq, cmd: "NODE_CLUSTER" } };
+  const reply = {
+    cmd: "NODE_HANDLE",
+    type: "bun.ServeUnixFd",
+    message: { errno: 0, key, ack: message.seq, cmd: "NODE_CLUSTER" },
+  };
   sendHelper(worker.process[kHandle], reply, { fd: entry.fd }, null);
 }
 

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -298,6 +298,8 @@ const bunServeUnixHandles = new Map(); // path -> { fd, workers: Set<id> }
 
 // Shared AF_UNIX listen fds for Bun.serve({ unix }) in workers (SO_REUSEPORT is TCP-only).
 function bunServeUnix(worker, message) {
+  // Stop processing if worker already disconnecting
+  if (worker.exitedAfterDisconnect) return;
   const sockPath = message.path;
   const key = `bunServeUnix:${sockPath}`;
   if (typeof sockPath !== "string" || process.platform === "win32") {

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -334,7 +334,12 @@ function bunServeUnix(worker, message) {
     type: "bun.ServeUnixFd",
     message: { errno: 0, key, ack: message.seq, cmd: "NODE_CLUSTER" },
   };
-  sendHelper(worker.process[kHandle], reply, { fd: entry.fd }, null);
+  const sent = sendHelper(worker.process[kHandle], reply, { fd: entry.fd }, null);
+  if (sent === false) {
+    // Transfer failed: drop this worker's claim so a sole worker can fall back to a direct bind.
+    const handle = handles.get(key);
+    if (handle && handle.remove(worker)) handles.delete(key);
+  }
 }
 
 function listening(worker, message) {

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -7,6 +7,7 @@ const { throwNotImplemented, kHandle } = require("internal/shared");
 
 const sendHelper = $newRustFunction("node_cluster_binding.rs", "sendHelperPrimary", 4);
 const onInternalMessage = $newRustFunction("node_cluster_binding.rs", "onInternalMessagePrimary", 3);
+const bindUnixListenFd = $newRustFunction("node_cluster_binding.rs", "bindUnixListenFd", 1);
 
 let child_process;
 
@@ -207,6 +208,7 @@ const methodMessageMapping = {
   listening,
   online,
   queryServer,
+  bunServeUnix,
 };
 
 function onmessage(message, _handle) {
@@ -290,6 +292,45 @@ function queryServer(worker, message) {
       handle,
     );
   });
+}
+
+// path -> { fd, workers: Set<id> }
+const bunServeUnixHandles = new Map();
+
+// Bun.serve({ unix }) in a worker asks the primary for a shared listen fd so
+// every worker accepts on the same AF_UNIX socket (SO_REUSEPORT is TCP-only).
+function bunServeUnix(worker, message) {
+  const path = message.path;
+  const key = `bunServeUnix:${path}`;
+  if (typeof path !== "string" || process.platform === "win32") {
+    send(worker, { errno: -22 /* EINVAL */, key, ack: message.seq });
+    return;
+  }
+  let entry = bunServeUnixHandles.get(path);
+  if (entry === undefined) {
+    const result = bindUnixListenFd(path);
+    if (result < 0) {
+      send(worker, { errno: result, key, ack: message.seq });
+      return;
+    }
+    entry = { fd: result, workers: new Set() };
+    bunServeUnixHandles.set(path, entry);
+    handles.set(key, {
+      remove(w) {
+        if (!entry!.workers.delete(w.id)) return false;
+        if (entry!.workers.size !== 0) return false;
+        bunServeUnixHandles.delete(path);
+        require("node:fs").closeSync(entry!.fd);
+        try {
+          if (path.charCodeAt(0) !== 0) require("node:fs").unlinkSync(path);
+        } catch {}
+        return true;
+      },
+    });
+  }
+  entry.workers.add(worker.id);
+  const reply = { cmd: "NODE_HANDLE", type: "bun.ServeUnixFd", message: { errno: 0, key, ack: message.seq, cmd: "NODE_CLUSTER" } };
+  sendHelper(worker.process[kHandle], reply, { fd: entry.fd }, null);
 }
 
 function listening(worker, message) {

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -294,35 +294,33 @@ function queryServer(worker, message) {
   });
 }
 
-// path -> { fd, workers: Set<id> }
-const bunServeUnixHandles = new Map();
+const bunServeUnixHandles = new Map(); // path -> { fd, workers: Set<id> }
 
-// Bun.serve({ unix }) in a worker asks the primary for a shared listen fd so
-// every worker accepts on the same AF_UNIX socket (SO_REUSEPORT is TCP-only).
+// Shared AF_UNIX listen fds for Bun.serve({ unix }) in workers (SO_REUSEPORT is TCP-only).
 function bunServeUnix(worker, message) {
-  const path = message.path;
-  const key = `bunServeUnix:${path}`;
-  if (typeof path !== "string" || process.platform === "win32") {
+  const sockPath = message.path;
+  const key = `bunServeUnix:${sockPath}`;
+  if (typeof sockPath !== "string" || process.platform === "win32") {
     send(worker, { errno: -22 /* EINVAL */, key, ack: message.seq });
     return;
   }
-  let entry = bunServeUnixHandles.get(path);
+  let entry = bunServeUnixHandles.get(sockPath);
   if (entry === undefined) {
-    const result = bindUnixListenFd(path);
+    const result = bindUnixListenFd(sockPath);
     if (result < 0) {
       send(worker, { errno: result, key, ack: message.seq });
       return;
     }
     entry = { fd: result, workers: new Set() };
-    bunServeUnixHandles.set(path, entry);
+    bunServeUnixHandles.set(sockPath, entry);
     handles.set(key, {
       remove(w) {
         if (!entry!.workers.delete(w.id)) return false;
         if (entry!.workers.size !== 0) return false;
-        bunServeUnixHandles.delete(path);
+        bunServeUnixHandles.delete(sockPath);
         require("node:fs").closeSync(entry!.fd);
         try {
-          if (path.charCodeAt(0) !== 0) require("node:fs").unlinkSync(path);
+          if (sockPath.charCodeAt(0) !== 0) require("node:fs").unlinkSync(sockPath);
         } catch {}
         return true;
       },

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -359,8 +359,9 @@ extern "C" JSC::EncodedJSValue Bun__requestClusterUnixServeFd(JSGlobalObject* gl
     args.append(JSValue::decode(pathValue));
     auto callData = JSC::getCallData(fn);
     JSValue result = JSC::call(globalObject, fn, callData, cluster, args);
+    // The caller is Rust: check fully here instead of releasing to a C++ parent scope.
     RETURN_IF_EXCEPTION(scope, {});
-    RELEASE_AND_RETURN(scope, JSValue::encode(result));
+    return JSValue::encode(result);
 }
 
 extern "C" JSC::EncodedJSValue JSPasswordObject__create(JSGlobalObject*);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -339,6 +339,30 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));
 }
 
+extern "C" JSC::EncodedJSValue Bun__requestClusterUnixServeFd(JSGlobalObject* globalObject, JSC::EncodedJSValue pathValue)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* zigGlobal = defaultGlobalObject(globalObject);
+    JSValue clusterModule = zigGlobal->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::NodeCluster);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* clusterObject = clusterModule.getObject();
+    if (!clusterObject) return JSValue::encode(jsUndefined());
+    JSValue defaultExport = clusterObject->get(globalObject, vm.propertyNames->defaultKeyword);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* cluster = defaultExport.getObject();
+    if (!cluster) cluster = clusterObject;
+    JSValue fn = cluster->get(globalObject, Identifier::fromString(vm, "_bunServeUnix"_s));
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!fn.isCallable()) return JSValue::encode(jsUndefined());
+    MarkedArgumentBuffer args;
+    args.append(JSValue::decode(pathValue));
+    auto callData = JSC::getCallData(fn);
+    JSValue result = JSC::call(globalObject, fn, callData, cluster, args);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, JSValue::encode(result));
+}
+
 extern "C" JSC::EncodedJSValue JSPasswordObject__create(JSGlobalObject*);
 
 static JSValue constructPasswordObject(VM& vm, JSObject* bunObject)

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1579,6 +1579,45 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
         }
     }
 
+    // Bun.serve({ unix }) in a node:cluster worker: SO_REUSEPORT does not
+    // apply to AF_UNIX, so instead of each worker binding independently (the
+    // last bind wins and every other worker EADDRINUSEs), ask the primary for
+    // a single shared listen descriptor and adopt it. The IPC round-trip
+    // pumps the event loop so Bun.serve() stays synchronous to callers.
+    #[cfg(not(windows))]
+    if config.reuse_port && global_object.bun_vm().ipc.is_some() {
+        if let crate::server::server_config::Address::Unix(path) = &config.address {
+            let bytes = path.as_bytes();
+            if !bytes.is_empty() {
+                unsafe extern "C" {
+                    fn Bun__requestClusterUnixServeFd(
+                        global: &JSGlobalObject,
+                        path: JSValue,
+                    ) -> JSValue;
+                }
+                let path_js = bun_jsc::bun_string_jsc::create_utf8_for_js(global_object, bytes)?;
+                // SAFETY: FFI to C++ shim in BunObject.cpp; both args valid.
+                let promise = unsafe { Bun__requestClusterUnixServeFd(global_object, path_js) };
+                if global_object.has_exception() {
+                    return Err(bun_jsc::JsError::Thrown);
+                }
+                if let Some(any) = promise.as_any_promise() {
+                    global_object.bun_vm().as_mut().wait_for_promise(any);
+                    if global_object.has_exception() {
+                        return Err(bun_jsc::JsError::Thrown);
+                    }
+                    let result = any.result(global_object.vm());
+                    if result.is_number() {
+                        let fd = result.to_int32();
+                        if fd >= 0 {
+                            config.cluster_unix_fd = Some(fd);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     macro_rules! serve_with {
         ($ServerType:ty, $tag:expr) => {{
             let server = <$ServerType>::init(&mut config, global_object)?;

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1592,11 +1592,10 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
                     ) -> JSValue;
                 }
                 let path_js = bun_jsc::bun_string_jsc::create_utf8_for_js(global_object, bytes)?;
-                // SAFETY: FFI to C++ shim in BunObject.cpp; both args valid.
-                let promise = unsafe { Bun__requestClusterUnixServeFd(global_object, path_js) };
-                if global_object.has_exception() {
-                    return Err(bun_jsc::JsError::Thrown);
-                }
+                let promise = bun_jsc::from_js_host_call(global_object, || {
+                    // SAFETY: FFI to C++ shim in BunObject.cpp; both args valid.
+                    unsafe { Bun__requestClusterUnixServeFd(global_object, path_js) }
+                })?;
                 if let Some(any) = promise.as_any_promise() {
                     global_object.bun_vm().as_mut().wait_for_promise(any);
                     if global_object.has_exception() {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1579,11 +1579,7 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
         }
     }
 
-    // Bun.serve({ unix }) in a node:cluster worker: SO_REUSEPORT does not
-    // apply to AF_UNIX, so instead of each worker binding independently (the
-    // last bind wins and every other worker EADDRINUSEs), ask the primary for
-    // a single shared listen descriptor and adopt it. The IPC round-trip
-    // pumps the event loop so Bun.serve() stays synchronous to callers.
+    // Cluster workers adopt one shared AF_UNIX listen fd from the primary (SO_REUSEPORT is TCP-only).
     #[cfg(not(windows))]
     if config.reuse_port && global_object.bun_vm().ipc.is_some() {
         if let crate::server::server_config::Address::Unix(path) = &config.address {
@@ -1610,7 +1606,10 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
                     if result.is_number() {
                         let fd = result.to_int32();
                         if fd >= 0 {
-                            config.cluster_unix_fd = Some(fd);
+                            // `File` closes the fd on drop if `Bun.serve` fails before adopting it.
+                            config.cluster_unix_fd =
+                                Some(bun_sys::File::from_fd(bun_sys::Fd::from_native(fd)));
+                            config.cluster_owns_unix_path = true;
                         }
                     }
                 }

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -396,3 +396,51 @@ pub fn should_ignore_one_disconnect_event_listener(global: &JSGlobalObject) -> b
     let vm = global.bun_vm();
     vm.channel_ref_should_ignore_one_disconnect_event_listener
 }
+
+#[cfg(not(windows))]
+unsafe extern "C" {
+    fn bsd_create_listen_socket_unix(
+        path: *const core::ffi::c_char,
+        pathlen: usize,
+        options: core::ffi::c_int,
+        error: *mut core::ffi::c_int,
+    ) -> core::ffi::c_int;
+}
+
+/// Bind+listen an AF_UNIX stream socket at `path` without attaching it to an
+/// event loop. Used by the cluster primary to create a shared listen
+/// descriptor that is handed to every worker over SCM_RIGHTS so `Bun.serve`
+/// in the workers can adopt it (SO_REUSEPORT does not apply to AF_UNIX).
+/// Returns the fd on success, or the negative errno on failure.
+#[bun_jsc::host_fn]
+pub(crate) fn bind_unix_listen_fd(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    #[cfg(windows)]
+    {
+        let _ = frame;
+        let _ = global;
+        return Ok(JSValue::js_number(-(bun_sys::SystemErrno::ENOTSUP as i32) as f64));
+    }
+    #[cfg(not(windows))]
+    {
+        let [path] = frame.arguments_as_array::<1>();
+        if !path.is_string() {
+            return Err(global.throw_invalid_argument_type_value("path", "string", path));
+        }
+        let slice = path.to_slice(global)?;
+        let bytes = slice.slice();
+        let mut errno: core::ffi::c_int = 0;
+        // SAFETY: bytes is valid for the duration of the call.
+        let fd = unsafe {
+            bsd_create_listen_socket_unix(bytes.as_ptr().cast(), bytes.len(), 0, &mut errno)
+        };
+        if fd < 0 {
+            let e = if errno != 0 {
+                errno
+            } else {
+                bun_sys::SystemErrno::EADDRINUSE as i32
+            };
+            return Ok(JSValue::js_number(-(e as f64)));
+        }
+        Ok(JSValue::js_number(fd as f64))
+    }
+}

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -127,11 +127,9 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
         return Ok(JSValue::FALSE);
     }
 
-    Ok(if good == SerializeAndSendResult::Success {
-        JSValue::TRUE
-    } else {
-        JSValue::FALSE
-    })
+    // Backoff means the message was queued behind a pending handle ack and will
+    // still be delivered, so only Failure reports false.
+    Ok(JSValue::TRUE)
 }
 
 #[bun_jsc::host_fn]
@@ -256,10 +254,12 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
 
     let success =
         ipc_data.serialize_and_send(global, message, is_internal, JSValue::NULL, zig_handle);
-    Ok(if success == SerializeAndSendResult::Success {
-        JSValue::TRUE
-    } else {
+    // Backoff means the message (and any handle fd) was queued behind a pending
+    // handle ack and will still be delivered, so only Failure reports false.
+    Ok(if success == SerializeAndSendResult::Failure {
         JSValue::FALSE
+    } else {
+        JSValue::TRUE
     })
 }
 

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -407,11 +407,7 @@ unsafe extern "C" {
     ) -> core::ffi::c_int;
 }
 
-/// Bind+listen an AF_UNIX stream socket at `path` without attaching it to an
-/// event loop. Used by the cluster primary to create a shared listen
-/// descriptor that is handed to every worker over SCM_RIGHTS so `Bun.serve`
-/// in the workers can adopt it (SO_REUSEPORT does not apply to AF_UNIX).
-/// Returns the fd on success, or the negative errno on failure.
+/// Bind+listen an AF_UNIX socket at `path`; returns the fd, or the negative errno on failure.
 #[bun_jsc::host_fn]
 pub(crate) fn bind_unix_listen_fd(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     #[cfg(windows)]

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -418,7 +418,9 @@ pub(crate) fn bind_unix_listen_fd(global: &JSGlobalObject, frame: &CallFrame) ->
     {
         let _ = frame;
         let _ = global;
-        return Ok(JSValue::js_number(-(bun_sys::SystemErrno::ENOTSUP as i32) as f64));
+        return Ok(JSValue::js_number(
+            -(bun_sys::SystemErrno::ENOTSUP as i32) as f64,
+        ));
     }
     #[cfg(not(windows))]
     {

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -127,8 +127,7 @@ pub(crate) fn send_helper_child(global: &JSGlobalObject, frame: &CallFrame) -> J
         return Ok(JSValue::FALSE);
     }
 
-    // Backoff means the message was queued behind a pending handle ack and will
-    // still be delivered, so only Failure reports false.
+    // Backoff still delivers (queued behind a pending handle ack), so only Failure reports false.
     Ok(JSValue::TRUE)
 }
 
@@ -254,8 +253,7 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
 
     let success =
         ipc_data.serialize_and_send(global, message, is_internal, JSValue::NULL, zig_handle);
-    // Backoff means the message (and any handle fd) was queued behind a pending
-    // handle ack and will still be delivered, so only Failure reports false.
+    // Backoff still delivers (queued behind a pending handle ack), so only Failure reports false.
     Ok(if success == SerializeAndSendResult::Failure {
         JSValue::FALSE
     } else {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -55,10 +55,10 @@ pub struct ServerConfig {
     pub websocket: Option<WebSocketServerContext>,
 
     pub reuse_port: bool,
-    /// Set by `Bun.serve` (not parsed from JS) when this process is a
-    /// `node:cluster` worker and the primary handed us a shared AF_UNIX listen
-    /// descriptor; `listen()` adopts it instead of binding `address`.
-    pub cluster_unix_fd: Option<i32>,
+    /// Shared AF_UNIX listen fd from the cluster primary; adopted instead of binding `address`.
+    pub cluster_unix_fd: Option<bun_sys::File>,
+    /// The cluster primary owns the socket file at `address`; never unlink it here.
+    pub cluster_owns_unix_path: bool,
     pub id: Box<[u8]>,
     pub allow_hot: bool,
     pub ipv6_only: bool,
@@ -93,6 +93,7 @@ impl Default for ServerConfig {
             websocket: None,
             reuse_port: false,
             cluster_unix_fd: None,
+            cluster_owns_unix_path: false,
             id: Box::default(),
             allow_hot: true,
             ipv6_only: false,
@@ -277,7 +278,8 @@ impl ServerConfig {
             on_node_http_request: self.on_node_http_request,
             websocket: self.websocket.take(),
             reuse_port: self.reuse_port,
-            cluster_unix_fd: self.cluster_unix_fd,
+            cluster_unix_fd: self.cluster_unix_fd.take(),
+            cluster_owns_unix_path: self.cluster_owns_unix_path,
             id: core::mem::take(&mut self.id),
             allow_hot: self.allow_hot,
             ipv6_only: self.ipv6_only,

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -55,6 +55,10 @@ pub struct ServerConfig {
     pub websocket: Option<WebSocketServerContext>,
 
     pub reuse_port: bool,
+    /// Set by `Bun.serve` (not parsed from JS) when this process is a
+    /// `node:cluster` worker and the primary handed us a shared AF_UNIX listen
+    /// descriptor; `listen()` adopts it instead of binding `address`.
+    pub cluster_unix_fd: Option<i32>,
     pub id: Box<[u8]>,
     pub allow_hot: bool,
     pub ipv6_only: bool,
@@ -88,6 +92,7 @@ impl Default for ServerConfig {
             on_node_http_request: JSValue::ZERO,
             websocket: None,
             reuse_port: false,
+            cluster_unix_fd: None,
             id: Box::default(),
             allow_hot: true,
             ipv6_only: false,
@@ -272,6 +277,7 @@ impl ServerConfig {
             on_node_http_request: self.on_node_http_request,
             websocket: self.websocket.take(),
             reuse_port: self.reuse_port,
+            cluster_unix_fd: self.cluster_unix_fd,
             id: core::mem::take(&mut self.id),
             allow_hot: self.allow_hot,
             ipv6_only: self.ipv6_only,

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1612,8 +1612,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if let server_config::Address::Unix(path) = &self.config.address {
             let bytes = path.as_bytes();
-            // The primary owns the socket file when it handed us the fd.
-            if !bytes.is_empty() && bytes[0] != 0 && self.config.cluster_unix_fd.is_none() {
+            if !bytes.is_empty() && bytes[0] != 0 && !self.config.cluster_owns_unix_path {
                 let _ = bun_sys::unlink(path.as_zstr());
             }
         }
@@ -2815,7 +2814,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             Tcp { port: u16, host: *const c_char },
             Unix { ptr: *const u8, len: usize },
         }
-        let (addr, http1, options, cluster_unix_fd) = {
+        let (addr, http1, options) = {
             let cfg = &this_ref.get().config;
             let addr = match &cfg.address {
                 server_config::Address::Tcp { port, hostname } => {
@@ -2839,13 +2838,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     len: unix.as_bytes().len(),
                 },
             };
-            (
-                addr,
-                cfg.http1,
-                cfg.get_usockets_options(),
-                cfg.cluster_unix_fd,
-            )
+            (addr, cfg.http1, cfg.get_usockets_options())
         };
+        // Take the adopted cluster fd out of config: `listen_fd` consumes it,
+        // and it must not reach `config`'s eventual drop once handed over.
+        // SAFETY: `this` is the live boxed server; the borrow ends at the `;`.
+        let cluster_unix_fd = unsafe { &mut *this }.config.cluster_unix_fd.take();
 
         match addr {
             Addr::Tcp { port, host } => {
@@ -2949,30 +2947,36 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         unsafe { uws_sys::h3::App::destroy(h3a) };
                     }
                 }
-                if let Some(fd) = cluster_unix_fd {
-                    // SAFETY: app is a live uws handle owned by this server. No
-                    // `&*this` is live across this call.
-                    unsafe {
-                        (*app).listen_fd(
-                            trampoline::on_listen::<SSL, DEBUG>,
-                            this.cast::<c_void>(),
-                            fd,
-                            options,
-                        );
+                match cluster_unix_fd {
+                    #[cfg(not(windows))]
+                    Some(fd) => {
+                        // SAFETY: app is a live uws handle owned by this server.
+                        // No `&*this` is live across this call. `into_raw`
+                        // disarms the close-on-drop guard; `listen_fd` consumes
+                        // the descriptor (closes it on failure).
+                        unsafe {
+                            (*app).listen_fd(
+                                trampoline::on_listen::<SSL, DEBUG>,
+                                this.cast::<c_void>(),
+                                fd.into_raw().native(),
+                                options,
+                            );
+                        }
                     }
-                } else {
-                    // SAFETY: ptr/len reference `config.address`'s ZBox; NUL
-                    // sentinel at `ptr[len]` holds for ZStr::from_raw.
-                    let z = unsafe { bun_core::ZStr::from_raw(ptr, len) };
-                    // SAFETY: app is a live uws handle owned by this server. No
-                    // `&*this` is live across this call.
-                    unsafe {
-                        (*app).listen_on_unix_socket(
-                            trampoline::on_listen_unix::<SSL, DEBUG>,
-                            this.cast::<c_void>(),
-                            z,
-                            options,
-                        );
+                    _ => {
+                        // SAFETY: ptr/len reference `config.address`'s ZBox; NUL
+                        // sentinel at `ptr[len]` holds for ZStr::from_raw.
+                        let z = unsafe { bun_core::ZStr::from_raw(ptr, len) };
+                        // SAFETY: app is a live uws handle owned by this server. No
+                        // `&*this` is live across this call.
+                        unsafe {
+                            (*app).listen_on_unix_socket(
+                                trampoline::on_listen_unix::<SSL, DEBUG>,
+                                this.cast::<c_void>(),
+                                z,
+                                options,
+                            );
+                        }
                     }
                 }
             }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1612,7 +1612,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if let server_config::Address::Unix(path) = &self.config.address {
             let bytes = path.as_bytes();
-            if !bytes.is_empty() && bytes[0] != 0 {
+            // The primary owns the socket file when it handed us the fd.
+            if !bytes.is_empty() && bytes[0] != 0 && self.config.cluster_unix_fd.is_none() {
                 let _ = bun_sys::unlink(path.as_zstr());
             }
         }
@@ -2814,7 +2815,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             Tcp { port: u16, host: *const c_char },
             Unix { ptr: *const u8, len: usize },
         }
-        let (addr, http1, options) = {
+        let (addr, http1, options, cluster_unix_fd) = {
             let cfg = &this_ref.get().config;
             let addr = match &cfg.address {
                 server_config::Address::Tcp { port, hostname } => {
@@ -2838,7 +2839,12 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     len: unix.as_bytes().len(),
                 },
             };
-            (addr, cfg.http1, cfg.get_usockets_options())
+            (
+                addr,
+                cfg.http1,
+                cfg.get_usockets_options(),
+                cfg.cluster_unix_fd,
+            )
         };
 
         match addr {
@@ -2943,18 +2949,31 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         unsafe { uws_sys::h3::App::destroy(h3a) };
                     }
                 }
-                // SAFETY: ptr/len reference `config.address`'s ZBox; NUL
-                // sentinel at `ptr[len]` holds for ZStr::from_raw.
-                let z = unsafe { bun_core::ZStr::from_raw(ptr, len) };
-                // SAFETY: app is a live uws handle owned by this server. No
-                // `&*this` is live across this call.
-                unsafe {
-                    (*app).listen_on_unix_socket(
-                        trampoline::on_listen_unix::<SSL, DEBUG>,
-                        this.cast::<c_void>(),
-                        z,
-                        options,
-                    );
+                if let Some(fd) = cluster_unix_fd {
+                    // SAFETY: app is a live uws handle owned by this server. No
+                    // `&*this` is live across this call.
+                    unsafe {
+                        (*app).listen_fd(
+                            trampoline::on_listen::<SSL, DEBUG>,
+                            this.cast::<c_void>(),
+                            fd,
+                            options,
+                        );
+                    }
+                } else {
+                    // SAFETY: ptr/len reference `config.address`'s ZBox; NUL
+                    // sentinel at `ptr[len]` holds for ZStr::from_raw.
+                    let z = unsafe { bun_core::ZStr::from_raw(ptr, len) };
+                    // SAFETY: app is a live uws handle owned by this server. No
+                    // `&*this` is live across this call.
+                    unsafe {
+                        (*app).listen_on_unix_socket(
+                            trampoline::on_listen_unix::<SSL, DEBUG>,
+                            this.cast::<c_void>(),
+                            z,
+                            options,
+                        );
+                    }
                 }
             }
         }

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -304,6 +304,26 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
+    pub fn listen_fd(
+        &mut self,
+        handler: extern "C" fn(*mut UwsListenSocket, *mut c_void),
+        user_data: *mut c_void,
+        fd: i32,
+        flags: i32,
+    ) {
+        // SAFETY: self is a valid app.
+        unsafe {
+            c::uws_app_listen_fd(
+                Self::SSL_FLAG,
+                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                fd,
+                flags,
+                handler,
+                user_data,
+            )
+        }
+    }
+
     pub fn num_subscribers(&mut self, topic: &[u8]) -> u32 {
         // SAFETY: self is a valid app; topic valid for the call.
         unsafe {
@@ -626,6 +646,15 @@ pub mod c {
             pathlen: usize,
             flags: i32,
             handler: extern "C" fn(*mut UwsListenSocket, *const c_char, i32, *mut c_void),
+            user_data: *mut c_void,
+        );
+
+        pub(crate) fn uws_app_listen_fd(
+            ssl_flag: c_int,
+            app: *mut uws_app_t,
+            fd: i32,
+            flags: i32,
+            handler: extern "C" fn(*mut UwsListenSocket, *mut c_void),
             user_data: *mut c_void,
         );
 

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -498,6 +498,27 @@ extern "C"
     }
   }
 
+  void uws_app_listen_fd(int ssl, uws_app_t *app, int32_t fd, int32_t options,
+                         uws_listen_handler handler, void *user_data)
+  {
+    if (ssl)
+    {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->listen_fd(
+          (LIBUS_SOCKET_DESCRIPTOR)fd, options,
+          [handler, user_data](struct us_listen_socket_t *listen_socket)
+          { handler((struct us_listen_socket_t *)listen_socket, user_data); });
+    }
+    else
+    {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->listen_fd(
+          (LIBUS_SOCKET_DESCRIPTOR)fd, options,
+          [handler, user_data](struct us_listen_socket_t *listen_socket)
+          { handler((struct us_listen_socket_t *)listen_socket, user_data); });
+    }
+  }
+
   /* callback, path to unix domain socket */
   void uws_app_listen_domain_with_options(int ssl, uws_app_t *app, const char *domain, size_t pathlen, int options, uws_listen_domain_handler handler, void *user_data)
   {

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -171,7 +171,17 @@ test.skipIf(isWindows)("Bun.serve({ unix }) shares one listen socket across clus
       import net from "node:net";
       import path from "node:path";
       const SOCK = path.join(process.cwd(), "serve.sock");
-      const WORKERS = 4;
+      const WORKERS = 3;
+      async function request(): Promise<string> {
+        return new Promise(r => {
+          const c = net.connect(SOCK);
+          let b = "";
+          c.on("data", d => b += d);
+          c.on("close", () => r(b.split("\\r\\n\\r\\n")[1] ?? ""));
+          c.on("error", () => r(""));
+          c.write("GET / HTTP/1.0\\r\\nHost: x\\r\\n\\r\\n");
+        });
+      }
       if (cluster.isPrimary) {
         let ready = 0;
         const workers: any[] = [];
@@ -196,26 +206,33 @@ test.skipIf(isWindows)("Bun.serve({ unix }) shares one listen socket across clus
           // answered. Without the fix this never passes because only one
           // worker ever bound.
           const seen = new Set<string>();
-          for (let i = 0; i < 100 && seen.size < 2; i++) {
-            await new Promise<void>(r => {
-              const c = net.connect(SOCK);
-              let b = "";
-              c.on("data", d => b += d);
-              c.on("close", () => { seen.add(b.split("\\r\\n\\r\\n")[1] ?? ""); r(); });
-              c.on("error", () => r());
-              c.write("GET / HTTP/1.0\\r\\nHost: x\\r\\n\\r\\n");
-            });
-          }
+          for (let i = 0; i < 100 && seen.size < 2; i++) seen.add(await request());
           console.log("distinct=" + seen.size);
+          // One worker stopping must not unlink the primary-owned socket file
+          // or break the remaining workers' accepts.
+          const stopped = await new Promise<string>(r => {
+            workers[0].once("message", r);
+            workers[0].send("stop");
+          });
+          console.log("sock-after-stop=" + require("fs").existsSync(SOCK));
+          let responder = "";
+          for (let i = 0; i < 100 && (!responder || responder === stopped); i++)
+            responder = await request();
+          console.log("after-stop-responder=" + (responder && responder !== stopped));
           for (const w of workers) w.kill();
           process.exit(seen.size >= 2 ? 0 : 1);
         }
       } else {
         const id = process.env.WORKER_NUM;
-        Bun.serve({
+        const server = Bun.serve({
           unix: SOCK,
           reusePort: true,
           fetch() { return new Response("worker-" + id); },
+        });
+        process.on("message", m => {
+          if (m !== "stop") return;
+          server.stop(true);
+          process.send!("worker-" + id);
         });
         process.send!("ready");
       }
@@ -229,10 +246,12 @@ test.skipIf(isWindows)("Bun.serve({ unix }) shares one listen socket across clus
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).not.toContain("EADDRINUSE");
-  expect(stdout).toContain("listening=4");
+  expect(stdout).toContain("listening=3");
   expect(stdout).toContain("distinct=2");
+  expect(stdout).toContain("sock-after-stop=true");
+  expect(stdout).toContain("after-stop-responder=true");
   expect(exitCode).toBe(0);
-});
+}, 20_000);
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {
   // `kHandle` is a private symbol that only `cluster.fork()` sets, so a

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -200,7 +200,7 @@ test.skipIf(isWindows)(
         }
         async function go() {
           // Every worker returned from Bun.serve without throwing: on an
-          // unpatched build 3 of 4 workers EADDRINUSE and exit before this
+          // unpatched build 2 of 3 workers EADDRINUSE and exit before this
           // prints.
           console.log("listening=" + WORKERS);
           // accept() on a shared fd is kernel-scheduled across the epoll set,
@@ -208,7 +208,10 @@ test.skipIf(isWindows)(
           // answered. Without the fix this never passes because only one
           // worker ever bound.
           const seen = new Set<string>();
-          for (let i = 0; i < 100 && seen.size < 2; i++) seen.add(await request());
+          for (let i = 0; i < 100 && seen.size < 2; i++) {
+            const body = await request();
+            if (body) seen.add(body);
+          }
           console.log("distinct=" + seen.size);
           // One worker stopping must not unlink the primary-owned socket file
           // or break the remaining workers' accepts.

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, joinP, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
 
 test("cloneable and transferable equals", () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -159,6 +159,79 @@ process.send("regular message");
   });
   const { stdout } = bunRun(joinP(dir, "parent.ts"), bunEnv);
   expect(stdout).toContain("P received regular message");
+});
+
+// https://github.com/oven-sh/bun/issues/13611
+// SO_REUSEPORT does not apply to AF_UNIX; every worker must adopt the same
+// listen descriptor from the primary instead of binding independently.
+test.skipIf(isWindows)("Bun.serve({ unix }) shares one listen socket across cluster workers", async () => {
+  using dir = tempDir("bun-serve-cluster-unix", {
+    "index.ts": `
+      import cluster from "node:cluster";
+      import net from "node:net";
+      import path from "node:path";
+      const SOCK = path.join(process.cwd(), "serve.sock");
+      const WORKERS = 4;
+      if (cluster.isPrimary) {
+        let ready = 0;
+        const workers: any[] = [];
+        for (let i = 0; i < WORKERS; i++) {
+          const w = cluster.fork({ WORKER_NUM: String(i) });
+          workers.push(w);
+          w.on("message", m => { if (m === "ready" && ++ready === WORKERS) go(); });
+          w.on("exit", (code, sig) => {
+            if ((code ?? 0) !== 0 && sig !== "SIGTERM") {
+              console.error("worker " + i + " exited " + code);
+              process.exit(1);
+            }
+          });
+        }
+        async function go() {
+          // Every worker returned from Bun.serve without throwing: on an
+          // unpatched build 3 of 4 workers EADDRINUSE and exit before this
+          // prints.
+          console.log("listening=" + WORKERS);
+          // accept() on a shared fd is kernel-scheduled across the epoll set,
+          // not round-robin; keep going until at least two workers have
+          // answered. Without the fix this never passes because only one
+          // worker ever bound.
+          const seen = new Set<string>();
+          for (let i = 0; i < 100 && seen.size < 2; i++) {
+            await new Promise<void>(r => {
+              const c = net.connect(SOCK);
+              let b = "";
+              c.on("data", d => b += d);
+              c.on("close", () => { seen.add(b.split("\\r\\n\\r\\n")[1] ?? ""); r(); });
+              c.on("error", () => r());
+              c.write("GET / HTTP/1.0\\r\\nHost: x\\r\\n\\r\\n");
+            });
+          }
+          console.log("distinct=" + seen.size);
+          for (const w of workers) w.kill();
+          process.exit(seen.size >= 2 ? 0 : 1);
+        }
+      } else {
+        const id = process.env.WORKER_NUM;
+        Bun.serve({
+          unix: SOCK,
+          reusePort: true,
+          fetch() { return new Response("worker-" + id); },
+        });
+        process.send!("ready");
+      }
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("EADDRINUSE");
+  expect(stdout).toContain("listening=4");
+  expect(stdout).toContain("distinct=2");
+  expect(exitCode).toBe(0);
 });
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -192,8 +192,8 @@ test.skipIf(isWindows)(
           workers.push(w);
           w.on("message", m => { if (m === "ready" && ++ready === WORKERS) go(); });
           w.on("exit", (code, sig) => {
-            if ((code ?? 0) !== 0 && sig !== "SIGTERM") {
-              console.error("worker " + i + " exited " + code);
+            if (code !== 0 && sig !== "SIGTERM") {
+              console.error("worker " + i + " exited " + code + " signal " + sig);
               process.exit(1);
             }
           });

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -164,9 +164,11 @@ process.send("regular message");
 // https://github.com/oven-sh/bun/issues/13611
 // SO_REUSEPORT does not apply to AF_UNIX; every worker must adopt the same
 // listen descriptor from the primary instead of binding independently.
-test.skipIf(isWindows)("Bun.serve({ unix }) shares one listen socket across cluster workers", async () => {
-  using dir = tempDir("bun-serve-cluster-unix", {
-    "index.ts": `
+test.skipIf(isWindows)(
+  "Bun.serve({ unix }) shares one listen socket across cluster workers",
+  async () => {
+    using dir = tempDir("bun-serve-cluster-unix", {
+      "index.ts": `
       import cluster from "node:cluster";
       import net from "node:net";
       import path from "node:path";
@@ -237,21 +239,23 @@ test.skipIf(isWindows)("Bun.serve({ unix }) shares one listen socket across clus
         process.send!("ready");
       }
     `,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "index.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).not.toContain("EADDRINUSE");
-  expect(stdout).toContain("listening=3");
-  expect(stdout).toContain("distinct=2");
-  expect(stdout).toContain("sock-after-stop=true");
-  expect(stdout).toContain("after-stop-responder=true");
-  expect(exitCode).toBe(0);
-}, 20_000);
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("EADDRINUSE");
+    expect(stdout).toContain("listening=3");
+    expect(stdout).toContain("distinct=2");
+    expect(stdout).toContain("sock-after-stop=true");
+    expect(stdout).toContain("after-stop-responder=true");
+    expect(exitCode).toBe(0);
+  },
+  20_000,
+);
 
 test("disconnect() on a cluster.Worker built around a plain object does not abort", async () => {
   // `kHandle` is a private symbol that only `cluster.fork()` sets, so a


### PR DESCRIPTION
## What

Makes `Bun.serve({ unix })` distribute connections across `node:cluster` workers instead of failing with `EADDRINUSE` on every worker but one.

Fixes #13611.

## Why

`SO_REUSEPORT` (what Bun.serve's cluster-worker default `reuse_port = true` relies on) only applies to `AF_INET`/`AF_INET6`. For `AF_UNIX`, each worker binding the same path either unlinks the previous listener or gets `EADDRINUSE`, so only the last worker to bind ever receives connections:

```
EADDRINUSE: address already in use, listen '/tmp/serve.sock'
```

Node.js solves this for `net.Server`/`http.Server` by having the primary own the listen socket and hand connections (or the listen fd) to workers. This PR does the fd-sharing variant for `Bun.serve`.

## How

When `Bun.serve` sees a unix address in a process that has a cluster IPC channel and `reusePort` is on (the default in workers), it sends the primary a new internal `bunServeUnix` request. The primary binds+listens once per path via `bsd_create_listen_socket_unix` (without attaching to an event loop) and replies with the fd over the existing `NODE_HANDLE` SCM_RIGHTS path. Each worker adopts the fd through a new `us_socket_group_listen_fd` / `uws_app_listen_fd` chain (fd is consumed: closed on failure, owned by the listen socket on success) and accepts on the shared socket. The primary owns the socket file and cleans it up when the last worker disconnects.

`Bun.serve` stays synchronous: the single IPC round-trip pumps the event loop via `wait_for_promise`. The wait is bounded (resolves `-1` on disconnect or after 5s without a reply) so a primary that does not understand the request (Node.js, an older Bun, or a plain `child_process.fork` with `NODE_UNIQUE_ID` in env) lets the worker fall through to the existing direct bind instead of hanging. This is a tradeoff: running the event loop inside a synchronous API means timers, IPC messages, and `disconnect` handlers can fire before `Bun.serve()` returns, and a nested `wait_for_promise` from an outer I/O dispatch can drop events on edge-triggered polls. In practice `Bun.serve({ unix })` is called at module scope in cluster workers (the only place this path activates), and the pattern already has precedent in `expect().resolves` and the repl; a wider async-capable `Bun.serve` is out of scope here.

Because `node:http`'s `Server.listen({ path })` is backed by `Bun.serve` with `reusePort: true` in workers, this also makes `node:http` + cluster over a unix socket distribute across workers.

Skipped on Windows (no SCM_RIGHTS for AF_UNIX there); workers fall through to the existing direct bind.

## Relationship to open PRs

#31829 and #34659 are implementing Node-style round-robin / `listen({ fd })` for `net.Server` and `node:http`. Neither wires raw `Bun.serve({ unix })` into cluster. The `us_socket_group_listen_fd` / `uws_app_listen_fd` primitives added here match the ones those PRs add, so any overlap resolves by keeping one copy.

## Verification

Before: `test/js/node/cluster.test.ts` fails in ~60ms with `EADDRINUSE` on two of three workers.

After: all three workers return from `Bun.serve` on the same path; the primary observes responses from multiple workers; stopping one worker's server leaves the socket file in place and the remaining workers keep accepting.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/cluster.test.ts

<!-- robobun:evidence:end -->