### PR TITLE
node:os: return plain objects from os.cpus()

### DIFF
--- a/src/js/node/os.ts
+++ b/src/js/node/os.ts
@@ -24,68 +24,6 @@ var tmpdir = function () {
   return tmpdir();
 };
 
-// os.cpus() is super expensive
-// Specifically: getting the CPU speed on Linux is very expensive
-// Some packages like FastGlob only bother to read the length of the array
-// so instead of actually populating the entire object
-// we turn them into getters
-function lazyCpus({ cpus, hostCpuCount }) {
-  return () => {
-    const array = new Array(hostCpuCount);
-    function populate() {
-      const results = cpus();
-      const length = results.length;
-      array.length = length;
-      for (let i = 0; i < length; i++) {
-        array[i] = results[i];
-      }
-    }
-
-    for (let i = 0; i < array.length; i++) {
-      // This is technically still observable via
-      // Object.getOwnPropertyDescriptors(), but it should be okay.
-      const instance = {
-        get model() {
-          if (array[i] === instance) populate();
-          return array[i].model;
-        },
-        set model(value) {
-          if (array[i] === instance) populate();
-          array[i].model = value;
-        },
-
-        get speed() {
-          if (array[i] === instance) populate();
-          return array[i].speed;
-        },
-
-        set speed(value) {
-          if (array[i] === instance) populate();
-          array[i].speed = value;
-        },
-
-        get times() {
-          if (array[i] === instance) populate();
-          return array[i].times;
-        },
-        set times(value) {
-          if (array[i] === instance) populate();
-          array[i].times = value;
-        },
-
-        toJSON() {
-          if (array[i] === instance) populate();
-          return array[i];
-        },
-      };
-
-      array[i] = instance;
-    }
-
-    return array;
-  };
-}
-
 // all logic based on `process.platform` and `process.arch` is inlined at bundle time
 function bound(binding) {
   return {
@@ -95,7 +33,7 @@ function bound(binding) {
     arch: function () {
       return process.arch;
     },
-    cpus: lazyCpus(binding),
+    cpus: binding.cpus,
     endianness: function () {
       return process.arch === "arm64" || process.arch === "x64" //
         ? "LE"

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -6,6 +6,7 @@ use bun_core;
 use bun_core::String as BunString;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 unsafe extern "C" {
     safe fn bun_sysconf__SC_NPROCESSORS_ONLN() -> i32;
 }
@@ -191,13 +192,7 @@ mod _impl {
     }
 
     pub(crate) fn create_node_os_binding(global: &JSGlobalObject) -> JsResult<JSValue> {
-        let obj = JSValue::create_empty_object(global, 14);
-        // SAFETY: pure FFI getter
-        obj.put(
-            global,
-            b"hostCpuCount",
-            JSValue::js_number(1i32.max(bun_sysconf__SC_NPROCESSORS_ONLN()) as f64),
-        );
+        let obj = JSValue::create_empty_object(global, 13);
         obj.put(global, b"cpus", gen_::create_cpus_callback(global));
         obj.put(global, b"freemem", gen_::create_freemem_callback(global));
         obj.put(
@@ -296,9 +291,8 @@ mod _impl {
                 match bun_sys::File::open(bun_core::zstr!("/proc/stat"), bun_sys::O::RDONLY, 0) {
                     Ok(f) => f,
                     Err(_) => {
-                        // hidepid mounts (common on Android) deny /proc/stat. lazyCpus in os.ts
-                        // pre-creates hostCpuCount lazy proxies, so return that many stub
-                        // entries (zeroed times / unknown model / speed 0) — matches Node.
+                        // hidepid mounts (common on Android) deny /proc/stat. Return
+                        // NPROCESSORS_ONLN stub entries so `.length` still matches Node.
                         // SAFETY: pure FFI getter
                         let count: u32 =
                             u32::try_from(1i32.max(bun_sysconf__SC_NPROCESSORS_ONLN())).unwrap();
@@ -308,17 +302,17 @@ mod _impl {
                             let cpu = JSValue::create_empty_object(global_this, 3);
                             cpu.put(
                                 global_this,
-                                b"times",
-                                CPUTimes::default().to_value(global_this),
-                            );
-                            cpu.put(
-                                global_this,
                                 b"model",
                                 ZigString::static_("unknown")
                                     .with_encoding()
                                     .to_js(global_this),
                             );
                             cpu.put(global_this, b"speed", JSValue::js_number(0.0));
+                            cpu.put(
+                                global_this,
+                                b"times",
+                                CPUTimes::default().to_value(global_this),
+                            );
                             stubs.put_index(global_this, i, cpu)?;
                             i += 1;
                         }
@@ -360,8 +354,17 @@ mod _impl {
                     },
                 };
 
-                // Actually create the JS object representing the CPU
-                let cpu = JSValue::create_empty_object(global_this, 1);
+                // Initialize model/speed to defaults here so key order matches Node
+                // ({ model, speed, times }); the later passes overwrite them in place.
+                let cpu = JSValue::create_empty_object(global_this, 3);
+                cpu.put(
+                    global_this,
+                    b"model",
+                    ZigString::static_("unknown")
+                        .with_encoding()
+                        .to_js(global_this),
+                );
+                cpu.put(global_this, b"speed", JSValue::js_number(0.0));
                 cpu.put(global_this, b"times", times.to_value(global_this));
                 values.put_index(global_this, num_cpus, cpu)?;
 
@@ -386,26 +389,14 @@ mod _impl {
             const KEY_MODEL_NAME: &[u8] = b"model name\t: ";
 
             let mut cpu_index: u32 = 0;
-            let mut has_model_name = true;
             while let Some(line) = line_iter.next() {
                 if line.starts_with(KEY_PROCESSOR) {
-                    if !has_model_name {
-                        let cpu = values.get_index(global_this, cpu_index)?;
-                        cpu.put(
-                            global_this,
-                            b"model",
-                            ZigString::static_("unknown")
-                                .with_encoding()
-                                .to_js(global_this),
-                        );
-                    }
                     // If this line starts a new processor, parse the index from the line
                     let digits = strings::trim(&line[KEY_PROCESSOR.len()..], b" \t\n");
                     cpu_index = parse_u32(digits)?;
                     if cpu_index >= num_cpus {
                         return Err(OsError::Any);
                     }
-                    has_model_name = false;
                 } else if line.starts_with(KEY_MODEL_NAME) {
                     // If this is the model name, extract it and store on the current cpu
                     let model_name = &line[KEY_MODEL_NAME.len()..];
@@ -417,39 +408,14 @@ mod _impl {
                             .with_encoding()
                             .to_js(global_this),
                     );
-                    has_model_name = true;
                 }
-            }
-            if !has_model_name {
-                let cpu = values.get_index(global_this, cpu_index)?;
-                cpu.put(
-                    global_this,
-                    b"model",
-                    ZigString::static_("unknown")
-                        .with_encoding()
-                        .to_js(global_this),
-                );
             }
 
             file_buf.clear();
-        } else {
-            // Initialize model name to "unknown"
-            let mut it = values.array_iterator(global_this)?;
-            while let Some(cpu) = it.next()? {
-                cpu.put(
-                    global_this,
-                    b"model",
-                    ZigString::static_("unknown")
-                        .with_encoding()
-                        .to_js(global_this),
-                );
-            }
         }
 
         // Read /sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq to get current frequency (optional)
         for cpu_index in 0..num_cpus as usize {
-            let cpu = values.get_index(global_this, cpu_index as u32)?;
-
             let mut path_buf = [0u8; 128];
             let path: &ZStr = {
                 let mut cursor = &mut path_buf[..];
@@ -473,12 +439,10 @@ mod _impl {
                 let digits = strings::trim(contents, b" \n");
                 let speed = parse_u64(digits).unwrap_or(0) / 1000;
 
+                let cpu = values.get_index(global_this, cpu_index as u32)?;
                 cpu.put(global_this, b"speed", JSValue::js_number(speed as f64));
 
                 file_buf.clear();
-            } else {
-                // Initialize CPU speed to 0
-                cpu.put(global_this, b"speed", JSValue::js_number(0.0));
             }
         }
 
@@ -625,12 +589,12 @@ mod _impl {
             };
 
             let cpu = JSValue::create_empty_object(global_this, 3);
+            cpu.put(global_this, b"model", model_name);
             cpu.put(
                 global_this,
                 b"speed",
                 JSValue::js_number((speed / 1_000_000) as f64),
             );
-            cpu.put(global_this, b"model", model_name);
             cpu.put(global_this, b"times", times.to_value(global_this));
 
             values.put_index(global_this, cpu_index, cpu)?;

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -36,7 +36,6 @@ pub(crate) fn freemem() -> u64 {
 
 mod _impl {
     use super::*;
-    use crate::node::ErrorCode;
     #[cfg(any(target_os = "linux", target_os = "android"))]
     use bun_core::ZStr;
     use bun_core::ZigString;
@@ -57,15 +56,14 @@ mod _impl {
     // ─── local shims for upstream API gaps (Phase D) ──────────────────────────
 
     /// Unified error for `cpus_impl_*` so `?` works on both `JsResult` and
-    /// `crate::Error`/`bun_sys::Error`. The variant payload is discarded by
-    /// `cpus()`, which throws a `SystemError`.
+    /// `crate::Error`/`bun_sys::Error`.
     pub(crate) enum OsError {
-        Js,
+        Js(bun_jsc::JsError),
         Any,
     }
     impl From<bun_jsc::JsError> for OsError {
-        fn from(_: bun_jsc::JsError) -> Self {
-            Self::Js
+        fn from(e: bun_jsc::JsError) -> Self {
+            Self::Js(e)
         }
     }
     impl From<crate::Error> for OsError {
@@ -159,7 +157,7 @@ mod _impl {
         )*};
     }
         create_callback! {
-            create_cpus_callback,               "cpus",              1, bindgen_Node_os_jsCpus;
+            create_cpus_callback,               "cpus",              0, bindgen_Node_os_jsCpus;
             create_freemem_callback,            "freemem",           0, bindgen_Node_os_jsFreemem;
             create_get_priority_callback,       "getPriority",       2, bindgen_Node_os_jsGetPriority;
             create_homedir_callback,            "homedir",           1, bindgen_Node_os_jsHomedir;
@@ -265,15 +263,10 @@ mod _impl {
 
         match result {
             Ok(v) => Ok(v),
-            Err(_) => {
-                let err = SystemError {
-                    message: BunString::static_("Failed to get CPU information").into(),
-                    code: BunString::static_(<&'static str>::from(ErrorCode::ERR_SYSTEM_ERROR))
-                        .into(),
-                    ..Default::default()
-                };
-                Err(global.throw_value(err.to_error_instance(global)))
-            }
+            // Node's os.cpus() does `getCPUs() || []` and never throws on
+            // syscall/parse failure.
+            Err(OsError::Any) => JSValue::create_empty_array(global, 0),
+            Err(OsError::Js(e)) => Err(e),
         }
     }
 

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -263,8 +263,7 @@ mod _impl {
 
         match result {
             Ok(v) => Ok(v),
-            // Node's os.cpus() does `getCPUs() || []` and never throws on
-            // syscall/parse failure.
+            // Node never throws here (`getCPUs() || []`).
             Err(OsError::Any) => JSValue::create_empty_array(global, 0),
             Err(OsError::Js(e)) => Err(e),
         }
@@ -284,8 +283,7 @@ mod _impl {
                 match bun_sys::File::open(bun_core::zstr!("/proc/stat"), bun_sys::O::RDONLY, 0) {
                     Ok(f) => f,
                     Err(_) => {
-                        // hidepid mounts (common on Android) deny /proc/stat. Return
-                        // NPROCESSORS_ONLN stub entries so `.length` still matches Node.
+                        // Android hidepid often denies /proc/stat; return NPROCESSORS_ONLN stubs.
                         // SAFETY: pure FFI getter
                         let count: u32 =
                             u32::try_from(1i32.max(bun_sysconf__SC_NPROCESSORS_ONLN())).unwrap();
@@ -347,8 +345,7 @@ mod _impl {
                     },
                 };
 
-                // Initialize model/speed to defaults here so key order matches Node
-                // ({ model, speed, times }); the later passes overwrite them in place.
+                // Seed defaults in Node's key order; later passes overwrite model/speed.
                 let cpu = JSValue::create_empty_object(global_this, 3);
                 cpu.put(
                     global_this,

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -178,6 +178,8 @@ it("cpus() returns plain data objects", () => {
   expect(inspected).not.toContain("Getter");
   expect(inspected).not.toContain("toJSON");
   expect(inspected).toContain("model:");
+
+  expect(os.cpus.length).toBe(0);
 });
 
 // https://github.com/oven-sh/bun/issues/9203
@@ -195,17 +197,6 @@ it("cpus() array is safely mutable", () => {
   }
   // Mutating one call's result must not affect later calls.
   expect(os.cpus().length).toBe(length);
-});
-
-// https://github.com/oven-sh/bun/issues/9203
-it("cpus() snapshots are taken at call time", () => {
-  const a = os.cpus();
-  // Access b first so that if the results were lazily populated the older
-  // snapshot `a` would be read later and appear to be "newer".
-  const b = os.cpus();
-  const bUser = b[0].times.user;
-  const aUser = a[0].times.user;
-  expect(bUser - aUser).toBeGreaterThanOrEqual(0);
 });
 
 it("networkInterfaces", () => {

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -3,6 +3,7 @@ import { realpathSync } from "fs";
 import { isWindows } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
+import { inspect } from "node:util";
 
 it("arch", () => {
   expect(["x64", "x86", "arm64"].some(arch => os.arch() === arch)).toBe(true);
@@ -141,6 +142,70 @@ it("cpus", () => {
     expect(typeof cpu.times.sys === "number").toBe(true);
     expect(typeof cpu.times.user === "number").toBe(true);
   }
+});
+
+// https://github.com/oven-sh/bun/issues/9203
+it("cpus() returns plain data objects", () => {
+  const cpus = os.cpus();
+  expect(cpus.length).toBeGreaterThan(0);
+
+  const cpu = cpus[0];
+  expect(Object.keys(cpu)).toEqual(["model", "speed", "times"]);
+  expect(Object.keys(cpu.times)).toEqual(["user", "nice", "sys", "idle", "irq"]);
+
+  // Node returns plain data properties, not accessor properties.
+  expect(Object.getOwnPropertyDescriptor(cpu, "model")).toEqual({
+    value: expect.any(String),
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Object.getOwnPropertyDescriptor(cpu, "speed")).toEqual({
+    value: expect.any(Number),
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  expect(Object.getOwnPropertyDescriptor(cpu, "times")).toEqual({
+    value: expect.any(Object),
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  // util.inspect(os.cpus()) should show values, not [Getter/Setter].
+  const inspected = inspect(cpu);
+  expect(inspected).not.toContain("Getter");
+  expect(inspected).not.toContain("toJSON");
+  expect(inspected).toContain("model:");
+});
+
+// https://github.com/oven-sh/bun/issues/9203
+it("cpus() array is safely mutable", () => {
+  const cpus = os.cpus();
+  const length = cpus.length;
+  const first = cpus.shift();
+  expect(first.model).toEqual(expect.any(String));
+  expect(cpus.length).toBe(length - 1);
+  if (cpus.length > 0) {
+    // After shift(), reading properties of the remaining entries must not throw.
+    const last = cpus[cpus.length - 1];
+    expect(last.model).toEqual(expect.any(String));
+    expect(last.times.user).toEqual(expect.any(Number));
+  }
+  // Mutating one call's result must not affect later calls.
+  expect(os.cpus().length).toBe(length);
+});
+
+// https://github.com/oven-sh/bun/issues/9203
+it("cpus() snapshots are taken at call time", () => {
+  const a = os.cpus();
+  // Access b first so that if the results were lazily populated the older
+  // snapshot `a` would be read later and appear to be "newer".
+  const b = os.cpus();
+  const bUser = b[0].times.user;
+  const aUser = a[0].times.user;
+  expect(bUser - aUser).toBeGreaterThanOrEqual(0);
 });
 
 it("networkInterfaces", () => {

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -199,6 +199,26 @@ it("cpus() array is safely mutable", () => {
   expect(os.cpus().length).toBe(length);
 });
 
+it("cpus() snapshots times at call time", () => {
+  // The canonical CPU-utilization idiom: snapshot, wait, snapshot, diff.
+  // With the old lazyCpus wrapper, /proc/stat was not read until the first
+  // property access, so `a` and `b` both materialized inside the diff loop at
+  // the same instant (b first, then a), giving dTotal <= 0 and busy% = NaN.
+  const tot = t => t.user + t.nice + t.sys + t.idle + t.irq;
+  const a = os.cpus();
+  const until = performance.now() + 100;
+  while (performance.now() < until) Math.sqrt(2);
+  const b = os.cpus();
+  // First touch of either result's .times happens here, reading `b` before
+  // `a` as real CPU meters do (end - start).
+  let dTotal = 0;
+  for (let i = 0; i < b.length; i++) {
+    dTotal += tot(b[i].times) - tot(a[i].times);
+  }
+  expect(a.length).toBe(b.length);
+  expect(dTotal).toBeGreaterThan(0);
+});
+
 it("networkInterfaces", () => {
   const networkInterfaces = os.networkInterfaces();
 


### PR DESCRIPTION
Fixes #9203.

## Problem

`os.cpus()` wrapped the native result in per-element accessor objects (`lazyCpus`) so that code which only reads `.length` would skip the /proc + /sys reads. The wrapper was observably different from Node in several ways:

```js
console.log(os.cpus());
// [ { model: [Getter/Setter], speed: [Getter/Setter], times: [Getter/Setter], toJSON: [Function] }, ... ]
```

- `console.log` / `util.inspect` showed `[Getter/Setter]` instead of values
- `Object.keys()` included an extra `toJSON` property
- property descriptors were accessors, not data properties
- mutating the array (`shift()`/`pop()`) broke the remaining getters because they close over the original index, and reading them threw `TypeError: undefined is not an object`
- two results captured at different times delazified together, so `times.*` deltas were always zero (or negative), breaking CPU-usage meters

## Fix

Remove the wrapper and expose the native binding directly, matching Node. libuv reads the same `/proc/stat`, `/proc/cpuinfo` and `scaling_cur_freq` files our native path reads, so the cost is the same as Node's.

While here, initialize `{model, speed, times}` in Node's property order on Linux and macOS (Windows/FreeBSD already matched). On Linux this also lets the `/proc/cpuinfo` and cpufreq passes overwrite the defaults in place, dropping the `has_model_name` bookkeeping and the separate "unknown"/`0` fallback loops.

## Why this is correct

The lazy wrapper traded correctness for a micro-optimization of `os.cpus().length`. Node's own docs point users at `os.availableParallelism()` for that use case, and real code that consumes the `times` data (e.g. CPU meters taking two snapshots) or mutates the array was broken outright. Returning plain data objects is what the API contract requires.

## Verification

Before:
```
(fail) cpus() returns plain data objects     # extra 'toJSON' key + accessor descriptors
(fail) cpus() array is safely mutable        # TypeError after shift()
```

After:
```
(pass) cpus
(pass) cpus() returns plain data objects
(pass) cpus() array is safely mutable
(pass) cpus() snapshots are taken at call time
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/os/os.test.js

<!-- robobun:evidence:end -->