### PR TITLE
bundler: resolve require('bindings')(name) to the built .node file

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -835,7 +835,7 @@ const addon = require("./addon.node");
 console.log(addon.hello());
 ```
 
-If you're using `@mapbox/node-pre-gyp` or similar tools, the `.node` file must be required directly or it won't bundle correctly.
+Packages that load their addon via `require('bindings')('name')` (for example `better-sqlite3`) are handled automatically: Bun locates the built `.node` file under the package's `build/Release` (or `build/Debug`) directory at bundle time and embeds it. If you're using `@mapbox/node-pre-gyp` or other loaders that compute the path at runtime, the `.node` file must be required directly or it won't bundle correctly.
 
 ### Embed directories
 

--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -835,7 +835,7 @@ const addon = require("./addon.node");
 console.log(addon.hello());
 ```
 
-Packages that load their addon via `require('bindings')('name')` (for example `better-sqlite3`) are handled automatically: Bun locates the built `.node` file under the package's `build/Release` (or `build/Debug`) directory at bundle time and embeds it. If you're using `@mapbox/node-pre-gyp` or other loaders that compute the path at runtime, the `.node` file must be required directly or it won't bundle correctly.
+Packages that load their addon with the inline call `require('bindings')('name')` (for example `better-sqlite3`) are handled automatically: Bun locates the built `.node` file under the package's `build/Release` (or `build/Debug`) directory at bundle time and embeds it. The two-step form (`const b = require('bindings'); b('name')`) is not detected. If you're using `@mapbox/node-pre-gyp` or other loaders that compute the path at runtime, the `.node` file must be required directly or it won't bundle correctly.
 
 ### Embed directories
 

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -106,10 +106,7 @@ pub enum Tag {
     Bun,
     /// A builtin module, such as `node:fs` or `bun:sqlite`
     Builtin,
-    /// Parser rewrote `require('bindings')(<name>)` to `require(<name>)`.
-    /// The bundler locates the `.node` file relative to the importer's
-    /// package root (the same search the `bindings` npm package performs at
-    /// runtime) before normal resolution.
+    /// `require('bindings')(<name>)` rewritten to `require(<name>.node)`; bundler resolves it under the importer's package root.
     NativeBindings,
     /// An import to the internal runtime
     Runtime,

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -106,6 +106,11 @@ pub enum Tag {
     Bun,
     /// A builtin module, such as `node:fs` or `bun:sqlite`
     Builtin,
+    /// Parser rewrote `require('bindings')(<name>)` to `require(<name>)`.
+    /// The bundler locates the `.node` file relative to the importer's
+    /// package root (the same search the `bindings` npm package performs at
+    /// runtime) before normal resolution.
+    NativeBindings,
     /// An import to the internal runtime
     Runtime,
     /// A 'macro:' import namespace or 'with { type: "macro" }'

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6059,6 +6059,26 @@ pub mod bv2_impl {
                     }
                 }
 
+                if import_record.tag == bun_ast::ImportRecordTag::NativeBindings {
+                    import_record.tag = bun_ast::ImportRecordTag::None;
+                    if let Some(abs) = transpiler
+                        .resolver
+                        .resolve_node_gyp_bindings(source_dir, import_record.path.text)
+                    {
+                        import_record.path = bun_paths::fs::Path::init(abs);
+                    } else {
+                        // No built addon on disk. Leave the record external so the
+                        // output still contains `require("<name>.node")` and fails
+                        // with a clear message at runtime instead of a misleading
+                        // resolve error at build time.
+                        import_record.source_index = Index::INVALID;
+                        import_record
+                            .flags
+                            .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                        continue;
+                    }
+                }
+
                 let mut had_busted_dir_cache = false;
                 let resolve_result: _resolver::Result = 'inner: loop {
                     match transpiler.resolver.resolve_with_framework(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5872,11 +5872,15 @@ pub mod bv2_impl {
 
                 if import_record.tag == bun_ast::ImportRecordTag::NativeBindings {
                     import_record.tag = bun_ast::ImportRecordTag::None;
-                    if let Some(abs) = self
-                        .transpiler
-                        .resolver
-                        .resolve_node_gyp_bindings(source_dir, import_record.path.text)
-                    {
+                    let abs = if ctx.target.is_server_side() {
+                        self.transpiler
+                            .resolver
+                            .resolve_node_gyp_bindings(source_dir, import_record.path.text)
+                    } else {
+                        // Browser: `Loader::Napi` hard-errors, so skip the probe and fall through to external.
+                        None
+                    };
+                    if let Some(abs) = abs {
                         import_record.path = bun_paths::fs::Path::init(abs);
                     } else {
                         // No built addon on disk: leave `require("<name>.node")` external for runtime.

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5870,6 +5870,24 @@ pub mod bv2_impl {
                     continue;
                 }
 
+                if import_record.tag == bun_ast::ImportRecordTag::NativeBindings {
+                    import_record.tag = bun_ast::ImportRecordTag::None;
+                    if let Some(abs) = self
+                        .transpiler
+                        .resolver
+                        .resolve_node_gyp_bindings(source_dir, import_record.path.text)
+                    {
+                        import_record.path = bun_paths::fs::Path::init(abs);
+                    } else {
+                        // No built addon on disk: leave `require("<name>.node")` external for runtime.
+                        import_record.source_index = Index::INVALID;
+                        import_record
+                            .flags
+                            .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                        continue;
+                    }
+                }
+
                 if ctx.target.is_bun() {
                     if let Some(replacement) = bun_resolve_builtins::HardcodedModule::Alias::get(
                         import_record.path.text,
@@ -6055,26 +6073,6 @@ pub mod bv2_impl {
                         resolve_task.tree_shaking = transpiler.options.tree_shaking;
                         resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
                         *resolve_entry.value_ptr = resolve_task;
-                        continue;
-                    }
-                }
-
-                if import_record.tag == bun_ast::ImportRecordTag::NativeBindings {
-                    import_record.tag = bun_ast::ImportRecordTag::None;
-                    if let Some(abs) = transpiler
-                        .resolver
-                        .resolve_node_gyp_bindings(source_dir, import_record.path.text)
-                    {
-                        import_record.path = bun_paths::fs::Path::init(abs);
-                    } else {
-                        // No built addon on disk. Leave the record external so the
-                        // output still contains `require("<name>.node")` and fails
-                        // with a clear message at runtime instead of a misleading
-                        // resolve error at build time.
-                        import_record.source_index = Index::INVALID;
-                        import_record
-                            .flags
-                            .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
                         continue;
                     }
                 }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2008,6 +2008,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // `require('bindings')('<name>.node')` — rewrite to a direct require
+        // of the native addon so the bundler's napi loader can copy it.
+        // https://github.com/oven-sh/bun/issues/8895
+        if p.options.bundle && e_.args.len_u32() == 1 {
+            if let Data::ERequireString(req) = e_.target.data {
+                let idx = req.import_record_index as usize;
+                if p.import_records.items()[idx].path.text == b"bindings" {
+                    if let Data::EString(mut str_) = e_.args.slice()[0].data {
+                        str_.resolve_rope_if_needed(p.arena);
+                        let name = str_.string(p.arena).expect("unreachable");
+                        if !name.is_empty() {
+                            let record = &mut p.import_records.items_mut()[idx];
+                            // SAFETY: `name` is arena-owned via `p.arena`; see
+                            // `add_import_record_by_range_and_path`.
+                            record.path =
+                                unsafe { crate::parser::fs::Path::init(name).into_static() };
+                            record.tag = bun_ast::ImportRecordTag::NativeBindings;
+                            *e = e_.target;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
         if matches!(e_.target.data, Data::ERequireCallTarget) {
             e_.can_be_unwrapped_if_unused = E::CallUnwrap::Never;
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2017,18 +2017,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let name = str_.slice(p.arena);
                         if !name.is_empty() {
                             // Always store `<name>.node` so the record never collides with a bare builtin alias (e.g. `zlib`).
-                            let name: &[u8] = if strings::has_suffix_comptime(name, b".node") {
+                            const EXT: &[u8] = b".node";
+                            let name: &[u8] = if strings::has_suffix_comptime(name, EXT) {
                                 name
                             } else {
-                                let mut buf =
-                                    bun_alloc::ArenaVec::with_capacity_in(name.len() + 5, p.arena);
+                                let mut buf = bun_alloc::ArenaVec::with_capacity_in(
+                                    name.len() + EXT.len(),
+                                    p.arena,
+                                );
                                 buf.extend_from_slice(name);
-                                buf.extend_from_slice(b".node");
+                                buf.extend_from_slice(EXT);
                                 buf.into_bump_slice()
                             };
                             let record = &mut p.import_records.items_mut()[idx];
-                            // SAFETY: `name` is arena-owned via `p.arena`; see
-                            // `add_import_record_by_range_and_path`.
+                            // SAFETY: `name` is arena-owned via `p.arena`; see `add_import_record_by_range_and_path`.
                             record.path =
                                 unsafe { crate::parser::fs::Path::init(name).into_static() };
                             record.tag = bun_ast::ImportRecordTag::NativeBindings;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2008,17 +2008,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // `require('bindings')('<name>.node')` — rewrite to a direct require
-        // of the native addon so the bundler's napi loader can copy it.
-        // https://github.com/oven-sh/bun/issues/8895
+        // `require('bindings')('<name>')` -> `require('<name>.node')` so the napi loader copies the addon (oven-sh/bun#8895).
         if p.options.bundle && e_.args.len_u32() == 1 {
             if let Data::ERequireString(req) = e_.target.data {
                 let idx = req.import_record_index as usize;
                 if p.import_records.items()[idx].path.text == b"bindings" {
                     if let Data::EString(mut str_) = e_.args.slice()[0].data {
-                        str_.resolve_rope_if_needed(p.arena);
-                        let name = str_.string(p.arena).expect("unreachable");
+                        let name = str_.slice(p.arena);
                         if !name.is_empty() {
+                            // Always store `<name>.node` so the record never collides with a bare builtin alias (e.g. `zlib`).
+                            let name: &[u8] = if strings::has_suffix_comptime(name, b".node") {
+                                name
+                            } else {
+                                let mut buf =
+                                    bun_alloc::ArenaVec::with_capacity_in(name.len() + 5, p.arena);
+                                buf.extend_from_slice(name);
+                                buf.extend_from_slice(b".node");
+                                buf.into_bump_slice()
+                            };
                             let record = &mut p.import_records.items_mut()[idx];
                             // SAFETY: `name` is arena-owned via `p.arena`; see
                             // `add_import_record_by_range_and_path`.

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1554,7 +1554,7 @@ impl<'a> Resolver<'a> {
         source_dir: &[u8],
         binding_name: &[u8],
     ) -> Option<&'static [u8]> {
-        // `try` table from npm `bindings` 1.5.0, minus entries that embed runtime-version strings.
+        // `try` table from npm `bindings` 1.5.0, minus runtime-templated entries, reordered Release-before-Debug.
         const BINDINGS_SEARCH: &[&[&[u8]]] = &[
             &[b"build"],
             &[b"build", b"Release"],
@@ -1569,8 +1569,14 @@ impl<'a> Resolver<'a> {
             &[b"addon-build", b"default", b"install-root"],
         ];
 
-        let dir_info = self.dir_info_cached(source_dir).ok().flatten()?;
-        let module_root = dir_info.enclosing_package_json?.source.path.source_dir();
+        let mut dir_info = self.dir_info_cached(source_dir).ok().flatten()?;
+        // `enclosing_package_json` skips nameless package.json; `bindings.getRoot()` does not.
+        let module_root = loop {
+            if let Some(pkg) = dir_info.package_json() {
+                break pkg.source.path.source_dir();
+            }
+            dir_info = dir_info.get_parent()?;
+        };
 
         let mut parts: [&[u8]; 5] = [module_root, b"", b"", b"", binding_name];
         for sub in BINDINGS_SEARCH {
@@ -1581,7 +1587,7 @@ impl<'a> Resolver<'a> {
                 .fs_ref()
                 .abs_buf_checked(&parts, bufs!(native_bindings_candidate))
             else {
-                return None;
+                continue;
             };
             if let Some(found) = self.load_as_file(candidate, options::ExtOrder::DefaultDefault) {
                 return Some(found.path);

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1548,29 +1548,22 @@ impl<'a> Resolver<'a> {
         self.resolve(source_dir, import_path, kind)
     }
 
-    /// Locate a native addon the way the npm `bindings` package does at
-    /// runtime: walk up from `source_dir` to the nearest package.json, then
-    /// probe the conventional node-gyp output directories for `<name>.node`.
-    /// Used by the bundler for `require('bindings')('<name>')` so the `.node`
-    /// file gets picked up by the napi loader.
+    /// Find `<name>.node` under the importer's package root, probing the same node-gyp output dirs the npm `bindings` package does.
     pub fn resolve_node_gyp_bindings(
         &mut self,
         source_dir: &[u8],
         binding_name: &[u8],
     ) -> Option<&'static [u8]> {
-        // Paths mirror the `try` table in npm `bindings` 1.5.0, minus the
-        // legacy/waf entries that node-gyp has not produced in a decade and
-        // the ABI-versioned node-pre-gyp path. `build/Release` is what an
-        // `npm install` postinstall produces, so it is probed first.
+        // `try` table from npm `bindings` 1.5.0, minus entries that embed runtime-version strings.
         const BINDINGS_SEARCH: &[&[&[u8]]] = &[
+            &[b"build"],
             &[b"build", b"Release"],
             &[b"build", b"Debug"],
-            &[b"build"],
             &[b"out", b"Release"],
             &[b"Release"],
             &[b"out", b"Debug"],
             &[b"Debug"],
-            &[b"prebuilds"],
+            &[b"build", b"default"],
             &[b"addon-build", b"release", b"install-root"],
             &[b"addon-build", b"debug", b"install-root"],
             &[b"addon-build", b"default", b"install-root"],
@@ -1578,26 +1571,18 @@ impl<'a> Resolver<'a> {
 
         let dir_info = self.dir_info_cached(source_dir).ok().flatten()?;
         let module_root = dir_info.enclosing_package_json?.source.path.source_dir();
-        let mut name_buf = [0u8; 256];
-        let name = if strings::has_suffix_comptime(binding_name, b".node") {
-            binding_name
-        } else {
-            let n = binding_name.len();
-            if n + 5 > name_buf.len() {
-                return None;
-            }
-            name_buf[..n].copy_from_slice(binding_name);
-            name_buf[n..n + 5].copy_from_slice(b".node");
-            &name_buf[..n + 5]
-        };
 
-        let buf = bufs!(native_bindings_candidate);
-        let mut parts: [&[u8]; 5] = [module_root, b"", b"", b"", name];
+        let mut parts: [&[u8]; 5] = [module_root, b"", b"", b"", binding_name];
         for sub in BINDINGS_SEARCH {
             for (i, slot) in parts[1..4].iter_mut().enumerate() {
                 *slot = sub.get(i).copied().unwrap_or(b"");
             }
-            let candidate = self.fs_ref().abs_buf(&parts, buf);
+            let Some(candidate) = self
+                .fs_ref()
+                .abs_buf_checked(&parts, bufs!(native_bindings_candidate))
+            else {
+                return None;
+            };
             if let Some(found) = self.load_as_file(candidate, options::ExtOrder::DefaultDefault) {
                 return Some(found.path);
             }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -369,6 +369,7 @@ pub struct Bufs {
     pub path_in_global_disk_cache: PathBuffer,
     pub abs_to_rel: PathBuffer,
     pub import_path_for_standalone_module_graph: PathBuffer,
+    pub native_bindings_candidate: PathBuffer,
 
     #[cfg(windows)]
     pub win32_normalized_dir_info_cache: [u8; MAX_PATH_BYTES * 2],
@@ -1545,6 +1546,63 @@ impl<'a> Resolver<'a> {
             }
         }
         self.resolve(source_dir, import_path, kind)
+    }
+
+    /// Locate a native addon the way the npm `bindings` package does at
+    /// runtime: walk up from `source_dir` to the nearest package.json, then
+    /// probe the conventional node-gyp output directories for `<name>.node`.
+    /// Used by the bundler for `require('bindings')('<name>')` so the `.node`
+    /// file gets picked up by the napi loader.
+    pub fn resolve_node_gyp_bindings(
+        &mut self,
+        source_dir: &[u8],
+        binding_name: &[u8],
+    ) -> Option<&'static [u8]> {
+        // Paths mirror the `try` table in npm `bindings` 1.5.0, minus the
+        // legacy/waf entries that node-gyp has not produced in a decade and
+        // the ABI-versioned node-pre-gyp path. `build/Release` is what an
+        // `npm install` postinstall produces, so it is probed first.
+        const BINDINGS_SEARCH: &[&[&[u8]]] = &[
+            &[b"build", b"Release"],
+            &[b"build", b"Debug"],
+            &[b"build"],
+            &[b"out", b"Release"],
+            &[b"Release"],
+            &[b"out", b"Debug"],
+            &[b"Debug"],
+            &[b"prebuilds"],
+            &[b"addon-build", b"release", b"install-root"],
+            &[b"addon-build", b"debug", b"install-root"],
+            &[b"addon-build", b"default", b"install-root"],
+        ];
+
+        let dir_info = self.dir_info_cached(source_dir).ok().flatten()?;
+        let module_root = dir_info.enclosing_package_json?.source.path.source_dir();
+        let mut name_buf = [0u8; 256];
+        let name = if strings::has_suffix_comptime(binding_name, b".node") {
+            binding_name
+        } else {
+            let n = binding_name.len();
+            if n + 5 > name_buf.len() {
+                return None;
+            }
+            name_buf[..n].copy_from_slice(binding_name);
+            name_buf[n..n + 5].copy_from_slice(b".node");
+            &name_buf[..n + 5]
+        };
+
+        let buf = bufs!(native_bindings_candidate);
+        let mut parts: [&[u8]; 5] = [module_root, b"", b"", b"", name];
+        for sub in BINDINGS_SEARCH {
+            for (i, slot) in parts[1..4].iter_mut().enumerate() {
+                *slot = sub.get(i).copied().unwrap_or(b"");
+            }
+            let candidate = self.fs_ref().abs_buf(&parts, buf);
+            if let Some(found) = self.load_as_file(candidate, options::ExtOrder::DefaultDefault) {
+                return Some(found.path);
+            }
+        }
+        None
     }
 
     pub fn finalize_result(

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -621,6 +621,32 @@ describe("bundler", async () => {
     });
   }
 
+  // Browser target: the napi loader hard-errors, so the probe is skipped and a
+  // try/catch around `require('bindings')` falls through instead of failing the build.
+  itBundled("browser/napi-require-bindings-browser-target#8895", {
+    target: "browser",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* ts */ `
+        const addon = require("mypkg");
+        console.log(addon);
+      `,
+      "/node_modules/mypkg/package.json": `{"name":"mypkg","main":"./index.js"}`,
+      "/node_modules/mypkg/index.js": /* js */ `
+        try { module.exports = require('bindings')('mypkg_native'); }
+        catch { module.exports = { fallback: true }; }
+      `,
+      "/node_modules/mypkg/build/Release/mypkg_native.node": "<binary placeholder>",
+      "/node_modules/bindings/package.json": `{"name":"bindings","main":"./bindings.js"}`,
+      "/node_modules/bindings/bindings.js": "module.exports = () => {};",
+    },
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).some(x => x.endsWith(".node"))).toBe(false);
+      const js = api.readFile(join("/out", readdirSync(api.outdir).find(x => x.endsWith(".js"))!));
+      expect(js).toContain("fallback: true");
+    },
+  });
+
   // An addon named like a node builtin must not be hijacked by the alias table.
   itBundled("bun/napi-require-bindings-builtin-name-collision#8895", {
     target: "bun",

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -541,4 +541,81 @@ describe("bundler", async () => {
       },
     });
   });
+
+  // https://github.com/oven-sh/bun/issues/8895
+  // `require('bindings')('<name>')` is how better-sqlite3 and many other
+  // node-gyp addons locate their compiled .node file. The bundler rewrites
+  // this to a direct require so the napi loader copies the addon to output.
+  for (const withExt of [true, false]) {
+    itBundled(`bun/napi-require-bindings-pattern${withExt ? "" : "-no-ext"}#8895`, {
+      target: "bun",
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* ts */ `
+          const addon = require("mypkg");
+          console.log(addon);
+        `,
+        "/node_modules/mypkg/package.json": `{"name":"mypkg","main":"./lib/index.js"}`,
+        "/node_modules/mypkg/lib/index.js": /* js */ `
+          module.exports = require('bindings')('mypkg_native${withExt ? ".node" : ""}');
+        `,
+        "/node_modules/mypkg/build/Release/mypkg_native.node": "<binary placeholder>",
+        "/node_modules/bindings/package.json": `{"name":"bindings","main":"./bindings.js"}`,
+        "/node_modules/bindings/bindings.js": /* js */ `
+          module.exports = function () { throw new Error("bindings stub reached"); };
+        `,
+      },
+      onAfterBundle(api) {
+        const names = readdirSync(api.outdir);
+        const addon = names.find(x => x.endsWith(".node"));
+        expect(addon).toBeDefined();
+        expect(api.readFile(join("/out", addon!))).toBe("<binary placeholder>");
+
+        const js = api.readFile(join("/out", names.find(x => x.endsWith(".js"))!));
+        expect(js).toContain(`require("./${addon}")`);
+        expect(js).not.toContain("bindings stub");
+      },
+    });
+  }
+
+  itBundled("bun/napi-require-bindings-debug-dir#8895", {
+    target: "bun",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* ts */ `
+        const addon = require("mypkg");
+        console.log(addon);
+      `,
+      "/node_modules/mypkg/package.json": `{"name":"mypkg","main":"./index.js"}`,
+      "/node_modules/mypkg/index.js": `module.exports = require('bindings')('mypkg_native');`,
+      "/node_modules/mypkg/build/Debug/mypkg_native.node": "debug build",
+      "/node_modules/bindings/package.json": `{"name":"bindings","main":"./bindings.js"}`,
+      "/node_modules/bindings/bindings.js": "module.exports = () => {};",
+    },
+    onAfterBundle(api) {
+      const addon = readdirSync(api.outdir).find(x => x.endsWith(".node"));
+      expect(addon).toBeDefined();
+      expect(api.readFile(join("/out", addon!))).toBe("debug build");
+    },
+  });
+
+  itBundled("bun/napi-require-bindings-not-built#8895", {
+    target: "bun",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* ts */ `
+        const addon = require("mypkg");
+        console.log(addon);
+      `,
+      "/node_modules/mypkg/package.json": `{"name":"mypkg","main":"./index.js"}`,
+      "/node_modules/mypkg/index.js": `module.exports = require('bindings')('never_built.node');`,
+      "/node_modules/bindings/package.json": `{"name":"bindings","main":"./bindings.js"}`,
+      "/node_modules/bindings/bindings.js": "module.exports = () => {};",
+    },
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).some(x => x.endsWith(".node"))).toBe(false);
+      const js = api.readFile(join("/out", readdirSync(api.outdir).find(x => x.endsWith(".js"))!));
+      expect(js).toContain(`require("never_built.node")`);
+    },
+  });
 });

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -599,7 +599,30 @@ describe("bundler", async () => {
     },
   });
 
-  itBundled("bun/napi-require-bindings-not-built#8895", {
+  for (const withExt of [true, false]) {
+    itBundled(`bun/napi-require-bindings-not-built${withExt ? "" : "-no-ext"}#8895`, {
+      target: "bun",
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* ts */ `
+          const addon = require("mypkg");
+          console.log(addon);
+        `,
+        "/node_modules/mypkg/package.json": `{"name":"mypkg","main":"./index.js"}`,
+        "/node_modules/mypkg/index.js": `module.exports = require('bindings')('never_built${withExt ? ".node" : ""}');`,
+        "/node_modules/bindings/package.json": `{"name":"bindings","main":"./bindings.js"}`,
+        "/node_modules/bindings/bindings.js": "module.exports = () => {};",
+      },
+      onAfterBundle(api) {
+        expect(readdirSync(api.outdir).some(x => x.endsWith(".node"))).toBe(false);
+        const js = api.readFile(join("/out", readdirSync(api.outdir).find(x => x.endsWith(".js"))!));
+        expect(js).toContain(`require("never_built.node")`);
+      },
+    });
+  }
+
+  // An addon named like a node builtin must not be hijacked by the alias table.
+  itBundled("bun/napi-require-bindings-builtin-name-collision#8895", {
     target: "bun",
     outdir: "/out",
     files: {
@@ -608,14 +631,17 @@ describe("bundler", async () => {
         console.log(addon);
       `,
       "/node_modules/mypkg/package.json": `{"name":"mypkg","main":"./index.js"}`,
-      "/node_modules/mypkg/index.js": `module.exports = require('bindings')('never_built.node');`,
+      "/node_modules/mypkg/index.js": `module.exports = require('bindings')('zlib');`,
+      "/node_modules/mypkg/build/Release/zlib.node": "<zlib addon>",
       "/node_modules/bindings/package.json": `{"name":"bindings","main":"./bindings.js"}`,
       "/node_modules/bindings/bindings.js": "module.exports = () => {};",
     },
     onAfterBundle(api) {
-      expect(readdirSync(api.outdir).some(x => x.endsWith(".node"))).toBe(false);
+      const addon = readdirSync(api.outdir).find(x => x.endsWith(".node"));
+      expect(addon).toBeDefined();
+      expect(api.readFile(join("/out", addon!))).toBe("<zlib addon>");
       const js = api.readFile(join("/out", readdirSync(api.outdir).find(x => x.endsWith(".js"))!));
-      expect(js).toContain(`require("never_built.node")`);
+      expect(js).not.toMatch(/require\("zlib"\)/);
     },
   });
 });

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -578,6 +578,8 @@ describe("bundler", async () => {
     });
   }
 
+  // No node_modules/bindings here: the import record is repurposed before
+  // resolution, so the package itself never needs to be installed.
   itBundled("bun/napi-require-bindings-debug-dir#8895", {
     target: "bun",
     outdir: "/out",
@@ -589,8 +591,6 @@ describe("bundler", async () => {
       "/node_modules/mypkg/package.json": `{"name":"mypkg","main":"./index.js"}`,
       "/node_modules/mypkg/index.js": `module.exports = require('bindings')('mypkg_native');`,
       "/node_modules/mypkg/build/Debug/mypkg_native.node": "debug build",
-      "/node_modules/bindings/package.json": `{"name":"bindings","main":"./bindings.js"}`,
-      "/node_modules/bindings/bindings.js": "module.exports = () => {};",
     },
     onAfterBundle(api) {
       const addon = readdirSync(api.outdir).find(x => x.endsWith(".node"));


### PR DESCRIPTION
## What

Packages like `better-sqlite3` load their native addon with

```js
addon = require('bindings')('better_sqlite3.node');
```

The `bindings` npm package walks the caller's package root at runtime looking for `build/Release/<name>.node` (and a few fallback directories). Because the `.node` path never appears as a literal specifier, the bundler only resolved the `bindings` package's own JS and never reached the addon, so `bun build --target bun` / `--compile` produced a bundle with no `.node` file in it. In a compiled executable the bundled `bindings` code then fails with `Could not find module root given file: "/$bunfs/..."`. Packages that use static `require('./foo.linux-x64.node')` (e.g. `@node-rs/*`) were already handled; `bindings`-based packages were not.

## How

- Parser: in bundle mode, when a call's target is `require('bindings')` and the single argument is a string, retarget that same import record at `<name>.node` (the extension is appended so the record can never collide with a bare node-builtin alias like `zlib`) and tag it `NativeBindings`, dropping the outer call.
- Resolver: new `resolve_node_gyp_bindings(source_dir, name)` that finds the importer's enclosing `package.json` and probes the node-gyp output directories from the `bindings` 1.5.0 try table (`build`, `build/Release`, `build/Debug`, `out/Release`, `Release`, `out/Debug`, `Debug`, `build/default`, `addon-build/*/install-root`).
- Bundler: before the builtin alias table and `onResolve` plugins, a `NativeBindings` record is routed through the resolver helper. On success the record is rewritten to the absolute `.node` path and flows through the existing `Loader::Napi` path, which copies the file into the output and substitutes the hashed filename. If no built addon exists on disk the record is left external so the output contains `require("<name>.node")` and fails with a clear message at runtime rather than a build-time resolve error.

Because the same import record is repurposed, the `bindings` package itself is never resolved and does not need to be present in `node_modules`.

The transform only fires when `require('bindings')` is the immediate call target with a single string argument (the shape `better-sqlite3`, `zeromq`, `leveldown`, `serialport`, etc. use). Any other use of the `bindings` package is untouched.

## Tests

`test/bundler/bundler_loader.test.ts` gains six cases covering the `.node`/no-extension argument forms, the `build/Debug` fallback, the not-built external fallback for both argument forms, and an addon named after a node builtin (`zlib`).

Fixes #8895
Fixes #10964
