### PR TITLE
bundler: keep the symlink spelling of entry-point output paths

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2589,11 +2589,7 @@ pub mod bv2_impl {
                 .loader(&self.transpiler.options.loaders)
                 .unwrap_or(Loader::File);
 
-            // When the resolver followed a symlink, `path.pretty` still holds the
-            // pre-symlink absolute path (`set_realpath` moved the old `text` there).
-            // Keep it for output naming so `outdir` mirrors the entry-point spelling
-            // the user wrote, matching esbuild. `path_with_pretty_initialized` below
-            // overwrites `pretty`.
+            // #8467: stash the pre-symlink spelling (in `pretty` until overwritten below) for output naming; matches esbuild.
             if is_entry_point && path.is_symlink && path.is_file() && !path.pretty.is_empty() {
                 self.graph
                     .entry_point_original_names
@@ -4502,19 +4498,9 @@ pub mod bv2_impl {
                                 return;
                             };
                             let mut resolved = resolved;
-                            let Ok(source_index) =
-                                this.enqueue_entry_item(&mut resolved, true, target)
-                            else {
+                            let Ok(_) = this.enqueue_entry_item(&mut resolved, true, target) else {
                                 return;
                             };
-
-                            // Store the original entry point name for virtual entries that fall back to file resolution
-                            if let Some(idx) = source_index {
-                                let _ = this
-                                    .graph
-                                    .entry_point_original_names
-                                    .put(idx, &resolve.import_record.specifier);
-                            }
                             return;
                         }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2589,6 +2589,17 @@ pub mod bv2_impl {
                 .loader(&self.transpiler.options.loaders)
                 .unwrap_or(Loader::File);
 
+            // When the resolver followed a symlink, `path.pretty` still holds the
+            // pre-symlink absolute path (`set_realpath` moved the old `text` there).
+            // Keep it for output naming so `outdir` mirrors the entry-point spelling
+            // the user wrote, matching esbuild. `path_with_pretty_initialized` below
+            // overwrites `pretty`.
+            if is_entry_point && path.is_symlink && path.is_file() && !path.pretty.is_empty() {
+                self.graph
+                    .entry_point_original_names
+                    .put(source_index.get(), path.pretty)?;
+            }
+
             // SAFETY: `path_with_pretty_initialized` allocates into `self.graph.heap`, which
             // outlives the bundle pass; erase the arena lifetime back to the resolver's
             // `Path<'static>` alias so `path` doesn't keep `self` borrowed.

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -643,12 +643,7 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
             let root_dir = &this.resolver().opts.root_dir;
             let mut real_path_buf = PathBuffer::uninit();
             let dir: &[u8] = 'dir: {
-                // When `dir_path` already sits under `root_dir`, skip the
-                // open+get_fd_path round-trip: that canonicalization would
-                // discard the symlink spelling an entry point was reached
-                // through (#8467). Fall through when the plain relativization
-                // walks above root so a short-name/symlinked cwd still finds a
-                // common prefix.
+                // #8467: skip get_fd_path when dir_path is already under root_dir (canonicalizing drops the symlink spelling); fall through so a short-name/symlinked cwd still finds a prefix.
                 if bun_paths::is_absolute(dir_path)
                     && !resolve_path::relative_platform::<bun_paths::platform::Auto, false>(
                         root_dir, dir_path,

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -640,8 +640,23 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
             } else {
                 b"."
             };
+            let root_dir = &this.resolver().opts.root_dir;
             let mut real_path_buf = PathBuffer::uninit();
             let dir: &[u8] = 'dir: {
+                // When `dir_path` already sits under `root_dir`, skip the
+                // open+get_fd_path round-trip: that canonicalization would
+                // discard the symlink spelling an entry point was reached
+                // through (#8467). Fall through when the plain relativization
+                // walks above root so a short-name/symlinked cwd still finds a
+                // common prefix.
+                if bun_paths::is_absolute(dir_path)
+                    && !resolve_path::relative_platform::<bun_paths::platform::Auto, false>(
+                        root_dir, dir_path,
+                    )
+                    .starts_with(b"..")
+                {
+                    break 'dir dir_path;
+                }
                 let Ok(dir_file) = bun_sys::File::openat(
                     bun_sys::Fd::cwd(),
                     dir_path,
@@ -672,7 +687,6 @@ pub fn compute_chunks(this: &mut LinkerContext, unique_key: u64) -> crate::Resul
                 }
             };
 
-            let root_dir = &this.resolver().opts.root_dir;
             chunk.template.placeholder.dir = resolve_path::relative_alloc(root_dir, dir)?;
         }
     }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -527,6 +527,55 @@ describe("Bun.build", () => {
     },
   );
 
