### PR TITLE
dns: preserve raw TXT/CAA/NAPTR RDATA octets as latin1 instead of decoding as UTF-8

### DIFF
--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -306,7 +306,7 @@ pub(crate) fn caa_reply_to_js(
 
     let property = this.property_bytes();
     let value = this.value_bytes();
-    obj.put(global_this, property, utf8_to_js(global_this, value)?);
+    obj.put(global_this, property, latin1_to_js(global_this, value)?);
 
     Ok(obj)
 }
@@ -428,22 +428,22 @@ pub(crate) fn naptr_reply_to_js(
 
     // SAFETY: flags is a non-null NUL-terminated C string from c-ares.
     let flags = unsafe { bun_core::ffi::cstr(this.flags.cast()) }.to_bytes();
-    obj.put(global_this, b"flags", utf8_to_js(global_this, flags)?);
+    obj.put(global_this, b"flags", latin1_to_js(global_this, flags)?);
 
     // SAFETY: service is a non-null NUL-terminated C string from c-ares.
     let service = unsafe { bun_core::ffi::cstr(this.service.cast()) }.to_bytes();
-    obj.put(global_this, b"service", utf8_to_js(global_this, service)?);
+    obj.put(global_this, b"service", latin1_to_js(global_this, service)?);
 
     // SAFETY: regexp is a non-null NUL-terminated C string from c-ares.
     let regexp = unsafe { bun_core::ffi::cstr(this.regexp.cast()) }.to_bytes();
-    obj.put(global_this, b"regexp", utf8_to_js(global_this, regexp)?);
+    obj.put(global_this, b"regexp", latin1_to_js(global_this, regexp)?);
 
     // SAFETY: replacement is a non-null NUL-terminated C string from c-ares.
     let replacement = unsafe { bun_core::ffi::cstr(this.replacement.cast()) }.to_bytes();
     obj.put(
         global_this,
         b"replacement",
-        utf8_to_js(global_this, replacement)?,
+        latin1_to_js(global_this, replacement)?,
     );
 
     Ok(obj)

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -19,11 +19,8 @@ fn utf8_to_js(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
     bun_string_jsc::create_utf8_for_js(global, bytes)
 }
 
-/// Create a JS string from raw octets, one byte per code unit (Latin-1).
-/// TXT RDATA is a sequence of arbitrary-octet <character-string>s (RFC 1035
-/// §3.3.14 / §3.3); Node's cares_wrap uses `OneByteString` here so the bytes
-/// round-trip via `Buffer.from(s, "latin1")`. UTF-8 decoding would replace
-/// any 0x80–0xFF byte that isn't part of a valid sequence with U+FFFD.
+/// Create a JS string from raw octets, one byte per code unit. TXT RDATA is
+/// arbitrary octets (RFC 1035 §3.3); Node's cares_wrap uses `OneByteString`.
 #[inline]
 fn latin1_to_js(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
     bstr::String::clone_latin1(bytes).transfer_to_js(global)

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -400,8 +400,9 @@ pub(crate) fn txt_reply_to_js_for_any(
     global_this: &JSGlobalObject,
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
-    let array =
-        cares_list_to_js_array(this, global_this, |node, g| latin1_to_js(g, node.txt_bytes()))?;
+    let array = cares_list_to_js_array(this, global_this, |node, g| {
+        latin1_to_js(g, node.txt_bytes())
+    })?;
     let obj = JSValue::create_empty_object(global_this, 1);
     obj.put(global_this, b"entries", array);
     Ok(obj)

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -19,8 +19,7 @@ fn utf8_to_js(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
     bun_string_jsc::create_utf8_for_js(global, bytes)
 }
 
-/// Create a JS string from raw octets, one byte per code unit. TXT RDATA is
-/// arbitrary octets (RFC 1035 §3.3); Node's cares_wrap uses `OneByteString`.
+/// Create a JS string from raw octets, one byte per code unit (Latin-1).
 #[inline]
 fn latin1_to_js(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
     bstr::String::clone_latin1(bytes).transfer_to_js(global)

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -19,6 +19,16 @@ fn utf8_to_js(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
     bun_string_jsc::create_utf8_for_js(global, bytes)
 }
 
+/// Create a JS string from raw octets, one byte per code unit (Latin-1).
+/// TXT RDATA is a sequence of arbitrary-octet <character-string>s (RFC 1035
+/// §3.3.14 / §3.3); Node's cares_wrap uses `OneByteString` here so the bytes
+/// round-trip via `Buffer.from(s, "latin1")`. UTF-8 decoding would replace
+/// any 0x80–0xFF byte that isn't part of a valid sequence with U+FFFD.
+#[inline]
+fn latin1_to_js(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
+    bstr::String::clone_latin1(bytes).transfer_to_js(global)
+}
+
 // ── struct_hostent ─────────────────────────────────────────────────────────
 pub(crate) fn hostent_to_js_response(
     this: &mut c_ares::struct_hostent,
@@ -381,7 +391,7 @@ pub(crate) fn txt_reply_to_js(
 ) -> JsResult<JSValue> {
     let array = JSValue::create_empty_array(global_this, 1)?;
     let value = this.txt_bytes();
-    array.put_index(global_this, 0, utf8_to_js(global_this, value)?)?;
+    array.put_index(global_this, 0, latin1_to_js(global_this, value)?)?;
     Ok(array)
 }
 
@@ -391,7 +401,7 @@ pub(crate) fn txt_reply_to_js_for_any(
     _lookup_name: &'static [u8],
 ) -> JsResult<JSValue> {
     let array =
-        cares_list_to_js_array(this, global_this, |node, g| utf8_to_js(g, node.txt_bytes()))?;
+        cares_list_to_js_array(this, global_this, |node, g| latin1_to_js(g, node.txt_bytes()))?;
     let obj = JSValue::create_empty_object(global_this, 1);
     obj.put(global_this, b"entries", array);
     Ok(obj)

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -664,21 +664,21 @@ describe("dns.lookupService with a numeric-string port", () => {
   });
 });
 
-// TXT RDATA is a sequence of arbitrary-octet <character-string>s (RFC 1035
-// §3.3). Node exposes each as a one-byte-per-code-unit string (OneByteString)
-// so the original bytes round-trip via Buffer.from(s, "latin1"); decoding as
-// UTF-8 would replace e.g. 0xFF and lone 0x80 with U+FFFD and lose data.
-describe("dns.resolveTxt preserves raw TXT octets as latin1", () => {
-  // One TXT record whose single <character-string> is `payload`.
-  async function withTxtServer(payload, fn) {
+// TXT/CAA/NAPTR RDATA fields that carry length-delimited arbitrary octets
+// (RFC 1035 §3.3 <character-string>, RFC 8659 §4.1.1 CAA value) are exposed by
+// Node's cares_wrap as one-byte-per-code-unit strings (OneByteString), so the
+// original bytes round-trip via Buffer.from(s, "latin1"); decoding as UTF-8
+// would replace e.g. 0xFF and lone 0x80 with U+FFFD and lose data.
+describe("node:dns preserves raw RDATA octets as latin1", () => {
+  // Loopback server that answers every question with one RR of `type`/`rdata`.
+  async function withServer(type, rdata, fn) {
     const udp = dgram.createSocket("udp4");
     udp.on("message", (msg, rinfo) => {
       let off = 12;
       while (off < msg.length && msg[off] !== 0) off += msg[off] + 1;
       const question = msg.subarray(12, off + 5);
-      const rdata = Buffer.concat([Buffer.from([payload.length]), payload]);
       const answer = Buffer.concat([
-        Buffer.from([0xc0, 0x0c, 0x00, 0x10, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c]),
+        Buffer.from([0xc0, 0x0c, type >> 8, type & 0xff, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c]),
         Buffer.from([rdata.length >> 8, rdata.length & 0xff]),
         rdata,
       ]);
@@ -688,44 +688,62 @@ describe("dns.resolveTxt preserves raw TXT octets as latin1", () => {
     udp.bind(0, "127.0.0.1");
     await once(udp, "listening");
     try {
-      await fn(udp.address().port);
+      const r = new dns_promises.Resolver({ timeout: 1000, tries: 1 });
+      r.setServers([`127.0.0.1:${udp.address().port}`]);
+      await fn(r, udp.address().port);
     } finally {
       udp.close();
     }
   }
+  const charString = s => Buffer.concat([Buffer.from([s.length]), s]);
+  const codes = s => [...s].map(c => c.charCodeAt(0));
 
   const bytes = Buffer.from([0x00, 0xff, 0x41, 0x0a, 0x80, 0xe9, 0xc3]);
   const expectedCodes = [0x00, 0xff, 0x41, 0x0a, 0x80, 0xe9, 0xc3];
 
   it("promises.Resolver#resolveTxt returns bytes losslessly", async () => {
-    await withTxtServer(bytes, async port => {
-      const r = new dns_promises.Resolver({ timeout: 1000, tries: 1 });
-      r.setServers([`127.0.0.1:${port}`]);
+    await withServer(16, charString(bytes), async r => {
       const [[str]] = await r.resolveTxt("txtbin.test");
-      expect([...str].map(c => c.charCodeAt(0))).toEqual(expectedCodes);
+      expect(codes(str)).toEqual(expectedCodes);
       expect(Buffer.from(str, "latin1").equals(bytes)).toBe(true);
     });
   });
 
   it("callback Resolver#resolveTxt returns bytes losslessly", async () => {
-    await withTxtServer(bytes, async port => {
+    await withServer(16, charString(bytes), async (_, port) => {
       const r = new dns.Resolver({ timeout: 1000, tries: 1 });
       r.setServers([`127.0.0.1:${port}`]);
       const { promise, resolve, reject } = Promise.withResolvers();
       r.resolveTxt("txtbin.test", (err, records) => (err ? reject(err) : resolve(records)));
       const [[str]] = await promise;
-      expect([...str].map(c => c.charCodeAt(0))).toEqual(expectedCodes);
+      expect(codes(str)).toEqual(expectedCodes);
       expect(Buffer.from(str, "latin1").equals(bytes)).toBe(true);
     });
   });
 
   it("all-ASCII TXT data is unchanged", async () => {
-    const ascii = Buffer.from("hello world");
-    await withTxtServer(ascii, async port => {
-      const r = new dns_promises.Resolver({ timeout: 1000, tries: 1 });
-      r.setServers([`127.0.0.1:${port}`]);
-      const records = await r.resolveTxt("txtbin.test");
-      expect(records).toEqual([["hello world"]]);
+    await withServer(16, charString(Buffer.from("hello world")), async r => {
+      expect(await r.resolveTxt("txtbin.test")).toEqual([["hello world"]]);
+    });
+  });
+
+  it("resolveAny TXT entries return bytes losslessly", async () => {
+    await withServer(16, charString(bytes), async r => {
+      const results = await r.resolveAny("txtbin.test");
+      const txt = results.find(e => e.type === "TXT");
+      expect(codes(txt.entries[0])).toEqual(expectedCodes);
+      expect(Buffer.from(txt.entries[0], "latin1").equals(bytes)).toBe(true);
+    });
+  });
+
+  it("resolveCaa value returns bytes losslessly", async () => {
+    // CAA RDATA: flags(1) tag-len(1) tag(n) value(rest)
+    const value = Buffer.from([0x63, 0x61, 0x2e, 0x65, 0x78, 0xff, 0x80]); // "ca.ex" + 0xFF 0x80
+    const rdata = Buffer.concat([Buffer.from([0, 5]), Buffer.from("issue"), value]);
+    await withServer(257, rdata, async r => {
+      const [rec] = await r.resolveCaa("caa.test");
+      expect(codes(rec.issue)).toEqual([0x63, 0x61, 0x2e, 0x65, 0x78, 0xff, 0x80]);
+      expect(Buffer.from(rec.issue, "latin1").equals(value)).toBe(true);
     });
   });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,7 +1,9 @@
 import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
 import { isWindows } from "harness";
+import * as dgram from "node:dgram";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
+import { once } from "node:events";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as util from "node:util";
@@ -659,5 +661,71 @@ describe("dns.lookupService with a numeric-string port", () => {
     expect(() => dns_promises.lookupService("127.0.0.1", "nope")).toThrow(
       expect.objectContaining({ code: "ERR_SOCKET_BAD_PORT" }),
     );
+  });
+});
+
+// TXT RDATA is a sequence of arbitrary-octet <character-string>s (RFC 1035
+// §3.3). Node exposes each as a one-byte-per-code-unit string (OneByteString)
+// so the original bytes round-trip via Buffer.from(s, "latin1"); decoding as
+// UTF-8 would replace e.g. 0xFF and lone 0x80 with U+FFFD and lose data.
+describe("dns.resolveTxt preserves raw TXT octets as latin1", () => {
+  // One TXT record whose single <character-string> is `payload`.
+  async function withTxtServer(payload, fn) {
+    const udp = dgram.createSocket("udp4");
+    udp.on("message", (msg, rinfo) => {
+      let off = 12;
+      while (off < msg.length && msg[off] !== 0) off += msg[off] + 1;
+      const question = msg.subarray(12, off + 5);
+      const rdata = Buffer.concat([Buffer.from([payload.length]), payload]);
+      const answer = Buffer.concat([
+        Buffer.from([0xc0, 0x0c, 0x00, 0x10, 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c]),
+        Buffer.from([rdata.length >> 8, rdata.length & 0xff]),
+        rdata,
+      ]);
+      const header = Buffer.from([msg[0], msg[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
+      udp.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
+    });
+    udp.bind(0, "127.0.0.1");
+    await once(udp, "listening");
+    try {
+      await fn(udp.address().port);
+    } finally {
+      udp.close();
+    }
+  }
+
+  const bytes = Buffer.from([0x00, 0xff, 0x41, 0x0a, 0x80, 0xe9, 0xc3]);
+  const expectedCodes = [0x00, 0xff, 0x41, 0x0a, 0x80, 0xe9, 0xc3];
+
+  it("promises.Resolver#resolveTxt returns bytes losslessly", async () => {
+    await withTxtServer(bytes, async port => {
+      const r = new dns_promises.Resolver({ timeout: 1000, tries: 1 });
+      r.setServers([`127.0.0.1:${port}`]);
+      const [[str]] = await r.resolveTxt("txtbin.test");
+      expect([...str].map(c => c.charCodeAt(0))).toEqual(expectedCodes);
+      expect(Buffer.from(str, "latin1").equals(bytes)).toBe(true);
+    });
+  });
+
+  it("callback Resolver#resolveTxt returns bytes losslessly", async () => {
+    await withTxtServer(bytes, async port => {
+      const r = new dns.Resolver({ timeout: 1000, tries: 1 });
+      r.setServers([`127.0.0.1:${port}`]);
+      const { promise, resolve, reject } = Promise.withResolvers();
+      r.resolveTxt("txtbin.test", (err, records) => (err ? reject(err) : resolve(records)));
+      const [[str]] = await promise;
+      expect([...str].map(c => c.charCodeAt(0))).toEqual(expectedCodes);
+      expect(Buffer.from(str, "latin1").equals(bytes)).toBe(true);
+    });
+  });
+
+  it("all-ASCII TXT data is unchanged", async () => {
+    const ascii = Buffer.from("hello world");
+    await withTxtServer(ascii, async port => {
+      const r = new dns_promises.Resolver({ timeout: 1000, tries: 1 });
+      r.setServers([`127.0.0.1:${port}`]);
+      const records = await r.resolveTxt("txtbin.test");
+      expect(records).toEqual([["hello world"]]);
+    });
   });
 });


### PR DESCRIPTION
## Problem

`dns.resolveTxt()` (and the CAA value / NAPTR character-string fields) run RDATA bytes through UTF-8 decoding, which replaces any byte in `0x80..=0xFF` that is not part of a valid UTF-8 sequence with U+FFFD. These fields are defined as arbitrary octets (RFC 1035 §3.3 `<character-string>`, RFC 8659 §4.1.1 CAA Value), and Node's `cares_wrap.cc` wraps each with `OneByteString` (one byte per UTF-16 code unit), so `Buffer.from(str, "latin1")` recovers the exact wire bytes. In Bun the bytes were irrecoverably corrupted.

## Reproduction

Self-contained loopback responder serving one TXT record with bytes `00 ff 41 0a 80 e9 c3`:

```js
import dgram from "node:dgram"; import dns from "node:dns";
const payload = Buffer.from([0x00, 0xff, 0x41, 0x0a, 0x80, 0xe9, 0xc3]);
const s = dgram.createSocket("udp4");
s.on("message", (m, ri) => {
  let i = 12; while (m[i]) i += m[i] + 1; const q = m.slice(12, i + 5);
  const rd = Buffer.concat([Buffer.from([payload.length]), payload]);
  const ans = Buffer.concat([Buffer.from([0xc0, 0x0c, 0, 16, 0, 1, 0, 0, 0, 60, 0, rd.length]), rd]);
  s.send(Buffer.concat([Buffer.from([m[0], m[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]), q, ans]), ri.port, ri.address);
});
s.bind(0, "127.0.0.1", async () => {
  const R = new dns.promises.Resolver({ timeout: 800, tries: 1 }); R.setServers(["127.0.0.1:" + s.address().port]);
  const [[str]] = await R.resolveTxt("txtbin.z.example");
  const back = Buffer.from(str, "latin1");
  console.log("served bytes :", payload.toString("hex"));
  console.log("string codes :", JSON.stringify([...str].map((c) => c.charCodeAt(0))));
  console.log("latin1 back  :", back.toString("hex"), back.equals(payload) ? "== original (LOSSLESS)" : "!= original (CORRUPTED)");
  s.close();
});
```

| | Node v26.3.0 | Bun 1.4.0 (before) | Bun (after) |
| --- | --- | --- | --- |
| string codes | `[0,255,65,10,128,233,195]` | `[0,65533,65,10,65533,65533,65533]` | `[0,255,65,10,128,233,195]` |
| latin1 round-trip | `00ff410a80e9c3` LOSSLESS | `00fd410afdfdfd` CORRUPTED | `00ff410a80e9c3` LOSSLESS |

## Cause

`txt_reply_to_js`, `txt_reply_to_js_for_any`, `caa_reply_to_js`, and `naptr_reply_to_js` in `src/runtime/dns_jsc/cares_jsc.rs` passed the c-ares-owned octet buffers to `create_utf8_for_js`, which decodes as UTF-8 with replacement.

## Fix

Build the JS string via `String::clone_latin1` (an 8-bit `WTFStringImpl`, one byte per code unit) for:
- TXT entries in both `resolveTxt` and the `resolveAny` TXT path
- CAA `value`
- NAPTR `flags` / `service` / `regexp` / `replacement`

Domain-name fields (SRV `name`, MX `exchange`, SOA `nsname`/`hostmaster`, NS/PTR/CNAME aliases) are left on `utf8_to_js`; they are ASCII on the wire so the encoding is equivalent there.

Tests use a loopback UDP responder and cover `resolveTxt` (promises + callback), `resolveAny` TXT, and `resolveCaa`. No NAPTR test is added: c-ares validates NAPTR flags/services/regexp as printable ASCII (`ares_buf_parse_dns_binstr_int` with `validate_printable=true`) and rejects any byte outside `0x20..=0x7E` with `EBADRESP` before the binding is reached, on both Bun and Node; the encoding difference is therefore unreachable for NAPTR today.

Note: #32816 touches the same TXT lines for a separate record-grouping fix and still calls `utf8_to_js`; whichever lands second will need a one-line rebase.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->
