### PR TITLE
bundler: keep CJS wrapped when module.exports escapes as a value

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -343,6 +343,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
 
                             // rewrite `module.exports` to `exports`
+                            //
+                            // `ESpecial::ModuleExports` is printed as `exports_ref`, so
+                            // this is a use of that symbol. When the parent expression is a
+                            // property access (`module.exports.foo`), the
+                            // `ESpecial::ModuleExports` arm below balances this with
+                            // `ignore_usage`. When it isn't (e.g.
+                            // `Object.assign(module.exports, ...)`), the unbalanced use
+                            // makes `uses_exports_ref` true and deoptimizes the CJS→ESM
+                            // unwrapping, keeping the module wrapped as CommonJS so
+                            // dynamically-added exports remain reachable.
+                            let exports_ref = p.exports_ref;
+                            p.record_usage(exports_ref);
                             return Some(Expr {
                                 data: js_ast::ExprData::ESpecial(E::Special::ModuleExports),
                                 loc: name_loc,
@@ -608,6 +620,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         p.deoptimize_common_js_named_exports();
                                         return None;
                                     }
+
+                                    // Balance the `record_usage(exports_ref)` from the
+                                    // `module.exports` rewrite above: this property access
+                                    // consumes the `ESpecial::ModuleExports` value, so it
+                                    // is not an escaping use of the exports object.
+                                    let exports_ref = p.exports_ref;
+                                    p.ignore_usage(exports_ref);
 
                                     // Note: reshaped for borrowck — see exports_ref arm above.
                                     let ref_ = if let Some(existing) =

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -342,17 +342,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 return None;
                             }
 
