### PR TITLE
worker_threads: preserve data:/blob: URL identity in import.meta

### DIFF
--- a/src/js/builtins/ImportMetaObject.ts
+++ b/src/js/builtins/ImportMetaObject.ts
@@ -2,5 +2,6 @@ type ImportMetaObject = Partial<ImportMeta>;
 
 $getter;
 export function main(this: ImportMetaObject) {
-  return this.path === Bun.main && Bun.isMainThread;
+  const m = Bun.main;
+  return this.path === m || this.url === m;
 }

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -167,6 +167,16 @@ ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JS
 
 ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier)
 {
+    // A specifier that already carries a URL scheme (data:, blob:, file:, http:, ...)
+    // must be preserved so import.meta.url reflects the module's real identity.
+    // Only filesystem paths are wrapped as file:// URLs below.
+    if (!isAbsolutePath(specifier)) {
+        WTF::URL parsed(specifier);
+        if (parsed.isValid() && !parsed.protocol().isEmpty()) {
+            return create(globalObject, specifier);
+        }
+    }
+
     auto index = specifier.find('?');
     URL url;
     if (index != notFound) {

--- a/test/js/node/worker_threads/import-meta-main-fixture.mjs
+++ b/test/js/node/worker_threads/import-meta-main-fixture.mjs
@@ -1,0 +1,3 @@
+import { parentPort } from "node:worker_threads";
+import { otherMain } from "./import-meta-main-other-fixture.mjs";
+parentPort.postMessage({ entry: import.meta.main, other: otherMain });

--- a/test/js/node/worker_threads/import-meta-main-other-fixture.mjs
+++ b/test/js/node/worker_threads/import-meta-main-other-fixture.mjs
@@ -1,0 +1,1 @@
+export const otherMain = import.meta.main;

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -38,6 +38,44 @@ test("support eval in worker", async () => {
   await worker.terminate();
 });
 
+test("data: URL worker exposes its own URL via import.meta.url and can self-spawn", async () => {
+  const kid = `import { parentPort, workerData, Worker } from "node:worker_threads";
+if (workerData?.grand) {
+  parentPort.postMessage("grand-ok");
+} else {
+  let nested;
+  try {
+    const w = new Worker(new URL(import.meta.url), { workerData: { grand: true } });
+    nested = await new Promise(r => {
+      w.once("message", r);
+      w.once("error", e => r("error:" + String(e.message).slice(0, 60)));
+    });
+    await w.terminate();
+  } catch (e) {
+    nested = "ctor-throw:" + (e.code || e.name);
+  }
+  parentPort.postMessage({ url: import.meta.url, main: import.meta.main, nested });
+}`;
+  const dataUrl = "data:text/javascript," + encodeURIComponent(kid);
+  const worker = new Worker(new URL(dataUrl));
+  const result = await new Promise((resolve, reject) => {
+    worker.once("message", resolve);
+    worker.once("error", reject);
+  });
+  await worker.terminate();
+  expect(result).toEqual({ url: dataUrl, main: true, nested: "grand-ok" });
+});
+
+test("import.meta.main is true for a worker's entry module and false for its imports", async () => {
+  const worker = new Worker(new URL("./import-meta-main-fixture.mjs", import.meta.url));
+  const result = await new Promise((resolve, reject) => {
+    worker.once("message", resolve);
+    worker.once("error", reject);
+  });
+  await worker.terminate();
+  expect(result).toEqual({ entry: true, other: false });
+});
+
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");


### PR DESCRIPTION
A `node:worker_threads` Worker spawned from a `data:` URL sees its module identity mangled, breaking the canonical self-spawn idiom:

```js
import { Worker } from "node:worker_threads";
const kid = `import { parentPort, workerData, Worker } from "node:worker_threads";
if (workerData?.grand) parentPort.postMessage("grand-ok");
else {
  const w = new Worker(new URL(import.meta.url), { workerData: { grand: true } });
  parentPort.postMessage({ url: import.meta.url, main: import.meta.main,
    nested: await new Promise(r => w.once("message", r)) });
}`;
const w = new Worker(new URL("data:text/javascript," + encodeURIComponent(kid)));
console.log(await new Promise(r => w.once("message", r)));
// node : { url: "data:text/javascript,...", main: true, nested: "grand-ok" }
// bun  : { url: "file:///data:text/javasc...", main: false,
//          nested: "error:Cannot find module '/data:text/javascrip..." }
```

### Cause

`ImportMetaObject::createFromSpecifier` unconditionally wrapped every module key with `URL::fileURLWithFileSystemPath`, turning `data:text/javascript,...` into `file:///data:text/javascript,...` (double-percent-encoded). Any `new URL(rel, import.meta.url)` inside the worker then resolved against a bogus filesystem path, and `new Worker(new URL(import.meta.url))` died with `Cannot find module '/data:text/javascript,...'`.

Separately, the `import.meta.main` getter was gated on `Bun.isMainThread`, so it was always `false` inside any worker. Node reports `true` for a worker's entry module (both file-based and data-URL).

### Fix

`createFromSpecifier` now checks whether the specifier already carries a URL scheme (`data:`, `blob:`, `file:`, `http:`, ...) and passes it through unchanged; only filesystem paths get the `file://` wrap.

The `import.meta.main` getter drops the `Bun.isMainThread` gate and compares against `Bun.main` by path for file modules or by url for non-file modules, so it is `true` for a worker's entry whether that entry is a file, a `blob:` (`eval: true`), or a `data:` URL.

### Verification

`bun bd test test/js/node/worker_threads/worker_threads.test.ts` (93 pass). With `src/` stashed the two new tests fail with `url: "file:///data:..."`, `main: false`, and `Cannot find module '/data:text/javascript,...'`; with the fix they pass matching Node v26.
