### PR TITLE
HTMLRewriter: validate EndTag.name setter like element.tagName

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1457,6 +1457,29 @@ fn setter_utf8_arg(global: &JSGlobalObject, value: JSValue) -> JsResult<String> 
     Ok(utf8_or_throw(global, slice.slice())?.to_owned())
 }
 
+/// Same checks `Element::set_tag_name` applies, for setters lol-html exposes
+/// without validation (`EndTag::set_name_str`). Keeps the error text identical
+/// to `element.tagName = ...` by reusing lol-html's `TagNameError`.
+fn validate_tag_name(name: &str) -> Result<(), lol_html::errors::TagNameError> {
+    use lol_html::errors::TagNameError;
+    match name.as_bytes().first() {
+        None => Err(TagNameError::Empty),
+        Some(ch) if !ch.is_ascii_alphabetic() => Err(TagNameError::InvalidFirstCharacter),
+        Some(_) => {
+            if let Some(ch) = name
+                .as_bytes()
+                .iter()
+                .copied()
+                .find(|&ch| matches!(ch, b' ' | b'\n' | b'\r' | b'\t' | b'\x0C' | b'/' | b'>'))
+            {
+                Err(TagNameError::ForbiddenCharacter(ch as char))
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
 fn string_to_js(s: &str, global: &JSGlobalObject) -> JsResult<JSValue> {
     bun_string_jsc::create_utf8_for_js(global, s.as_bytes())
 }
@@ -1790,6 +1813,9 @@ impl EndTag {
             return Ok(());
         }
         let name = setter_utf8_arg(global, value)?;
+        if let Err(e) = validate_tag_name(&name) {
+            return Err(global.throw_value(create_lolhtml_error(global, &e)));
+        }
         let Some(end_tag) = cell_get(&self.end_tag) else {
             return Ok(());
         };

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1208,6 +1208,49 @@ describe("tagName, endTag.name, and comment.text setters", () => {
     expect(out).toBe("<p>hi</div>");
   });
 
+  it.each([
+    ["", "Tag name can't be empty."],
+    ["a b", "` ` character is forbidden in the tag name"],
+    ["a>b", "`>` character is forbidden in the tag name"],
+    ["a/b", "`/` character is forbidden in the tag name"],
+    ["a\nb", "`\n` character is forbidden in the tag name"],
+    ["1ab", "The first character of the tag name should be an ASCII alphabetical character."],
+    ["\0", "The first character of the tag name should be an ASCII alphabetical character."],
+  ])("endTag.name = %j throws the same error as element.tagName", (value, message) => {
+    const setEndTagName = () =>
+      new HTMLRewriter()
+        .on("div", {
+          element(el) {
+            el.onEndTag(end => {
+              end.name = value;
+            });
+          },
+        })
+        .transform("<div>hi</div>");
+    expect(setEndTagName).toThrow(message);
+    expect(setEndTagName).toThrow(expect.objectContaining({ name: "HTMLRewriterError" }));
+  });
+
+  it("endTag.name rejects the invalid name and leaves the output unchanged", async () => {
+    let caught;
+    const out = await new HTMLRewriter()
+      .on("div", {
+        element(el) {
+          el.onEndTag(end => {
+            try {
+              end.name = "a b>c";
+            } catch (e) {
+              caught = e;
+            }
+          });
+        },
+      })
+      .transform(new Response("<div>hi</div>"))
+      .text();
+    expect(caught?.message).toBe("` ` character is forbidden in the tag name");
+    expect(out).toBe("<div>hi</div>");
+  });
+
   it("the assigned value is coerced with ToString, which may re-enter the wrapper", () => {
     const out = new HTMLRewriter()
       .on("p", {


### PR DESCRIPTION
## Problem

The `EndTag.name` setter (reached via `element.onEndTag`) accepts any string with zero validation and writes it raw into the closing tag. Spaces, `>`, `/`, newlines, NUL, and the empty string are all accepted, so a data-derived end-tag name can inject structural markup into the output:

```js
const out = await new HTMLRewriter()
  .on("div", { element(el) { el.onEndTag(e => { e.name = "a b>c<"; }); } })
  .transform(new Response("<div>hi</div>"))
  .text();
// out === "<div>hi</a b>c<>"   (the '>' terminates the tag, rest is content)
```

Meanwhile the sibling setter on the same object model already validates:

```js
el.tagName = "a b";  // throws: ` ` character is forbidden in the tag name
```

## Cause

lol-html's `EndTag::set_name_str` performs no validation (it just encodes and stores the bytes), unlike `Element::set_tag_name` which runs `tag_name_bytes_from_str` first. Bun's `EndTag::set_name` wrapper passed the value straight through.

## Fix

Add a `validate_tag_name` helper in `html_rewriter.rs` that applies the same checks `Element::set_tag_name` does (empty / non-alpha first char / whitespace, `/`, `>`), returning `lol_html::errors::TagNameError` so the thrown `HTMLRewriterError` text is identical to `element.tagName`. The validation runs after `setter_utf8_arg` and before `cell_get`, matching the existing early-out ordering.

Vendor lol-html is left untouched.

## Verification

New `it.each` cases in `test/js/workerd/html-rewriter.test.js` covering empty, space, `>`, `/`, newline, digit-first, and NUL-first; plus a case that catches the error inside the handler and asserts the output is unchanged. All new cases fail with `USE_SYSTEM_BUN=1` (no throw / injected output).