+  // https://github.com/oven-sh/bun/issues/8467
+  test.concurrent("output paths keep the symlink spelling of an entry point", async () => {
+    using dir = tempDir("build-symlink-entry-output", {
+      "packages/mypkg/index.ts": `export const a = 1;\n`,
+      "packages/mypkg/other.ts": `export const b = 2;\n`,
+      "app/src/local.ts": `export const c = 3;\n`,
+      "app/build.ts": `
+        const result = await Bun.build({
+          entrypoints: ["./node_modules/mypkg/index.ts", "./node_modules/mypkg/other.ts", "./src/local.ts"],
+          outdir: "./dist",
+        });
+        if (!result.success) {
+          for (const m of result.logs) console.error(String(m));
+          process.exit(1);
+        }
+        for (const out of result.outputs) {
+          console.log(out.kind + " " + out.path.slice(process.cwd().length + 1).replaceAll("\\\\", "/"));
+        }
+      `,
+    });
+    mkdirSync(join(String(dir), "app", "node_modules"), { recursive: true });
+    symlinkSync(
+      join(String(dir), "packages", "mypkg"),
+      join(String(dir), "app", "node_modules", "mypkg"),
+      isWindows ? "junction" : "dir",
+    );
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.ts"],
+      env: bunEnv,
+      cwd: join(String(dir), "app"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const lines = stdout.trim().split("\n").sort();
+    expect({ lines, stderr }).toEqual({
+      lines: [
+        "entry-point dist/node_modules/mypkg/index.js",
+        "entry-point dist/node_modules/mypkg/other.js",
+        "entry-point dist/src/local.js",
+      ],
+      stderr: "",
+    });
+    expect(stdout).not.toContain("_.._");
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("errors are returned as an array", async () => {
     const x = await buildNoThrow({
       entrypoints: [join(import.meta.dir, "does-not-exist.ts")],

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -528,53 +528,66 @@ describe("Bun.build", () => {
   );
 
   // https://github.com/oven-sh/bun/issues/8467
-  test.concurrent("output paths keep the symlink spelling of an entry point", async () => {
-    using dir = tempDir("build-symlink-entry-output", {
-      "packages/mypkg/index.ts": `export const a = 1;\n`,
-      "packages/mypkg/other.ts": `export const b = 2;\n`,
-      "app/src/local.ts": `export const c = 3;\n`,
-      "app/build.ts": `
-        const result = await Bun.build({
-          entrypoints: ["./node_modules/mypkg/index.ts", "./node_modules/mypkg/other.ts", "./src/local.ts"],
-          outdir: "./dist",
-        });
-        if (!result.success) {
-          for (const m of result.logs) console.error(String(m));
-          process.exit(1);
-        }
-        for (const out of result.outputs) {
-          console.log(out.kind + " " + out.path.slice(process.cwd().length + 1).replaceAll("\\\\", "/"));
-        }
-      `,
-    });
-    mkdirSync(join(String(dir), "app", "node_modules"), { recursive: true });
-    symlinkSync(
-      join(String(dir), "packages", "mypkg"),
-      join(String(dir), "app", "node_modules", "mypkg"),
-      isWindows ? "junction" : "dir",
-    );
+  test.concurrent.each([false, true])(
+    "output paths keep the symlink spelling of an entry point (onResolve plugin: %p)",
+    async withPlugin => {
+      using dir = tempDir("build-symlink-entry-output", {
+        "packages/mypkg/index.ts": `export const a = 1;\n`,
+        "packages/mypkg/other.ts": `export const b = 2;\n`,
+        "app/src/real-impl.ts": `export const c = 3;\n`,
+        "app/build.ts": `
+          const result = await Bun.build({
+            entrypoints: [
+              "./node_modules/mypkg/index.ts",
+              "./node_modules/mypkg/other.ts",
+              "./src/alias.ts",
+            ],
+            outdir: "./dist",
+            plugins: ${withPlugin}
+              ? [{ name: "noop", setup(b) { b.onResolve({ filter: /.*/ }, () => undefined); } }]
+              : [],
+          });
+          if (!result.success) {
+            for (const m of result.logs) console.error(String(m));
+            process.exit(1);
+          }
+          for (const out of result.outputs) {
+            console.log(out.kind + " " + out.path.slice(process.cwd().length + 1).replaceAll("\\\\", "/"));
+          }
+        `,
+      });
+      mkdirSync(join(String(dir), "app", "node_modules"), { recursive: true });
+      symlinkSync(
+        join(String(dir), "packages", "mypkg"),
+        join(String(dir), "app", "node_modules", "mypkg"),
+        isWindows ? "junction" : "dir",
+      );
+      // File-level symlink with a different basename, target inside root: pins [name].
+      symlinkSync("real-impl.ts", join(String(dir), "app", "src", "alias.ts"), "file");
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "build.ts"],
-      env: bunEnv,
-      cwd: join(String(dir), "app"),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.ts"],
+        env: bunEnv,
+        cwd: join(String(dir), "app"),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const lines = stdout.trim().split("\n").sort();
-    expect({ lines, stderr }).toEqual({
-      lines: [
-        "entry-point dist/node_modules/mypkg/index.js",
-        "entry-point dist/node_modules/mypkg/other.js",
-        "entry-point dist/src/local.js",
-      ],
-      stderr: "",
-    });
-    expect(stdout).not.toContain("_.._");
-    expect(exitCode).toBe(0);
-  });
+      const lines = stdout.trim().split("\n").sort();
+      expect({ lines, stderr }).toEqual({
+        lines: [
+          "entry-point dist/node_modules/mypkg/index.js",
+          "entry-point dist/node_modules/mypkg/other.js",
+          "entry-point dist/src/alias.js",
+        ],
+        stderr: "",
+      });
+      expect(stdout).not.toContain("_.._");
+      expect(stdout).not.toContain("real-impl");
+      expect(exitCode).toBe(0);
+    },
+  );
 
   test.concurrent("errors are returned as an array", async () => {
     const x = await buildNoThrow({


### PR DESCRIPTION
Fixes #8467
Fixes #13365

### Repro

```
packages/mypkg/index.ts
app/
  node_modules/mypkg -> ../../packages/mypkg
  src/local.ts
```

```js
await Bun.build({
  entrypoints: ['./node_modules/mypkg/index.ts', './src/local.ts'],
  outdir: './dist',
});
```

```
bun:     dist/_.._/packages/mypkg/index.js
esbuild: dist/node_modules/mypkg/index.js
```

### Cause

`resolve_entry_point` runs `finalize_result`, which calls `Path::set_realpath` so `source.path.text` becomes the canonical location. `LinkerGraph::load` copies that into `entry_points.output_path`, and `compute_chunks` additionally opens the directory and reads its `get_fd_path` before relativizing against `root_dir`. The real path sits above `root_dir` (which is derived from the user-spelled entry-point prefix), so the result is `../packages/mypkg` and the `[dir]` sanitizer rewrites that to `_.._/packages/mypkg`.

### Fix

- `enqueue_entry_item`: when the resolver followed a symlink for a file entry, record the pre-symlink absolute path (still in `path.pretty` at that point) in `graph.entry_point_original_names[source_index]`. That map already feeds `entry_points.output_path` for plugin-resolved virtual entries.
- `compute_chunks`: before opening the directory, try a plain `relative(root_dir, dir)`. If it does not walk above `root_dir`, use `dir` as-is; only fall back to `open + get_fd_path` otherwise. This preserves the entry-point spelling, skips a per-chunk syscall in the common case, and keeps the canonicalization path for Windows short-name / symlinked-cwd spellings that need it to find a common prefix.

esbuild derives entry output paths from the input path the user wrote, not the canonical path; this brings Bun in line.

### Test

`test/bundler/bun-build-api.test.ts` adds a three-entry build (two behind a junction/symlink into `node_modules`, one local) and asserts the output paths are `dist/node_modules/mypkg/*` and `dist/src/local.js` with no `_.._`. Fails on main with `dist/_.._/packages/mypkg/*`, passes with this change.

Verified: `bundler_naming`, `bundler_loader`, `esbuild/loader`, `bundler_splitting`, `bundler_plugin`, and the full `bun-build-api` suite. The CLI (`bun build`) path goes through the same `enqueue_entry_item`, confirmed manually.

Related: #31958 adds `preserveSymlinks` for resolution but leaves output naming on the real path; #34558 touches the adjacent asset-naming canonicalization. Both are open and will have a small, aligned merge conflict with the `compute_chunks` hunk here.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->