### PR TITLE
node:http: don't leave the server socket Duplex corked across kept-alive requests

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1388,10 +1388,7 @@ function detachSocketListenersForHandoff(socket) {
   socket.removeListener("error", socketOnError);
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
-  // Node's OutgoingMessage.end() fully uncorks the connection; a response
-  // on this kept-alive socket may have corked the Duplex (res.cork() forwards
-  // to the socket) without ever reaching the standalone OutgoingMessage end
-  // path, so bring it back to zero before the raw socket is handed over.
+  // Hand the raw socket over uncorked, like Node.
   const writableState = socket._writableState;
   if (writableState && writableState.corked) {
     writableState.corked = 1;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1388,12 +1388,6 @@ function detachSocketListenersForHandoff(socket) {
   socket.removeListener("error", socketOnError);
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
-  // Hand the raw socket over uncorked, like Node.
-  const writableState = socket._writableState;
-  if (writableState && writableState.corked) {
-    writableState.corked = 1;
-    socket.uncork();
-  }
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");
@@ -3222,14 +3216,14 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
     }
   }
   this._header = " ";
-  const req = this.req;
-  const reqSocket = req?.socket;
-  const reqSocketWritableState = reqSocket?._writableState;
-  if (reqSocketWritableState && reqSocketWritableState.corked) {
-    // Like Node's OutgoingMessage.prototype.end: fully uncork the connection.
-    reqSocketWritableState.corked = 1;
-    reqSocket.uncork();
+  // Like Node's OutgoingMessage.prototype.end: fully uncork the connection.
+  const resSocket = this[fakeSocketSymbol];
+  const resSocketWritableState = resSocket?._writableState;
+  if (resSocketWritableState && resSocketWritableState.corked) {
+    resSocketWritableState.corked = 1;
+    resSocket.uncork();
   }
+  const req = this.req;
   if (!req._consuming && !req?._readableState?.resumeScheduled) {
     req._dump();
   }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3227,9 +3227,10 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   this._header = " ";
   const req = this.req;
   const reqSocket = req?.socket;
-  if (reqSocket && reqSocket._writableState?.corked) {
+  const reqSocketWritableState = reqSocket?._writableState;
+  if (reqSocketWritableState && reqSocketWritableState.corked) {
     // Like Node's OutgoingMessage.prototype.end: fully uncork the connection.
-    reqSocket._writableState.corked = 1;
+    reqSocketWritableState.corked = 1;
     reqSocket.uncork();
   }
   if (!req._consuming && !req?._readableState?.resumeScheduled) {

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1066,8 +1066,6 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           }
         }
 
-        socket.cork();
-
         if (isPipelined) {
           // Completion of a queued response is tracked through the pipeline
           // (advanceResponsePipeline) and its native handle, not this dispatch.
@@ -1390,6 +1388,15 @@ function detachSocketListenersForHandoff(socket) {
   socket.removeListener("error", socketOnError);
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
+  // Node's OutgoingMessage.end() fully uncorks the connection; a response
+  // on this kept-alive socket may have corked the Duplex (res.cork() forwards
+  // to the socket) without ever reaching the standalone OutgoingMessage end
+  // path, so bring it back to zero before the raw socket is handed over.
+  const writableState = socket._writableState;
+  if (writableState && writableState.corked) {
+    writableState.corked = 1;
+    socket.uncork();
+  }
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");
@@ -3219,6 +3226,12 @@ ServerResponse.prototype.end = function (chunk, encoding, callback) {
   }
   this._header = " ";
   const req = this.req;
+  const reqSocket = req?.socket;
+  if (reqSocket && reqSocket._writableState?.corked) {
+    // Like Node's OutgoingMessage.prototype.end: fully uncork the connection.
+    reqSocket._writableState.corked = 1;
+    reqSocket.uncork();
+  }
   if (!req._consuming && !req?._readableState?.resumeScheduled) {
     req._dump();
   }

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -783,6 +783,99 @@ describe("Should be compatible with node.js", () => {
   });
 });
 
+// A ServerResponse writes through the native handle, not the socket Duplex,
+// so a cork() left on the Duplex after a kept-alive request would make a
+// 'connect'/'upgrade' handler's socket.write() buffer forever. Covers the
+// proxy-chain / puppeteer-with-proxy failure in #12213.
+describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", () => {
+  async function runKeepAliveHandoff(method: "CONNECT" | "Upgrade", writeAsync: boolean) {
+    await using server = http.createServer((req, res) => {
+      res.end("body");
+    }) as http.Server & AsyncDisposable;
+    let corkedAtHandoff: number | undefined;
+    const handler = (req: http.IncomingMessage, socket: net.Socket) => {
+      corkedAtHandoff = socket.writableCorked;
+      const respond = () => {
+        socket.write(
+          method === "CONNECT"
+            ? "HTTP/1.1 200 Connection Established\r\n\r\n"
+            : "HTTP/1.1 101 Switching Protocols\r\nUpgrade: raw\r\nConnection: Upgrade\r\n\r\n",
+        );
+        socket.end("tunnel-data");
+      };
+      if (writeAsync) setImmediate(respond);
+      else respond();
+    };
+    server.on(method === "CONNECT" ? "connect" : "upgrade", handler);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const received = await new Promise<string>((resolve, reject) => {
+      const sock = net.connect({ port, host: "127.0.0.1" });
+      sock.on("error", reject);
+      let buf = "";
+      let phase = 0;
+      sock.on("connect", () => {
+        sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+      });
+      sock.on("data", d => {
+        buf += d.toString();
+        if (phase === 0 && buf.includes("body")) {
+          phase = 1;
+          buf = "";
+          sock.write(
+            method === "CONNECT"
+              ? "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n"
+              : "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: raw\r\nConnection: Upgrade\r\n\r\n",
+          );
+        }
+      });
+      sock.on("close", () => resolve(buf));
+    });
+
+    expect(corkedAtHandoff).toBe(0);
+    expect(received).toContain("tunnel-data");
+  }
+
+  for (const method of ["CONNECT", "Upgrade"] as const) {
+    for (const writeAsync of [false, true]) {
+      test(`${method}, ${writeAsync ? "async" : "sync"} write`, async () => {
+        await runKeepAliveHandoff(method, writeAsync);
+      });
+    }
+  }
+
+  // The dispatch path left the connection Duplex corked after every 'request'
+  // emit (proxy-chain hit this via CONNECT on a kept-alive socket above, but
+  // writing to req.socket directly after res.end() is the same leak).
+  test("req.socket is not corked across 'request' dispatches", async () => {
+    const seen: number[] = [];
+    await using server = http.createServer((req, res) => {
+      seen.push(req.socket.writableCorked);
+      res.cork();
+      res.end("body");
+      // Node's OutgoingMessage.end() fully uncorks the connection.
+      seen.push(req.socket.writableCorked);
+    }) as http.Server & AsyncDisposable;
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const sock = net.connect({ port, host: "127.0.0.1" });
+    await once(sock, "connect");
+    let buf = "";
+    sock.on("data", d => (buf += d.toString()));
+    for (let i = 0; i < 3; i++) {
+      sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+      while (buf.split("body").length - 1 < i + 1) await once(sock, "data");
+    }
+    sock.end();
+    await once(sock, "close");
+    expect(seen).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+});
+
 // Windows: after FIN on a CONNECT-tunnel socket, AFD's level-triggered
 // UV_DISCONNECT used to re-derive EOF and bounce the poll between 0 and
 // WRITABLE forever (pins the poll_cb allow_half_open arm).

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -880,17 +880,22 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
     await once(server, "listening");
     const { port } = server.address() as AddressInfo;
 
-    const sock = net.connect({ port, host: "127.0.0.1" });
-    await once(sock, "connect");
-    let buf = "";
-    sock.on("data", d => (buf += d.toString()));
-    const closed = once(sock, "close");
-    for (let i = 0; i < 3; i++) {
-      sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
-      while (!sock.readableEnded && buf.split("body").length - 1 < i + 1) await once(sock, "data");
-    }
-    sock.end();
-    await closed;
+    let bodies = 0;
+    await new Promise<void>((resolve, reject) => {
+      const sock = net.connect({ port, host: "127.0.0.1" });
+      sock.on("error", reject);
+      sock.on("close", () => (bodies === 3 ? resolve() : reject(new Error(`closed after ${bodies}/3 responses`))));
+      sock.on("connect", () => sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
+      let buf = "";
+      sock.on("data", d => {
+        buf += d.toString();
+        while (buf.includes("body")) {
+          buf = buf.slice(buf.indexOf("body") + 4);
+          if (++bodies < 3) sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+          else sock.end();
+        }
+      });
+    });
     expect(seen).toEqual([0, 0, 0, 0, 0, 0]);
   });
 });

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -884,12 +884,13 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
     await once(sock, "connect");
     let buf = "";
     sock.on("data", d => (buf += d.toString()));
