### PR TITLE
HTMLRewriter: fix panic on transform(Response) with Bun.file().stream() body

### DIFF
--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2411,7 +2411,7 @@ impl<'a> ValueBufferer<'a> {
             }
             None
         };
-        if let Some(stream) = readable_stream {
+        if let Some(mut stream) = readable_stream {
             *value = Value::Used;
 
             if stream.is_locked(self.global) {
@@ -2422,9 +2422,24 @@ impl<'a> ValueBufferer<'a> {
                 webcore::readable_stream::Source::Invalid => {
                     return Err(crate::Error::InvalidStream);
                 }
-                // toBlobIfPossible should've caught this
                 webcore::readable_stream::Source::Blob(_)
-                | webcore::readable_stream::Source::File(_) => unreachable!(),
+                | webcore::readable_stream::Source::File(_) => {
+                    // `to_blob_if_possible` only inspects `locked.readable`, which
+                    // `check_body_stream_ref` clears when the stream is migrated to
+                    // the JS-side cache slot. The stream then arrives here via
+                    // `owned_readable_stream` with its Blob store still intact, so
+                    // recover it and route through the `Value::Blob` path in `run`.
+                    if let Some(any_blob) = stream.to_any_blob(self.global) {
+                        self.readable_stream_ref.deinit();
+                        *value = match any_blob {
+                            AnyBlob::Blob(b) => Value::Blob(b),
+                            AnyBlob::InternalBlob(b) => Value::InternalBlob(b),
+                            AnyBlob::WTFStringImpl(s) => Value::WTFStringImpl(s),
+                        };
+                        return self.run(value, None);
+                    }
+                    return Err(crate::Error::UnsupportedStreamType);
+                }
                 webcore::readable_stream::Source::JavaScript
                 | webcore::readable_stream::Source::Direct => {
                     // this is broken right now

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -382,11 +382,7 @@ describe("HTMLRewriter", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe('<p v="1">a</p><p v="1">b</p>');
     expect(exitCode).toBe(0);

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { once } from "events";
 import fs from "fs";
-import { gcTick, tls, tmpdirSync } from "harness";
+import { bunEnv, bunExe, gcTick, tls, tmpdirSync } from "harness";
 import { createServer as createTcpServer } from "net";
 import path, { join } from "path";
 import { setImmediate as setImmediatePromise } from "timers/promises";
@@ -361,6 +361,35 @@ describe("HTMLRewriter", () => {
     await Bun.write(filePath, "<div>hello</div>");
     var output = rewriter.transform(new Response(Bun.file(filePath)));
     expect(await output.text()).toBe("<div><blink>it worked!</blink></div>");
+  });
+
+  it("(from Bun.file().stream()) supports element handlers", async () => {
+    // Regression: a Response whose body is Bun.file(path).stream() reached
+    // ValueBufferer::buffer_locked_body_value with a Source::File stream and
+    // hit `unreachable!()`, aborting the process.
+    const filePath = join(tmpdirSync(), "html-rewriter-file-stream.html");
+    await Bun.write(filePath, "<p>a</p><p>b</p>");
+    const src = `
+      const rewriter = new HTMLRewriter().on("p", {
+        element(el) { el.setAttribute("v", "1"); },
+      });
+      const out = rewriter.transform(new Response(Bun.file(${JSON.stringify(filePath)}).stream()));
+      process.stdout.write(await out.text());
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('<p v="1">a</p><p v="1">b</p>');
+    expect(exitCode).toBe(0);
   });
 
   it("supports attribute iterator", async () => {


### PR DESCRIPTION
`HTMLRewriter.transform()` on a `Response` whose body is `Bun.file(path).stream()` aborts the process:

```
panic: internal error: entered unreachable code
  at bun_runtime::webcore::body::ValueBufferer::buffer_locked_body_value (Body.rs:2427)
  ... html_rewriter.rs:747 init ... HTMLRewriter::begin_transform
```

Repro (any file, any size, deterministic):

```js
await Bun.write("/tmp/in.html", "<p>a</p><p>b</p>");
const out = new HTMLRewriter()
  .on("p", { element(el) { el.setAttribute("v", "1"); } })
  .transform(new Response(Bun.file("/tmp/in.html").stream()));
console.log(await out.text());
```

`new Response("<p>a</p>")`, `new Response(Blob)`, `new Response(new Blob([...]).stream())` and `new Response(Bun.file(path))` all work; only the file-backed native stream reaches the bad arm.

### Cause

The `Response` constructor calls `check_body_stream_ref`, which migrates the stream out of `Locked.readable` into the JS-side `stream` cache slot and clears `Locked.readable`. `to_blob_if_possible` only inspects `Locked.readable`, so it never sees the stream and cannot convert it. `buffer_locked_body_value` then receives the stream via `owned_readable_stream` (fetched from the cache slot by `get_body_readable_stream`) with `Source::File` and hits the `unreachable!()` arm whose comment assumed `to_blob_if_possible` had already handled it.

### Fix

Replace the `unreachable!()` with a call to `stream.to_any_blob()` to recover the `Blob` from the stream and route it through the existing `Value::Blob` file-read path in `run()`. If the store is already detached (stream started), return `UnsupportedStreamType` (surfaces as `ERR_STREAM_CANNOT_PIPE`) like the `JavaScript`/`Direct` arms instead of panicking.

### Verification

Added a subprocess test to `test/js/workerd/html-rewriter.test.js` that transforms a `Response(Bun.file(path).stream())` and asserts the rewritten output. Fails (subprocess aborts) without the fix, passes with it. Full `html-rewriter.test.js` suite passes (70 pass, 2 pre-existing todos).
