### PR TITLE
parser: treat top-level return as a CommonJS hint

### DIFF
--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -26,11 +26,6 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
         parts: &mut BumpVec<'bump, js_ast::Part>,
         bump: &'bump Bump,
     ) -> Result<(), bun_alloc::AllocError> {
-        // Skip transform if there's a top-level return (indicates module pattern)
-        if self.has_top_level_return {
-            return Ok(());
-        }
-
         // Collect all statements
         let mut total_stmts_count: usize = 0;
         for part in parts.iter() {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1533,7 +1533,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<(), Error> {
         // Forbid top-level return inside modules with ECMAScript-style exports
         if p.fn_or_arrow_data_visit.is_outside_fn_or_arrow {
-            if !p.is_file_considered_to_have_esm_exports {
+            if !p.is_file_considered_to_have_esm_exports
+                && p.esm_import_keyword.len == 0
+                && !p.has_import_meta
+            {
                 p.has_top_level_return = true;
             }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1533,6 +1533,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<(), Error> {
         // Forbid top-level return inside modules with ECMAScript-style exports
         if p.fn_or_arrow_data_visit.is_outside_fn_or_arrow {
+            if !p.is_file_considered_to_have_esm_exports {
+                p.has_top_level_return = true;
+            }
+
             let where_ = if p.esm_export_keyword.len > 0 {
                 p.esm_export_keyword
             } else if p.top_level_await_keyword.len > 0 {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -48,7 +48,8 @@ bun_core::declare_scope!(cache, visible);
 /// bindings from the compiled bytecode after the module-loader rewrite, so the
 /// record no longer carries them; blobs written in the old numbering must not
 /// be read back.
-const EXPECTED_VERSION: u32 = 24;
+/// Version 25: a bare top-level `return` now classifies a module as CommonJS (#8908).
+const EXPECTED_VERSION: u32 = 25;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -577,6 +577,97 @@ describe("bundler", () => {
     },
   });
 
+  // ============================================================================
+  // Top-level `return` is only legal inside the CJS function wrapper, so its
+  // presence must force the module to be treated as CommonJS even when no other
+  // CJS marker (module/exports/__dirname/...) appears.
+  // https://github.com/oven-sh/bun/issues/8908
+  // ============================================================================
+
+  itBundled("cjs/TopLevelReturnEntryBrowser", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log("before");
+        return;
+        console.log("after");
+      `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__commonJS");
+    },
+    run: { stdout: "before" },
+  });
+
+  itBundled("cjs/TopLevelReturnEntryBun", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log("before");
+        return;
+        console.log("after");
+      `,
+    },
+    target: "bun",
+    run: { stdout: "before" },
+  });
+
+  itBundled("cjs/TopLevelReturnEntryNode", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log("before");
+        return;
+        console.log("after");
+      `,
+    },
+    target: "node",
+    run: { stdout: "before" },
+  });
+
+  itBundled("cjs/TopLevelReturnImported", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./lib.js";
+        console.log("entry");
+      `,
+      "/lib.js": /* js */ `
+        console.log("lib: before");
+        if (1) return;
+        console.log("lib: after");
+      `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__commonJS");
+    },
+    run: { stdout: "lib: before\nentry" },
+  });
+
+  itBundled("cjs/TopLevelReturnNested", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log("A");
+        {
+          if (1) return;
+        }
+        console.log("B");
+      `,
+    },
+    run: { stdout: "A" },
+  });
+
+  // Negative: a return inside a function must not flip the module to CJS.
+  itBundled("cjs/ReturnInsideFunctionIsNotTopLevel", {
+    files: {
+      "/entry.js": /* js */ `
+        function f() { return 1; }
+        const g = () => { return 2; };
+        console.log(f() + g());
+      `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__commonJS");
+    },
+    run: { stdout: "3" },
+  });
+
   // Test 28: export * from an external package whose module.exports is null.
   // CJS output emits __reExport(exports, require("ext"), module.exports) with
   // the raw require() result, so __reExport itself must tolerate null.

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -1545,6 +1545,7 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/TopLevelReturnForbiddenImport", {
+    todo: true,
     files: {
       "/entry.js": /* js */ `
         console.log('A');

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -1545,7 +1545,6 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/TopLevelReturnForbiddenImport", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         console.log('A');

--- a/test/cli/run/commonjs-no-export.test.ts
+++ b/test/cli/run/commonjs-no-export.test.ts
@@ -36,21 +36,25 @@ describe.concurrent("commonjs-no-export", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("top-level return does not flip an .mjs file to CommonJS", async () => {
-    using dir = tempDir("cjs-top-level-return-mjs", {
-      "entry.mjs": `return 1;\n`,
+  for (const [label, source] of [
+    [".mjs", { "entry.mjs": `return 1;\n` }],
+    ["import statement", { "entry.js": `import "node:os";\nreturn 1;\n` }],
+    ["import.meta", { "entry.js": `void import.meta;\nreturn 1;\n` }],
+  ] as const) {
+    test(`top-level return does not flip a file with ${label} to CommonJS`, async () => {
+      using dir = tempDir("cjs-top-level-return-esm", source);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", join(String(dir), Object.keys(source)[0])],
+        env: bunEnv,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("Return statements are only valid inside functions");
+      expect(stdout).toBe("");
+      expect(exitCode).not.toBe(0);
     });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", join(String(dir), "entry.mjs")],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("Return statements are only valid inside functions");
-    expect(stdout).toBe("");
-    expect(exitCode).not.toBe(0);
-  });
+  }
 
   test("top-level return switches a required module to CommonJS", async () => {
     using dir = tempDir("cjs-top-level-return-require", {

--- a/test/cli/run/commonjs-no-export.test.ts
+++ b/test/cli/run/commonjs-no-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "path";
 
 describe.concurrent("commonjs-no-export", () => {
@@ -14,6 +14,58 @@ describe.concurrent("commonjs-no-export", () => {
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
     expect(stdout.trim().endsWith("--pass--")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/8908
+  // A bare top-level `return` is only legal inside the CJS function wrapper, so
+  // its presence alone must switch the module to CommonJS.
+  test("top-level return switches an entry point to CommonJS", async () => {
+    using dir = tempDir("cjs-top-level-return-entry", {
+      "entry.js": `console.log("before");\nreturn;\nconsole.log("after");\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", join(String(dir), "entry.js")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("before\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("top-level return does not flip an .mjs file to CommonJS", async () => {
+    using dir = tempDir("cjs-top-level-return-mjs", {
+      "entry.mjs": `return 1;\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", join(String(dir), "entry.mjs")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Return statements are only valid inside functions");
+    expect(stdout).toBe("");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("top-level return switches a required module to CommonJS", async () => {
+    using dir = tempDir("cjs-top-level-return-require", {
+      "main.js": `const lib = require("./lib.js"); console.log("got", JSON.stringify(lib));`,
+      "lib.js": `console.log("lib: before");\nif (typeof global !== "undefined") return;\nconsole.log("lib: after");\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", join(String(dir), "main.js")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("lib: before\ngot {}\n");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/transpiler/repl-transform.test.ts
+++ b/test/js/bun/transpiler/repl-transform.test.ts
@@ -72,6 +72,11 @@ describe("Bun.Transpiler replMode", () => {
       expect(result).toContain("console.log(this)");
       expect(result).not.toContain("console.log(exports)");
     });
+
+    test("top-level return is still wrapped in the IIFE", () => {
+      const result = transpiler.transformSync("return 42");
+      expect(result.trim()).toBe("(() => {\n  return 42;\n})();");
+    });
   });
 
   describe("REPL session with node:vm", () => {


### PR DESCRIPTION
Fixes #8908.

## Repro

```js
// entry.js
return 1;
```

```
$ bun build entry.js
// entry.js
return 1;

$ bun build entry.js | bun -
SyntaxError: Return statements are only valid inside functions.
```

The bundler emits the `return` at the top level of the output, which is a syntax error in every module format. The runtime path hits the same thing: `bun entry.js` hands the file to JSC unwrapped and dies with the same SyntaxError, whereas Node runs it as CJS and exits 0.

## Cause

`p.has_top_level_return` is declared on the parser state and read in the `exports_kind` determination (alongside `uses_exports_ref`, `uses_module_ref`, `has_with_scope`) as well as in the "This file is CommonJS because top-level return was used" diagnostic note. But nothing ever assigns it `true`. Every read has been dead since the field was added.

## Fix

Set the flag in `s_return` during the visit pass when we are outside any function/arrow and the file has no ES-module signal: not `.mjs` / `"type": "module"`, no `export` keyword, no top-level `await`, no `import` statement, no `import.meta`. The `exports_kind` logic and the CJS wrapper already handle the rest. A previously dead guard in `apply_repl_transforms` that would have changed REPL behaviour once this flag went live is removed so `return 42` at the prompt is unchanged.

`RuntimeTranspilerCache`'s version is bumped so entries written by an older build (which classified these files as `Esm`) are invalidated rather than replaying the old output on a hit.

## Why this is correct

A bare `return` at module scope is only legal inside the CommonJS function wrapper; it is a syntax error in ESM and in script mode. So in an ambiguous `.js` file its presence is as strong a CJS signal as `module.exports`, and both esbuild and Node treat it that way. With the flag set the bundler now wraps such a file in `__commonJS` (so the output runs), and the runtime now loads it as CJS (matching Node). Files that already have an ES-module signal are left alone, so `.mjs`, `"type": "module"`, `import ...`, `import.meta`, `export` and top-level `await` all keep their existing Node-matching SyntaxError.

## Verification

```
$ bun build entry.js
var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);

// entry.js
var require_entry = __commonJS(function() {
  return 1;
});
export default require_entry();
```

New tests cover the bundler (entry/browser/bun/node targets, imported dep, nested block, and the negative "return inside a function does not flip to CJS" case), the runtime (entry point, `require()`d dep, and `.mjs` / `import` / `import.meta` stay ESM), and the REPL transform.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts test/cli/run/commonjs-no-export.test.ts test/js/bun/transpiler/repl-transform.test.ts
bun test v1.4.0 (48699ad68)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [901.27ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [498.54ms]
(pass) bundler > cjs/__toESM_import_syntax_function [444.93ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [400.01ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [584.40ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [476.18ms]
(pass) bundler > cjs/__toESM_target_node [406.20ms]
(pass) bundler > cjs/__toESM_target_browser [422.56ms]
(pass) bundler > cjs/__toESM_target_bun [420.79ms]
(pass) bundler > cjs/__toESM_format_esm [421.18ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [465.39ms]
(pass) bundler > cjs/__toESM_mjs_reexport [779.55ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [419.52ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [617.16ms]
(pass) bundler 
... (truncated)

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [118.10ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [94.21ms]
(pass) bundler > cjs/__toESM_import_syntax_function [113.33ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [22.04ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [77.48ms]
runtime failed file: /tmp/bun-build-tests/bun-B7nPhy/cjs/__toESM_import_syntax_namespace/out.js
stdout output:
{"foo":"foo","bar":"bar"}
---
expected stdout:
{"bar":"bar","foo":"foo"}
---
1843 |               console.log(`---`);
1844 |               console.log(`expected ${name}:`);
1845 |               console.log(expected);
1846 |               console.log(`---`);
1847 |             }
1848 |             expect(result).toBe(expected);
                                  ^
error: expect(received).toBe(expected)

Expected: "{"bar":"bar","foo":"foo"}"
Received: "{"foo":"foo","bar":"bar"}"

      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1848:28)
(fail) bundler > cjs/__toESM_import_syntax_namespace [55.48ms]
(pass) bundler > cjs/__toESM_target_node [43.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_cjs.test.ts test/cli/run/commonjs-no-export.test.ts test/js/bun/transpiler/repl-transform.test.ts
bun test v1.4.0 (48699ad68)

test/bundler/bundler_cjs.test.ts:
(pass) bundler > cjs/__toESM_import_syntax_with_esModule [950.40ms]
(pass) bundler > cjs/__toESM_import_syntax_without_esModule [602.26ms]
(pass) bundler > cjs/__toESM_import_syntax_function [514.70ms]
(pass) bundler > cjs/__toESM_import_syntax_primitive [461.32ms]
(pass) bundler > cjs/__toESM_import_syntax_named_and_default [512.48ms]
(pass) bundler > cjs/__toESM_import_syntax_namespace [470.59ms]
(pass) bundler > cjs/__toESM_target_node [614.31ms]
(pass) bundler > cjs/__toESM_target_browser [472.96ms]
(pass) bundler > cjs/__toESM_target_bun [470.98ms]
(pass) bundler > cjs/__toESM_format_esm [503.72ms]
(pass) bundler > cjs/__toESM_format_cjs_with_import [832.46ms]
(pass) bundler > cjs/__toESM_mjs_reexport [538.70ms]
(pass) bundler > cjs/__toESM_mjs_reexport_with_esModule [506.27ms]
(pass) bundler > cjs/__toESM_deep_reexport_chain [590.99ms]
(pass) bundler 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     48699ad686
  features     baseline

22 deps, 108 codegen, 1171 objects in 1806ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] gen bindgenv2
[2/1234] gen ErrorCode+*.h
[3/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[6/1234] gen .bind.ts → GeneratedBindings.cpp
[7/1234] fetch zlib
[zlib] up to date
[8/1234] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [274.00ms]
[9/1234] fetch picohttpparser
[picohttpparser] up to date
[10/1234] fetch libjpeg-tu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/repl_transforms.rs              |  5 --
 src/js_parser/visit/visit_stmt.rs             |  7 +++
 src/jsc/RuntimeTranspilerCache.rs             |  3 +-
 test/bundler/bundler_cjs.test.ts              | 91 +++++++++++++++++++++++++++
 test/cli/run/commonjs-no-export.test.ts       | 58 ++++++++++++++++-
 test/js/bun/transpiler/repl-transform.test.ts |  5 ++
 6 files changed, 162 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/repl_transforms.rs                   4      3      0
src/js_parser/visit/visit_stmt.rs                  2      3      0
src/jsc/RuntimeTranspilerCache.rs                  1      1      0
test/bundler/bundler_cjs.test.ts                   3      2      0
test/cli/run/commonjs-no-export.test.ts            2      3      0
test/js/bun/transpiler/repl-transform.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->