### PR TITLE
bundler: downgrade unresolvable require() in catch handler to runtime throw

### DIFF
--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -36,14 +36,9 @@ pub struct ImportRecord {
 bitflags::bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Default, Debug)]
     pub struct Flags: u16 {
-        /// True for the following cases:
-        ///
-        ///   try { require('x') } catch { handle }
-        ///   try { ... } catch { require('x') }
-        ///   try { await import('x') } catch { handle }
-        ///   try { require.resolve('x') } catch { handle }
-        ///   import('x').catch(handle)
-        ///   import('x').then(_, handle)
+        /// True for require('x') / await import('x') / require.resolve('x')
+        /// inside the body or catch handler of a try/catch statement, and for
+        /// import('x').catch(handle) / import('x').then(_, handle).
         ///
         /// In these cases we shouldn't generate an error if the path could not be
         /// resolved.
@@ -70,6 +65,13 @@ bitflags::bitflags! {
         /// If true, this "export * from 'path'" statement is evaluated at run-time by
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
+
+        /// Resolution failed for this path (ModuleNotFound). Distinguishes a
+        /// resolve failure from an intentionally-disabled path (`"browser": false`
+        /// remap, node builtin under `--target=browser`): both end up with
+        /// `path.is_disabled`, but only the former should emit a runtime throw
+        /// when `HANDLES_IMPORT_ERRORS` is set; the latter stays the `{}` stub.
+        const WAS_UNRESOLVED = 1 << 7;
 
         /// If true, this was originally written as a bare "import 'file'" statement
         const WAS_ORIGINALLY_BARE_IMPORT = 1 << 8;

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -36,12 +36,9 @@ pub struct ImportRecord {
 bitflags::bitflags! {
     #[derive(Copy, Clone, Eq, PartialEq, Default, Debug)]
     pub struct Flags: u16 {
-        /// True for require('x') / await import('x') / require.resolve('x')
-        /// inside the body or catch handler of a try/catch statement, and for
-        /// import('x').catch(handle) / import('x').then(_, handle).
-        ///
-        /// In these cases we shouldn't generate an error if the path could not be
-        /// resolved.
+        /// require() / await import() / require.resolve() inside the try or
+        /// catch body of a try/catch, or import('x').catch(..) / .then(_, ..):
+        /// don't fail the build when the path can't be resolved.
         const HANDLES_IMPORT_ERRORS = 1 << 0;
 
         const IS_INTERNAL = 1 << 1;
@@ -66,11 +63,8 @@ bitflags::bitflags! {
         /// calling the "__reExport()" helper function
         const CALLS_RUNTIME_RE_EXPORT_FN = 1 << 6;
 
-        /// Resolution failed for this path (ModuleNotFound). Distinguishes a
-        /// resolve failure from an intentionally-disabled path (`"browser": false`
-        /// remap, node builtin under `--target=browser`): both end up with
-        /// `path.is_disabled`, but only the former should emit a runtime throw
-        /// when `HANDLES_IMPORT_ERRORS` is set; the latter stays the `{}` stub.
+        /// Resolution failed (ModuleNotFound). `path.is_disabled` alone can't
+        /// tell this apart from an intentional `"browser": false` disable.
         const WAS_UNRESOLVED = 1 << 7;
 
         /// If true, this was originally written as a bare "import 'file'" statement

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -39,6 +39,7 @@ bitflags::bitflags! {
         /// True for the following cases:
         ///
         ///   try { require('x') } catch { handle }
+        ///   try { ... } catch { require('x') }
         ///   try { await import('x') } catch { handle }
         ///   try { require.resolve('x') } catch { handle }
         ///   import('x').catch(handle)

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2268,6 +2268,9 @@ pub mod bv2_impl {
                             // However, doing this means we tell them all the resolve errors
                             // Rather than just the first one.
                             record.path.is_disabled = true;
+                            record
+                                .flags
+                                .insert(bun_ast::ImportRecordFlags::WAS_UNRESOLVED);
                         }
                         let source: Option<&bun_ast::Source> = Some(
                             &self.graph.input_files.items_source()
@@ -6118,6 +6121,9 @@ pub mod bv2_impl {
                             // However, doing this means we tell them all the resolve errors
                             // Rather than just the first one.
                             import_record.path.is_disabled = true;
+                            import_record
+                                .flags
+                                .insert(bun_ast::ImportRecordFlags::WAS_UNRESOLVED);
 
                             if err == _resolver::Error::ModuleNotFound {
                                 let add_error = bun_ast::Log::add_resolve_error_with_text_dupe;

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -541,6 +541,9 @@ impl Linker {
             .contains(ImportRecordFlags::HANDLES_IMPORT_ERRORS)
         {
             import_record.path.is_disabled = true;
+            import_record
+                .flags
+                .insert(ImportRecordFlags::WAS_UNRESOLVED);
             return Ok(false);
         }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1377,7 +1377,8 @@ pub struct FnOrArrowDataVisit {
 
     /// This is used to silence unresolvable imports due to "require" calls inside
     /// a try/catch statement. The assumption is that the try/catch statement is
-    /// there to handle the case where the reference to "require" crashes.
+    /// there to handle the case where the reference to "require" crashes. Counts
+    /// both the try body and the catch body.
     pub(crate) try_body_count: i32,
 }
 

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2053,8 +2053,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let mut _stmts = stmts_to_list(p.arena, catch.body);
                 p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, catch.body_loc)
                     .expect("unreachable");
+                p.fn_or_arrow_data_visit.try_body_count += 1;
                 p.visit_stmts(&mut _stmts, StmtsKind::None)
                     .expect("unreachable");
+                p.fn_or_arrow_data_visit.try_body_count -= 1;
                 p.pop_scope();
                 catch.body = list_to_stmts(_stmts);
             }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2492,9 +2492,10 @@ pub(crate) mod __gated_printer {
 
                 if self.options.inline_require_and_import_errors {
                     if record.path.is_disabled
-                        && record
-                            .flags
-                            .contains(ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                        && record.flags.contains(
+                            ImportRecordFlags::HANDLES_IMPORT_ERRORS
+                                | ImportRecordFlags::WAS_UNRESOLVED,
+                        )
                     {
                         self.print_require_error(record.path.text);
                         if wrap {
@@ -3880,10 +3881,10 @@ pub(crate) mod __gated_printer {
                             {
                                 self.add_source_mapping(expr.loc);
 
-                                if import_record
-                                    .flags
-                                    .contains(ImportRecordFlags::HANDLES_IMPORT_ERRORS)
-                                {
+                                if import_record.flags.contains(
+                                    ImportRecordFlags::HANDLES_IMPORT_ERRORS
+                                        | ImportRecordFlags::WAS_UNRESOLVED,
+                                ) {
                                     self.print_require_error(import_record.path.text);
                                 } else {
                                     self.print_disabled_import();

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2858,6 +2858,125 @@ describe("bundler", () => {
       expect(out).not.toContain("require_foo\u2014bar");
     },
   });
+  // https://github.com/oven-sh/bun/issues/14509
+  // A require() in the catch handler of a try/catch is the common "fallback
+  // require" pattern and should not fail the build when unresolvable.
+  itBundled("edgecase/RequireInCatchBody", {
+    files: {
+      "/entry.js": /* js */ `
+        let v;
+        try {
+          v = require('pkg');
+        } catch (e) {
+          v = require('pkg/sub.cjs');
+        }
+        console.log(v);
+      `,
+      "/node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        exports: { ".": "./index.js" },
+      }),
+      "/node_modules/pkg/index.js": `module.exports = "main";`,
+    },
+    target: "bun",
+    run: { stdout: "main" },
+  });
+  itBundled("edgecase/RequireInCatchBodyFromNodeModules", {
+    files: {
+      "/entry.js": `console.log(require('lib'));`,
+      "/node_modules/lib/package.json": JSON.stringify({ name: "lib", main: "index.js" }),
+      "/node_modules/lib/index.js": /* js */ `
+        let v;
+        try {
+          v = require('pkg');
+        } catch (e) {
+          v = require('pkg/dist/node/pkg.cjs');
+        }
+        module.exports = v;
+      `,
+      "/node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        exports: { ".": "./index.js" },
+      }),
+      "/node_modules/pkg/index.js": `module.exports = "pkg-main";`,
+    },
+    target: "bun",
+    run: { stdout: "pkg-main" },
+  });
+  itBundled("edgecase/RequireInCatchBodyBothUnresolved", {
+    files: {
+      "/entry.js": /* js */ `
+        exports.load = function () {
+          try {
+            return require('does-not-exist-a');
+          } catch (e) {
+            return require('does-not-exist-b');
+          }
+        };
+      `,
+    },
+    target: "bun",
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        const { load } = require('./out.js');
+        try {
+          load();
+          console.log("no throw");
+        } catch (e) {
+          console.log("threw: " + e.message.includes("does-not-exist-b"));
+        }
+      `,
+    },
+    run: { file: "/test.js", stdout: "threw: true" },
+  });
+  itBundled("edgecase/RequireResolveInCatchBody", {
+    files: {
+      "/entry.js": /* js */ `
+        let v;
+        try {
+          v = require.resolve('does-not-exist-a');
+        } catch (e) {
+          v = require.resolve('does-not-exist-b');
+        }
+        console.log(typeof v);
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("does-not-exist-b");
+    },
+  });
+  itBundled("edgecase/AwaitImportInCatchBody", {
+    files: {
+      "/entry.js": /* js */ `
+        async function load() {
+          try {
+            return await import('does-not-exist-a');
+          } catch (e) {
+            return await import('does-not-exist-b');
+          }
+        }
+        load().catch(e => console.log("caught"));
+      `,
+    },
+    target: "bun",
+    run: { stdout: "caught" },
+  });
+  itBundled("edgecase/RequireInFinallyStillErrors", {
+    files: {
+      "/entry.js": /* js */ `
+        try {
+          console.log("ok");
+        } finally {
+          require('does-not-exist');
+        }
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/entry.js": [`Could not resolve: "does-not-exist". Maybe you need to "bun install"?`],
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2967,6 +2967,7 @@ describe("bundler", () => {
       "/entry.js": /* js */ `
         try {
           console.log("ok");
+        } catch (e) {
         } finally {
           require('does-not-exist');
         }
@@ -2976,6 +2977,69 @@ describe("bundler", () => {
     bundleErrors: {
       "/entry.js": [`Could not resolve: "does-not-exist". Maybe you need to "bun install"?`],
     },
+  });
+  itBundled("edgecase/RequireAfterCatchBodyStillErrors", {
+    files: {
+      "/entry.js": /* js */ `
+        try {
+          require('does-not-exist-a');
+        } catch (e) {
+          require('does-not-exist-b');
+        }
+        require('does-not-exist-c');
+      `,
+    },
+    target: "bun",
+    bundleErrors: {
+      "/entry.js": [`Could not resolve: "does-not-exist-c". Maybe you need to "bun install"?`],
+    },
+  });
+  // A resolved-but-disabled path (node builtin under --target=browser, or a
+  // `"browser": { "pkg": false }` remap) in a try/catch body must keep emitting
+  // the empty-module stub, not a runtime throw.
+  itBundled("edgecase/RequireDisabledInCatchBodyStaysEmpty", {
+    files: {
+      "/entry.js": /* js */ `
+        try {
+          throw 0;
+        } catch (e) {
+          const a = require('fs');
+          const b = require('mapped-false');
+          if (a instanceof Error || b instanceof Error) throw new Error("unreachable");
+          console.log("ok");
+        }
+      `,
+      "/package.json": JSON.stringify({ name: "app", browser: { "mapped-false": false } }),
+      "/node_modules/mapped-false/package.json": JSON.stringify({ name: "mapped-false", main: "index.js" }),
+      "/node_modules/mapped-false/index.js": `module.exports = "real";`,
+    },
+    target: "browser",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("Cannot require module");
+    },
+    run: { stdout: "ok" },
+  });
+  itBundled("edgecase/RequireDisabledInTryBodyStaysEmpty", {
+    files: {
+      "/entry.js": /* js */ `
+        let hit = "";
+        try {
+          const x = require('mapped-false');
+          hit = "try:" + (x instanceof Error);
+        } catch (e) {
+          hit = "catch:" + e.message;
+        }
+        console.log(hit);
+      `,
+      "/package.json": JSON.stringify({ name: "app", browser: { "mapped-false": false } }),
+      "/node_modules/mapped-false/package.json": JSON.stringify({ name: "mapped-false", main: "index.js" }),
+      "/node_modules/mapped-false/index.js": `module.exports = "real";`,
+    },
+    target: "browser",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("Cannot require module");
+    },
+    run: { stdout: "try:false" },
   });
 });
 


### PR DESCRIPTION
Fixes #14509.

## Repro

```js
// node_modules/pkg/package.json:  { "name": "pkg", "exports": { ".": "./index.js" } }
// node_modules/lib/index.js:
let axios;
try {
  axios = require('pkg');
} catch (e) {
  axios = require('pkg/sub.cjs');   // not in exports map
}
module.exports = axios;
```

```
$ bun build entry.js --target=bun
error: Could not resolve: "pkg/sub.cjs". Maybe you need to "bun install"?
    at node_modules/lib/index.js:6:21
```

At runtime the catch handler only runs when the try body threw, so when `require('pkg')` resolves, `require('pkg/sub.cjs')` is unreachable. The build fails on dead code.

The original #14509 report hit this via a dependency that wrapped `require('axios')` / `require('axios/dist/node/axios.cjs')` this way; older axios versions did not export `./dist/node/axios.cjs` so the fallback path was unresolvable.

## Cause

`s_try` in `src/js_parser/visit/visit_stmt.rs` increments `fn_or_arrow_data_visit.try_body_count` around the `try` body only. `transpose_require` / `transpose_require_resolve_known_string` / `transpose_import_expr` use that counter to set `ImportRecordFlags::HANDLES_IMPORT_ERRORS` on the import record, which is what makes `bundle_v2` emit a runtime `throw` instead of a hard "Could not resolve" error. A `require()` in the catch handler never got the flag.

## Fix

Increment `try_body_count` around the catch body as well. An unresolvable `require()` / `require.resolve()` / `await import()` in a catch handler now bundles as a runtime throw, matching what the same code does under `bun run` / Node. The `finally` body is left alone: it always executes, so an unresolved require there stays a bundle error.

Setting `HANDLES_IMPORT_ERRORS` on the catch body would otherwise have flipped resolved-but-disabled paths (`"browser": {"pkg": false}` remaps, node builtins under `--target=browser`) from the empty-module stub to a throw-IIFE, crashing bundles that previously ran clean. The printer was conflating "resolve failed" with "intentionally disabled" via `path.is_disabled`. A new `ImportRecordFlags::WAS_UNRESOLVED` bit, set at the three resolve-failure sites, lets the printer emit the runtime throw only for actual resolve failures; an intentionally-disabled path keeps the empty-module stub in both the try and catch body. This also aligns the try-body case with esbuild, which always emits `{}` for a disabled path regardless of try/catch.

esbuild only covers the `try` body and hard-errors on the catch body. The divergence only widens the set of inputs that bundle successfully.

## Verification

Nine new cases in `test/bundler/bundler_edgecase.test.ts`:

- `RequireInCatchBody`: subpath blocked by `exports` map, try body resolves → bundles, prints try-body value
- `RequireInCatchBodyFromNodeModules`: same pattern inside `node_modules` (the #14509 shape)
- `RequireInCatchBodyBothUnresolved`: neither resolves → bundles, catch-body require throws at runtime with the catch-body specifier in the message
- `RequireResolveInCatchBody` / `AwaitImportInCatchBody`: `require.resolve` / `await import()` variants
- `RequireInFinallyStillErrors`: `try {} catch {} finally { require('x') }` still hard-errors
- `RequireAfterCatchBodyStillErrors`: a require after the try/catch still hard-errors (pins the catch-body counter decrement)
- `RequireDisabledInCatchBodyStaysEmpty` / `RequireDisabledInTryBodyStaysEmpty`: `"browser": false` remap and node builtin under `--target=browser` keep the empty-module stub in both bodies

```
$ USE_SYSTEM_BUN=1 bun test test/bundler/bundler_edgecase.test.ts -t "InCatchBody|InFinallyStillErrors|AfterCatchBody|InTryBodyStays"
 2 pass   7 fail

$ bun bd test test/bundler/bundler_edgecase.test.ts -t "InCatchBody|InFinallyStillErrors|AfterCatchBody|InTryBodyStays"
 9 pass   0 fail
```

`bundler_edgecase`, `bundler_browser`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_allow_unresolved`, `esbuild/default`, and `esbuild/packagejson` all pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->