### PR TITLE
output: enable ANSI colors by default on CI providers that render them

### DIFF
--- a/src/bun_core/Progress.rs
+++ b/src/bun_core/Progress.rs
@@ -353,6 +353,7 @@ impl Progress {
             self.terminal = Some(stderr);
             self.supports_ansi_escape_codes = true;
         } else {
+            self.supports_ansi_escape_codes = false;
             #[cfg(windows)]
             if stderr.is_tty() {
                 self.is_windows_terminal = true;

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -148,6 +148,7 @@ new!(pub JENKINS_URL: string, "JENKINS_URL", {});
 new!(pub MI_VERBOSE: boolean, "MI_VERBOSE", { default: false });
 new!(pub NO_COLOR: boolean, "NO_COLOR", { default: false });
 new!(pub NODE_CHANNEL_FD: string, "NODE_CHANNEL_FD", {});
+new!(pub NODE_DISABLE_COLORS: string, "NODE_DISABLE_COLORS", {});
 // A string, not a boolean: node suppresses warnings only when the value is
 // exactly "1" (lib/internal/process/pre_execution.js).
 new!(pub NODE_NO_WARNINGS: string, "NODE_NO_WARNINGS", {});

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1136,8 +1136,10 @@ pub fn writer_buffered() -> &'static mut io::Writer {
 }
 
 pub fn reset_terminal() {
-    let stderr = ENABLE_ANSI_COLORS_STDERR.load(Ordering::Relaxed);
-    let stdout = ENABLE_ANSI_COLORS_STDOUT.load(Ordering::Relaxed);
+    let stderr = ENABLE_ANSI_COLORS_STDERR.load(Ordering::Relaxed)
+        && stderr_descriptor_type() == OutputStreamDescriptor::Terminal;
+    let stdout = ENABLE_ANSI_COLORS_STDOUT.load(Ordering::Relaxed)
+        && stdout_descriptor_type() == OutputStreamDescriptor::Terminal;
     if !stderr && !stdout {
         return;
     }
@@ -1152,10 +1154,14 @@ pub fn reset_terminal() {
 
 pub fn reset_terminal_all() {
     SOURCE.with_borrow_mut(|s| {
-        if ENABLE_ANSI_COLORS_STDERR.load(Ordering::Relaxed) {
+        if ENABLE_ANSI_COLORS_STDERR.load(Ordering::Relaxed)
+            && stderr_descriptor_type() == OutputStreamDescriptor::Terminal
+        {
             let _ = s.error_stream().write_all(b"\x1B[2J\x1B[3J\x1B[H");
         }
-        if ENABLE_ANSI_COLORS_STDOUT.load(Ordering::Relaxed) {
+        if ENABLE_ANSI_COLORS_STDOUT.load(Ordering::Relaxed)
+            && stdout_descriptor_type() == OutputStreamDescriptor::Terminal
+        {
             let _ = s.stream().write_all(b"\x1B[2J\x1B[3J\x1B[H");
         }
     });

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -545,9 +545,9 @@ impl Source {
                     enable_color = Some(depth != ColorDepth::None);
                 } else if Self::is_no_color() {
                     enable_color = Some(false);
-                } else if Self::is_color_terminal() && (is_stdout_tty || is_stderr_tty) {
-                    enable_color = Some(true);
-                } else if env_var::TERM.get().unwrap_or(b"") != b"dumb" && is_ansi_capable_ci() {
+                } else if (Self::is_color_terminal() && (is_stdout_tty || is_stderr_tty))
+                    || (env_var::TERM.get().unwrap_or(b"") != b"dumb" && is_ansi_capable_ci())
+                {
                     enable_color = Some(true);
                 }
 

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -546,6 +546,9 @@ impl Source {
                     enable_color = Some(false);
                 } else if Self::is_color_terminal() && (is_stdout_tty || is_stderr_tty) {
                     enable_color = Some(true);
+                } else if env_var::TERM.get().unwrap_or(b"") != b"dumb" && is_ansi_capable_ci()
+                {
+                    enable_color = Some(true);
                 }
 
                 ENABLE_ANSI_COLORS_STDOUT
@@ -890,6 +893,36 @@ fn compute_color_depth() -> ColorDepth {
     }
 
     ColorDepth::None
+}
+
+/// CI environments whose log viewers render ANSI escape sequences. On such a
+/// system we enable color output even when stdout/stderr are pipes. The
+/// provider list is the same one used by Node's `tty.WriteStream#getColorDepth`
+/// (`src/js/internal/tty.ts`) and `chalk/supports-color`, so behaviour matches
+/// the broader ecosystem. Bare `CI` without a known provider stays uncoloured.
+#[cfg(not(target_arch = "wasm32"))]
+fn is_ansi_capable_ci() -> bool {
+    macro_rules! set {
+        ($k:literal) => {
+            crate::getenv_z(crate::zstr!($k)).is_some()
+        };
+    }
+    // Azure DevOps does not set `CI`.
+    if set!("TF_BUILD") && set!("AGENT_NAME") {
+        return true;
+    }
+    if !set!("CI") {
+        return false;
+    }
+    set!("GITHUB_ACTIONS")
+        || set!("GITEA_ACTIONS")
+        || set!("GITLAB_CI")
+        || set!("CIRCLECI")
+        || set!("TRAVIS")
+        || set!("APPVEYOR")
+        || set!("BUILDKITE")
+        || set!("DRONE")
+        || crate::getenv_z(crate::zstr!("CI_NAME")) == Some(b"codeship")
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -894,11 +894,7 @@ fn compute_color_depth() -> ColorDepth {
     ColorDepth::None
 }
 
-/// CI environments whose log viewers render ANSI escape sequences. On such a
-/// system we enable color output even when stdout/stderr are pipes. The
-/// provider list is the same one used by Node's `tty.WriteStream#getColorDepth`
-/// (`src/js/internal/tty.ts`) and `chalk/supports-color`, so behaviour matches
-/// the broader ecosystem. Bare `CI` without a known provider stays uncoloured.
+/// CI log viewers that render ANSI; list matches `src/js/internal/tty.ts`.
 #[cfg(not(target_arch = "wasm32"))]
 fn is_ansi_capable_ci() -> bool {
     macro_rules! set {

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -546,8 +546,7 @@ impl Source {
                     enable_color = Some(false);
                 } else if Self::is_color_terminal() && (is_stdout_tty || is_stderr_tty) {
                     enable_color = Some(true);
-                } else if env_var::TERM.get().unwrap_or(b"") != b"dumb" && is_ansi_capable_ci()
-                {
+                } else if env_var::TERM.get().unwrap_or(b"") != b"dumb" && is_ansi_capable_ci() {
                     enable_color = Some(true);
                 }
 

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -481,6 +481,7 @@ impl Source {
     pub fn is_no_color() -> bool {
         // Parsed bool, default false. NO_COLOR=0 → false.
         env_var::NO_COLOR.get().unwrap_or(false)
+            || env_var::NODE_DISABLE_COLORS.get_not_empty().is_some()
     }
 
     pub fn get_force_color_depth() -> Option<ColorDepth> {
@@ -540,8 +541,8 @@ impl Source {
                 }
 
                 let mut enable_color: Option<bool> = None;
-                if Self::is_force_color() {
-                    enable_color = Some(true);
+                if let Some(depth) = Self::get_force_color_depth() {
+                    enable_color = Some(depth != ColorDepth::None);
                 } else if Self::is_no_color() {
                     enable_color = Some(false);
                 } else if Self::is_color_terminal() && (is_stdout_tty || is_stderr_tty) {
@@ -894,7 +895,7 @@ fn compute_color_depth() -> ColorDepth {
     ColorDepth::None
 }
 
-/// CI log viewers that render ANSI; list matches `src/js/internal/tty.ts`.
+/// CI log viewers that render ANSI; subset of `CI_ENVS` in `src/js/internal/tty.ts`.
 #[cfg(not(target_arch = "wasm32"))]
 fn is_ansi_capable_ci() -> bool {
     macro_rules! set {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2404,7 +2404,6 @@ pub(crate) fn init_with_runtime_once(
 
     if Output::stderr_descriptor_type() == Output::DescriptorType::Terminal {
         manager.progress = Progress::default();
-        manager.progress.supports_ansi_escape_codes = true;
         // `Progress::start` returns `&mut Node` borrowing `manager.progress.root`.
         // Coerce to a raw pointer immediately so the borrow doesn't outlive the
         // statement; `root_progress_node` is BORROW_FIELD into `self.progress`.

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2402,9 +2402,9 @@ pub(crate) fn init_with_runtime_once(
     // The lockfile allocation is folded into the struct literal above
     // (`Box::new(Lockfile::default())`).
 
-    if Output::enable_ansi_colors_stderr() {
+    if Output::stderr_descriptor_type() == Output::DescriptorType::Terminal {
         manager.progress = Progress::default();
-        manager.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
+        manager.progress.supports_ansi_escape_codes = true;
         // `Progress::start` returns `&mut Node` borrowing `manager.progress.root`.
         // Coerce to a raw pointer immediately so the borrow doesn't outlive the
         // statement; `root_progress_node` is BORROW_FIELD into `self.progress`.

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -1123,7 +1123,6 @@ pub fn save_lockfile(
     let mut save_node: *mut ProgressNode = core::ptr::null_mut();
 
     if log_level.show_progress() {
-        this.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
         save_node = this.progress.start(ProgressStrings::save(), 0);
         // SAFETY: `save_node` was just set by `progress.start()` and is non-null.
         unsafe { (*save_node).activate() };

--- a/src/install/PackageManager/ProgressStrings.rs
+++ b/src/install/PackageManager/ProgressStrings.rs
@@ -138,8 +138,6 @@ impl PackageManager {
     }
 
     pub fn start_progress_bar(&mut self) {
-        self.progress.supports_ansi_escape_codes =
-            Output::stderr_descriptor_type() == Output::DescriptorType::Terminal;
         // `Progress::start` returns `&mut Node` borrowing `self.progress`;
         // decay to a raw ptr immediately so the exclusive borrow ends before we
         // re-borrow `&mut self` for `set_node_name` / `progress.refresh()`.

--- a/src/install/PackageManager/ProgressStrings.rs
+++ b/src/install/PackageManager/ProgressStrings.rs
@@ -138,7 +138,8 @@ impl PackageManager {
     }
 
     pub fn start_progress_bar(&mut self) {
-        self.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
+        self.progress.supports_ansi_escape_codes =
+            Output::stderr_descriptor_type() == Output::DescriptorType::Terminal;
         // `Progress::start` returns `&mut Node` borrowing `self.progress`;
         // decay to a raw ptr immediately so the exclusive borrow ends before we
         // re-borrow `&mut self` for `set_node_name` / `progress.refresh()`.

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1784,7 +1784,6 @@ fn write_yarn_lock_with_progress(
     // `&mut manager` borrow ends instead of keeping a live `&mut Node`.
     let mut node_started = false;
     if log_level.show_progress() {
-        manager.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
         let _ = manager.progress.start(b"Saving yarn.lock", 0);
         manager.progress.refresh();
         node_started = true;

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -136,7 +136,6 @@ pub(crate) fn install_hoisted_packages(
         // `this.lockfile` read doesn't overlap the live `root_node` reborrow.
         let hoisted_len = this.lockfile.buffers.hoisted_dependencies.len();
         let progress = &mut this.progress;
-        progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
         // `Progress::start` returns `&mut Node` (points into `progress.root`);
         // keep it as a safe reborrow — it's only used to spawn the three
         // children below and is dead before any other `this.*` write.

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1928,7 +1928,6 @@ pub(crate) fn install_isolated_packages(
         let progress = unsafe { &mut *progress };
 
         if manager.options.log_level.show_progress() {
-            progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
             // `Progress::start` returns `&mut Node` (points into `progress.root`);
             // keep it as a safe reborrow — it's only used to spawn the three
             // children below and is dead before the `manager.*` writes that

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3500,9 +3500,9 @@ impl VirtualMachine {
         self.hot_reload_deferred = false;
 
         bun_core::debug!("Reloading...");
-        let should_clear_terminal = !self
-            .env_loader()
-            .has_set_no_clear_terminal_on_reload(!bun_core::Output::enable_ansi_colors_stdout());
+        let should_clear_terminal = !self.env_loader().has_set_no_clear_terminal_on_reload(
+            bun_core::Output::stdout_descriptor_type() != bun_core::Output::DescriptorType::Terminal,
+        );
         if self.hot_reload == HOT_RELOAD_WATCH {
             bun_core::Output::flush();
             bun_core::reload_process(should_clear_terminal, false);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3501,7 +3501,8 @@ impl VirtualMachine {
 
         bun_core::debug!("Reloading...");
         let should_clear_terminal = !self.env_loader().has_set_no_clear_terminal_on_reload(
-            bun_core::Output::stdout_descriptor_type() != bun_core::Output::DescriptorType::Terminal,
+            bun_core::Output::stdout_descriptor_type()
+                != bun_core::Output::DescriptorType::Terminal,
         );
         if self.hot_reload == HOT_RELOAD_WATCH {
             bun_core::Output::flush();

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -234,9 +234,9 @@ impl HotReloaderCtx for VirtualMachine {
     }
 
     fn compute_clear_screen(&self) -> bool {
-        !self
-            .env_loader()
-            .has_set_no_clear_terminal_on_reload(!Output::enable_ansi_colors_stdout())
+        !self.env_loader().has_set_no_clear_terminal_on_reload(
+            Output::stdout_descriptor_type() != Output::DescriptorType::Terminal,
+        )
     }
 }
 
@@ -1381,10 +1381,9 @@ impl<'a> HotReloaderCtx for bun_bundler::BundleV2<'a> {
     }
 
     fn compute_clear_screen(&self) -> bool {
-        !self
-            .transpiler
-            .env()
-            .has_set_no_clear_terminal_on_reload(!Output::enable_ansi_colors_stdout())
+        !self.transpiler.env().has_set_no_clear_terminal_on_reload(
+            Output::stdout_descriptor_type() != Output::DescriptorType::Terminal,
+        )
     }
 }
 

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -298,7 +298,8 @@ impl CreateCommand {
                 >(filesystem.top_level_dir, dirname))?;
 
         let mut progress = Progress {
-            supports_ansi_escape_codes: Output::enable_ansi_colors_stderr(),
+            supports_ansi_escape_codes: Output::stderr_descriptor_type()
+                == Output::DescriptorType::Terminal,
             ..Default::default()
         };
         // `Progress::start` returns
@@ -2340,7 +2341,8 @@ impl CreateListExamplesCommand {
         env_loader.load_process()?;
 
         let mut progress = Progress {
-            supports_ansi_escape_codes: Output::enable_ansi_colors_stderr(),
+            supports_ansi_escape_codes: Output::stderr_descriptor_type()
+                == Output::DescriptorType::Terminal,
             ..Default::default()
         };
         // `Progress::start` returns `&mut Node` borrowing `progress`; detach

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -297,11 +297,7 @@ impl CreateCommand {
                     bun_paths::platform::Loose,
                 >(filesystem.top_level_dir, dirname))?;
 
-        let mut progress = Progress {
-            supports_ansi_escape_codes: Output::stderr_descriptor_type()
-                == Output::DescriptorType::Terminal,
-            ..Default::default()
-        };
+        let mut progress = Progress::default();
         // `Progress::start` returns
         // `&mut Node` borrowing `progress` exclusively for the node's lifetime.
         // Convert to `*mut` immediately so `progress` and `node` can be used
@@ -2340,11 +2336,7 @@ impl CreateListExamplesCommand {
 
         env_loader.load_process()?;
 
-        let mut progress = Progress {
-            supports_ansi_escape_codes: Output::stderr_descriptor_type()
-                == Output::DescriptorType::Terminal,
-            ..Default::default()
-        };
+        let mut progress = Progress::default();
         // `Progress::start` returns `&mut Node` borrowing `progress`; detach
         // via raw pointer so `progress.refresh()` can re-borrow below.
         let node: *mut ProgressNode = progress.start(b"Fetching manifest", 0);

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -915,6 +915,8 @@ pub(crate) fn run_scripts_with_filter(
             #[cfg(not(windows))]
             {
                 Output::enable_ansi_colors_stdout()
+                    && (Output::stdout_descriptor_type() == Output::DescriptorType::Terminal
+                        || Output::Source::is_force_color())
             }
         },
         shell_bin,

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2590,7 +2590,8 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         let mut progress = Progress::Progress::default();
         let mut node: Option<&mut Progress::Node> = None;
         if log_level.show_progress() {
-            progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
+            progress.supports_ansi_escape_codes =
+                Output::stderr_descriptor_type() == Output::DescriptorType::Terminal;
             node = Some(progress.start(b"", pack_queue.count() + bundled_pack_queue.count() + 1));
             node.as_mut().expect("infallible: progress active").unit = Progress::Unit::Files;
         }

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2590,8 +2590,6 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         let mut progress = Progress::Progress::default();
         let mut node: Option<&mut Progress::Node> = None;
         if log_level.show_progress() {
-            progress.supports_ansi_escape_codes =
-                Output::stderr_descriptor_type() == Output::DescriptorType::Terminal;
             node = Some(progress.start(b"", pack_queue.count() + bundled_pack_queue.count() + 1));
             node.as_mut().expect("infallible: progress active").unit = Progress::Unit::Files;
         }

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -448,7 +448,6 @@ impl TrustCommand {
             // immediately consumed by `Node::start` (returns an owned `Node`
             // with raw backrefs into `pm.progress`).
             unsafe {
-                (*pm_raw).progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
                 scripts_node = (*pm_raw)
                     .progress
                     .start(b"", 0)

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -592,6 +592,40 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("CI env enables colour but not the live-redraw UI", () => {
+    const dir = tempDirWithFiles("testworkspace", {
+      packages: {
+        dep0: {
+          "index.js": Array(20).fill("console.log('log_line');").join("\n"),
+          "package.json": JSON.stringify({ name: "dep0", scripts: { script: `${bunExe()} run index.js` } }),
+        },
+      },
+      "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    });
+
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--filter", "./packages/dep0", "script"],
+      env: {
+        ...bunEnv,
+        NO_COLOR: undefined,
+        FORCE_COLOR: undefined,
+        CI: "true",
+        GITHUB_ACTIONS: "true",
+        BUILDKITE: undefined,
+        TERM: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdoutval = stdout.toString();
+    expect(stdoutval).not.toContain("\x1b[1A");
+    expect(stdoutval).not.toContain("\x1b[?2026");
+    expect(stdoutval).not.toMatch(/lines elided/);
+    expect(stdoutval).toMatch(/(?:log_line[\s\S]*?){20}/);
+    expect(exitCode).toBe(0);
+  });
+
   test("self-referential directory symlink in a workspace does not loop", () => {
     const dir = tempDirWithFiles("filter-symlink-loop", {
       packages: {

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -592,7 +592,7 @@ describe("bun", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("CI env enables colour but not the live-redraw UI", () => {
+  test("CI env does not enable the live-redraw UI on a pipe", () => {
     const dir = tempDirWithFiles("testworkspace", {
       packages: {
         dep0: {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -405,8 +405,7 @@ describe("bun test", () => {
     }, 10000);
   });
   describe("color output", () => {
-    // Env vars that influence color detection must all be scrubbed so the
-    // only signals the child sees are the ones each case sets.
+    // Scrub everything that feeds colour detection; each case sets its own.
     const colorNeutralEnv = {
       NO_COLOR: undefined,
       FORCE_COLOR: undefined,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -404,6 +404,90 @@ describe("bun test", () => {
       expect(stderr).toHaveTestTimedOutAfter(5000);
     }, 10000);
   });
+  describe("color output", () => {
+    // Env vars that influence color detection must all be scrubbed so the
+    // only signals the child sees are the ones each case sets.
+    const colorNeutralEnv = {
+      NO_COLOR: undefined,
+      FORCE_COLOR: undefined,
+      CI: undefined,
+      GITHUB_ACTIONS: undefined,
+      GITEA_ACTIONS: undefined,
+      GITLAB_CI: undefined,
+      CIRCLECI: undefined,
+      TRAVIS: undefined,
+      APPVEYOR: undefined,
+      BUILDKITE: undefined,
+      DRONE: undefined,
+      CI_NAME: undefined,
+      TF_BUILD: undefined,
+      AGENT_NAME: undefined,
+      TERM: undefined,
+      COLORTERM: undefined,
+      TERM_PROGRAM: undefined,
+      TMUX: undefined,
+      NODE_DISABLE_COLORS: undefined,
+    } as const;
+
+    const colorCases: Array<[string, Record<string, string>, boolean]> = [
+      ["piped, no CI env", {}, false],
+      ["CI=true alone (unknown provider)", { CI: "true" }, false],
+      ["CI + GITHUB_ACTIONS", { CI: "true", GITHUB_ACTIONS: "true" }, true],
+      ["CI + GITEA_ACTIONS", { CI: "true", GITEA_ACTIONS: "true" }, true],
+      ["CI + GITLAB_CI", { CI: "true", GITLAB_CI: "true" }, true],
+      ["CI + CIRCLECI", { CI: "true", CIRCLECI: "true" }, true],
+      ["CI + BUILDKITE", { CI: "true", BUILDKITE: "true" }, true],
+      ["CI + TRAVIS", { CI: "true", TRAVIS: "1" }, true],
+      ["CI + APPVEYOR", { CI: "True", APPVEYOR: "True" }, true],
+      ["CI + DRONE", { CI: "true", DRONE: "true" }, true],
+      ["CI + CI_NAME=codeship", { CI: "true", CI_NAME: "codeship" }, true],
+      ["Azure DevOps (TF_BUILD + AGENT_NAME)", { TF_BUILD: "True", AGENT_NAME: "a" }, true],
+      ["GITHUB_ACTIONS without CI", { GITHUB_ACTIONS: "true" }, false],
+      ["CI + GITHUB_ACTIONS + NO_COLOR=1", { CI: "true", GITHUB_ACTIONS: "true", NO_COLOR: "1" }, false],
+      ["CI + GITHUB_ACTIONS + TERM=dumb", { CI: "true", GITHUB_ACTIONS: "true", TERM: "dumb" }, false],
+    ];
+
+    test.concurrent.each(colorCases)("Bun.enableANSIColors: %s", async (_name, extra, expected) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", "process.stdout.write(String(Bun.enableANSIColors))"],
+        env: { ...bunEnv, ...colorNeutralEnv, ...extra },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(String(expected));
+      expect(exitCode).toBe(0);
+    });
+
+    // https://github.com/oven-sh/bun/issues/8070
+    test("bun test emits ANSI colors under GITHUB_ACTIONS with piped output", () => {
+      const stderr = runTest({
+        input: `
+          import { test, expect } from "bun:test";
+          test("pass", () => { expect(1).toBe(1); });
+          test("fail", () => { expect(1).toBe(2); });
+        `,
+        env: { ...colorNeutralEnv, CI: "true", GITHUB_ACTIONS: "true" },
+      });
+      expect(stderr).toContain("\x1b[");
+      // `::error` annotations themselves stay plain text for the Actions parser.
+      for (const line of stderr.split("\n")) {
+        if (line.startsWith("::error")) expect(line).not.toContain("\x1b[");
+      }
+    });
+
+    test("bun test emits no ANSI colors under bare CI with piped output", () => {
+      const stderr = runTest({
+        input: `
+          import { test, expect } from "bun:test";
+          test("pass", () => { expect(1).toBe(1); });
+        `,
+        env: { ...colorNeutralEnv, CI: "true" },
+      });
+      expect(stderr).not.toContain("\x1b[");
+    });
+  });
   describe("support for Github Actions", () => {
     test("should not group logs by default", () => {
       const stderr = runTest({

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -444,7 +444,11 @@ describe("bun test", () => {
       ["GITHUB_ACTIONS without CI", { GITHUB_ACTIONS: "true" }, false],
       ["CI + GITHUB_ACTIONS + NO_COLOR=1", { CI: "true", GITHUB_ACTIONS: "true", NO_COLOR: "1" }, false],
       ["CI + GITHUB_ACTIONS + FORCE_COLOR=0", { CI: "true", GITHUB_ACTIONS: "true", FORCE_COLOR: "0" }, false],
-      ["CI + GITHUB_ACTIONS + NODE_DISABLE_COLORS=1", { CI: "true", GITHUB_ACTIONS: "true", NODE_DISABLE_COLORS: "1" }, false],
+      [
+        "CI + GITHUB_ACTIONS + NODE_DISABLE_COLORS=1",
+        { CI: "true", GITHUB_ACTIONS: "true", NODE_DISABLE_COLORS: "1" },
+        false,
+      ],
       ["CI + GITHUB_ACTIONS + TERM=dumb", { CI: "true", GITHUB_ACTIONS: "true", TERM: "dumb" }, false],
     ];
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -443,6 +443,8 @@ describe("bun test", () => {
       ["Azure DevOps (TF_BUILD + AGENT_NAME)", { TF_BUILD: "True", AGENT_NAME: "a" }, true],
       ["GITHUB_ACTIONS without CI", { GITHUB_ACTIONS: "true" }, false],
       ["CI + GITHUB_ACTIONS + NO_COLOR=1", { CI: "true", GITHUB_ACTIONS: "true", NO_COLOR: "1" }, false],
+      ["CI + GITHUB_ACTIONS + FORCE_COLOR=0", { CI: "true", GITHUB_ACTIONS: "true", FORCE_COLOR: "0" }, false],
+      ["CI + GITHUB_ACTIONS + NODE_DISABLE_COLORS=1", { CI: "true", GITHUB_ACTIONS: "true", NODE_DISABLE_COLORS: "1" }, false],
       ["CI + GITHUB_ACTIONS + TERM=dumb", { CI: "true", GITHUB_ACTIONS: "true", TERM: "dumb" }, false],
     ];
 
@@ -471,8 +473,11 @@ describe("bun test", () => {
       });
       expect(stderr).toContain("\x1b[");
       // `::error` annotations themselves stay plain text for the Actions parser.
-      for (const line of stderr.split("\n")) {
-        if (line.startsWith("::error")) expect(line).not.toContain("\x1b[");
+      const annotations = stderr.split("\n").filter(l => l.includes("::error"));
+      expect(annotations).not.toBeEmpty();
+      for (const line of annotations) {
+        expect(line).toStartWith("::error");
+        expect(line).not.toContain("\x1b[");
       }
     });
 

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -495,6 +495,19 @@ describe("bun test", () => {
       });
       expect(stderr).not.toContain("\x1b[");
     });
+
+    test("console.clear() is a no-op on a pipe under GITHUB_ACTIONS", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", "console.clear()"],
+        env: { ...bunEnv, ...colorNeutralEnv, CI: "true", GITHUB_ACTIONS: "true" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(0);
+    });
   });
   describe("support for Github Actions", () => {
     test("should not group logs by default", () => {


### PR DESCRIPTION
Fixes #8070.
Fixes #16066.

## What

`bun test` (and every other colourised CLI surface) prints no colour in GitHub Actions unless the user sets `FORCE_COLOR`:

```
$ env -i CI=true GITHUB_ACTIONS=true bun test pass.test.ts 2>&1 | cat -v
# no ANSI escapes
```

The report in #8070 is specifically about how hard that makes snapshot diffs to read in the Actions log.

## Cause

[`Source::set_init`](https://github.com/oven-sh/bun/blob/65f3fe3e5e/src/bun_core/output.rs#L547) gates colour on `is_stdout_tty || is_stderr_tty`. CI runners capture output through a pipe, so without `FORCE_COLOR` colour is always off, even though `compute_color_depth()` already recognises `CI` and Bun's own `getColorDepth` reports 24-bit for `GITHUB_ACTIONS` (#33124 fixed that path).

## Fix

Add an `is_ansi_capable_ci()` probe that recognises the same provider set as the `CI_ENVS` table in Node's [`tty.WriteStream#getColorDepth`](https://github.com/oven-sh/bun/blob/main/src/js/internal/tty.ts): GitHub Actions, Gitea Actions, GitLab CI, CircleCI, Travis, Appveyor, Buildkite, Drone, Codeship, and Azure DevOps (`TF_BUILD`+`AGENT_NAME`). When one of those matches, enable colour for piped streams.

Precedence is preserved and tightened: `FORCE_COLOR` wins (including `FORCE_COLOR=0`, which now forces colour off on the native path the same way it does on the JS side), `NO_COLOR` and `NODE_DISABLE_COLORS` win, `TERM=dumb` suppresses, and bare `CI` with no known provider stays uncoloured so unknown log viewers don't get raw escape bytes. Inside a recognised CI the detection is purely env-based, so shell redirects (`> log.txt`, `| tee`) are also coloured; set `NO_COLOR=1` for plain-text artifacts. Outside CI, local `bun test | cat` is unchanged.

### Splitting "renders colour" from "is a live terminal"

`enable_ansi_colors_*` had also been used as a proxy for "interactive terminal" by several consumers. Flipping the colour flag for CI would have turned those cursor-movement paths on in a log viewer, so they now key off the real TTY bit (`Output::std{out,err}_descriptor_type() == Terminal`) or get it from a structural backstop:

* `bun run --filter` pretty-mode redraw keeps its `FORCE_COLOR` escape hatch (so the existing `--elide-lines` tests remain runnable) but otherwise requires a real terminal;
* `--hot`/`--watch` clear-screen default is derived from the stdout descriptor type instead of the colour flag;
* `reset_terminal()` / `reset_terminal_all()` (and therefore `console.clear()` and the bake DevServer reload) require a real terminal before emitting the ED/CUP sequence, matching Node's "does nothing when stdout is not a TTY" contract;
* `Progress::start()` now writes `supports_ansi_escape_codes` on both branches from its own `isatty`/VT-mode probe, so a caller can't accidentally force cursor movement on a pipe. The nine caller-side assignments of that field (across `bun create`, `bun pack`, `bun pm trust`, and every install progress path) were dead stores once `start()` became authoritative and are deleted;
* the PackageManager init-time progress/`DefaultNoProgress` branch keys on the stderr descriptor instead of the colour flag so its control flow on CI is unchanged.

## Why this is correct

The Actions log UI (and GitLab's, Buildkite's, etc.) interprets ANSI SGR sequences. Vitest, Jest and most popular CLI tools already colour their output there by default; Bun gating on `isatty` alone is what the issue reporter compared against. Matching Node's `CI_ENVS` list means we only flip the default where the log viewer is known to render SGR, while every cursor-movement / clear-screen / progress path stays gated on the real TTY so CI logs don't get raw `ESC[1A` / `ESC[2J` bytes.

## Verification

`test/cli/test/bun-test.test.ts` gains a `color output` block:

* a 17-row env matrix over `Bun.enableANSIColors` covering every provider, the negative cases (no CI, bare CI, `NO_COLOR`, `NODE_DISABLE_COLORS`, `FORCE_COLOR=0`, `TERM=dumb`, `GITHUB_ACTIONS` without `CI`), run with a scrubbed environment so Buildkite/local env vars can't leak in;
* an end-to-end `bun test` spawn under `CI`+`GITHUB_ACTIONS` that asserts ANSI escapes are present while `::error` annotation lines stay plain and start at column 0;
* the same spawn under bare `CI` that stays uncoloured;
* a `console.clear()` spawn under `CI`+`GITHUB_ACTIONS` that asserts nothing is written to either stream.

`test/cli/run/filter-workspace.test.ts` gains a case that runs `bun run --filter` under `CI`+`GITHUB_ACTIONS` and asserts the line-prefixed streaming path is used (no `\x1b[1A`, no `\x1b[?2026`, no elision, all 20 lines present). The existing `--elide-lines` tests still pass via their `FORCE_COLOR` override.

Eleven matrix rows plus the end-to-end ANSI check fail on the current release and pass with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->