+    const closed = once(sock, "close");
     for (let i = 0; i < 3; i++) {
       sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
-      while (buf.split("body").length - 1 < i + 1) await once(sock, "data");
+      while (!sock.readableEnded && buf.split("body").length - 1 < i + 1) await once(sock, "data");
     }
     sock.end();
-    await once(sock, "close");
+    await closed;
     expect(seen).toEqual([0, 0, 0, 0, 0, 0]);
   });
 });

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -793,6 +793,7 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
       res.end("body");
     }) as http.Server & AsyncDisposable;
     let corkedAtHandoff: number | undefined;
+    let writableLengthAfterWrite: number | undefined;
     const handler = (req: http.IncomingMessage, socket: net.Socket) => {
       corkedAtHandoff = socket.writableCorked;
       const respond = () => {
@@ -801,10 +802,15 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
             ? "HTTP/1.1 200 Connection Established\r\n\r\n"
             : "HTTP/1.1 101 Switching Protocols\r\nUpgrade: raw\r\nConnection: Upgrade\r\n\r\n",
         );
-        socket.end("tunnel-data");
+        // write() only (no end), matching an open proxy tunnel; Writable.end's
+        // force-uncork would flush the leaked cork and mask the regression.
+        socket.write("tunnel-data");
+        writableLengthAfterWrite = socket.writableLength;
       };
       if (writeAsync) setImmediate(respond);
       else respond();
