### PR TITLE
bundler: merge duplicate external ESM imports across the files of a chunk

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1254,6 +1254,9 @@ pub struct JavaScriptChunk {
     pub(crate) files_in_chunk_order: Box<[IndexInt]>,
     pub parts_in_chunk_in_order: Box<[PartRange]>,
 
+    /// Sorted `(source_index << 32) | import_record_index`; see `merge_external_esm_imports`.
+    pub(crate) redundant_external_imports: Vec<u64>,
+
     // for code splitting
     // The map hashes via `Ref`'s `Hash` impl. Values
     // are `&'static`-erased slices into bundler-owned storage (see the

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -810,6 +810,11 @@ impl<'a> LinkerContext<'a> {
             self.check_for_memory_corruption();
         }
 
+        crate::linker_context::merge_external_esm_imports::merge_external_esm_imports(
+            self,
+            &mut chunks,
+        );
+
         self.graph.symbols.follow_all();
 
         Ok(chunks)

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -135,6 +135,9 @@ pub mod linker_context {
     #[path = "findAllImportedPartsInJSOrder.rs"]
     pub mod find_all_imported_parts_in_js_order;
 
+    #[path = "mergeExternalESMImports.rs"]
+    pub(crate) mod merge_external_esm_imports;
+
     #[path = "findImportedCSSFilesInJSOrder.rs"]
     pub(crate) mod find_imported_css_files_in_js_order;
 

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -107,6 +107,14 @@ pub(crate) fn convert_stmts_for_chunk(
                         continue 'stmt_loop;
                     }
 
+                    if crate::linker_context::merge_external_esm_imports::is_redundant_external_import(
+                        chunk,
+                        source_index,
+                        s.import_record_index,
+                    ) {
+                        continue 'stmt_loop;
+                    }
+
                     // Make sure these don't end up in the wrapper closure
                     if should_extract_esm_stmts_for_wrap {
                         stmts.append(StmtListWhich::OutsideWrapperPrefix, stmt);

--- a/src/bundler/linker_context/mergeExternalESMImports.rs
+++ b/src/bundler/linker_context/mergeExternalESMImports.rs
@@ -1,0 +1,248 @@
+use crate::mal_prelude::*;
+
+use bun_ast::ImportRecordFlags;
+use bun_ast::Ref;
+use bun_ast::StmtData;
+use bun_collections::HashMap;
+
+use crate::chunk;
+use crate::{Chunk, LinkerContext};
+
+/// Everything the printer emits after `from` (path and `with { type }` suffix).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct PathKey {
+    text: &'static [u8],
+    namespace: &'static [u8],
+    print_namespace: bool,
+    loader: Option<bun_ast::Loader>,
+}
+
+/// The exports a statement binds; empty outside exact mode so a path shares one `Seen`.
+#[derive(Default, PartialEq, Eq, Hash)]
+struct Shape {
+    star: bool,
+    default: bool,
+    /// Sorted export names (`ClauseItem.alias`).
+    aliases: Box<[&'static [u8]]>,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct ImportKey {
+    path: PathKey,
+    shape: Shape,
+}
+
+/// The ref a kept statement in the current chunk declares for each binding.
+#[derive(Default)]
+struct Seen {
+    star: Ref,
+    default: Ref,
+    /// Keyed by export name (`ClauseItem.alias`).
+    items: HashMap<&'static [u8], Ref>,
+}
+
+#[inline]
+fn pack(source_index: u32, import_record_index: u32) -> u64 {
+    ((source_index as u64) << 32) | (import_record_index as u64)
+}
+
+/// #8671: drop external imports whose bindings an earlier statement in the chunk declares.
+pub(crate) fn merge_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) {
+    if !c.options.output_format.keep_es6_import_export_syntax() {
+        return;
+    }
+    // SAFETY: `symbols.merge` is graph-global while keep/drop is per chunk. With
+    // splitting (or one JS chunk) a file lands in exactly one chunk, so a ref is
+    // only merged into a statement kept alongside it. Without splitting a file is
+    // copied into every entry chunk reaching it and may be kept in one chunk but
+    // dropped in another, so merges are restricted to statements of identical
+    // `Shape`: each chunk keeps exactly one per shape, and every ref of a shape
+    // prints as the binding that chunk declares.
+    let exact = !c.graph.code_splitting
+        && chunks
+            .iter()
+            .filter(|chunk| matches!(chunk.content, chunk::Content::Javascript(_)))
+            .count()
+            > 1;
+
+    let all_parts = c.graph.ast.items_parts();
+    let all_import_records = c.graph.ast.items_import_records();
+    let parts_live = c.graph.parts_live.as_slice();
+
+    let mut paths: HashMap<PathKey, ()> = HashMap::default();
+    let mut seen: HashMap<ImportKey, Seen> = HashMap::default();
+    let mut aliases: Vec<&'static [u8]> = Vec::new();
+
+    for chunk in chunks.iter_mut() {
+        let js = match &mut chunk.content {
+            chunk::Content::Javascript(js) => js,
+            _ => continue,
+        };
+
+        paths.clear();
+        seen.clear();
+
+        for part_range in js.parts_in_chunk_in_order.iter() {
+            let source_index = part_range.source_index.get();
+            let file_parts = all_parts[source_index as usize].as_slice();
+            let file_records = all_import_records[source_index as usize].as_slice();
+            let live = &parts_live[source_index as usize];
+
+            for part_i in part_range.part_index_begin..part_range.part_index_end {
+                if !live.is_set(part_i as usize) {
+                    continue;
+                }
+                for stmt in file_parts[part_i as usize].stmts.iter() {
+                    let StmtData::SImport(s) = stmt.data else {
+                        continue;
+                    };
+                    let record = &file_records[s.import_record_index as usize];
+
+                    // The records `convert_stmts_for_chunk` leaves to print as plain `import`s.
+                    if record.source_index.is_valid()
+                        || record.path.is_disabled
+                        || record.kind != bun_ast::ImportKind::Stmt
+                        || !matches!(
+                            record.tag,
+                            bun_ast::import_record::Tag::None
+                                | bun_ast::import_record::Tag::Builtin
+                        )
+                        || record.flags.intersects(
+                            ImportRecordFlags::IS_UNUSED | ImportRecordFlags::PHASE_DEFER,
+                        )
+                    {
+                        continue;
+                    }
+
+                    let path = PathKey {
+                        text: record.path.text,
+                        namespace: record.path.namespace,
+                        print_namespace: record
+                            .flags
+                            .contains(ImportRecordFlags::PRINT_NAMESPACE_IN_PATH),
+                        loader: record.loader,
+                    };
+                    let star_ref = record
+                        .flags
+                        .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR)
+                        .then(|| s.namespace_ref.to_nullable())
+                        .flatten();
+                    let default_ref = s.default_name.and_then(|d| d.ref_.to_nullable());
+                    let items = s.items.slice();
+
+                    let path_already_imported =
+                        bun_core::handle_oom(paths.get_or_put(path)).found_existing;
+                    if star_ref.is_none() && default_ref.is_none() && items.is_empty() {
+                        // Bare `import "x"`: an earlier import of the path already evaluates it.
+                        if path_already_imported {
+                            js.redundant_external_imports
+                                .push(pack(source_index, s.import_record_index));
+                        }
+                        continue;
+                    }
+
+                    let shape = if exact {
+                        aliases.clear();
+                        aliases.extend(items.iter().map(|item| item.alias.slice()));
+                        aliases.sort_unstable();
+                        let distinct = {
+                            let before = aliases.len();
+                            aliases.dedup();
+                            aliases.len() == before
+                        };
+                        // `import { x, x as y }` binds one export twice; `Seen` holds one ref per export.
+                        if !distinct {
+                            continue;
+                        }
+                        Shape {
+                            star: star_ref.is_some(),
+                            default: default_ref.is_some(),
+                            aliases: aliases.as_slice().into(),
+                        }
+                    } else {
+                        Shape::default()
+                    };
+                    let entry =
+                        bun_core::handle_oom(seen.get_or_put(ImportKey { path, shape })).value_ptr;
+
+                    // A ref another chunk already imports by name must keep its own declaration.
+                    let introduces = |kept: Ref, ref_: Ref| {
+                        kept.is_empty() || js.exports_to_other_chunks.contains_key(&ref_)
+                    };
+                    let must_keep = star_ref.is_some_and(|r| introduces(entry.star, r))
+                        || default_ref.is_some_and(|r| introduces(entry.default, r))
+                        || items.iter().any(|item| {
+                            item.name.ref_.to_nullable().is_some_and(|r| {
+                                introduces(
+                                    entry
+                                        .items
+                                        .get(item.alias.slice())
+                                        .copied()
+                                        .unwrap_or_default(),
+                                    r,
+                                )
+                            })
+                        });
+
+                    if must_keep || !path_already_imported {
+                        // Bindings overlapping an earlier statement stay distinct; the renamer suffixes them.
+                        if let Some(ns) = star_ref
+                            && entry.star.is_empty()
+                        {
+                            entry.star = ns;
+                        }
+                        if let Some(d) = default_ref
+                            && entry.default.is_empty()
+                        {
+                            entry.default = d;
+                        }
+                        for item in items {
+                            if let Some(item_ref) = item.name.ref_.to_nullable() {
+                                let slot = bun_core::handle_oom(
+                                    entry.items.get_or_put(item.alias.slice()),
+                                );
+                                if !slot.found_existing {
+                                    *slot.value_ptr = item_ref;
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
+                    if let Some(ns) = star_ref {
+                        let _ = c.graph.symbols.merge(ns, entry.star);
+                    }
+                    if let Some(d) = default_ref {
+                        let _ = c.graph.symbols.merge(d, entry.default);
+                    }
+                    for item in items {
+                        if let Some(item_ref) = item.name.ref_.to_nullable()
+                            && let Some(&kept) = entry.items.get(item.alias.slice())
+                        {
+                            let _ = c.graph.symbols.merge(item_ref, kept);
+                        }
+                    }
+                    js.redundant_external_imports
+                        .push(pack(source_index, s.import_record_index));
+                }
+            }
+        }
+
+        js.redundant_external_imports.sort_unstable();
+    }
+}
+
+#[inline]
+pub(crate) fn is_redundant_external_import(
+    chunk: &Chunk,
+    source_index: u32,
+    import_record_index: u32,
+) -> bool {
+    let js = match &chunk.content {
+        chunk::Content::Javascript(js) => js,
+        _ => return false,
+    };
+    js.redundant_external_imports
+        .binary_search(&pack(source_index, import_record_index))
+        .is_ok()
+}

--- a/src/bundler/linker_context/mergeExternalESMImports.rs
+++ b/src/bundler/linker_context/mergeExternalESMImports.rs
@@ -17,13 +17,17 @@ struct PathKey {
     loader: Option<bun_ast::Loader>,
 }
 
-/// The exports a statement binds; empty outside exact mode so a path shares one `Seen`.
+/// The statement's clause as written (exports bound and the local names used
+/// for them); empty outside exact mode so a path shares one `Seen`. Keying on
+/// the local names too means a chunk only ever prints a name one of its own
+/// files wrote, even when the merged root ref belongs to a file it does not
+/// contain, so each entry's output depends on its own files alone.
 #[derive(Default, PartialEq, Eq, Hash)]
 struct Shape {
-    star: bool,
-    default: bool,
-    /// Sorted export names (`ClauseItem.alias`).
-    aliases: Box<[&'static [u8]]>,
+    star: Option<&'static [u8]>,
+    default: Option<&'static [u8]>,
+    /// `(export name, local name)`, sorted by export name.
+    items: Box<[(&'static [u8], &'static [u8])]>,
 }
 
 #[derive(PartialEq, Eq, Hash)]
@@ -57,7 +61,9 @@ pub(crate) fn merge_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Ch
     // copied into every entry chunk reaching it and may be kept in one chunk but
     // dropped in another, so merges are restricted to statements of identical
     // `Shape`: each chunk keeps exactly one per shape, and every ref of a shape
-    // prints as the binding that chunk declares.
+    // prints as the binding that chunk declares. Because the shape includes the
+    // local names, that binding is also printed under a name the chunk's own
+    // files wrote, whichever file's ref ends up as the merged root.
     let exact = !c.graph.code_splitting
         && chunks
             .iter()
@@ -71,7 +77,7 @@ pub(crate) fn merge_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Ch
 
     let mut paths: HashMap<PathKey, ()> = HashMap::default();
     let mut seen: HashMap<ImportKey, Seen> = HashMap::default();
-    let mut aliases: Vec<&'static [u8]> = Vec::new();
+    let mut clause: Vec<(&'static [u8], &'static [u8])> = Vec::new();
 
     for chunk in chunks.iter_mut() {
         let js = match &mut chunk.content {
@@ -142,22 +148,30 @@ pub(crate) fn merge_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Ch
                     }
 
                     let shape = if exact {
-                        aliases.clear();
-                        aliases.extend(items.iter().map(|item| item.alias.slice()));
-                        aliases.sort_unstable();
-                        let distinct = {
-                            let before = aliases.len();
-                            aliases.dedup();
-                            aliases.len() == before
+                        let symbols = &c.graph.symbols;
+                        let local_name = |ref_: Ref| -> &'static [u8] {
+                            match symbols.get_const(ref_) {
+                                Some(symbol) => symbol.original_name.slice(),
+                                None => &[],
+                            }
                         };
+                        clause.clear();
+                        clause.extend(
+                            items
+                                .iter()
+                                .map(|item| (item.alias.slice(), local_name(item.name.ref_))),
+                        );
+                        clause.sort_unstable();
                         // `import { x, x as y }` binds one export twice; `Seen` holds one ref per export.
-                        if !distinct {
+                        let bindings = clause.len();
+                        clause.dedup_by_key(|binding| binding.0);
+                        if clause.len() != bindings {
                             continue;
                         }
                         Shape {
-                            star: star_ref.is_some(),
-                            default: default_ref.is_some(),
-                            aliases: aliases.as_slice().into(),
+                            star: star_ref.map(local_name),
+                            default: default_ref.map(local_name),
+                            items: clause.as_slice().into(),
                         }
                     } else {
                         Shape::default()

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -306,6 +306,33 @@ describe("bundler", () => {
       },
       stdout: "function",
     },
+    {
+      // Several files import the same builtins; the linker drops the statements
+      // that add no binding (#8671), so the module record, which is built from
+      // what gets printed, must list each surviving import once, under the kept
+      // statement's names, including the one hoisted out of a __commonJS wrapper.
+      // The debug build cross-checks the record against JSC's own parse of the
+      // chunk and refuses to start the binary when they differ.
+      name: "DedupedExternalImports",
+      files: {
+        "/entry.ts": `
+          import { join } from "node:path";
+          import { a } from "./a.ts";
+          import mixed from "./mixed.js";
+          console.log(typeof join, a, typeof mixed.join);
+        `,
+        "/a.ts": `
+          import { join, sep } from "node:path";
+          import * as path from "node:path";
+          export const a = join("x", "y").length + sep.length + (typeof path.dirname === "function" ? 1 : 0);
+        `,
+        "/mixed.js": `
+          import { join } from "node:path";
+          module.exports = { join };
+        `,
+      },
+      stdout: "function 5 function",
+    },
   ];
 
   for (const scenario of esmBytecodeScenarios) {

--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -1,7 +1,536 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
+import { readdirSync } from "node:fs";
 import { itBundled } from "./expectBundled";
 
+const extRuntime = {
+  "/node_modules/ext/index.js": /* js */ `
+    export const join = (...p) => p.join("/");
+    export const dirname = p => p.split("/").slice(0, -1).join("/");
+    export const sep = "/";
+    export default { join, dirname, sep };
+  `,
+  "/node_modules/ext/package.json": /* json */ `{ "name": "ext", "type": "module", "main": "index.js" }`,
+};
+
+/** Top-level `import` statements of a chunk, in output order. */
+const importStatements = (code: string) => code.match(/^import\b[^;]*;/gm) ?? [];
+
 describe("bundler", () => {
+  // https://github.com/oven-sh/bun/issues/8671
+  // Every source file's external `import path from "node:path"` used to survive
+  // into the chunk as its own `import pathN from "path"`.
+  itBundled("regression/ExternalImportDedupeDefault#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        console.log(a(), b(), c());
+      `,
+      "/a.js": /* js */ `
+        import path from "node:path";
+        import { shared } from "./shared.js";
+        export const a = () => path.posix.join(shared, "a");
+      `,
+      "/b.js": /* js */ `
+        import path from "node:path";
+        import { shared } from "./shared.js";
+        export const b = () => path.posix.join(shared, "b");
+      `,
+      "/c.js": /* js */ `
+        import path from "node:path";
+        import { shared } from "./shared.js";
+        export const c = () => path.posix.join(shared, "c");
+      `,
+      "/shared.js": /* js */ `export const shared = "shared";`,
+    },
+    target: "bun",
+    external: ["node:path"],
+    run: { stdout: "shared/a shared/b shared/c" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const imports = out.match(/^import .* from "path";$/gm) ?? [];
+      expect(imports).toEqual(['import path from "path";']);
+      expect(out).not.toMatch(/\bpath2\b/);
+    },
+  });
+  itBundled("regression/ExternalImportDedupeNamedAndStar#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        import { d } from "./d.js";
+        console.log(a(), b(), c(), d);
+      `,
+      "/a.js": /* js */ `
+        import { join } from "ext";
+        import * as ns from "ext";
+        export const a = () => join(ns.sep, "a");
+      `,
+      "/b.js": /* js */ `
+        import { join } from "ext";
+        import * as ns from "ext";
+        export const b = () => join(ns.sep, "b");
+      `,
+      // brings in a binding the earlier imports don't cover: must be kept
+      "/c.js": /* js */ `
+        import { dirname } from "ext";
+        export const c = () => dirname("x/y");
+      `,
+      // bare side-effect import: second occurrence redundant
+      "/d.js": /* js */ `
+        import "ext";
+        export const d = "d";
+      `,
+    },
+    format: "esm",
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    run: { stdout: "//a //b x d" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const importLines = (out.match(/^import .*"ext";$/gm) ?? []).sort();
+      expect(importLines).toEqual([
+        'import * as ns from "ext";',
+        'import { dirname } from "ext";',
+        'import { join } from "ext";',
+      ]);
+    },
+  });
+  // A later import that adds a new binding must be kept; its overlapping
+  // bindings stay distinct so the two statements don't declare the same name.
+  itBundled("regression/ExternalImportDedupePartialOverlap#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        console.log(a(), b(), c());
+      `,
+      "/a.js": /* js */ `
+        import { join } from "ext";
+        export const a = () => join("x", "a");
+      `,
+      "/b.js": /* js */ `
+        import { join, sep } from "ext";
+        export const b = () => join(sep, "b");
+      `,
+      "/c.js": /* js */ `
+        import { join } from "ext";
+        export const c = () => join("x", "c");
+      `,
+    },
+    format: "esm",
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    run: { stdout: "x/a //b x/c" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out.match(/^import .* from "ext";$/gm)).toEqual([
+        'import { join } from "ext";',
+        'import { join as join2, sep } from "ext";',
+      ]);
+    },
+  });
+  itBundled("regression/ExternalImportDedupePartialOverlapDefault#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        console.log(a(), b(), c());
+      `,
+      "/a.js": /* js */ `
+        import ext from "ext";
+        export const a = () => ext.join("x", "a");
+      `,
+      "/b.js": /* js */ `
+        import ext, { sep } from "ext";
+        export const b = () => ext.join(sep, "b");
+      `,
+      "/c.js": /* js */ `
+        import ext from "ext";
+        export const c = () => ext.join("x", "c");
+      `,
+    },
+    format: "esm",
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    run: { stdout: "x/a //b x/c" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out.match(/^import .* from "ext";$/gm)).toEqual([
+        'import ext from "ext";',
+        'import ext2, { sep } from "ext";',
+      ]);
+    },
+  });
+  itBundled("regression/ExternalImportDedupeSplitting#8671", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        console.log(a(), b());
+      `,
+      "/entry2.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        console.log(b(), a());
+      `,
+      "/a.js": /* js */ `
+        import ext from "ext";
+        export const a = () => ext.join("x", "a");
+      `,
+      "/b.js": /* js */ `
+        import ext from "ext";
+        export const b = () => ext.join("x", "b");
+      `,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    format: "esm",
+    splitting: true,
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    outdir: "/out",
+    run: [
+      { file: "/out/entry1.js", stdout: "x/a x/b" },
+      { file: "/out/entry2.js", stdout: "x/b x/a" },
+    ],
+    onAfterBundle(api) {
+      const chunks = readdirSync(api.outdir).filter(f => f.endsWith(".js") && f !== "entry1.js" && f !== "entry2.js");
+      expect(chunks.length).toBe(1);
+      const chunk = api.readFile("/out/" + chunks[0]);
+      expect(chunk.match(/^import .* from "ext";$/gm) ?? []).toEqual(['import ext from "ext";']);
+    },
+  });
+  // A second import from the same path that adds no new bindings is dropped,
+  // but the import kept for the first file must keep the renamer's name for
+  // the shared binding so the second file's uses still resolve.
+  itBundled("regression/ExternalImportDedupeMinified#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        console.log(a(), b());
+      `,
+      "/a.js": /* js */ `
+        import ext from "ext";
+        export const a = () => ext.join("x", "a");
+      `,
+      "/b.js": /* js */ `
+        import ext from "ext";
+        export const b = () => ext.join("x", "b");
+      `,
+    },
+    format: "esm",
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    run: { stdout: "x/a x/b" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect([...out.matchAll(/from"ext"/g)]).toHaveLength(1);
+    },
+  });
+  // compute_cross_chunk_dependencies captures both re-exported external refs
+  // before this pass runs; merging them would make the entry chunk's cross-
+  // chunk import declare the same local twice.
+  for (const [kind, reexportingFile, join] of [
+    ["Named", /* js */ `import { join as j } from "ext"; export { j };`, (binding: string) => binding],
+    ["Star", /* js */ `import * as j from "ext"; export { j };`, (binding: string) => `${binding}.join`],
+  ] as const) {
+    itBundled(`regression/ExternalImportDedupeSplittingReexport${kind}#8671`, {
+      files: {
+        "/entry1.js": /* js */ `
+          import { j as a } from "./a.js";
+          import { j as b } from "./b.js";
+          console.log(${join("a")}("x", "y"), ${join("b")}("p", "q"));
+        `,
+        "/entry2.js": /* js */ `
+          import { j as a } from "./a.js";
+          import { j as b } from "./b.js";
+          console.log(${join("b")}("x", "y"), ${join("a")}("p", "q"));
+        `,
+        "/a.js": reexportingFile,
+        "/b.js": reexportingFile,
+      },
+      entryPoints: ["/entry1.js", "/entry2.js"],
+      format: "esm",
+      splitting: true,
+      external: ["ext"],
+      runtimeFiles: extRuntime,
+      outdir: "/out",
+      run: [
+        { file: "/out/entry1.js", stdout: "x/y p/q" },
+        { file: "/out/entry2.js", stdout: "x/y p/q" },
+      ],
+    });
+  }
+  // The first import of a path is the one that is kept, even a bare one, so
+  // the order in which the externals are evaluated is unchanged. Dropping the
+  // bare import in favour of the later binding import would move "side" after
+  // "other".
+  itBundled("regression/ExternalImportDedupeKeepsEvaluationOrder#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./a.js";
+        import "./b.js";
+        import "./c.js";
+        console.log("entry");
+      `,
+      "/a.js": /* js */ `
+        import "side";
+        import { tag } from "other";
+        console.log("a", tag);
+      `,
+      "/b.js": /* js */ `
+        import { v } from "side";
+        console.log("b", v);
+      `,
+      "/c.js": /* js */ `
+        import "side";
+        import { tag } from "other";
+        console.log("c", tag);
+      `,
+    },
+    format: "esm",
+    external: ["side", "other"],
+    runtimeFiles: {
+      "/node_modules/side/index.js": /* js */ `console.log("evaluating side"); export const v = "V";`,
+      "/node_modules/side/package.json": /* json */ `{ "name": "side", "type": "module", "main": "index.js" }`,
+      "/node_modules/other/index.js": /* js */ `console.log("evaluating other"); export const tag = "O";`,
+      "/node_modules/other/package.json": /* json */ `{ "name": "other", "type": "module", "main": "index.js" }`,
+    },
+    run: {
+      stdout: `
+        evaluating side
+        evaluating other
+        a O
+        b V
+        c O
+        entry
+      `,
+    },
+    onAfterBundle(api) {
+      expect(importStatements(api.readFile("/out.js"))).toEqual([
+        'import"side";',
+        'import { tag } from "other";',
+        'import { v } from "side";',
+      ]);
+    },
+  });
+  // Clause order does not matter; the same export name from a different
+  // package is a different binding.
+  itBundled("regression/ExternalImportDedupeClauseOrder#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        console.log(a, b, c);
+      `,
+      "/a.js": /* js */ `
+        import { join, sep } from "ext";
+        export const a = join("a", sep);
+      `,
+      "/b.js": /* js */ `
+        import { sep, join } from "ext";
+        export const b = join(sep, "b");
+      `,
+      "/c.js": /* js */ `
+        import { join } from "ext2";
+        export const c = join("c");
+      `,
+    },
+    format: "esm",
+    external: ["ext", "ext2"],
+    runtimeFiles: {
+      ...extRuntime,
+      "/node_modules/ext2/index.js": /* js */ `export const join = (...p) => "ext2:" + p.join("/");`,
+      "/node_modules/ext2/package.json": /* json */ `{ "name": "ext2", "type": "module", "main": "index.js" }`,
+    },
+    run: { stdout: "a// //b ext2:c" },
+    onAfterBundle(api) {
+      expect(importStatements(api.readFile("/out.js"))).toEqual([
+        'import { join, sep } from "ext";',
+        'import { join as join2 } from "ext2";',
+      ]);
+    },
+  });
+  // The entry point re-exports a binding whose import statement was dropped;
+  // the export clause has to print the kept statement's name.
+  itBundled("regression/ExternalImportDedupeEntryReexport#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        export { joinA } from "./a.js";
+        export { joinB } from "./b.js";
+      `,
+      "/a.js": /* js */ `import { join } from "ext"; export { join as joinA };`,
+      "/b.js": /* js */ `import { join } from "ext"; export { join as joinB };`,
+    },
+    format: "esm",
+    external: ["ext"],
+    runtimeFiles: {
+      ...extRuntime,
+      "/consumer.js": /* js */ `
+        import { joinA, joinB } from "./out.js";
+        console.log(joinA("a", "1"), joinB("b", "2"), joinA === joinB);
+      `,
+    },
+    run: { file: "/consumer.js", stdout: "a/1 b/2 true" },
+    onAfterBundle(api) {
+      expect(importStatements(api.readFile("/out.js"))).toEqual(['import { join } from "ext";']);
+    },
+  });
+  // Import attributes are part of what the statement imports: the two JSON
+  // imports collapse, the attribute-less one stays separate.
+  itBundled("regression/ExternalImportDedupeImportAttributes#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        console.log(a, b, c);
+      `,
+      "/a.js": /* js */ `
+        import data from "pkg" with { type: "json" };
+        export const a = data;
+      `,
+      "/b.js": /* js */ `
+        import data from "pkg";
+        export const b = data;
+      `,
+      "/c.js": /* js */ `
+        import data from "pkg" with { type: "json" };
+        export const c = data;
+      `,
+    },
+    target: "bun",
+    format: "esm",
+    external: ["pkg"],
+    onAfterBundle(api) {
+      expect(importStatements(api.readFile("/out.js"))).toEqual([
+        'import data from "pkg" with { type: "json" };',
+        'import data2 from "pkg";',
+      ]);
+    },
+  });
+  // Without splitting a source file is copied into every entry-point chunk
+  // that reaches it, while the symbol merge is global. Only statements with an
+  // identical clause list may merge there: merging r into p in entry2 and into
+  // q in entry3 would otherwise link p's and q's `x`, and entry1, which keeps
+  // both p and q, would declare that binding twice.
+  itBundled("regression/ExternalImportDedupeMultiEntryNoSplitting#8671", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { p } from "./p.js";
+        import { q } from "./q.js";
+        console.log(p, q);
+      `,
+      "/entry2.js": /* js */ `
+        import { p } from "./p.js";
+        import { r } from "./r.js";
+        console.log(p, r);
+      `,
+      "/entry3.js": /* js */ `
+        import { q } from "./q.js";
+        import { r } from "./r.js";
+        console.log(q, r);
+      `,
+      "/p.js": /* js */ `import { sep } from "ext"; export const p = "p" + sep;`,
+      "/q.js": /* js */ `import { sep, join } from "ext"; export const q = join("q", sep);`,
+      "/r.js": /* js */ `import { sep } from "ext"; export const r = "r" + sep;`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js", "/entry3.js"],
+    format: "esm",
+    splitting: false,
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    outdir: "/out",
+    run: [
+      { file: "/out/entry1.js", stdout: "p/ q//" },
+      { file: "/out/entry2.js", stdout: "p/ r/" },
+      { file: "/out/entry3.js", stdout: "q// r/" },
+    ],
+    onAfterBundle(api) {
+      expect(importStatements(api.readFile("/out/entry2.js"))).toEqual(['import { sep } from "ext";']);
+      expect(importStatements(api.readFile("/out/entry1.js"))).toHaveLength(2);
+      expect(importStatements(api.readFile("/out/entry3.js"))).toHaveLength(2);
+    },
+  });
+  // shared.js is the kept statement in entry1's chunk and a dropped one in
+  // entry2's chunk; every chunk still declares the merged binding exactly once.
+  itBundled("regression/ExternalImportDedupeMultiEntryNoSplittingSharedFile#8671", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { s } from "./shared.js";
+        import { o1 } from "./only1.js";
+        console.log(s, o1);
+      `,
+      "/entry2.js": /* js */ `
+        import { o2 } from "./only2.js";
+        import { s } from "./shared.js";
+        console.log(s, o2);
+      `,
+      "/shared.js": /* js */ `import * as ns from "ext"; export const s = ns.sep;`,
+      "/only1.js": /* js */ `import * as ns from "ext"; export const o1 = ns.join("only", "1");`,
+      "/only2.js": /* js */ `import * as ns from "ext"; export const o2 = ns.join("only", "2");`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    format: "esm",
+    splitting: false,
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    outdir: "/out",
+    run: [
+      { file: "/out/entry1.js", stdout: "/ only/1" },
+      { file: "/out/entry2.js", stdout: "/ only/2" },
+    ],
+    onAfterBundle(api) {
+      for (const file of ["/out/entry1.js", "/out/entry2.js"]) {
+        expect(importStatements(api.readFile(file))).toEqual(['import * as ns from "ext";']);
+      }
+    },
+  });
+  // `import { x, x as y }` binds one export to two locals. Merging b.js's pair
+  // into a.js's single recorded `sep` in entry1 would make entry2, where b.js is
+  // the kept statement, declare the same local twice. Such statements are left alone.
+  itBundled("regression/ExternalImportDedupeMultiEntryNoSplittingDuplicateAlias#8671", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { A } from "./a.js";
+        import { B } from "./b.js";
+        console.log(A, B);
+      `,
+      "/entry2.js": /* js */ `
+        import { B } from "./b.js";
+        console.log(B);
+      `,
+      "/a.js": /* js */ `import { sep, sep as sep1 } from "ext"; export const A = sep + sep1 + "a";`,
+      "/b.js": /* js */ `import { sep, sep as sep2 } from "ext"; export const B = sep + sep2 + "b";`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    format: "esm",
+    splitting: false,
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    outdir: "/out",
+    run: [
+      { file: "/out/entry1.js", stdout: "//a //b" },
+      { file: "/out/entry2.js", stdout: "//b" },
+    ],
+    onAfterBundle(api) {
+      // Neither statement is merged: each file keeps its own two locals.
+      const entry1 = importStatements(api.readFile("/out/entry1.js"));
+      expect(entry1).toHaveLength(2);
+      expect(entry1[0]).toBe('import { sep, sep as sep1 } from "ext";');
+      expect(entry1[1]).toMatch(/^import \{ sep as (\w+), sep as (?!\1\b)\w+ \} from "ext";$/);
+      expect(importStatements(api.readFile("/out/entry2.js"))).toEqual(['import { sep, sep as sep2 } from "ext";']);
+    },
+  });
+
   // Exercises the bundler's chunking/linking internals end-to-end: code
   // splitting produces cross-chunk imports (sorted deterministically), CSS is
   // compiled into its own chunk, symbols are renamed across chunks, and every

--- a/test/bundler/bundler_regressions.test.ts
+++ b/test/bundler/bundler_regressions.test.ts
@@ -494,9 +494,10 @@ describe("bundler", () => {
       }
     },
   });
-  // `import { x, x as y }` binds one export to two locals. Merging b.js's pair
-  // into a.js's single recorded `sep` in entry1 would make entry2, where b.js is
-  // the kept statement, declare the same local twice. Such statements are left alone.
+  // `import { x, x as y }` binds one export to two locals. Merging b.js's
+  // identical pair into the one `sep` ref recorded for a.js in entry1 would make
+  // entry2, where b.js is the kept statement, declare the same local twice.
+  // Such statements are left alone.
   itBundled("regression/ExternalImportDedupeMultiEntryNoSplittingDuplicateAlias#8671", {
     files: {
       "/entry1.js": /* js */ `
@@ -509,7 +510,7 @@ describe("bundler", () => {
         console.log(B);
       `,
       "/a.js": /* js */ `import { sep, sep as sep1 } from "ext"; export const A = sep + sep1 + "a";`,
-      "/b.js": /* js */ `import { sep, sep as sep2 } from "ext"; export const B = sep + sep2 + "b";`,
+      "/b.js": /* js */ `import { sep, sep as sep1 } from "ext"; export const B = sep + sep1 + "b";`,
     },
     entryPoints: ["/entry1.js", "/entry2.js"],
     format: "esm",
@@ -527,7 +528,103 @@ describe("bundler", () => {
       expect(entry1).toHaveLength(2);
       expect(entry1[0]).toBe('import { sep, sep as sep1 } from "ext";');
       expect(entry1[1]).toMatch(/^import \{ sep as (\w+), sep as (?!\1\b)\w+ \} from "ext";$/);
-      expect(importStatements(api.readFile("/out/entry2.js"))).toEqual(['import { sep, sep as sep2 } from "ext";']);
+      expect(importStatements(api.readFile("/out/entry2.js"))).toEqual(['import { sep, sep as sep1 } from "ext";']);
+    },
+  });
+  // Without splitting, only statements written the same way merge, so a chunk
+  // never prints a local name taken from a file it does not contain: entry2
+  // keeps p.js's `path` even though entry1 merged nothing with q.js's `ext`,
+  // and entry2's own `ext` is not pushed aside by a name from q.js.
+  itBundled("regression/ExternalImportDedupeMultiEntryNoSplittingLocalNames#8671", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { q } from "./q.js";
+        import { p } from "./p.js";
+        console.log(q, p);
+      `,
+      "/entry2.js": /* js */ `
+        import { p } from "./p.js";
+        const ext = "local";
+        console.log(p, ext);
+      `,
+      "/p.js": /* js */ `import path from "ext"; export const p = path.join("p", "1");`,
+      "/q.js": /* js */ `import ext from "ext"; export const q = ext.join("q", "1");`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    format: "esm",
+    splitting: false,
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    outdir: "/out",
+    run: [
+      { file: "/out/entry1.js", stdout: "q/1 p/1" },
+      { file: "/out/entry2.js", stdout: "p/1 local" },
+    ],
+    onAfterBundle(api) {
+      expect(importStatements(api.readFile("/out/entry1.js"))).toEqual([
+        'import ext from "ext";',
+        'import path from "ext";',
+      ]);
+      const entry2 = api.readFile("/out/entry2.js");
+      expect(importStatements(entry2)).toEqual(['import path from "ext";']);
+      expect(entry2).toMatch(/\b(?:var|let|const) ext = "local"/);
+    },
+  });
+  itBundled("regression/ExternalImportDedupeMultiEntryNoSplittingMinified#8671", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { s } from "./shared.js";
+        import { o1 } from "./only1.js";
+        console.log(s, o1);
+      `,
+      "/entry2.js": /* js */ `
+        import { o2 } from "./only2.js";
+        import { s } from "./shared.js";
+        console.log(s, o2);
+      `,
+      "/shared.js": /* js */ `import { join, sep } from "ext"; export const s = join("s", sep);`,
+      "/only1.js": /* js */ `import { join, sep } from "ext"; export const o1 = join("o1", sep);`,
+      "/only2.js": /* js */ `import { join, sep } from "ext"; export const o2 = join("o2", sep);`,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    format: "esm",
+    splitting: false,
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    minifyIdentifiers: true,
+    minifyWhitespace: true,
+    outdir: "/out",
+    run: [
+      { file: "/out/entry1.js", stdout: "s// o1//" },
+      { file: "/out/entry2.js", stdout: "s// o2//" },
+    ],
+    onAfterBundle(api) {
+      for (const file of ["/out/entry1.js", "/out/entry2.js"]) {
+        expect([...api.readFile(file).matchAll(/from"ext"/g)]).toHaveLength(1);
+      }
+    },
+  });
+  // A default import and `{ default as x }` bind the same export through two
+  // different clause slots; the pass does not try to unify them.
+  itBundled("regression/ExternalImportDedupeDefaultViaNamedClause#8671", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        console.log(a, b);
+      `,
+      "/a.js": /* js */ `import ext from "ext"; export const a = ext.sep;`,
+      "/b.js": /* js */ `import { default as ext } from "ext"; export const b = ext.sep;`,
+    },
+    format: "esm",
+    external: ["ext"],
+    runtimeFiles: extRuntime,
+    run: { stdout: "/ /" },
+    onAfterBundle(api) {
+      expect(importStatements(api.readFile("/out.js"))).toEqual([
+        'import ext from "ext";',
+        'import { default as ext2 } from "ext";',
+      ]);
     },
   });
 


