### PR TITLE
bundler: register every top-level symbol before renaming nested scopes

### DIFF
--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -280,6 +280,7 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
 
     let mut sorted: Vec<u32> = Vec::new();
 
+    // Pass 1 of 2 (#14588, #30269): register every top-level symbol in `r.root` before any nested scope is renamed.
     for &source_index in files_in_order {
         let wrap = all_flags[source_index as usize].wrap;
         // Need `&mut [Part]` for `add_top_level_declared_symbols`.
@@ -358,16 +359,6 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
                         }
                     }
                 }
-                // Reshaped for borrowck — `&mut r.root` while `r` is the
-                // `&mut self` receiver. Take a raw pointer; `assign_names_*` does
-                // not touch `self.root` through `self`.
-                let root: *mut renamer::NumberScope = core::ptr::addr_of_mut!(r.root);
-                r.assign_names_recursive_with_number_scope(
-                    root,
-                    &all_module_scopes[source_index as usize],
-                    source_index,
-                    &mut sorted,
-                );
                 continue;
             }
 
@@ -399,19 +390,43 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
             }
 
             r.add_top_level_declared_symbols(&mut part.declared_symbols);
-            // `Part.scopes: StoreSlice<*mut Scope>` — safe `Deref` to `&[*mut Scope]`.
-            for scope in part.scopes.iter() {
+        }
+    }
+
+    // Pass 2: walk nested scopes now that `r.root` knows every top-level name.
+    for &source_index in files_in_order {
+        match all_flags[source_index as usize].wrap {
+            WrapKind::Cjs => {
                 let root: *mut renamer::NumberScope = core::ptr::addr_of_mut!(r.root);
-                // SAFETY: each `*mut Scope` is a valid arena-allocated scope.
                 r.assign_names_recursive_with_number_scope(
                     root,
-                    unsafe { &**scope },
+                    &all_module_scopes[source_index as usize],
                     source_index,
                     &mut sorted,
                 );
             }
-            r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
+            WrapKind::Esm | WrapKind::None => {
+                let parts: &[Part] = all_parts[source_index as usize].as_slice();
+                let parts_live = &c.graph.parts_live[source_index as usize];
+                for (part_index, part) in parts.iter().enumerate() {
+                    if !parts_live.is_set(part_index) {
+                        continue;
+                    }
+                    // `Part.scopes: StoreSlice<*mut Scope>` — safe `Deref` to `&[*mut Scope]`.
+                    for scope in part.scopes.iter() {
+                        let root: *mut renamer::NumberScope = core::ptr::addr_of_mut!(r.root);
+                        // SAFETY: each `*mut Scope` is a valid arena-allocated scope.
+                        r.assign_names_recursive_with_number_scope(
+                            root,
+                            unsafe { &**scope },
+                            source_index,
+                            &mut sorted,
+                        );
+                    }
+                }
+            }
         }
+        r.number_scope_pool.hive.used = bun_collections::hive_array::HiveBitSet::init_empty();
     }
 
     Ok(ChunkRenamer::Number(r))

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2632,6 +2632,113 @@ describe("bundler", () => {
       stdout: "",
     },
   });
