### PR TITLE
Bun.Transpiler: drop imports whose bindings are all DCE'd in TypeScript

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2466,7 +2466,27 @@ declare module "bun" {
     allowBunRuntime?: boolean;
     exports?: {
       eliminate?: string[];
-      replace?: Record<string, string>;
+      /**
+       * Replace exported declarations with a literal value, or rename+replace
+       * them by passing a `[newName, value]` tuple.
+       *
+       * @example
+       * ```js
+       * // export var foo = ... -> export var foo = "bar";
+       * foo: "bar",
+       * // export function getStaticProps() { ... } -> export var __N_SSG = true;
+       * getStaticProps: ["__N_SSG", true],
+       * ```
+       */
+      replace?: Record<
+        string,
+        | string
+        | number
+        | boolean
+        | null
+        | undefined
+        | readonly [name: string, value: string | number | boolean | null | undefined]
+      >;
     };
     treeShaking?: boolean;
     trimUnusedImports?: boolean;

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -265,17 +265,26 @@ impl<'a> ImportScanner<'a> {
                         // e.g. `import 'fancy-stylesheet-thing/style.css';`
                         // This is a breaking change though. We can make it an option with some guardrail
                         // so maybe if it errors, it shows a suggestion "retry without trimming unused imports"
+                        //
+                        // The second arm covers imports whose bindings were all culled above
+                        // (use_count_estimate == 0). It applies to TypeScript too: an import
+                        // binding that was used as a value but only in dead code (DCE'd or
+                        // replace_exports'd) has ts_use_counts > 0 yet no surviving bindings.
+                        // Without this arm TypeScript would keep the statement as a bare
+                        // side-effect import while JavaScript drops it entirely (#12892).
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript
                             && !p.options.preserve_unused_imports_ts)
-                            || (!is_typescript_enabled
-                                && p.options.features.trim_unused_imports
+                            || (p.options.features.trim_unused_imports
                                 && found_imports
                                 && st.star_name_loc.is_empty()
                                 // SAFETY: arena-owned slice; see above.
                                 && st.items.slice().is_empty()
-                                && st.default_name.is_none())
+                                && st.default_name.is_none()
+                                && !(is_typescript_enabled
+                                    && is_unused_in_typescript
+                                    && p.options.preserve_unused_imports_ts))
                         {
                             // internal imports are presumed to be always used
                             // require statements cannot be stripped

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -265,28 +265,21 @@ impl<'a> ImportScanner<'a> {
                         // e.g. `import 'fancy-stylesheet-thing/style.css';`
                         // This is a breaking change though. We can make it an option with some guardrail
                         // so maybe if it errors, it shows a suggestion "retry without trimming unused imports"
-                        //
-                        // The second arm covers imports whose bindings were all culled above
-                        // (use_count_estimate == 0). For TypeScript it only applies outside
-                        // the bundler: a binding used as a value but only in dead code has
-                        // ts_use_counts > 0 yet no surviving bindings, and without this arm
-                        // Bun.Transpiler would keep the statement as a bare side-effect
-                        // import while JavaScript drops it entirely (#12892). When bundling,
-                        // the import record feeds resolution, so a TypeScript value import
-                        // stays reachable and the linker decides whether the module is kept.
+                        let all_bindings_culled = found_imports
+                            && st.star_name_loc.is_empty()
+                            && st.items.slice().is_empty()
+                            && st.default_name.is_none();
+                        // replace_exports is Bun.Transpiler-only; it opts TS into dropping
+                        // value imports orphaned by the replaced export (#12892).
+                        let has_replace_exports =
+                            p.options.features.replace_exports.count() > 0;
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript
                             && !p.options.preserve_unused_imports_ts)
                             || (p.options.features.trim_unused_imports
-                                && found_imports
-                                && st.star_name_loc.is_empty()
-                                // SAFETY: arena-owned slice; see above.
-                                && st.items.slice().is_empty()
-                                && st.default_name.is_none()
-                                && (!is_typescript_enabled
-                                    || (!p.options.bundle
-                                        && !p.options.preserve_unused_imports_ts)))
+                                && all_bindings_culled
+                                && (!is_typescript_enabled || has_replace_exports))
                         {
                             // internal imports are presumed to be always used
                             // require statements cannot be stripped

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -269,8 +269,7 @@ impl<'a> ImportScanner<'a> {
                             && st.star_name_loc.is_empty()
                             && st.items.slice().is_empty()
                             && st.default_name.is_none();
-                        // replace_exports is Bun.Transpiler-only; it opts TS into dropping
-                        // value imports orphaned by the replaced export (#12892).
+                        // replace_exports (Bun.Transpiler-only) opts TS into dropping orphaned value imports (#12892).
                         let has_replace_exports = p.options.features.replace_exports.count() > 0;
                         if (is_typescript_enabled
                             && found_imports

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -271,8 +271,7 @@ impl<'a> ImportScanner<'a> {
                             && st.default_name.is_none();
                         // replace_exports is Bun.Transpiler-only; it opts TS into dropping
                         // value imports orphaned by the replaced export (#12892).
-                        let has_replace_exports =
-                            p.options.features.replace_exports.count() > 0;
+                        let has_replace_exports = p.options.features.replace_exports.count() > 0;
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -267,11 +267,13 @@ impl<'a> ImportScanner<'a> {
                         // so maybe if it errors, it shows a suggestion "retry without trimming unused imports"
                         //
                         // The second arm covers imports whose bindings were all culled above
-                        // (use_count_estimate == 0). It applies to TypeScript too: an import
-                        // binding that was used as a value but only in dead code (DCE'd or
-                        // replace_exports'd) has ts_use_counts > 0 yet no surviving bindings.
-                        // Without this arm TypeScript would keep the statement as a bare
-                        // side-effect import while JavaScript drops it entirely (#12892).
+                        // (use_count_estimate == 0). For TypeScript it only applies outside
+                        // the bundler: a binding used as a value but only in dead code has
+                        // ts_use_counts > 0 yet no surviving bindings, and without this arm
+                        // Bun.Transpiler would keep the statement as a bare side-effect
+                        // import while JavaScript drops it entirely (#12892). When bundling,
+                        // the import record feeds resolution, so a TypeScript value import
+                        // stays reachable and the linker decides whether the module is kept.
                         if (is_typescript_enabled
                             && found_imports
                             && is_unused_in_typescript
@@ -282,9 +284,9 @@ impl<'a> ImportScanner<'a> {
                                 // SAFETY: arena-owned slice; see above.
                                 && st.items.slice().is_empty()
                                 && st.default_name.is_none()
-                                && !(is_typescript_enabled
-                                    && is_unused_in_typescript
-                                    && p.options.preserve_unused_imports_ts))
+                                && (!is_typescript_enabled
+                                    || (!p.options.bundle
+                                        && !p.options.preserve_unused_imports_ts)))
                         {
                             // internal imports are presumed to be always used
                             // require statements cannot be stripped

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2858,6 +2858,29 @@ describe("bundler", () => {
       expect(out).not.toContain("require_foo\u2014bar");
     },
   });
+  // https://github.com/oven-sh/bun/issues/12892
+  // Bun.Transpiler drops an import whose only binding is used in dead code, but
+  // the bundler must still resolve it so the module's side effects are kept.
+  itBundled("edgecase/TSImportUsedOnlyInDeadCodeKeepsSideEffect", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { devOnly } from './setup';
+        if (process.env.NODE_ENV !== 'production') {
+          devOnly();
+        }
+        console.log('entry');
+      `,
+      "/setup.ts": /* ts */ `
+        console.log('setup side effect');
+        export function devOnly() {}
+      `,
+    },
+    define: { "process.env.NODE_ENV": '"production"' },
+    run: { stdout: "setup side effect\nentry" },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toContain("setup side effect");
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -252,3 +252,29 @@ describe("unterminated string literals in large files", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/12892
+test("TS import whose only binding is used in dead code still loads for side effects", async () => {
+  using dir = tempDir("ts-dead-import-side-effect", {
+    "entry.ts": `
+      import { setup } from './side';
+      if (false) { setup(); }
+      console.log('entry');
+    `,
+    "side.ts": `
+      console.log('side effect');
+      export function setup() {}
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("side effect\nentry\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1949,8 +1949,8 @@ export default class {
 
           export const y = shared();
         `);
-        expect(out).toContain("./shared");
-        expect(out).toContain("shared");
+        expect(out).toMatch(/\{\s*shared\s*\}\s*from\s*"\.\/shared"/);
+        expect(out).toContain("shared()");
       });
 
       it("keeps originally-bare imports", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1924,7 +1924,7 @@ export default class {
         expect(out).toContain("action");
       });
 
-      it("drops imports only used in dead code", () => {
+      it("drops imports only used in dead code when exports.replace is configured", () => {
         const out = t.transformSync(`
           import {devOnly} from './dev-stuff';
 
@@ -1937,6 +1937,30 @@ export default class {
         expect(out).not.toContain("dev-stuff");
         expect(out).not.toContain("devOnly");
         expect(out).toContain("export const x = 1");
+      });
+
+      it("without exports.replace: TypeScript keeps the bare import for side effects", () => {
+        const noReplace = new Bun.Transpiler({
+          loader,
+          treeShaking: true,
+          trimUnusedImports: true,
+          define: { "process.env.NODE_ENV": '"production"' },
+        });
+        const out = noReplace.transformSync(`
+          import {devOnly} from './dev-stuff';
+
+          if (process.env.NODE_ENV !== "production") {
+            devOnly();
+          }
+
+          export const x = 1;
+        `);
+        if (loader === "ts" || loader === "tsx") {
+          expect(out).toContain("./dev-stuff");
+          expect(out).not.toContain("devOnly");
+        } else {
+          expect(out).not.toContain("dev-stuff");
+        }
       });
 
       it("keeps imports with live uses", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1851,19 +1851,118 @@ export default class {
       trimUnusedImports: true,
     });
 
-    it("a deletes dead exports and any imports only referenced in dead regions", () => {
-      const out = transpiler.transformSync(`
-    import {getUserById} from './my-database';
+    // https://github.com/oven-sh/bun/issues/12892
+    describe.each(["jsx", "js", "tsx", "ts"])(`loader: %s`, loader => {
+      const t = new Bun.Transpiler({
+        loader,
+        exports: {
+          replace: {
+            getStaticProps: ["__N_SSG", true],
+          },
+          eliminate: ["loader"],
+        },
+        treeShaking: true,
+        trimUnusedImports: true,
+        define: { "process.env.NODE_ENV": '"production"' },
+      });
+      const jsx = loader.endsWith("x") ? `<div id='user'>{user.name}</div>` : `user.name`;
 
-    export async function getStaticProps(ctx){
-      return { props: { user: await getUserById(ctx.params.id)  } };
-    }
+      it("drops imports only used by a replaced export", () => {
+        const out = t.transformSync(`
+          import {getUserById} from './my-database';
 
-    export default function MyComponent({user}) {
-      getStaticProps();
-      return <div id='user'>{user.name}</div>;
-    }
-  `);
+          export async function getStaticProps(ctx){
+            return { props: { user: await getUserById(ctx.params.id)  } };
+          }
+
+          export default function MyComponent({user}) {
+            getStaticProps();
+            return ${jsx};
+          }
+        `);
+        expect(out).not.toContain("my-database");
+        expect(out).not.toContain("getUserById");
+        expect(out).toContain("__N_SSG");
+        expect(out).toContain("MyComponent");
+      });
+
+      it("drops default and namespace imports only used by a replaced export", () => {
+        const out = t.transformSync(`
+          import db from './my-database';
+          import * as ns from './other';
+
+          export async function getStaticProps(ctx){
+            return { props: { user: await db.getUserById(ns.params.id)  } };
+          }
+
+          export const live = 1;
+        `);
+        expect(out).not.toContain("my-database");
+        expect(out).not.toContain("./other");
+        expect(out).toContain("__N_SSG");
+        expect(out).toContain("live");
+      });
+
+      it("drops imports only used by an eliminated export", () => {
+        const out = t.transformSync(`
+          import {deadFS} from 'dead-fs';
+          import {liveFS} from 'live-fs';
+
+          export function loader() {
+            return deadFS.readFileSync("/etc/passwd");
+          }
+
+          export function action() {
+            return liveFS.readFileSync("/etc/passwd");
+          }
+        `);
+        expect(out).not.toContain("dead-fs");
+        expect(out).not.toContain("deadFS");
+        expect(out).not.toContain("loader");
+        expect(out).toContain("live-fs");
+        expect(out).toContain("liveFS");
+        expect(out).toContain("action");
+      });
+
+      it("drops imports only used in dead code", () => {
+        const out = t.transformSync(`
+          import {devOnly} from './dev-stuff';
+
+          if (process.env.NODE_ENV !== "production") {
+            devOnly();
+          }
+
+          export const x = 1;
+        `);
+        expect(out).not.toContain("dev-stuff");
+        expect(out).not.toContain("devOnly");
+        expect(out).toContain("export const x = 1");
+      });
+
+      it("keeps imports with live uses", () => {
+        const out = t.transformSync(`
+          import {shared} from './shared';
+
+          export async function getStaticProps(ctx){
+            return { props: { x: shared() } };
+          }
+
+          export const y = shared();
+        `);
+        expect(out).toContain("./shared");
+        expect(out).toContain("shared");
+      });
+
+      it("keeps originally-bare imports", () => {
+        const out = t.transformSync(`
+          import './side-effect';
+
+          export async function getStaticProps(ctx){
+            return { props: {} };
+          }
+        `);
+        expect(out).toContain("./side-effect");
+      });
     });
 
     it("deletes dead exports and any imports only referenced in dead regions", () => {


### PR DESCRIPTION
Fixes #12892.

## Problem

`Bun.Transpiler` with a `ts`/`tsx` loader keeps a bare side-effect import after `exports.replace`/`exports.eliminate` removes the only code that used its bindings, even with `trimUnusedImports: true`. The same input with a `js`/`jsx` loader drops the import entirely.

```ts
const t = new Bun.Transpiler({
  loader: 'tsx',
  exports: { replace: { getStaticProps: ['__N_SSG', true] } },
  treeShaking: true,
  trimUnusedImports: true,
});
await t.transform(`
import {getUserById} from './my-database';
export async function getStaticProps(ctx) {
  return { props: { user: await getUserById(ctx.params.id) } };
}
export default function MyComponent({user}) {
  return <div id='user'>{user.name}</div>;
}
`);
```

Before:
```js
export default function MyComponent({ user }) { ... }
import"./my-database";
export var __N_SSG = true;
```

After:
```js
export default function MyComponent({ user }) { ... }
export var __N_SSG = true;
```

## Cause

`ImportScanner::scan` has two ways to mark an import record as unused:

1. TypeScript-only: every binding has `ts_use_counts == 0` (only ever used in type positions).
2. `trim_unused_imports` is on and every binding was culled (`use_count_estimate == 0`), so the statement has no star, no default, and no items left.

Branch (2) was gated on `!is_typescript_enabled`. `ts_use_counts` is incremented for value-position references and is never rolled back by `ignore_usage`, so an import used only inside a replaced/eliminated export has `ts_use_counts > 0` (fails branch 1) but no surviving bindings. It fell through and was printed as a bare `import "./x";`.

## Fix

Allow branch (2) to apply to TypeScript when `replace_exports` is non-empty. Only `Bun.Transpiler` populates that map (via `exports.replace`/`exports.eliminate`), so `Bun.build` and `bun run` are unaffected: they continue to resolve the module and keep its side effects, matching their current behaviour. Configuring `exports.replace` already implies the user wants the replaced export and anything it alone pulled in removed from the output.

Also widens the `exports.replace` type in `bun.d.ts` to accept non-string literals and the `[name, value]` rename tuple, which the runtime already accepts (raised in the same issue).

## Testing

- `describe.each(['jsx','js','tsx','ts'])` block in `test/bundler/transpiler/transpiler.test.js` covers named/default/namespace imports against `exports.replace`, `exports.eliminate`, and `define`-driven dead code, plus negative cases for live imports, originally-bare side-effect imports, and define-only DCE without `exports` configured (TS keeps the bare import there). The `ts`/`tsx` `exports.replace` cases fail on main and pass with this change; `js`/`jsx` pass on both.
- `edgecase/TSImportUsedOnlyInDeadCodeKeepsSideEffect` in `test/bundler/bundler_edgecase.test.ts` pins `Bun.build` still bundling the side-effect module.
- A spawned `bun run` case in `test/bundler/transpiler/runtime-transpiler.test.ts` pins the runtime loader still evaluating the side-effect module.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->