### PR TITLE
bundler: rewrite Bun.env / import.meta.env to process.env for --target=node

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -945,10 +945,17 @@ pub fn defines_from_transform_options(
         }
     }
 
-    // `Bun.env` is an alias for `process.env` at runtime; Node has the latter
-    // but not the former, so rewrite it so the bundle runs there.
+    // `Bun.env` / `import.meta.env` are aliases for `process.env` at runtime;
+    // Node has neither, so rewrite them so the bundle runs there. Target the
+    // global explicitly so a local `process` binding does not capture the
+    // rewrite.
     if target == Target::Node {
-        user_defines.get_or_put_value(b"Bun.env", Box::from(b"process.env".as_slice()))?;
+        user_defines
+            .get_or_put_value(b"Bun.env", Box::from(b"globalThis.process.env".as_slice()))?;
+        user_defines.get_or_put_value(
+            b"import.meta.env",
+            Box::from(b"globalThis.process.env".as_slice()),
+        )?;
     }
 
     let resolved_defines = defines::DefineData::from_input(&user_defines, drop, log, bump)?;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -945,6 +945,12 @@ pub fn defines_from_transform_options(
         }
     }
 
+    // `Bun.env` is an alias for `process.env` at runtime; Node has the latter
+    // but not the former, so rewrite it so the bundle runs there.
+    if target == Target::Node {
+        user_defines.get_or_put_value(b"Bun.env", Box::from(b"process.env".as_slice()))?;
+    }
+
     let resolved_defines = defines::DefineData::from_input(&user_defines, drop, log, bump)?;
 
     let drop_debugger = drop.iter().any(|item| *item == b"debugger");

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -945,8 +945,7 @@ pub fn defines_from_transform_options(
         }
     }
 
-    // Bun.env / import.meta.env alias process.env; Node lacks them. globalThis
-    // keeps the rewrite pointed at the real env if `process` is shadowed locally.
+    // `globalThis.` so a local `const process` binding doesn't capture the rewrite.
     if target == Target::Node {
         user_defines
             .get_or_put_value(b"Bun.env", Box::from(b"globalThis.process.env".as_slice()))?;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -945,10 +945,8 @@ pub fn defines_from_transform_options(
         }
     }
 
-    // `Bun.env` / `import.meta.env` are aliases for `process.env` at runtime;
-    // Node has neither, so rewrite them so the bundle runs there. Target the
-    // global explicitly so a local `process` binding does not capture the
-    // rewrite.
+    // Bun.env / import.meta.env alias process.env; Node lacks them. globalThis
+    // keeps the rewrite pointed at the real env if `process` is shadowed locally.
     if target == Target::Node {
         user_defines
             .get_or_put_value(b"Bun.env", Box::from(b"globalThis.process.env".as_slice()))?;

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2124,6 +2124,57 @@ describe("bundler", () => {
       api.expectFile("/out.js").not.toMatch(/[^\.:]module/); // `.module` and `node:module` are ok.
     },
   });
