### PR TITLE
bundler: inject __dirname/__filename into CJS wrappers that use direct eval

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1890,10 +1890,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // Pessimistically assume that if this looks like a CommonJS module
                     // (e.g. no "export" keywords), a direct call to "eval" means that
-                    // code could potentially access "module" or "exports".
+                    // code could potentially access "module", "exports", "__dirname",
+                    // or "__filename".
                     if p.options.bundle && !p.is_file_considered_to_have_esm_exports {
                         p.record_usage(p.module_ref);
                         p.record_usage(p.exports_ref);
+                        p.record_usage(p.dirname_ref);
+                        p.record_usage(p.filename_ref);
                     }
 
                     // Walk `Scope.parent` (`Option<StoreRef<Scope>>`) via the safe

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -392,6 +392,76 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
+  // https://github.com/oven-sh/bun/issues/13194
+  // Some npm packages ship pre-bundled code containing `eval("__dirname")` to
+  // dodge the upstream bundler's path rewriting. When we wrap such a module in
+  // `__commonJS(function(exports, module) { ... })`, the eval must still see
+  // `__dirname` and `__filename`.
+  itBundled("cjs2esm/DirectEvalKeepsDirnameFilename", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import lib from "./node_modules/pkg/index.js";
+        console.log(JSON.stringify(lib));
+      `,
+      "/node_modules/pkg/index.js": /* js */ `
+        var dir = eval("__dirname");
+        var file = eval("__filename");
+        module.exports = {
+          dir: dir.split(/[\\\\/]/).slice(-2).join("/"),
+          file: file.split(/[\\\\/]/).slice(-3).join("/"),
+        };
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: '{"dir":"node_modules/pkg","file":"node_modules/pkg/index.js"}',
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).toMatch(/var __dirname = ".*", __filename = "/);
+    },
+  });
+  itBundled("cjs2esm/DirectEvalKeepsDirnameFilenameMinified", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import lib from "./node_modules/pkg/index.js";
+        console.log(JSON.stringify(lib));
+      `,
+      "/node_modules/pkg/index.js": /* js */ `
+        var path = require("path");
+        var childPath = path.join(eval("__dirname"), "child");
+        module.exports = {
+          child: childPath.split(/[\\\\/]/).slice(-3).join("/"),
+          file: eval("typeof __filename"),
+        };
+      `,
+    },
+    target: "bun",
+    minifyIdentifiers: true,
+    run: {
+      stdout: '{"child":"node_modules/pkg/child","file":"string"}',
+    },
+  });
+  itBundled("cjs2esm/DirectEvalDirnameNotInjectedForEsm", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import lib from "./lib.mjs";
+        console.log(lib);
+      `,
+      "/lib.mjs": /* js */ `
+        export default eval("typeof __dirname") + " " + eval("typeof __filename");
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: "undefined undefined",
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("out.js");
+      expect(out).not.toContain("var __dirname");
+      expect(out).not.toContain("var __filename");
+    },
+  });
   // https://github.com/oven-sh/bun/issues/4565
   // `exports.x = ...` as the unbraced body of if/while/do/else must not be
   // converted to `var $x = ...; export { $x as x };` because `export` is only


### PR DESCRIPTION
Fixes #13194.

## Problem

Some npm packages ship pre-bundled CommonJS that contains `eval("__dirname")` as a way to stop the upstream bundler from rewriting the path at build time (`checkpoint-client`, pulled in by `@prisma/internals`, is the case from the issue). When bun bundles such a module with `--target bun`, it wraps the file in a `__commonJS(function(exports, module) { ... })` closure and emits ESM, so `eval("__dirname")` throws:

```
ReferenceError: Can't find variable: __dirname
```

A direct `__dirname` reference already works because the parser injects `var __dirname = "..."` into the wrapper when the symbol is used. The injection is skipped here only because the reference is hidden inside a string.

## Fix

When a direct `eval()` is seen inside a CJS module while bundling, the parser already pessimistically records usage of `module` and `exports` so the wrapper keeps them in scope. Extend that to `__dirname` and `__filename` so the existing injection in `parse_entry.rs` emits both into the closure:

```js
var require_pkg = __commonJS(function(exports, module) {
  var __dirname = "/path/to/pkg", __filename = "/path/to/pkg/index.js";
  var childPath = path.join(eval("__dirname"), "child");
  ...
});
```

Both symbols are declared `Unbound`, so the minifier already leaves their names intact and `eval` can resolve them even under `--minify`. ESM files are unchanged (no `__dirname`/`__filename` there), so `eval("typeof __dirname")` in a `.mjs` still reports `undefined`.

## Tests

Added in `test/bundler/bundler_cjs2esm.test.ts`:

- `cjs2esm/DirectEvalKeepsDirnameFilename`: bundles a CJS module with `eval("__dirname")` / `eval("__filename")`, asserts the `var __dirname = ..., __filename = ...` injection and the runtime values.
- `cjs2esm/DirectEvalKeepsDirnameFilenameMinified`: same under `--minify-identifiers`, matching the repro in the issue.
- `cjs2esm/DirectEvalDirnameNotInjectedForEsm`: guard that ESM modules still do not get the injection.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/123] gen bindgenv2
[2/122] gen ErrorCode+*.h
[3/122] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/122] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (13 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [289.38ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [125.57ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [34.14ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [110.03ms]
(pass) bundler > cjs2esm/ExportsFunction [35.33ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [26.27ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [40.07ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [38.68ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [50.41ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [126.29ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [40.87ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [84.80ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [73.65ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [29.49ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignDeOpt [272.24ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignExportsDeOpt [34.98ms]
416 |     run: {
417 |       stdout: '{"d
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (ac62ac986)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [1339.58ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [618.37ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [564.48ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [857.46ms]
(pass) bundler > cjs2esm/ExportsFunction [557.16ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [524.94ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [604.57ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [1350.97ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [743.41ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [662.65ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [1147.53ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [571.11ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [2080.91ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [593.06ms]
(pass) b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ac62ac9864
  features     baseline

22 deps, 108 codegen, 1171 objects in 4311ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch zlib
[zlib] up to date
[2/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[3/1234] fetch tinycc
[tinycc] up to date
[4/1234] fetch picohttpparser
[picohttpparser] up to date
[5/1234] gen ErrorCode+*.h
[6/1234] subst deps/zlib/zconf.h
[7/1234] subst deps/zlib/zlib.h
[8/1234] gen bindgenv2
[9/1234] fetch zstd
[zstd] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[11/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[12/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[13/1234] gen ProcessBindingFs.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingFs.lut.h from /workspace/bun/src/jsc/b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/visit_expr.rs    |  5 ++-
 test/bundler/bundler_cjs2esm.test.ts | 70 ++++++++++++++++++++++++++++++++++++
 2 files changed, 74 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js_parser/visit/visit_expr.rs         1      1      0
test/bundler/bundler_cjs2esm.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->