### PR TITLE
bundler: deduplicate external ES-module imports across files in a chunk

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1263,6 +1263,14 @@ pub struct JavaScriptChunk {
     pub files_in_chunk_order: Box<[IndexInt]>,
     pub parts_in_chunk_in_order: Box<[PartRange]>,
 
+    /// External ES-module `SImport` statements that are redundant for this
+    /// chunk because an earlier file in `files_in_chunk_order` already emits
+    /// an import for the same path covering every clause. Keyed by
+    /// `(source_index as u64) << 32 | import_record_index as u64`; populated
+    /// in `dedupe_external_esm_imports` and consulted in
+    /// `convert_stmts_for_chunk`.
+    pub external_import_records_to_skip: bun_collections::HashMap<u64, ()>,
+
     // for code splitting
     // The map hashes via `Ref`'s `Hash` impl. Values
     // are `&'static`-erased slices into bundler-owned storage (see the

--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1263,12 +1263,8 @@ pub struct JavaScriptChunk {
     pub files_in_chunk_order: Box<[IndexInt]>,
     pub parts_in_chunk_in_order: Box<[PartRange]>,
 
-    /// External ES-module `SImport` statements that are redundant for this
-    /// chunk because an earlier file in `files_in_chunk_order` already emits
-    /// an import for the same path covering every clause. Keyed by
-    /// `(source_index as u64) << 32 | import_record_index as u64`; populated
-    /// in `dedupe_external_esm_imports` and consulted in
-    /// `convert_stmts_for_chunk`.
+    /// `(source_index << 32) | import_record_index` for external `SImport`s
+    /// that `dedupe_external_esm_imports` found redundant in this chunk.
     pub external_import_records_to_skip: bun_collections::HashMap<u64, ()>,
 
     // for code splitting

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -132,6 +132,7 @@ pub use crate::linker_context::static_route_visitor as StaticRouteVisitor;
 // `linker_context/doStep5.rs`), not free functions — no item re-export.
 pub use crate::linker_context::compute_cross_chunk_dependencies::compute_cross_chunk_dependencies;
 pub use crate::linker_context::convert_stmts_for_chunk::convert_stmts_for_chunk;
+pub use crate::linker_context::dedupe_external_esm_imports::dedupe_external_esm_imports;
 pub use crate::linker_context::convert_stmts_for_chunk_for_dev_server::convert_stmts_for_chunk_for_dev_server;
 pub use crate::linker_context::do_step5;
 pub use crate::linker_context::generate_chunks_in_parallel::generate_chunks_in_parallel;
@@ -865,6 +866,8 @@ impl<'a> LinkerContext<'a> {
         if FeatureFlags::HELP_CATCH_MEMORY_ISSUES {
             self.check_for_memory_corruption();
         }
+
+        dedupe_external_esm_imports(self, &mut chunks);
 
         self.graph.symbols.follow_all();
 

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -132,8 +132,8 @@ pub use crate::linker_context::static_route_visitor as StaticRouteVisitor;
 // `linker_context/doStep5.rs`), not free functions — no item re-export.
 pub use crate::linker_context::compute_cross_chunk_dependencies::compute_cross_chunk_dependencies;
 pub use crate::linker_context::convert_stmts_for_chunk::convert_stmts_for_chunk;
-pub use crate::linker_context::dedupe_external_esm_imports::dedupe_external_esm_imports;
 pub use crate::linker_context::convert_stmts_for_chunk_for_dev_server::convert_stmts_for_chunk_for_dev_server;
+pub use crate::linker_context::dedupe_external_esm_imports::dedupe_external_esm_imports;
 pub use crate::linker_context::do_step5;
 pub use crate::linker_context::generate_chunks_in_parallel::generate_chunks_in_parallel;
 pub use crate::linker_context::generate_code_for_file_in_chunk_js::generate_code_for_file_in_chunk_js;

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -861,13 +861,13 @@ impl<'a> LinkerContext<'a> {
             self.check_for_memory_corruption();
         }
 
+        dedupe_external_esm_imports(self, &mut chunks);
+
         compute_cross_chunk_dependencies(self, &mut chunks)?;
 
         if FeatureFlags::HELP_CATCH_MEMORY_ISSUES {
             self.check_for_memory_corruption();
         }
-
-        dedupe_external_esm_imports(self, &mut chunks);
 
         self.graph.symbols.follow_all();
 

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -130,6 +130,9 @@ pub mod linker_context {
     #[path = "convertStmtsForChunkForDevServer.rs"]
     pub mod convert_stmts_for_chunk_for_dev_server;
 
+    #[path = "dedupeExternalESMImports.rs"]
+    pub mod dedupe_external_esm_imports;
+
     #[path = "doStep5.rs"]
     pub mod do_step5;
 

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -285,6 +285,7 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
                         {
                             target_ref = namespace_alias.namespace_ref;
                         }
+                        let target_ref = symbols.follow(target_ref);
 
                         if cfg!(debug_assertions) {
                             // SAFETY: arena slice valid for the link pass.

--- a/src/bundler/linker_context/computeCrossChunkDependencies.rs
+++ b/src/bundler/linker_context/computeCrossChunkDependencies.rs
@@ -231,7 +231,7 @@ impl<'a, 'bump> CrossChunkDependencies<'a, 'bump> {
                         if let Some(namespace_alias) = &symbol.namespace_alias {
                             ref_to_use = namespace_alias.namespace_ref;
                         }
-                        ref_to_use
+                        symbols.follow(ref_to_use)
                     };
 
                     if cfg!(debug_assertions) {

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -102,11 +102,12 @@ pub fn convert_stmts_for_chunk(
                         continue 'stmt_loop;
                     }
 
-                    if let crate::chunk::Content::Javascript(js) = &chunk.content {
-                        let key = ((source_index as u64) << 32) | (s.import_record_index as u64);
-                        if js.external_import_records_to_skip.contains_key(&key) {
-                            continue 'stmt_loop;
-                        }
+                    if crate::linker_context::dedupe_external_esm_imports::is_redundant_external_import(
+                        chunk,
+                        source_index,
+                        s.import_record_index,
+                    ) {
+                        continue 'stmt_loop;
                     }
 
                     // Make sure these don't end up in the wrapper closure

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -103,8 +103,7 @@ pub fn convert_stmts_for_chunk(
                     }
 
                     if let crate::chunk::Content::Javascript(js) = &chunk.content {
-                        let key =
-                            ((source_index as u64) << 32) | (s.import_record_index as u64);
+                        let key = ((source_index as u64) << 32) | (s.import_record_index as u64);
                         if js.external_import_records_to_skip.contains_key(&key) {
                             continue 'stmt_loop;
                         }

--- a/src/bundler/linker_context/convertStmtsForChunk.rs
+++ b/src/bundler/linker_context/convertStmtsForChunk.rs
@@ -102,6 +102,14 @@ pub fn convert_stmts_for_chunk(
                         continue 'stmt_loop;
                     }
 
+                    if let crate::chunk::Content::Javascript(js) = &chunk.content {
+                        let key =
+                            ((source_index as u64) << 32) | (s.import_record_index as u64);
+                        if js.external_import_records_to_skip.contains_key(&key) {
+                            continue 'stmt_loop;
+                        }
+                    }
+
                     // Make sure these don't end up in the wrapper closure
                     if should_extract_esm_stmts_for_wrap {
                         stmts.append(StmtListWhich::OutsideWrapperPrefix, stmt);

--- a/src/bundler/linker_context/dedupeExternalESMImports.rs
+++ b/src/bundler/linker_context/dedupeExternalESMImports.rs
@@ -113,7 +113,11 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
                             path_text: record.path.text,
                             path_namespace: record.path.namespace,
                             loader: record.loader,
-                            star_ref: if has_star { Some(s.namespace_ref) } else { None },
+                            star_ref: if has_star {
+                                Some(s.namespace_ref)
+                            } else {
+                                None
+                            },
                             default_ref,
                             items,
                         });
@@ -146,8 +150,7 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
                                 .unwrap();
                             symbols.merge(item.name.ref_, canonical);
                         }
-                        let key =
-                            ((source_index as u64) << 32) | (s.import_record_index as u64);
+                        let key = ((source_index as u64) << 32) | (s.import_record_index as u64);
                         js.external_import_records_to_skip.insert(key, ());
                     } else {
                         // Not fully covered: the statement is kept. Record the

--- a/src/bundler/linker_context/dedupeExternalESMImports.rs
+++ b/src/bundler/linker_context/dedupeExternalESMImports.rs
@@ -1,42 +1,42 @@
 use crate::mal_prelude::*;
 use bun_ast::StmtData;
-use bun_ast::{ImportKind, Ref};
+use bun_ast::{ImportKind, ImportRecordFlags, Ref, import_record::Tag as RecordTag};
 use bun_core::strings;
 
 use crate::chunk::{self, Chunk};
 use crate::options::Loader;
 use crate::{LinkerContext, LinkerGraph};
 
-/// For ESM output, collapse redundant external `import` statements that would
-/// otherwise be repeated once per source file in the printed chunk.
-///
-/// Example (two input files each with `import * as ns from "pkg"`):
-///
-/// ```js
-/// // before
-/// import * as ns from "pkg";
-/// import * as ns2 from "pkg";
-/// // after
-/// import * as ns from "pkg";
-/// ```
-///
-/// Runs after `compute_chunks` (so `files_in_chunk_order` is populated) and
-/// before `symbols.follow_all()`. For each chunk it walks files in output
-/// order, and for every external `SImport` whose star / default / named
-/// clauses are all already introduced by an earlier kept import of the same
-/// path it (a) `symbols.merge`s the later refs into the earlier ones so every
-/// use prints the same name, and (b) records the later statement in the
-/// chunk's `external_import_records_to_skip` set so
-/// `convert_stmts_for_chunk` drops it.
-///
-/// The merge is a global union-find link, which is safe even when the merge
-/// target lives in a file outside the current chunk: each chunk's
-/// `NumberRenamer` / `MinifyRenamer` owns its own name table and
-/// `assign_name` calls `symbols.follow()` before assigning, so every chunk
-/// that references the merged ref assigns (and prints) a local name for the
-/// followed root. Suppression, on the other hand, is recorded per chunk so a
-/// file shared between entry points still emits its import in any chunk where
-/// it is the first importer of that path.
+#[inline]
+fn pack(source_index: u32, import_record_index: u32) -> u64 {
+    ((source_index as u64) << 32) | (import_record_index as u64)
+}
+
+/// True if `dedupe_external_esm_imports` marked this `(source_index,
+/// import_record_index)` as redundant for `chunk`.
+#[inline]
+pub fn is_redundant_external_import(
+    chunk: &Chunk,
+    source_index: u32,
+    import_record_index: u32,
+) -> bool {
+    match &chunk.content {
+        chunk::Content::Javascript(js) => js
+            .external_import_records_to_skip
+            .contains_key(&pack(source_index, import_record_index)),
+        _ => false,
+    }
+}
+
+/// Collapse redundant external ESM `import` statements per chunk. Two imports
+/// are considered redundant only when they print the same `from` specifier and
+/// bind an identical set of clauses (same star / default / named aliases):
+/// within that equivalence class the later statements in the chunk are dropped
+/// and their clause refs `symbols.merge`d into the first's. Partially
+/// overlapping imports (e.g. `{x}` vs `{x, y}`) are left untouched; merging a
+/// clause of a kept statement would let a different chunk's merge transitively
+/// unify two refs that are both kept in a third chunk and so emit a duplicate
+/// top-level binding.
 pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) {
     if !c.options.output_format.keep_es6_import_export_syntax() {
         return;
@@ -54,14 +54,16 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
     struct Entry {
         path_text: &'static [u8],
         path_namespace: &'static [u8],
+        print_namespace: bool,
         loader: Option<Loader>,
-        star_ref: Option<Ref>,
+        has_star: bool,
+        star_ref: Ref,
         default_ref: Option<Ref>,
-        // (imported alias, local ref) for `import { alias as local }`
         items: Vec<(&'static [u8], Ref)>,
     }
 
     let mut seen: Vec<Entry> = Vec::new();
+    let mut aliases: Vec<&'static [u8]> = Vec::new();
 
     for chunk in chunks.iter_mut() {
         let chunk::Content::Javascript(js) = &mut chunk.content else {
@@ -70,108 +72,134 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
 
         seen.clear();
 
-        for &source_index in js.files_in_chunk_order.iter() {
+        for part_range in js.parts_in_chunk_in_order.iter() {
+            let source_index = part_range.source_index.get();
             let parts = all_parts[source_index as usize].as_slice();
             let import_records = all_import_records[source_index as usize].as_slice();
             let live = &parts_live[source_index as usize];
 
-            for (part_index, part) in parts.iter().enumerate() {
-                if !live.is_set(part_index) {
+            for part_i in part_range.part_index_begin..part_range.part_index_end {
+                if !live.is_set(part_i as usize) {
                     continue;
                 }
-                for stmt in part.stmts.slice() {
+                for stmt in parts[part_i as usize].stmts.slice() {
                     let StmtData::SImport(s) = stmt.data else {
                         continue;
                     };
                     let record = &import_records[s.import_record_index as usize];
 
-                    use bun_ast::ImportRecordFlags as F;
                     if record.source_index.is_valid()
                         || record.kind != ImportKind::Stmt
                         || record.path.is_disabled
-                        || record.flags.contains(F::IS_UNUSED)
-                        || record.flags.contains(F::PHASE_DEFER)
+                        || !matches!(record.tag, RecordTag::None | RecordTag::Builtin)
+                        || record.flags.intersects(
+                            ImportRecordFlags::IS_UNUSED | ImportRecordFlags::PHASE_DEFER,
+                        )
                     {
                         continue;
                     }
 
-                    let has_star = record.flags.contains(F::CONTAINS_IMPORT_STAR);
-                    let default_ref = s.default_name.as_ref().map(|d| d.ref_);
+                    let has_star = record
+                        .flags
+                        .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR);
+                    let default_ref = s.default_name.as_ref().and_then(|d| d.ref_.to_nullable());
+                    let print_namespace = record
+                        .flags
+                        .contains(ImportRecordFlags::PRINT_NAMESPACE_IN_PATH);
 
-                    let existing = seen.iter_mut().find(|e| {
+                    aliases.clear();
+                    for item in s.items.slice() {
+                        aliases.push(item.alias.slice());
+                    }
+                    aliases.sort_unstable();
+
+                    let same_path = |e: &Entry| {
                         e.loader == record.loader
+                            && e.print_namespace == print_namespace
                             && strings::eql(e.path_text, record.path.text)
                             && strings::eql(e.path_namespace, record.path.namespace)
+                    };
+
+                    // A bare `import "pkg"` is pure side-effect; any kept import for the
+                    // same specifier already evaluates the module, so drop the bare one.
+                    if !has_star && default_ref.is_none() && aliases.is_empty() {
+                        if seen.iter().any(same_path) {
+                            js.external_import_records_to_skip
+                                .insert(pack(source_index, s.import_record_index), ());
+                        } else {
+                            seen.push(Entry {
+                                path_text: record.path.text,
+                                path_namespace: record.path.namespace,
+                                print_namespace,
+                                loader: record.loader,
+                                has_star: false,
+                                star_ref: Ref::NONE,
+                                default_ref: None,
+                                items: Vec::new(),
+                            });
+                        }
+                        continue;
+                    }
+
+                    let existing = seen.iter().find(|e| {
+                        same_path(e)
+                            && e.has_star == has_star
+                            && e.default_ref.is_some() == default_ref.is_some()
+                            && e.items.len() == aliases.len()
+                            && e.items
+                                .iter()
+                                .zip(aliases.iter())
+                                .all(|((a, _), b)| strings::eql(a, b))
                     });
 
                     let Some(entry) = existing else {
-                        let mut items = Vec::with_capacity(s.items.len() as usize);
-                        for item in s.items.slice() {
-                            items.push((item.alias.slice(), item.name.ref_));
+                        let mut items: Vec<(&'static [u8], Ref)> =
+                            Vec::with_capacity(aliases.len());
+                        for &alias in aliases.iter() {
+                            let r = s
+                                .items
+                                .slice()
+                                .iter()
+                                .find(|it| strings::eql(it.alias.slice(), alias))
+                                .and_then(|it| it.name.ref_.to_nullable())
+                                .unwrap_or(Ref::NONE);
+                            items.push((alias, r));
                         }
                         seen.push(Entry {
                             path_text: record.path.text,
                             path_namespace: record.path.namespace,
+                            print_namespace,
                             loader: record.loader,
-                            star_ref: if has_star {
-                                Some(s.namespace_ref)
-                            } else {
-                                None
-                            },
+                            has_star,
+                            star_ref: s.namespace_ref,
                             default_ref,
                             items,
                         });
                         continue;
                     };
 
-                    let star_covered = !has_star || entry.star_ref.is_some();
-                    let default_covered = default_ref.is_none() || entry.default_ref.is_some();
-                    let items_covered = s.items.slice().iter().all(|item| {
-                        entry
+                    if has_star {
+                        symbols.merge(s.namespace_ref, entry.star_ref);
+                    }
+                    if let (Some(this_def), Some(entry_def)) = (default_ref, entry.default_ref) {
+                        symbols.merge(this_def, entry_def);
+                    }
+                    for item in s.items.slice() {
+                        let Some(item_ref) = item.name.ref_.to_nullable() else {
+                            continue;
+                        };
+                        if let Some((_, canonical)) = entry
                             .items
                             .iter()
-                            .any(|(alias, _)| strings::eql(alias, item.alias.slice()))
-                    });
-
-                    if star_covered && default_covered && items_covered {
-                        if has_star {
-                            symbols.merge(s.namespace_ref, entry.star_ref.unwrap());
-                        }
-                        if let (Some(this_def), Some(entry_def)) = (default_ref, entry.default_ref)
+                            .find(|(a, _)| strings::eql(a, item.alias.slice()))
                         {
-                            symbols.merge(this_def, entry_def);
-                        }
-                        for item in s.items.slice() {
-                            let canonical = entry
-                                .items
-                                .iter()
-                                .find(|(alias, _)| strings::eql(alias, item.alias.slice()))
-                                .map(|(_, r)| *r)
-                                .unwrap();
-                            symbols.merge(item.name.ref_, canonical);
-                        }
-                        let key = ((source_index as u64) << 32) | (s.import_record_index as u64);
-                        js.external_import_records_to_skip.insert(key, ());
-                    } else {
-                        // Not fully covered: the statement is kept. Record the
-                        // clauses it introduces so a later import that only
-                        // needs those can be dropped against this one.
-                        if has_star && entry.star_ref.is_none() {
-                            entry.star_ref = Some(s.namespace_ref);
-                        }
-                        if let (Some(this_def), None) = (default_ref, entry.default_ref) {
-                            entry.default_ref = Some(this_def);
-                        }
-                        for item in s.items.slice() {
-                            if !entry
-                                .items
-                                .iter()
-                                .any(|(alias, _)| strings::eql(alias, item.alias.slice()))
-                            {
-                                entry.items.push((item.alias.slice(), item.name.ref_));
+                            if canonical.is_valid() {
+                                symbols.merge(item_ref, *canonical);
                             }
                         }
                     }
+                    js.external_import_records_to_skip
+                        .insert(pack(source_index, s.import_record_index), ());
                 }
             }
         }

--- a/src/bundler/linker_context/dedupeExternalESMImports.rs
+++ b/src/bundler/linker_context/dedupeExternalESMImports.rs
@@ -1,0 +1,176 @@
+use crate::mal_prelude::*;
+use bun_ast::StmtData;
+use bun_ast::{ImportKind, Ref};
+use bun_core::strings;
+
+use crate::chunk::{self, Chunk};
+use crate::options::Loader;
+use crate::{LinkerContext, LinkerGraph};
+
+/// For ESM output, collapse redundant external `import` statements that would
+/// otherwise be repeated once per source file in the printed chunk.
+///
+/// Example (two input files each with `import * as ns from "pkg"`):
+///
+/// ```js
+/// // before
+/// import * as ns from "pkg";
+/// import * as ns2 from "pkg";
+/// // after
+/// import * as ns from "pkg";
+/// ```
+///
+/// Runs after `compute_chunks` (so `files_in_chunk_order` is populated) and
+/// before `symbols.follow_all()`. For each chunk it walks files in output
+/// order, and for every external `SImport` whose star / default / named
+/// clauses are all already introduced by an earlier kept import of the same
+/// path it (a) `symbols.merge`s the later refs into the earlier ones so every
+/// use prints the same name, and (b) records the later statement in the
+/// chunk's `external_import_records_to_skip` set so
+/// `convert_stmts_for_chunk` drops it.
+///
+/// The merge is a global union-find link, which is safe even when the merge
+/// target lives in a file outside the current chunk: each chunk's
+/// `NumberRenamer` / `MinifyRenamer` owns its own name table and
+/// `assign_name` calls `symbols.follow()` before assigning, so every chunk
+/// that references the merged ref assigns (and prints) a local name for the
+/// followed root. Suppression, on the other hand, is recorded per chunk so a
+/// file shared between entry points still emits its import in any chunk where
+/// it is the first importer of that path.
+pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) {
+    if !c.options.output_format.keep_es6_import_export_syntax() {
+        return;
+    }
+
+    let LinkerGraph {
+        symbols,
+        ast,
+        parts_live,
+        ..
+    } = &mut c.graph;
+    let all_parts = ast.items_parts();
+    let all_import_records = ast.items_import_records();
+
+    struct Entry {
+        path_text: &'static [u8],
+        path_namespace: &'static [u8],
+        loader: Option<Loader>,
+        star_ref: Option<Ref>,
+        default_ref: Option<Ref>,
+        // (imported alias, local ref) for `import { alias as local }`
+        items: Vec<(&'static [u8], Ref)>,
+    }
+
+    let mut seen: Vec<Entry> = Vec::new();
+
+    for chunk in chunks.iter_mut() {
+        let chunk::Content::Javascript(js) = &mut chunk.content else {
+            continue;
+        };
+
+        seen.clear();
+
+        for &source_index in js.files_in_chunk_order.iter() {
+            let parts = all_parts[source_index as usize].as_slice();
+            let import_records = all_import_records[source_index as usize].as_slice();
+            let live = &parts_live[source_index as usize];
+
+            for (part_index, part) in parts.iter().enumerate() {
+                if !live.is_set(part_index) {
+                    continue;
+                }
+                for stmt in part.stmts.slice() {
+                    let StmtData::SImport(s) = stmt.data else {
+                        continue;
+                    };
+                    let record = &import_records[s.import_record_index as usize];
+
+                    use bun_ast::ImportRecordFlags as F;
+                    if record.source_index.is_valid()
+                        || record.kind != ImportKind::Stmt
+                        || record.path.is_disabled
+                        || record.flags.contains(F::IS_UNUSED)
+                        || record.flags.contains(F::PHASE_DEFER)
+                    {
+                        continue;
+                    }
+
+                    let has_star = record.flags.contains(F::CONTAINS_IMPORT_STAR);
+                    let default_ref = s.default_name.as_ref().map(|d| d.ref_);
+
+                    let existing = seen.iter_mut().find(|e| {
+                        e.loader == record.loader
+                            && strings::eql(e.path_text, record.path.text)
+                            && strings::eql(e.path_namespace, record.path.namespace)
+                    });
+
+                    let Some(entry) = existing else {
+                        let mut items = Vec::with_capacity(s.items.len() as usize);
+                        for item in s.items.slice() {
+                            items.push((item.alias.slice(), item.name.ref_));
+                        }
+                        seen.push(Entry {
+                            path_text: record.path.text,
+                            path_namespace: record.path.namespace,
+                            loader: record.loader,
+                            star_ref: if has_star { Some(s.namespace_ref) } else { None },
+                            default_ref,
+                            items,
+                        });
+                        continue;
+                    };
+
+                    let star_covered = !has_star || entry.star_ref.is_some();
+                    let default_covered = default_ref.is_none() || entry.default_ref.is_some();
+                    let items_covered = s.items.slice().iter().all(|item| {
+                        entry
+                            .items
+                            .iter()
+                            .any(|(alias, _)| strings::eql(alias, item.alias.slice()))
+                    });
+
+                    if star_covered && default_covered && items_covered {
+                        if has_star {
+                            symbols.merge(s.namespace_ref, entry.star_ref.unwrap());
+                        }
+                        if let (Some(this_def), Some(entry_def)) = (default_ref, entry.default_ref)
+                        {
+                            symbols.merge(this_def, entry_def);
+                        }
+                        for item in s.items.slice() {
+                            let canonical = entry
+                                .items
+                                .iter()
+                                .find(|(alias, _)| strings::eql(alias, item.alias.slice()))
+                                .map(|(_, r)| *r)
+                                .unwrap();
+                            symbols.merge(item.name.ref_, canonical);
+                        }
+                        let key =
+                            ((source_index as u64) << 32) | (s.import_record_index as u64);
+                        js.external_import_records_to_skip.insert(key, ());
+                    } else {
+                        // Not fully covered: the statement is kept. Record the
+                        // clauses it introduces so a later import that only
+                        // needs those can be dropped against this one.
+                        if has_star && entry.star_ref.is_none() {
+                            entry.star_ref = Some(s.namespace_ref);
+                        }
+                        if let (Some(this_def), None) = (default_ref, entry.default_ref) {
+                            entry.default_ref = Some(this_def);
+                        }
+                        for item in s.items.slice() {
+                            if !entry
+                                .items
+                                .iter()
+                                .any(|(alias, _)| strings::eql(alias, item.alias.slice()))
+                            {
+                                entry.items.push((item.alias.slice(), item.name.ref_));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/bundler/linker_context/dedupeExternalESMImports.rs
+++ b/src/bundler/linker_context/dedupeExternalESMImports.rs
@@ -60,6 +60,7 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
         star_ref: Ref,
         default_ref: Option<Ref>,
         items: Vec<(&'static [u8], Ref)>,
+        bare_key: u64,
     }
 
     let mut seen: Vec<Entry> = Vec::new();
@@ -120,8 +121,10 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
                             && strings::eql(e.path_namespace, record.path.namespace)
                     };
 
-                    // A bare `import "pkg"` is pure side-effect; any kept import for the
-                    // same specifier already evaluates the module, so drop the bare one.
+                    // A bare `import "pkg"` is pure side-effect; any other kept
+                    // import for the same specifier (before or after) makes it
+                    // redundant. `bare_key` lets a later binding import drop it
+                    // retroactively.
                     if !has_star && default_ref.is_none() && aliases.is_empty() {
                         if seen.iter().any(same_path) {
                             js.external_import_records_to_skip
@@ -136,9 +139,15 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
                                 star_ref: Ref::NONE,
                                 default_ref: None,
                                 items: Vec::new(),
+                                bare_key: pack(source_index, s.import_record_index),
                             });
                         }
                         continue;
+                    }
+
+                    if let Some(bare) = seen.iter_mut().find(|e| e.bare_key != 0 && same_path(e)) {
+                        js.external_import_records_to_skip.insert(bare.bare_key, ());
+                        bare.bare_key = 0;
                     }
 
                     let existing = seen.iter().find(|e| {
@@ -174,6 +183,7 @@ pub fn dedupe_external_esm_imports(c: &mut LinkerContext, chunks: &mut [Chunk]) 
                             star_ref: s.namespace_ref,
                             default_ref,
                             items,
+                            bare_key: 0,
                         });
                         continue;
                     };

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -324,6 +324,13 @@ pub fn post_process_js_chunk(
                             if record.flags.contains(ImportRecordFlags::IS_UNUSED) {
                                 continue;
                             }
+                            if crate::linker_context::dedupe_external_esm_imports::is_redundant_external_import(
+                                chunk,
+                                part_range.source_index.get(),
+                                s.import_record_index,
+                            ) {
+                                continue;
+                            }
 
                             let import_path = record.path.text;
                             let irp_id = mi.str(import_path);

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -251,58 +251,63 @@ describe("bundler", () => {
       { file: "/out/entry3.js", stdout: "XY X" },
     ],
   });
-  itBundled("edgecase/DedupeExternalESMImportsSplittingReExport", {
-    files: {
-      "/entry1.js": /* js */ `
-        import { utilNS } from "./util.js";
-        import { sharedNS } from "./shared.js";
-        console.log(utilNS.tag, sharedNS.tag);
-      `,
-      "/entry2.js": /* js */ `
-        import { utilNS } from "./util.js";
-        import { sharedNS } from "./shared.js";
-        console.log(utilNS.tag, sharedNS.tag);
-      `,
-      "/util.js": /* js */ `
-        import * as NS from "pkg";
-        export { NS as utilNS };
-      `,
-      "/shared.js": /* js */ `
-        import * as NS from "pkg";
-        export { NS as sharedNS };
-      `,
-    },
-    entryPoints: ["/entry1.js", "/entry2.js"],
-    splitting: true,
-    external: ["pkg"],
-    format: "esm",
-    runtimeFiles: {
-      "/node_modules/pkg/index.mjs": `export const tag = "EXT";`,
-      "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
-    },
-    onAfterBundle(api) {
-      // util.js and shared.js land in one shared chunk. Their two
-      // `import * as NS` collapse to one, and both re-exported namespaces
-      // follow to the same ref, so the shared chunk exports one symbol and
-      // each entry's cross-chunk import has a single clause. The dedupe must
-      // run before cross-chunk dependency recording so that walk() follows
-      // the merged ref and records one import; otherwise the entry chunk gets
-      // two clause items with the same local name (a SyntaxError).
-      const chunkFiles = readdirSync(api.outdir).filter(f => !/^entry[12]\.js$/.test(f));
-      expect(chunkFiles).toHaveLength(1);
-      const sharedChunk = api.readFile("/out/" + chunkFiles[0]);
-      expect(sharedChunk.match(/^import\s*\*\s*as\s/gm) ?? []).toHaveLength(1);
-      for (const file of ["/out/entry1.js", "/out/entry2.js"]) {
-        const out = api.readFile(file);
-        const locals = [...out.matchAll(/\b(?:as\s+)?(\w+)\s*\n?[,}]/g)].map(m => m[1]);
-        expect(new Set(locals).size).toBe(locals.length);
-      }
-    },
-    run: [
-      { file: "/out/entry1.js", stdout: "EXT EXT" },
-      { file: "/out/entry2.js", stdout: "EXT EXT" },
+  for (const [name, entry] of [
+    [
+      "Use",
+      `import { utilNS } from "./util.js"; import { sharedNS } from "./shared.js"; console.log(utilNS.tag, sharedNS.tag);`,
     ],
-  });
+    ["ReExport", `export { utilNS } from "./util.js"; export { sharedNS } from "./shared.js";`],
+  ] as const) {
+    itBundled(`edgecase/DedupeExternalESMImportsSplitting${name}`, {
+      files: {
+        "/entry1.js": entry,
+        "/entry2.js": entry,
+        "/util.js": /* js */ `
+          import * as NS from "pkg";
+          export { NS as utilNS };
+        `,
+        "/shared.js": /* js */ `
+          import * as NS from "pkg";
+          export { NS as sharedNS };
+        `,
+        "/consumer.js": /* js */ `
+          import { utilNS, sharedNS } from "./entry1.js";
+          console.log(utilNS.tag, sharedNS.tag);
+        `,
+      },
+      entryPoints: ["/entry1.js", "/entry2.js"],
+      splitting: true,
+      external: ["pkg"],
+      format: "esm",
+      runtimeFiles: {
+        "/node_modules/pkg/index.mjs": `export const tag = "EXT";`,
+        "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+      },
+      onAfterBundle(api) {
+        // util.js and shared.js land in one shared chunk. Their two
+        // `import * as NS` collapse to one, and both re-exported namespaces
+        // follow to the same ref, so the shared chunk exports one symbol and
+        // each entry's cross-chunk import has a single clause. Both walk()'s
+        // used-refs loop and its entry-exports loop must follow() before
+        // recording; otherwise each entry chunk gets two clause items with the
+        // same local name (a SyntaxError).
+        const chunkFiles = readdirSync(api.outdir).filter(f => !/^entry[12]\.js$/.test(f));
+        expect(chunkFiles).toHaveLength(1);
+        const sharedChunk = api.readFile("/out/" + chunkFiles[0]);
+        expect(sharedChunk.match(/^import\s*\*\s*as\s/gm) ?? []).toHaveLength(1);
+        for (const file of ["/out/entry1.js", "/out/entry2.js"]) {
+          const out = api.readFile(file);
+          const head = out.split(/^export\b/m)[0];
+          const locals = [...head.matchAll(/\b(?:as\s+)?(\w+)\s*\n?[,}]/g)].map(m => m[1]);
+          expect(new Set(locals).size).toBe(locals.length);
+        }
+      },
+      run: [
+        { file: name === "Use" ? "/out/entry1.js" : "/consumer.js", stdout: "EXT EXT" },
+        { file: name === "Use" ? "/out/entry2.js" : "/consumer.js", stdout: "EXT EXT" },
+      ],
+    });
+  }
   itBundled("edgecase/DedupeExternalESMImportsNotAcrossLoader", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -137,7 +137,7 @@ describe("bundler", () => {
       stdout: '{"a":"EXT","b":"EXT2","c":"DEF","d":"DEF!","e":"NAMED","f":"NAMED?","g":"G"}',
     },
   });
-  itBundled("edgecase/DedupeExternalESMImportsSubset", {
+  itBundled("edgecase/DedupeExternalESMImportsExactOnly", {
     files: {
       "/entry.js": /* js */ `
         import { a } from "./a.js";
@@ -148,20 +148,20 @@ describe("bundler", () => {
         console.log(JSON.stringify({ a, b, c, d, e }));
       `,
       "/a.js": /* js */ `
-        import def, { x, y } from "pkg";
-        export const a = def() + x + y;
+        import { x, y } from "pkg";
+        export const a = x + y;
       `,
       "/b.js": /* js */ `
-        import { x } from "pkg";
-        export const b = x;
+        import { y, x } from "pkg";
+        export const b = x + y;
       `,
       "/c.js": /* js */ `
-        import { y, z } from "pkg";
-        export const c = y + z;
+        import { x } from "pkg";
+        export const c = x;
       `,
       "/d.js": /* js */ `
-        import { z } from "pkg";
-        export const d = z;
+        import { x } from "pkg";
+        export const d = x;
       `,
       "/e.js": /* js */ `
         import { x } from "other";
@@ -171,10 +171,7 @@ describe("bundler", () => {
     external: ["pkg", "other"],
     format: "esm",
     runtimeFiles: {
-      "/node_modules/pkg/index.mjs": /* js */ `
-        export default function def() { return "D"; }
-        export const x = "X", y = "Y", z = "Z";
-      `,
+      "/node_modules/pkg/index.mjs": `export const x = "X", y = "Y";`,
       "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
       "/node_modules/other/index.mjs": `export const x = "OX";`,
       "/node_modules/other/package.json": `{ "type": "module", "main": "./index.mjs" }`,
@@ -182,17 +179,108 @@ describe("bundler", () => {
     onAfterBundle(api) {
       const out = api.readFile("/out.js");
       const imports = out.match(/^import[^;]*;/gm) ?? [];
-      // b's `{x}` is covered by a. c introduces `z` so it is kept (its `y`
-      // stays a separate binding because c's statement is kept). d's `{z}` is
-      // covered by c. e is a different module.
+      // a and b bind the same set (order-insensitive) -> one. c and d bind the
+      // same set -> one. a/b vs c/d are different sets and stay separate so
+      // the kept `{x}` gets its own local name. e is a different package.
       expect(imports).toEqual([
-        'import def, { x, y } from "pkg";',
-        'import { y as y2, z } from "pkg";',
-        'import { x as x2 } from "other";',
+        'import { x, y } from "pkg";',
+        'import { x as x2 } from "pkg";',
+        'import { x as x3 } from "other";',
       ]);
     },
     run: {
-      stdout: '{"a":"DXY","b":"X","c":"YZ","d":"Z","e":"OX"}',
+      stdout: '{"a":"XY","b":"XY","c":"X","d":"X","e":"OX"}',
+    },
+  });
+  itBundled("edgecase/DedupeExternalESMImportsMultiEntryOverlap", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { p } from "./p.js";
+        import { q } from "./q.js";
+        console.log(p, q);
+      `,
+      "/entry2.js": /* js */ `
+        import { p } from "./p.js";
+        import { r } from "./r.js";
+        console.log(p, r);
+      `,
+      "/entry3.js": /* js */ `
+        import { q } from "./q.js";
+        import { r } from "./r.js";
+        console.log(q, r);
+      `,
+      "/p.js": /* js */ `
+        import { x } from "pkg";
+        export const p = x;
+      `,
+      "/q.js": /* js */ `
+        import { x, y } from "pkg";
+        export const q = x + y;
+      `,
+      "/r.js": /* js */ `
+        import { x } from "pkg";
+        export const r = x;
+      `,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js", "/entry3.js"],
+    external: ["pkg"],
+    format: "esm",
+    runtimeFiles: {
+      "/node_modules/pkg/index.mjs": `export const x = "X", y = "Y";`,
+      "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+    },
+    onAfterBundle(api) {
+      // entry2 holds p and r, both `{x}`: collapses to one. entry1 holds p `{x}`
+      // and q `{x, y}`: different shapes, both kept. A subset-based merge of
+      // r -> p in entry2 and r -> q in entry3 would transitively unify p.x with
+      // q.x and make entry1 emit two `import { x }` bindings with the same name
+      // (a SyntaxError). Exact-match dedup never merges across shapes, so every
+      // bundle stays valid.
+      const entry2 = api.readFile("/out/entry2.js");
+      expect(entry2.match(/^import[^;]*;/gm) ?? []).toEqual(['import { x } from "pkg";']);
+      for (const file of ["/out/entry1.js", "/out/entry3.js"]) {
+        const imports = api.readFile(file).match(/^import[^;]*;/gm) ?? [];
+        expect(imports).toHaveLength(2);
+        const names = imports.flatMap(i => [...i.matchAll(/\b(?:as\s+)?(\w+)\s*[,}]/g)].map(m => m[1]));
+        expect(new Set(names).size).toBe(names.length);
+      }
+    },
+    run: [
+      { file: "/out/entry1.js", stdout: "X XY" },
+      { file: "/out/entry2.js", stdout: "X X" },
+      { file: "/out/entry3.js", stdout: "XY X" },
+    ],
+  });
+  itBundled("edgecase/DedupeExternalESMImportsNotAcrossLoader", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        console.log(a, b, c);
+      `,
+      "/a.js": /* js */ `
+        import data from "pkg" with { type: "json" };
+        export const a = data;
+      `,
+      "/b.js": /* js */ `
+        import data from "pkg";
+        export const b = data;
+      `,
+      "/c.js": /* js */ `
+        import data from "pkg" with { type: "json" };
+        export const c = data;
+      `,
+    },
+    external: ["pkg"],
+    target: "bun",
+    format: "esm",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const imports = out.match(/^import.*?;/gm) ?? [];
+      // a and c share `with { type: "json" }`; b has no attribute. a and c
+      // collapse, b stays separate.
+      expect(imports).toEqual(['import data from "pkg" with { type: "json" };', 'import data2 from "pkg";']);
     },
   });
   itBundled("edgecase/DedupeExternalESMImportsMultiEntry", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -251,6 +251,58 @@ describe("bundler", () => {
       { file: "/out/entry3.js", stdout: "XY X" },
     ],
   });
+  itBundled("edgecase/DedupeExternalESMImportsSplittingReExport", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { utilNS } from "./util.js";
+        import { sharedNS } from "./shared.js";
+        console.log(utilNS.tag, sharedNS.tag);
+      `,
+      "/entry2.js": /* js */ `
+        import { utilNS } from "./util.js";
+        import { sharedNS } from "./shared.js";
+        console.log(utilNS.tag, sharedNS.tag);
+      `,
+      "/util.js": /* js */ `
+        import * as NS from "pkg";
+        export { NS as utilNS };
+      `,
+      "/shared.js": /* js */ `
+        import * as NS from "pkg";
+        export { NS as sharedNS };
+      `,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    splitting: true,
+    external: ["pkg"],
+    format: "esm",
+    runtimeFiles: {
+      "/node_modules/pkg/index.mjs": `export const tag = "EXT";`,
+      "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+    },
+    onAfterBundle(api) {
+      // util.js and shared.js land in one shared chunk. Their two
+      // `import * as NS` collapse to one, and both re-exported namespaces
+      // follow to the same ref, so the shared chunk exports one symbol and
+      // each entry's cross-chunk import has a single clause. The dedupe must
+      // run before cross-chunk dependency recording so that walk() follows
+      // the merged ref and records one import; otherwise the entry chunk gets
+      // two clause items with the same local name (a SyntaxError).
+      const chunkFiles = readdirSync(api.outdir).filter(f => !/^entry[12]\.js$/.test(f));
+      expect(chunkFiles).toHaveLength(1);
+      const sharedChunk = api.readFile("/out/" + chunkFiles[0]);
+      expect(sharedChunk.match(/^import\s*\*\s*as\s/gm) ?? []).toHaveLength(1);
+      for (const file of ["/out/entry1.js", "/out/entry2.js"]) {
+        const out = api.readFile(file);
+        const locals = [...out.matchAll(/\b(?:as\s+)?(\w+)\s*\n?[,}]/g)].map(m => m[1]);
+        expect(new Set(locals).size).toBe(locals.length);
+      }
+    },
+    run: [
+      { file: "/out/entry1.js", stdout: "EXT EXT" },
+      { file: "/out/entry2.js", stdout: "EXT EXT" },
+    ],
+  });
   itBundled("edgecase/DedupeExternalESMImportsNotAcrossLoader", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -73,6 +73,178 @@ describe("bundler", () => {
     },
     run: true,
   });
+  // https://github.com/oven-sh/bun/issues/13092
+  itBundled("edgecase/DedupeExternalESMImports", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        import { d } from "./d.js";
+        import { e } from "./e.js";
+        import { f } from "./f.js";
+        import { g } from "./g.js";
+        console.log(JSON.stringify({ a, b, c, d, e, f, g }));
+      `,
+      "/a.js": /* js */ `
+        import * as NS from "pkg";
+        export const a = NS.tag;
+      `,
+      "/b.js": /* js */ `
+        import * as NS from "pkg";
+        export const b = NS.tag + "2";
+      `,
+      "/c.js": /* js */ `
+        import def from "pkg";
+        export const c = def();
+      `,
+      "/d.js": /* js */ `
+        import def from "pkg";
+        export const d = def() + "!";
+      `,
+      "/e.js": /* js */ `
+        import { named } from "pkg";
+        export const e = named();
+      `,
+      "/f.js": /* js */ `
+        import { named } from "pkg";
+        export const f = named() + "?";
+      `,
+      "/g.js": /* js */ `
+        import "pkg";
+        export const g = "G";
+      `,
+    },
+    external: ["pkg"],
+    format: "esm",
+    runtimeFiles: {
+      "/node_modules/pkg/index.mjs": /* js */ `
+        export const tag = "EXT";
+        export default function def() { return "DEF"; }
+        export function named() { return "NAMED"; }
+      `,
+      "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const imports = out.match(/^import[^;]*;/gm) ?? [];
+      // One import statement per distinct clause shape (star, default, named);
+      // the second file of each pair and the bare side-effect import are
+      // dropped and reference the first file's binding.
+      expect(imports).toEqual([
+        'import * as NS from "pkg";',
+        'import def from "pkg";',
+        'import { named } from "pkg";',
+      ]);
+    },
+    run: {
+      stdout: '{"a":"EXT","b":"EXT2","c":"DEF","d":"DEF!","e":"NAMED","f":"NAMED?","g":"G"}',
+    },
+  });
+  itBundled("edgecase/DedupeExternalESMImportsSubset", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a } from "./a.js";
+        import { b } from "./b.js";
+        import { c } from "./c.js";
+        import { d } from "./d.js";
+        import { e } from "./e.js";
+        console.log(JSON.stringify({ a, b, c, d, e }));
+      `,
+      "/a.js": /* js */ `
+        import def, { x, y } from "pkg";
+        export const a = def() + x + y;
+      `,
+      "/b.js": /* js */ `
+        import { x } from "pkg";
+        export const b = x;
+      `,
+      "/c.js": /* js */ `
+        import { y, z } from "pkg";
+        export const c = y + z;
+      `,
+      "/d.js": /* js */ `
+        import { z } from "pkg";
+        export const d = z;
+      `,
+      "/e.js": /* js */ `
+        import { x } from "other";
+        export const e = x;
+      `,
+    },
+    external: ["pkg", "other"],
+    format: "esm",
+    runtimeFiles: {
+      "/node_modules/pkg/index.mjs": /* js */ `
+        export default function def() { return "D"; }
+        export const x = "X", y = "Y", z = "Z";
+      `,
+      "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+      "/node_modules/other/index.mjs": `export const x = "OX";`,
+      "/node_modules/other/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const imports = out.match(/^import[^;]*;/gm) ?? [];
+      // b's `{x}` is covered by a. c introduces `z` so it is kept (its `y`
+      // stays a separate binding because c's statement is kept). d's `{z}` is
+      // covered by c. e is a different module.
+      expect(imports).toEqual([
+        'import def, { x, y } from "pkg";',
+        'import { y as y2, z } from "pkg";',
+        'import { x as x2 } from "other";',
+      ]);
+    },
+    run: {
+      stdout: '{"a":"DXY","b":"X","c":"YZ","d":"Z","e":"OX"}',
+    },
+  });
+  itBundled("edgecase/DedupeExternalESMImportsMultiEntry", {
+    files: {
+      "/entry1.js": /* js */ `
+        import { s } from "./shared.js";
+        import { o1 } from "./only1.js";
+        console.log(s, o1);
+      `,
+      "/entry2.js": /* js */ `
+        import { o2 } from "./only2.js";
+        import { s } from "./shared.js";
+        console.log(s, o2);
+      `,
+      "/shared.js": /* js */ `
+        import * as NS from "pkg";
+        export const s = NS.tag;
+      `,
+      "/only1.js": /* js */ `
+        import * as NS from "pkg";
+        export const o1 = NS.tag + "1";
+      `,
+      "/only2.js": /* js */ `
+        import * as NS from "pkg";
+        export const o2 = NS.tag + "2";
+      `,
+    },
+    entryPoints: ["/entry1.js", "/entry2.js"],
+    external: ["pkg"],
+    format: "esm",
+    runtimeFiles: {
+      "/node_modules/pkg/index.mjs": `export const tag = "EXT";`,
+      "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+    },
+    onAfterBundle(api) {
+      for (const file of ["/out/entry1.js", "/out/entry2.js"]) {
+        const out = api.readFile(file);
+        const imports = out.match(/^import[^;]*;/gm) ?? [];
+        // Each entry must still carry its own (single) import for "pkg":
+        // shared.js's statement is dropped in one chunk and kept in the other.
+        expect(imports).toEqual(['import * as NS from "pkg";']);
+      }
+    },
+    run: [
+      { file: "/out/entry1.js", stdout: "EXT EXT1" },
+      { file: "/out/entry2.js", stdout: "EXT EXT2" },
+    ],
+  });
   itBundled("edgecase/BunPluginTreeShakeImport", {
     todo: true,
     // This only appears at runtime and not with bun build, even with --no-bundle

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -131,11 +131,7 @@ describe("bundler", () => {
       // One import statement per distinct clause shape (star, default, named);
       // the second file of each pair and the bare side-effect import are
       // dropped and reference the first file's binding.
-      expect(imports).toEqual([
-        'import * as NS from "pkg";',
-        'import def from "pkg";',
-        'import { named } from "pkg";',
-      ]);
+      expect(imports).toEqual(['import * as NS from "pkg";', 'import def from "pkg";', 'import { named } from "pkg";']);
     },
     run: {
       stdout: '{"a":"EXT","b":"EXT2","c":"DEF","d":"DEF!","e":"NAMED","f":"NAMED?","g":"G"}',

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -77,6 +77,7 @@ describe("bundler", () => {
   itBundled("edgecase/DedupeExternalESMImports", {
     files: {
       "/entry.js": /* js */ `
+        import { h } from "./h.js";
         import { a } from "./a.js";
         import { b } from "./b.js";
         import { c } from "./c.js";
@@ -84,7 +85,11 @@ describe("bundler", () => {
         import { e } from "./e.js";
         import { f } from "./f.js";
         import { g } from "./g.js";
-        console.log(JSON.stringify({ a, b, c, d, e, f, g }));
+        console.log(JSON.stringify({ a, b, c, d, e, f, g, h }));
+      `,
+      "/h.js": /* js */ `
+        import "pkg";
+        export const h = "H";
       `,
       "/a.js": /* js */ `
         import * as NS from "pkg";
@@ -129,12 +134,12 @@ describe("bundler", () => {
       const out = api.readFile("/out.js");
       const imports = out.match(/^import[^;]*;/gm) ?? [];
       // One import statement per distinct clause shape (star, default, named);
-      // the second file of each pair and the bare side-effect import are
-      // dropped and reference the first file's binding.
+      // the second file of each pair and both bare side-effect imports (h
+      // before, g after the binding imports) are dropped.
       expect(imports).toEqual(['import * as NS from "pkg";', 'import def from "pkg";', 'import { named } from "pkg";']);
     },
     run: {
-      stdout: '{"a":"EXT","b":"EXT2","c":"DEF","d":"DEF!","e":"NAMED","f":"NAMED?","g":"G"}',
+      stdout: '{"a":"EXT","b":"EXT2","c":"DEF","d":"DEF!","e":"NAMED","f":"NAMED?","g":"G","h":"H"}',
     },
   });
   itBundled("edgecase/DedupeExternalESMImportsExactOnly", {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -270,10 +270,6 @@ describe("bundler", () => {
           import * as NS from "pkg";
           export { NS as sharedNS };
         `,
-        "/consumer.js": /* js */ `
-          import { utilNS, sharedNS } from "./entry1.js";
-          console.log(utilNS.tag, sharedNS.tag);
-        `,
       },
       entryPoints: ["/entry1.js", "/entry2.js"],
       splitting: true,
@@ -282,6 +278,10 @@ describe("bundler", () => {
       runtimeFiles: {
         "/node_modules/pkg/index.mjs": `export const tag = "EXT";`,
         "/node_modules/pkg/package.json": `{ "type": "module", "main": "./index.mjs" }`,
+        "/out/consumer.js": /* js */ `
+          import { utilNS, sharedNS } from "./entry1.js";
+          console.log(utilNS.tag, sharedNS.tag);
+        `,
       },
       onAfterBundle(api) {
         // util.js and shared.js land in one shared chunk. Their two
@@ -291,7 +291,7 @@ describe("bundler", () => {
         // used-refs loop and its entry-exports loop must follow() before
         // recording; otherwise each entry chunk gets two clause items with the
         // same local name (a SyntaxError).
-        const chunkFiles = readdirSync(api.outdir).filter(f => !/^entry[12]\.js$/.test(f));
+        const chunkFiles = readdirSync(api.outdir).filter(f => !/^(entry[12]|consumer)\.js$/.test(f));
         expect(chunkFiles).toHaveLength(1);
         const sharedChunk = api.readFile("/out/" + chunkFiles[0]);
         expect(sharedChunk.match(/^import\s*\*\s*as\s/gm) ?? []).toHaveLength(1);
@@ -303,8 +303,8 @@ describe("bundler", () => {
         }
       },
       run: [
-        { file: name === "Use" ? "/out/entry1.js" : "/consumer.js", stdout: "EXT EXT" },
-        { file: name === "Use" ? "/out/entry2.js" : "/consumer.js", stdout: "EXT EXT" },
+        { file: name === "Use" ? "/out/entry1.js" : "/out/consumer.js", stdout: "EXT EXT" },
+        { file: name === "Use" ? "/out/entry2.js" : "/out/consumer.js", stdout: "EXT EXT" },
       ],
     });
   }


### PR DESCRIPTION
## What

With ESM output and an external package, every bundled source file's `import` statement for that package is printed verbatim, so N files that each write `import * as NS from "pkg"` produce N import statements with N distinct bindings in the chunk:

```js
// f1.mjs
import * as Https from "firebase-functions/v2/https";
var fn = Https.onCall(...);
// f2.mjs
import * as Https2 from "firebase-functions/v2/https";
var fn2 = Https2.onCall(...);
```

The extra statements are semantically redundant (every binding is a live view of the same module namespace) and scale linearly with the number of importing files. esbuild has the same behaviour (evanw/esbuild#475).

## Fix

A per-chunk pass between `compute_chunks` and `compute_cross_chunk_dependencies` walks `parts_in_chunk_in_order` and groups external `SImport` statements by the exact specifier they print (path text, namespace, `PRINT_NAMESPACE_IN_PATH`, `with { type }` loader) and the exact set of clauses they bind (star / default / sorted named aliases). Within an equivalence class the first statement in the chunk is kept and later ones have their refs `symbols.merge`d into it and the statement recorded in a chunk-local `external_import_records_to_skip` set, which `convert_stmts_for_chunk` and the `--compile --bytecode` `ModuleInfo` builder in `postProcessJSChunk` consult to drop it. `compute_cross_chunk_dependencies.walk()` now `follow()`s the ref it records so a re-exported namespace that was merged away still produces exactly one cross-chunk import clause under `--splitting`.

Bare side-effect imports (`import "pkg"`) are also dropped once any import for that specifier is kept, since ES modules evaluate the target once regardless of how many statements reference it.

Partially overlapping imports (`{x}` vs `{x, y}`) are left untouched. Collapsing a strict subset would require merging a clause ref of a statement that is kept, and with multiple entry points a different chunk's merge can then transitively unify two refs that are both kept in a third chunk, producing duplicate top-level bindings. `DedupeExternalESMImportsMultiEntryOverlap` covers that case. `export { x } from "pkg"` / `export * as ns from "pkg"` are also left untouched for now; their item refs feed the entry point's resolved-exports table, so they stay at their pre-PR (correct) output.

After:

```js
// f1.mjs
import * as Https from "firebase-functions/v2/https";
var fn = Https.onCall(...);
// f2.mjs
var fn2 = Https.onCall(...);
```

## Verification

New `itBundled` cases in `test/bundler/bundler_edgecase.test.ts`:

- `DedupeExternalESMImports`: pairs of star / default / named imports plus a bare side-effect import collapse to one statement per clause shape; the bundle runs under the external at runtime and prints the expected values.
- `DedupeExternalESMImportsExactOnly`: `{x, y}` and `{y, x}` collapse (order-insensitive); `{x, y}` and `{x}` stay separate so the kept `{x}` gets its own local; a `{x}` from a different package is unaffected. Bundle runs correctly.
- `DedupeExternalESMImportsMultiEntryOverlap`: three entry points share `{x}` / `{x, y}` / `{x}` across files so every pair co-occurs; each bundle runs with no duplicate top-level bindings and the pair of identical `{x}` imports collapses where they share a chunk.
- `DedupeExternalESMImportsSplittingReExport`: `splitting: true`, two files in the shared chunk each `import * as NS from "pkg"` and re-export it; the shared chunk has one `import * as NS` and each entry's cross-chunk import has a single clause (runs correctly).
- `DedupeExternalESMImportsNotAcrossLoader`: two `with { type: "json" }` defaults collapse; a plain default for the same specifier stays separate.
- `DedupeExternalESMImportsMultiEntry`: two entry points share a file, file order differs between the chunks; each chunk keeps exactly one `import * as NS from "pkg"` and runs correctly.

All six fail on the released binary and pass with this change. `esbuild/importstar`, `esbuild/default`, `esbuild/splitting`, `esbuild/packagejson`, `esbuild/loader`, `bundler_cjs2esm`, `bundler_minify`, `bundler_npm`, `bundler_compile_splitting`, `bun-build-api` and the rest of `bundler_edgecase` pass unchanged.

Fixes #13092
Fixes #18963

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->