### PR TITLE
HTMLRewriter: propagate handler errors to the caller without leaking to unhandledRejection

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1296,10 +1296,27 @@ where
         }
 
         if let Some(promise) = result.as_any_promise() {
+            // HTMLRewriter observes the rejection and propagates it to the
+            // caller, so this is a handled rejection. Mark it before waiting
+            // so `handle_rejected_promises()` (run by `wait_for_promise`'s
+            // tick, and again on the next event-loop turn) skips it instead of
+            // firing `process.on("unhandledRejection")`.
+            promise.set_handled(global.vm());
             vm().wait_for_promise(promise);
             let fail = promise.status() == jsc::js_promise::Status::Rejected;
             if fail {
-                vm().unhandled_rejection(global, promise.result(global.vm()), promise.as_value());
+                // Capture the rejection directly (same slot the sync-throw arm
+                // above writes). `vm.unhandled_rejection()` is NOT equivalent:
+                // it dispatches to `process.on("unhandledRejection")` first and
+                // only reaches the capture handler when no listener exists, so
+                // with a listener the original error is lost and the caller
+                // sees the generic "rewriter has been stopped" instead.
+                let err = promise.result(global.vm());
+                err.ensure_still_alive();
+                if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
+                    // SAFETY: VM-owned pointer set by BufferOutputSink::init.
+                    unsafe { *err_ptr = err };
+                }
             }
             return fail;
         }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -885,17 +885,47 @@ impl BufferOutputSink {
             ((*sink).global, (*sink).response, (*sink).rewriter)
         };
 
+        // Install the capture slot `handler_callback` writes to. `init()`
+        // already does this for the sync path, but on the async path `init()`
+        // has returned and torn its scope down; without this the handler's
+        // error is lost and the caller only sees the generic lol-html string.
+        // Note (Stacked Borrows): `Cell::as_ptr` yields SharedReadWrite
+        // provenance, so local `.get()` reads don't invalidate the stored raw
+        // pointer.
+        let captured: core::cell::Cell<JSValue> = core::cell::Cell::new(JSValue::ZERO);
+        let vm: &mut VirtualMachine = global.bun_vm().as_mut();
+        let scope = vm.unhandled_rejection_scope();
+        let prev_capture = vm.unhandled_pending_rejection_to_capture;
+        vm.unhandled_pending_rejection_to_capture = Some(captured.as_ptr());
+        vm.on_unhandled_rejection =
+            VirtualMachine::on_quiet_unhandled_rejection_handler_capture_value;
+        scopeguard::defer! {
+            captured.get().ensure_still_alive();
+            let vm = VirtualMachine::get().as_mut();
+            vm.unhandled_pending_rejection_to_capture = prev_capture;
+            scope.apply(vm);
+        }
+
+        let deliver_async =
+            |e: &lol_html::errors::RewritingError, captured: &core::cell::Cell<JSValue>| {
+                let err = if captured.get().is_empty() {
+                    webcore::body::ValueError::Message(lol_err_string(e))
+                } else {
+                    webcore::body::ValueError::JSValue(StrongOptional::create(
+                        captured.get(),
+                        &global,
+                    ))
+                };
+                // SAFETY: response kept alive by response_value Strong.
+                let _ = unsafe { (*response).get_body_value() }.to_error_instance(err, &global);
+            };
+
         // SAFETY: rewriter heap-allocated by init(), not yet freed.
         if let Err(e) = unsafe { (*rewriter).write(bytes) } {
             // Poisoned: never call `end()` after a failed `write()`. The
             // field stays non-null so `Drop` frees the rewriter.
             if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
+                deliver_async(&e, &captured);
                 return None;
             } else {
                 return Some(create_lolhtml_error(&global, &e));
@@ -909,12 +939,7 @@ impl BufferOutputSink {
         // SAFETY: `rewriter` was heap-allocated by init(); sole owner now.
         if let Err(e) = unsafe { bun_core::heap::take(rewriter) }.end() {
             if is_async {
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(
-                    webcore::body::ValueError::Message(lol_err_string(&e)),
-                    &global,
-                );
-                // TODO: properly propagate exception upwards
+                deliver_async(&e, &captured);
                 return None;
             } else {
                 return Some(create_lolhtml_error(&global, &e));
@@ -1252,36 +1277,31 @@ where
     ) {
         Ok(v) => v,
         Err(_) => {
-            // If there's an exception in the scope, capture it for later retrieval
             if let Some(exc) = scope.exception() {
                 let exc_value = JSValue::from_cell(exc.as_ptr());
-                // Store the exception in the VM's unhandled rejection capture
-                // mechanism if it's available (this is the same mechanism used
-                // by BufferOutputSink)
+                exc_value.ensure_still_alive();
+                // The slot is a stack local in run_output_sink (conservatively
+                // scanned) read by `create_lolhtml_error` / `deliver_async`
+                // before any JSC allocation. No protect here: the reader does
+                // not unprotect, so protecting leaks one Exception root per
+                // throw (#31804).
                 if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-                    // SAFETY: VM-owned pointer set by BufferOutputSink::init.
+                    // SAFETY: VM-owned pointer set by run_output_sink.
                     unsafe { *err_ptr = exc_value };
-                    exc_value.protect();
                 }
             }
-            // Clear the exception from the scope to prevent assertion failures
             scope.clear_exception();
-            // Return true to indicate failure to LOLHTML, which will cause the
-            // write operation to fail and the error handling logic to take over.
             return true;
         }
     };
 
-    // Check if there's an exception that was thrown but not caught by the error union
     if let Some(exc) = scope.exception() {
         let exc_value = JSValue::from_cell(exc.as_ptr());
-        // Store the exception in the VM's unhandled rejection capture mechanism
+        exc_value.ensure_still_alive();
         if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-            // SAFETY: VM-owned pointer set by BufferOutputSink::init.
+            // SAFETY: VM-owned pointer set by run_output_sink.
             unsafe { *err_ptr = exc_value };
-            exc_value.protect();
         }
-        // Clear the exception to prevent assertion failures
         scope.clear_exception();
         return true;
     }
@@ -1314,7 +1334,7 @@ where
                 let err = promise.result(global.vm());
                 err.ensure_still_alive();
                 if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-                    // SAFETY: VM-owned pointer set by BufferOutputSink::init.
+                    // SAFETY: VM-owned pointer set by run_output_sink.
                     unsafe { *err_ptr = err };
                 }
             }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -906,19 +906,16 @@ impl BufferOutputSink {
             scope.apply(vm);
         }
 
