### PR TITLE
bundler: resolve require('bindings')(name) to the .node addon at build time

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -835,7 +835,7 @@ const addon = require("./addon.node");
 console.log(addon.hello());
 ```
 
-If you're using `@mapbox/node-pre-gyp` or similar tools, the `.node` file must be required directly or it won't bundle correctly.
+Packages that load their addon through the [`bindings`](https://npmjs.com/package/bindings) helper (for example, `require("bindings")("addon")`) are handled automatically: the bundler locates the `.node` file in the package's `build/` output directories at build time and embeds it. If you're using `@mapbox/node-pre-gyp` or another loader that computes the addon path dynamically, the `.node` file must be required directly or it won't bundle correctly.
 
 ### Embed directories
 

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -70,6 +70,12 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
+        /// The specifier is the `<name>.node` argument of
+        /// `require('bindings')('<name>')`. The bundler resolves it by walking
+        /// up to the enclosing package root and probing the build directories
+        /// the `bindings` npm package would search at runtime.
+        const NODE_BINDINGS_SEARCH = 1 << 7;
+
         /// If true, this was originally written as a bare "import 'file'" statement
         const WAS_ORIGINALLY_BARE_IMPORT = 1 << 8;
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5756,6 +5756,60 @@ pub mod bv2_impl {
         }
     }
 
+    /// Resolve a `require('bindings')('<name>.node')` addon name to an absolute
+    /// path the same way the npm `bindings` package does at runtime: walk up
+    /// from `source_dir` to the nearest directory that contains `package.json`,
+    /// then probe that package's build-output directories for `<name>.node`.
+    /// Returns the found path written into `out`, or `None` if no match.
+    fn locate_node_bindings_addon<'b>(
+        source_dir: &[u8],
+        name: &[u8],
+        out: &'b mut bun_paths::PathBuffer,
+    ) -> Option<&'b [u8]> {
+        const SEARCH_DIRS: &[&[u8]] = &[
+            b"build",
+            b"build/Debug",
+            b"build/Release",
+            b"out/Debug",
+            b"Debug",
+            b"out/Release",
+            b"Release",
+            b"build/default",
+            b"addon-build/release/install-root",
+            b"addon-build/debug/install-root",
+            b"addon-build/default/install-root",
+        ];
+
+        let mut root_buf = bun_paths::path_buffer_pool::get();
+        let mut dir: &[u8] = source_dir;
+        let module_root: &[u8] = loop {
+            if dir.is_empty() {
+                return None;
+            }
+            let probe = bun_paths::resolve_path::join_string_buf::<
+                bun_paths::resolve_path::platform::Auto,
+            >(&mut **root_buf, &[dir, b"package.json"]);
+            if bun_sys::exists(probe) {
+                break dir;
+            }
+            match bun_paths::dirname(dir) {
+                Some(parent) if parent.len() < dir.len() => dir = parent,
+                _ => return None,
+            }
+        };
+
+        for sub in SEARCH_DIRS {
+            let candidate = bun_paths::resolve_path::join_string_buf::<
+                bun_paths::resolve_path::platform::Auto,
+            >(&mut **out, &[module_root, sub, name]);
+            if bun_sys::exists(candidate) {
+                let len = candidate.len();
+                return Some(&out[..len]);
+            }
+        }
+        None
+    }
+
     pub struct ResolveImportRecordCtx<'a> {
         pub import_records: &'a mut [ImportRecord],
         pub source: &'a bun_ast::Source,
@@ -5922,6 +5976,55 @@ pub mod bv2_impl {
                     import_record
                         .flags
                         .insert(bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+                }
+
+                if import_record
+                    .flags
+                    .contains(bun_ast::ImportRecordFlags::NODE_BINDINGS_SEARCH)
+                    && source.path.is_file()
+                {
+                    let mut buf = bun_paths::path_buffer_pool::get();
+                    if let Some(found) = locate_node_bindings_addon(
+                        source_dir,
+                        import_record.path.text,
+                        &mut buf,
+                    ) {
+                        // SAFETY: arena outlives every ImportRecord in this pass.
+                        let text: &'static [u8] = unsafe {
+                            bun_ptr::detach_lifetime(self.arena().alloc_slice_copy(found))
+                        };
+                        import_record.path = Fs::Path::init(text);
+                    } else if !import_record
+                        .flags
+                        .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                        && !self.transpiler.options.ignore_module_resolution_errors
+                    {
+                        let log: &mut bun_ast::Log = unsafe {
+                            &mut *std::ptr::from_mut::<bun_ast::Log>(
+                                self.log_for_resolution_failures(
+                                    source.path.text,
+                                    ctx.target.bake_graph(),
+                                ),
+                            )
+                        };
+                        bun_ast::Log::add_resolve_error_with_text_dupe(
+                            log,
+                            Some(source),
+                            import_record.range,
+                            format_args!(
+                                "Could not locate the \"{}\" addon for require(\"bindings\"). Is it built?",
+                                bstr::BStr::new(&import_record.path.text),
+                            ),
+                            import_record.path.text,
+                            import_record.kind,
+                        );
+                        last_error = Some(_resolver::Error::ModuleNotFound.into());
+                        import_record.path.is_disabled = true;
+                        continue;
+                    } else {
+                        import_record.path.is_disabled = true;
+                        continue;
+                    }
                 }
 
                 if self.enqueue_on_resolve_plugin_if_needed(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5984,11 +5984,9 @@ pub mod bv2_impl {
                     && source.path.is_file()
                 {
                     let mut buf = bun_paths::path_buffer_pool::get();
-                    if let Some(found) = locate_node_bindings_addon(
-                        source_dir,
-                        import_record.path.text,
-                        &mut buf,
-                    ) {
+                    if let Some(found) =
+                        locate_node_bindings_addon(source_dir, import_record.path.text, &mut buf)
+                    {
                         // SAFETY: arena outlives every ImportRecord in this pass.
                         let text: &'static [u8] = unsafe {
                             bun_ptr::detach_lifetime(self.arena().alloc_slice_copy(found))

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2025,18 +2025,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         s.resolve_rope_if_needed(p.arena);
                         let raw = s.string(p.arena).expect("unreachable");
                         if !raw.is_empty() {
-                            let name: &'a [u8] =
-                                if strings::has_suffix_comptime(raw, b".node") {
-                                    raw
-                                } else {
-                                    let mut buf = bun_alloc::ArenaVec::with_capacity_in(
-                                        raw.len() + 5,
-                                        p.arena,
-                                    );
-                                    buf.extend_from_slice(raw);
-                                    buf.extend_from_slice(b".node");
-                                    buf.into_bump_slice()
-                                };
+                            let name: &'a [u8] = if strings::has_suffix_comptime(raw, b".node") {
+                                raw
+                            } else {
+                                let mut buf =
+                                    bun_alloc::ArenaVec::with_capacity_in(raw.len() + 5, p.arena);
+                                buf.extend_from_slice(raw);
+                                buf.extend_from_slice(b".node");
+                                buf.into_bump_slice()
+                            };
                             let handles_import_errors =
                                 p.fn_or_arrow_data_visit.try_body_count != 0;
                             let new_index = p.add_import_record_by_range(
@@ -2046,9 +2043,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             );
                             {
                                 let recs = p.import_records.items_mut();
-                                recs[new_index as usize].flags.insert(
-                                    js_ast::ImportRecordFlags::NODE_BINDINGS_SEARCH,
-                                );
+                                recs[new_index as usize]
+                                    .flags
+                                    .insert(js_ast::ImportRecordFlags::NODE_BINDINGS_SEARCH);
                                 recs[new_index as usize].flags.set(
                                     js_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
                                     handles_import_errors,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2008,6 +2008,70 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // Rewrite `require('bindings')('<name>')` to a direct require of the
+        // `.node` addon so the bundler can embed it. The `bindings` npm package
+        // locates the addon at runtime relative to the calling module's package
+        // root, which cannot work once the module is bundled into a single file.
+        if p.options.bundle && !p.is_control_flow_dead {
+            if let Data::ERequireString(req) = e_.target.data {
+                if e_.args.len_u32() == 1
+                    && p.import_records.items()[req.import_record_index as usize]
+                        .path
+                        .text
+                        == b"bindings"
+                {
+                    let arg = e_.args.slice()[0];
+                    if let Data::EString(mut s) = arg.data {
+                        s.resolve_rope_if_needed(p.arena);
+                        let raw = s.string(p.arena).expect("unreachable");
+                        if !raw.is_empty() {
+                            let name: &'a [u8] =
+                                if strings::has_suffix_comptime(raw, b".node") {
+                                    raw
+                                } else {
+                                    let mut buf = bun_alloc::ArenaVec::with_capacity_in(
+                                        raw.len() + 5,
+                                        p.arena,
+                                    );
+                                    buf.extend_from_slice(raw);
+                                    buf.extend_from_slice(b".node");
+                                    buf.into_bump_slice()
+                                };
+                            let handles_import_errors =
+                                p.fn_or_arrow_data_visit.try_body_count != 0;
+                            let new_index = p.add_import_record_by_range(
+                                js_ast::ImportKind::Require,
+                                p.source.range_of_string(arg.loc),
+                                name,
+                            );
+                            {
+                                let recs = p.import_records.items_mut();
+                                recs[new_index as usize].flags.insert(
+                                    js_ast::ImportRecordFlags::NODE_BINDINGS_SEARCH,
+                                );
+                                recs[new_index as usize].flags.set(
+                                    js_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS,
+                                    handles_import_errors,
+                                );
+                                recs[req.import_record_index as usize]
+                                    .flags
+                                    .insert(js_ast::ImportRecordFlags::IS_UNUSED);
+                            }
+                            p.import_records_for_current_part.push(new_index);
+                            *e = p.new_expr(
+                                E::RequireString {
+                                    import_record_index: new_index,
+                                    ..Default::default()
+                                },
+                                expr.loc,
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
         if matches!(e_.target.data, Data::ERequireCallTarget) {
             e_.can_be_unwrapped_if_unused = E::CallUnwrap::Never;
 

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -541,4 +541,118 @@ describe("bundler", async () => {
       },
     });
   });
+
+  // The `bindings` npm package locates a .node addon at runtime by walking up
+  // from the calling file to the nearest package.json and probing build/ dirs.
+  // That search cannot work once the module is bundled: __dirname points at the
+  // bundle (or /$bunfs/root/... for --compile) and neither the package.json nor
+  // the addon live there. The bundler now rewrites `require('bindings')(name)`
+  // at build time so the addon is resolved statically and copied/embedded via
+  // the existing napi loader. https://github.com/oven-sh/bun/issues/14301
+  describe("napi require('bindings') rewrite", () => {
+    const bindingsPkg = {
+      "/node_modules/bindings/package.json": JSON.stringify({ name: "bindings", main: "bindings.js" }),
+      "/node_modules/bindings/bindings.js": /* js */ `
+        module.exports = function bindings() {
+          throw new Error("the bundled bindings() shim was called at runtime");
+        };
+        module.exports.getRoot = function getRoot(file) {
+          throw new Error('Could not find module root given file: "' + file + '".');
+        };
+      `,
+    };
+
+    itBundled("bun/napi-bindings-rewrite", {
+      target: "bun",
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* js */ `
+          const addon = require("mypkg");
+          console.log(typeof addon);
+        `,
+        "/node_modules/mypkg/package.json": JSON.stringify({ name: "mypkg", main: "lib/binding.js" }),
+        "/node_modules/mypkg/lib/binding.js": /* js */ `
+          module.exports = require('bindings')('mypkg_native');
+        `,
+        "/node_modules/mypkg/build/Release/mypkg_native.node": Buffer.from("<native addon bytes>"),
+        ...bindingsPkg,
+      },
+      onAfterBundle(api) {
+        const files = readdirSync(api.outdir);
+        const nodeFile = files.find(x => x.endsWith(".node"));
+        expect(nodeFile).toBeDefined();
+        expect(fs.readFileSync(join(api.outdir, nodeFile!), "utf8")).toBe("<native addon bytes>");
+        const js = api.readFile("/out/entry.js");
+        expect(js).toContain(".node");
+        expect(js).not.toContain("Could not find module root");
+        expect(js).not.toContain("the bundled bindings() shim");
+      },
+    });
+
+    itBundled("bun/napi-bindings-rewrite-appends-node-extension", {
+      target: "bun",
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* js */ `require("mypkg");`,
+        "/node_modules/mypkg/package.json": JSON.stringify({ name: "mypkg", main: "index.js" }),
+        "/node_modules/mypkg/index.js": /* js */ `
+          module.exports = require('bindings')('mypkg_native.node');
+        `,
+        "/node_modules/mypkg/build/Release/mypkg_native.node": Buffer.from("x"),
+        ...bindingsPkg,
+      },
+      onAfterBundle(api) {
+        const nodeFile = readdirSync(api.outdir).find(x => x.endsWith(".node"));
+        expect(nodeFile).toBeDefined();
+      },
+    });
+
+    itBundled("bun/napi-bindings-rewrite-inside-try-catch", {
+      target: "bun",
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* js */ `
+          let loaded;
+          try {
+            loaded = require('bindings')('does_not_exist');
+          } catch {
+            loaded = { fallback: true };
+          }
+          console.log(JSON.stringify(loaded));
+        `,
+        "/package.json": JSON.stringify({ name: "entry" }),
+        ...bindingsPkg,
+      },
+      run: { stdout: '{"fallback":true}' },
+    });
+
+    itBundled("bun/napi-bindings-not-found-error", {
+      target: "bun",
+      files: {
+        "/entry.ts": /* js */ `
+          module.exports = require('bindings')('does_not_exist');
+        `,
+        "/package.json": JSON.stringify({ name: "entry" }),
+        ...bindingsPkg,
+      },
+      bundleErrors: {
+        "/entry.ts": [
+          `Could not locate the "does_not_exist.node" addon for require("bindings"). Is it built?`,
+        ],
+      },
+    });
+
+    itBundled("bun/napi-bindings-leaves-non-call-alone", {
+      target: "bun",
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* js */ `
+          const bindings = require('bindings');
+          console.log(typeof bindings.getRoot);
+        `,
+        ...bindingsPkg,
+      },
+      run: { stdout: "function" },
+    });
+  });
 });

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -636,9 +636,7 @@ describe("bundler", async () => {
         ...bindingsPkg,
       },
       bundleErrors: {
-        "/entry.ts": [
-          `Could not locate the "does_not_exist.node" addon for require("bindings"). Is it built?`,
-        ],
+        "/entry.ts": [`Could not locate the "does_not_exist.node" addon for require("bindings"). Is it built?`],
       },
     });
 


### PR DESCRIPTION
## What

`bun build` now rewrites `require("bindings")("<name>")` into a direct require of the `.node` addon, so native modules that use the [`bindings`](https://npmjs.com/package/bindings) helper bundle correctly instead of failing at runtime.

Fixes #10964
Fixes #14301

## Repro

```sh
bun add sqlite3
echo 'require("sqlite3")' > index.ts
bun build --compile ./index.ts --outfile ./server
./server
```

Before:

```
error: Could not find module root given file: "/$bunfs/root/server". Do you have a `package.json` file?
      at getRoot (/$bunfs/root/server:186:15)
      at bindings (/$bunfs/root/server:116:41)
