### PR TITLE
bun build --no-bundle: write output files when --outdir is set

### DIFF
--- a/src/ast/target.rs
+++ b/src/ast/target.rs
@@ -57,8 +57,7 @@ impl Target {
         matches!(self, Target::Node)
     }
 
-    /// What `[target]` expands to in `--entry-naming` / `--chunk-naming` /
-    /// `--asset-naming` templates.
+    /// What `[target]` expands to in `--entry-naming` and friends.
     #[inline]
     pub fn naming_placeholder(self) -> &'static [u8] {
         match self {

--- a/src/ast/target.rs
+++ b/src/ast/target.rs
@@ -57,6 +57,19 @@ impl Target {
         matches!(self, Target::Node)
     }
 
+    /// What `[target]` expands to in `--entry-naming` / `--chunk-naming` /
+    /// `--asset-naming` templates.
+    #[inline]
+    pub fn naming_placeholder(self) -> &'static [u8] {
+        match self {
+            Target::Browser => b"browser",
+            Target::Bun => b"bun",
+            Target::Node => b"node",
+            Target::BunMacro => b"macro",
+            Target::ServerComponentsSsr => b"ssr",
+        }
+    }
+
     #[inline]
     pub fn process_browser_define_value(self) -> Option<&'static str> {
         match self {

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -255,11 +255,13 @@ impl OutputFile {
                 // already written to disk
             }
             Value::Buffer { bytes } => {
-                let mut rel_path: &[u8] = &self.dest_path;
-                if self.dest_path.len() > root_dir_path.len() {
-                    rel_path = resolve_path::relative(root_dir_path, &self.dest_path);
-                }
-                // `dirname` returns `b""` when there's no separator.
+                let rel_path: &[u8] = if bun_paths::is_absolute(&self.dest_path)
+                    && self.dest_path.len() > root_dir_path.len()
+                {
+                    resolve_path::relative(root_dir_path, &self.dest_path)
+                } else {
+                    &self.dest_path
+                };
                 let parent = resolve_path::dirname::<platform::Auto>(rel_path);
                 if !parent.is_empty() && parent != b"." {
                     bun_sys::Dir::borrow(&root_dir).make_path(parent)?;

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -248,21 +248,15 @@ impl OutputFile {
         }
     }
 
-    pub fn write_to_disk(&self, root_dir: Fd, root_dir_path: &[u8]) -> Result<(), Error> {
+    /// `dest_path` is relative to `root_dir`.
+    pub fn write_to_disk(&self, root_dir: Fd) -> Result<(), Error> {
         match &self.value {
             Value::Noop => {}
             Value::Saved(_) => {
                 // already written to disk
             }
             Value::Buffer { bytes } => {
-                let rel_path: &[u8] = if bun_paths::is_absolute(&self.dest_path)
-                    && self.dest_path.len() > root_dir_path.len()
-                {
-                    resolve_path::relative(root_dir_path, &self.dest_path)
-                } else {
-                    &self.dest_path
-                };
-                let parent = resolve_path::dirname::<platform::Auto>(rel_path);
+                let parent = resolve_path::dirname::<platform::Auto>(&self.dest_path);
                 if !parent.is_empty() && parent != b"." {
                     bun_sys::Dir::borrow(&root_dir).make_path(parent)?;
                 }
@@ -275,18 +269,18 @@ impl OutputFile {
                         encoding: bun_sys::WriteFileEncoding::Buffer,
                         mode: if self.is_executable { 0o755 } else { 0o644 },
                         dirfd: root_dir,
-                        file: bun_sys::PathOrFileDescriptor::Path(rel_path),
+                        file: bun_sys::PathOrFileDescriptor::Path(&self.dest_path),
                     },
                 )?;
             }
             Value::Copy(value) => {
-                self.copy_to(root_dir_path, &value.pathname, root_dir)?;
+                self.copy_to(&value.pathname, root_dir)?;
             }
         }
         Ok(())
     }
 
-    pub(crate) fn copy_to(&self, _: &[u8], rel_path: &[u8], dir: Fd) -> Result<(), Error> {
+    pub(crate) fn copy_to(&self, rel_path: &[u8], dir: Fd) -> Result<(), Error> {
         let mut out_buf = PathBuffer::uninit();
         let fd_out = bun_sys::openat(
             dir,

--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -258,11 +258,11 @@ impl OutputFile {
                 let mut rel_path: &[u8] = &self.dest_path;
                 if self.dest_path.len() > root_dir_path.len() {
                     rel_path = resolve_path::relative(root_dir_path, &self.dest_path);
-                    // `dirname` returns `b""` when there's no separator.
-                    let parent = resolve_path::dirname::<platform::Auto>(rel_path);
-                    if !parent.is_empty() {
-                        bun_sys::Dir::borrow(&root_dir).make_path(parent)?;
-                    }
+                }
+                // `dirname` returns `b""` when there's no separator.
+                let parent = resolve_path::dirname::<platform::Auto>(rel_path);
+                if !parent.is_empty() && parent != b"." {
+                    bun_sys::Dir::borrow(&root_dir).make_path(parent)?;
                 }
 
                 let mut path_buf = PathBuffer::uninit();

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4252,10 +4252,7 @@ pub mod bv2_impl {
                             }
 
                             if template.needs(options::PlaceholderField::Target) {
-                                template.placeholder.target = <&'static str>::from(target)
-                                    .as_bytes()
-                                    .to_vec()
-                                    .into_boxed_slice();
+                                template.placeholder.target = target.naming_placeholder().into();
                             }
                             let mut v = Vec::new();
                             template

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -625,13 +625,7 @@ pub(crate) fn compute_chunks(
         if chunk.template.needs(PlaceholderField::Target) {
             // Determine the target from the AST of the entry point source
             let chunk_target = ast_targets[chunk.entry_point.source_index() as usize];
-            chunk.template.placeholder.target = match chunk_target {
-                Target::Browser => b"browser".to_vec().into_boxed_slice(),
-                Target::Bun => b"bun".to_vec().into_boxed_slice(),
-                Target::Node => b"node".to_vec().into_boxed_slice(),
-                Target::BunMacro => b"macro".to_vec().into_boxed_slice(),
-                Target::ServerComponentsSsr => b"ssr".to_vec().into_boxed_slice(),
-            };
+            chunk.template.placeholder.target = chunk_target.naming_placeholder().into();
         }
 
         if chunk.template.needs(PlaceholderField::Dir) {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2955,7 +2955,12 @@ impl<'a> Transpiler<'a> {
                     resolve_result.dirname_fd,
                     file_path.pretty,
                 ) {
-                    Some(v) => output_file.value = v,
+                    Some(v) => {
+                        if let crate::output_file::Value::Buffer { bytes } = &v {
+                            output_file.size = bytes.len();
+                        }
+                        output_file.value = v;
+                    }
                     None => return Ok(None),
                 }
             }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2786,8 +2786,7 @@ impl<'a> Transpiler<'a> {
         Ok(())
     }
 
-    /// Same check the bundler does in `generateChunksInParallel`: two inputs
-    /// rendering to one output path is an error, not a silent overwrite.
+    /// Mirrors the duplicate-path error in `generateChunksInParallel`.
     fn reject_duplicate_output_paths(&mut self) -> crate::Result<()> {
         use std::io::Write as _;
 
@@ -3045,9 +3044,7 @@ impl<'a> Transpiler<'a> {
         template
     }
 
-    /// Same template the bundler applies to entry points
-    /// (`computeChunks`), so `--no-bundle --outdir` names files the way
-    /// `bun build --outdir` does.
+    /// Mirrors the entry-point naming in `computeChunks`.
     fn transform_only_dest_path(
         &self,
         file_path_text: &[u8],

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2835,44 +2835,6 @@ impl<'a> Transpiler<'a> {
         output_file.output_kind = options::OutputKind::Chunk;
         output_file.side = None;
         output_file.entry_point_index = None;
-        output_file.dest_path = {
-            let rel_to_root = bun_paths::resolve_path::relative_platform::<
-                bun_paths::resolve_path::platform::Loose,
-                false,
-            >(&self.options.root_dir, file_path_text);
-            let pathname = Fs::PathName::init(rel_to_root);
-            let out_ext: &[u8] = if self.options.preserve_extensions {
-                pathname.ext
-            } else {
-                self.options
-                    .out_extensions
-                    .get(pathname.ext)
-                    .copied()
-                    .unwrap_or(pathname.ext)
-            };
-            let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
-            if !self.options.entry_naming.is_empty() {
-                template.data.clone_from(&self.options.entry_naming);
-            }
-            template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
-            template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
-            template.placeholder.ext = match out_ext {
-                [b'.', rest @ ..] => rest,
-                ext => ext,
-            }
-            .to_vec()
-            .into_boxed_slice();
-            if template.needs(options::PlaceholderField::Target) {
-                template.placeholder.target = <&'static str>::from(self.options.target)
-                    .as_bytes()
-                    .to_vec()
-                    .into_boxed_slice();
-            }
-            let mut v = Vec::new();
-            template.print(&mut v, true).expect("write to Vec<u8>");
-            bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut v);
-            v.into_boxed_slice()
-        };
 
         match loader {
             options::Loader::Jsx
@@ -3007,6 +2969,50 @@ impl<'a> Transpiler<'a> {
                 output_file.value = self.build_copied_file_output(file_path_text, file_path_ext)?;
             }
         }
+
+        output_file.dest_path = {
+            let rel_to_root = bun_paths::resolve_path::relative_platform::<
+                bun_paths::resolve_path::platform::Loose,
+                false,
+            >(&self.options.root_dir, file_path_text);
+            let pathname = Fs::PathName::init(rel_to_root);
+            let out_ext: &[u8] = if self.options.preserve_extensions {
+                pathname.ext
+            } else {
+                self.options
+                    .out_extensions
+                    .get(pathname.ext)
+                    .copied()
+                    .unwrap_or(pathname.ext)
+            };
+            let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
+            if !self.options.entry_naming.is_empty() {
+                template.data.clone_from(&self.options.entry_naming);
+            }
+            template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
+            template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
+            template.placeholder.ext = match out_ext {
+                [b'.', rest @ ..] => rest,
+                ext => ext,
+            }
+            .to_vec()
+            .into_boxed_slice();
+            if template.needs(options::PlaceholderField::Target) {
+                template.placeholder.target = <&'static str>::from(self.options.target)
+                    .as_bytes()
+                    .to_vec()
+                    .into_boxed_slice();
+            }
+            if template.needs(options::PlaceholderField::Hash) {
+                if let crate::output_file::Value::Buffer { bytes } = &output_file.value {
+                    template.placeholder.hash = Some(crate::ContentHasher::run(bytes));
+                }
+            }
+            let mut v = Vec::new();
+            template.print(&mut v, true).expect("write to Vec<u8>");
+            bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut v);
+            v.into_boxed_slice()
+        };
 
         Ok(Some(output_file))
     }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2970,48 +2970,57 @@ impl<'a> Transpiler<'a> {
             }
         }
 
-        output_file.dest_path = {
-            let rel_to_root = bun_paths::resolve_path::relative_platform::<
-                bun_paths::resolve_path::platform::Loose,
-                false,
-            >(&self.options.root_dir, file_path_text);
-            let pathname = Fs::PathName::init(rel_to_root);
-            let out_ext: &[u8] = if self.options.preserve_extensions {
-                pathname.ext
-            } else {
-                self.options
-                    .out_extensions
-                    .get(pathname.ext)
-                    .copied()
-                    .unwrap_or(pathname.ext)
-            };
-            let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
-            if !self.options.entry_naming.is_empty() {
-                template.data.clone_from(&self.options.entry_naming);
+        output_file.dest_path = match &output_file.value {
+            crate::output_file::Value::Copy(op) => {
+                strings::concat(&[b"./", &op.pathname])
             }
-            template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
-            template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
-            template.placeholder.ext = match out_ext {
-                [b'.', rest @ ..] => rest,
-                ext => ext,
-            }
-            .to_vec()
-            .into_boxed_slice();
-            if template.needs(options::PlaceholderField::Target) {
-                template.placeholder.target = <&'static str>::from(self.options.target)
-                    .as_bytes()
-                    .to_vec()
-                    .into_boxed_slice();
-            }
-            if template.needs(options::PlaceholderField::Hash) {
-                if let crate::output_file::Value::Buffer { bytes } = &output_file.value {
-                    template.placeholder.hash = Some(crate::ContentHasher::run(bytes));
+            value => {
+                let rel_to_root = bun_paths::resolve_path::relative_platform::<
+                    bun_paths::resolve_path::platform::Loose,
+                    false,
+                >(&self.options.root_dir, file_path_text);
+                let pathname = Fs::PathName::init(rel_to_root);
+                let out_ext: &[u8] = if self.options.preserve_extensions {
+                    pathname.ext
+                } else {
+                    self.options
+                        .out_extensions
+                        .get(pathname.ext)
+                        .copied()
+                        .unwrap_or(if loader == options::Loader::Css {
+                            pathname.ext
+                        } else {
+                            b".js"
+                        })
+                };
+                let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
+                if !self.options.entry_naming.is_empty() {
+                    template.data.clone_from(&self.options.entry_naming);
                 }
+                template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
+                template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
+                template.placeholder.ext = match out_ext {
+                    [b'.', rest @ ..] => rest,
+                    ext => ext,
+                }
+                .to_vec()
+                .into_boxed_slice();
+                if template.needs(options::PlaceholderField::Target) {
+                    template.placeholder.target = <&'static str>::from(self.options.target)
+                        .as_bytes()
+                        .to_vec()
+                        .into_boxed_slice();
+                }
+                if template.needs(options::PlaceholderField::Hash) {
+                    if let crate::output_file::Value::Buffer { bytes } = value {
+                        template.placeholder.hash = Some(crate::ContentHasher::run(bytes));
+                    }
+                }
+                let mut v = Vec::new();
+                template.print(&mut v, true).expect("write to Vec<u8>");
+                bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut v);
+                v.into_boxed_slice()
             }
-            let mut v = Vec::new();
-            template.print(&mut v, true).expect("write to Vec<u8>");
-            bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut v);
-            v.into_boxed_slice()
         };
 
         Ok(Some(output_file))

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2836,8 +2836,10 @@ impl<'a> Transpiler<'a> {
         output_file.side = None;
         output_file.entry_point_index = None;
         output_file.dest_path = {
-            let rel_to_root =
-                bun_paths::resolve_path::relative(&self.options.root_dir, file_path_text);
+            let rel_to_root = bun_paths::resolve_path::relative_platform::<
+                bun_paths::resolve_path::platform::Loose,
+                false,
+            >(&self.options.root_dir, file_path_text);
             let pathname = Fs::PathName::init(rel_to_root);
             let out_ext: &[u8] = if self.options.preserve_extensions {
                 pathname.ext
@@ -2848,12 +2850,28 @@ impl<'a> Transpiler<'a> {
                     .copied()
                     .unwrap_or(pathname.ext)
             };
-            let dir: &[u8] = if pathname.dir.is_empty() {
-                b""
-            } else {
-                pathname.dir_with_trailing_slash()
-            };
-            strings::concat(&[b"./", dir, pathname.base, out_ext])
+            let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
+            if !self.options.entry_naming.is_empty() {
+                template.data.clone_from(&self.options.entry_naming);
+            }
+            template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
+            template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
+            template.placeholder.ext = match out_ext {
+                [b'.', rest @ ..] => rest,
+                ext => ext,
+            }
+            .to_vec()
+            .into_boxed_slice();
+            if template.needs(options::PlaceholderField::Target) {
+                template.placeholder.target = <&'static str>::from(self.options.target)
+                    .as_bytes()
+                    .to_vec()
+                    .into_boxed_slice();
+            }
+            let mut v = Vec::new();
+            template.print(&mut v, true).expect("write to Vec<u8>");
+            bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut v);
+            v.into_boxed_slice()
         };
 
         match loader {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2729,6 +2729,8 @@ impl<'a> Transpiler<'a> {
             );
         }
 
+        self.reject_duplicate_output_paths()?;
+
         let outbase: Box<[u8]> = self.result.outbase.clone();
         let output_files: Box<[options::OutputFile]> =
             std::mem::take(&mut self.output_files).into_boxed_slice();
@@ -2784,6 +2786,59 @@ impl<'a> Transpiler<'a> {
         Ok(())
     }
 
+    /// Same check the bundler does in `generateChunksInParallel`: two inputs
+    /// rendering to one output path is an error, not a silent overwrite.
+    fn reject_duplicate_output_paths(&mut self) -> crate::Result<()> {
+        use std::io::Write as _;
+
+        let mut by_dest_path: bun_collections::StringArrayHashMap<Vec<usize>> = Default::default();
+        let mut has_duplicates = false;
+        for (index, file) in self.output_files.iter().enumerate() {
+            if file.dest_path.is_empty() {
+                continue;
+            }
+            let entry = by_dest_path.get_or_put(&file.dest_path)?;
+            has_duplicates |= entry.found_existing;
+            entry.value_ptr.push(index);
+        }
+        if !has_duplicates {
+            return Ok(());
+        }
+
+        let mut msg: Vec<u8> = Vec::new();
+        writeln!(&mut msg, "Multiple files share the same output path")?;
+        for (dest_path, indices) in by_dest_path.keys().iter().zip(by_dest_path.values()) {
+            if indices.len() < 2 {
+                continue;
+            }
+            writeln!(&mut msg, "  {}:", bstr::BStr::new(dest_path))?;
+            for &index in indices {
+                writeln!(
+                    &mut msg,
+                    "    from input {}",
+                    bstr::BStr::new(self.output_files[index].src_path.pretty)
+                )?;
+            }
+        }
+
+        let mut note: Vec<u8> = Vec::new();
+        write!(
+            &mut note,
+            "entry naming is '{}', consider adding '[hash]' to make filenames unique",
+            bstr::BStr::new(&self.entry_naming_template().data),
+        )?;
+        self.log_mut().add_range_error_with_notes(
+            None,
+            Default::default(),
+            msg,
+            Box::new([bun_ast::Data {
+                text: note.into(),
+                ..Default::default()
+            }]),
+        );
+        Ok(())
+    }
+
     fn build_with_resolve_result_eager(
         &mut self,
         resolve_result: &resolver::Result,
@@ -2830,7 +2885,7 @@ impl<'a> Transpiler<'a> {
         file_path.pretty = crate::linker::dupe(rel);
 
         let mut output_file = options::OutputFile::zero_value();
-        output_file.src_path = bun_paths::fs::Path::init(file_path_text);
+        output_file.src_path = file_path;
         output_file.loader = loader;
         output_file.output_kind = options::OutputKind::Chunk;
         output_file.side = None;
@@ -2975,58 +3030,59 @@ impl<'a> Transpiler<'a> {
             }
         }
 
-        output_file.dest_path = match &output_file.value {
-            crate::output_file::Value::Copy(op) => strings::concat(&[b"./", &op.pathname]),
-            value => {
-                let rel_to_root = bun_paths::resolve_path::relative_platform::<
-                    bun_paths::resolve_path::platform::Loose,
-                    false,
-                >(&self.options.root_dir, file_path_text);
-                let pathname = Fs::PathName::init(rel_to_root);
-                let out_ext: &[u8] = if self.options.preserve_extensions {
-                    pathname.ext
-                } else {
-                    self.options
-                        .out_extensions
-                        .get(pathname.ext)
-                        .copied()
-                        .unwrap_or(if loader == options::Loader::Css {
-                            pathname.ext
-                        } else {
-                            b".js"
-                        })
-                };
-                let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
-                if !self.options.entry_naming.is_empty() {
-                    template.data.clone_from(&self.options.entry_naming);
-                }
-                template.placeholder.name = pathname.base.to_vec().into_boxed_slice();
-                template.placeholder.dir = pathname.dir.to_vec().into_boxed_slice();
-                template.placeholder.ext = match out_ext {
-                    [b'.', rest @ ..] => rest,
-                    ext => ext,
-                }
-                .to_vec()
-                .into_boxed_slice();
-                if template.needs(options::PlaceholderField::Target) {
-                    template.placeholder.target = <&'static str>::from(self.options.target)
-                        .as_bytes()
-                        .to_vec()
-                        .into_boxed_slice();
-                }
-                if template.needs(options::PlaceholderField::Hash) {
-                    if let crate::output_file::Value::Buffer { bytes } = value {
-                        template.placeholder.hash = Some(crate::ContentHasher::run(bytes));
-                    }
-                }
-                let mut v = Vec::new();
-                template.print(&mut v, true).expect("write to Vec<u8>");
-                bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut v);
-                v.into_boxed_slice()
-            }
-        };
+        if let crate::output_file::Value::Buffer { bytes } = &output_file.value {
+            output_file.dest_path = self.transform_only_dest_path(file_path_text, loader, bytes);
+        }
 
         Ok(Some(output_file))
+    }
+
+    fn entry_naming_template(&self) -> options::PathTemplate {
+        let mut template: options::PathTemplate = options::PathTemplate::FILE.into();
+        if !self.options.entry_naming.is_empty() {
+            template.data.clone_from(&self.options.entry_naming);
+        }
+        template
+    }
+
+    /// Same template the bundler applies to entry points
+    /// (`computeChunks`), so `--no-bundle --outdir` names files the way
+    /// `bun build --outdir` does.
+    fn transform_only_dest_path(
+        &self,
+        file_path_text: &[u8],
+        loader: options::Loader,
+        output: &[u8],
+    ) -> Box<[u8]> {
+        let rel_to_root = bun_paths::resolve_path::relative_platform::<
+            bun_paths::resolve_path::platform::Loose,
+            false,
+        >(&self.options.root_dir, file_path_text);
+        let pathname = Fs::PathName::init(rel_to_root);
+
+        let ext: &[u8] = if loader == options::Loader::Css {
+            b"css"
+        } else {
+            b"js"
+        };
+
+        let mut template = self.entry_naming_template();
+        template.placeholder.dir = pathname.dir.into();
+        template.placeholder.name = pathname.base.into();
+        template.placeholder.ext = ext.into();
+        if template.needs(options::PlaceholderField::Target) {
+            template.placeholder.target = self.options.target.naming_placeholder().into();
+        }
+        if template.needs(options::PlaceholderField::Hash) {
+            template.placeholder.hash = Some(crate::ContentHasher::run(output));
+        }
+
+        let mut dest_path = Vec::new();
+        template
+            .print(&mut dest_path, true)
+            .expect("write to Vec<u8>");
+        bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut dest_path);
+        dest_path.into_boxed_slice()
     }
 
     /// Cold path: `bun build` of a `.css` entry. Split out of

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2971,9 +2971,7 @@ impl<'a> Transpiler<'a> {
         }
 
         output_file.dest_path = match &output_file.value {
-            crate::output_file::Value::Copy(op) => {
-                strings::concat(&[b"./", &op.pathname])
-            }
+            crate::output_file::Value::Copy(op) => strings::concat(&[b"./", &op.pathname]),
             value => {
                 let rel_to_root = bun_paths::resolve_path::relative_platform::<
                     bun_paths::resolve_path::platform::Loose,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2835,6 +2835,26 @@ impl<'a> Transpiler<'a> {
         output_file.output_kind = options::OutputKind::Chunk;
         output_file.side = None;
         output_file.entry_point_index = None;
+        output_file.dest_path = {
+            let rel_to_root =
+                bun_paths::resolve_path::relative(&self.options.root_dir, file_path_text);
+            let pathname = Fs::PathName::init(rel_to_root);
+            let out_ext: &[u8] = if self.options.preserve_extensions {
+                pathname.ext
+            } else {
+                self.options
+                    .out_extensions
+                    .get(pathname.ext)
+                    .copied()
+                    .unwrap_or(pathname.ext)
+            };
+            let dir: &[u8] = if pathname.dir.is_empty() {
+                b""
+            } else {
+                pathname.dir_with_trailing_slash()
+            };
+            strings::concat(&[b"./", dir, pathname.base, out_ext])
+        };
 
         match loader {
             options::Loader::Jsx

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -703,7 +703,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             match side {
                 bun_bundler::options::Side::Client => {
                     // Client-side resources will be written to disk for usage on the client side
-                    if let Err(err) = file.write_to_disk(root_dir.fd(), b".") {
+                    if let Err(err) = file.write_to_disk(root_dir.fd()) {
                         bun_core::handle_error_return_trace(err);
                         Output::err(
                             err,
@@ -714,7 +714,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 }
                 bun_bundler::options::Side::Server => {
                     if ctx.bundler_options.bake_debug_dump_server {
-                        if let Err(err) = file.write_to_disk(root_dir.fd(), b".") {
+                        if let Err(err) = file.write_to_disk(root_dir.fd()) {
                             bun_core::handle_error_return_trace(err);
                             Output::err(
                                 err,
@@ -794,7 +794,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         });
         if any_client_chunks {
             let runtime_file: &OutputFile = &bundled_outputs_list[runtime_file_index as usize];
-            if let Err(err) = runtime_file.write_to_disk(root_dir.fd(), b".") {
+            if let Err(err) = runtime_file.write_to_disk(root_dir.fd()) {
                 bun_core::handle_error_return_trace(err);
                 Output::err(
                     err,

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1065,7 +1065,7 @@ impl BuildCommand {
             }
 
             for f in output_files.iter() {
-                if let Err(err) = f.write_to_disk(root_dir.fd, from_path) {
+                if let Err(err) = f.write_to_disk(root_dir.fd) {
                     Output::err(
                         err,
                         "failed to write file '{}'",

--- a/test/bundler/bundler_naming.test.ts
+++ b/test/bundler/bundler_naming.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { readdirSync } from "node:fs";
 import { ESBUILD, itBundled } from "./expectBundled";
 
 describe("bundler", () => {
@@ -191,6 +192,49 @@ describe("bundler", () => {
         stdout: "./lib/second/test.file",
       },
     ],
+  });
+  itBundled("naming/EntryNamingTarget", {
+    files: {
+      "/src/entry.js": /* js */ `
+        console.log(1);
+      `,
+    },
+    root: "/src",
+    target: "bun",
+    entryNaming: "[target]/[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir)).toEqual(["bun"]);
+    },
+    run: {
+      file: "/out/bun/entry.js",
+      stdout: "1",
+    },
+  });
+  itBundled("naming/AssetNamingTarget", {
+    files: {
+      "/src/entry.js": /* js */ `
+        import file from "./data.file";
+        console.log(file);
+      `,
+      "/src/data.file": `
+        this is a file
+      `,
+    },
+    root: "/src",
+    target: "bun",
+    assetNaming: "[target]/[name].[ext]",
+    entryPointsRaw: ["./src/entry.js"],
+    loader: {
+      ".file": "file",
+    },
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual(["bun", "entry.js"]);
+    },
+    run: {
+      file: "/out/entry.js",
+      stdout: "./bun/data.file",
+    },
   });
   itBundled("naming/AssetNoOverwrite", {
     todo: true,

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -466,6 +466,83 @@ test("multi-entry build writes each entry point into the output directory", asyn
   expect(b).toContain('"B"');
 });
 
+// https://github.com/oven-sh/bun/issues/9859
+describe.concurrent("--no-bundle with --outdir", () => {
+  test("writes a single entry point", async () => {
+    using dir = tempDir("no-bundle-outdir-single", {
+      "src/app.tsx": `export const App = () => <div>app</div>;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./src/app.tsx", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("app.js");
+    expect(exitCode).toBe(0);
+
+    const out = await Bun.file(path.join(String(dir), "dist", "app.js")).text();
+    expect(out).toContain("jsx");
+    expect(out).toContain("app");
+  });
+
+  test("writes multiple entry points", async () => {
+    using dir = tempDir("no-bundle-outdir-multi", {
+      "src/main.tsx": `import { App } from "./app";\nexport const Main = () => <div><App /></div>;\n`,
+      "src/app.tsx": `export const App = () => <div>app</div>;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./src/main.tsx", "./src/app.tsx", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("main.js");
+    expect(stdout).toContain("app.js");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(path.join(String(dir), "dist")).sort()).toEqual(["app.js", "main.js"]);
+
+    const main = await Bun.file(path.join(String(dir), "dist", "main.js")).text();
+    const app = await Bun.file(path.join(String(dir), "dist", "app.js")).text();
+    expect(main).toContain('from "./app"');
+    expect(app).toContain("app");
+  });
+
+  test("preserves nested directory structure relative to the source root", async () => {
+    using dir = tempDir("no-bundle-outdir-nested", {
+      "src/main.ts": `export const main = 1;\n`,
+      "src/nested/deep.ts": `export const deep = 2;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./src/main.ts", "./src/nested/deep.ts", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const main = await Bun.file(path.join(String(dir), "dist", "main.js")).text();
+    const deep = await Bun.file(path.join(String(dir), "dist", "nested", "deep.js")).text();
+    expect(main).toContain("main");
+    expect(deep).toContain("deep");
+    expect(stdout).toContain("main.js");
+    expect(stdout).toContain(path.join("nested", "deep.js"));
+  });
+});
+
 describe("CLI argument error messages", () => {
   test("--format with an unrecognized value echoes the value back", async () => {
     using dir = tempDir("build-format-err", { "in.js": "console.log(1)" });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -640,6 +640,7 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(stdout).toContain("config.js");
     expect(stdout).toContain("data.js");
     expect(stdout).toContain("style.css");
+    expect(stdout).not.toMatch(/style\.css\s+0 /);
   });
 
   test("does not escape --outdir when an entry point is outside --root", async () => {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -584,6 +584,31 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(out).toContain("app");
   });
 
+  test("fills [hash] in --entry-naming with distinct values per entry", async () => {
+    using dir = tempDir("no-bundle-outdir-hash", {
+      "a.ts": `export const a = 1;\n`,
+      "b.ts": `export const b = 2;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./a.ts", "./b.ts", "--outdir=dist", "--entry-naming", "[name]-[hash].[ext]"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const files = fs.readdirSync(path.join(String(dir), "dist")).sort();
+    expect(files).toHaveLength(2);
+    expect(files[0]).toMatch(/^a-[0-9a-z]+\.js$/);
+    expect(files[1]).toMatch(/^b-[0-9a-z]+\.js$/);
+    expect(stdout).toContain(files[0]);
+    expect(stdout).toContain(files[1]);
+  });
+
   test("does not escape --outdir when an entry point is outside --root", async () => {
     using dir = tempDir("no-bundle-outdir-escape", {
       "src/a.ts": `export const a = 1;\n`,

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -541,6 +541,27 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(stdout).toContain("main.js");
     expect(stdout).toContain(path.join("nested", "deep.js"));
   });
+
+  test("creates nested directories for a single entry point with --root", async () => {
+    using dir = tempDir("no-bundle-outdir-root", {
+      "src/nested/deep.ts": `export const deep = 2;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--root=.", "./src/nested/deep.ts", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const deep = await Bun.file(path.join(String(dir), "dist", "src", "nested", "deep.js")).text();
+    expect(deep).toContain("deep");
+    expect(stdout).toContain(path.join("src", "nested", "deep.js"));
+  });
 });
 
 describe("CLI argument error messages", () => {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -591,7 +591,16 @@ describe.concurrent("--no-bundle with --outdir", () => {
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--no-bundle", "./a.ts", "./b.ts", "--outdir=dist", "--entry-naming", "[name]-[hash].[ext]"],
+      cmd: [
+        bunExe(),
+        "build",
+        "--no-bundle",
+        "./a.ts",
+        "./b.ts",
+        "--outdir=dist",
+        "--entry-naming",
+        "[name]-[hash].[ext]",
+      ],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -539,7 +539,7 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(main).toContain("main");
     expect(deep).toContain("deep");
     expect(stdout).toContain("main.js");
-    expect(stdout).toContain(path.join("nested", "deep.js"));
+    expect(stdout).toContain("nested/deep.js");
   });
 
   test("creates nested directories for a single entry point with --root", async () => {
@@ -560,7 +560,51 @@ describe.concurrent("--no-bundle with --outdir", () => {
 
     const deep = await Bun.file(path.join(String(dir), "dist", "src", "nested", "deep.js")).text();
     expect(deep).toContain("deep");
-    expect(stdout).toContain(path.join("src", "nested", "deep.js"));
+    expect(stdout).toContain("src/nested/deep.js");
+  });
+
+  test("respects --entry-naming", async () => {
+    using dir = tempDir("no-bundle-outdir-naming", {
+      "src/app.ts": `export const app = 1;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./src/app.ts", "--outdir=dist", "--entry-naming", "[name].mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("app.mjs");
+    expect(exitCode).toBe(0);
+
+    const out = await Bun.file(path.join(String(dir), "dist", "app.mjs")).text();
+    expect(out).toContain("app");
+  });
+
+  test("does not escape --outdir when an entry point is outside --root", async () => {
+    using dir = tempDir("no-bundle-outdir-escape", {
+      "src/a.ts": `export const a = 1;\n`,
+      "other/b.ts": `export const b = 2;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--root=src", "./src/a.ts", "./other/b.ts", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.existsSync(path.join(String(dir), "other", "b.js"))).toBe(false);
+    const b = await Bun.file(path.join(String(dir), "dist", "_.._", "other", "b.js")).text();
+    expect(b).toContain("b");
+    expect(stdout).toContain("_.._/other/b.js");
   });
 });
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -618,6 +618,30 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(stdout).toContain(files[1]);
   });
 
+  test("writes data-loader entry points with a .js extension", async () => {
+    using dir = tempDir("no-bundle-outdir-data-loaders", {
+      "config.toml": `key = 1\n`,
+      "data.yaml": `key: 2\n`,
+      "style.css": `.x { color: red; }\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./config.toml", "./data.yaml", "./style.css", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(path.join(String(dir), "dist")).sort()).toEqual(["config.js", "data.js", "style.css"]);
+    expect(stdout).toContain("config.js");
+    expect(stdout).toContain("data.js");
+    expect(stdout).toContain("style.css");
+  });
+
   test("does not escape --outdir when an entry point is outside --root", async () => {
     using dir = tempDir("no-bundle-outdir-escape", {
       "src/a.ts": `export const a = 1;\n`,

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -665,6 +665,31 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(b).toContain("b");
     expect(stdout).toContain("_.._/other/b.js");
   });
+
+  // https://github.com/oven-sh/bun/issues/5206
+  test("transpiles bare entry points in place with --outdir .", async () => {
+    using dir = tempDir("no-bundle-outdir-in-place", {
+      "a.ts": `console.log("hello world!" as string);\n`,
+      "b.ts": `console.log("foo bar baz" as string);\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "a.ts", "b.ts", "--no-bundle", "--outdir", "."],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("a.js");
+    expect(stdout).toContain("b.js");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(String(dir)).sort()).toEqual(["a.js", "a.ts", "b.js", "b.ts"]);
+    expect(await Bun.file(path.join(String(dir), "a.js")).text()).toContain('console.log("hello world!")');
+    expect(await Bun.file(path.join(String(dir), "b.js")).text()).toContain('console.log("foo bar baz")');
+  });
 });
 
 describe("CLI argument error messages", () => {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import fs, { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path, { join } from "node:path";
 
@@ -563,6 +563,95 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(stdout).toContain("src/nested/deep.js");
   });
 
+  test("writes entry points that share a subdirectory under --root", async () => {
+    using dir = tempDir("no-bundle-outdir-shared-subdir", {
+      "src/a.ts": `export const a = 1;\n`,
+      "src/b.ts": `export const b = 2;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "--root=.", "./src/a.ts", "./src/b.ts", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("src/a.js");
+    expect(stdout).toContain("src/b.js");
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(path.join(String(dir), "dist"), { recursive: true }).sort()).toEqual([
+      "src",
+      path.join("src", "a.js"),
+      path.join("src", "b.js"),
+    ]);
+  });
+
+  test("rejects two entry points that map to the same output path", async () => {
+    using dir = tempDir("no-bundle-outdir-collision", {
+      "src/app.ts": `export const a = 1;\n`,
+      "src/app.js": `export const b = 2;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--no-bundle", "./src/app.ts", "./src/app.js", "--outdir=dist"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "error: Multiple files share the same output path
+        ./app.js:
+          from input src/app.ts
+          from input src/app.js
+
+
+      note: entry naming is '[dir]/[name].[ext]', consider adding '[hash]' to make filenames unique"
+    `);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+
+    expect(fs.existsSync(path.join(String(dir), "dist", "app.js"))).toBe(false);
+  });
+
+  test.each([
+    ["browser", []],
+    ["bun", ["--target=bun"]],
+    ["node", ["--target=node"]],
+  ])("fills [target] in --entry-naming with %s", async (expected, targetArgs) => {
+    using dir = tempDir("no-bundle-outdir-target", {
+      "app.ts": `export const app = 1;\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--no-bundle",
+        ...targetArgs,
+        "./app.ts",
+        "--outdir=dist",
+        "--entry-naming",
+        "[target]/[name].[ext]",
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain(`${expected}/app.js`);
+    expect(exitCode).toBe(0);
+
+    expect(fs.readdirSync(path.join(String(dir), "dist"))).toEqual([expected]);
+    expect(fs.readdirSync(path.join(String(dir), "dist", expected))).toEqual(["app.js"]);
+  });
+
   test("respects --entry-naming", async () => {
     using dir = tempDir("no-bundle-outdir-naming", {
       "src/app.ts": `export const app = 1;\n`,
@@ -618,15 +707,27 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(stdout).toContain(files[1]);
   });
 
-  test("writes data-loader entry points with a .js extension", async () => {
-    using dir = tempDir("no-bundle-outdir-data-loaders", {
+  test("names outputs by loader: js for transpiled data, css for the css loader", async () => {
+    using dir = tempDir("no-bundle-outdir-loaders", {
       "config.toml": `key = 1\n`,
       "data.yaml": `key: 2\n`,
       "style.css": `.x { color: red; }\n`,
+      "theme.pcss": `.y { color: blue; }\n`,
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "build", "--no-bundle", "./config.toml", "./data.yaml", "./style.css", "--outdir=dist"],
+      cmd: [
+        bunExe(),
+        "build",
+        "--no-bundle",
+        "./config.toml",
+        "./data.yaml",
+        "./style.css",
+        "./theme.pcss",
+        "--loader",
+        ".pcss:css",
+        "--outdir=dist",
+      ],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -636,11 +737,17 @@ describe.concurrent("--no-bundle with --outdir", () => {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
-    expect(fs.readdirSync(path.join(String(dir), "dist")).sort()).toEqual(["config.js", "data.js", "style.css"]);
+    expect(fs.readdirSync(path.join(String(dir), "dist")).sort()).toEqual([
+      "config.js",
+      "data.js",
+      "style.css",
+      "theme.css",
+    ]);
     expect(stdout).toContain("config.js");
     expect(stdout).toContain("data.js");
     expect(stdout).toContain("style.css");
-    expect(stdout).not.toMatch(/style\.css\s+0 /);
+    expect(stdout).toContain("theme.css");
+    expect(stdout).not.toMatch(/\.css\s+0 /);
   });
 
   test("does not escape --outdir when an entry point is outside --root", async () => {


### PR DESCRIPTION
Fixes #9859
Fixes #5206
Fixes #10370

### Problem
- `bun build --no-bundle <entries> --outdir=<dir>` prints `ENOENT: failed to write file '""'` for every entry and writes nothing. Single and multiple entry points both fail; only `--outfile` and stdout work.
- `Transpiler::build_with_resolve_result_eager` (src/bundler/transpiler.rs) builds each `OutputFile` from `zero_value()` and never sets `dest_path`, so the write loop in src/runtime/cli/build_command.rs opens `""` under the outdir fd.
- Related: assets in bundle mode wrote `[target]` as `Browser/` (src/bundler/bundle_v2.rs used the enum variant name) while entry points wrote `browser/`. This is a regression from the Rust port: the old Zig site used `@tagName` (bundle_v2.zig:1806), so assets came out as `browser/` and `bun/`. It also affects the default `[dir]/[target]/[name]-[hash].[ext]` asset template that fullstack builds with server HTML imports get without any `--asset-naming` flag, not just an explicit `--asset-naming '[target]/...'`.

### Fix
- In the transform path, set `dest_path` for every transpiled (`Value::Buffer`) output through the same `PathTemplate` entry points use in `computeChunks`: `[dir]`/`[name]` from the path relative to `--root`, `[ext]` from the loader (`css` for the css loader, `js` otherwise, like `Content::ext()`), `[hash]` from the output bytes, `[target]` from the new `Target::naming_placeholder()`, `..` sanitised to `_.._`, posix separators. So `--no-bundle --outdir` produces the same file names as `bun build --outdir` for the same flags, which matters because these names become a compatibility surface once they are written.
- After the queue is processed, `transform()` rejects two inputs landing on one `dest_path` with the same `Multiple files share the same output path` error (and entry-naming note) bundle mode emits, instead of the second write truncating the first and exiting 0.
- `Target::naming_placeholder()` (src/ast/target.rs) replaces the inline match in `computeChunks` and the `IntoStaticStr` use in `bundle_v2.rs`, so `[target]` spells the same in entry, asset, and `--no-bundle` output. For assets this restores the pre-port `browser` / `bun` spelling; `macro` and `ssr` change from the old `bun_macro` / `bake_server_components_ssr` to `macro` / `ssr`, matching what `computeChunks` already emits for entry points.
- `OutputFile::write_to_disk` now takes only the dir fd: `dest_path` is always outdir-relative at its callers (build_command asserts this right after the call; bake passes template output), so the `relative()` branch and its `root_dir_path` parameter are gone and the Buffer arm is mkdir parent, write. The parent is created unconditionally, which also covers a single entry with `--root` above it (previously `longest_common_path` of one path echoed it back and the length gate skipped the mkdir).
- File-copy loaders (`.wasm`, `.node`, ...) are unchanged: `copy_to` writes to `FileOperation.pathname` and ignores `dest_path`, so they keep an empty `dest_path` as on main. Their output still lands next to the source; that is a separate pre-existing bug and is filed separately.
- CSS outputs in this path also get `size` set so the summary does not print `0 B`.
- Verified: `test/bundler/cli.test.ts` (`--no-bundle with --outdir` block, 14 tests: single, multiple, nested, single + `--root`, shared subdir + `--root`, collision error, `[target]` x3 via `readdir`, `--entry-naming`, `[hash]`, loader-based extensions incl. `--loader .pcss:css`, outside-root, in-place `--outdir .`) all fail on the released build and pass with this change; `test/bundler/bundler_naming.test.ts` gains `naming/EntryNamingTarget` and `naming/AssetNamingTarget` (the asset one fails on main); `test/bake/dev/production.test.ts` passes with the `write_to_disk` signature change; `bundler_string.test.ts` and the `NoBundle` esbuild tests still pass.

### Background
- `--no-bundle` makes `bun build` transpile each entry point independently (`Transpiler::transform` -> `process_resolve_queue` -> `build_with_resolve_result_eager`) instead of going through `BundleV2`; the bundler's linker, which normally computes output paths and writes files, is never involved, so this path has to produce `dest_path` itself.
- `PathTemplate` is the `[dir]/[name].[ext]`-style template behind `--entry-naming` / `--chunk-naming` / `--asset-naming`. `print(.., sanitize_parent_dirs)` fills the placeholders and rewrites `..` segments so an input outside `--root` cannot write outside `--outdir`.
- `OutputFile.dest_path` is the outdir-relative path the CLI prints in the summary and passes to `openat` on the outdir fd; `OutputFile.value` is either the bytes to write (`Buffer`), a file to copy (`Copy`), or already written by the linker (`Saved`).
- `--root` (outbase) is the directory output paths are computed relative to; it defaults to the common ancestor of the entry points.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->
