### PR TITLE
node:http: emit 'data' on the server 'connection' socket with the raw request bytes

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -750,6 +750,9 @@ public:
     void setOnSocketData(HttpContextData<SSL>::OnSocketDataCallback onData) {
         httpContext->getSocketContextData()->onSocketData = onData;
     }
+    void setOnSocketRawData(HttpContextData<SSL>::OnSocketDataCallback onRawData) {
+        httpContext->getSocketContextData()->onSocketRawData = onRawData;
+    }
 
     void setOnClientError(HttpContextData<SSL>::OnClientErrorCallback onClientError) {
         httpContext->getSocketContextData()->onClientError = std::move(onClientError);

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -750,7 +750,7 @@ public:
     void setOnSocketData(HttpContextData<SSL>::OnSocketDataCallback onData) {
         httpContext->getSocketContextData()->onSocketData = onData;
     }
-    void setOnSocketRawData(HttpContextData<SSL>::OnSocketDataCallback onRawData) {
+    void setOnSocketRawData(HttpContextData<SSL>::OnSocketRawDataCallback onRawData) {
         httpContext->getSocketContextData()->onSocketRawData = onRawData;
     }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -295,6 +295,20 @@ private:
 
         HttpResponseData<SSL> *httpResponseData = (HttpResponseData<SSL> *) us_socket_ext(s);
 
+        /* node:http compat: forward the raw TCP payload to the JS socket
+         * wrapper so a user 'data' listener on the 'connection' socket sees the
+         * raw request bytes (Node feeds its parser from that event). Tunnel
+         * mode routes through onSocketData instead. */
+        if constexpr (IsNodeHttp) {
+            if (!httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketRawData) {
+                httpContextData->onSocketRawData(httpResponseData->socketData, SSL, s, data, length, false);
+                if (us_socket_is_closed(s)) {
+                    us_socket_unref(s);
+                    return s;
+                }
+            }
+        }
+
         /* node:http compat: HTTP parsing stopped on this connection (a parse error
          * was already delivered to 'clientError', or the JS layer freed the
          * parser); ignore further request bytes. CONNECT/Upgrade tunnels are not
@@ -303,23 +317,6 @@ private:
             if ((httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_PARSING_STOPPED) && !httpResponseData->isConnectRequest) {
                 us_socket_unref(s);
                 return s;
-            }
-        }
-
-        /* node:http compat: Node's server socket is a net.Socket whose 'data'
-         * event carries the raw TCP payload (the parser is just another 'data'
-         * listener). Forward the raw bytes to the JS socket wrapper before
-         * parsing so a user 'data' listener on the 'connection' socket sees
-         * them. Tunnel mode routes through onSocketData instead. The receiver
-         * early-returns when no JS callback is installed, so the common path
-         * pays only the indirect call. */
-        if constexpr (IsNodeHttp) {
-            if (!httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketRawData) {
-                httpContextData->onSocketRawData(httpResponseData->socketData, SSL, s, data, length, false);
-                if (us_socket_is_closed(s)) {
-                    us_socket_unref(s);
-                    return s;
-                }
             }
         }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -299,9 +299,10 @@ private:
          * wrapper so a user 'data' listener on the 'connection' socket sees the
          * raw request bytes (Node feeds its parser from that event). Tunnel
          * mode routes through onSocketData instead. */
+        bool rawTapCoveredThisRead = false;
         if constexpr (IsNodeHttp) {
             if (!httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketRawData) {
-                httpContextData->onSocketRawData(httpResponseData->socketData, SSL, s, data, length, false);
+                rawTapCoveredThisRead = httpContextData->onSocketRawData(httpResponseData->socketData, SSL, s, data, length);
                 if (us_socket_is_closed(s)) {
                     us_socket_unref(s);
                     return s;
@@ -489,7 +490,7 @@ private:
             /* Continue parsing */
             return s;
 
-        }, [httpResponseData, httpContextData](void *user, std::string_view data, bool fin) -> void * {
+        }, [httpResponseData, httpContextData, rawTapCoveredThisRead](void *user, std::string_view data, bool fin) -> void * {
 
             /* node:http compat: an accepted Upgrade request's body just completed -
              * after this fin chunk has been delivered to the request body stream
@@ -513,7 +514,7 @@ private:
                 }
             }
 
-            if (httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketData) {
+            if (httpResponseData->isConnectRequest && !rawTapCoveredThisRead && httpResponseData->socketData && httpContextData->onSocketData) {
                 httpContextData->onSocketData(httpResponseData->socketData, SSL, (struct us_socket_t *) user, data.data(), data.length(), fin);
             }
 

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -306,6 +306,23 @@ private:
             }
         }
 
+        /* node:http compat: Node's server socket is a net.Socket whose 'data'
+         * event carries the raw TCP payload (the parser is just another 'data'
+         * listener). Forward the raw bytes to the JS socket wrapper before
+         * parsing so a user 'data' listener on the 'connection' socket sees
+         * them. Tunnel mode routes through onSocketData instead. The receiver
+         * early-returns when no JS callback is installed, so the common path
+         * pays only the indirect call. */
+        if constexpr (IsNodeHttp) {
+            if (!httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketRawData) {
+                httpContextData->onSocketRawData(httpResponseData->socketData, SSL, s, data, length, false);
+                if (us_socket_is_closed(s)) {
+                    us_socket_unref(s);
+                    return s;
+                }
+            }
+        }
+
         /* Cork this socket */
         ((AsyncSocket<SSL> *) s)->cork();
 

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -76,10 +76,8 @@ private:
     OnSocketClosedCallback onSocketClosed = nullptr;
     OnSocketDrainCallback onSocketDrain = nullptr;
     OnSocketDataCallback onSocketData = nullptr;
-    /* node:http compat: tap of every TCP payload before HTTP parsing (Node's
-     * server socket emits 'data' with the raw request bytes to every listener,
-     * its parser included). The receiver gates on its own callback slot so this
-     * is a null-check when no user 'data' listener is attached. */
+    /* node:http: tap of every TCP payload before HTTP parsing, so a user
+     * 'data' listener on the 'connection' socket sees the raw request bytes. */
     OnSocketDataCallback onSocketRawData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
     OnClientErrorCallback onClientError = nullptr;

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -76,6 +76,11 @@ private:
     OnSocketClosedCallback onSocketClosed = nullptr;
     OnSocketDrainCallback onSocketDrain = nullptr;
     OnSocketDataCallback onSocketData = nullptr;
+    /* node:http compat: tap of every TCP payload before HTTP parsing (Node's
+     * server socket emits 'data' with the raw request bytes to every listener,
+     * its parser included). The receiver gates on its own callback slot so this
+     * is a null-check when no user 'data' listener is attached. */
+    OnSocketDataCallback onSocketRawData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
     OnClientErrorCallback onClientError = nullptr;
 

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -54,6 +54,7 @@ struct alignas(16) HttpContextData {
 private:
     std::vector<MoveOnlyFunction<void(HttpResponse<SSL> *, int)>> filterHandlers;
     using OnSocketDataCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket, const char *data, int length, bool last);
+    using OnSocketRawDataCallback = bool (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket, const char *data, int length);
     using OnSocketDrainCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnSocketUpgradedCallback = void (*)(void* userData, int is_ssl, struct us_socket_t *rawSocket);
     using OnClientErrorCallback = MoveOnlyFunction<void(int is_ssl, struct us_socket_t *rawSocket, uWS::HttpParserError errorCode, char *rawPacket, int rawPacketLength)>;
@@ -77,8 +78,9 @@ private:
     OnSocketDrainCallback onSocketDrain = nullptr;
     OnSocketDataCallback onSocketData = nullptr;
     /* node:http: tap of every TCP payload before HTTP parsing, so a user
-     * 'data' listener on the 'connection' socket sees the raw request bytes. */
-    OnSocketDataCallback onSocketRawData = nullptr;
+     * 'data' listener on the 'connection' socket sees the raw request bytes.
+     * Returns true when a JS callback was armed (the bytes will reach JS). */
+    OnSocketRawDataCallback onSocketRawData = nullptr;
     OnSocketUpgradedCallback onSocketUpgraded = nullptr;
     OnClientErrorCallback onClientError = nullptr;
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1224,10 +1224,10 @@ function onServerConnection(this: Server, socketHandle) {
   // emitting 'connection'; expose the shim here so listeners see it populated.
   socket.parser = createServerParserShim(socket);
   this.emit("connection", socket);
-  maybeEnableRawSocketData(socket);
   if (isTLS && socketHandle.secureEstablished) {
     this.emit("secureConnection", socket);
   }
+  maybeEnableRawSocketData(socket);
 }
 
 // Like Node.js: server.setTimeout only records the per-socket inactivity

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1396,8 +1396,7 @@ function detachSocketListenersForHandoff(socket) {
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");
 const kEnableRawData = Symbol("kEnableRawData");
-// Node feeds its parser from the socket's 'data' event, so user listeners see
-// the raw request bytes; arm the native raw-bytes tap when a listener exists.
+// Arm the native raw-bytes tap so 'data'/'readable' see the raw request bytes.
 function maybeEnableRawSocketData(socket) {
   if (!socket[kStreamingEnabled] && (socket.listenerCount("data") > 0 || socket.listenerCount("readable") > 0)) {
     socket[kEnableRawData]();
@@ -1894,8 +1893,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
         const message = this._httpMessage;
         const req = message?.req;
 
-        // The raw-bytes tap feeds this socket's readable side with wire
-        // bytes; the parsed body goes to the IncomingMessage only.
+        // The raw tap owns the socket readable; parsed body goes to req only.
         if (!handle.onrawdata) {
           if ((bodyReadState & NodeHTTPBodyReadState.done) !== 0) {
             emitServerSocketEOFNT(this, req);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1401,10 +1401,7 @@ const kEnableRawData = Symbol("kEnableRawData");
 // a user reads the socket, have the native side forward the raw TCP payload
 // into this Duplex so 'data'/'readable' behave the same.
 function maybeEnableRawSocketData(socket) {
-  if (
-    !socket[kStreamingEnabled] &&
-    (socket.listenerCount("data") > 0 || socket.listenerCount("readable") > 0)
-  ) {
+  if (!socket[kStreamingEnabled] && (socket.listenerCount("data") > 0 || socket.listenerCount("readable") > 0)) {
     socket[kEnableRawData]();
   }
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -898,6 +898,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
 
         if (isSocketNew && !reachedRequestsLimit) {
           server.emit("connection", socket);
+          maybeEnableRawSocketData(socket);
         }
 
         if (!isPipelined) {
@@ -1223,6 +1224,7 @@ function onServerConnection(this: Server, socketHandle) {
   // emitting 'connection'; expose the shim here so listeners see it populated.
   socket.parser = createServerParserShim(socket);
   this.emit("connection", socket);
+  maybeEnableRawSocketData(socket);
   if (isTLS && socketHandle.secureEstablished) {
     this.emit("secureConnection", socket);
   }
@@ -1393,6 +1395,19 @@ function detachSocketListenersForHandoff(socket) {
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");
+const kEnableRawData = Symbol("kEnableRawData");
+// Node's server socket is the net.Socket the parser reads from, so every
+// 'data' listener sees the raw request bytes. Here parsing runs natively; when
+// a user reads the socket, have the native side forward the raw TCP payload
+// into this Duplex so 'data'/'readable' behave the same.
+function maybeEnableRawSocketData(socket) {
+  if (
+    !socket[kStreamingEnabled] &&
+    (socket.listenerCount("data") > 0 || socket.listenerCount("readable") > 0)
+  ) {
+    socket[kEnableRawData]();
+  }
+}
 // Scratch options object for the builtin ServerResponse (see the dispatcher).
 const scratchResponseOptions = {
   [kHandle]: undefined,
@@ -1609,6 +1624,10 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
       if (enable) {
         handle.ondata = this.#onData.bind(this);
         handle.ondrain = this.#onDrain.bind(this);
+        // Tunnel mode owns the readable side from here; the raw-bytes tap would
+        // deliver the same bytes a second time. The already-queued chunk for
+        // this packet is dropped by the task's own null-check.
+        handle.onrawdata = undefined;
       } else {
         handle.ondata = undefined;
         handle.ondrain = undefined;
@@ -1624,6 +1643,23 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
       (callback as Function)();
     }
     this.emit("drain");
+  }
+  #onRawData(chunk) {
+    this._unrefTimer();
+    this.bytesRead += chunk.length;
+    if (!this.push(chunk)) {
+      // Readable buffer filled: drop the tap so the native side stops
+      // allocating a Buffer per TCP read; _read() re-arms on next demand.
+      // HTTP parsing continues natively regardless.
+      const handle = this[kHandle];
+      if (handle) handle.onrawdata = undefined;
+    }
+  }
+  [kEnableRawData]() {
+    const handle = this[kHandle];
+    if (handle && !handle.onrawdata) {
+      handle.onrawdata = this.#onRawData.bind(this);
+    }
   }
   #onData(chunk, last) {
     this._unrefTimer();
@@ -1879,6 +1915,10 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
 
   _read(_size) {
     // https://github.com/nodejs/node/blob/13e3aef053776be9be262f210dc438ecec4a3c8d/lib/net.js#L725-L737
+    // (Re-)arm the raw-bytes tap: a listener added after 'connection' reaches
+    // here via the Readable's resume() → read(0), and a push()==false disarm
+    // re-arms on the next demand.
+    maybeEnableRawSocketData(this);
     this.#resumeSocket();
   }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1618,8 +1618,6 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
       if (enable) {
         handle.ondata = this.#onData.bind(this);
         handle.ondrain = this.#onDrain.bind(this);
-        // Tunnel mode owns the readable side; the raw tap would double-deliver.
-        handle.onrawdata = undefined;
       } else {
         handle.ondata = undefined;
         handle.ondrain = undefined;
@@ -1639,11 +1637,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
   #onRawData(chunk) {
     this._unrefTimer();
     this.bytesRead += chunk.length;
-    if (!this.push(chunk)) {
-      // Buffer full: drop the tap; _read() re-arms on next demand.
-      const handle = this[kHandle];
-      if (handle) handle.onrawdata = undefined;
-    }
+    this.push(chunk);
   }
   [kEnableRawData]() {
     const handle = this[kHandle];

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1396,10 +1396,8 @@ function detachSocketListenersForHandoff(socket) {
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");
 const kEnableRawData = Symbol("kEnableRawData");
-// Node's server socket is the net.Socket the parser reads from, so every
-// 'data' listener sees the raw request bytes. Here parsing runs natively; when
-// a user reads the socket, have the native side forward the raw TCP payload
-// into this Duplex so 'data'/'readable' behave the same.
+// Node feeds its parser from the socket's 'data' event, so user listeners see
+// the raw request bytes; arm the native raw-bytes tap when a listener exists.
 function maybeEnableRawSocketData(socket) {
   if (!socket[kStreamingEnabled] && (socket.listenerCount("data") > 0 || socket.listenerCount("readable") > 0)) {
     socket[kEnableRawData]();
@@ -1621,9 +1619,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
       if (enable) {
         handle.ondata = this.#onData.bind(this);
         handle.ondrain = this.#onDrain.bind(this);
-        // Tunnel mode owns the readable side from here; the raw-bytes tap would
-        // deliver the same bytes a second time. The already-queued chunk for
-        // this packet is dropped by the task's own null-check.
+        // Tunnel mode owns the readable side; the raw tap would double-deliver.
         handle.onrawdata = undefined;
       } else {
         handle.ondata = undefined;
@@ -1645,9 +1641,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
     this._unrefTimer();
     this.bytesRead += chunk.length;
     if (!this.push(chunk)) {
-      // Readable buffer filled: drop the tap so the native side stops
-      // allocating a Buffer per TCP read; _read() re-arms on next demand.
-      // HTTP parsing continues natively regardless.
+      // Buffer full: drop the tap; _read() re-arms on next demand.
       const handle = this[kHandle];
       if (handle) handle.onrawdata = undefined;
     }
@@ -1661,6 +1655,7 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
   #onData(chunk, last) {
     this._unrefTimer();
     if (chunk) {
+      this.bytesRead += chunk.length;
       this.push(chunk);
     }
     if (last) {
@@ -1899,22 +1894,23 @@ const NodeHTTPServerSocket = class Socket extends NetSocket {
         const message = this._httpMessage;
         const req = message?.req;
 
-        if ((bodyReadState & NodeHTTPBodyReadState.done) !== 0) {
-          emitServerSocketEOFNT(this, req);
+        // The raw-bytes tap feeds this socket's readable side with wire
+        // bytes; the parsed body goes to the IncomingMessage only.
+        if (!handle.onrawdata) {
+          if ((bodyReadState & NodeHTTPBodyReadState.done) !== 0) {
+            emitServerSocketEOFNT(this, req);
+          }
+          this.push(resumed);
         }
         if (req) {
           req.push(resumed);
         }
-        this.push(resumed);
       }
     }
   }
 
   _read(_size) {
     // https://github.com/nodejs/node/blob/13e3aef053776be9be262f210dc438ecec4a3c8d/lib/net.js#L725-L737
-    // (Re-)arm the raw-bytes tap: a listener added after 'connection' reaches
-    // here via the Readable's resume() → read(0), and a push()==false disarm
-    // re-arms on the next demand.
     maybeEnableRawSocketData(this);
     this.#resumeSocket();
   }

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -613,6 +613,11 @@ static void assignOnNodeJSCompat(uWS::TemplatedApp<isSSL>* app)
         ASSERT(rawSocket == socket->socket || socket->socket == nullptr);
         socket->onData(data, length, last);
     });
+    app->setOnSocketRawData([](void* socketData, int is_ssl, struct us_socket_t* rawSocket, const char* data, int length, bool last) -> void {
+        auto* socket = reinterpret_cast<JSNodeHTTPServerSocket*>(socketData);
+        ASSERT(rawSocket == socket->socket || socket->socket == nullptr);
+        socket->onRawData(data, length);
+    });
     app->setOnSocketUpgraded([](void* socketData, int is_ssl, struct us_socket_t* rawSocket) -> void {
         auto* socket = reinterpret_cast<JSNodeHTTPServerSocket*>(socketData);
         // the socket is adopted and might not be the same as the rawSocket

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -613,10 +613,10 @@ static void assignOnNodeJSCompat(uWS::TemplatedApp<isSSL>* app)
         ASSERT(rawSocket == socket->socket || socket->socket == nullptr);
         socket->onData(data, length, last);
     });
-    app->setOnSocketRawData([](void* socketData, int is_ssl, struct us_socket_t* rawSocket, const char* data, int length, bool last) -> void {
+    app->setOnSocketRawData([](void* socketData, int is_ssl, struct us_socket_t* rawSocket, const char* data, int length) -> bool {
         auto* socket = reinterpret_cast<JSNodeHTTPServerSocket*>(socketData);
         ASSERT(rawSocket == socket->socket || socket->socket == nullptr);
-        socket->onRawData(data, length);
+        return socket->onRawData(data, length);
     });
     app->setOnSocketUpgraded([](void* socketData, int is_ssl, struct us_socket_t* rawSocket) -> void {
         auto* socket = reinterpret_cast<JSNodeHTTPServerSocket*>(socketData);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -649,6 +649,56 @@ void JSNodeHTTPServerSocket::onData(const char* data, int length, bool last)
     }
 }
 
+void JSNodeHTTPServerSocket::onRawData(const char* data, int length)
+{
+    // Called for every TCP payload on a node:http connection before HTTP
+    // parsing. When no JS 'data' listener is attached the callback slot is
+    // null and this is the only work done.
+    if (!functionToCallOnRawData) {
+        return;
+    }
+    Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(this->globalObject());
+    WebCore::ScriptExecutionContext* scriptExecutionContext = globalObject->scriptExecutionContext();
+    if (!scriptExecutionContext) {
+        return;
+    }
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
+    JSC::JSUint8Array* buffer = WebCore::createBuffer(globalObject, std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(data), length));
+    auto chunk = JSC::JSValue(buffer);
+    if (auto* exception = scope.exception()) {
+        (void)scope.tryClearException();
+        globalObject->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        return;
+    }
+    gcProtect(chunk);
+    scriptExecutionContext->postTask([self = this, chunk = chunk](ScriptExecutionContext& context) {
+        WTF::NakedPtr<JSC::Exception> exception;
+        auto* globalObject = defaultGlobalObject(context.globalObject());
+        auto* thisObject = self;
+        auto* callbackObject = thisObject->functionToCallOnRawData.get();
+        EnsureStillAliveScope ensureChunkStillAlive(chunk);
+        gcUnprotect(chunk);
+        if (!callbackObject) {
+            return;
+        }
+
+        auto callData = JSC::getCallData(callbackObject);
+        MarkedArgumentBuffer args;
+        args.append(chunk);
+        EnsureStillAliveScope ensureStillAlive(self);
+
+        if (globalObject->scriptExecutionStatus(globalObject, thisObject) == ScriptExecutionStatus::Running) {
+            profiledCall(globalObject, JSC::ProfilingReason::API, callbackObject, callData, thisObject, args, exception);
+
+            if (auto* ptr = exception.get()) {
+                exception.clear();
+                globalObject->reportUncaughtExceptionAtEventLoop(globalObject, ptr);
+            }
+        }
+    });
+}
+
 JSC::Structure* JSNodeHTTPServerSocket::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     auto* structure = JSC::Structure::create(vm, globalObject, globalObject->objectPrototype(), JSC::TypeInfo(JSC::ObjectType, StructureFlags), JSNodeHTTPServerSocketPrototype::info());
@@ -672,6 +722,7 @@ void JSNodeHTTPServerSocket::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(fn->functionToCallOnClose);
     visitor.append(fn->functionToCallOnDrain);
     visitor.append(fn->functionToCallOnData);
+    visitor.append(fn->functionToCallOnRawData);
     visitor.append(fn->m_remoteAddress);
     visitor.append(fn->m_localAddress);
     visitor.append(fn->m_duplex);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -651,9 +651,6 @@ void JSNodeHTTPServerSocket::onData(const char* data, int length, bool last)
 
 void JSNodeHTTPServerSocket::onRawData(const char* data, int length)
 {
-    // Called for every TCP payload on a node:http connection before HTTP
-    // parsing. When no JS 'data' listener is attached the callback slot is
-    // null and this is the only work done.
     if (!functionToCallOnRawData) {
         return;
     }

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -649,15 +649,15 @@ void JSNodeHTTPServerSocket::onData(const char* data, int length, bool last)
     }
 }
 
-void JSNodeHTTPServerSocket::onRawData(const char* data, int length)
+bool JSNodeHTTPServerSocket::onRawData(const char* data, int length)
 {
     if (!functionToCallOnRawData) {
-        return;
+        return false;
     }
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(this->globalObject());
     WebCore::ScriptExecutionContext* scriptExecutionContext = globalObject->scriptExecutionContext();
     if (!scriptExecutionContext) {
-        return;
+        return false;
     }
 
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
@@ -666,7 +666,7 @@ void JSNodeHTTPServerSocket::onRawData(const char* data, int length)
     if (auto* exception = scope.exception()) {
         (void)scope.tryClearException();
         globalObject->reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        return;
+        return false;
     }
     gcProtect(chunk);
     scriptExecutionContext->postTask([self = this, chunk = chunk](ScriptExecutionContext& context) {
@@ -694,6 +694,7 @@ void JSNodeHTTPServerSocket::onRawData(const char* data, int length)
             }
         }
     });
+    return true;
 }
 
 JSC::Structure* JSNodeHTTPServerSocket::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -128,6 +128,7 @@ public:
     mutable JSC::WriteBarrier<JSC::JSObject> functionToCallOnClose;
     mutable JSC::WriteBarrier<JSC::JSObject> functionToCallOnDrain;
     mutable JSC::WriteBarrier<JSC::JSObject> functionToCallOnData;
+    mutable JSC::WriteBarrier<JSC::JSObject> functionToCallOnRawData;
     mutable JSC::WriteBarrier<WebCore::JSNodeHTTPResponse> currentResponseObject;
     mutable JSC::WriteBarrier<JSC::JSObject> m_remoteAddress;
     mutable JSC::WriteBarrier<JSC::JSObject> m_localAddress;
@@ -160,6 +161,7 @@ public:
     void onClose();
     void onDrain();
     void onData(const char* data, int length, bool last);
+    void onRawData(const char* data, int length);
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
     void finishCreation(JSC::VM& vm);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -161,7 +161,7 @@ public:
     void onClose();
     void onDrain();
     void onData(const char* data, int length, bool last);
-    void onRawData(const char* data, int length);
+    bool onRawData(const char* data, int length);
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
     void finishCreation(JSC::VM& vm);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -27,6 +27,8 @@ JSC_DECLARE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterOnClose);
 JSC_DECLARE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterOnDrain);
 JSC_DECLARE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterOnData);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterOnData);
+JSC_DECLARE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterOnRawData);
+JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterOnRawData);
 JSC_DECLARE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterBytesWritten);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocketClose);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocketWrite);
@@ -57,6 +59,7 @@ static const JSC::HashTableValue JSNodeHTTPServerSocketPrototypeTableValues[] = 
     { "onclose"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterOnClose, jsNodeHttpServerSocketSetterOnClose } },
     { "ondrain"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterOnDrain, jsNodeHttpServerSocketSetterOnDrain } },
     { "ondata"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterOnData, jsNodeHttpServerSocketSetterOnData } },
+    { "onrawdata"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterOnRawData, jsNodeHttpServerSocketSetterOnRawData } },
     { "bytesWritten"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterBytesWritten, noOpSetter } },
     { "closed"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterClosed, noOpSetter } },
     { "response"_s, static_cast<unsigned>(JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::ReadOnly), JSC::NoIntrinsic, { JSC::HashTableValue::GetterSetterType, jsNodeHttpServerSocketGetterResponse, noOpSetter } },
