### PR TITLE
bundler: preserve require.resolve() specifier instead of emitting absolute path

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2137,6 +2137,42 @@ pub mod bv2_impl {
             true
         }
 
+        /// `should_skip_require_resolve_enqueue` for the post-plugin-dispatch
+        /// paths, where the importer's `Source` and `ImportRecord` are reached
+        /// via graph indices rather than being in scope.
+        fn should_skip_require_resolve_for_importer(
+            &mut self,
+            ir: &jsc_api::JSBundler::MiniImportRecord,
+            bake_graph: bake::Graph,
+        ) -> bool {
+            if ir.kind != ImportKind::RequireResolve || self.dev_server.is_some() {
+                return false;
+            }
+            let handles_import_errors = self.graph.ast.items_import_records()
+                [ir.importer_source_index as usize]
+                .as_slice()
+                .get(ir.import_record_index as usize)
+                .is_some_and(|r| {
+                    r.flags
+                        .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                });
+            // SAFETY: `input_files` is not mutated by the callee; the detach
+            // avoids a `&mut self` vs `&self.graph` overlap.
+            let source: &bun_ast::Source = unsafe {
+                bun_ptr::detach_lifetime_ref(
+                    &self.graph.input_files.items_source()[ir.importer_source_index as usize],
+                )
+            };
+            self.should_skip_require_resolve_enqueue(
+                ir.kind,
+                source,
+                ir.range,
+                &ir.specifier,
+                handles_import_errors,
+                bake_graph,
+            )
+        }
+
         /// This runs on the Bundle Thread.
         pub fn run_resolver(
             &mut self,
@@ -2161,29 +2197,10 @@ pub mod bv2_impl {
                     &import_record.source_file,
                     &import_record.specifier,
                 ) {
+                    if self
+                        .should_skip_require_resolve_for_importer(import_record, target.bake_graph())
                     {
-                        let handles_import_errors = self.graph.ast.items_import_records()
-                            [import_record.importer_source_index as usize]
-                            .as_slice()[import_record.import_record_index as usize]
-                            .flags
-                            .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
-                        // SAFETY: `input_files` is not mutated by the helper.
-                        let source: &bun_ast::Source = unsafe {
-                            bun_ptr::detach_lifetime_ref(
-                                &self.graph.input_files.items_source()
-                                    [import_record.importer_source_index as usize],
-                            )
-                        };
-                        if self.should_skip_require_resolve_enqueue(
-                            import_record.kind,
-                            source,
-                            import_record.range,
-                            &import_record.specifier,
-                            handles_import_errors,
-                            target.bake_graph(),
-                        ) {
-                            return;
-                        }
+                        return;
                     }
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
@@ -2416,30 +2433,8 @@ pub mod bv2_impl {
                 return;
             }
 
-            {
-                let handles_import_errors = self.graph.ast.items_import_records()
-                    [import_record.importer_source_index as usize]
-                    .as_slice()[import_record.import_record_index as usize]
-                    .flags
-                    .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
-                // SAFETY: `input_files` is not mutated by the helper; the
-                // detach avoids a `&mut self` vs `&self.graph` overlap.
-                let source: &bun_ast::Source = unsafe {
-                    bun_ptr::detach_lifetime_ref(
-                        &self.graph.input_files.items_source()
-                            [import_record.importer_source_index as usize],
-                    )
-                };
-                if self.should_skip_require_resolve_enqueue(
-                    import_record.kind,
-                    source,
-                    import_record.range,
-                    &import_record.specifier,
-                    handles_import_errors,
-                    target.bake_graph(),
-                ) {
-                    return;
-                }
+            if self.should_skip_require_resolve_for_importer(import_record, target.bake_graph()) {
+                return;
             }
 
             if path.pretty.as_ptr() == path.text.as_ptr() {
@@ -4635,35 +4630,16 @@ pub mod bv2_impl {
                 }
                 jsc_api::JSBundler::ResolveValue::Success(result) => {
                     let mut out_source_index: Option<Index> = None;
-                    if !result.external && resolve.import_record.kind != ImportKind::EntryPointBuild
-                    {
-                        let handles_import_errors = this.graph.ast.items_import_records()
-                            [resolve.import_record.importer_source_index as usize]
-                            .as_slice()
-                            .get(resolve.import_record.import_record_index as usize)
-                            .is_some_and(|r| {
-                                r.flags
-                                    .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
-                            });
-                        // SAFETY: `input_files` is not mutated by the helper.
-                        let source: &bun_ast::Source = unsafe {
-                            bun_ptr::detach_lifetime_ref(
-                                &this.graph.input_files.items_source()
-                                    [resolve.import_record.importer_source_index as usize],
-                            )
-                        };
-                        if this.should_skip_require_resolve_enqueue(
-                            resolve.import_record.kind,
-                            source,
-                            resolve.import_record.range,
-                            &resolve.import_record.specifier,
-                            handles_import_errors,
+                    if !result.external
+                        && resolve.import_record.kind != ImportKind::EntryPointBuild
+                        && this.should_skip_require_resolve_for_importer(
+                            &resolve.import_record,
                             resolve.import_record.original_target.bake_graph(),
-                        ) {
-                            drop(result.namespace);
-                            drop(result.path);
-                            return;
-                        }
+                        )
+                    {
+                        drop(result.namespace);
+                        drop(result.path);
+                        return;
                     }
                     if !result.external {
                         // SAFETY: `result.{path,namespace}` are `Box<[u8]>` whose heap

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4641,8 +4641,7 @@ pub mod bv2_impl {
                 }
                 jsc_api::JSBundler::ResolveValue::Success(result) => {
                     let mut out_source_index: Option<Index> = None;
-                    if !result.external
-                        && resolve.import_record.kind != ImportKind::EntryPointBuild
+                    if !result.external && resolve.import_record.kind != ImportKind::EntryPointBuild
                     {
                         let handles_import_errors = this.graph.ast.items_import_records()
                             [resolve.import_record.importer_source_index as usize]

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2106,6 +2106,43 @@ pub mod bv2_impl {
             }
         }
 
+        /// Returns true when a `RequireResolve` import record should stop at
+        /// resolution and not be added to the bundle graph. `require.resolve()`
+        /// returns a filesystem path string at runtime, so bundling its target
+        /// is never useful: the caller needs a real path to read/spawn/stat,
+        /// not the module's exports. esbuild resolves the specifier (so the
+        /// caller still sees module-not-found errors) and then leaves the
+        /// original text in place, emitting the `require-resolve-not-external`
+        /// warning. The dev server is excluded: its `hmr.requireResolve`
+        /// runtime is a pass-through that expects the bundler to have written
+        /// the resolved module id into the record, and build machine == run
+        /// machine so the absolute path is the correct answer there.
+        fn should_skip_require_resolve_enqueue(
+            &mut self,
+            kind: ImportKind,
+            source: &bun_ast::Source,
+            range: bun_ast::Range,
+            specifier: &[u8],
+            handles_import_errors: bool,
+            bake_graph: bake::Graph,
+        ) -> bool {
+            if kind != ImportKind::RequireResolve || self.dev_server.is_some() {
+                return false;
+            }
+            if !handles_import_errors {
+                self.log_for_resolution_failures(source.path.text, bake_graph)
+                    .add_range_warning_fmt(
+                        Some(source),
+                        range,
+                        format_args!(
+                            "\"{}\" should be marked as external for use with \"require.resolve\"",
+                            bstr::BStr::new(specifier),
+                        ),
+                    );
+            }
+            true
+        }
+
         /// This runs on the Bundle Thread.
         pub fn run_resolver(
             &mut self,
@@ -2130,6 +2167,30 @@ pub mod bv2_impl {
                     &import_record.source_file,
                     &import_record.specifier,
                 ) {
+                    {
+                        let handles_import_errors = self.graph.ast.items_import_records()
+                            [import_record.importer_source_index as usize]
+                            .as_slice()[import_record.import_record_index as usize]
+                            .flags
+                            .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
+                        // SAFETY: `input_files` is not mutated by the helper.
+                        let source: &bun_ast::Source = unsafe {
+                            bun_ptr::detach_lifetime_ref(
+                                &self.graph.input_files.items_source()
+                                    [import_record.importer_source_index as usize],
+                            )
+                        };
+                        if self.should_skip_require_resolve_enqueue(
+                            import_record.kind,
+                            source,
+                            import_record.range,
+                            &import_record.specifier,
+                            handles_import_errors,
+                            target.bake_graph(),
+                        ) {
+                            return;
+                        }
+                    }
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
@@ -2359,6 +2420,32 @@ pub mod bv2_impl {
 
             if resolve_result.flags.is_external() {
                 return;
+            }
+
+            {
+                let handles_import_errors = self.graph.ast.items_import_records()
+                    [import_record.importer_source_index as usize]
+                    .as_slice()[import_record.import_record_index as usize]
+                    .flags
+                    .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
+                // SAFETY: `input_files` is not mutated by the helper; the
+                // detach avoids a `&mut self` vs `&self.graph` overlap.
+                let source: &bun_ast::Source = unsafe {
+                    bun_ptr::detach_lifetime_ref(
+                        &self.graph.input_files.items_source()
+                            [import_record.importer_source_index as usize],
+                    )
+                };
+                if self.should_skip_require_resolve_enqueue(
+                    import_record.kind,
+                    source,
+                    import_record.range,
+                    &import_record.specifier,
+                    handles_import_errors,
+                    target.bake_graph(),
+                ) {
+                    return;
+                }
             }
 
             if path.pretty.as_ptr() == path.text.as_ptr() {
@@ -4554,6 +4641,37 @@ pub mod bv2_impl {
                 }
                 jsc_api::JSBundler::ResolveValue::Success(result) => {
                     let mut out_source_index: Option<Index> = None;
+                    if !result.external
+                        && resolve.import_record.kind != ImportKind::EntryPointBuild
+                    {
+                        let handles_import_errors = this.graph.ast.items_import_records()
+                            [resolve.import_record.importer_source_index as usize]
+                            .as_slice()
+                            .get(resolve.import_record.import_record_index as usize)
+                            .is_some_and(|r| {
+                                r.flags
+                                    .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                            });
+                        // SAFETY: `input_files` is not mutated by the helper.
+                        let source: &bun_ast::Source = unsafe {
+                            bun_ptr::detach_lifetime_ref(
+                                &this.graph.input_files.items_source()
+                                    [resolve.import_record.importer_source_index as usize],
+                            )
+                        };
+                        if this.should_skip_require_resolve_enqueue(
+                            resolve.import_record.kind,
+                            source,
+                            resolve.import_record.range,
+                            &resolve.import_record.specifier,
+                            handles_import_errors,
+                            resolve.import_record.original_target.bake_graph(),
+                        ) {
+                            drop(result.namespace);
+                            drop(result.path);
+                            return;
+                        }
+                    }
                     if !result.external {
                         // SAFETY: `result.{path,namespace}` are `Box<[u8]>` whose heap
                         // allocations are moved into `this.free_list` below (in the
@@ -5993,21 +6111,16 @@ pub mod bv2_impl {
                     if let Some(_file_map_result) =
                         file_map.resolve(self.arena(), source.path.text, import_record.path.text)
                     {
-                        if import_record.kind == ImportKind::RequireResolve {
-                            if !import_record
+                        if self.should_skip_require_resolve_enqueue(
+                            import_record.kind,
+                            source,
+                            import_record.range,
+                            import_record.path.text,
+                            import_record
                                 .flags
-                                .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
-                            {
-                                self.log_for_resolution_failures(source.path.text, bake_graph)
-                                    .add_range_warning_fmt(
-                                        Some(source),
-                                        import_record.range,
-                                        format_args!(
-                                            "\"{}\" should be marked as external for use with \"require.resolve\"",
-                                            bstr::BStr::new(import_record.path.text),
-                                        ),
-                                    );
-                            }
+                                .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS),
+                            bake_graph,
+                        ) {
                             continue;
                         }
                         let mut file_map_result = _file_map_result;
@@ -6284,28 +6397,16 @@ pub mod bv2_impl {
                     continue;
                 }
 
-                // require.resolve() returns a filesystem path string at runtime,
-                // so bundling its target is never useful: the caller needs a real
-                // path to read/spawn/stat, not the module's exports. esbuild
-                // resolves the specifier (so missing-module errors above still
-                // fire) but then leaves the original text in place and never adds
-                // the file to the graph through this record. If the same file is
-                // also reached via `require()`/`import`, that record bundles it.
-                if import_record.kind == ImportKind::RequireResolve {
-                    if !import_record
+                if self.should_skip_require_resolve_enqueue(
+                    import_record.kind,
+                    source,
+                    import_record.range,
+                    import_record.path.text,
+                    import_record
                         .flags
-                        .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
-                    {
-                        self.log_for_resolution_failures(source.path.text, bake_graph)
-                            .add_range_warning_fmt(
-                                Some(source),
-                                import_record.range,
-                                format_args!(
-                                    "\"{}\" should be marked as external for use with \"require.resolve\"",
-                                    bstr::BStr::new(import_record.path.text),
-                                ),
-                            );
-                    }
+                        .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS),
+                    bake_graph,
+                ) {
                     continue;
                 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2197,9 +2197,10 @@ pub mod bv2_impl {
                     &import_record.source_file,
                     &import_record.specifier,
                 ) {
-                    if self
-                        .should_skip_require_resolve_for_importer(import_record, target.bake_graph())
-                    {
+                    if self.should_skip_require_resolve_for_importer(
+                        import_record,
+                        target.bake_graph(),
+                    ) {
                         return;
                     }
                     let file_map_result = _file_map_result;

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2106,11 +2106,7 @@ pub mod bv2_impl {
             }
         }
 
-        /// esbuild's `require-resolve-not-external` handling: a `RequireResolve`
-        /// record is resolved for diagnostics only, its path text stays as the
-        /// original specifier, and the target is not pulled into the graph.
-        /// Skipped for the dev server, whose `hmr.requireResolve` pass-through
-        /// relies on the bundler writing the resolved module id.
+        /// esbuild's `require-resolve-not-external`: warn and skip graph-enqueue for a resolved `RequireResolve` record, except under the dev server whose `hmr.requireResolve` needs the resolved id written.
         fn should_skip_require_resolve_enqueue(
             &mut self,
             kind: ImportKind,
@@ -2137,9 +2133,7 @@ pub mod bv2_impl {
             true
         }
 
-        /// `should_skip_require_resolve_enqueue` for the post-plugin-dispatch
-        /// paths, where the importer's `Source` and `ImportRecord` are reached
-        /// via graph indices rather than being in scope.
+        /// `should_skip_require_resolve_enqueue` for the post-plugin-dispatch paths where the importer's `Source` and flags are reached via graph indices.
         fn should_skip_require_resolve_for_importer(
             &mut self,
             ir: &jsc_api::JSBundler::MiniImportRecord,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2106,17 +2106,11 @@ pub mod bv2_impl {
             }
         }
 
-        /// Returns true when a `RequireResolve` import record should stop at
-        /// resolution and not be added to the bundle graph. `require.resolve()`
-        /// returns a filesystem path string at runtime, so bundling its target
-        /// is never useful: the caller needs a real path to read/spawn/stat,
-        /// not the module's exports. esbuild resolves the specifier (so the
-        /// caller still sees module-not-found errors) and then leaves the
-        /// original text in place, emitting the `require-resolve-not-external`
-        /// warning. The dev server is excluded: its `hmr.requireResolve`
-        /// runtime is a pass-through that expects the bundler to have written
-        /// the resolved module id into the record, and build machine == run
-        /// machine so the absolute path is the correct answer there.
+        /// esbuild's `require-resolve-not-external` handling: a `RequireResolve`
+        /// record is resolved for diagnostics only, its path text stays as the
+        /// original specifier, and the target is not pulled into the graph.
+        /// Skipped for the dev server, whose `hmr.requireResolve` pass-through
+        /// relies on the bundler writing the resolved module id.
         fn should_skip_require_resolve_enqueue(
             &mut self,
             kind: ImportKind,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5993,6 +5993,23 @@ pub mod bv2_impl {
                     if let Some(_file_map_result) =
                         file_map.resolve(self.arena(), source.path.text, import_record.path.text)
                     {
+                        if import_record.kind == ImportKind::RequireResolve {
+                            if !import_record
+                                .flags
+                                .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                            {
+                                self.log_for_resolution_failures(source.path.text, bake_graph)
+                                    .add_range_warning_fmt(
+                                        Some(source),
+                                        import_record.range,
+                                        format_args!(
+                                            "\"{}\" should be marked as external for use with \"require.resolve\"",
+                                            bstr::BStr::new(import_record.path.text),
+                                        ),
+                                    );
+                            }
+                            continue;
+                        }
                         let mut file_map_result = _file_map_result;
                         let mut path_primary = file_map_result.path_pair.primary;
                         let import_record_loader = import_record.loader.unwrap_or_else(|| {
@@ -6264,6 +6281,31 @@ pub mod bv2_impl {
                         resolve_result.primary_side_effects_data
                             != bun_ast::SideEffects::HasSideEffects,
                     );
+                    continue;
+                }
+
+                // require.resolve() returns a filesystem path string at runtime,
+                // so bundling its target is never useful: the caller needs a real
+                // path to read/spawn/stat, not the module's exports. esbuild
+                // resolves the specifier (so missing-module errors above still
+                // fire) but then leaves the original text in place and never adds
+                // the file to the graph through this record. If the same file is
+                // also reached via `require()`/`import`, that record bundles it.
+                if import_record.kind == ImportKind::RequireResolve {
+                    if !import_record
+                        .flags
+                        .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                    {
+                        self.log_for_resolution_failures(source.path.text, bake_graph)
+                            .add_range_warning_fmt(
+                                Some(source),
+                                import_record.range,
+                                format_args!(
+                                    "\"{}\" should be marked as external for use with \"require.resolve\"",
+                                    bstr::BStr::new(import_record.path.text),
+                                ),
+                            );
+                    }
                     continue;
                 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4626,14 +4626,11 @@ pub mod bv2_impl {
                 jsc_api::JSBundler::ResolveValue::Success(result) => {
                     let mut out_source_index: Option<Index> = None;
                     if !result.external
-                        && resolve.import_record.kind != ImportKind::EntryPointBuild
                         && this.should_skip_require_resolve_for_importer(
                             &resolve.import_record,
                             resolve.import_record.original_target.bake_graph(),
                         )
                     {
-                        drop(result.namespace);
-                        drop(result.path);
                         return;
                     }
                     if !result.external {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -4004,6 +4004,47 @@ describe.concurrent("bundler", () => {
     },
     external: ["external-pkg", "@scope/external-pkg", "{{root}}/external-file"],
   });
+  // https://github.com/evanw/esbuild/blob/main/internal/bundler_tests/bundler_default_test.go (TestRequireResolve output)
+  // Previously the resolved absolute path was written into the bundle, leaking
+  // the build machine's node_modules layout and breaking the output when the
+  // bundle is run from anywhere else (e.g. bundling jsdom).
+  itBundled("default/RequireResolvePreservesSpecifier", {
+    files: {
+      "/entry.js": /* js */ `
+        const a = require.resolve("./only-resolved.js");
+        const b = require("./also-required.js");
+        const c = require.resolve("./also-required.js");
+        let d;
+        try { d = require.resolve("./inside-try.js"); } catch {}
+        console.log(a, b, c, d);
+      `,
+      "/only-resolved.js": `module.exports = "ONLY_RESOLVED_SENTINEL";`,
+      "/also-required.js": `module.exports = "ALSO_REQUIRED_SENTINEL";`,
+      "/inside-try.js": `module.exports = "INSIDE_TRY_SENTINEL";`,
+    },
+    target: "node",
+    format: "cjs",
+    bundleWarnings: {
+      "/entry.js": [
+        '"./only-resolved.js" should be marked as external for use with "require.resolve"',
+        '"./also-required.js" should be marked as external for use with "require.resolve"',
+      ],
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // Original specifiers must be preserved verbatim.
+      expect(out).toContain('require.resolve("./only-resolved.js")');
+      expect(out).toContain('require.resolve("./also-required.js")');
+      expect(out).toContain('require.resolve("./inside-try.js")');
+      // A file reached via `require()` is bundled; a file reached only via
+      // `require.resolve()` is not.
+      expect(out).toContain("ALSO_REQUIRED_SENTINEL");
+      expect(out).not.toContain("ONLY_RESOLVED_SENTINEL");
+      expect(out).not.toContain("INSIDE_TRY_SENTINEL");
+      // No absolute paths in the output.
+      expect(out).not.toMatch(/require\.resolve\(["']\/|require\.resolve\(["'][A-Za-z]:/);
+    },
+  });
   itBundled("default/InjectMissing", {
     files: {
       "/entry.js": ``,

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -4045,6 +4045,43 @@ describe.concurrent("bundler", () => {
       expect(out).not.toMatch(/require\.resolve\(["']\/|require\.resolve\(["'][A-Za-z]:/);
     },
   });
+  // Same behaviour when an onResolve plugin matches: the record takes the
+  // plugin-dispatched resolution path instead of the direct resolver, and
+  // must still leave the specifier alone and not enqueue the target.
+  for (const [label, plugin] of [
+    // NoMatch: plugin returns undefined, run_resolver() falls back to disk.
+    ["Passthrough", (b: any) => b.onResolve({ filter: /.*/ }, () => undefined)],
+    // Success: plugin returns a concrete non-external path.
+    [
+      "Returned",
+      (b: any) =>
+        b.onResolve({ filter: /^\.\/only-resolved\.js$/ }, (args: any) => ({
+          path: path.join(args.resolveDir, "only-resolved.js"),
+        })),
+    ],
+  ] as const) {
+    itBundled(`default/RequireResolvePreservesSpecifierOnResolve${label}`, {
+      files: {
+        "/entry.js": /* js */ `
+          const a = require.resolve("./only-resolved.js");
+          const b = require("./also-required.js");
+          console.log(a, b);
+        `,
+        "/only-resolved.js": `module.exports = "ONLY_RESOLVED_SENTINEL";`,
+        "/also-required.js": `module.exports = "ALSO_REQUIRED_SENTINEL";`,
+      },
+      target: "node",
+      format: "cjs",
+      plugins: plugin,
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        expect(out).toContain('require.resolve("./only-resolved.js")');
+        expect(out).toContain("ALSO_REQUIRED_SENTINEL");
+        expect(out).not.toContain("ONLY_RESOLVED_SENTINEL");
+        expect(out).not.toMatch(/require\.resolve\(["']\/|require\.resolve\(["'][A-Za-z]:/);
+      },
+    });
+  }
   itBundled("default/InjectMissing", {
     files: {
       "/entry.js": ``,

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -4016,14 +4016,20 @@ describe.concurrent("bundler", () => {
         const c = require.resolve("./also-required.js");
         let d;
         try { d = require.resolve("./inside-try.js"); } catch {}
-        console.log(a, b, c, d);
+        const e = require.resolve("./marked-external.js");
+        console.log(a, b, c, d, e);
       `,
       "/only-resolved.js": `module.exports = "ONLY_RESOLVED_SENTINEL";`,
       "/also-required.js": `module.exports = "ALSO_REQUIRED_SENTINEL";`,
       "/inside-try.js": `module.exports = "INSIDE_TRY_SENTINEL";`,
+      "/marked-external.js": `module.exports = "MARKED_EXTERNAL_SENTINEL";`,
     },
     target: "node",
     format: "cjs",
+    external: ["{{root}}/marked-external.js"],
+    // The harness fails on an unexpected warning, so the absence of entries
+    // for ./inside-try.js (suppressed by try/catch) and ./marked-external.js
+    // (silenced by --external) is enforced here.
     bundleWarnings: {
       "/entry.js": [
         '"./only-resolved.js" should be marked as external for use with "require.resolve"',
@@ -4036,11 +4042,13 @@ describe.concurrent("bundler", () => {
       expect(out).toContain('require.resolve("./only-resolved.js")');
       expect(out).toContain('require.resolve("./also-required.js")');
       expect(out).toContain('require.resolve("./inside-try.js")');
+      expect(out).toContain('require.resolve("./marked-external.js")');
       // A file reached via `require()` is bundled; a file reached only via
       // `require.resolve()` is not.
       expect(out).toContain("ALSO_REQUIRED_SENTINEL");
       expect(out).not.toContain("ONLY_RESOLVED_SENTINEL");
       expect(out).not.toContain("INSIDE_TRY_SENTINEL");
+      expect(out).not.toContain("MARKED_EXTERNAL_SENTINEL");
       // No absolute paths in the output.
       expect(out).not.toMatch(/require\.resolve\(["']\/|require\.resolve\(["'][A-Za-z]:/);
     },

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -315,7 +315,17 @@ describe("bundler", () => {
       expect(out).toMatch(/\b_c\(\d+\)/);
       expect(out).toContain("BUNDLED_OTHER_SENTINEL");
       expect(out).not.toMatch(/require\(["']\.\/other["']\)/);
-      expect(out).not.toMatch(/require\.resolve\(["']\.\/other["']\)/);
+      // The require.resolve argument must stay the original specifier; the
+      // bundler never rewrites it to a resolved absolute path.
+      expect(out).toMatch(/\.resolve\(["']\.\/other["']\)/);
+      expect(out).not.toMatch(/\.resolve\(["'][A-Za-z]:|\.resolve\(["']\//);
+    },
+    // That the import record survived the react-compiler round-trip is
+    // observable as the bundler's require.resolve-not-external warning; if the
+    // record were lost the call would degrade to an opaque runtime call and
+    // the bundler would not see it.
+    bundleWarnings: {
+      "/entry.jsx": ['"./other" should be marked as external for use with "require.resolve"'],
     },
   });
 


### PR DESCRIPTION
## Problem

Bundling code that calls `require.resolve()` with a relative specifier writes the build machine's absolute path into the output and pulls the target file into the bundle as unreachable code. jsdom is the common real-world case:

```sh
bun add jsdom
echo 'import { JSDOM } from "jsdom"; console.log(JSDOM);' > entry.js
bun build entry.js --target=node --outfile=bundled.js
grep xhr-sync-worker bundled.js
```
```js
// node_modules/jsdom/lib/jsdom/living/xhr/xhr-sync-worker.js
var require_xhr_sync_worker = __commonJS(function() { ... });   // bundled, never referenced
...
var syncWorkerFile = __require.resolve ? __require.resolve("/tmp/repro/node_modules/jsdom/lib/jsdom/living/xhr/xhr-sync-worker.js") : null;
```

The bundle leaks the build machine's layout into the output and cannot run from any other directory.

## Cause

`resolve_import_records` treats an `ImportKind::RequireResolve` record like any other import: it resolves the specifier, overwrites `record.path.text` with the absolute path, and enqueues a `ParseTask` so the file lands in the graph. The printer then emits `path.text` verbatim. The onResolve-plugin resolution paths (`run_resolver`, the `on_resolve` Success arm) do the same.

## Fix

Match esbuild. `should_skip_require_resolve_enqueue` returns true for a `RequireResolve` record that resolved to a local (non-external) file and is called after each successful resolution in `resolve_import_records`, `run_resolver`, and the `on_resolve` Success arm:

- `path.text` stays as the original specifier
- the file is not enqueued through this record (a separate `require()`/`import` of the same file still bundles it)
- warn `"<spec>" should be marked as external for use with "require.resolve"` unless the call is inside `try`

Module-not-found errors still fire because the resolver still runs; only the overwrite/enqueue is skipped. The dev server is excluded: `hmr.requireResolve` is a pass-through that relies on the bundler writing the resolved module id, and build machine == run machine in that mode.

esbuild on the same input:
```
▲ [WARNING] "./xhr-sync-worker.js" should be marked as external for use with "require.resolve" [require-resolve-not-external]
...
var syncWorkerFile = require.resolve ? require.resolve("./xhr-sync-worker.js") : null;
```

Bun now produces the same call site and warning, and the worker file is no longer dead code in the bundle.

## Why keep the original specifier rather than invent one

`require.resolve()` returns a filesystem path string, not a module; the caller reads/spawns/stats that path. Bundling the file does nothing useful because there is no on-disk path to return for bundled content. The original relative specifier is the only value that can succeed at runtime if the user ships the file alongside the bundle (or marks it external), and it is what esbuild has always emitted. The warning tells the user which path needs handling.

## Tests

- `default/RequireResolvePreservesSpecifier`: original specifier preserved, no absolute path in output, file bundled only when also `require()`'d, warning emitted for each non-external target, warning suppressed inside `try`, warning suppressed when the target is listed in `--external`.
- `default/RequireResolvePreservesSpecifierOnResolvePassthrough` / `...OnResolveReturned`: same invariants when an `onResolve` plugin matches and either returns `undefined` (fallback to `run_resolver`) or returns a concrete path (plugin Success arm).
- `react-compiler/RequireStringPreservesImportRecord` updated: the preserved import record is now observed via the new warning, and the call site must contain `./other` rather than an absolute path.

Fixes #14011
