### PR TITLE
bundler: derive __toESM isNodeMode from resolver module type, not exports_kind

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -878,9 +878,6 @@ impl ExportsKind {
             Self::EsmWithDynamicFallback | Self::EsmWithDynamicFallbackFromCjs
         )
     }
-
-    // `to_module_type()` lives in `bun_options_types` as
-    // `impl From<ExportsKind> for ModuleType` (would cycle here).
 }
 
 #[derive(Copy, Clone)]

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2193,7 +2193,11 @@ impl<'a> LinkerContext<'a> {
 
             minify_whitespace: self.options.minify_whitespace,
             minify_syntax: self.options.minify_syntax,
-            input_module_type: ast.exports_kind.into(),
+            input_module_type: if ast.flags.contains(AstFlags::MODULE_TYPE_WAS_ESM) {
+                crate::options::ModuleType::Esm
+            } else {
+                crate::options::ModuleType::Unknown
+            },
             module_type: self.options.output_format,
             print_dce_annotations: self.options.emit_dce_annotations,
             has_run_symbol_renamer: true,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2661,7 +2661,20 @@ pub mod parse_worker {
         };
 
         ast.target = target;
-        if task.module_type == options::ModuleType::Esm {
+        let module_type_for_print = if task.module_type == options::ModuleType::Unknown {
+            // Some ParseTask construction sites bypass the resolver (plugin
+            // onResolve, server-component re-parse, in-memory entries) and
+            // leave module_type Unknown. Fall back to the file extension so
+            // .mjs/.mts still get Node ESM interop semantics.
+            match task.path.name().ext {
+                b".mjs" | b".mts" => options::ModuleType::Esm,
+                b".cjs" | b".cts" => options::ModuleType::Cjs,
+                _ => options::ModuleType::Unknown,
+            }
+        } else {
+            task.module_type
+        };
+        if module_type_for_print == options::ModuleType::Esm {
             ast.flags
                 .insert(crate::bundled_ast::Flags::MODULE_TYPE_WAS_ESM);
         }

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2663,11 +2663,8 @@ pub mod parse_worker {
         ast.target = target;
         // Construction sites that bypass the resolver leave module_type Unknown; fall back to extension.
         let module_type_for_print = if task.module_type == options::ModuleType::Unknown {
-            match task.path.name().ext {
-                b".mjs" | b".mts" => options::ModuleType::Esm,
-                b".cjs" | b".cts" => options::ModuleType::Cjs,
-                _ => options::ModuleType::Unknown,
-            }
+            _resolver::module_type_from_ext(task.path.name().ext)
+                .unwrap_or(options::ModuleType::Unknown)
         } else {
             task.module_type
         };

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2661,6 +2661,10 @@ pub mod parse_worker {
         };
 
         ast.target = target;
+        if task.module_type == options::ModuleType::Esm {
+            ast.flags
+                .insert(crate::bundled_ast::Flags::MODULE_TYPE_WAS_ESM);
+        }
         if ast.parts.len() <= 1
             && ast.css.is_none()
             && (task.loader.is_none() || task.loader.unwrap() != Loader::Html)

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2661,11 +2661,8 @@ pub mod parse_worker {
         };
 
         ast.target = target;
+        // Construction sites that bypass the resolver leave module_type Unknown; fall back to extension.
         let module_type_for_print = if task.module_type == options::ModuleType::Unknown {
-            // Some ParseTask construction sites bypass the resolver (plugin
-            // onResolve, server-component re-parse, in-memory entries) and
-            // leave module_type Unknown. Fall back to the file extension so
-            // .mjs/.mts still get Node ESM interop semantics.
             match task.path.name().ext {
                 b".mjs" | b".mts" => options::ModuleType::Esm,
                 b".cjs" | b".cts" => options::ModuleType::Cjs,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3483,6 +3483,7 @@ pub mod bv2_impl {
             source: &mut bun_ast::Source,
             loader: Loader,
             known_target: options::Target,
+            module_type: options::ModuleType,
         ) -> Result<IndexInt, AllocError> {
             let source_index = Index::init(u32::try_from(self.graph.ast.len()).expect("int cast"));
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
@@ -3537,7 +3538,7 @@ pub mod bv2_impl {
                 side_effects: bun_ast::SideEffects::HasSideEffects,
                 jsx,
                 source_index: bun_ast::Index::init(source_index.get()),
-                module_type: options::ModuleType::Unknown,
+                module_type,
                 emit_decorator_metadata: false, // TODO
                 package_version: bun_ast::StoreStr::EMPTY,
                 loader: Some(loader),
@@ -7077,6 +7078,14 @@ pub mod bv2_impl {
                         let source_loader: Loader =
                             this.graph.input_files.items_loader()[result_source_index];
 
+                        let original_module_type = if this.graph.ast.items_flags()
+                            [result_source_index]
+                            .contains(crate::bundled_ast::Flags::MODULE_TYPE_WAS_ESM)
+                        {
+                            options::ModuleType::Esm
+                        } else {
+                            options::ModuleType::Unknown
+                        };
                         let (reference_source_index, ssr_index) = if separate_ssr_graph {
                             // Enqueue two files, one in server graph, one in ssr graph.
                             let other_source =
@@ -7115,6 +7124,7 @@ pub mod bv2_impl {
                                     &mut ssr_source,
                                     source_loader,
                                     Target::ServerComponentsSsr,
+                                    original_module_type,
                                 )
                                 .expect("oom");
 
@@ -7138,6 +7148,7 @@ pub mod bv2_impl {
                                     &mut server_source,
                                     source_loader,
                                     Target::Browser,
+                                    original_module_type,
                                 )
                                 .expect("oom");
 

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -145,12 +145,10 @@ bitflags::bitflags! {
         const COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED = 1 << 6;
         const HAS_EXPLICIT_USE_STRICT_DIRECTIVE = 1 << 7;
         const HAS_IMPORT_META = 1 << 8;
-        // Set when the resolver determined this file is unambiguously ESM by
-        // Node.js rules (.mjs/.mts, or "type": "module" in the nearest
-        // package.json). This is distinct from `exports_kind == Esm`: a .js
-        // file with `import` syntax inside a package without "type": "module"
-        // has `exports_kind == Esm` but this flag unset. Used to decide the
-        // `isNodeMode` argument to `__toESM` at print time.
+        // The resolver determined this file is ESM by Node.js rules (.mjs/.mts
+        // or nearest package.json has "type": "module"). Distinct from
+        // `exports_kind == Esm`, which is set by syntax alone. Controls the
+        // `isNodeMode` arg to `__toESM`.
         const MODULE_TYPE_WAS_ESM = 1 << 9;
         // _padding: u6 fills the rest
     }

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -145,10 +145,7 @@ bitflags::bitflags! {
         const COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED = 1 << 6;
         const HAS_EXPLICIT_USE_STRICT_DIRECTIVE = 1 << 7;
         const HAS_IMPORT_META = 1 << 8;
-        // The resolver determined this file is ESM by Node.js rules (.mjs/.mts
-        // or nearest package.json has "type": "module"). Distinct from
-        // `exports_kind == Esm`, which is set by syntax alone. Controls the
-        // `isNodeMode` arg to `__toESM`.
+        // Node.js would load this file as ESM (.mjs/.mts or nearest package.json has "type": "module"); controls __toESM isNodeMode.
         const MODULE_TYPE_WAS_ESM = 1 << 9;
         // _padding: u6 fills the rest
     }

--- a/src/bundler/bundled_ast.rs
+++ b/src/bundler/bundled_ast.rs
@@ -145,7 +145,14 @@ bitflags::bitflags! {
         const COMMONJS_MODULE_EXPORTS_ASSIGNED_DEOPTIMIZED = 1 << 6;
         const HAS_EXPLICIT_USE_STRICT_DIRECTIVE = 1 << 7;
         const HAS_IMPORT_META = 1 << 8;
-        // _padding: u7 fills the rest
+        // Set when the resolver determined this file is unambiguously ESM by
+        // Node.js rules (.mjs/.mts, or "type": "module" in the nearest
+        // package.json). This is distinct from `exports_kind == Esm`: a .js
+        // file with `import` syntax inside a package without "type": "module"
+        // has `exports_kind == Esm` but this flag unset. Used to decide the
+        // `isNodeMode` argument to `__toESM` at print time.
+        const MODULE_TYPE_WAS_ESM = 1 << 9;
+        // _padding: u6 fills the rest
     }
 }
 

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -263,4 +263,3 @@ pub enum BuiltInModule {
     Import(Box<[u8]>),
     Code(Box<[u8]>),
 }
-

--- a/src/options_types/bundle_enums.rs
+++ b/src/options_types/bundle_enums.rs
@@ -264,17 +264,3 @@ pub enum BuiltInModule {
     Code(Box<[u8]>),
 }
 
-// `ExportsKind::to_module_type` — moved here from `bun_ast::nodes` to avoid
-// the `bun_options_types → bun_ast → bun_options_types` cycle.
-impl From<bun_ast::ExportsKind> for ModuleType {
-    fn from(k: bun_ast::ExportsKind) -> Self {
-        use bun_ast::ExportsKind as K;
-        match k {
-            K::None => ModuleType::Unknown,
-            K::Cjs => ModuleType::Cjs,
-            K::EsmWithDynamicFallback | K::EsmWithDynamicFallbackFromCjs | K::Esm => {
-                ModuleType::Esm
-            }
-        }
-    }
-}

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -50,7 +50,9 @@ pub use tsconfig_json::TSConfigJSON;
 // `result` / `standalone_module_graph` sibling modules.
 /// Re-export so dependents can spell `bun_resolver::install_types::AutoInstaller`.
 pub use ::bun_install_types::resolver_hooks as install_types;
-pub use resolver::{AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver};
+pub use resolver::{
+    AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver, module_type_from_ext,
+};
 pub use result::{
     DebugLogs, DirEntryResolveQueueItem, ExternalKind, FlushMode, LoadResult, MatchResult,
     MatchStatus, PathPair, PendingResolution, PendingResolutionTag, Result, ResultFlags,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1277,7 +1277,6 @@ pub(crate) struct ESModule<'a> {
     pub(crate) debug_logs: Option<&'a mut resolver::DebugLogs>,
     pub(crate) conditions: &'a ConditionsMap,
     // allocator dropped — global mimalloc
-    pub(crate) module_type: &'a mut ModuleType,
 }
 
 #[derive(Clone)]
@@ -1556,8 +1555,8 @@ fn module_bufs() -> *mut ModuleBufs {
     })
 }
 
-// `module_type` / `debug_logs` are `&'a mut T`, so reading/writing them
-// requires `&mut self`. All resolution methods take `&mut self`.
+// `debug_logs` is `&'a mut T`, so writing it requires `&mut self`. All
+// resolution methods take `&mut self`.
 impl<'a> ESModule<'a> {
     pub(crate) fn resolve(
         &mut self,
@@ -2118,7 +2117,6 @@ impl<'a> ESModule<'a> {
                             ));
                         }
 
-                        let prev_module_type = *self.module_type;
                         let result = self.resolve_target::<PATTERN>(
                             package_url,
                             &entry.value,
@@ -2126,16 +2124,7 @@ impl<'a> ESModule<'a> {
                             internal,
                         );
                         if result.status.is_undefined() {
-                            *self.module_type = prev_module_type;
                             continue;
-                        }
-
-                        if key == b"import" {
-                            *self.module_type = ModuleType::Esm;
-                        }
-
-                        if key == b"require" {
-                            *self.module_type = ModuleType::Cjs;
                         }
 
                         return result;
@@ -2177,7 +2166,6 @@ impl<'a> ESModule<'a> {
 
                 for target_value in array.iter() {
                     // Let resolved be the result, continuing the loop on any Invalid Package Target error.
-                    let prev_module_type = *self.module_type;
                     let result = self.resolve_target::<PATTERN>(
                         package_url,
                         target_value,
@@ -2191,7 +2179,6 @@ impl<'a> ESModule<'a> {
                     }
 
                     if result.status.is_undefined() {
-                        *self.module_type = prev_module_type;
                         continue;
                     }
 

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1555,8 +1555,6 @@ fn module_bufs() -> *mut ModuleBufs {
     })
 }
 
-// `debug_logs` is `&'a mut T`, so writing it requires `&mut self`. All
-// resolution methods take `&mut self`.
 impl<'a> ESModule<'a> {
     pub(crate) fn resolve(
         &mut self,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1654,15 +1654,12 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            // If you use mjs or mts, then you're using esm
-            // If you use cjs or cts, then you're using cjs
-            // This should win out over the module type from package.json
-            if !kind.is_from_css()
-                && module_type == options::ModuleType::Unknown
-                && name.ext.len() == 4
-            {
-                module_type =
-                    module_type_from_ext(name.ext).unwrap_or(options::ModuleType::Unknown);
+            // .mjs/.mts are always ESM and .cjs/.cts are always CJS, regardless
+            // of any package.json "type" field.
+            if !kind.is_from_css() && name.ext.len() == 4 {
+                if let Some(from_ext) = module_type_from_ext(name.ext) {
+                    module_type = from_ext;
+                }
             }
 
             if let Some(entries) = dir.get_entries_ref(self.generation) {
@@ -2706,7 +2703,6 @@ impl<'a> Resolver<'a> {
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import
-                                    let module_type = package_json.module_type;
                                     // NOTE: keeping a single
                                     // `ESModule` (which holds `&mut self.debug_logs`) alive across a
                                     // `&mut self` call is aliased-&mut UB. Build a fresh short-lived
@@ -2748,7 +2744,6 @@ impl<'a> Resolver<'a> {
                                             .is_success()
                                         {
                                             out.is_node_module = true;
-                                            out.module_type = module_type;
                                             self.extension_order = prev_extension_order;
                                             if let Some(d) = self.debug_logs.as_mut() {
                                                 d.decrease_indent();
@@ -2806,7 +2801,6 @@ impl<'a> Resolver<'a> {
                                             .is_success()
                                         {
                                             out.is_node_module = true;
-                                            out.module_type = module_type;
                                             self.extension_order = prev_extension_order;
                                             if let Some(d) = self.debug_logs.as_mut() {
                                                 d.decrease_indent();

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2706,7 +2706,7 @@ impl<'a> Resolver<'a> {
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import
-                                    let mut module_type = package_json.module_type;
+                                    let module_type = package_json.module_type;
                                     // NOTE: keeping a single
                                     // `ESModule` (which holds `&mut self.debug_logs`) alive across a
                                     // `&mut self` call is aliased-&mut UB. Build a fresh short-lived
@@ -2732,7 +2732,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
                                         // ESModule temporary dropped here; `self` is unborrowed.
@@ -2789,7 +2788,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(
                                             b"/",
@@ -3206,7 +3204,6 @@ impl<'a> Resolver<'a> {
                     Ok(dir_info_to_use_) => {
                         if let Some(pkg_dir_info) = dir_info_to_use_ {
                             let abs_package_path = pkg_dir_info.abs_path;
-                            let mut module_type = options::ModuleType::Unknown;
                             if let Some(package_json) = pkg_dir_info.package_json() {
                                 if let Some(exports_map) = package_json.exports.as_ref() {
                                     // The condition set is determined by the kind of import
@@ -3227,7 +3224,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(b"/", esm.subpath, &exports_map.root);
 
@@ -3266,7 +3262,6 @@ impl<'a> Resolver<'a> {
                                                 _ => &self.opts.conditions.import,
                                             },
                                             debug_logs: self.debug_logs.as_mut(),
-                                            module_type: &mut module_type,
                                         }
                                         .resolve(
                                             b"/",
@@ -4889,7 +4884,6 @@ impl<'a> Resolver<'a> {
             }
             return MatchStatus::NotFound;
         }
-        let mut module_type = options::ModuleType::Unknown;
 
         // NOTE: keeping the `ESModule`'s borrow of `self.debug_logs` alive
         // across the subsequent `&mut self` calls would be aliased-&mut UB, so
@@ -4903,10 +4897,8 @@ impl<'a> Resolver<'a> {
                 _ => &self.opts.conditions.import,
             },
             debug_logs: self.debug_logs.as_mut(),
-            module_type: &mut module_type,
         }
         .resolve_imports(import_path, &imports_map.root);
-        let _ = module_type;
 
         if esm_resolution.status == crate::package_json::Status::PackageResolve {
             // https://github.com/oven-sh/bun/issues/4972

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1654,13 +1654,6 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            // .mjs/.mts/.cjs/.cts override any package.json "type".
-            if !kind.is_from_css() && name.ext.len() == 4 {
-                if let Some(from_ext) = module_type_from_ext(name.ext) {
-                    module_type = from_ext;
-                }
-            }
-
             if let Some(entries) = dir.get_entries_ref(self.generation) {
                 if let Some(query) = entries.get(name.filename) {
                     // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
@@ -1760,6 +1753,13 @@ impl<'a> Resolver<'a> {
         if !kind.is_from_css() && module_type == options::ModuleType::Unknown {
             if let Some(pkg) = result.package_json_ref() {
                 module_type = pkg.module_type;
+            }
+        }
+
+        // .mjs/.mts/.cjs/.cts override any package.json "type".
+        if !kind.is_from_css() {
+            if let Some(from_ext) = module_type_from_ext(result.path_pair.primary.name().ext) {
+                module_type = from_ext;
             }
         }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6635,8 +6635,11 @@ bun_core::comptime_string_map! {
     };
 }
 
+/// The module format Node.js infers from a file extension alone
+/// (`.mjs`/`.mts` => ESM, `.cjs`/`.cts` => CJS), or `None` for every other
+/// extension.
 #[inline]
-fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
+pub fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()
 }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -1654,8 +1654,7 @@ impl<'a> Resolver<'a> {
                 }
             }
 
-            // .mjs/.mts are always ESM and .cjs/.cts are always CJS, regardless
-            // of any package.json "type" field.
+            // .mjs/.mts/.cjs/.cts override any package.json "type".
             if !kind.is_from_css() && name.ext.len() == 4 {
                 if let Some(from_ext) = module_type_from_ext(name.ext) {
                     module_type = from_ext;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6635,9 +6635,7 @@ bun_core::comptime_string_map! {
     };
 }
 
-/// The module format Node.js infers from a file extension alone
-/// (`.mjs`/`.mts` => ESM, `.cjs`/`.cts` => CJS), or `None` for every other
-/// extension.
+/// The module format Node.js infers from the file extension alone (.mjs/.mts/.cjs/.cts).
 #[inline]
 pub fn module_type_from_ext(ext: &[u8]) -> Option<options::ModuleType> {
     MODULE_TYPE_FROM_EXT.get(ext).copied()

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -3,31 +3,27 @@ import { itBundled } from "./expectBundled";
 
 // Tests for CommonJS <> ESM interop, specifically the __toESM helper behavior.
 //
-// The key insight from the code change:
-// - `input_module_type` is set based on the AST's exports_kind (whether the importing
-//   file uses ESM syntax like import/export or CJS syntax like require/module.exports)
-// - When a file uses ESM syntax (import/export), isNodeMode = 1
-// - When a file uses CJS syntax (require), __toESM is not used at all
+// `input_module_type` is set based on the resolver's module_type for the
+// importing file (i.e. .mjs/.mts, or a .js file inside a package with
+// "type": "module"). When the importer is a Node ESM module by those rules,
+// isNodeMode = 1 and `__esModule` is IGNORED: the default import is the whole
+// `module.exports` object, matching Node.js.
 //
-// This means:
-// - Any file using `import` will always get isNodeMode=1, which IGNORES __esModule
-//   and always wraps the CJS module as the default export
-// - This matches Node.js ESM behavior where importing CJS from .mjs always wraps
-//   the entire exports object as the default
-//
-// The __esModule marker is only respected in non-bundled scenarios or when using
-// actual CommonJS require() syntax.
+// When the importer is a .js file without "type": "module" that happens to use
+// `import` syntax (the common "fake ESM" shape shipped by many npm packages),
+// isNodeMode is NOT set and the Babel-style `__esModule` interop is respected.
+// This matches esbuild and webpack.
 
 describe("bundler", () => {
   // ============================================================================
-  // Tests with ESM syntax (import statements)
+  // Tests with Node ESM importers (.mjs entry)
   // These all use isNodeMode=1, which IGNORES __esModule
   // ============================================================================
 
   // Test 1: import with __esModule marker - IGNORED
   itBundled("cjs/__toESM_import_syntax_with_esModule", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -38,7 +34,7 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // With import syntax, isNodeMode=1, so __esModule is IGNORED
+      // .mjs importer => isNodeMode=1, so __esModule is IGNORED
       // The entire CJS exports object is wrapped as default
       stdout: '{"__esModule":true,"default":{"value":"default export"},"named":"named export"}',
     },
@@ -196,7 +192,7 @@ describe("bundler", () => {
   // Test 10: format=esm
   itBundled("cjs/__toESM_format_esm", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -208,7 +204,7 @@ describe("bundler", () => {
     },
     format: "esm",
     run: {
-      // __esModule ignored because we're using import syntax
+      // __esModule ignored because importer is .mjs
       stdout: '{"__esModule":true,"default":"the default","other":"other"}',
     },
   });
@@ -216,7 +212,7 @@ describe("bundler", () => {
   // Test 11: format=cjs with import syntax
   itBundled("cjs/__toESM_format_cjs_with_import", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -228,7 +224,7 @@ describe("bundler", () => {
     },
     format: "cjs",
     run: {
-      // Still ignores __esModule because entry uses import syntax
+      // Still ignores __esModule because importer is .mjs (output format does not matter)
       stdout: '{"__esModule":true,"default":"the default","other":"other"}',
     },
   });
@@ -369,7 +365,7 @@ describe("bundler", () => {
   // Test 18: __esModule with non-true value
   itBundled("cjs/__toESM_esModule_non_true", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -380,8 +376,7 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // Even if __esModule were respected, only `true` would work
-      // But it's ignored anyway due to import syntax
+      // .mjs importer => __esModule ignored regardless of its value
       stdout: '{"__esModule":"truthy","default":{"value":"default"},"other":"other"}',
     },
   });
@@ -408,7 +403,7 @@ describe("bundler", () => {
   // Test 20: module.exports with __esModule
   itBundled("cjs/__toESM_module_exports_with_esModule", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -421,7 +416,7 @@ describe("bundler", () => {
       `,
     },
     run: {
-      // __esModule is in the object but ignored due to import syntax
+      // __esModule is in the object but ignored because importer is .mjs
       stdout: '{"__esModule":true,"default":{"value":"nested"},"other":"prop"}',
     },
   });
@@ -431,7 +426,7 @@ describe("bundler", () => {
   // and input uses ESM syntax to import both default and named exports from CJS with __esModule
   itBundled("cjs/__toESM_input_esm_output_cjs_wrapper_print", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib, { named } from "./lib.cjs";
         console.log(JSON.stringify({ default: lib, named }));
       `,
@@ -443,7 +438,7 @@ describe("bundler", () => {
     },
     format: "cjs",
     run: {
-      // With the fix: ignores __esModule, wraps entire module as default
+      // .mjs importer => ignores __esModule, wraps entire module as default
       // So default gets the whole exports object, named gets the named property
       stdout:
         '{"default":{"__esModule":true,"default":{"value":"default"},"named":"named export"},"named":"named export"}',

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -43,7 +43,7 @@ describe("bundler", () => {
   // Test 2: import WITHOUT __esModule marker
   itBundled("cjs/__toESM_import_syntax_without_esModule", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -61,7 +61,7 @@ describe("bundler", () => {
   // Test 3: import with module.exports = function
   itBundled("cjs/__toESM_import_syntax_function", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(lib.name + ':' + lib());
       `,
@@ -77,7 +77,7 @@ describe("bundler", () => {
   // Test 4: import with module.exports = primitive
   itBundled("cjs/__toESM_import_syntax_primitive", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(lib);
       `,
@@ -93,7 +93,7 @@ describe("bundler", () => {
   // Test 5: import with named + default
   itBundled("cjs/__toESM_import_syntax_named_and_default", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib, { foo } from './lib.cjs';
         console.log(JSON.stringify({ default: lib, named: foo }));
       `,
@@ -110,7 +110,7 @@ describe("bundler", () => {
   // Test 6: Namespace import (import *)
   itBundled("cjs/__toESM_import_syntax_namespace", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import * as lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -127,13 +127,13 @@ describe("bundler", () => {
 
   // ============================================================================
   // Tests with different targets
-  // Target doesn't affect isNodeMode - it's based on syntax
+  // Target doesn't affect isNodeMode - it's based on the importer's module type
   // ============================================================================
 
   // Test 7: target=node
   itBundled("cjs/__toESM_target_node", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -151,7 +151,7 @@ describe("bundler", () => {
   // Test 8: target=browser
   itBundled("cjs/__toESM_target_browser", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -169,7 +169,7 @@ describe("bundler", () => {
   // Test 9: target=bun
   itBundled("cjs/__toESM_target_bun", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -236,7 +236,7 @@ describe("bundler", () => {
   // Test 12: .mjs re-exporting default from CJS
   itBundled("cjs/__toESM_mjs_reexport", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './wrapper.mjs';
         console.log(JSON.stringify(lib));
       `,
@@ -256,7 +256,7 @@ describe("bundler", () => {
   // Test 13: .mjs re-exporting with __esModule (still ignored)
   itBundled("cjs/__toESM_mjs_reexport_with_esModule", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './wrapper.mjs';
         console.log(JSON.stringify(lib));
       `,
@@ -278,7 +278,7 @@ describe("bundler", () => {
   // Test 14: Deep re-export chain
   itBundled("cjs/__toESM_deep_reexport_chain", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './layer1.mjs';
         console.log(JSON.stringify(lib));
       `,
@@ -300,7 +300,7 @@ describe("bundler", () => {
   // Test 15: Re-export with rename
   itBundled("cjs/__toESM_reexport_with_rename", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import { myDefault } from './wrapper.mjs';
         console.log(JSON.stringify(myDefault));
       `,
@@ -323,7 +323,7 @@ describe("bundler", () => {
   // Test 16: CJS with a property named "default" but no __esModule
   itBundled("cjs/__toESM_default_prop_no_esModule", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -341,7 +341,7 @@ describe("bundler", () => {
   // Test 17: Mixed import styles
   itBundled("cjs/__toESM_mixed_import_styles", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import defaultExport from './lib.cjs';
         import { foo } from './lib.cjs';
         import * as namespace from './lib.cjs';
@@ -384,7 +384,7 @@ describe("bundler", () => {
   // Test 19: __esModule = false
   itBundled("cjs/__toESM_esModule_false", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -448,7 +448,7 @@ describe("bundler", () => {
   // Test 22: Star import with __esModule
   itBundled("cjs/__toESM_star_import_with_esModule", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import * as lib from './lib.cjs';
         console.log(JSON.stringify(lib));
       `,
@@ -467,7 +467,7 @@ describe("bundler", () => {
   // Test 23: Practical example - importing lodash-like library
   itBundled("cjs/__toESM_practical_lodash_style", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import _ from './lodash.cjs';
         import { map } from './lodash.cjs';
         console.log(JSON.stringify({
@@ -495,7 +495,7 @@ describe("bundler", () => {
   // Test 24: module.exports = null, format=esm
   itBundled("cjs/__toESM_module_exports_null", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import z from "./z.cjs";
         console.log("z is", z);
       `,
@@ -514,7 +514,7 @@ describe("bundler", () => {
   // Test 25: module.exports = null, format=cjs
   itBundled("cjs/__toESM_module_exports_null_format_cjs", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import z from "./z.cjs";
         console.log("z is", z);
       `,
@@ -532,7 +532,7 @@ describe("bundler", () => {
   // Test 26: module.exports = undefined
   itBundled("cjs/__toESM_module_exports_undefined", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import u from "./u.cjs";
         console.log("u is", u);
       `,
@@ -556,7 +556,7 @@ describe("bundler", () => {
   // Test 27: top-level `arguments` inside a CJS module
   itBundled("cjs/__commonJS_top_level_arguments", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         import tag from "./args.cjs";
         console.log(tag);
       `,
@@ -577,7 +577,7 @@ describe("bundler", () => {
   // the raw require() result, so __reExport itself must tolerate null.
   itBundled("cjs/__reExport_external_null_module_exports", {
     files: {
-      "/entry.js": /* js */ `
+      "/entry.mjs": /* js */ `
         export * from "ext";
         console.log("loaded ok");
       `,

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -584,6 +584,39 @@ describe("bundler", () => {
     },
     run: { stdout: `"THE_DEFAULT"` },
   });
+  // Same as above but the fake-ESM package uses an "exports" map with an
+  // "import" condition instead of the legacy "module" field. Matching the
+  // "import" condition must not be treated as a module-format signal: Node
+  // still loads the target by its extension and nearest package.json "type".
+  itBundled("cjs2esm/ToESMDoesNotSetNodeModeForUntypedESMViaExportsCondition", {
+    files: {
+      "/entry.js": /* js */ `
+        import mod from 'fake-esm';
+        console.log(JSON.stringify(mod.Base));
+      `,
+      "/package.json": `{ "type": "module" }`,
+      "/node_modules/fake-esm/package.json": `{ "name": "fake-esm", "exports": { "import": "./esm/index.js", "require": "./cjs/index.js" } }`,
+      "/node_modules/fake-esm/esm/index.js": /* js */ `
+        import Base from 'cjs-dep';
+        export default { Base: Base };
+      `,
+      "/node_modules/fake-esm/cjs/index.js": /* js */ `
+        module.exports = { Base: require('cjs-dep').default };
+      `,
+      "/node_modules/cjs-dep/package.json": `{ "name": "cjs-dep", "main": "index.js" }`,
+      "/node_modules/cjs-dep/index.js": /* js */ `
+        exports.__esModule = true;
+        exports.default = "THE_DEFAULT";
+        exports.named = "NAMED";
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("out.js");
+      expect(code).toContain("__toESM(require_cjs_dep())");
+    },
+    run: { stdout: `"THE_DEFAULT"` },
+  });
   itBundled("cjs2esm/ToESMSetsNodeModeForTypeModule", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -550,4 +550,88 @@ describe("bundler", () => {
     cjs2esm: true,
     run: { stdout: "[1,2]" },
   });
+  // https://github.com/oven-sh/bun/issues/7709
+  // A .js file with import/export syntax that is not inside a "type": "module"
+  // package should use Babel-style __esModule interop when importing CJS (i.e.
+  // __toESM is called without the isNodeMode flag), matching esbuild and
+  // webpack. Passing isNodeMode=1 here made `default` resolve to the whole
+  // module.exports object instead of `exports.default`.
+  itBundled("cjs2esm/ToESMDoesNotSetNodeModeForUntypedESM", {
+    files: {
+      "/entry.js": /* js */ `
+        import mod from 'fake-esm';
+        console.log(JSON.stringify(mod.Base));
+      `,
+      "/package.json": `{ "type": "module" }`,
+      "/node_modules/fake-esm/package.json": `{ "name": "fake-esm", "module": "esm/index.js", "main": "esm/index.js" }`,
+      "/node_modules/fake-esm/esm/index.js": /* js */ `
+        import Base from 'cjs-dep';
+        export default { Base: Base };
+      `,
+      "/node_modules/cjs-dep/package.json": `{ "name": "cjs-dep", "main": "index.js" }`,
+      "/node_modules/cjs-dep/index.js": /* js */ `
+        exports.__esModule = true;
+        exports.default = "THE_DEFAULT";
+        exports.named = "NAMED";
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("out.js");
+      // fake-esm/esm/index.js is not in a "type": "module" scope, so the
+      // __toESM call it generates must not pass the second arg.
+      expect(code).toContain("__toESM(require_cjs_dep())");
+    },
+    run: { stdout: `"THE_DEFAULT"` },
+  });
+  itBundled("cjs2esm/ToESMSetsNodeModeForTypeModule", {
+    files: {
+      "/entry.js": /* js */ `
+        import mod from 'real-esm';
+        console.log(JSON.stringify(mod.Base));
+      `,
+      "/package.json": `{ "type": "module" }`,
+      "/node_modules/real-esm/package.json": `{ "name": "real-esm", "type": "module", "main": "index.js" }`,
+      "/node_modules/real-esm/index.js": /* js */ `
+        import Base from 'cjs-dep';
+        export default { Base: Base };
+      `,
+      "/node_modules/cjs-dep/package.json": `{ "name": "cjs-dep", "main": "index.js" }`,
+      "/node_modules/cjs-dep/index.js": /* js */ `
+        exports.__esModule = true;
+        exports.default = "THE_DEFAULT";
+        exports.named = "NAMED";
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("out.js");
+      expect(code).toContain("__toESM(require_cjs_dep(), 1)");
+    },
+    run: { stdout: `{"__esModule":true,"default":"THE_DEFAULT","named":"NAMED"}` },
+  });
+  itBundled("cjs2esm/ToESMSetsNodeModeForMJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import mod from './mid.mjs';
+        console.log(JSON.stringify(mod.Base));
+      `,
+      "/mid.mjs": /* js */ `
+        import Base from 'cjs-dep';
+        export default { Base: Base };
+      `,
+      "/node_modules/cjs-dep/package.json": `{ "name": "cjs-dep", "main": "index.js" }`,
+      "/node_modules/cjs-dep/index.js": /* js */ `
+        exports.__esModule = true;
+        exports.default = "THE_DEFAULT";
+        exports.named = "NAMED";
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("out.js");
+      expect(code).toContain("__toESM(require_cjs_dep(), 1)");
+    },
+    run: { stdout: `{"__esModule":true,"default":"THE_DEFAULT","named":"NAMED"}` },
+  });
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -667,4 +667,36 @@ describe("bundler", () => {
     },
     run: { stdout: `{"__esModule":true,"default":"THE_DEFAULT","named":"NAMED"}` },
   });
+  // A .mjs file reached via the "import" condition inside a package with
+  // "type": "commonjs" is still a Node ESM module: .mjs wins over the
+  // package "type" field.
+  itBundled("cjs2esm/ToESMSetsNodeModeForMJSInsideTypeCommonJS", {
+    files: {
+      "/entry.js": /* js */ `
+        import mod from 'dual';
+        console.log(JSON.stringify(mod.Base));
+      `,
+      "/package.json": `{ "type": "module" }`,
+      "/node_modules/dual/package.json": `{ "name": "dual", "type": "commonjs", "exports": { "import": "./index.mjs", "require": "./index.cjs" } }`,
+      "/node_modules/dual/index.mjs": /* js */ `
+        import Base from 'cjs-dep';
+        export default { Base: Base };
+      `,
+      "/node_modules/dual/index.cjs": /* js */ `
+        module.exports = { Base: require('cjs-dep').default };
+      `,
+      "/node_modules/cjs-dep/package.json": `{ "name": "cjs-dep", "main": "index.js" }`,
+      "/node_modules/cjs-dep/index.js": /* js */ `
+        exports.__esModule = true;
+        exports.default = "THE_DEFAULT";
+        exports.named = "NAMED";
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("out.js");
+      expect(code).toContain("__toESM(require_cjs_dep(), 1)");
+    },
+    run: { stdout: `{"__esModule":true,"default":"THE_DEFAULT","named":"NAMED"}` },
+  });
 });

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -699,4 +699,35 @@ describe("bundler", () => {
     },
     run: { stdout: `{"__esModule":true,"default":"THE_DEFAULT","named":"NAMED"}` },
   });
+  // When resolution yields both a "module" (.mjs) primary and a "main" (.cjs)
+  // secondary, the primary's extension determines module_type.
+  itBundled("cjs2esm/ToESMSetsNodeModeForMJSPrimaryWithCJSSecondary", {
+    files: {
+      "/entry.js": /* js */ `
+        import mod from 'dual';
+        console.log(JSON.stringify(mod.Base));
+      `,
+      "/package.json": `{ "type": "module" }`,
+      "/node_modules/dual/package.json": `{ "name": "dual", "module": "dist/index.mjs", "main": "dist/index.cjs" }`,
+      "/node_modules/dual/dist/index.mjs": /* js */ `
+        import Base from 'cjs-dep';
+        export default { Base: Base };
+      `,
+      "/node_modules/dual/dist/index.cjs": /* js */ `
+        module.exports = { Base: require('cjs-dep').default };
+      `,
+      "/node_modules/cjs-dep/package.json": `{ "name": "cjs-dep", "main": "index.js" }`,
+      "/node_modules/cjs-dep/index.js": /* js */ `
+        exports.__esModule = true;
+        exports.default = "THE_DEFAULT";
+        exports.named = "NAMED";
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      const code = api.readFile("out.js");
+      expect(code).toContain("__toESM(require_cjs_dep(), 1)");
+    },
+    run: { stdout: `{"__esModule":true,"default":"THE_DEFAULT","named":"NAMED"}` },
+  });
 });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1254,7 +1254,7 @@ describe("bundler", () => {
     snapshotSourceMap: {
       "entry.js.map": {
         files: ["../node_modules/react/index.js", "../entry.js"],
-        mappingsExactMatch: "2lBACA,WAAW,IAAQ,EAAE,ICDrB,eACA,QAAQ,IAAI,CAAK",
+        mappingsExactMatch: "2lBACA,WAAW,IAAQ,EAAE,ICDrB,aACA,QAAQ,IAAI,CAAK",
       },
     },
   });

--- a/test/bundler/bundler_npm.test.ts
+++ b/test/bundler/bundler_npm.test.ts
@@ -60,14 +60,14 @@ describe("bundler", () => {
           ["react.development.js:524:'getContextName'", "1:5623:at"],
           ["react.development.js:2495:'actScopeDepth'", "23:4082:or++"],
           ["react.development.js:696:''Component'", '1:7685:\'Component "%s"'],
-          ["entry.tsx:6:'\"Content-Type\"'", '100:18808:"Content-Type"'],
-          ["entry.tsx:11:'<html>'", "100:19062:void"],
-          ["entry.tsx:23:'await'", "100:19161:await"],
+          ["entry.tsx:6:'\"Content-Type\"'", '100:18802:"Content-Type"'],
+          ["entry.tsx:11:'<html>'", "100:19056:void"],
+          ["entry.tsx:23:'await'", "100:19155:await"],
         ],
       },
     },
     expectExactFilesize: {
-      "out/entry.js": 222000,
+      "out/entry.js": 221994,
     },
     run: {
       stdout: "<!DOCTYPE html><html><body><h1>Hello World</h1><p>This is an example.</p></body></html>",

--- a/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
+++ b/test/bundler/transpiler/__snapshots__/react-compiler.test.ts.snap
@@ -134,7 +134,7 @@ var require_react = __commonJS(function(exports) {
 });
 
 // entry.tsx
-var import_react = __toESM(require_react(), 1);
+var import_react = __toESM(require_react());
 
 // node_modules/react/jsx-dev-runtime.js
 var $jsxDEV = () => null;


### PR DESCRIPTION
### What does this PR do?

Fixes #7709
Fixes #18615

When a `.js` file that uses `import`/`export` syntax lives in a package **without** `"type": "module"` (the "fake ESM" shape shipped by many npm packages such as `react-bootstrap/esm/*`, `@restart/hooks/esm/*`, `react-ga4`), and it imports a CommonJS module that sets `exports.__esModule = true`, the bundler was passing `isNodeMode = 1` to `__toESM()`. That makes `__toESM` ignore the `__esModule` marker and set `default` to the whole `module.exports` object instead of `exports.default`.

For react-bootstrap this turns into:

```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
```

because `BaseDropdown` ends up as `{__esModule: true, default: <fn>}` instead of the function.

#### Repro

```sh
# package.json: { "type": "module" }
# node_modules/fake-esm/package.json:  { "module": "esm/index.js" }  (no "type")
# node_modules/fake-esm/esm/index.js:  import Base from 'cjs-dep'; export default { Base };
# node_modules/cjs-dep/index.js:       exports.__esModule = true; exports.default = "THE_DEFAULT";

$ bun index.ts           # runtime: "THE_DEFAULT"
$ bun build index.ts --target=bun && bun out/index.js
{"__esModule":true,"default":"THE_DEFAULT"}    # wrong
```

esbuild on the same input prints `"THE_DEFAULT"`.

#### Cause

`input_module_type` in the printer options was derived from `ast.exports_kind`, which is `Esm` whenever a file contains `import`/`export` syntax. The correct input for the `isNodeMode` decision is how Node would classify the file: `.mjs`/`.mts`, or `.js` inside a `"type": "module"` package. That is what esbuild checks (`p.options.ModuleTypeData.Type.IsESM()`).

Additionally, the resolver was setting `module_type` based on which `"import"`/`"require"` condition matched in an `exports` map, and the package-root `"type"` field was overwriting the value `handle_esm_resolution` had already derived from the resolved file's nearest `package.json`. Neither of those is a module-format signal in Node.

#### Fix

- Carry the resolver-determined module type on `BundledAst` as a new `MODULE_TYPE_WAS_ESM` flag (set in `ParseTask` from `task.module_type`), and use that for `input_module_type` in `print_code_for_file_in_chunk_js` instead of `exports_kind`.
- Stop setting `module_type` from the matched `"import"`/`"require"` export condition (removed `ESModule.module_type` and its plumbing).
- Let `handle_esm_resolution`'s nearest-package.json derivation stand by dropping the redundant overwrite at the call site, and make the `.mjs`/`.cjs` extension check in `finalize_result` unconditional so extension always wins (as its comment already claimed).
- In `ParseTask`, fall back to extension-based derivation for construction sites that bypass the resolver (plugin `onResolve`, server-component re-parse, in-memory entries) so a `.mjs` file on those paths still gets Node ESM interop.
- Deleted the now-unused `impl From<ExportsKind> for ModuleType` and its pointer comment.

Files that Node would actually load as ESM (`.mjs`, `.mts`, `"type": "module"`) still get `isNodeMode = 1` and keep Node's semantics (default import = whole `module.exports`).

#### Tests

New tests in `bundler_cjs2esm.test.ts`:
- `ToESMDoesNotSetNodeModeForUntypedESM`: fake-ESM via legacy `"module"` field, `__esModule` now respected.
- `ToESMDoesNotSetNodeModeForUntypedESMViaExportsCondition`: same but via `"exports": {"import": ...}` with no `"type"`.
- `ToESMSetsNodeModeForTypeModule` / `ToESMSetsNodeModeForMJS`: real-ESM importers still get `isNodeMode = 1`.
- `ToESMSetsNodeModeForMJSInsideTypeCommonJS`: `.mjs` reached via `"exports": {"import": ...}` inside a `"type": "commonjs"` package still gets `isNodeMode = 1` (extension wins).

Existing tests in `bundler_cjs.test.ts` that asserted the old behaviour for a `.js` entry with no enclosing `"type": "module"` now use `.mjs` entries so they continue to test the Node-mode path. Their assertions match esbuild's output for `.mjs`. Updated one react-compiler snapshot and one `EmitInvalidSourceMap2` expected mapping for the two-character column shift where `, 1` is no longer emitted.

Verified end to end against the original react-bootstrap reproduction from #7709.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts test/bundler/bundler_npm.test.ts

<!-- robobun:evidence:end -->