-                            // rewrite `module.exports` to `exports`
-                            //
-                            // `ESpecial::ModuleExports` is printed as `exports_ref`, so
-                            // this is a use of that symbol. When the parent expression is a
-                            // property access (`module.exports.foo`), the
-                            // `ESpecial::ModuleExports` arm below balances this with
-                            // `ignore_usage`. When it isn't (e.g.
-                            // `Object.assign(module.exports, ...)`), the unbalanced use
-                            // makes `uses_exports_ref` true and deoptimizes the CJS→ESM
-                            // unwrapping, keeping the module wrapped as CommonJS so
-                            // dynamically-added exports remain reachable.
+                            // rewrite `module.exports` to `exports` — counts as a use of exports_ref; the ESpecial::ModuleExports arm below balances this when the value is consumed by a property access.
                             let exports_ref = p.exports_ref;
                             p.record_usage(exports_ref);
                             return Some(Expr {
@@ -621,10 +611,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         return None;
                                     }
 
-                                    // Balance the `record_usage(exports_ref)` from the
-                                    // `module.exports` rewrite above: this property access
-                                    // consumes the `ESpecial::ModuleExports` value, so it
-                                    // is not an escaping use of the exports object.
+                                    // Balance record_usage(exports_ref) from the module.exports rewrite above; this property access consumes the value so it's not an escaping use.
                                     let exports_ref = p.exports_ref;
                                     p.ignore_usage(exports_ref);
 

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -573,6 +573,24 @@ describe("bundler", () => {
     cjs2esm: { unhandled: ["/lib.js"] },
     run: { stdout: "[2,1]" },
   });
+  // https://github.com/oven-sh/bun/issues/14939 — wasm-bindgen output shape
+  itBundled("cjs2esm/ModuleExportsStoredBeforeAssign", {
+    files: {
+      "/entry.js": /* js */ `
+        import { transform } from './wasm.js';
+        console.log(transform());
+      `,
+      "/wasm.js": /* js */ `
+        let imports = {};
+        imports['__wbindgen_placeholder__'] = module.exports;
+        module.exports.transform = function() {
+          return imports['__wbindgen_placeholder__'] === module.exports ? 'ok' : 'bad';
+        };
+      `,
+    },
+    cjs2esm: { unhandled: ["/wasm.js"] },
+    run: { stdout: "ok" },
+  });
   itBundled("cjs2esm/ModuleExportsComputedIndexDeoptimizes", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -501,4 +501,104 @@ describe("bundler", () => {
     cjs2esm: true,
     run: { stdout: "[1,2]" },
   });
+  // https://github.com/oven-sh/bun/issues/12518
+  itBundled("cjs2esm/ObjectAssignModuleExportsDeoptimizes", {
+    files: {
+      "/entry.js": /* js */ `
+        import { createContext, useState, known } from './lib.js';
+        console.log(JSON.stringify([createContext(), useState(), known]));
+      `,
+      "/lib.js": /* js */ `
+        module.exports.known = 1;
+        Object.assign(module.exports, require('./other.js'));
+      `,
+      "/other.js": /* js */ `
+        module.exports.createContext = function() { return 'context'; };
+        module.exports.useState = function() { return 'state'; };
+      `,
+    },
+    cjs2esm: { unhandled: ["/lib.js", "/other.js"] },
+    run: { stdout: '["context","state",1]' },
+  });
+  // https://github.com/oven-sh/bun/issues/12518 — the rehackt pattern
+  itBundled("cjs2esm/ObjectAssignModuleExportsWithDeadHint", {
+    files: {
+      "/entry.js": /* js */ `
+        import { createContext, known } from './lib.js';
+        console.log(JSON.stringify([createContext(), known]));
+      `,
+      "/lib.js": /* js */ `
+        "use strict";
+        if (0) {
+          module.exports = require('./other.js');
+        }
+        module.exports.known = 1;
+        Object.assign(module.exports, require('./other.js'));
+      `,
+      "/other.js": /* js */ `
+        module.exports.createContext = function() { return 'context'; };
+      `,
+    },
+    cjs2esm: { unhandled: ["/lib.js", "/other.js"] },
+    run: { stdout: '["context",1]' },
+  });
+  itBundled("cjs2esm/ObjectAssignModuleExportsNamespaceImport", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as lib from './lib.js';
+        console.log(JSON.stringify([lib.createContext(), lib.known]));
+      `,
+      "/lib.js": /* js */ `
+        module.exports.known = 1;
+        Object.assign(module.exports, require('./other.js'));
+      `,
+      "/other.js": /* js */ `
+        module.exports.createContext = function() { return 'context'; };
+      `,
+    },
+    cjs2esm: { unhandled: ["/lib.js", "/other.js"] },
+    run: { stdout: '["context",1]' },
+  });
+  itBundled("cjs2esm/ModuleExportsEscapesAsValue", {
+    files: {
+      "/entry.js": /* js */ `
+        import { added, known } from './lib.js';
+        console.log(JSON.stringify([added, known]));
+      `,
+      "/lib.js": /* js */ `
+        module.exports.known = 1;
+        (function(obj) { obj.added = 2; })(module.exports);
+      `,
+    },
+    cjs2esm: { unhandled: ["/lib.js"] },
+    run: { stdout: "[2,1]" },
+  });
+  itBundled("cjs2esm/ModuleExportsComputedIndexDeoptimizes", {
+    files: {
+      "/entry.js": /* js */ `
+        import { added, known } from './lib.js';
+        console.log(JSON.stringify([added, known]));
+      `,
+      "/lib.js": /* js */ `
+        module.exports.known = 1;
+        for (const k of ['added']) module.exports[k] = 2;
+      `,
+    },
+    cjs2esm: { unhandled: ["/lib.js"] },
+    run: { stdout: "[2,1]" },
+  });
+  itBundled("cjs2esm/ModuleExportsPropertyReadStillConverts", {
+    files: {
+      "/entry.js": /* js */ `
+        import { a, b } from './lib.js';
+        console.log(JSON.stringify([a, b]));
+      `,
+      "/lib.js": /* js */ `
+        module.exports.a = 1;
+        module.exports.b = module.exports.a + 1;
+      `,
+    },
+    cjs2esm: true,
+    run: { stdout: "[1,2]" },
+  });
 });


### PR DESCRIPTION
Fixes #12518.
Fixes #14939.

## Reproduction

The `rehackt` package (a dependency of `@apollo/client`) uses this shape to re-export React while hiding it from the RSC compiler:

```js
// rehackt/index.js
if (0) {
  module.exports = require("react"); // hint for cjs-module-lexer
}
module.exports.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED = undefined;
Object.assign(module.exports, require("react"));
```

When bundled with `--target=bun` (or `--compile`), named imports from this module were inlined as `undefined`:

```
TypeError: undefined is not an object (evaluating '(void 0)[contextKey]')
```

## Cause

The CJS→ESM unwrapper in `maybe_rewrite_property_access` tracks `module.exports.X = Y` assignments as static named exports so the module can be flattened and tree-shaken. When `module.exports` is read as a plain value (e.g. as an argument to `Object.assign`, or with a computed index), it is rewritten to `ESpecial::ModuleExports` but not counted as a use of `exports_ref`. Because at least one static export (`__SECRET_INTERNALS...`) was found, the parser synthesizes `esm_export_keyword` and marks the module `EsmWithDynamicFallbackFromCjs`, so it is never wrapped. The linker then resolves unknown named imports against the (incomplete) static export set and marks them `ImportItemStatus::Missing`, which the printer emits as `undefined`. The `Object.assign(exports_rehackt, ...)` call is still emitted but references a symbol that was never declared.

esbuild does not attempt this unwrapping and keeps the module in a `__commonJS` closure.

## Fix

`ESpecial::ModuleExports` prints as `exports_ref`, so record it as a use of that symbol at the point of the rewrite. When the value is immediately consumed by a property access (`module.exports.foo`), the `ESpecial::ModuleExports` target arm balances it with `ignore_usage`, so straightforward `module.exports.X = Y` modules are still unwrapped to ESM exactly as before. When the value escapes (passed to a function, computed index, stored in a variable), the unbalanced use makes `uses_exports_ref` true and triggers the existing deopt path in `parse_entry.rs`, keeping the module wrapped as CommonJS and resolving named imports at runtime.

## Tests

Added to `test/bundler/bundler_cjs2esm.test.ts`:

- `ObjectAssignModuleExportsDeoptimizes`: named imports of properties added via `Object.assign(module.exports, require(...))`
- `ObjectAssignModuleExportsWithDeadHint`: the exact `rehackt` shape with the `if (0)` lexer hint
- `ObjectAssignModuleExportsNamespaceImport`: `import *` over the same shape
- `ModuleExportsEscapesAsValue`: `module.exports` passed to an arbitrary function
- `ModuleExportsComputedIndexDeoptimizes`: `module.exports[k] = ...` with a computed key
- `ModuleExportsPropertyReadStillConverts`: regression check that `module.exports.b = module.exports.a + 1` still converts to ESM with no `__commonJS` wrapper

All 29 tests in `bundler_cjs2esm.test.ts` pass, and `bundler_cjs`, `bundler_edgecase`, `bundler_npm`, `esbuild/default`, `esbuild/importstar`, and `esbuild/dce` show no new failures.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (b5d5e2cf3)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [1737.57ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [749.28ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [1485.24ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [2348.02ms]
(pass) bundler > cjs2esm/ExportsFunction [1461.89ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [5635.53ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [1003.65ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [2867.45ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [1965.79ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [1631.32ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [2284.03ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [1746.46ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [3384.06ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [1524.21ms]
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [519.67ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [37.39ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [39.37ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [38.44ms]
(pass) bundler > cjs2esm/ExportsFunction [85.04ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [34.86ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [99.23ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [81.11ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [573.02ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [155.55ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [549.05ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [317.46ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [244.83ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [87.84ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignDeOpt [103.92ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingAssignExportsDeOpt [41.76ms]
397 |   // converted to `var $x = ...; 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (b5d5e2cf3)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [2726.00ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [1823.76ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [1240.65ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [1404.92ms]
(pass) bundler > cjs2esm/ExportsFunction [1237.35ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [988.88ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [950.13ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [1091.48ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [1977.02ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [1272.89ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [1969.08ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping [1161.44ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping2 [2812.23ms]
(pass) bundler > cjs2esm/ModuleExportsRenamingNoDeopt [917.97ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 2380ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/51] gen cpp.rs (cppbind)
[2/51] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 239 extern-C blocks audited
[2/51] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/fold.rs                |   8 ++-
 test/bundler/bundler_cjs2esm.test.ts | 118 +++++++++++++++++++++++++++++++++++
 2 files changed, 125 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js_parser/fold.rs                     6      5      0
test/bundler/bundler_cjs2esm.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->