@@ -466,6 +469,44 @@ JSC_DEFINE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterOnData, (JSC::JSGlobalObjec
     }
 
     thisObject->functionToCallOnData.set(vm, thisObject, value.getObject());
+    return true;
+}
+
+JSC_DEFINE_CUSTOM_GETTER(jsNodeHttpServerSocketGetterOnRawData, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName))
+{
+    auto* thisObject = dynamicDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        return JSValue::encode(JSC::jsUndefined());
+    }
+
+    if (thisObject->functionToCallOnRawData) {
+        return JSValue::encode(thisObject->functionToCallOnRawData.get());
+    }
+
+    return JSValue::encode(JSC::jsUndefined());
+}
+
+JSC_DEFINE_CUSTOM_SETTER(jsNodeHttpServerSocketSetterOnRawData, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = dynamicDowncast<JSNodeHTTPServerSocket>(JSC::JSValue::decode(thisValue));
+    if (!thisObject) [[unlikely]] {
+        return false;
+    }
+    JSValue value = JSC::JSValue::decode(encodedValue);
+
+    if (value.isUndefined() || value.isNull()) {
+        thisObject->functionToCallOnRawData.clear();
+        return true;
+    }
+
+    if (!value.isCallable()) {
+        return false;
+    }
+
+    thisObject->functionToCallOnRawData.set(vm, thisObject, value.getObject());
     return true;
 }
 