```

After:

```
 [456ms]  bundle  4 modules
[ ... ] compile  ./server
```

The compiled binary loads `node_sqlite3.node` from its embedded asset via `process.dlopen`. (On Linux `sqlite3` then hits the separate `uv_async_init` limitation, #18546, but that is unrelated to bundling and also happens with plain `bun run`.)

## Cause

The `bindings` package locates the addon at runtime by reading the calling file's path from a stack trace, walking up to the nearest `package.json`, and probing `build/Release/`, `build/Debug/`, etc. Once the module is bundled, the calling file is the bundle itself (`/$bunfs/root/server` for `--compile`), and neither the `package.json` nor the `build/` directory exist relative to it. The addon is never embedded either, because the `require()` that would reach it is computed dynamically and invisible to static analysis.

## Fix

When bundling, the parser detects a call on `require("bindings")` with a single string argument and rewrites it to a tagged `require("<name>.node")` import record. During import-record resolution the bundler walks up from the source file's directory to the enclosing `package.json` and probes the same set of build directories `bindings` would try at runtime. When found, the path is replaced with the absolute location and the existing `Loader::Napi` handling copies/embeds it like any directly required `.node` file. The now-unused `require("bindings")` record is dropped, so the `bindings` package itself (and its `file-uri-to-path` dependency) are no longer pulled into the bundle.

When the addon is not found:
- inside `try`/`catch`, the record is disabled and the runtime require throws for the `catch` to handle;
- otherwise, the build fails with `Could not locate the "<name>.node" addon for require("bindings"). Is it built?`.

A bare `const b = require("bindings")` that is not immediately called is left alone.

## Verification

- New `napi require('bindings') rewrite` group in `test/bundler/bundler_loader.test.ts`: 5 cases (found in `build/Release/`, `.node` suffix appended, missing inside `try`/`catch` falls through, missing outside `try` errors at build time, non-call `require("bindings")` untouched). 3 of 5 fail on `main`.
- `bun bd test test/bundler/bundler_loader.test.ts`: 50 pass.
- `bun bd test test/bundler/bundler_cjs.test.ts`: 28 pass.
- End-to-end against real `sqlite3`: `bun build --target=bun` emits `node_sqlite3-<hash>.node` as an asset and the JS contains `require("./node_sqlite3-<hash>.node")`; the `bindings.js` / `getRoot` code is gone from the output.