-        let deliver_async =
-            |e: &lol_html::errors::RewritingError, captured: &core::cell::Cell<JSValue>| {
-                let err = if captured.get().is_empty() {
-                    webcore::body::ValueError::Message(lol_err_string(e))
-                } else {
-                    webcore::body::ValueError::JSValue(StrongOptional::create(
-                        captured.get(),
-                        &global,
-                    ))
-                };
-                // SAFETY: response kept alive by response_value Strong.
-                let _ = unsafe { (*response).get_body_value() }.to_error_instance(err, &global);
+        let deliver_async = |e: &lol_html::errors::RewritingError,
+                             captured: &core::cell::Cell<JSValue>| {
+            let err = if captured.get().is_empty() {
+                webcore::body::ValueError::Message(lol_err_string(e))
+            } else {
+                webcore::body::ValueError::JSValue(StrongOptional::create(captured.get(), &global))
             };
+            // SAFETY: response kept alive by response_value Strong.
+            let _ = unsafe { (*response).get_body_value() }.to_error_instance(err, &global);
+        };
 
         // SAFETY: rewriter heap-allocated by init(), not yet freed.
         if let Err(e) = unsafe { (*rewriter).write(bytes) } {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1259,6 +1259,7 @@ where
         // coverage (Exception cells / `Symbol.error` vs cross-realm
         // AggregateError).
         if result.is_error() || result.is_aggregate_error(global) {
+            capture_handler_error(vm(), result);
             return true;
         }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -9,11 +9,8 @@ use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsResult, ProtectedJSValue,
     StrongOptional, SystemError, bun_string_jsc,
 };
-// Note: `bun_jsc::VirtualMachine` is a *module* re-export
-// (`pub use self::virtual_machine as VirtualMachine;`). The struct lives at
-// `bun_jsc::virtual_machine::VirtualMachine` — import that directly so the
-// name resolves as a type at `&mut VirtualMachine` annotations and as the
-// owner of the `on_quiet_unhandled_rejection_handler_capture_value` assoc fn.
+// Note: `bun_jsc::VirtualMachine` is a *module* re-export; import the struct
+// directly so the name resolves as a type and as the owner of `get()`.
 use bun_jsc::virtual_machine::VirtualMachine;
 
 use crate::webcore::response::HeadersRef;
@@ -618,41 +615,17 @@ impl BufferOutputSink {
 
         // SAFETY: sink was just allocated via heap::alloc above; refcount==1.
         unsafe { (*sink).response = result };
-        // Note (Stacked Borrows): `sink_error` is written via raw pointer
-        // by the unhandled-rejection handler during `bufferer.run()` and via
-        // `tmp_sync_error` from `on_finished_buffering`. Use a `Cell` so the
-        // exported `*mut` (via `Cell::as_ptr`, i.e. `UnsafeCell::get`) carries
-        // SharedReadWrite provenance — local `.get()` reads do NOT invalidate
-        // the stored raw pointer the way a `&`/`&mut` reborrow of a plain
-        // `mut` local would.
+        // `Cell` so the exported `*mut` (via `Cell::as_ptr`) carries
+        // SharedReadWrite provenance: `write_tmp_sync_error` writes through the
+        // raw pointer, local `.get()` reads must not invalidate it.
         let sink_error: core::cell::Cell<JSValue> = core::cell::Cell::new(JSValue::ZERO);
-        let sink_error_ptr: *mut JSValue = sink_error.as_ptr();
+        // SAFETY: sink is a live heap allocation (refcount >= 1); addr of a
+        // stack local is non-null.
+        unsafe { (*sink).tmp_sync_error = Some(NonNull::new_unchecked(sink_error.as_ptr())) };
+        scopeguard::defer! { sink_error.get().ensure_still_alive(); }
         // SAFETY: original is a live *Response passed from begin_transform; its
         // JS wrapper is on the caller's stack.
         let input_size = unsafe { (*original).get_body_len() };
-        // SAFETY: bun_vm() returns the live VM raw ptr; VM outlives this fn.
-        let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-
-        // Since we're still using vm.waitForPromise, we have to also override
-        // the error rejection handler. That way, we can propagate errors to the
-        // caller.
-        let scope = vm.unhandled_rejection_scope();
-        let prev_unhandled_pending_rejection_to_capture = vm.unhandled_pending_rejection_to_capture;
-        vm.unhandled_pending_rejection_to_capture = Some(sink_error_ptr);
-        // SAFETY: sink is a live heap allocation (refcount >= 1); sink_error_ptr
-        // is non-null (addr of stack local).
-        unsafe { (*sink).tmp_sync_error = Some(NonNull::new_unchecked(sink_error_ptr)) };
-        vm.on_unhandled_rejection =
-            VirtualMachine::on_quiet_unhandled_rejection_handler_capture_value;
-        // Read the *live* slot at scope exit (Cell shares provenance with the
-        // raw-pointer writers).
-        scopeguard::defer! {
-            sink_error.get().ensure_still_alive();
-            // SAFETY: VM outlives this guard (sync stack frame).
-            let vm = VirtualMachine::get().as_mut();
-            vm.unhandled_pending_rejection_to_capture = prev_unhandled_pending_rejection_to_capture;
-            scope.apply(vm);
-        }
 
         // The handler closures point into `Box`es owned by `(*sink).context`,
         // which `sink` keeps alive for the rewriter's whole lifetime.
@@ -885,25 +858,17 @@ impl BufferOutputSink {
             ((*sink).global, (*sink).response, (*sink).rewriter)
         };
 
-        // Install the capture slot `handler_callback` writes to. `init()`
-        // already does this for the sync path, but on the async path `init()`
-        // has returned and torn its scope down; without this the handler's
-        // error is lost and the caller only sees the generic lol-html string.
-        // Note (Stacked Borrows): `Cell::as_ptr` yields SharedReadWrite
-        // provenance, so local `.get()` reads don't invalidate the stored raw
-        // pointer.
+        // Capture slot `handler_callback` writes the thrown value / rejection
+        // into; forwarded to the caller below in place of the generic lol-html
+        // string. `Cell::as_ptr` yields SharedReadWrite provenance so `.get()`
+        // reads don't invalidate the raw pointer the VM stores.
         let captured: core::cell::Cell<JSValue> = core::cell::Cell::new(JSValue::ZERO);
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        let scope = vm.unhandled_rejection_scope();
         let prev_capture = vm.unhandled_pending_rejection_to_capture;
         vm.unhandled_pending_rejection_to_capture = Some(captured.as_ptr());
-        vm.on_unhandled_rejection =
-            VirtualMachine::on_quiet_unhandled_rejection_handler_capture_value;
         scopeguard::defer! {
             captured.get().ensure_still_alive();
-            let vm = VirtualMachine::get().as_mut();
-            vm.unhandled_pending_rejection_to_capture = prev_capture;
-            scope.apply(vm);
+            VirtualMachine::get().as_mut().unhandled_pending_rejection_to_capture = prev_capture;
         }
 
         let deliver_async = |e: &lol_html::errors::RewritingError,
@@ -1275,17 +1240,7 @@ where
         Ok(v) => v,
         Err(_) => {
             if let Some(exc) = scope.exception() {
-                let exc_value = JSValue::from_cell(exc.as_ptr());
-                exc_value.ensure_still_alive();
-                // The slot is a stack local in run_output_sink (conservatively
-                // scanned) read by `create_lolhtml_error` / `deliver_async`
-                // before any JSC allocation. No protect here: the reader does
-                // not unprotect, so protecting leaks one Exception root per
-                // throw (#31804).
-                if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-                    // SAFETY: VM-owned pointer set by run_output_sink.
-                    unsafe { *err_ptr = exc_value };
-                }
+                capture_handler_error(vm(), JSValue::from_cell(exc.as_ptr()));
             }
             scope.clear_exception();
             return true;
@@ -1293,12 +1248,7 @@ where
     };
 
     if let Some(exc) = scope.exception() {
-        let exc_value = JSValue::from_cell(exc.as_ptr());
-        exc_value.ensure_still_alive();
-        if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-            // SAFETY: VM-owned pointer set by run_output_sink.
-            unsafe { *err_ptr = exc_value };
-        }
+        capture_handler_error(vm(), JSValue::from_cell(exc.as_ptr()));
         scope.clear_exception();
         return true;
     }
