### PR TITLE
node-fetch: forward https.Agent TLS options to the tls fetch option

### DIFF
--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -176,8 +176,7 @@ async function fetch(
   let agent = init && (init as any).agent;
   if (agent != null && (init as any).tls == null) {
     if ($isCallable(agent)) {
-      const href =
-        typeof url === "string" ? url : $isObject(url) ? (url as any).href || (url as any).url : `${url}`;
+      const href = typeof url === "string" ? url : $isObject(url) ? (url as any).href || (url as any).url : `${url}`;
       agent = agent.$call(undefined, require("node:url").parse(href));
     }
     if ($isObject(agent)) {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -170,6 +170,37 @@ async function fetch(
       init = { ...init, body: Readable.toWeb(readable) };
     }
   }
+  // node-fetch forwards `agent` to https.request, which carries TLS options
+  // (ca, cert, key, rejectUnauthorized, ...) on agent.options. Bun's native
+  // fetch reads those from a `tls` option instead, so translate them here.
+  let agent = init && (init as any).agent;
+  if (agent != null && (init as any).tls == null) {
+    if ($isCallable(agent)) {
+      const href =
+        typeof url === "string" ? url : $isObject(url) ? (url as any).href || (url as any).url : `${url}`;
+      agent = agent.$call(undefined, require("node:url").parse(href));
+    }
+    if ($isObject(agent)) {
+      const agentOpts = agent.options;
+      const connectOpts = agent.connectOpts;
+      const opts =
+        $isObject(agentOpts) && $isObject(connectOpts)
+          ? { __proto__: null, ...connectOpts, ...agentOpts }
+          : $isObject(agentOpts)
+            ? agentOpts
+            : $isObject(connectOpts)
+              ? connectOpts
+              : undefined;
+      if (opts !== undefined) {
+        let tls: Record<string, unknown> | undefined;
+        for (const k of kAgentTlsOptionKeys) {
+          const v = opts[k];
+          if (v !== undefined) (tls ??= { __proto__: null })[k] = v;
+        }
+        if (tls !== undefined) init = { ...init, tls } as any;
+      }
+    }
+  }
   const response = await nativeFetch.$call(undefined, url, init);
   Object.setPrototypeOf(response, ResponsePrototype);
   return response;
@@ -207,6 +238,21 @@ function blobFromSync(path, options) {
 
 var fileFrom = blobFrom;
 var fileFromSync = blobFromSync;
+
+const kAgentTlsOptionKeys = [
+  "ca",
+  "cert",
+  "key",
+  "pfx",
+  "passphrase",
+  "rejectUnauthorized",
+  "checkServerIdentity",
+  "servername",
+  "secureOptions",
+  "ciphers",
+  "crl",
+  "sigalgs",
+] as const;
 
 function isRedirect(code) {
   return code === 301 || code === 302 || code === 303 || code === 307 || code === 308;

--- a/test/js/node/http/node-fetch-agent-tls.test.ts
+++ b/test/js/node/http/node-fetch-agent-tls.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { tls as serverTls } from "harness";
+import https from "node:https";
+
+const nodeFetch = require("node-fetch");
+
+// https://github.com/oven-sh/bun/issues/7332
+// https://github.com/oven-sh/bun/issues/10642
+// https://github.com/oven-sh/bun/issues/16546
+// https://github.com/oven-sh/bun/issues/19754
+describe("node-fetch with https.Agent TLS options", () => {
+  test("rejects self-signed certificate without a trusted CA", async () => {
+    using server = Bun.serve({
+      tls: serverTls,
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    expect(nodeFetch(`https://localhost:${server.port}/`)).rejects.toThrow();
+  });
+
+  test("uses ca from agent.options to verify the server", async () => {
+    using server = Bun.serve({
+      tls: serverTls,
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    const agent = new https.Agent({ ca: serverTls.cert });
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+      expect(await res.text()).toBe("ok");
+      expect(res.status).toBe(200);
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("uses rejectUnauthorized: false from agent.options", async () => {
+    using server = Bun.serve({
+      tls: serverTls,
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    const agent = new https.Agent({ rejectUnauthorized: false });
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+      expect(await res.text()).toBe("ok");
+      expect(res.status).toBe(200);
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("accepts agent as a function", async () => {
+    using server = Bun.serve({
+      tls: serverTls,
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    const agent = new https.Agent({ ca: serverTls.cert });
+    try {
+      let receivedUrl: { protocol?: string } | undefined;
+      const res = await nodeFetch(`https://localhost:${server.port}/`, {
+        agent: (parsedUrl: { protocol?: string }) => {
+          receivedUrl = parsedUrl;
+          return agent;
+        },
+      });
+      expect(await res.text()).toBe("ok");
+      expect(receivedUrl?.protocol).toBe("https:");
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("presents client certificate from agent.options", async () => {
+    // Server requires a client certificate signed by `ca`; without one the TLS
+    // handshake is rejected. This is the mTLS path @kubernetes/client-node uses.
+    using server = Bun.serve({
+      tls: {
+        cert: serverTls.cert,
+        key: serverTls.key,
+        ca: serverTls.cert,
+        requestCert: true,
+        rejectUnauthorized: true,
+      },
+      port: 0,
+      fetch: () => new Response("have-cert"),
+    });
+
+    // No client cert: handshake fails.
+    {
+      const agent = new https.Agent({ ca: serverTls.cert });
+      try {
+        expect(nodeFetch(`https://localhost:${server.port}/`, { agent })).rejects.toThrow();
+      } finally {
+        agent.destroy();
+      }
+    }
+
+    // With client cert/key on the agent: succeeds.
+    {
+      const agent = new https.Agent({
+        ca: serverTls.cert,
+        cert: serverTls.cert,
+        key: serverTls.key,
+      });
+      try {
+        const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+        expect(await res.text()).toBe("have-cert");
+        expect(res.status).toBe(200);
+      } finally {
+        agent.destroy();
+      }
+    }
+  });
+
+  test("does not override an explicit tls option", async () => {
+    using server = Bun.serve({
+      tls: serverTls,
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    // Agent has no ca (would fail verification), but the explicit tls option does.
+    const agent = new https.Agent({ rejectUnauthorized: true });
+    try {
+      const res = await nodeFetch(`https://localhost:${server.port}/`, {
+        agent,
+        tls: { ca: serverTls.cert },
+      });
+      expect(await res.text()).toBe("ok");
+    } finally {
+      agent.destroy();
+    }
+  });
+
+  test("reads options from agent.connectOpts (proxy-agent shape)", async () => {
+    using server = Bun.serve({
+      tls: serverTls,
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    const agent = { connectOpts: { ca: serverTls.cert } };
+    const res = await nodeFetch(`https://localhost:${server.port}/`, { agent });
+    expect(await res.text()).toBe("ok");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`node-fetch` on Node passes the `agent` option through to `https.request`, so any TLS connect options set on the `https.Agent` (`ca`, `cert`, `key`, `rejectUnauthorized`, `servername`, ...) reach the underlying socket. Bun's `node-fetch` polyfill calls `Bun.fetch`, which reads TLS options from a `tls` option and ignores `agent`, so those options were silently dropped.

Libraries that configure mTLS via an `https.Agent`, most prominently `@kubernetes/client-node`, failed with
```
DEPTH_ZERO_SELF_SIGNED_CERT / SELF_SIGNED_CERT_IN_CHAIN
```
or `401 Unauthorized`, because neither the cluster CA nor the client certificate was presented.

When an `agent` is supplied and no `tls` option is already set, this PR lifts the TLS-relevant fields off `agent.options` (standard `http(s).Agent`) or `agent.connectOpts` (the shape `hpagent` / `socks-proxy-agent` expose) and forwards them as the `tls` option to the native fetch. Both an `Agent` instance and the `(parsedUrl) => Agent` callback form that `node-fetch` documents are supported. An explicit `tls` option still takes precedence.

Fixes #7332
Fixes #10642
Fixes #16546
Fixes #19754

## How did you verify your code works?

New test file `test/js/node/http/node-fetch-agent-tls.test.ts`:
- rejects a self-signed server cert when no `ca` is configured (negative)
- accepts the server when `ca` is supplied on `agent.options`
- honours `rejectUnauthorized: false` on the agent
- resolves `agent` as a function and passes the parsed URL
- presents a client certificate from `agent.options` against a `requestCert: true, rejectUnauthorized: true` server
- does not override an explicit `tls` option
- reads options from `agent.connectOpts` (proxy-agent shape)

Fail-before: 5/7 fail on the released bun with `DEPTH_ZERO_SELF_SIGNED_CERT`. With the change all 7 pass. Existing `node-fetch` tests (`node-fetch-primordials.test.ts`, `26225.test.ts`, `014865.test.ts`) continue to pass.