+  // https://github.com/oven-sh/bun/issues/14594
+  itBundled("edgecase/BunEnvTargetNode", {
+    files: {
+      "/entry.ts": /* js */ `
+        capture(Bun.env.VAR);
+        capture(Bun.env);
+        capture(Bun.env["computed"]);
+      `,
+    },
+    target: "node",
+    capture: ["process.env.VAR", "process.env", 'process.env["computed"]'],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("Bun");
+    },
+  });
+  itBundled("edgecase/BunEnvTargetNodeRun", {
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(Bun.env.FOO);
+        console.log(JSON.stringify(Bun.env.MISSING));
+        console.log(typeof Bun.env);
+      `,
+    },
+    target: "node",
+    run: {
+      runtime: "node",
+      env: { FOO: "from-node" },
+      stdout: "from-node\nundefined\nobject",
+    },
+  });
+  itBundled("edgecase/BunEnvTargetNodeUserDefineWins", {
+    files: {
+      "/entry.ts": /* js */ `
+        capture(Bun.env);
+        capture(Bun.env.X);
+      `,
+    },
+    target: "node",
+    define: { "Bun.env": "globalThis.myEnv" },
+    capture: ["globalThis.myEnv", "globalThis.myEnv.X"],
+  });
+  itBundled("edgecase/BunEnvTargetBunUnchanged", {
+    files: {
+      "/entry.ts": /* js */ `
+        capture(Bun.env.VAR);
+        capture(Bun.env);
+      `,
+    },
+    target: "bun",
+    capture: ["Bun.env.VAR", "Bun.env"],
+  });
   itBundled("edgecase/build-cjs-module#20308", {
     files: {
       "/entry.ts": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2131,12 +2131,21 @@ describe("bundler", () => {
         capture(Bun.env.VAR);
         capture(Bun.env);
         capture(Bun.env["computed"]);
+        capture(import.meta.env.VAR);
+        capture(import.meta.env);
       `,
     },
     target: "node",
-    capture: ["process.env.VAR", "process.env", 'process.env["computed"]'],
+    capture: [
+      "globalThis.process.env.VAR",
+      "globalThis.process.env",
+      'globalThis.process.env["computed"]',
+      "globalThis.process.env.VAR",
+      "globalThis.process.env",
+    ],
     onAfterBundle(api) {
       api.expectFile("/out.js").not.toContain("Bun");
+      api.expectFile("/out.js").not.toContain("import.meta.env");
     },
   });
   itBundled("edgecase/BunEnvTargetNodeRun", {
@@ -2145,13 +2154,29 @@ describe("bundler", () => {
         console.log(Bun.env.FOO);
         console.log(JSON.stringify(Bun.env.MISSING));
         console.log(typeof Bun.env);
+        console.log(import.meta.env.FOO);
       `,
     },
     target: "node",
     run: {
       runtime: "node",
       env: { FOO: "from-node" },
-      stdout: "from-node\nundefined\nobject",
+      stdout: "from-node\nundefined\nobject\nfrom-node",
+    },
+  });
+  itBundled("edgecase/BunEnvTargetNodeLocalProcessShadow", {
+    files: {
+      "/entry.ts": /* js */ `
+        const process = { env: { FOO: "local" }, other: "ok" };
+        console.log(process.other);
+        console.log(Bun.env.FOO);
+      `,
+    },
+    target: "node",
+    run: {
+      runtime: "node",
+      env: { FOO: "global" },
+      stdout: "ok\nglobal",
     },
   });
   itBundled("edgecase/BunEnvTargetNodeUserDefineWins", {
@@ -2159,21 +2184,26 @@ describe("bundler", () => {
       "/entry.ts": /* js */ `
         capture(Bun.env);
         capture(Bun.env.X);
+        capture(import.meta.env);
       `,
     },
     target: "node",
-    define: { "Bun.env": "globalThis.myEnv" },
-    capture: ["globalThis.myEnv", "globalThis.myEnv.X"],
+    define: {
+      "Bun.env": "globalThis.myEnv",
+      "import.meta.env": "globalThis.otherEnv",
+    },
+    capture: ["globalThis.myEnv", "globalThis.myEnv.X", "globalThis.otherEnv"],
   });
   itBundled("edgecase/BunEnvTargetBunUnchanged", {
     files: {
       "/entry.ts": /* js */ `
         capture(Bun.env.VAR);
         capture(Bun.env);
+        capture(import.meta.env.VAR);
       `,
     },
     target: "bun",
-    capture: ["Bun.env.VAR", "Bun.env"],
+    capture: ["Bun.env.VAR", "Bun.env", "import.meta.env.VAR"],
   });
   itBundled("edgecase/build-cjs-module#20308", {
     files: {


### PR DESCRIPTION
Fixes #14594

## Repro

```ts
const foo = Bun.env.VAR;
console.log(foo);
```

```sh
$ bun build entry.ts --target=node | node
ReferenceError: Bun is not defined
```

`import.meta.env.VAR` has the same problem: Node's `import.meta` has no `.env`, so it throws `TypeError: Cannot read properties of undefined (reading 'VAR')`.

## Cause

In Bun, `Bun.env === import.meta.env === process.env` (documented in `docs/runtime/environment-variables.mdx`), but Node has neither of the first two. The bundler already injects target-specific defines (e.g. `process.browser`, lowered `import.meta.main`) in `defines_from_transform_options`, but had no mapping for these aliases.

## Fix

Register default `Bun.env` and `import.meta.env` -> `globalThis.process.env` defines when `target == Target::Node`, alongside the existing target-specific defines. Uses `get_or_put_value` so a user-supplied `--define` for either key still takes precedence. The `globalThis.` prefix keeps the rewrite pointed at the real environment even when user code declares a local `const process = ...` binding. Applies to `bun build`, `Bun.build()`, and `Bun.Transpiler`.

`import.meta.env` is included because it is the other documented `process.env` alias with an identical failure mode under Node, and the existing Bake/HTML-bundle paths already register `import.meta.env.*` defines through the same machinery. If maintainers would rather scope this PR to `Bun.env` only (e.g. to reserve `import.meta.env` for a Vite-style object), the second `get_or_put_value` line and its test assertions can be dropped.

## After

```sh
$ bun build entry.ts --target=node
var foo = globalThis.process.env.VAR;
console.log(foo);
```

## Tests

Added to `test/bundler/bundler_edgecase.test.ts` next to `ImportMetaMainTargetNode`:
- `BunEnvTargetNode`: `Bun.env.*` and `import.meta.env.*` become `globalThis.process.env.*`; output contains no `Bun` / `import.meta.env`
- `BunEnvTargetNodeRun`: bundle with `target: node`, execute under `node`, reads real `process.env`
- `BunEnvTargetNodeLocalProcessShadow`: a local `const process` does not capture the rewrite; Node still reads the real env var
- `BunEnvTargetNodeUserDefineWins`: explicit `--define Bun.env=...` / `--define import.meta.env=...` overrides the default
- `BunEnvTargetBunUnchanged`: `target: bun` leaves both untouched

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->