### PR DESCRIPTION
### Problem

- With `format: "esm"` and an external package, every bundled source file's `import` of that package is printed as its own statement, so N files importing `node:path` produce `import path from "path"`, `import path2 from "path"`, ... in one chunk (#8671, #13092, #18963).
- Cause: `convert_stmts_for_chunk` handles each file on its own and `should_remove_import_export_stmt` (`src/bundler/LinkerContext.rs`) keeps every external import when ESM syntax is kept, so nothing ever looks at the chunk as a whole.

Before:
```js
// a.js
import path from "path";
// b.js
import path2 from "path";
// c.js
import path3 from "path";
```
After:
```js
// a.js
import path from "path";
// b.js
// c.js
```

### Fix

- New linker pass `merge_external_esm_imports` (`src/bundler/linker_context/mergeExternalESMImports.rs`), run at the end of `link()` after `compute_cross_chunk_dependencies` and before `symbols.follow_all()`. Per JS chunk it walks the live external `S::Import` statements in output order, keyed by what the printer emits after `from` (path text, namespace, `with { type }` loader). A statement that introduces no binding the chunk has not already imported is recorded on the chunk and its refs are `symbols.merge`d into the first statement's refs; `convert_stmts_for_chunk` drops the recorded statements. A statement that introduces at least one new binding is kept as a whole, and its overlapping bindings stay separate refs (the renamer suffixes them), so `import { join }` followed by `import { join, dirname }` stays two statements while a third `import { join }` is dropped.
- The first statement for a path is always kept, including a bare `import "x"`, so the order in which the externals are evaluated is unchanged; only later statements are dropped.
- A binding listed in the chunk's `exports_to_other_chunks` keeps its own statement: cross-chunk imports were already recorded under that ref, and merging it would make the importing chunk bind two aliases to one local.
- Without code splitting and with more than one JS chunk, a source file is copied into every entry-point chunk that reaches it, while `symbols.merge` is global, so a statement kept in one chunk can be dropped in another. In that configuration the pass runs in exact mode: statements are additionally keyed by their clause as written (star / default / export names, each with the local name it is bound to), so merges only happen between statements that are textually the same. Every chunk keeps exactly one statement per clause, so no chunk ever declares a merged binding twice, and because the local names are part of the key, the name a chunk prints is always one its own files wrote, whichever file's ref ends up as the merged root; an entry's output therefore does not depend on files it does not contain. A statement that binds one export to two locals (`import { x, x as y }`) is left out of exact mode altogether, since the per-export bookkeeping would otherwise collapse its two locals. The `SAFETY` note above the `exact` flag in `mergeExternalESMImports.rs` carries this argument.
- Why this is correct: an ES module is evaluated once no matter how many `import` statements name it, and two bindings of the same export of the same module are interchangeable live bindings, so dropping a statement whose bindings all exist already and pointing its refs at the surviving bindings changes nothing observable. The only non-local effect is the global symbol merge, which the rules above confine to bindings declared exactly once per chunk.
- The `--compile --bytecode` module record needs no separate handling any more: since #37677 the printer builds it from the statements `convert_stmts_for_chunk` emits.
- Verified with `test/bundler/bundler_regressions.test.ts`: 18 `ExternalImportDedupe*` cases, 13 of which fail on the released binary; the other five pass on both and pin guards (the two `SplittingReexport*` cases, `DuplicateAlias`, `LocalNames`, which fails on the earlier revision of exact mode, and `DefaultViaNamedClause`). They cover default / named / star / bare imports, partial overlap, minified output, code splitting, evaluation order with a bare first import, clause order, an entry point re-exporting a merged binding, import attributes, and, without splitting: the three-entry transitive-merge hazard, a shared file kept in one chunk and dropped in another, identical duplicate-alias statements, different local names across entries (the chunk without the root's file prints its own name and keeps its own colliding local), and exact mode under `minifyIdentifiers`. `test/bundler/bundler_compile.test.ts` gains a `--compile --bytecode --format=esm` scenario (`ESMBytecode+DedupedExternalImports`, plain and minified) in which three files import the same builtins, one of them from inside a `__commonJS` wrapper; the debug build cross-checks the module record built from the deduplicated chunk against JSC's own parse of it. Also ran `esbuild/{importstar,splitting,default}`, `bundler_{splitting,jsx,defer,edgecase,minify,cjs2esm,compile_splitting,html}` with no failures.

### Consolidation

This PR now also carries the ideas and cases from #35645, which took the identical-clause-list approach for every build: that approach is used here only where it is needed (multi-entry builds without splitting, which this PR previously left unoptimized), and its multi-entry, shared-file, clause-order and import-attribute cases were folded in. #35645's retroactive dropping of an earlier bare import was not adopted because it reorders external evaluation; `ExternalImportDedupeKeepsEvaluationOrder` pins the order. Files containing direct `eval` get no special treatment: Bun, like esbuild, already does not keep top-level bindings reachable by `eval` when bundling (a colliding top-level name is renamed today), so an `eval` reaching a dropped import binding is the same pre-existing limitation. #36600 addresses the JSX-runtime import specifically by rewriting the surviving statement to the union of the needed names; it is complementary to this pass and will need a rebase on top of it since both touch `convert_stmts_for_chunk`.

### Background

- Chunk: one output file. With code splitting each source file is placed in exactly one chunk, keyed by the set of entry points that reach it; without splitting each entry point gets a chunk containing a copy of every file it reaches.
- Symbol merge: the linker's symbol table is a union-find; `symbols.merge(a, b)` makes every reference to `a` print with `b`'s name. It is graph-wide, not per chunk, which is what makes the multi-entry case need exact mode.
- `exports_to_other_chunks`: filled by `compute_cross_chunk_dependencies` when splitting; lists the refs of this chunk that other chunks import, keyed by the ref as it was before this pass.

Fixes #8671
Fixes #13092
Fixes #18963

