### PR TITLE
HTMLRewriter: match attribute selectors with uppercase names

### DIFF
--- a/patches/lolhtml/uppercase-attribute-name-selector.patch
+++ b/patches/lolhtml/uppercase-attribute-name-selector.patch
@@ -1,0 +1,111 @@
+--- a/src/selectors_vm/parser.rs
++++ b/src/selectors_vm/parser.rs
+@@ -146,6 +146,11 @@
+             | Component::AttributeInNoNamespaceExists { .. }
+             | Component::AttributeInNoNamespace { .. } => Ok(()),
+ 
++            // NOTE: the `selectors` crate emits AttributeOther not only for namespaced
++            // selectors, but also for `[Foo=bar]` where the attribute name contains
++            // ASCII uppercase. Only reject when a namespace is actually present.
++            Component::AttributeOther(attr) if attr.namespace.is_none() => Ok(()),
++
+             Component::Nth(data) => Self::validate_nth(data),
+ 
+             Component::Negation(selectors) => selectors
+--- a/src/selectors_vm/ast.rs
++++ b/src/selectors_vm/ast.rs
+@@ -1,6 +1,6 @@
+ use super::parser::{Selector, SelectorImplDescriptor};
+ use hashbrown::{DefaultHashBuilder, HashSet};
+-use selectors::attr::{AttrSelectorOperator, ParsedCaseSensitivity};
++use selectors::attr::{AttrSelectorOperator, ParsedAttrSelectorOperation, ParsedCaseSensitivity};
+ use selectors::parser::{Combinator, Component, NthType};
+ use std::fmt::{self, Debug, Formatter};
+ use std::hash::Hash;
+@@ -124,9 +124,15 @@
+             Component::ExplicitNoNamespace => Self::OnTagName(OnTagNameExpr::Unmatchable),
+             Component::ID(id) => Self::OnAttributes(OnAttributesExpr::Id(id.to_boxed_slice())),
+             Component::Class(c) => Self::OnAttributes(OnAttributesExpr::Class(c.to_boxed_slice())),
+-            Component::AttributeInNoNamespaceExists { local_name, .. } => Self::OnAttributes(
+-                OnAttributesExpr::AttributeExists(local_name.to_boxed_slice()),
+-            ),
++            // NOTE: the attribute matcher lowercases the element's attribute names
++            // before comparing, so the selector side must be lowercase too. Use
++            // `local_name_lower`; `local_name` preserves the selector's original case
++            // and would make `[HREF]` never match.
++            Component::AttributeInNoNamespaceExists {
++                local_name_lower, ..
++            } => Self::OnAttributes(OnAttributesExpr::AttributeExists(
++                local_name_lower.to_boxed_slice(),
++            )),
+             &Component::AttributeInNoNamespace {
+                 ref local_name,
+                 ref value,
+@@ -140,6 +146,30 @@
+                     operator,
+                 ),
+             )),
++            // NOTE: the `selectors` crate emits AttributeOther for `[Foo=bar]` (an
++            // attribute name containing ASCII uppercase) even when no namespace is
++            // present, so handle the no-namespace case here instead of treating it
++            // as unsupported.
++            Component::AttributeOther(attr) if attr.namespace.is_none() => {
++                let name = attr.local_name_lower.to_boxed_slice();
++                match attr.operation {
++                    ParsedAttrSelectorOperation::Exists => {
++                        Self::OnAttributes(OnAttributesExpr::AttributeExists(name))
++                    }
++                    ParsedAttrSelectorOperation::WithValue {
++                        operator,
++                        case_sensitivity,
++                        ref value,
++                    } => Self::OnAttributes(OnAttributesExpr::AttributeComparisonExpr(
++                        AttributeComparisonExpr::new(
++                            name,
++                            value.to_boxed_slice(),
++                            case_sensitivity,
++                            operator,
++                        ),
++                    )),
++                }
++            }
+             Component::Nth(data) if data.ty == NthType::Child => Self::OnTagName(
+                 OnTagNameExpr::NthChild(NthChild::new(data.an_plus_b.0, data.an_plus_b.1)),
+             ),
+@@ -412,6 +442,27 @@
+                 },
+             ),
+             (
++                "[Data-Foo]",
++                Expr {
++                    simple_expr: OnAttributesExpr::AttributeExists("data-foo".into()),
++                    negation: false,
++                },
++            ),
++            (
++                r#"[Data-Foo="bar"]"#,
++                Expr {
++                    simple_expr: OnAttributesExpr::AttributeComparisonExpr(
++                        AttributeComparisonExpr {
++                            name: "data-foo".into(),
++                            value: "bar".into(),
++                            case_sensitivity: ParsedCaseSensitivity::CaseSensitive,
++                            operator: AttrSelectorOperator::Equal,
++                        },
++                    ),
++                    negation: false,
++                },
++            ),
++            (
+                 r#"[foo="bar"]"#,
+                 Expr {
+                     simple_expr: OnAttributesExpr::AttributeComparisonExpr(
+@@ -826,6 +877,8 @@
+             SelectorError::UnexpectedTokenInAttribute,
+         );
+         assert_err("svg|img", SelectorError::NamespacedSelector);
++        assert_err("[*|foo]", SelectorError::NamespacedSelector);
++        assert_err(r#"[*|Foo="bar"]"#, SelectorError::NamespacedSelector);
+         assert_err(".foo()", SelectorError::InvalidClassName);
+         assert_err(":not()", SelectorError::EmptySelector);
+         assert_err("div + span", SelectorError::UnsupportedCombinator('+'));

--- a/patches/lolhtml/uppercase-attribute-name-selector.patch
+++ b/patches/lolhtml/uppercase-attribute-name-selector.patch
@@ -1,3 +1,14 @@
+Match attribute selector names ASCII case-insensitively.
+
+`[HREF]` was accepted but silently matched nothing (ast.rs stored the
+selector's original-case name while the matcher compares against
+lowercased element attribute names), and `[HREF="x"]` threw a bogus
+NamespacedSelector error (the `selectors` crate emits AttributeOther
+for non-lowercase names even without a namespace; parser.rs rejected
+all AttributeOther unconditionally).
+
+Upstream: https://github.com/cloudflare/lol-html/issues/328
+
 --- a/src/selectors_vm/parser.rs
 +++ b/src/selectors_vm/parser.rs
 @@ -146,6 +146,11 @@

--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -33,6 +33,8 @@ export const lolhtml: Dependency = {
     commit: LOLHTML_COMMIT,
   }),
 
+  patches: ["patches/lolhtml/uppercase-attribute-name-selector.patch"],
+
   // No separate build — compiled as part of the workspace cargo build via
   // `bun_runtime`/`bun_bundler`'s path dep on `vendor/lolhtml`.
   build: () => ({ kind: "none" }),

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -683,6 +683,58 @@ describe("HTMLRewriter", () => {
     );
   });
 
+  it("attribute selectors match the attribute name case-insensitively", async () => {
+    // HTML attribute names are ASCII case-insensitive. Before this was fixed,
+    // `[HREF]` was accepted but silently matched nothing, and `[ID="x"]` threw
+    // a bogus "Selectors with explicit namespaces are not supported" error.
+    const countMatches = async (selector, input) => {
+      let count = 0;
+      const res = new HTMLRewriter()
+        .on(selector, {
+          element() {
+            count++;
+          },
+        })
+        .transform(new Response(input));
+      await res.text();
+      return count;
+    };
+
+    const doc = `<div ID="X" data-x="1"><a HREF="#" href="#z">l</a><input type="text"></div>`;
+
+    // Existence: [NAME] must match regardless of the selector's case or the
+    // case used in the source document.
+    expect(await countMatches("[id]", doc)).toBe(1);
+    expect(await countMatches("[ID]", doc)).toBe(1);
+    expect(await countMatches("[Id]", doc)).toBe(1);
+    expect(await countMatches("a[href]", doc)).toBe(1);
+    expect(await countMatches("a[HREF]", doc)).toBe(1);
+    expect(await countMatches("A[HREF]", doc)).toBe(1);
+    expect(await countMatches("[data-x]", doc)).toBe(1);
+    expect(await countMatches("[DATA-X]", doc)).toBe(1);
+    expect(await countMatches("[Data-X]", doc)).toBe(1);
+
+    // With a value: [NAME=value] must not throw and must match.
+    expect(await countMatches("[id=X]", doc)).toBe(1);
+    expect(await countMatches("[ID=X]", doc)).toBe(1);
+    expect(await countMatches('input[TYPE="text"]', doc)).toBe(1);
+    expect(await countMatches('[Data-X="1"]', doc)).toBe(1);
+    expect(await countMatches('[DATA-X^="1"]', doc)).toBe(1);
+    // Attribute *value* comparison stays case-sensitive by default.
+    expect(await countMatches("[ID=x]", doc)).toBe(0);
+    expect(await countMatches('[ID="x" i]', doc)).toBe(1);
+
+    // :not() with an uppercase attribute name.
+    expect(await countMatches("div:not([ID])", doc)).toBe(0);
+    expect(await countMatches('div:not([ID="X"])', doc)).toBe(0);
+    expect(await countMatches("a:not([ID])", doc)).toBe(1);
+
+    // A selector with an actual namespace is still rejected.
+    expect(() => new HTMLRewriter().on("[*|foo]", { element() {} }).transform(new Response("<a>"))).toThrow(
+      /namespaces are not supported/,
+    );
+  });
+
   it("supports deleting innerContent", async () => {
     expect(
       await new HTMLRewriter()


### PR DESCRIPTION
## What

HTMLRewriter attribute selectors now match the attribute *name* ASCII case-insensitively, matching browser `querySelectorAll` behaviour.

## Repro

```js
const doc = `<div ID="X" data-x="1"><a HREF="#" href="#z">l</a></div>`;
const t = async (sel) => {
  let c = 0;
  try {
    await new HTMLRewriter().on(sel, { element() { c++; } }).transform(new Response(doc)).text();
    return c;
  } catch (e) { return "THROW: " + e.message; }
};
console.log(await t("[id]"), await t("[ID]"), await t("a[href]"), await t("a[HREF]"));
// before: 1 0 1 0        ([ID] and a[HREF] accepted but silently match nothing)
// after:  1 1 1 1
console.log(await t("[ID=X]"), await t("[id=X]"));
// before: THROW: Selectors with explicit namespaces are not supported.   1
// after:  1 1
```

## Cause

Two separate lol-html bugs in `selectors_vm`:

1. **`[HREF]` silently matches nothing.** `AttributeMatcher::find` lowercases each element attribute name before comparing, so the selector side must be lowercase too. `Condition::from` was storing `Component::AttributeInNoNamespaceExists.local_name` (the selector as written) instead of `local_name_lower`, so an uppercase-named selector could never match.

2. **`[ID=X]` throws a bogus namespace error.** The `selectors` crate emits `Component::AttributeOther` not only for namespaced selectors but also for any `[Name=value]` where the attribute name is not already ASCII-lowercase (`parse_attribute_selector`: `if namespace.is_some() || !local_name_is_ascii_lowercase`). lol-html's `validate_component` mapped every `AttributeOther` to `SelectorError::NamespacedSelector`.

## Fix

Applied as a patch to the vendored lol-html (`patches/lolhtml/uppercase-attribute-name-selector.patch`):

* `ast.rs`: use `local_name_lower` for `AttributeInNoNamespaceExists`, and handle `AttributeOther` with `namespace == None` by lowering it to `AttributeExists` / `AttributeComparisonExpr` using `local_name_lower`.
* `parser.rs`: accept `AttributeOther` in `validate_component` when `namespace` is `None`; actual namespaced selectors (`[*|foo]`, `[svg|href]`) are still rejected.

## Verification

* New test in `test/js/workerd/html-rewriter.test.js` covers existence selectors, value selectors, mixed case in selector and document, `:not([ID])`, default/`i` value case sensitivity, and confirms `[*|foo]` is still rejected.
* Existing `selector tests` block (70 tests, 0 fail) still passes.
* lol-html's own `selectors_vm::ast` unit tests pass with the patch applied (new cases added for `[Data-Foo]`, `[Data-Foo="bar"]`, `[*|foo]`, `[*|Foo="bar"]`).