### PR TITLE
worker_threads: don't expose Web Worker globals on globalThis

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -249,7 +249,8 @@ export function getJS2NativeCPP() {
     "\n" + "namespace JS2NativeGenerated {",
     "using namespace Bun;",
     "using namespace JSC;",
-    "using namespace WebCore;" + "\n",
+    "using namespace WebCore;",
+    "using namespace Zig;" + "\n",
     ...nativeCallStrings,
     ...wrapperCallStrings,
     ...nativeCalls

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -1,6 +1,5 @@
 // import type { Readable, Writable } from "node:stream";
 // import type { WorkerOptions } from "node:worker_threads";
-declare const self: typeof globalThis;
 type WebWorker = InstanceType<typeof globalThis.Worker>;
 
 const EventEmitter = require("node:events");
@@ -754,29 +753,43 @@ function receiveMessageOnPort(port: MessagePort) {
 
 // TODO: parent port emulation is not complete
 function fakeParentPort() {
+  // Inside a node:worker_threads worker the Web Worker globals
+  // (self/addEventListener/postMessage/...) are not on globalThis, so reach
+  // the backing global EventTarget through direct native bindings instead.
+  const postMessage = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionPostMessage", 1);
+  const addEventListener = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionAddEventListener", 2);
+  const removeEventListener = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionRemoveEventListener", 2);
+  const dispatchEvent = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionDispatchEvent", 1);
+
   const fake = Object.create(MessagePort.prototype);
+
+  let onmessage: unknown = null;
   Object.defineProperty(fake, "onmessage", {
     get() {
-      return self.onmessage;
+      return onmessage;
     },
     set(value) {
-      self.onmessage = value;
+      if (onmessage) removeEventListener.$call(undefined, "message", onmessage);
+      onmessage = typeof value === "function" ? value : null;
+      if (onmessage) addEventListener.$call(undefined, "message", onmessage);
     },
   });
 
+  let onmessageerror: unknown = null;
   Object.defineProperty(fake, "onmessageerror", {
     get() {
-      return self.onmessageerror;
+      return onmessageerror;
     },
     set(value) {
-      self.onmessageerror = value;
+      if (onmessageerror) removeEventListener.$call(undefined, "messageerror", onmessageerror);
+      onmessageerror = typeof value === "function" ? value : null;
+      if (onmessageerror) addEventListener.$call(undefined, "messageerror", onmessageerror);
     },
   });
 
-  const postMessage = $newCppFunction("ZigGlobalObject.cpp", "jsFunctionPostMessage", 1);
   Object.defineProperty(fake, "postMessage", {
     value(...args: [any, any]) {
-      return postMessage.$apply(null, args);
+      return postMessage.$apply(undefined, args);
     },
   });
 
@@ -807,20 +820,24 @@ function fakeParentPort() {
   });
 
   Object.defineProperty(fake, "addEventListener", {
-    value: self.addEventListener.bind(self),
+    value: addEventListener,
   });
 
   Object.defineProperty(fake, "removeEventListener", {
-    value: self.removeEventListener.bind(self),
+    value: removeEventListener,
+  });
+
+  Object.defineProperty(fake, "dispatchEvent", {
+    value: dispatchEvent,
   });
 
   Object.defineProperty(fake, "removeListener", {
-    value: self.removeEventListener.bind(self),
+    value: removeEventListener,
     enumerable: false,
   });
 
   Object.defineProperty(fake, "addListener", {
-    value: self.addEventListener.bind(self),
+    value: addEventListener,
     enumerable: false,
   });
 

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -763,28 +763,14 @@ function fakeParentPort() {
 
   const fake = Object.create(MessagePort.prototype);
 
-  let onmessage: unknown = null;
   Object.defineProperty(fake, "onmessage", {
-    get() {
-      return onmessage;
-    },
-    set(value) {
-      if (onmessage) removeEventListener.$call(undefined, "message", onmessage);
-      onmessage = typeof value === "function" ? value : null;
-      if (onmessage) addEventListener.$call(undefined, "message", onmessage);
-    },
+    get: $newCppFunction("ZigGlobalObject.cpp", "jsFunctionGetGlobalOnMessage", 0),
+    set: $newCppFunction("ZigGlobalObject.cpp", "jsFunctionSetGlobalOnMessage", 1),
   });
 
-  let onmessageerror: unknown = null;
   Object.defineProperty(fake, "onmessageerror", {
-    get() {
-      return onmessageerror;
-    },
-    set(value) {
-      if (onmessageerror) removeEventListener.$call(undefined, "messageerror", onmessageerror);
-      onmessageerror = typeof value === "function" ? value : null;
-      if (onmessageerror) addEventListener.$call(undefined, "messageerror", onmessageerror);
-    },
+    get: $newCppFunction("ZigGlobalObject.cpp", "jsFunctionGetGlobalOnMessageError", 0),
+    set: $newCppFunction("ZigGlobalObject.cpp", "jsFunctionSetGlobalOnMessageError", 1),
   });
 
   Object.defineProperty(fake, "postMessage", {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -417,9 +417,10 @@ GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure)
     return ptr;
 }
 
-GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure, uint32_t scriptExecutionContextId)
+GlobalObject* GlobalObject::create(JSC::VM& vm, JSC::Structure* structure, uint32_t scriptExecutionContextId, bool isNodeWorker)
 {
     GlobalObject* ptr = new (NotNull, JSC::allocateCell<GlobalObject>(vm)) GlobalObject(vm, structure, scriptExecutionContextId, &globalObjectMethodTable());
+    ptr->m_isNodeWorker = isNodeWorker;
     ptr->finishCreation(vm);
     return ptr;
 }
@@ -509,6 +510,8 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
 
     WebCore::JSVMClientData::create(&vm, Bun__getVM());
 
+    bool isNodeWorker = worker_ptr && static_cast<WebCore::Worker*>(worker_ptr)->options().kind == WebCore::WorkerOptions::Kind::Node;
+
     const auto createGlobalObject = [&]() -> Zig::GlobalObject* {
         if (executionContextId == std::numeric_limits<int32_t>::max() || executionContextId > 1) [[unlikely]] {
             auto* structure = Zig::GlobalObject::createStructure(vm);
@@ -518,7 +521,8 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
             return Zig::GlobalObject::create(
                 vm,
                 structure,
-                static_cast<ScriptExecutionContextIdentifier>(executionContextId));
+                static_cast<ScriptExecutionContextIdentifier>(executionContextId),
+                isNodeWorker);
         } else if (evalMode) {
             auto* structure = Zig::EvalGlobalObject::createStructure(vm);
             if (!structure) [[unlikely]] {
@@ -570,25 +574,6 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     if (executionContextId > -1) {
         const auto initializeWorker = [&](WebCore::Worker& worker) -> void {
             auto& options = worker.options();
-
-            if (options.kind == WebCore::WorkerOptions::Kind::Node) {
-                // Node.js worker_threads do not expose Web Worker APIs on globalThis.
-                // node:worker_threads reaches the backing EventTarget through
-                // $newCppFunction instead (see fakeParentPort in worker_threads.ts).
-                static constexpr ASCIILiteral names[] = {
-                    "addEventListener"_s,
-                    "dispatchEvent"_s,
-                    "onerror"_s,
-                    "onmessage"_s,
-                    "postMessage"_s,
-                    "removeEventListener"_s,
-                    "self"_s,
-                };
-                for (auto name : names) {
-                    JSC::DeletePropertySlot slot;
-                    JSC::JSCell::deleteProperty(globalObject, globalObject, JSC::Identifier::fromString(vm, name), slot);
-                }
-            }
 
             if (options.env.has_value()) {
                 HashMap<String, String> map = *std::exchange(options.env, std::nullopt);
@@ -1205,6 +1190,43 @@ JSC_DEFINE_CUSTOM_SETTER(setGlobalOnError,
     vm.writeBarrier(thisObject, value);
     ensureStillAliveHere(value);
     return true;
+}
+
+// Host-function wrappers so node:worker_threads' fakeParentPort can reach the
+// globalEventScope attribute-listener slot without the onmessage/onerror
+// accessors being exposed on globalThis.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionGetGlobalOnMessage, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame*))
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    return JSValue::encode(eventHandlerAttribute(globalObject->eventTarget(), eventNames().messageEvent, globalObject->world()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionSetGlobalOnMessage, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    JSValue value = callFrame->argument(0);
+    setEventHandlerAttribute<JSEventListener>(globalObject->eventTarget(), eventNames().messageEvent, value, *globalObject);
+    vm.writeBarrier(globalObject, value);
+    ensureStillAliveHere(value);
+    return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionGetGlobalOnMessageError, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame*))
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    return JSValue::encode(eventHandlerAttribute(globalObject->eventTarget(), eventNames().messageerrorEvent, globalObject->world()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionSetGlobalOnMessageError, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    JSValue value = callFrame->argument(0);
+    setEventHandlerAttribute<JSEventListener>(globalObject->eventTarget(), eventNames().messageerrorEvent, value, *globalObject);
+    vm.writeBarrier(globalObject, value);
+    ensureStillAliveHere(value);
+    return JSValue::encode(jsUndefined());
 }
 
 WebCore::EventTarget& GlobalObject::eventTarget()
@@ -3191,20 +3213,30 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     // ----- Public Properties -----
 
-    // a direct accessor (uses js functions for get and set) cannot be on the lookup table. i think.
-    putDirectAccessor(
-        this,
-        builtinNames.selfPublicName(),
-        JSC::GetterSetter::create(
-            vm,
+    // Web Worker-style globals. Node.js worker_threads workers don't expose
+    // these on globalThis; node:worker_threads reaches the backing
+    // globalEventScope via $newCppFunction instead (see fakeParentPort).
+    if (!m_isNodeWorker) {
+        // a direct accessor (uses js functions for get and set) cannot be on the lookup table. i think.
+        putDirectAccessor(
             this,
-            JSFunction::create(vm, this, 0, "get"_s, functionGetSelf, ImplementationVisibility::Public),
-            JSFunction::create(vm, this, 0, "set"_s, functionSetSelf, ImplementationVisibility::Public)),
-        PropertyAttribute::Accessor | 0);
+            builtinNames.selfPublicName(),
+            JSC::GetterSetter::create(
+                vm,
+                this,
+                JSFunction::create(vm, this, 0, "get"_s, functionGetSelf, ImplementationVisibility::Public),
+                JSFunction::create(vm, this, 0, "set"_s, functionSetSelf, ImplementationVisibility::Public)),
+            PropertyAttribute::Accessor | 0);
 
-    // TODO: this should be usable on the lookup table. it crashed las time i tried it
-    putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onmessage"_s), JSC::CustomGetterSetter::create(vm, globalOnMessage, setGlobalOnMessage), 0);
-    putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onerror"_s), JSC::CustomGetterSetter::create(vm, globalOnError, setGlobalOnError), 0);
+        // TODO: this should be usable on the lookup table. it crashed las time i tried it
+        putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onmessage"_s), JSC::CustomGetterSetter::create(vm, globalOnMessage, setGlobalOnMessage), 0);
+        putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onerror"_s), JSC::CustomGetterSetter::create(vm, globalOnError, setGlobalOnError), 0);
+
+        putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "addEventListener"_s), 2, jsFunctionAddEventListener, ImplementationVisibility::Public, NoIntrinsic, 0);
+        putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "removeEventListener"_s), 2, jsFunctionRemoveEventListener, ImplementationVisibility::Public, NoIntrinsic, 0);
+        putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "dispatchEvent"_s), 1, jsFunctionDispatchEvent, ImplementationVisibility::Public, NoIntrinsic, 0);
+        putDirectNativeFunction(vm, this, JSC::Identifier::fromString(vm, "postMessage"_s), 1, WebCore::jsFunctionPostMessage, ImplementationVisibility::Public, NoIntrinsic, 0);
+    }
 
     // ----- Extensions to Built-in objects -----
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3217,7 +3217,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     // these on globalThis; node:worker_threads reaches the backing
     // globalEventScope via $newCppFunction instead (see fakeParentPort).
     if (!m_isNodeWorker) {
-        // a direct accessor (uses js functions for get and set) cannot be on the lookup table. i think.
+        // A JSFunction-backed accessor cannot live in the static lookup table.
         putDirectAccessor(
             this,
             builtinNames.selfPublicName(),
@@ -3228,7 +3228,6 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
                 JSFunction::create(vm, this, 0, "set"_s, functionSetSelf, ImplementationVisibility::Public)),
             PropertyAttribute::Accessor | 0);
 
-        // TODO: this should be usable on the lookup table. it crashed las time i tried it
         putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onmessage"_s), JSC::CustomGetterSetter::create(vm, globalOnMessage, setGlobalOnMessage), 0);
         putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onerror"_s), JSC::CustomGetterSetter::create(vm, globalOnError, setGlobalOnError), 0);
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -571,6 +571,25 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
         const auto initializeWorker = [&](WebCore::Worker& worker) -> void {
             auto& options = worker.options();
 
+            if (options.kind == WebCore::WorkerOptions::Kind::Node) {
+                // Node.js worker_threads do not expose Web Worker APIs on globalThis.
+                // node:worker_threads reaches the backing EventTarget through
+                // $newCppFunction instead (see fakeParentPort in worker_threads.ts).
+                static constexpr ASCIILiteral names[] = {
+                    "addEventListener"_s,
+                    "dispatchEvent"_s,
+                    "onerror"_s,
+                    "onmessage"_s,
+                    "postMessage"_s,
+                    "removeEventListener"_s,
+                    "self"_s,
+                };
+                for (auto name : names) {
+                    JSC::DeletePropertySlot slot;
+                    JSC::JSCell::deleteProperty(globalObject, globalObject, JSC::Identifier::fromString(vm, name), slot);
+                }
+            }
+
             if (options.env.has_value()) {
                 HashMap<String, String> map = *std::exchange(options.env, std::nullopt);
                 auto size = map.size();

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -153,7 +153,7 @@ public:
     }
 
     static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure);
-    static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure, uint32_t scriptExecutionContextId);
+    static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure, uint32_t scriptExecutionContextId, bool isNodeWorker = false);
     static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure, const JSC::GlobalObjectMethodTable* methodTable);
     static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure, uint32_t scriptExecutionContextId, const JSC::GlobalObjectMethodTable* methodTable);
 
