### PR TITLE
Report unhandled promise rejections from ShadowRealm globals

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -921,8 +921,7 @@ using namespace WebCore;
 
 static void promiseRejectionTrackerForShadowRealm(JSGlobalObject*, JSC::JSPromise* promise, JSC::JSPromiseRejectionOperation operation)
 {
-    // Only the thread-default global's m_aboutToBeNotifiedRejectedPromises is
-    // ever drained by the event loop, so route ShadowRealm rejections there.
+    // handleRejectedPromises() only drains the thread-default global's queue.
     Zig::GlobalObject::promiseRejectionTracker(defaultGlobalObject(), promise, operation);
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -919,6 +919,23 @@ namespace Zig {
 
 using namespace WebCore;
 
+static void promiseRejectionTrackerForShadowRealm(JSGlobalObject*, JSC::JSPromise* promise, JSC::JSPromiseRejectionOperation operation)
+{
+    // Only the thread-default global's m_aboutToBeNotifiedRejectedPromises is
+    // ever drained by the event loop, so route ShadowRealm rejections there.
+    Zig::GlobalObject::promiseRejectionTracker(defaultGlobalObject(), promise, operation);
+}
+
+static const JSC::GlobalObjectMethodTable& shadowRealmGlobalObjectMethodTable()
+{
+    static const JSC::GlobalObjectMethodTable table = [] {
+        JSC::GlobalObjectMethodTable t = GlobalObject::globalObjectMethodTable();
+        t.promiseRejectionTracker = &promiseRejectionTrackerForShadowRealm;
+        return t;
+    }();
+    return table;
+}
+
 static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -929,7 +946,8 @@ static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObjec
     Zig::GlobalObject* shadow = Zig::GlobalObject::create(
         vm,
         Zig::GlobalObject::createStructure(vm),
-        ScriptExecutionContext::generateIdentifier());
+        ScriptExecutionContext::generateIdentifier(),
+        &shadowRealmGlobalObjectMethodTable());
     shadow->setConsole(shadow);
 
     return shadow;
@@ -1080,15 +1098,7 @@ extern "C" void Bun__handleHandledPromise(Zig::GlobalObject* JSGlobalObject, JSC
 void GlobalObject::promiseRejectionTracker(JSGlobalObject* obj, JSC::JSPromise* promise,
     JSC::JSPromiseRejectionOperation operation)
 {
-    // The event loop only drains the thread-default Zig::GlobalObject's
-    // m_aboutToBeNotifiedRejectedPromises. A ShadowRealm's global is also a
-    // Zig::GlobalObject but is never drained, so route its rejections (and the
-    // matching Handle) to the default global so they are reported.
     auto* globalObj = static_cast<GlobalObject*>(obj);
-    if (!globalObj->isThreadLocalDefaultGlobalObject) [[unlikely]] {
-        if (auto* defaultGlobal = defaultGlobalObject())
-            globalObj = defaultGlobal;
-    }
 
     switch (operation) {
     case JSPromiseRejectionOperation::Reject:

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1080,7 +1080,15 @@ extern "C" void Bun__handleHandledPromise(Zig::GlobalObject* JSGlobalObject, JSC
 void GlobalObject::promiseRejectionTracker(JSGlobalObject* obj, JSC::JSPromise* promise,
     JSC::JSPromiseRejectionOperation operation)
 {
+    // The event loop only drains the thread-default Zig::GlobalObject's
+    // m_aboutToBeNotifiedRejectedPromises. A ShadowRealm's global is also a
+    // Zig::GlobalObject but is never drained, so route its rejections (and the
+    // matching Handle) to the default global so they are reported.
     auto* globalObj = static_cast<GlobalObject*>(obj);
+    if (!globalObj->isThreadLocalDefaultGlobalObject) [[unlikely]] {
+        if (auto* defaultGlobal = defaultGlobalObject())
+            globalObj = defaultGlobal;
+    }
 
     switch (operation) {
     case JSPromiseRejectionOperation::Reject:

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -1,4 +1,5 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 it("shadow realm works", () => {
   const red = new ShadowRealm();
@@ -7,4 +8,134 @@ it("shadow realm works", () => {
   const result = red.evaluate("globalThis.someValue = 2;");
   expect(globalThis.someValue).toBe(1);
   expect(result).toBe(2);
+});
+
+// https://github.com/oven-sh/bun/issues/11845
+describe.concurrent("unhandled rejection inside a ShadowRealm", () => {
+  it("is reported as an unhandled rejection", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = new ShadowRealm();
+         r.evaluate("Promise.reject(new Error('boom-from-realm')); undefined");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("boom-from-realm");
+    expect(exitCode).toBe(1);
+  });
+
+  it("from an async function is reported", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const r = new ShadowRealm();
+         const run = r.evaluate(
+           "() => { (async () => { throw new Error('async-boom'); })(); }"
+         );
+         run();`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("async-boom");
+    expect(exitCode).toBe(1);
+  });
+
+  it("reaches process.on('unhandledRejection')", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("unhandledRejection", (err) => {
+           console.log("caught", err.message);
+           process.exit(0);
+         });
+         const r = new ShadowRealm();
+         r.evaluate("Promise.reject(new Error('handled-by-process')); undefined");
+         setTimeout(() => process.exit(2), 1000);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("caught handled-by-process\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("is not reported when caught inside the realm", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("unhandledRejection", () => {
+           console.error("unhandledRejection fired");
+           process.exit(1);
+         });
+         const r = new ShadowRealm();
+         r.evaluate("Promise.reject(new Error('should-be-caught')).catch(() => {}); undefined");
+         await new Promise(queueMicrotask);
+         console.log("ok");`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("emits rejectionHandled when caught after being reported", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("unhandledRejection", () => console.log("unhandled"));
+         process.on("rejectionHandled", () => {
+           console.log("handled");
+           process.exit(0);
+         });
+         const r = new ShadowRealm();
+         const attach = r.evaluate(
+           "var p = Promise.reject(new Error('late')); () => { p.catch(() => {}); }"
+         );
+         setTimeout(() => { attach(); setTimeout(() => process.exit(2), 1000); }, 0);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("unhandled\nhandled\n");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -23,11 +23,7 @@ describe.concurrent("unhandled rejection inside a ShadowRealm", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("");
     expect(stderr).toContain("boom-from-realm");
     expect(exitCode).toBe(1);
@@ -47,11 +43,7 @@ describe.concurrent("unhandled rejection inside a ShadowRealm", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("");
     expect(stderr).toContain("async-boom");
     expect(exitCode).toBe(1);
@@ -73,11 +65,7 @@ describe.concurrent("unhandled rejection inside a ShadowRealm", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("caught handled-by-process\n");
     expect(exitCode).toBe(0);
@@ -100,11 +88,7 @@ describe.concurrent("unhandled rejection inside a ShadowRealm", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("ok\n");
     expect(exitCode).toBe(0);
@@ -129,11 +113,7 @@ describe.concurrent("unhandled rejection inside a ShadowRealm", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("unhandled\nhandled\n");
     expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes #11845.

## What

Unhandled promise rejections originating inside a `ShadowRealm` (including errors thrown from `async` functions) were silently swallowed: nothing was printed and the process exited 0.

```js
const r = new ShadowRealm();
r.evaluate("Promise.reject(new Error('boom')); undefined");
// before: no output, exit 0
// after:  "error: boom" on stderr, exit 1
```

## Why

JSC calls `promiseRejectionTracker(globalObject, promise, Reject)` with the promise's own realm's global. `deriveShadowRealmGlobalObject` created the ShadowRealm global as a plain `Zig::GlobalObject` with the main method table, so the tracker appended the promise to the *ShadowRealm* global's `m_aboutToBeNotifiedRejectedPromises`. The event loop only ever drains that list on the thread's default `Zig::GlobalObject`, so the ShadowRealm's queue was never processed.

`node:vm` was already immune because `NodeVMGlobalObject` is not a `Zig::GlobalObject` and has its own method-table wrapper that redirects to the default global.

## How

Give the ShadowRealm global its own `GlobalObjectMethodTable` that is a copy of the main table with `promiseRejectionTracker` replaced by a wrapper that forwards to the thread-default global (same pattern `NodeVMGlobalObject` uses). The main tracker is left untouched, so the default global and retired `bun test --isolate` globals keep their existing behaviour; only ShadowRealm globals redirect.

## Verification

New tests in `test/js/bun/jsc/shadow.test.js`:
- bare `Promise.reject` in a realm is reported (stderr + exit 1)
- `async` function throwing in a realm is reported
- `process.on('unhandledRejection')` receives it
- a rejection caught inside the realm is *not* reported
- attaching a handler after the report fires `rejectionHandled`

<details>
<summary>Original issue repro (after)</summary>

```
$ bun run index.js
TEST
1 | export default function out(arg) {
2 | 	async function run() {
3 | 		console.log(arg);
4 | 		console.log(foo);
                     ^
ReferenceError: foo is not defined
      at run (erroring.js:4:18)
      at out (erroring.js:6:2)
      at index.js:3:1
```
</details>