@@ -1313,32 +1263,31 @@ where
         }
 
         if let Some(promise) = result.as_any_promise() {
-            // HTMLRewriter observes the rejection and propagates it to the
-            // caller, so this is a handled rejection. Mark it before waiting
-            // so `handle_rejected_promises()` (run by `wait_for_promise`'s
-            // tick, and again on the next event-loop turn) skips it instead of
-            // firing `process.on("unhandledRejection")`.
+            // The rejection is propagated to the caller, so mark it handled
+            // before waiting: `wait_for_promise`'s tick and the next event-loop
+            // turn both run `handle_rejected_promises()`.
             promise.set_handled(global.vm());
             vm().wait_for_promise(promise);
             let fail = promise.status() == jsc::js_promise::Status::Rejected;
             if fail {
-                // Capture the rejection directly (same slot the sync-throw arm
-                // above writes). `vm.unhandled_rejection()` is NOT equivalent:
-                // it dispatches to `process.on("unhandledRejection")` first and
-                // only reaches the capture handler when no listener exists, so
-                // with a listener the original error is lost and the caller
-                // sees the generic "rewriter has been stopped" instead.
-                let err = promise.result(global.vm());
-                err.ensure_still_alive();
-                if let Some(err_ptr) = vm().unhandled_pending_rejection_to_capture {
-                    // SAFETY: VM-owned pointer set by run_output_sink.
-                    unsafe { *err_ptr = err };
-                }
+                capture_handler_error(vm(), promise.result(global.vm()));
             }
             return fail;
         }
     }
     false