@@ -364,6 +364,10 @@ public:
     }
 #endif
     bool isThreadLocalDefaultGlobalObject = false;
+    // Set by Zig__GlobalObject__create before finishCreation() when this
+    // global backs a node:worker_threads worker. Gates the Web Worker
+    // globals (self/postMessage/addEventListener/...) in addBuiltinGlobals.
+    bool m_isNodeWorker = false;
 
     JSObject* subtleCrypto() { return m_subtleCryptoObject.getInitializedOnMainThread(this); }
 
@@ -909,6 +913,10 @@ namespace Zig {
 JSC_DECLARE_HOST_FUNCTION(jsFunctionAddEventListener);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionRemoveEventListener);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionDispatchEvent);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionGetGlobalOnMessage);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionSetGlobalOnMessage);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionGetGlobalOnMessageError);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionSetGlobalOnMessageError);
 } // namespace Zig
 
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToText(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -905,6 +905,12 @@ inline void* bunVM(Zig::GlobalObject* globalObject)
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNotImplemented);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionCreateFunctionThatMasqueradesAsUndefined);
 
+namespace Zig {
+JSC_DECLARE_HOST_FUNCTION(jsFunctionAddEventListener);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionRemoveEventListener);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionDispatchEvent);
+} // namespace Zig
+
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToText(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToArrayBuffer(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);
 extern "C" JSC::EncodedJSValue ZigGlobalObject__readableStreamToBytes(Zig::GlobalObject* globalObject, JSC::EncodedJSValue readableStreamValue);

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -2,7 +2,6 @@
 
 /* Source for ZigGlobalObject.lut.h
 @begin bunGlobalObjectTable
-  addEventListener                jsFunctionAddEventListener                           Function 2
   alert                           WebCore__alert                                       Function 1
   atob                            functionATOB                                         Function 1
   btoa                            functionBTOA                                         Function 1
@@ -10,12 +9,9 @@
   clearInterval                   functionClearInterval                                Function 1
   clearTimeout                    functionClearTimeout                                 Function 1
   confirm                         WebCore__confirm                                     Function 1
-  dispatchEvent                   jsFunctionDispatchEvent                              Function 1
   fetch                           constructBunFetchObject                              PropertyCallback
-  postMessage                     jsFunctionPostMessage                                Function 1
   prompt                          WebCore__prompt                                      Function 1
   queueMicrotask                  functionQueueMicrotask                               Function 1
-  removeEventListener             jsFunctionRemoveEventListener                        Function 2
   reportError                     functionReportError                                  Function 1
   setImmediate                    functionSetImmediate                                 Function 1
   setInterval                     functionSetInterval                                  Function 1

--- a/test/js/node/worker_threads/worker-shadow-global-fixture.js
+++ b/test/js/node/worker_threads/worker-shadow-global-fixture.js
@@ -1,7 +1,7 @@
-// Mimics the `web-worker` npm package: polyfills a WorkerGlobalScope by
-// swapping globalThis' prototype to a user-defined EventTarget. That only
-// works when globalThis has no own addEventListener/dispatchEvent, which is
-// how Node.js worker_threads behave.
+// https://github.com/oven-sh/bun/issues/11005
+// Mimics the `web-worker` npm package: swaps globalThis' prototype for a
+// user-defined EventTarget, which only works when globalThis has no own
+// addEventListener/dispatchEvent (Node.js worker_threads behavior).
 const { parentPort } = require("worker_threads");
 
 const self = (global.self = global);

--- a/test/js/node/worker_threads/worker-shadow-global-fixture.js
+++ b/test/js/node/worker_threads/worker-shadow-global-fixture.js
@@ -1,0 +1,35 @@
+// Mimics the `web-worker` npm package: polyfills a WorkerGlobalScope by
+// swapping globalThis' prototype to a user-defined EventTarget. That only
+// works when globalThis has no own addEventListener/dispatchEvent, which is
+// how Node.js worker_threads behave.
+const { parentPort } = require("worker_threads");
+
+const self = (global.self = global);
+
+const dispatched = [];
+
+class EventTarget {
+  dispatchEvent(event) {
+    dispatched.push(event.type + ":" + event.data);
+  }
+}
+class WorkerGlobalScope extends EventTarget {}
+
+Object.setPrototypeOf(global, new WorkerGlobalScope());
+
+function Event(type) {
+  this.type = type;
+  this.data = null;
+}
+
+const event = new Event("message");
+event.data = "hello";
+
+let threw = false;
+try {
+  self.dispatchEvent(event);
+} catch {
+  threw = true;
+}
+
+parentPort.postMessage({ dispatched, threw });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1858,7 +1858,8 @@ test("globalThis inside a Web Worker still exposes Web Worker globals", async ()
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+  // Don't require an empty stderr on success: ASAN/debug lanes emit benign warnings there.
+  expect({ out: JSON.parse(stdout.trim()), stderr: exitCode === 0 ? "" : stderr, exitCode }).toEqual({
     out: {
       self: "object",
       addEventListener: "function",

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -28,7 +28,7 @@ import wt, {
 setDefaultTimeout(isDebug ? 90_000 : 10_000);
 
 test("support eval in worker", async () => {
-  const worker = new Worker(`postMessage(1 + 1)`, {
+  const worker = new Worker(`require('worker_threads').parentPort.postMessage(1 + 1)`, {
     eval: true,
   });
   const result = await new Promise(resolve => {
@@ -268,7 +268,9 @@ test("you can override globalThis.postMessage", async () => {
 });
 
 test("support require in eval", async () => {
-  const worker = new Worker(`postMessage(require('process').argv[0])`, { eval: true });
+  const worker = new Worker(`require('worker_threads').parentPort.postMessage(require('process').argv[0])`, {
+    eval: true,
+  });
   const result = await new Promise(resolve => {
     worker.on("message", resolve);
     worker.on("error", resolve);
@@ -285,7 +287,9 @@ test("support require in eval for a file", async () => {
   const realpath = relative(cwd, testfile).replaceAll("\\", "/");
   console.log("realpath", realpath);
   expect(() => fs.accessSync(join(cwd, realpath))).not.toThrow();
-  const worker = new Worker(`postMessage(require('./${realpath}').argv[0])`, { eval: true });
+  const worker = new Worker(`require('worker_threads').parentPort.postMessage(require('./${realpath}').argv[0])`, {
+    eval: true,
+  });
   const result = await new Promise(resolve => {
     worker.on("message", resolve);
     worker.on("error", resolve);
@@ -295,7 +299,10 @@ test("support require in eval for a file", async () => {
 });
 
 test("support require in eval for a file that doesnt exist", async () => {
-  const worker = new Worker(`postMessage(require('./fixture-invalid.js').argv[0])`, { eval: true });
+  const worker = new Worker(
+    `require('worker_threads').parentPort.postMessage(require('./fixture-invalid.js').argv[0])`,
+    { eval: true },
+  );
   const result = await new Promise(resolve => {
     worker.on("message", resolve);
     worker.on("error", resolve);
@@ -1755,4 +1762,111 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout.trim()).toBe("yes,unset");
   expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/11005
+describe("globalThis inside a node:worker_threads worker", () => {
+  test("does not expose Web Worker globals", async () => {
+    const worker = new Worker(
+      `const own = Object.getOwnPropertyNames(globalThis);
+       const names = ["self", "addEventListener", "removeEventListener", "dispatchEvent", "postMessage", "onmessage", "onerror"];
+       const result = {};
+       for (const name of names) result[name] = { own: own.includes(name), type: typeof globalThis[name] };
+       require("worker_threads").parentPort.postMessage(result);`,
+      { eval: true },
+    );
+    const [msg] = await once(worker, "message");
+    await worker.terminate();
+    const absent = { own: false, type: "undefined" };
+    expect(msg).toEqual({
+      self: absent,
+      addEventListener: absent,
+      removeEventListener: absent,
+      dispatchEvent: absent,
+      postMessage: absent,
+      onmessage: absent,
+      onerror: absent,
+    });
+  });
+
+  test("user-defined dispatchEvent on globalThis is reachable (web-worker npm package pattern)", async () => {
+    const worker = new Worker(new URL("./worker-shadow-global-fixture.js", import.meta.url).href);
+    const [msg] = await once(worker, "message");
+    await worker.terminate();
+    expect(msg).toEqual({
+      dispatched: ["message:hello"],
+      threw: false,
+    });
+  });
+
+  test("parentPort still delivers messages and onmessage works", async () => {
+    const worker = new Worker(
+      `const { parentPort } = require("worker_threads");
+       let via = [];
+       parentPort.onmessage = e => { via.push("onmessage:" + e.data); };
+       parentPort.on("message", d => {
+         via.push("on:" + d);
+         if (d === 2) parentPort.postMessage(via);
+       });`,
+      { eval: true },
+    );
+    worker.postMessage(1);
+    worker.postMessage(2);
+    const [msg] = await once(worker, "message");
+    await worker.terminate();
+    expect(msg).toEqual(["onmessage:1", "on:1", "onmessage:2", "on:2"]);
+  });
+
+  test("parentPort.onmessage uses the attribute-listener slot, not addEventListener's", async () => {
+    const worker = new Worker(
+      `const { parentPort } = require("worker_threads");
+       let calls = 0;
+       const fn = () => calls++;
+       parentPort.addEventListener("message", fn);
+       parentPort.onmessage = fn;
+       parentPort.onmessage = null;
+       parentPort.addEventListener("message", () => parentPort.postMessage({ calls }));`,
+      { eval: true },
+    );
+    await once(worker, "online");
+    worker.postMessage("go");
+    const [msg] = await once(worker, "message");
+    await worker.terminate();
+    expect(msg).toEqual({ calls: 1 });
+  });
+});
+
+// Web Workers (the global Worker constructor) keep their DedicatedWorkerGlobalScope API.
+test("globalThis inside a Web Worker still exposes Web Worker globals", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const w = new Worker(URL.createObjectURL(new Blob([
+         'self.postMessage({ ' +
+         '  self: typeof self, ' +
+         '  addEventListener: typeof addEventListener, ' +
+         '  removeEventListener: typeof removeEventListener, ' +
+         '  dispatchEvent: typeof dispatchEvent, ' +
+         '  postMessage: typeof postMessage, ' +
+         '});',
+       ])));
+       w.onerror = e => { console.error(e.message || e); process.exit(1); };
+       w.onmessage = e => { console.log(JSON.stringify(e.data)); w.terminate(); };`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ out: JSON.parse(stdout.trim()), stderr, exitCode }).toEqual({
+    out: {
+      self: "object",
+      addEventListener: "function",
+      removeEventListener: "function",
+      dispatchEvent: "function",
+      postMessage: "function",
+    },
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1790,7 +1790,7 @@ describe("globalThis inside a node:worker_threads worker", () => {
   });
 
   test("user-defined dispatchEvent on globalThis is reachable (web-worker npm package pattern)", async () => {
-    const worker = new Worker(new URL("./worker-shadow-global-fixture.js", import.meta.url).href);
+    const worker = new Worker(new URL("./worker-shadow-global-fixture.js", import.meta.url));
     const [msg] = await once(worker, "message");
     await worker.terminate();
     expect(msg).toEqual({

--- a/test/js/web/workers/worker-fixture-argv.js
+++ b/test/js/web/workers/worker-fixture-argv.js
@@ -1,7 +1,7 @@
 const parentPort = require("node:worker_threads").parentPort;
-const target = globalThis.addEventListener ? globalThis : parentPort;
+const target = typeof globalThis.addEventListener === "function" ? globalThis : parentPort;
 target.addEventListener("message", () => {
   const reply = { argv: process.argv, execArgv: process.execArgv };
-  if (globalThis.postMessage) globalThis.postMessage(reply);
+  if (typeof globalThis.postMessage === "function") globalThis.postMessage(reply);
   else parentPort.postMessage(reply);
 });

--- a/test/js/web/workers/worker-fixture-argv.js
+++ b/test/js/web/workers/worker-fixture-argv.js
@@ -1,7 +1,7 @@
-(globalThis.addEventListener || require("node:worker_threads").parentPort.on)("message", () => {
-  const postMessage = globalThis.postMessage || require("node:worker_threads").parentPort.postMessage;
-  postMessage({
-    argv: process.argv,
-    execArgv: process.execArgv,
-  });
+const parentPort = require("node:worker_threads").parentPort;
+const target = globalThis.addEventListener ? globalThis : parentPort;
+target.addEventListener("message", () => {
+  const reply = { argv: process.argv, execArgv: process.execArgv };
+  if (globalThis.postMessage) globalThis.postMessage(reply);
+  else parentPort.postMessage(reply);
 });

--- a/test/js/web/workers/worker-fixture-while-true.js
+++ b/test/js/web/workers/worker-fixture-while-true.js
@@ -1,4 +1,5 @@
+const { parentPort } = require("node:worker_threads");
 let i = 0;
 while (true) {
-  postMessage({ i: i++ });
+  parentPort.postMessage({ i: i++ });
 }

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -447,7 +447,7 @@ describe("worker_threads", () => {
 
   test("worker with eval = true succeeds with valid code", async () => {
     let message;
-    const worker = new wt.Worker("postMessage('hello')", { eval: true });
+    const worker = new wt.Worker("require('worker_threads').parentPort.postMessage('hello')", { eval: true });
     worker.on("message", e => {
       message = e;
     });

--- a/test/napi/node-napi-tests/test/common/index.js
+++ b/test/napi/node-napi-tests/test/common/index.js
@@ -339,25 +339,28 @@ let knownGlobals = [
 ];
 
 if (typeof Bun === "object") {
+  // Property accesses: worker_threads workers don't have the Web Worker
+  // globals (addEventListener, postMessage, onmessage, ...), and a bare
+  // identifier reference would throw there.
   knownGlobals.push(
-    addEventListener,
-    alert,
-    confirm,
-    dispatchEvent,
-    postMessage,
-    prompt,
-    removeEventListener,
-    Bun,
-    reportError,
-    BuildError,
-    BuildMessage,
-    HTMLRewriter,
-    ResolveError,
-    ResolveMessage,
-    ErrorEvent,
-    Worker,
-    onmessage,
-    onerror,
+    global.addEventListener,
+    global.alert,
+    global.confirm,
+    global.dispatchEvent,
+    global.postMessage,
+    global.prompt,
+    global.removeEventListener,
+    global.Bun,
+    global.reportError,
+    global.BuildError,
+    global.BuildMessage,
+    global.HTMLRewriter,
+    global.ResolveError,
+    global.ResolveMessage,
+    global.ErrorEvent,
+    global.Worker,
+    global.onmessage,
+    global.onerror,
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #11005.

Node.js `worker_threads` workers have the same `globalThis` shape as the main thread: no `self`, `postMessage`, `addEventListener`, `removeEventListener`, `dispatchEvent`, `onmessage`, or `onerror`. Bun was installing all of these as own properties of `globalThis` inside every worker regardless of how it was created.

This breaks the [`web-worker`](https://www.npmjs.com/package/web-worker) npm package (used by `ffjavascript`, which is used by circom/semaphore and other zk tooling). That package polyfills a `WorkerGlobalScope` on top of `worker_threads` by swapping `globalThis`' prototype to its own `EventTarget` subclass. In Node that works because nothing on `globalThis` shadows the prototype; in Bun the own-property native `dispatchEvent` won and rejected the polyfill's plain-object events with:

```
TypeError: Argument 1 ('event') to EventTarget.dispatchEvent must be an instance of Event
```

followed by `panic: Uncaught exception while handling uncaught exception`.

### Repro

```ts
import { buildBn128, F1Field } from "ffjavascript";
let bn128 = await buildBn128();
const F = new F1Field(bn128.r);
console.log(F.sqrt(F.e("9")));   // expected 3n
bn128.terminate();
```

| | Node | Bun before | Bun after |
|--|--|--|--|
| output | `3n` | TypeError + panic | `3n` |

### Fix

* `Zig__GlobalObject__create`: when the worker was created via `node:worker_threads` (`WorkerOptions::Kind::Node`), delete `self` / `addEventListener` / `removeEventListener` / `dispatchEvent` / `postMessage` / `onmessage` / `onerror` from `globalThis` before user code runs. The backing `globalEventScope` is untouched.
* `worker_threads.ts` `fakeParentPort()`: stop reading those properties off `self`; reach the same native functions through `$newCppFunction` and implement `onmessage`/`onmessageerror` locally on top of them.
* Web Workers created via the global `new Worker()` constructor (`Kind::Web`) are unchanged and keep their DedicatedWorkerGlobalScope API. The main thread is also unchanged.

A handful of existing tests encoded the old Bun-specific behaviour by calling bare `postMessage(...)` inside `worker_threads.Worker` eval strings; those now go through `parentPort.postMessage` so they work the same in Node and Bun.

## How did you verify your code works?

New tests in `test/js/node/worker_threads/worker_threads.test.ts`:
* `globalThis` inside a `node:worker_threads` worker has none of the seven Web Worker globals as own properties (fails on the baked build)
* a user-defined `dispatchEvent` reached via `Object.setPrototypeOf(global, ...)` is now callable with a plain object (the `web-worker` package pattern; fails on the baked build)
* `parentPort.on` / `parentPort.onmessage` / `parentPort.postMessage` still round-trip messages
* a Web Worker created via the global constructor still has `self` / `addEventListener` / `dispatchEvent` / `postMessage`

Also verified the `ffjavascript` repro from #11005 now prints `3n` and exits 0, and `test/js/node/test/parallel/test-worker-onmessage*.js` still pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (f14ff9587)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [12.84ms]
(pass) web worker > preload > string [164.80ms]
(pass) web worker > preload > array of 2 strings [171.17ms]
(pass) web worker > preload > array of string [161.52ms]
(pass) web worker > preload > error in preload doesn't crash parent [238.55ms]
(pass) web worker > worker [149.22ms]
(pass) web worker > worker-env [161.58ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1101.07ms]
(pass) web worker > worker-env with a lot of properties [353.61ms]
(pass) web worker > argv / execArgv defaults [683.48ms]
(pass) web worker > argv / execArgv options [697.93ms]
(pass) web worker > sending 50 messages should just work [176.37ms]
(pass) web worker > worker with event listeners doesn't close event loop [623.83ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [658.91ms]
(pass) web work
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.26ms]
(pass) web worker > preload > string [7.77ms]
(pass) web worker > preload > array of 2 strings [5.56ms]
(pass) web worker > preload > array of string [3.47ms]
(pass) web worker > preload > error in preload doesn't crash parent [3.35ms]
(pass) web worker > worker [5.18ms]
(pass) web worker > worker-env [3.84ms]
162 |       ],
163 |       env: bunEnv,
164 |       stderr: "pipe",
165 |     });
166 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
167 |     expect(JSON.parse(stdout)).toEqual({ seen: "from-parent", parentSees: "from-worker" });
                      ^
SyntaxError: JSON Parse error: Unexpected EOF
      at <anonymous> (/workspace/bun/test/js/web/workers/worker.test.ts:167:17)
(fail) web worker > worker-env: SHARE_ENV via the global Worker constructor [35.07ms]
(pass) web worker > worker-env with a lot of properties [9.22ms]
(pass) web worker > argv / execArgv defaults [9.76ms]
(pass) web worker > argv / execArgv options [9.27ms]
(pass) web worker > sending 50 mess
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/worker.test.ts
bun test v1.4.0 (f14ff9587)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [14.10ms]
(pass) web worker > preload > string [154.47ms]
(pass) web worker > preload > array of 2 strings [160.31ms]
(pass) web worker > preload > array of string [151.01ms]
(pass) web worker > preload > error in preload doesn't crash parent [147.30ms]
(pass) web worker > worker [142.74ms]
(pass) web worker > worker-env [149.87ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [999.46ms]
(pass) web worker > worker-env with a lot of properties [352.71ms]
(pass) web worker > argv / execArgv defaults [650.10ms]
(pass) web worker > argv / execArgv options [649.01ms]
(pass) web worker > sending 50 messages should just work [180.72ms]
(pass) web worker > worker with event listeners doesn't close event loop [599.16ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [567.88ms]
(pass) web worke
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1074ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/435] cxx obj/vendor/boringssl/crypto/x509/v3_extku.cc.o
[2/435] cxx obj/vendor/boringssl/crypto/x509/v3_conf.cc.o
[3/435] cxx obj/vendor/boringssl/crypto/x509/v3_info.cc.o
[4/435] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/release/codegen/ZigGlobalObject.lut.h from /workspace/bun/src/jsc/bindings/ZigGlobalObject.lut.txt
[5/435] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[6/435] gen cpp.rs (cppbind)
[7/435] cxx obj/vendor/boringssl/crypto/x509/v3_lib.cc.o
[8/435] cxx obj/vendor/boringssl/crypto/x509/v3_pmaps.cc.o
[9/435] cxx obj/vendor/boringssl/crypto/x509/v3_prn.cc.o
[10/435] cxx obj/vendor/boringssl/crypto/x509/v3_purp.cc.o
[11/435] cxx obj/vendor/boringssl/crypto/x509/v3_ocsp.cc.o
[12/435] cxx obj/vendor/boringssl/crypto/x509/v3_pcons.cc.o
[13/435] cxx obj/vendor/boringssl/crypto/x509/v3_int.cc.o
[14/435] cxx obj/vendor/boringssl/crypto/x509/x509_cmp.cc.o
[15/435] cxx obj/vendor/boringssl/crypt
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/generate-js2native.ts                  |   3 +-
 src/js/node/worker_threads.ts                      |  41 +++----
 src/jsc/bindings/ZigGlobalObject.cpp               |  80 +++++++++++---
 src/jsc/bindings/ZigGlobalObject.h                 |  16 ++-
 src/jsc/bindings/ZigGlobalObject.lut.txt           |   4 -
 .../worker_threads/worker-shadow-global-fixture.js |  35 ++++++
 test/js/node/worker_threads/worker_threads.test.ts | 123 ++++++++++++++++++++-
 test/js/web/workers/worker-fixture-argv.js         |  12 +-
 test/js/web/workers/worker-fixture-while-true.js   |   3 +-
 test/js/web/workers/worker.test.ts                 |   2 +-
 test/napi/node-napi-tests/test/common/index.js     |  39 ++++---
 11 files changed, 288 insertions(+), 70 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/codegen/generate-js2native.ts                             0      0      0
src/js/node/worker_threads.ts                                 0      0      0
src/jsc/bindings/ZigGlobalObject.cpp                          2      2      0
src/jsc/bindings/ZigGlobalObject.h                            0      0      0
src/jsc/bindings/ZigGlobalObject.lut.txt                      0      0      0
…/js/node/worker_threads/worker-shadow-global-fixture.js      2      2      0
test/js/node/worker_threads/worker_threads.test.ts            2      2      0
test/js/web/workers/worker-fixture-argv.js                    2      2      0
test/js/web/workers/worker-fixture-while-true.js              0      0      0
test/js/web/workers/worker.test.ts                            1      0      0
test/napi/node-napi-tests/test/common/index.js                2      1      0
```

</details>

**root cause** · written by the author bot

Bun installed the Web Worker globals (self, postMessage, addEventListener, removeEventListener, dispatchEvent, onmessage, onerror) unconditionally on every global object, so workers created via node:worker_threads exposed a Web Worker shaped globalThis instead of the Node shaped one. The fix introduces an m_isNodeWorker flag set before finishCreation and gates installation of those seven globals on it, moving four entries out of the static lut table into the guarded runtime path so main thread, Web Worker, and node:vm contexts are unaffected. Because parentPort previously read those globals…

<!-- robobun:evidence:end -->