+  // https://github.com/oven-sh/bun/issues/14588
+  // A function parameter must not be collision-renamed into the name of a
+  // hoisted top-level function that is declared later in the same file.
+  itBundled("identifiers/NestedParamDoesNotShadowLaterHoistedFunction", {
+    files: {
+      "/dep.js": `
+        export var e = "outer_e";
+        export var e2 = "outer_e2";
+      `,
+      "/entry.js": `
+        import { e as _e, e2 as _e2 } from "./dep.js";
+
+        function ZI(t, e, n) {
+          return e3(t, e, n);
+        }
+
+        function e3(a, b, c) {
+          return "range:" + b;
+        }
+
+        console.log(ZI(1, 2, 3), _e, _e2);
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    minifyIdentifiers: false,
+    run: { stdout: "range:2 outer_e outer_e2" },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("function ZI(t, e3, n)");
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/14588
+  // Same bug for a module wrapped in `__esm` via dynamic `import()`: the
+  // module's own top-level declarations are hoisted outside the closure, so a
+  // parameter in that module must not be renamed into one of them.
+  itBundled("identifiers/NestedParamDoesNotShadowLaterHoistedFunctionInEsmWrap", {
+    files: {
+      "/names.js": `
+        export var e = "E";
+        export var e2 = "E2";
+      `,
+      "/lib.js": `
+        var sideEffect = Date.now();
+        export function ZI(t, e, n) {
+          return e3(t, e, n);
+        }
+        function e3(a, b, c) {
+          return "range:" + b;
+        }
+      `,
+      "/entry.js": `
+        import { e as _e, e2 as _e2 } from "./names.js";
+        const mod = await import("./lib.js");
+        console.log(mod.ZI(1, 2, 3), _e, _e2);
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    target: "bun",
+    minifyIdentifiers: false,
+    run: { stdout: "range:2 E E2" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("__esm");
+      expect(out).not.toMatch(/function ZI\(\w+, e3,/);
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/30269
+  // Same bug for a nested `let` binding instead of a function parameter.
+  itBundled("identifiers/NestedLocalDoesNotShadowLaterHoistedFunction", {
+    files: {
+      "/conflict.js": `
+        export function r() { return "top-level r"; }
+      `,
+      "/module.js": `
+        class Expression {}
+
+        export function run() {
+          const result = typecheck({ left: new Expression(), op: {}, right: {} });
+          if (result !== true) throw new Error("expected true, got " + result);
+          return result;
+        }
+
+        function typecheck(node) {
+          let r, t, c;
+          block: {
+            r = node.left;
+            t = node.op;
+            c = node.right;
+            break block;
+          }
+          return r2().bo4(r, t, c).a();
+        }
+
+        function r2() {
+          return { bo4() { return { a() { return true; } }; } };
+        }
+      `,
+      "/entry.js": `
+        import * as conflict from "./conflict.js";
+        import { run } from "./module.js";
+        conflict.r();
+        console.log("ok:" + run());
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    minifyIdentifiers: false,
+    run: { stdout: "ok:true" },
+  });
   itBundled("edgecase/MacroProtoKeyIsOwnProperty", {
     files: {
       "/entry.ts": /* js */ `


### PR DESCRIPTION
## What this fixes

When bundling without minification, the `NumberRenamer` can rename a nested binding (function parameter or `let`/`var`) into the name of a top-level binding that is declared later in the same chunk, shadowing it in the output and breaking the bundle at runtime.

## Reproduction

```js
// dep.js
export var e = 1;
export var e2 = 2;

// entry.js
import { e as _e, e2 as _e2 } from "./dep.js";
function ZI(t, e, n) { return e3(t, e, n); }  // uses hoisted e3
function e3(a, b, c) { return "range:" + b; } // declared after ZI
console.log(ZI(1, 2, 3), _e, _e2);
```

```
$ bun build entry.js --target bun
function ZI(t, e3, n) {
  return e3(t, e3, n);  // e3 is now the parameter, not the function
}
```

Running the bundle throws `TypeError: e3 is not a function`. The same happens for a module wrapped in `__esm` via dynamic `import()` (the #14588 `@react-email/tailwind` case): its top-level declarations are hoisted outside the closure, so a parameter inside that module can be renamed into one of its own hoisted functions.

## Root cause

`rename_symbols_in_chunk` iterated parts sequentially and, for each part, registered that part's top-level symbols in `r.root` and then immediately walked that part's nested scopes. `NumberScope::find_unused_name` checks only the current scope and its parent chain, so a nested scope in part N had no knowledge of top-level names declared in any later part M > N. Function hoisting makes this ordering common in real code (and in minified dependencies, which is where #14588 hit it).

## Fix

Split the single interleaved loop into two passes over `files_in_order`:

1. Register every top-level symbol in the chunk in `r.root`.
2. Walk nested scopes; `r.root` is now fully populated so `find_unused_name` sees every potential top-level collision.

This matches esbuild's structure. It is also the same fix as #30272, which was closed unmerged when the Zig source it edited was removed during the Rust migration; this PR reapplies it to the Rust implementation.

## Verification

Three `itBundled` tests in `bundler_edgecase.test.ts` covering the parameter case (#14588), the `__esm`-wrapped dynamic import case (#14588, the `@react-email/tailwind` shape), and the `let` case (#30269). All three fail on `main` with the shadowing TypeError and pass with the fix. Ran `bundler_edgecase`, `bundler_cjs`, `bundler_naming`, `bundler_regressions`, `esbuild/default`, `esbuild/splitting`, and `bun-build-api` (snapshots) with no regressions.

Fixes #14588
Fixes #30269

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->