--- a/test/js/node/http/node-http-connection-socket-data.test.ts
+++ b/test/js/node/http/node-http-connection-socket-data.test.ts
@@ -58,27 +58,30 @@ test("http.Server 'connection' socket 'data' covers the body and every keep-aliv
   const { port } = server.address() as AddressInfo;
 
   const client = connect(port);
-  await once(client, "connect");
-  let replies = "";
-  client.on("data", d => (replies += d.toString("latin1")));
+  try {
+    await once(client, "connect");
+    let replies = "";
+    client.on("data", d => (replies += d.toString("latin1")));
 
-  // Two body-bearing requests over one keep-alive connection; the second is
-  // chunked so the raw bytes include the chunk framing, like Node.
-  client.write("POST /one HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nHELLO");
-  while ((replies.match(/HTTP\/1\.1 200/g) ?? []).length < 1) await once(client, "data");
-  client.write("POST /two HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nWORLD\r\n0\r\n\r\n");
-  while ((replies.match(/HTTP\/1\.1 200/g) ?? []).length < 2) await once(client, "data");
-  client.end();
-  await once(client, "close");
+    // Two body-bearing requests over one keep-alive connection; the second is
+    // chunked so the raw bytes include the chunk framing, like Node.
+    client.write("POST /one HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nHELLO");
+    while ((replies.match(/HTTP\/1\.1 200/g) ?? []).length < 1) await once(client, "data");
+    client.write("POST /two HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nWORLD\r\n0\r\n\r\n");
+    while ((replies.match(/HTTP\/1\.1 200/g) ?? []).length < 2) await once(client, "data");
+    client.end();
+    await once(client, "close");
 
-  const raw = Buffer.concat(received).toString("latin1");
-  expect(raw).toContain("POST /one HTTP/1.1\r\n");
-  expect(raw).toContain("\r\n\r\nHELLO");
-  expect(raw).toContain("POST /two HTTP/1.1\r\n");
-  expect(raw).toContain("5\r\nWORLD\r\n0\r\n\r\n");
-
-  server.closeAllConnections();
-  server.close();
+    const raw = Buffer.concat(received).toString("latin1");
+    expect(raw).toContain("POST /one HTTP/1.1\r\n");
+    expect(raw).toContain("\r\n\r\nHELLO");
+    expect(raw).toContain("POST /two HTTP/1.1\r\n");
+    expect(raw).toContain("5\r\nWORLD\r\n0\r\n\r\n");
+  } finally {
+    client.destroy();
+    server.closeAllConnections();
+    server.close();
+  }
 });
 
 test("http.Server 'connection' socket 'readable' + read() yields the raw request bytes", async () => {
@@ -126,18 +129,21 @@ test("https.Server 'connection' socket 'data' carries the decrypted request byte
   const { port } = server.address() as AddressInfo;
 
   const client = tlsConnect({ port, rejectUnauthorized: false });
-  await once(client, "secureConnect");
-  client.write("GET /tls-path HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
-  let reply = "";
-  client.on("data", d => (reply += d.toString("latin1")));
-  await once(client, "close");
+  try {
+    await once(client, "secureConnect");
+    client.write("GET /tls-path HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    let reply = "";
+    client.on("data", d => (reply += d.toString("latin1")));
+    await once(client, "close");
 
-  const chunk = await firstData;
-  expect(chunk.toString("latin1").startsWith("GET /tls-path HTTP/1.1\r\n")).toBe(true);
-  expect(reply).toContain("HTTP/1.1 200");
-
-  server.closeAllConnections();
-  server.close();
+    const chunk = await firstData;
+    expect(chunk.toString("latin1").startsWith("GET /tls-path HTTP/1.1\r\n")).toBe(true);
+    expect(reply).toContain("HTTP/1.1 200");
+  } finally {
+    client.destroy();
+    server.closeAllConnections();
+    server.close();
+  }
 });
 
 // A 'data' listener added later (inside the 'request' handler) arms via the
@@ -159,18 +165,21 @@ test("req.socket 'data' listener added inside the request handler sees subsequen
   const { port } = server.address() as AddressInfo;
 
   const client = connect(port);
-  await once(client, "connect");
-  client.on("data", () => {});
-  client.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n");
-  await once(client, "data");
-  client.write("GET /second HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
-  await done;
-  client.end();
-  await once(client, "close");
+  try {
+    await once(client, "connect");
+    client.on("data", () => {});
+    client.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n");
+    await once(client, "data");
+    client.write("GET /second HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+    await done;
+    client.end();
+    await once(client, "close");
 
-  const raw = Buffer.concat(received).toString("latin1");
-  expect(raw).toContain("GET /second HTTP/1.1\r\n");
-
-  server.closeAllConnections();
-  server.close();
+    const raw = Buffer.concat(received).toString("latin1");
+    expect(raw).toContain("GET /second HTTP/1.1\r\n");
+  } finally {
+    client.destroy();
+    server.closeAllConnections();
+    server.close();
+  }
 });

--- a/test/js/node/http/node-http-connection-socket-data.test.ts
+++ b/test/js/node/http/node-http-connection-socket-data.test.ts
@@ -115,14 +115,15 @@ test("http.Server 'connection' socket 'readable' + read() yields the raw request
   }
 });
 
-test("https.Server 'connection' socket 'data' carries the decrypted request bytes", async () => {
+test("https.Server 'secureConnection' socket 'data' carries the decrypted request bytes", async () => {
   let resolveData!: (b: Buffer) => void;
   const firstData = new Promise<Buffer>(r => (resolveData = r));
 
   const server = createHttpsServer({ key: tlsCerts.key, cert: tlsCerts.cert }, (req, res) => {
     res.end("ok");
   });
-  server.on("connection", socket => {
+  // Node's https 'connection' is the raw net.Socket; the TLSSocket is 'secureConnection'.
+  server.on("secureConnection", socket => {
     socket.on("data", chunk => resolveData(chunk));
   });
   await once(server.listen(0), "listening");
@@ -203,15 +204,13 @@ test("http.Server 'connection' socket 'data' sees the CONNECT request line once"
     await once(client, "connect");
     client.write("CONNECT x:1 HTTP/1.1\r\nHost: x\r\n\r\nEXTRA");
     await once(client, "data");
-    client.write("HELLO");
     const deadline = Date.now() + 1000;
-    while (!Buffer.concat(received).includes("HELLO") && Date.now() < deadline) {
+    while (!Buffer.concat(received).includes("EXTRA") && Date.now() < deadline) {
       await new Promise(r => setImmediate(r));
     }
     const raw = Buffer.concat(received).toString("latin1");
     expect(raw).toContain("CONNECT x:1 HTTP/1.1\r\n");
     expect((raw.match(/EXTRA/g) ?? []).length).toBe(1);
-    expect((raw.match(/HELLO/g) ?? []).length).toBe(1);
   } finally {
     client.destroy();
     server.closeAllConnections();

--- a/test/js/node/http/node-http-connection-socket-data.test.ts
+++ b/test/js/node/http/node-http-connection-socket-data.test.ts
@@ -217,3 +217,39 @@ test("http.Server 'connection' socket 'data' sees the CONNECT request line once"
     server.close();
   }
 });
+
+// Upgrade-with-body: the body-fin and the first tunnel bytes can share one TCP
+// read. The raw tap delivers that whole read; the tunnel path must not also
+// deliver the tail.
+test("http.Server 'connection' socket 'data' does not double-deliver an Upgrade tunnel tail", async () => {
+  const received: Buffer[] = [];
+  const server = createServer();
+  server.on("connection", socket => {
+    socket.on("data", chunk => received.push(chunk));
+  });
+  server.on("upgrade", (req, sock) => {
+    req.resume();
+    sock.write("HTTP/1.1 101\r\n\r\n");
+  });
+  await once(server.listen(0), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = connect(port);
+  try {
+    await once(client, "connect");
+    client.write("POST / HTTP/1.1\r\nHost: x\r\nUpgrade: foo\r\nConnection: Upgrade\r\nContent-Length: 5\r\n\r\n");
+    await once(client, "data");
+    client.write("HELLOTUNNELDATA");
+    const deadline = Date.now() + 1000;
+    while (!Buffer.concat(received).includes("TUNNELDATA") && Date.now() < deadline) {
+      await new Promise(r => setImmediate(r));
+    }
+    const raw = Buffer.concat(received).toString("latin1");
+    expect(raw).toContain("POST / HTTP/1.1\r\n");
+    expect((raw.match(/TUNNELDATA/g) ?? []).length).toBe(1);
+  } finally {
+    client.destroy();
+    server.closeAllConnections();
+    server.close();
+  }
+});

--- a/test/js/node/http/node-http-connection-socket-data.test.ts
+++ b/test/js/node/http/node-http-connection-socket-data.test.ts
@@ -183,3 +183,38 @@ test("req.socket 'data' listener added inside the request handler sees subsequen
     server.close();
   }
 });
+
+// The native tap fires for the packet that carries the CONNECT line; tunnel
+// bytes route through the tunnel ondata path. No byte appears twice.
+test("http.Server 'connection' socket 'data' sees the CONNECT request line once", async () => {
+  const received: Buffer[] = [];
+  const server = createServer();
+  server.on("connection", socket => {
+    socket.on("data", chunk => received.push(chunk));
+  });
+  server.on("connect", (req, sock) => {
+    sock.write("HTTP/1.1 200 OK\r\n\r\n");
+  });
+  await once(server.listen(0), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = connect(port);
+  try {
+    await once(client, "connect");
+    client.write("CONNECT x:1 HTTP/1.1\r\nHost: x\r\n\r\nEXTRA");
+    await once(client, "data");
+    client.write("HELLO");
+    const deadline = Date.now() + 1000;
+    while (!Buffer.concat(received).includes("HELLO") && Date.now() < deadline) {
+      await new Promise(r => setImmediate(r));
+    }
+    const raw = Buffer.concat(received).toString("latin1");
+    expect(raw).toContain("CONNECT x:1 HTTP/1.1\r\n");
+    expect((raw.match(/EXTRA/g) ?? []).length).toBe(1);
+    expect((raw.match(/HELLO/g) ?? []).length).toBe(1);
+  } finally {
+    client.destroy();
+    server.closeAllConnections();
+    server.close();
+  }
+});

--- a/test/js/node/http/node-http-connection-socket-data.test.ts
+++ b/test/js/node/http/node-http-connection-socket-data.test.ts
@@ -1,0 +1,176 @@
+import { test, expect } from "bun:test";
+import { createServer, request } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import { once } from "node:events";
+import { connect } from "node:net";
+import { connect as tlsConnect } from "node:tls";
+import type { AddressInfo } from "node:net";
+import { tls as tlsCerts } from "harness";
+
+// https://github.com/oven-sh/bun/issues/11924
+// Node's http.Server feeds its parser from the connection socket's 'data'
+// event, so a user 'data' listener on that socket sees the raw request bytes.
+test("http.Server 'connection' socket emits 'data' with the raw request bytes", async () => {
+  let resolveData!: (b: Buffer) => void;
+  const firstData = new Promise<Buffer>(r => (resolveData = r));
+  let bytesReadAtData = -1;
+
+  const server = createServer((req, res) => {
+    res.end("ok");
+  });
+  server.on("connection", socket => {
+    socket.on("data", chunk => {
+      bytesReadAtData = socket.bytesRead;
+      resolveData(chunk);
+    });
+  });
+  await once(server.listen(0), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    const req = request({ port, path: "/hello-path", headers: { "x-probe": "yes" } });
+    req.end();
+    const [res] = await once(req, "response");
+    res.resume();
+    await once(res, "end");
+
+    const chunk = await firstData;
+    const text = chunk.toString("latin1");
+    expect(text.startsWith("GET /hello-path HTTP/1.1\r\n")).toBe(true);
+    expect(text).toContain("\r\nx-probe: yes\r\n");
+    expect(bytesReadAtData).toBe(chunk.length);
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+test("http.Server 'connection' socket 'data' covers the body and every keep-alive request", async () => {
+  const received: Buffer[] = [];
+  const server = createServer((req, res) => {
+    req.resume();
+    req.on("end", () => res.end("ok"));
+  });
+  server.on("connection", socket => {
+    socket.on("data", chunk => received.push(chunk));
+  });
+  await once(server.listen(0), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = connect(port);
+  await once(client, "connect");
+  let replies = "";
+  client.on("data", d => (replies += d.toString("latin1")));
+
+  // Two body-bearing requests over one keep-alive connection; the second is
+  // chunked so the raw bytes include the chunk framing, like Node.
+  client.write("POST /one HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nHELLO");
+  while ((replies.match(/HTTP\/1\.1 200/g) ?? []).length < 1) await once(client, "data");
+  client.write("POST /two HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nWORLD\r\n0\r\n\r\n");
+  while ((replies.match(/HTTP\/1\.1 200/g) ?? []).length < 2) await once(client, "data");
+  client.end();
+  await once(client, "close");
+
+  const raw = Buffer.concat(received).toString("latin1");
+  expect(raw).toContain("POST /one HTTP/1.1\r\n");
+  expect(raw).toContain("\r\n\r\nHELLO");
+  expect(raw).toContain("POST /two HTTP/1.1\r\n");
+  expect(raw).toContain("5\r\nWORLD\r\n0\r\n\r\n");
+
+  server.closeAllConnections();
+  server.close();
+});
+
+test("http.Server 'connection' socket 'readable' + read() yields the raw request bytes", async () => {
+  let resolveData!: (b: Buffer) => void;
+  const firstData = new Promise<Buffer>(r => (resolveData = r));
+
+  const server = createServer((req, res) => {
+    res.end("ok");
+  });
+  server.on("connection", socket => {
+    socket.on("readable", () => {
+      const chunk = socket.read();
+      if (chunk) resolveData(chunk);
+    });
+  });
+  await once(server.listen(0), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    const req = request({ port, path: "/via-readable" });
+    req.end();
+    const [res] = await once(req, "response");
+    res.resume();
+    await once(res, "end");
+
+    const chunk = await firstData;
+    expect(chunk.toString("latin1").startsWith("GET /via-readable HTTP/1.1\r\n")).toBe(true);
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+test("https.Server 'connection' socket 'data' carries the decrypted request bytes", async () => {
+  let resolveData!: (b: Buffer) => void;
+  const firstData = new Promise<Buffer>(r => (resolveData = r));
+
+  const server = createHttpsServer({ key: tlsCerts.key, cert: tlsCerts.cert }, (req, res) => {
+    res.end("ok");
+  });
+  server.on("connection", socket => {
+    socket.on("data", chunk => resolveData(chunk));
+  });
+  await once(server.listen(0), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = tlsConnect({ port, rejectUnauthorized: false });
+  await once(client, "secureConnect");
+  client.write("GET /tls-path HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  let reply = "";
+  client.on("data", d => (reply += d.toString("latin1")));
+  await once(client, "close");
+
+  const chunk = await firstData;
+  expect(chunk.toString("latin1").startsWith("GET /tls-path HTTP/1.1\r\n")).toBe(true);
+  expect(reply).toContain("HTTP/1.1 200");
+
+  server.closeAllConnections();
+  server.close();
+});
+
+// A 'data' listener added later (inside the 'request' handler) arms via the
+// Readable's _read(); it sees bytes that arrive after it was added.
+test("req.socket 'data' listener added inside the request handler sees subsequent raw bytes", async () => {
+  const received: Buffer[] = [];
+  const { promise: done, resolve: onDone } = Promise.withResolvers<void>();
+
+  const server = createServer((req, res) => {
+    if (req.url === "/first") {
+      req.socket.on("data", chunk => received.push(chunk));
+      res.end("ok");
+    } else {
+      res.end("ok");
+      onDone();
+    }
+  });
+  await once(server.listen(0), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const client = connect(port);
+  await once(client, "connect");
+  client.on("data", () => {});
+  client.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n");
+  await once(client, "data");
+  client.write("GET /second HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n");
+  await done;
+  client.end();
+  await once(client, "close");
+
+  const raw = Buffer.concat(received).toString("latin1");
+  expect(raw).toContain("GET /second HTTP/1.1\r\n");
+
+  server.closeAllConnections();
+  server.close();
+});

--- a/test/js/node/http/node-http-connection-socket-data.test.ts
+++ b/test/js/node/http/node-http-connection-socket-data.test.ts
@@ -1,11 +1,11 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
+import { tls as tlsCerts } from "harness";
+import { once } from "node:events";
 import { createServer, request } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
-import { once } from "node:events";
+import type { AddressInfo } from "node:net";
 import { connect } from "node:net";
 import { connect as tlsConnect } from "node:tls";
-import type { AddressInfo } from "node:net";
-import { tls as tlsCerts } from "harness";
 
 // https://github.com/oven-sh/bun/issues/11924
 // Node's http.Server feeds its parser from the connection socket's 'data'


### PR DESCRIPTION
A `node:http` server's `'connection'` event hands over a socket whose `'data'` event never fires for normal requests. In Node that socket is the `net.Socket` the parser reads from, so every `'data'` listener (the parser's included) receives the raw HTTP request bytes.

```js
const http = require('http');
const server = http.createServer((req, res) => res.end('ok'));
server.on('connection', socket => {
  socket.on('data', d => console.log('data:', d.length));   // node: fires with raw request bytes
});                                                         // bun: never fires
server.listen(0, () => fetch(`http://127.0.0.1:${server.address().port}/`));
```

## Cause

Bun's node:http server parses HTTP natively in uWS: `HttpContext::onData` consumes the TCP payload and dispatches the parsed request straight to `onNodeHTTPRequest`. The JS `NodeHTTPServerSocket` wrapper is a Duplex whose readable side is only fed in CONNECT/Upgrade tunnel mode (via `handle.ondata`), so for an ordinary request nothing ever pushes into it and `'data'`/`'readable'` never fire.

## Fix

Add a raw-bytes tap in `HttpContext::onData` that forwards each TCP payload, before HTTP parsing (and before the parser-stopped gate, so a custom `'clientError'` handler that keeps the socket open keeps seeing bytes), to a new `onrawdata` callback slot on `JSNodeHTTPServerSocket`. The slot is only populated when the JS socket actually has a `'data'`/`'readable'` listener (checked right after `emit('connection')` and on each `_read()`); when it is null the native tap reduces to a single null-check, so the common path (no user listener) pays no Buffer allocation or JS call. The JS side pushes the chunk into the Duplex, so `'data'`/`'readable'` fire with the raw request bytes, and `socket.bytesRead` advances.

Once armed the tap stays armed; the native `!isConnectRequest` gate (set synchronously by `upgradeToTunnel()`) stops it for tunnel payloads, and `#resumeSocket()` skips its parsed-body socket push when the tap owns the readable side.

## Why this is the right fix

In Node, `connectionListenerInternal` attaches `socketOnData` as a `'data'` listener on the connection's `net.Socket`; the parser is fed from that event, so a second user listener sees the same bytes. Replicating that exactly would mean round-tripping every HTTP byte through JS, defeating the native parser. Tapping the raw payload only when a user actually subscribes preserves the native fast path while matching the observable contract: a `'data'` listener on the `'connection'` socket receives the raw request bytes (request line, headers, body framing and all), same as Node.

## Verification

New `test/js/node/http/node-http-connection-socket-data.test.ts` (all six fail on main, pass with this change, and the first five match Node v26 exactly):

- `'connection'` socket `'data'` carries the full request line + headers and updates `bytesRead`
- two keep-alive body-bearing requests (Content-Length and chunked) both reach the listener with framing intact
- `'readable'` + `read()` yields the same bytes
- `https.Server` `'secureConnection'` socket delivers the decrypted request bytes (Node's https `'connection'` hands over the raw `net.Socket`, whose `'data'` never fires there; the TLSSocket is on `'secureConnection'`)
- a `req.socket.on('data')` added inside the request handler sees subsequent raw bytes
- a CONNECT request's line + head bytes reach the listener once (no double-delivery)

No regressions in `node-http.test.ts`, the CONNECT/Upgrade suites, `node-http-req-socket-pause`, `node-http-backpressure`, `node-http-transfer-encoding`, `node-http-server-timeouts`, or Node's upstream `test-http-connect*` / `test-http-upgrade*` / `test-http-server-unconsume*` tests.

### Known differences from Node

- The tap is a passive observer of bytes the native parser is consuming anyway, so `socket.pause()` on the `'connection'` socket does not throttle HTTP parsing (Node pauses the fd, which stops its parser too). The Readable buffer grows while paused, bounded by what the connection already holds.
- The tap does not `push(null)` on peer FIN for a non-tunnel connection; `'close'` fires as before.

Fixes #11924.