+}
+
+/// Stash the handler's thrown value / rejection in `run_output_sink`'s capture
+/// slot. The slot is a conservatively-scanned stack local read back before any
+/// JSC allocation, so no `protect()` pair is needed (protecting here without a
+/// matching unprotect in the reader leaked one root per throw: #31804).
+fn capture_handler_error(vm: &mut VirtualMachine, err: JSValue) {
+    err.ensure_still_alive();
+    if let Some(err_ptr) = vm.unhandled_pending_rejection_to_capture {
+        // SAFETY: VM-owned pointer set by run_output_sink.
+        unsafe { *err_ptr = err };
+    }
 }
 
 // ───────────────────────── ElementHandler ────────────────────────────────

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -42,6 +42,40 @@ test("onEndTag callbacks are released after the rewrite", () => {
   expect(after - before).toBe(0);
 });
 
+// https://github.com/oven-sh/bun/issues/31804
+// The sync-throw arm of handler_callback wrote the Exception cell into the
+// capture slot and JSValue::protect()ed it, but create_lolhtml_error drains
+// that slot without a matching unprotect, so every caught handler exception
+// stayed GC-rooted.
+test("handler exceptions do not leak protected Exception roots", () => {
+  const protectedExceptions = () => {
+    Bun.gc(true);
+    return heapStats().protectedObjectTypeCounts.Exception ?? 0;
+  };
+  const run = (n: number) => {
+    for (let i = 0; i < n; i++) {
+      try {
+        new HTMLRewriter()
+          .on("div", {
+            element() {
+              throw new Error("boom");
+            },
+          })
+          .transform("<div>x</div>");
+      } catch {}
+    }
+  };
+
+  run(50);
+  const before = protectedExceptions();
+  run(200);
+  const after = protectedExceptions();
+
+  // Unfixed, each of the 200 throws after the baseline left one protected
+  // Exception behind.
+  expect(after - before).toBe(0);
+});
+
 // Each .on() / .onDocument() call heap-allocates an ElementHandler / DocumentHandler
 // struct via bun.default_allocator. When the HTMLRewriter is garbage-collected,
 // LOLHTMLContext.deinit() must destroy those allocations. Previously it only

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -95,17 +95,15 @@ describe("HTMLRewriter", () => {
   describe.concurrent("handler errors propagate to the caller and not to unhandledRejection", () => {
     const handlers = {
       "sync throw": `element() { throw new Zed("boom"); }`,
+      "return Error from sync handler": `element() { return new Zed("boom"); }`,
       "async throw before first await": `async element() { throw new Zed("boom"); }`,
       "Promise.reject from sync handler": `element() { return Promise.reject(new Zed("boom")); }`,
       "async throw after await": `async element() { await 1; throw new Zed("boom"); }`,
     };
     const bodies = {
-      // is_async == false in on_finished_buffering: the body is available
-      // synchronously, so the capture scope set up by init() is still live.
+      // is_async == false in on_finished_buffering (init() still on the stack).
       "string body": `new Response("<p>1</p>")`,
-      // is_async == true: init() has returned before the handler runs, so
-      // run_output_sink must install its own capture scope for the handler's
-      // error to reach the caller.
+      // is_async == true (init() has already returned when the handler runs).
       "Bun.file body": `new Response(Bun.file("async.html"))`,
     };
     const run = async (handler, body, withListener) => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { bunEnv, bunExe, gcTick, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tempDir, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -86,19 +86,30 @@ describe("HTMLRewriter", () => {
     }
   });
 
-  // A handler that returns a rejected promise must surface that rejection to
-  // the caller *and nowhere else*: no `unhandledRejection`, and the caller
+  // A handler that throws / returns a rejected promise must surface the error
+  // to the caller *and nowhere else*: no `unhandledRejection`, and the caller
   // sees the original error (not the generic "rewriter has been stopped").
   // Under `bun test` the VM's unhandled-rejection path short-circuits to the
   // capture handler, so these must run in a child process to exercise the
   // real `process.on("unhandledRejection")` dispatch.
-  describe.concurrent("rejected handler promise does not leak unhandledRejection", () => {
+  describe.concurrent("handler errors propagate to the caller and not to unhandledRejection", () => {
     const handlers = {
+      "sync throw": `element() { throw new Zed("boom"); }`,
       "async throw before first await": `async element() { throw new Zed("boom"); }`,
       "Promise.reject from sync handler": `element() { return Promise.reject(new Zed("boom")); }`,
       "async throw after await": `async element() { await 1; throw new Zed("boom"); }`,
     };
-    const run = async (handler, withListener) => {
+    const bodies = {
+      // is_async == false in on_finished_buffering: the body is available
+      // synchronously, so the capture scope set up by init() is still live.
+      "string body": `new Response("<p>1</p>")`,
+      // is_async == true: init() has returned before the handler runs, so
+      // run_output_sink must install its own capture scope for the handler's
+      // error to reach the caller.
+      "Bun.file body": `new Response(Bun.file("async.html"))`,
+    };
+    const run = async (handler, body, withListener) => {
+      using dir = tempDir("htmlrewriter-handler-error", { "async.html": "<p>1</p>" });
       const listener =
         `let unhandled = 0;` +
         (withListener
@@ -113,7 +124,7 @@ describe("HTMLRewriter", () => {
            try {
              await new HTMLRewriter()
                .on("p", { ${handler} })
-               .transform(new Response("<p>1</p>"))
+               .transform(${body})
                .text();
            } catch (e) {
              console.log("caught", e.constructor.name, e.message);
@@ -122,6 +133,7 @@ describe("HTMLRewriter", () => {
            console.log("alive", unhandled);`,
         ],
         env: bunEnv,
+        cwd: String(dir),
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -129,19 +141,21 @@ describe("HTMLRewriter", () => {
       return { stdout: stdout.trim(), stderr, exitCode };
     };
 
-    for (const [name, handler] of Object.entries(handlers)) {
-      it(`${name} (no listener)`, async () => {
-        const { stdout, stderr, exitCode } = await run(handler, false);
-        expect(stderr).toBe("");
-        expect(stdout).toBe("caught Zed boom\nalive 0");
-        expect(exitCode).toBe(0);
-      });
-      it(`${name} (with unhandledRejection listener)`, async () => {
-        const { stdout, stderr, exitCode } = await run(handler, true);
-        expect(stderr).toBe("");
-        expect(stdout).toBe("caught Zed boom\nalive 0");
-        expect(exitCode).toBe(0);
-      });
+    for (const [bodyName, body] of Object.entries(bodies)) {
+      for (const [name, handler] of Object.entries(handlers)) {
+        it(`${bodyName}, ${name} (no listener)`, async () => {
+          const { stdout, stderr, exitCode } = await run(handler, body, false);
+          expect(stderr).toBe("");
+          expect(stdout).toBe("caught Zed boom\nalive 0");
+          expect(exitCode).toBe(0);
+        });
+        it(`${bodyName}, ${name} (with unhandledRejection listener)`, async () => {
+          const { stdout, stderr, exitCode } = await run(handler, body, true);
+          expect(stderr).toBe("");
+          expect(stdout).toBe("caught Zed boom\nalive 0");
+          expect(exitCode).toBe(0);
+        });
+      }
     }
   });
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -83,6 +83,65 @@ describe("HTMLRewriter", () => {
       expect(e.message).toBe("test");
     } finally {
       expect(caught).toBeTrue();
+    }
+  });
+
+  // A handler that returns a rejected promise must surface that rejection to
+  // the caller *and nowhere else*: no `unhandledRejection`, and the caller
+  // sees the original error (not the generic "rewriter has been stopped").
+  // Under `bun test` the VM's unhandled-rejection path short-circuits to the
+  // capture handler, so these must run in a child process to exercise the
+  // real `process.on("unhandledRejection")` dispatch.
+  describe.concurrent("rejected handler promise does not leak unhandledRejection", () => {
+    const handlers = {
+      "async throw before first await": `async element() { throw new Zed("boom"); }`,
+      "Promise.reject from sync handler": `element() { return Promise.reject(new Zed("boom")); }`,
+      "async throw after await": `async element() { await 1; throw new Zed("boom"); }`,
+    };
+    const run = async (handler, withListener) => {
+      const listener =
+        `let unhandled = 0;` +
+        (withListener
+          ? `process.on("unhandledRejection", e => { unhandled++; console.log("UNHANDLED", e?.constructor?.name); });`
+          : ``);
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `${listener}
+           class Zed extends Error {}
+           try {
+             await new HTMLRewriter()
+               .on("p", { ${handler} })
+               .transform(new Response("<p>1</p>"))
+               .text();
+           } catch (e) {
+             console.log("caught", e.constructor.name, e.message);
+           }
+           await Bun.sleep(1);
+           console.log("alive", unhandled);`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr, exitCode };
+    };
+
+    for (const [name, handler] of Object.entries(handlers)) {
+      it(`${name} (no listener)`, async () => {
+        const { stdout, stderr, exitCode } = await run(handler, false);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("caught Zed boom\nalive 0");
+        expect(exitCode).toBe(0);
+      });
+      it(`${name} (with unhandledRejection listener)`, async () => {
+        const { stdout, stderr, exitCode } = await run(handler, true);
+        expect(stderr).toBe("");
+        expect(stdout).toBe("caught Zed boom\nalive 0");
+        expect(exitCode).toBe(0);
+      });
     }
   });
 


### PR DESCRIPTION
An element/document handler that throws or returns a rejected promise was delivering the error on two channels: once to the caller awaiting `.text()`, and again as an unhandled rejection on a later event loop turn. With no `unhandledRejection` listener that sets exit code 1 even though the caller caught the error; with a listener installed it fires (twice), and the error the caller catches degrades to the generic `HTMLRewriterError: The rewriter has been stopped.` instead of the original. On an asynchronously-buffered body (`Bun.file`, `fetch`) the caller only ever saw the generic message.

Fixes #31804.

## Repro

```js
class Zed extends Error {}
try {
  await new HTMLRewriter()
    .on("p", { async element() { throw new Zed("boom"); } })
    .transform(new Response("<p>1</p>"))
    .text();
} catch (e) {
  console.log("caught:", e.constructor.name);   // caught: Zed
}
await Bun.sleep(10);
console.log("still alive");
// error: boom  (unhandled rejection, exit 1)
```

## Cause

`handler_callback` never marked the returned promise as handled, so `handleRejectedPromises()` reported it again on the next tick (and inside `wait_for_promise`'s own tick for a handler that awaits). It also routed the rejection through `vm.unhandled_rejection()`, which dispatches to `process.on("unhandledRejection")` before the quiet capture handler; with a listener installed the capture slot stayed empty and the caller got the generic lol-html message.

The capture slot was only live while `BufferOutputSink::init()` was on the stack, so for an asynchronously-buffered body the handler's error was lost even without a listener.

The sync-throw arm of the same function `protect()`ed the Exception it wrote to the capture slot, but the reader (`create_lolhtml_error`) never unprotected it, leaking one protected Exception root per caught handler throw (#31804).

## Fix

In `handler_callback`: mark the promise handled before `wait_for_promise`, and write the thrown value / rejection directly to the capture slot via `capture_handler_error()` (no `protect()`, no detour through `vm.unhandled_rejection()`).

In `run_output_sink`: install the capture slot around `write()`/`end()` so it is live on both the sync and async body paths, and have the async error arm deliver the captured JS value as `ValueError::JSValue` instead of the stringified lol-html error. Only the capture slot is touched; `on_unhandled_rejection` is left alone so an unrelated rejection that happens while a handler awaits is still reported normally.

`init()` no longer needs its own capture scope (dropped).

## Tests

- `html-rewriter.test.js`: 16 subprocess cases (sync throw / async throw before first await / `Promise.reject` / async throw after await, each against a string body and a `Bun.file` body, each with and without an `unhandledRejection` listener). All assert the caller catches the original error class, stderr is empty, the listener never fires, and exit code is 0.
- `html-rewriter-leak.test.ts`: `heapStats().protectedObjectTypeCounts.Exception` stays flat across 200 caught handler throws.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 18 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter-leak.test.ts test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (be484458e)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [19.23ms]
(pass) HTMLRewriter > error inside element handler [8.21ms]
(pass) HTMLRewriter > error inside element handler (string) [5.97ms]
(pass) HTMLRewriter > fast async error inside element handler [25.97ms]
(pass) HTMLRewriter > slow async error inside element handler [26.05ms]
(pass) HTMLRewriter > handler errors propagate to the caller and not to unhandledRejection > string body, sync throw (no listener) [620.51ms]
(pass) HTMLRewriter > handler errors propagate to the caller and not to unhandledRejection > string body, sync throw (with unhandledRejection listener) [752.59ms]
141 | 
142 |     for (const [bodyName, body] of Object.entries(bodies)) {
143 |       for (const [name, handler] of Object.entries(handlers)) {
144 |         it(`${bodyName}, ${name} (no listener)`, async () => {
145 |           const { stdout, stderr, exitCode } = await run(h
... (truncated)

release without fix: 18 failed, 2 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [1.30ms]
(pass) HTMLRewriter > error inside element handler [2.14ms]
(pass) HTMLRewriter > error inside element handler (string) [0.14ms]
(pass) HTMLRewriter > fast async error inside element handler [1.21ms]
(pass) HTMLRewriter > slow async error inside element handler [2.16ms]
142 |     for (const [bodyName, body] of Object.entries(bodies)) {
143 |       for (const [name, handler] of Object.entries(handlers)) {
144 |         it(`${bodyName}, ${name} (no listener)`, async () => {
145 |           const { stdout, stderr, exitCode } = await run(handler, body, false);
146 |           expect(stderr).toBe("");
147 |           expect(stdout).toBe("caught Zed boom\nalive 0");
                               ^
error: expect(received).toBe(expected)

- "caught Zed boom
+ "caught Error The rewriter has been stopped.
  alive 0"

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/workerd/html-rewriter.test.js:147:26)
148 |           expect(exitCode).toBe(0);
149 |         });
150 |         it(`${bodyName}, ${name} (with unhandledRejection l
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/workerd/html-rewriter-leak.test.ts test/js/workerd/html-rewriter.test.js
bun test v1.4.0 (be484458e)

test/js/workerd/html-rewriter.test.js:
(pass) HTMLRewriter > error handling [11.76ms]
(pass) HTMLRewriter > error inside element handler [7.23ms]
(pass) HTMLRewriter > error inside element handler (string) [5.70ms]
(pass) HTMLRewriter > fast async error inside element handler [22.21ms]
(pass) HTMLRewriter > slow async error inside element handler [28.59ms]
(pass) HTMLRewriter > handler errors propagate to the caller and not to unhandledRejection > string body, return Error from sync handler (no listener) [394.54ms]
(pass) HTMLRewriter > handler errors propagate to the caller and not to unhandledRejection > string body, return Error from sync handler (with unhandledRejection listener) [391.49ms]
(pass) HTMLRewriter > handler errors propagate to the caller and not to unhandledRejection > string body, sync throw (with unhandledRejection listener) [665.08ms]
(pass) HTMLRewriter > handler errors propagate to the caller and not to un
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     be484458e3
  features     baseline

22 deps, 108 codegen, 1171 objects in 3196ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch picohttpparser
[picohttpparser] up to date
[2/1234] fetch zlib
[zlib] up to date
[3/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1234] fetch tinycc
[tinycc] up to date
[6/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1234] subst deps/zlib/zlib.h
[8/1234] subst deps/zlib/zconf.h
[9/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1234] fetch brotli
[brotli] up to date
[11/1234] fetch zstd
[zstd] up to date
[12/1234] gen Pro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/html_rewriter.rs           | 126 +++++++++++++----------------
 test/js/workerd/html-rewriter-leak.test.ts |  34 ++++++++
 test/js/workerd/html-rewriter.test.js      |  73 ++++++++++++++++-
 3 files changed, 161 insertions(+), 72 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/api/html_rewriter.rs               14     17      0
test/js/workerd/html-rewriter-leak.test.ts      1      1      0
test/js/workerd/html-rewriter.test.js           4      7      0
```

</details>

<!-- robobun:evidence:end -->