### PR TITLE
bundler: wrap CJS module when exports.x appears in braceless control flow

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -309,6 +309,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub commonjs_named_exports_needs_conversion: u32,
     pub had_commonjs_named_exports_this_visit: bool,
     pub commonjs_replacement_stmts: StmtNodeList,
+    /// Nesting depth inside `visit_single_stmt` (braceless control-flow bodies).
+    /// Used alongside the scope check to decide whether an expression statement
+    /// is truly at the module top level for CommonJS-to-ESM export lowering.
+    pub visit_single_stmt_depth: u32,
 
     pub parse_pass_symbol_uses: ParsePassSymbolUsageType<'a>,
 
@@ -9138,6 +9142,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             commonjs_named_exports_needs_conversion: u32::MAX,
             had_commonjs_named_exports_this_visit: false,
             commonjs_replacement_stmts: js_ast::StmtNodeList::EMPTY,
+            visit_single_stmt_depth: 0,
             parse_pass_symbol_uses: None,
             has_commonjs_export_names: false,
             should_fold_typescript_constant_expressions: false,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -762,6 +762,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub fn visit_single_stmt(&mut self, stmt: Stmt, kind: StmtsKind) -> Stmt {
+        // Braceless if/else/while/do-while bodies do not push a scope, so track
+        // nesting here for the `is_top_level` check in `s_expr` to avoid
+        // emitting an `export {}` clause inside control flow (#11032).
+        self.visit_single_stmt_depth += 1;
+        let result = self.visit_single_stmt_inner(stmt, kind);
+        self.visit_single_stmt_depth -= 1;
+        result
+    }
+
+    fn visit_single_stmt_inner(&mut self, stmt: Stmt, kind: StmtsKind) -> Stmt {
         if matches!(stmt.data, StmtData::SBlock(_)) {
             return self.visit_single_stmt_block(stmt, kind);
         }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1366,7 +1366,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             && (p.options.features.minify_syntax && data.value.is_primitive_literal());
         p.stmt_expr_value = data.value.data;
 
-        let is_top_level = p.current_scope == p.module_scope;
+        let is_top_level = p.current_scope == p.module_scope && p.visit_single_stmt_depth == 0;
         if p.should_unwrap_common_js_to_esm() {
             p.commonjs_named_exports_needs_conversion = if is_top_level {
                 u32::MAX

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -392,4 +392,137 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
+  // https://github.com/oven-sh/bun/issues/11032
+  itBundled("cjs2esm/ExportsInBracelessIfElse", {
+    files: {
+      "/entry.js": /* js */ `
+        import { x } from './mod.cjs';
+        console.log(x);
+      `,
+      "/mod.cjs": /* js */ `
+        if (!globalThis.NEVER_SET) exports.x = "yes"; else exports.x = "no";
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/mod.cjs"],
+    },
+    onAfterBundle(api) {
+      const text = api.readFile("/out.js");
+      expect(text).not.toContain("__INVALID__REF__");
+      expect(text).not.toContain("tagSymbol");
+    },
+    run: {
+      stdout: "yes",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/11032
+  itBundled("cjs2esm/ExportsInBracelessIf", {
+    files: {
+      "/entry.js": /* js */ `
+        import { x } from './mod.cjs';
+        console.log(x);
+      `,
+      "/mod.cjs": /* js */ `
+        if (!globalThis.NEVER_SET) exports.x = "yes";
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/mod.cjs"],
+    },
+    onAfterBundle(api) {
+      const text = api.readFile("/out.js");
+      expect(text).not.toContain("__INVALID__REF__");
+      expect(text).not.toContain("tagSymbol");
+    },
+    run: {
+      stdout: "yes",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/11032
+  itBundled("cjs2esm/ExportsInBracelessWhile", {
+    files: {
+      "/entry.js": /* js */ `
+        import { x } from './mod.cjs';
+        console.log(x);
+      `,
+      "/mod.cjs": /* js */ `
+        var i = 0; while (i++ < 1) exports.x = "loop";
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/mod.cjs"],
+    },
+    onAfterBundle(api) {
+      const text = api.readFile("/out.js");
+      expect(text).not.toContain("__INVALID__REF__");
+      expect(text).not.toContain("tagSymbol");
+    },
+    run: {
+      stdout: "loop",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/11032
+  itBundled("cjs2esm/ExportsInBracelessDoWhile", {
+    files: {
+      "/entry.js": /* js */ `
+        import { x } from './mod.cjs';
+        console.log(x);
+      `,
+      "/mod.cjs": /* js */ `
+        var i = 0; do exports.x = "do"; while (i++ < 0);
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/mod.cjs"],
+    },
+    onAfterBundle(api) {
+      const text = api.readFile("/out.js");
+      expect(text).not.toContain("__INVALID__REF__");
+      expect(text).not.toContain("tagSymbol");
+    },
+    run: {
+      stdout: "do",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/11032
+  itBundled("cjs2esm/ModuleExportsInBracelessIfElse", {
+    files: {
+      "/entry.js": /* js */ `
+        import { x } from './mod.cjs';
+        console.log(x);
+      `,
+      "/mod.cjs": /* js */ `
+        if (!globalThis.NEVER_SET) module.exports.x = "yes"; else module.exports.x = "no";
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/mod.cjs"],
+    },
+    onAfterBundle(api) {
+      const text = api.readFile("/out.js");
+      expect(text).not.toContain("__INVALID__REF__");
+      expect(text).not.toContain("tagSymbol");
+    },
+    run: {
+      stdout: "yes",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/11032
+  itBundled("cjs2esm/ExportsAfterBracelessIfStillOptimized", {
+    files: {
+      "/entry.js": /* js */ `
+        import { x, y } from './mod.cjs';
+        console.log(x, y);
+      `,
+      "/mod.cjs": /* js */ `
+        exports.x = "top";
+        if (!globalThis.NEVER_SET) exports.x = "overridden";
+        exports.y = "second";
+      `,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "overridden second",
+    },
+  });
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -393,6 +393,28 @@ describe("bundler", () => {
     },
   });
   // https://github.com/oven-sh/bun/issues/11032
+  itBundled("cjs2esm/ExportsInBracelessIfElseReExport", {
+    files: {
+      "/entry.js": /* js */ `
+        import { x } from './mod.cjs';
+        export { x };
+        console.log(x);
+      `,
+      "/mod.cjs": /* js */ `
+        if (!globalThis.NEVER_SET) exports.x = "yes"; else exports.x = "no";
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/mod.cjs"],
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("__INVALID__REF__");
+    },
+    run: {
+      stdout: "yes",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/11032
   itBundled("cjs2esm/ExportsInBracelessIfElse", {
     files: {
       "/entry.js": /* js */ `
@@ -405,11 +427,6 @@ describe("bundler", () => {
     },
     cjs2esm: {
       unhandled: ["/mod.cjs"],
-    },
-    onAfterBundle(api) {
-      const text = api.readFile("/out.js");
-      expect(text).not.toContain("__INVALID__REF__");
-      expect(text).not.toContain("tagSymbol");
     },
     run: {
       stdout: "yes",
@@ -429,11 +446,6 @@ describe("bundler", () => {
     cjs2esm: {
       unhandled: ["/mod.cjs"],
     },
-    onAfterBundle(api) {
-      const text = api.readFile("/out.js");
-      expect(text).not.toContain("__INVALID__REF__");
-      expect(text).not.toContain("tagSymbol");
-    },
     run: {
       stdout: "yes",
     },
@@ -451,11 +463,6 @@ describe("bundler", () => {
     },
     cjs2esm: {
       unhandled: ["/mod.cjs"],
-    },
-    onAfterBundle(api) {
-      const text = api.readFile("/out.js");
-      expect(text).not.toContain("__INVALID__REF__");
-      expect(text).not.toContain("tagSymbol");
     },
     run: {
       stdout: "loop",
@@ -475,11 +482,6 @@ describe("bundler", () => {
     cjs2esm: {
       unhandled: ["/mod.cjs"],
     },
-    onAfterBundle(api) {
-      const text = api.readFile("/out.js");
-      expect(text).not.toContain("__INVALID__REF__");
-      expect(text).not.toContain("tagSymbol");
-    },
     run: {
       stdout: "do",
     },
@@ -497,11 +499,6 @@ describe("bundler", () => {
     },
     cjs2esm: {
       unhandled: ["/mod.cjs"],
-    },
-    onAfterBundle(api) {
-      const text = api.readFile("/out.js");
-      expect(text).not.toContain("__INVALID__REF__");
-      expect(text).not.toContain("tagSymbol");
     },
     run: {
       stdout: "yes",


### PR DESCRIPTION
## Repro

```sh
$ cat mod.cjs
if (condition) exports.x = "x"; else exports.x = "y";

$ cat entry.mjs
import {x} from "./mod.cjs"; export {x};

$ bun build entry.mjs
if (condition) {
  var $x = "x";
  export { $x as x };    // invalid: export inside if body
}
export {
  __INVALID__REF__ as x   // invalid: unresolved ref
};
```

## Cause

The CJS-to-ESM lowering in `s_expr` decides whether an `exports.x = ...` assignment is at the module top level by checking `current_scope == module_scope`. A braceless `if`/`else`/`while`/`do-while` body does not push a new scope, so that check is true inside the body and the lowering emits `var $x = ...; export { $x as x };` there. `export` clauses are only valid at the module top level, so the bundle is invalid JavaScript, and the downstream re-export cannot link to the symbol and falls back to the `__INVALID__REF__` sentinel.

The braced form (`if (cond) { exports.x = ... }`) already worked because the block pushes a scope, so the assignment falls through to the deoptimized `__commonJS` wrapper via the existing `needs_decl` bookkeeping.

## Fix

Track nesting depth across `visit_single_stmt` (the shared entry point for every braceless control-flow body) and include it in the `is_top_level` check in `s_expr`. A first-seen `exports.x` inside a braceless body now follows the same path as the braced form and deoptimizes to the `__commonJS` wrapper, matching esbuild. When the export was already declared at the true top level, subsequent assignments inside braceless bodies still resolve to the existing symbol and the module stays unwrapped.

## Tests

Added to `test/bundler/bundler_cjs2esm.test.ts`:
- `cjs2esm/ExportsInBracelessIfElse`, `ExportsInBracelessIf`, `ExportsInBracelessWhile`, `ExportsInBracelessDoWhile`, `ModuleExportsInBracelessIfElse`: the affected constructs now wrap in `__commonJS`, produce no `__INVALID__REF__`/`tagSymbol`, and run with the expected stdout.
- `cjs2esm/ExportsAfterBracelessIfStillOptimized`: a top-level `exports.x` followed by a reassignment inside a braceless `if` still stays unwrapped.

5 of the 6 new tests fail on the released binary; all 6 pass with this change. Existing `bundler_cjs2esm` (16), `bundler_cjs` (28), `bundler_edgecase` (106+13 todo), `bundler_browser` (12), `transpiler` (171), and `react-compiler` (31) suites pass.

Fixes #11032