+      // End once the client FINs so the received promise below never hangs.
+      socket.on("end", () => socket.end());
     };
     server.on(method === "CONNECT" ? "connect" : "upgrade", handler);
     server.listen(0, "127.0.0.1");
@@ -824,7 +830,7 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
         if (phase === 0 && buf.includes("body")) {
           phase = 1;
           buf = "";
-          sock.write(
+          sock.end(
             method === "CONNECT"
               ? "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n"
               : "GET / HTTP/1.1\r\nHost: x\r\nUpgrade: raw\r\nConnection: Upgrade\r\n\r\n",
@@ -834,8 +840,11 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
       sock.on("close", () => resolve(buf));
     });
 
-    expect(corkedAtHandoff).toBe(0);
-    expect(received).toContain("tunnel-data");
+    expect({ received, corkedAtHandoff, writableLengthAfterWrite }).toEqual({
+      received: expect.stringContaining("tunnel-data"),
+      corkedAtHandoff: 0,
+      writableLengthAfterWrite: 0,
+    });
   }
 
   for (const method of ["CONNECT", "Upgrade"] as const) {

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -796,6 +796,8 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
     let writableLengthAfterWrite: number | undefined;
     const handler = (req: http.IncomingMessage, socket: net.Socket) => {
       corkedAtHandoff = socket.writableCorked;
+      let clientEnded = false;
+      let responded = false;
       const respond = () => {
         socket.write(
           method === "CONNECT"
@@ -806,11 +808,18 @@ describe("CONNECT/Upgrade on a kept-alive connection can write to the socket", (
         // force-uncork would flush the leaked cork and mask the regression.
         socket.write("tunnel-data");
         writableLengthAfterWrite = socket.writableLength;
+        responded = true;
+        if (clientEnded) socket.end();
       };
+      // End once the client FINs so the received promise below never hangs.
+      // The client's FIN can arrive before a setImmediate-deferred respond() on
+      // Windows, so end() is deferred until both have happened.
+      socket.on("end", () => {
+        clientEnded = true;
+        if (responded) socket.end();
+      });
       if (writeAsync) setImmediate(respond);
       else respond();
-      // End once the client FINs so the received promise below never hangs.
-      socket.on("end", () => socket.end());
     };
     server.on(method === "CONNECT" ? "connect" : "upgrade", handler);
     server.listen(0, "127.0.0.1");


### PR DESCRIPTION
## What

The `node:http` server dispatch path corked the connection's socket Duplex after every `'request'` emit and never uncorked it. Bun's `ServerResponse` writes through the native response handle rather than the Duplex, so the cork was a no-op for response bytes but left `socket._writableState.corked` incrementing on every kept-alive request. When a `CONNECT` or `Upgrade` later arrived on the same connection and the handler wrote to the raw socket, those writes sat in the Writable's cork buffer and never reached the wire until `socket.end()` force-uncorked.

## Repro

```js
import http from "node:http";
import net from "node:net";

const server = http.createServer((req, res) => res.end("body"));
server.on("connect", (req, socket) => {
  socket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
  socket.write("tunnel-data"); // stays open: proxy tunnels pipe both ways
  console.log("corked:", socket.writableCorked, "buffered:", socket.writableLength);
});
server.listen(0, () => {
  const sock = net.connect(server.address().port);
  sock.on("connect", () => sock.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
  let buf = "";
  sock.on("data", d => {
    buf += d;
    if (buf.includes("body")) {
      buf = "";
      sock.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
    }
  });
});
```

Node prints `corked: 0 buffered: 0` and the client receives `tunnel-data`. Bun printed `corked: 1 buffered: 50` and the client never saw the writes (a later `socket.end()` would flush them, but an open tunnel never ends).

This is the failure behind #12213 (`proxy-chain` + puppeteer): `anonymizeProxy` starts a local `http.Server`; the first request on a connection goes through `forward()`, and `chain()`'s outgoing `CONNECT` reuses the kept-alive socket to the upstream proxy. The upstream's `'connect'` handler writes `200 Connection Established` and then pipes, but the Duplex is corked so nothing reaches the client and Chrome reports `net::ERR_TUNNEL_CONNECTION_FAILED`. It is also the root of the "connection reset" write-side failure in #26553.

## Fix

- Drop the stray `socket.cork()` in `onNodeHTTPRequest`. Bun's `ServerResponse` writes through the native handle (`handle.writeHeadAndEnd` / `handle.end`), not the socket Duplex, so this cork was not coalescing any response bytes; it only leaked a cork count per request.
- In `ServerResponse.prototype.end`, fully uncork the connection like Node's `OutgoingMessage.prototype.end` does (`_writableState.corked = 1; uncork()`), reading the socket via the response's own `this[fakeSocketSymbol]` (the storage `res.cork()` corked), so a user-issued `res.cork()` is cleared when the response completes even if `req.socket` was nulled by the stream destroyer.

With this change Bun matches Node: `req.socket.writableCorked` is `0` at the start of every request and inside `'connect'` / `'upgrade'` handlers, and a `proxy-chain`-style CONNECT tunnel over a kept-alive socket delivers its writes immediately.

Fixes #12213
Addresses the write-side portion of #26553

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http/node-http-connect.test.ts

<!-- robobun:evidence:end -->